### PR TITLE
feat: the MCP server becomes its own module

### DIFF
--- a/memex/Memex.Portal.Monolith/appsettings.json
+++ b/memex/Memex.Portal.Monolith/appsettings.json
@@ -29,6 +29,7 @@
       "MeshWeaver.AI.WebSearch.dll",
       "MeshWeaver.Courses.dll",
       "MeshWeaver.Mail.MicrosoftGraph.dll",
+      "MeshWeaver.Mcp.dll",
       "MeshWeaver.Blazor.Radzen.dll",
       "MeshWeaver.Blazor.Analysis.dll",
       "MeshWeaver.Blazor.GoogleMaps.dll",

--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -3,7 +3,7 @@ using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using MeshWeaver.AI;
 using MeshWeaver.Blazor.Infrastructure; // PortalApplication
-using MeshWeaver.Mcp;
+using MeshWeaver.Hosting.AspNetCore;    // SessionHubResolver, McpConfiguration
 using MeshWeaver.Mesh.Security;         // WellKnownUsers
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;             // AccessService
@@ -309,8 +309,10 @@ public static class MeshApiEndpoints
             o.MultipartHeadersLengthLimit = int.MaxValue;
         });
 
-        // McpConfiguration is already bound by AddMeshMcp(); BindConfiguration is
-        // idempotent so a second call is harmless if the MCP wiring is absent.
+        // 🚨 This binding is the REST surface's OWN — it must not depend on the MCP module being
+        // listed. AddMeshMcp() binds the same options when MeshWeaver.Mcp IS installed;
+        // BindConfiguration is idempotent, so both lanes coexist and /api/mesh/base-url keeps
+        // answering when MCP is delisted.
         services.AddOptions<McpConfiguration>().BindConfiguration("Mcp");
 
         return services;

--- a/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
@@ -1,7 +1,7 @@
 using System.Collections.Concurrent;
 using System.Reactive.Linq;
 using MeshWeaver.AI.Connect;
-using MeshWeaver.Mcp;
+using MeshWeaver.Hosting.AspNetCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -8,7 +8,6 @@ using Memex.Portal.Shared.Settings;
 using Memex.Portal.Shared.Social;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MeshWeaver.AI;
-using MeshWeaver.Mcp;
 using MeshWeaver.Blazor.Graph;
 using MeshWeaver.Blazor.Infrastructure;
 using MeshWeaver.Hosting.Grpc;
@@ -1131,8 +1130,10 @@ public static class MemexConfiguration
         // explicit opt-out (the transport authenticates connections itself — Bearer token in
         // gRPC metadata / trusted loopback port).
 
-        // Map MCP endpoint
-        app.MapMeshMcp();
+        // The MCP endpoint (/mcp) rides MapMeshModuleEndpoints below: the MeshWeaver.Mcp module's
+        // McpEndpointModuleAttribute maps it with the same RequireAuthorization("McpAuth") policy
+        // this line carried. The POLICY itself stays here (AddMcpAuthentication above) — the REST
+        // mirror /api/mesh/* is gated by the same one and is not part of that module.
 
         // REST surface that mirrors MCP — POST /api/mesh/* (1:1 with MCP tools).
         // Same Bearer auth policy as /mcp; multipart upload at /api/mesh/upload.

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -82,6 +82,7 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.WebSearch/MeshWeaver.AI.WebSearch.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Courses/MeshWeaver.Courses.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Mail.MicrosoftGraph/MeshWeaver.Mail.MicrosoftGraph.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Mcp/MeshWeaver.Mcp.csproj" />
 
     <!-- Alternative storage backends. These were BORN flipped: no host has ever referenced them
          (only their own test projects do), and both attributes state the intent verbatim —

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -14,6 +14,7 @@
       "MeshWeaver.AI.WebSearch.dll",
       "MeshWeaver.Courses.dll",
       "MeshWeaver.Mail.MicrosoftGraph.dll",
+      "MeshWeaver.Mcp.dll",
       "MeshWeaver.Blazor.Radzen.dll",
       "MeshWeaver.Blazor.Analysis.dll",
       "MeshWeaver.Blazor.GoogleMaps.dll",

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -150,6 +150,7 @@ The current first-party inventory and each module's configuration section:
 | `MeshWeaver.Teams.dll` | Microsoft Teams bot channel: messaging endpoint, inbound routing into threads, proactive replies | `Teams` (inert until bot credentials set) |
 | `MeshWeaver.Courses.dll` | Course delivery: the entitlement-gated `/assets/{Space}/…` route over a Space's synced repo | `GitHub:App:*` (shared with GitSync) |
 | `MeshWeaver.Mail.MicrosoftGraph.dll` | Mail over Microsoft Graph: system email, inbound intake + its webhook, the Executive Assistant's mailbox tools | `Email` (`Enabled`, `InboundEnabled`) |
+| `MeshWeaver.Mcp.dll` | The Model Context Protocol server: the mesh tool surface + the `/mcp` HTTP transport | `Mcp` (`BaseUrl`; the `McpAuth` policy stays platform-side) |
 | `MeshWeaver.Hosting.Grpc.dll` | The mesh gRPC transport: `meshweaver.v1.Mesh` + gRPC-web, `py`/`node` foreign participants AND the React GUI's browser data plane | `Grpc` (`TrustedPort`) |
 | `MeshWeaver.Hosting.Cosmos.dll` | Cosmos DB storage backend (keyed adapter factory + native query) | selected by `Graph:Storage:Type` = `Cosmos` |
 | `MeshWeaver.Hosting.Snowflake.dll` | Snowflake storage backend (persistence, change feed, cross-schema query, access projection) | selected by `Graph:Storage:Type` = `Snowflake` |

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-the-mcp-server-is-a-module.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-the-mcp-server-is-a-module.md
@@ -1,0 +1,25 @@
+---
+Name: The MCP server is a module
+Category: Feature
+Description: The Model Context Protocol server moved into its own MeshWeaver.Mcp module, so a deployment publishes the /mcp surface by listing it rather than by compiling it in.
+Icon: PlugConnected
+Order: -20260817
+---
+
+# The MCP server is a module
+
+The Model Context Protocol server — the mesh tool surface external assistants call (`get`,
+`search`, `create`, `update`, `render_area`, the LSP and chunk tools) and the `/mcp` HTTP
+transport that carries them — now ships as `MeshWeaver.Mcp` instead of being compiled into every
+portal.
+
+Publishing an MCP surface is a deployment decision: it opens the mesh to any client holding an API
+token. Listing the DLL is now that decision. A portal that lists it is unchanged — same `/mcp`
+route, same Bearer-only `McpAuth` gate, same `Mcp` configuration section, same tools. A portal that
+delists it answers `404` on `/mcp` and carries no server at all.
+
+The REST mirror at `/api/mesh/*` is deliberately **not** part of the module and keeps working
+either way, together with everything the two surfaces share: the per-caller session hub both route
+requests onto, the `Mcp:BaseUrl` used to compose links back into the UI, and the API-token
+authentication itself. So the co-hosted Claude Code and Copilot harnesses, `navigate_to` links, and
+a server-side renderer reading through `/api/mesh` all keep their behaviour when MCP is delisted.

--- a/src/MeshWeaver.Hosting.AspNetCore/McpConfiguration.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/McpConfiguration.cs
@@ -1,0 +1,23 @@
+namespace MeshWeaver.Hosting.AspNetCore;
+
+/// <summary>
+/// The portal's own externally-reachable base URL, bound from the <c>Mcp</c> configuration
+/// section (<c>Mcp__BaseUrl</c> — the Aspire AppHost wires the portal's external endpoint into it
+/// at deployment time). Used to compose absolute links back into the MeshWeaver UI.
+///
+/// <para>
+/// 🚨 It lives PLATFORM-side, not in <c>MeshWeaver.Mcp</c>, because three surfaces read it and
+/// only one of them is the MCP module: the REST mirror <c>/api/mesh/navigate_to</c> +
+/// <c>/api/mesh/base_url</c>, the co-hosted CLI back-connection (which composes
+/// <c>{BaseUrl}/mcp</c>), and the MCP <c>navigate_to</c> tool itself. Delisting
+/// <c>MeshWeaver.Mcp</c> from <c>Modules:Assemblies</c> must not take the other two with it.
+/// The section name stays <c>Mcp</c> so no deployment's configuration changes.
+/// </para>
+/// </summary>
+public class McpConfiguration
+{
+    /// <summary>
+    /// Base URL for the MeshWeaver UI. Used for generating NavigateTo URLs.
+    /// </summary>
+    public string BaseUrl { get; set; } = string.Empty;
+}

--- a/src/MeshWeaver.Hosting.AspNetCore/MeshWeaver.Hosting.AspNetCore.csproj
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshWeaver.Hosting.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>ASP.NET Core host integration for MeshWeaver modules: the endpoint-contribution hook — a module assembly declares HTTP endpoints the host maps at startup (design #1655).</Description>
+    <Description>ASP.NET Core host integration for MeshWeaver: the endpoint-contribution hook — a module assembly declares HTTP endpoints the host maps at startup (design #1655) — plus the pieces every HTTP transport shares (per-caller session-hub resolution, the portal base-URL option).</Description>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +14,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
+    <!-- SessionHubResolver is the HTTP half of SessionHubFactory, which lives in MeshWeaver.Hosting
+         below the transports so MCP, REST, gRPC and the headless sidecar cannot drift apart. The
+         reference is what lets the resolver stay platform-side now that MCP is a module. -->
+    <ProjectReference Include="..\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/MeshWeaver.Hosting.AspNetCore/SessionHubResolver.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/SessionHubResolver.cs
@@ -4,7 +4,7 @@ using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
-namespace MeshWeaver.Mcp;
+namespace MeshWeaver.Hosting.AspNetCore;
 
 /// <summary>
 /// Resolves a per-caller hosted hub at <c>portal/{prefix}-{sessionId}</c> for
@@ -16,6 +16,13 @@ namespace MeshWeaver.Mcp;
 /// it derives the session id from the request and hands off to
 /// <see cref="SessionHubFactory"/>, which owns the hub materialisation and is
 /// shared with the headless surfaces that have no <see cref="HttpContext"/>.
+/// </para>
+///
+/// <para>
+/// 🚨 It lives PLATFORM-side rather than in <c>MeshWeaver.Mcp</c> because MCP is a
+/// module now (<c>Modules:Assemblies</c>) while the REST mirror <c>/api/mesh/*</c> is
+/// not: a delisted MCP module must not take the REST surface's hub routing with it, and
+/// a second copy is exactly the drift this helper exists to prevent.
 /// </para>
 ///
 /// <para>

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -3,7 +3,6 @@ using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using MeshWeaver.Blazor;
 using MeshWeaver.Blazor.Infrastructure;
-using MeshWeaver.Mcp;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Data;
 using MeshWeaver.Layout.Client;
@@ -71,7 +70,10 @@ public static class BlazorHostingExtensions
                 // scoped, because Blazor resolves circuit handlers per circuit.
                 .AddSingleton<ActiveCircuitTracker>()
                 .AddScoped<CircuitHandler, CircuitDrainHandler>()
-                .AddMeshMcp()
+            // 🚨 The MCP server used to be registered here. It rides the MeshWeaver.Mcp module
+            // now (Modules:Assemblies -> McpMeshModuleAttribute folds the identical
+            // AddMeshMcp()), so a Blazor portal that publishes no MCP surface no longer
+            // compiles one in. The /mcp route comes from the same module's endpoint half.
             )
             .ConfigureHub(hub => hub.AddBlazor(clientConfig));
 

--- a/src/MeshWeaver.Hosting.Blazor/MeshWeaver.Hosting.Blazor.csproj
+++ b/src/MeshWeaver.Hosting.Blazor/MeshWeaver.Hosting.Blazor.csproj
@@ -9,7 +9,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MeshWeaver.Blazor\MeshWeaver.Blazor.csproj" />
-    <ProjectReference Include="..\MeshWeaver.Mcp\MeshWeaver.Mcp.csproj" />
+    <!-- MeshWeaver.Mcp is deliberately NOT referenced (#1644 step 2): the MCP server ships via
+         the modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
+         Modules:Assemblies -> McpMeshModuleAttribute (services) + McpEndpointModuleAttribute
+         (the /mcp route). The pieces the platform's REST mirror shares with it —
+         SessionHubResolver, McpConfiguration — stay in MeshWeaver.Hosting.AspNetCore. -->
     <ProjectReference Include="..\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
     <ProjectReference Include="..\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
   </ItemGroup>

--- a/src/MeshWeaver.Mcp/McpExtensions.cs
+++ b/src/MeshWeaver.Mcp/McpExtensions.cs
@@ -1,4 +1,5 @@
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.AspNetCore;
 using MeshWeaver.Mesh;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;

--- a/src/MeshWeaver.Mcp/McpMeshPlugin.cs
+++ b/src/MeshWeaver.Mcp/McpMeshPlugin.cs
@@ -7,6 +7,7 @@ using MeshWeaver.AI;
 using MeshWeaver.AI.Plugins;
 using MeshWeaver.Data.Completion;
 using MeshWeaver.GitSync;
+using MeshWeaver.Hosting.AspNetCore;
 using MeshWeaver.InstanceSync;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -1164,15 +1165,4 @@ Examples:
             </html>
             """;
     }
-}
-
-/// <summary>
-/// Configuration options for MCP integration.
-/// </summary>
-public class McpConfiguration
-{
-    /// <summary>
-    /// Base URL for the MeshWeaver UI. Used for generating NavigateTo URLs.
-    /// </summary>
-    public string BaseUrl { get; set; } = string.Empty;
 }

--- a/src/MeshWeaver.Mcp/McpModuleAttribute.cs
+++ b/src/MeshWeaver.Mcp/McpModuleAttribute.cs
@@ -1,0 +1,62 @@
+using MeshWeaver.Hosting.AspNetCore;
+using MeshWeaver.Mesh;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: MeshWeaver.Mcp.McpMeshModule]
+[assembly: MeshWeaver.Mcp.McpEndpointModule]
+
+namespace MeshWeaver.Mcp;
+
+/// <summary>
+/// The mesh half of the MCP module: the MCP server itself — the tool surface over
+/// <see cref="McpMeshPlugin"/>, the resources of <see cref="McpResources"/>, the stateless HTTP
+/// transport and the shared argument-validation filter.
+///
+/// <para>MCP is a protocol surface a deployment either publishes or does not. Listing the DLL is
+/// now that decision, instead of every portal compiling in a server whose only switch was the
+/// route. Nothing else changes for a deployment that publishes it: same <c>/mcp</c> route, same
+/// <c>McpAuth</c> policy, same <c>Mcp</c> configuration section.</para>
+///
+/// <para>🚨 Two pieces deliberately do NOT ride this module, because surfaces that outlive it
+/// depend on them:</para>
+/// <list type="bullet">
+/// <item>The <b>authentication scheme</b> (<c>McpAuthenticationExtensions</c>, the <c>McpAuth</c>
+///   and <c>MeshApiRead</c> policies) stays in the portal composition root — the REST mirror
+///   <c>/api/mesh/*</c> is gated by the same policies and is not part of this module, and an
+///   auth scheme must be registered before the pipeline is built either way. This module names
+///   the policy by STRING only, so there is no compiled edge back to the host.</item>
+/// <item><c>SessionHubResolver</c> and <c>McpConfiguration</c> moved to
+///   <c>MeshWeaver.Hosting.AspNetCore</c> for the same reason: REST callers resolve the same
+///   per-caller hub, and the co-hosted CLI back-connection reads the same base URL.</item>
+/// </list>
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class McpMeshModuleAttribute : MeshNodeProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<MeshNode> Nodes =>
+    [
+        new MeshNode("MeshWeaver.Mcp")
+        {
+            Name = "MCP server",
+            NodeType = "ModuleDefinition",
+        }
+        .WithGlobalServiceRegistry(services => services.AddMeshMcp()),
+    ];
+}
+
+/// <summary>
+/// The endpoint half: <c>/mcp</c>, the Model Context Protocol HTTP transport. The module's OWN
+/// protocol surface, so delisting it removing the route is the right semantic — an MCP client
+/// gets a 404 it can act on rather than a server that answers but has no mesh behind it.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class McpEndpointModuleAttribute : MeshEndpointProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<Action<IEndpointRouteBuilder>> EndpointConfigurations =>
+    [
+        endpoints => endpoints.MapMeshMcp(),
+    ];
+}

--- a/src/MeshWeaver.Mcp/MeshWeaver.Mcp.csproj
+++ b/src/MeshWeaver.Mcp/MeshWeaver.Mcp.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{2f7d9c14-3b8e-4a6c-9d21-7e5b0a4c8f13}</ProjectGuid>
     <NoWarn>$(NoWarn);NU1510</NoWarn>
+    <Description>Model Context Protocol server for MeshWeaver: the mesh tool surface (get/search/create/update/…), the MCP resources, and the /mcp HTTP transport. Ships as a module — list the DLL under Modules:Assemblies to activate.</Description>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" />
@@ -13,6 +14,10 @@
     <ProjectReference Include="..\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
     <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
+    <!-- The endpoint-contribution hook (/mcp maps through MapMeshModuleEndpoints), plus the two
+         pieces this module SHARES with the platform's REST mirror: SessionHubResolver and
+         McpConfiguration. -->
+    <ProjectReference Include="..\MeshWeaver.Hosting.AspNetCore\MeshWeaver.Hosting.AspNetCore.csproj" />
     <ProjectReference Include="..\MeshWeaver.InstanceSync\MeshWeaver.InstanceSync.csproj" />
     <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
     <ProjectReference Include="..\MeshWeaver.Messaging.Hub\MeshWeaver.Messaging.Hub.csproj" />

--- a/src/MeshWeaver.Mcp/README.md
+++ b/src/MeshWeaver.Mcp/README.md
@@ -4,6 +4,15 @@ Exposes MeshWeaver mesh operations as a Model Context Protocol (MCP) server, ena
 
 This is the transport-layer MCP module — **independent of Blazor** (it was previously `MeshWeaver.Blazor.AI`; that name was a misnomer — none of its files are Blazor components). It depends only on ASP.NET Core (`ModelContextProtocol.AspNetCore`) and the mesh feature modules, so any ASP.NET host — Blazor or not — can host it.
 
+## It ships as a MODULE
+
+No host compiles this in. `McpMeshModuleAttribute` folds `AddMeshMcp()` and `McpEndpointModuleAttribute` maps `/mcp` through the host's `MapMeshModuleEndpoints()` hook, so **listing `MeshWeaver.Mcp.dll` under `Modules:Assemblies` is the complete activation** (restart-required — see `Doc/Architecture/Modules.md`). Delisting removes the route wholesale: an MCP client gets a `404` it can act on, not a server with no mesh behind it.
+
+Two things deliberately stay PLATFORM-side, because surfaces that outlive a delisted module depend on them:
+
+- **The authentication scheme.** `McpAuthenticationExtensions` (the `McpAuth` and `MeshApiRead` policies, the ApiToken handler, the Bearer-only challenge) lives in the portal composition root — the REST mirror `/api/mesh/*` is gated by the same policies and is not part of this module, and an auth scheme has to be registered before the pipeline is built either way. This module names the policy by **string** only, so there is no compiled edge back to the host.
+- **`SessionHubResolver` and `McpConfiguration`**, now in `MeshWeaver.Hosting.AspNetCore`. REST callers resolve the same per-caller hub (a second copy is exactly the drift the shared helper exists to prevent), and the co-hosted CLI back-connection reads the same `Mcp:BaseUrl`.
+
 ## Features
 
 - MCP server with HTTP transport via `ModelContextProtocol.AspNetCore`
@@ -31,8 +40,18 @@ The check is deliberately conservative — it must never reject a call the binde
 
 ## Usage
 
+In a deployment, all of it is one line of configuration:
+
+```jsonc
+// appsettings.json
+"Modules": { "Assemblies": [ "MeshWeaver.Mcp.dll" ] }
+```
+
+A fixture or a bespoke host that is not module-driven calls the same registrations directly — the
+two lanes must never drift:
+
 ```csharp
-// In MeshBuilder setup
+// In MeshBuilder setup (ApiToken node type; AddGraph already does this in a portal)
 builder.AddMcp();
 
 // In service registration

--- a/test/MeshWeaver.GitSync.Test/McpGitHubSyncToolTest.cs
+++ b/test/MeshWeaver.GitSync.Test/McpGitHubSyncToolTest.cs
@@ -3,6 +3,7 @@ using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using MeshWeaver.Data;
 using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.AspNetCore;
 using MeshWeaver.Mcp;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;

--- a/test/MeshWeaver.Hosting.Monolith.Test/McpModuleContributionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/McpModuleContributionTest.cs
@@ -1,0 +1,100 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using MeshWeaver.Hosting.AspNetCore;
+using MeshWeaver.Mcp;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the MCP server's module shape: the assembly carries BOTH module halves, installing it
+/// folds the same <c>AddMeshMcp()</c> the portal used to compile in, and <c>/mcp</c> maps through
+/// <c>MapMeshModuleEndpoints</c> still gated by the <c>McpAuth</c> policy.
+///
+/// <para>🚨 The policy is named by STRING on purpose. <c>McpAuth</c> is registered by the portal
+/// composition root (<c>McpAuthenticationExtensions</c>), which also gates the REST mirror
+/// <c>/api/mesh/*</c> — a surface that outlives a delisted MCP module — so the auth scheme must
+/// NOT ride this module and there is no compiled edge from here back to the host.</para>
+/// </summary>
+public class McpModuleContributionTest
+{
+    [Fact]
+    public void TheAssembly_CarriesBothModuleAttributes_WithNonEmptyContributions()
+    {
+        var assembly = typeof(McpMeshModuleAttribute).Assembly;
+
+        var meshHalf = Assert.Single(assembly.GetCustomAttributes<MeshNodeProviderAttribute>());
+        Assert.NotEmpty(meshHalf.Nodes);
+
+        var endpointHalf = Assert.Single(assembly.GetCustomAttributes<MeshEndpointProviderAttribute>());
+        Assert.NotEmpty(endpointHalf.EndpointConfigurations);
+    }
+
+    [Fact]
+    public void InstallingTheAssembly_AppliesAddMeshMcp()
+    {
+        var serviceConfigs = new List<Func<IServiceCollection, IServiceCollection>>();
+        var builder = new MeshBuilder(configure => serviceConfigs.Add(configure), AddressExtensions.CreateMeshAddress());
+
+        builder.InstallAssemblies(typeof(McpMeshModuleAttribute).Assembly.Location);
+
+        var services = serviceConfigs.Aggregate(
+            (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+
+        // The tool surface: one McpServerTool descriptor per [McpServerTool] method on
+        // McpMeshPlugin — the observable proof WithToolsFromAssembly ran in the fold.
+        Assert.Contains(services, d => d.ServiceType == typeof(McpServerTool));
+        // The resources half (tools-reference et al.).
+        Assert.Contains(services, d => d.ServiceType == typeof(McpServerResource));
+        // Mcp:BaseUrl rides the options pipeline — the same binding the REST mirror keeps
+        // platform-side so a delisted module cannot take /api/mesh/base_url with it.
+        Assert.Contains(services, d =>
+            d.ServiceType == typeof(Microsoft.Extensions.Options.IConfigureOptions<McpConfiguration>));
+    }
+
+    [Fact]
+    public void McpEndpoint_MapsThroughTheHook_StillGatedByMcpAuth()
+    {
+        // Built but never started — endpoint metadata is inspectable without Kestrel
+        // (same shape as GrpcModuleContributionTest).
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddAuthorization();
+        // Only what MapMcp itself needs. Deliberately NOT the module's full DI half: its tools
+        // resolve McpMeshPlugin, whose ctor takes IMessageHub, and this host has no mesh — under
+        // CI's DOTNET_ENVIRONMENT=Development, ValidateOnBuild would fail Build() on that. The DI
+        // half is asserted descriptor-level by InstallingTheAssembly_AppliesAddMeshMcp.
+        builder.Services.AddMcpServer().WithHttpTransport(options => options.Stateless = true);
+        builder.Services.AddSingleton(
+            new InstalledModuleAssembly(typeof(McpMeshModuleAttribute).Assembly));
+        using var app = builder.Build();
+        app.MapMeshModuleEndpoints();
+
+        var endpoints = ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(source => source.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Where(e => e.RoutePattern.RawText?.StartsWith("/mcp", StringComparison.Ordinal) == true)
+            .ToList();
+
+        Assert.NotEmpty(endpoints);
+        foreach (var endpoint in endpoints)
+        {
+            // NOT anonymous — the hook's authenticated-by-default group applies, and the module
+            // adds the Bearer-only McpAuth policy on top (never a cookie redirect to /login).
+            Assert.Null(endpoint.Metadata.GetMetadata<IAllowAnonymous>());
+            Assert.Contains(
+                endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>(),
+                data => data.Policy == "McpAuth");
+        }
+    }
+}

--- a/test/MeshWeaver.Security.Test/McpRenderAreaTests.cs
+++ b/test/MeshWeaver.Security.Test/McpRenderAreaTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.AspNetCore;
 using MeshWeaver.Mcp;
 using MeshWeaver.Mesh;
 using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
The Model Context Protocol server — the mesh tool surface over `McpMeshPlugin`, the resources, the stateless HTTP transport and the shared argument-validation filter — no longer compiles into every portal.

`MeshWeaver.Hosting.Blazor` drops the ProjectReference and the `AddMeshMcp()` call. The assembly now carries `McpMeshModuleAttribute` (folds the identical `AddMeshMcp`) and `McpEndpointModuleAttribute` (maps `/mcp` through `MapMeshModuleEndpoints`), and rides the closure lane in `MeshModulesPublish.targets`. **Listing `MeshWeaver.Mcp.dll` under `Modules:Assemblies` is now the complete activation** (restart-required); delisting removes `/mcp` wholesale — a 404 an MCP client can act on, rather than a server with no mesh behind it. Both memex portals list it, so nothing changes for them.

## Two seams deliberately did NOT move

Surfaces that outlive a delisted module depend on them.

1. **The auth scheme stays in the portal composition root.** `McpAuthenticationExtensions` registers the ApiToken + MCP schemes and the `McpAuth` / `MeshApiRead` policies, and the REST mirror `/api/mesh/*` — not part of this module — is gated by the same ones. The module names the policy by **string**, so there is no compiled edge back to the host, and `Memex.Portal.Shared` keeps its own direct `ModelContextProtocol.AspNetCore` reference for the scheme (that package therefore does not leave the image).

2. **`SessionHubResolver` + `McpConfiguration` moved to `MeshWeaver.Hosting.AspNetCore`,** not into the module. REST callers resolve the *same* per-caller session hub — the helper exists precisely so the two transports' routing cannot drift, and a second copy would be that drift — and the co-hosted CLI back-connection composes `{Mcp:BaseUrl}/mcp`. That project gains a ProjectReference to `MeshWeaver.Hosting`, which owns `SessionHubFactory`, the mesh-side half the resolver hands off to. The config section stays `Mcp`, so no deployment's configuration changes.

**No internal-query blocker here.** `MeshWeaver.Mcp` already compiled as its own assembly and never reached `IMeshQueryCore`, so nothing needed re-granting or a system-identity read.

## Verification

`MW_ALLOW_SOLUTION_BUILD=1 dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` → **0 errors, 0 warnings**. It is what caught the two host-side call sites (`MeshApiEndpoints`, `McpBackConnectionService`) that a per-project build structurally cannot see.

Boot-smoke on a running Monolith, module loaded from `modules/MeshWeaver.Mcp/`:

| Check | Result |
|---|---|
| `POST /mcp` unauthenticated | `401` + `WWW-Authenticate: Bearer resource_metadata="…"` — the API-shaped challenge, **not** a cookie redirect to `/login`. The hook's authenticated-by-default group combines with `McpAuth` without stealing the challenge scheme. |
| `POST /mcp` with `Bearer mw_…` | `initialize`, `tools/call get`, `resources/list` all answer |
| `POST /api/mesh/whoami`, `/api/mesh/get` | still answer — through the **moved** `SessionHubResolver` |

New `McpModuleContributionTest` pins the shape: both module halves present, the fold registers the tool/resource/options descriptors, and `/mcp` maps through the hook still carrying the `McpAuth` policy and **not** `AllowAnonymous`. `MeshApiCookieAuthTest`, `McpRenderAreaTests`, `McpGitHubSyncToolTest` and `DocumentationLinkIntegrityTest` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)