### PR TITLE
fix: /api/content hung ~50% of the time on multi-replica portals (#1729)

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
+++ b/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
@@ -1,6 +1,7 @@
 using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Data;
+using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
@@ -133,7 +134,37 @@ public static class ContentFileResolver
                 ? new[] { explicitCollection, defaultCollection }
                 : [defaultCollection];
 
-            return hub.Observe(
+            // 🚨 NEVER issue this read on the ROOT MESH HUB — the router. The /api/content endpoint
+            // holds the DI-injected IMessageHub, which in the mesh's root container IS mesh/{id}
+            // (MeshHostApplicationBuilder makes the mesh hub's provider the ASP.NET root provider),
+            // so this GetDataRequest used to make the router an END of the delivery in BOTH
+            // directions: the request reached the per-node hub stamped Sender = mesh/{id}, and the
+            // GetDataResponse (or, for a denied/missing node, the DeliveryFailure) was addressed
+            // straight back at mesh/{id}. Same-silo that reply short-circuits on the routing
+            // service's local table and everything looks fine; CROSS-silo it has to arrive over the
+            // cluster-wide memory stream, and it does not — so the request never answers, the
+            // caller waits out its full 60 s budget and the route 500s with a TimeoutException.
+            //
+            // Prod signature (memex-cloud, 2 replicas, issue #1729): each pod served /api/content
+            // ONLY for the nodes whose per-node hub grain it happened to host and hung for ~60 s on
+            // every other node, so round-robin across the two replicas made ~half of all requests to
+            // ANY given asset hang — broken images on course/doc pages, and a red live-smoke gate.
+            // The pod's own diagnostics named the caller exactly as documented:
+            //   [STALE-CALLBACK] mesh/IJ1R4… : GetDataRequest@AgenticEngineering(55672ms)
+            //     → ROUTED onTarget=False state=Forwarded ⇒ no handler was ever entered
+            //   System.TimeoutException: No response received in hub mesh/IJ1R4… within 00:01:00
+            // while the OWNING silo logged the matching pair:
+            //   ROUTER_TRAFFIC: GetDataResponse has the mesh hub as target (sender: MeshWeaver,
+            //   target: mesh/IJ1R4…)
+            // i.e. the reply WAS produced and had nowhere to go.
+            //
+            // NodeOperationIssuingHub is the one shared seam for this: it hops a root-hub caller onto
+            // portal/nodeops-{meshId} — routing-registered so responses land on it cross-silo, and
+            // sharing the mesh's type registry and permission evaluator — and returns any NON-router
+            // hub unchanged, so in-mesh callers (the deck export's SlideAssetInliner, a portal hub,
+            // a test client) keep their identity byte-for-byte. GetMeshNode/GetMeshNodeOutcome and
+            // every node-CRUD path already went this way (2c796d297); this read was the straggler.
+            return hub.NodeOperationIssuingHub().Observe(
                     new GetDataRequest(new ContentCollectionReference(candidates)),
                     o =>
                     {

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-content-route-hang.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-content-route-hang.md
@@ -1,0 +1,19 @@
+---
+Name: Images and downloads no longer hang
+Category: Fix
+Description: Content files served from /api/content could hang instead of loading on portals running more than one replica.
+Icon: Sparkle
+Order: -20260817
+---
+
+# Images and downloads no longer hang
+
+Pictures, videos and file downloads stored on a node are served through the content route. On a
+portal running more than one replica, roughly half of those requests never answered — the page
+showed a broken image or an empty player, and a download simply stalled. Reloading sometimes
+"fixed" it, which made the problem look random rather than reproducible.
+
+The request was being issued from the mesh's internal routing hub, so when the file's owning node
+happened to live on a different replica the answer had nowhere to come back to and the request sat
+until it timed out. It is now issued from a normal application hub, which every other part of the
+portal already used, so the answer always finds its way home.

--- a/test/MeshWeaver.Hosting.Blazor.Test/ContentRouteIssuingHubTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ContentRouteIssuingHubTest.cs
@@ -121,6 +121,24 @@ public class ContentRouteIssuingHubTest(ITestOutputHelper output) : MonolithMesh
         client = portal.GetTestClient();
     }
 
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        client?.Dispose();
+        if (portal is not null)
+            await portal.DisposeAsync();
+        try
+        {
+            if (Directory.Exists(storageRoot))
+                Directory.Delete(storageRoot, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover fixture directory is harmless; never fail teardown on it.
+        }
+        await base.DisposeAsync();
+    }
+
     /// <summary>The REAL <c>MapMeshWeaver()</c> endpoints, behind the anonymous-stamping middleware
     /// production runs (the never-null <c>AccessContext</c> invariant).</summary>
     private WebApplication BuildPortal()
@@ -154,6 +172,12 @@ public class ContentRouteIssuingHubTest(ITestOutputHelper output) : MonolithMesh
     [Fact(Timeout = 30000)]
     public async Task ContentRead_IsNotIssuedFromTheRootMeshHub()
     {
+        // 🚨 Clear it IMMEDIATELY before the request, so the assertion can only ever be about THIS
+        // HTTP call. Mesh start-up also reads collection configs, and an earlier observation from a
+        // legitimately non-router hub would otherwise satisfy the assertion while the route itself
+        // still posted from the router — a test that cannot fail is not a test.
+        collectionConfigSender = null;
+
         var response = await client.GetAsync(
             $"{ContentCollectionsExtensions.ContentFileRoutePrefix}/{Space}/{CoverFile}",
             TestContext.Current.CancellationToken);

--- a/test/MeshWeaver.Hosting.Blazor.Test/ContentRouteIssuingHubTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ContentRouteIssuingHubTest.cs
@@ -1,0 +1,179 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// 🚨 THE <c>/api/content</c> ROUTE MUST NOT ISSUE ITS COLLECTION-CONFIG READ FROM THE ROUTER —
+/// issue #1729, driven over REAL HTTP against a REAL monolith mesh.
+///
+/// <para><b>What broke.</b> <c>MapContentFiles</c> resolves <c>services.GetRequiredService&lt;
+/// IMessageHub&gt;()</c>, which in the mesh's root container IS the root <c>mesh/{id}</c> hub — the
+/// ROUTER — and handed it to <see cref="ContentFileResolver.Resolve"/>, which posted the owning
+/// node's <c>GetDataRequest</c> from it. That makes the router an END of the delivery in BOTH
+/// directions: the request reaches the per-node hub stamped <c>Sender = mesh/{id}</c> and the
+/// <c>GetDataResponse</c> is addressed straight back at <c>mesh/{id}</c>.</para>
+///
+/// <para><b>Why that is fatal in production and invisible in a monolith.</b> Same-silo the reply
+/// short-circuits on the routing service's local table, so one process looks perfectly healthy —
+/// which is exactly why every existing content-route test (all monolith, all single-process)
+/// stayed green. CROSS-silo the reply has to arrive over the cluster-wide memory stream, and it
+/// does not: the request never answers, the caller waits out its full 60 s budget and the route
+/// 500s with a <c>TimeoutException</c>. On memex-cloud (2 replicas) each pod therefore served
+/// <c>/api/content</c> ONLY for the nodes whose per-node hub grain it happened to host and hung on
+/// every other node, so round-robin made ~half of all requests to ANY given asset hang — broken
+/// course/doc images for real users, and a red live-smoke gate on MeshWeaver.Education.</para>
+///
+/// <para><b>Why this test asserts the SENDER rather than reproducing the hang.</b> The hang needs
+/// two silos in two PROCESSES. Orleans' in-process <c>TestCluster</c> does not reproduce it — a
+/// two-silo variant of this test passes with and without the fix, which makes it worse than no
+/// test at all. The sender is the wire-observable property that DECIDES whether the reply is
+/// routable at all, and "the router is never an end of a delivery" is the standing rule the
+/// framework already enforces everywhere else (<c>ROUTER_TRAFFIC</c>,
+/// <see cref="MeshExtensions.NodeOperationIssuingHub"/>, <c>SessionHubResolver</c>). Pinning it
+/// here is deterministic, single-process, and fails loudly the moment the route regresses.</para>
+/// </summary>
+public class ContentRouteIssuingHubTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Space = "IssuerSpace";
+    private const string CoverFile = "cover.txt";
+    private const string CoverBody = "cover-bytes";
+
+    private readonly string storageRoot = CreateStorageFixture();
+
+    /// <summary>
+    /// The sender of the collection-config <c>GetDataRequest</c> as the OWNING NODE HUB saw it —
+    /// i.e. what a remote silo would have to address its reply to. Instance state, written on the
+    /// node hub's action block and read after the HTTP round trip has completed, so no gate is
+    /// needed: the response cannot exist unless the handler already ran.
+    /// </summary>
+    private Address? collectionConfigSender;
+
+    private WebApplication? portal;
+    private HttpClient client = null!;
+
+    private static string CreateStorageFixture()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "content-issuer-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(Path.Combine(root, "content", Space));
+        File.WriteAllText(Path.Combine(root, "content", Space, CoverFile), CoverBody);
+        return root;
+    }
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                new MeshNode(Space) { Name = "Issuer Space", NodeType = "Markdown" },
+                // An explicit Anonymous Viewer grant, so the route runs its FULL happy path and the
+                // assertion below is made about a request that genuinely served bytes — not about a
+                // pipeline that stopped at the access gate.
+                AssignmentNodeFactory.UserRole(
+                    WellKnownUsers.Anonymous, "Viewer", Space,
+                    accessObject: WellKnownUsers.Anonymous))
+            .ConfigureDefaultNodeHub(config =>
+                config.Address.ToString() == Space
+                    // 🚨 The capture handler is registered FIRST and passes the delivery through
+                    // unchanged, so the real HandleCollectionConfigRequest still answers it. It only
+                    // observes; it never decides.
+                    ? config
+                        .WithHandler<GetDataRequest>((_, delivery) =>
+                        {
+                            if (delivery.Message.Reference is ContentCollectionReference)
+                                collectionConfigSender = delivery.Sender;
+                            return delivery;
+                        })
+                        .AddContentCollection(_ => new ContentCollectionConfig
+                        {
+                            Name = ContentCollectionsExtensions.DefaultCollectionName,
+                            SourceType = "FileSystem",
+                            BasePath = Path.Combine(storageRoot, "content", Space),
+                            Address = config.Address,
+                            IsEditable = true,
+                            ExposeInChildren = true,
+                            IsStatic = true,
+                        })
+                    : config);
+
+    // Granular permissions only — the blanket PublicAdmin seed would make the Anonymous grant moot.
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        portal = BuildPortal();
+        await portal.StartAsync(TestContext.Current.CancellationToken);
+        client = portal.GetTestClient();
+    }
+
+    /// <summary>The REAL <c>MapMeshWeaver()</c> endpoints, behind the anonymous-stamping middleware
+    /// production runs (the never-null <c>AccessContext</c> invariant).</summary>
+    private WebApplication BuildPortal()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.Services.AddSingleton(Mesh);
+
+        var app = builder.Build();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        app.Use(async (ctx, next) =>
+        {
+            accessService.SetContext(new AccessContext
+            {
+                ObjectId = WellKnownUsers.Anonymous,
+                Name = WellKnownUsers.Anonymous
+            });
+            await next();
+        });
+        app.MapMeshWeaver();
+        return app;
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION TEST FOR #1729. Serving a content file must not make the ROUTER an end of
+    /// the delivery: the owning node hub must see the request from an off-router hub
+    /// (<c>portal/nodeops-{meshId}</c>), which is routing-registered and can therefore be replied
+    /// to from another silo.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ContentRead_IsNotIssuedFromTheRootMeshHub()
+    {
+        var response = await client.GetAsync(
+            $"{ContentCollectionsExtensions.ContentFileRoutePrefix}/{Space}/{CoverFile}",
+            TestContext.Current.CancellationToken);
+
+        // Sanity: the happy path really ran, so the assertion below is about a live request.
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "the partition carries an explicit Anonymous Viewer grant, so the file is served");
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))
+            .Should().Be(CoverBody);
+
+        collectionConfigSender.Should().NotBeNull(
+            "the route must ask the owning node hub for its collection config — if nothing was "
+            + "observed the request never reached the node and this test is no longer guarding "
+            + "anything");
+
+        collectionConfigSender!.Type.Should().NotBe(AddressExtensions.MeshType,
+            "issue #1729: the collection-config GetDataRequest must NOT be issued on the root mesh "
+            + "hub. The router is the mesh's ROUTING infrastructure, not a call target — a request "
+            + "posted there is answered straight back at it, and that reply is unroutable from any "
+            + "OTHER silo, so on a multi-replica portal the request never answers and /api/content "
+            + "hangs for 60 s. ContentFileResolver.Resolve must issue on NodeOperationIssuingHub()");
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansCrossSiloReplyTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansCrossSiloReplyTest.cs
@@ -27,6 +27,21 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// <para>The repro is DETERMINISTIC without knowing the grain placement: the same read is
 /// issued from BOTH silos' root mesh hubs — whichever silo does not own the per-node grain is
 /// guaranteed to exercise the cross-silo reply.</para>
+///
+/// <para>🚨 <b>READ THIS BEFORE TRUSTING THIS CLASS AS THE /api/content GUARD — it is not, any
+/// more.</b> The paragraph above still describes the ORIGINAL intent, but <c>2c796d297</c>
+/// (2026-08-10) moved <c>GetMeshNode</c>/<c>GetMeshNodeOutcome</c> onto
+/// <c>MeshExtensions.NodeOperationIssuingHub</c>, so the fact below now exercises the
+/// <c>portal/nodeops-…</c> reply path and no longer posts from <c>mesh/{id}</c> at all. That is
+/// worth keeping — but it silently stopped covering the static-content endpoint it names, and
+/// issue #1729 is what that cost: <c>ContentFileResolver.Resolve</c> was left posting from the
+/// router and hung ~half of all <c>/api/content</c> requests on the 2-replica memex-cloud portal.
+/// The guard for that now lives in
+/// <c>MeshWeaver.Hosting.Blazor.Test.ContentRouteIssuingHubTest</c>, which asserts the SENDER the
+/// owning node hub sees — deliberately NOT here, because an IN-PROCESS <c>TestCluster</c> does not
+/// reproduce the cross-PROCESS reply loss: a two-silo version of that assertion passes with and
+/// without the fix, which is worse than no test. Do not "restore" the coverage by adding a
+/// content-route fact to this class without first proving it FAILS on the unfixed code.</para>
 /// </summary>
 public class OrleansCrossSiloReplyTest : IClassFixture<TwoSiloCacheUpdateFixture>
 {


### PR DESCRIPTION
Fixes #1729.

## What was actually wrong (the issue's premise was falsified)

The issue reported a **per-request** ~50/50 hang on a **single replica**. Both halves are wrong, and finding that out is what located the defect:

* `memex.meshweaver.cloud` is served by namespace **`memex-cloud`**, not `memex` — and its portal Deployment runs **2 replicas**, both in the Service.
* Probing each pod directly (in-cluster, bypassing the ingress) is **fully deterministic**, not 50/50:

  | pod | `AgenticEngineering/content/og.png` | `Chess/content/zz.png` |
  |---|---|---|
  | `10.244.2.139` | **hang** (5/5) | 404 in 2.3 s |
  | `10.244.3.119` | 200 in 18 ms | **hang** |

  Each pod serves `/api/content` **only for the nodes whose per-node hub grain it hosts**, and hangs on every other node. Round-robin across the two replicas is what turns that into "~half of requests to any given asset hang".
* It is **not an infinite hang** — a request with a long client budget returns **HTTP 500 after 60.009 s**. Browsers and the smoke test simply give up first.

## Root cause

`MapContentFiles` resolves `services.GetRequiredService<IMessageHub>()` — which, because `MeshHostApplicationBuilder` makes the mesh hub's provider the ASP.NET root provider, **IS the root `mesh/{id}` hub, the ROUTER** — and hands it to `ContentFileResolver.Resolve`, which posts the owning node's collection-config `GetDataRequest` from it.

That makes the router an END of the delivery in both directions: the request reaches the per-node hub stamped `Sender = mesh/{id}`, and the `GetDataResponse` is addressed straight back at `mesh/{id}`. Same-silo the reply short-circuits on the routing service's local table (healthy); **cross-silo it never arrives**, so the request runs out its 60 s budget.

Both pods' own diagnostics name it precisely. Requesting pod:

```
[STALE-CALLBACK] mesh/IJ1R4… : 1 callback(s) pending > 30000ms: GetDataRequest@AgenticEngineering(55672ms)
  → ROUTED onTarget=False state=Forwarded ⇒ the delivery reached a hub but no handler was ever entered
System.TimeoutException: No response received in hub mesh/IJ1R4… within 00:01:00 for request GetDataRequest → target AgenticEngineering
```

Owning pod, same request — the reply **was** produced and had nowhere to go:

```
AccessControlPipeline: Access denied: user 'Anonymous' lacks Read permission on 'MeshWeaver'
  (triggered by message=GetDataRequest sender=mesh/IJ1R4… hub=MeshWeaver)
ROUTER_TRAFFIC: GetDataResponse has the mesh hub as target (sender: MeshWeaver, target: mesh/IJ1R4…)
```

This is a documented, absolute rule the rest of the codebase already follows — `SessionHubResolver`: *"This helper NEVER returns the root `mesh/{id}` hub … request-shaped work issued on it never answers … Every API surface (MCP, REST, gRPC, CLI) issues on a portal hub."* The content route is the **last unmigrated caller**.

## The fix

One seam, the same one every other caller uses:

```csharp
return hub.NodeOperationIssuingHub().Observe(new GetDataRequest(...), …)
```

`NodeOperationIssuingHub()` hops a root-hub caller onto `portal/nodeops-{meshId}` — routing-registered so replies land cross-silo, sharing the mesh's type registry and permission evaluator — and returns any **non-router** hub unchanged, so in-mesh callers (the deck export's `SlideAssetInliner`, a portal hub, a test client) keep their identity byte-for-byte. `GetMeshNode`/`GetMeshNodeOutcome` and every node-CRUD path already went this way in `2c796d297`.

No timeout, no retry, no watchdog, no `catch` — the dropped emission is fixed at its source.

## How the gap survived

`OrleansCrossSiloReplyTest` was written for exactly this failure (core#694 layer 2) and its docstring still names the static-content endpoint. But `2c796d297` moved `GetMeshNode` onto `NodeOperationIssuingHub`, so since 2026-08-10 that test has exercised the `portal/nodeops-…` reply path and **no longer posts from `mesh/{id}` at all** — it silently stopped guarding the endpoint it names. A docstring now records that, and points at the new test.

## Regression test

`ContentRouteIssuingHubTest` drives the **real** `/api/content` endpoint over HTTP against a real monolith mesh and asserts the **sender the owning node hub sees** is not the router.

* **Fails on the unfixed code** — `Did not expect value to be "mesh"`, and the run reproduces the exact production `ROUTER_TRAFFIC` pair.
* **Passes with the fix.**

It deliberately does **not** live in the two-silo Orleans suite: an in-process `TestCluster` does not reproduce the cross-PROCESS reply loss. I wrote that version first and **it passed with and without the fix** — worse than no test — so it was removed rather than shipped as false assurance.

## Verification

* `dotnet build -c Release -p:CIRun=true -warnaserror` (whole solution): 0 warnings, 0 errors
* `MeshWeaver.Hosting.Blazor.Test`: **403/403** (includes every existing `/api/content` authorization test)
* `DeckAssetInliningTest` (the other `ContentFileResolver.Resolve` consumer): 5/5
* `DocumentationLinkIntegrityTest`: 1/1

Also unblocks `MeshWeaver.Education`'s `Read-only smoke against a live instance`, which is red solely because it is correctly catching this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)