### PR TITLE
feat(#1724): serve module static assets — the blocker keeping the view packs out of modules/

### DIFF
--- a/memex/Memex.Portal.Shared/App.razor
+++ b/memex/Memex.Portal.Shared/App.razor
@@ -4,6 +4,7 @@
 
 @inject IConfiguration Configuration
 @inject AccessService Access
+@inject MeshWeaver.Hosting.AspNetCore.ModuleStaticAssetManifest ModuleAssets
 
 @{
     // Instance identity: when Portal:InstanceName is set (e.g. "Local"), the tab
@@ -34,6 +35,15 @@
     @* No pack tags here: view packs (Radzen, …) self-load their CSS/JS on first render via
        _content/MeshWeaver.Blazor/assetLoader.js — the shell stays pack-free so a pack can be
        added or dropped without touching it. *@
+    @* …with ONE exception that cannot self-load: SCOPED css. A referenced RCL's .razor.css is
+       bundled into the host aggregate linked above at HOST build; a module shipping via
+       modules/<Name>/ is outside that build, so its bundle is published standalone and nothing
+       links it — the module's components would render unstyled while all their JS worked. This
+       loop is data-driven off what actually landed, so it stays empty until a pack flips (#1724). *@
+    @foreach (var stylesheet in ModuleAssets.Stylesheets)
+    {
+        <link href="@stylesheet" rel="stylesheet" />
+    }
     <ImportMap />
     @if (hasInstance)
     {

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -89,6 +89,12 @@ public static class MemexConfiguration
 
         services.AddRazorPages();
 
+        // Static web assets of modules that ship via modules/<Name>/ (#1724). Mounted by
+        // UseMeshModuleStaticAssets below; the manifest it builds also tells App.razor which
+        // module stylesheets to link, since a flipped module's scoped CSS is published
+        // standalone rather than folded into the host's <App>.styles.css aggregate.
+        services.AddMeshModuleStaticAssets();
+
         services.AddRazorComponents()
             .AddInteractiveServerComponents()
             .AddHubOptions(opt =>
@@ -1078,6 +1084,12 @@ public static class MemexConfiguration
 
         // Static files middleware must run before routing to serve _content/* paths from RCLs
         app.UseStaticFiles();
+
+        // …and the same for modules that ship via modules/<Name>/ rather than a ProjectReference,
+        // whose assets are in no build-time manifest of this host (#1724). Registered AFTER the
+        // host's own UseStaticFiles so the platform copy of any shared dependency answers first —
+        // the module lane never shadows a platform asset.
+        app.UseMeshModuleStaticAssets();
 
         app.UseRouting();
 

--- a/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
@@ -277,7 +277,7 @@ public static class MeshModuleStaticAssetExtensions
         // First mount wins per request path — two modules carrying the SAME dependency (a shared
         // RCL) is ordinary composition, not a fault, so the second is skipped quietly rather than
         // refused. Shadowing the HOST is the case that must never happen, and that is the
-        // hostContentRoot check below.
+        // hostAssets check below.
         var claimed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var module in modules)

--- a/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
@@ -1,0 +1,219 @@
+using MeshWeaver.Mesh;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting.AspNetCore;
+
+/// <summary>
+/// Serves the static web assets of modules that ship in <c>modules/&lt;Name&gt;/</c> — the host
+/// half of the module static-asset lane (issue #1724, design #1644 step 2).
+///
+/// <para><b>Why this exists.</b> A Razor Class Library's <c>wwwroot</c> reaches the browser at
+/// <c>_content/&lt;lib&gt;/…</c> through the HOST's <em>build-time</em> static-web-assets graph —
+/// i.e. through the <c>ProjectReference</c> that flipping a module to the <c>modules/</c> lane
+/// deliberately removes. Nothing served <c>modules/&lt;Name&gt;/wwwroot</c>, so a flipped view pack
+/// lost its CSS/JS: <c>UseStaticFiles</c> reads the host's manifests, and a standalone RCL publish
+/// lays the pack's own assets at <c>wwwroot/</c> ROOT rather than at <c>_content/&lt;Name&gt;/</c> —
+/// which is the URL its own components request. That mismatch is what kept Radzen, GoogleMaps and
+/// Analysis referenced by the portal long after the rest of the modules flipped.</para>
+///
+/// <para><b>The mapping.</b> A standalone module publish produces exactly two shapes under its
+/// <c>wwwroot</c>, and they need opposite treatment:</para>
+/// <list type="bullet">
+/// <item><b>The module's OWN assets</b> sit at the root (<c>wwwroot/GoogleMapView.razor.js</c>,
+/// <c>wwwroot/&lt;Name&gt;.styles.css</c>) and are re-based to <c>_content/&lt;Name&gt;/…</c>.</item>
+/// <item><b>Its DEPENDENCIES' assets</b> are already correctly namespaced
+/// (<c>wwwroot/_content/&lt;Dep&gt;/…</c>) and are served at that same path — but only when the
+/// host does not already provide <c>&lt;Dep&gt;</c>, so a module can never shadow a platform asset.
+/// That is the same same-identity prune the DLL closure lane applies, in its request-path form, and
+/// it is what keeps this off the route-collision surface of #1677/#1678/#1679.</item>
+/// </list>
+///
+/// <para><b>Startup-time only, deliberately.</b> Assets are discovered from the folders present when
+/// the app starts. A module installed at RUNTIME (a Store package) is not served until the next
+/// start — the same concession the module loader itself already makes, since
+/// <c>MeshBuilder.InstallAssemblies</c> is boot-only by construction and ASP.NET Core cannot accept
+/// new static-asset endpoints after the <see cref="WebApplication"/> is built. Restart-as-activation
+/// is the contract; inventing a second, dynamic mechanism here would outrun the loader it serves.</para>
+/// </summary>
+public static class MeshModuleStaticAssetExtensions
+{
+    /// <summary>The request-path prefix every Razor Class Library's assets live under.</summary>
+    internal const string ContentRoot = "_content";
+
+    /// <summary>
+    /// Registers the <see cref="ModuleStaticAssetManifest"/> — what each installed module
+    /// contributes, resolved once on first use. Pair it with
+    /// <see cref="UseMeshModuleStaticAssets"/>; a host that mounts without registering gets a
+    /// speaking exception rather than silently unstyled modules.
+    /// </summary>
+    /// <param name="services">The service collection to register on.</param>
+    /// <returns>The same <paramref name="services"/> for chaining.</returns>
+    public static IServiceCollection AddMeshModuleStaticAssets(this IServiceCollection services)
+        => services.AddSingleton(sp => Discover(
+            sp.GetServices<InstalledModuleAssembly>(),
+            sp.GetRequiredService<IWebHostEnvironment>(),
+            sp.GetRequiredService<ILoggerFactory>()
+                .CreateLogger(typeof(MeshModuleStaticAssetExtensions))));
+
+    /// <summary>
+    /// Mounts every installed module's static web assets. Call it with the host's other
+    /// <c>UseStaticFiles</c> registrations — BEFORE <c>UseRouting</c>, because these are middleware
+    /// and not endpoints.
+    /// </summary>
+    /// <param name="app">The application to add the middleware to.</param>
+    /// <returns>The same <paramref name="app"/> for chaining.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="AddMeshModuleStaticAssets"/> was not called.
+    /// </exception>
+    public static WebApplication UseMeshModuleStaticAssets(this WebApplication app)
+    {
+        var manifest = app.Services.GetService<ModuleStaticAssetManifest>()
+            ?? throw new InvalidOperationException(
+                "UseMeshModuleStaticAssets() requires AddMeshModuleStaticAssets() on the service "
+                + "collection — without it the module manifest is never built, and a flipped "
+                + "module's CSS/JS would 404 at runtime with nothing in the log to say why.");
+
+        foreach (var mount in manifest.Mounts)
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = new PhysicalFileProvider(mount.PhysicalPath),
+                RequestPath = mount.RequestPath,
+            });
+
+        return app;
+    }
+
+    /// <summary>
+    /// Resolves what each installed module contributes. Internal so the mapping rules are testable
+    /// against a laid-out folder without standing up a web host.
+    /// </summary>
+    /// <param name="modules">The boot-installed modules to inspect.</param>
+    /// <param name="environment">Supplies the host's web root, used for the shadowing check.</param>
+    /// <param name="logger">Receives one line per mounted or skipped dependency.</param>
+    /// <param name="baseDirectory">
+    /// Where <c>modules/</c> lives; defaults to <see cref="AppContext.BaseDirectory"/>, which is
+    /// what <c>MeshBuilder.ResolveModulePath</c> probes. A parameter only so the mapping rules can
+    /// be exercised against a laid-out folder in a test.
+    /// </param>
+    internal static ModuleStaticAssetManifest Discover(
+        IEnumerable<InstalledModuleAssembly> modules,
+        IWebHostEnvironment environment,
+        ILogger logger,
+        string? baseDirectory = null)
+    {
+        baseDirectory ??= AppContext.BaseDirectory;
+        // The host's own _content/<dep> roots. A published app materialises them physically under
+        // wwwroot, so their presence is the cheap, checkable form of "the platform already serves
+        // this dependency" — and the reason a module's copy is skipped rather than racing it.
+        var hostContentRoot = string.IsNullOrEmpty(environment.WebRootPath)
+            ? null
+            : Path.Combine(environment.WebRootPath, ContentRoot);
+
+        var mounts = new List<ModuleStaticAssetMount>();
+        var stylesheets = new List<string>();
+        // First mount wins per request path — two modules carrying the SAME dependency (a shared
+        // RCL) is ordinary composition, not a fault, so the second is skipped quietly rather than
+        // refused. Shadowing the HOST is the case that must never happen, and that is the
+        // hostContentRoot check below.
+        var claimed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var module in modules)
+        {
+            var name = module.Assembly.GetName().Name;
+            if (string.IsNullOrEmpty(name))
+                continue;
+
+            // AppContext.BaseDirectory, matching MeshBuilder.ResolveModulePath — a module that
+            // still rides the app closure (the step-1 double-ship) has an EMPTY or absent folder
+            // here, so it simply contributes nothing and the host's build-time manifest keeps
+            // serving it. That is what makes this safe to switch on before any pack flips.
+            var moduleWwwroot = Path.Combine(baseDirectory, "modules", name, "wwwroot");
+            if (!Directory.Exists(moduleWwwroot))
+                continue;
+
+            // 1. The module's own assets, re-based onto its _content/<Name> namespace. A module
+            //    name is unique, so this mount can never collide with another module's.
+            var ownPath = $"/{ContentRoot}/{name}";
+            if (claimed.Add(ownPath))
+                mounts.Add(new ModuleStaticAssetMount(ownPath, moduleWwwroot));
+
+            // The scoped-CSS bundle a standalone publish emits for the module's own .razor.css
+            // files. It EXISTS (contrary to the "scoped CSS is lost" reading) — it is simply not
+            // linked, because App.razor links only the host's aggregate. Hand it to the host.
+            if (File.Exists(Path.Combine(moduleWwwroot, $"{name}.styles.css")))
+                stylesheets.Add($"{ContentRoot}/{name}/{name}.styles.css");
+
+            // 2. The module's DEPENDENCIES, already namespaced under its wwwroot/_content.
+            var moduleContentRoot = Path.Combine(moduleWwwroot, ContentRoot);
+            if (!Directory.Exists(moduleContentRoot))
+                continue;
+
+            foreach (var dependency in Directory.EnumerateDirectories(moduleContentRoot))
+            {
+                var dependencyName = Path.GetFileName(dependency);
+
+                // The host wins, always. Serving a module's copy over a platform-provided one is
+                // how you get two versions of the same RCL's JS answering the same URL depending
+                // on middleware order — a shadowing bug that presents as a caching bug.
+                if (hostContentRoot is not null
+                    && Directory.Exists(Path.Combine(hostContentRoot, dependencyName)))
+                {
+                    logger.LogDebug(
+                        "Module {Module}: not serving _content/{Dependency} — the host already provides it",
+                        name, dependencyName);
+                    continue;
+                }
+
+                var dependencyPath = $"/{ContentRoot}/{dependencyName}";
+                if (!claimed.Add(dependencyPath))
+                {
+                    logger.LogDebug(
+                        "Module {Module}: _content/{Dependency} already mounted by an earlier module",
+                        name, dependencyName);
+                    continue;
+                }
+
+                mounts.Add(new ModuleStaticAssetMount(dependencyPath, dependency));
+                logger.LogInformation(
+                    "Module {Module}: serving dependency assets at _content/{Dependency}",
+                    name, dependencyName);
+            }
+        }
+
+        if (mounts.Count > 0)
+            logger.LogInformation(
+                "Module static assets: {Count} root(s) mounted, {Stylesheets} stylesheet(s) to link",
+                mounts.Count, stylesheets.Count);
+
+        return new ModuleStaticAssetManifest(mounts, stylesheets);
+    }
+}
+
+/// <summary>One mounted asset root: everything under <paramref name="PhysicalPath"/> is served at
+/// <paramref name="RequestPath"/>.</summary>
+/// <param name="RequestPath">Rooted request path, e.g. <c>/_content/MeshWeaver.Blazor.GoogleMaps</c>.</param>
+/// <param name="PhysicalPath">Absolute directory backing it.</param>
+public sealed record ModuleStaticAssetMount(string RequestPath, string PhysicalPath);
+
+/// <summary>
+/// What the module static-asset lane contributes: the roots to mount, and the scoped-CSS bundles a
+/// host must link itself.
+///
+/// <para>A REFERENCED Razor Class Library's <c>.razor.css</c> is bundled into the host's
+/// <c>&lt;App&gt;.styles.css</c> at host build, and <c>App.razor</c> links only that aggregate. A
+/// module that ships via <c>modules/</c> is outside that build, so its bundle is published
+/// standalone and nothing links it — which renders the module's components unstyled while every
+/// script still works, the most confusing possible half-failure. Hosts render one
+/// <c>&lt;link&gt;</c> per <paramref name="Stylesheets"/> entry to close that gap.</para>
+/// </summary>
+/// <param name="Mounts">Asset roots to serve, in module order.</param>
+/// <param name="Stylesheets">
+/// Root-relative paths (<c>_content/&lt;Name&gt;/&lt;Name&gt;.styles.css</c>), in module order.
+/// </param>
+public sealed record ModuleStaticAssetManifest(
+    IReadOnlyList<ModuleStaticAssetMount> Mounts,
+    IReadOnlyList<string> Stylesheets);

--- a/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
@@ -1,9 +1,12 @@
 using MeshWeaver.Mesh;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
 
 namespace MeshWeaver.Hosting.AspNetCore;
 
@@ -45,6 +48,16 @@ public static class MeshModuleStaticAssetExtensions
     internal const string ContentRoot = "_content";
 
     /// <summary>
+    /// The precompressed sibling encodings a module publish emits, best ratio first. Immutable
+    /// lookup — a constant, not state.
+    /// </summary>
+    private static readonly (string Suffix, string Encoding)[] PrecompressedVariants =
+        [(".br", "br"), (".gz", "gzip")];
+
+    /// <summary>Resolves <c>x.js.br</c> to the media type of <c>x.js</c>. See the negotiation.</summary>
+    private static readonly PrecompressedContentTypeProvider PrecompressedContentTypes = new();
+
+    /// <summary>
     /// Registers the <see cref="ModuleStaticAssetManifest"/> — what each installed module
     /// contributes, resolved once on first use. Pair it with
     /// <see cref="UseMeshModuleStaticAssets"/>; a host that mounts without registering gets a
@@ -63,6 +76,24 @@ public static class MeshModuleStaticAssetExtensions
     /// Mounts every installed module's static web assets. Call it with the host's other
     /// <c>UseStaticFiles</c> registrations — BEFORE <c>UseRouting</c>, because these are middleware
     /// and not endpoints.
+    ///
+    /// <para><b>Precompressed variants.</b> A module publish emits <c>.br</c> and <c>.gz</c>
+    /// siblings beside every compressible asset (measured on a real publish:
+    /// <c>GoogleMapView.razor.js</c> 12,649 B → 1,945 B brotli). The host's own assets reach the
+    /// browser compressed because <c>MapStaticAssets</c> serves them off an endpoint manifest that
+    /// declares one endpoint per encoding — a manifest whose routes are relative to the module's
+    /// OWN wwwroot root, so it cannot be re-based onto <c>_content/&lt;Name&gt;/</c> and cannot be
+    /// reused here. Plain <c>UseStaticFiles</c> has no notion of a precompressed sibling and would
+    /// ship every module asset at full size, so the mounts negotiate it themselves: a request that
+    /// accepts an encoding whose sibling EXISTS is rewritten onto that sibling and answered with
+    /// the matching <c>Content-Encoding</c>, keeping the identity file's media type.</para>
+    ///
+    /// <para>Where no sibling is on disk — a module folder produced by anything other than a
+    /// publish — nothing is rewritten and the identity file is served exactly as before, so this
+    /// is a payload optimisation in the published container and a no-op everywhere else. It is
+    /// deliberately NOT a route-count property: a published layout exposes three representations
+    /// per asset and a dev one exposes a single file, and asserting one number across both is how
+    /// #1680 shipped a check that passed everywhere except production.</para>
     /// </summary>
     /// <param name="app">The application to add the middleware to.</param>
     /// <returns>The same <paramref name="app"/> for chaining.</returns>
@@ -77,14 +108,135 @@ public static class MeshModuleStaticAssetExtensions
                 + "collection — without it the module manifest is never built, and a flipped "
                 + "module's CSS/JS would 404 at runtime with nothing in the log to say why.");
 
-        foreach (var mount in manifest.Mounts)
+        if (manifest.Mounts.Count == 0)
+            return app;
+
+        var mounts = manifest.Mounts
+            .Select(mount => (
+                RequestPath: new PathString(mount.RequestPath),
+                Provider: new PhysicalFileProvider(mount.PhysicalPath)))
+            .ToArray();
+
+        // Encoding negotiation runs ONCE, in front of every mount: it only rewrites the path, so
+        // the mounts below stay ordinary static-file middleware.
+        app.Use((context, next) =>
+        {
+            NegotiatePrecompressed(context, mounts);
+            return next();
+        });
+
+        foreach (var (requestPath, provider) in mounts)
             app.UseStaticFiles(new StaticFileOptions
             {
-                FileProvider = new PhysicalFileProvider(mount.PhysicalPath),
-                RequestPath = mount.RequestPath,
+                FileProvider = provider,
+                RequestPath = requestPath,
+                ContentTypeProvider = PrecompressedContentTypes,
+                // Every representation of these URLs varies by Accept-Encoding — including the
+                // identity one, or a shared cache hands a brotli body to a client that cannot
+                // decode it.
+                OnPrepareResponse = static served =>
+                    served.Context.Response.Headers.Vary = HeaderNames.AcceptEncoding,
             });
 
         return app;
+    }
+
+    /// <summary>
+    /// Points the request at the best precompressed sibling the client accepts, and states the
+    /// encoding it is getting. A no-op when the client accepts none, or when the publish laid down
+    /// no sibling — in which case the identity file is served unchanged.
+    /// </summary>
+    private static void NegotiatePrecompressed(
+        HttpContext context,
+        (PathString RequestPath, PhysicalFileProvider Provider)[] mounts)
+    {
+        var path = context.Request.Path;
+        if (!path.HasValue)
+            return;
+
+        foreach (var (requestPath, provider) in mounts)
+        {
+            // Mount request paths are distinct and StartsWithSegments is segment-aware, so at
+            // most one mount owns a path — the first match is the answer either way.
+            if (!path.StartsWithSegments(requestPath, out var remainder) || !remainder.HasValue)
+                continue;
+
+            var subpath = remainder.Value!;
+
+            // A URL that already names a variant is a request for THAT representation. Its media
+            // type still resolves off the identity name (below), so it needs the matching
+            // Content-Encoding or the client receives compressed bytes labelled as JavaScript.
+            foreach (var (suffix, encoding) in PrecompressedVariants)
+                if (subpath.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Response.Headers.ContentEncoding = encoding;
+                    return;
+                }
+
+            foreach (var (suffix, encoding) in PrecompressedVariants)
+            {
+                if (!Accepts(context.Request, encoding)
+                    || !provider.GetFileInfo(subpath + suffix).Exists)
+                    continue;
+
+                context.Response.Headers.ContentEncoding = encoding;
+                context.Request.Path = new PathString(path.Value + suffix);
+                return;
+            }
+
+            return;
+        }
+    }
+
+    /// <summary>
+    /// Whether the client accepts <paramref name="encoding"/>, honouring an explicit
+    /// <c>q=0</c> rejection the way the framework's own content negotiation does.
+    /// </summary>
+    private static bool Accepts(HttpRequest request, string encoding)
+    {
+        if (!StringWithQualityHeaderValue.TryParseList(
+                request.Headers.AcceptEncoding, out var accepted))
+            return false;
+
+        foreach (var candidate in accepted)
+            if (string.Equals(candidate.Value.Value, encoding, StringComparison.OrdinalIgnoreCase))
+                return candidate.Quality is not 0;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gives a precompressed file the media type of what it decodes TO — <c>x.js.br</c> is
+    /// <c>text/javascript</c> carried under <c>Content-Encoding: br</c>, not a media type of its
+    /// own. Without this the static-file middleware finds no type for <c>.br</c> and refuses to
+    /// serve it (and, worse, maps <c>.gz</c> to <c>application/x-gzip</c>, which would break a
+    /// negotiated response that the browser has already decoded).
+    /// </summary>
+    private sealed class PrecompressedContentTypeProvider : IContentTypeProvider
+    {
+        private readonly FileExtensionContentTypeProvider inner = new();
+
+        public bool TryGetContentType(string subpath, out string contentType)
+        {
+            foreach (var (suffix, _) in PrecompressedVariants)
+                if (subpath.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+                    && inner.TryGetContentType(subpath[..^suffix.Length], out var identityType)
+                    && identityType is not null)
+                {
+                    contentType = identityType;
+                    return true;
+                }
+
+            // A genuinely-shipped archive (`data.gz`, nothing underneath it) keeps its own type.
+            if (inner.TryGetContentType(subpath, out var ownType) && ownType is not null)
+            {
+                contentType = ownType;
+                return true;
+            }
+
+            contentType = null!;
+            return false;
+        }
     }
 
     /// <summary>
@@ -92,7 +244,11 @@ public static class MeshModuleStaticAssetExtensions
     /// against a laid-out folder without standing up a web host.
     /// </summary>
     /// <param name="modules">The boot-installed modules to inspect.</param>
-    /// <param name="environment">Supplies the host's web root, used for the shadowing check.</param>
+    /// <param name="environment">
+    /// Supplies <see cref="IWebHostEnvironment.WebRootFileProvider"/> — what the host actually
+    /// SERVES, which is what the shadowing check must ask. Outside a published layout the host's
+    /// <c>_content/*</c> paths have no directory on disk at all.
+    /// </param>
     /// <param name="logger">Receives one line per mounted or skipped dependency.</param>
     /// <param name="baseDirectory">
     /// Where <c>modules/</c> lives; defaults to <see cref="AppContext.BaseDirectory"/>, which is
@@ -106,12 +262,15 @@ public static class MeshModuleStaticAssetExtensions
         string? baseDirectory = null)
     {
         baseDirectory ??= AppContext.BaseDirectory;
-        // The host's own _content/<dep> roots. A published app materialises them physically under
-        // wwwroot, so their presence is the cheap, checkable form of "the platform already serves
-        // this dependency" — and the reason a module's copy is skipped rather than racing it.
-        var hostContentRoot = string.IsNullOrEmpty(environment.WebRootPath)
-            ? null
-            : Path.Combine(environment.WebRootPath, ContentRoot);
+        // 🚨 "Does the host already serve _content/<dep>?" is a question for the WEB ROOT FILE
+        // PROVIDER, never for the filesystem. Only a PUBLISHED app materialises its static web
+        // assets physically under wwwroot; a dev run leaves wwwroot/_content empty on disk and
+        // serves those paths through the manifest-backed provider StaticWebAssetsLoader composes
+        // over the physical one. A Directory.Exists probe therefore answers "the host does not
+        // have it" for EVERY referenced RCL outside a published layout — and the module's copy
+        // gets mounted straight on top of a live platform mapping, which is the shadowing this
+        // check exists to prevent. The provider is the one source that is right in both.
+        var hostAssets = environment.WebRootFileProvider;
 
         var mounts = new List<ModuleStaticAssetMount>();
         var stylesheets = new List<string>();
@@ -159,8 +318,7 @@ public static class MeshModuleStaticAssetExtensions
                 // The host wins, always. Serving a module's copy over a platform-provided one is
                 // how you get two versions of the same RCL's JS answering the same URL depending
                 // on middleware order — a shadowing bug that presents as a caching bug.
-                if (hostContentRoot is not null
-                    && Directory.Exists(Path.Combine(hostContentRoot, dependencyName)))
+                if (hostAssets.GetDirectoryContents($"{ContentRoot}/{dependencyName}").Exists)
                 {
                     logger.LogDebug(
                         "Module {Module}: not serving _content/{Dependency} — the host already provides it",

--- a/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -75,10 +76,18 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>The PUBLISHED shape: the host's static web assets are materialised under wwwroot,
+    /// so the web root and what the host serves are the same directory.</summary>
     private ModuleStaticAssetManifest Discover(params System.Reflection.Assembly[] modules)
+        => Discover(
+            new StubWebHostEnvironment(HostWebRoot, new PhysicalFileProvider(HostWebRoot)),
+            modules);
+
+    private ModuleStaticAssetManifest Discover(
+        IWebHostEnvironment environment, params System.Reflection.Assembly[] modules)
         => MeshModuleStaticAssetExtensions.Discover(
             modules.Select(a => new InstalledModuleAssembly(a)),
-            new StubWebHostEnvironment(HostWebRoot),
+            environment,
             NullLogger.Instance,
             root);
 
@@ -127,6 +136,37 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
 
         manifest.Mounts.Should().NotContain(m => m.RequestPath == "/_content/SharedDep",
             "the host's copy is authoritative — the module lane must never shadow a platform asset");
+    }
+
+    /// <summary>
+    /// 🚨 …and the host still wins when it serves that dependency WITHOUT a directory on disk.
+    /// Only a published layout materialises <c>wwwroot/_content/&lt;Dep&gt;</c>; a dev run serves the
+    /// very same URLs out of the manifest-backed provider composed over the web root, with nothing
+    /// under <c>wwwroot</c> to stat. A <c>Directory.Exists</c> probe concludes "the host does not
+    /// have it" for EVERY referenced RCL there and mounts the module's copy over a live platform
+    /// mapping — so the shadowing check has to ask what the host SERVES, not what it stores.
+    /// </summary>
+    [Fact]
+    public void DependencyTheHostServesWithoutAPhysicalDirectory_IsNotMounted()
+    {
+        var emptyWebRoot = Path.Combine(root, "wwwroot-dev");
+        Directory.CreateDirectory(emptyWebRoot);
+
+        // What the host SERVES — the dev stand-in for the composed static-web-assets provider.
+        var servedRoot = Path.Combine(root, "host-served");
+        Directory.CreateDirectory(Path.Combine(servedRoot, "_content", "SharedDep"));
+
+        var manifest = Discover(
+            new StubWebHostEnvironment(emptyWebRoot, new PhysicalFileProvider(servedRoot)),
+            WithAssets);
+
+        Directory.Exists(Path.Combine(emptyWebRoot, "_content", "SharedDep")).Should().BeFalse(
+            "the premise: outside a published layout the host's asset has no directory to find");
+        manifest.Mounts.Should().NotContain(m => m.RequestPath == "/_content/SharedDep",
+            "the host serves it through its file provider, so the module must not shadow it");
+
+        // …while a dependency the host genuinely lacks is still served from the module.
+        manifest.Mounts.Should().Contain(m => m.RequestPath == "/_content/PrivateDep");
     }
 
     /// <summary>
@@ -188,17 +228,7 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
     [Fact]
     public async Task MountedAsset_IsServedOverHttp()
     {
-        var builder = WebApplication.CreateBuilder();
-        builder.WebHost.UseTestServer();
-        builder.Services.AddSingleton(
-            MeshModuleStaticAssetExtensions.Discover(
-                [new InstalledModuleAssembly(WithAssets)],
-                new StubWebHostEnvironment(HostWebRoot),
-                NullLogger.Instance,
-                root));
-
-        await using var app = builder.Build();
-        app.UseMeshModuleStaticAssets();
+        await using var app = BuildHost();
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -206,7 +236,7 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
         var served = await client.GetAsync($"/_content/{ModuleName}/PackView.razor.js");
         served.StatusCode.Should().Be(HttpStatusCode.OK,
             "the module's own asset must answer at the URL its component hard-codes");
-        (await served.Content.ReadAsStringAsync()).Should().Be("export {};");
+        (await served.Content.ReadAsStringAsync()).Should().Be(IdentityBody);
 
         var dependency = await client.GetAsync("/_content/PrivateDep/dep.js");
         dependency.StatusCode.Should().Be(HttpStatusCode.OK,
@@ -219,10 +249,108 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
         await app.StopAsync();
     }
 
-    private sealed class StubWebHostEnvironment(string webRootPath) : IWebHostEnvironment
+    /// <summary>
+    /// PUBLISHED layout: a module publish lays a <c>.br</c> beside every compressible asset
+    /// (measured: <c>GoogleMapView.razor.js</c> 12,649 B → 1,945 B). Plain <c>UseStaticFiles</c>
+    /// ignores that sibling and ships the full-size file, so the mount negotiates it — the client
+    /// gets the compressed representation under the IDENTITY media type, which is the whole point:
+    /// <c>Content-Encoding</c> says how to decode it, <c>Content-Type</c> says what it then is.
+    /// </summary>
+    [Fact]
+    public async Task PrecompressedSibling_IsServedWhenTheClientAcceptsIt()
+    {
+        var brotli = Compress(IdentityBody);
+        await File.WriteAllBytesAsync(
+            Path.Combine(ModuleWwwroot, "PackView.razor.js.br"), brotli);
+
+        await using var app = BuildHost();
+        await app.StartAsync();
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get, $"/_content/{ModuleName}/PackView.razor.js");
+        request.Headers.AcceptEncoding.ParseAdd("br");
+
+        var response = await app.GetTestClient().SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentEncoding.Should().Equal(new[] { "br" },
+            "the response must say which encoding it carries, or the browser cannot decode it");
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/javascript",
+            "the media type is the identity file's — .br is an encoding, not a type");
+        response.Headers.Vary.Should().Contain("Accept-Encoding",
+            "a shared cache must not hand this body to a client that did not ask for brotli");
+        (await response.Content.ReadAsByteArrayAsync()).Should().Equal(brotli);
+
+        await app.StopAsync();
+    }
+
+    /// <summary>
+    /// DEV/CI layout: nothing published the module, so no <c>.br</c> exists next to the asset and
+    /// negotiation must fall straight through to the identity file rather than 404 on a sibling
+    /// that was never laid down.
+    ///
+    /// <para>Deliberately asserted as its own behaviour rather than by comparing route counts
+    /// across the two worlds: a published layout exposes three representations per asset and a dev
+    /// one exposes a single file, and a whole-table assertion over that is exactly how #1680
+    /// shipped a check that passed everywhere except production.</para>
+    /// </summary>
+    [Fact]
+    public async Task WithNoPrecompressedSibling_TheIdentityFileIsServed()
+    {
+        await using var app = BuildHost();
+        await app.StartAsync();
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get, $"/_content/{ModuleName}/PackView.razor.js");
+        request.Headers.AcceptEncoding.ParseAdd("br");
+
+        var response = await app.GetTestClient().SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentEncoding.Should().BeEmpty(
+            "there is no compressed representation to announce");
+        (await response.Content.ReadAsStringAsync()).Should().Be(IdentityBody);
+
+        await app.StopAsync();
+    }
+
+    private const string IdentityBody = "export {};";
+
+    private static byte[] Compress(string content)
+    {
+        using var output = new MemoryStream();
+        using (var brotli = new BrotliStream(output, CompressionLevel.Optimal))
+            brotli.Write(System.Text.Encoding.UTF8.GetBytes(content));
+        return output.ToArray();
+    }
+
+    private WebApplication BuildHost()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(
+            MeshModuleStaticAssetExtensions.Discover(
+                [new InstalledModuleAssembly(WithAssets)],
+                new StubWebHostEnvironment(HostWebRoot, new PhysicalFileProvider(HostWebRoot)),
+                NullLogger.Instance,
+                root));
+
+        var app = builder.Build();
+        app.UseMeshModuleStaticAssets();
+        return app;
+    }
+
+    /// <summary>
+    /// A host environment whose WEB ROOT and whose SERVED assets can be pointed at different
+    /// places — which is not an artificial split but the ordinary dev shape: outside a published
+    /// layout the host's <c>_content/*</c> paths exist only in the manifest-backed provider
+    /// <c>StaticWebAssetsLoader</c> composes over the physical web root.
+    /// </summary>
+    private sealed class StubWebHostEnvironment(string webRootPath, IFileProvider served)
+        : IWebHostEnvironment
     {
         public string WebRootPath { get; set; } = webRootPath;
-        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public IFileProvider WebRootFileProvider { get; set; } = served;
         public string ApplicationName { get; set; } = "test";
         public string ContentRootPath { get; set; } = webRootPath;
         public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();

--- a/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
@@ -1,0 +1,231 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.AspNetCore;
+using MeshWeaver.Mesh;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the mapping rules of the module static-asset lane (#1724) — the half of a
+/// <c>modules/&lt;Name&gt;/</c> flip that a <c>dotnet build</c> cannot see.
+///
+/// <para>A flipped Razor Class Library's assets are published to <c>modules/&lt;Name&gt;/wwwroot</c>
+/// with its OWN files at the root and its DEPENDENCIES' already namespaced under
+/// <c>_content/&lt;Dep&gt;/</c>. Those two shapes need opposite treatment, and getting either wrong
+/// fails at RUNTIME as a 404 for a script the component hard-codes — invisible to every compile
+/// gate, which is exactly why it is pinned here rather than left to a boot smoke test.</para>
+///
+/// <para>Exercised against a laid-out folder rather than a live host: the rules are filesystem
+/// shape in, mount list out, and a real <c>WebApplication</c> would test ASP.NET's static-file
+/// middleware instead of the mapping this owns.</para>
+/// </summary>
+public class ModuleStaticAssetDiscoveryTest : IDisposable
+{
+    // Two real assemblies, used only for their NAMES — Discover reads
+    // Assembly.GetName().Name to find modules/<Name>/, and never loads anything.
+    private static readonly System.Reflection.Assembly WithAssets =
+        typeof(MeshModuleStaticAssetExtensions).Assembly;   // MeshWeaver.Hosting.AspNetCore
+    private static readonly System.Reflection.Assembly WithoutAssets =
+        typeof(InstalledModuleAssembly).Assembly;           // MeshWeaver.Mesh.Contract
+
+    private static string ModuleName => WithAssets.GetName().Name!;
+
+    private readonly string root = Path.Combine(
+        Path.GetTempPath(), $"mw-modassets-{Guid.NewGuid():N}");
+
+    private string ModuleWwwroot => Path.Combine(root, "modules", ModuleName, "wwwroot");
+    private string HostWebRoot => Path.Combine(root, "wwwroot");
+
+    public ModuleStaticAssetDiscoveryTest()
+    {
+        // The module's OWN assets — published at the wwwroot ROOT, which is precisely why they
+        // cannot be served as-is: the component requests _content/<Name>/GoogleMapView.razor.js.
+        Directory.CreateDirectory(ModuleWwwroot);
+        File.WriteAllText(Path.Combine(ModuleWwwroot, "PackView.razor.js"), "export {};");
+        File.WriteAllText(Path.Combine(ModuleWwwroot, $"{ModuleName}.styles.css"), ".x{}");
+
+        // A dependency the host does NOT provide → the module's copy is the only one.
+        Directory.CreateDirectory(Path.Combine(ModuleWwwroot, "_content", "PrivateDep"));
+        File.WriteAllText(
+            Path.Combine(ModuleWwwroot, "_content", "PrivateDep", "dep.js"), "export {};");
+
+        // A dependency the host ALREADY serves → must be skipped, or two copies of the same RCL
+        // answer the same URL depending on middleware order.
+        Directory.CreateDirectory(Path.Combine(ModuleWwwroot, "_content", "SharedDep"));
+        File.WriteAllText(
+            Path.Combine(ModuleWwwroot, "_content", "SharedDep", "shared.js"), "export {};");
+        Directory.CreateDirectory(Path.Combine(HostWebRoot, "_content", "SharedDep"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+            Directory.Delete(root, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private ModuleStaticAssetManifest Discover(params System.Reflection.Assembly[] modules)
+        => MeshModuleStaticAssetExtensions.Discover(
+            modules.Select(a => new InstalledModuleAssembly(a)),
+            new StubWebHostEnvironment(HostWebRoot),
+            NullLogger.Instance,
+            root);
+
+    /// <summary>
+    /// The module's own assets are re-based onto <c>_content/&lt;Name&gt;</c> — the URL its
+    /// components actually request — rather than left at the publish's wwwroot root.
+    /// </summary>
+    [Fact]
+    public void OwnAssets_AreRebasedOntoTheModuleContentNamespace()
+    {
+        var manifest = Discover(WithAssets);
+
+        var own = manifest.Mounts.Single(m => m.RequestPath == $"/_content/{ModuleName}");
+        own.PhysicalPath.Should().Be(ModuleWwwroot);
+        File.Exists(Path.Combine(own.PhysicalPath, "PackView.razor.js")).Should().BeTrue(
+            "the mount must expose the module's own root-level assets");
+    }
+
+    /// <summary>
+    /// A dependency the host does not carry is served from the module, at its OWN namespace —
+    /// NOT nested under the module's (which is the URL nobody requests).
+    /// </summary>
+    [Fact]
+    public void PrivateDependency_IsServedAtItsOwnContentNamespace()
+    {
+        var manifest = Discover(WithAssets);
+
+        manifest.Mounts.Should().ContainSingle(m => m.RequestPath == "/_content/PrivateDep")
+            .Which.PhysicalPath.Should().Be(
+                Path.Combine(ModuleWwwroot, "_content", "PrivateDep"));
+
+        manifest.Mounts.Should().NotContain(
+            m => m.RequestPath.Contains($"/_content/{ModuleName}/_content"),
+            "a dependency must keep its own _content/<Dep> namespace, not be nested under the module's");
+    }
+
+    /// <summary>
+    /// 🚨 The host always wins. A module carrying a dependency the platform already serves must NOT
+    /// mount its copy — otherwise two builds of the same RCL answer one URL and which one you get
+    /// depends on middleware order, a shadowing bug that presents as a caching bug.
+    /// </summary>
+    [Fact]
+    public void DependencyTheHostAlreadyServes_IsNotMounted()
+    {
+        var manifest = Discover(WithAssets);
+
+        manifest.Mounts.Should().NotContain(m => m.RequestPath == "/_content/SharedDep",
+            "the host's copy is authoritative — the module lane must never shadow a platform asset");
+    }
+
+    /// <summary>
+    /// The scoped-CSS bundle is surfaced for the host to link. It EXISTS in a standalone publish
+    /// (the "scoped CSS is lost on flip" reading is wrong) — it is simply not folded into the
+    /// host's aggregate, so nothing links it and the module renders unstyled while its JS works.
+    /// </summary>
+    [Fact]
+    public void ScopedStyleBundle_IsSurfacedForTheHostToLink()
+    {
+        var manifest = Discover(WithAssets);
+
+        manifest.Stylesheets.Should().ContainSingle()
+            .Which.Should().Be($"_content/{ModuleName}/{ModuleName}.styles.css");
+    }
+
+    /// <summary>
+    /// A module with no <c>modules/&lt;Name&gt;/wwwroot</c> contributes nothing and does not throw.
+    /// That is every module today — the step-1 double-ship prunes the folder empty — so this is
+    /// what makes the lane safe to switch on BEFORE any pack flips.
+    /// </summary>
+    [Fact]
+    public void ModuleWithoutAnAssetFolder_ContributesNothing()
+    {
+        var manifest = Discover(WithoutAssets);
+
+        manifest.Mounts.Should().BeEmpty();
+        manifest.Stylesheets.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Two modules carrying the SAME private dependency is ordinary composition, not a fault: the
+    /// first mount wins and the second is skipped, rather than the loud refusal a genuine route
+    /// collision gets (#1677/#1678/#1679). Refusing here would make shared RCLs unusable.
+    /// </summary>
+    [Fact]
+    public void SameDependencyFromTwoModules_MountsOnce()
+    {
+        var second = WithoutAssets.GetName().Name!;
+        var secondWwwroot = Path.Combine(root, "modules", second, "wwwroot");
+        Directory.CreateDirectory(Path.Combine(secondWwwroot, "_content", "PrivateDep"));
+        File.WriteAllText(
+            Path.Combine(secondWwwroot, "_content", "PrivateDep", "dep.js"), "export {};");
+
+        var manifest = Discover(WithAssets, WithoutAssets);
+
+        manifest.Mounts.Count(m => m.RequestPath == "/_content/PrivateDep").Should().Be(1);
+    }
+
+    /// <summary>
+    /// End-to-end through real ASP.NET middleware: a file under <c>modules/&lt;Name&gt;/wwwroot</c>
+    /// is actually SERVED at <c>_content/&lt;Name&gt;/…</c>, and a path outside the lane still 404s.
+    ///
+    /// <para>The mapping tests above prove the manifest; this proves the mount, which is the half
+    /// that a wrong <c>RequestPath</c> or a middleware-ordering mistake breaks. Without it the
+    /// suite could be green while every flipped pack 404s in the browser — the exact failure the
+    /// lane exists to prevent.</para>
+    /// </summary>
+    [Fact]
+    public async Task MountedAsset_IsServedOverHttp()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(
+            MeshModuleStaticAssetExtensions.Discover(
+                [new InstalledModuleAssembly(WithAssets)],
+                new StubWebHostEnvironment(HostWebRoot),
+                NullLogger.Instance,
+                root));
+
+        await using var app = builder.Build();
+        app.UseMeshModuleStaticAssets();
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+
+        var served = await client.GetAsync($"/_content/{ModuleName}/PackView.razor.js");
+        served.StatusCode.Should().Be(HttpStatusCode.OK,
+            "the module's own asset must answer at the URL its component hard-codes");
+        (await served.Content.ReadAsStringAsync()).Should().Be("export {};");
+
+        var dependency = await client.GetAsync("/_content/PrivateDep/dep.js");
+        dependency.StatusCode.Should().Be(HttpStatusCode.OK,
+            "a dependency the host does not carry is served from the module");
+
+        var shadowed = await client.GetAsync("/_content/SharedDep/shared.js");
+        shadowed.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "the module's copy of a host-provided dependency must never be mounted");
+
+        await app.StopAsync();
+    }
+
+    private sealed class StubWebHostEnvironment(string webRootPath) : IWebHostEnvironment
+    {
+        public string WebRootPath { get; set; } = webRootPath;
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string ApplicationName { get; set; } = "test";
+        public string ContentRootPath { get; set; } = webRootPath;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        public string EnvironmentName { get; set; } = "Development";
+    }
+}


### PR DESCRIPTION
Closes the prerequisite in #1724. Sibling native-asset gap is #1728.

## The problem

A module shipping via `modules/<Name>/` instead of a `ProjectReference` **loses its CSS and JS**. An RCL's `wwwroot` reaches the browser at `_content/<lib>/…` through the HOST's *build-time* static-web-assets graph — the very reference the flip removes — and nothing served `modules/<Name>/wwwroot`.

That is why Radzen, GoogleMaps and Analysis were still referenced long after Observability and Markdown.Export flipped: **the DLL lane was ready and the asset lane did not exist.**

## Grounded on a real publish, not the docs

```
wwwroot/GoogleMapView.razor.js                  ← own assets, at wwwroot ROOT
wwwroot/MeshWeaver.Blazor.GoogleMaps.styles.css ← own scoped-CSS bundle, standalone
wwwroot/_content/<dep>/…                        ← dependencies, already namespaced
```

Two shapes, opposite treatment:

| shape | served at | rule |
|---|---|---|
| own assets | `_content/<Name>/…` | re-based — the URL the component hard-codes |
| dependencies | `_content/<Dep>/…` | own namespace, **only if the host doesn't provide it** |

That last rule is the request-path form of the same-identity prune the DLL closure lane already applies, and it keeps this off the route-collision surface of #1677/#1678/#1679.

## 🚨 One premise in the targets comment is wrong — and it shrinks the work

**Scoped CSS is NOT lost on flip.** A standalone publish *does* emit `<Name>.styles.css`; it is simply never linked, because `App.razor` links only the host's build-time aggregate. So the fix is a link per landed module — a data-driven loop in `App.razor`, empty until a pack flips — **not** runtime CSS bundling.

## Startup-time only, deliberately

A module installed at RUNTIME is served after the next restart. ASP.NET Core cannot accept new static-asset endpoints once `WebApplication` is built, and `InstallAssemblies` is boot-only by construction — restart-as-activation is already the contract (#1664 step 8). A second dynamic mechanism here would outrun the loader it serves.

## Inert until a pack flips

A module still riding a `ProjectReference` has an empty `modules/<Name>/` folder (the step-1 double-ship prunes it), so it contributes nothing and the host's manifest keeps serving it. Safe to land ahead of any flip — **this PR flips nothing**; that is #1644 step 2, one pack at a time behind its own CI.

## Review fixes (Copilot, both real)

### 1. The shadowing check asked the filesystem instead of what the host SERVES

`Directory.Exists(wwwroot/_content/<Dep>)` is only a valid proxy for "the platform already provides this dependency" **in a published layout**, which is the one place those directories are materialised. A dev run (and any host whose assets ride the static-web-assets manifest) serves the same URLs out of the manifest-backed provider `StaticWebAssetsLoader` composes over the physical web root — nothing under `wwwroot` to stat.

So outside a published container the check answered "the host does not have it" for **every referenced RCL**, and the module's copy would mount on top of a live platform mapping — the shadowing the check exists to prevent, presenting as a caching bug. It now asks `IWebHostEnvironment.WebRootFileProvider`, which is correct in both worlds.

**Environment:** the defect was live in dev/local runs and any non-published hosting; a published container was already correct by accident. Pinned by `DependencyTheHostServesWithoutAPhysicalDirectory_IsNotMounted`, confirmed **red against the old check** before being kept.

### 2. Module assets never got their precompressed variants

Verified against a real standalone publish (the same one the closure lane runs, `NoBuild=true` included): a module publish lays `.br` and `.gz` siblings beside every compressible asset — **64 of them** for GoogleMaps, at the wwwroot root *and* under `_content/<Dep>/`. `GoogleMapView.razor.js` is 12,649 B identity vs **1,945 B brotli**. Plain `UseStaticFiles` has no notion of a precompressed sibling, so all of that shipped at full size.

The host's own lane gets this from `MapStaticAssets`' endpoint manifest, which **cannot be reused here**: a module's manifest declares its own-asset routes relative to its wwwroot ROOT (`GoogleMapView.razor.js`, no `_content/<Name>/` prefix — confirmed by reading the emitted manifest), and re-basing them onto `_content/<Name>/` is the entire reason this lane exists. `UseResponseCompression()` was not the answer either — it would burn CPU per request re-compressing bytes the publish already compressed, and change host-wide behaviour for a module-scoped gap.

So the mounts negotiate it themselves: a request whose accepted encoding has a sibling on disk is answered with that sibling, the matching `Content-Encoding`, `Vary: Accept-Encoding` on **every** representation (identity included, or a shared cache hands brotli to a client that can't decode it), and the **identity file's** media type — `.br` is an encoding, not a media type.

**Environment:** the win lands wherever `modules/<Name>/wwwroot` exists at all, since that folder is produced by a *publish* in both the publish and build-time closure lanes — most importantly the deployed container. Where no sibling is on disk, nothing is rewritten and the identity file is served exactly as before.

🚨 The two worlds are pinned as **two separate behaviours** (`PrecompressedSibling_IsServedWhenTheClientAcceptsIt`, `WithNoPrecompressedSibling_TheIdentityFileIsServed`), never by comparing route counts across them: a published layout exposes three representations per asset and a dev one exposes a single file, and asserting one number over both is exactly how #1680 shipped a check that passed everywhere except production.

## Verification

**10/10** — eight on the mapping rules, two **end-to-end through real ASP.NET middleware**:

- own asset served at `_content/<Name>/…` → 200
- private dependency served → 200
- host-provided dependency **not** mounted → 404, whether the host holds it physically or serves it through its file provider only
- precompressed sibling negotiated → `Content-Encoding: br`, identity media type, `Vary` set
- no sibling → identity file, unchanged

Release/`-warnaserror` clean on `Hosting.AspNetCore`, `Portal.Shared` and the test project.

## What's New

Skipped — infrastructure with no user-visible change until a pack flips. The lane is still inert: every module's `modules/<Name>/wwwroot` is empty today, so both review fixes change behaviour only for a flip that has not happened yet.
