### PR TITLE
feat(ci): a repo must not build until its upstreams have published for the target framework (#1755)

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1106,6 +1106,14 @@ jobs:
   # REPORTER-CLASS like notify-platform-update: a lost dispatch costs one delayed rebake wave
   # (the next release re-notifies) and can never hide a defect — unconfigured stays a loud
   # NOTICE, never a red.
+  #
+  # 🚨 Provisioning note (#1755): a subscriber whose own upstreams are not yet published EXITS
+  # without building and is re-woken by its upstream's `meshweaver-upstream-published` event, so
+  # naming every satellite here is CORRECT but noisy — the dependent repos paint one red per
+  # release before their upstream publishes. Naming only the ROOTS (the repos with no upstreams:
+  # MeshWeaver.Plugins) gets the identical result quietly, because the satellite→satellite edge in
+  # node-repo-publish-bake carries the wave the rest of the way. Either list is safe; the roots-only
+  # list is the tidy one.
   notify-dependents:
     name: "Notify dependent repos"
     needs: [gate, portal-image, promote]

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -21,6 +21,12 @@ name: Node repo publish-bake (reusable)
 #
 # Caller contract (see the SocialMedia/Plugins ci.yml for a worked example):
 #
+#   on:
+#     repository_dispatch:
+#       # BOTH: the platform releasing, and an UPSTREAM of this repo publishing (#1755). The second
+#       # is what wakes a run that exited because its upstreams were not ready yet.
+#       types: [meshweaver-framework-released, meshweaver-upstream-published]
+#
 #   publish-bake:
 #     if: >
 #       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
@@ -33,6 +39,9 @@ name: Node repo publish-bake (reusable)
 #       test-image: ${{ vars.MW_TEST_IMAGE }}
 #       image-digest: ${{ vars.MW_IMAGE_DIGEST }}     # or a workflow env / literal pin
 #       bake-publish-targets: ${{ vars.BAKE_PUBLISH_TARGETS }}
+#       upstream-sources: plugins                    # exit unless `plugins` is published for the
+#                                                    # framework identity this bake targets
+#       dependent-repos: ''                          # e.g. Systemorph/MeshWeaver.Reinsurance
 #       stage-repo: Systemorph/MeshWeaver.Plugins
 #       stage-modules: Store
 #     secrets:
@@ -42,6 +51,17 @@ name: Node repo publish-bake (reusable)
 #       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
 #       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 #       stage-repo-token: ${{ secrets.MESHWEAVER_REPO_TOKEN }}
+#       dependent-dispatch-token: ${{ secrets.DEPENDENT_DISPATCH_TOKEN }}   # iff dependent-repos
+#
+# The real topology, and the order it produces without any central scheduler:
+#
+#   platform ──dispatch──▶ plugins (no upstreams)            builds, publishes
+#                            └──dispatch──▶ education        (was exited) builds, publishes
+#                            │                 └──dispatch──▶ reinsurance
+#                            └──dispatch──▶ socialmedia      (was exited) builds, publishes
+#
+# A repo woken before its upstreams are ready EXITS immediately and is woken again by the
+# publication it was waiting for. Nothing polls; nothing sleeps in a runner.
 #
 # Every externally-provisioned value is an EXPLICIT input/secret — nothing is read from the
 # caller's `vars`/`env` implicitly — so the preflight step below can assert the complete set and
@@ -84,10 +104,36 @@ on:
           (the caller's vars.BAKE_PUBLISH_TARGETS — same value the platform repo carries).
         required: true
         type: string
+      upstream-sources:
+        description: >-
+          The bake-source segments this repo DEPENDS ON, whitespace-separated (e.g. `plugins`
+          for Education / Reinsurance / SocialMedia). Before building, the job asserts each one
+          has a SEALED publication under the framework identity it is about to bake against; if
+          any has not, it EXITS WITHOUT BUILDING (#1755) rather than gating against an upstream
+          that no longer matches the framework. Empty = this repo has no upstreams (the roots:
+          the platform itself, and MeshWeaver.Plugins), and the gate does not apply.
+        required: false
+        type: string
+        default: ''
+      dependent-repos:
+        description: >-
+          Repositories to notify (owner/repo, whitespace-separated) once THIS repo's publication
+          lands — the satellite→satellite edge of the cascade. It is what wakes a downstream repo
+          that exited on `upstream-sources`, so without it that repo never rebuilds for the
+          release. Declaring it REQUIRES the `dependent-dispatch-token` secret; declaring one
+          without the other fails red rather than silently breaking the chain.
+        required: false
+        type: string
+        default: ''
       stage-repo:
         description: >-
           Repository to stage cross-repo modules from (e.g. Systemorph/MeshWeaver.Plugins),
           so the caller's packages' `requires` resolve. Empty = no staging.
+          🚧 Transitional. The directive is that a repo builds only what it OWNS and consumes its
+          upstreams as pre-built released artifacts; `upstream-sources` above is the half of that
+          which exists today (the availability gate). Staging cannot be dropped until a published
+          artifact carries the upstream's NODE DEFINITIONS and not just its compiled assemblies —
+          see Doc/Architecture/ReleaseGates → "Build only what you own".
         required: false
         type: string
         default: ''
@@ -154,6 +200,12 @@ on:
       stage-repo-token:
         description: Token able to read stage-repo (needed only when stage-modules is set).
         required: false
+      dependent-dispatch-token:
+        description: >-
+          Token with repo scope on every repo named by `dependent-repos`, used to fire the
+          `meshweaver-upstream-published` event that wakes them. Required exactly when
+          `dependent-repos` is set.
+        required: false
 
 jobs:
   publish-bake:
@@ -177,6 +229,8 @@ jobs:
           STAGE_TOKEN: ${{ secrets.stage-repo-token }}
           BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
           STAGE_MODULES: ${{ inputs.stage-modules }}
+          DEPENDENT_REPOS: ${{ inputs.dependent-repos }}
+          DEPENDENT_TOKEN: ${{ secrets.dependent-dispatch-token }}
         run: |
           set -euo pipefail
           missing=()
@@ -188,6 +242,14 @@ jobs:
           [ -n "${BAKE_PUBLISH_TARGETS:-}" ]   || missing+=("bake-publish-targets (input, from the caller's repo VARIABLE) — the portals' Azure Files targets, whitespace-separated <account>/<share>[/<base-path>]")
           if [ -n "${STAGE_MODULES:-}" ] && [ -z "${STAGE_TOKEN:-}" ]; then
             missing+=("stage-repo-token (secret) — token able to read the stage repo (stage-modules is set)")
+          fi
+          # 🚨 Declaring dependents is declaring an OBLIGATION: those repos exit on their own
+          # upstream gate and are woken only by the event this job fires. A missing token would
+          # break the chain silently — every downstream repo would sit un-rebuilt for the whole
+          # release with nothing red anywhere. Asserted here, as a DECLARED-INPUT check, never as
+          # an "is the secret set?" probe that decides whether to run.
+          if [ -n "${DEPENDENT_REPOS:-}" ] && [ -z "${DEPENDENT_TOKEN:-}" ]; then
+            missing+=("dependent-dispatch-token (secret) — token with repo scope on ${DEPENDENT_REPOS}; without it this repo's publication cannot wake its dependents and they never rebuild for the release")
           fi
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::The bake publication cannot reach any portal — required credentials are not provisioned. This job fails RED rather than skipping: a grey skip is indistinguishable from a pass and would silently leave every portal re-compiling this repo's content at boot."
@@ -206,16 +268,25 @@ jobs:
           RELEASED_SHA: ${{ github.event.client_payload.sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            # The release's own identity tag (main-cd promote, phase A). A dispatch without a
-            # resolvable image is a platform CD contract break — fail loudly, never fall back to
-            # the pinned digest (that would publish the OLD identity and call it a re-bake).
-            if [ -z "${RELEASED_VERSION:-}" ]; then
-              echo "::error::repository_dispatch payload carries no client_payload.version — cannot resolve the released image."
-              exit 1
-            fi
+          if [ "${{ github.event_name }}" = "repository_dispatch" ] && [ -n "${RELEASED_VERSION:-}" ]; then
+            # The release's own identity tag (main-cd promote, phase A). A framework-release
+            # dispatch without a resolvable image is a platform CD contract break — fail loudly
+            # below, never fall back to the pinned digest (that would publish the OLD identity and
+            # call it a re-bake).
             echo "ref=${TEST_IMAGE%%:*}:${RELEASED_VERSION}" >> "$GITHUB_OUTPUT"
             echo "baking against released ${RELEASED_VERSION} (${RELEASED_SHA:-sha unknown})"
+          elif [ "${{ github.event.action }}" = "meshweaver-framework-released" ]; then
+            echo "::error::meshweaver-framework-released payload carries no client_payload.version — cannot resolve the released image."
+            exit 1
+          elif [ "${{ github.event_name }}" = "repository_dispatch" ] && [ -n "${IMAGE_DIGEST:-}" ]; then
+            # 🚨 An UPSTREAM-published wake, not a framework release. The upstream may have been
+            # publishing for the caller's own pinned platform (its own push), in which case there
+            # is no released version to bake against and the pin is exactly right: the identity the
+            # gate just verified its upstreams against came from THIS image. Falling back here is
+            # therefore the same identity, not an older one — the case the framework-release branch
+            # above must never take.
+            echo "ref=${TEST_IMAGE%%:*}@${IMAGE_DIGEST}" >> "$GITHUB_OUTPUT"
+            echo "woken by an upstream publication; baking against the pinned digest ${IMAGE_DIGEST}"
           elif [ -n "${IMAGE_DIGEST:-}" ]; then
             # tag@digest: the tag names the image, the digest pins the build (reproducible runs;
             # an image regression lands on the commit that bumps the pin).
@@ -236,6 +307,90 @@ jobs:
         run: >
           echo "${{ secrets.acr-password }}" |
           docker login "${TEST_IMAGE%%/*}" -u "${{ secrets.acr-username }}" --password-stdin
+      # ───────────────────── THE UPSTREAM GATE (#1755) ─────────────────────
+      # A repo's build must not start until every upstream it depends on has a published artifact
+      # for the TARGET framework. Otherwise it compiles and gates against an upstream that no
+      # longer matches the framework it is building for: the publication comes out clean and the
+      # verdict means nothing.
+      #
+      # The identity comes from the IMAGE, because that is the only place it exists — a framework
+      # identity is a property of the shipped binaries, not of a tag or a commit. `mw-plugin-test
+      # --print-framework-identity` resolves it without standing up a mesh (one container start).
+      #
+      # 🚨 EXIT, do not wait. Not a poll, not a bounded re-check, not a sleep in a runner: the job
+      # ends immediately — no runner burned, no partial build, no false green — and is re-triggered
+      # by the EVENT its upstream fires when it publishes (the `Notify dependent repos` step at the
+      # end of this same workflow). That turns the platform's concurrent fan-out into a correct
+      # topological order with no central scheduler: the roots have no upstreams, so they build and
+      # publish; each publication wakes the repos that exited.
+      #
+      # 🚨 It exits RED, and that is deliberate. GitHub renders a skipped job with the same tick as
+      # a passed one, so "upstreams not ready, did not build" must not be a grey skip or a silent
+      # success — the exact trapdoor AGENTS.md forbids. A red here means "this repo has not been
+      # rebuilt for this release yet", which is TRUE and is exactly what an operator needs to see.
+      # The canonical scripts, fetched BEFORE the gate because the gate is what decides whether the
+      # bake runs at all. Same sparse checkout as the publish-side fetch further down, into its own
+      # path: it carries no root index.json, so the tester never treats it as a module (identical
+      # reasoning to `cross-repo-stage/`).
+      - name: Fetch the canonical gate script (platform repo)
+        if: inputs.upstream-sources != ''
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.platform-ref }}
+          path: mw-platform-gate
+          sparse-checkout: .github/scripts
+      # A SECOND login, deliberately: the gate must authenticate before a bake that can run 40
+      # minutes, and the publish side re-logs in afterwards rather than relying on a token minted
+      # before it. Two cheap OIDC exchanges beat one that can expire mid-job.
+      - name: Azure login for the gate (OIDC)
+        if: inputs.upstream-sources != ''
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.azure-client-id }}
+          tenant-id: ${{ secrets.azure-tenant-id }}
+          subscription-id: ${{ secrets.azure-subscription-id }}
+      - name: "Resolve the framework identity this bake will target"
+        if: inputs.upstream-sources != ''
+        id: identity
+        run: |
+          set -euo pipefail
+          line=$(docker run --rm --entrypoint /app/mw-plugin-test "${{ steps.image.outputs.ref }}" \
+            --print-framework-identity)
+          identity="${line#*identity=}"
+          identity="${identity%% *}"
+          if [ -z "$identity" ]; then
+            echo "::error::could not resolve a framework identity from the bake image (got: '$line'). Availability CANNOT BE DETERMINED, which is not clearance to build."
+            exit 1
+          fi
+          echo "identity=$identity" >> "$GITHUB_OUTPUT"
+          echo "this bake targets framework identity $identity"
+      - name: "Gate: every upstream must be published for that identity"
+        if: inputs.upstream-sources != ''
+        env:
+          BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
+          UPSTREAMS: ${{ inputs.upstream-sources }}
+        run: |
+          set -uo pipefail
+          # shellcheck disable=SC2086
+          if mw-platform-gate/.github/scripts/check-release-availability.sh \
+               --identity "${{ steps.identity.outputs.identity }}" $UPSTREAMS; then
+            echo "every upstream is published for ${{ steps.identity.outputs.identity }} — building."
+            exit 0
+          fi
+          {
+            echo "### ⛔ Upstreams not ready — did NOT build"
+            echo ""
+            echo "This repo depends on \`$UPSTREAMS\`, and at least one of them has no sealed"
+            echo "publication for framework identity \`${{ steps.identity.outputs.identity }}\`."
+            echo "Building anyway would gate this repo's content against an upstream that does not"
+            echo "match the framework it is being built for."
+            echo ""
+            echo "**Nothing to do.** This run is re-triggered automatically when the missing"
+            echo "upstream publishes (\`meshweaver-upstream-published\`)."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error title=Upstreams not ready — did not build::at least one upstream of this repo has no published artifact for framework identity ${{ steps.identity.outputs.identity }}; exiting without building. The upstream's own publication re-triggers this run."
+          exit 1
       # Same staging the caller's gate does, for the same reason: cross-repo `requires` must
       # resolve for the package roots to bind.
       - name: Stage cross-repo modules
@@ -333,3 +488,48 @@ jobs:
             echo "- identity: \`$(cat "$BAKE_DIR/framework-mvid.txt")\`"
             echo "- source: \`${{ inputs.bake-source }}\`  targets: \`${BAKE_PUBLISH_TARGETS}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+      # ───────────────────── WAKE THE DEPENDENTS (#1755) ─────────────────────
+      # 🚨 The edge that makes "exit, don't wait" work at all. A downstream repo whose upstream was
+      # not ready EXITED — it is not polling and nothing else will ever start it again. This
+      # publication is the event it is waiting for, so this repo fires it.
+      #
+      # Until this existed only the PLATFORM dispatched, so the very first satellite→satellite
+      # dependency (Education on Plugins) would have deadlocked on its first use: Education exits,
+      # Plugins publishes, and nothing tells Education to try again until the next platform release.
+      #
+      # It runs only after the publish it announces — an event claiming an artifact that is not
+      # sealed would send every dependent into a build against something that is not there. The
+      # payload carries the framework identity so a receiver can gate on the exact generation, and
+      # the platform version when this run was itself woken by one (the receiver needs it to resolve
+      # the released image).
+      - name: Notify dependent repos
+        if: inputs.dependent-repos != ''
+        env:
+          TOKEN: ${{ secrets.dependent-dispatch-token }}
+          REPOS: ${{ inputs.dependent-repos }}
+          SOURCE: ${{ inputs.bake-source }}
+          VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          set -euo pipefail
+          # The token is asserted in preflight (declaring dependents declares the obligation), so
+          # reaching here without one is impossible rather than tolerated.
+          IDENTITY="$(cat "$BAKE_DIR/framework-mvid.txt" | tr -d '[:space:]')"
+          failed=0
+          for repo in $REPOS; do
+            echo "→ $repo"
+            code=$(curl -sS -o /tmp/dispatch-resp -w '%{http_code}' -X POST \
+              -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$repo/dispatches" \
+              -d "{\"event_type\":\"meshweaver-upstream-published\",\"client_payload\":{\"source\":\"$SOURCE\",\"identity\":\"$IDENTITY\",\"version\":\"${VERSION:-}\",\"sha\":\"$GITHUB_SHA\"}}") || code=000
+            case "$code" in
+              2*) echo "woken: $repo";;
+              # 🚨 NOT a warning. A lost dispatch here leaves a repo that already exited with
+              # nothing to wake it — it silently never rebuilds for this release, which is the
+              # terminal-exit failure #1755 names explicitly. The publication itself has already
+              # landed and is idempotent, so failing the job is safe and a re-run re-notifies.
+              *)  echo "::error::could not wake $repo (HTTP $code: $(cat /tmp/dispatch-resp)) — it exited waiting for THIS publication and nothing else will re-trigger it."
+                  failed=1;;
+            esac
+          done
+          echo "### 📣 Dependents woken: $REPOS" >> "$GITHUB_STEP_SUMMARY"
+          exit "$failed"

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -274,6 +274,13 @@ Provisioning state (2026-08-17): the two halves of this cascade are in different
   provisioned, satellites re-bake only on their own `main` pushes, and a release-triggered rebuild
   can be hand-fired by anyone with `repo` scope:
   `gh api repos/Systemorph/<repo>/dispatches -f event_type=meshweaver-framework-released`.
+- **The cascade is now a DAG, not a fan-out.** A satellite that depends on another declares
+  `upstream-sources` and, if its upstream has not published for the target framework, exits without
+  building — waking again on that upstream's own `meshweaver-upstream-published` event, which
+  `node-repo-publish-bake` fires to its `dependent-repos`. See [Release Availability
+  Gates](../ReleaseGates) → "The build gate". One provisioning consequence: naming only the ROOT
+  repos in `BAKE_SUBSCRIBER_REPOS` (those with no upstreams) produces the same wave without the
+  dependent repos each painting one red per release before their upstream publishes.
 
 ### 🚨 Register BOTH OIDC subject formats — the classic one AND the immutable one
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGates.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGates.md
@@ -161,6 +161,91 @@ a gate that could not run resolves to a hold with its own reason rather than to 
 kills the tick. An install with no gate registered at all logs that fact and rolls — said out loud,
 never inferred from silence.
 
+## The build gate — exit, don't wait
+
+A repo must not build against a released framework until every upstream it depends on has published
+for that framework. Otherwise it compiles and gates its content against an upstream that no longer
+matches: the publication comes out clean and the verdict means nothing.
+
+The gate lives at the receiving end of the cascade, in the reusable `node-repo-publish-bake`
+workflow every node repo calls. A caller declares its upstreams:
+
+```yaml
+with:
+  bake-source: education
+  upstream-sources: plugins          # exit unless `plugins` is published for the target identity
+  dependent-repos: Systemorph/MeshWeaver.Reinsurance
+```
+
+Before staging or baking anything the job resolves the identity it is about to target — from the
+**image**, with `mw-plugin-test --print-framework-identity`, because that is the only place an
+identity exists — and asks the same availability question the deployment gate asks, through the same
+script (`.github/scripts/check-release-availability.sh`).
+
+### Not ready ⇒ EXIT. Not a poll, not a sleep, not a bounded re-check.
+
+The job ends immediately: no runner burned, no partial build, no false green. It is re-triggered by
+the **event** its upstream fires when it publishes. That is what turns the platform's concurrent
+fan-out into a correct topological order with no central scheduler:
+
+```
+platform ──▶ plugins (no upstreams)          builds, publishes
+               ├──▶ education   (had exited) builds, publishes
+               │      └──▶ reinsurance
+               └──▶ socialmedia (had exited) builds, publishes
+```
+
+🚨 **The exit is RED, deliberately.** GitHub renders a skipped job with the same tick as a passed
+one, so "upstreams not ready, did not build" must never be a grey skip or a silent success. A red
+here is also simply *true*: this repo has not been rebuilt for this release yet.
+
+### The edge that makes it work: a satellite wakes its own dependents
+
+Until now only the **platform** dispatched. A downstream repo that exited was waiting for an event
+nobody fired, so the very first satellite→satellite dependency would have deadlocked on first use.
+So `node-repo-publish-bake` now fires `meshweaver-upstream-published` — carrying
+`{source, identity, version, sha}` — to each repo in `dependent-repos`, **after** the publication it
+announces has sealed.
+
+Two rules keep that edge honest:
+
+- **Declaring `dependent-repos` declares an obligation**, so its token is asserted in preflight and
+  a missing one fails RED. Without the token those repos never wake, and nothing anywhere would be
+  red about it.
+- **A failed dispatch fails the job**, unlike the platform's reporter-class notification. A lost
+  wake-up leaves a repo that already exited with nothing to re-trigger it — the terminal-exit
+  failure this design must not have. The publication is already sealed and idempotent, so re-running
+  is safe.
+
+Receivers subscribe to both event types:
+
+```yaml
+on:
+  repository_dispatch:
+    types: [meshweaver-framework-released, meshweaver-upstream-published]
+```
+
+### Build only what you own — the half that is not done
+
+The directive is that a repo builds only its own content and consumes upstreams as **pre-built
+released artifacts** — dissolving the staging machinery (`stage-repo`/`stage-modules`) in every
+satellite. `upstream-sources` above is the half of that which exists: the availability gate is
+precisely the exit condition such a build needs.
+
+The other half is blocked on the artifact's shape, and it is worth stating exactly:
+
+> A published bundle carries **compiled assembly bytes keyed by node path**, plus a manifest
+> (`BundleWriter.Write`). It does **not** carry the upstream's node definitions. But a satellite
+> needs those definitions, not just the bytes: its package roots are typed by an upstream type
+> (`nodeType: Store/Plugin`), and its NodeTypes' `sources` queries reach into upstream packages
+> (`@Edu/…`). Seeding an assembly only stamps a node that already exists — with no upstream nodes in
+> the tree there is nothing to stamp, and the roots do not bind.
+
+So dropping staging requires the published artifact to carry the upstream's node definitions
+alongside its assemblies. Until it does, `stage-repo`/`stage-modules` stay, marked transitional; the
+gate already refuses to build when the upstream artifact is missing, which is the behaviour that
+does not change when the artifact grows.
+
 ## See also
 
 - [CI Content Bake](../CiContentBake) — where the sealed bundles and the framework identity come from

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-c-repos-wait-for-their-upstreams.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-c-repos-wait-for-their-upstreams.md
@@ -1,0 +1,31 @@
+---
+Name: Content repos wait for the upstreams they build on
+Category: Feature
+Description: A content repo no longer rebuilds against a new platform release until the repos it depends on have published for it — it stops immediately and is restarted by their publication, so the whole family rebuilds in the right order without anything scheduling it.
+Icon: ArrowSortDown
+Order: -20260817
+---
+
+# Content repos wait for the upstreams they build on
+
+A platform release tells every content repository to rebuild, and until now they all started at
+once. That is the wrong order whenever one of them builds on another: a repo that starts before its
+upstream has finished checks its content against an upstream that no longer matches the platform it
+is building for. The result looks clean and means nothing.
+
+Now a repo declares what it builds on, and checks before it starts. If an upstream has not published
+yet, the run **stops immediately** — it does not build, it does not half-build, and it does not
+report success. Nothing waits in a queue and nothing polls.
+
+What restarts it is the upstream itself: finishing a publication now notifies the repos that depend
+on it. So the simultaneous start sorts itself out — the repos with nothing above them go first, and
+each finished publication releases the ones waiting on it — with nothing anywhere scheduling the
+order.
+
+Two details make that safe rather than merely tidy:
+
+- **Stopping is visible.** A run that did not build is reported as such, never as a pass. A repo
+  quietly skipped for a release would be indistinguishable from one that succeeded.
+- **A lost notification is a failure, not a shrug.** A repo that stopped is waiting for exactly one
+  signal, so if that signal cannot be delivered the run says so loudly — otherwise that repo would
+  simply never rebuild for the release, and nothing would show it.

--- a/test/MeshWeaver.Documentation.Test/UpstreamBuildGateGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/UpstreamBuildGateGuard.cs
@@ -1,0 +1,144 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard for the build gate (#1755) in the reusable <c>node-repo-publish-bake</c>
+/// workflow — the ONE lane every node repo bakes and publishes through.
+///
+/// <para>🚨 <b>Why a guard and not a test:</b> nothing else in this repository can fail when this
+/// gate regresses. It runs in OTHER repositories' CI, so a change that quietly makes it skippable —
+/// a <c>continue-on-error</c>, an <c>if:</c> that asks whether a secret is set, an exit code
+/// swallowed into a warning — would be invisible here and would show up as four satellites
+/// publishing bakes gated against the wrong framework. Each assertion below names the failure it
+/// would let through.</para>
+/// </summary>
+public class UpstreamBuildGateGuard
+{
+    private const string Workflow = ".github/workflows/node-repo-publish-bake.yml";
+
+    private static string ExecutableLinesOf(string text) =>
+        string.Join("\n", text.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+
+    /// <summary>The workflow's steps, comments stripped — a guard must judge what RUNS, never the
+    /// prose explaining it.</summary>
+    private static string Body() => ExecutableLinesOf(
+        File.ReadAllText(Path.Combine(FindRepoRoot(), Workflow)));
+
+    [Fact]
+    public void TheGateAsksTheSharedPredicate_AgainstTheIdentityTheImageResolves()
+    {
+        var body = Body();
+
+        Assert.Contains("--print-framework-identity", body, StringComparison.Ordinal);
+        Assert.Contains("check-release-availability.sh", body, StringComparison.Ordinal);
+        Assert.Contains("upstream-sources", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 The gate must run BEFORE anything is built. A gate that ran after the bake would have
+    /// burned the runner and produced the very artifact it exists to prevent — and, worse, would
+    /// still look like it was doing its job.
+    /// </summary>
+    [Fact]
+    public void TheGateRunsBeforeTheBake()
+    {
+        var body = Body();
+        var gate = body.IndexOf("check-release-availability.sh", StringComparison.Ordinal);
+        var bake = body.IndexOf("--bake-output", StringComparison.Ordinal);
+
+        Assert.True(gate > 0 && bake > 0 && gate < bake,
+            "the upstream gate must be evaluated before the bake step — checking afterwards proves "
+            + "nothing and wastes the whole run.");
+    }
+
+    /// <summary>
+    /// 🚨 No skip-trapdoor. GitHub renders a skipped job with the same tick as a passed one, so a
+    /// gate that can be skipped or whose failure is downgraded is indistinguishable from one that
+    /// passed. This asserts the two shapes that would do it.
+    /// </summary>
+    [Fact]
+    public void NeitherTheGateNorTheDispatchCanBeSkippedOrDowngraded()
+    {
+        var body = Body();
+
+        Assert.DoesNotContain("continue-on-error", body, StringComparison.Ordinal);
+
+        // The gate's own refusal path must terminate the job.
+        var gateBlock = SectionAfter(body, "Gate: every upstream must be published");
+        Assert.Contains("exit 1", gateBlock, StringComparison.Ordinal);
+        Assert.Contains("::error", gateBlock, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 The edge that makes "exit, don't wait" work: a repo that exited is woken ONLY by its
+    /// upstream's publication event. If that dispatch is lost and the job still passes, the
+    /// downstream repo silently never rebuilds for the release — the terminal-exit failure #1755
+    /// names explicitly. So a failed dispatch must fail the job, never merely warn.
+    /// </summary>
+    [Fact]
+    public void ALostWakeUpFailsTheJob_RatherThanWarning()
+    {
+        var notify = SectionAfter(Body(), "Notify dependent repos");
+
+        Assert.Contains("meshweaver-upstream-published", notify, StringComparison.Ordinal);
+        Assert.Contains("::error", notify, StringComparison.Ordinal);
+        Assert.DoesNotContain("::warning", notify, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 The dispatch may only announce a publication that actually sealed. Firing it earlier
+    /// would send every dependent into a build against an artifact that is not there — turning one
+    /// repo's failure into the whole wave's.
+    /// </summary>
+    [Fact]
+    public void TheWakeUpFiresOnlyAfterThePublication()
+    {
+        var body = Body();
+        var publish = body.IndexOf("publish-bake-bundles.sh", StringComparison.Ordinal);
+        // The STEP's position, not the first mention of the event name — the input/secret
+        // declarations at the top of the file name it too, and comparing against those would make
+        // this assertion pass or fail for reasons that have nothing to do with ordering.
+        var notify = body.IndexOf("Notify dependent repos", StringComparison.Ordinal);
+
+        Assert.True(publish > 0 && notify > publish,
+            "the dependent wake-up must come after the publish step it announces.");
+    }
+
+    /// <summary>
+    /// Declaring dependents declares an OBLIGATION, so the token is asserted as a declared-input
+    /// check — never as an "is the secret set?" probe deciding whether to run, which is the exact
+    /// trapdoor that let the cross-repo plugin gate report green without ever running.
+    /// </summary>
+    [Fact]
+    public void DeclaringDependentsWithoutATokenIsPreflightedRed()
+    {
+        var preflight = SectionAfter(Body(), "Preflight: the publish credentials");
+
+        Assert.Contains("DEPENDENT_REPOS", preflight, StringComparison.Ordinal);
+        Assert.Contains("dependent-dispatch-token", preflight, StringComparison.Ordinal);
+    }
+
+    /// <summary>Everything from <paramref name="marker"/> to the next step boundary at the same
+    /// indent, so an assertion about one step cannot be satisfied by another.</summary>
+    private static string SectionAfter(string body, string marker)
+    {
+        var start = body.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"'{marker}' is gone from {Workflow} — the gate it belongs to has "
+                                + "been removed or renamed, which no other check would catch.");
+        var next = body.IndexOf("\n      - name:", start + marker.Length, StringComparison.Ordinal);
+        return next < 0 ? body[start..] : body[start..next];
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".github")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
Stacked on #1762 (which is stacked on #1761). **Base is `feat/1754-deployment-gate`** — review this branch's diff only; it retargets as the stack merges.

Same shared predicate as #1761/#1762, asked from CI through the same script — the two gates were one task because they are one question.

## The gate

The reusable `node-repo-publish-bake` lane — the ONE lane every node repo bakes through — now takes `upstream-sources` and, **before staging or building anything**, asserts each upstream has a sealed publication under the framework identity this bake targets. The identity comes from the **image** (`mw-plugin-test --print-framework-identity`), because that is the only place a framework identity exists.

## 🚨 Not ready ⇒ EXIT. Not a poll, not a bounded re-check, not a sleep.

The job ends immediately — no runner burned, no partial build, no false green — and is re-triggered by the **event** its upstream fires when it publishes. The platform's concurrent fan-out becomes a correct topological order with no central scheduler:

```
platform ──▶ plugins (no upstreams)          builds, publishes
               ├──▶ education   (had exited) builds, publishes
               │      └──▶ reinsurance
               └──▶ socialmedia (had exited) builds, publishes
```

The exit is **RED**, deliberately: GitHub renders a skipped job with the same tick as a passed one, so "upstreams not ready, did not build" must never be a grey skip — and red is simply *true* here.

## 🚨 The missing edge, built

Until now **only the platform dispatched**, so a repo that exited was waiting for an event nobody fired — the first satellite→satellite dependency (Education on Plugins) would have deadlocked on first use. The lane now fires `meshweaver-upstream-published` `{source, identity, version, sha}` to its `dependent-repos`, strictly **after** the publication it announces has sealed. Two rules keep it honest:

- **Declaring `dependent-repos` declares an obligation** — the token is asserted in preflight and a missing one fails RED, as a *declared-input* check, never an "is the secret set?" probe (the exact trapdoor that let the cross-repo plugin gate report green without ever running).
- **A failed dispatch fails the job**, unlike the platform's reporter-class notification. A lost wake-up leaves a repo that already exited with nothing to re-trigger it — precisely the terminal-exit failure #1755 forbids. The publication is already sealed and idempotent, so re-running is safe.

`Resolve the bake image` now distinguishes the two events: a framework release still fails loudly without a resolvable version, while an upstream-published wake bakes against the caller's pin — the identity the gate just verified came from *that* image, so the pin is the same identity, never an older one.

## Deferred, with the blocker named — "build only what you own"

The directive is that a repo builds only its own content and consumes upstreams as pre-built released artifacts, dissolving `stage-repo`/`stage-modules`. `upstream-sources` is the half that exists; the other half is blocked on the artifact's shape:

> A published bundle carries **compiled assembly bytes keyed by node path** plus a manifest (`BundleWriter.Write`) — **not** the upstream's node definitions. A satellite needs the definitions: its package roots are typed by an upstream type (`nodeType: Store/Plugin`) and its NodeTypes' `sources` queries reach into upstream packages (`@Edu/…`). Seeding an assembly only stamps a node that already exists, so with no upstream nodes in the tree there is nothing to stamp and the roots do not bind.

So staging stays, marked transitional in both the workflow inputs and the docs, until a published artifact carries node definitions alongside assemblies. **The gate is the exit condition such a build needs, and it does not change when the artifact grows** — this PR is the part that is correct today, not a placeholder.

## Verification

Both workflows parse; both scripts pass `bash -n`. `MeshWeaver.Documentation.Test` 34/34.

New guard **`UpstreamBuildGateGuard`** (6 pins) — it exists because *nothing else in this repo can fail when this gate regresses*: it runs in other repositories' CI. It pins that the gate asks the shared predicate against the image's identity, runs **before** the bake, cannot be skipped or downgraded (no `continue-on-error`; the refusal exits non-zero with `::error`), that a lost wake-up **fails** rather than warns, that the wake-up fires only after the publish, and that dependents-without-token is preflighted red.

Docs: `ReleaseGates` → "The build gate — exit, don't wait" (topology diagram, the wake-up edge, and the "Build only what you own — the half that is not done" finding). `main-cd`'s `notify-dependents` gains a provisioning note: a roots-only `BAKE_SUBSCRIBER_REPOS` now produces the same wave quietly, because the satellite→satellite edge carries it the rest of the way. What's New: *Content repos wait for the upstreams they build on*.

Closes #1755 (pending the deferred artifact-shape work, tracked in the doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)