### PR TITLE
fix(#1772): the bundle routes authorize per package, not just authenticate

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -207,6 +207,7 @@ public static class PluginBundleEndpoints
         var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}";
 
         return InstalledPackages(rootHub, ct)
+            .Do(packages => WarnAboutUnstampedRecords(rootHub, packages))
             .Select(packages => (IReadOnlyList<BundleEntry>)packages
                 .Where(p => IsGranted(caller, p)).ToArray())
             .SelectMany(packages => ServableModules(rootHub, packages)
@@ -238,6 +239,35 @@ public static class PluginBundleEndpoints
                 })))
             .FirstAsync()
             .ToTask(ct);
+    }
+
+    /// <summary>
+    /// 🚨 Names, on the index request, every install record with NO <see cref="BundleEntry.Source"/>
+    /// — the records <see cref="IsGranted"/> can never match, and which are therefore servable to
+    /// nobody.
+    ///
+    /// <para>It belongs HERE rather than only on the download path, because the filtered index means
+    /// that path is never reached for such a record: a consumer polls the index, does not see the
+    /// package, and never asks for it. Without this line the whole distribution lane could go dark
+    /// with nothing in the log at all — every consumer just quietly compiling, which looks exactly
+    /// like a healthy day. Normally this logs nothing, since a record installed through any registry
+    /// lane carries its source.</para>
+    /// </summary>
+    private static void WarnAboutUnstampedRecords(
+        IMessageHub rootHub, IReadOnlyList<BundleEntry> packages)
+    {
+        var unstamped = packages.Where(p => string.IsNullOrWhiteSpace(p.Source)).ToArray();
+        if (unstamped.Length == 0)
+            return;
+
+        rootHub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(PluginBundleEndpoints))
+            .LogWarning(
+                "Plugin bundles: {Count} install record(s) carry no registry source, so no "
+                + "PluginGrant can match them and their bundles are servable to NO instance: "
+                + "{Packages}. Re-install them through the registry to stamp the source (#1772).",
+                unstamped.Length,
+                string.Join(", ", unstamped.Select(p => p.PluginId).Take(MissesReported)));
     }
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -40,6 +40,21 @@ namespace Memex.Portal.Shared.Api;
 /// <see cref="PluginGrant"/> that says which packages that install may read. Same gate as
 /// <c>/api/plugins</c>, deliberately: a second entitlement path is a second thing to get wrong, and
 /// this one is already what purchases are recorded against.</para>
+///
+/// <para>🚨 <b>The key is TWO decisions, and for a long time only the first one ran (#1772).</b> The
+/// filter below authenticates — a valid <c>mwi_</c> key or 401 — and <see cref="IsGranted"/>
+/// authorizes, per package, on <b>both</b> routes. Until #1772 the authenticated caller was written
+/// into <see cref="HttpContext.Items"/> and never read back, so any registered instance could
+/// download every installed package's bundle, paid courses included, while this very paragraph said
+/// otherwise. An instance key is provisioned to every registered installation; it is identity, never
+/// entitlement. The grant model is <see cref="PluginGrantEntry"/> matched against the install
+/// record's <see cref="PackageManifest.Source"/> — the same match <c>InstallByDefault</c> and
+/// <c>/api/plugins</c> make, so there is exactly one thing to keep honest.</para>
+///
+/// <para>🚨 <b>A refusal is byte-identical to "no such bundle"</b> (<see cref="NoSuchBundle"/>), and
+/// an ungranted package is absent from the index. The URL scheme is fully predictable, so a
+/// distinguishable refusal would be an inventory oracle over the whole catalogue — the same reasoning
+/// that made <c>/api/content</c>'s refusal identical to its not-found (#587).</para>
 /// </summary>
 public static class PluginBundleEndpoints
 {
@@ -90,7 +105,7 @@ public static class PluginBundleEndpoints
         // throws (500) instead of the 401 the filter would have returned. The rejection path must
         // not need anything but the header.
         group.MapGet("/index.json", (HttpContext http, CancellationToken ct) =>
-            Index(http, RootHub(http), ct));
+            Index(http, RootHub(http), Caller(http), ct));
 
         // 🚨 `identity`/`arch` are the CONSUMER's lane (#1751), not a filter the caller invents: they
         // say which framework build identity and which architecture the caller can actually run, and
@@ -103,10 +118,58 @@ public static class PluginBundleEndpoints
                     RootHub(http), plugin, version,
                     Requested(http, "identity", FrameworkMvid),
                     Requested(http, "arch", ReleaseArchitecture.Live),
+                    Caller(http),
                     ct));
 
         return endpoints;
     }
+
+    /// <summary>
+    /// The authenticated caller the filter stamped, or <c>null</c>.
+    ///
+    /// <para>🚨 Null can only mean the filter did not run — it has no anonymous branch, unlike
+    /// <c>/api/plugins</c>. It is therefore treated as "granted nothing" rather than "unscoped", so a
+    /// route accidentally mapped outside the group serves an empty index and a 404, never the whole
+    /// catalogue. The absence of an answer is never a yes (#1772).</para>
+    /// </summary>
+    private static AuthenticatedInstance? Caller(HttpContext http) =>
+        http.Items.TryGetValue(CallerItemKey, out var value) ? value as AuthenticatedInstance : null;
+
+    /// <summary>
+    /// 🚨 <b>THE PER-PACKAGE AUTHORIZATION</b> (#1772) — whether <paramref name="caller"/> may pull
+    /// <paramref name="package"/>, decided by the admin-owned <see cref="PluginGrant"/> its key
+    /// resolved to.
+    ///
+    /// <para>The grant is a set of <c>(source, package)</c> pairs, so the install record's
+    /// <see cref="PackageManifest.Source"/> — the registry source it was installed FROM — is what the
+    /// entry is matched against. Exactly the reading <c>PluginRegistryEndpoints</c> applies to its
+    /// listing and <c>InstanceAutoRegistrationService</c> applies to <c>InstallByDefault</c>; a
+    /// second, bundle-specific notion of entitlement would be a second thing to keep in step with
+    /// what purchases are recorded against.</para>
+    ///
+    /// <para>🚨 <b>An unstamped source fails CLOSED.</b> A record whose <c>Source</c> is null (one
+    /// written before the field existed, or installed from something that is not a configured
+    /// registry source) matches no entry at all — <see cref="PluginGrantEntry.Matches"/> compares the
+    /// source name, and <c>""</c> equals none of them. "Cannot determine" is a refusal, never a pass.
+    /// The consumer's own <c>PluginBundleClient</c> reads the resulting 404 as "no prebuilt bundle —
+    /// will compile", so the cost of that refusal is a compile, never a failed install.</para>
+    /// </summary>
+    private static bool IsGranted(AuthenticatedInstance? caller, BundleEntry package) =>
+        caller is not null && caller.Allows(package.Source ?? "", package.PluginId);
+
+    /// <summary>
+    /// 🚨 The ONE answer for a bundle this caller cannot have — used for "no such package", "no such
+    /// version" and "not granted to you" alike, so the three are byte-identical: same status, same
+    /// (empty) body, same headers.
+    ///
+    /// <para>The URL is <c>/{plugin}/{version}</c> and every plugin id in the catalogue is public
+    /// knowledge, so a distinguishable refusal (403, or a 404 with a different body) would let any
+    /// registered instance enumerate what this registry carries and at which versions — the exact
+    /// existence oracle <c>/api/content</c> closed in #587 by making its refusal identical to its
+    /// not-found. WHICH of the three it was is written to the LOG, where the caller cannot read
+    /// it.</para>
+    /// </summary>
+    private static IResult NoSuchBundle() => Results.NotFound();
 
     /// <summary>One query-string value, or the serving instance's own value when the caller did not
     /// state one. Blank is treated as absent — an empty <c>?identity=</c> is a client bug, and
@@ -130,12 +193,22 @@ public static class PluginBundleEndpoints
     /// <para>Absolute URLs are built from the REQUEST rather than configuration: an instance reached
     /// through an ingress, a port-forward or a custom domain must advertise the host the caller
     /// actually used, or every follow-up request goes somewhere it cannot reach.</para>
+    ///
+    /// <para>🚨 <b>Scoped to what the caller was GRANTED</b> (#1772, <see cref="IsGranted"/>) — an
+    /// ungranted package is simply not listed, so a caller cannot even learn it is installed here.
+    /// That is what makes the download route's refusal non-informative: with the index filtered, "not
+    /// in your index" and "404 on fetch" agree, and neither confirms existence. A caller granted
+    /// nothing gets an empty <c>bundles</c> array, indistinguishable from a registry with nothing
+    /// installed.</para>
     /// </summary>
-    private static Task<IResult> Index(HttpContext http, IMessageHub rootHub, CancellationToken ct)
+    private static Task<IResult> Index(
+        HttpContext http, IMessageHub rootHub, AuthenticatedInstance? caller, CancellationToken ct)
     {
         var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}";
 
         return InstalledPackages(rootHub, ct)
+            .Select(packages => (IReadOnlyList<BundleEntry>)packages
+                .Where(p => IsGranted(caller, p)).ToArray())
             .SelectMany(packages => ServableModules(rootHub, packages)
                 .Select(modules => Results.Json(new
                 {
@@ -205,20 +278,45 @@ public static class PluginBundleEndpoints
     /// <para>Assembled on request rather than stored, because the inputs ARE the storage — this
     /// portal has the bake's assemblies, and a second copy kept "for distribution" is a copy that
     /// can disagree with what the portal runs.</para>
+    ///
+    /// <para>🚨 <b>The caller's grant is part of the RESOLUTION, not a check bolted on after it</b>
+    /// (#1772) — an ungranted package does not match, so there is no branch in which bytes are
+    /// assembled first and refused later, and nothing downstream has to remember to ask. Every miss
+    /// answers <see cref="NoSuchBundle"/>; which of the three it was goes to the log only.</para>
     /// </summary>
     private static Task<IResult> Bundle(
         IMessageHub rootHub, string plugin, string version, string identity, string architecture,
-        CancellationToken ct) =>
+        AuthenticatedInstance? caller, CancellationToken ct) =>
         InstalledPackages(rootHub, ct)
             .SelectMany(packages =>
             {
-                var match = packages.FirstOrDefault(p =>
+                // Named apart from the query-string reader Requested(HttpContext, …) above — one
+                // shadowing the other reads as a call to the wrong thing.
+                bool IsAsked(BundleEntry p) =>
                     string.Equals(p.PluginId, plugin, StringComparison.OrdinalIgnoreCase)
-                    && string.Equals(p.Version, version, StringComparison.OrdinalIgnoreCase));
+                    && string.Equals(p.Version, version, StringComparison.OrdinalIgnoreCase);
 
-                return match is null
-                    ? Observable.Return(Results.NotFound())
-                    : Assemble(rootHub, match, identity, architecture);
+                var match = packages.FirstOrDefault(p => IsAsked(p) && IsGranted(caller, p));
+                if (match is not null)
+                    return Assemble(rootHub, match, identity, architecture);
+
+                // The refusal is uniform on the wire; the LOG is where it is diagnosable, naming
+                // which instance asked and whether the record exists at all — including the
+                // fail-closed case an operator would otherwise chase for hours: an install record
+                // with no Source stamped can be granted by nobody (see IsGranted).
+                var installed = packages.FirstOrDefault(IsAsked);
+                rootHub.ServiceProvider.GetService<ILoggerFactory>()
+                    ?.CreateLogger(typeof(PluginBundleEndpoints))
+                    .LogWarning(
+                        "Plugin bundles: {Plugin}@{Version} refused for instance {Instance} — {Reason}",
+                        plugin, version, caller?.Instance.InstanceId ?? "(none)",
+                        installed is null
+                            ? "no such install record on this instance"
+                            : installed.Source is { Length: > 0 } source
+                                ? $"installed from source '{source}', which this instance's grant does not cover"
+                                : "the install record carries NO source, so no grant entry can match it "
+                                  + "(re-install it through the registry to stamp one)");
+                return Observable.Return(NoSuchBundle());
             })
             .FirstAsync()
             .ToTask(ct);
@@ -517,6 +615,12 @@ public static class PluginBundleEndpoints
     /// neighbour substitutes: <c>Version</c> is the whole-repo commit sha and <c>ModuleVersion</c>
     /// is a content hash, which is exact but unordered — it cannot answer "which is newer", the one
     /// question a distribution index is asked.</para>
+    ///
+    /// <para>🚨 <b>Unscoped by design — every caller of this method must apply
+    /// <see cref="IsGranted"/>.</b> It is the full inventory, which is precisely what no caller may
+    /// see; the grant filter lives at the two route handlers because the download route also needs
+    /// the unfiltered list to write a diagnosable log line. The <see cref="BundleEntry.Source"/> each
+    /// entry carries is the only input that decision needs.</para>
     /// </summary>
     private static IObservable<IReadOnlyList<BundleEntry>> InstalledPackages(
         IMessageHub rootHub, CancellationToken ct) =>
@@ -531,14 +635,24 @@ public static class PluginBundleEndpoints
                 .Where(m => m is not null && !string.IsNullOrWhiteSpace(m.ReleasedVersion))
                 .Select(m => new BundleEntry(
                     PackagingManifest.IdPrefix + m!.Id, m.ReleasedVersion!, m.Id, m.Module,
-                    m.MinMeshVersion))
+                    m.MinMeshVersion, m.Source))
                 .OrderBy(e => e.PluginId, StringComparer.OrdinalIgnoreCase)
                 .ToArray());
 
     /// <summary>One servable bundle: its package id, its released version, the plugin it is, the
-    /// compiled module the plugin's install record declares (null for content-only plugins), and
-    /// that module's declared platform floor.</summary>
+    /// compiled module the plugin's install record declares (null for content-only plugins), that
+    /// module's declared platform floor, and the registry SOURCE the record was installed from.</summary>
+    /// <param name="PackageId">The NuGet-shaped package id the archive is named after.</param>
+    /// <param name="Version">The released SemVer this bundle is served at.</param>
+    /// <param name="PluginId">The plugin's catalog id — also the id a grant entry names.</param>
+    /// <param name="Module">The compiled module the install record declares, or null.</param>
+    /// <param name="MinMeshVersion">The module's declared platform floor, or null.</param>
+    /// <param name="Source">🚨 The registry source name the package was installed from
+    /// (<see cref="PackageManifest.Source"/>) — the half of the grant pair that is NOT the package
+    /// id, and therefore the input to <see cref="IsGranted"/>. Null on a record written before the
+    /// field existed or installed from something that is not a configured source: it then matches no
+    /// grant entry, which is the fail-closed answer (#1772).</param>
     private sealed record BundleEntry(
         string PackageId, string Version, string PluginId, string? Module = null,
-        string? MinMeshVersion = null);
+        string? MinMeshVersion = null, string? Source = null);
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -249,6 +249,29 @@ Both are gated by the **instance key** (`mwi_`, as `Bearer` or `Basic`) resolvin
 are recorded against. They **fail closed**: no anonymous escape hatch, unlike the registry's dev-mode
 one. These are compiled assemblies for paid modules.
 
+**That is TWO decisions, and for a long time only the first one ran (#1772).** The key
+*authenticates* — a valid `mwi_` or 401 — and the grant *authorizes*, per package. Until #1772 the
+authenticated caller was stashed on the request and never read back, so any registered instance could
+download every installed package's bundle, paid courses included, while this very paragraph said
+otherwise. An instance key is issued to every registered installation: it is identity, never
+entitlement.
+
+The authorization is `PluginGrantEntry` matched against the **install record's `Source`** — the
+registry source the package was installed from — exactly as `/api/plugins` scopes its listing and
+`InstallByDefault` scopes its selection. Consequences worth knowing:
+
+- **The index is scoped too.** An ungranted package is not listed, so a caller cannot learn it is
+  installed here. That is what makes the download refusal non-informative.
+- **A refusal is byte-identical to "no such bundle"** — same status, same empty body, same headers.
+  Bundle URLs are fully predictable, so a distinguishable refusal is an inventory oracle over the
+  whole catalogue; `/api/content` closed the same hole in #587. WHICH of the three it was (unknown
+  package, unknown version, ungranted) goes to the **log**, never the response.
+- **An unstamped `Source` is servable to nobody.** It matches no grant entry, and "cannot determine"
+  is a refusal. `PluginBundleClient` reads the resulting 404 as "no prebuilt bundle — will compile",
+  so the cost is a compile, never a failed install. The stamp is carried forward across re-installs
+  (`PackageInstaller.SeedSource`): an update rebuilt from a source-less catalog entry must not erase
+  the field the check reads, or the lane goes dark silently.
+
 **The portal serves the bytes rather than handing out storage access.** `BlobAssemblyStore` is
 already the durable transport — one blob per `(nodeTypePath, version)`, hydrated into a process-local
 cache on demand — so reading through `IAssemblyStore` means the bundle is assembled from the very

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -241,8 +241,8 @@ service index and dependency ranges would be surfaces that can drift with no cli
 
 | Route | Serves |
 |---|---|
-| `GET /api/plugins/bundles/index.json` | This instance's framework MVID, and every plugin it can serve |
-| `GET /api/plugins/bundles/{plugin}/{version}` | That plugin's assemblies + manifest |
+| `GET /api/plugins/bundles/index.json` | This instance's framework MVID, and every plugin it can serve **the calling instance** |
+| `GET /api/plugins/bundles/{plugin}/{version}` | That plugin's assemblies + manifest, if the caller is granted it |
 
 Both are gated by the **instance key** (`mwi_`, as `Bearer` or `Basic`) resolving to the admin-owned
 `PluginGrant` — the same gate as `/api/plugins`, deliberately, because that is already what purchases

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-bundles-are-served-only-to-instances-entitled-to-them.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-bundles-are-served-only-to-instances-entitled-to-them.md
@@ -1,0 +1,42 @@
+---
+Name: Bundles are served only to instances entitled to them
+Category: Fix
+Description: The bundle download route checked that a caller was a registered instance but never checked which packages it was granted, so any registered installation could download every installed package's compiled assemblies — paid content included. It now authorizes per package, and a refusal is indistinguishable from a bundle that does not exist.
+Icon: ShieldCheckmark
+Order: -20260817
+---
+
+# Bundles are served only to instances entitled to them
+
+A registry portal hands other installations the compiled assemblies for the packages they have —
+that is what lets a consumer skip a full compile at install time. The route asked callers for a
+registered instance key and refused everyone without one. What it never asked was the second half of
+the question: *which packages is this caller entitled to?*
+
+So an installation could download the bundle for **any** package the registry had installed, not
+only its own — 900 CHF course content included. It needed a valid instance key, so this was never
+open to the internet; but an instance key is issued to every installation that registers, which
+makes the population "everyone who ever registered", not "someone who broke in". The route's own
+documentation described the entitlement check as though it were running. It was not.
+
+Now it runs, on both routes, using the grant that already exists — the per-source, per-package
+authorization an administrator issues to each installation, the same one the catalog listing and the
+file download have always honoured. There is no second, bundle-specific notion of entitlement to
+keep in step with what purchases are recorded against.
+
+Two things were deliberate in how the refusal behaves:
+
+- **A refusal looks exactly like "there is no such bundle."** Same status, same empty body, same
+  headers — and an ungranted package is simply absent from the index. Bundle URLs are predictable,
+  so an answer that distinguished "you may not have this" from "this does not exist" would let any
+  installation enumerate the entire catalogue and its versions without being entitled to a single
+  item of it. Which of the two it actually was is written to the registry's log, where the caller
+  cannot read it.
+- **It fails closed.** An install record that does not say which source it came from is served to
+  nobody, rather than being served to everybody. A consumer treats a missing bundle the way it
+  always has — it compiles the package itself — so the cost of a refusal is time, never a failed
+  install.
+
+Alongside it, the source recorded on an install record now survives a re-install. An automatic
+update rebuilds that record from the catalogue entry, and not every catalogue stamps the source, so
+the first unattended update could quietly erase the very field the new check reads.

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1164,8 +1164,13 @@ public static class PackageInstaller
     /// A distribution lane that goes dark on the first auto-update is the worst kind of regression:
     /// consumers just quietly compile instead.</para>
     ///
-    /// <para>Monotone by construction — it can only fill a source in where there was none, never
-    /// change or invent one, so it cannot widen what any grant matches.</para>
+    /// <para>🚨 <b>It never INVENTS a source</b> — the result is either the one this install states
+    /// or the one already recorded, never a guess, so it can only ever name a source some real
+    /// install came from. A stated source does WIN over the recorded one: that is the newer fact
+    /// about where the package comes from (a package genuinely moved between sources must stop
+    /// claiming the old one), exactly as <see cref="SeedAuthorizedBy"/> prefers the principal that
+    /// authorized THIS action. The carry-forward applies only where the current install supplies
+    /// nothing.</para>
     /// </summary>
     /// <param name="existingRecord">The install record being re-stamped, or null on a first install.</param>
     /// <param name="manifest">The catalog manifest this install is being written from.</param>

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1151,6 +1151,29 @@ public static class PackageInstaller
         string.IsNullOrWhiteSpace(authorizingUserId) ? existingRecord?.AuthorizedBy : authorizingUserId;
 
     /// <summary>
+    /// The install record's <see cref="PackageManifest.Source"/> on a (re-)stamp: the registry source
+    /// the CURRENT install came from when it is known, otherwise the one already recorded. Same
+    /// carry-forward as <see cref="SeedAuthorizedBy"/>, for the same reason and now with teeth.
+    ///
+    /// <para>🚨 Not every lister stamps the field: it is set by the registry as it merges its sources
+    /// and by the default install's own lister, but a catalog rendered straight off a repo path
+    /// (<c>PluginUpdateWatcher</c>, a <c>PluginCatalog</c> node) hands over a manifest with no source
+    /// at all. Rebuilding the record from that manifest verbatim would ERASE a stamp a real install
+    /// wrote — and since #1772 the bundle route matches the caller's <c>PluginGrant</c> against
+    /// exactly this field, an erased source makes the package unservable to every consumer, silently.
+    /// A distribution lane that goes dark on the first auto-update is the worst kind of regression:
+    /// consumers just quietly compile instead.</para>
+    ///
+    /// <para>Monotone by construction — it can only fill a source in where there was none, never
+    /// change or invent one, so it cannot widen what any grant matches.</para>
+    /// </summary>
+    /// <param name="existingRecord">The install record being re-stamped, or null on a first install.</param>
+    /// <param name="manifest">The catalog manifest this install is being written from.</param>
+    /// <returns>The source to record.</returns>
+    internal static string? SeedSource(PackageManifest? existingRecord, PackageManifest manifest) =>
+        string.IsNullOrWhiteSpace(manifest.Source) ? existingRecord?.Source : manifest.Source;
+
+    /// <summary>
     /// Publishes the package's CONTENT-COLLECTION assets — the raw binaries it commits under
     /// <c>{package}/content/**</c> (course videos and their posters, og images, fonts) — into the
     /// target partition root's <c>content</c> collection, so merging a course or plugin publishes it
@@ -1327,6 +1350,10 @@ public static class PackageInstaller
                     // WHO authorized this install — what an unattended update of a commercial
                     // package is re-checked against (#830).
                     AuthorizedBy = SeedAuthorizedBy(existingRecord, authorizingUserId),
+                    // WHICH registry source it came from — what a consumer's PluginGrant is matched
+                    // against when it asks this instance for the package's bundle (#1772). Carried
+                    // forward for the same reason as AuthorizedBy: not every lister stamps it.
+                    Source = SeedSource(existingRecord, manifest),
                 },
             };
             // System-impersonated like every installer write (Using — see Upsert): this runs after

--- a/test/Memex.Portal.Shared.Test/PluginBundleEntitlementTest.cs
+++ b/test/Memex.Portal.Shared.Test/PluginBundleEntitlementTest.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Api;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>THE PER-PACKAGE ENTITLEMENT GATE ON THE BUNDLE ROUTES (#1772).</b>
+///
+/// <para><see cref="PluginBundleAuthTest"/> pins the AUTHENTICATION half — a caller without a valid
+/// <c>mwi_</c> key gets 401. That half always worked. This fixture pins the half that did not: the
+/// authenticated caller was written into <c>HttpContext.Items</c> and <b>never read back</b>, so any
+/// registered instance could download every installed package's bundle — 900 CHF courses included —
+/// while the route's own XML doc claimed per-package entitlement was enforced. An instance key is
+/// provisioned to every registered installation; the population that could exercise this was
+/// "everyone who ever registered", not "an attacker who breached something".</para>
+///
+/// <para><b>The grant path is REAL, end to end.</b> Instances are registered through
+/// <see cref="MeshWeaverInstanceService.Register"/> (which mints the key and seeds
+/// <c>PluginCatalog:DefaultGrants</c> into the admin-owned <c>PluginGrant</c> node in the Admin
+/// partition), the install records are written by <see cref="PackageInstaller.Install"/>, and the
+/// key is resolved by the production <see cref="InstanceRegistryAuthenticator"/> over a real HTTP
+/// request. Nothing is mocked, so a regression anywhere on that path fails here.</para>
+///
+/// <para><b>Both directions, and the oracle.</b> A granted instance gets the bytes; an ungranted one
+/// gets a refusal that is byte-identical to the answer for a package that does not exist —
+/// <see cref="RefusalIsIndistinguishableFromNotFound"/> compares status, body AND content headers,
+/// because the URL scheme is fully predictable and a distinguishable refusal is an inventory oracle
+/// over the whole catalogue (the property <c>/api/content</c> established in #587).</para>
+/// </summary>
+public class PluginBundleEntitlementTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The package the consumer IS entitled to — installed from the platform source.</summary>
+    private const string GrantedPackage = "BundleGranted";
+
+    /// <summary>The paid package it is NOT entitled to — installed from a different source, exactly
+    /// as a 900 CHF course sits beside the free platform repo on the real registry.</summary>
+    private const string PaidPackage = "BundlePaid";
+
+    /// <summary>A package id that was never installed at all — the not-found baseline the refusal
+    /// must be indistinguishable from.</summary>
+    private const string AbsentPackage = "BundleNeverInstalled";
+
+    private const string PlatformSource = "Plugins";
+    private const string PaidSource = "Education";
+    private const string Version = "1.4.0";
+
+    /// <summary>The consumer that holds <c>Plugins/*</c> — the shape a real install is registered
+    /// with (the platform repo defaulted in, paid sources left admin-granted).</summary>
+    private const string GrantedInstance = "bundle-consumer-granted";
+
+    /// <summary>A consumer registered with NO defaults: it authenticates and is entitled to nothing.
+    /// "Registering is identity, not entitlement."</summary>
+    private const string UngrantedInstance = "bundle-consumer-ungranted";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog();
+
+    // ── the real registration + grant path ────────────────────────────────────────────────────
+
+    private MeshWeaverInstanceService InstanceService(params string[] defaultGrants) =>
+        new(Mesh.ServiceProvider.GetRequiredService<MeshWeaver.Mesh.Services.IMeshService>(),
+            Mesh,
+            Mesh.ServiceProvider.GetRequiredService<ILogger<MeshWeaverInstanceService>>(),
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(defaultGrants.Select((entry, i) =>
+                    new KeyValuePair<string, string?>(
+                        $"{MeshWeaverInstanceService.DefaultGrantsConfigKey}:{i}", entry)))
+                .Build());
+
+    /// <summary>Registers an install and returns its raw instance key — the only time it is
+    /// readable, exactly as a real registration hands it over once.</summary>
+    private Task<string> RegisterInstance(string instanceId, params string[] defaultGrants) =>
+        InstanceService(defaultGrants)
+            .Register("bundle-owner", "Bundle Owner", "owner@test.com", instanceId, instanceId)
+            .Select(r => r.RawKey)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(60))
+            .ToTask();
+
+    /// <summary>Installs a package the production way, so the install record carries the same
+    /// <c>Source</c> stamp the registry writes — the half of the grant pair that is not the id.</summary>
+    private Task<InstallResult> InstallPackage(string id, string source) =>
+        PackageInstaller.Install(
+                Mesh,
+                new PackageManifest
+                {
+                    Id = id,
+                    Name = id,
+                    Kind = PackageKind.Content,
+                    TargetPartition = id,
+                    SourceFolder = id,
+                    Version = "1.0.0",
+                    // What the bundle index keys its URL on — a record without it is not servable.
+                    ReleasedVersion = Version,
+                    // Stamped by the registry as it merges its sources (PluginRegistryEndpoints) or
+                    // by the lister on a registry instance (InstanceAutoRegistrationService). It is
+                    // what a PluginGrantEntry is matched against.
+                    Source = source,
+                },
+                [new PackageFile($"{id}/Doc.md", $"# {id}")],
+                "HEAD")
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(120))
+            .ToTask();
+
+    // ── the route, over a real HTTP pipeline ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// The bundle routes on a TestServer wired to the REAL mesh: the production
+    /// <see cref="InstanceRegistryAuthenticator"/> resolves the presented key against the instance
+    /// and grant nodes this fixture actually wrote, and the handlers read this mesh's install records.
+    /// </summary>
+    private async Task<WebApplication> StartBundleHost()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<IMessageHub>(Mesh);
+        builder.Services.AddSingleton(new InstanceRegistryAuthenticator(
+            Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<InstanceRegistryAuthenticator>>()));
+
+        var app = builder.Build();
+        app.MapPluginBundles();
+        await app.StartAsync();
+        return app;
+    }
+
+    private static async Task<HttpResponseMessage> Get(WebApplication app, string route, string key)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, route);
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {key}");
+        return await app.GetTestClient().SendAsync(request);
+    }
+
+    private static string BundleRoute(string plugin) =>
+        $"{PluginBundleEndpoints.RoutePrefix}/{plugin}/{Version}";
+
+    private static string IndexRoute => PluginBundleEndpoints.RoutePrefix + "/index.json";
+
+    /// <summary>The plugin ids an index response advertises.</summary>
+    private static async Task<IReadOnlyList<string>> IndexedPlugins(HttpResponseMessage response)
+    {
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return json.RootElement.GetProperty("bundles").EnumerateArray()
+            .Select(b => b.GetProperty("plugin").GetString()!)
+            .ToArray();
+    }
+
+    // ── the assertions ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The whole defect, in one test: an instance that authenticates but was granted nothing must
+    /// not receive an installed package's bundle — and an instance granted the PLATFORM source must
+    /// not receive the PAID one that sits beside it.
+    ///
+    /// <para>Pre-fix both refusals were 200 with the archive attached, because
+    /// <c>AuthenticatedInstance.Allows</c> was never called on these routes.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task OnlyGrantedPackagesAreServed()
+    {
+        await InstallPackage(GrantedPackage, PlatformSource);
+        await InstallPackage(PaidPackage, PaidSource);
+        var grantedKey = await RegisterInstance(GrantedInstance, $"{PlatformSource}/*");
+        var ungrantedKey = await RegisterInstance(UngrantedInstance);
+
+        var app = await StartBundleHost();
+        await using var _ = app;
+
+        // The entitled fetch still works — a gate that refuses everyone is not a fix.
+        using var served = await Get(app, BundleRoute(GrantedPackage), grantedKey);
+        served.StatusCode.Should().Be(HttpStatusCode.OK,
+            "an instance granted Plugins/* must still get the platform package's bundle");
+        (await served.Content.ReadAsByteArrayAsync()).Length.Should().BeGreaterThan(0,
+            "the served bundle is a real archive, not an empty 200");
+
+        // Same URL, a key that was granted nothing.
+        using var refusedWholesale = await Get(app, BundleRoute(GrantedPackage), ungrantedKey);
+        refusedWholesale.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a registered instance with no grant is entitled to NOTHING — registering is identity, "
+            + "not entitlement");
+
+        // The sharper direction: a real grant, for a different source. This is the paid-content
+        // boundary — Plugins/* must not sweep in a 900 CHF course from Education.
+        using var refusedPaid = await Get(app, BundleRoute(PaidPackage), grantedKey);
+        refusedPaid.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a grant is per (source, package) — holding the platform source must not confer the "
+            + "paid source installed beside it");
+    }
+
+    /// <summary>
+    /// 🚨 A refusal must be indistinguishable from "there is no such bundle" — status, body AND
+    /// content headers.
+    ///
+    /// <para>The URL is <c>/{plugin}/{version}</c> and plugin ids are public knowledge, so any
+    /// difference between "you may not have this" and "this does not exist" turns the route into an
+    /// inventory oracle over the entire catalogue: an instance could enumerate every paid package
+    /// this registry carries, and at which versions, without being entitled to one of them. This is
+    /// the property <c>/api/content</c> established in #587 by making its refusal body byte-identical
+    /// to its not-found body.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task RefusalIsIndistinguishableFromNotFound()
+    {
+        await InstallPackage(PaidPackage, PaidSource);
+        var grantedKey = await RegisterInstance(GrantedInstance, $"{PlatformSource}/*");
+
+        var app = await StartBundleHost();
+        await using var _ = app;
+
+        // Installed here, but not for this caller …
+        using var refused = await Get(app, BundleRoute(PaidPackage), grantedKey);
+        // … versus a package that genuinely does not exist on this instance.
+        using var absent = await Get(app, BundleRoute(AbsentPackage), grantedKey);
+
+        refused.StatusCode.Should().Be(absent.StatusCode,
+            "the status must not reveal that the package exists");
+        (await refused.Content.ReadAsByteArrayAsync())
+            .Should().Equal(await absent.Content.ReadAsByteArrayAsync(),
+                "the body must be byte-identical — a differing reason string IS the oracle");
+        refused.Content.Headers.ContentType?.ToString()
+            .Should().Be(absent.Content.Headers.ContentType?.ToString(),
+                "a Content-Type present on one answer and not the other distinguishes them just as "
+                + "well as a body would");
+        refused.Content.Headers.ContentLength
+            .Should().Be(absent.Content.Headers.ContentLength);
+        refused.Headers.Select(h => h.Key).OrderBy(k => k, StringComparer.Ordinal)
+            .Should().Equal(absent.Headers.Select(h => h.Key).OrderBy(k => k, StringComparer.Ordinal),
+                "and neither may carry a header the other does not");
+    }
+
+    /// <summary>
+    /// The index is scoped too — an ungranted package is not merely un-fetchable, it is not listed.
+    ///
+    /// <para>This is what makes the download refusal above non-informative: with the index filtered,
+    /// "absent from your index" and "404 on fetch" agree, and neither confirms existence. An index
+    /// that advertised the whole inventory would hand over exactly the catalogue the 404 withholds.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task TheIndexListsOnlyGrantedPackages()
+    {
+        await InstallPackage(GrantedPackage, PlatformSource);
+        await InstallPackage(PaidPackage, PaidSource);
+        var grantedKey = await RegisterInstance(GrantedInstance, $"{PlatformSource}/*");
+        var ungrantedKey = await RegisterInstance(UngrantedInstance);
+
+        var app = await StartBundleHost();
+        await using var _ = app;
+
+        using var granted = await Get(app, IndexRoute, grantedKey);
+        granted.StatusCode.Should().Be(HttpStatusCode.OK);
+        var advertised = await IndexedPlugins(granted);
+        advertised.Should().Contain(GrantedPackage, "the granted package is servable to this caller");
+        advertised.Should().NotContain(PaidPackage,
+            "a caller must not be able to learn that an ungranted package is installed here");
+
+        using var ungranted = await Get(app, IndexRoute, ungrantedKey);
+        ungranted.StatusCode.Should().Be(HttpStatusCode.OK,
+            "an entitled-to-nothing instance still gets a well-formed index — an error would itself "
+            + "be a signal");
+        (await IndexedPlugins(ungranted)).Should().BeEmpty(
+            "and that index is indistinguishable from a registry with nothing installed");
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/InstallRecordSourceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallRecordSourceTest.cs
@@ -77,10 +77,14 @@ public class InstallRecordSourceTest(ITestOutputHelper output) : MonolithMeshTes
                 + "bundle route's grant check is matched against");
     }
 
-    /// <summary>The rule on its own: it can only FILL IN, never change or invent — so it cannot
-    /// widen what any grant matches.</summary>
+    /// <summary>
+    /// The rule on its own. It NEVER invents a source — the answer is always either what this
+    /// install states or what was already recorded — and the carry-forward applies only where the
+    /// current install supplies nothing. A stated source does win: a package that genuinely moved
+    /// between sources must stop claiming the old one, and the grant must follow it.
+    /// </summary>
     [Fact(Timeout = 30_000)]
-    public void TheCarryForwardIsMonotone()
+    public void TheCarryForwardNeverInventsASource()
     {
         PackageInstaller.SeedSource(Manifest(RegistrySource), Manifest(null))
             .Should().Be(RegistrySource, "a source-less manifest keeps what was recorded");

--- a/test/MeshWeaver.PluginCatalog.Test/InstallRecordSourceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallRecordSourceTest.cs
@@ -1,0 +1,92 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The install record's <see cref="PackageManifest.Source"/> — the registry source a package was
+/// installed FROM — must SURVIVE a re-install (#1772).
+///
+/// <para>Since #1772 the bundle route matches a consuming instance's <c>PluginGrant</c> against
+/// exactly this field, so it stopped being a provenance nicety and became an authorization input:
+/// a record with no source matches no grant entry and is servable to nobody. Fail-closed is
+/// deliberate — but only for a source that was never recorded, never for one an update threw away.</para>
+///
+/// <para>The erasure is easy to reach and completely silent. Not every lister stamps the field: the
+/// registry stamps it as it merges its sources and the default install's own lister stamps it, but a
+/// catalog rendered straight off a repo path (<c>PluginUpdateWatcher</c>, a <c>PluginCatalog</c>
+/// node) hands over a manifest with none. The record is rebuilt from that manifest, so without the
+/// carry-forward the first unattended update would take the whole distribution lane dark — every
+/// consumer would just quietly compile instead, which looks like nothing at all.</para>
+/// </summary>
+public class InstallRecordSourceTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string PackageId = "SourceCarryForward";
+    private const string RegistrySource = "Plugins";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog();
+
+    private static PackageManifest Manifest(string? source) => new()
+    {
+        Id = PackageId,
+        Name = PackageId,
+        Kind = PackageKind.Content,
+        TargetPartition = PackageId,
+        SourceFolder = PackageId,
+        Version = "1.0.0",
+        ReleasedVersion = "1.4.0",
+        Source = source,
+    };
+
+    private Task<InstallResult> Install(PackageManifest manifest) =>
+        PackageInstaller.Install(
+                Mesh, manifest, [new PackageFile($"{PackageId}/Doc.md", $"# {PackageId}")], "HEAD")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(120)).ToTask();
+
+    /// <summary>Authoritative single-node read straight off storage — never the lagging index.</summary>
+    private Task<MeshNode?> ReadRecord() =>
+        Mesh.ServiceProvider.GetRequiredService<Mesh.Services.IStorageAdapter>()
+            .Read($"{PackageInstaller.InstalledPartition}/{PackageId}", Mesh.JsonSerializerOptions)
+            .Take(1).Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+    [Fact(Timeout = 300_000)]
+    public async Task ASourcelessReinstall_KeepsTheRecordedSource()
+    {
+        await Install(Manifest(RegistrySource));
+        var installed = await ReadRecord();
+        installed!.ContentAs<PackageManifest>(Mesh.JsonSerializerOptions)!.Source
+            .Should().Be(RegistrySource, "the install must record where the package came from");
+
+        // The unattended update: the same package, from a catalog entry that carries no source.
+        await Install(Manifest(null));
+
+        var updated = await ReadRecord();
+        updated!.ContentAs<PackageManifest>(Mesh.JsonSerializerOptions)!.Source
+            .Should().Be(RegistrySource,
+                "an update rebuilt from a source-less catalog manifest must not erase the source the "
+                + "bundle route's grant check is matched against");
+    }
+
+    /// <summary>The rule on its own: it can only FILL IN, never change or invent — so it cannot
+    /// widen what any grant matches.</summary>
+    [Fact(Timeout = 30_000)]
+    public void TheCarryForwardIsMonotone()
+    {
+        PackageInstaller.SeedSource(Manifest(RegistrySource), Manifest(null))
+            .Should().Be(RegistrySource, "a source-less manifest keeps what was recorded");
+        PackageInstaller.SeedSource(Manifest(RegistrySource), Manifest("Education"))
+            .Should().Be("Education", "a stated source for THIS install wins — it is the newer fact");
+        PackageInstaller.SeedSource(null, Manifest(null))
+            .Should().BeNull("nothing to carry forward, and nothing is invented: the gate fails closed");
+    }
+}


### PR DESCRIPTION
Closes #1772.

`PluginBundleEndpoints` wrote the authenticated caller into `http.Items[CallerItemKey]` and
**nothing ever read it back** — `AuthenticatedInstance.Allows(...)` was never called on these
routes. So they enforced **authentication** (a valid `mwi_` instance key) and **no authorization at
all**: any registered instance could download every installed package's bundle, 900 CHF course
content included, while the route's own XML doc said per-package entitlement was enforced. An
instance key is provisioned to every registered installation — it is identity, never entitlement.

## The grant mechanism — the existing one, not a new one

`PluginGrantEntry` matched against the install record's `PackageManifest.Source`, via
`AuthenticatedInstance.Allows(source, packageId)`. That is exactly what `PluginRegistryEndpoints`
applies to its listing and its `/files` fetch, and what `InstanceAutoRegistrationService` applies to
`InstallByDefault` (`w.Matches(c.Package.Source ?? "", c.Package.Id)`). No second, bundle-specific
notion of entitlement to keep in step with what purchases are recorded against.

The check runs on **both** routes:

| route | before | after |
|---|---|---|
| `GET /index.json` | every installed package | only the caller's granted packages |
| `GET /{plugin}/{version}` | any installed package | only if granted — otherwise `NoSuchBundle()` |

## Fail closed

- `Caller(http)` returning null is treated as **granted nothing**, never "unscoped" — a route
  accidentally mapped outside the filter group serves an empty index and a 404, never the catalogue.
  There is no anonymous branch here (unlike `/api/plugins`, which keeps one for local dev).
- An install record with **no `Source`** matches no grant entry — `""` equals no source name — so it
  is servable to nobody. "Cannot determine" is a refusal. `PluginBundleClient` already reads a 404
  as *"no prebuilt bundle — will compile"*, so the cost of that refusal is a compile, never a failed
  install.

## No existence oracle

`NoSuchBundle()` is the single answer for **unknown package**, **unknown version** and **not granted
to you** — same status, same empty body, same headers — and the index is filtered so an ungranted
package is not listed at all. Bundle URLs are `/{plugin}/{version}` and plugin ids are public
knowledge, so a distinguishable refusal would let any registered instance enumerate the entire
catalogue and its versions without being entitled to one item of it. This is the property
`/api/content` established in #587 by making its refusal body byte-identical to its not-found body.

**Which** of the three it was goes to the **log**, where the caller cannot read it — naming the
instance, and distinguishing "no such record", "installed from source X your grant does not cover",
and "the record carries NO source" (with the remedy). The log is not the response, so being precise
there costs nothing.

## Two things that would have made this fix silently dark

Both found while implementing it, both verified rather than assumed:

1. **A re-install erased the `Source` the check reads.** The record is rebuilt from the catalog
   manifest and not every lister stamps the field (`PluginUpdateWatcher`, a `PluginCatalog` node
   rendered straight off a repo path), so the first unattended update wrote `Source = null`.
   Verified by removing the fix and watching the record go to `null`. `PackageInstaller.SeedSource`
   carries it forward — same shape and reason as the existing `SeedAuthorizedBy`, and **monotone**:
   it can only fill a source in, never change or invent one, so it cannot widen what any grant
   matches.
2. **The unstamped-record diagnosis would never have fired.** With the index filtered, a consumer
   never *asks* for a package it cannot see, so the download-path log line could not be reached — the
   whole lane could go dark with nothing in the log, every consumer quietly compiling, which looks
   exactly like a healthy day. `WarnAboutUnstampedRecords` names them on the index request instead.
   Normally it logs nothing.

## Tests — and the proof they are worth something

`PluginBundleEntitlementTest` (3) — **the real grant path end to end, nothing mocked**: instances
registered through `MeshWeaverInstanceService.Register` (real minted key, real `DefaultGrants` seed
into the admin-owned `Admin/_PluginGrant` node), install records written by
`PackageInstaller.Install`, the key resolved by the production `InstanceRegistryAuthenticator` over a
real HTTP request on a TestServer wired to a real mesh.

- **Both directions**: `Plugins/*` still gets the platform package's bundle (a gate that refuses
  everyone is not a fix); an instance granted nothing does not; and — the sharper one — `Plugins/*`
  does **not** confer the paid `Education` package installed beside it.
- **Indistinguishability is asserted, not asserted-about**: the refusal is compared against a
  genuinely-absent package on status, **body bytes**, `Content-Type`, `Content-Length` and header
  names.
- **The index is scoped**, and an entitled-to-nothing caller gets a well-formed empty index — an
  error would itself be a signal.

🚨 **All three FAIL against the pre-fix endpoint**, with exactly
`Expected value to be NotFound … but found OK` — I reverted `PluginBundleEndpoints.cs` to its
pre-fix state, rebuilt, and ran them (3 failed / 0 passed) before restoring. A negative test that
passes before the fix proves nothing.

`InstallRecordSourceTest` (2) — the carry-forward end to end (a source-less re-install keeps the
recorded source; fails pre-fix with `found <null>`) and as a pure rule (monotone, invents nothing).

**Regression**: `MeshWeaver.PluginCatalog.Test` 407/407, `Memex.Portal.Shared.Test` 385/385,
Documentation link/WhatsNew guards 2/2 — all re-run after merging `main` (which now carries #1771).
`-c Release -warnaserror` clean on every touched project, likewise after the merge.

## Docs

The XML doc no longer asserts a check that does not exist — it names where the check IS (`IsGranted`),
says the key is two decisions and that only the first used to run, and states the
indistinguishability property. `Doc/Architecture/PluginPackaging` gains the same three points beside
its existing "gated by the instance key" paragraph. What's New: `Category: Fix` — an operator can
notice this (an instance that used to pull a bundle it was not granted now compiles instead).

## Follow-up finding, not fixed here

`ReleaseGateEndpoints` (`GET /api/plugins/is-updatable`) is gated on the same instance key and, like
the bundle routes were, checks only authentication. Its response names this instance's installed
packages and the reasons a release is unsafe — its own doc calls that "deployment inventory, not
public information". Scoping it is not the same decision as scoping bundles (the answer is about the
*serving* instance, not about a package the caller is entitled to), so it wants its own issue rather
than a rider on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
