### PR TITLE
feat: Excel/CSV import becomes its own module

### DIFF
--- a/memex/Memex.Portal.Monolith/Memex.Portal.Monolith.csproj
+++ b/memex/Memex.Portal.Monolith/Memex.Portal.Monolith.csproj
@@ -10,11 +10,29 @@
     <!-- The API-surface manifest (#1660 WS3): the framework build identity resolves from it, so
          local NodeType caches survive internal-only framework rebuilds (see Directory.Build.props). -->
     <MeshWeaverSurfaceManifest>true</MeshWeaverSurfaceManifest>
+    <!-- 🚨 The closure lane's "a closure module's DLL is in the app publish root" refusal is OFF for
+         this host, and ONLY this host. This is the DEV portal, and it bundles the Northwind SAMPLE,
+         whose data sources compile against MeshWeaver.Import (AddImport() over the sample CSVs). So
+         MeshWeaver.Import.dll legitimately rides this host's app closure — which is the documented
+         THIN-lane state, not a broken flip: modules/MeshWeaver.Import/ prunes empty and
+         ResolveModulePath's app-folder fallback activates the very same assembly.
+         Turning it off HOST-side rather than module-side is what keeps the guarantee where it
+         matters: Memex.Portal.Distributed — the published image — keeps the refusal ARMED for every
+         module, so a ships-the-bits ProjectReference sneaking back into the IMAGE still fails RED. -->
+    <MeshModulesGuardPublishAppRoot>false</MeshModulesGuardPublishAppRoot>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
-    <ProjectReference Include="..\..\src\MeshWeaver.Import\MeshWeaver.Import.csproj" />
+    <!-- MeshWeaver.Import is deliberately NOT referenced (#1644 step 2): it ships via the
+         modules/<Name>/ closure layout in MeshModulesPublish.targets and joins the in-mesh compile
+         reference set by being listed in Modules:Assemblies — see the note in
+         Memex.Portal.Distributed.csproj for why that surface has to be preserved.
+         🚨 It nonetheless still ARRIVES in this host's app closure, transitively through the
+         Northwind SAMPLE below, whose data sources call AddImport() over the sample CSVs. That is
+         why this host turns the publish-time app-root refusal off (see the property group above);
+         the refusal stays ARMED for Memex.Portal.Distributed, which is the published image and
+         references no sample. -->
     <ProjectReference Include="..\aspire\Memex.Portal.ServiceDefaults\Memex.Portal.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Memex.Portal.Shared\Memex.Portal.Shared.csproj" />
     <ProjectReference Include="..\..\samples\Northwind\MeshWeaver.Northwind.Application\MeshWeaver.Northwind.Application.csproj" />

--- a/memex/Memex.Portal.Monolith/appsettings.json
+++ b/memex/Memex.Portal.Monolith/appsettings.json
@@ -21,6 +21,9 @@
   "AllowedHosts": "*",
   "Modules": {
     "Assemblies": [
+      // 🚨 FIRST: the in-mesh compile reference set is composed from the installed modules in
+      // list order, so a module whose content compiles against MeshWeaver.Import must follow it.
+      "MeshWeaver.Import.dll",
       "MeshWeaver.AI.OpenAI.dll",
       "MeshWeaver.AI.AzureFoundry.dll",
       "MeshWeaver.AI.ClaudeCode.dll",

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -83,8 +83,10 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Courses/MeshWeaver.Courses.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Mail.MicrosoftGraph/MeshWeaver.Mail.MicrosoftGraph.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Mcp/MeshWeaver.Mcp.csproj" />
-    <!-- Import + its PRIVATE MeshWeaver.DataSetReader.* closure (nothing else in the tree
-         references those five projects). No host ever called AddImport() — the portals referenced
+    <!-- Import + its PRIVATE closure: the SIX MeshWeaver.DataSetReader* projects (the base, Csv,
+         Excel, Excel.BinaryFormat, Excel.OpenXmlFormat, Excel.Utils) and MeshWeaver.DataStructures
+         beneath them — nothing outside their own test project references any of them.
+         No host ever called AddImport() — the portals referenced
          this assembly purely so IN-MESH source could `using MeshWeaver.Import`, and the module lane
          carries that surface instead (InstallAssemblies -> InstalledModuleAssembly ->
          CompileReferences.ComposeWithModules). NOT a dependency win: ClosedXML / OpenXml / CsvHelper

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -82,6 +82,13 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.AI.WebSearch/MeshWeaver.AI.WebSearch.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Courses/MeshWeaver.Courses.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Mail.MicrosoftGraph/MeshWeaver.Mail.MicrosoftGraph.csproj" />
+    <!-- Import + its PRIVATE MeshWeaver.DataSetReader.* closure (nothing else in the tree
+         references those five projects). No host ever called AddImport() — the portals referenced
+         this assembly purely so IN-MESH source could `using MeshWeaver.Import`, and the module lane
+         carries that surface instead (InstallAssemblies -> InstalledModuleAssembly ->
+         CompileReferences.ComposeWithModules). NOT a dependency win: ClosedXML / OpenXml / CsvHelper
+         stay in the image via MeshWeaver.Blazor + MeshWeaver.ContentCollections and prune out here. -->
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Import/MeshWeaver.Import.csproj" />
 
     <!-- Alternative storage backends. These were BORN flipped: no host has ever referenced them
          (only their own test projects do), and both attributes state the intent verbatim —
@@ -123,6 +130,24 @@
   -->
   <PropertyGroup>
     <_MeshModulesSubsetNames>;$(MeshModulesClosureSubset);</_MeshModulesSubsetNames>
+
+    <!--
+      MeshModulesGuardPublishAppRoot — the publish-time "a closure module's own DLL is sitting in
+      the app root" refusal. ON by default, and it must stay on for anything that becomes an IMAGE:
+      a DLL in both places means a ships-the-bits ProjectReference came back and the flip is a lie.
+
+      A HOST may set it false in its .csproj, and exactly one does: Memex.Portal.Monolith, the DEV
+      portal, which bundles the Northwind SAMPLE whose data sources compile against
+      MeshWeaver.Import. That transitive reference puts the module in its app closure legitimately —
+      the documented THIN-lane state, where modules/<Name>/ prunes empty and ResolveModulePath falls
+      back to the app folder for the same assembly.
+
+      🚨 HOST-scoped, never module-scoped. Exempting the module (metadata on @(MeshModuleClosure))
+      would disarm the check in the published image too, which is the one place it is load-bearing —
+      a gate that cannot fail is not a gate (AGENTS.md). Exempting the dev HOST leaves
+      Memex.Portal.Distributed refusing every re-added reference, for every module.
+    -->
+    <MeshModulesGuardPublishAppRoot Condition="'$(MeshModulesGuardPublishAppRoot)' == ''">true</MeshModulesGuardPublishAppRoot>
   </PropertyGroup>
 
   <Target Name="PublishMeshModules" AfterTargets="Publish" Condition="'$(PublishMeshModules)' != 'false'">
@@ -168,11 +193,12 @@
          AND Publish in one instance, so a shared in-instance worker would fire for only one of
          the two directories. MeshModulesGuardAppRoot: only the publish lane hard-fails on the
          module's own dll in the app root (in a dev bin/ that is routinely a STALE file from the
-         pre-flip era, not a re-added reference). -->
+         pre-flip era, not a re-added reference), and a HOST may turn even that off — see
+         MeshModulesGuardPublishAppRoot below. -->
     <MSBuild Projects="$(MSBuildThisFileFullPath)"
              Targets="LayoutMeshModuleClosures"
              BuildInParallel="false"
-             Properties="MeshModulesAppDir=$(_AppPublishDir);Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=true;MeshModulesClosureSubset=$([MSBuild]::Escape('$(MeshModulesClosureSubset)'))" />
+             Properties="MeshModulesAppDir=$(_AppPublishDir);Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=$(MeshModulesGuardPublishAppRoot);MeshModulesClosureSubset=$([MSBuild]::Escape('$(MeshModulesClosureSubset)'))" />
 
     <ItemGroup>
       <_ModuleFileKept Include="$(_AppPublishDir)modules/**/*.*" />

--- a/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+++ b/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
@@ -34,14 +34,18 @@
     <Compile Include="..\Memex.Database.Migration\DbVersion.cs" Link="DbVersion.cs" />
     <ProjectReference Include="..\..\..\src\MeshWeaver.Hosting.PostgreSql\MeshWeaver.Hosting.PostgreSql.csproj" />
     <ProjectReference Include="..\..\..\src\MeshWeaver.NuGet.AzureBlob\MeshWeaver.NuGet.AzureBlob.csproj" />
-    <!-- 🚨 Referenced for IN-MESH compiles, not for this project's own code. NodeType sources are
-         compiled at runtime against TRUSTED_PLATFORM_ASSEMBLIES — i.e. whatever is in the publish
-         output — so an assembly this portal does not reference is invisible to them no matter that
-         the framework ships it. Memex.Portal.Monolith already references it, which is why
-         `Northwind/Product` (and Cornerstone/Pricing's Excel sample loader) compile in dev and fail
-         on memex-cloud with `CS0234: the type or namespace name 'Import' does not exist in the
-         namespace 'MeshWeaver'`. Do not "clean up" as unused. -->
-    <ProjectReference Include="..\..\..\src\MeshWeaver.Import\MeshWeaver.Import.csproj" />
+    <!-- 🚨 MeshWeaver.Import is deliberately NOT referenced (#1644 step 2), and the reason it was
+         referenced before is preserved rather than dropped. It was here for IN-MESH compiles, never
+         for this project's own code: NodeType sources compile against TRUSTED_PLATFORM_ASSEMBLIES,
+         so an assembly this portal does not reference is invisible to them — which is how
+         Cornerstone/Pricing's Excel sample loader once failed on memex-cloud with `CS0234: the type
+         or namespace name 'Import' does not exist in the namespace 'MeshWeaver'`.
+         The module lane carries that surface now: MeshBuilder.InstallAssemblies registers an
+         InstalledModuleAssembly per listed DLL and CompileReferences.ComposeWithModules adds each
+         one to the reference set, so `MeshWeaver.Import.dll` in Modules:Assemblies IS the
+         declaration. It is listed FIRST there — the reference set is composed from the installed
+         modules, so it must precede anything that compiles against it. The bits ship via the
+         modules/<Name>/ closure layout in MeshModulesPublish.targets. -->
   </ItemGroup>
 
   <!-- Ship nuget.config into the image so the runtime `#r "nuget:..."` resolver can

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -6,6 +6,9 @@
     // data plane (grpc-web Connect+Deliver) AND the py/node foreign-participant transport —
     // delist only where a deployment has neither.
     "Assemblies": [
+      // 🚨 FIRST: the in-mesh compile reference set is composed from the installed modules in
+      // list order, so a module whose content compiles against MeshWeaver.Import must follow it.
+      "MeshWeaver.Import.dll",
       "MeshWeaver.AI.OpenAI.dll",
       "MeshWeaver.AI.AzureFoundry.dll",
       "MeshWeaver.AI.ClaudeCode.dll",

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -174,7 +174,8 @@ that compile surface. Because the reference set is composed in list order, a mod
 content compiles against `MeshWeaver.Import` must be listed **after** it.
 
 Note what a module contributes to that surface: **its entry assembly, not its private closure.** A
-module's own dependencies (here the five `MeshWeaver.DataSetReader.*` assemblies) resolve at
+module's own dependencies (here the six `MeshWeaver.DataSetReader.*` assemblies, plus
+`MeshWeaver.DataStructures` and `CsvHelper`) resolve at
 RUNTIME from the module folder, but they are not metadata references — so in-mesh code may use the
 module's public types freely, and would need the platform to carry any *other* assembly whose types
 appear in those signatures. Keep a module's in-mesh-facing surface self-contained.

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -150,6 +150,7 @@ The current first-party inventory and each module's configuration section:
 | `MeshWeaver.Teams.dll` | Microsoft Teams bot channel: messaging endpoint, inbound routing into threads, proactive replies | `Teams` (inert until bot credentials set) |
 | `MeshWeaver.Courses.dll` | Course delivery: the entitlement-gated `/assets/{Space}/…` route over a Space's synced repo | `GitHub:App:*` (shared with GitSync) |
 | `MeshWeaver.Mail.MicrosoftGraph.dll` | Mail over Microsoft Graph: system email, inbound intake + its webhook, the Executive Assistant's mailbox tools | `Email` (`Enabled`, `InboundEnabled`) |
+| `MeshWeaver.Import.dll` | Tabular import: Excel/CSV readers (its private `MeshWeaver.DataSetReader.*` closure), mapping configuration, the `ImportRequest` handler | — (🚨 list it FIRST — see below) |
 | `MeshWeaver.Hosting.Grpc.dll` | The mesh gRPC transport: `meshweaver.v1.Mesh` + gRPC-web, `py`/`node` foreign participants AND the React GUI's browser data plane | `Grpc` (`TrustedPort`) |
 | `MeshWeaver.Hosting.Cosmos.dll` | Cosmos DB storage backend (keyed adapter factory + native query) | selected by `Graph:Storage:Type` = `Cosmos` |
 | `MeshWeaver.Hosting.Snowflake.dll` | Snowflake storage backend (persistence, change feed, cross-schema query, access projection) | selected by `Graph:Storage:Type` = `Snowflake` |
@@ -160,6 +161,22 @@ grpc-web `Connect`+`Deliver` split at the origin root (`clients/portal-next`, `c
 Delist it only in a deployment with NO React GUI and NO foreign participants; anywhere else a
 delist silently breaks the React frontend's live connection. (The former `Features:Grpc` flag is
 gone — the module listing is the switch.)
+
+🚨 **`MeshWeaver.Import` is listed FIRST, and a module that registers nothing is still doing work.**
+No host ever called `AddImport()` — `AddImport(...)` is an application-level call a data source
+makes for itself, and the portals referenced the assembly for exactly one reason: so that **in-mesh
+source could `using MeshWeaver.Import`**. NodeType sources compile against
+`TRUSTED_PLATFORM_ASSEMBLIES` **composed with the deployment's installed modules**
+(`CompileReferences.ComposeWithModules`), and `MeshBuilder.InstallAssemblies` records an
+`InstalledModuleAssembly` for **every** listed DLL — attribute or not — so listing it is what keeps
+that compile surface. Because the reference set is composed in list order, a module whose own
+content compiles against `MeshWeaver.Import` must be listed **after** it.
+
+Note what a module contributes to that surface: **its entry assembly, not its private closure.** A
+module's own dependencies (here the five `MeshWeaver.DataSetReader.*` assemblies) resolve at
+RUNTIME from the module folder, but they are not metadata references — so in-mesh code may use the
+module's public types freely, and would need the platform to carry any *other* assembly whose types
+appear in those signatures. Keep a module's in-mesh-facing surface self-contained.
 
 Boot packs select by OTHER configuration too: `Graph:Storage:Type` `Cosmos`/`Snowflake` requires
 the matching `MeshWeaver.Hosting.Cosmos`/`.Snowflake` DLL in this list — installation runs before

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-import-is-a-module.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-import-is-a-module.md
@@ -1,0 +1,25 @@
+---
+Name: Excel and CSV import is a module
+Category: Feature
+Description: The import stack and its Excel/CSV readers moved into a MeshWeaver.Import module, so a deployment that never ingests spreadsheets no longer carries it.
+Icon: DocumentTable
+Order: -20260817
+---
+
+# Excel and CSV import is a module
+
+Tabular import — the Excel and CSV readers, the mapping configuration, and the handler that turns
+an uploaded file into typed entities — now ships as `MeshWeaver.Import` instead of being compiled
+into every portal. Along with it goes the whole `MeshWeaver.DataSetReader` family, which nothing
+else in the platform uses.
+
+Every portal shipped today lists it, so nothing changes for anyone importing spreadsheets. What
+changes is that a deployment which never ingests one can leave it out.
+
+Content keeps working the same way. Node sources that write `using MeshWeaver.Import` — a pricing
+sheet's import configuration, for instance — still compile: a listed module joins the same
+reference set the platform's own assemblies are on. That is why the module is listed first, ahead
+of anything that compiles against it.
+
+One thing this is honestly *not*: a smaller image. The spreadsheet libraries themselves are used
+elsewhere in the portal and stay exactly where they were.

--- a/src/MeshWeaver.Import/ImportModuleAttribute.cs
+++ b/src/MeshWeaver.Import/ImportModuleAttribute.cs
@@ -1,0 +1,45 @@
+using MeshWeaver.Mesh;
+
+[assembly: MeshWeaver.Import.ImportMeshModule]
+
+namespace MeshWeaver.Import;
+
+/// <summary>
+/// The import stack as a module: <c>MeshWeaver.Import</c> plus its private
+/// <c>MeshWeaver.DataSetReader.*</c> closure (CSV, the two Excel formats, the shared utils) —
+/// tabular ingestion, the Excel/CSV readers, the mapping configuration and the
+/// <c>ImportRequest</c> handler.
+///
+/// <para>🚨 <b>This module registers nothing.</b> That is deliberate and it is the whole point.
+/// No host ever called <c>AddImport()</c>: <c>MessageHubConfiguration.AddImport(...)</c> is an
+/// APPLICATION-level call a data source makes for itself, and both portals referenced this
+/// assembly for exactly one reason — so that IN-MESH source could <c>using MeshWeaver.Import</c>.
+/// NodeType sources compile against <c>TRUSTED_PLATFORM_ASSEMBLIES</c> composed with the
+/// deployment's installed modules (<c>CompileReferences.ComposeWithModules</c>), and
+/// <c>MeshBuilder.InstallAssemblies</c> registers an <c>InstalledModuleAssembly</c> for every
+/// listed DLL — so listing this one preserves that compile surface exactly, with no compiled
+/// reference from either host.</para>
+///
+/// <para>🚨 <b>Order matters in <c>Modules:Assemblies</c>.</b> The compile reference set is
+/// composed from the installed modules, so this DLL must be listed BEFORE any module whose own
+/// content compiles against it. It is listed first in both portals.</para>
+///
+/// <para>This is NOT a dependency win, and must not be advertised as one: <c>ClosedXML</c>,
+/// <c>DocumentFormat.OpenXml</c> and <c>CsvHelper</c> stay in the image regardless, pulled in by
+/// <c>MeshWeaver.Blazor</c> and <c>MeshWeaver.ContentCollections</c>. What the flip buys is that
+/// the import stack itself — and the DataSetReader family, which nothing else references — is a
+/// deployment's choice rather than every portal's fixed cost.</para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class ImportMeshModuleAttribute : MeshNodeProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<MeshNode> Nodes =>
+    [
+        new MeshNode("MeshWeaver.Import")
+        {
+            Name = "Import (Excel / CSV)",
+            NodeType = "ModuleDefinition",
+        },
+    ];
+}

--- a/src/MeshWeaver.Import/MeshWeaver.Import.csproj
+++ b/src/MeshWeaver.Import/MeshWeaver.Import.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{a5fcd4c2-4a9d-43c0-a65b-a868af8deb27}</ProjectGuid>
     <RootNamespace>MeshWeaver.Import</RootNamespace>
+    <Description>Tabular import for MeshWeaver: Excel/CSV readers, the mapping configuration and the ImportRequest handler. Ships as a module — list the DLL under Modules:Assemblies to activate (and to put it on the in-mesh compile surface).</Description>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ClosedXML" />
@@ -11,5 +12,7 @@
     <ProjectReference Include="..\MeshWeaver.DataSetReader.Excel\MeshWeaver.DataSetReader.Excel.csproj" />
     <ProjectReference Include="..\MeshWeaver.Data\MeshWeaver.Data.csproj" />
     <ProjectReference Include="..\MeshWeaver.ContentCollections\MeshWeaver.ContentCollections.csproj" />
+    <!-- MeshNodeProviderAttribute — the module half (ImportModuleAttribute). -->
+    <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Memex.Portal.Shared.Test/ImportModuleLayoutTest.cs
+++ b/test/Memex.Portal.Shared.Test/ImportModuleLayoutTest.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The import stack's deployment-shape gate. <c>MeshWeaver.Import</c> ships as a
+/// <c>modules/&lt;Name&gt;/</c> closure with its ENTIRE private reader family inside it — the five
+/// <c>MeshWeaver.DataSetReader.*</c> assemblies plus <c>CsvHelper</c>, none of which any host
+/// references — so the folder either loads as a unit or the first spreadsheet import faults.
+///
+/// <para>🚨 It has to be gated HERE, not from a portal boot. <c>Memex.Portal.Monolith</c> bundles
+/// the Northwind SAMPLE, whose data sources call <c>AddImport()</c>, so Import rides that host's
+/// app closure and <c>ResolveModulePath</c> falls back to the app folder — booting it proves the
+/// module list resolves but says NOTHING about the module-only layout every other deployment runs.
+/// This project holds no compiled reference to any of it, which is the whole claim under test.</para>
+/// </summary>
+public class ImportModuleLayoutTest
+{
+    private const string ModuleName = "MeshWeaver.Import";
+
+    /// <summary>
+    /// The private closure that must ride the prune. Named rather than inferred, for the same
+    /// reason the storage gate names its drivers: their presence is the single thing the prune can
+    /// take away, and dropping one should be a deliberate edit here rather than a silently
+    /// weakened assertion.
+    /// </summary>
+    public static TheoryData<string> PrivateClosure() =>
+    [
+        "MeshWeaver.DataStructures.dll",   // IDataSet / IDataTable / IDataRow — the reader contract
+        "MeshWeaver.DataSetReader.dll",
+        "MeshWeaver.DataSetReader.Csv.dll",
+        "MeshWeaver.DataSetReader.Excel.dll",
+        "MeshWeaver.DataSetReader.Excel.BinaryFormat.dll",
+        "MeshWeaver.DataSetReader.Excel.OpenXmlFormat.dll",
+        "MeshWeaver.DataSetReader.Excel.Utils.dll",
+        "CsvHelper.dll",
+    ];
+
+    [Fact]
+    public void ClosureLane_LaysImportOut_UnderModules()
+    {
+        var expected = Path.Combine(AppContext.BaseDirectory, "modules", ModuleName, ModuleName + ".dll");
+        var resolved = MeshBuilder.ResolveModulePath(ModuleName + ".dll");
+
+        // ResolveModulePath falls back to the app folder when modules/<Name>/<Name>.dll is absent,
+        // so "the file exists" is NOT the assertion — WHERE it resolved is.
+        Assert.True(File.Exists(resolved),
+            $"{ModuleName}: the closure lane laid out nothing loadable — ResolveModulePath returned '{resolved}', which does not exist.");
+        Assert.Equal(expected, resolved);
+    }
+
+    [Theory]
+    [MemberData(nameof(PrivateClosure))]
+    public void ImportModule_CarriesItsReaderFamily(string assemblyFile)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "modules", ModuleName, assemblyFile);
+
+        Assert.True(File.Exists(path),
+            $"'{assemblyFile}' is missing from modules/{ModuleName}/. Nothing in the app closure "
+            + "references it, so a deployment importing a spreadsheet would fault at first read. "
+            + "Check the closure lane's prune in memex/MeshModulesPublish.targets.");
+        Assert.NotNull(Assembly.LoadFrom(path));
+    }
+
+    /// <summary>
+    /// The seam a portal walks: <c>InstallAssemblies</c> loads the module folder DLL, folds its
+    /// <see cref="MeshNodeProviderAttribute"/>, and — the point of this module — records an
+    /// <see cref="InstalledModuleAssembly"/> so the in-mesh compile reference set gets it. It
+    /// registers no services BY DESIGN: <c>AddImport()</c> is an application-level call a data
+    /// source makes for itself, never the host's.
+    /// </summary>
+    [Fact]
+    public void Portal_WithNoCompiledReference_InstallsImportAsAModule()
+    {
+        var modulePath = MeshBuilder.ResolveModulePath(ModuleName + ".dll");
+
+        var serviceConfigs = new List<Func<IServiceCollection, IServiceCollection>>();
+        var builder = new MeshBuilder(configure => serviceConfigs.Add(configure), AddressExtensions.CreateMeshAddress());
+        builder.InstallAssemblies(modulePath);
+        var services = serviceConfigs.Aggregate(
+            (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+
+        var installed = Assert.Single(services
+            .Where(d => d.ServiceType == typeof(InstalledModuleAssembly))
+            .Select(d => (InstalledModuleAssembly)d.ImplementationInstance!));
+
+        // From THAT dll — an app-root copy resolving here would make the assertion true of the
+        // wrong bytes, which is precisely the false green the Monolith would give.
+        Assert.Equal(modulePath, installed.Assembly.Location);
+
+        // …and the private closure binds FROM THE MODULE FOLDER. ImportRequest.DataSetReaderOptions
+        // is typed in MeshWeaver.DataSetReader, which no host references, so resolving this property
+        // type is the load a spreadsheet import walks. A missing or mismatched private dependency
+        // surfaces here as a loader exception naming what broke — no file, no hub, milliseconds.
+        var moduleFolder = Path.GetDirectoryName(modulePath)!;
+        var optionsType = installed.Assembly
+            .GetType("MeshWeaver.Import.ImportRequest", throwOnError: true)!
+            .GetProperty("DataSetReaderOptions")!
+            .PropertyType;
+        Assert.Equal("MeshWeaver.DataSetReader", optionsType.Assembly.GetName().Name);
+        Assert.Equal(moduleFolder, Path.GetDirectoryName(optionsType.Assembly.Location));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/ImportModuleLayoutTest.cs
+++ b/test/Memex.Portal.Shared.Test/ImportModuleLayoutTest.cs
@@ -12,7 +12,7 @@ namespace Memex.Portal.Shared.Test;
 
 /// <summary>
 /// The import stack's deployment-shape gate. <c>MeshWeaver.Import</c> ships as a
-/// <c>modules/&lt;Name&gt;/</c> closure with its ENTIRE private reader family inside it — the five
+/// <c>modules/&lt;Name&gt;/</c> closure with its ENTIRE private reader family inside it — the six
 /// <c>MeshWeaver.DataSetReader.*</c> assemblies plus <c>CsvHelper</c>, none of which any host
 /// references — so the folder either loads as a unit or the first spreadsheet import faults.
 ///

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -1,16 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <!-- ═════════ The storage-backend contract gate (#1752) ═════════
-       StorageModuleLayoutTest loads the Cosmos/Snowflake backends the way a PORTAL does — off
-       disk, from modules/<Name>/, with NO compiled reference — so the layout has to exist in THIS
-       project's own bin. Reuse the real lane (MeshModulesClosureSubset narrows it to these two)
-       rather than hand-copying a publish+prune here: a copy would be a second detector, free to
-       agree with itself while the shipped layout is broken.
+  <!-- ═════════ The module-layout contract gate (#1752) ═════════
+       StorageModuleLayoutTest and ImportModuleLayoutTest load their modules the way a PORTAL does —
+       off disk, from modules/<Name>/, with NO compiled reference — so the layout has to exist in
+       THIS project's own bin. Reuse the real lane (MeshModulesClosureSubset narrows it to the
+       modules named below) rather than hand-copying a publish+prune here: a copy would be a second
+       detector, free to agree with itself while the shipped layout is broken.
 
-       🚨 Deliberately NO ProjectReference to either backend. One would put the module's own DLL in
+       🚨 Deliberately NO ProjectReference to any of them. One would put the module's own DLL in
        this bin's root, where prune (a) deletes it from modules/ as a same-identity duplicate — the
-       gate would then load the app-root copy and assert nothing about the shipped layout. -->
+       gate would then load the app-root copy and assert nothing about the shipped layout. That is
+       exactly why MeshWeaver.Import is gated HERE and not in Memex.Portal.Monolith's own tests: the
+       dev portal still carries Import in its app closure through the Northwind sample, so it is a
+       false green for the module-only path every other deployment runs. -->
   <PropertyGroup>
-    <MeshModulesClosureSubset>MeshWeaver.Hosting.Cosmos;MeshWeaver.Hosting.Snowflake</MeshModulesClosureSubset>
+    <MeshModulesClosureSubset>MeshWeaver.Hosting.Cosmos;MeshWeaver.Hosting.Snowflake;MeshWeaver.Import</MeshModulesClosureSubset>
   </PropertyGroup>
   <Import Project="..\..\memex\MeshModulesPublish.targets" />
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/ImportModuleContributionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ImportModuleContributionTest.cs
@@ -23,7 +23,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 ///
 /// <para>So the thing that has to hold is not a service descriptor: it is that listing the DLL puts
 /// it on the <b>in-mesh compile reference set</b>, and that the types in-mesh content actually uses
-/// compile with the module's ENTRY assembly alone — a module's private closure (here the five
+/// compile with the module's ENTRY assembly alone — a module's private closure (here the six
 /// <c>MeshWeaver.DataSetReader.*</c> assemblies) resolves at runtime from the module folder but is
 /// NOT a metadata reference. Both are asserted below, the second by compiling the real shape from
 /// <c>Cornerstone/Pricing</c>'s <c>MicrosoftSampleData</c> node source.</para>
@@ -67,7 +67,15 @@ public class ImportModuleContributionTest
     /// deployment where Import is module-only — and NOT in the dev Monolith, which still carries
     /// Import in its app closure through the Northwind sample. That asymmetry makes a portal
     /// boot-smoke a false green here, so the claim is pinned as a compile instead: the real node
-    /// source shape, against corelib + MeshWeaver.Import.dll and nothing else from the import stack.
+    /// source shape, against the deployment's own reference set.
+    ///
+    /// <para>🚨 The reference set is <see cref="CompileReferences.ComposeWithModules"/> — the
+    /// PRODUCTION composition, not a hand-listed one — <b>minus the module's private closure</b>.
+    /// Subtracting is the entire experiment: this test process resolves Import through an ordinary
+    /// ProjectReference, so its <c>TRUSTED_PLATFORM_ASSEMBLIES</c> carry the DataSetReader family
+    /// too, and composing without the filter would pass no matter what leaked. What is left models
+    /// the deployment exactly — platform TPA plus the module ENTRY assembly, which is all
+    /// <c>ComposeWithModules</c> ever contributes.</para>
     /// </summary>
     [Fact]
     public void InMeshSource_CompilesAgainstTheEntryAssemblyAlone()
@@ -103,17 +111,26 @@ public class ImportModuleContributionTest
             }
             """;
 
-        // corelib + the framework facades the SDK splits System.* across, then the module's entry
-        // assembly — and NOTHING from its private DataSetReader closure.
-        var coreDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-        var references = new List<MetadataReference>
-        {
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-            MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.Runtime.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.Collections.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.ComponentModel.Annotations.dll")),
-            MetadataReference.CreateFromFile(typeof(ExcelImportConfiguration).Assembly.Location),
-        };
+        var entry = typeof(ExcelImportConfiguration).Assembly;
+        var composed = CompileReferences.ComposeWithModules([new InstalledModuleAssembly(entry)]);
+
+        // Everything the module folder carries privately — the closure ComposeWithModules never
+        // adds. Prefix-matched so a new reader assembly joins the subtraction automatically rather
+        // than quietly weakening the experiment.
+        string[] modulePrivatePrefixes = ["MeshWeaver.DataSetReader", "MeshWeaver.DataStructures"];
+        var references = composed
+            .Where(r => !modulePrivatePrefixes.Any(prefix =>
+                Path.GetFileName(r.Display ?? string.Empty)
+                    .StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        // The subtraction has to have BITTEN and the entry assembly has to have SURVIVED, or the
+        // compile below would prove the opposite of what it claims.
+        Assert.True(references.Count < composed.Count,
+            "The private-closure filter matched nothing — this process does not carry the "
+            + "DataSetReader assemblies, so the compile below cannot falsify a leak.");
+        Assert.Contains(references, r => string.Equals(
+            r.Display, entry.Location, StringComparison.OrdinalIgnoreCase));
 
         var compilation = CSharpCompilation.Create(
             "InMeshSampleCompile",

--- a/test/MeshWeaver.Hosting.Monolith.Test/ImportModuleContributionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ImportModuleContributionTest.cs
@@ -1,0 +1,135 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using MeshWeaver.Compiler;
+using MeshWeaver.Import;
+using MeshWeaver.Import.Configuration;
+using MeshWeaver.Mesh;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the import stack's module shape. Import is the module that <b>registers nothing</b>: no
+/// host ever called <c>AddImport()</c> — that is an application-level call a data source makes for
+/// itself — and both portals referenced the assembly for exactly one reason, so that IN-MESH source
+/// could <c>using MeshWeaver.Import</c>.
+///
+/// <para>So the thing that has to hold is not a service descriptor: it is that listing the DLL puts
+/// it on the <b>in-mesh compile reference set</b>, and that the types in-mesh content actually uses
+/// compile with the module's ENTRY assembly alone — a module's private closure (here the five
+/// <c>MeshWeaver.DataSetReader.*</c> assemblies) resolves at runtime from the module folder but is
+/// NOT a metadata reference. Both are asserted below, the second by compiling the real shape from
+/// <c>Cornerstone/Pricing</c>'s <c>MicrosoftSampleData</c> node source.</para>
+/// </summary>
+public class ImportModuleContributionTest
+{
+    [Fact]
+    public void TheAssembly_CarriesTheMeshModuleAttribute_AndRegistersNothing()
+    {
+        var assembly = typeof(ImportMeshModuleAttribute).Assembly;
+
+        var meshHalf = Assert.Single(assembly.GetCustomAttributes<MeshNodeProviderAttribute>());
+        var node = Assert.Single(meshHalf.Nodes);
+        Assert.Equal("ModuleDefinition", node.NodeType);
+        // Deliberately empty: AddImport() is the application's call, never the host's.
+        Assert.Empty(node.GlobalServiceConfigurations);
+        Assert.Empty(meshHalf.BuilderConfigurations);
+
+        // No endpoint half — the import stack publishes no HTTP surface, and this assembly does
+        // not reference the ASP.NET hook at all (matched by name so it stays reference-free).
+        Assert.DoesNotContain(
+            assembly.GetCustomAttributes(),
+            a => a.GetType().BaseType?.Name == "MeshEndpointProviderAttribute");
+    }
+
+    [Fact]
+    public void InstalledModule_JoinsTheInMeshCompileReferenceSet()
+    {
+        var module = new InstalledModuleAssembly(typeof(ImportMeshModuleAttribute).Assembly);
+
+        var composed = CompileReferences.ComposeWithModules([module]);
+
+        Assert.Contains(composed, r => string.Equals(
+            r.Display, module.Assembly.Location, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// 🚨 The falsification that matters. `ComposeWithModules` adds the module's ENTRY assembly
+    /// only, so if <c>ExcelImportConfiguration</c> (or anything on its base chain) exposed a
+    /// <c>MeshWeaver.DataSetReader</c> type, in-mesh source would fail CS0012 in exactly the
+    /// deployment where Import is module-only — and NOT in the dev Monolith, which still carries
+    /// Import in its app closure through the Northwind sample. That asymmetry makes a portal
+    /// boot-smoke a false green here, so the claim is pinned as a compile instead: the real node
+    /// source shape, against corelib + MeshWeaver.Import.dll and nothing else from the import stack.
+    /// </summary>
+    [Fact]
+    public void InMeshSource_CompilesAgainstTheEntryAssemblyAlone()
+    {
+        // The shape of samples/Graph/Data/Cornerstone/Pricing/Source/MicrosoftSampleData.cs.
+        const string source = """
+            using System.Collections.Generic;
+            using MeshWeaver.Import.Configuration;
+
+            public static class InMeshSample
+            {
+                public static readonly ExcelImportConfiguration[] ImportConfigs =
+                [
+                    new()
+                    {
+                        Name = "Microsoft.xlsx",
+                        Address = "pricing/Microsoft/2026",
+                        TypeName = "PropertyRisk",
+                        DataStartRow = 7,
+                        TotalRowMarkers = new HashSet<string> { "Total", "Grand Total" },
+                        TotalRowScanAllCells = true,
+                        TotalRowMatchExact = false,
+                        Mappings =
+                        [
+                            new() { TargetProperty = "Id", Kind = MappingKind.Direct, SourceColumns = ["C"] },
+                            new() { TargetProperty = "PricingId", Kind = MappingKind.Constant, ConstantValue = "2026" },
+                            new() { TargetProperty = "TsiContent", Kind = MappingKind.Sum, SourceColumns = ["G", "I"] }
+                        ],
+                        Allocations = [new() { TargetProperty = "TsiBi", WeightColumns = ["Q"] }],
+                        IgnoreRowExpressions = ["Id == null"]
+                    }
+                ];
+            }
+            """;
+
+        // corelib + the framework facades the SDK splits System.* across, then the module's entry
+        // assembly — and NOTHING from its private DataSetReader closure.
+        var coreDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.Runtime.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.Collections.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.ComponentModel.Annotations.dll")),
+            MetadataReference.CreateFromFile(typeof(ExcelImportConfiguration).Assembly.Location),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            "InMeshSampleCompile",
+            [CSharpSyntaxTree.ParseText(source)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.ToString())
+            .ToList();
+
+        Assert.True(errors.Count == 0,
+            "In-mesh source must compile with the Import module's entry assembly alone — a CS0012 "
+            + "here means a MeshWeaver.DataSetReader type leaked into the public surface in-mesh "
+            + "content uses, which would break every deployment where Import is module-only:\n"
+            + string.Join("\n", errors));
+    }
+}


### PR DESCRIPTION
`MeshWeaver.Import` — and its private `MeshWeaver.DataSetReader.*` closure, which nothing else in the tree references — leaves both portals' compiled reference graphs and rides the `modules/<Name>/` closure lane. Listing `MeshWeaver.Import.dll` under `Modules:Assemblies` is the complete activation (restart-required).

## 🚨 This module registers nothing, and that is the point

No host ever called `AddImport()`. `MessageHubConfiguration.AddImport(...)` is an **application-level** call a data source makes for itself, and both portals referenced the assembly for exactly one reason — so IN-MESH source could `using MeshWeaver.Import` (there was a 🚨 comment in `Memex.Portal.Distributed.csproj` saying so).

That surface is preserved, not dropped: `MeshBuilder.InstallAssemblies` records an `InstalledModuleAssembly` for **every** listed DLL, attribute or not, and `CompileReferences.ComposeWithModules` adds each one to the NodeType compile reference set. Import is therefore listed **first** in both portals — the set is composed in list order, so it must precede anything that compiles against it.

**Not a dependency win, and not advertised as one**: `ClosedXML` and `DocumentFormat.OpenXml` stay in the image via `MeshWeaver.Blazor` / `MeshWeaver.ContentCollections` and prune straight out of the module folder. What actually ships in `modules/MeshWeaver.Import/` on the image is the entry assembly, the six `MeshWeaver.DataSetReader.*` assemblies, `MeshWeaver.DataStructures` and `CsvHelper` — all genuinely private (verified against a real `dotnet publish` of `Memex.Portal.Distributed`).

## One host keeps Import in its app closure, deliberately

`Memex.Portal.Monolith` bundles the **Northwind sample**, whose data sources call `AddImport()` over the sample CSVs. That transitive reference is the documented **thin-lane** state — `modules/` prunes empty and `ResolveModulePath` falls back to the app folder for the same assembly — so the dev portal turns the publish-time app-root refusal off through a new `MeshModulesGuardPublishAppRoot` property.

🚨 **Host-scoped, never module-scoped.** Exempting the *module* would disarm the check in the published image too, which is the one place it is load-bearing — a gate that cannot fail is not a gate. `Memex.Portal.Distributed` keeps it **armed for every module**; verified by property evaluation (`Monolith → false`, `Distributed → true`, `Portal.Shared.Test → true`) and by a real publish of Distributed, which passes the guard.

## The Monolith is a false green here, so the claims are pinned as tests

Because Import still rides the dev portal's app closure, booting it proves the module list resolves but says nothing about the module-only path every other deployment runs. The two claims that matter are therefore asserted directly:

- **`ImportModuleLayoutTest`** (in `Memex.Portal.Shared.Test`, which holds no compiled reference to any of it) loads the module the way a portal does: `ResolveModulePath` lands *inside* `modules/`, the whole reader family survived the prune and loads, `InstallAssemblies` records the `InstalledModuleAssembly` from **that** DLL, and `ImportRequest.DataSetReaderOptions` resolves its type out of the module folder.
- **`ImportModuleContributionTest`** compiles the real shape of `Cornerstone/Pricing`'s `MicrosoftSampleData` node source against corelib + `MeshWeaver.Import.dll` **alone**. `ComposeWithModules` contributes a module's *entry* assembly, not its closure — so a `DataSetReader` type leaking into the public surface in-mesh content uses would be `CS0012` in every deployment except the dev Monolith. It does not leak; this test is what keeps it that way.

## Verification

`MW_ALLOW_SOLUTION_BUILD=1 dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` → **0 errors, 0 warnings** (re-run after merging main, which now carries #1769).

`MeshWeaver.Import.Test` 21/21 · the two new module tests 13/13 · `StorageModuleLayoutTest` + `ModuleLaneSwitchTest` green (the closure subset changed) · `DocumentationLinkIntegrityTest` green. Booted Monolith: the platform starts with the new module list, and `Cornerstone/Pricing` — the in-mesh `using MeshWeaver.Import` consumer — compiles clean at runtime (`Compile SUCCEEDED … loaded`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)