### PR TITLE
fix(#1616): a push that lands after a local delete no longer reports drained

### DIFF
--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -330,10 +330,11 @@ public sealed class InstanceSyncWorker : IDisposable
 
         // Push the node's CURRENT content; a node deleted since the change was observed
         // degrades to a delete.
-        return hub.GetMeshNodeOutcome(change.Path, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
+        return hub.GetMeshNodeOutcome(change.Path, LocalReadTimeout, ReadTimeoutBehavior.EmitNull)
             .SelectMany(outcome => outcome.Status switch
             {
-                NodeReadStatus.Present => PushNode(remote, cfg, outcome.Node!).Select(_ => true),
+                NodeReadStatus.Present => PushNode(remote, cfg, outcome.Node!)
+                    .SelectMany(_ => ConfirmNotDeletedDuringPush(remote, change.Path, remotePath)),
                 NodeReadStatus.Absent => DeleteRemote(remote, remotePath),
                 // The local delete is in flight; the authoritative next state is "gone", and the
                 // manifest holds a Deleted entry for it too. Pushing the delete now is idempotent.
@@ -347,6 +348,43 @@ public sealed class InstanceSyncWorker : IDisposable
                     $"Cannot push {change.Path}: unhandled read outcome '{outcome.Status}'.")),
             });
     }
+
+    /// <summary>How long a LOCAL node read may take before the drain gives up on it.</summary>
+    private static readonly TimeSpan LocalReadTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// 🚨 Re-resolves the local node AFTER a successful push, and converts the push into a delete
+    /// when the node went away while it was in flight (#1616).
+    ///
+    /// <para><b>The defect this closes.</b> <see cref="DrainOne"/> reads local state and then pushes,
+    /// and those two are separated by a full remote round trip. A local delete landing inside that
+    /// window used to be invisible: the push reported success on content that was already stale,
+    /// <see cref="DrainPending"/> removed the entry as drained, and the remote kept a node that had
+    /// been deleted here — with nothing left in the manifest to correct it. The window is widest
+    /// exactly where the test pins it: while the remote is unreachable, attempts retry every
+    /// 100–400 ms, so an attempt that read the node just before the delete can complete its push
+    /// just after the remote comes back.</para>
+    ///
+    /// <para>The tombstone that makes this detectable is written SYNCHRONOUSLY by the delete handler
+    /// (<c>RecentlyDeletedRegistry.MarkDeleted</c>) and emits no change event, which is why nothing
+    /// re-enters the manifest to catch it and why the read below — the same one
+    /// <see cref="DrainOne"/> already trusts — is the authority.</para>
+    ///
+    /// <para>Only <see cref="NodeReadStatus.Absent"/> / <see cref="NodeReadStatus.DeleteInProgress"/>
+    /// change the outcome. A still-present node, an unreadable one, or a status this predates all
+    /// report the push as drained exactly as before: the push DID succeed, and any later delete
+    /// raises its own change event and its own manifest entry. Never destroy the remote copy on
+    /// evidence we could not gather — the same rule <see cref="DrainOne"/> states for its first read.</para>
+    /// </summary>
+    private IObservable<bool> ConfirmNotDeletedDuringPush(
+        IRemoteMeshClient remote, string localPath, string remotePath) =>
+        hub.GetMeshNodeOutcome(localPath, LocalReadTimeout, ReadTimeoutBehavior.EmitNull)
+            .SelectMany(after => after.Status is NodeReadStatus.Absent or NodeReadStatus.DeleteInProgress
+                ? DeleteRemote(remote, remotePath)
+                : Observable.Return(true))
+            // An unreadable local node here must not fail an entry whose push already succeeded:
+            // that would re-push identical content on every pass. Treat it as drained, as before.
+            .Catch<bool, Exception>(_ => Observable.Return(true));
 
     private static IObservable<bool> DeleteRemote(IRemoteMeshClient remote, string remotePath) =>
         remote.Get(remotePath).SelectMany(existing => existing is null

--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -379,12 +379,19 @@ public sealed class InstanceSyncWorker : IDisposable
     private IObservable<bool> ConfirmNotDeletedDuringPush(
         IRemoteMeshClient remote, string localPath, string remotePath) =>
         hub.GetMeshNodeOutcome(localPath, LocalReadTimeout, ReadTimeoutBehavior.EmitNull)
-            .SelectMany(after => after.Status is NodeReadStatus.Absent or NodeReadStatus.DeleteInProgress
+            .Select(after => after.Status is NodeReadStatus.Absent or NodeReadStatus.DeleteInProgress)
+            // 🚨 The catch is scoped to the RE-READ, never to the corrective delete below. An
+            // unreadable local node must not fail an entry whose push already succeeded (that would
+            // re-push identical content on every pass), so it reports drained — but a FAILING
+            // DeleteRemote must propagate: swallowing it would mark the entry drained while the
+            // remote still holds the locally-deleted node, which is precisely the defect this
+            // method exists to close. Propagating leaves the entry pending, and DrainPending
+            // classifies it: a connectivity fault aborts the pass for the retry probe, anything
+            // else surfaces on the config as LastError. Either way the next pass tries again.
+            .Catch<bool, Exception>(_ => Observable.Return(false))
+            .SelectMany(mustDelete => mustDelete
                 ? DeleteRemote(remote, remotePath)
-                : Observable.Return(true))
-            // An unreadable local node here must not fail an entry whose push already succeeded:
-            // that would re-push identical content on every pass. Treat it as drained, as before.
-            .Catch<bool, Exception>(_ => Observable.Return(true));
+                : Observable.Return(true));
 
     private static IObservable<bool> DeleteRemote(IRemoteMeshClient remote, string remotePath) =>
         remote.Get(remotePath).SelectMany(existing => existing is null


### PR DESCRIPTION
Closes #1616.

## Measurement first

Same instrument, same filter, same iteration count, ~40 minutes apart:

| arm | result |
|---|---|
| `main` | **8 failures in 100** — iterations 12, 33, 39, 47, 50, 61, 64, 96 ([run 32024085067](https://github.com/Systemorph/MeshWeaver/actions/runs/32024085067)) |
| this branch | **0 failures in 100** ([run 32026294545](https://github.com/Systemorph/MeshWeaver/actions/runs/32026294545)) |

🚨 **This contradicts something recorded on #1616 and it matters for anyone else working there.** The issue concludes that a filtered `flake-repro` loop does *not* reproduce and that "the instrument is a full shard" — measured 0/40 on main and 0/40 on a failing branch on 2026-08-14. That is no longer true: the same loop measured 8/100 on main three days later. The rate moved, so the A/B this issue asks for is possible again. Its warning still stands in principle — a green loop is not evidence when the loop cannot go red — which is exactly why the before-arm was measured on `main` first rather than assumed.

## Root cause

`DrainOne` resolves the local node **before** the push; `DrainPending` removes the entry **after** the push reports success. Those two are separated by a full remote round trip:

1. While the remote is unreachable, attempts retry every 100–400 ms, each reading the local node and then failing at the network.
2. An attempt reads the node as `Present` **just before** the delete tombstone lands.
3. `MarkDeleted` is written **synchronously** by the delete handler and emits **no change event** — so nothing re-enters the manifest to catch it.
4. The remote comes back. That in-flight attempt's push now succeeds, pushing content that is already stale, and reports the entry drained.
5. The entry is removed. The remote keeps a node that was deleted locally, and there is nothing left in the manifest to correct it.

That is why the test waits out its full 30 s: the DELETE it waits for is never produced. It also explains the `Dropping DataChangedEvent … the target stream is gone` at ~5.5 s quoted in the issue — the same window seen from the other side.

The bound was never the defect. The issue says so, and the test's own intervals (`DrainDebounce` 50 ms, `PullInterval` 200 ms, `RetryInitial` 100 ms) cover ~150 pull attempts inside the wait.

## The fix

The drain re-resolves the local node after a successful push and converts it into a delete when the node went away while it was in flight.

Deliberately narrow — **only `Absent` and `DeleteInProgress` change the outcome**. A still-present node, an unreadable one, or a status this predates all report the push as drained exactly as before. Never destroy the remote copy on evidence we could not gather: that is the rule `DrainOne`'s first read already states, and an earlier fix in this same file exists to enforce it.

Not fixed by raising a bound, adding a retry, or a `Task.Delay`.

## Blast radius

One added local node read per successfully pushed entry, against a push that is already a remote round trip. No change to the delete fast-path, the pull sweep, or the connectivity/retry classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjujCq1BsJkNKuZ4wXodo1