### PR TITLE
feat: self-update reacts to publications instead of polling

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateConfiguration.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateConfiguration.cs
@@ -33,9 +33,10 @@ public static class SelfUpdateConfiguration
             // them is not a gate. Platform-neutral (a query plus file-system reads).
             services.AddSingleton<ReleaseAvailabilityService>();
             // Bind from configuration when the caller passes nothing. Without this the defaults were
-            // baked into the image: PollInterval sat at 6h with NO way for an environment to change
-            // it, and a SelfUpdate__PollInterval in the configmap silently did nothing — the failure
-            // mode where an operator sets a knob, sees no effect, and concludes self-update is dead.
+            // baked into the image and a SelfUpdate__* value in the configmap silently did nothing —
+            // the failure mode where an operator sets a knob, sees no effect, and concludes
+            // self-update is dead. (The former PollInterval is now RetryInterval: the check is
+            // event-driven, so the value only paces re-establishing a faulted watch.)
             services.AddSingleton(sp =>
                 options
                 ?? sp.GetService<IConfiguration>()?.GetSection(SelfUpdateOptions.SectionName)

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -1,3 +1,5 @@
+using System.Reactive.Disposables;
+using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
@@ -62,31 +64,72 @@ public class SelfUpdateHostedService : IHostedService
     public Task StartAsync(CancellationToken cancellationToken)
     {
         _logger?.LogInformation(
-            "[SelfUpdate] starting; version={Version}, registry={Registry}/{Repo}, canPatch={CanPatch}, interval={Interval}.",
+            "[SelfUpdate] starting (event-driven; one startup pass, then a check per build-completion event); version={Version}, registry={Registry}/{Repo}, canPatch={CanPatch}, retryInterval={Interval}.",
             ShippedReleaseSeed.InstalledPlatformVersion, _options.Registry, _options.PortalRepository,
-            _updater.CanPatch, _options.PollInterval);
+            _updater.CanPatch, _options.RetryInterval);
 
-        _subscription = CreatePolicySource()
-            // The policy re-drives the poller via Switch. With DistinctUntilChanged the timer is only
-            // re-subscribed when the admin ACTUALLY changes the policy (human-rare) — not a storm.
-            .Select(content => content.Policy == UpdatePolicyKind.None
-                ? Observable.Empty<Unit>()                            // None => never poll
-                : Observable.Merge(
-                        Observable.Interval(_options.PollInterval).StartWith(-1L),
-                        BuildCompletionTicks())
-                    .SelectMany(_ => RunOnce(content)
-                        .Catch((Exception ex) =>
-                        {
-                            // wedges-to-zero: a tick error (ACR outage, k8s 403) logs and the poller
-                            // keeps ticking. No outer .Retry (that would be a resubscribe storm).
-                            _logger?.LogWarning(ex, "[SelfUpdate] check failed (policy={Policy}).", content.Policy);
-                            return Observable.Empty<Unit>();
-                        })))
-            .Switch()
+        // 🚨 EVENT-DRIVEN, and the event source is deliberately OUTSIDE the policy stream.
+        //
+        // Exactly ONE pass at startup — to catch publications missed while this install was down —
+        // and after that a check per build completion, of the platform OR of any module the
+        // environment deploys. There is no recurring interval: a timer that re-asks a question
+        // nothing has answered is the shape this codebase treats as a band-aid, and the
+        // availability gate already defers a roll whose artifacts are not ready. What makes
+        // deferral safe without a timer is that the NEXT publication is itself an event, so a
+        // deferred roll is re-decided the moment its missing artifact appears.
+        //
+        // 🚨 The policy is STATE, not a driver — WithLatestFrom, never Switch. Under Switch every
+        // policy emission re-subscribed the watch, which RE-BASELINED it: a publication landing in
+        // that window was read as "current state" rather than as a new build and silently swallowed.
+        // The recurring interval used to cover that; with the interval gone it would be a lost
+        // update with nothing to recover it. One long-lived watch, the latest policy read at
+        // decision time, is what closes it. (CreatePolicySource emits the default exactly once
+        // before the first live read, so the startup pass always has a policy to run under.)
+        // The policy is shared STATE with a replayed latest value, connected for the lifetime of the
+        // service. Replay(1)+Connect rather than RefCount: a RefCount would drop to zero between the
+        // Take(1) below and the WithLatestFrom re-subscribe, re-running the seed and re-baselining
+        // everything downstream — the very class of bug this restructure exists to remove.
+        var policy = CreatePolicySource().Replay(1);
+
+        // 🚨 The first check waits for a policy to exist. CreatePolicySource emits the default only
+        // AFTER its async seed, so a startup pass composed with WithLatestFrom alone fires before
+        // any policy is available and is silently dropped — no first check at all. Take(1) gates the
+        // trigger stream on that first emission; every LATER policy change is picked up by
+        // WithLatestFrom without re-subscribing the watch.
+        // Three trigger sources, no timer among them:
+        //   • the one startup pass,
+        //   • a build completion from the platform or ANY module the environment deploys,
+        //   • an admin CHANGING the policy — enabling updates must not wait for the next
+        //     publication, which could be weeks away. DistinctUntilChanged so a re-emission of the
+        //     same policy is not a trigger, and Skip(1) so the replayed CURRENT policy is not one
+        //     either (the startup pass already covers it).
+        var checks = policy
+            .Take(1)
+            .SelectMany(_ => Observable.Merge(
+                Observable.Return(-1L),
+                BuildCompletionTicks(),
+                policy.DistinctUntilChanged(content => content.Policy).Skip(1).Select(_ => -3L)))
+            // 🚨 Read the CURRENT policy at decision time — never WithLatestFrom. That operator only
+            // pairs once its secondary has produced, and the startup trigger fires synchronously on
+            // subscribe, so whether the first check survives came down to Rx's internal subscribe
+            // ordering: it silently dropped the startup pass. policy is Replay(1), so Take(1) yields
+            // the latest value immediately and deterministically.
+            .SelectMany(_ => policy.Take(1))
+            .Where(content => content.Policy != UpdatePolicyKind.None)   // None => never update
+            .SelectMany(content => RunOnce(content)
+                .Catch((Exception ex) =>
+                {
+                    // wedges-to-zero: a check error (ACR outage, k8s 403) logs and the watch stays
+                    // live. No outer .Retry — that would be a resubscribe storm.
+                    _logger?.LogWarning(ex, "[SelfUpdate] check failed (policy={Policy}).", content.Policy);
+                    return Observable.Empty<Unit>();
+                }))
             .SubscribeOn(TaskPoolScheduler.Default)
             .Subscribe(
                 _ => { },
-                ex => _logger?.LogError(ex, "[SelfUpdate] poller terminated unexpectedly."));
+                ex => _logger?.LogError(ex, "[SelfUpdate] update watch terminated unexpectedly."));
+
+        _subscription = new CompositeDisposable(checks, policy.Connect());
         return Task.CompletedTask;
     }
 
@@ -120,11 +163,11 @@ public class SelfUpdateHostedService : IHostedService
         var accessService = _hub.ServiceProvider.GetService<AccessService>();
         return Observable
             .Defer(() => UpdatePolicyNodeType.EnsureExists(_hub, accessService, _options.DefaultPolicy, _logger))
-            .RetryWhen(ResubscribeAfterPollInterval("policy-node seeding"))
+            .RetryWhen(ResubscribeAfterRetryInterval("policy-node seeding"))
             .Take(1)
             .SelectMany(_ => Observable
                 .Defer(ReadPolicyStream)
-                .RetryWhen(ResubscribeAfterPollInterval("policy stream"))
+                .RetryWhen(ResubscribeAfterRetryInterval("policy stream"))
                 .StartWith(new UpdatePolicyContent { Policy = _options.DefaultPolicy }))
             .DistinctUntilChanged(c => (c.Policy, c.RequireCiGreen)); // <-- re-switch only on a REAL policy change
     }
@@ -143,7 +186,8 @@ public class SelfUpdateHostedService : IHostedService
     }
 
     /// <summary>
-    /// Ticks once per NEW green build of <see cref="SelfUpdateOptions.BuildTriggerRepository"/> —
+    /// Ticks once per NEW green build of ANY repository that publishes — the platform and every
+    /// satellite alike —
     /// the event-driven complement to the interval. The <c>BuildCompletion</c> node is a FACT the
     /// GitHub webhook writes; on an install without the webhook the query never yields and the
     /// interval still drives everything. Throttled so a burst of workflow completions coalesces
@@ -152,22 +196,14 @@ public class SelfUpdateHostedService : IHostedService
     /// and <see cref="RunOnce"/> still lists ACR itself, so a spurious tick costs one cheap tag
     /// list and can never cause a wrong roll.
     /// </summary>
-    protected virtual IObservable<long> BuildCompletionTicks()
-    {
-        var parts = (_options.BuildTriggerRepository ?? "")
-            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (parts.Length != 2)
-            return Observable.Empty<long>();
-
-        var path = BuildCompletion.PathFor(parts[0], parts[1]);
-        return Observable
-            .Defer(() => NewBuildEvents(_hub
-                .GetQuery($"SelfUpdate.BuildTrigger:{_hub.Address}", $"path:{path}")
-                .Select(nodes => nodes?.FirstOrDefault())))
-            .Throttle(TimeSpan.FromMinutes(1))
+    protected virtual IObservable<long> BuildCompletionTicks() =>
+        Observable
+            .Defer(() => NewBuildEventsAcross(_hub
+                .GetQuery($"SelfUpdate.BuildTrigger:{_hub.Address}",
+                    $"nodeType:{BuildCompletion.NodeType}")))
+            .Throttle(_options.EventCoalesceWindow)
             .Select(_ => -2L)
-            .RetryWhen(ResubscribeAfterPollInterval("build-completion watch"));
-    }
+            .RetryWhen(ResubscribeAfterRetryInterval("build-completion watch"));
 
     /// <summary>
     /// Turns a live read of one node into "a NEW write happened while we were watching": the
@@ -188,14 +224,48 @@ public class SelfUpdateHostedService : IHostedService
             .Where(s => s.IsEvent)
             .Select(_ => Unit.Default);
 
-    /// <summary>Retry signal for <c>RetryWhen</c>: log the fault and resubscribe after one poll
+    /// <summary>
+    /// The collection-wide form: "a NEW build completed for ANY repository we care about".
+    ///
+    /// <para>Every repository that publishes writes its own <c>BuildCompletion</c> record under
+    /// <c>Admin/_Build</c> — the platform and every satellite alike — so watching the whole
+    /// collection is what makes "listen for updates of any module or platform" one subscription
+    /// rather than a per-repo fan-out that would have to be rebuilt whenever the installed set
+    /// changes.</para>
+    ///
+    /// <para>Same baseline rule as the single-node form and for the same reason: the replayed
+    /// current state is baseline, never an event, so a pod start cannot look like a fresh build.
+    /// After that, a record whose version moved OR a record that appeared is one event. A record
+    /// that DISAPPEARS is deliberately not an event — there is nothing to update toward.</para>
+    ///
+    /// <para>Pure and static, so the distinction is pinned by unit tests instead of re-derived
+    /// from Rx operator lore.</para>
+    /// </summary>
+    public static IObservable<Unit> NewBuildEventsAcross(IObservable<IEnumerable<MeshNode>?> nodes) =>
+        nodes.Scan(
+                (Baselined: false, Versions: ImmutableDictionary<string, long>.Empty, IsEvent: false),
+                (state, current) =>
+                {
+                    var snapshot = (current ?? [])
+                        .GroupBy(n => n.Path)
+                        .ToImmutableDictionary(g => g.Key, g => g.Max(n => n.Version));
+                    if (!state.Baselined)
+                        return (true, snapshot, false);
+                    var advanced = snapshot.Any(kv =>
+                        !state.Versions.TryGetValue(kv.Key, out var seen) || kv.Value != seen);
+                    return (true, snapshot, advanced);
+                })
+            .Where(s => s.IsEvent)
+            .Select(_ => Unit.Default);
+
+    /// <summary>Retry signal for <c>RetryWhen</c>: log the fault and resubscribe after the retry
     /// interval (delayed, Rx-composed — no hot loop).</summary>
-    private Func<IObservable<Exception>, IObservable<long>> ResubscribeAfterPollInterval(string stage) =>
+    private Func<IObservable<Exception>, IObservable<long>> ResubscribeAfterRetryInterval(string stage) =>
         faults => faults.SelectMany(ex =>
         {
             _logger?.LogWarning(ex,
-                "[SelfUpdate] {Stage} faulted; re-establishing in {Interval}.", stage, _options.PollInterval);
-            return Observable.Timer(_options.PollInterval);
+                "[SelfUpdate] {Stage} faulted; re-establishing in {Interval}.", stage, _options.RetryInterval);
+            return Observable.Timer(_options.RetryInterval);
         });
 
     /// <summary>One evaluation: list tags → pick target per policy → gate target &gt; current →

--- a/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
@@ -7,7 +7,7 @@ namespace MeshWeaver.Hosting.SelfUpdate;
 /// </summary>
 public record SelfUpdateOptions
 {
-    /// <summary>Configuration section this binds from (e.g. <c>SelfUpdate__PollInterval</c>).</summary>
+    /// <summary>Configuration section this binds from (e.g. <c>SelfUpdate__RetryInterval</c>).</summary>
     public const string SectionName = "SelfUpdate";
 
     /// <summary>The container registry login server the running install pulls from and polls.</summary>
@@ -33,18 +33,26 @@ public record SelfUpdateOptions
     /// <summary>The migration container name within <see cref="MigrationDeployment"/>.</summary>
     public string MigrationContainer { get; init; } = "memex-migration";
 
-    /// <summary>How often the running install polls the registry ("a few times a day").</summary>
-    public TimeSpan PollInterval { get; init; } = TimeSpan.FromHours(6);
+    /// <summary>
+    /// The RETRY interval — how long a faulted watch waits before re-establishing itself.
+    ///
+    /// <para>🚨 No longer a poll cadence. The update check is event-driven: exactly one pass at
+    /// startup (to catch publications missed while this install was down), and after that a check
+    /// per build-completion event from the platform or from any module the environment deploys.
+    /// This value survives because a stream that faults still has to come back, and it must not
+    /// come back in a hot loop.</para>
+    /// </summary>
+    public TimeSpan RetryInterval { get; init; } = TimeSpan.FromHours(6);
 
     /// <summary>
-    /// The repository ("owner/repo") whose green builds trigger an IMMEDIATE check, on top of the
-    /// interval. The platform image is built by this repo's CD, so reacting to its
-    /// <c>BuildCompletion</c> node (written by the GitHub webhook — see
-    /// <c>Doc/Architecture/PluginUpdateOnGreenBuild</c>) turns "up to a PollInterval late" into
-    /// "minutes after the image lands". On an install without the webhook the stream simply never
-    /// emits and the interval still drives everything. Empty disables the trigger.
+    /// How long a burst of build-completion events is coalesced before one check runs.
+    ///
+    /// <para>Several repositories publishing at once (a platform release plus its satellites
+    /// re-baking) should cost ONE availability check, not one per repository. Configurable rather
+    /// than hard-coded so tests can drive the event path without waiting out the production
+    /// window.</para>
     /// </summary>
-    public string BuildTriggerRepository { get; init; } = "Systemorph/MeshWeaver";
+    public TimeSpan EventCoalesceWindow { get; init; } = TimeSpan.FromMinutes(1);
 
     /// <summary>The policy seeded onto <c>Admin/UpdatePolicy</c> when it doesn't exist yet, and the
     /// fallback used before the policy node's first live emission.</summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
@@ -38,6 +38,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Hosting.AzureBlob\MeshWeaver.Hosting.AzureBlob.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
         <!-- GrpcModuleContributionTest pins the gRPC transport's module shape (mesh half +

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.GitSync;
 
 namespace MeshWeaver.Hosting.Monolith.Test;
 
@@ -41,7 +42,10 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
     private const string CandidateTag = "9999.0.0-ci.1";
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
-        => base.ConfigureMesh(builder).AddUpdatePolicyType();
+        // AddGitHubSyncTypes registers the BuildCompletion satellite — the record the workflow_run
+        // webhook writes and the self-update watch reacts to. Types only, no credentials: the same
+        // production registration rather than a duplicate declaration that could drift from it.
+        => base.ConfigureMesh(builder).AddUpdatePolicyType().AddGitHubSyncTypes();
 
     /// <summary>Fake registry (the documented IO seam): one build newer than anything installed.</summary>
     private sealed class FakeAcrTagLister : IAcrTagLister
@@ -111,7 +115,10 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
 
     private static SelfUpdateOptions FastPoll() => new()
     {
-        PollInterval = TimeSpan.FromMilliseconds(500),
+        RetryInterval = TimeSpan.FromMilliseconds(500),
+        // Coalescing is a production concern (one check for a burst of publications); a test that
+        // drives one event must not wait out the real window.
+        EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
         DefaultPolicy = UpdatePolicyKind.Continuous,
     };
 
@@ -175,9 +182,14 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
                 .Timeout(TimeSpan.FromSeconds(30))
                 .ToTask(ct);
 
-            // The bake lands. Nothing is un-stuck by hand — the hold is re-evaluated every tick, and
-            // that is precisely what makes refusing safe.
+            // The bake lands...
             gate.Allow();
+
+            // ...and the PUBLICATION that carries it is the event that re-decides the hold. The check
+            // is event-driven now, so nothing is re-evaluated on a timer: what makes refusing safe is
+            // that the very act of the missing artifact becoming available is itself a build
+            // completion, and this watch reacts to ANY repository's — platform or module.
+            await SelfUpdateEventDriver.PublishBuildAsync(Mesh, "MeshWeaver.Plugins", runNumber: 1);
 
             var applied = await updater.Patched
                 .FirstAsync()

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateBuildTriggerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateBuildTriggerTest.cs
@@ -50,6 +50,74 @@ public class SelfUpdateBuildTriggerTest
         Assert.Single(events);
     }
 
+    // ── The collection-wide watch: "a new build of ANY module or the platform" ──────────────
+    //
+    // The self-update check is event-driven with no recurring poll, so these are the events that
+    // wake a DEFERRED roll — one held because some package had no artifact for the target release.
+    // If a module publishing its build is not an event here, that roll waits for a process restart.
+
+    private static MeshNode Repo(string ownerDotRepo, long version) =>
+        new(ownerDotRepo, $"Admin/_Build/{ownerDotRepo}") { Version = version };
+
+    private static (Subject<IEnumerable<MeshNode>?> Input, List<Unit> Events) WatchAll()
+    {
+        var input = new Subject<IEnumerable<MeshNode>?>();
+        var events = new List<Unit>();
+        SelfUpdateHostedService.NewBuildEventsAcross(input).Subscribe(events.Add);
+        return (input, events);
+    }
+
+    [Fact]
+    public void ReplayedCollection_IsBaseline_NotEvents()
+    {
+        var (input, events) = WatchAll();
+        input.OnNext([Repo("Systemorph.MeshWeaver", 5), Repo("Systemorph.MeshWeaver-Education", 2)]);
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void AVersionBumpOnAnyRepo_IsOneEvent()
+    {
+        var (input, events) = WatchAll();
+        input.OnNext([Repo("Systemorph.MeshWeaver", 5), Repo("Systemorph.MeshWeaver-Education", 2)]);
+
+        // the SATELLITE published, not the platform — this is the case that unblocks a roll
+        // deferred because that module had no artifact for the target framework.
+        input.OnNext([Repo("Systemorph.MeshWeaver", 5), Repo("Systemorph.MeshWeaver-Education", 3)]);
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void ARepoPublishingForTheFirstTime_IsAnEvent()
+    {
+        var (input, events) = WatchAll();
+        input.OnNext([Repo("Systemorph.MeshWeaver", 5)]);
+
+        // a newly-installed module publishes its first build: the record APPEARS rather than moving.
+        input.OnNext([Repo("Systemorph.MeshWeaver", 5), Repo("Systemorph.MeshWeaver.Plugins", 1)]);
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void ARepoDisappearing_IsNotAnEvent()
+    {
+        var (input, events) = WatchAll();
+        input.OnNext([Repo("Systemorph.MeshWeaver", 5), Repo("Systemorph.MeshWeaver.Plugins", 1)]);
+
+        // nothing to update TOWARD, so a vanished record must not trigger a check.
+        input.OnNext([Repo("Systemorph.MeshWeaver", 5)]);
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void UnchangedCollectionReEmission_IsNotAnEvent()
+    {
+        var (input, events) = WatchAll();
+        input.OnNext([Repo("Systemorph.MeshWeaver", 5)]);
+        input.OnNext([Repo("Systemorph.MeshWeaver", 5)]);
+        Assert.Empty(events);
+    }
+
     [Fact]
     public void UnchangedVersionReEmission_IsNotAnEvent()
     {

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateEventDriver.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateEventDriver.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Drives the self-update check the way production does: by publishing a <c>BuildCompletion</c>
+/// record, which is what the GitHub webhook writes when a repository's build goes green.
+///
+/// <para>🚨 These suites used to be driven by the poller's recurring interval — "wait for the next
+/// tick". The check is event-driven now (one startup pass, then a check per build completion of the
+/// platform or of ANY module the environment deploys), so a test that waits for a timer waits
+/// forever. The assertions are unchanged; only the stimulus moved to the real one, which makes
+/// these tests exercise the production wake-up path rather than a timer that no longer exists.</para>
+/// </summary>
+internal static class SelfUpdateEventDriver
+{
+    /// <summary>A repository whose green build wakes the check. Any repo works — that is the point
+    /// of watching the whole <c>Admin/_Build</c> collection rather than one configured repo.</summary>
+    internal const string Owner = "Systemorph";
+
+    /// <summary>Publishes (or re-publishes) a green build for <paramref name="repo"/>, bumping the
+    /// record so the watch sees a NEW build rather than a replayed baseline.</summary>
+    internal static async Task PublishBuildAsync(IMessageHub mesh, string repo, long runNumber)
+    {
+        var meshService = mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var path = BuildCompletion.PathFor(Owner, repo);
+        var slash = path.LastIndexOf('/');
+        var node = new MeshNode(path[(slash + 1)..], path[..slash])
+        {
+            NodeType = BuildCompletion.NodeType,
+            Name = $"{Owner}/{repo} build",
+            State = MeshNodeState.Active,
+            Content = new BuildCompletion
+            {
+                RepositoryUrl = $"https://github.com/{Owner}/{repo}",
+                Branch = "main",
+                HeadSha = $"sha{runNumber}",
+                WorkflowName = "MeshWeaver Build and Test",
+                RunId = runNumber,
+                RunNumber = runNumber,
+                CompletedAtUtc = DateTimeOffset.UtcNow,
+                Conclusion = "success",
+            },
+        };
+        await meshService.CreateOrUpdateNode(node).FirstAsync().ToTask();
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.GitSync;
 
 namespace MeshWeaver.Hosting.Monolith.Test;
 
@@ -35,7 +36,9 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
-        => base.ConfigureMesh(builder).AddUpdatePolicyType();
+        // AddGitHubSyncTypes registers the BuildCompletion satellite the self-update watch reacts
+        // to. Types only, no credentials — the production registration rather than a copy.
+        => base.ConfigureMesh(builder).AddUpdatePolicyType().AddGitHubSyncTypes();
 
     /// <summary>Fake registry (the documented injectable IO seam): a ci build newer than anything
     /// installed plus an even "older" clean release — Continuous picks the ci tag, Stable the clean
@@ -149,7 +152,7 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
         var updater = new RecordingUpdater();
         var options = new SelfUpdateOptions
         {
-            PollInterval = TimeSpan.FromMilliseconds(500),
+            RetryInterval = TimeSpan.FromMilliseconds(500),
             DefaultPolicy = UpdatePolicyKind.Continuous,
         };
         var service = new FaultingRecordService(
@@ -188,7 +191,7 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
         {
             // The poll interval doubles as the fault-resubscribe delay — short so the test observes
             // the recovery promptly.
-            PollInterval = TimeSpan.FromMilliseconds(500),
+            RetryInterval = TimeSpan.FromMilliseconds(500),
             DefaultPolicy = UpdatePolicyKind.Continuous,
         };
         var service = new FaultingFirstReadService(
@@ -249,7 +252,8 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
         var updater = new RecordingUpdater();
         var options = new SelfUpdateOptions
         {
-            PollInterval = TimeSpan.FromMilliseconds(500),
+            RetryInterval = TimeSpan.FromMilliseconds(500),
+            EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
             DefaultPolicy = UpdatePolicyKind.Continuous, // default ≠ the node's Stable — the wrong-policy tell
         };
 
@@ -273,12 +277,23 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
         await service.StartAsync(CancellationToken.None);
         try
         {
-            // Startup: the default (Continuous) drives polling ONCE until the live Stable emission
-            // arrives (by-design fallback window), then Stable-only patches. Wait for TWO Stable
-            // patches so any in-flight startup Continuous tick has long since drained, then snapshot.
+            // Startup: the default (Continuous) drives the ONE startup pass until the live Stable
+            // emission arrives (by-design fallback window), then Stable-only patches. Checks are
+            // event-driven now, so the second Stable patch is driven by a build completion rather
+            // than by waiting out a timer.
+            // 🚨 The startup pass must be OBSERVED before publishing: StartAsync subscribes via
+            // SubscribeOn(TaskPool), so it returns before the build-completion watch is established,
+            // and a publication racing that subscription is absorbed as the watch's BASELINE rather
+            // than seen as a new build. Waiting for the first patch proves the watch is live.
+            await updater.Patched.FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask(ct);
+
+            await SelfUpdateEventDriver.PublishBuildAsync(Mesh, "MeshWeaver", runNumber: 1);
+            // ONE publication is ONE check now — the old "two patches" wait was a proxy for "the
+            // interval has ticked enough times", which no longer exists. What the test proves is
+            // unchanged and asserted at the end: nothing after the fault runs under the default.
             await updater.Patched
                 .Where(tag => tag == FakeAcrTagLister.StableTag)
-                .Take(2).LastAsync()
+                .FirstAsync()
                 .Timeout(TimeSpan.FromSeconds(30))
                 .ToTask(ct);
             var beforeFault = updater.Tags.Count;
@@ -291,13 +306,16 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
                 "No response received in hub cache/test within 00:01:00 for request SubscribeRequest "
                 + $"→ target {UpdatePolicyNodeType.NodePath}"));
 
-            // Positive signal: polling continues past the fault (two more Stable patches — a window
-            // in which the pre-fix wrong-policy tick would land, since the retry fires after one
-            // PollInterval with an immediate first tick).
+            // Positive signal: checks continue past the fault (two more Stable patches — the window
+            // in which the pre-fix wrong-policy tick would land, since the retry re-establishes the
+            // read after one RetryInterval). Each check is now driven by a publication, so the
+            // events that must survive a mid-life fault are emitted explicitly.
+            await SelfUpdateEventDriver.PublishBuildAsync(Mesh, "MeshWeaver", runNumber: 2);
+            await SelfUpdateEventDriver.PublishBuildAsync(Mesh, "MeshWeaver.Plugins", runNumber: 1);
             await updater.Patched
                 .Skip(beforeFault)
                 .Where(tag => tag == FakeAcrTagLister.StableTag)
-                .Take(2).LastAsync()
+                .FirstAsync()
                 .Timeout(TimeSpan.FromSeconds(30))
                 .ToTask(ct);
 


### PR DESCRIPTION
Stacked on #1768 (both touch `SelfUpdateHostedService`); base retargets to `main` when that merges.

## What changed

The check is **event-driven**: one pass at startup — to catch publications missed while the install was down — then a check per event. **No recurring interval.** Three triggers, none of them a timer:

- the startup pass;
- a build completion from the platform **or from any module the environment deploys** (the watch covers the whole `Admin/_Build` collection, not one configured repo);
- an admin **changing the update policy** — enabling updates must not wait weeks for the next publication.

The decision was already there and is untouched: `ReleaseAvailabilityService` (#1754) holds a roll unless every deployed package has a usable artifact for the target — sealed content bake under the target's framework identity, or a module whose `MinMeshVersion` floor it satisfies — with indeterminate a **hold, never a pass**.

**What makes deferral safe without a timer**: the missing artifact becoming available *is itself a publication*, and this watch reacts to any repository's.

## 🚨 Three defects the tests caught in this restructure

Each would have shipped as *"self-update silently stops checking"* — the failure that cannot self-heal, because the update is what would fix it.

1. **The watch lived inside the policy `.Switch()`**, so every policy emission re-subscribed and **re-baselined** it — a publication in that window was read as current state and dropped. The interval used to mask this. Fixed structurally: the policy is **state, not a driver**; one long-lived watch, policy read at decision time.
2. **`WithLatestFrom` silently dropped the startup pass** — the trigger fires synchronously on subscribe while the policy seeds asynchronously, so whether the first check ran depended on Rx's internal subscribe ordering. Replaced with `SelectMany(_ => policy.Take(1))` over a `Replay(1)`.
3. **`Replay(1).RefCount()` would have re-seeded** — subscriber count hits zero between the gating `Take(1)` and the re-subscribe, disconnecting and re-running the seed: the very re-baselining class being removed. Uses `Replay(1)` + an explicit `Connect()` held in the subscription.

## Config follows behaviour

- `PollInterval` → **`RetryInterval`** (it only paces re-establishing a faulted watch now; the old name would advertise a poll that no longer exists).
- **`BuildTriggerRepository` deleted** — the watch is collection-wide, so it would have become a knob an operator sets and sees no effect from. Set in no config or chart anywhere in the tree.
- The hard-coded one-minute coalescing becomes **`EventCoalesceWindow`**: a burst of publications still costs one check, and tests can drive the event path without waiting it out.

## Tests

Driven by the **real production stimulus** — publishing a `BuildCompletion` record, which is what the `workflow_run` webhook writes — through a shared `SelfUpdateEventDriver`, registering the type via the production `AddGitHubSyncTypes` rather than a copy that could drift.

**Assertions are unchanged.** The old "wait for two patches" waits were proxies for "the interval has ticked", which cannot complete when one publication is one check. Five new unit tests pin the collection semantics, including the two that make deferral safe: a satellite's version bump is an event, and a repo publishing for the **first** time is an event; a record disappearing is not.

- Whole solution `-c Release -p:CIRun=true -warnaserror` → `0 Error(s)`.
- 14/14 Monolith self-update — **91 s → 1 s**, because nothing waits on a timer any more.
- 63/63 `Memex.Portal.Shared.Test`.

## 🚨 Known limit, deliberate

An install GitHub cannot reach (private cluster, `memex.localhost`) receives no webhooks, so it checks at **startup and on policy changes only**. The interval used to cover those; they now update on restart. Stated rather than papered over with a timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjujCq1BsJkNKuZ4wXodo1