### PR TITLE
Gate that the Cosmos/Snowflake module layout actually loads

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -105,6 +105,25 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Hosting.Snowflake/MeshWeaver.Hosting.Snowflake.csproj" />
   </ItemGroup>
 
+  <!--
+    MeshModulesClosureSubset — narrow the CLOSURE lane to the named modules (semicolon-separated,
+    no extension). The inventory above stays the ONE place a module's path is written; a consumer
+    picks from it by name, never restates it.
+
+    Today exactly one consumer sets it: test/Memex.Portal.Shared.Test, which lays the two storage
+    backends into its OWN bin so StorageModuleLayoutTest can load the very layout the image ships
+    (#1752 — the backends have no ProjectReference anywhere, so nothing else proves their folder is
+    loadable). Reusing THIS worker is the whole point: a hand-copied publish+prune in the test would
+    be a second detector, free to agree with itself while the shipped layout is broken.
+
+    🚨 A HOST must never set it: -p: makes a property global to every project in the build, so one
+    stray flag would narrow the image's own layout too. A subset naming nothing fails the lane RED
+    (below) rather than laying out nothing and reporting success.
+  -->
+  <PropertyGroup>
+    <_MeshModulesSubsetNames>;$(MeshModulesClosureSubset);</_MeshModulesSubsetNames>
+  </PropertyGroup>
+
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">
     <PropertyGroup>
       <!-- EnsureTrailingSlash: GetFullPath does not guarantee one, and every use below
@@ -152,7 +171,7 @@
     <MSBuild Projects="$(MSBuildThisFileFullPath)"
              Targets="LayoutMeshModuleClosures"
              BuildInParallel="false"
-             Properties="MeshModulesAppDir=$(_AppPublishDir);Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=true" />
+             Properties="MeshModulesAppDir=$(_AppPublishDir);Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=true;MeshModulesClosureSubset=$([MSBuild]::Escape('$(MeshModulesClosureSubset)'))" />
 
     <ItemGroup>
       <_ModuleFileKept Include="$(_AppPublishDir)modules/**/*.*" />
@@ -170,7 +189,7 @@
     <MSBuild Projects="$(MSBuildThisFileFullPath)"
              Targets="LayoutMeshModuleClosures"
              BuildInParallel="false"
-             Properties="MeshModulesAppDir=$([System.IO.Path]::GetFullPath('$(OutDir)', '$(MSBuildProjectDirectory)'));Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=false" />
+             Properties="MeshModulesAppDir=$([System.IO.Path]::GetFullPath('$(OutDir)', '$(MSBuildProjectDirectory)'));Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=false;MeshModulesClosureSubset=$([MSBuild]::Escape('$(MeshModulesClosureSubset)'))" />
   </Target>
 
   <!-- The closure-lane worker. Runs against THIS file as its own project (see the callers for
@@ -181,6 +200,18 @@
     <PropertyGroup>
       <_AppDir>$([MSBuild]::EnsureTrailingSlash('$(MeshModulesAppDir)'))</_AppDir>
     </PropertyGroup>
+
+    <!-- Narrow to @(MeshModuleClosure) entries named by MeshModulesClosureSubset. INSIDE the
+         target on purpose: %(Filename) in a top-level ItemGroup condition evaluates to EMPTY
+         rather than erroring, which silently drops EVERY module — a lane that lays out nothing
+         while reporting success. Batching only binds metadata within a target. -->
+    <ItemGroup Condition="'$(MeshModulesClosureSubset)' != ''">
+      <_MeshModuleClosureDropped Include="@(MeshModuleClosure)"
+                                 Condition="!$(_MeshModulesSubsetNames.Contains(';%(Filename);'))" />
+      <MeshModuleClosure Remove="@(_MeshModuleClosureDropped)" />
+    </ItemGroup>
+    <Error Condition="'$(MeshModulesClosureSubset)' != '' And '@(MeshModuleClosure->Count())' == '0'"
+           Text="LayoutMeshModuleClosures: MeshModulesClosureSubset='$(MeshModulesClosureSubset)' names no module in the inventory, so this lane would lay out nothing and report success. Use the bare assembly names from the @(MeshModuleClosure) list above." />
 
     <!-- The module's own dll in the APP root means a ships-the-bits ProjectReference came back
          (the same-identity double-load trap — #1644's fail-if-referenced guard) or the publish
@@ -205,7 +236,7 @@
              Targets="Restore"
              BuildInParallel="false"
              Properties="Configuration=$(Configuration)"
-             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
+             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
 
     <!-- Build, then Publish with NoBuild — deliberately TWO invocations, and the Build one runs
          with the module's ordinary global properties (RemoveProperties strips everything this
@@ -219,7 +250,7 @@
              Targets="Build"
              BuildInParallel="false"
              Properties="Configuration=$(Configuration)"
-             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
+             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
     <!-- SatelliteResourceLanguages=en: without it the closure publish lays out a culture folder
          per Roslyn localization (cs/de/es/… via Kernel.Hub), every one a same-identity duplicate
          of the app's own satellite folders. Suppressing them at the SOURCE beats deleting them
@@ -230,7 +261,7 @@
              Targets="Publish"
              BuildInParallel="false"
              Properties="Configuration=$(Configuration);NoBuild=true;SatelliteResourceLanguages=en;PublishDir=$(_AppDir)modules/%(Filename)/"
-             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;NetCoreTargetingPackRoot;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
+             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
 
     <!-- Prune (0): RID trees. A module loads via Assembly.LoadFrom, which never consults the
          module's deps.json — the fallback probe is the module's FLAT folder only — so a

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -174,6 +174,20 @@ the Direct/ServiceInterop client, Snowflake ~10 MB — its driver carries Arrow 
 GCS SDKs for stage transfer); `-p:PublishMeshModules=false` skips the whole layout for a host
 that wants none of it.
 
+Being **bootstrap tier** — the mesh cannot read itself without a storage backend, so the Store's
+catalog lives behind the very storage an install would be delivering — is also what leaves these
+two with no compiled reference anywhere in the tree, and therefore nothing that would notice their
+folder going wrong. `StorageModuleLayoutTest` (`test/Memex.Portal.Shared.Test`) is that gate: it
+walks the seam a portal walks and asserts nothing more — `ResolveModulePath` lands inside
+`modules/<Name>/` rather than on its app-folder fallback, the private driver survived the prune and
+loads, `InstallAssemblies` folds the assembly's `MeshNodeProviderAttribute`, and the keyed
+`IStorageAdapterFactory` that `Graph:Storage:Type` resolves comes from THAT DLL. No emulator, no
+endpoint, ~40 ms. It closes two blind spots at once: the compiler proves the SOURCE binds but says
+nothing about the publish layout, and the emulator suites green-SKIP when their backend is
+unreachable, so they can pass by not running. The same test is what a released binary would have to
+satisfy if these backends ever moved out of the platform repo (#1752) — point it at the pinned bytes
+instead of the in-tree build and it answers the question a moved backend raises.
+
 Entries resolve through `MeshBuilder.ResolveModulePath`: a rooted path passes through; a bare
 DLL name probes **`modules/<name>/<name>.dll`** beside the app first (the publish layout below),
 then falls back to the app folder.
@@ -188,6 +202,12 @@ Flipping a module's reference off (one module at a time, its entry upgraded to a
 correct for that module) is what makes the folder carry real content; which modules EXIST then
 becomes a publish (or Store-install) decision while which ACTIVATE stays the boot union above.
 Skip the whole target with `-p:PublishMeshModules=false`.
+
+`-p:MeshModulesClosureSubset=<Name>;<Name>` narrows the closure lane to the named modules, so a
+project that is not a host can lay out a couple of them into its own `bin/` — today only
+`Memex.Portal.Shared.Test`, so `StorageModuleLayoutTest` loads the real layout rather than a copy
+of it. 🚨 A host must never pass it: `-p:` is global to every project in the build. A subset naming
+nothing fails the lane RED instead of laying out nothing and reporting success.
 
 The first flipped module is `MeshWeaver.Markdown.Export`: no host references it any more — its
 targets entry runs a full closure publish pruned against the app root AND the shared-framework

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-the-storage-backends-keep-their-guarantee.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-the-storage-backends-keep-their-guarantee.md
@@ -1,0 +1,29 @@
+---
+Name: The storage backends keep their guarantee
+Category: Fix
+Description: Cosmos and Snowflake now have a test that loads them the way a portal does, so a broken publish layout fails CI instead of failing a deployment at boot.
+Icon: ShieldCheckmark
+Order: -20260817
+---
+
+# The storage backends keep their guarantee
+
+Cosmos and Snowflake started shipping with the image so that `Graph:Storage:Type` could actually
+select them. What shipped with them was a blind spot: nothing in the repo references either backend,
+so nothing would have noticed their folder going wrong.
+
+Two things that look like coverage are not. The compiler proves the **source** binds — it says
+nothing about the publish **layout**, and the layout is where these two are fragile: their drivers
+(the Cosmos client, the Snowflake driver with its Arrow/AWS/GCS closure) exist nowhere else in the
+image, so a prune that took one away would leave an assembly that faults the first time a portal
+touched it. And the emulator suites green-skip when their backend is unreachable, so they can pass
+by not running.
+
+There is now a test that loads each backend exactly the way a booting portal does — off disk, from
+`modules/<Name>/`, with no compiled reference — and asserts the keyed storage factory that
+`Graph:Storage:Type` resolves comes from that DLL. It needs no emulator, no endpoint and no network,
+and runs in about 40 ms.
+
+Nothing changes for a deployment that does not select one of these backends, which today is all of
+them. For one that does, the guarantee is now checked on every commit rather than at its next
+restart.

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -1,4 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <!-- ═════════ The storage-backend contract gate (#1752) ═════════
+       StorageModuleLayoutTest loads the Cosmos/Snowflake backends the way a PORTAL does — off
+       disk, from modules/<Name>/, with NO compiled reference — so the layout has to exist in THIS
+       project's own bin. Reuse the real lane (MeshModulesClosureSubset narrows it to these two)
+       rather than hand-copying a publish+prune here: a copy would be a second detector, free to
+       agree with itself while the shipped layout is broken.
+
+       🚨 Deliberately NO ProjectReference to either backend. One would put the module's own DLL in
+       this bin's root, where prune (a) deletes it from modules/ as a same-identity duplicate — the
+       gate would then load the app-root copy and assert nothing about the shipped layout. -->
+  <PropertyGroup>
+    <MeshModulesClosureSubset>MeshWeaver.Hosting.Cosmos;MeshWeaver.Hosting.Snowflake</MeshModulesClosureSubset>
+  </PropertyGroup>
+  <Import Project="..\..\memex\MeshModulesPublish.targets" />
+
   <ItemGroup>
     <!-- VersionEndpointTest drives GET /api/version over a real HTTP pipeline (TestServer) to
          prove it answers with NO authenticated session — the whole point of the endpoint. -->

--- a/test/Memex.Portal.Shared.Test/StorageModuleLayoutTest.cs
+++ b/test/Memex.Portal.Shared.Test/StorageModuleLayoutTest.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The storage-backend contract gate (#1752). Cosmos and Snowflake are <b>bootstrap tier</b>: the
+/// mesh cannot read itself without a storage backend, so they can never be Store-installed (the
+/// Store's catalog lives behind the very storage you would be installing) and must ride the image
+/// as a <c>modules/&lt;Name&gt;/</c> closure. What was missing when #1727 put them on that lane is any
+/// assertion that the laid-out folder is <i>loadable</i>:
+/// <list type="bullet">
+///   <item>the compiler proves the source binds while the source is in-tree — but it says nothing
+///     about the publish LAYOUT, and the closure lane's own prune is what can break it
+///     ("a thin-lane row would land an assembly that fails to load its own driver at first use");</item>
+///   <item>and the emulator suites cannot stand in for it: both fixtures green-SKIP when their
+///     backend is unreachable, so they pass by not running.</item>
+/// </list>
+/// So this asserts exactly the seam a portal walks and nothing more — no emulator, no network,
+/// milliseconds: <c>ResolveModulePath</c> finds the module under <c>modules/</c>, its private
+/// driver rode the prune, <c>InstallAssemblies</c> folds the assembly's
+/// <see cref="MeshNodeProviderAttribute"/>, and the keyed <see cref="IStorageAdapterFactory"/> that
+/// <c>Graph:Storage:Type</c> resolves lands from THAT DLL. This project holds no compiled reference
+/// to either backend, which is the whole claim under test.
+///
+/// <para>It is also the gate that has to stand before the source could move to a satellite repo:
+/// point it at a pinned released binary instead of the in-tree build and it answers the question a
+/// moved backend raises — does a module built against platform N−1 still bind in N.</para>
+/// </summary>
+public class StorageModuleLayoutTest
+{
+    /// <summary>
+    /// module name · the PRIVATE driver assembly that must ride the closure. The driver is named
+    /// rather than inferred on purpose: its presence in the module folder is the single thing the
+    /// prune can take away, and swapping a backend's driver should be a deliberate edit here, not
+    /// a silently weakened assertion.
+    /// </summary>
+    public static TheoryData<string, string> Layouts() => new()
+    {
+        { "MeshWeaver.Hosting.Cosmos", "Microsoft.Azure.Cosmos.Client.dll" },
+        { "MeshWeaver.Hosting.Snowflake", "Snowflake.Data.dll" },
+    };
+
+    /// <summary>
+    /// module name · the <c>Graph:Storage:Type</c> value · the factory that value must resolve to.
+    /// </summary>
+    public static TheoryData<string, string, string> Backends() => new()
+    {
+        { "MeshWeaver.Hosting.Cosmos", "Cosmos", "MeshWeaver.Hosting.Cosmos.CosmosStorageAdapterFactory" },
+        { "MeshWeaver.Hosting.Snowflake", "Snowflake", "MeshWeaver.Hosting.Snowflake.SnowflakeStorageAdapterFactory" },
+    };
+
+    /// <summary>
+    /// The bits actually ship: <c>ResolveModulePath</c> lands inside <c>modules/&lt;Name&gt;/</c> — not on
+    /// its app-folder fallback, which would mean a ships-the-bits reference came back — and the
+    /// module's private driver survived the prune and loads.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Layouts))]
+    public void ClosureLane_LaysTheBackendOut_WithItsPrivateDriver(
+        string moduleName, string driverAssemblyFile)
+    {
+        var expectedFolder = Path.Combine(AppContext.BaseDirectory, "modules", moduleName);
+        var resolved = MeshBuilder.ResolveModulePath(moduleName + ".dll");
+
+        // ResolveModulePath falls back to the app folder when modules/<Name>/<Name>.dll is absent,
+        // so "the file exists" is NOT the assertion — WHERE it resolved is.
+        Assert.True(
+            File.Exists(resolved),
+            $"{moduleName}: the closure lane laid out nothing loadable — ResolveModulePath returned '{resolved}', which does not exist.");
+        Assert.Equal(Path.Combine(expectedFolder, moduleName + ".dll"), resolved);
+
+        var driver = Path.Combine(expectedFolder, driverAssemblyFile);
+        Assert.True(
+            File.Exists(driver),
+            $"{moduleName}: '{driverAssemblyFile}' is missing from {expectedFolder}. The backend's driver exists nowhere else — no host references it — so a portal selecting this backend would fault at first use. Check the closure lane's prune in memex/MeshModulesPublish.targets.");
+        Assert.NotNull(Assembly.LoadFrom(driver));
+    }
+
+    /// <summary>
+    /// The seam binds: loading the module the way <c>Modules:Assemblies</c> does registers the keyed
+    /// factory <c>Graph:Storage:Type</c> resolves, and the registration comes from the module folder
+    /// DLL. Then <c>Create</c> runs far enough to JIT against the platform's contract types and its
+    /// own driver, refusing on configuration (<see cref="InvalidOperationException"/>) rather than
+    /// on a loader failure — with no endpoint, no container and no network.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Backends))]
+    public void Portal_WithNoCompiledReference_ResolvesTheKeyedFactory(
+        string moduleName, string storageKey, string factoryTypeName)
+    {
+        var modulePath = MeshBuilder.ResolveModulePath(moduleName + ".dll");
+        var services = Install(modulePath);
+
+        var descriptor = Assert.Single(
+            services,
+            d => d.ServiceType == typeof(IStorageAdapterFactory) && Equals(d.ServiceKey, storageKey));
+        var implementation = descriptor.KeyedImplementationType;
+        Assert.NotNull(implementation);
+        Assert.Equal(factoryTypeName, implementation.FullName);
+
+        // The registration must come from the DLL under modules/ — an app-root copy resolving here
+        // would make every other assertion true of the wrong bytes.
+        Assert.Equal(modulePath, implementation.Assembly.Location);
+
+        var provider = services.AddOptions().BuildServiceProvider();
+        var factory = provider.GetRequiredKeyedService<IStorageAdapterFactory>(storageKey);
+
+        // Unconfigured, both backends refuse with InvalidOperationException. Reaching that refusal
+        // means the method JITted: its contract types (GraphStorageConfig, IStorageAdapter) bound
+        // against the platform, and its driver types bound against the module folder. A missing or
+        // mismatched dependency surfaces here as a loader exception instead, naming what broke.
+        Assert.Throws<InvalidOperationException>(
+            () => factory.Create(new GraphStorageConfig { Type = storageKey }, provider));
+    }
+
+    /// <summary>
+    /// The portal's own fold: <see cref="MeshBuilder.InstallAssemblies"/> is what reads
+    /// <c>Modules:Assemblies</c> at boot — <c>Assembly.LoadFrom</c> plus attribute discovery.
+    /// </summary>
+    private static IServiceCollection Install(string modulePath)
+    {
+        var serviceConfigs = new List<Func<IServiceCollection, IServiceCollection>>();
+        var builder = new MeshBuilder(configure => serviceConfigs.Add(configure), AddressExtensions.CreateMeshAddress());
+        builder.InstallAssemblies(modulePath);
+        return serviceConfigs.Aggregate(
+            (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+    }
+}


### PR DESCRIPTION
Groundwork for #1752 — and, on its own, the gate #1727 shipped without.

## What was missing

#1727 put both storage backends on the closure lane so their DLLs reach the image. Nothing checks that the folder it lays out is **loadable**, and nothing would: neither backend has a compiled reference anywhere in the tree.

The two things that look like coverage are not:

- **The compiler** proves the source binds — it says nothing about the publish **layout**, which is where these two are fragile. Their drivers (the Cosmos client; the Snowflake driver with its Arrow/AWS/GCS closure) exist nowhere else in the image, so a prune that took one away would land exactly what `MeshModulesPublish.targets` warns about: *"an assembly that fails to load its own driver at first use."*
- **The emulator suites** green-SKIP when their backend is unreachable, so they can pass by not running. `MeshWeaver.Hosting.Snowflake.Test` skips **103 of its 140 tests** on every CI run today.

## The gate

`StorageModuleLayoutTest` walks the seam a portal walks and asserts nothing more:

1. `ResolveModulePath` lands inside `modules/<Name>/` — not on its app-folder fallback;
2. the private driver survived the prune and loads;
3. `InstallAssemblies` folds the assembly's `MeshNodeProviderAttribute`;
4. the keyed `IStorageAdapterFactory` that `Graph:Storage:Type` resolves comes from **that** DLL, and `Create` JITs against both the platform's contract types and its own driver — refusing on configuration rather than on a loader failure.

No emulator, no endpoint, no network. 4 facts in ~40 ms.

## Verified it can fail

A gate that cannot fail is not a gate, so both failure modes were exercised:

| Break | Result |
|---|---|
| delete `Microsoft.Azure.Cosmos.Client.dll` from the folder | both Cosmos tests red — the layout one naming the file, the seam one surfacing the real `FileNotFoundException` from JITting `Create` |
| delete `modules/` entirely | all four red, naming the app-folder fallback they resolved to instead |

## The one mechanism change

The layout has to exist in the test project's own bin, so `MeshModulesPublish.targets` grows **`MeshModulesClosureSubset`** — narrow the closure lane to named modules. Reusing the real worker is the point: a hand-copied publish+prune in the test would be a second detector, free to agree with itself while the shipped layout is broken.

Two traps handled: the filter lives **inside** the target, because `%(Filename)` in a top-level `ItemGroup` condition evaluates to *empty* rather than erroring — which silently drops every module and reports success (hit while building this); and a subset naming nothing now fails **RED**. A host must never pass it, since `-p:` is global to every project in the build.

## Host publish unchanged

A single-RID publish of `Memex.Portal.Distributed` lays out the same **6 thin + 14 closure** modules, 99 files, both storage folders intact with their drivers.

Deliberately **no** `ProjectReference` to either backend from the test project — one would put the module's own DLL in the bin root, where the app-duplicate prune deletes it from `modules/` and the gate would assert against the wrong bytes.

## Scope

This is the contract gate #1752 requires *before* the source could move to a satellite repo — point it at a pinned released binary instead of the in-tree build and it answers the question a moved backend raises. The move itself is **not** in this PR; findings are on the issue.

Refs #1752, #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)