### PR TITLE
fix: apply the default node hub chain exactly once, and name the duplicate (#1684)

### DIFF
--- a/src/MeshWeaver.Data/DataContext.cs
+++ b/src/MeshWeaver.Data/DataContext.cs
@@ -220,12 +220,45 @@ public sealed record DataContext : IDisposable
         }
         DataSourcesById = deduped.ToImmutableDictionary();
 
-        // Build TypeSources first to get collection names
-        TypeSources = DataSourcesById
-            .Values
-            .SelectMany(ds => ds.TypeSources)
-            .ToDictionary(x => x.CollectionName);
-        TypeSourcesByType = DataSourcesById.Values.SelectMany(ds => ds.TypeSources).ToDictionary(ts => ts.TypeDefinition.Type);
+        // Build TypeSources first to get collection names.
+        //
+        // 🚨 NEVER .ToDictionary() here. A duplicate collection name is a real configuration
+        // defect and it FAILS HUB CREATION — but Dictionary.Add's message is the single word
+        // that collided ("An item with the same key has already been added. Key: Approval"),
+        // naming neither the hub whose workspace was being built nor either contributor. Four
+        // separate production/CI reports of Systemorph/MeshWeaver#1684 each had to be
+        // reverse-engineered from exactly that. Say what collided, on which node, and who
+        // contributed it — the failure stays a failure (a DistinctBy would HIDE a real
+        // duplicate), it just becomes a one-line diagnosis.
+        var typeSourcesByCollection = new Dictionary<string, ITypeSource>();
+        var typeSourcesByType = new Dictionary<Type, ITypeSource>();
+        var collectionContributors = new Dictionary<string, IDataSource>();
+        var typeContributors = new Dictionary<Type, IDataSource>();
+        foreach (var dataSource in DataSourcesById.Values)
+        {
+            foreach (var typeSource in dataSource.TypeSources)
+            {
+                var collectionName = typeSource.CollectionName;
+                if (typeSourcesByCollection.TryGetValue(collectionName, out var clashingCollection))
+                    throw DuplicateRegistration(
+                        "collection", collectionName,
+                        collectionContributors[collectionName], clashingCollection,
+                        dataSource, typeSource);
+                typeSourcesByCollection[collectionName] = typeSource;
+                collectionContributors[collectionName] = dataSource;
+
+                var entityType = typeSource.TypeDefinition.Type;
+                if (typeSourcesByType.TryGetValue(entityType, out var clashingType))
+                    throw DuplicateRegistration(
+                        "entity type", entityType.FullName ?? entityType.Name,
+                        typeContributors[entityType], clashingType,
+                        dataSource, typeSource);
+                typeSourcesByType[entityType] = typeSource;
+                typeContributors[entityType] = dataSource;
+            }
+        }
+        TypeSources = typeSourcesByCollection;
+        TypeSourcesByType = typeSourcesByType;
 
         // Register types with TypeRegistry BEFORE creating DataSourcesByCollection
         // This ensures GetCollectionName returns the correct collection name
@@ -236,17 +269,38 @@ public sealed record DataContext : IDisposable
             TypeRegistry.WithType(typeSource.TypeDefinition.Type, typeSource.TypeDefinition.CollectionName);
         }
 
-        DataSourcesByType = DataSourcesById.Values
-            .SelectMany(ds => ds.MappedTypes.Select(t => new KeyValuePair<Type, IDataSource>(t, ds))).ToDictionary();
+        // Same contract for the data-source lookups: a type or a collection claimed by two data
+        // sources is a defect that must NAME both claimants, not just the key.
+        var dataSourcesByType = new Dictionary<Type, IDataSource>();
+        var dataSourcesByCollection = new Dictionary<string, IDataSource>();
+        foreach (var dataSource in DataSourcesById.Values)
+        {
+            foreach (var mappedType in dataSource.MappedTypes)
+            {
+                if (dataSourcesByType.TryGetValue(mappedType, out var owner))
+                    throw DuplicateDataSource(
+                        "entity type", mappedType.FullName ?? mappedType.Name, owner, dataSource);
+                dataSourcesByType[mappedType] = dataSource;
+
+                var collectionName = TypeRegistry.GetCollectionName(mappedType);
+                logger.LogTrace("DataContext: Type {Type} -> CollectionName {CollectionName}",
+                    mappedType.Name, collectionName ?? "NULL");
+                if (collectionName is null)
+                    throw Fail(
+                        $"Data source '{Describe(dataSource)}' maps entity type "
+                        + $"'{mappedType.FullName ?? mappedType.Name}' but the type registry of hub "
+                        + $"'{Hub.Address}' resolves no collection name for it. Register the type on the "
+                        + "data source (WithType<T>(...)) so its collection name is known.");
+                if (dataSourcesByCollection.TryGetValue(collectionName, out var collectionOwner))
+                    throw DuplicateDataSource(
+                        "collection", collectionName, collectionOwner, dataSource);
+                dataSourcesByCollection[collectionName] = dataSource;
+            }
+        }
+        DataSourcesByType = dataSourcesByType;
         logger.LogDebug("DataContext: DataSourcesByType has {Count} entries: {Types}",
             DataSourcesByType.Count, string.Join(", ", DataSourcesByType.Keys.Select(t => t.Name)));
-        DataSourcesByCollection = DataSourcesByType.Select(kvp =>
-        {
-            var collectionName = TypeRegistry.GetCollectionName(kvp.Key);
-            logger.LogTrace("DataContext: Type {Type} -> CollectionName {CollectionName}",
-                kvp.Key.Name, collectionName ?? "NULL");
-            return new KeyValuePair<string, IDataSource>(collectionName!, kvp.Value);
-        }).ToDictionary();
+        DataSourcesByCollection = dataSourcesByCollection;
         logger.LogDebug("DataContext: DataSourcesByCollection has {Count} entries: {Collections}",
             DataSourcesByCollection.Count, string.Join(", ", DataSourcesByCollection.Keys));
 
@@ -259,6 +313,67 @@ public sealed record DataContext : IDisposable
         }
 
         logger.LogDebug("DataContext initialization setup complete for {Address}, waiting for OpenInitializationGate", Hub.Address);
+    }
+
+    /// <summary>
+    /// Identifies a data source in a diagnostic: its id plus the implementation type, which
+    /// together are what a reader needs to find the registration that produced it.
+    /// </summary>
+    private static string Describe(IDataSource dataSource) =>
+        $"{dataSource.Id} ({dataSource.GetType().Name})";
+
+    /// <summary>
+    /// Identifies a type source in a diagnostic by its entity type AND the assembly that type
+    /// comes from — the closest thing the framework can know to "which module contributed this",
+    /// since the contribution itself is an anonymous configuration lambda.
+    /// </summary>
+    private static string Describe(ITypeSource typeSource)
+    {
+        var type = typeSource.TypeDefinition.Type;
+        return $"{type.FullName ?? type.Name} from {type.Assembly.GetName().Name ?? "(unknown assembly)"}";
+    }
+
+    /// <summary>
+    /// The diagnostic for two <see cref="ITypeSource"/>s claiming one key. Names the key, the NODE
+    /// whose hub was being created, and both contributors — see the remarks at the
+    /// <see cref="Initialize"/> call site for why a bare <c>ToDictionary</c> is banned here.
+    /// </summary>
+    private Exception DuplicateRegistration(
+        string keyKind,
+        string key,
+        IDataSource firstDataSource,
+        ITypeSource firstTypeSource,
+        IDataSource secondDataSource,
+        ITypeSource secondTypeSource) =>
+        Fail(
+            $"Duplicate {keyKind} '{key}' while building the workspace of node '{Hub.Address}'. "
+            + $"It is claimed by data source '{Describe(firstDataSource)}' → {Describe(firstTypeSource)} "
+            + $"AND by data source '{Describe(secondDataSource)}' → {Describe(secondTypeSource)}. "
+            + $"A {keyKind} may be registered only once per hub. The usual cause is a hub-configuration "
+            + "lambda that is applied twice and is not idempotent — give its data source a STABLE id so "
+            + "the keep-last-by-id dedupe above collapses the second application (a fresh Guid defeats "
+            + "it), and make sure nothing composes the same configuration chain twice. The other cause "
+            + "is two modules genuinely claiming the same name; rename one.");
+
+    /// <summary>
+    /// The diagnostic for two data sources claiming one key (entity type / collection).
+    /// </summary>
+    private Exception DuplicateDataSource(
+        string keyKind, string key, IDataSource first, IDataSource second) =>
+        Fail(
+            $"Duplicate {keyKind} '{key}' while building the workspace of node '{Hub.Address}'. "
+            + $"Data sources '{Describe(first)}' and '{Describe(second)}' both claim it. "
+            + $"A {keyKind} may be owned by only one data source per hub.");
+
+    /// <summary>
+    /// Logs at Error (so the diagnostic reaches the log pipeline even where the exception is
+    /// swallowed by a hub-creation catch) and returns the exception for the caller to throw.
+    /// </summary>
+    private Exception Fail(string message)
+    {
+        logger.LogError("DataContext initialization failed for {Address}: {Message}",
+            Hub.Address, message);
+        return new InvalidOperationException(message);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/SatelliteNodePatterns.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SatelliteNodePatterns.md
@@ -250,6 +250,10 @@ var hubConfig = defaultConfig != null
 
 Skipping this composition means the shared registrations — type-registry entries such as `config.TypeRegistry.AddAITypes()`, default layout areas, and the framework's own watchers — are absent from the node hub, so cross-hub messages arrive as raw `JsonElement` and areas silently fail to resolve.
 
+🚨 **Exactly one component composes it: `MeshNodeHubFactory`** — the single funnel both activation paths (Monolith routing, `MessageHubGrain`) go through. Everything that produces a node's *own* `HubConfiguration` — the compilation-error overlay, the compilation-in-progress overlay, static/dynamic NodeType configurations, the self-heal wraps — returns its **own delta only**. Composing `DefaultNodeHubConfiguration` a second time runs **every** `ConfigureDefaultNodeHub` lambda twice for that hub. Lambdas that only add views or types absorb that silently; one that contributes a **type source** does not: `DataContext.Initialize` keys `TypeSources` by collection name, so the second application contributes a second entry for the same collection and **hub creation fails outright** — the node never comes up, and the message (`An item with the same key has already been added. Key: Approval`) names neither the lambda nor the node. That is issue #1684, seen on production memex's `Doc` hub and on three further addresses in the plugin gate; the victim is simply whichever NodeType happened to take the overlay path.
+
+Corollary for anyone writing a `ConfigureDefaultNodeHub` lambda: give any data source you contribute a **stable id** (`DataExtensions.DefaultId` is a fresh `Guid`, which defeats `DataContext.Initialize`'s keep-last-by-id dedupe), and prefer the already-idempotent `AddMeshDataSource`.
+
 ---
 
 ## Type Registry

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-node-hub-duplicate-collection.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-node-hub-duplicate-collection.md
@@ -1,0 +1,20 @@
+---
+Name: Pages no longer go dark when a node type fails to compile
+Category: Fix
+Description: A page whose node type could not be compiled could take its whole hub down; it now falls back to the error overlay as intended.
+Icon: Sparkle
+Order: -20260817
+---
+
+# Pages no longer go dark when a node type fails to compile
+
+When a node type could not be compiled, the affected page was supposed to fall back to a
+read-only "compilation error" view that still tells you what went wrong. Instead, the fallback
+could take the whole node down: its hub never started, so the page — and everything else served
+from that node — answered nothing at all. Which node was hit was effectively arbitrary; it was
+whichever type happened to fail to compile first.
+
+The fallback now applies the shared per-node setup exactly once instead of twice, so it comes up
+as designed. And in the rare case where a genuine configuration clash does stop a node from
+starting, the log now names the clashing collection, the node it happened on, and both pieces of
+configuration that claimed it — instead of a single word with no context.

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeHubFactory.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeHubFactory.cs
@@ -11,6 +11,24 @@ namespace MeshWeaver.Graph.Configuration;
 /// <see cref="NodeTypeEnrichmentHelpers.EnrichWithNodeType"/>, then composes
 /// with <c>DefaultNodeHubConfiguration</c>. Stateless — the persisted
 /// NodeType MeshNode is the cache.
+///
+/// <para>🚨 <b>THIS CLASS OWNS the default node chain — it is the ONE place that applies
+/// <see cref="MeshConfiguration.DefaultNodeHubConfiguration"/>, and it applies it EXACTLY ONCE.</b>
+/// Both real activation paths funnel through here (<c>MonolithRoutingService.CreateHub</c> and
+/// <c>MessageHubGrain.ResolveHubConfigurationObservable</c>), so nothing downstream needs to —
+/// and nothing upstream may. Every producer of a node's own <c>HubConfiguration</c>
+/// (<see cref="NodeTypeEnrichmentHelpers.WithCompilationErrorOverlay"/>, the
+/// compilation-in-progress overlay, the static/dynamic NodeType configurations, the self-heal
+/// wraps) returns its OWN delta only; this factory layers the default chain underneath it.</para>
+///
+/// <para>The rule is not cosmetic. When <c>WithCompilationErrorOverlay</c> also composed the
+/// default chain, an overlaid hub ran EVERY <c>ConfigureDefaultNodeHub</c> lambda twice. Lambdas
+/// that only add views or types absorb that silently; one that contributes a <b>type source</b>
+/// does not — <c>DataContext.Initialize</c> keys <c>TypeSources</c> by collection name, so two
+/// applications produced two <c>Approval</c> collections and <b>hub creation failed outright</b>
+/// (<c>An item with the same key has already been added. Key: Approval</c>) on production
+/// memex's <c>Doc</c> hub and on three further addresses in the plugin gate — the victim being
+/// simply whichever NodeType happened to take the overlay path (Systemorph/MeshWeaver#1684).</para>
 /// </summary>
 internal class MeshNodeHubFactory(
     IMessageHub meshHub,
@@ -56,6 +74,9 @@ internal class MeshNodeHubFactory(
                 // Repro: NodeTypePathRegistrationTest.ActivatingANodeTypeDefinition_DoesNotClaimItsOwnPathForItsInstances.
                 var nodeTypePath = enriched.NodeType;
 
+                // 🚨 The SINGLE application of the default node chain (see the class remarks).
+                // `nodeConfig` is the node's OWN delta and never contains `defaultConfig` —
+                // applying it here a second time is the #1684 defect.
                 var defaultConfig = meshConfiguration.DefaultNodeHubConfiguration;
                 var nodeConfig = enriched.HubConfiguration;
                 if (defaultConfig != null)

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -110,9 +110,9 @@ internal static class NodeTypeEnrichmentHelpers
         }
 
         var nodeType = node.NodeType;
-        // No NodeType at all: there is no node-specific configuration to resolve. Emit the node
-        // with a null HubConfiguration — MeshNodeHubFactory applies the mesh default chain
-        // (exactly once) around it. Setting it here as well is what made the chain run twice.
+        // No NodeType at all: there is no node-specific configuration to resolve, so hand the node
+        // back UNCHANGED and let MeshNodeHubFactory apply the mesh default chain — exactly once.
+        // Applying it here as well is what made the chain run twice (#1684).
         if (string.IsNullOrEmpty(nodeType))
             return Observable.Return(node);
 

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -110,8 +110,11 @@ internal static class NodeTypeEnrichmentHelpers
         }
 
         var nodeType = node.NodeType;
+        // No NodeType at all: there is no node-specific configuration to resolve. Emit the node
+        // with a null HubConfiguration — MeshNodeHubFactory applies the mesh default chain
+        // (exactly once) around it. Setting it here as well is what made the chain run twice.
         if (string.IsNullOrEmpty(nodeType))
-            return Observable.Return(ApplyDefaultConfig(node, meshConfiguration));
+            return Observable.Return(node);
 
         // Static-provider fast-path: IStaticNodeProvider-registered NodeTypes
         // ship HubConfiguration in-process (the delegate doesn't survive
@@ -179,7 +182,7 @@ internal static class NodeTypeEnrichmentHelpers
                         // instance off the overlay.
                         return Observable.Return(
                             WithOverlaySelfHeal(
-                                WithCompilationErrorOverlay(node, nodeType, msg, meshConfiguration),
+                                WithCompilationErrorOverlay(node, nodeType, msg),
                                 meshHub, nodeType, typeVersionAtOverlay: null, logger));
                     }
                     if (outcome == ProbeOutcome.Indeterminate)
@@ -369,7 +372,7 @@ internal static class NodeTypeEnrichmentHelpers
                 // and recycles this instance off the overlay.
                 return Observable.Return(
                     WithOverlaySelfHeal(
-                        WithCompilationErrorOverlay(node, nodeType, userMessage, meshConfiguration,
+                        WithCompilationErrorOverlay(node, nodeType, userMessage,
                             guidance: guidance, intro: intro, callToAction: callToAction),
                         meshHub, nodeType, typeVersionAtOverlay: null, logger));
             });
@@ -475,7 +478,7 @@ internal static class NodeTypeEnrichmentHelpers
             // predicate rejects Pending/Compiling): activate the progress overlay now
             // and let its self-heal recycle the instance when the compile lands.
             .SelectMany(typeNode => IsCompileInFlight(typeNode, meshHub.JsonSerializerOptions)
-                ? WithCompilationInProgressOverlay(node, nodeType, typeNode, meshConfiguration, meshHub, logger)
+                ? WithCompilationInProgressOverlay(node, nodeType, typeNode, meshHub, logger)
                 : ApplyStreamResult(
                     typeNode, node, nodeType, meshConfiguration, compilationService, meshHub, logger));
     }
@@ -498,7 +501,7 @@ internal static class NodeTypeEnrichmentHelpers
     /// "this path holds something that is not a NodeType at all" — admitted the emission as
     /// SETTLED. <see cref="ApplyStreamResult"/> then deserialized the very same node successfully
     /// and acted on a state this gate exists to reject: a pre-compile snapshot
-    /// (<c>CompilationStatus</c> null/Unknown) routes to <see cref="ApplyDefaultConfig"/>, so the
+    /// (<c>CompilationStatus</c> null/Unknown) routes to the no-node-configuration branch, so the
     /// instance hub binds the mesh DEFAULT configuration for the grain's WHOLE lifetime (enrichment
     /// binds once and never re-observes) — the NodeType's real areas, and a broken type's
     /// compilation-error overlay, can then never appear on the instance's page. A Pending/Compiling
@@ -772,21 +775,22 @@ internal static class NodeTypeEnrichmentHelpers
 
         // The NodeType path does not resolve to a NodeTypeDefinition — it is a
         // plain node (or a node mis-used as a type path). There is nothing to
-        // compile; apply the default hub config so the instance is still usable
-        // and queryable, rather than overlaying a (false) compilation error.
+        // compile; emit with no node configuration so the instance still gets the mesh
+        // default chain from MeshNodeHubFactory (and is usable and queryable), rather
+        // than overlaying a (false) compilation error.
         if (def is null)
-            return Observable.Return(ApplyDefaultConfig(node, meshConfiguration));
+            return Observable.Return(node);
 
         // NodeTypeDefinition with no compile lifecycle attached and no
         // HubConfiguration: a test-seeded type definition (or any framework
-        // type that won't be Roslyn-compiled). Apply the default node hub
-        // config so per-instance hubs activate without waiting on a compile
-        // that will never start.
+        // type that won't be Roslyn-compiled). No node configuration to resolve — the
+        // factory's default node chain alone lets per-instance hubs activate without
+        // waiting on a compile that will never start.
         if ((def.CompilationStatus is null
                 || def.CompilationStatus == CompilationStatus.Unknown)
             && typeNode.HubConfiguration is null)
         {
-            return Observable.Return(ApplyDefaultConfig(node, meshConfiguration));
+            return Observable.Return(node);
         }
 
         // Pinned release: when NodeTypeDefinition.RequestedReleasePath is set,
@@ -824,7 +828,6 @@ internal static class NodeTypeEnrichmentHelpers
                             WithOverlaySelfHeal(
                                 WithCompilationErrorOverlay(node, nodeType,
                                     $"Pinned release '{requestedReleasePath}' for '{nodeType}' could not be resolved.",
-                                    meshConfiguration,
                                     guidance: unresolvedGuidance,
                                     intro: unresolvedIntro,
                                     callToAction: unresolvedCta,
@@ -866,7 +869,6 @@ internal static class NodeTypeEnrichmentHelpers
                                         WithOverlaySelfHeal(
                                             WithCompilationErrorOverlay(node, nodeType,
                                                 $"Pinned release '{requestedReleasePath}' assembly not found in store.",
-                                                meshConfiguration,
                                                 guidance: missGuidance,
                                                 intro: missIntro,
                                                 callToAction: missCta,
@@ -1069,7 +1071,6 @@ internal static class NodeTypeEnrichmentHelpers
                     WithOverlaySelfHeal(
                         WithCompilationErrorOverlay(node, nodeType,
                             "Built against a previous framework version",
-                            meshConfiguration,
                             guidance: staleGuidance,
                             intro: staleIntro,
                             callToAction: staleCta,
@@ -1098,7 +1099,6 @@ internal static class NodeTypeEnrichmentHelpers
                     WithCompilationErrorOverlay(node, nodeType,
                         def.CompilationError
                             ?? $"The compile state of NodeType '{nodeType}' could not be determined.",
-                        meshConfiguration,
                         guidance: undeterminedGuidance,
                         intro: undeterminedIntro,
                         callToAction: undeterminedCta,
@@ -1116,7 +1116,7 @@ internal static class NodeTypeEnrichmentHelpers
         // diagnostics the NodeType's own Overview offers.
         return Observable.Return(
             WithOverlaySelfHeal(
-                WithCompilationErrorOverlay(node, nodeType, error, meshConfiguration,
+                WithCompilationErrorOverlay(node, nodeType, error,
                     activityPath: def.LastCompilationActivityPath),
                 meshHub, nodeType, typeNode.Version, logger));
     }
@@ -1226,7 +1226,7 @@ internal static class NodeTypeEnrichmentHelpers
                 // every dynamic type): stop holding the activation and serve the live
                 // progress overlay; its self-heal recycles the instance when the build lands.
                 .SelectMany(newTypeNode => IsCompileInFlight(newTypeNode, meshHub.JsonSerializerOptions)
-                    ? WithCompilationInProgressOverlay(node, nodeType, newTypeNode, meshConfiguration, meshHub, logger)
+                    ? WithCompilationInProgressOverlay(node, nodeType, newTypeNode, meshHub, logger)
                     : ApplyStreamResult(
                         newTypeNode, node, nodeType, meshConfiguration,
                         compilationService, meshHub, logger, recompileAttempts + 1));
@@ -1353,15 +1353,6 @@ internal static class NodeTypeEnrichmentHelpers
         var dash = version.IndexOf('-');
         var head = dash > 0 ? version[..dash] : version;
         return long.TryParse(head, out var v) ? v : 0;
-    }
-
-    public static MeshNode ApplyDefaultConfig(MeshNode node, MeshConfiguration meshConfiguration)
-    {
-        if (node.HubConfiguration != null) return node;
-        var defaultConfig = meshConfiguration.DefaultNodeHubConfiguration;
-        return defaultConfig != null
-            ? node with { HubConfiguration = defaultConfig }
-            : node;
     }
 
     /// <summary>
@@ -1787,22 +1778,31 @@ internal static class NodeTypeEnrichmentHelpers
     /// anchor the NodeType's OWN Overview offers — the broken INSTANCE page used to be the
     /// one place with no route to the diagnostics (#641). Null simply omits the link.
     /// </param>
+    /// <remarks>
+    /// 🚨 Returns the overlay DELTA ONLY. It must never compose
+    /// <see cref="MeshConfiguration.DefaultNodeHubConfiguration"/> itself —
+    /// <see cref="MeshNodeHubFactory"/> is the single owner of the default node chain and layers
+    /// it UNDERNEATH whatever configuration the node carries. Composing it here as well ran every
+    /// <c>ConfigureDefaultNodeHub</c> lambda TWICE on the overlay path; a lambda contributing a
+    /// type source then produced two entries for one collection name and
+    /// <c>DataContext.Initialize</c> FAILED HUB CREATION with
+    /// <c>An item with the same key has already been added. Key: Approval</c> — production
+    /// memex's <c>Doc</c> hub plus three further addresses in the plugin gate
+    /// (Systemorph/MeshWeaver#1684). Repro: <c>DefaultNodeChainSingleApplicationTest</c>.
+    /// </remarks>
     public static MeshNode WithCompilationErrorOverlay(
         MeshNode node,
         string nodeType,
         string? error,
-        MeshConfiguration meshConfiguration,
         string? guidance = null,
         string? intro = null,
         string? callToAction = null,
         string? activityPath = null)
     {
-        var baseConfig = string.IsNullOrEmpty(error)
-            ? (node.HubConfiguration ?? meshConfiguration.DefaultNodeHubConfiguration)
-            : meshConfiguration.DefaultNodeHubConfiguration;
-
+        // Nothing to overlay: hand the node back untouched and let the factory apply the
+        // default chain (exactly once) around whatever configuration it already carries.
         if (string.IsNullOrEmpty(error))
-            return node with { HubConfiguration = baseConfig };
+            return node;
 
         var overlay = CreateCompilationErrorConfiguration(error, guidance, intro, callToAction, activityPath);
         // Fallback-hub contract: the overlay hub serves what its default config CAN
@@ -1815,9 +1815,8 @@ internal static class NodeTypeEnrichmentHelpers
             $"NodeType '{nodeType}' has no usable hub configuration for '{node.Path}': {error}",
             ErrorType.CompilationFailed,
             nodeType);
-        Func<MessageHubConfiguration, MessageHubConfiguration> composed = baseConfig != null
-            ? (config => overlay(baseConfig(config)).Set(nack))
-            : (config => overlay(config).Set(nack));
+        Func<MessageHubConfiguration, MessageHubConfiguration> composed =
+            config => overlay(config).Set(nack);
         return node with { HubConfiguration = composed };
     }
 
@@ -1838,11 +1837,14 @@ internal static class NodeTypeEnrichmentHelpers
     ///     recycles this instance, and the next access enriches against the settled type.</item>
     /// </list>
     /// </summary>
+    /// <remarks>
+    /// 🚨 Like <see cref="WithCompilationErrorOverlay"/>, this returns the overlay DELTA ONLY —
+    /// <see cref="MeshNodeHubFactory"/> owns applying the default node chain, exactly once.
+    /// </remarks>
     internal static IObservable<MeshNode> WithCompilationInProgressOverlay(
         MeshNode node,
         string nodeType,
         MeshNode typeNode,
-        MeshConfiguration meshConfiguration,
         IMessageHub meshHub,
         ILogger? logger)
     {
@@ -1856,10 +1858,8 @@ internal static class NodeTypeEnrichmentHelpers
             $"NodeType '{nodeType}' is compiling — '{node.Path}' activates when the build settles.",
             ErrorType.CompilationInProgress,
             nodeType);
-        var baseConfig = meshConfiguration.DefaultNodeHubConfiguration;
-        Func<MessageHubConfiguration, MessageHubConfiguration> composed = baseConfig != null
-            ? (config => overlay(baseConfig(config)).Set(nack))
-            : (config => overlay(config).Set(nack));
+        Func<MessageHubConfiguration, MessageHubConfiguration> composed =
+            config => overlay(config).Set(nack);
         return Observable.Return(WithOverlaySelfHeal(
             node with { HubConfiguration = composed },
             meshHub, nodeType, typeVersionAtOverlay: typeNode.Version, logger));

--- a/src/MeshWeaver.Mesh.Contract/MeshConfiguration.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshConfiguration.cs
@@ -84,6 +84,14 @@ public class MeshConfiguration(
     /// Default configuration applied to all node hubs.
     /// Use this to set up content collections, views, or other configuration
     /// that should be available on every node hub.
+    ///
+    /// <para>🚨 <b>Exactly ONE component applies this: <c>MeshNodeHubFactory</c></b> (the single
+    /// funnel both activation paths — Monolith routing and <c>MessageHubGrain</c> — go through).
+    /// Never compose it into a node's own <c>HubConfiguration</c> as well: the chain would then run
+    /// TWICE for that hub, doubling every <c>ConfigureDefaultNodeHub</c> lambda's contribution. A
+    /// lambda that registers a type source then contributes two type sources for one collection
+    /// name and <c>DataContext.Initialize</c> FAILS HUB CREATION — the node never comes up
+    /// (Systemorph/MeshWeaver#1684).</para>
     /// </summary>
     public Func<MessageHubConfiguration, MessageHubConfiguration>? DefaultNodeHubConfiguration { get; } = defaultNodeHubConfiguration;
 

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshNodeHubFactory.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshNodeHubFactory.cs
@@ -31,6 +31,12 @@ public interface IMeshNodeHubFactory
     /// configuration with the mesh's <c>DefaultNodeHubConfiguration</c> so
     /// per-node hubs inherit cross-cutting concerns (security pipeline, layout
     /// areas, etc.) registered globally.
+    ///
+    /// <para>🚨 This is the SINGLE place the default node chain is applied, and it is applied
+    /// EXACTLY ONCE. The node configuration it composes is the node's own delta; anything that
+    /// also folds <c>DefaultNodeHubConfiguration</c> in makes the chain run twice for that hub,
+    /// which fails hub creation for any <c>ConfigureDefaultNodeHub</c> lambda that registers a
+    /// type source (Systemorph/MeshWeaver#1684).</para>
     /// </summary>
     IObservable<MeshNode> ResolveHubConfiguration(MeshNode node);
 }

--- a/test/MeshWeaver.Graph.Test/CompileSettlePredicateTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompileSettlePredicateTest.cs
@@ -24,8 +24,9 @@ namespace MeshWeaver.Graph.Test;
 /// the gate exists to reject.</para>
 ///
 /// <para>Consequence, and why it is user-visible rather than merely untidy: a PRE-COMPILE snapshot
-/// (<c>CompilationStatus</c> null/Unknown) routes to <c>ApplyDefaultConfig</c>, so the instance hub
-/// binds the mesh DEFAULT configuration — and enrichment binds ONCE, never re-observing, so it is
+/// (<c>CompilationStatus</c> null/Unknown) routes to the "no node configuration" branch, so the
+/// instance hub binds only the mesh DEFAULT configuration the hub factory applies — and enrichment
+/// binds ONCE, never re-observing, so it is
 /// bound for the grain's whole lifetime. The NodeType's own layout areas never appear on the
 /// instance's page, and for a NON-COMPILING type the compilation-error overlay can never surface:
 /// the page renders (data flows, the area emits) and simply never contains the error. An in-flight

--- a/test/MeshWeaver.Hosting.Monolith.Test/DefaultNodeChainIdempotenceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DefaultNodeChainIdempotenceTest.cs
@@ -13,12 +13,15 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// Pins that the default-node-hub configuration chain is IDEMPOTENT — applying it twice to one
 /// hub must be harmless (#1700).
 ///
-/// <para>Twice is not hypothetical: <c>NodeTypeEnrichmentHelpers.WithCompilationErrorOverlay</c>
-/// composes <c>MeshConfiguration.DefaultNodeHubConfiguration</c> INTO the instance's hub
-/// configuration (<c>config =&gt; overlay(baseConfig(config))</c>), on top of whatever default
-/// application the hub creation path already performs — so every package-root node that lands on
-/// the unresolvable-NodeType overlay (e.g. a <c>Store/Plugin</c>-typed root in a gate mesh that
-/// does not mount Store) runs the chain twice.</para>
+/// <para>Twice was not hypothetical: <c>NodeTypeEnrichmentHelpers.WithCompilationErrorOverlay</c>
+/// used to compose <c>MeshConfiguration.DefaultNodeHubConfiguration</c> INTO the instance's hub
+/// configuration (<c>config =&gt; overlay(baseConfig(config))</c>), on top of the application
+/// <c>MeshNodeHubFactory</c> already performs — so every node that landed on the
+/// unresolvable-NodeType overlay ran the chain twice. #1684 removed that second application at its
+/// root: the factory is now the SINGLE owner of the default chain, pinned by
+/// <c>DefaultNodeChainSingleApplicationTest</c>. This test keeps the belt-and-braces half — a chain
+/// that IS applied twice must remain harmless — because the chain is composed by third-party
+/// modules and a non-idempotent one is a live trap regardless of who applies it.</para>
 ///
 /// <para>Before the fix, the Approvals module's per-node registration added a
 /// <c>MeshDataSource</c> whose id was <c>Guid.NewGuid()</c> on EVERY application, defeating

--- a/test/MeshWeaver.Hosting.Monolith.Test/DefaultNodeChainSingleApplicationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DefaultNodeChainSingleApplicationTest.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Concurrent;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the two halves of Systemorph/MeshWeaver#1684.
+///
+/// <para><b>(1) The default node chain is applied EXACTLY ONCE per hub.</b>
+/// <see cref="MeshNodeHubFactory"/> owns applying <c>MeshConfiguration.DefaultNodeHubConfiguration</c>;
+/// every producer of a node's own configuration — notably
+/// <see cref="NodeTypeEnrichmentHelpers.WithCompilationErrorOverlay"/> — returns its own delta only.
+/// The overlay used to compose the default chain as well, so an overlaid hub ran every
+/// <c>ConfigureDefaultNodeHub</c> lambda TWICE. Lambdas that only add views or types absorb that
+/// silently; one that contributes a TYPE SOURCE does not — <c>DataContext.Initialize</c> keys
+/// <c>TypeSources</c> by collection name, so the second application produced a second
+/// <c>Approval</c> collection and <b>hub creation failed outright</b>. Production memex's
+/// <c>Doc</c> hub, then <c>Store</c>, <c>Publish/Deck/GateProbe</c> and
+/// <c>DoublePendulum/Pendulum/GateProbe</c> in the plugin gate — the victim is simply whichever
+/// NodeType happens to take the overlay path.</para>
+///
+/// <para><b>(2) A genuine duplicate still FAILS — but says what and where.</b> Four separate
+/// incident reports had to be reverse-engineered from <c>An item with the same key has already been
+/// added. Key: Approval</c>, which names neither the hub nor either contributor. The diagnostic now
+/// names the colliding collection, the node whose hub was being created, and both data sources.
+/// (Deliberately not a <c>DistinctBy</c> — that would HIDE a real duplicate.)</para>
+/// </summary>
+public class DefaultNodeChainSingleApplicationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string InstanceId = "overlay-probe";
+    private const string MissingNodeType = "No/Such/NodeType";
+    private const string FirstContributorId = "first-contributor-data-source";
+    private const string SecondContributorId = "second-contributor-data-source";
+
+    /// <summary>The entity the probe lambda contributes a type source for; its name IS the collection name.</summary>
+    public record DefaultChainProbe([property: Key] string Id);
+
+    /// <summary>
+    /// How often the default node chain ran, per hub address path. INSTANCE state — never static
+    /// (AGENTS.md: no static collections); its lifetime is this class's mesh.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, int> applicationsPerAddress = new();
+
+    /// <summary>Error-level log lines emitted by this mesh — the operator-visible half of the diagnostic.</summary>
+    private readonly ConcurrentQueue<string> errorLog = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+                services.AddSingleton<ILoggerProvider>(new CapturingLoggerProvider(errorLog)))
+            .ConfigureDefaultNodeHub(config =>
+            {
+                applicationsPerAddress.AddOrUpdate(config.Address.Path, 1, (_, count) => count + 1);
+                // Deliberately NON-idempotent, in the exact shape of the #1684 victim: a data source
+                // whose id is fresh on every application — which is what AddSource's DEFAULT id
+                // already is (DataExtensions.DefaultId = a new Guid), so this is not an exotic
+                // mistake — contributing a type source for a FIXED collection name. Applied twice,
+                // the keep-last-by-id dedupe in DataContext.Initialize can never fire, two type
+                // sources claim the 'DefaultChainProbe' collection, and hub creation dies.
+                return config.AddData(data =>
+                    data.AddSource(source => source.WithType<DefaultChainProbe>()));
+            });
+
+    /// <summary>
+    /// The compilation-error overlay composed by the real <see cref="IMeshNodeHubFactory"/> — the
+    /// exact composition <c>MonolithRoutingService.CreateHub</c> and
+    /// <c>MessageHubGrain.ResolveHubConfigurationObservable</c> build — must run the default node
+    /// chain once, and the resulting hub must come up.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task OverlaidInstanceHub_RunsTheDefaultNodeChainExactlyOnce()
+    {
+        // Not persisted on purpose: `CreateNode` refuses an unregistered NodeType, and the
+        // composition under test is the hub-configuration chain, which never reads the node row.
+        var node = new MeshNode(InstanceId, TestPartition)
+        {
+            Name = "Overlay probe",
+            NodeType = MissingNodeType
+        };
+
+        // The shape EnrichWithNodeType produces when a NodeType cannot be resolved.
+        var overlaid = NodeTypeEnrichmentHelpers.WithCompilationErrorOverlay(
+            node, MissingNodeType, "deliberate: this NodeType has no usable hub configuration");
+        overlaid.HubConfiguration.Should().NotBeNull(
+            "the overlay always yields a usable hub configuration so the instance still activates");
+
+        var factory = Mesh.ServiceProvider.GetRequiredService<IMeshNodeHubFactory>();
+        var enriched = await factory.ResolveHubConfiguration(overlaid).Should().Emit();
+        enriched.HubConfiguration.Should().NotBeNull();
+
+        var address = new Address(TestPartition, InstanceId);
+        var hub = Mesh.GetHostedHub(address, c => enriched.HubConfiguration!(c));
+
+        hub.Should().NotBeNull(
+            "an overlaid instance must still activate — HostedHubsCollection swallows a failed "
+            + "creation and returns null, which is exactly how the #1684 hubs went missing");
+
+        applicationsPerAddress.GetValueOrDefault(address.Path).Should().Be(1,
+            "MeshNodeHubFactory is the SINGLE owner of the default node chain. Two applications "
+            + "double every ConfigureDefaultNodeHub lambda's contribution, and the next one that "
+            + "registers a type source fails hub creation with a message that names neither the "
+            + "lambda nor the node (#1684)");
+
+        hub!.ServiceProvider.GetRequiredService<IWorkspace>().Should().NotBeNull(
+            "resolving IWorkspace forces DataContext.Initialize — a doubled non-idempotent "
+            + "contribution threw 'duplicate collection' right here and left the hub uncreatable");
+    }
+
+    /// <summary>
+    /// A collection genuinely claimed by two data sources must still FAIL — and the diagnostic must
+    /// name the collection, the node, and BOTH contributors, so the next report is a one-line
+    /// diagnosis instead of a fifth reverse-engineering from a stack trace.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void DuplicateCollection_Diagnostic_NamesCollectionNodeAndBothContributors()
+    {
+        var address = new Address(TestPartition, "duplicate-collection-diagnostic");
+
+        var hub = Mesh.GetHostedHub(address, config => config.AddData(data => data
+            .AddSource(source => source.WithType<DefaultChainProbe>(), id: FirstContributorId)
+            .AddSource(source => source.WithType<DefaultChainProbe>(), id: SecondContributorId)));
+
+        hub.Should().BeNull(
+            "two data sources claiming one collection is a configuration defect — DataContext must "
+            + "FAIL rather than silently dedupe it away (a DistinctBy would hide a real duplicate)");
+
+        var diagnostic = errorLog.FirstOrDefault(line => line.Contains(nameof(DefaultChainProbe)));
+        diagnostic.Should().NotBeNull(
+            "the duplicate must be reported at Error level — HostedHubsCollection swallows the "
+            + "exception, so the log line is all an operator ever sees");
+        diagnostic.Should().Contain(nameof(DefaultChainProbe),
+            "the diagnostic must name the colliding collection");
+        diagnostic.Should().Contain(address.Path,
+            "the diagnostic must name the node whose hub was being created — every #1684 report had "
+            + "to recover this from the surrounding log lines");
+        diagnostic.Should().Contain(FirstContributorId,
+            "the diagnostic must name the first contributing data source");
+        diagnostic.Should().Contain(SecondContributorId,
+            "the diagnostic must name the second contributing data source");
+        diagnostic.Should().Contain(typeof(DefaultChainProbe).Assembly.GetName().Name!,
+            "the entity type's assembly is the closest the framework can get to naming the module "
+            + "that contributed an otherwise anonymous configuration lambda");
+    }
+
+    /// <summary>
+    /// In-memory Error-level log sink. An instance per mesh (constructed in <c>ConfigureMesh</c>),
+    /// writing into a queue owned by the test instance — no static state.
+    /// </summary>
+    private sealed class CapturingLoggerProvider(ConcurrentQueue<string> sink) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(sink);
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(ConcurrentQueue<string> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel))
+                    return;
+                var line = formatter(state, exception);
+                if (exception is not null)
+                    line += Environment.NewLine + exception;
+                sink.Enqueue(line);
+            }
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicGraphIntegrationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicGraphIntegrationTest.cs
@@ -924,8 +924,25 @@ public class DynamicGraphFileSystemPersistenceTest : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Tests the complete flow: node loading, type compilation, and HubConfiguration setting.
+    /// Tests the complete flow: node loading, type resolution, and HubConfiguration setting.
     /// This is the end-to-end test for the production scenario.
+    ///
+    /// <para>🚨 It resolves through <see cref="IMeshNodeHubFactory"/> — the component production
+    /// actually uses (<c>MonolithRoutingService.CreateHub</c>, <c>MessageHubGrain</c>) and the ONE
+    /// owner of the mesh default node chain — NOT <c>INodeConfigurationResolver</c>, which returns
+    /// only the node's OWN configuration.</para>
+    ///
+    /// <para>It used to use the resolver and claim the configuration came "from the compiled
+    /// assembly". It never did, and could not: measured on this fixture, <c>Type/Organizations</c>
+    /// stays at <c>CompilationStatus = null</c> indefinitely (45 s, exactly one emission — no
+    /// compile is ever driven), its <c>NodeTypeDefinition</c> declares no <c>Configuration</c>
+    /// lambda and no <c>Sources</c>, and <c>LatestAssemblyPath</c> is never set. What the assertion
+    /// actually observed was the mesh DEFAULT chain, which the enrichment used to stamp onto the
+    /// node in its "NodeTypeDefinition with no compile lifecycle" branch. #1684 moved that single
+    /// application to the factory, which is why this test has to ask the factory for it. The
+    /// property under test is real and still fails if it breaks — a node whose type resolves to
+    /// nothing compilable must STILL come out with a usable hub configuration — it just no longer
+    /// claims a provenance it never had.</para>
     /// </summary>
     // 🚨 The waits below are EXPLICIT because this test performs a real on-demand Roslyn compile.
     // The default stream-assertion budget is 10s (ObservableAssertions.DefaultTimeout), which a
@@ -933,24 +950,27 @@ public class DynamicGraphFileSystemPersistenceTest : MonolithMeshTestBase
     // on PRs that changed nothing (#834). The declared Fact budget already anticipated a slow
     // operation; the inner waits now match it instead of silently capping at half.
     [Fact(Timeout = 60_000)]
-    public async Task FileSystem_Organizations_GetsHubConfiguration_FromCompiledAssembly()
+    public async Task FileSystem_Organizations_GetsUsableHubConfiguration()
     {
-        var compileBudget = TimeSpan.FromSeconds(30);
+        var resolveBudget = TimeSpan.FromSeconds(30);
 
-        // Act - get the Organizations node (triggers on-demand compilation from disk files)
-        var node = await ReadNode("Organizations").Should(compileBudget).Emit();
+        // Act - get the Organizations node from disk
+        var node = await ReadNode("Organizations").Should(resolveBudget).Emit();
 
         // Assert
         node.Should().NotBeNull("Organizations node should exist on disk");
 
-        // Resolve via INodeConfigurationResolver to trigger compilation and populate HubConfiguration.
-        var resolver = Mesh.ServiceProvider.GetRequiredService<INodeConfigurationResolver>();
-        node = await resolver.ResolveConfiguration(node!).Should(compileBudget).Emit();
+        // Resolve through the production funnel: enrichment PLUS the single application of the
+        // mesh default node chain. This is exactly what routing does before creating the hub.
+        var factory = Mesh.ServiceProvider.GetRequiredService<IMeshNodeHubFactory>();
+        node = await factory.ResolveHubConfiguration(node!).Should(resolveBudget).Emit();
 
         node.HubConfiguration.Should().NotBeNull(
-            "Organizations node should have HubConfiguration from the compiled assembly. " +
-            "If null, the on-demand compilation failed - likely because NodeTypeDefinition or CodeConfiguration " +
-            "were not properly deserialized from JSON (returned as JsonElement instead).");
+            "the Organizations node must come out of hub-configuration resolution with a usable " +
+            "configuration — routing keys its fail-fast NACK-fallback hub on a null one. If this " +
+            "is null, either enrichment produced nothing AND the mesh registers no default node " +
+            "chain, or NodeTypeDefinition/CodeConfiguration failed to deserialize from JSON " +
+            "(returned as JsonElement instead of the typed content).");
     }
 }
 


### PR DESCRIPTION
Closes #1684 — the two items left open after #1700.

## 1. `DefaultNodeHubConfiguration` was still applied TWICE per overlaid hub

#1700 fixed the *victim*, not the *cause*: it made the Approvals lambda tolerant (a
`HasApprovals()` short-circuit + a stable data-source id). The double application itself was
untouched, so the next non-idempotent `ConfigureDefaultNodeHub` lambda anyone wrote would have
reproduced the outage exactly — hub creation dying with a message naming neither the lambda nor the
node.

The two composing sites were:

1. `NodeTypeEnrichmentHelpers.WithCompilationErrorOverlay` / `WithCompilationInProgressOverlay` /
   `ApplyDefaultConfig` — composed the mesh default chain **into** `node.HubConfiguration`;
2. `MeshNodeHubFactory` — then wrapped that with the same chain again.

**`MeshNodeHubFactory` now owns it and applies it exactly once.** It is already the single funnel
both real activation paths go through (`MonolithRoutingService.CreateHub`,
`MessageHubGrain.ResolveHubConfigurationObservable`), and its `nodeConfig == null` branch already
handled "node has no configuration of its own". So:

- both overlays return their **delta only** (`config => overlay(config).Set(nack)`), and lose their
  now-unused `meshConfiguration` parameter;
- `ApplyDefaultConfig` is **deleted**; its three branches emit the node with a null
  `HubConfiguration`, which the factory's existing else-branch turns into
  `defaultConfig(config).WithNodeTypePath(path)` — one application, same ordering, same stamp.

The overlay path is not weakened: a type with a compile error still yields a usable hub (the overlay
layout + the `UnhandledMessageNack`), just with the default chain applied underneath it once instead
of twice.

Audited every `ConfigureDefaultNodeHub` call site in the repo: Approvals was the only lambda that
contributed a data source with a non-stable id. Everything else goes through `AddMeshDataSource`
(marker-idempotent, stable id keyed on the hub address), which is why the double application was
silently absorbed everywhere else — exactly matching the evidence in the issue.

## 2. The exception named neither the declarer nor the node

`DataContext.Initialize`'s `ToDictionary(x => x.CollectionName)` threw
`An item with the same key has already been added. Key: Approval` — one word, no hub, no
contributor. Four separate production/CI reports each had to be reverse-engineered from it.

The four lookups are now built explicitly and fail with a message naming the colliding key, the
**node** whose hub was being created, and **both** contributors — data-source id, implementation
type, entity type, and the entity type's **assembly** (the closest the framework can get to naming
the module behind an otherwise anonymous configuration lambda). Logged at `Error` as well as thrown,
because `HostedHubsCollection` swallows a failed hub creation and returns null — the log line is all
an operator ever sees.

Still a hard failure. Not a `DistinctBy`, not a try/catch — a real duplicate must still stop the hub.

Actual output from the regression test:

```
[Error] [MeshWeaver.Data.DataContext] DataContext initialization failed for TestData/overlay-probe:
Duplicate collection 'DefaultChainProbe' while building the workspace of node 'TestData/overlay-probe'.
It is claimed by data source 'EWIY9YcHg02fabLbD8wpiw (GenericUnpartitionedDataSource)' →
…+DefaultChainProbe from MeshWeaver.Hosting.Monolith.Test AND by data source
'Vo7xQAdrvEam4AvTCCI0eg (GenericUnpartitionedDataSource)' → …+DefaultChainProbe from
MeshWeaver.Hosting.Monolith.Test. A collection may be registered only once per hub. The usual cause
is a hub-configuration lambda that is applied twice and is not idempotent — …
```

## Regression tests

`test/MeshWeaver.Hosting.Monolith.Test/DefaultNodeChainSingleApplicationTest.cs`
(`MonolithMeshTestBase`, no mocking, no `Task.Delay`). Its `ConfigureDefaultNodeHub` lambda is
deliberately **non-idempotent** in the exact pre-#1700 Approvals shape — a data source with a fresh
id per application (which is `AddSource`'s *default*: `DataExtensions.DefaultId` is a new Guid) plus
a type source for a fixed collection name — and counts its own applications per hub address.

- `OverlaidInstanceHub_RunsTheDefaultNodeChainExactlyOnce` — drives the real overlay through the real
  `IMeshNodeHubFactory` (the exact composition routing/grain build), asserts the chain ran **once**
  and that the resulting hub comes up with a working `IWorkspace`.
- `DuplicateCollection_Diagnostic_NamesCollectionNodeAndBothContributors` — a genuine duplicate must
  still fail, and the Error log must name the collection, the node, both data-source ids and the
  contributing assembly.

**Both were verified to FAIL with the double application reintroduced** (`GetHostedHub` returns
null — precisely the production symptom), and to pass with the fix.

`DefaultNodeChainIdempotenceTest` (#1700) is kept as the belt-and-braces half — a chain that *is*
applied twice must remain harmless — with its doc comment corrected to say the double application is
gone.

## Verification

- Release `-warnaserror` (`-p:CIRun=true`), 0 warnings / 0 errors: `MeshWeaver.Mesh.Contract`,
  `MeshWeaver.Data`, `MeshWeaver.Graph`, `MeshWeaver.Hosting`, `MeshWeaver.Documentation`,
  `MeshWeaver.Plugin.Build`, and every test project with `InternalsVisibleTo` on
  `MeshWeaver.Graph` (`Graph.Test`, `Query.Test`, `Hosting.Monolith.Test`) plus `Data.Test`,
  `Content.Test`, `Documentation.Test`.
- Tests: `MeshWeaver.Graph.Test` 1233/1233 · `MeshWeaver.Data.Test` 374/374 ·
  `MeshWeaver.Documentation.Test` 23/23 · `MeshWeaver.Content.Test` `CompileErrorOverviewTest` 4/4 ·
  `MeshWeaver.Hosting.Monolith.Test` overlay/compile-park/default-chain subset 26/26.

## Docs

`SatelliteNodePatterns.md` (the page that shows the composition) now states the single-owner rule and
the "stable id / prefer `AddMeshDataSource`" corollary; `MeshConfiguration.DefaultNodeHubConfiguration`,
`IMeshNodeHubFactory` and `MeshNodeHubFactory` carry it in XML docs.

What's New: `Category: Fix` — a page whose node type fails to compile used to take its whole hub
down instead of falling back to the error overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
