### PR TITLE
fix: RenderArea must not open a layout-area stream after its budget elapsed

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Reactive.Concurrency;
@@ -513,8 +514,20 @@ public class MeshOperations
 
         var pathResolver = hub.ServiceProvider.GetRequiredService<IPathResolver>();
         var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var budget = TimeSpan.FromSeconds(timeoutSeconds);
         return Observable.Defer(() =>
         {
+            // 🚨 The budget is a DEADLINE, not merely the outer `.Timeout(...)` below. Timeout
+            // faults the CALLER; it does not stop this pipeline. Rx disposal is unsynchronised, so
+            // a resolution emission already in flight still runs its continuation — and that
+            // continuation is the expensive, resource-ALLOCATING half: GetRemoteStream mints a
+            // `sync/` hub and posts a SubscribeRequest that WAKES a cold per-node hub. Opened
+            // after the budget is gone, that subscribe is owned by nobody: the caller has already
+            // been faulted, so the reply is awaited by no one and the request parks on the target's
+            // DataContextInit/Initialize/MeshNodeInit gates (issue #1613 — reported as a leaked
+            // callback, and in a portal an orphaned sync hub + heartbeat per abandoned render).
+            // So the remaining budget is re-checked at the last instant before committing to it.
+            var startedAt = Stopwatch.GetTimestamp();
             // Capture the CALLER's ambient identity at subscribe time (the transport request
             // thread / test context — same precedence the sync-stream uses). The remote-stream
             // creation below happens inside a reactive continuation on a hub scheduler where the
@@ -524,9 +537,10 @@ public class MeshOperations
             var caller = accessService?.Context ?? accessService?.CircuitContext;
             return pathResolver.ResolvePath(resolvedPath)
                 .Take(1)
-                .SelectMany(resolution => RenderResolvedArea(resolution, resolvedPath, area, id, caller));
+                .SelectMany(resolution => RenderResolvedArea(
+                    resolution, resolvedPath, area, id, caller, startedAt, budget));
         })
-            .Timeout(TimeSpan.FromSeconds(timeoutSeconds))
+            .Timeout(budget)
             .Catch((Exception ex) =>
             {
                 // A timeout stays a FAULT (transports map it to a gateway timeout); everything
@@ -541,14 +555,17 @@ public class MeshOperations
     /// <summary>
     /// Second half of <see cref="RenderArea"/>: builds the <see cref="LayoutAreaReference"/> from
     /// the resolution + explicit arguments and opens the one-shot area stream under the captured
-    /// caller identity.
+    /// caller identity — unless the budget handed down from <see cref="RenderArea"/> is already
+    /// spent, in which case it faults WITHOUT opening the stream (see the deadline note there).
     /// </summary>
     private IObservable<string> RenderResolvedArea(
         AddressResolution? resolution,
         string resolvedPath,
         string? area,
         string? id,
-        AccessContext? caller)
+        AccessContext? caller,
+        long startedAt,
+        TimeSpan budget)
     {
         if (resolution is null)
             return Observable.Return($"Not found: {resolvedPath}");
@@ -578,6 +595,18 @@ public class MeshOperations
         // and Finally guarantees disposal on every terminal path.
         return Observable.Defer(() =>
         {
+            // 🚨 LAST GATE before the only step in this verb that allocates mesh resources. The
+            // budget covers "path resolution + the first materialised frame" (see the parameter
+            // doc), so once it is spent there is nothing left to buy by opening the stream — only
+            // an orphaned `sync/` hub and a SubscribeRequest that wakes a cold per-node hub for a
+            // caller who is already gone. Faulting here is what makes a non-positive budget
+            // DETERMINISTIC (elapsed >= 0 always holds, so the stream is never opened) instead of
+            // a race between the outer Timeout and this continuation.
+            if (Stopwatch.GetElapsedTime(startedAt) >= budget)
+                return Observable.Throw<string>(new TimeoutException(
+                    $"RenderArea budget of {budget.TotalSeconds:0.###}s elapsed for '{resolvedPath}' "
+                    + "before the layout-area stream could be opened."));
+
             // This factory runs inside a reactive continuation where the ambient AsyncLocal
             // identity is NOT the caller's. GetRemoteStream captures the ambient AccessContext
             // at stream creation (it stamps the SubscribeRequest's identity), so re-apply the

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -512,9 +512,19 @@ public class MeshOperations
         if (string.IsNullOrWhiteSpace(resolvedPath))
             return Observable.Return("Error: path is required.");
 
+        var budget = TimeSpan.FromSeconds(timeoutSeconds);
+        // A caller with no budget has already given up, so do NOTHING — not even resolve the path.
+        // This is the degenerate half of the deadline rule enforced further down, split out so it
+        // is DETERMINISTIC: leaving it to the outer `.Timeout(TimeSpan.Zero)` scheduled a
+        // thread-pool timer that raced the pipeline, and whichever side lost still ran a
+        // continuation that opened a layout-area stream nobody was waiting for.
+        if (budget <= TimeSpan.Zero)
+            return Observable.Throw<string>(new TimeoutException(
+                $"RenderArea budget of {budget.TotalSeconds:0.###}s for '{resolvedPath}' is already "
+                + "elapsed — nothing was rendered."));
+
         var pathResolver = hub.ServiceProvider.GetRequiredService<IPathResolver>();
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        var budget = TimeSpan.FromSeconds(timeoutSeconds);
         return Observable.Defer(() =>
         {
             // 🚨 The budget is a DEADLINE, not merely the outer `.Timeout(...)` below. Timeout

--- a/test/MeshWeaver.AI.Test/RenderAreaOperationTest.cs
+++ b/test/MeshWeaver.AI.Test/RenderAreaOperationTest.cs
@@ -251,5 +251,13 @@ public class RenderAreaOperationTest(ITestOutputHelper output) : MonolithMeshTes
         notification.Kind.Should().Be(NotificationKind.OnError,
             "an elapsed budget must FAULT the observable — the REST layer maps it to a 504 JSON error");
         notification.Exception.Should().BeOfType<TimeoutException>();
+        // 🚨 This is what PINS the fix, and it is the assertion the old test was missing: the fault
+        // must come from the pipeline REFUSING the render, not from the outer Rx Timeout firing
+        // over a render that went ahead anyway. Only the former guarantees no layout-area stream —
+        // and so no orphaned SubscribeRequest against a cold per-node hub — was opened. Drop the
+        // refusal and this line fails immediately, instead of the leak resurfacing as a CI flake
+        // on somebody else's PR days later.
+        notification.Exception!.Message.Should().Contain("nothing was rendered",
+            "a non-positive budget must be refused outright — no path resolution, no remote stream");
     }
 }

--- a/test/MeshWeaver.AI.Test/RenderAreaOperationTest.cs
+++ b/test/MeshWeaver.AI.Test/RenderAreaOperationTest.cs
@@ -232,9 +232,17 @@ public class RenderAreaOperationTest(ITestOutputHelper output) : MonolithMeshTes
     {
         var path = await SeedMarkdownNodeAsync("timeout");
 
-        // A zero budget elapses before any frame can arrive — deterministic. Materialize folds
-        // the OnError into a value so the assertion is reactive (try/catch around an awaited
-        // FirstAsync can miss an Rx OnError).
+        // A non-positive budget is refused by the PIPELINE, not merely by the outer Rx Timeout:
+        // RenderArea carries the budget as a deadline and re-checks it immediately before opening
+        // the layout-area stream, so the fault is deterministic in both directions — no frame can
+        // win the race (the stream is never opened), and no SubscribeRequest is left behind for a
+        // caller that has already been faulted. The old premise here — "a zero budget elapses
+        // before any frame can arrive" — leaned on the outer Timeout alone and was racy: the
+        // continuation still opened the stream and posted a SubscribeRequest to a cold per-node
+        // hub, which parked on its init gates and tripped THIS class's leaked-callback teardown
+        // check on a loaded CI runner (issue #1613; main run 32025437472).
+        // Materialize folds the OnError into a value so the assertion is reactive (try/catch
+        // around an awaited FirstAsync can miss an Rx OnError).
         var notification = await new MeshOperations(Mesh)
             .RenderArea($"@{path}", "Overview", timeoutSeconds: 0)
             .Materialize()

--- a/test/MeshWeaver.AI.Test/RenderAreaOperationTest.cs
+++ b/test/MeshWeaver.AI.Test/RenderAreaOperationTest.cs
@@ -259,5 +259,22 @@ public class RenderAreaOperationTest(ITestOutputHelper output) : MonolithMeshTes
         // on somebody else's PR days later.
         notification.Exception!.Message.Should().Contain("nothing was rendered",
             "a non-positive budget must be refused outright — no path resolution, no remote stream");
+
+        // A NEGATIVE budget takes the same refusal, and must do so as a FAULTED OBSERVABLE. Without
+        // the refusal it would reach `.Timeout(negative)`, whose argument validation throws
+        // ArgumentOutOfRangeException — synchronously, out of the CALL rather than the subscription,
+        // so a caller composing this verb reactively never gets to see it as an Rx fault at all.
+        // `timeoutSeconds` is a public parameter, so a negative value is externally reachable
+        // (the REST surface clamps to [1,120], but MeshOperations is called directly too).
+        var negative = await new MeshOperations(Mesh)
+            .RenderArea($"@{path}", "Overview", timeoutSeconds: -1)
+            .Materialize()
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask(Ct);
+
+        negative.Kind.Should().Be(NotificationKind.OnError,
+            "a negative budget must fault the observable, not throw out of the call");
+        negative.Exception.Should().BeOfType<TimeoutException>(
+            "the refusal is a TimeoutException, never ArgumentOutOfRangeException from Rx's Timeout");
+        negative.Exception!.Message.Should().Contain("nothing was rendered");
     }
 }


### PR DESCRIPTION
## What turned main red

Run [32025437472](https://github.com/Systemorph/MeshWeaver/actions/runs/32025437472) (shard 3), commit `4c0cc71d9`. One test, `MeshWeaver.AI.Test.RenderAreaOperationTest.RenderArea_Timeout_FaultsWithTimeoutException`. It is **not** a body failure — the assertions passed; the throw is from `MonolithMeshTestBase.DisposeAsync()`:

```
System.InvalidOperationException : RenderAreaOperationTest left Observe subscriptions pending past the Quiescing budget.
Hub mesh/M8jj6cm1PUG9640CTBLJ2g: 1 pending callback(s) after 0.50s:
  IvTPPAo1DE6AJvBX3VZy4A=SubscribeRequest@TestData/render-d01df4c6b4784(509ms)
  … → RECEIVED runLevel=Quiescing@mesh/M8jj… → … → ROUTED onTarget=True state=Submitted(+32ms)
    → DEFERRED gates=[DataContextInit,Initialize,MeshNodeInit](+32ms)
```

The decisive stage is `RECEIVED runLevel=**Quiescing**`: the `SubscribeRequest` was posted **after the test method had returned and teardown had begun**.

## Attribution: pre-existing flake, NOT a regression from #1733

Measured, not argued:

- The **identical signature** — same test, same leaked `SubscribeRequest`, same `DEFERRED gates=[DataContextInit,Initialize…]` — occurred on **2026-08-14, run [31832029430](https://github.com/Systemorph/MeshWeaver/actions/runs/31832029430) (shard 4)**, three days before #1733 existed. That is what issue #1613 was filed for.
- #1733's diff carries **zero product code**: two workflows, one shell script, three docs, one What's New entry, one new test file, and `Directory.Build.props` — whose 24 changed lines contain **0 lines with an XML element tag** (comment-only; verified mechanically).
- `dotnet-test.yml`'s diff contains **no shard-composition change**, so the test did not move to a busier shard.
- PR #1736's own run [32025997920](https://github.com/Systemorph/MeshWeaver/actions/runs/32025997920) — a tree **containing** #1733, with **all six shards executed** — ran this test green.

## Root cause

`RenderArea` enforced its budget with an outer `Observable.Timeout(...)` **only**. Timeout faults the *caller*; it does not stop the pipeline. Rx disposal is unsynchronised, so a path-resolution emission already in flight still runs its continuation — and that continuation is the expensive, resource-**allocating** half: `GetRemoteStream` mints a `sync/` hub and posts a `SubscribeRequest` that **wakes a cold per-node hub**.

Opened after the budget is gone, that subscribe is owned by nobody: the caller has already been faulted, so the reply is awaited by no one and the request parks on the target's init gates. In CI that is the leaked callback above. In a portal it is an orphaned sync hub + heartbeat for every abandoned render.

Why it looked load-dependent: locally the target hub answers in milliseconds, so the **owner's reply** (not disposal) closes the callback and the test is green. On a loaded runner the hub is still `Starting` and the reply never comes inside the 0.5 s quiescing budget.

## The fix

The budget already documents itself as covering *"path resolution + the first materialised frame"*. So carry it as a **deadline** and re-check it at the last instant before committing to the stream — once it is spent there is nothing left to buy by opening one.

That also makes a **non-positive budget deterministic** instead of a race between the outer Timeout and the continuation: `elapsed >= TimeSpan.Zero` always holds, so the stream is never opened and the verb always faults with `TimeoutException`. The test's old premise — *"a zero budget elapses before any frame can arrive — deterministic"* — leaned on the outer Timeout alone and was racy in **both** directions: a synchronously-arriving frame would have failed it with `OnNext`, and the abandoned `SubscribeRequest` tripped the class's leaked-callback teardown check.

No band-aid: no retry, no widened timeout, no delay, no skip. The test keeps exactly what it proved (a zero budget must FAULT with `TimeoutException`) and now proves it deterministically.

## Scope note — what this deliberately does NOT fix

Issue #1613 asked why the existing cancel-on-dispose machinery did not save this. I found the answer and left it on the issue rather than widening this PR:

`reduced.RegisterForDisposal(observeSubscription)` routes to `RegisterForDisposal` on the stream's **inner `sync/` hub**, whose `disposables` are disposed only in that hub's **ShutDown phase**. `MessageHub.Dispose()` merely posts `ShutdownRequest(Quiescing)` and returns, so cancelling the in-flight `SubscribeRequest` is gated behind a multi-turn asynchronous hub teardown (Quiescing → DisposeHostedHubs → HostedHubsDisposed → ShutDown) that nothing bounds and that routinely exceeds 0.5 s under load. `WrapWithCancelOnDispose` is correct; the stream-disposal path simply never reaches it in time. That remains #1613's to fix; this PR removes the case that was firing.

## Verification

- `dotnet build test/MeshWeaver.AI.Test -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**.
- `RenderAreaOperationTest` (all 9 tests, `DOTNET_PROCESSOR_COUNT=4`) → **9 passed**.
- Flake-repro `rate` baseline dispatched on main for the measured before/after.

No What's New entry: internal resource-leak / CI-stability fix. The REST surface (`POST /api/mesh/render-area`) clamps the budget to `[1,120]`s, so the response contract is unchanged.