### PR TITLE
fix(ci): chart-drift's preflight passed on a token GitHub rejects — assert VALID, not merely present

### DIFF
--- a/.github/workflows/chart-drift.yml
+++ b/.github/workflows/chart-drift.yml
@@ -107,6 +107,56 @@ jobs:
           fi
           echo "All external inputs are present."
 
+      # 🚨 PRESENT is not VALID, and this gate learned that the hard way (2026-08-17): the
+      # secret above was provisioned, the check on this page went GREEN — and all three drift
+      # jobs then died at `actions/checkout` with "Bad credentials". A non-empty string passed
+      # an emptiness test while being worthless, so the job reported "all external inputs are
+      # present" having proven nothing about the only input that had just changed. That is
+      # precisely the "a gate NEVER tests its own inputs" failure this workflow's header warns
+      # about, one level in: we checked that a value EXISTS instead of that it WORKS.
+      #
+      # So assert the capability the drift job actually needs — reading $DEPLOY_REPO — against
+      # the real API, and name what each rejection means, because the three causes are
+      # indistinguishable from the checkout error and take very different fixes. Read-only, one
+      # request, no `if:`, no continue-on-error: it fails RED like everything else here.
+      - name: The token can actually READ the deploy repo
+        env:
+          MEMEX_DEPLOY_REPO_TOKEN: ${{ secrets.MEMEX_DEPLOY_REPO_TOKEN }}
+        run: |
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $MEMEX_DEPLOY_REPO_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$DEPLOY_REPO")
+          case "$code" in
+            200)
+              echo "secrets.MEMEX_DEPLOY_REPO_TOKEN reads $DEPLOY_REPO (HTTP 200)." ;;
+            401)
+              echo "::error::secrets.MEMEX_DEPLOY_REPO_TOKEN is set but GitHub rejects it (HTTP 401, Bad credentials)."
+              echo "  The stored value is not a usable token. Most often it is not the token at all —"
+              echo "  a clipboard-piped 'gh secret set' stores whatever was on the clipboard — or the"
+              echo "  token was revoked, expired, or truncated on copy. Re-mint at"
+              echo "  https://github.com/settings/personal-access-tokens and store it again."
+              exit 1 ;;
+            403)
+              echo "::error::secrets.MEMEX_DEPLOY_REPO_TOKEN is refused (HTTP 403)."
+              echo "  The token exists but is not authorised for $DEPLOY_REPO's organisation. A"
+              echo "  fine-grained PAT whose resource owner is an org stays inert until an org owner"
+              echo "  APPROVES it — check https://github.com/settings/personal-access-tokens for a"
+              echo "  'Pending owner approval' badge, and the org's pending-requests page to grant it."
+              exit 1 ;;
+            404)
+              echo "::error::secrets.MEMEX_DEPLOY_REPO_TOKEN authenticates but cannot see $DEPLOY_REPO (HTTP 404)."
+              echo "  GitHub returns 404 rather than 403 for a repository a token may not read, so this"
+              echo "  is a SCOPE problem: the PAT's repository access does not include $DEPLOY_REPO, or"
+              echo "  it lacks 'Contents: Read-only'. Re-scope it — no other permission is needed."
+              exit 1 ;;
+            *)
+              echo "::error::Unexpected HTTP $code probing $DEPLOY_REPO with secrets.MEMEX_DEPLOY_REPO_TOKEN."
+              echo "  Treating as FAILURE: an indeterminate answer must never read as a working token."
+              exit 1 ;;
+          esac
+
   drift:
     name: ${{ matrix.env.ns }}
     needs: [preflight]

--- a/.github/workflows/chart-drift.yml
+++ b/.github/workflows/chart-drift.yml
@@ -123,11 +123,20 @@ jobs:
         env:
           MEMEX_DEPLOY_REPO_TOKEN: ${{ secrets.MEMEX_DEPLOY_REPO_TOKEN }}
         run: |
+          # 🚨 `|| code=000` is not defensive noise. `run:` steps are `bash -e`, so a curl that
+          # fails at the TRANSPORT level (DNS, TLS, connection refused) makes this assignment
+          # non-zero and kills the step right here — before the case block, i.e. before the one
+          # thing this step exists to print. The job would still fail closed, but with a bare
+          # curl error instead of the sentence naming what to provision, which is the whole
+          # point of the probe (Copilot review, #1774). The timeouts are the other half: an
+          # unbounded probe against a slow API hangs until the JOB timeout, turning a 10-second
+          # answer into a 20-minute one.
           code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            --connect-timeout 10 --max-time 30 \
             -H "Authorization: Bearer $MEMEX_DEPLOY_REPO_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/$DEPLOY_REPO")
+            "https://api.github.com/repos/$DEPLOY_REPO") || code=000
           case "$code" in
             200)
               echo "secrets.MEMEX_DEPLOY_REPO_TOKEN reads $DEPLOY_REPO (HTTP 200)." ;;
@@ -150,6 +159,18 @@ jobs:
               echo "  GitHub returns 404 rather than 403 for a repository a token may not read, so this"
               echo "  is a SCOPE problem: the PAT's repository access does not include $DEPLOY_REPO, or"
               echo "  it lacks 'Contents: Read-only'. Re-scope it — no other permission is needed."
+              exit 1 ;;
+            000)
+              echo "::error::Could not reach api.github.com to probe $DEPLOY_REPO (no HTTP response)."
+              echo "  Transport failure — DNS, TLS, a refused connection, or the 30 s cap. This says"
+              echo "  NOTHING about the token: it may be perfectly good. Re-run once the network or"
+              echo "  api.github.com is answering. Failing closed anyway, because a gate that cannot"
+              echo "  reach its subject has not checked it."
+              exit 1 ;;
+            5*)
+              echo "::error::api.github.com returned HTTP $code probing $DEPLOY_REPO."
+              echo "  That is GitHub failing, not the token — check https://www.githubstatus.com and"
+              echo "  re-run when the incident clears. Failing closed: indeterminate is not a pass."
               exit 1 ;;
             *)
               echo "::error::Unexpected HTTP $code probing $DEPLOY_REPO with secrets.MEMEX_DEPLOY_REPO_TOKEN."


### PR DESCRIPTION
## What happened

`secrets.MEMEX_DEPLOY_REPO_TOKEN` was provisioned (#1709). Preflight went **green**. All three drift jobs then died at `actions/checkout` with `Bad credentials`.

## Why the gate let it through

```bash
[ -n "$MEMEX_DEPLOY_REPO_TOKEN" ] || missing+=(...)
echo "All external inputs are present."
```

A non-empty string passes an emptiness test while being worthless. The job announced every external input was present, having proven **nothing** about the only input that had just changed — this workflow's own header rule (*"a gate NEVER tests its own inputs"*) failing one level in: checking that a value EXISTS rather than that it WORKS.

## The fix

Preflight now probes the capability the drift job needs — reading `$DEPLOY_REPO` — and names each rejection, because the three causes are indistinguishable from the checkout error and take different fixes:

| code | meaning |
|---|---|
| **401** | not a usable token (often not the token at all — a clipboard-piped `gh secret set` stores whatever was on the clipboard) |
| **403** | token exists, org has not **approved** it |
| **404** | authenticates but cannot see the repo — a **scope** problem (GitHub returns 404, not 403) |

## Verified against the live API

```
bogus token -> 401 ✓   'x' -> 401 ✓   valid/no-access -> 404 ✓   valid+access -> 200 ✓
```

No `if:`, no `continue-on-error`, `drift` still `needs: [preflight]`. One extra request per run.

## What's New
Skipped — CI gate hardening, no user-visible change. Refs #1709.