### PR TITLE
fix: bake the platform's own content INSIDE the shipped image (#1725)

### DIFF
--- a/.github/scripts/stage-doc-gate.sh
+++ b/.github/scripts/stage-doc-gate.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# stage-doc-gate.sh <src-data-dir> <stage-dir>
+#
+# Stages src/MeshWeaver.Documentation/Data as the `Doc/` package root mw-plugin-test imports —
+# the shape BOTH consumers need, which is why it lives here rather than inline in one workflow:
+#
+#   * dotnet-test.yml's `doc-gate` — the PR verdict ("the Doc tree compiles, renders, tests"),
+#   * main-cd.yml's `publish-bake` — the SHIPPED IMAGE re-running the same content to produce the
+#     bundles the pods adopt.
+#
+# Those two must stage byte-identical trees: the bake publishes what the gate proved. A second,
+# drifting copy of this staging is exactly how a bake could publish something the gate never judged.
+#
+# The tree has no index.json of its own (index.md is the partition's root PAGE, and committing a
+# JSON root would ship a duplicate root node in the embedded partition), so the root is synthesized
+# HERE and index.md is dropped from the STAGE only — shipped content is untouched. NodeFileMapper
+# then maps Doc/DataMesh/SocialMedia/Post.json et al. to the exact namespaces the files themselves
+# declare, so the gate compiles the tree under its canonical paths.
+set -euo pipefail
+SRC="${1:?usage: stage-doc-gate.sh <src-data-dir> <stage-dir>}"
+STAGE="${2:?usage: stage-doc-gate.sh <src-data-dir> <stage-dir>}"
+if [ ! -d "$SRC" ]; then echo "::error::doc gate: source tree '$SRC' is missing"; exit 1; fi
+rm -rf "$STAGE"
+mkdir -p "$STAGE/Doc"
+cp -R "$SRC/." "$STAGE/Doc/"
+rm -f "$STAGE/Doc/index.md"
+printf '%s' '{"$type":"MeshNode","id":"Doc","path":"Doc","mainNode":"Doc","name":"MeshWeaver Documentation","nodeType":"Space","state":"Active"}' > "$STAGE/Doc/index.json"
+echo "staged: $(find "$STAGE" -name '*.cs' | wc -l | tr -d ' ') .cs files under $STAGE/Doc"

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1305,15 +1305,20 @@ jobs:
         set -euo pipefail
         tar -I 'zstd --long=27' -xf build-output-0.tar.zst
         rm -f build-output-0.tar.zst
-    # 🚨 Since #1660 WS1 this job is not verdict-only: the SAME tester run that proves the content
-    # compiles also PERSISTS the compiled assemblies (--bake-output) as identity-keyed prebuilt
-    # bundles, uploaded below as `baked-assemblies-<identity>`. Since #1660 WS3 the framework
-    # identity is COMMIT-DETERMINISTIC (for CI builds: g<sha>, stamped by Directory.Build.props —
-    # no run number or ticks reach any compiled attribute), so consumers are no longer limited to
-    # this run: main-cd's publish-bake job copies these bundles to the portals' shared storage,
-    # where every pod built from the SAME COMMIT seeds them at boot
-    # (ShippedPrebuiltBundles.SeedPublishedRoot) instead of recompiling. The seeder's identity
-    # gate still declines anything from another commit — that is the ABI gate, not a bug.
+    # 🚨 `--bake-output` here is a SMOKE TEST of the bake stage, NOT a delivery lane (#1725).
+    # It costs almost nothing — the tester has already compiled everything, this only persists it —
+    # and it makes a bake-stage regression fail on the PR that causes it rather than in CD.
+    #
+    # What it deliberately no longer does is FEED the portals. Until #1725 this job's bundles were
+    # uploaded as `baked-assemblies-<identity>` and published to portal storage by main-cd. That can
+    # never work: the framework identity is derived from the exact binaries a host ships, and this
+    # job's binaries are a DIFFERENT compilation from the ones in the shipped image. Measured on
+    # commit babb3bc, same source, same runner path: every implementation assembly's MVID differs
+    # between the two (Data/Layout/AI/Utils included), and 4 of the 37 canonical REFERENCE
+    # assemblies differ too (Graph, Hosting, Kernel, Markdown.Collaboration) — so the two hosts
+    # resolved `sd0d0daa…` and `s377941f…` for one commit, and no pod could ever adopt what this run
+    # baked. The platform's own bake now runs INSIDE the shipped image (main-cd's `publish-bake`),
+    # exactly as every satellite repo's does. See Doc/Architecture/CiContentBake.
     - name: "Compile + run the Doc content against this PR"
       id: gate
       run: |
@@ -1324,18 +1329,12 @@ jobs:
           exit 1
         fi
         BAKE="${RUNNER_TEMP:-/tmp}/bake"
-        # Stage src/MeshWeaver.Documentation/Data as a package root named Doc/. The tree has no
-        # index.json of its own (index.md is the partition's root PAGE, and committing a JSON
-        # root would ship a duplicate root node in the embedded partition), so the root is
-        # synthesized here and index.md is dropped from the STAGE only — shipped content is
-        # untouched. NodeFileMapper then maps Doc/DataMesh/SocialMedia/Post.json et al. to the
-        # exact namespaces the files themselves declare, so the gate compiles the tree under
-        # its canonical paths.
+        # Stage src/MeshWeaver.Documentation/Data as a package root named Doc/. The staging lives
+        # in a script because main-cd's publish-bake stages the SAME tree for the in-image bake —
+        # the bake must publish exactly what this gate judged, so the two cannot have separate
+        # copies of the staging rules.
         STAGE="${RUNNER_TEMP:-/tmp}/doc"
-        mkdir -p "$STAGE/Doc"
-        cp -R src/MeshWeaver.Documentation/Data/. "$STAGE/Doc/"
-        rm -f "$STAGE/Doc/index.md"
-        printf '%s' '{"$type":"MeshNode","id":"Doc","path":"Doc","mainNode":"Doc","name":"MeshWeaver Documentation","nodeType":"Space","state":"Active"}' > "$STAGE/Doc/index.json"
+        bash .github/scripts/stage-doc-gate.sh src/MeshWeaver.Documentation/Data "$STAGE"
         # .github/doc-gate.allow is THIS repo's known-debt ratchet for doc content: listed
         # failures are tolerated, NEW failures fail the PR, and a listed check that starts
         # passing fails the PR until its line is removed — the list can only shrink.
@@ -1376,11 +1375,12 @@ jobs:
           fi
           exit 1
         fi
-    # A green gate that produced no bake identity is a bake-stage REGRESSION — fail RED, never
-    # upload a partial or unnamed artifact (no continue-on-error, no "is the file there?" skip:
-    # the gate above already proved the tester ran green, so the identity file is a POSTcondition).
+    # A green gate that produced no bake identity is a bake-stage REGRESSION — fail RED (no
+    # continue-on-error, no "is the file there?" skip: the gate above already proved the tester ran
+    # green, so the identity file is a POSTcondition). This is the whole point of keeping
+    # --bake-output on the PR lane: the bake stage breaks HERE, on the PR that breaks it, instead of
+    # in CD after the merge.
     - name: "Bake summary + identity"
-      id: bake
       run: |
         set -euo pipefail
         mvid_file="${RUNNER_TEMP:-/tmp}/bake/framework-mvid.txt"
@@ -1388,22 +1388,23 @@ jobs:
           echo "::error::the content gate ran green but wrote no bake identity ($mvid_file) — the bake stage regressed."
           exit 1
         fi
-        echo "mvid=$(cat "$mvid_file")" >> "$GITHUB_OUTPUT"
         {
-          echo "### 📦 Baked shipped-content assemblies (framework $(cat "$mvid_file"))"
+          echo "### 🧪 Bake stage exercised (framework $(cat "$mvid_file")) — NOT published"
+          echo
+          echo "This identity is this job's own build; the portals adopt the bake main-cd takes"
+          echo "inside the shipped image. See Doc/Architecture/CiContentBake."
           echo
           echo '```'
           grep -h '^bake: ' "${RUNNER_TEMP:-/tmp}/doc-gate.log" "${RUNNER_TEMP:-/tmp}/samples-gate.log" || true
           echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
-    # The MVID-keyed artifact every lane of THIS run can adopt (same solution build ⇒ same
-    # Graph.dll ⇒ the seeder's gate accepts it). Stable name shape: baked-assemblies-<mvid>.
-    - name: "Upload artifact: baked shipped-content assemblies"
-      uses: actions/upload-artifact@v7
-      with:
-        name: baked-assemblies-${{ steps.bake.outputs.mvid }}
-        path: ${{ runner.temp }}/bake
-        retention-days: 7
+    # 🚨 NO artifact upload — deliberately, since #1725. These bundles are keyed to THIS job's
+    # binaries, which no shipped image ever contains, so an uploaded `baked-assemblies-<identity>`
+    # was adoptable by nothing: main-cd published it under an identity no pod resolves and every
+    # pod kept Roslyn-compiling ~80 platform types at boot (64.8 s warm-up, compiled=80
+    # alreadyBaked=4). An artifact that looks like delivery and delivers nothing is worse than no
+    # artifact — it is what made that regression invisible for a whole release train. The bundles
+    # pods actually adopt are baked by main-cd INSIDE the shipped image.
 
   licence-gate:
     name: "Dependency licences"

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -92,9 +92,6 @@ permissions:
   # packages: write — the mw-plugin-test image is ALSO published to GHCR so the
   # MeshWeaver.Plugins CI can pull it with a GitHub token instead of ACR credentials.
   packages: write
-  # actions: read — publish-bake downloads the Build-and-Test run's baked-assemblies-* artifact
-  # (the CI NodeType bake this CD publishes to the portals' storage, #1660 WS3).
-  actions: read
 
 # Every green main merge ships its OWN image increment — CD runs never supersede each
 # other. The previous shared `main-cd` group dated from when this workflow also ROLLED
@@ -926,29 +923,65 @@ jobs:
             echo "- memex-portal-next \`$V_NEXT\`, \`$SHA\`, \`main\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # ────────────────── PUBLISH THE CI NODETYPE BAKE TO PORTAL STORAGE ──────────────────
-  # #1660 WS3 — "bake on CI": the Build-and-Test run of this same commit already compiled every
-  # shipped NodeType (its doc-gate runs mw-plugin-test with --bake-output and uploads the result
-  # as `baked-assemblies-<framework-identity>`). The framework identity is the API-SURFACE hash
-  # (FrameworkBuildIdentity — deterministic per source+references, stable across internal-only
-  # merges), so that artifact's identity EQUALS the identity of the images promote just armed —
-  # and usually equals the PREVIOUS release's too, in which case the publish below skips — this job
-  # copies the bundles into the storage the portals mount, laid out
-  # `prebuilt-bundles/<identity>/<source>/`, and each booting pod seeds its own identity's
-  # directory (ShippedPrebuiltBundles.SeedPublishedRoot) before its NodeType sweep: pending drops
-  # to the user-content remainder, with zero Roslyn for shipped content on the pod.
+  # ────────── BAKE THE PLATFORM'S OWN CONTENT *IN THE SHIPPED IMAGE*, THEN PUBLISH ──────────
+  # #1660 WS3 delivery, corrected by #1725. The portals adopt a prebuilt NodeType bundle only when
+  # its framework identity EQUALS the one the booting process resolves — that identity IS the
+  # ABI-compatibility proof, and adopting bytes from an identity you did not resolve is precisely
+  # what it exists to prevent. So the only sound producer is the very build the consumer runs.
   #
-  # 🚨 The CONFIG is preflighted RED, not skipped: BAKE_PUBLISH_TARGETS missing means no portal
-  # can ever receive a bake, which is exactly the silent regression (#1347) this lane fixes — a
-  # grey skip here would hide it forever (AGENTS.md: a gate never tests its own inputs).
-  # A missing ARTIFACT, by contrast, is a legitimate per-run state (a reuse-green run skips the
-  # doc-gate, so THAT run baked nothing; the pods then compile as before) and only warns.
+  # 🚨 THE REGRESSION THIS SHAPE FIXES. Until #1725 this job downloaded the Build-and-Test run's
+  # `baked-assemblies-*` artifact — a DIFFERENT compilation of the same source — and published it.
+  # Two compilations never agree on the identity. Measured on commit `babb3bc` (Build-and-Test run
+  # 32016820517 vs the images CD run 32018411051 promoted), same sources, same runner path:
+  #   * EVERY implementation assembly's MVID differs between the two hosts — the controls too
+  #     (Data, Layout, AI, Utils) — so every `FrameworkBuildIdentity.FullMvidAssemblies` member
+  #     (the MeshWeaver.Compiler + MeshWeaver.NuGet toolchain closure) contributes a different id;
+  #   * 4 of the 37 canonical REFERENCE assemblies differ as well — MeshWeaver.Graph, .Hosting,
+  #     .Kernel, .Markdown.Collaboration — so the surface half diverges independently.
+  # Result: the artifact resolved `sd0d0daa9398c4d810e0e730a0495b9db` while the running pods
+  # resolve `s377941f549f721e01ac764e0fb8db84a`. `prebuilt-bundles/<runtime-identity>/` never
+  # contained `meshweaver-content`, so every pod Roslyn-compiled ~80 platform types on EVERY boot
+  # (64.8 s warm-up, `compiled=80 alreadyBaked=4`) — the exact regression (#1347 → #1660) this lane
+  # exists to prevent, behind a green tick.
+  #
+  # The satellites never had this problem because they bake INSIDE the shipped image
+  # (`node-repo-publish-bake.yml`: `docker run … mw-plugin-test … --bake-output`). This job now does
+  # the same for the platform's own content: one producer, one toolchain, one identity, and the
+  # producer/consumer question stops existing. The bake is also strictly STRONGER as a gate than the
+  # artifact hop was — it proves the shipped content compiles against the binaries that SHIP, not
+  # against a build output that never leaves CI.
+  #
+  # 🚨 ARCHITECTURE IS PART OF THE IDENTITY, so the platform is pinned explicitly. The same four
+  # reference assemblies differ between the amd64 and arm64 variants of ONE image, so a multi-arch
+  # image carries two identities. Every AKS node is amd64, so the bake must be taken on amd64 —
+  # `--platform linux/amd64` says so out loud instead of inheriting whatever the runner happens to
+  # be. An arm64 install (memex-local) resolves the other identity and compiles locally, exactly as
+  # it does today; publishing under a second identity to "cover" it is forbidden — that is the
+  # adopt-what-you-did-not-resolve shape, not a fix.
+  #
+  # 🚨 The CONFIG is preflighted RED, not skipped: BAKE_PUBLISH_TARGETS missing means no portal can
+  # ever receive a bake — a grey skip would hide that forever (AGENTS.md: a gate never tests its own
+  # inputs). And there is no longer any "nothing to publish" branch to warn about: the bake happens
+  # HERE, from this run's image, so it either produces bundles or fails.
+  #
+  # Ordering: after `promote` (the image is armed) and therefore after `plugin-test-image` pushed
+  # the staging tag this job bakes with. The staging tag is exact and immutable for this run —
+  # `latest`/`main` are moving pointers a concurrent CD run can re-aim mid-job. Publication itself
+  # stays all-or-nothing inside `publish-bake-bundles.sh`: every bundle first, the `_complete`
+  # sentinel strictly LAST, and pods seed only sealed directories.
   publish-bake:
-    name: "Publish CI bake to portal storage"
-    needs: [gate, promote]
+    name: "Bake platform content in the shipped image + publish"
+    needs: [gate, plugin-test-image, promote]
     if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The bake compiles every shipped NodeType twice over (Doc + samples) inside the container;
+    # the doc-gate's equivalent budget is 12 min, and the pull plus the publish add to it.
+    timeout-minutes: 40
+    # Job-level permissions REPLACE the workflow-level map, so every one this job needs is here.
+    # `actions: read` is deliberately GONE — nothing cross-run is downloaded any more.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -960,56 +993,65 @@ jobs:
             echo "::error::Repo variable BAKE_PUBLISH_TARGETS is not provisioned — the CI bake can reach no portal. Set it to the portals' Azure Files targets, whitespace-separated <account>/<share>[/<base-path>] (on AKS: the account/share behind each portal's memex-data PVC — resolve with 'kubectl get pv -o jsonpath' on the claim; the CD identity needs the 'Storage File Data Privileged Contributor' role on those accounts)."
             exit 1
           fi
-      - name: "Locate the Build-and-Test run for this commit"
-        id: bt
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SHA: ${{ needs.gate.outputs.sha }}
-        run: |
-          set -euo pipefail
-          run_id=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/dotnet-test.yml/runs?head_sha=$SHA&status=success&per_page=1" \
-            --jq '.workflow_runs[0].id // empty')
-          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
-          echo "Build-and-Test run for $SHA: ${run_id:-<none>}"
-      - name: "Download the bake artifact"
-        id: dl
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if [ -z "${{ steps.bt.outputs.run_id }}" ]; then
-            echo "::warning::No successful Build-and-Test run found for this commit — nothing to publish; pods bake locally."
-            echo "found=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          mkdir -p "$RUNNER_TEMP/bake-dl"
-          if ! gh run download "${{ steps.bt.outputs.run_id }}" --repo "$GITHUB_REPOSITORY" \
-               --pattern 'baked-assemblies-*' --dir "$RUNNER_TEMP/bake-dl"; then
-            # Legitimate on a reuse-green run (the doc-gate — the bake producer — was skipped
-            # because an identical tree was already proven green): that run baked nothing, and an
-            # earlier commit's bake carries a DIFFERENT identity anyway. Pods compile as before.
-            echo "::warning::Build-and-Test run ${{ steps.bt.outputs.run_id }} carries no baked-assemblies-* artifact (reuse-green run, or expired) — nothing to publish; pods bake locally."
-            echo "### ⚠️ No CI bake artifact for this commit — pods bake locally" >> "$GITHUB_STEP_SUMMARY"
-            echo "found=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          bake_dir=$(find "$RUNNER_TEMP/bake-dl" -maxdepth 1 -type d -name 'baked-assemblies-*' | head -1)
-          if [ -z "$bake_dir" ] || [ ! -s "$bake_dir/framework-mvid.txt" ]; then
-            echo "::error::baked-assemblies artifact downloaded but carries no framework-mvid.txt — the bake artifact contract regressed."
-            exit 1
-          fi
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "bake_dir=$bake_dir" >> "$GITHUB_OUTPUT"
       - name: Ensure Azure CLI
-        if: steps.dl.outputs.found == 'true'
         run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       - name: Azure login (OIDC)
-        if: steps.dl.outputs.found == 'true'
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      # Both a docker pull credential (the bake image) and, further down, the data-plane token the
+      # publish script uses against Azure Files.
+      - name: ACR login
+        run: az acr login --name meshweaver
+      - name: "Bake the platform's shipped content INSIDE the promoted image"
+        env:
+          IMAGE: ${{ env.ACR }}/mw-plugin-test:${{ needs.gate.outputs.staging_tag }}
+          SHA: ${{ needs.gate.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # The SAME staging the doc-gate judges — one script, so the bake can only ever publish
+          # content that was gated in exactly the shape it was gated in.
+          STAGE="$RUNNER_TEMP/bake-stage"
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE"
+          bash .github/scripts/stage-doc-gate.sh src/MeshWeaver.Documentation/Data "$STAGE/doc"
+          bash .github/scripts/stage-samples-gate.sh samples/Graph/Data "$STAGE/samples"
+          # The two known-debt ratchets travel INTO the mount: the tester runs in the container and
+          # cannot see the checkout. Same files the doc-gate passes, so the same verdict applies.
+          cp .github/doc-gate.allow "$STAGE/doc-gate.allow"
+          cp .github/samples-gate.allow "$STAGE/samples-gate.allow"
+          # The image's tester runs as a non-root user: it must be able to read the mount and write
+          # the bake directory.
+          chmod -R a+rX "$STAGE"
+          BAKE="$RUNNER_TEMP/bake"
+          rm -rf "$BAKE"
+          mkdir -p "$BAKE"
+          chmod 777 "$BAKE"
+          # Two stages, one bake directory — exactly as the doc-gate runs them. A red tester FAILS
+          # this job: the platform's own shipped content not compiling against the image that ships
+          # it is a release defect, not a reason to publish less.
+          for stage in doc samples; do
+            echo "── baking /repo/$stage against $IMAGE"
+            docker run --rm --platform linux/amd64 -v "$STAGE:/repo" -v "$BAKE:/bake" \
+              --entrypoint /app/mw-plugin-test "$IMAGE" "/repo/$stage" \
+              --allow "/repo/$stage-gate.allow" --bake-output /bake --source-sha "$SHA"
+          done
+          # Postconditions, not hopes: a green tester that wrote no identity, or no bundles, is a
+          # bake-stage regression — never a quiet publish of nothing.
+          if [ ! -s "$BAKE/framework-mvid.txt" ]; then
+            echo "::error::the tester ran green but wrote no bake identity ($BAKE/framework-mvid.txt) — the bake stage regressed (or the image predates --bake-output support)."
+            exit 1
+          fi
+          if ! ls "$BAKE"/*.zip >/dev/null 2>&1; then
+            echo "::error::the tester ran green but produced no bundles under $BAKE — nothing could be published."
+            exit 1
+          fi
+          echo "BAKE_DIR=$BAKE" >> "$GITHUB_ENV"
+          echo "baked identity: $(cat "$BAKE/framework-mvid.txt")"
+          ls -l "$BAKE"/*.zip
       - name: "Publish bundles to every portal target"
-        if: steps.dl.outputs.found == 'true'
         env:
           BAKE_PUBLISH_TARGETS: ${{ vars.BAKE_PUBLISH_TARGETS }}
         run: |
@@ -1020,10 +1062,10 @@ jobs:
           # the whole surface generation, and pods would keep declining its stale per-type source
           # SHAs and recompiling. With it, a content change under an unchanged surface republishes
           # (cheap uploads), and a truly unchanged bake still skips.
-          .github/scripts/publish-bake-bundles.sh "${{ steps.dl.outputs.bake_dir }}" meshweaver-content "${{ needs.gate.outputs.sha }}"
+          .github/scripts/publish-bake-bundles.sh "$BAKE_DIR" meshweaver-content "${{ needs.gate.outputs.sha }}"
           {
-            echo "### 📦 CI bake published"
-            echo "- identity: \`$(cat "${{ steps.dl.outputs.bake_dir }}/framework-mvid.txt")\`"
+            echo "### 📦 Platform content bake published"
+            echo "- identity: \`$(cat "$BAKE_DIR/framework-mvid.txt")\` (resolved by the image this run promoted)"
             echo "- source: \`meshweaver-content\`  targets: \`${BAKE_PUBLISH_TARGETS}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -315,10 +315,26 @@
        (FrameworkBuildIdentity.ResolveProcessIdentity) hashes the manifest's canonical subset into
        the framework build identity `s<hash>` — so a NodeType bake stays valid across
        internal-only framework merges and is invalidated exactly by breaking changes.
-       Deterministic by construction: ref-assembly bytes are deterministic per source+references
-       (proven: byte-identical across independent from-clean, non-incremental rebuilds), so the
-       Build-and-Test bake host and the main-cd image compute the SAME identity for the same
-       surfaces — which is what lets the CI bake seed at boot without rebaking per commit. -->
+
+       🚨 SCOPE OF THAT STABILITY — corrected by #1725, because the previous claim here ("so the
+       Build-and-Test bake host and the main-cd image compute the SAME identity") was FALSE and a
+       whole delivery lane was built on it. Ref-assembly bytes are stable across REBUILDS OF THE
+       SAME BUILD INVOCATION (from-clean, non-incremental, same project, same output paths) — that
+       is what makes an internal-only merge keep its identity. They are NOT stable across DIFFERENT
+       build invocations. Measured on commit babb3bc, same sources, same runner path, Build-and-Test
+       `dotnet build` output vs the `dotnet publish -t:PublishContainer` image:
+         * all 37 canonical assemblies' IMPLEMENTATION MVIDs differ (Data, Layout, AI, Utils
+           included) — so every FullMvidAssemblies member contributes a different id;
+         * 4 of the 37 canonical REFERENCE assemblies differ too (MeshWeaver.Graph, .Hosting,
+           .Kernel, .Markdown.Collaboration), and the same four differ between the amd64 and arm64
+           variants of ONE multi-arch image.
+       So: the identity is a property of the exact binaries a host SHIPS, not of the source they
+       were built from — which is what makes it a real ABI proof. The consequence for delivery is
+       absolute: a NodeType bake is adoptable only when its producer ran the SAME binaries as the
+       consumer. That is why the platform's own content is baked INSIDE the shipped image
+       (main-cd's publish-bake, exactly as every satellite repo bakes), never from a CI build
+       output. Do NOT reintroduce a cross-build bake hop on the strength of "the sources are
+       identical". See Doc/Architecture/CiContentBake. -->
   <Target Name="_MeshWeaverWriteSurfaceManifest"
           AfterTargets="Build"
           Condition="'$(MeshWeaverSurfaceManifest)' == 'true'">

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -41,9 +41,14 @@ tolerates simply has no entry — the consumer compiles it as it would have anyw
 *claims* Ok while the run's assembly store has no bytes for it faults the run: an artifact stage
 that ships less than the verdict claims would be the skip-trapdoor shape CI forbids.
 
-The workflow uploads the directories as **`baked-assemblies-<mvid>`** (Doc + samples) and
-**`baked-plugins-<mvid>`** (vital plugin modules), and fails RED when a green gate produced no bake
-identity.
+Both gates fail RED when a green run produced no bake identity — the bake stage is a
+postcondition of the verdict, never an optional extra.
+
+🚨 **What the gates' bake is FOR: proving the bake stage still works, on the PR that breaks it.** It
+is *not* the delivery lane. A gate job's bundles are keyed to that job's own binaries, and no
+shipped image ever contains those (see "The identity rule" below), so `doc-gate` uploads nothing;
+`plugin-gate` still uploads `baked-plugins-<mvid>` for in-run diagnosis. What the portals adopt is
+baked **inside the shipped image** — see "The delivery" below.
 
 ## The identity rule: adoptable when the SURFACE is unchanged
 
@@ -68,13 +73,41 @@ rebaked the world; the extraction is what makes "rebuild only when we need to" h
 
 Three consequences:
 
-- **a bundle is adoptable across CI runs, images, and internal-only merges** — the bake for
-  commit X seeds at boot on the image of commit Y whenever nothing in the content-facing surface
-  changed between them ("rebuild only when we need to");
+- **a bundle is adoptable across images and internal-only merges** — the bake taken from image X
+  seeds at boot on image Y whenever nothing in the content-facing surface changed between them
+  ("rebuild only when we need to");
 - **a breaking surface change (or any toolchain change) mints a new identity** — every cached and
-  published build for the old surface is stale, and the next Build-and-Test run bakes fresh;
+  published build for the old surface is stale, and the next release bakes fresh;
 - **a declined bundle costs exactly what today costs — a compile.** Shipping bundles is strictly
   safe; declines are logged with both identities.
+
+### 🚨 The identity is a property of the BINARIES, not of the source (#1725)
+
+The stability above holds across *rebuilds of the same build invocation*. It does **not** hold
+across *different* build invocations of the same source, and a delivery lane was once built on the
+belief that it did. Measured on commit `babb3bc` — same sources, same runner path — between the
+Build-and-Test job's `dotnet build` output and the `dotnet publish -t:PublishContainer` image the
+same commit shipped:
+
+| half of the identity | result |
+|---|---|
+| implementation MVIDs (`FullMvidAssemblies` — the toolchain closure) | **all differ**, controls (Data, Layout, AI, Utils) included |
+| reference-assembly hashes (the other 33 canonical entries) | 29 identical, **4 differ**: `MeshWeaver.Graph`, `MeshWeaver.Hosting`, `MeshWeaver.Kernel`, `MeshWeaver.Markdown.Collaboration` |
+
+The two hosts therefore resolved `sd0d0daa…` and `s377941f…` for one commit. The same four
+reference assemblies also differ between the **amd64 and arm64 variants of one multi-arch image**,
+so a multi-arch image carries two identities and a bake is valid for the architecture it was taken
+on. Every AKS node is amd64, so the platform bake is pinned to `--platform linux/amd64`; an arm64
+install resolves the other identity and compiles locally.
+
+None of this is a defect in the identity — it is the identity doing its job. A bake is an ABI
+claim about *bytes*, and bytes from another compilation are not the bytes a pod loaded. The
+operational rule that follows is absolute:
+
+> **The producer of a bake must be the binaries the consumer runs.** Never publish a bake under
+> several identities, never let a pod scan for a "nearest" one, never relax the sentinel or the
+> identity check — adopting bytes from an identity you did not resolve is exactly what the check
+> exists to prevent.
 
 Manifest-less CI processes (test hosts) fall back to the commit identity `g<sha>` stamped by
 `Directory.Build.props`; local manifest-less builds fall back to the identity anchor's MVID
@@ -112,10 +145,13 @@ logged and skipped, and the sweep compiles that type as it always has. Nothing c
 from this path — the bake gate keeps probing the store, which only ever holds what was actually
 adopted.
 
-## The delivery: main-cd publishes, boot seeds
+## The delivery: main-cd bakes IN THE IMAGE, then publishes
 
-Since #1660 WS3, `main-cd`'s **`publish-bake`** job downloads the Build-and-Test run's
-`baked-assemblies-*` artifact for the promoted commit and copies the bundles to the portals'
+`main-cd`'s **`publish-bake`** job runs the platform's own shipped content — the `Doc` tree and the
+`samples/Graph/Data` trees, staged by `.github/scripts/stage-doc-gate.sh` and
+`stage-samples-gate.sh`, the same staging the PR gate judges — through
+`docker run … mw-plugin-test … --bake-output` against **the `mw-plugin-test` image this very CD run
+built and promoted**, and copies the resulting bundles to the portals'
 shared storage (`.github/scripts/publish-bake-bundles.sh`), laid out
 `prebuilt-bundles/<identity>/<source>/<bundle>.zip`, sealed by a `_complete` sentinel written
 strictly LAST. Each booting pod seeds ONLY its own identity's SEALED source directories
@@ -126,6 +162,23 @@ identity's directory is already sealed — an internal-only merge resolves the s
 identity as its predecessor — the script skips with a notice instead of re-uploading. See
 [The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract)
 for the job's preflight discipline and the dependent-repo dispatch.
+
+Three properties fall out of baking in the image rather than shipping a CI artifact across jobs:
+
+- **the identity always matches**, by construction — producer and consumer are the same binaries,
+  so there is no compatibility question left to get wrong;
+- **the bake is a stronger gate**, not just a producer: it proves the platform's shipped content
+  compiles, renders and passes its `Tests` areas against the binaries that actually SHIP. A red
+  bake fails CD loudly (the images are already promoted; nothing silently ships less);
+- **there is no "nothing to publish" state.** The old lane had one — a reuse-green Build-and-Test
+  run produced no artifact and the publish warned and skipped — which is the shape that let a lane
+  publishing to an unusable identity look healthy for a whole release train.
+
+The platform deliberately does not call `node-repo-publish-bake.yml` even though the two lanes are
+the same idea: it authenticates to the registry by OIDC rather than the reusable workflow's
+username/password secrets, and it bakes **two** trees against **two** known-debt ratchets in one
+bake directory, where the reusable workflow bakes one mount. Both run the identical publish script,
+which is the part that must never drift.
 
 ## Node repos run the same lane — as reusable workflows
 
@@ -169,8 +222,16 @@ The design rules the extraction preserves:
 ## What this step does not do yet
 
 - **DB-resident types** (user/partition content CI cannot see) stay on the runtime bake.
-- Test lanes do not consume the artifact yet — it is named stably (`baked-assemblies-<identity>`)
-  precisely so they can start.
+- **A bundle is matched to a deployment by node PATH**, so a portal that mounts a tree somewhere
+  other than its canonical root adopts nothing from it. Measured on `memex`: the `Doc/…` types match
+  and adopt, while the sample trees live under `MeshWeaver/samples/Graph/Data/ACME/…` there and the
+  bundles are keyed `ACME/…`, so those seven bundles are published but inert on that portal. They do
+  adopt on a deployment that mounts the samples at their canonical roots. Closing that gap means
+  agreeing one canonical path per shipped tree — it is a content-layout question, not an identity
+  one.
+- **An arm64 install adopts nothing the amd64 lane publishes** — the two architectures of one image
+  resolve different identities (see the identity rule above). Local arm64 installs compile at boot
+  as they always have; nothing may paper over this by publishing the same bundles twice.
 
 See also: [Plugin Packaging](/Doc/Architecture/PluginPackaging) (the compilation-unit rules and the
 MVID rationale) · [Build Coordination](/Doc/Architecture/BuildCoordination) (who bakes when several

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -182,26 +182,34 @@ produces it rather than silently "fixed". This is also why `check-image-set.sh` 
 
 Two post-promote legs ride every armed release (#1660 WS3):
 
-**`publish-bake`** copies the Build-and-Test run's CI NodeType bake (the
-`baked-assemblies-<framework-identity>` artifact its doc-gate produced with
-`mw-plugin-test --bake-output`) onto the portals' shared storage, laid out
-`prebuilt-bundles/<framework-identity>/<source>/<bundle>.zip`
-(`.github/scripts/publish-bake-bundles.sh`). The framework identity is the **API-surface hash**
-(`FrameworkBuildIdentity` — reference-assembly hashes, deterministic per source+references), so
-the identity the bake was keyed under equals the identity of the images promote just armed — and
-stays equal across internal-only merges: when the identity's directory is already **sealed** (the
-`_complete` sentinel the publisher writes strictly LAST, after every bundle), the script skips
-with a notice instead of re-uploading ("rebuild only when we need to"). A publish that died
-mid-way leaves no sentinel — the next run re-publishes wholesale, and the portal reader refuses
+**`publish-bake`** runs the platform's own shipped content (the `Doc` tree and the
+`samples/Graph/Data` trees) through `mw-plugin-test --bake-output` **inside the `mw-plugin-test`
+image this run just built and promoted**, then copies the bundles onto the portals' shared storage,
+laid out `prebuilt-bundles/<framework-identity>/<source>/<bundle>.zip`
+(`.github/scripts/publish-bake-bundles.sh`). Baking in the image is not an implementation detail —
+it is the whole correctness argument. The framework identity is derived from the **binaries a host
+ships**, so two different compilations of one source resolve different identities; until #1725 this
+job published a Build-and-Test *artifact* — a different compilation — under an identity **no pod
+ever resolves**, and every pod re-compiled ~80 platform NodeTypes on every boot behind a green
+tick. Producer and consumer are now the same binaries, so the compatibility question cannot be got
+wrong. Architecture is part of the identity too (the amd64 and arm64 variants of one image resolve
+differently), so the bake is pinned to `--platform linux/amd64`, the architecture every AKS node
+runs.
+
+The identity stays equal across internal-only merges: when the identity's directory is already
+**sealed** (the `_complete` sentinel the publisher writes strictly LAST, after every bundle), the
+script skips with a notice instead of re-uploading ("rebuild only when we need to"). A publish that
+died mid-way leaves no sentinel — the next run re-publishes wholesale, and the portal reader refuses
 unsealed or torn directories, so a partial publication can neither freeze nor be seeded.
 Each booting pod seeds its own identity's bundles (`PreWarm:PrebuiltBundleRoot` →
 `ShippedPrebuiltBundles.SeedPublishedRoot`) before its NodeType sweep, and compiles only what CI
 did not bake. Its configuration is **preflighted red, never skipped**: repo variable
 `BAKE_PUBLISH_TARGETS` names the Azure Files targets (`<account>/<share>[/<base-path>]`,
 whitespace-separated), and a missing value fails the job naming exactly that — a grey skip here
-would silently restore the every-pod-rebakes-everything regression (#1347). A missing bake
-*artifact* only warns: a reuse-green run legitimately skips the doc-gate, and that run simply has
-nothing to publish.
+would silently restore the every-pod-rebakes-everything regression (#1347). There is no
+"nothing to publish" branch any more: the bake happens in this job, so it either produces bundles
+or fails red. Because it re-runs the content gate against the binaries that SHIP, a red here is a
+genuine release defect — the images are already promoted, and nothing quietly ships less.
 
 **`notify-dependents`** sends one `repository_dispatch` (`meshweaver-framework-released`, payload:
 commit, version — receivers resolve the framework identity themselves from the new image) to each

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseToProductionPipeline.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseToProductionPipeline.md
@@ -121,10 +121,14 @@ generation; bake = pre-compiling every dynamic NodeType for the NEW framework fi
 — the old pod is torn down grains-and-all (rule 1 violated: every active hub dies with its pod);
 the pre-run bake IMAGE stays retired
 ([#1347](https://github.com/Systemorph/MeshWeaver/issues/1347)), but since
-[#1660](https://github.com/Systemorph/MeshWeaver/issues/1660) WS3 the framework identity is
-commit-scoped (`g<sha>` — CI builds are commit-deterministic, so the old "every `dotnet publish`
-mints a fresh Graph MVID" barrier is gone) and the Build-and-Test run's NodeType bake is published
-to the portals' storage, where the booting pod adopts it before its sweep — the sweep compiles
+[#1660](https://github.com/Systemorph/MeshWeaver/issues/1660) WS3 the framework identity is the
+API-surface hash `s<hash>` (stable across internal-only merges, so the old "every `dotnet publish`
+mints a fresh Graph MVID" barrier is gone) and the release's NodeType bake — taken by CD **inside
+the image it just promoted**, since [#1725](https://github.com/Systemorph/MeshWeaver/issues/1725) —
+is published to the portals' storage, where the booting pod adopts it before its sweep. Baking in
+the image is what makes the adoption possible at all: the identity is a property of the shipped
+binaries, so a bake taken from any other build resolves an identity no pod ever asks for. The sweep
+then compiles
 only what CI did not bake, instead of racing the first visitors with a cold 76-second full bake
 (rules 2–4 approximated only by the readiness gate). The sweep no longer warms the most user-visible types last — the
 `Store/Coupon → Store/Order → Store/Plugin` cycle trio and the store chain behind it are now warmed

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-platform-content-bake-adoptable.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-platform-content-bake-adoptable.md
@@ -1,0 +1,22 @@
+---
+Name: Shipped content no longer recompiles on every start
+Category: Fix
+Description: The platform ships its own pre-compiled content again, so pages are ready shortly after a portal starts instead of after a minute of warm-up.
+Icon: Sparkle
+Order: -20260817
+---
+
+# Shipped content no longer recompiles on every start
+
+Everything the platform ships as content — the documentation pages, the sample spaces and their
+types — is compiled once during the release build and delivered ready-to-run. A portal is supposed
+to load that result and start serving straight away.
+
+Since the last release it was silently recompiling all of it instead, on every single start, because
+the pre-compiled result was published in a form the running portal could not recognise as its own.
+The visible cost was a minute of warm-up after every restart and every update, during which pages
+were slow to open.
+
+The release build now produces that result with the very same build the portal runs, so a starting
+portal recognises and loads it. Nothing about your content changes — it simply comes up quickly
+again.

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -40,15 +40,19 @@ public class PlatformBakeLaneGuard
     [Fact]
     public void PlatformBake_RunsInsideTheShippedImage()
     {
-        var job = ReadJobBlock();
+        // 🚨 Comment lines are stripped first, and the probes below name details that appear ONLY on
+        // a real command line (the entrypoint, the bake mount). Otherwise this guard could be
+        // satisfied by the prose explaining the lane while the step doing it was gone — a check
+        // that cannot fail is not a check.
+        var job = ExecutableLinesOf(ReadJobBlock());
 
         Assert.True(job.Contains("docker run", StringComparison.Ordinal)
-                    && job.Contains("mw-plugin-test", StringComparison.Ordinal)
-                    && job.Contains("--bake-output", StringComparison.Ordinal),
+                    && job.Contains("--entrypoint /app/mw-plugin-test", StringComparison.Ordinal)
+                    && job.Contains("--bake-output /bake", StringComparison.Ordinal),
             $"'{JobName}' in {Workflow} must bake the platform's content by running mw-plugin-test "
-            + "INSIDE the image this run built (docker run … mw-plugin-test … --bake-output). The "
-            + "framework identity is a property of the shipped binaries, so only the image the pods "
-            + "run can produce a bake those pods will adopt.");
+            + "INSIDE the image this run built (docker run … --entrypoint /app/mw-plugin-test … "
+            + "--bake-output /bake). The framework identity is a property of the shipped binaries, "
+            + "so only the image the pods run can produce a bake those pods will adopt.");
 
         Assert.True(job.Contains("--platform linux/amd64", StringComparison.Ordinal),
             $"'{JobName}' in {Workflow} must pin the bake platform explicitly. Architecture is part "
@@ -63,13 +67,21 @@ public class PlatformBakeLaneGuard
             + "ShippedPrebuiltBundles.CompletionSentinelFileName.");
     }
 
+    /// <summary>The block's lines that can actually DO something: YAML and shell comment lines
+    /// (first non-blank character <c>#</c>) dropped, everything else kept verbatim.</summary>
+    private static string ExecutableLinesOf(string block) =>
+        string.Join("\n", block.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+
     [Fact]
     public void PlatformBake_NeverAdoptsAnotherBuildsBundles()
     {
         var workflows = Path.Combine(FindRepoRoot(), ".github", "workflows");
         var offenders = Directory
             .EnumerateFiles(workflows, "*.yml", SearchOption.TopDirectoryOnly)
-            .Select(f => (file: Path.GetFileName(f), text: File.ReadAllText(f)))
+            // Comments stripped for the same reason as above, in the other direction: a workflow is
+            // judged on what it RUNS, so prose explaining why the artifact hop was removed must
+            // never read as the hop itself.
+            .Select(f => (file: Path.GetFileName(f), text: ExecutableLinesOf(File.ReadAllText(f))))
             .Where(x => x.text.Contains("publish-bake-bundles.sh", StringComparison.Ordinal))
             .Where(x => x.text.Contains("gh run download", StringComparison.Ordinal)
                         || x.text.Contains("download-artifact", StringComparison.Ordinal))

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard for the ONE invariant of the platform's prebuilt-NodeType delivery lane
+/// (issue #1725): <b>a bake must be produced by the binaries the consumer runs.</b>
+///
+/// <para>The framework build identity (<c>FrameworkBuildIdentity</c>) is derived from the exact
+/// assemblies a host ships — implementation MVIDs for the toolchain closure, reference-assembly
+/// hashes for the rest — so it is a property of the BINARIES, not of the source they were built
+/// from. Two compilations of one commit resolve DIFFERENT identities. Measured on <c>babb3bc</c>,
+/// same sources and same runner path, between the Build-and-Test job's build output and the image
+/// that same commit shipped: every implementation assembly's MVID differed (controls included),
+/// and 4 of the 37 canonical reference assemblies differed too. The two hosts resolved
+/// <c>sd0d0daa…</c> and <c>s377941f…</c>.</para>
+///
+/// <para>🚨 What that cost, and what this guard prevents from recurring: <c>main-cd</c> used to
+/// publish the Build-and-Test run's <c>baked-assemblies-*</c> artifact — a different compilation —
+/// so <c>prebuilt-bundles/&lt;runtime-identity&gt;/</c> never contained the platform's own content
+/// and every pod Roslyn-compiled ~80 shipped NodeTypes on EVERY boot (64.8 s warm-up,
+/// <c>compiled=80 alreadyBaked=4</c>). Nothing went red: the artifact existed, the publish
+/// succeeded, and the identity nobody compared was the whole defect. A cross-build hop is
+/// therefore not a thing to review case by case — it is banned outright, and the fix (bake inside
+/// the shipped image, exactly as every satellite content repo does) is asserted positively so
+/// "the lane quietly stopped baking" cannot pass either.</para>
+///
+/// <para>This is a text guard over the workflow because the invariant lives in CI, not in the
+/// product: no C# unit test can observe which build produced a published bundle. See
+/// Doc/Architecture/CiContentBake.</para>
+/// </summary>
+public class PlatformBakeLaneGuard
+{
+    private const string Workflow = ".github/workflows/main-cd.yml";
+    private const string JobName = "publish-bake";
+
+    [Fact]
+    public void PlatformBake_RunsInsideTheShippedImage()
+    {
+        var job = ReadJobBlock();
+
+        Assert.True(job.Contains("docker run", StringComparison.Ordinal)
+                    && job.Contains("mw-plugin-test", StringComparison.Ordinal)
+                    && job.Contains("--bake-output", StringComparison.Ordinal),
+            $"'{JobName}' in {Workflow} must bake the platform's content by running mw-plugin-test "
+            + "INSIDE the image this run built (docker run … mw-plugin-test … --bake-output). The "
+            + "framework identity is a property of the shipped binaries, so only the image the pods "
+            + "run can produce a bake those pods will adopt.");
+
+        Assert.True(job.Contains("--platform linux/amd64", StringComparison.Ordinal),
+            $"'{JobName}' in {Workflow} must pin the bake platform explicitly. Architecture is part "
+            + "of the identity — the amd64 and arm64 variants of one multi-arch image resolve "
+            + "different identities — and every AKS node is amd64, so inheriting whatever "
+            + "architecture the runner happens to be would silently key the bake to an identity no "
+            + "pod resolves.");
+
+        Assert.True(job.Contains("publish-bake-bundles.sh", StringComparison.Ordinal),
+            $"'{JobName}' in {Workflow} must publish through .github/scripts/publish-bake-bundles.sh "
+            + "— the one script whose '_complete' sentinel matches "
+            + "ShippedPrebuiltBundles.CompletionSentinelFileName.");
+    }
+
+    [Fact]
+    public void PlatformBake_NeverAdoptsAnotherBuildsBundles()
+    {
+        var workflows = Path.Combine(FindRepoRoot(), ".github", "workflows");
+        var offenders = Directory
+            .EnumerateFiles(workflows, "*.yml", SearchOption.TopDirectoryOnly)
+            .Select(f => (file: Path.GetFileName(f), text: File.ReadAllText(f)))
+            .Where(x => x.text.Contains("publish-bake-bundles.sh", StringComparison.Ordinal))
+            .Where(x => x.text.Contains("gh run download", StringComparison.Ordinal)
+                        || x.text.Contains("download-artifact", StringComparison.Ordinal))
+            .Select(x => x.file)
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "A workflow that publishes prebuilt bundles must never take them from a cross-run "
+            + "artifact — that is a DIFFERENT compilation of the same source and resolves a "
+            + "different framework identity, so no pod can adopt what it publishes (#1725). "
+            + "Bake inside the image being shipped instead. Offending workflow(s): "
+            + string.Join(", ", offenders));
+    }
+
+    /// <summary>The <c>publish-bake</c> job's own YAML block: from its two-space-indented key to
+    /// the next job key at the same indentation. The terminator is matched as a bare
+    /// <c>  &lt;name&gt;:</c> line rather than "indented and ends with a colon", so a two-space
+    /// comment between jobs cannot truncate the block and turn this guard into a false failure.
+    /// </summary>
+    private static string ReadJobBlock()
+    {
+        var path = Path.Combine(FindRepoRoot(), Workflow);
+        Assert.True(File.Exists(path), $"expected {Workflow} at the repo root");
+        var lines = File.ReadAllLines(path);
+
+        var start = Array.FindIndex(lines, l => l.Equals($"  {JobName}:", StringComparison.Ordinal));
+        Assert.True(start >= 0, $"no '{JobName}:' job in {Workflow} — the platform's own content "
+            + "bake is what publishes the shipped NodeType bundles the portals adopt; deleting it "
+            + "returns every pod to compiling every shipped type at boot (#1347, #1725).");
+
+        var end = Array.FindIndex(lines, start + 1, IsJobKey);
+        if (end < 0)
+            end = lines.Length;
+        return string.Join("\n", lines[start..end]);
+    }
+
+    private static bool IsJobKey(string line) =>
+        line.Length > 3
+        && line.StartsWith("  ", StringComparison.Ordinal)
+        && line[2] != ' '
+        && line[^1] == ':'
+        && line[2..^1].All(c => char.IsLetterOrDigit(c) || c == '-' || c == '_');
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
Fixes #1725.

## What I measured (the issue's hypothesis, tested)

For commit `babb3bc` — same sources, same runner path — I compared the **Build-and-Test host** (`build-output-0`'s `mw-plugin-test`) against the **shipped image** (`mw-plugin-test:babb3bc`, both arches), reading the real `meshweaver-surface.manifest` and the real assembly MVIDs out of each:

| half of the identity | CI build host vs image (same commit) |
|---|---|
| implementation MVIDs (`FullMvidAssemblies` = the MeshWeaver.Compiler + MeshWeaver.NuGet closure) | **all differ** — including the controls `MeshWeaver.Data`, `.Layout`, `.AI`, `.Utils` |
| reference-assembly hashes (the other canonical entries) | 33/37 identical, **4 differ**: `MeshWeaver.Graph`, `MeshWeaver.Hosting`, `MeshWeaver.Kernel`, `MeshWeaver.Markdown.Collaboration` |

So the issue's hypothesis is **confirmed but incomplete**: the impl-MVID half guarantees divergence, *and* the surface half diverges independently. That second finding matters — the issue's alternative fix ("hash the ref-assembly surface instead of impl MVIDs") would **not** have worked.

Two more measurements:

* **amd64 vs arm64 of the SAME image**: the same four reference assemblies differ ⇒ a multi-arch image carries **two identities**.
* **CI's identity moves every run**: the last four green main runs produced `sd0d0daa…`, `sff0502a…`, `s576bb8d…`, `sf9e5b20…`, while the container identity `s377941f…` is shared by three satellite repos *and* the running pods — the satellites bake in the image, which is exactly why they were never affected.

Determinism itself is fine (a from-clean `--no-incremental` rebuild at the same path is byte-identical). The identity is a property of the **binaries a host ships**, not of the source they were built from — which is what makes it a real ABI proof. Nothing here is a defect in the identity; the defect was a lane that fed it bytes from another build.

## The fix

`main-cd`'s `publish-bake` now bakes the platform's own content **inside the image this run promoted**, exactly as every satellite repo does via `node-repo-publish-bake.yml`:

* stages the `Doc` tree and the `samples/Graph/Data` trees (the two scripts the PR gate uses), then `docker run --platform linux/amd64 … mw-plugin-test … --bake-output` against `mw-plugin-test:<staging_tag>` — the exact, immutable tag this run's `plugin-test-image` leg pushed, never the moving `latest`/`main`;
* `--platform` is **pinned, not inherited**: architecture is part of the identity and every AKS node is amd64;
* publication is unchanged — the canonical `publish-bake-bundles.sh`, every bundle first, `_complete` sentinel strictly LAST;
* the cross-run artifact hop is gone, and with it `actions: read` and the "no artifact ⇒ warn and skip" branch. The bake happens in the job: it produces bundles or fails red. It is also a **stronger gate** than the artifact hop — it proves the shipped content compiles, renders and passes its `Tests` areas against the binaries that actually ship.

`doc-gate` keeps `--bake-output` as a PR-time **smoke test** of the bake stage (the identity postcondition still fails red on a regression) but no longer uploads `baked-assemblies-*` — an artifact that looks like delivery and delivers nothing is what made this invisible.

🚨 Explicitly **not** done, per the issue: no publishing under several identities, no "nearest identity" scan, no relaxed sentinel/identity check, no fallback that adopts bytes from an identity the pod did not resolve.

## Guard

`PlatformBakeLaneGuard` (test/MeshWeaver.Documentation.Test) pins the invariant: `publish-bake` must run `mw-plugin-test` in the image with an explicit `--platform`, and **no** workflow may publish prebuilt bundles taken from a cross-run artifact. Verified it fails on the exact regression (I reinstated `gh run download` and both assertions went red with the right messages), then restored.

## Verified locally

* Both stages baked green **inside** `mw-plugin-test:babb3bc` — 8 bundles, 28 assemblies, `framework-mvid.txt` written by the non-root container user through the bind mounts.
* `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → 0 warnings, 0 errors; **23/23** tests green (incl. `DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest`).
* Both workflows re-parse; every new shell block passes `bash -n`; `Directory.Build.props` is valid XML.

## Honest scope note (measured, documented, not fixed here)

A bundle is matched to a deployment by **node path**. On `memex` the `Doc/…` types match and will adopt; the sample trees live there under `MeshWeaver/samples/Graph/Data/ACME/…` while the bundles are keyed `ACME/…`, so those seven bundles are published but inert on that portal (they do adopt where the samples sit at their canonical roots). That is a content-layout question, not an identity one, and it is written up under "What this step does not do yet" in `CiContentBake.md` rather than silently bundled into this change.

## Docs

`CiContentBake.md` (new "The identity is a property of the BINARIES" section + the corrected delivery lane), `ContinuousDeliveryContract.md`, and the false determinism claim in `Directory.Build.props` that the old lane was built on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)