### PR TITLE
fix: sequence the install so NodeType compiles never read a root it is recycling (#1732)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-install-compile-teardown-ordering.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-install-compile-teardown-ordering.md
@@ -1,0 +1,23 @@
+---
+Name: Package installs no longer race their own teardown
+Category: Fix
+Description: Installing a package no longer starts its NodeType compiles against a hub the install is about to recycle, so types stop landing on the compilation-error overlay.
+Icon: Sparkle
+Order: -20260817
+---
+
+# Package installs no longer race their own teardown
+
+Installing a package used to start compiling every node type it ships and then, moments later,
+recycle the package's own root — the very node those compiles read. Types that happened to be
+reading at that instant were marked as failing to compile, so a freshly installed package could
+show a handful of its types on the compilation-error overlay for no reason you could see, and a
+re-install would "fix" it.
+
+The install now sequences the two: the root is recycled first and answers again before the
+remaining types are asked to compile. Nothing is retried and nothing waits longer — the work is
+simply put in an order where it cannot collide.
+
+Teardown problems are also easier to diagnose now: when a hub takes too long to shut down, the
+error names the hub that is actually holding things up and the message occupying it, instead of
+reporting only which shutdown phase was reached.

--- a/src/MeshWeaver.Graph/NodeTypeReleaseExtensions.cs
+++ b/src/MeshWeaver.Graph/NodeTypeReleaseExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
@@ -14,6 +15,11 @@ namespace MeshWeaver.Graph;
 /// operation. Every caller — the GUI button on the NodeType Configuration pane, MCP
 /// agents, tests — goes through <see cref="RequestNodeTypeRelease"/>; there is no other
 /// surface for a user to author a release.
+///
+/// <para>Two forms, ONE implementation: <see cref="ObserveNodeTypeRelease"/> returns the cold
+/// <c>IObservable&lt;bool&gt;</c> and is what a caller composes against when it must ORDER other
+/// work around the flip landing; <see cref="RequestNodeTypeRelease"/> is that observable plus a
+/// Subscribe, for the click handlers that have nothing to sequence.</para>
 ///
 /// <para><b>The credential split this entry point enforces:</b></para>
 /// <list type="number">
@@ -65,35 +71,74 @@ public static class NodeTypeReleaseExtensions
         bool force = false,
         string? releaseNotes = null,
         Action<string>? onError = null)
+        => hub.ObserveNodeTypeRelease(nodeTypePath, force, releaseNotes, onError)
+            .Subscribe(_ => { });
+
+    /// <summary>
+    /// The OBSERVABLE form of <see cref="RequestNodeTypeRelease"/>: identical semantics, but the
+    /// caller learns when the trigger has actually LANDED and can therefore ORDER other work
+    /// against it. Emits <c>true</c> once the <see cref="NodeTypeDefinition.RequestedReleaseAt"/>
+    /// flip has been written, <c>false</c> when the caller was refused
+    /// (<see cref="Permission.Compile"/>) or the write failed — the same outcomes
+    /// <paramref name="onError"/> reports. Never faults: a refusal is an answer, not a fault, and
+    /// a caller batching many releases must not lose the rest to one of them.
+    ///
+    /// <para>🚨 This exists because a fire-and-forget release is UNORDERABLE. The package
+    /// installer used to launch every installed type's compile through the void overload and then,
+    /// in the same continuation chain, recycle the package ROOT hub those very compiles read
+    /// (<c>ValidateCellSurfaceSingleHome</c> → <c>GetMeshNode('&lt;packageRoot&gt;')</c>) — a
+    /// teardown deliberately raced against work the same code path had just started, and nothing
+    /// in the chain could sequence the two because the release side returned nothing (#1732). The
+    /// installer now composes on this observable instead.</para>
+    /// </summary>
+    /// <param name="hub">The hub whose AccessContext identifies the caller.</param>
+    /// <param name="nodeTypePath">Path of the NodeType to release.</param>
+    /// <param name="force">When <c>true</c>, bypass the "sources unchanged since last compile"
+    /// short-circuit and always run a fresh compile (the "Up to Date" button path).</param>
+    /// <param name="releaseNotes">Optional markdown release notes to stamp alongside the trigger.
+    /// When <c>null</c>, whatever the author already auto-saved on
+    /// <see cref="NodeTypeDefinition.ReleaseNotes"/> is used.</param>
+    /// <param name="onError">Invoked (with a human-readable reason) when the caller lacks
+    /// <c>Compile</c> or the trigger write fails — the clean refusal path.</param>
+    /// <returns>A COLD observable; Subscribe to request the release.</returns>
+    public static IObservable<bool> ObserveNodeTypeRelease(
+        this IMessageHub hub,
+        string nodeTypePath,
+        bool force = false,
+        string? releaseNotes = null,
+        Action<string>? onError = null)
     {
         ArgumentNullException.ThrowIfNull(hub);
         if (string.IsNullOrEmpty(nodeTypePath))
         {
             onError?.Invoke("RequestNodeTypeRelease requires a NodeType path.");
-            return;
+            return Observable.Return(false);
         }
 
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.Graph.NodeTypeReleaseExtensions");
 
-        // Capture the caller's FULL AccessContext synchronously, here on the calling thread —
-        // before CheckPermission's reactive chain can hop schedulers (PermissionEvaluator reads
-        // through a TaskPool-scheduled synced query, and AsyncLocal does NOT flow through that
-        // hop). We re-establish this exact context around the trigger write below so the flip's
-        // PatchDataRequest always runs under the caller's identity (it needs Update on the node),
-        // and stamp RequestedReleaseBy for the owner-attributed release-node creation.
-        var accessService = hub.ServiceProvider.GetService<AccessService>();
-        var callerContext = accessService?.Context ?? accessService?.CircuitContext;
-        var userId = callerContext?.ObjectId;
+        return Observable.Defer(() =>
+        {
+            // Capture the caller's FULL AccessContext synchronously, on the SUBSCRIBING thread —
+            // before CheckPermission's reactive chain can hop schedulers (PermissionEvaluator reads
+            // through a TaskPool-scheduled synced query, and AsyncLocal does NOT flow through that
+            // hop). We re-establish this exact context around the trigger write below so the flip's
+            // PatchDataRequest always runs under the caller's identity (it needs Update on the node),
+            // and stamp RequestedReleaseBy for the owner-attributed release-node creation.
+            // Defer, not the enclosing method body: a cold observable's identity is fixed at
+            // Subscribe, and the installer subscribes inside its own System impersonation scope.
+            var accessService = hub.ServiceProvider.GetService<AccessService>();
+            var callerContext = accessService?.Context ?? accessService?.CircuitContext;
+            var userId = callerContext?.ObjectId;
 
-        var check = string.IsNullOrEmpty(userId)
-            ? hub.CheckPermission(nodeTypePath, Permission.Compile)
-            : hub.CheckPermission(nodeTypePath, userId, Permission.Compile);
+            var check = string.IsNullOrEmpty(userId)
+                ? hub.CheckPermission(nodeTypePath, Permission.Compile)
+                : hub.CheckPermission(nodeTypePath, userId, Permission.Compile);
 
-        check
-            .Take(1)
-            .Subscribe(
-                granted =>
+            return check
+                .Take(1)
+                .SelectMany(granted =>
                 {
                     if (!granted)
                     {
@@ -102,43 +147,54 @@ public static class NodeTypeReleaseExtensions
                             userId ?? "(anonymous)", nodeTypePath);
                         onError?.Invoke(
                             "You need the Compile permission (Editor or above) to create a release.");
-                        return;
+                        return Observable.Return(false);
                     }
 
                     var triggerAt = DateTimeOffset.UtcNow;
                     // Re-establish the caller's identity for the write (it may have been lost to a
-                    // scheduler hop in CheckPermission). The Subscribe runs synchronously inside the
-                    // scope, so the PatchDataRequest captures the caller — never the ambient hub/null.
-                    using (callerContext is not null
-                        ? accessService?.SwitchAccessContext(callerContext)
-                        : null)
-                        hub.GetWorkspace().GetMeshNodeStream(nodeTypePath).Update(curr =>
-                        {
-                            if (curr?.Content is not NodeTypeDefinition def) return curr!;
-                            return curr with
+                    // scheduler hop in CheckPermission). Update is COLD, so the scope has to be
+                    // alive when it is SUBSCRIBED, not merely when it is composed — Observable.Using
+                    // is what guarantees that (the old shape subscribed synchronously inside a
+                    // `using`, which this SelectMany continuation no longer is).
+                    return Observable.Using(
+                            () => (callerContext is not null
+                                ? accessService?.SwitchAccessContext(callerContext)
+                                : null) ?? Disposable.Empty,
+                            _ => hub.GetWorkspace().GetMeshNodeStream(nodeTypePath).Update(curr =>
                             {
-                                Content = def with
+                                if (curr?.Content is not NodeTypeDefinition def) return curr!;
+                                return curr with
                                 {
-                                    RequestedReleaseAt = triggerAt,
-                                    RequestedReleaseForce = force,
-                                    RequestedReleaseBy = userId,
-                                    ReleaseNotes = releaseNotes ?? def.ReleaseNotes
-                                }
-                            };
-                        }).Subscribe(
-                            _ => { },
-                            ex =>
-                            {
-                                logger?.LogWarning(ex,
-                                    "[RequestNodeTypeRelease] Trigger write failed for {Path}", nodeTypePath);
-                                onError?.Invoke($"Failed to start the release: {ex.Message}");
-                            });
-                },
-                ex =>
+                                    Content = def with
+                                    {
+                                        RequestedReleaseAt = triggerAt,
+                                        RequestedReleaseForce = force,
+                                        RequestedReleaseBy = userId,
+                                        ReleaseNotes = releaseNotes ?? def.ReleaseNotes
+                                    }
+                                };
+                            }))
+                        .Take(1)
+                        .Select(_ => true)
+                        .Catch((Exception ex) =>
+                        {
+                            logger?.LogWarning(ex,
+                                "[RequestNodeTypeRelease] Trigger write failed for {Path}", nodeTypePath);
+                            onError?.Invoke($"Failed to start the release: {ex.Message}");
+                            return Observable.Return(false);
+                        });
+                })
+                .Catch((Exception ex) =>
                 {
                     logger?.LogWarning(ex,
                         "[RequestNodeTypeRelease] Permission check faulted for {Path}", nodeTypePath);
                     onError?.Invoke($"Failed to verify Compile permission: {ex.Message}");
-                });
+                    return Observable.Return(false);
+                })
+                // EXACTLY one emission, always — a permission source that completes without
+                // answering must not turn into a sequence that completes without answering, or a
+                // caller composing `.FirstAsync()` on it faults instead of learning "no release".
+                .DefaultIfEmpty(false);
+        });
     }
 }

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1590,13 +1590,45 @@ public sealed class MessageHub : IMessageHub
                         return;
                     logger.LogError(
                         "DISPOSAL DEADLOCK DETECTED: Hub {Address} did not complete shutdown within {Timeout}. " +
-                        "RunLevel={RunLevel}. Forcing out-of-band teardown so children/subscriptions cannot leak.",
-                        Address, DisposalWatchdogTimeout, RunLevel);
+                        "RunLevel={RunLevel}. Forcing out-of-band teardown so children/subscriptions cannot leak.\n" +
+                        "{Diagnostics}",
+                        Address, DisposalWatchdogTimeout, RunLevel, DescribeWedge());
                     ForceTeardownAfterWatchdog();
                 },
                 // disposalCompleted faulting (SignalDisposalFaulted) propagates through TakeUntil;
                 // the watchdog is no longer needed — swallow so it isn't an unobserved error.
                 _ => { });
+    }
+
+    /// <summary>
+    /// The evidence that turns "DISPOSAL DEADLOCK DETECTED" into a diagnosis: the recursive
+    /// disposal snapshot (<see cref="GetDisposalDiagnostics"/>) — every hosted hub's RunLevel,
+    /// queue depths, the message currently on its action block, and its pending callbacks.
+    ///
+    /// <para>🚨 Without this the error names a PHASE and nothing else, and the four mechanisms
+    /// that produce <c>RunLevel=DisposeHostedHubs</c> are indistinguishable from the log: a child
+    /// whose pump is starved behind a FIFO backlog (<c>buffer</c> in the hundreds, <c>Executing</c>
+    /// a few ms), a child frozen on one non-terminating turn (<c>buffer</c> small,
+    /// <c>Executing</c> 8000+ ms and NAMED), an in-flight hosted-hub construction the join is
+    /// correctly waiting out, or simply a child that answers on its OWN watchdog — which is armed
+    /// one quiesce budget LATER than this one and therefore cannot answer before it. #1701 sat on
+    /// "the compile-pool children are the prime suspects" for exactly this reason: the log records
+    /// the parent's phase and nothing about the child that is holding it.</para>
+    ///
+    /// <para>Never throws: a diagnostic that can fault the teardown it is diagnosing is worse than
+    /// no diagnostic. The tree walk is depth-capped (<see cref="MaxHostedHubRecursionDepth"/>) and
+    /// runs once, at the moment a deadlock has already been detected.</para>
+    /// </summary>
+    private string DescribeWedge()
+    {
+        try
+        {
+            return GetDisposalDiagnostics();
+        }
+        catch (Exception e)
+        {
+            return $"(disposal diagnostics unavailable: {e.GetType().Name}: {e.Message})";
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1407,11 +1407,15 @@ public static class PackageInstaller
                     "Installed code package {Id} v{Version}: {Written} written, {Unchanged} unchanged ({Path}) @ {Ref}",
                     manifest.Id, manifest.Version, result.Written, result.Unchanged, nodeTypePath, installedFromRef);
                 // Only recompile when something actually changed — an unchanged re-install must not
-                // kick a redundant Roslyn build.
-                if (written > 0)
-                    SeedThenRequestReleases(hub, [nodeTypePath], logger);
-                return WriteInstalledRecord(
-                        hub, manifest, installedFromRef, all.Length, authorizingUserId: authorizingUserId)
+                // kick a redundant Roslyn build. SEQUENCED, never fire-and-forget: the observable is
+                // cold, so a bare call would request no release at all, and an install that cannot
+                // order against the compiles it starts is the defect #1732 is about.
+                var releases = written > 0
+                    ? SeedThenRequestReleases(hub, [nodeTypePath], logger)
+                    : Observable.Return(System.Reactive.Unit.Default);
+                return releases
+                    .SelectMany(_ => WriteInstalledRecord(
+                        hub, manifest, installedFromRef, all.Length, authorizingUserId: authorizingUserId))
                     .SelectMany(_ => WarmInstalledRoots(hub, all, logger))
                     .Select(_ => result);
             });
@@ -2078,22 +2082,43 @@ public static class PackageInstaller
                 logger?.LogInformation(
                     "Installed node-repo plugin {Id}: {Written} written, {Unchanged} unchanged ({Count} node(s)) @ {Ref}",
                     manifest.Id, result.Written, result.Unchanged, nodes.Length, installedFromRef);
-                // Recompile only the NodeTypes, and only when something changed.
-                if (result.Written > 0)
-                    SeedThenRequestReleases(hub, nodeTypePaths, logger);
+
+                // Recompile only the NodeTypes, and only when something changed — in TWO ORDERED
+                // WAVES around the root's recycle. See ReleaseWaves for why the split exists and
+                // why the root's own type has to be in the first one (#1732).
+                var retypedRoot = placeholderRoot is not null ? root?.Path : null;
+                var (firstWave, deferredWave) = ReleaseWaves(retypedRoot, nodeTypePaths, nodes);
+                var releases = result.Written > 0
+                    ? SeedPrebuiltAssemblies(hub, nodeTypePaths, logger)
+                    : Observable.Return(0);
+
                 // Same order as the content path: publish the partition BEFORE warming its roots
                 // (activation's gating pass must see the declared shape).
                 return EnsureDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id,
                         logger, nodes.Select(n => n.Path))
                     .SelectMany(_ => WriteInstalledRecord(
                         hub, manifest, installedFromRef, nodes.Length, moduleManifest, authorizingUserId))
+                    // Adoption first (it can settle a release without compiling at all), then the
+                    // FIRST wave: the root's own in-package NodeType, whose rebuild is precisely
+                    // what SettleRetypedRoot waits for.
+                    .SelectMany(_ => releases)
+                    .SelectMany(_ => result.Written > 0
+                        ? RequestReleases(hub, firstWave, logger)
+                        : Observable.Return(System.Reactive.Unit.Default))
                     // The retyped root's recycle, moved here from the write stage and made ORDERED
                     // (see the note there). Only now can it do its job: the in-package type has had
                     // its rebuild, so the hub that comes back binds the package's own configuration
                     // instead of the fallback — and the install no longer returns while a teardown
                     // it started is still running.
-                    .SelectMany(_ => SettleRetypedRoot(
-                        hub, placeholderRoot is not null ? root?.Path : null, nodes, logger))
+                    .SelectMany(_ => SettleRetypedRoot(hub, retypedRoot, nodes, logger))
+                    // …and ONLY NOW the rest of the package's types. Their compiles read the root
+                    // (ValidateCellSurfaceSingleHome → GetMeshNode('<packageRoot>') for every
+                    // `shared=` consumer), so launching them before the recycle above pointed a
+                    // whole package's compiles at a hub this very method was about to dispose
+                    // (#1732).
+                    .SelectMany(_ => result.Written > 0
+                        ? RequestReleases(hub, deferredWave, logger)
+                        : Observable.Return(System.Reactive.Unit.Default))
                     .SelectMany(_ => WarmInstalledRoots(hub, nodes, logger))
                     // …then the package's committed binaries (course videos/posters) into the
                     // warmed root's content collection — the half of "publish" that merging used
@@ -2271,14 +2296,19 @@ public static class PackageInstaller
                     manifest.Id, result.Written, result.Unchanged, t.Pruned,
                     releaseTargets.Length, installedFromRef, newManifest.ModuleVersion);
 
-                if (releaseTargets.Length > 0)
-                    SeedThenRequestReleases(hub, releaseTargets, logger);
+                // SEQUENCED, never fire-and-forget (the observable is cold — a bare call requests
+                // nothing). A delta runs no placeholder dance, so there is no root recycle to split
+                // the waves around; one wave is the whole set.
+                var releases = releaseTargets.Length > 0
+                    ? SeedThenRequestReleases(hub, releaseTargets, logger)
+                    : Observable.Return(System.Reactive.Unit.Default);
                 // An UPDATE re-asserts the declared access too: a package that only just flipped
                 // its declaration (or whose policy was lost) must converge on the next sync rather
                 // than wait for a full re-install. Create-only, so an existing shape is untouched
                 // and this is free on the common path.
-                return EnsureDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id,
-                        logger, nodes.Select(n => n.Path))
+                return releases
+                    .SelectMany(_ => EnsureDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id,
+                        logger, nodes.Select(n => n.Path)))
                     .SelectMany(_ => WriteInstalledRecord(hub, manifest, installedFromRef,
                         newManifest.Files.Count, newManifest, authorizingUserId))
                     .SelectMany(_ => WarmInstalledRoots(hub, nodes, logger))
@@ -2527,50 +2557,136 @@ public static class PackageInstaller
     }
 
     /// <summary>
-    /// #1707 slice 3 — adopt-before-compile at INSTALL: give the deployment's prebuilt bundle
-    /// sources one bounded chance to supply the just-installed types' assemblies, THEN issue the
-    /// release requests. An adopted type's request is SATISFIED by the release watcher (Ok +
-    /// sources current + usable build ⇒ no Roslyn); anything not adopted compiles exactly as
-    /// before. Fire-and-forget like the requests it wraps (an install never waits for compiles);
-    /// never faults — every failure degrades to "the installed types compile".
+    /// Splits the package's installed NodeTypes into the two release waves the install issues
+    /// around <see cref="SettleRetypedRoot"/>.
+    ///
+    /// <para>🚨 <b>Why a split, and not simply "release everything after the recycle"</b> (#1732).
+    /// The recycle exists to re-activate the retyped root against its FINAL type, and
+    /// <see cref="MayPublishIntoRoot"/> — the wait that decides whether recycling is even worth it
+    /// — is a wait for exactly that type's rebuild. Deferring the root type's own release behind
+    /// the settle would therefore wait for a compile nobody asked for, and answer only when
+    /// <see cref="RootTypeSettleTimeout"/> elapsed: a 90 s stall on every self-typed package (the
+    /// Store shape). So the root's own in-package type goes in wave ONE.</para>
+    ///
+    /// <para>Everything else goes in wave TWO, AFTER the root has been torn down and answered
+    /// again. Those are the compiles that read the root: a <c>shared=</c> consumer's compile runs
+    /// the cell-surface single-home gate, which reads the owning package root
+    /// (<c>ValidateCellSurfaceSingleHome</c> → <c>ReadCompileSourceNode</c> →
+    /// <c>GetMeshNode('&lt;packageRoot&gt;')</c>). Launching them before the recycle made the
+    /// installer race its own teardown — the faulting set in every incident was exactly the
+    /// module's <c>shared=</c> consumers, never anything else. #1726 made those reads PATIENT
+    /// (they re-probe across a recycle and, if it outlasts the budget, report
+    /// <c>CompilationStatus.Unavailable</c> rather than a code verdict); this makes them
+    /// UNNECESSARY, which is the half #1726 deliberately did not do.</para>
+    ///
+    /// <para>With no recycle to order against (<paramref name="retypedRoot"/> null — the common
+    /// re-install, where the root already carries its final type) there is nothing to defer and
+    /// every type stays in wave one, exactly as before.</para>
     /// </summary>
-    private static void SeedThenRequestReleases(
+    private static (IReadOnlyCollection<string> First, IReadOnlyCollection<string> Deferred) ReleaseWaves(
+        string? retypedRoot, IReadOnlyCollection<string> nodeTypePaths, IReadOnlyCollection<MeshNode> nodes)
+    {
+        if (retypedRoot is null || nodeTypePaths.Count == 0)
+            return (nodeTypePaths, Array.Empty<string>());
+        var rootType = InPackageTypeOf(retypedRoot, nodes);
+        if (rootType is null)
+            return (Array.Empty<string>(), nodeTypePaths);
+        // OrdinalIgnoreCase to match InPackageTypeOf's own type↔path comparison.
+        var first = nodeTypePaths
+            .Where(p => string.Equals(p, rootType, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        var deferred = nodeTypePaths
+            .Where(p => !string.Equals(p, rootType, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        return (first, deferred);
+    }
+
+    /// <summary>
+    /// #1707 slice 3 — adopt-before-compile at INSTALL: give the deployment's prebuilt bundle
+    /// sources one bounded chance to supply the just-installed types' assemblies, BEFORE any
+    /// release request is issued. An adopted type's request is SATISFIED by the release watcher
+    /// (Ok + sources current + usable build ⇒ no Roslyn); anything not adopted compiles exactly as
+    /// before. Never faults — every failure degrades to "the installed types compile".
+    /// </summary>
+    /// <returns>A cold observable of the number of adopted assemblies; Subscribe to run.</returns>
+    private static IObservable<int> SeedPrebuiltAssemblies(
         IMessageHub hub, IReadOnlyCollection<string> nodeTypePaths, ILogger? logger)
     {
         var consumer = hub.ServiceProvider.GetService<IPrebuiltAssemblyConsumer>();
-        var seed = consumer is null
-            ? Observable.Return(0)
-            : consumer.SeedForTypes(nodeTypePaths)
-                .Take(1)
-                .Timeout(TimeSpan.FromSeconds(60))
-                .Catch<int, Exception>(ex =>
-                {
-                    logger?.LogWarning(ex,
-                        "Install: prebuilt adoption attempt failed — the installed types compile instead");
-                    return Observable.Return(0);
-                });
-        seed.Subscribe(
-            adopted =>
+        if (consumer is null || nodeTypePaths.Count == 0)
+            return Observable.Return(0);
+        return consumer.SeedForTypes(nodeTypePaths)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(60))
+            .Catch<int, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "Install: prebuilt adoption attempt failed — the installed types compile instead");
+                return Observable.Return(0);
+            })
+            .Do(adopted =>
             {
                 if (adopted > 0)
                     logger?.LogInformation(
                         "Install: adopted {Adopted} prebuilt assembly(ies) for {Count} installed "
                         + "type(s) — their release requests settle without compiling",
                         adopted, nodeTypePaths.Count);
-                // System-impersonated: the release flips are stream writes posted from a pool
-                // continuation with no ambient context — and the seed's own System scope does not
-                // flow across the subscription hop (AsyncLocal), so it is re-established here.
-                var accessService = hub.ServiceProvider.GetService<AccessService>();
-                using (accessService?.ImpersonateAsSystem())
-                    foreach (var path in nodeTypePaths)
-                        hub.RequestNodeTypeRelease(path,
-                            onError: msg => logger?.LogWarning(
-                                "Release request for {Path} failed: {Msg}", path, msg));
-            },
-            ex => logger?.LogWarning(ex,
-                "Install: seed-then-release failed for {Count} type(s) — request releases manually "
-                + "(Compile button) if assemblies stay stale", nodeTypePaths.Count));
+            });
     }
+
+    /// <summary>
+    /// Flips the release trigger on each of <paramref name="nodeTypePaths"/> and completes once
+    /// every flip has LANDED.
+    ///
+    /// <para>🚨 The completion is the whole point: an install must be able to ORDER a teardown
+    /// against the compiles it starts, and the previous fire-and-forget shape returned nothing to
+    /// order against (#1732). Merged, not concatenated — the flips are independent writes to
+    /// different per-type hubs, exactly as concurrent as the old synchronous <c>foreach</c> made
+    /// them; only the "and now they have all landed" signal is new.</para>
+    ///
+    /// <para>Never faults: a refused or failed flip is logged and the install carries on, so one
+    /// unreleasable type can neither fail the install nor strand the types after it.</para>
+    /// </summary>
+    /// <returns>A cold observable; Subscribe to request the releases.</returns>
+    private static IObservable<System.Reactive.Unit> RequestReleases(
+        IMessageHub hub, IReadOnlyCollection<string> nodeTypePaths, ILogger? logger)
+    {
+        if (nodeTypePaths.Count == 0)
+            return Observable.Return(System.Reactive.Unit.Default);
+        // System-impersonated: the release flips are stream writes posted from a pool continuation
+        // with no ambient context — and the seed's own System scope does not flow across the
+        // subscription hop (AsyncLocal), so it is re-established here. Observable.Using keeps the
+        // scope alive for the SUBSCRIBE of every flip (each is cold), which a bare `using` around
+        // the composition would not.
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        return Observable.Using(
+                () => accessService?.ImpersonateAsSystem()
+                      ?? System.Reactive.Disposables.Disposable.Empty,
+                _ => nodeTypePaths
+                    .Select(path => hub.ObserveNodeTypeRelease(path,
+                        onError: msg => logger?.LogWarning(
+                            "Release request for {Path} failed: {Msg}", path, msg)))
+                    .Merge()
+                    .ToList())
+            .Select(_ => System.Reactive.Unit.Default)
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex,
+                    "Install: seed-then-release failed for {Count} type(s) — request releases manually "
+                    + "(Compile button) if assemblies stay stale", nodeTypePaths.Count);
+                return Observable.Return(System.Reactive.Unit.Default);
+            });
+    }
+
+    /// <summary>
+    /// The composed <see cref="SeedPrebuiltAssemblies"/> → <see cref="RequestReleases"/> pair, for
+    /// the paths that have no root recycle to order around (the incremental delta update). Cold:
+    /// Subscribe to run, and the completion means every release trigger has landed.
+    /// </summary>
+    private static IObservable<System.Reactive.Unit> SeedThenRequestReleases(
+        IMessageHub hub, IReadOnlyCollection<string> nodeTypePaths, ILogger? logger)
+        => SeedPrebuiltAssemblies(hub, nodeTypePaths, logger)
+            .SelectMany(_ => RequestReleases(hub, nodeTypePaths, logger));
 
 }
 

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposalDeadlockDiagnosticsTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposalDeadlockDiagnosticsTest.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// #1701 — the disposal-deadlock error must carry the EVIDENCE, not just the phase.
+///
+/// <para><b>What was wrong.</b> When the watchdog fires, the log said only
+/// <c>"Hub &lt;X&gt; did not complete shutdown within 00:00:08. RunLevel=DisposeHostedHubs"</c>.
+/// <c>RunLevel=DisposeHostedHubs</c> means "a hosted child has not answered yet" and NOTHING
+/// about which child or why — and at least four different mechanisms produce it: a child whose
+/// pump is starved behind a FIFO backlog, a child frozen on one non-terminating turn, an
+/// in-flight hosted-hub construction the join is (correctly) waiting out, and a child that simply
+/// answers on its OWN watchdog — which is armed one quiesce budget LATER than the parent's and
+/// therefore structurally cannot answer before it. #1701 sat on "the compile-pool children are
+/// the prime suspects" for months because the log could not tell those apart.</para>
+///
+/// <para><b>What is pinned.</b> The error now carries the recursive disposal snapshot: the wedged
+/// hub's queue depths and — decisive — the message currently occupying its action block, by name
+/// and elapsed. Those two numbers are what discriminate "starved behind a backlog"
+/// (<c>buffer</c> large, <c>Executing</c> a few ms) from "frozen on one turn" (<c>buffer</c>
+/// small, <c>Executing</c> thousands of ms) from "waiting on a child" (this hub idle, a CHILD
+/// line carrying the backlog).</para>
+///
+/// <para>The wedge itself is the harness <c>MessageHubTest.Dispose_WhenActionBlockWedged_…</c>
+/// already uses — a genuine FIFO backlog of slow turns that the phased <c>ShutdownRequest</c>
+/// cannot jump — so this test asserts on a REAL watchdog trip, never a simulated one.</para>
+/// </summary>
+public class DisposalDeadlockDiagnosticsTest : HubTestBase
+{
+    private readonly DeadlockLogCapture _capture = new();
+
+    public DisposalDeadlockDiagnosticsTest(ITestOutputHelper output)
+        : base(output)
+    {
+        Services.AddLogging(l => l.Services.AddSingleton<ILoggerProvider>(_capture));
+    }
+
+    private record WedgeEvent;
+
+    [Fact(Timeout = 120_000)]
+    public async Task DisposalDeadlock_NamesTheMessageHoldingTheActionBlock()
+    {
+        var wedgeTurns = 0;
+        // Same starvation recipe as MessageHubTest's zombie-hub regression: a queue backlog of
+        // slow turns, sized under the storm breaker's trip threshold (a tripped flood is dropped
+        // at ingestion and never builds a backlog) and long enough to outlast the 8 s watchdog.
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "diagnostics"), c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithHandler<WedgeEvent>((_, d) =>
+            {
+                Interlocked.Increment(ref wedgeTurns);
+                Thread.Sleep(15);
+                return d.Processed();
+            }), HostedHubCreation.Always)!;
+
+        for (var i = 0; i < 800; i++)
+            victim.Post(new WedgeEvent(), o => o.WithTarget(victim.Address));
+        // Let the first turn start so the backlog is genuinely queued when Dispose posts.
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        victim.Dispose();
+        await victim.DisposalCompleted.FirstOrDefaultAsync().ToTask().WaitAsync(30.Seconds());
+
+        var deadlock = _capture.Entries.FirstOrDefault(e => e.Contains("DISPOSAL DEADLOCK DETECTED"));
+        deadlock.Should().NotBeNull(
+            "the backlog must starve the phased shutdown so the watchdog is what completes disposal "
+            + $"(wedge turns processed: {Volatile.Read(ref wedgeTurns)})");
+        Output.WriteLine(deadlock!);
+
+        deadlock!.Should().Contain("Queue(buffer=",
+            "the deadlock report must carry the wedged hub's queue depths — a backlog and a frozen "
+            + "turn produce the same RunLevel and are told apart by nothing else");
+        deadlock.Should().Contain(nameof(WedgeEvent),
+            "the deadlock report must NAME the message occupying the action block; without it the "
+            + "log identifies a phase and leaves the culprit to guesswork (#1701)");
+    }
+
+    /// <summary>
+    /// Keeps only the disposal-deadlock lines — the provider is attached to every category, so
+    /// storing everything would make the capture the test's dominant cost.
+    /// </summary>
+    private sealed class DeadlockLogCapture : ILoggerProvider
+    {
+        public ConcurrentQueue<string> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new Capturing(Entries);
+        public void Dispose() { }
+
+        private sealed class Capturing(ConcurrentQueue<string> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel < LogLevel.Error)
+                    return;
+                var message = formatter(state, exception);
+                if (message.Contains("DISPOSAL DEADLOCK DETECTED", StringComparison.Ordinal))
+                    sink.Enqueue(message);
+            }
+        }
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/InstallReleaseOrderingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallReleaseOrderingTest.cs
@@ -134,14 +134,14 @@ public class InstallReleaseOrderingTest(ITestOutputHelper output) : MonolithMesh
         // root whose in-package type has a build an instance could load. If Kit/Front did not
         // compile there is no recycle to order around and every assertion below would fail for a
         // reason that has nothing to do with ordering.
-        var frontNode = await Mesh.GetWorkspace().GetMeshNodeStream($"{PackageId}/Front")
-            .Where(n => n?.Content is NodeTypeDefinition
-            {
-                CompilationStatus: CompilationStatus.Ok or CompilationStatus.Error
-            })
+        var frontDef = await Mesh.GetWorkspace().GetMeshNodeStream($"{PackageId}/Front")
+            // ContentAs, never `is NodeTypeDefinition`: a cross-hub mirror snapshot is routinely
+            // un-materialized JSON, and a CLR type test blinds this to an in-flight compile — the
+            // same reason MayPublishIntoRoot reads it this way.
+            .Select(n => n.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions))
+            .Where(def => def?.CompilationStatus is CompilationStatus.Ok or CompilationStatus.Error)
             .FirstAsync().Timeout(StepTimeout).ToTask();
-        var frontDef = (NodeTypeDefinition)frontNode!.Content!;
-        frontDef.CompilationStatus.Should().Be(CompilationStatus.Ok,
+        frontDef!.CompilationStatus.Should().Be(CompilationStatus.Ok,
             $"the root's own type must compile or there is no recycle to order around; error: {frontDef.CompilationError}");
 
         var recycles = _rootRecycles.ToArray();
@@ -183,11 +183,13 @@ public class InstallReleaseOrderingTest(ITestOutputHelper output) : MonolithMesh
     /// </summary>
     private async Task<DateTimeOffset> ReleaseTrigger(string typePath)
     {
-        var node = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
-            .Where(n => n?.Content is NodeTypeDefinition { RequestedReleaseAt: not null })
+        // ContentAs, never a CLR type test — see the note at the precondition read above.
+        var def = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Select(n => n.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions))
+            .Where(d => d?.RequestedReleaseAt is not null)
             .FirstAsync()
             .Timeout(TimeSpan.FromSeconds(30))
             .ToTask();
-        return ((NodeTypeDefinition)node!.Content!).RequestedReleaseAt!.Value;
+        return def!.RequestedReleaseAt!.Value;
     }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/InstallReleaseOrderingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallReleaseOrderingTest.cs
@@ -1,0 +1,193 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// #1732 — the install must not race its OWN teardown.
+///
+/// <para><b>The defect.</b> <c>PackageInstaller.InstallNodeRepoCore</c> launched a compile of
+/// EVERY installed NodeType fire-and-forget (<c>SeedThenRequestReleases</c>, a <c>void</c> method)
+/// and then, a few <c>SelectMany</c>s later in the SAME continuation chain, posted a
+/// <c>DisposeRequest</c> to the retyped package ROOT (<c>SettleRetypedRoot</c>). Every one of
+/// those compiles reads that root — a <c>shared=</c> consumer runs the cell-surface single-home
+/// gate, <c>ValidateCellSurfaceSingleHome</c> → <c>ReadCompileSourceNode(owner)</c> →
+/// <c>GetMeshNode('&lt;packageRoot&gt;')</c> — so the installer deliberately tore down the hub its
+/// own just-started work was reading. In the field the faulting set was always exactly the
+/// module's <c>shared=</c> consumers: 3 of 3 for Claims, 33 for Ifrs17, never a non-<c>shared=</c>
+/// type. #1726 made those reads PATIENT (they re-probe across a recycle and degrade to
+/// <c>CompilationStatus.Unavailable</c> rather than a code verdict); it did NOT make the ordering
+/// right, and a read with a tighter budget — or a teardown that outlasts the budget (#1701) —
+/// brings the mystery compile failures straight back.
+///
+/// <para><b>What is pinned.</b> The release trigger each NodeType carries
+/// (<c>NodeTypeDefinition.RequestedReleaseAt</c>, stamped by <c>ObserveNodeTypeRelease</c> at flip
+/// time) versus the moment the root's hub received the recycle's <c>DisposeRequest</c>. The
+/// contract is a SPLIT, not a blanket "release last":</para>
+/// <list type="bullet">
+///   <item>the root's OWN in-package type is released BEFORE the recycle — the recycle's
+///     <c>MayPublishIntoRoot</c> gate is a wait for precisely that type's rebuild, so deferring it
+///     would wait 90 s for a compile nobody asked for;</item>
+///   <item>every OTHER installed type is released AFTER the root has been recycled and answered
+///     again — those are the compiles that read the root.</item>
+/// </list>
+/// The test therefore fails in BOTH directions: on the old fire-and-forget shape the deferred
+/// type's trigger predates the DisposeRequest, and on a naive "defer everything" fix the install
+/// blows its budget on the root type's settle timeout.
+/// </summary>
+public class InstallReleaseOrderingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string PackageId = "Kit";
+    private static readonly TimeSpan StepTimeout = TimeSpan.FromSeconds(120);
+
+    // One real Roslyn compile (the root type's rebuild, which the recycle waits for) plus the
+    // install's own barriers.
+    protected override TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(150);
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(280);
+
+    /// <summary>
+    /// Every recycle the package root's hub received, in order. Captured on the hub itself so the
+    /// ordering is asserted against the PRODUCTION teardown, not a test-side approximation — and
+    /// as a LIST because an install legitimately produces more than one: the framework's
+    /// <c>NodeTypeRebindWatcher</c> recycles the root when the change feed reports the retype, and
+    /// <c>SettleRetypedRoot</c> recycles it again once the in-package type has rebuilt.
+    /// </summary>
+    private readonly ConcurrentQueue<DateTimeOffset> _rootRecycles = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddPluginCatalog()
+            .ConfigureDefaultNodeHub(config =>
+            {
+                if (config.Address.ToString() != PackageId)
+                    return config;
+                // Passive observer: returns the delivery UNPROCESSED so the framework's own
+                // HandleDispose still runs (config handlers are registered last and therefore run
+                // FIRST — MessageHub.Register uses AddFirst).
+                return config.WithHandler<DisposeRequest>((_, delivery) =>
+                {
+                    _rootRecycles.Enqueue(DateTimeOffset.UtcNow);
+                    return delivery;
+                });
+            });
+
+    // ── The fixture: a SELF-TYPED root (the Store shape — the only shape that reaches
+    //    SettleRetypedRoot, because only it runs the placeholder dance) PLUS a second in-package
+    //    NodeType that the root does not use. That second type is the whole point: it is the one
+    //    whose compile used to be launched into a hub the installer was about to dispose. ──
+
+    private static readonly IReadOnlyList<RepoFile> Repo = new List<RepoFile>
+    {
+        new("Kit/index.json",
+            """{"$type":"MeshNode","id":"Kit","namespace":"","path":"Kit","mainNode":"Kit","name":"Kit","nodeType":"Kit/Front","state":"Active","content":{"$type":"FrontContent","intro":"hello"}}"""),
+        // The ROOT's type — wave one.
+        new("Kit/Front.json",
+            """{"$type":"MeshNode","id":"Front","namespace":"Kit","path":"Kit/Front","mainNode":"Kit/Front","name":"Front","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"The kit front.","configuration":"config => config.WithContentType<FrontContent>()","includeGlobalTypes":true}}"""),
+        new("Kit/Front/Source/FrontContent.cs",
+            "public record FrontContent { public string? Intro { get; init; } }"),
+        // A SECOND type, used by nothing in this package — wave two.
+        new("Kit/Widget.json",
+            """{"$type":"MeshNode","id":"Widget","namespace":"Kit","path":"Kit/Widget","mainNode":"Kit/Widget","name":"Widget","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A widget.","configuration":"config => config.WithContentType<WidgetContent>()","includeGlobalTypes":true}}"""),
+        new("Kit/Widget/Source/WidgetContent.cs",
+            "public record WidgetContent { public string? Label { get; init; } }"),
+    };
+
+    [Fact(Timeout = 240_000)]
+    public async Task DeferredNodeTypeReleases_AreRequestedAfterTheRootRecycle()
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-kit", Repo));
+        var source = new NodeRepoPackageSource(fetch, "https://github.com/acme/kit");
+        var manifest = new PackageManifest
+        {
+            Id = PackageId,
+            Name = PackageId,
+            Kind = PackageKind.NodeRepo,
+            TargetPartition = PackageId,
+            SourceFolder = PackageId,
+            Version = "commit-kit",
+        };
+        var files = await source.FetchPackageFiles(manifest, "HEAD").FirstAsync().ToTask();
+
+        var result = await PackageInstaller.Install(Mesh, manifest, files, "HEAD")
+            .FirstAsync().Timeout(StepTimeout).ToTask();
+        result.Written.Should().Be(Repo.Count);
+
+        // PRECONDITION, asserted so its failure reads as itself: SettleRetypedRoot only recycles a
+        // root whose in-package type has a build an instance could load. If Kit/Front did not
+        // compile there is no recycle to order around and every assertion below would fail for a
+        // reason that has nothing to do with ordering.
+        var frontNode = await Mesh.GetWorkspace().GetMeshNodeStream($"{PackageId}/Front")
+            .Where(n => n?.Content is NodeTypeDefinition
+            {
+                CompilationStatus: CompilationStatus.Ok or CompilationStatus.Error
+            })
+            .FirstAsync().Timeout(StepTimeout).ToTask();
+        var frontDef = (NodeTypeDefinition)frontNode!.Content!;
+        frontDef.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            $"the root's own type must compile or there is no recycle to order around; error: {frontDef.CompilationError}");
+
+        var recycles = _rootRecycles.ToArray();
+        foreach (var r in recycles)
+            Output.WriteLine($"root recycle observed at {r:O}");
+        recycles.Should().NotBeEmpty(
+            "the retyped root must be recycled — SettleRetypedRoot is what this ordering is about");
+
+        var front = await ReleaseTrigger($"{PackageId}/Front");
+        var widget = await ReleaseTrigger($"{PackageId}/Widget");
+        Output.WriteLine($"{PackageId}/Front  requestedReleaseAt={front:O}");
+        Output.WriteLine($"{PackageId}/Widget requestedReleaseAt={widget:O}");
+
+        // Wave one before wave two. Necessary but not sufficient — the old fire-and-forget shape
+        // satisfies this too, by microseconds, from inside one `foreach`.
+        front.Should().BeBefore(widget,
+            "the root's own in-package NodeType goes in the first wave, everything else in the second");
+
+        // THE pin: a recycle of the root sits BETWEEN the two waves. That is the whole contract —
+        // the root's own type is released before the recycle (its rebuild is what
+        // SettleRetypedRoot waits for; deferring it would stall on RootTypeSettleTimeout, 90 s,
+        // which the install budget above also catches), and every other type is released only
+        // once that recycle has settled.
+        //
+        // On the fire-and-forget shape both stamps land in the same turn, microseconds apart and
+        // strictly BEFORE any recycle, so no recycle can fall between them and this fails.
+        var sandwiched = recycles.Where(r => r > front && r < widget).ToArray();
+        sandwiched.Should().NotBeEmpty(
+            "a NodeType compile reads the package root (ValidateCellSurfaceSingleHome → "
+            + "GetMeshNode('<packageRoot>')), so the deferred types' releases must not be issued "
+            + "until the installer's own recycle of that root has settled — but no recycle was "
+            + $"observed between {front:O} and {widget:O} (#1732)");
+    }
+
+    /// <summary>
+    /// The release trigger the installer stamped on <paramref name="typePath"/>. The install
+    /// completes only once every flip has LANDED, so this read never waits on the compile that
+    /// follows it — the value is already there.
+    /// </summary>
+    private async Task<DateTimeOffset> ReleaseTrigger(string typePath)
+    {
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Where(n => n?.Content is NodeTypeDefinition { RequestedReleaseAt: not null })
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask();
+        return ((NodeTypeDefinition)node!.Content!).RequestedReleaseAt!.Value;
+    }
+}


### PR DESCRIPTION
Fixes #1732. Advances #1701 (diagnosis + the diagnostic that closes it; see below).

## #1732 — the install stops racing its own teardown

`PackageInstaller.InstallNodeRepoCore` launched a compile of **every** installed NodeType
fire-and-forget (`SeedThenRequestReleases`, a `void` method) and then, a few `SelectMany`s later in
the same continuation chain, posted a `DisposeRequest` to the retyped package **root**
(`SettleRetypedRoot`). Every one of those compiles reads that root — a `shared=` consumer runs the
cell-surface single-home gate, `ValidateCellSurfaceSingleHome` → `ReadCompileSourceNode(owner)` →
`GetMeshNode('<packageRoot>')`. The installer was tearing down the hub its own just-started work was
reading, and the faulting set in every incident was exactly the module's `shared=` consumers (3 of 3
for Claims, 33 for Ifrs17) — never a non-`shared=` type.

#1726 made those reads **patient**. This makes them **unnecessary** — the half #1726 deliberately
did not do.

- **`NodeTypeReleaseExtensions` gains `ObserveNodeTypeRelease`** — the same implementation,
  returning the cold `IObservable<bool>` a caller can order against. `RequestNodeTypeRelease` is now
  that observable plus a `Subscribe`, so the GUI/MCP surface is unchanged. The fire-and-forget shape
  was the specific thing that made ordering impossible: it returned nothing to sequence.
- **The releases are issued in TWO ordered waves around the recycle.** The root's OWN in-package
  type goes **first** — `SettleRetypedRoot`'s `MayPublishIntoRoot` gate *is* a wait for exactly that
  type's rebuild, so deferring it would wait for a compile nobody asked for and answer only when
  `RootTypeSettleTimeout` (90 s) elapsed. Every **other** type goes **after** the root has been
  recycled and answered again. With no recycle to order against (the common re-install, root already
  final) nothing is deferred and behaviour is as before.
- **The two remaining fire-and-forget call sites are sequenced too** (code-package install,
  node-repo delta). Making `SeedThenRequestReleases` return an observable turned those into silent
  no-ops — a cold observable nobody subscribes requests no release at all — so both now compose it
  into their chain.

No sleep, no retry, no widened bound; the work is simply put in an order where it cannot collide.

**Regression test** — `InstallReleaseOrderingTest` (`test/MeshWeaver.PluginCatalog.Test`). Installs a
self-typed-root package (the only shape that reaches `SettleRetypedRoot`) carrying a second NodeType,
observes the root hub's own `DisposeRequest` deliveries via `ConfigureDefaultNodeHub`, and asserts a
recycle falls **between** the two types' `RequestedReleaseAt` stamps. Verified in both directions on
this branch: against pre-fix `src/` it fails with

> no recycle was observed between 2026-08-17T11:25:35.2466270+00:00 and 2026-08-17T11:25:35.2498640+00:00

(both stamps land in one turn, 3 ms apart, before any recycle), and passes with the fix. It also
fails if someone "simplifies" the fix by deferring everything: the root type's settle then burns 90 s
and the install blows the test's budget.

## #1701 — the premise is wrong; one wedge, not two. Plus the diagnostic that names it

Full write-up in the issue. In short, the two `[FORCE-TEARDOWN]` pairs are **not** independent:
the watchdog is armed **per hub at that hub's own `Dispose()`**, and a child's `Dispose()` is only
called in the parent's `DisposeHostedHubs` phase — strictly later. So whenever a child needs its own
watchdog to answer, the parent's **always** expires first, and `DISPOSAL DEADLOCK DETECTED: Hub
Ifrs17 … RunLevel=DisposeHostedHubs` is a guaranteed consequence rather than evidence that `Ifrs17`
wedged. (This is the inversion #1317 fixed one level down — *"a join must not out-run the answers it
is joining"* — left in place one level up.) The real wedge is the `sync/*` child at
`RunLevel=Started`: its `ShutdownRequest` was never dequeued.

Four mechanisms produce that, and **the log as it stood could not tell them apart** — which is why
the issue sat on "the compile-pool children are the prime suspects" (a hypothesis the code does not
support: compiles run off-hub on `CompileThread`, and every `RegisterForDisposal` in Graph/Data runs
in the *ShutDown* phase, fire-and-forget, after `DisposeHostedHubs`). So the error now carries
`GetDisposalDiagnostics()` — the recursive snapshot with, per hub, `RunLevel`, `Disposal=`,
`Queue(buffer=,deferred=,exec=,openGates=)`, `Executing(<messageType>, <ms>)` and pending callbacks.
Those two numbers discriminate the shapes in a single occurrence: a large `buffer` with a few-ms
`Executing` is FIFO starvation; a small `buffer` with an 8000+ ms `Executing` is one non-terminating
turn, **named**.

**Regression test** — `DisposalDeadlockDiagnosticsTest` (`test/MeshWeaver.Messaging.Hub.Test`) drives a
real watchdog trip (the same genuine FIFO-backlog starvation the existing zombie-hub regression uses,
no simulation) and asserts the report carries the queue depths and names the message occupying the
wedged action block.

**Deliberately NOT in this PR**, and left open on #1701: (a) the actual `sync/*` wedge — guessing
between the remaining two mechanisms and "fixing" the guess is how a bound gets widened; the next
occurrence now answers it. (b) the watchdog inversion itself — the fix that moves no bound is a
*stall* watchdog rather than a *duration* one (re-arm on observable progress), which is a second,
independent change to the most delicate path in the repo and does not fix (a).

## Verification

`-c Release -warnaserror` clean on every touched project and its dependents. Local suites, all green:

| suite | result |
|---|---|
| `MeshWeaver.PluginCatalog.Test` | 356 / 356 |
| `MeshWeaver.Graph.Test` | 1233 / 1233 |
| `MeshWeaver.Messaging.Hub.Test` | 252 / 252 |
| `MeshWeaver.Documentation.Test` | 21 / 21 |
| `MeshWeaver.Hosting.Monolith.Test` | 714 / 714 (3 skipped) |

What's New entry: `Category: Fix` — a package install intermittently parking some of its own types on
the compilation-error overlay is user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
