### PR TITLE
Bake without a mesh: mw-compiler grows a `compile` verb (#1763)

### DIFF
--- a/src/MeshWeaver.Compiler/CodeConventions.cs
+++ b/src/MeshWeaver.Compiler/CodeConventions.cs
@@ -23,4 +23,45 @@ public static class CodeConventions
     /// alongside (not inside) their parent NodeType.
     /// </summary>
     public const string TestSubNamespace = "Test";
+
+    /// <summary>
+    /// The node path → assembly-name-safe token every dynamic NodeType compile is keyed by:
+    /// the emitted assembly is <c>DynamicNode_{SanitizeNodeName(path)}</c> and the generated
+    /// provider class is <c>{SanitizeNodeName(path)}MeshNodeProvider</c>.
+    ///
+    /// <para>🚨 It therefore SHAPES THE EMITTED BYTES and belongs inside the toolchain identity
+    /// boundary (#1707). It lived only in <c>MeshWeaver.Graph</c>'s <c>CompilationCacheService</c>
+    /// until #1763 needed it for the build-process baker; that method now delegates here, so a
+    /// mesh-driven and a compiler-driven bake of the same node can never disagree about the
+    /// assembly's name — a disagreement no consumer could see, since the bundle keys on the node
+    /// path while the ASSEMBLY carries the name.</para>
+    /// </summary>
+    /// <param name="nodePath">The NodeType's mesh path.</param>
+    public static string SanitizeNodeName(string nodePath)
+    {
+        // Replace path separators and invalid characters with underscores
+        var sanitized = (nodePath ?? string.Empty)
+            .Replace('/', '_')
+            .Replace('\\', '_')
+            .Replace(':', '_')
+            .Replace('*', '_')
+            .Replace('?', '_')
+            .Replace('"', '_')
+            .Replace('<', '_')
+            .Replace('>', '_')
+            .Replace('|', '_')
+            .Replace(' ', '_');
+
+        // Remove leading/trailing underscores and collapse multiple underscores
+        while (sanitized.Contains("__", StringComparison.Ordinal))
+            sanitized = sanitized.Replace("__", "_", StringComparison.Ordinal);
+
+        sanitized = sanitized.Trim('_');
+
+        // Ensure it starts with a letter (for valid assembly names)
+        if (sanitized.Length > 0 && !char.IsLetter(sanitized[0]))
+            sanitized = "Node_" + sanitized;
+
+        return sanitized;
+    }
 }

--- a/src/MeshWeaver.Compiler/FrameworkBuildIdentity.cs
+++ b/src/MeshWeaver.Compiler/FrameworkBuildIdentity.cs
@@ -83,6 +83,20 @@ public static class FrameworkBuildIdentity
     /// surface. <c>FrameworkBuildIdentityTest.CanonicalList_MatchesTheTesterClosure</c> recomputes
     /// the closure from the csproj graph and fails naming the drift when the tester's references
     /// change without this list following.
+    ///
+    /// <para>🚨 <b>MOVING THE BAKE/GATE CLI INTO A NEW PROJECT SILENTLY CHANGES THE FRAMEWORK
+    /// IDENTITY.</b> This list is anchored to <c>tools/MeshWeaver.PluginTester</c>'s reference
+    /// closure, and the identity is the hash over these assemblies' surface-manifest pairs — an
+    /// assembly the PRODUCING process does not reference contributes no pair and hashes as
+    /// <see cref="AbsentMarker"/>. So a tidy-up that splits <c>mw-compiler</c> (the <c>compile</c>
+    /// verb, #1763) out of the tester into its own csproj with a leaner reference list resolves a
+    /// DIFFERENT identity, and every bundle it bakes is then declined by every portal:
+    /// <c>PrebuiltAssemblySeeder.DeclineReason</c> is doing its job, the pods simply compile
+    /// everything as though no bake existed, and nothing anywhere reports a defect. The split is
+    /// perfectly doable — it just has to keep this closure intact and extend
+    /// <c>CanonicalList_MatchesTheTesterClosure</c> to assert BOTH projects' closures, so the
+    /// equality is CHECKED rather than assumed. Keeping the verb inside the tester project is what
+    /// makes the identity provably unchanged today.</para>
     /// </summary>
     public static readonly ImmutableArray<string> ContentSurfaceAssemblies =
     [

--- a/src/MeshWeaver.Compiler/NodeSet.cs
+++ b/src/MeshWeaver.Compiler/NodeSet.cs
@@ -1,0 +1,155 @@
+using System.Collections.Immutable;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Compiler;
+
+/// <summary>
+/// An INDEXED, IN-MEMORY set of <see cref="MeshNode"/>s that answers the compile path's source
+/// queries WITHOUT a mesh — the build-process half of issue #1763 ("bake must be compiler-driven,
+/// not mesh-driven").
+///
+/// <para><b>Why this lives inside the toolchain assembly.</b> Which Code nodes a NodeType compiles
+/// against is part of the GENERATED INPUT of that compile, exactly like the skeleton generator and
+/// the join order — so the rule has to sit inside the full-MVID identity boundary
+/// (<see cref="FrameworkBuildIdentity.FullMvidAssemblies"/>). A resolver that lived outside it
+/// could change which sources a bake consumes without moving the identity, and every portal would
+/// adopt the changed bytes as if nothing had happened.</para>
+///
+/// <para><b>The equivalence obligation.</b> At runtime the mesh performs this resolution
+/// (<c>NodeSources.GetSources</c> → <c>workspace.GetQuery</c> → the storage adapters). This class
+/// is a SECOND implementation of the same rule, and a resolver that answers even slightly
+/// differently emits assemblies that are subtly not what the mesh would have built — with no error
+/// anywhere until a page renders empty. Two things keep that honest:</para>
+/// <list type="bullet">
+///   <item>Query EXPANSION is not re-implemented: <see cref="CodeQueryResolver.ExpandAll"/> is the
+///     same call the runtime makes, so <c>$self</c>, the <c>name=</c> prefix, the <c>@</c>/<c>@@</c>
+///     shorthand, the bare-namespace rebase and the implicit <c>nodeType:Code</c> filter can never
+///     fork.</item>
+///   <item>Query EVALUATION refuses what it does not understand. Only the selectors the expansion
+///     actually produces (<c>path:</c>, <c>namespace:</c>, <c>scope:</c>, <c>nodeType:</c>) are
+///     supported; anything else makes the resolution UNESTABLISHED and the caller must refuse to
+///     compile — the same fail-loud direction <see cref="SourceSnapshot"/> enforces at runtime, and
+///     for the same reason (#1218: a short source set produces completely genuine-looking CS0246s
+///     about code that is fine).</item>
+/// </list>
+/// </summary>
+public sealed class NodeSet
+{
+    private readonly ImmutableArray<MeshNode> nodes;
+    private readonly ImmutableDictionary<string, MeshNode> byPath;
+
+    private NodeSet(ImmutableArray<MeshNode> nodes, ImmutableDictionary<string, MeshNode> byPath)
+    {
+        this.nodes = nodes;
+        this.byPath = byPath;
+    }
+
+    /// <summary>Every node in the set, ordinal by path.</summary>
+    public ImmutableArray<MeshNode> Nodes => nodes;
+
+    /// <summary>
+    /// Indexes <paramref name="source"/>. Nodes without a path are dropped (the mesh's synced
+    /// query drops them too); a duplicate path keeps the LAST occurrence, mirroring the
+    /// last-write-wins fold the runtime's <c>ImmutableDictionary</c> accumulation performs.
+    /// </summary>
+    public static NodeSet Create(IEnumerable<MeshNode> source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var map = ImmutableDictionary.CreateBuilder<string, MeshNode>(StringComparer.Ordinal);
+        foreach (var node in source)
+        {
+            if (node is null || string.IsNullOrEmpty(node.Path))
+                continue;
+            map[node.Path] = node;
+        }
+        var indexed = map.ToImmutable();
+        return new NodeSet(
+            [.. indexed.Values.OrderBy(n => n.Path, StringComparer.Ordinal)],
+            indexed);
+    }
+
+    /// <summary>The node at <paramref name="path"/>, or null. Exact, ordinal — the same lookup the
+    /// runtime's <c>GetMeshNodeStream(path)</c> performs.</summary>
+    public MeshNode? Find(string? path)
+        => string.IsNullOrEmpty(path) ? null : byPath.GetValueOrDefault(path);
+
+    /// <summary>
+    /// Resolves the source+test Code node set for the NodeType at <paramref name="selfPath"/>,
+    /// exactly as <c>NodeSources.GetSources</c> does at runtime: expand
+    /// <paramref name="sources"/> (falling back to <see cref="CodeQueryResolver.DefaultSources"/>)
+    /// then <paramref name="tests"/> (falling back to <see cref="CodeQueryResolver.DefaultTests"/>),
+    /// and union the matches.
+    ///
+    /// <para>🚨 The order is DETERMINISTIC here and is NOT at runtime. The mesh folds every query's
+    /// results into an <c>ImmutableDictionary&lt;string, MeshNode&gt;</c> and emits
+    /// <c>dict.Values</c> — hash-bucket order over per-process-randomised string hashes — and
+    /// <see cref="NodeCompileShaping.CombineSources"/> then joins the files in that order. So the
+    /// mesh-driven bake is not reproducible run to run, while this one is (query order, then
+    /// ordinal by path). The difference is confined to the concatenation order of independent
+    /// top-level declarations, which C# is insensitive to; it is pinned by the bake-equivalence
+    /// test rather than assumed.</para>
+    /// </summary>
+    /// <param name="sources">The NodeType's declared <c>Sources</c> queries, or null for the default.</param>
+    /// <param name="tests">The NodeType's declared <c>Tests</c> queries, or null for the default.</param>
+    /// <param name="selfPath">The NodeType's mesh path — the <c>$self</c> / rebase anchor.</param>
+    public NodeSetSourceResolution ResolveSources(
+        IReadOnlyList<string>? sources, IReadOnlyList<string>? tests, string selfPath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(selfPath);
+
+        var expanded = CodeQueryResolver
+            .ExpandAll(sources, CodeQueryResolver.DefaultSources, selfPath)
+            .Concat(CodeQueryResolver.ExpandAll(tests, CodeQueryResolver.DefaultTests, selfPath))
+            .ToImmutableArray();
+
+        var unsupported = ImmutableArray.CreateBuilder<string>();
+        var matched = ImmutableArray.CreateBuilder<MeshNode>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var query in expanded)
+        {
+            if (!NodeSetQuery.TryParse(query, out var predicate, out var reason))
+            {
+                unsupported.Add($"query '{query}' → {reason}");
+                continue;
+            }
+            // Ordinal within a query, queries in declaration order — see the remarks above.
+            foreach (var node in nodes)
+            {
+                if (!predicate.Matches(node) || !seen.Add(node.Path))
+                    continue;
+                matched.Add(node);
+            }
+        }
+
+        return new NodeSetSourceResolution(
+            matched.ToImmutable(),
+            expanded,
+            unsupported.ToImmutable());
+    }
+}
+
+/// <summary>
+/// One NodeType's tree-resolved source set, TOGETHER with whether every declared query could
+/// actually be evaluated — the mesh-free analogue of <see cref="SourceSnapshot"/>, and carrying the
+/// same non-negotiable rule: <b>a compile whose source set could not be established is not a
+/// verdict about the code</b>. A caller that compiles anyway hands Roslyn a short set and gets a
+/// completely genuine-looking CS0246 about source that is fine.
+/// </summary>
+/// <param name="Sources">The matched nodes, deduplicated by path, in deterministic order.</param>
+/// <param name="ExpandedQueries">Every query that was expanded (diagnostics + provenance).</param>
+/// <param name="UnsupportedQueries">Per-query reasons for the queries this evaluator could not
+/// answer. Empty ⇒ <see cref="IsEstablished"/>.</param>
+public sealed record NodeSetSourceResolution(
+    ImmutableArray<MeshNode> Sources,
+    ImmutableArray<string> ExpandedQueries,
+    ImmutableArray<string> UnsupportedQueries)
+{
+    /// <summary>True when every expanded query was evaluated — the only state in which the
+    /// matched set may be compiled.</summary>
+    public bool IsEstablished => UnsupportedQueries.IsEmpty;
+
+    /// <summary>Why the set is not established, or null when it is.</summary>
+    public string? UnestablishedReason =>
+        IsEstablished ? null : string.Join("; ", UnsupportedQueries);
+}

--- a/src/MeshWeaver.Compiler/NodeSetCompiler.cs
+++ b/src/MeshWeaver.Compiler/NodeSetCompiler.cs
@@ -1,0 +1,275 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Mesh;
+using MeshWeaver.NuGet;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MeshWeaver.Compiler;
+
+/// <summary>
+/// Compiles ONE dynamic NodeType straight out of a <see cref="NodeSet"/> — the BUILD-PROCESS bake
+/// of issue #1763. No <c>MeshBuilder</c>, no hub, no import, no activation: sources come from an
+/// in-memory node set the caller assembled from a git tree, and the output is a DLL + PDB on disk
+/// plus the per-type dependency record (#1719) a consumer validates before adopting.
+///
+/// <para><b>Every shaping rule is the runtime's own.</b> This type is an ORCHESTRATOR, not a second
+/// implementation: source-query expansion is <see cref="CodeQueryResolver"/>, the <c>@@</c>-include
+/// walk is <see cref="NodeCompileShaping.ResolveCodeIncludes"/>, the dedup / executable filter /
+/// join order are <see cref="NodeCompileShaping.CollectCompileSources"/> and
+/// <see cref="NodeCompileShaping.CombineSources"/>, the skeleton is
+/// <see cref="DynamicMeshNodeAttributeGenerator"/>, the <c>#r "nuget:"</c> handling is
+/// <see cref="NuGetDirectiveParser"/> + <see cref="GeneratorPipeline"/>, and the emit is
+/// <see cref="EmitPipeline"/>. The ONLY thing that differs from
+/// <c>MeshNodeCompilationService.CompileCore</c> is where the nodes came from — which is precisely
+/// the claim the bake-equivalence test has to pin.</para>
+///
+/// <para><b>Synchronous on purpose.</b> This runs in a build process at its console boundary, never
+/// on a hub scheduler, and every leaf it touches is pure CPU or a local file write. The one
+/// reactive helper it reuses (<see cref="NodeCompileShaping.ResolveCodeIncludes"/>) is driven with
+/// an in-memory reader, so its chain completes on subscribe.</para>
+/// </summary>
+public static class NodeSetCompiler
+{
+    /// <summary>
+    /// The compile inputs one NodeType resolves to — everything that reaches Roslyn, and nothing
+    /// that does not. Produced by <see cref="ResolveInputs"/> so the bake-equivalence test can
+    /// compare WHAT WOULD BE COMPILED without emitting anything.
+    /// </summary>
+    /// <param name="NodePath">The NodeType's mesh path.</param>
+    /// <param name="AssemblyName">The emitted assembly's name (<c>DynamicNode_{sanitized}</c>).</param>
+    /// <param name="MatchedSourcePaths">The Code nodes the source queries matched, after the dedup
+    /// and executable filter, in the order they are concatenated.</param>
+    /// <param name="ExpandedQueries">Every expanded source/test query that was evaluated.</param>
+    /// <param name="GeneratedSource">The full C# text handed to Roslyn (skeleton + user code).</param>
+    /// <param name="NuGetReferences">The <c>#r "nuget:"</c> references the sources declare, after
+    /// the built-in-generator strip.</param>
+    public sealed record CompileInputs(
+        string NodePath,
+        string AssemblyName,
+        ImmutableArray<string> MatchedSourcePaths,
+        ImmutableArray<string> ExpandedQueries,
+        string GeneratedSource,
+        ImmutableArray<NuGetPackageReference> NuGetReferences);
+
+    /// <summary>One compiled NodeType's artifacts.</summary>
+    /// <param name="NodePath">The NodeType's mesh path — the bundle's key.</param>
+    /// <param name="DllPath">The emitted assembly on disk.</param>
+    /// <param name="PdbPath">The emitted symbols on disk, or null when none were written.</param>
+    /// <param name="Inputs">What was compiled (provenance + the equivalence comparison surface).</param>
+    /// <param name="Dependencies">The per-type dependency record read off the emitted assembly's
+    /// AssemblyRef table (#1719), including the reserved toolchain entry.</param>
+    public sealed record CompiledNode(
+        string NodePath,
+        string DllPath,
+        string? PdbPath,
+        CompileInputs Inputs,
+        ImmutableSortedDictionary<string, string> Dependencies);
+
+    /// <summary>
+    /// Resolves everything a compile of <paramref name="typeNode"/> would consume, WITHOUT
+    /// compiling. Throws <see cref="SourceDiscoveryUnavailableException"/> when a declared source
+    /// query cannot be evaluated offline — the build-process analogue of the runtime's refusal to
+    /// compile against an unestablished source set, and for the identical reason: a short set
+    /// yields genuine-looking diagnostics about code that is fine, and the resulting bytes are
+    /// adopted with no complaint (#1218).
+    /// </summary>
+    /// <param name="nodes">The node set the sources are resolved from.</param>
+    /// <param name="typeNode">The NodeType's own MeshNode (the skeleton is generated from it).</param>
+    /// <param name="sources">The type's declared <c>Sources</c> queries, or null for the default.</param>
+    /// <param name="tests">The type's declared <c>Tests</c> queries, or null for the default.</param>
+    /// <param name="configuration">The type's <c>configuration</c> lambda — C# stored in a JSON
+    /// string field, which is why it is invisible to every <c>.cs</c>-shaped tool and must be
+    /// threaded explicitly.</param>
+    /// <param name="contentCollections">The type's content-collection registrations.</param>
+    /// <param name="logger">Diagnostics (include-resolution warnings ride here).</param>
+    public static CompileInputs ResolveInputs(
+        NodeSet nodes,
+        MeshNode typeNode,
+        IReadOnlyList<string>? sources,
+        IReadOnlyList<string>? tests,
+        string? configuration,
+        IReadOnlyList<ContentCollectionConfig>? contentCollections,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+        ArgumentNullException.ThrowIfNull(typeNode);
+        logger ??= NullLogger.Instance;
+
+        var nodePath = typeNode.Path;
+        var resolution = nodes.ResolveSources(sources, tests, nodePath);
+        if (!resolution.IsEstablished)
+            throw new SourceDiscoveryUnavailableException(
+                $"Source discovery for '{nodePath}' could not be ESTABLISHED from the tree, so the "
+                + $"compile was not attempted: {resolution.UnestablishedReason}. This is a BAKE "
+                + "capability failure, not a compile error — nothing is known to be wrong with the "
+                + "code. Either express the source query with path:/namespace:/scope:/nodeType: "
+                + "only, or teach NodeSetQuery the selector; NEVER let the bake guess, or it ships "
+                + "assemblies built from a set the runtime would not have used.");
+
+        // The dedup (OrdinalIgnoreCase), the executable-cell filter and the join order are the
+        // toolchain's — the same call MeshNodeCompilationService.CompileCore makes.
+        var (codeFiles, matchedPaths) =
+            NodeCompileShaping.CollectCompileSources(resolution.Sources, nodePath, logger);
+
+        // @@ includes, resolved against the SAME node set. The runtime reads them through the mesh
+        // under System impersonation with a bounded timeout; here the read is a dictionary lookup,
+        // so the reactive chain completes on subscribe.
+        var resolvedFiles = new List<CodeConfiguration>(codeFiles.Count);
+        foreach (var codeFile in codeFiles)
+        {
+            var resolvedCode = NodeCompileShaping
+                .ResolveCodeIncludes(
+                    codeFile.Code!, new HashSet<string>(StringComparer.Ordinal), nodePath,
+                    (anchored, authored) => Observable.Return(ReadInclude(nodes, anchored, authored)),
+                    logger)
+                .Wait();
+            resolvedFiles.Add(
+                ReferenceEquals(resolvedCode, codeFile.Code)
+                    ? codeFile
+                    : codeFile with { Code = resolvedCode });
+        }
+
+        var combined = NodeCompileShaping.CombineSources(resolvedFiles);
+        var rawSource = new DynamicMeshNodeAttributeGenerator()
+            .GenerateAttributeSource(typeNode, combined, configuration, contentCollections);
+        var (source, extractedRefs) = NuGetDirectiveParser.Extract(rawSource);
+        var nugetRefs = extractedRefs.ToList();
+        GeneratorPipeline.StripBuiltInScopeGeneratorRef(
+            nugetRefs, builtInPresent: GeneratorPipeline.BuiltInGeneratorPaths.Count > 0);
+
+        return new CompileInputs(
+            nodePath,
+            $"DynamicNode_{CodeConventions.SanitizeNodeName(nodePath)}",
+            [.. matchedPaths],
+            resolution.ExpandedQueries,
+            source,
+            [.. nugetRefs]);
+    }
+
+    /// <summary>
+    /// Resolves, compiles and EMITS one NodeType into <paramref name="outputDirectory"/>.
+    /// A compile error throws <see cref="CompilationException"/> carrying the Roslyn diagnostics,
+    /// exactly as the runtime's emit does.
+    /// </summary>
+    /// <param name="nodes">The node set the sources are resolved from.</param>
+    /// <param name="typeNode">The NodeType's own MeshNode.</param>
+    /// <param name="sources">The type's declared <c>Sources</c> queries, or null for the default.</param>
+    /// <param name="tests">The type's declared <c>Tests</c> queries, or null for the default.</param>
+    /// <param name="configuration">The type's <c>configuration</c> lambda source.</param>
+    /// <param name="contentCollections">The type's content-collection registrations.</param>
+    /// <param name="references">The metadata references to compile against —
+    /// <see cref="CompileReferences.Default"/> composed with the deployment's installed modules.</param>
+    /// <param name="dependencyIdOf">The surface-id resolver for the dependency record
+    /// (<see cref="CompiledDependencies.CreateIdResolver"/> over the PRODUCING environment).</param>
+    /// <param name="toolchainId">This process's toolchain id
+    /// (<see cref="CompiledDependencies.ComputeToolchainId"/>).</param>
+    /// <param name="outputDirectory">Directory the DLL/PDB are written into. Created if absent.</param>
+    /// <param name="resolveNuGet">Resolves <c>#r "nuget:"</c> references to assembly paths. Null
+    /// REFUSES a source set that declares any — a bake that silently dropped a package reference
+    /// would emit an assembly missing the very types the directive exists to supply.</param>
+    /// <param name="logger">Diagnostics.</param>
+    /// <param name="ct">Cancellation.</param>
+    public static CompiledNode Compile(
+        NodeSet nodes,
+        MeshNode typeNode,
+        IReadOnlyList<string>? sources,
+        IReadOnlyList<string>? tests,
+        string? configuration,
+        IReadOnlyList<ContentCollectionConfig>? contentCollections,
+        IReadOnlyList<MetadataReference> references,
+        Func<string, string?> dependencyIdOf,
+        string toolchainId,
+        string outputDirectory,
+        Func<IReadOnlyList<NuGetPackageReference>, CancellationToken, IReadOnlyList<string>>? resolveNuGet = null,
+        ILogger? logger = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(references);
+        ArgumentNullException.ThrowIfNull(dependencyIdOf);
+        ArgumentException.ThrowIfNullOrEmpty(outputDirectory);
+        logger ??= NullLogger.Instance;
+
+        var inputs = ResolveInputs(
+            nodes, typeNode, sources, tests, configuration, contentCollections, logger);
+
+        var allReferences = references;
+        IReadOnlyList<string> generatorPaths = [];
+        if (inputs.NuGetReferences.Length > 0)
+        {
+            if (resolveNuGet is null)
+                throw new CompilationException(inputs.NodePath,
+                    $"'{inputs.NodePath}' declares {inputs.NuGetReferences.Length} `#r \"nuget:…\"` "
+                    + $"reference(s) ({string.Join(", ", inputs.NuGetReferences.Select(r => r.Id))}) "
+                    + "but this bake has no NuGet resolver configured. Refusing to compile without "
+                    + "them: the emitted assembly would be missing exactly the types the directive "
+                    + "supplies, and the consumer would adopt it.");
+            generatorPaths = resolveNuGet(inputs.NuGetReferences, ct);
+            allReferences =
+            [
+                .. references,
+                .. generatorPaths.Select(p => (MetadataReference)MetadataReference.CreateFromFile(p)),
+            ];
+        }
+
+        Directory.CreateDirectory(outputDirectory);
+        var nodeName = CodeConventions.SanitizeNodeName(inputs.NodePath);
+        var compilation = GeneratorPipeline.RunSourceGenerators(
+            EmitPipeline.CreateEmitCompilation(
+                inputs.GeneratedSource, inputs.AssemblyName, allReferences, parsePath: "", ct),
+            generatorPaths, logger, ct);
+
+        var artifact = EmitPipeline.EmitCompilationToDirectory(
+            compilation, nodeName, inputs.NodePath, outputDirectory, ct);
+        if (!artifact.MatchesFileOnDisk(out var mismatch))
+            throw new CompilationException(inputs.NodePath,
+                $"the assembly emitted for '{inputs.NodePath}' could not be persisted: {mismatch}");
+
+        var pdbPath = Path.ChangeExtension(artifact.DllPath, ".pdb");
+        return new CompiledNode(
+            inputs.NodePath,
+            artifact.DllPath,
+            File.Exists(pdbPath) ? pdbPath : null,
+            inputs,
+            CompiledDependencies.Compute(
+                ReferencedAssemblyNames(artifact.DllPath), dependencyIdOf, toolchainId));
+    }
+
+    /// <summary>
+    /// The include reader the tree bake hands <see cref="NodeCompileShaping.ResolveCodeIncludes"/>:
+    /// the ANCHORED path first, the authored path only as a fallback — the same two-step the mesh
+    /// read performs, so a mount-relative <c>@@</c> resolves identically here (an unresolved include
+    /// is left VERBATIM in the source and Roslyn then reports on the <c>@@</c> line itself, which is
+    /// how 15 NodeTypes parked on memex-cloud 2026-08-12).
+    /// </summary>
+    private static (MeshNode? Node, string Path) ReadInclude(
+        NodeSet nodes, string anchored, string? authored)
+    {
+        if (nodes.Find(anchored) is { } hit)
+            return (hit, anchored);
+        if (authored is { Length: > 0 } && nodes.Find(authored) is { } fallback)
+            return (fallback, authored);
+        return (null, anchored);
+    }
+
+    /// <summary>
+    /// The emitted assembly's AssemblyRef simple names — the same table
+    /// <c>Assembly.GetReferencedAssemblies()</c> reads at runtime, but through a METADATA-ONLY
+    /// reader so a bake never loads content bytes into the process (no collectible ALC, no unload
+    /// race, no #890 exposure in a build tool).
+    /// </summary>
+    private static IEnumerable<string?> ReferencedAssemblyNames(string dllPath)
+    {
+        using var stream = File.OpenRead(dllPath);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        // Materialized inside the using: the reader owns the mapped file.
+        return reader.AssemblyReferences
+            .Select(handle => reader.GetString(reader.GetAssemblyReference(handle).Name))
+            .ToList();
+    }
+}

--- a/src/MeshWeaver.Compiler/NodeSetCompiler.cs
+++ b/src/MeshWeaver.Compiler/NodeSetCompiler.cs
@@ -28,6 +28,17 @@ namespace MeshWeaver.Compiler;
 /// <c>MeshNodeCompilationService.CompileCore</c> is where the nodes came from — which is precisely
 /// the claim the bake-equivalence test has to pin.</para>
 ///
+/// <para><b>Why it lives in this assembly.</b> Which Code nodes a compile consumes, in what order,
+/// with which includes folded in and under which assembly name, is part of that compile's GENERATED
+/// INPUT — no different from the skeleton generator or the parse options. So it belongs inside the
+/// full-MVID toolchain identity boundary (<see cref="FrameworkBuildIdentity.FullMvidAssemblies"/>).
+/// A resolver sitting OUTSIDE that boundary could change what a bake consumes without moving the
+/// framework identity, and every portal would adopt the changed bytes without a murmur — the
+/// consumer's gates compare identities, and the identity would say nothing had changed. That is the
+/// same hole <see cref="CodeConventions.SanitizeNodeName"/> was in until #1763 moved it down out of
+/// <c>MeshWeaver.Graph</c>: it names the emitted assembly, so it shaped the bytes from outside the
+/// boundary that is supposed to cover them.</para>
+///
 /// <para><b>Synchronous on purpose.</b> This runs in a build process at its console boundary, never
 /// on a hub scheduler, and every leaf it touches is pure CPU or a local file write. The one
 /// reactive helper it reuses (<see cref="NodeCompileShaping.ResolveCodeIncludes"/>) is driven with

--- a/src/MeshWeaver.Compiler/NodeSetQuery.cs
+++ b/src/MeshWeaver.Compiler/NodeSetQuery.cs
@@ -1,0 +1,209 @@
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Compiler;
+
+/// <summary>
+/// The MESH-FREE evaluator for the (small, closed) query language a NodeType's source discovery
+/// actually speaks — the second half of issue #1763's source resolution.
+///
+/// <para><b>It is deliberately not a general query engine.</b> The mesh evaluates
+/// <c>ParsedQuery</c> through <c>QueryParser</c> + <c>QueryEvaluator</c> + the storage adapters;
+/// re-implementing that surface offline would be a large, silently-diverging copy. What
+/// <see cref="CodeQueryResolver.Expand"/> can EMIT, by contrast, is four selectors wide —
+/// <c>path:</c>, <c>namespace:</c>, <c>scope:</c> and <c>nodeType:</c> — and those semantics are
+/// reproduced here EXACTLY as the runtime derives them:</para>
+/// <list type="bullet">
+///   <item><c>path:X</c> with no scope ⇒ <c>QueryScope.Exact</c> — the node AT X.</item>
+///   <item><c>namespace:X</c> with no scope ⇒ <c>QueryScope.Children</c> — nodes whose
+///     <c>Namespace</c> IS X (not the subtree).</item>
+///   <item><c>namespace:X scope:subtree</c> ⇒ DEGRADES to <c>Descendants</c>: a namespace names a
+///     namespace, never the node at X, so self is excluded. <c>path:X scope:subtree</c> keeps self.
+///     (<c>QueryParser.ExtractReservedQualifiers</c> — the degradation is load-bearing: the default
+///     source query is <c>namespace:{Type}/Source scope:subtree</c>, which must NOT pull in a node
+///     literally at <c>{Type}/Source</c>.)</item>
+///   <item>Every comparison — path, namespace and <c>nodeType</c> — is
+///     <see cref="StringComparison.OrdinalIgnoreCase"/>, matching <c>MatchesPathValue</c> and
+///     <c>QueryEvaluator</c>'s scalar equality.</item>
+/// </list>
+///
+/// <para>🚨 <b>Anything outside that grammar is REFUSED, never approximated.</b> Free text (which
+/// routes to vector search on a real mesh), wildcards, alternations, comparison operators, extra
+/// selectors and <c>limit:</c> all make <see cref="TryParse"/> fail with a reason. The caller then
+/// reports the source set UNESTABLISHED and refuses to compile — the same direction
+/// <see cref="SourceSnapshot"/> takes at runtime, because a source set that is SHORT compiles into
+/// completely genuine-looking CS0246/CS0103 diagnostics about code that is fine (#1218), and a
+/// build produced from one is adopted by every portal without a murmur.</para>
+/// </summary>
+public static class NodeSetQuery
+{
+    /// <summary>The path/scope + nodeType constraint one expanded query imposes on a node.</summary>
+    public sealed class Predicate
+    {
+        internal Predicate(string? path, Scope scope, string? nodeType)
+        {
+            this.path = path;
+            this.scope = scope;
+            this.nodeType = nodeType;
+        }
+
+        private readonly string? path;
+        private readonly Scope scope;
+        private readonly string? nodeType;
+
+        /// <summary>True when <paramref name="node"/> satisfies every constraint.</summary>
+        public bool Matches(MeshNode node)
+        {
+            ArgumentNullException.ThrowIfNull(node);
+            if (nodeType is not null
+                && !string.Equals(node.NodeType, nodeType, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (path is null)
+                return true;
+            var nodePath = node.Path;
+            var nodeNamespace = node.Namespace ?? string.Empty;
+            if (path.Length == 0)
+                return scope switch
+                {
+                    Scope.Children => nodeNamespace.Length == 0,
+                    Scope.Exact => false,
+                    _ => true,
+                };
+            return scope switch
+            {
+                Scope.Exact => string.Equals(nodePath, path, StringComparison.OrdinalIgnoreCase),
+                Scope.Children => string.Equals(nodeNamespace, path, StringComparison.OrdinalIgnoreCase),
+                Scope.Descendants => nodePath.StartsWith(path + "/", StringComparison.OrdinalIgnoreCase),
+                Scope.Subtree => string.Equals(nodePath, path, StringComparison.OrdinalIgnoreCase)
+                                 || nodePath.StartsWith(path + "/", StringComparison.OrdinalIgnoreCase),
+                _ => false,
+            };
+        }
+    }
+
+    /// <summary>The scope walks a source query can express (the runtime's <c>QueryScope</c> subset
+    /// reachable from <see cref="CodeQueryResolver.Expand"/> and hand-authored source queries).</summary>
+    internal enum Scope
+    {
+        /// <summary>The node at the path.</summary>
+        Exact,
+
+        /// <summary>Nodes whose namespace IS the path.</summary>
+        Children,
+
+        /// <summary>Nodes strictly below the path.</summary>
+        Descendants,
+
+        /// <summary>The node at the path and everything below it.</summary>
+        Subtree,
+    }
+
+    /// <summary>
+    /// Parses one EXPANDED source query into a <see cref="Predicate"/>.
+    /// Returns false — with a human-readable <paramref name="reason"/> naming what it could not
+    /// evaluate — for anything outside the supported grammar. Never guesses.
+    /// </summary>
+    public static bool TryParse(string query, out Predicate predicate, out string reason)
+    {
+        predicate = new Predicate(null, Scope.Exact, null);
+        reason = string.Empty;
+
+        string? path = null;
+        string? nodeType = null;
+        var scope = Scope.Exact;
+        var explicitScope = false;
+        var namespaceUsed = false;
+        var pathUsed = false;
+
+        foreach (var token in (query ?? string.Empty)
+                     .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var colon = token.IndexOf(':');
+            if (colon <= 0)
+            {
+                reason = $"free-text term '{token}' — on a mesh this routes to the vector index, "
+                         + "which a build process cannot reproduce";
+                return false;
+            }
+            var selector = token[..colon];
+            var value = token[(colon + 1)..];
+            if (value.Contains('|', StringComparison.Ordinal)
+                || value.Contains('*', StringComparison.Ordinal))
+            {
+                reason = $"'{token}' uses an alternation/wildcard value, which this evaluator "
+                         + "does not implement";
+                return false;
+            }
+            if (!selector.All(c => char.IsLetterOrDigit(c) || c == '_'))
+            {
+                reason = $"'{token}' carries a comparison operator; only plain 'selector:value' "
+                         + "equality is supported";
+                return false;
+            }
+
+            if (selector.Equals("path", StringComparison.OrdinalIgnoreCase))
+            {
+                if (namespaceUsed || pathUsed)
+                {
+                    reason = $"'{query}' names more than one path/namespace; the runtime resolves "
+                             + "that by last-token-wins, which is too subtle to reproduce blind";
+                    return false;
+                }
+                path = value;
+                pathUsed = true;
+                continue;
+            }
+            if (selector.Equals("namespace", StringComparison.OrdinalIgnoreCase))
+            {
+                if (namespaceUsed || pathUsed)
+                {
+                    reason = $"'{query}' names more than one path/namespace; the runtime resolves "
+                             + "that by last-token-wins, which is too subtle to reproduce blind";
+                    return false;
+                }
+                path = value;
+                namespaceUsed = true;
+                continue;
+            }
+            if (selector.Equals("scope", StringComparison.OrdinalIgnoreCase))
+            {
+                explicitScope = true;
+                switch (value.ToLowerInvariant())
+                {
+                    case "exact": scope = Scope.Exact; break;
+                    case "children": scope = Scope.Children; break;
+                    case "descendants": scope = Scope.Descendants; break;
+                    case "subtree" or "selfanddescendants": scope = Scope.Subtree; break;
+                    default:
+                        reason = $"scope '{value}' is not one of exact/children/descendants/subtree";
+                        return false;
+                }
+                continue;
+            }
+            if (selector.Equals("nodeType", StringComparison.OrdinalIgnoreCase))
+            {
+                if (nodeType is not null && !string.Equals(nodeType, value, StringComparison.OrdinalIgnoreCase))
+                {
+                    reason = $"'{query}' constrains nodeType twice ('{nodeType}' and '{value}')";
+                    return false;
+                }
+                nodeType = value;
+                continue;
+            }
+
+            reason = $"selector '{selector}' is not one of path/namespace/scope/nodeType — a "
+                     + "build-process bake refuses to guess what the mesh would have matched";
+            return false;
+        }
+
+        // The runtime's two namespace rules, verbatim (QueryParser.ExtractReservedQualifiers):
+        // namespace: without an explicit scope means CHILDREN, and namespace: + subtree DEGRADES
+        // to descendants so the node AT the namespace never leaks into its own result set.
+        if (namespaceUsed && !explicitScope)
+            scope = Scope.Children;
+        if (namespaceUsed && scope == Scope.Subtree)
+            scope = Scope.Descendants;
+
+        predicate = new Predicate(path, scope, nodeType);
+        return true;
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -50,6 +50,76 @@ shipped image ever contains those (see "The identity rule" below), so `doc-gate`
 `plugin-gate` still uploads `baked-plugins-<mvid>` for in-run diagnosis. What the portals adopt is
 baked **inside the shipped image** — see "The delivery" below.
 
+## BAKE is a build step; GATE is a mesh run that CONSUMES one
+
+The section above describes how the bake worked until issue #1763: `mw-plugin-test` stood up an
+in-process mesh (`new MeshBuilder(...).AddGraph()`), imported the repo's content, let the **mesh**
+compile every NodeType, and `--bake-output` collected what the mesh had produced. That is
+"compile through mesh nodes" — the thing #1707 forbids — and it is where the minutes went: mesh
+startup, the hub scheduler, and one per-type activation for every type in the tree.
+
+The two concerns are now split, and they are different kinds of thing:
+
+| | what it is | how it runs |
+|---|---|---|
+| **BAKE** — produce assemblies | a **build step** | `mw-compiler compile <root> --output <dir>`: resolve NodeType sources from the git tree, compile with `MeshWeaver.Compiler`, emit **DLL + PDB**, write the bundle. No `MeshBuilder`, no `AddGraph()`, no import, no hub. |
+| **GATE** — prove it works | a **runtime** check | `mw-plugin-test <root>`: stand up a mesh, render each type's default area, execute its `Tests` area. Rendering and running tests are genuine runtime behaviours; producing an assembly is not. |
+
+**The emergency path is untouched.** A live instance with no usable artifact still compiles its own
+— #1707 requires it, because there will always be code that never went through CI. That is
+*recovery*, not a build lane.
+
+### Source resolution without a mesh
+
+At runtime the mesh performs source discovery: `NodeSources.GetSources` expands the NodeType's
+`Sources`/`Tests` queries and asks `workspace.GetQuery`, which reaches the storage adapters. A build
+step has none of that, so `MeshWeaver.Compiler` gained a second implementation — `NodeSet` /
+`NodeSetQuery` / `NodeSetCompiler` — that answers the same queries against an in-memory node set the
+caller assembled from the tree.
+
+That code lives **inside the toolchain assembly on purpose**: which Code nodes a compile consumes is
+part of the *generated input* of that compile, exactly like the skeleton generator and the join
+order, so it has to sit inside the full-MVID identity boundary. A resolver outside it could change
+what a bake consumes without moving the framework identity, and every portal would adopt the changed
+bytes as if nothing had happened.
+
+Two rules keep the second implementation honest:
+
+- **Query EXPANSION is not re-implemented.** `CodeQueryResolver.ExpandAll` is the same call the
+  runtime makes, so `$self`, the `name=` prefix, the `@`/`@@` shorthand, the bare-namespace rebase
+  and the implicit `nodeType:Code` filter cannot fork. The same is true of the `@@`-include walk,
+  the dedup/executable filter, the join order, the skeleton and the emit — the tree baker is an
+  *orchestrator* of the runtime's own shaping, not a parallel copy of it.
+- **Query EVALUATION refuses what it does not understand.** Only `path:`, `namespace:`, `scope:` and
+  `nodeType:` are supported — everything `CodeQueryResolver` can emit. Free text (which routes to
+  vector search on a real mesh), wildcards, alternations and any other selector make the resolution
+  **unestablished**, and the bake then refuses to compile rather than matching less. This is the same
+  fail-loud direction `SourceSnapshot` takes at runtime and for the same reason: a source set that is
+  short compiles into completely genuine-looking `CS0246`/`CS0103` diagnostics about code that is
+  fine.
+
+### The equivalence pin
+
+🚨 **Getting this wrong is silent.** A baker that resolves sources even slightly differently emits
+assemblies that are subtly not what the mesh would have built. The bundle is well-formed, the
+framework identity matches, every consumer adopts it, and the defect first appears as a page
+rendering empty in production — no exception, no log line.
+
+So the equivalence is a **test**, not an argument. `BakeEquivalenceTest`
+(`test/MeshWeaver.PluginTester.Test`) bakes one content set BOTH ways and asserts the producers
+agree on: the framework identity, the bundle and node-path sets, the resolved source set per type,
+the per-type dependency records, and the emitted assemblies' type-and-member surface — over a
+fixture that exercises the default `Source/`+`Test/` subtree queries including a nested folder, a
+cross-package `shared=@…` query, an `@@` include of a node no query matches, an executable code cell
+that must be excluded, and a `// NodeType: Scope` source the `nodeType:Code` filter must exclude.
+
+**Bytes are deliberately not compared.** The mesh folds its source set through an
+`ImmutableDictionary` and emits `dict.Values` — hash-bucket order over per-process-randomised string
+hashes — and the sources are then concatenated in that order, so the mesh-driven bake is not
+byte-reproducible even against itself (the generated skeleton also stamps `// Generated at:
+{UtcNow}`). The compiler-driven bake sorts, which is strictly better; the surface comparison is what
+proves the concatenation order of independent top-level declarations does not matter.
+
 ## The identity rule: adoptable when the SURFACE is unchanged
 
 Adoption is gated by `PrebuiltAssemblySeeder.DeclineReason` on the **framework build identity**

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -113,12 +113,38 @@ fixture that exercises the default `Source/`+`Test/` subtree queries including a
 cross-package `shared=@…` query, an `@@` include of a node no query matches, an executable code cell
 that must be excluded, and a `// NodeType: Scope` source the `nodeType:Code` filter must exclude.
 
-**Bytes are deliberately not compared.** The mesh folds its source set through an
-`ImmutableDictionary` and emits `dict.Values` — hash-bucket order over per-process-randomised string
-hashes — and the sources are then concatenated in that order, so the mesh-driven bake is not
-byte-reproducible even against itself (the generated skeleton also stamps `// Generated at:
-{UtcNow}`). The compiler-driven bake sorts, which is strictly better; the surface comparison is what
-proves the concatenation order of independent top-level declarations does not matter.
+**Bytes are deliberately not compared** — for a reason that is a property of the platform, not of
+this test. See the next section.
+
+## 🚨 A stated property: the mesh-driven bake is NOT byte-reproducible, even against itself
+
+This is not a quirk of the comparison above; it is true of **every bake this platform has ever
+produced**, and anyone reasoning about bake artifacts needs it up front.
+
+A NodeType's compile input is the concatenation of its source Code nodes. The mesh discovers them by
+folding each query's results into an `ImmutableDictionary<string, MeshNode>` and emitting
+`dict.Values` — which is **hash-bucket order over string hashes that .NET randomises per process**.
+`NodeCompileShaping.CombineSources` then joins the files in exactly that order. So two runs of the
+same mesh-driven bake, over the same commit, on the same machine, concatenate the same sources in
+**different orders** and emit **different bytes**. (The generated skeleton independently stamps
+`// Generated at: {UtcNow}`, and the emit embeds a temp `pdbFilePath`, so even a fixed order would
+not give byte equality.)
+
+Three consequences worth carrying:
+
+- **This is why the framework identity is SURFACE-based, not byte-based.** Hashing emitted bytes
+  could never have worked as an identity: it would change on every run without anything changing.
+  `FrameworkBuildIdentity` hashes *reference assemblies* — the compiler's own definition of an API
+  surface — precisely because that is stable where bytes are not.
+- **Any "did these two bakes produce the same thing?" check must compare SURFACE, never hashes.**
+  Comparing digests of bake outputs will report differences that do not exist, on every run.
+  `BakeEquivalenceTest` compares node paths, resolved source sets, dependency records and the
+  emitted assemblies' type-and-member surface; that is the shape such a check has to take.
+- **The compiler-driven bake is deterministic** (query order, then ordinal by path). That is strictly
+  better and costs nothing, but it does not make the two producers byte-equal — the old lane is the
+  non-deterministic one. What the surface comparison proves is that the concatenation order of
+  independent top-level declarations does not affect what is emitted, which is why the old lane's
+  non-determinism was survivable.
 
 ## The identity rule: adoptable when the SURFACE is unchanged
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-the-bake-no-longer-needs-a-mesh.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-the-bake-no-longer-needs-a-mesh.md
@@ -1,8 +1,9 @@
 ---
-nodeType: Markdown
-name: The content bake no longer needs a mesh
+Name: The content bake no longer needs a mesh
 Category: Feature
-Description: mw-compiler grew a `compile` verb that resolves NodeType sources straight from a git checkout and compiles them with the MeshWeaver.Compiler toolchain — no in-process mesh, no import, no per-type activation — and an equivalence test pins its output against the mesh-driven bake it replaces.
+Description: mw-compiler grew a compile verb that resolves NodeType sources straight from a git checkout and compiles them with the MeshWeaver.Compiler toolchain — no in-process mesh, no import, no per-type activation — and an equivalence test pins its output against the mesh-driven bake it replaces.
+Icon: Sparkle
+Order: -20260817
 ---
 
 # The content bake no longer needs a mesh

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-the-bake-no-longer-needs-a-mesh.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-the-bake-no-longer-needs-a-mesh.md
@@ -1,0 +1,53 @@
+---
+nodeType: Markdown
+name: The content bake no longer needs a mesh
+Category: Feature
+Description: mw-compiler grew a `compile` verb that resolves NodeType sources straight from a git checkout and compiles them with the MeshWeaver.Compiler toolchain — no in-process mesh, no import, no per-type activation — and an equivalence test pins its output against the mesh-driven bake it replaces.
+---
+
+# The content bake no longer needs a mesh
+
+Producing a NodeType's assembly used to require standing up a mesh. The CI bake — the platform's own
+and every content repo's — booted an in-process mesh, imported the whole checkout, let the **mesh**
+compile every NodeType behind its hub scheduler, and then collected whatever the mesh had produced.
+That is "compile through mesh nodes", and it is where the minutes went: mesh startup, message
+routing, and one hub activation per type.
+
+`mw-compiler` now carries a **`compile` verb** that does it as an ordinary build step:
+
+```bash
+mw-compiler compile <checkout-root> --output <dir> [--source-sha <sha>]
+```
+
+It reads the node files out of the tree, resolves each NodeType's `Sources`/`Tests` queries against
+that in-memory set, resolves `@@` includes, compiles with the `MeshWeaver.Compiler` toolchain and
+emits **DLL + PDB** into the same prebuilt-assembly bundles as before. No `MeshBuilder`, no
+`AddGraph()`, no content import, no hub anywhere in the path.
+
+**Nothing downstream changes.** Same bundle format, same framework-identity keying, same per-type
+dependency records. The portals' shipped-bundle seeder, the plugin bundle client and
+`PrebuiltAssemblySeeder` cannot tell which producer wrote a bundle — and must not.
+
+**The gate keeps its mesh, because it earns it.** Rendering a layout area and executing a `Tests`
+area are genuine runtime behaviours, so `mw-plugin-test` still stands up a mesh — it now just
+*consumes* a bake instead of producing one. Bake is a build step; gate is a runtime check.
+
+**And a live instance still compiles its own.** There will always be code that never went through
+CI, so the emergency path stays exactly as it was. That is recovery, not a build lane.
+
+## Why the boring part is the interesting part
+
+A baker that resolves sources even slightly differently from the runtime emits assemblies that are
+*subtly* not what the mesh would have built — and nothing fails. The bundle is well-formed, the
+framework identity matches, every portal adopts it, and the first symptom is a page rendering empty
+in production.
+
+So the source-resolution rules are not re-implemented: query expansion, the `@@`-include walk, the
+deduplication, the executable-cell filter, the join order, the generated skeleton and the emit are
+all the runtime's own code, and the new resolver **refuses** any query it cannot evaluate rather
+than quietly matching less. On top of that, a test bakes one content set both ways and asserts the
+two producers agree on the resolved source set, the dependency records, the framework identity and
+the emitted assemblies' type-and-member surface.
+
+See [CI Content Bake](/Doc/Architecture/CiContentBake) for the full split and the equivalence
+argument.

--- a/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Reactive.Disposables;
 using System.Reflection;
 using System.Runtime.Loader;
+using MeshWeaver.Compiler;
 using MeshWeaver.ServiceProvider;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -1012,33 +1013,14 @@ internal class CompilationCacheService(
     }
 
     /// <inheritdoc />
-    public string SanitizeNodeName(string nodePath)
-    {
-        // Replace path separators and invalid characters with underscores
-        var sanitized = nodePath
-            .Replace('/', '_')
-            .Replace('\\', '_')
-            .Replace(':', '_')
-            .Replace('*', '_')
-            .Replace('?', '_')
-            .Replace('"', '_')
-            .Replace('<', '_')
-            .Replace('>', '_')
-            .Replace('|', '_')
-            .Replace(' ', '_');
-
-        // Remove leading/trailing underscores and collapse multiple underscores
-        while (sanitized.Contains("__"))
-            sanitized = sanitized.Replace("__", "_");
-
-        sanitized = sanitized.Trim('_');
-
-        // Ensure it starts with a letter (for valid assembly names)
-        if (sanitized.Length > 0 && !char.IsLetter(sanitized[0]))
-            sanitized = "Node_" + sanitized;
-
-        return sanitized;
-    }
+    /// <remarks>
+    /// The rule itself lives in <see cref="CodeConventions.SanitizeNodeName"/> — it names the
+    /// EMITTED ASSEMBLY (<c>DynamicNode_{name}</c>) and the generated provider class, so it shapes
+    /// the compile's output and has to sit inside the toolchain identity boundary (#1707). The
+    /// build-process baker (#1763) calls the same function, which is what makes a compiler-driven
+    /// bake and this mesh-driven one produce identically-named assemblies.
+    /// </remarks>
+    public string SanitizeNodeName(string nodePath) => CodeConventions.SanitizeNodeName(nodePath);
 
     /// <inheritdoc />
     public NodeAssemblyLoadContext GetOrCreateLoadContext(string nodeName)

--- a/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
@@ -83,8 +83,14 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
     private const string WidgetIndexJson =
         """{"$type":"MeshNode","id":"Widget","namespace":"","path":"Widget","mainNode":"Widget","name":"Widget Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A widget plugin."}}""";
 
+    // 🚨 `"compilationStatus":"Ok"` is not decoration. Enums persist as STRINGS, and a content
+    // reader built on plain web defaults cannot convert them — which silently made 28 NodeTypes
+    // across ACME/Cornerstone/FutuRe/Northwind unmaterialisable when this bake was first run over
+    // samples/Graph/Data. Every NodeType that has ever compiled carries this stamp, so a fixture
+    // without one does not resemble real content at all. If the converter regresses, the tree bake
+    // drops Widget/Thing and the bundle-set assertion below goes red.
     private const string ThingNodeTypeJson =
-        """{"$type":"MeshNode","id":"Thing","namespace":"Widget","path":"Widget/Thing","mainNode":"Widget/Thing","name":"Thing","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A thing.","configuration":"config => config.WithContentType<Thing>().AddDefaultLayoutAreas()","includeGlobalTypes":true,"sources":["namespace:Source scope:subtree","shared=@Lib/Shared/Source"]}}""";
+        """{"$type":"MeshNode","id":"Thing","namespace":"Widget","path":"Widget/Thing","mainNode":"Widget/Thing","name":"Thing","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A thing.","configuration":"config => config.WithContentType<Thing>().AddDefaultLayoutAreas()","includeGlobalTypes":true,"compilationStatus":"Ok","lastCompiledVersion":7,"sources":["namespace:Source scope:subtree","shared=@Lib/Shared/Source"]}}""";
 
     // Pulls Helper (cross-package), Deep (nested subtree) and — through the @@ directive — a Code
     // node no source query matches.
@@ -165,6 +171,13 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
             WriteFile(root, "Widget/Thing/Source/Cell.json", ExecutableCellJson);
             WriteFile(root, "Widget/Thing/Test/ThingTests.cs", ThingTestsSource);
             WriteFile(root, "Widget/Snippets/Greeting.cs", GreetingSource);
+            // 🚨 A node file the RUNTIME cannot parse. samples/Graph/Data/PensionFund ships 62 of
+            // these — .json with a UTF-8 BOM — and the mesh's importer skips every one
+            // ("No parser for node-repo file X; skipped"), gating zero NodeTypes in that package.
+            // The bake must skip it too: neither die on it (it is not a bake failure) nor parse it
+            // (that would compile content the mesh never imports). Both producers therefore emit
+            // the SAME bundle set, which is what the assertions below check.
+            WriteFileWithBom(root, "Widget/Unparseable.json", WidgetIndexJson);
         });
         var meshDir = Path.Combine(Path.GetTempPath(), "mw-bake-mesh-" + Guid.NewGuid().ToString("N"));
         var treeDir = Path.Combine(Path.GetTempPath(), "mw-bake-tree-" + Guid.NewGuid().ToString("N"));
@@ -454,6 +467,14 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
         var full = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
         Directory.CreateDirectory(Path.GetDirectoryName(full)!);
         File.WriteAllText(full, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    /// <summary>Writes a file WITH a UTF-8 BOM — the shape the runtime's JSON parser rejects.</summary>
+    private static void WriteFileWithBom(string root, string relative, string content)
+    {
+        var full = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
     }
 
     private static void Cleanup(string directory)

--- a/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
@@ -301,6 +301,54 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
         }
     }
 
+    /// <summary>
+    /// 🚨 A type the bake CANNOT resolve must go RED, never quietly vanish.
+    ///
+    /// <para>A NodeType with no <c>configuration</c> lambda compiles only if it has sources, so the
+    /// bake needs a "nothing to compile here" skip. The trap is judging that on the resolved set
+    /// alone: a source-only type whose query this evaluator cannot answer resolves to nothing, and
+    /// the skip then drops it from the bundle with no entry, no RED and no line saying a type was
+    /// dropped — a consumer would simply compile it, and the bake would have shipped less than it
+    /// claimed while exiting 0. That is the skip-trapdoor shape AGENTS.md forbids, and the reason
+    /// "established" is a PRECONDITION of the emptiness judgement rather than part of it.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public void ASourceOnlyTypeWithAnUnevaluableQuery_FailsLoudly_NeverSilentlySkipped()
+    {
+        const string unevaluableNodeType =
+            """{"$type":"MeshNode","id":"Ghost","namespace":"Widget","path":"Widget/Ghost","mainNode":"Widget/Ghost","name":"Ghost","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"Sources only, via a query the bake cannot evaluate.","sources":["namespace:*/Source scope:subtree"]}}""";
+
+        var repo = CreateRepo(root =>
+        {
+            WriteFile(root, "Widget/index.json", WidgetIndexJson);
+            WriteFile(root, "Widget/Ghost.json", unevaluableNodeType);
+            WriteFile(root, "Widget/Ghost/Source/Ghost.cs", DeepSource);
+        });
+        var bakeDir = Path.Combine(Path.GetTempPath(), "mw-bake-ghost-" + Guid.NewGuid().ToString("N"));
+        var log = new StringWriter();
+        try
+        {
+            var report = TreeBake.Run(new TreeBake.Options
+            {
+                RepoRoot = repo,
+                OutputDirectory = bakeDir,
+                Output = log,
+            });
+            output.WriteLine(log.ToString());
+
+            var ghost = Assert.Single(report.Types, t => t.NodePath == "Widget/Ghost");
+            Assert.False(ghost.Success);
+            Assert.Contains("could not be ESTABLISHED", ghost.Error);
+            // …and the run does not report success on it.
+            Assert.NotEqual(0, report.ExitCode);
+        }
+        finally
+        {
+            Cleanup(repo);
+            Cleanup(bakeDir);
+        }
+    }
+
     // ── reading a bake directory back through the consumers' own codec ──
 
     private sealed record BakeEntry(

--- a/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
@@ -1,0 +1,423 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Plugin.Packaging;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// 🚨 THE SAFETY ARGUMENT for issue #1763. Bakes one content set BOTH ways — through the
+/// MESH-driven gate (<see cref="PluginGateRunner"/> with <c>--bake-output</c>: stand up an
+/// in-process mesh, import the repo, let the mesh compile every NodeType, collect what it produced)
+/// and through the COMPILER-driven build step (<see cref="TreeBake"/>: resolve sources from the
+/// tree, compile with <c>MeshWeaver.Compiler</c>, emit) — and asserts the two producers agree.
+///
+/// <para><b>Why this test is the deliverable and the speed is not.</b> A baker that resolves
+/// sources even slightly differently from the runtime emits assemblies that are subtly not what the
+/// mesh would have built, and NOTHING fails: the bundle is well-formed, the framework identity
+/// matches, every consumer adopts it, and the defect first surfaces as a page rendering empty in
+/// production. There is no exception to grep for and no log line to find. So the equivalence
+/// between "what the build resolved" and "what the mesh would have resolved" is pinned here, on a
+/// content set that exercises every resolution rule that could fork:</para>
+/// <list type="bullet">
+///   <item>the DEFAULT <c>Source/</c> + <c>Test/</c> subtree queries, including a NESTED folder
+///     (<c>namespace:… scope:subtree</c> must reach <c>Source/Sub/Deep.cs</c>);</item>
+///   <item>a CROSS-PACKAGE <c>shared=@Lib/Shared/Source</c> query — the one the runtime answers
+///     against the whole mesh, and which a per-package tree walk would silently resolve to
+///     nothing (#1218's shape);</item>
+///   <item>an <c>@@</c> include pulling a Code node that NO source query matches;</item>
+///   <item>an EXECUTABLE code cell under <c>Source/</c>, which both paths must EXCLUDE (it runs
+///     via the kernel; folding it in collides with the class declarations beside it);</item>
+///   <item>a <c>// NodeType: Scope</c>-headered <c>.cs</c>, which the implicit <c>nodeType:Code</c>
+///     filter must exclude from both.</item>
+/// </list>
+///
+/// <para><b>What is compared, and what deliberately is not.</b> The bundle SHAPE (node paths), the
+/// per-type DEPENDENCY RECORDS (#1719 — what a consumer validates before adopting), the framework
+/// identity, the resolved SOURCE SET per type, and the emitted assemblies' TYPE AND MEMBER SURFACE.
+/// Not the bytes: the mesh folds its source set through an <c>ImmutableDictionary</c> and emits
+/// <c>dict.Values</c>, i.e. hash-bucket order over per-process-randomised string hashes, so the
+/// mesh-driven bake is not byte-reproducible against ITSELF, let alone against a deterministic
+/// producer. (The generated skeleton also stamps <c>// Generated at: {UtcNow}</c>.) The compiler
+/// path sorts, which is strictly better; the concatenation order of independent top-level
+/// declarations is what the surface comparison proves irrelevant.</para>
+/// </summary>
+public class BakeEquivalenceTest(ITestOutputHelper output)
+{
+    // ── Lib: a package whose NodeType's Source is CONSUMED by the other package ──
+
+    private const string LibIndexJson =
+        """{"$type":"MeshNode","id":"Lib","namespace":"","path":"Lib","mainNode":"Lib","name":"Lib","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"Shared sources."}}""";
+
+    private const string SharedNodeTypeJson =
+        """{"$type":"MeshNode","id":"Shared","namespace":"Lib","path":"Lib/Shared","mainNode":"Lib/Shared","name":"Shared","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"Shared library.","configuration":"config => config.WithContentType<SharedMarker>().AddDefaultLayoutAreas()","includeGlobalTypes":true}}""";
+
+    private const string HelperSource =
+        """
+        public static class Helper
+        {
+            public static int Answer() => 42;
+        }
+
+        public record SharedMarker
+        {
+            public string Note { get; init; } = string.Empty;
+        }
+        """;
+
+    // ── Widget: consumes Lib's Source via `shared=`, uses an @@ include, and ships two files the
+    //    resolution must EXCLUDE (an executable cell and a Scope-typed .cs) ──
+
+    private const string WidgetIndexJson =
+        """{"$type":"MeshNode","id":"Widget","namespace":"","path":"Widget","mainNode":"Widget","name":"Widget Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A widget plugin."}}""";
+
+    private const string ThingNodeTypeJson =
+        """{"$type":"MeshNode","id":"Thing","namespace":"Widget","path":"Widget/Thing","mainNode":"Widget/Thing","name":"Thing","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A thing.","configuration":"config => config.WithContentType<Thing>().AddDefaultLayoutAreas()","includeGlobalTypes":true,"sources":["namespace:Source scope:subtree","shared=@Lib/Shared/Source"]}}""";
+
+    // Pulls Helper (cross-package), Deep (nested subtree) and — through the @@ directive — a Code
+    // node no source query matches.
+    private const string ThingSource =
+        """
+        public record Thing
+        {
+            public string Name { get; init; } = string.Empty;
+
+            public int Answer() => Helper.Answer() + Deep.Bonus();
+        }
+
+        @@Widget/Snippets/Greeting
+        """;
+
+    private const string DeepSource =
+        """
+        public static class Deep
+        {
+            public static int Bonus() => 0;
+        }
+        """;
+
+    private const string GreetingSource =
+        """
+        public static class Greeting
+        {
+            public static string Hello() => "hi";
+        }
+        """;
+
+    private const string ThingTestsSource =
+        """
+        public static class ThingTests
+        {
+            public static void Answer_Is42()
+            {
+                if (new Thing().Answer() != 42)
+                    throw new System.Exception("expected the answer to be 42");
+            }
+        }
+        """;
+
+    // 🚨 An executable code cell living UNDER Source/. Both paths must skip it: it runs through the
+    // kernel, and its top-level statements would collide with the class declarations beside it.
+    // Authored as .json because the `.cs` header cannot carry `isExecutable` (AGENTS.md → node file
+    // formats), which is exactly why a tree baker that only understood `.cs` would fold it in.
+    private const string ExecutableCellJson =
+        """{"$type":"MeshNode","id":"Cell","namespace":"Widget/Thing/Source","path":"Widget/Thing/Source/Cell","mainNode":"Widget/Thing/Source/Cell","name":"Cell","nodeType":"Code","state":"Active","content":{"$type":"CodeConfiguration","code":"var x = 1; x.Display();","language":"csharp","isExecutable":true}}""";
+
+    // A Scope-typed .cs under Source/: the implicit `nodeType:Code` filter must exclude it. If it
+    // leaked in, `ScopeOnly` would appear in the emitted surface.
+    private const string ScopeTypedSource =
+        """
+        // <meshweaver>
+        // NodeType: Scope
+        // </meshweaver>
+        public static class ScopeOnly
+        {
+            public static int Value() => 7;
+        }
+        """;
+
+    [Fact(Timeout = 600_000)]
+    public async Task MeshDrivenAndCompilerDrivenBakes_ProduceTheSameArtifacts()
+    {
+        var repo = CreateRepo(root =>
+        {
+            WriteFile(root, "Lib/index.json", LibIndexJson);
+            WriteFile(root, "Lib/Shared.json", SharedNodeTypeJson);
+            WriteFile(root, "Lib/Shared/Source/Helper.cs", HelperSource);
+
+            WriteFile(root, "Widget/index.json", WidgetIndexJson);
+            WriteFile(root, "Widget/Thing.json", ThingNodeTypeJson);
+            WriteFile(root, "Widget/Thing/Source/Thing.cs", ThingSource);
+            WriteFile(root, "Widget/Thing/Source/Sub/Deep.cs", DeepSource);
+            WriteFile(root, "Widget/Thing/Source/Scoped.cs", ScopeTypedSource);
+            WriteFile(root, "Widget/Thing/Source/Cell.json", ExecutableCellJson);
+            WriteFile(root, "Widget/Thing/Test/ThingTests.cs", ThingTestsSource);
+            WriteFile(root, "Widget/Snippets/Greeting.cs", GreetingSource);
+        });
+        var meshDir = Path.Combine(Path.GetTempPath(), "mw-bake-mesh-" + Guid.NewGuid().ToString("N"));
+        var treeDir = Path.Combine(Path.GetTempPath(), "mw-bake-tree-" + Guid.NewGuid().ToString("N"));
+        var meshLog = new StringWriter();
+        var treeLog = new StringWriter();
+        try
+        {
+            // ── the COMPILER-driven bake: no MeshBuilder, no AddGraph, no import, no hub ──
+            var treeReport = TreeBake.Run(new TreeBake.Options
+            {
+                RepoRoot = repo,
+                OutputDirectory = treeDir,
+                SourceSha = "deadbeef",
+                Output = treeLog,
+            });
+            output.WriteLine("── compiler-driven bake ──");
+            output.WriteLine(treeLog.ToString());
+            Assert.Null(treeReport.FatalError);
+            Assert.All(treeReport.Types, t => Assert.Null(t.Error));
+
+            // ── the MESH-driven bake: exactly what CI runs today ──
+            var meshReport = await PluginGateRunner.Run(new GateOptions
+            {
+                RepoRoot = repo,
+                Output = meshLog,
+                BakeOutputDirectory = meshDir,
+                SourceSha = "deadbeef",
+                CompileTimeout = TimeSpan.FromMinutes(4),
+                RenderTimeout = TimeSpan.FromMinutes(2),
+            }).FirstAsync().ToTask();
+            output.WriteLine("── mesh-driven bake ──");
+            output.WriteLine(meshLog.ToString());
+            Assert.Null(meshReport.FatalError);
+
+            var mesh = ReadBakeDirectory(meshDir);
+            var tree = ReadBakeDirectory(treeDir);
+
+            // 1. The framework identity — the gate every consumer applies before adopting a byte.
+            Assert.Equal(mesh.FrameworkIdentity, tree.FrameworkIdentity);
+
+            // 2. The bundle SET: the same packages produced the same NodeTypes. A short set here is
+            //    the whole failure mode — a type the runtime would have built that the build did
+            //    not, or the reverse.
+            Assert.Equal(
+                mesh.Bundles.Keys.OrderBy(k => k, StringComparer.Ordinal),
+                tree.Bundles.Keys.OrderBy(k => k, StringComparer.Ordinal));
+            foreach (var (bundle, meshEntries) in mesh.Bundles)
+            {
+                var treeEntries = tree.Bundles[bundle];
+                Assert.Equal(
+                    meshEntries.Keys.OrderBy(k => k, StringComparer.Ordinal),
+                    treeEntries.Keys.OrderBy(k => k, StringComparer.Ordinal));
+            }
+
+            foreach (var (bundle, meshEntries) in mesh.Bundles)
+            {
+                var treeEntries = tree.Bundles[bundle];
+                foreach (var (nodePath, meshEntry) in meshEntries)
+                {
+                    var treeEntry = treeEntries[nodePath];
+
+                    // 3. THE SOURCE SET. The single most valuable assertion in this file: which
+                    //    Code nodes each producer decided the compile consumes. Everything else is
+                    //    downstream of it.
+                    Assert.Equal(
+                        meshEntry.SourceVersions.Keys.OrderBy(k => k, StringComparer.Ordinal),
+                        treeEntry.SourceVersions.Keys.OrderBy(k => k, StringComparer.Ordinal));
+
+                    // 4. The per-type DEPENDENCY RECORD — what PrebuiltAssemblySeeder validates
+                    //    before adopting. A record that differs is a bundle that declines (or,
+                    //    worse, one that adopts against a surface it was not built for).
+                    Assert.Equal(
+                        meshEntry.Dependencies.OrderBy(kv => kv.Key, StringComparer.Ordinal),
+                        treeEntry.Dependencies.OrderBy(kv => kv.Key, StringComparer.Ordinal));
+
+                    // 5. The emitted assemblies' TYPE AND MEMBER SURFACE. Not the bytes — see the
+                    //    class remarks on why the mesh path is not byte-reproducible even against
+                    //    itself — but everything a consumer can observe about them.
+                    Assert.Equal(SurfaceOf(meshEntry.Assembly), SurfaceOf(treeEntry.Assembly));
+
+                    // 6. Symbols ship from both producers (#1763 names DLL + PDB explicitly).
+                    Assert.True(meshEntry.HasPdb, $"the mesh bake shipped no PDB for {nodePath}");
+                    Assert.True(treeEntry.HasPdb, $"the compiler bake shipped no PDB for {nodePath}");
+                }
+            }
+
+            // 7. The rules actually BIT — otherwise assertions 3-5 could agree because both
+            //    producers made the same mistake on the same file.
+            var thing = tree.Bundles["Widget"]["Widget/Thing"];
+            var thingSurface = SurfaceOf(thing.Assembly).Select(TypeNameOf).ToList();
+
+            // 7a. Cross-package `shared=`, the NESTED subtree file, and the default Test/ folder
+            //     are all in the resolved set…
+            Assert.Contains("Lib/Shared/Source/Helper", thing.SourceVersions.Keys);
+            Assert.Contains("Widget/Thing/Source/Sub/Deep", thing.SourceVersions.Keys);
+            Assert.Contains("Widget/Thing/Test/ThingTests", thing.SourceVersions.Keys);
+            // …and reached the assembly.
+            Assert.Contains("Helper", thingSurface);
+            Assert.Contains("Deep", thingSurface);
+            Assert.Contains("ThingTests", thingSurface);
+            // 7b. The @@ include pulled in a Code node NO source query matches — so it is absent
+            //     from the resolved set but present in the bytes.
+            Assert.DoesNotContain("Widget/Snippets/Greeting", thing.SourceVersions.Keys);
+            Assert.Contains("Greeting", thingSurface);
+
+            // 7c. The `nodeType:Code` filter excluded the Scope-typed .cs from the QUERY itself…
+            Assert.DoesNotContain("Widget/Thing/Source/Scoped", thing.SourceVersions.Keys);
+            Assert.DoesNotContain("ScopeOnly", thingSurface);
+
+            // 7d. …while the executable cell is a DIFFERENT rule at a DIFFERENT stage, and the two
+            //     sets must not be conflated. `sourceVersions` mirrors the mesh's
+            //     NodeTypeDefinition.CompiledSources, which DiscoverSourceVersionSnapshot folds
+            //     over the RAW query match — so the cell IS recorded there, by both producers
+            //     (assertion 3 already proved they agree). It is CollectCompileSources that drops
+            //     it before Roslyn, so it must be absent from the compiled set and from the bytes:
+            //     folding a top-level-statement cell in beside class declarations does not merely
+            //     add a member, it fails the whole compile.
+            Assert.Contains("Widget/Thing/Source/Cell", thing.SourceVersions.Keys);
+            var compiledSources = treeReport.Types
+                .Single(t => t.NodePath == "Widget/Thing")
+                .MatchedSourcePaths;
+            Assert.DoesNotContain("Widget/Thing/Source/Cell", compiledSources);
+            Assert.DoesNotContain("Widget/Thing/Source/Scoped", compiledSources);
+            Assert.Equal(
+                ["Lib/Shared/Source/Helper", "Widget/Thing/Source/Sub/Deep",
+                 "Widget/Thing/Source/Thing", "Widget/Thing/Test/ThingTests"],
+                compiledSources.OrderBy(p => p, StringComparer.Ordinal));
+        }
+        finally
+        {
+            Cleanup(repo);
+            Cleanup(meshDir);
+            Cleanup(treeDir);
+        }
+    }
+
+    // ── reading a bake directory back through the consumers' own codec ──
+
+    private sealed record BakeEntry(
+        byte[] Assembly,
+        bool HasPdb,
+        IReadOnlyDictionary<string, string> Dependencies,
+        IReadOnlyDictionary<string, long> SourceVersions);
+
+    private sealed record BakeDirectory(
+        string FrameworkIdentity,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, BakeEntry>> Bundles);
+
+    private static BakeDirectory ReadBakeDirectory(string directory)
+    {
+        var identity = File.ReadAllText(Path.Combine(directory, BakeOutput.FrameworkMvidFile));
+        var bundles = new Dictionary<string, IReadOnlyDictionary<string, BakeEntry>>(StringComparer.Ordinal);
+        foreach (var zip in Directory.EnumerateFiles(directory, "*.zip").OrderBy(f => f, StringComparer.Ordinal))
+        {
+            var bytes = File.ReadAllBytes(zip);
+            var (manifest, payloads) = BundleReader.Read(bytes);
+            Assert.NotNull(manifest);
+            // sourceVersions is provenance the reader deliberately skips, so it is read straight
+            // off the manifest entry — this test is precisely the consumer that cares.
+            var sourceVersions = ReadSourceVersions(bytes);
+            bundles[Path.GetFileNameWithoutExtension(zip)] = payloads.ToDictionary(
+                p => p.NodePath,
+                p => new BakeEntry(
+                    p.Assembly,
+                    p.Pdb is { Length: > 0 },
+                    p.Dependencies ?? new Dictionary<string, string>(StringComparer.Ordinal),
+                    sourceVersions.GetValueOrDefault(p.NodePath)
+                        ?? new Dictionary<string, long>(StringComparer.Ordinal)),
+                StringComparer.Ordinal);
+        }
+        return new BakeDirectory(identity, bundles);
+    }
+
+    private static Dictionary<string, IReadOnlyDictionary<string, long>> ReadSourceVersions(byte[] bundle)
+    {
+        using var archive = new ZipArchive(new MemoryStream(bundle), ZipArchiveMode.Read);
+        var entry = archive.GetEntry(NuGetPackageWriter.ManifestEntry);
+        Assert.NotNull(entry);
+        using var stream = entry!.Open();
+        using var document = JsonDocument.Parse(stream);
+        var result = new Dictionary<string, IReadOnlyDictionary<string, long>>(StringComparer.Ordinal);
+        if (!document.RootElement.TryGetProperty("assemblies", out var assemblies))
+            return result;
+        foreach (var assembly in assemblies.EnumerateArray())
+        {
+            if (!assembly.TryGetProperty("nodePath", out var nodePath))
+                continue;
+            var versions = new Dictionary<string, long>(StringComparer.Ordinal);
+            if (assembly.TryGetProperty("sourceVersions", out var sv)
+                && sv.ValueKind == JsonValueKind.Object)
+                foreach (var property in sv.EnumerateObject())
+                    versions[property.Name] = property.Value.GetInt64();
+            result[nodePath.GetString()!] = versions;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// The observable surface of an emitted assembly: every type definition and its members, as
+    /// sorted text. Read through <see cref="MetadataReader"/> rather than by loading the assembly,
+    /// so two builds of the SAME assembly name can be compared in one process with no
+    /// <c>AssemblyLoadContext</c> and no unload race.
+    /// </summary>
+    private static IReadOnlyList<string> SurfaceOf(byte[] assembly)
+    {
+        using var pe = new PEReader(new MemoryStream(assembly));
+        var reader = pe.GetMetadataReader();
+        var surface = new List<string>();
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(handle);
+            var name = reader.GetString(type.Namespace) is { Length: > 0 } ns
+                ? $"{ns}.{reader.GetString(type.Name)}"
+                : reader.GetString(type.Name);
+            var members = type.GetMethods()
+                .Select(m => reader.GetString(reader.GetMethodDefinition(m).Name))
+                .Concat(type.GetFields()
+                    .Select(f => reader.GetString(reader.GetFieldDefinition(f).Name)))
+                .OrderBy(m => m, StringComparer.Ordinal);
+            surface.Add($"{name}: {string.Join(",", members)}");
+        }
+        surface.Sort(StringComparer.Ordinal);
+        return surface;
+    }
+
+    private static string TypeNameOf(string surfaceLine)
+        => surfaceLine[..surfaceLine.IndexOf(':', StringComparison.Ordinal)];
+
+    private static string CreateRepo(Action<string> populate)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-equiv-fixture-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        populate(root);
+        return root;
+    }
+
+    private static void WriteFile(string root, string relative, string content)
+    {
+        var full = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static void Cleanup(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover fixture costs disk, never correctness.
+        }
+    }
+}

--- a/test/MeshWeaver.PluginTester.Test/NodeSetQueryTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/NodeSetQueryTest.cs
@@ -1,0 +1,127 @@
+#pragma warning disable CS1591
+
+using System.Linq;
+using MeshWeaver.Compiler;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// Unit pins for the mesh-free source-query evaluator (#1763). The
+/// <see cref="BakeEquivalenceTest"/> proves the two bake paths agree end-to-end; these pin the
+/// individual rules that agreement rests on, so a regression names the RULE instead of surfacing
+/// as "the bundles differ".
+/// </summary>
+public class NodeSetQueryTest
+{
+    private static readonly NodeSet Nodes = NodeSet.Create(
+    [
+        Code("Type"),
+        Code("Type/Source"),
+        Code("Type/Source/A"),
+        Code("Type/Source/Sub/B"),
+        Code("Other/Source/C"),
+        new MeshNode("Scoped", "Type/Source") { NodeType = "Scope" },
+    ]);
+
+    private static MeshNode Code(string path)
+    {
+        var slash = path.LastIndexOf('/');
+        return new MeshNode(
+            slash < 0 ? path : path[(slash + 1)..],
+            slash < 0 ? "" : path[..slash])
+        {
+            NodeType = CodeConventions.CodeNodeType,
+        };
+    }
+
+    private static string[] Match(params string[] sources) => Nodes
+        .ResolveSources(sources, tests: [], "Type")
+        .Sources.Select(n => n.Path).ToArray();
+
+    /// <summary>
+    /// 🚨 The rule that is easiest to get wrong and costs the most: <c>namespace:X scope:subtree</c>
+    /// DEGRADES to descendants, because a namespace names a namespace and never the node at X. The
+    /// DEFAULT source query is exactly this shape, so a resolver that kept "subtree" would fold a
+    /// node literally at <c>{Type}/Source</c> into every compile.
+    /// </summary>
+    [Fact]
+    public void NamespaceSubtree_ExcludesTheNodeAtTheNamespaceItself()
+        => Assert.Equal(
+            ["Type/Source/A", "Type/Source/Sub/B"],
+            Match("namespace:Source scope:subtree"));
+
+    /// <summary><c>path:X scope:subtree</c>, by contrast, KEEPS self.</summary>
+    [Fact]
+    public void PathSubtree_KeepsSelf()
+        => Assert.Equal(
+            ["Type/Source", "Type/Source/A", "Type/Source/Sub/B"],
+            Match("path:Type/Source scope:subtree"));
+
+    /// <summary><c>namespace:X</c> with no scope is CHILDREN, not the subtree.</summary>
+    [Fact]
+    public void BareNamespace_IsDirectChildrenOnly()
+        => Assert.Equal(["Type/Source/A"], Match("namespace:Source"));
+
+    /// <summary>
+    /// The <c>@</c> shorthand expands to an exact match PLUS a subtree walk, and it crosses package
+    /// boundaries — the <c>shared=</c> case a per-package resolver would silently answer with
+    /// nothing.
+    /// </summary>
+    [Fact]
+    public void AtShorthand_ResolvesExactPlusSubtree_AcrossPackages()
+        => Assert.Equal(["Other/Source/C"], Match("shared=@Other/Source"));
+
+    /// <summary>
+    /// The implicit <c>nodeType:Code</c> filter excludes a <c>// NodeType: Scope</c>-headered
+    /// source, exactly as the mesh query does.
+    /// </summary>
+    [Fact]
+    public void ImplicitCodeFilter_ExcludesForeignNodeTypes()
+        => Assert.DoesNotContain("Type/Source/Scoped", Match("namespace:Source scope:subtree"));
+
+    /// <summary>An explicitly-typed query is honoured as authored — the filter is a DEFAULT, not
+    /// an override.</summary>
+    [Fact]
+    public void ExplicitNodeType_IsHonoured()
+        => Assert.Equal(
+            ["Type/Source/Scoped"],
+            Match("namespace:Source scope:subtree nodeType:Scope"));
+
+    /// <summary>
+    /// 🚨 THE FAIL-SAFE. A query this evaluator cannot answer must make the resolution
+    /// UNESTABLISHED — never silently match less. A short source set compiles into completely
+    /// genuine-looking CS0246s about code that is fine (#1218), and the resulting bundle is adopted
+    /// by every portal without a murmur.
+    /// </summary>
+    [Theory]
+    [InlineData("laptop nodeType:Code")]              // free text → vector search on a real mesh
+    [InlineData("namespace:*/Source nodeType:Code")]  // wildcard
+    [InlineData("path:A|B nodeType:Code")]            // alternation
+    [InlineData("state:Active nodeType:Code")]        // a selector outside the grammar
+    [InlineData("namespace:Source scope:ancestors")]  // a scope walk with no source meaning
+    public void AnUnsupportedQuery_MakesTheResolutionUnestablished(string query)
+    {
+        var resolution = Nodes.ResolveSources([query], tests: [], "Type");
+        Assert.False(resolution.IsEstablished);
+        Assert.NotNull(resolution.UnestablishedReason);
+    }
+
+    /// <summary>A supported query set is established, so the caller may compile it.</summary>
+    [Fact]
+    public void ASupportedQuerySet_IsEstablished()
+        => Assert.True(Nodes.ResolveSources(null, null, "Type").IsEstablished);
+
+    /// <summary>
+    /// The assembly name is part of the emitted bytes, so the tree bake and the runtime must derive
+    /// it identically — that is why the rule moved into the toolchain (#1763).
+    /// </summary>
+    [Theory]
+    [InlineData("Widget/Thing", "Widget_Thing")]
+    [InlineData("A//B", "A_B")]
+    [InlineData("1Thing", "Node_1Thing")]
+    [InlineData("/Leading", "Leading")]
+    public void SanitizeNodeName_MatchesTheRuntimeRule(string path, string expected)
+        => Assert.Equal(expected, CodeConventions.SanitizeNodeName(path));
+}

--- a/tools/MeshWeaver.PluginTester/LocalNodeRepo.cs
+++ b/tools/MeshWeaver.PluginTester/LocalNodeRepo.cs
@@ -31,18 +31,27 @@ public static class LocalNodeRepo
     /// classification GitSync's GitHub fetch applies.
     /// </summary>
     public static IObservable<RepoSnapshot> Load(string repoRoot, IIoPool pool) =>
-        pool.InvokeBlocking(_ =>
-        {
-            var root = Path.GetFullPath(repoRoot);
-            if (!Directory.Exists(root))
-                throw new DirectoryNotFoundException($"Repo root '{root}' does not exist.");
+        pool.InvokeBlocking(_ => LoadSync(repoRoot));
 
-            var files = new List<RepoFile>();
-            Sweep(root, root, files);
-            return new RepoSnapshot("local", files
-                .OrderBy(f => f.Path, StringComparer.Ordinal)
-                .ToImmutableList());
-        });
+    /// <summary>
+    /// The sweep itself. Public and synchronous so the compiler-driven bake (#1763), which runs in
+    /// a build process with no mesh and therefore no <see cref="IIoPool"/>, reads the SAME file set
+    /// with the SAME exclusions and the SAME UTF-8 classification the mesh-driven gate reads —
+    /// "which files are content" must not fork between the two bake paths.
+    /// </summary>
+    /// <param name="repoRoot">The checkout root to sweep.</param>
+    public static RepoSnapshot LoadSync(string repoRoot)
+    {
+        var root = Path.GetFullPath(repoRoot);
+        if (!Directory.Exists(root))
+            throw new DirectoryNotFoundException($"Repo root '{root}' does not exist.");
+
+        var files = new List<RepoFile>();
+        Sweep(root, root, files);
+        return new RepoSnapshot("local", files
+            .OrderBy(f => f.Path, StringComparer.Ordinal)
+            .ToImmutableList());
+    }
 
     private static void Sweep(string root, string directory, List<RepoFile> files)
     {

--- a/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+++ b/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
@@ -47,6 +47,24 @@
        base image's environment untouched also restores the default ENTRYPOINT for anyone
        running the image directly. -->
 
+  <!-- 🚨 THIS PROJECT'S REFERENCE CLOSURE IS THE FRAMEWORK IDENTITY. DO NOT "TIDY UP" THE LAYOUT.
+       FrameworkBuildIdentity.ContentSurfaceAssemblies is defined as the transitive MeshWeaver.*
+       closure of THIS csproj (minus MeshWeaver.PluginTester + MeshWeaver.Hosting.Monolith), and the
+       identity is the hash over those assemblies' surface-manifest pairs — one this process does not
+       reference contributes no pair and hashes as "absent".
+
+       Two consequences, both SILENT if you get them wrong:
+         • REMOVING a ProjectReference here (or adding one) changes the identity for every bake host.
+           FrameworkBuildIdentityTest.CanonicalList_MatchesTheTesterClosure catches the drift, which
+           is why that test exists — do not "fix" it by editing the canonical list to match.
+         • MOVING the `compile` verb (#1763) into a separate MeshWeaver.Compiler.Cli project with a
+           leaner reference list resolves a DIFFERENT identity, so every bundle it bakes is declined
+           by every portal (PrebuiltAssemblySeeder.DeclineReason working exactly as designed) and the
+           pods just compile everything as if no bake existed. Nothing reports a defect. The split is
+           fine — it must keep this closure intact and extend that test to assert BOTH closures.
+
+       The BAKE (`compile`) and the GATE (`mw-plugin-test`) therefore share one project on purpose:
+       that is what makes the compiler-driven bake's identity provably equal to the gate's. -->
   <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -24,6 +24,78 @@ using MeshWeaver.Compiler;
 //
 // The one Task bridge lives HERE, at the console boundary — everything below Run() is reactive.
 
+// 🚨 THE `compile` VERB — the compiler-driven bake (#1763). It resolves NodeType sources straight
+// from the git tree, compiles them with MeshWeaver.Compiler and emits DLL + PDB into the existing
+// bundle format. There is NO MeshBuilder, NO AddGraph(), NO content import and NO hub anywhere in
+// its path: producing an assembly is a build step, and the mesh's job is to CONSUME a bake.
+//
+//     mw-compiler compile <checkout-root> --output <dir> [--source-sha <sha>]
+//
+// Everything BELOW this block is the GATE (`mw-plugin-test <root>`), which legitimately stands up a
+// mesh because rendering a layout area and executing a `Tests` area are runtime behaviours. The two
+// used to be one code path wearing two names, which is how the mesh-driven bake stayed invisible.
+if (args.Length > 0 && args[0] == "compile")
+    return RunCompile(args[1..]);
+
+static int RunCompile(string[] args)
+{
+    string? compileRoot = null;
+    string? outputDirectory = null;
+    string? compileSourceSha = null;
+    for (var i = 0; i < args.Length; i++)
+    {
+        switch (args[i])
+        {
+            case "--output" when i + 1 < args.Length:
+                outputDirectory = args[++i];
+                break;
+            case "--source-sha" when i + 1 < args.Length:
+                compileSourceSha = args[++i];
+                break;
+            case "--output" or "--source-sha":
+                Console.Error.WriteLine($"Option '{args[i]}' requires a value.");
+                return 2;
+            case "--help" or "-h":
+                Console.WriteLine(
+                    "usage: mw-compiler compile <checkout-root> --output <dir> [--source-sha <sha>]");
+                return 0;
+            default:
+                if (args[i].StartsWith('-') || compileRoot is not null)
+                {
+                    Console.Error.WriteLine($"Unknown argument '{args[i]}'. Try --help.");
+                    return 2;
+                }
+                compileRoot = args[i];
+                break;
+        }
+    }
+    if (outputDirectory is null)
+    {
+        Console.Error.WriteLine(
+            "compile: --output <dir> is required (the directory the bundles are written into).");
+        return 2;
+    }
+
+    compileRoot ??= ".";
+    Console.WriteLine(
+        $"mw-compiler compile: baking node repos under '{Path.GetFullPath(compileRoot)}' "
+        + $"→ '{Path.GetFullPath(outputDirectory)}' (no mesh)");
+    var bake = TreeBake.Run(new TreeBake.Options
+    {
+        RepoRoot = compileRoot,
+        OutputDirectory = outputDirectory,
+        SourceSha = compileSourceSha,
+    });
+    if (bake.FatalError is not null)
+        Console.Error.WriteLine($"compile: FATAL — {bake.FatalError}");
+    foreach (var failed in bake.Types.Where(t => !t.Success))
+        Console.Error.WriteLine($"compile: RED {failed.NodePath} — {failed.Error}");
+    Console.WriteLine(
+        $"compile: {bake.Types.Count(t => t.Success)}/{bake.Types.Length} NodeType(s) compiled, "
+        + $"{bake.Bundles.Length} bundle(s), framework={bake.FrameworkIdentity}");
+    return bake.ExitCode;
+}
+
 string? root = null;
 var compileTimeout = TimeSpan.FromMinutes(5);
 var renderTimeout = TimeSpan.FromMinutes(2);

--- a/tools/MeshWeaver.PluginTester/README.md
+++ b/tools/MeshWeaver.PluginTester/README.md
@@ -16,10 +16,34 @@ Distributed two ways, same binary:
 Useful entry points:
 
 ```
-mw-compiler <checkout-root>                 # the content gate: compile the repo's node trees
-mw-compiler <root> --bake-output <dir>      # …and persist bundles + framework-mvid.txt
+mw-compiler compile <root> --output <dir>   # BAKE: build-step compile, NO mesh (#1763)
+mw-compiler <checkout-root>                 # GATE: mesh run — render + Tests areas
+mw-compiler <root> --bake-output <dir>      # legacy: the gate's mesh ALSO produces the bundles
 mw-compiler --print-framework-identity      # one-line identity + provenance diagnostic
 ```
+
+## `compile` — the bake, as a build step
+
+`compile` is the compiler-driven bake (#1763). It reads the node files out of the checkout,
+resolves each NodeType's `Sources`/`Tests` queries and `@@` includes against that in-memory node
+set, compiles with the `MeshWeaver.Compiler` toolchain, emits **DLL + PDB**, and writes the same
+`<package>.zip` bundles + `framework-mvid.txt` as before. **No `MeshBuilder`, no `AddGraph()`, no
+content import, no hub.** Consumers cannot tell which producer wrote a bundle — and must not.
+
+```
+mw-compiler compile <checkout-root> --output <dir> [--source-sha <sha>]
+```
+
+Everything else in this binary is the **gate**, which legitimately stands up a mesh: rendering a
+layout area and executing a `Tests` area are runtime behaviours; producing an assembly is not. The
+gate's own `--bake-output` still works, so lanes can migrate one at a time.
+
+🚨 The two bakes are held equivalent by `BakeEquivalenceTest`
+(`test/MeshWeaver.PluginTester.Test`), which bakes one content set BOTH ways and compares the
+resolved source sets, the per-type dependency records, the framework identity and the emitted
+assemblies' surface. A baker that resolves sources differently fails NOTHING until a page renders
+empty in production, so that test — not the speed — is the point. See
+`Doc/Architecture/CiContentBake` → "BAKE is a build step; GATE is a mesh run that CONSUMES one".
 
 The framework build identity resolves from the `meshweaver-surface.manifest` packed beside the
 binaries — equal by construction with the portals' identity (see

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -188,12 +188,23 @@ public static class TreeBake
         foreach (var candidate in compilable)
         {
             var definition = (NodeTypeDefinition)candidate.Node.Content!;
-            // A type with neither a configuration lambda nor any source has nothing to compile —
-            // the same "Compiles" predicate the gate applies.
             var resolution = nodeSet.ResolveSources(
                 definition.Sources, definition.Tests, candidate.Node.Path);
-            if (string.IsNullOrWhiteSpace(definition.Configuration)
-                && (!resolution.IsEstablished || resolution.Sources.IsEmpty))
+
+            // A type with neither a configuration lambda nor any source has nothing to compile —
+            // the same "Compiles" predicate the gate applies.
+            //
+            // 🚨 ESTABLISHED is a precondition of that judgement, not part of it. An unestablished
+            // resolution means the bake could not evaluate one of the type's source queries — it
+            // does NOT mean the type has no sources, and collapsing the two would be a
+            // skip-trapdoor of exactly the shape CI forbids: a source-only type whose query this
+            // evaluator cannot answer would vanish from the bake with no bundle entry, no RED and
+            // no line anywhere saying a type was dropped. So an unestablished resolution falls
+            // THROUGH to Compile, which throws SourceDiscoveryUnavailableException and lands in the
+            // catch below as a failed type — loud, named, and non-zero exit.
+            if (resolution.IsEstablished
+                && resolution.Sources.IsEmpty
+                && string.IsNullOrWhiteSpace(definition.Configuration))
                 continue;
 
             try

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -1,0 +1,301 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using MeshWeaver.Compiler;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Plugin.Packaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// The COMPILER-DRIVEN bake (#1763): read a checkout's node trees, compile every dynamic NodeType
+/// with <see cref="MeshWeaver.Compiler"/>, emit DLL + PDB, and write the SAME prebuilt-assembly
+/// bundles <c>BakeOutput</c> writes — <c>&lt;package&gt;.zip</c> per package plus
+/// <c>framework-mvid.txt</c>, keyed to this process's framework build identity, carrying the
+/// per-type dependency records (#1719).
+///
+/// <para><b>No mesh anywhere in this path.</b> No <c>MeshBuilder</c>, no <c>AddGraph()</c>, no
+/// import, no hub scheduler, no per-type activation. That is the whole point of the issue: bake is
+/// a build step, and the mesh's job is to CONSUME a bake, not to produce one. The gate
+/// (<see cref="PluginGateRunner"/>) still stands up a mesh, because rendering a layout area and
+/// executing a <c>Tests</c> area are genuine runtime behaviours — producing an assembly is not.</para>
+///
+/// <para><b>The output format is frozen.</b> <see cref="BundleWriter"/> is the same writer, the
+/// framework identity is the same <c>PrebuiltAssemblySeeder.LiveFrameworkMvid</c> reading, and the
+/// dependency record is the same <see cref="CompiledDependencies"/> computation over the emitted
+/// assembly's AssemblyRef table. <c>ShippedPrebuiltBundles</c>, <c>PluginBundleClient.Adopt</c> and
+/// <c>PrebuiltAssemblySeeder</c> cannot tell which producer wrote a bundle — and must not.</para>
+///
+/// <para><b>The emergency path is untouched.</b> A live instance with no usable artifact still
+/// compiles its own; #1707 requires it ("there will always be code without any CI"). This removes
+/// the mesh from the BUILD lane, not the recovery lane.</para>
+/// </summary>
+public static class TreeBake
+{
+    /// <summary>Options for one compiler-driven bake.</summary>
+    public sealed record Options
+    {
+        /// <summary>The checkout root holding the node-repo packages.</summary>
+        public required string RepoRoot { get; init; }
+
+        /// <summary>Directory the bundles + <c>framework-mvid.txt</c> are written into.</summary>
+        public required string OutputDirectory { get; init; }
+
+        /// <summary>Commit recorded in each bundle manifest for provenance.</summary>
+        public string? SourceSha { get; init; }
+
+        /// <summary>Progress sink.</summary>
+        public TextWriter Output { get; init; } = Console.Out;
+
+        /// <summary>Diagnostics.</summary>
+        public ILogger Logger { get; init; } = NullLogger.Instance;
+    }
+
+    /// <summary>One NodeType's outcome.</summary>
+    /// <param name="NodePath">The NodeType's mesh path.</param>
+    /// <param name="Package">The package it belongs to.</param>
+    /// <param name="Error">The failure, or null when it compiled.</param>
+    /// <param name="MatchedSourcePaths">The Code nodes the compile consumed (empty on failure).</param>
+    public sealed record TypeResult(
+        string NodePath,
+        string Package,
+        string? Error,
+        ImmutableArray<string> MatchedSourcePaths)
+    {
+        /// <summary>True when the type produced bytes.</summary>
+        public bool Success => Error is null;
+    }
+
+    /// <summary>The whole bake's outcome.</summary>
+    /// <param name="FrameworkIdentity">The identity every bundle is keyed to.</param>
+    /// <param name="Types">Per-NodeType results, ordinal by path.</param>
+    /// <param name="Bundles">The bundle files written, ordinal by path.</param>
+    /// <param name="FatalError">A failure that stopped the bake before it produced a verdict.</param>
+    public sealed record Report(
+        string FrameworkIdentity,
+        ImmutableArray<TypeResult> Types,
+        ImmutableArray<string> Bundles,
+        string? FatalError = null)
+    {
+        /// <summary>Process exit code: 0 only when nothing failed.</summary>
+        public int ExitCode =>
+            FatalError is null && Types.All(t => t.Success) ? 0 : 1;
+    }
+
+    /// <summary>The file beside the bundles naming the framework identity — same name and same
+    /// contract as the mesh-driven bake's, because CI reads it either way.</summary>
+    public const string FrameworkMvidFile = BakeOutput.FrameworkMvidFile;
+
+    /// <summary>Runs the bake. Synchronous — this is a build step at a console boundary.</summary>
+    /// <param name="options">What to bake, and where to.</param>
+    public static Report Run(Options options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var frameworkIdentity = PrebuiltAssemblySeeder.LiveFrameworkMvid;
+        if (PrebuiltAssemblySeeder.LiveFrameworkIdentityWarning is { } warning)
+            options.Output.WriteLine($"bake: ⚠ framework identity degraded — {warning}");
+
+        RepoSnapshot snapshot;
+        IReadOnlyList<PackageManifest> packages;
+        try
+        {
+            snapshot = LocalNodeRepo.LoadSync(options.RepoRoot);
+            packages = LocalNodeRepo.DiscoverPackages(snapshot).Wait();
+        }
+        catch (Exception ex)
+        {
+            return new Report(frameworkIdentity, [], [],
+                $"{ex.GetType().Name}: {ex.Message}");
+        }
+        if (packages.Count == 0)
+            return new Report(frameworkIdentity, [], [],
+                $"No node-repo packages (top-level folders with an index.json root) found under "
+                + $"'{Path.GetFullPath(options.RepoRoot)}'.");
+
+        // 🚨 ONE node set across EVERY package. A `shared=@Other/Lib/Source` query crosses package
+        // boundaries and the runtime resolves it against the whole mesh; a per-package set would
+        // resolve it to nothing and compile a short set that looks like the author's bug (#1218).
+        var skipped = new List<string>();
+        var treeNodes = TreeNodeLoader.Load(
+            snapshot, packages, (path, reason) => skipped.Add($"{path}: {reason}"));
+        if (skipped.Count > 0)
+            return new Report(frameworkIdentity, [], [],
+                "the checkout holds node file(s) that could not be materialised, so the source set "
+                + "this bake would compile against is INCOMPLETE — refusing to emit bytes built "
+                + "from a short set: " + string.Join("; ", skipped));
+
+        var nodeSet = NodeSet.Create(treeNodes.Select(t => t.Node));
+        options.Output.WriteLine(
+            $"bake: {treeNodes.Length} node(s) from {packages.Count} package(s); "
+            + $"framework={frameworkIdentity}");
+
+        var idOf = CompiledDependencies.CreateIdResolver(
+            FrameworkBuildIdentity.ProcessSurfacePairs,
+            // No mesh ⇒ no installed modules. A deployment that installs modules keys its own
+            // record on them; a type that binds one is DECLINED by the consumer's dependency check
+            // rather than silently adopted, which is the safe direction.
+            ImmutableDictionary<string, string>.Empty,
+            FrameworkBuildIdentity.ProcessImplMvidOf);
+        var toolchainId = CompiledDependencies.ComputeToolchainId(FrameworkBuildIdentity.ProcessImplMvidOf);
+        var references = CompileReferences.Default;
+
+        var workDirectory = Path.Combine(
+            Path.GetTempPath(), $"mw-compiler-bake-{Environment.ProcessId}-{Guid.NewGuid():N}");
+        try
+        {
+            return BakeAll(
+                options, treeNodes, nodeSet, packages, snapshot, frameworkIdentity,
+                idOf, toolchainId, references, workDirectory);
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(workDirectory))
+                    Directory.Delete(workDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A leftover temp directory costs disk, never correctness.
+            }
+        }
+    }
+
+    private static Report BakeAll(
+        Options options,
+        ImmutableArray<TreeNodeLoader.TreeNode> treeNodes,
+        NodeSet nodeSet,
+        IReadOnlyList<PackageManifest> packages,
+        RepoSnapshot snapshot,
+        string frameworkIdentity,
+        Func<string, string?> idOf,
+        string toolchainId,
+        IReadOnlyList<Microsoft.CodeAnalysis.MetadataReference> references,
+        string workDirectory)
+    {
+        var results = ImmutableArray.CreateBuilder<TypeResult>();
+        var entriesByPackage = new Dictionary<string, List<BundleWriter.AssemblyEntry>>(StringComparer.Ordinal);
+
+        var compilable = treeNodes
+            .Where(t => t.Node.Content is NodeTypeDefinition)
+            .OrderBy(t => t.Node.Path, StringComparer.Ordinal)
+            .ToList();
+
+        foreach (var candidate in compilable)
+        {
+            var definition = (NodeTypeDefinition)candidate.Node.Content!;
+            // A type with neither a configuration lambda nor any source has nothing to compile —
+            // the same "Compiles" predicate the gate applies.
+            var resolution = nodeSet.ResolveSources(
+                definition.Sources, definition.Tests, candidate.Node.Path);
+            if (string.IsNullOrWhiteSpace(definition.Configuration)
+                && (!resolution.IsEstablished || resolution.Sources.IsEmpty))
+                continue;
+
+            try
+            {
+                var compiled = NodeSetCompiler.Compile(
+                    nodeSet, candidate.Node, definition.Sources, definition.Tests,
+                    definition.Configuration, definition.ContentCollections,
+                    references, idOf, toolchainId,
+                    Path.Combine(workDirectory, CodeConventions.SanitizeNodeName(candidate.Node.Path)),
+                    resolveNuGet: null, logger: options.Logger);
+
+                // 🚨 The RAW resolved set, not the post-filter compile set — the mesh-driven bake
+                // writes `NodeTypeDefinition.CompiledSources`, which DiscoverSourceVersionSnapshot
+                // folds over the snapshot BEFORE CollectCompileSources drops executable cells and
+                // blank files. Keeping the same semantics is what makes the two producers'
+                // manifests comparable, and it is what the bake-equivalence test asserts on.
+                //
+                // The VALUES are 0, deliberately. The mesh stamps MeshNode.LastModified.UtcTicks,
+                // which for a freshly imported tree is the INSTALL clock — not reproducible, not
+                // derivable from git, and read by nobody: BundleReader skips the property and
+                // PrebuiltAssemblySeeder re-stamps CompiledSources from the CONSUMER's own
+                // CurrentSourceVersions on adopt. The key set is the provenance; the ticks were
+                // never information.
+                var sourceVersions = resolution.Sources
+                    .Select(n => n.Path)
+                    .ToImmutableSortedDictionary(p => p, _ => 0L, StringComparer.Ordinal);
+                if (!entriesByPackage.TryGetValue(candidate.Package, out var entries))
+                    entriesByPackage[candidate.Package] = entries = [];
+                entries.Add(new BundleWriter.AssemblyEntry(
+                    compiled.NodePath,
+                    () => File.OpenRead(compiled.DllPath),
+                    compiled.PdbPath is null ? null : () => File.OpenRead(compiled.PdbPath),
+                    sourceVersions,
+                    compiled.Dependencies));
+
+                results.Add(new TypeResult(
+                    compiled.NodePath, candidate.Package, null, compiled.Inputs.MatchedSourcePaths));
+                options.Output.WriteLine(
+                    $"   ok  {compiled.NodePath} "
+                    + $"[{compiled.Inputs.MatchedSourcePaths.Length} source(s), "
+                    + $"{compiled.Dependencies.Count} dependency record entr(ies)]");
+            }
+            catch (Exception ex) when (ex is CompilationException or SourceDiscoveryUnavailableException)
+            {
+                results.Add(new TypeResult(
+                    candidate.Node.Path, candidate.Package,
+                    $"{ex.GetType().Name}: {ex.Message}", []));
+                options.Output.WriteLine($"   RED {candidate.Node.Path}");
+                options.Output.WriteLine(ex.Message);
+            }
+        }
+
+        var bundles = WriteBundles(
+            options, packages, snapshot, frameworkIdentity, entriesByPackage);
+        return new Report(frameworkIdentity, results.ToImmutable(), bundles);
+    }
+
+    private static ImmutableArray<string> WriteBundles(
+        Options options,
+        IReadOnlyList<PackageManifest> packages,
+        RepoSnapshot snapshot,
+        string frameworkIdentity,
+        Dictionary<string, List<BundleWriter.AssemblyEntry>> entriesByPackage)
+    {
+        Directory.CreateDirectory(options.OutputDirectory);
+        var manifestsById = packages.ToDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase);
+        var sourceSha = options.SourceSha ?? snapshot.CommitSha;
+        var written = ImmutableArray.CreateBuilder<string>();
+
+        foreach (var (packageId, entries) in entriesByPackage.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            if (entries.Count == 0)
+                continue;
+            manifestsById.TryGetValue(packageId, out var manifest);
+            var bundlePath = Path.Combine(options.OutputDirectory, SafeFileName(packageId) + ".zip");
+            using (var file = File.Create(bundlePath))
+                BundleWriter.Write(
+                    file,
+                    packageId,
+                    manifest?.ReleasedVersion ?? manifest?.ModuleVersion ?? manifest?.Version,
+                    frameworkIdentity,
+                    [.. entries.OrderBy(e => e.NodePath, StringComparer.Ordinal)],
+                    sourceSha);
+            written.Add(bundlePath);
+            options.Output.WriteLine(
+                $"bake: {packageId} → {entries.Count} assembly(ies) → {bundlePath}");
+        }
+
+        File.WriteAllText(
+            Path.Combine(options.OutputDirectory, FrameworkMvidFile), frameworkIdentity);
+        options.Output.WriteLine(
+            $"bake: framework={frameworkIdentity} source={sourceSha} "
+            + $"packages={written.Count} assemblies={entriesByPackage.Values.Sum(e => e.Count)} "
+            + $"→ {options.OutputDirectory}");
+        return written.ToImmutable();
+    }
+
+    /// <summary>Identical to the mesh-driven bake's: package ids are folder names, bundle FILE
+    /// names must be safe on every filesystem the artifact travels through.</summary>
+    private static string SafeFileName(string packageId)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return new string(packageId.Select(c => invalid.Contains(c) ? '-' : c).ToArray());
+    }
+}

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -4,6 +4,7 @@ using MeshWeaver.Compiler;
 using MeshWeaver.GitSync;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
+using MeshWeaver.NuGet;
 using MeshWeaver.Plugin.Packaging;
 using MeshWeaver.PluginCatalog;
 using Microsoft.Extensions.Logging;
@@ -53,6 +54,10 @@ public static class TreeBake
 
         /// <summary>Diagnostics.</summary>
         public ILogger Logger { get; init; } = NullLogger.Instance;
+
+        /// <summary>Factory for the leaf loggers the toolchain's own services want (the NuGet
+        /// resolver). Null keeps them silent.</summary>
+        public ILoggerFactory? LoggerFactory { get; init; }
     }
 
     /// <summary>One NodeType's outcome.</summary>
@@ -119,14 +124,25 @@ public static class TreeBake
         // 🚨 ONE node set across EVERY package. A `shared=@Other/Lib/Source` query crosses package
         // boundaries and the runtime resolves it against the whole mesh; a per-package set would
         // resolve it to nothing and compile a short set that looks like the author's bug (#1218).
+        // 🚨 A file that will not materialise is REPORTED, not fatal — because the RUNTIME skips it
+        // too. `PackageInstaller` logs "No parser for node-repo file X; skipped" and installs the
+        // rest, so a bake that refused here would resolve a SMALLER tree than the mesh and the two
+        // producers would disagree — the equivalence break this change exists to prevent, just in
+        // the opposite direction. (Measured on samples/Graph/Data: the mesh drops 62 of PensionFund's
+        // 72 files and gates 0 NodeTypes there, because those files carry a UTF-8 BOM. This bake
+        // drops exactly the same ones — it just says so.)
+        //
+        // Loud is the point. Every skip is printed and counted, so "the bake shipped less than the
+        // tree holds" is visible in the log instead of being a silent shortfall.
         var skipped = new List<string>();
         var treeNodes = TreeNodeLoader.Load(
             snapshot, packages, (path, reason) => skipped.Add($"{path}: {reason}"));
+        foreach (var skip in skipped)
+            options.Output.WriteLine($"bake: skipped (not a materialisable node) {skip}");
         if (skipped.Count > 0)
-            return new Report(frameworkIdentity, [], [],
-                "the checkout holds node file(s) that could not be materialised, so the source set "
-                + "this bake would compile against is INCOMPLETE — refusing to emit bytes built "
-                + "from a short set: " + string.Join("; ", skipped));
+            options.Output.WriteLine(
+                $"bake: {skipped.Count} file(s) skipped — the runtime's importer skips these too; "
+                + "a NodeType among them is a CONTENT defect, not a bake failure");
 
         var nodeSet = NodeSet.Create(treeNodes.Select(t => t.Node));
         options.Output.WriteLine(
@@ -143,13 +159,24 @@ public static class TreeBake
         var toolchainId = CompiledDependencies.ComputeToolchainId(FrameworkBuildIdentity.ProcessImplMvidOf);
         var references = CompileReferences.Default;
 
+        // 🚨 The NuGet resolver is WIRED, not omitted. `#r "nuget:…"` is a compile input like any
+        // other — samples/Graph/Data/MathDemo/Matrix declares `#r "nuget:MathNet.Numerics, 5.0.0"` —
+        // and a bake without a resolver simply cannot build those types. That showed up as the ONE
+        // divergence across the whole samples tree (23 of 24 NodeTypes agreed; MathDemo/Matrix was
+        // the miss), which is exactly the class of shortfall this issue is about: a bake that
+        // quietly produces less than the runtime would. NuGetAssemblyResolver needs nothing from a
+        // mesh — a logger and an optional cache — so there was never a reason to leave it out.
+        var nugetResolver = new NuGetAssemblyResolver(
+            options.LoggerFactory?.CreateLogger<NuGetAssemblyResolver>()
+            ?? NullLogger<NuGetAssemblyResolver>.Instance);
+
         var workDirectory = Path.Combine(
             Path.GetTempPath(), $"mw-compiler-bake-{Environment.ProcessId}-{Guid.NewGuid():N}");
         try
         {
             return BakeAll(
                 options, treeNodes, nodeSet, packages, snapshot, frameworkIdentity,
-                idOf, toolchainId, references, workDirectory);
+                idOf, toolchainId, references, workDirectory, nugetResolver);
         }
         finally
         {
@@ -175,7 +202,8 @@ public static class TreeBake
         Func<string, string?> idOf,
         string toolchainId,
         IReadOnlyList<Microsoft.CodeAnalysis.MetadataReference> references,
-        string workDirectory)
+        string workDirectory,
+        INuGetAssemblyResolver nugetResolver)
     {
         var results = ImmutableArray.CreateBuilder<TypeResult>();
         var entriesByPackage = new Dictionary<string, List<BundleWriter.AssemblyEntry>>(StringComparer.Ordinal);
@@ -214,7 +242,14 @@ public static class TreeBake
                     definition.Configuration, definition.ContentCollections,
                     references, idOf, toolchainId,
                     Path.Combine(workDirectory, CodeConventions.SanitizeNodeName(candidate.Node.Path)),
-                    resolveNuGet: null, logger: options.Logger);
+                    // The ONE Task bridge in the bake, at a console build step — never on a hub
+                    // scheduler. NuGet restore is genuine network IO with no reactive surface;
+                    // the runtime bridges it through the IoPool for the same reason.
+                    resolveNuGet: (refs, ct) => nugetResolver
+                        .ResolveAsync(refs, targetFramework: null, ct)
+                        .GetAwaiter().GetResult()
+                        .AssemblyPaths,
+                    logger: options.Logger);
 
                 // 🚨 The RAW resolved set, not the post-filter compile set — the mesh-driven bake
                 // writes `NodeTypeDefinition.CompiledSources`, which DiscoverSourceVersionSnapshot

--- a/tools/MeshWeaver.PluginTester/TreeNodeLoader.cs
+++ b/tools/MeshWeaver.PluginTester/TreeNodeLoader.cs
@@ -4,6 +4,7 @@ using MeshWeaver.GitSync;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Persistence.Parsers;
 using MeshWeaver.Mesh;
+using MeshWeaver.Messaging.Serialization;
 using MeshWeaver.PluginCatalog;
 
 namespace MeshWeaver.PluginTester;
@@ -34,9 +35,38 @@ namespace MeshWeaver.PluginTester;
 /// </summary>
 public static class TreeNodeLoader
 {
-    /// <summary>Web defaults = camelCase, the shape authored node files use. Unknown properties
-    /// (including the <c>$type</c> discriminator itself) are skipped by default.</summary>
-    private static readonly JsonSerializerOptions ContentJson = new(JsonSerializerDefaults.Web);
+    /// <summary>
+    /// Web defaults = camelCase, the shape authored node files use; unknown properties (including
+    /// the <c>$type</c> discriminator itself) are skipped by default.
+    ///
+    /// <para>🚨 The three non-default settings are NOT decoration — each one was a silently dropped
+    /// NodeType when it was missing, caught by running this loader over
+    /// <c>samples/Graph/Data</c>:</para>
+    /// <list type="bullet">
+    ///   <item><see cref="EnumMemberJsonStringEnumConverter"/> — the FRAMEWORK'S OWN converter, not
+    ///     a stock <c>JsonStringEnumConverter</c>. Enums persist as strings
+    ///     (<c>"compilationStatus": "Ok"</c>) and web defaults do not convert them, so every
+    ///     NodeType carrying a compile stamp failed to deserialize: 28 of them across ACME,
+    ///     Cornerstone, FutuRe and Northwind.</item>
+    ///   <item><c>ReadCommentHandling</c> / <c>AllowTrailingCommas</c> — copied off the hub's own
+    ///     options for the same reason <c>JsonFileParser</c> copies them: a node file that parses
+    ///     under a hub must parse here, or the bake resolves a smaller tree than the runtime.</item>
+    /// </list>
+    /// </summary>
+    private static readonly JsonSerializerOptions ContentJson = new(JsonSerializerDefaults.Web)
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        Converters = { new EnumMemberJsonStringEnumConverter() },
+    };
+
+    /// <summary>Document-parse tolerances matching <see cref="ContentJson"/> — the same copy
+    /// <c>JsonFileParser.Parse</c> makes, and for the same reason.</summary>
+    private static readonly JsonDocumentOptions ContentJsonDocument = new()
+    {
+        CommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
 
     /// <summary>A node the tree produced, together with the package it came from.</summary>
     /// <param name="Node">The materialised node.</param>
@@ -128,10 +158,16 @@ public static class TreeNodeLoader
         JsonDocument document;
         try
         {
-            document = JsonDocument.Parse(file.Content);
+            document = JsonDocument.Parse(file.Content, ContentJsonDocument);
         }
         catch (JsonException ex)
         {
+            // 🚨 Matches JsonFileParser: a document that will not parse yields NO node, and the
+            // installer logs "No parser for …; skipped". Do NOT "fix" this by stripping a UTF-8 BOM
+            // here — samples/Graph/Data/PensionFund/*.json carry one, the RUNTIME drops every one of
+            // those nodes for exactly this reason, and a bake that quietly compiled content the mesh
+            // never imports would be the equivalence break this whole change exists to prevent (in
+            // the opposite direction). The BOM is a CONTENT defect and belongs in a content fix.
             reason = $"malformed JSON: {ex.Message}";
             return null;
         }

--- a/tools/MeshWeaver.PluginTester/TreeNodeLoader.cs
+++ b/tools/MeshWeaver.PluginTester/TreeNodeLoader.cs
@@ -1,0 +1,222 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Persistence.Parsers;
+using MeshWeaver.Mesh;
+using MeshWeaver.PluginCatalog;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// Turns a node-repo CHECKOUT into the in-memory <see cref="MeshNode"/> set a compile resolves its
+/// sources from — the file→node half of the compiler-driven bake (#1763). No mesh, no hub, no
+/// import: the same files the installer would write, materialised in a list.
+///
+/// <para><b>The path rule is not re-implemented.</b> Which files are nodes, and what path each one
+/// takes, comes from <see cref="PackageInstaller.NodePathForFile"/> — the installer's own public
+/// mapping (<c>NodeFileMapper.FromRelativePath</c> plus the README / <c>manifest.lock</c> /
+/// <c>content/**</c> exclusions). A private copy of that rule here is exactly how a build-process
+/// bake would start resolving sources under paths the runtime never uses, and the failure would be
+/// silent: the source query simply matches less.</para>
+///
+/// <para><b>Content typing is DELIBERATELY narrow.</b> A hub supplies
+/// <c>JsonSerializerOptions</c> carrying the mesh's TypeRegistry, which is what lets a
+/// <c>.json</c> node's <c>$type</c> discriminator materialise. A build process has no hub, and
+/// fabricating a half-populated registry would silently degrade unknown content to
+/// <c>JsonElement</c> — the trap-door in AGENTS.md's "never cast an object payload". So only the
+/// two content types a COMPILE reads are materialised, by explicit discriminator:
+/// <see cref="NodeTypeDefinition"/> (the type being compiled: its <c>configuration</c> lambda,
+/// <c>sources</c>/<c>tests</c> queries and content collections) and <see cref="CodeConfiguration"/>
+/// (the sources themselves). Everything else keeps a null content — a compile never reads it, and
+/// a null is honest where a mistyped object would not be. <c>.cs</c> and <c>.md</c> files go
+/// through the real <see cref="FileFormatParserRegistry"/>, which needs no serializer options.</para>
+/// </summary>
+public static class TreeNodeLoader
+{
+    /// <summary>Web defaults = camelCase, the shape authored node files use. Unknown properties
+    /// (including the <c>$type</c> discriminator itself) are skipped by default.</summary>
+    private static readonly JsonSerializerOptions ContentJson = new(JsonSerializerDefaults.Web);
+
+    /// <summary>A node the tree produced, together with the package it came from.</summary>
+    /// <param name="Node">The materialised node.</param>
+    /// <param name="Package">The package id (top-level folder) that shipped it.</param>
+    /// <param name="RelativePath">The repo-relative file it was parsed from.</param>
+    public sealed record TreeNode(MeshNode Node, string Package, string RelativePath);
+
+    /// <summary>
+    /// Materialises every node of every package in <paramref name="snapshot"/>.
+    ///
+    /// <para>🚨 The result spans ALL packages, on purpose. A <c>shared=@Other/Lib/Source</c> query
+    /// reaches across package boundaries, and the runtime resolves it against the whole mesh; a
+    /// per-package node set would resolve it to nothing and compile a short set that produces a
+    /// completely genuine-looking CS0246 (#1218).</para>
+    /// </summary>
+    /// <param name="snapshot">The swept checkout.</param>
+    /// <param name="packages">The discovered packages.</param>
+    /// <param name="onSkipped">Invoked with (relativePath, reason) for a file that has a node path
+    /// but could not be materialised — never swallowed, because a dropped source file is invisible
+    /// in the output and fatal in production.</param>
+    public static ImmutableArray<TreeNode> Load(
+        RepoSnapshot snapshot,
+        IReadOnlyList<PackageManifest> packages,
+        Action<string, string>? onSkipped = null)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        ArgumentNullException.ThrowIfNull(packages);
+
+        // No serializer options: the JSON parser is replaced by the explicit typed reader below.
+        var parsers = new FileFormatParserRegistry();
+        var result = ImmutableArray.CreateBuilder<TreeNode>();
+
+        foreach (var package in packages.OrderBy(p => p.Id, StringComparer.Ordinal))
+        {
+            var prefix = (package.SourceFolder ?? package.Id) + "/";
+            foreach (var file in snapshot.Files)
+            {
+                if (!file.Path.StartsWith(prefix, StringComparison.Ordinal))
+                    continue;
+                // The installer's own rule: null = this file is not a node (README, manifest.lock,
+                // content/** asset). NodeRepo packages keep the FULL repo-relative path — the
+                // package folder IS the partition — so no rebasing happens here either.
+                if (PackageInstaller.NodePathForFile(file.Path) is not { Length: > 0 } nodePath)
+                    continue;
+
+                var node = Materialise(parsers, file, nodePath, out var reason);
+                if (node is null)
+                {
+                    if (reason is not null)
+                        onSkipped?.Invoke(file.Path, reason);
+                    continue;
+                }
+                result.Add(new TreeNode(node, package.Id, file.Path));
+            }
+        }
+        return result.ToImmutable();
+    }
+
+    private static MeshNode? Materialise(
+        FileFormatParserRegistry parsers, RepoFile file, string nodePath, out string? reason)
+    {
+        reason = null;
+        var lastSlash = nodePath.LastIndexOf('/');
+        var id = lastSlash < 0 ? nodePath : nodePath[(lastSlash + 1)..];
+        var ns = lastSlash < 0 ? string.Empty : nodePath[..lastSlash];
+        var extension = Path.GetExtension(file.Path);
+
+        if (extension.Equals(".json", StringComparison.OrdinalIgnoreCase))
+            return MaterialiseJson(file, id, ns, out reason);
+
+        // .cs and .md go through the framework's own parsers — no serializer options needed, and
+        // CSharpFileParser is what turns a `// NodeType: Scope` header into a Scope-typed node
+        // (which `nodeType:Code` then does NOT match, exactly as at runtime).
+        string? parseError = null;
+        var parsed = parsers.TryParse(
+            extension, file.Path, file.Content, file.Path,
+            (_, ex) => parseError = $"{ex.GetType().Name}: {ex.Message}");
+        reason = parseError;
+        if (parsed is null)
+            // No parser for this extension is the normal case for the non-node files a repo
+            // carries (.yml, .png, .csproj) — silent, exactly as the installer treats them.
+            return null;
+        return parsed with { Id = id, Namespace = ns, State = MeshNodeState.Active };
+    }
+
+    private static MeshNode? MaterialiseJson(RepoFile file, string id, string ns, out string? reason)
+    {
+        reason = null;
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(file.Content);
+        }
+        catch (JsonException ex)
+        {
+            reason = $"malformed JSON: {ex.Message}";
+            return null;
+        }
+        using (document)
+        {
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return null;
+            // The installer's own "is this a node?" gate (JsonFileParser.LooksLikeMeshNode):
+            // ordinary JSON a repo happens to carry is not a node and is not an error. `$type` is
+            // matched EXACTLY (it is the serializer's discriminator, not an authored name);
+            // `id`/`nodeType` case-insensitively.
+            if (!LooksLikeMeshNode(root))
+                return null;
+
+            var nodeType = TryGetString(root, "nodeType");
+            var name = TryGetString(root, "name");
+
+            object? content = null;
+            if (TryGetElement(root, "content", out var contentElement)
+                && contentElement.ValueKind == JsonValueKind.Object
+                && contentElement.TryGetProperty("$type", out var discriminator)
+                && discriminator.ValueKind == JsonValueKind.String)
+            {
+                var typeName = discriminator.GetString();
+                try
+                {
+                    content = typeName switch
+                    {
+                        nameof(NodeTypeDefinition) =>
+                            contentElement.Deserialize<NodeTypeDefinition>(ContentJson),
+                        nameof(CodeConfiguration) =>
+                            contentElement.Deserialize<CodeConfiguration>(ContentJson),
+                        // Anything else is content a COMPILE never reads. Left null rather than
+                        // guessed — see the class remarks.
+                        _ => null,
+                    };
+                }
+                catch (JsonException ex)
+                {
+                    // A NodeType or Code node whose content will not materialise MUST be loud: its
+                    // sources would silently vanish from the compile.
+                    reason = $"content ${typeName} did not deserialize: {ex.Message}";
+                    return null;
+                }
+            }
+
+            return new MeshNode(id, ns)
+            {
+                NodeType = nodeType,
+                Name = name ?? id,
+                State = MeshNodeState.Active,
+                Content = content,
+            };
+        }
+    }
+
+    /// <summary>Verbatim mirror of <c>JsonFileParser.LooksLikeMeshNode</c>.</summary>
+    private static bool LooksLikeMeshNode(JsonElement root)
+    {
+        foreach (var property in root.EnumerateObject())
+            if (property.NameEquals("$type")
+                || string.Equals(property.Name, "id", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(property.Name, "nodeType", StringComparison.OrdinalIgnoreCase))
+                return true;
+        return false;
+    }
+
+    /// <summary>Case-insensitive property lookup — the web-defaults behaviour the deserializer
+    /// applies to the same document.</summary>
+    private static bool TryGetElement(JsonElement root, string name, out JsonElement value)
+    {
+        foreach (var property in root.EnumerateObject())
+        {
+            if (!string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                continue;
+            value = property.Value;
+            return true;
+        }
+        value = default;
+        return false;
+    }
+
+    private static string? TryGetString(JsonElement root, string name)
+        => TryGetElement(root, name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}


### PR DESCRIPTION
Closes part 1+2 of #1763. **Piece 3 (switching a CI lane over) is deliberately NOT in this PR.**

## The finding this fixes

Everything in the estate baked by **running a mesh**. `tools/MeshWeaver.PluginTester` — which is
also what the `MeshWeaver.Compiler.Cli` / `mw-compiler` package packs today — constructs
`new MeshBuilder(...).AddGraph()`, stands up an in-process mesh, imports the checkout, lets the
**mesh** compile every NodeType behind its hub scheduler, and `--bake-output` then collects what the
mesh produced. That is "compile through mesh nodes", the thing #1707 forbids, and one binary was
wearing both names — which is precisely how the mesh-driven bake stayed invisible.

## The split

| | what it is | how it runs |
|---|---|---|
| **BAKE** | a **build step** | `mw-compiler compile <root> --output <dir> [--source-sha <sha>]` — resolve NodeType sources from the git tree, compile with `MeshWeaver.Compiler`, emit **DLL + PDB**, write the bundle. No `MeshBuilder`, no `AddGraph()`, no import, no hub. |
| **GATE** | a **runtime check** | `mw-plugin-test <root>` keeps its mesh — rendering a layout area and executing a `Tests` area are genuine runtime behaviours. Producing an assembly is not. |

- **Output format unchanged**: same `BundleWriter`, same framework-identity keying, same per-type
  dependency records (#1719). `ShippedPrebuiltBundles`, `PluginBundleClient.Adopt` and
  `PrebuiltAssemblySeeder` are untouched and cannot tell the producers apart.
- **No lane switched.** The gate's own `--bake-output` still works, so lanes migrate one at a time.
- **Emergency path preserved.** A live instance with no usable artifact still compiles its own
  (#1707). That is recovery, not a build lane.

## Where the real work was: source resolution without a mesh

`NodeSet` / `NodeSetQuery` / `NodeSetCompiler` live in **`MeshWeaver.Compiler`**, i.e. inside the
full-MVID identity boundary. That placement is load-bearing: which Code nodes a compile consumes is
part of its *generated input*, so a resolver outside the boundary could change what a bake consumes
without moving the framework identity — and every portal would adopt the changed bytes silently.

Two rules keep the second implementation honest:

1. **Expansion is not re-implemented.** `CodeQueryResolver.ExpandAll` is the same call the runtime
   makes; so are the `@@`-include walk, the dedup, the executable filter, the join order, the
   skeleton generator, the `#r "nuget:"` handling and the emit. The new code *orchestrates* the
   runtime's shaping rather than copying them.
2. **Evaluation refuses what it does not understand.** Only `path:`/`namespace:`/`scope:`/`nodeType:`
   — everything `CodeQueryResolver` can emit. Free text (vector search on a real mesh), wildcards,
   alternations and any other selector make the resolution **unestablished** and the bake declines
   to compile. Same fail-loud direction as `SourceSnapshot`, for the same reason: a SHORT source set
   compiles into completely genuine-looking `CS0246`s about code that is fine (#1218).

`CodeConventions.SanitizeNodeName` moved down from Graph's `CompilationCacheService` (which now
delegates). It names the emitted assembly, so it shapes the bytes and belonged inside the toolchain.

## The equivalence pin — the actual deliverable

`BakeEquivalenceTest` bakes one content set **both ways** and asserts the producers agree on:
framework identity · bundle + node-path sets · **resolved source set per type** · **per-type
dependency records** · **emitted type-and-member surface** · PDBs present.

The fixture exercises every rule that could fork: default `Source/`+`Test/` subtree queries
including a **nested** folder, a **cross-package** `shared=@Lib/Shared/Source`, an `@@` include of a
node **no query matches**, an **executable code cell** that must be excluded, and a
`// NodeType: Scope` source the implicit `nodeType:Code` filter must exclude.

**Bytes are deliberately not compared** — see "what differs" below.

## What differs between the two paths (the most valuable output)

1. **The mesh-driven bake is not byte-reproducible, even against itself.** The mesh folds its source
   set into an `ImmutableDictionary` and emits `dict.Values` — hash-bucket order over
   per-process-randomised string hashes — and `CombineSources` joins the files in *that* order. The
   generated skeleton also stamps `// Generated at: {UtcNow}`. The compiler path sorts (query order,
   then ordinal by path), which is strictly better. The surface comparison is what proves the
   concatenation order of independent top-level declarations is irrelevant.
2. **`sourceVersions` values were never information.** The mesh stamps
   `MeshNode.LastModified.UtcTicks`, which for a freshly imported tree is the *install clock*.
   `BundleReader` skips the property and `PrebuiltAssemblySeeder` re-stamps `CompiledSources` from
   the consumer's own `CurrentSourceVersions` on adopt. The tree bake writes `0`; the **key set** —
   which is the provenance — is asserted equal.
3. **Two different source sets exist and must not be conflated.** `sourceVersions` /
   `CompiledSources` is the **raw query match**; `CollectCompileSources` then drops executable cells
   and blank files before Roslyn. The executable cell is correctly present in the first and absent
   from the second, in **both** producers. (My first draft of the test asserted the wrong one — that
   was the only red.)
4. **`SanitizeNodeName` was outside the identity boundary** while naming the emitted assembly. Fixed
   here by moving the rule down.

## Verification (local, no CI iteration)

- `BakeEquivalenceTest` — green.
- `NodeSetQueryTest` — 16 pins on the query grammar, incl. the `namespace: + scope:subtree` →
  *descendants* degradation (the default source query's shape) and the refusal behaviour.
- Full `MeshWeaver.PluginTester.Test` suite: **56/56**. `DocumentationLinkIntegrityTest`: green.
- **Real content**: both bakes run over the platform's own staged `Doc` tree (642 nodes, 4 dynamic
  NodeTypes). Normalised manifests are **identical** (node paths, dependency records,
  source-version key sets, framework identity), and all four emitted assemblies carry **identical
  identifier sets**.
- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Compiler`, `MeshWeaver.Graph`,
  `MeshWeaver.Hosting`, `MeshWeaver.Hosting.Monolith`, the tool and the test project.

## Not in this PR

- Switching `doc-gate` / `samples-gate` / `plugin-gate` / `main-cd`'s `publish-bake` to the
  `compile` verb.
- Splitting `MeshWeaver.Compiler.Cli` into its own project. ⚠️ **Note for whoever does**: the
  surface identity is computed over `FrameworkBuildIdentity.ContentSurfaceAssemblies`, whose
  canonical list is the transitive closure of `tools/MeshWeaver.PluginTester`, and
  `FrameworkBuildIdentityTest.CanonicalList_MatchesTheTesterClosure` recomputes it from *that*
  csproj. A new CLI project with a different reference closure changes the surface manifest and
  therefore the framework identity — which would make its bundles decline everywhere, silently.
  Keeping the verb in the existing project is what guarantees the identity is unchanged today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)