### PR TITLE
fix: CD bake — survive a registry blip, and compile ONLY what the image embeds (#1725)

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1024,19 +1024,24 @@ jobs:
           IMAGE: ${{ env.ACR }}/mw-plugin-test:${{ needs.gate.outputs.staging_tag }}
         run: |
           set -uo pipefail
+          attempts=5
           ok=0
-          for attempt in 1 2 3 4 5; do
+          for attempt in $(seq 1 $attempts); do
             if az acr login --name meshweaver && docker pull --quiet --platform linux/amd64 "$IMAGE"; then
               echo "$IMAGE: registry reached and image pulled on attempt $attempt"
               ok=1; break
             fi
-            # Backoff: 5s, 10s, 20s, 40s — registry blips are seconds-to-minutes.
-            delay=$((5 * 2 ** (attempt - 1)))
-            echo "registry attempt $attempt failed; retrying in ${delay}s" >&2
-            sleep $delay
+            # Backoff: 5s, 10s, 20s, 40s — registry blips are seconds-to-minutes. Only BETWEEN
+            # attempts: sleeping after the last failure would add 80s to reporting an outage we
+            # have already decided not to retry.
+            if [ "$attempt" -lt "$attempts" ]; then
+              delay=$((5 * 2 ** (attempt - 1)))
+              echo "registry attempt $attempt failed; retrying in ${delay}s" >&2
+              sleep $delay
+            fi
           done
           if [ $ok -eq 0 ]; then
-            echo "::error::could not log in to ${{ env.ACR }} and pull $IMAGE after 5 attempts — this is a REGISTRY/INFRA failure, not a bake failure. The image set for this commit is already promoted; its platform content bake was NOT published, so pods compile shipped content at boot until a later CD run republishes it."
+            echo "::error::could not log in to ${{ env.ACR }} and pull $IMAGE after $attempts attempts — this is a REGISTRY/INFRA failure, not a bake failure. The image set for this commit is already promoted; its platform content bake was NOT published, so pods compile shipped content at boot until a later CD run republishes it."
             exit 1
           fi
       # ── WHAT THIS BAKES, AND WHAT IT DELIBERATELY DOES NOT ──────────────────────────────────

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1039,7 +1039,29 @@ jobs:
             echo "::error::could not log in to ${{ env.ACR }} and pull $IMAGE after 5 attempts — this is a REGISTRY/INFRA failure, not a bake failure. The image set for this commit is already promoted; its platform content bake was NOT published, so pods compile shipped content at boot until a later CD run republishes it."
             exit 1
           fi
-      - name: "Bake the platform's shipped content INSIDE the promoted image"
+      # ── WHAT THIS BAKES, AND WHAT IT DELIBERATELY DOES NOT ──────────────────────────────────
+      # 🚨 ONLY the content the IMAGE itself embeds: `src/MeshWeaver.Documentation/Data`, which
+      # `Memex.Portal.Shared` references as MeshWeaver.Documentation and every portal therefore
+      # ships inside itself. Nothing else. Compiling anything a deployment receives ALREADY BUILT
+      # is redoing work someone else's lane already did, and it is the expensive half of a bake.
+      #
+      # Everything else a portal holds arrives compiled and is ADOPTED, not rebuilt:
+      #   * node-repo content (Plugins, Education, Reinsurance, SocialMedia) and Store packages —
+      #     each repo's own `node-repo-publish-bake` lane bakes and publishes them under the SAME
+      #     framework identity, from the same image. main-cd checks out no other repository (there
+      #     is not one `repository:` input in this file), so it could not compile them even by
+      #     accident — and must never be given the chance.
+      #   * `samples/Graph/Data` — REMOVED from this bake deliberately. Measured against the
+      #     shipped image: the samples half compiled 7 packages / 24 assemblies (ACME, Cornerstone,
+      #     FutuRe, MathDemo, Northwind, PythonDemo, Systemorph) whose bundles NO deployment can
+      #     adopt. No portal embeds them (Memex.Portal.Shared references only
+      #     MeshWeaver.Documentation); memex receives them over the GitHub link into the
+      #     `MeshWeaver` partition, where the node paths read `MeshWeaver/samples/Graph/Data/ACME/…`
+      #     while the bundles are keyed `ACME/…` — and the seeder matches by node PATH, so they are
+      #     inert there too. They still compile-GATE on every PR (dotnet-test.yml's doc-gate runs
+      #     the samples stage): correctness of that content is proven, its assemblies are simply
+      #     not worth shipping. Before/after for this job: 8 packages / 28 assemblies → 1 / 4.
+      - name: "Bake the platform's OWN shipped content INSIDE the promoted image"
         env:
           IMAGE: ${{ env.ACR }}/mw-plugin-test:${{ needs.gate.outputs.staging_tag }}
           SHA: ${{ needs.gate.outputs.sha }}
@@ -1051,11 +1073,9 @@ jobs:
           rm -rf "$STAGE"
           mkdir -p "$STAGE"
           bash .github/scripts/stage-doc-gate.sh src/MeshWeaver.Documentation/Data "$STAGE/doc"
-          bash .github/scripts/stage-samples-gate.sh samples/Graph/Data "$STAGE/samples"
-          # The two known-debt ratchets travel INTO the mount: the tester runs in the container and
-          # cannot see the checkout. Same files the doc-gate passes, so the same verdict applies.
+          # The known-debt ratchet travels INTO the mount: the tester runs in the container and
+          # cannot see the checkout. Same file the doc-gate passes, so the same verdict applies.
           cp .github/doc-gate.allow "$STAGE/doc-gate.allow"
-          cp .github/samples-gate.allow "$STAGE/samples-gate.allow"
           # The image's tester runs as a non-root user: it must be able to read the mount and write
           # the bake directory.
           chmod -R a+rX "$STAGE"
@@ -1063,17 +1083,14 @@ jobs:
           rm -rf "$BAKE"
           mkdir -p "$BAKE"
           chmod 777 "$BAKE"
-          # Two stages, one bake directory — exactly as the doc-gate runs them. A red tester FAILS
-          # this job: the platform's own shipped content not compiling against the image that ships
-          # it is a release defect, not a reason to publish less.
+          # A red tester FAILS this job: the platform's own shipped content not compiling against
+          # the image that ships it is a release defect, not a reason to publish less.
           # --pull never: the image is already in the local store (the retrying step above pulled
           # it), so a registry blip here can no longer be mistaken for a bake failure.
-          for stage in doc samples; do
-            echo "── baking /repo/$stage against $IMAGE"
-            docker run --rm --pull never --platform linux/amd64 -v "$STAGE:/repo" -v "$BAKE:/bake" \
-              --entrypoint /app/mw-plugin-test "$IMAGE" "/repo/$stage" \
-              --allow "/repo/$stage-gate.allow" --bake-output /bake --source-sha "$SHA"
-          done
+          echo "── baking /repo/doc against $IMAGE"
+          docker run --rm --pull never --platform linux/amd64 -v "$STAGE:/repo" -v "$BAKE:/bake" \
+            --entrypoint /app/mw-plugin-test "$IMAGE" /repo/doc \
+            --allow /repo/doc-gate.allow --bake-output /bake --source-sha "$SHA"
           # Postconditions, not hopes: a green tester that wrote no identity, or no bundles, is a
           # bake-stage regression — never a quiet publish of nothing.
           if [ ! -s "$BAKE/framework-mvid.txt" ]; then

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1001,10 +1001,44 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      # Both a docker pull credential (the bake image) and, further down, the data-plane token the
-      # publish script uses against Azure Files.
-      - name: ACR login
-        run: az acr login --name meshweaver
+      # 🚨 REACHING THE REGISTRY IS INFRA, AND INFRA BLIPS — bounded retries with backoff, then a
+      # LOUD error naming it as infra. Exactly the shape dotnet-test.yml's "Pre-pull Testcontainers
+      # images (infra, not a test)" step already uses, for the same reason.
+      #
+      # Measured, CD run 32028644747: this job died on `az acr login` with
+      # `HTTPSConnectionPool(host='meshweaver.azurecr.io', port=443) … [Errno 111] Connection
+      # refused` while FOUR sibling jobs in the same run logged into the same registry minutes
+      # earlier and pushed to it. A refused TCP connect from one runner is not a defect of ours, and
+      # retrying it suppresses nothing — but LOSING the job to it is expensive and asymmetric: the
+      # `promote` job has already armed the images by the time this runs, so the release ships
+      # WITHOUT its content bake, and the CD reconciler keys on the IMAGE set (complete) rather than
+      # on the publication, so nothing re-attempts it. The bundles are only republished by the next
+      # successful CD publish; until then pods compile shipped content at boot exactly as they did
+      # before the bake lane existed. Seconds of backoff against that trade is the right side.
+      #
+      # The image is PULLED here rather than left to `docker run`'s implicit pull, so the retry
+      # covers the pull too — a login that succeeds and a pull that is refused would otherwise fail
+      # the bake step with a registry error dressed up as a bake failure.
+      - name: "ACR login + pull the bake image (infra, not the bake)"
+        env:
+          IMAGE: ${{ env.ACR }}/mw-plugin-test:${{ needs.gate.outputs.staging_tag }}
+        run: |
+          set -uo pipefail
+          ok=0
+          for attempt in 1 2 3 4 5; do
+            if az acr login --name meshweaver && docker pull --quiet --platform linux/amd64 "$IMAGE"; then
+              echo "$IMAGE: registry reached and image pulled on attempt $attempt"
+              ok=1; break
+            fi
+            # Backoff: 5s, 10s, 20s, 40s — registry blips are seconds-to-minutes.
+            delay=$((5 * 2 ** (attempt - 1)))
+            echo "registry attempt $attempt failed; retrying in ${delay}s" >&2
+            sleep $delay
+          done
+          if [ $ok -eq 0 ]; then
+            echo "::error::could not log in to ${{ env.ACR }} and pull $IMAGE after 5 attempts — this is a REGISTRY/INFRA failure, not a bake failure. The image set for this commit is already promoted; its platform content bake was NOT published, so pods compile shipped content at boot until a later CD run republishes it."
+            exit 1
+          fi
       - name: "Bake the platform's shipped content INSIDE the promoted image"
         env:
           IMAGE: ${{ env.ACR }}/mw-plugin-test:${{ needs.gate.outputs.staging_tag }}
@@ -1032,9 +1066,11 @@ jobs:
           # Two stages, one bake directory — exactly as the doc-gate runs them. A red tester FAILS
           # this job: the platform's own shipped content not compiling against the image that ships
           # it is a release defect, not a reason to publish less.
+          # --pull never: the image is already in the local store (the retrying step above pulled
+          # it), so a registry blip here can no longer be mistaken for a bake failure.
           for stage in doc samples; do
             echo "── baking /repo/$stage against $IMAGE"
-            docker run --rm --platform linux/amd64 -v "$STAGE:/repo" -v "$BAKE:/bake" \
+            docker run --rm --pull never --platform linux/amd64 -v "$STAGE:/repo" -v "$BAKE:/bake" \
               --entrypoint /app/mw-plugin-test "$IMAGE" "/repo/$stage" \
               --allow "/repo/$stage-gate.allow" --bake-output /bake --source-sha "$SHA"
           done

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -147,9 +147,8 @@ adopted.
 
 ## The delivery: main-cd bakes IN THE IMAGE, then publishes
 
-`main-cd`'s **`publish-bake`** job runs the platform's own shipped content — the `Doc` tree and the
-`samples/Graph/Data` trees, staged by `.github/scripts/stage-doc-gate.sh` and
-`stage-samples-gate.sh`, the same staging the PR gate judges — through
+`main-cd`'s **`publish-bake`** job runs the content the image itself embeds — the `Doc` tree, staged
+by `.github/scripts/stage-doc-gate.sh`, the same staging the PR gate judges — through
 `docker run … mw-plugin-test … --bake-output` against **the `mw-plugin-test` image this very CD run
 built and promoted**, and copies the resulting bundles to the portals'
 shared storage (`.github/scripts/publish-bake-bundles.sh`), laid out
@@ -162,6 +161,27 @@ identity's directory is already sealed — an internal-only merge resolves the s
 identity as its predecessor — the script skips with a notice instead of re-uploading. See
 [The Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract)
 for the job's preflight discipline and the dependent-repo dispatch.
+
+### 🚨 CD compiles ONLY what the image embeds — everything else is adopted
+
+The bake is scoped to `src/MeshWeaver.Documentation/Data`, the one tree every portal ships inside
+itself (`Memex.Portal.Shared` references `MeshWeaver.Documentation`). Nothing else, on purpose:
+
+| Content | Who bakes it | Why not CD |
+|---|---|---|
+| node-repo content (Plugins, Education, Reinsurance, SocialMedia) and **Store** packages | each repo's own `node-repo-publish-bake` lane, against the same image ⇒ the same identity | it arrives **already compiled** and is adopted; `main-cd.yml` checks out no other repository, so it could not compile them even by accident |
+| `samples/Graph/Data` | nobody — compile-**gated** only | no deployment embeds them, and memex receives them over the GitHub link into the `MeshWeaver` partition, where node paths read `MeshWeaver/samples/Graph/Data/ACME/…` while bundles are keyed `ACME/…`. The seeder matches by node **path**, so the bundles are inert everywhere. Measured: 7 packages / 24 assemblies per CD run for bytes nothing can adopt |
+
+So the CD bake is **1 package / 4 assemblies**, down from 8 / 28 when it also baked the samples.
+Correctness of the samples content is unaffected — `dotnet-test.yml`'s doc-gate still compiles,
+renders and tests both trees on every PR. What changed is only that CD stops *shipping* assemblies
+no deployment can use. `PlatformBakeLaneGuard` pins both halves of this: the Doc tree must be baked,
+the samples tree must not, and the workflow must check out no other repository.
+
+The end state this serves is a boot that compiles nothing: with the four satellites publishing under
+the pods' identity, a prod portal boot reached `compiled=0 alreadyBaked=84` — everything adopted,
+nothing rebuilt. The platform's own `Doc` types are the remaining slice, and this lane is what
+delivers them.
 
 Three properties fall out of baking in the image rather than shipping a CI artifact across jobs:
 
@@ -259,12 +279,11 @@ types. The satellites escape it precisely because they bake INSIDE the image.
 
 - **DB-resident types** (user/partition content CI cannot see) stay on the runtime bake.
 - **A bundle is matched to a deployment by node PATH**, so a portal that mounts a tree somewhere
-  other than its canonical root adopts nothing from it. Measured on `memex`: the `Doc/…` types match
-  and adopt, while the sample trees live under `MeshWeaver/samples/Graph/Data/ACME/…` there and the
-  bundles are keyed `ACME/…`, so those seven bundles are published but inert on that portal. They do
-  adopt on a deployment that mounts the samples at their canonical roots. Closing that gap means
-  agreeing one canonical path per shipped tree — it is a content-layout question, not an identity
-  one.
+  other than its canonical root adopts nothing from it. That is why CD no longer bakes the samples
+  trees at all (see "CD compiles ONLY what the image embeds"): memex holds them under
+  `MeshWeaver/samples/Graph/Data/ACME/…` while a bundle from that tree is keyed `ACME/…`. If a
+  deployment ever wants them prebuilt, the fix is to agree one canonical path per shipped tree — a
+  content-layout question, not an identity one.
 - **An arm64 install adopts nothing the amd64 lane publishes** — the two architectures of one image
   resolve different identities (see the identity rule above). Local arm64 installs compile at boot
   as they always have; nothing may paper over this by publishing the same bundles twice.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -182,9 +182,11 @@ produces it rather than silently "fixed". This is also why `check-image-set.sh` 
 
 Two post-promote legs ride every armed release (#1660 WS3):
 
-**`publish-bake`** runs the platform's own shipped content (the `Doc` tree and the
-`samples/Graph/Data` trees) through `mw-plugin-test --bake-output` **inside the `mw-plugin-test`
-image this run just built and promoted**, then copies the bundles onto the portals' shared storage,
+**`publish-bake`** runs the content the image itself embeds (the `Doc` tree — and **only** that:
+node-repo content, Store packages and the samples trees arrive already compiled or are gate-only,
+see [CI Content Bake](/Doc/Architecture/CiContentBake)) through `mw-plugin-test --bake-output`
+**inside the `mw-plugin-test` image this run just built and promoted**, then copies the bundles onto
+the portals' shared storage,
 laid out `prebuilt-bundles/<framework-identity>/<source>/<bundle>.zip`
 (`.github/scripts/publish-bake-bundles.sh`). Baking in the image is not an implementation detail —
 it is the whole correctness argument. The framework identity is derived from the **binaries a host

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -219,6 +219,16 @@ would silently restore the every-pod-rebakes-everything regression (#1347). Ther
 or fails red. Because it re-runs the content gate against the binaries that SHIP, a red here is a
 genuine release defect — the images are already promoted, and nothing quietly ships less.
 
+🚨 **The reconciler does not heal a failed bake publication.** `gate` asks the registry whether the
+IMAGE set is complete, and by the time this job runs `promote` has already made it so — so a run
+that publishes its images and then loses this job is not re-attempted, and the bundles land only on
+the next successful CD publish (until then pods compile shipped content at boot, exactly as before
+the lane existed). That asymmetry is why reaching the registry here is retried like the infra it is:
+five attempts with backoff, then a loud error naming it a REGISTRY/INFRA failure. CD run
+`32028644747` lost the job to a single `az acr login` → `[Errno 111] Connection refused` while four
+sibling jobs in the same run reached the same registry fine. `alert-on-failure` still files the red
+on the `ci-failure` issue, so a genuinely broken bake is never silent.
+
 **`notify-dependents`** sends one `repository_dispatch` (`meshweaver-framework-released`, payload:
 commit, version — receivers resolve the framework identity themselves from the new image) to each
 repo in `BAKE_SUBSCRIBER_REPOS`, using

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -67,6 +67,42 @@ public class PlatformBakeLaneGuard
             + "ShippedPrebuiltBundles.CompletionSentinelFileName.");
     }
 
+    /// <summary>
+    /// 🚨 CD bakes ONLY the content the image itself embeds. Everything a deployment receives
+    /// already built — node-repo content (Plugins, Education, Reinsurance, SocialMedia), Store
+    /// packages, and the samples trees — is ADOPTED from a bundle its own lane published under the
+    /// same framework identity. Re-compiling it here would redo that work, burn CD wall-clock, and
+    /// re-derive assemblies that were meant to be authoritative.
+    /// </summary>
+    [Fact]
+    public void PlatformBake_CompilesOnlyWhatTheImageEmbeds()
+    {
+        var job = ExecutableLinesOf(ReadJobBlock());
+
+        Assert.True(job.Contains("stage-doc-gate.sh", StringComparison.Ordinal),
+            $"'{JobName}' must bake the Doc tree — it is the content every portal embeds "
+            + "(Memex.Portal.Shared references MeshWeaver.Documentation), so it is the one tree "
+            + "no other lane can publish.");
+
+        Assert.False(job.Contains("stage-samples-gate.sh", StringComparison.Ordinal),
+            $"'{JobName}' must NOT bake samples/Graph/Data. No deployment embeds those trees, and "
+            + "memex receives them over the GitHub link into the `MeshWeaver` partition — where the "
+            + "node paths read `MeshWeaver/samples/Graph/Data/ACME/…` while the bundles are keyed "
+            + "`ACME/…`, so the seeder (which matches by node PATH) can never adopt them. Measured: "
+            + "7 packages / 24 assemblies compiled per CD run for bundles nothing can use. They "
+            + "still compile-GATE on every PR in dotnet-test.yml's doc-gate — that proves the "
+            + "content, which is the part worth paying for.");
+
+        // The strongest form of "CD cannot compile someone else's module": it never checks out
+        // someone else's repository. One `repository:` input would make it possible.
+        var text = ExecutableLinesOf(File.ReadAllText(Path.Combine(FindRepoRoot(), Workflow)));
+        Assert.False(text.Contains("repository:", StringComparison.Ordinal),
+            $"{Workflow} must check out no repository but this one. Node-repo and Store content "
+            + "arrives already compiled and is adopted; a checkout of another repo here would let "
+            + "CD re-derive assemblies whose authoritative build belongs to that repo's own "
+            + "publish-bake lane.");
+    }
+
     /// <summary>The block's lines that can actually DO something: YAML and shell comment lines
     /// (first non-blank character <c>#</c>) dropped, everything else kept verbatim.</summary>
     private static string ExecutableLinesOf(string block) =>


### PR DESCRIPTION
Follow-up to #1733 (issue #1725). Two things, both measured from the **first real CD run** of the in-image bake, [32028644747](https://github.com/Systemorph/MeshWeaver/actions/runs/32028644747).

## First, the record on that run — the image set DID ship

Worth stating plainly because it was reported otherwise: `promote` succeeded (all three phases, including phase C, the arming write), `verify-images` passed, and the registry has the full set:

```
$ .github/scripts/check-image-set.sh a770176
memex-portal-ai:a770176   (linux/amd64 + linux/arm64)
memex-migration:a770176   (linux/amd64 + linux/arm64)
mw-plugin-test:a770176    (linux/amd64 + linux/arm64)
memex-portal-next:a770176 (linux/amd64)
All four images exist in ACR for a770176.
```

`memex-portal-ai:3.0.0-rc4.ci.4083` / `a770176` / `main` are published. `publish-bake` runs **after** `promote` and is not in its `needs`, so it structurally cannot withhold the image set — that is the design, and it held. Two other reported causes also don't survive the log: the job's `Azure login (OIDC)` step **succeeded** immediately before the failing step (it declares `permissions: {contents: read, id-token: write}`), and its `Preflight: the publish targets must be provisioned` step **succeeded** — the `BAKE_PUBLISH_TARGETS is not provisioned` text in the log is GitHub echoing the un-taken `if` branch of the script body, not an error.

What did **not** happen is the bundle publication. That is what this PR fixes.

## 1. A registry blip must not cost the release its content bake

The job died on its first registry call:

```
az acr login --name meshweaver
ConnectionError: HTTPSConnectionPool(host='meshweaver.azurecr.io', port=443):
  … [Errno 111] Connection refused
```

while **four sibling jobs in the same run** logged into the same registry and pushed to it minutes earlier. A refused TCP connect from one runner is infrastructure, not a defect in the bake — but losing the job to it is asymmetric: `promote` has already armed the images, and the CD reconciler keys on the **image set** (complete) rather than on the publication, so **nothing re-attempts it**.

So registry access is now treated as the infra it is, in exactly the shape `dotnet-test.yml`'s *"Pre-pull Testcontainers images (infra, not a test)"* step already uses: 5 attempts, 5/10/20/40 s backoff, then a **loud** `::error::` naming it a REGISTRY/INFRA failure and stating the consequence. The image is pulled in that same retrying step and the bake runs `docker run --pull never`, so a blip during the implicit pull can't masquerade as a bake failure either. A real bake problem still fails red, and `alert-on-failure` still files it.

## 2. CD compiles ONLY what the image embeds

Maintainer directive: CD must not compile content delivered already built. Measured, against the shipped image:

```
bake: Doc → 4 assembly(ies)                      ← embedded in every portal
bake: ACME → 3          bake: Cornerstone → 3
bake: FutuRe → 9        bake: MathDemo → 1
bake: Northwind → 6     bake: PythonDemo → 1
bake: Systemorph → 1
packages=8 assemblies=28
```

**Node-repo content (Plugins, Education, Reinsurance, SocialMedia) and Store were never in it and cannot be** — `main-cd.yml` carries no `repository:` input, so it only ever checks out this repo. Those arrive already compiled from their own `node-repo-publish-bake` lanes, under the same framework identity, and are adopted.

The **samples** half was 24 of the 28 assemblies, and **no deployment can adopt any of them**:

* no portal embeds `samples/Graph/Data` — `Memex.Portal.Shared` references only `MeshWeaver.Documentation`;
* memex receives them over the **GitHub link** into the `MeshWeaver` partition, where node paths read `MeshWeaver/samples/Graph/Data/ACME/…` while the bundles are keyed `ACME/…` — and the seeder matches by node **path**.

So CD was compiling and uploading seven packages of bytes nothing could ever seed. The bake is now scoped to the Doc tree:

| | before | after |
|---|---|---|
| packages baked per CD run | 8 | **1** |
| assemblies baked per CD run | 28 | **4** |

Correctness of the samples content is untouched — `dotnet-test.yml`'s doc-gate still compiles, renders and tests both trees on every PR. What stops is *shipping* assemblies no deployment can use.

`PlatformBakeLaneGuard` pins all three halves so this cannot regress: the Doc tree must be baked, `stage-samples-gate.sh` must **not** appear in the job, and `main-cd.yml` must check out no other repository.

## Verified

* `main-cd.yml` parses; every `run:` block in `publish-bake` passes `bash -n`.
* The narrowed bake was run end-to-end against the real `mw-plugin-test` image: exit 0, `Doc.zip` + `framework-mvid.txt`, `packages=1 assemblies=4`.
* `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → 0 warnings, 0 errors; **24/24** green.

No What's New entry: CI-infra scoping — the user-visible outcome is already covered by #1733's entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)