### PR TITLE
Retire the boot-time bake on every instance: adopt always, compile on demand

### DIFF
--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -173,8 +173,44 @@ config:
     # Failure mode if the gate DOES fire on a real regression: a stalled rollout
     # with the old image still serving — no outage, but self-update stops
     # advancing, so a stalled roll must be investigated, not waited out.
-    PreWarm__DynamicTypes: "true"
-    PreWarm__GateReadiness: "true"
+    # ---- 2026-08-17: the boot-time bake is RETIRED on the fleet too ----------
+    # Everything above describes the compiling sweep and the gate that rode on it.
+    # Both are now OFF, deliberately, and this is the reasoning — read it before
+    # turning either back on.
+    #
+    # WHY. Adoption made the sweep redundant. Once the four satellite repos
+    # published under the live framework identity, a prod boot measured
+    # `compiled=0 alreadyBaked=84` — the sweep compiled NOTHING and still charged
+    # 32.1 s of warm-up (64.8 s when adoption was broken). What it did on a MISS
+    # was worse than useless: it blocked readiness on compiling types no user had
+    # asked for. Adoption + the coverage report still run on every boot (they no
+    # longer sit behind PreWarm__DynamicTypes); what is left uncovered compiles on
+    # first access, when someone actually reaches it — measured at ~2.4 s per type
+    # on the fleet, paid once, by that type's first visitor.
+    #
+    # WHAT READINESS MEANS NOW — say it out loud, because it is strictly weaker.
+    # The gate certified a bake by COMPILING every type and refusing readiness if
+    # one that USED to build no longer did. With nothing compiling at boot there is
+    # no such verdict to reach, so the gate is turned OFF rather than left armed:
+    # armed-with-nothing-behind-it reports healthy on every rollout and protects
+    # NOTHING, which is the failure it exists to prevent. (The portal already
+    # screams that combination at Critical — Memex.Portal.Distributed/Program.cs.)
+    #
+    # WHAT WE GIVE UP, precisely: a NodeType that regresses on a new image is no
+    # longer caught at rollout. It now surfaces when a user first reaches it. That
+    # is the trade this change makes knowingly.
+    #
+    # WHAT REPLACES IT: the boot coverage report. Every uncovered type is named at
+    # warning with WHY, so "the bake lane broke" (an identity mismatch declines
+    # every bundle wholesale — #1725) shows up as a coverage collapse in the logs
+    # on the FIRST pod of a bad roll, before users meet it.
+    #
+    # 🚨 Do NOT "fix" this by gating on full adoption coverage. Uncovered>0 is the
+    # normal steady state of a real portal: users author NodeTypes in their own
+    # partitions and those have no CI bake by construction (the live memex share
+    # holds two such types under `rbuergi`). A coverage gate would never go ready.
+    PreWarm__DynamicTypes: "false"
+    PreWarm__GateReadiness: "false"
     # A sweep that ERRORED verified nothing, so it refuses readiness like a regression does —
     # the guard the retired pre-run bake Job enforced from outside ("FINDING NOTHING IS NOT
     # PASSING"), restored on the surviving path. Note "empty" is NOT "unproven": a mesh with no

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -32,10 +32,16 @@ data:
   Deployment__Backend: "{{ .Values.config.memex_portal.Deployment__Backend }}"
   Deployment__DataRoot: "{{ .Values.config.memex_portal.Deployment__DataRoot }}"
   # ---- NodeType bake ------------------------------------------------------
-  # PreWarm__DynamicTypes: compile every dynamic NodeType at startup, sequentially and in
-  #   dependency order, RESUMING from the shared assembly cache under Deployment__DataRoot
-  #   (already-baked types for this framework are skipped). Off → types compile lazily on
-  #   first access, which is what makes the first visitor after each image roll wait.
+  # 🚨 ADOPTION IS NOT CONFIGURED HERE — it is unconditional. Every boot seeds the prebuilt
+  #   bundles (PreWarm__PrebuiltBundleRoot below, plus the image's own prebuilt/ directory) and
+  #   logs what that covered, naming every type it did not. The keys below control only whether
+  #   the LEFTOVER is also compiled at boot. They used to gate the seeding too, which meant the
+  #   default deployment (DynamicTypes=false) adopted nothing at all.
+  # PreWarm__DynamicTypes: ALSO compile every uncovered dynamic NodeType at startup, sequentially
+  #   and in dependency order, RESUMING from the shared assembly cache under Deployment__DataRoot.
+  #   Off (the default, and now the fleet's setting too) → whatever adoption did not cover
+  #   compiles on first access, i.e. when a user reaches that type — ~2.4 s once, for that type's
+  #   first visitor, instead of a boot-time sweep of everything nobody asked for.
   # PreWarm__GateReadiness: hold /health RED until that bake is green. With the
   #   startupProbe on /health and maxUnavailable:0, a NodeType that REGRESSED on the new
   #   image stalls the rollout with the previous image still serving, instead of erroring
@@ -103,13 +109,6 @@ data:
          Empty renders harmlessly: the host skips blank values, and the seeding logs "no published
          bundle root configured" at debug and stays inert. */}}
   PreWarm__PrebuiltBundleRoot: "{{ .Values.config.memex_portal.PreWarm__PrebuiltBundleRoot }}"
-  {{- /* PreWarm__AdoptOnly: adopt the prebuilt bundles, then REPORT what they covered instead of
-         compiling the rest. Not the same as PreWarm__DynamicTypes=false — that would turn the
-         bundle seeding off too (it lives on the same service), so the instance would adopt nothing
-         AND compile everything lazily. Uncovered types are named at warning every boot and still
-         compile on first access. Cannot certify a bake, so it refuses to arm PreWarm__GateReadiness
-         and says so. Intended for local/dev instances. */}}
-  PreWarm__AdoptOnly: "{{ .Values.config.memex_portal.PreWarm__AdoptOnly }}"
   # ---- Assembly-cache retention -------------------------------------------
   # The bake writes one WHOLE GENERATION of NodeType assemblies per image, because the store
   # keys every file by the MeshWeaver.Graph MVID and a CI build changes it on every publish.

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -378,12 +378,6 @@ config:
     # pre-run bake Job used to enforce from outside the portal as Bake__AllowEmpty. It never
     # relaxes a real regression, and the /health payload keeps saying the bake was unproven.
     PreWarm__AllowUnprovenBake: "false"
-    # Adopt CI-baked NodeType assemblies instead of compiling them, and REPORT (by name, at
-    # warning) whatever the adoption did not cover. Off here because the chart's default
-    # deployment is a managed one that gates on a proven bake; the homebrew/local overlay turns
-    # it on, because a laptop should run the modules CI already built rather than rebuild them.
-    # Not a synonym for PreWarm__DynamicTypes:"false" — that disables the bundle SEEDING too.
-    PreWarm__AdoptOnly: "false"
     # Mount point of CI's published bake, consumed as <root>/<framework-identity>/<source>/*.zip.
     # Empty = the lane is inert and every dynamic type is compiled/lazily built as before.
     PreWarm__PrebuiltBundleRoot: ""

--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -469,10 +469,10 @@ helm_deploy() {
   done
 
   # Layering: chart defaults < TRACKED local defaults (ship with the brew package, so existing
-  # installs pick up new behaviour — e.g. adopt-only startup, PreWarm__AdoptOnly — on upgrade)
+  # installs pick up new behaviour — e.g. the adopt-only startup — on upgrade)
   # < the user's overlay (their secrets + overrides — generated once, never regenerated, always
   # wins). That last layer is also the supported escape hatch: someone AUTHORING NodeTypes
-  # locally, who therefore has no CI bake to adopt, sets PreWarm__AdoptOnly: "false" in the
+  # locally, who therefore has no CI bake to adopt, sets PreWarm__DynamicTypes: "true" in the
   # overlay and gets the compiling startup bake back.
   local share_dir; share_dir="$(resolve_share)"
   helm upgrade --install "$RELEASE" "$chart" \

--- a/deploy/homebrew/share/values.local.defaults.yaml
+++ b/deploy/homebrew/share/values.local.defaults.yaml
@@ -27,16 +27,11 @@ config:
     # sweep, all of it paid on the same CPU the developer is trying to work on.
     #
     # So: keep the ADOPTION (the CI-baked bytes are exactly what a local
-    # instance should be running) and drop the compiling.
-    #
-    # 🚨 The obvious spelling of this — PreWarm__DynamicTypes: "false" — is
-    # WRONG, and quietly so. The bundle seeding lives on the pre-warmer's own
-    # path, so switching the pre-warmer off switches ADOPTION off with it: the
-    # instance would adopt nothing AND still compile everything, just later and
-    # one hub activation at a time. PreWarm__AdoptOnly keeps the seeding and
-    # replaces only the compiling half with a report.
-    PreWarm__DynamicTypes: "true"
-    PreWarm__AdoptOnly: "true"
+    # instance should be running) and drop the compiling. Adoption + the
+    # coverage report now run on EVERY boot regardless of this key, which
+    # controls only whether the leftover is compiled at boot as well.
+    # Anything uncovered compiles on first access, when someone reaches it.
+    PreWarm__DynamicTypes: "false"
     # Where an adopted bake is read from: <root>/<framework-identity>/<source>/
     # *.zip, on the /data hostPath the chart already mounts. Absent (the normal
     # state today — nothing populates it on a laptop yet) the lane is simply
@@ -44,9 +39,9 @@ config:
     # Drop a `mw-plugin-test --bake-output` tree in here and it is adopted on
     # the next boot with no further configuration.
     PreWarm__PrebuiltBundleRoot: "/data/prebuilt-bundles"
-    # Batch/pacing only matter to the compiling sweep, which adopt-only does not
-    # run. Kept so that flipping PreWarm__AdoptOnly back to "false" — the escape
-    # hatch for authoring NodeTypes locally, where there is no CI bake by
+    # Batch/pacing only matter to the compiling sweep, which is off above. Kept
+    # so that flipping PreWarm__DynamicTypes back to "true" — the escape hatch
+    # for AUTHORING NodeTypes locally, where there is no CI bake by
     # construction and baking your own is the right answer — restores exactly
     # the previous behaviour rather than a slower variant of it.
     PreWarm__BatchBake: "true"

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -145,40 +145,58 @@ logged and skipped, and the sweep compiles that type as it always has. Nothing c
 from this path — the bake gate keeps probing the store, which only ever holds what was actually
 adopted.
 
-## Adopt-only: consume the bake, never build it (`PreWarm:AdoptOnly`)
+## Adopt, then compile on demand — the boot bake is retired everywhere
 
-A managed portal both adopts *and* compiles: whatever the bundles did not cover, the sweep builds,
-and the readiness gate certifies the result. That trade is wrong on a developer's laptop. The
-framework identity changes with every image, so every `memex-local update` invalidates the whole
-assembly cache and the startup bake recompiles the entire shipped content set on the same CPU the
-developer is trying to work on. One developer machine had accumulated **15 generations** under
-`/data/assembly-cache/.generations` — fifteen full sweeps of ~38 types, none of which produced
-anything CI had not already built.
+**Adoption and its coverage report are unconditional; only compiling is configurable.** Every boot
+seeds both bundle sources and then probes the assembly store:
 
-`PreWarm:AdoptOnly=true` keeps the adoption and drops the compiling:
-
-1. both bundle sources seed exactly as above (`SeedAll`, then `SeedPublishedRoot`);
+1. both bundle sources seed as above (`SeedAll`, then `SeedPublishedRoot`);
 2. `DynamicTypePreWarmer.ProbeDynamicTypes` enumerates the mesh's dynamic NodeTypes and asks the
    assembly store about each — the same `NodeTypeBakeStatus.Probe` the sweep uses to decide what to
    build, stopping at the answer;
-3. the boot log reports `adopted=N uncovered=M`, and **every uncovered type is NAMED at warning**.
+3. the boot log reports `adopted=N uncovered=M`, and **every uncovered type is NAMED at warning**,
+   with the `BakeState` and detail saying *why*.
 
-Nothing is compiled at boot. An uncovered type is still correct — it builds on first access through
-the ordinary lazy path — it is merely not warm. That is the deliberate escape for content with no CI
-bake *by construction*: a NodeType someone is authoring on a laptop has no published bundle and
-never will, and "bake your own" is the right answer for it. What adopt-only refuses is the silent
-version of that: a gap you only discover when a page renders empty.
+`PreWarm:DynamicTypes` then decides only whether the leftover is **also** compiled at boot. It is
+`false` everywhere, including the fleet.
 
-> 🚨 **`PreWarm:AdoptOnly` is not a synonym for `PreWarm:DynamicTypes=false`.** The bundle seeding
-> runs on the *same hosted service* as the sweep, so switching the service off switches adoption off
-> with it — the instance would adopt nothing **and** still compile everything, lazily and
-> unreported. Adopt-only is the key that removes the compiling; `DynamicTypes` is the key that keeps
-> the adoption. The homebrew defaults set both, and
-> `PlatformBakeLaneGuard.LocalDefaults_AdoptRatherThanPreBake_AndKeepTheSeedingOn` pins the pairing.
+> 🚨 These two used to be one switch, and the fusion was a real defect: the chart's default is
+> `DynamicTypes=false`, so the ordinary deployment adopted **nothing** — it ignored bundles sitting
+> in its own image and lazily compiled every type instead. Splitting them is what makes "no boot
+> bake" cheap rather than a regression.
 
-Adopt-only compiles nothing, so it can prove nothing: it never arms `PreWarm:GateReadiness`, and the
-contradictory combination is logged as an error naming both keys rather than quietly honoured in
-either direction. It is the default for the homebrew/local chart overlay, and off everywhere else.
+Why the sweep is retired rather than tuned: adoption made it redundant. Once the satellite repos
+published under the live identity, a prod boot measured `compiled=0 alreadyBaked=84` — the sweep
+compiled nothing and still charged 32.1 s of warm-up (64.8 s when adoption was broken). On a *miss*
+it was worse than useless: it blocked readiness on compiling types no user had asked for. On a
+laptop it was pure waste — one developer machine had **15 generations** under
+`/data/assembly-cache/.generations`, fifteen full sweeps that rebuilt what CI had already built.
+
+An uncovered type is still correct: it builds on **first access**, via
+`NodeTypeEnrichmentHelpers.WaitForCompileSettled`, when someone actually reaches it. Measured cost
+~2.0–2.1 s per type locally (~2.4 s on the fleet), paid once, by that type's first visitor. That is
+also the deliberate escape for content with no CI bake *by construction* — a NodeType someone is
+authoring on a laptop has no published bundle and never will. What the report refuses is the silent
+version: a gap you only discover when a page renders empty.
+
+### What readiness means now
+
+The bake gate certified a bake by **compiling** every type and refusing readiness when one that used
+to build no longer did. With nothing compiling at boot there is no such verdict, so
+`PreWarm:GateReadiness` is turned **off** rather than left armed — an armed gate with no sweep behind
+it reports healthy on every rollout and protects nothing, which is the exact failure it exists to
+prevent. (The portal already says so at Critical; `NoValuesFileArmsTheBakeGateWithoutTheSweepBehindIt`
+pins it at build time.)
+
+**What that gives up, precisely:** a NodeType that regresses on a new image is no longer caught at
+rollout; it surfaces when a user first reaches it. **What replaces it:** the boot coverage report —
+a broken bake lane (an identity mismatch declines every bundle wholesale, #1725) shows up as a
+coverage collapse in the logs of the *first* pod of a bad roll.
+
+> 🚨 **Do not "fix" this by gating on full adoption coverage.** `uncovered > 0` is the normal steady
+> state of a real portal: users author NodeTypes in their own partitions, and those have no CI bake
+> by construction — the live `memex` share holds two such types under `rbuergi`. A coverage gate
+> would never go ready.
 
 > 🚨 **A `PreWarm__*` key in a values file does nothing until the configmap renders it.**
 > `deploy/helm/templates/memex-portal/config.yaml` enumerates keys explicitly — it does not iterate

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-local-instances-adopt-instead-of-compiling.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-local-instances-adopt-instead-of-compiling.md
@@ -26,7 +26,7 @@ never will, and "build your own" remains the right answer for it. What the new d
 the *silent* version — a gap you would otherwise discover when a page renders empty.
 
 If you are authoring NodeTypes locally and want the old behaviour back, set
-`PreWarm__AdoptOnly: "false"` in your values overlay; the startup bake returns unchanged.
+`PreWarm__DynamicTypes: "true"` in your values overlay; the startup bake returns unchanged.
 
 Two related fixes ship with it. `PreWarm__PrebuiltBundleRoot` had been set in the AKS values since
 the CI-bake lane shipped, but the chart's configmap never rendered the key — so every

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-no-startup-bake-compile-on-demand.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-no-startup-bake-compile-on-demand.md
@@ -1,0 +1,39 @@
+---
+Name: No startup bake anywhere — modules arrive pre-built, the rest compiles on demand
+Category: Feature
+Description: Every instance now adopts the assemblies CI already built and compiles nothing at startup; whatever is left over builds the moment a user first reaches it, and the boot log names exactly what that is.
+Icon: Sparkle
+Order: -20260817
+---
+
+# No startup bake anywhere — modules arrive pre-built, the rest compiles on demand
+
+Portals used to compile every dynamic NodeType at startup. That made sense when nothing arrived
+pre-built. It stopped making sense once the content repos began publishing their compiled
+assemblies: a recent production boot compiled **nothing at all** — every one of its 84 types was
+already built — and still spent half a minute doing the sweep that discovered this.
+
+Startup now does the useful half and skips the rest:
+
+- **Adopting the pre-built assemblies is unconditional.** Every instance seeds what CI built for it,
+  every boot. This used to sit behind the same switch as the compiler, which had an unfortunate
+  consequence: the *default* configuration turned both off together, so an ordinary deployment
+  adopted nothing and quietly rebuilt content that was sitting pre-built in its own image.
+- **Nothing is compiled at startup.** Whatever the adoption did not cover compiles the first time
+  someone actually opens it — about two seconds, once, for that page's first visitor, instead of a
+  startup sweep over everything whether anyone wants it or not.
+- **The gap is named, every boot.** The log lists each type that did not arrive pre-built and why,
+  so "our modules ship pre-compiled" is a claim you can check rather than hope for.
+
+The practical effect is that starting a portal is fast and predictable, and a laptop stops burning
+its CPU rebuilding modules that were already built for it.
+
+**If you author NodeTypes locally** there is nothing to adopt — your own code has never been through
+CI, by construction — so it compiles when you open it, exactly as before. To get the old
+build-everything-at-startup behaviour back, set `PreWarm__DynamicTypes: "true"` in your values
+overlay.
+
+One trade worth stating plainly: because nothing compiles at startup, a NodeType that breaks against
+a new version is no longer caught while that version is rolling out — it surfaces when someone opens
+it. The startup coverage report is what replaces that early warning, and it fires on the first
+instance of a bad rollout rather than on the first user.

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -408,7 +408,7 @@ public static class DynamicTypePreWarmer
     }
 
     /// <summary>
-    /// 🚨 ASKS, NEVER BUILDS — the adopt-only pass (<c>PreWarm:AdoptOnly</c>).
+    /// 🚨 ASKS, NEVER BUILDS — the adopt-only pass that every boot runs.
     ///
     /// <para>Enumerates the mesh's dynamic NodeTypes and probes the assembly store for each,
     /// returning the same <see cref="NodeTypeBakeReport"/> the compiling sweep uses to decide what

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -27,13 +27,34 @@ namespace MeshWeaver.Hosting;
 /// immediately; the warm-up is launched from the <c>ApplicationStarted</c> callback and runs
 /// on a background Rx subscription. The subscription is torn down on shutdown.</para>
 ///
-/// <para><b>OFF by default</b> (<c>PreWarm:DynamicTypes</c> config, default <c>false</c>): the
-/// warm-up enumerates EVERY NodeType across EVERY partition and activates + compiles each dynamic
-/// one — on a mesh with many partitions that is a boot-time subscribe/compile storm that starves
-/// the hubs (and, multi-silo, the Orleans membership probes — the "I have been told I am dead"
-/// restart loop on memex, 2026-07-22). Correctness never needs it: first access compiles lazily
-/// via <c>NodeTypeEnrichmentHelpers.WaitForCompileSettled</c>. Opt in only where the
-/// first-visitor compile latency actually hurts and the mesh is small enough to warm quietly.</para>
+/// <para><b>Two halves, one service, and only the second is optional.</b></para>
+///
+/// <para><b>1. Adoption + reporting — ALWAYS.</b> Every boot seeds the prebuilt bundles
+/// (<see cref="ShippedPrebuiltBundles"/>: the image's own <c>prebuilt/</c> and the CI-published
+/// identity root) and then PROBES the assembly store, logging what the adoption covered and NAMING
+/// every type it did not. These used to sit behind the config gate below, which fused two unrelated
+/// decisions: with the sweep off — the default — a deployment adopted NOTHING and went straight to
+/// compiling every type lazily, ignoring bundles sitting in its own image.</para>
+///
+/// <para><b>2. The compiling sweep — OFF by default</b> (<c>PreWarm:DynamicTypes</c>, default
+/// <c>false</c>). It enumerates EVERY NodeType across EVERY partition and activates + compiles each
+/// dynamic one; on a mesh with many partitions that is a boot-time subscribe/compile storm that
+/// starves the hubs (and, multi-silo, the Orleans membership probes — the "I have been told I am
+/// dead" restart loop on memex, 2026-07-22). Correctness never needs it: whatever the adoption did
+/// not cover compiles on first access via
+/// <c>NodeTypeEnrichmentHelpers.WaitForCompileSettled</c> — when a user actually reaches the
+/// type, rather than for every type at boot whether anyone wants it or not.</para>
+///
+/// <para><b>What that costs, measured:</b> ~2 s per type, paid once, by that type's first visitor
+/// (2.0–2.1 s across four cold compiles locally; ~2.4 s per type on the fleet). Opt the sweep back
+/// in only where that first-visitor latency actually hurts AND the content is not covered by
+/// bundles anyway — for authoring a NodeType locally, where there is no CI bake by
+/// construction.</para>
+///
+/// <para>🚨 <b>Readiness.</b> The bake gate certifies a bake by COMPILING; with the sweep off there
+/// is nothing to certify, so the gate is not armed and stays <c>NotStarted</c> (fail-open). A
+/// deployment that leaves <c>PreWarm:GateReadiness=true</c> while the sweep is off is told at
+/// Critical that its gate protects nothing — see <c>Memex.Portal.Distributed/Program.cs</c>.</para>
 /// </summary>
 public sealed class DynamicTypePreWarmerHostedService(
     IServiceProvider services,
@@ -42,31 +63,6 @@ public sealed class DynamicTypePreWarmerHostedService(
 {
     /// <summary>Config key that opts a deployment into the startup warm-up (default: off).</summary>
     public const string EnabledConfigKey = "PreWarm:DynamicTypes";
-
-    /// <summary>
-    /// Config key selecting ADOPT-ONLY boot (default <c>false</c>): seed the prebuilt bundles, then
-    /// REPORT what that covered instead of compiling the remainder.
-    ///
-    /// <para><b>Why this is a separate key and not just <c>PreWarm:DynamicTypes=false</c>.</b> The
-    /// bundle seeding lives on this service's path — turning the warm-up off turns ADOPTION off with
-    /// it, which is the exact opposite of what a deployment that wants "adopt, don't compile" is
-    /// asking for: it would adopt nothing AND compile everything, just later and one hub activation
-    /// at a time. Adopt-only splits the two halves that were fused here: keep the adoption, drop the
-    /// Roslyn.</para>
-    ///
-    /// <para><b>The uncovered types are NAMED, at warning, every boot.</b> A type the adoption did
-    /// not cover is not silently broken and it is not silently compiled — it is reported, and it
-    /// still builds on first access through the ordinary lazy path
-    /// (<c>NodeTypeEnrichmentHelpers.WaitForCompileSettled</c>). That is the deliberate escape for
-    /// content that has no CI bake by construction — a type someone is authoring on a laptop —
-    /// which must keep working without a silent boot-time compile storm behind it.</para>
-    ///
-    /// <para><b>It cannot certify a bake.</b> Adopt-only verifies nothing by compiling, so it never
-    /// arms the readiness gate; combined with <c>PreWarm:GateReadiness=true</c> the gate is refused
-    /// LOUDLY rather than passed on no evidence. Intended for local/dev instances (the homebrew
-    /// chart defaults it on), not for a fleet that gates rollouts on a proven bake.</para>
-    /// </summary>
-    public const string AdoptOnlyConfigKey = "PreWarm:AdoptOnly";
 
     /// <summary>
     /// How many of the costliest NodeTypes the warm-up summary NAMES (issue #1439). Small on
@@ -144,18 +140,6 @@ public sealed class DynamicTypePreWarmerHostedService(
         // not coming. Resolved (not required) for resilience; AddDynamicTypePreWarming registers it.
         var bake = services.GetService<PreWarmCompletion>();
 
-        // Config-gated, DEFAULT OFF — see the class doc. Read as a raw string (no Binder
-        // dependency); anything but an explicit true stays lazy.
-        var enabled = services.GetService<IConfiguration>()?[EnabledConfigKey];
-        if (!bool.TryParse(enabled, out var isEnabled) || !isEnabled)
-        {
-            logger.LogInformation(
-                "DynamicTypePreWarmer: disabled ({Key} != true) — dynamic NodeTypes compile lazily on first access",
-                EnabledConfigKey);
-            bake?.MarkSettled(PreWarmSettlement.NotApplicable);
-            return;
-        }
-
         var mesh = services.GetService<IMessageHub>();
         if (mesh is null)
         {
@@ -164,13 +148,19 @@ public sealed class DynamicTypePreWarmerHostedService(
             return;
         }
 
-        // Adopt-only: keep the bundle seeding, drop the Roslyn. Read here — before the gate is
-        // armed and before the sweep's knobs are parsed — because it decides which of the two
-        // terminals below this method takes. See AdoptOnlyConfigKey for why it is not just
-        // "PreWarm:DynamicTypes=false".
-        var adoptOnly = bool.TryParse(
-            services.GetService<IConfiguration>()?[AdoptOnlyConfigKey], out var adoptOnlyParsed)
-            && adoptOnlyParsed;
+        // 🚨 ADOPTION AND REPORTING ARE UNCONDITIONAL — only COMPILING is config-gated.
+        //
+        // This check used to stand ABOVE the bundle seeding, which fused two unrelated decisions:
+        // "should this host pre-COMPILE its dynamic NodeTypes at boot" and "should this host adopt
+        // the assemblies CI already built for it". The chart's default is (and was) DynamicTypes
+        // =false, so the overwhelmingly common deployment adopted NOTHING — it went straight to
+        // compiling every type lazily, having ignored bundles sitting right there in its own image.
+        //
+        // Splitting them is what makes "no pre-bake anywhere" a cheap default instead of a
+        // regression: every host seeds what CI baked, every host SAYS what that covered, and only
+        // the leftover compiles — on first access, when a user actually reaches the type.
+        var enabled = services.GetService<IConfiguration>()?[EnabledConfigKey];
+        var sweepEnabled = bool.TryParse(enabled, out var isEnabled) && isEnabled;
 
         // Optional per-type budget override — raw string + TryParse like EnabledConfigKey, so a
         // malformed value degrades to the default rather than faulting the warm-up. Zero/negative
@@ -211,28 +201,15 @@ public sealed class DynamicTypePreWarmerHostedService(
         // The readiness gate reads this. Resolved (not required) so a host that never called
         // AddNodeTypeBakeGate simply warms without gating — the warmer stays a latency optimisation
         // unless a deployment explicitly opts into making it a rollout gate.
+        // 🚨 A GATE NEVER PASSES ON NO EVIDENCE — so it is armed only when something will actually
+        // measure. Without the sweep this host compiles nothing at boot and therefore proves
+        // nothing about whether its NodeTypes build on this image; MarkRunning there would start a
+        // verdict no one ever finishes. It is left NotStarted, the documented fail-OPEN state for a
+        // gate with nothing behind it, and the portal already says so at Critical on startup
+        // (Memex.Portal.Distributed/Program.cs) so "the gate is on" and "the gate measures
+        // something" cannot drift apart silently in an operator's head.
         var gate = services.GetService<NodeTypeBakeGateState>();
-        if (adoptOnly)
-        {
-            // 🚨 A GATE NEVER PASSES ON NO EVIDENCE. Adopt-only compiles nothing, so it can prove
-            // nothing about whether this image's NodeTypes build — arming the gate here would let a
-            // pod go Ready having verified strictly less than a sweep that merely RAN. The
-            // combination is a configuration mistake, so it is named rather than quietly honoured
-            // in either direction: the gate is left NotStarted (the documented fail-OPEN state for
-            // a misconfiguration, so it can never black-hole a pod) and the operator is told which
-            // of the two keys to change.
-            if (gate is { GatesReadiness: true })
-                logger.LogError(
-                    "DynamicTypePreWarmer: '{AdoptKey}'=true and '{GateKey}'=true are "
-                    + "CONTRADICTORY — adopt-only never compiles, so it cannot verify the bake the "
-                    + "readiness gate exists to certify. The gate is NOT armed for this boot. Set "
-                    + "'{AdoptKeyAgain}'=false to gate on a real sweep, or '{GateKeyAgain}'=false to "
-                    + "accept an ungated adopt-only boot (the intended shape for local/dev "
-                    + "instances).",
-                    AdoptOnlyConfigKey, NodeTypeBakeGateExtensions.EnabledConfigKey,
-                    AdoptOnlyConfigKey, NodeTypeBakeGateExtensions.EnabledConfigKey);
-        }
-        else
+        if (sweepEnabled)
             gate?.MarkRunning("enumerating dynamic NodeTypes");
 
         // Pacing: explicit config wins; otherwise a readiness-GATED pod sweeps at full speed (it
@@ -376,29 +353,31 @@ public sealed class DynamicTypePreWarmerHostedService(
             .SelectMany(_ => ShippedPrebuiltBundles.SeedAll(mesh, prebuiltDirectory, logger))
             .SelectMany(_ => ShippedPrebuiltBundles.SeedPublishedRoot(mesh, publishedBundleRoot, logger));
 
-        if (adoptOnly)
+        if (!sweepEnabled)
         {
+            // The default path for every deployment: adopt, say what that covered, compile nothing.
             _warmSubscription = seeded
                 .SelectMany(_ => DynamicTypePreWarmer.ProbeDynamicTypes(mesh, logger))
                 .Subscribe(
                     report => ReportAdoption(report, startedAt, sweepMemory, publishedBundleRoot),
                     ex =>
                     {
-                        // The enumeration is the whole measurement here. Losing it means the pod
-                        // cannot say WHICH types the adoption missed — and the uncovered set is the
-                        // one thing adopt-only owes its operator. Lazy compilation still covers
+                        // The enumeration IS the measurement here. Losing it means the pod cannot
+                        // say which types the adoption missed — and the uncovered set is the one
+                        // thing this path owes its operator. Lazy compilation still covers
                         // correctness, so this is loud but not fatal.
                         logger.LogError(ex,
-                            "DynamicTypePreWarmer: adopt-only boot could not enumerate its dynamic "
-                            + "NodeTypes, so it cannot report which ones the prebuilt bundles "
-                            + "covered. Adoption itself already ran; every type still compiles on "
-                            + "first access. Re-run with '{Key}'=false to fall back to a compiling "
-                            + "sweep if this persists.", AdoptOnlyConfigKey);
+                            "DynamicTypePreWarmer: could not enumerate the dynamic NodeTypes, so "
+                            + "this boot cannot report which ones the prebuilt bundles covered. "
+                            + "Adoption itself already ran; every type still compiles on first "
+                            + "access, so the pod stays correct — it just cannot tell you how much "
+                            + "of its content arrived pre-built.");
                         bake?.MarkSettled(PreWarmSettlement.Faulted);
                     },
-                    // NotApplicable, deliberately: no bake ran. Consumers sequenced behind the
-                    // barrier (the default-install pass adopts plugin bundles behind it) still get
-                    // their signal once the seeding has landed, and learn that nothing was compiled.
+                    // NotApplicable, deliberately: adoption ran but no BAKE did, and completion was
+                    // only ever a claim about a sweep. Consumers sequenced behind the barrier (the
+                    // default-install pass adopts plugin bundles behind it) still get their signal
+                    // once the seeding has landed, and learn that nothing was compiled.
                     () => bake?.MarkSettled(PreWarmSettlement.NotApplicable));
             return;
         }
@@ -595,9 +574,9 @@ public sealed class DynamicTypePreWarmerHostedService(
 
         logger.LogInformation(
             "DynamicTypePreWarmer: ADOPT-ONLY boot complete in {Elapsed} — adopted={Adopted} "
-            + "uncovered={Uncovered} of {Total} dynamic NodeType(s); nothing was compiled "
-            + "({Key}=true). {Summary} — {Memory}",
-            elapsed, covered, uncovered.Count, report.Entries.Count, AdoptOnlyConfigKey,
+            + "uncovered={Uncovered} of {Total} dynamic NodeType(s); nothing was compiled at boot "
+            + "({Key}!=true). {Summary} — {Memory}",
+            elapsed, covered, uncovered.Count, report.Entries.Count, EnabledConfigKey,
             report.Summary, memory);
 
         if (uncovered.Count == 0)
@@ -623,12 +602,12 @@ public sealed class DynamicTypePreWarmerHostedService(
         logger.LogWarning(
             "DynamicTypePreWarmer: {Uncovered} dynamic NodeType(s) were NOT covered by the "
             + "prebuilt bundles and will each pay a Roslyn compile on FIRST ACCESS: {Types}. "
-            + "This instance adopts rather than pre-bakes ({Key}=true), so nothing is compiled at "
+            + "This instance adopts rather than pre-bakes ({Key}!=true), so nothing is compiled at "
             + "boot — these are correct, just not warm. If they should have been covered, the "
             + "bundle source is the thing to check: image bundles at '{ImageKey}' and the "
             + "CI-published root '{Root}' (via '{RootKey}'); an identity mismatch declines every "
             + "bundle wholesale and is reported by ShippedPrebuiltBundles above.",
-            uncovered.Count, named, AdoptOnlyConfigKey,
+            uncovered.Count, named, EnabledConfigKey,
             ShippedPrebuiltBundles.DirectoryConfigKey,
             string.IsNullOrWhiteSpace(publishedBundleRoot) ? "(unset)" : publishedBundleRoot,
             ShippedPrebuiltBundles.PublishedRootConfigKey);

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -154,38 +154,64 @@ public class PlatformBakeLaneGuard
     }
 
     /// <summary>
-    /// 🚨 <c>PreWarm__AdoptOnly</c> only does anything while <c>PreWarm__DynamicTypes</c> is
-    /// <c>true</c> — and the "obvious simplification" of the local values (set
-    /// <c>PreWarm__DynamicTypes: "false"</c>, since we are not pre-baking any more) would silently
-    /// undo the whole point.
+    /// 🚨 <b>An armed readiness gate with no sweep behind it is a SILENT LIE.</b>
     ///
-    /// <para>The bundle SEEDING and the compiling sweep live on the same hosted service. Disabling
-    /// the service disables adoption with it, so the instance would adopt nothing AND still compile
-    /// every type — just lazily, one hub activation at a time, and with no boot report saying so.
-    /// The local default therefore has to keep the service ON and select adopt-only, which reads
-    /// like a contradiction to anyone who has not traced the boot path. This asserts the pairing so
-    /// it survives the next person who tidies the file.</para>
+    /// <para>The bake gate reads state that only the compiling sweep writes, and the health check
+    /// deliberately reports Healthy while the bake is <c>NotStarted</c> so a configuration mistake
+    /// can never black-hole a pod. The consequence is that <c>GateReadiness=true</c> with
+    /// <c>DynamicTypes=false</c> yields a gate that is registered, permanently green, and protects
+    /// NOTHING — which is precisely the failure the gate exists to prevent.</para>
+    ///
+    /// <para>The portal shouts that combination at Critical on startup, but a log line is a
+    /// runtime discovery; this is the compile-time one. It matters most right now, because the
+    /// fleet has just switched the sweep OFF: the next person who re-arms a gate "for safety"
+    /// without also restoring the sweep gets false confidence, not safety.</para>
     /// </summary>
     [Fact]
-    public void LocalDefaults_AdoptRatherThanPreBake_AndKeepTheSeedingOn()
+    public void NoValuesFileArmsTheBakeGateWithoutTheSweepBehindIt()
+    {
+        var root = FindRepoRoot();
+        var offenders = new[]
+            {
+                Path.Combine(root, "deploy", "helm", "values.yaml"),
+                Path.Combine(root, "deploy", "aks", "values.aks.yaml"),
+                Path.Combine(root, "deploy", "homebrew", "share", "values.local.defaults.yaml"),
+            }
+            .Where(File.Exists)
+            .Select(f => (file: Path.GetFileName(f), lines: File.ReadAllLines(f)
+                .Select(l => l.Trim())
+                .Where(l => !l.StartsWith('#'))
+                .ToList()))
+            .Where(x => Setting(x.lines, "PreWarm__GateReadiness") == "true"
+                        && Setting(x.lines, "PreWarm__DynamicTypes") != "true")
+            .Select(x => x.file)
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "These values files arm PreWarm__GateReadiness while PreWarm__DynamicTypes is not "
+            + "true. The gate can only reach a verdict from the compiling sweep, so with the sweep "
+            + "off it reports healthy on every rollout and protects nothing — worse than no gate, "
+            + "because the deployment believes it is protected. Either restore the sweep or turn "
+            + "the gate off. Offending file(s): " + string.Join(", ", offenders));
+    }
+
+    /// <summary>The value of a <c>KEY: "value"</c> line, unquoted, or null when unset.</summary>
+    private static string? Setting(IEnumerable<string> lines, string key) =>
+        lines.FirstOrDefault(l => l.StartsWith(key + ":", StringComparison.Ordinal))
+            ?.Split(':', 2)[1].Trim().Trim('"');
+
+    /// <summary>
+    /// The local instance must name a bundle root — adopt-only with nothing to adopt from reports
+    /// every dynamic type as uncovered forever, which is honest but useless.
+    /// </summary>
+    [Fact]
+    public void LocalDefaults_NameABundleRootToAdoptFrom()
     {
         var values = File.ReadAllLines(Path.Combine(
                 FindRepoRoot(), "deploy", "homebrew", "share", "values.local.defaults.yaml"))
             .Select(l => l.Trim())
             .Where(l => !l.StartsWith('#'))
             .ToList();
-
-        Assert.Contains(values, l => l.StartsWith("PreWarm__AdoptOnly:", StringComparison.Ordinal)
-                                     && l.Contains("true", StringComparison.Ordinal));
-
-        Assert.True(
-            values.Any(l => l.StartsWith("PreWarm__DynamicTypes:", StringComparison.Ordinal)
-                            && l.Contains("true", StringComparison.Ordinal)),
-            "The local instance selects adopt-only, which requires PreWarm__DynamicTypes to stay "
-            + "\"true\": the prebuilt-bundle seeding runs on the same hosted service as the sweep, "
-            + "so turning the service off would adopt NOTHING and compile everything lazily "
-            + "instead — the opposite of the intent, and silent. Adopt-only is the key that "
-            + "removes the compiling; DynamicTypes is the key that keeps the adoption.");
 
         Assert.True(
             values.Any(l => l.StartsWith("PreWarm__PrebuiltBundleRoot:", StringComparison.Ordinal)

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
@@ -92,7 +92,7 @@ public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTe
     }
 
     /// <summary>
-    /// The ADOPT-ONLY measurement (<c>PreWarm:AdoptOnly</c>): the probe must see the same dynamic
+    /// The ADOPT-ONLY measurement (the default boot, <c>PreWarm:DynamicTypes</c> off): the probe must see the same dynamic
     /// types the compiling sweep does and REPORT the ones that are not covered — without building
     /// anything itself.
     ///


### PR DESCRIPTION
Follows the maintainer's call: *"we should probably disable any pre-bake on instance level and just do it dynamically when user reaches place."* Builds on #1746.

## The load-bearing change: two fused decisions, split

Bundle seeding lived behind `PreWarm:DynamicTypes` — the same switch that turned on the compiling sweep. The chart's default is (and was) `DynamicTypes=false`, so **the ordinary deployment adopted nothing**: it ignored bundles sitting in its own image and lazily recompiled content CI had already built for it.

Now: **adoption + the coverage report are unconditional.** `PreWarm:DynamicTypes` controls only whether the *leftover* is also compiled at boot — and it is `false` everywhere, fleet included.

### Measured, same tree, `PreWarm:DynamicTypes=false`

That is the setting which until now printed one line — `disabled — dynamic NodeTypes compile lazily on first access` — and did nothing else. It now produces:

```
ADOPT-ONLY boot complete in 00:00:00.3344500 — adopted=0 uncovered=42 of 42 dynamic
NodeType(s); nothing was compiled at boot (PreWarm:DynamicTypes!=true).
framework=s6c49eea total=42 baked=0 pending=42 neverbuilt=13 frameworkstale=21 previouslybroken=8

42 dynamic NodeType(s) were NOT covered by the prebuilt bundles and will each pay a Roslyn
compile on FIRST ACCESS: ACME/Article (FrameworkStale: built against framework fe2dc96f),
… Doc/Architecture/BusinessRules/Cession (NeverBuilt: no assembly recorded),
… FutuRe/AsiaRe/LineOfBusiness (PreviouslyBroken: last compile settled at Error), …and 17 more.
```

**0.33 s**, and a fully reasoned coverage report where there had been one line of nothing.

## Why retire the sweep rather than tune it

Adoption made it redundant. A prod boot measured `compiled=0 alreadyBaked=84` — it compiled nothing and still charged 32.1 s of warm-up (64.8 s when adoption was broken). On a *miss* it was worse than useless: it blocked readiness on compiling types no user had asked for.

**First-hit cost, measured** (the number the change trades for): **2.0–2.1 s per type** locally (four cold compiles: 2.1, 2.1, 2.0, 2.0 s), ~2.4 s per type on the fleet — paid once, by that type's first visitor, instead of for every type at boot.

## Readiness — decided and stated, not silently changed

The bake gate certified a bake by **compiling** every type and refusing readiness when one that used to build no longer did. With nothing compiling at boot there is no such verdict to reach, so `PreWarm__GateReadiness` is turned **off** on the fleet rather than left armed. An armed gate with no sweep behind it reports healthy on every rollout and protects **nothing** — the exact failure it exists to prevent (the portal already shouts this at Critical; now a test pins it too).

- **What this gives up, precisely:** a NodeType that regresses on a new image is no longer caught at rollout — it surfaces when a user first reaches it.
- **What replaces it:** the boot coverage report. A broken bake lane (an identity mismatch declines every bundle wholesale, #1725) becomes a visible coverage collapse in the logs of the **first** pod of a bad roll, rather than something a user finds.

> 🚨 **Not a coverage gate.** `uncovered > 0` is the *normal* steady state of a real portal: users author NodeTypes in their own partitions and those have no CI bake by construction — the live `memex` assembly share holds two such types under `rbuergi`. Gating readiness on full coverage would never go ready. This is asserted in the docs so the next person does not "fix" it that way.

## `PreWarm:AdoptOnly` is retired

Added in #1746 hours ago and never released. After the split it means exactly `DynamicTypes=false`, and two names for one behaviour is worse than the churn of removing it.

## Tests

- `PlatformBakeLaneGuard.NoValuesFileArmsTheBakeGateWithoutTheSweepBehindIt` — new. **Verified it can fail**: flipping `values.aks.yaml` back to `GateReadiness: "true"` reddens it naming the file.
- `EveryPreWarmKeyInValues_IsTemplatedInTheConfigMap` still green (retired key removed from both template and values).
- `MeshWeaver.Hosting.Monolith.Test`: 61/61.
- `MeshWeaver.Documentation.Test` guards + link integrity + What's New integrity: 7/7.
- `helm template` verified for both overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)