### PR TITLE
fix(#1778): a floor between automatic rolls, since a roll is a pod restart

### DIFF
--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -244,23 +244,31 @@ config:
     # cadence and your rollback headroom.
     AssemblyCache__Retention__Delete: "false"
     # ---- Platform self-update cadence --------------------------------------
-    # The poller's built-in default is 6h, which is why a freshly published image
-    # could sit unpicked for hours and look like "self-update is broken" (memex,
-    # 2026-08-03: running ci.1672 while ci.1674 had been in ACR since 07:34).
+    # The check is EVENT-DRIVEN (#1773): one pass at startup, then a check per
+    # published build of the platform or of any module this environment deploys.
+    # There is no polling interval any more — SelfUpdate__PollInterval was renamed
+    # and this key sat here inert, reading like a live daily throttle while binding
+    # to nothing (#1778).
     #
-    # DAILY, deliberately (2026-08-10, measured): every roll invalidates the whole
-    # NodeType compile cache — the framework MVID changes on every CI image — so a
-    # roll costs a full sequential rebuild (~2.4 s/type; ~10 min on the largest
-    # mesh) plus a degraded warm-up window while the 3 s enrichment probe is
-    # starved. CI publishes ~44 images/day; polling faster than the rebuild is
-    # worth just multiplies that cost. One roll per day keeps fixes flowing daily
-    # at a quarter of the compile cost and a quarter of the degraded windows.
-    # For an URGENT fix, don't shorten this — `kubectl rollout restart` the
-    # portal: the poll fires on startup (StartWith(-1L)) and picks the newest
-    # image immediately. Binding only works from the image that added
-    # SelfUpdateOptions.SectionName — before that this key is inert, because
-    # AddSelfUpdate() constructed its options directly.
-    SelfUpdate__PollInterval: "1.00:00:00"
+    # What this number now sets is the floor between two AUTOMATIC rolls. It is a
+    # RESTART budget, not a delivery speed: a roll restarts the pod and drops every
+    # live circuit on it. The trade, so this can be changed by editing one number:
+    #
+    #     24h  ->  <=1 restart/day,     a merged fix reaches prod the NEXT DAY
+    #      6h  ->  <=4 restarts/day,    same working day
+    #      1h  ->  <=24 restarts/day,   ~1.5 h after merge   <-- current
+    #
+    # 1h matches CD's reconcile tick, so hourly publication actually means hourly
+    # delivery. The former 24h is deliberately NOT restored: it predates
+    # adopt-before-compile (a prod roll went from 80 compiles / 64.8 s to 0
+    # compiles / 32.1 s), so the compile-cost half of its 2026-08-10 rationale is
+    # gone, and "tomorrow" is the answer that prompted the faster tick in the first
+    # place. What remains true is the restart cost, which is what this bounds.
+    #
+    # Neither extreme delays an URGENT fix: `kubectl rollout restart` takes the
+    # newest image immediately (the startup pass), and `gh workflow run
+    # main-cd.yml --ref main` bypasses the batch window.
+    SelfUpdate__MinRollInterval: "01:00:00"
     Mcp__BaseUrl: "http://memex-portal-service:8080"
     # ---- AI model providers (templated by the chart) ------------------------
     # These seed the system model catalog on deploy (BuiltInLanguageModelProvider

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -434,6 +434,17 @@ public class SelfUpdateHostedService : IHostedService
             //
             // Deferring is safe WITHOUT a timer for the same reason an availability hold is: the
             // next publication event re-decides it. The floor never schedules anything.
+            // A disabled floor must not pay for the stamp read: LastRolledAtAsync is a Kubernetes GET
+            // in the AKS implementation, and its answer cannot change the decision when the floor is
+            // zero. Skipping it removes an API call and a failure point from the happy path.
+            if (_options.MinRollInterval <= TimeSpan.Zero)
+            {
+                _logger?.LogInformation(
+                    "[SelfUpdate] applying update {Tag} (was {Current}; no roll floor configured).",
+                    target, ShippedReleaseSeed.InstalledPlatformVersion);
+                return _http.Invoke(ct => _updater.PatchToVersionAsync(target, ct));
+            }
+
             return _http.Invoke(ct => _updater.LastRolledAtAsync(ct)).SelectMany(lastRolledAt =>
             {
                 var since = lastRolledAt is null ? (TimeSpan?)null : DateTimeOffset.UtcNow - lastRolledAt.Value;

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -426,10 +426,33 @@ public class SelfUpdateHostedService : IHostedService
                 return Observable.Return(Unit.Default);
             }
 
-            _logger?.LogInformation(
-                "[SelfUpdate] applying update {Tag} (was {Current}).",
-                target, ShippedReleaseSeed.InstalledPlatformVersion);
-            return _http.Invoke(ct => _updater.PatchToVersionAsync(target, ct));
+            // 🚨 The pacing floor. A roll is a POD RESTART, so without it publication frequency is
+            // restart frequency and every restart drops the live circuits of everyone using the
+            // portal. The floor bounds the AUTOMATIC cadence only: `kubectl rollout restart` still
+            // takes the newest image immediately (the startup pass), and a main-cd dispatch still
+            // bypasses the batch window, so nothing here delays an urgent fix.
+            //
+            // Deferring is safe WITHOUT a timer for the same reason an availability hold is: the
+            // next publication event re-decides it. The floor never schedules anything.
+            return _http.Invoke(ct => _updater.LastRolledAtAsync(ct)).SelectMany(lastRolledAt =>
+            {
+                var since = lastRolledAt is null ? (TimeSpan?)null : DateTimeOffset.UtcNow - lastRolledAt.Value;
+                if (since is { } elapsed && elapsed < _options.MinRollInterval)
+                {
+                    _logger?.LogInformation(
+                        "[SelfUpdate] {Tag} is available but this install rolled {Elapsed} ago, inside the "
+                        + "{Floor} floor — deferring. The next publication re-decides it; "
+                        + "`kubectl rollout restart` applies it now.",
+                        target, elapsed, _options.MinRollInterval);
+                    return Observable.Return(Unit.Default);
+                }
+
+                _logger?.LogInformation(
+                    "[SelfUpdate] applying update {Tag} (was {Current}; last rolled {Last}).",
+                    target, ShippedReleaseSeed.InstalledPlatformVersion,
+                    lastRolledAt?.ToString("O") ?? "never");
+                return _http.Invoke(ct => _updater.PatchToVersionAsync(target, ct));
+            });
         });
 
     /// <summary>Record the newest available tag on the policy node (as System). Drives the admin tab

--- a/memex/Memex.Portal.Shared/SelfUpdate/UnavailableUpdateMechanics.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/UnavailableUpdateMechanics.cs
@@ -51,6 +51,11 @@ internal static class UnavailableUpdateMechanics
     {
         public bool CanPatch => false;
 
+        /// <summary>Never — an install with no patcher has never rolled and never will, so the
+        /// floor can only ever pass. Correct rather than a hole: it cannot roll anyway.</summary>
+        public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) =>
+            Task.FromResult<DateTimeOffset?>(null);
+
         public Task PatchToVersionAsync(string versionTag, CancellationToken ct) =>
             throw new InvalidOperationException(
                 $"Cannot roll this install to '{versionTag}': no deployment patcher is registered. "

--- a/src/MeshWeaver.Hosting/SelfUpdate/IDeploymentUpdater.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/IDeploymentUpdater.cs
@@ -19,6 +19,21 @@ public interface IDeploymentUpdater
     /// rolling update. Patching the migration alongside the portal is how the database schema /
     /// <c>db_version</c> stays in step — the meaningful, safe "auto-update Postgres".</summary>
     Task PatchToVersionAsync(string versionTag, CancellationToken ct);
+
+    /// <summary>
+    /// When self-update last rolled THIS install, or null when it never has (or cannot tell).
+    ///
+    /// <para>🚨 This must be state that SURVIVES A RESTART, because a successful roll restarts the
+    /// process: an in-memory "last rolled at" is always empty exactly when it is needed, so a floor
+    /// built on it would never hold. The Kubernetes implementation stamps an annotation on the
+    /// Deployment it patches and reads that back.</para>
+    ///
+    /// <para>🚨 And it must NOT be process uptime, which is the tempting third option and is wrong
+    /// for crash recovery: a pod that comes back on an OLD image has a young process but an old
+    /// deployment, and uptime would make it wait out a floor it has long since satisfied. The
+    /// annotation gives the right answer there — old stamp, floor elapsed, roll immediately.</para>
+    /// </summary>
+    Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct);
 }
 
 /// <summary>Probes the deployment target so the k8s-patch path only arms where it can actually

--- a/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
@@ -45,6 +45,26 @@ public record SelfUpdateOptions
     public TimeSpan RetryInterval { get; init; } = TimeSpan.FromHours(6);
 
     /// <summary>
+    /// The minimum time between two automatic rolls of this install.
+    ///
+    /// <para>Since the check became event-driven, a publication is a roll and a roll is a pod
+    /// restart — so without a floor, publication frequency IS restart frequency, and every restart
+    /// drops the live circuits of everyone using the portal. This paces the AUTOMATIC cadence only:
+    /// an operator who wants a fix now still has <c>kubectl rollout restart</c> (which picks the
+    /// newest image immediately via the startup pass) and a <c>main-cd.yml</c> dispatch.</para>
+    ///
+    /// <para>The default is one hour, matching CD's reconcile tick — the value that makes hourly
+    /// publication actually mean hourly delivery. It is deliberately NOT the 24 h the AKS chart
+    /// used to impose: that predates adopt-before-compile (which took a prod roll from 80 compiles
+    /// / 64.8 s to 0 compiles / 32.1 s) and it answers "how fast can a fix reach prod" with
+    /// "tomorrow", which is the complaint that prompted the faster tick in the first place.</para>
+    ///
+    /// <para>A roll deferred by this floor is re-decided by the next publication event, exactly
+    /// like one deferred for a missing artifact — the floor introduces no timer.</para>
+    /// </summary>
+    public TimeSpan MinRollInterval { get; init; } = TimeSpan.FromHours(1);
+
+    /// <summary>
     /// How long a burst of build-completion events is coalesced before one check runs.
     ///
     /// <para>Several repositories publishing at once (a platform release plus its satellites

--- a/src/MeshWeaver.SelfUpdate.Aks/KubernetesDeploymentUpdater.cs
+++ b/src/MeshWeaver.SelfUpdate.Aks/KubernetesDeploymentUpdater.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Net.Http.Headers;
 using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -73,6 +75,42 @@ public sealed class KubernetesDeploymentUpdater : IDeploymentUpdater
 
     public bool CanPatch => _http is not null && _apiBase is not null && !string.IsNullOrEmpty(_namespace);
 
+    /// <summary>Annotation self-update stamps on the deployments it rolls; the floor reads it back.</summary>
+    internal const string LastRolledAnnotation = "meshweaver.io/self-update-rolled-at";
+
+    /// <inheritdoc />
+    public async Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct)
+    {
+        if (!CanPatch)
+            return null;
+        var token = SafeRead(TokenFile)?.Trim();
+        if (string.IsNullOrEmpty(token) || _http is null)
+            return null;
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get,
+                $"{_apiBase}/apis/apps/v1/namespaces/{_namespace}/deployments/{_options.PortalDeployment}");
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using var res = await _http.SendAsync(req, ct).ConfigureAwait(false);
+            if (!res.IsSuccessStatusCode)
+                return null;   // cannot tell ⇒ do not hold the roll on evidence we could not gather
+            using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
+            return doc.RootElement.TryGetProperty("metadata", out var meta)
+                   && meta.TryGetProperty("annotations", out var annotations)
+                   && annotations.TryGetProperty(LastRolledAnnotation, out var stamp)
+                   && DateTimeOffset.TryParse(stamp.GetString(), out var rolledAt)
+                ? rolledAt
+                : null;        // never rolled by self-update (or a stamp we cannot parse)
+        }
+        catch (Exception ex)
+        {
+            // Never let the floor's own read block a roll: an unreadable deployment reports "no
+            // stamp", which lets the roll proceed rather than freezing this install silently.
+            _logger?.LogWarning(ex, "[SelfUpdate] could not read the last-rolled annotation; treating as never.");
+            return null;
+        }
+    }
+
     public async Task PatchToVersionAsync(string versionTag, CancellationToken ct)
     {
         if (!CanPatch)
@@ -95,8 +133,21 @@ public sealed class KubernetesDeploymentUpdater : IDeploymentUpdater
 
         // Strategic-merge patch: matches the container by name and sets ONLY its image. Built with
         // JsonSerializer so the (deeply-nested) braces are never a string-literal hazard.
+        // Strategic-merge patch: matches the container by name and sets ONLY its image, and stamps
+        // WHEN self-update rolled this deployment. The stamp is the floor's restart-surviving state
+        // (MinRollInterval): a successful roll restarts this process, so anything held in memory is
+        // gone exactly when the floor needs it, while an annotation on the object being patched
+        // outlives the pod — and a pod that crash-restarts on an OLD image reads the OLD stamp and
+        // is correctly free to roll at once.
         var body = JsonSerializer.Serialize(new
         {
+            metadata = new
+            {
+                annotations = new Dictionary<string, string>
+                {
+                    [LastRolledAnnotation] = DateTimeOffset.UtcNow.ToString("O"),
+                },
+            },
             spec = new { template = new { spec = new { containers = new[] { new { name = container, image } } } } }
         });
         using var req = new HttpRequestMessage(HttpMethod.Patch,

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
@@ -65,9 +65,7 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
         public bool CanPatch => true;
 
         /// <summary>No stamp: these fakes exercise the roll decision, not the floor —
-
         /// the floor's own behaviour is pinned in SelfUpdateRollFloorTest.</summary>
-
         public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) =>
 
             Task.FromResult<DateTimeOffset?>(null);

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
@@ -64,6 +64,15 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
         public ImmutableList<string> Tags => tags;
         public bool CanPatch => true;
 
+        /// <summary>No stamp: these fakes exercise the roll decision, not the floor —
+
+        /// the floor's own behaviour is pinned in SelfUpdateRollFloorTest.</summary>
+
+        public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) =>
+
+            Task.FromResult<DateTimeOffset?>(null);
+
+
         public Task PatchToVersionAsync(string versionTag, CancellationToken ct)
         {
             ImmutableInterlocked.Update(ref tags, current => current.Add(versionTag));

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
@@ -64,9 +64,7 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
         public bool CanPatch => true;
 
         /// <summary>No stamp: these fakes exercise the roll decision, not the floor —
-
         /// the floor's own behaviour is pinned in SelfUpdateRollFloorTest.</summary>
-
         public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) =>
 
             Task.FromResult<DateTimeOffset?>(null);

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
@@ -63,6 +63,15 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
         public ImmutableList<string> Tags => _tags;
         public bool CanPatch => true;
 
+        /// <summary>No stamp: these fakes exercise the roll decision, not the floor —
+
+        /// the floor's own behaviour is pinned in SelfUpdateRollFloorTest.</summary>
+
+        public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) =>
+
+            Task.FromResult<DateTimeOffset?>(null);
+
+
         public Task PatchToVersionAsync(string versionTag, CancellationToken ct)
         {
             ImmutableInterlocked.Update(ref _tags, tags => tags.Add(versionTag));

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateRollFloorTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateRollFloorTest.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.GitSync;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the pacing floor (#1778): how often this install may roll ITSELF.
+///
+/// <para>Since the check became event-driven a publication is a roll and a roll is a pod restart,
+/// so without a floor publication frequency IS restart frequency — and every restart drops the
+/// live circuits of everyone on the portal. The floor bounds the AUTOMATIC cadence only; an
+/// operator still has <c>kubectl rollout restart</c>.</para>
+///
+/// <para>🚨 The case that decides the design is CRASH RECOVERY. The floor needs state that
+/// survives a restart, because a successful roll restarts the process — so "last rolled" cannot be
+/// held in memory. Process uptime is the tempting substitute and is WRONG: a pod that comes back
+/// on an OLD image has a young process but an old deployment and would wait out a floor it has
+/// long since satisfied. The stamp lives on the Deployment, so an old stamp frees it immediately.
+/// <see cref="AnOldStampRollsImmediately_TheCrashRecoveryCase"/> is that test.</para>
+/// </summary>
+public class SelfUpdateRollFloorTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddUpdatePolicyType().AddGitHubSyncTypes();
+
+    private const string CandidateTag = "3.0.0";
+
+    /// <summary>Updater whose "last rolled" stamp the test controls — the Deployment annotation's
+    /// stand-in, and the only thing the floor reads.</summary>
+    private sealed class StampedUpdater(DateTimeOffset? lastRolled) : IDeploymentUpdater
+    {
+        private readonly ReplaySubject<string> _patched = new();
+        private ImmutableList<string> _tags = ImmutableList<string>.Empty;
+
+        public IObservable<string> Patched => _patched;
+        public ImmutableList<string> Tags => _tags;
+        public bool CanPatch => true;
+
+        public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) =>
+            Task.FromResult(lastRolled);
+
+        public Task PatchToVersionAsync(string versionTag, CancellationToken ct)
+        {
+            ImmutableInterlocked.Update(ref _tags, tags => tags.Add(versionTag));
+            _patched.OnNext(versionTag);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class OneTagLister : IAcrTagLister
+    {
+        public Task<IReadOnlyList<string>> ListTagsAsync(string repository, CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<string>>([CandidateTag]);
+    }
+
+    private static SelfUpdateOptions Options(TimeSpan floor) => new()
+    {
+        RetryInterval = TimeSpan.FromMilliseconds(500),
+        EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
+        MinRollInterval = floor,
+        DefaultPolicy = UpdatePolicyKind.Continuous,
+    };
+
+    private async Task<ImmutableList<string>> RunStartupPassAsync(StampedUpdater updater, TimeSpan floor)
+    {
+        var service = new SelfUpdateHostedService(
+            Mesh, new OneTagLister(), updater, Options(floor),
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>());
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            // Give the startup pass room to reach the roll decision either way. A patch that is
+            // going to happen has happened well inside this; a deferral never will.
+            await Task.Delay(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+            return updater.Tags;
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task AFreshRoll_DefersTheNextOne()
+    {
+        var updater = new StampedUpdater(DateTimeOffset.UtcNow.AddMinutes(-5));
+        var tags = await RunStartupPassAsync(updater, floor: TimeSpan.FromHours(1));
+        tags.Should().BeEmpty(
+            "the install rolled 5 minutes ago and the floor is an hour — rolling again would restart "
+            + "the pod and drop every live circuit for a version it just took");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task AnOldStampRollsImmediately_TheCrashRecoveryCase()
+    {
+        // The shape process uptime gets wrong: a pod that has just started (young process) on an
+        // image rolled long ago (old stamp) must roll AT ONCE, not wait out the floor.
+        var updater = new StampedUpdater(DateTimeOffset.UtcNow.AddHours(-9));
+        var tags = await RunStartupPassAsync(updater, floor: TimeSpan.FromHours(1));
+        tags.Should().Equal([CandidateTag],
+            "the last roll is older than the floor, so a freshly-restarted pod on an old image "
+            + "must take the update immediately rather than waiting");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task NeverRolled_IsNotHeld()
+    {
+        // A first-ever roll has no stamp to compare against. It must not be held: an install that
+        // has never self-updated is the one most in need of the update.
+        var updater = new StampedUpdater(null);
+        var tags = await RunStartupPassAsync(updater, floor: TimeSpan.FromHours(1));
+        tags.Should().Equal([CandidateTag]);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task AZeroFloor_NeverHolds()
+    {
+        // The opt-out an install with no restart cost (a single-user dev portal) can set.
+        var updater = new StampedUpdater(DateTimeOffset.UtcNow.AddSeconds(-1));
+        var tags = await RunStartupPassAsync(updater, floor: TimeSpan.Zero);
+        tags.Should().Equal([CandidateTag]);
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateRollFloorTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateRollFloorTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
 using System.Threading;
 using System.Threading.Tasks;
 using Memex.Portal.Shared.SelfUpdate;
@@ -75,16 +76,34 @@ public class SelfUpdateRollFloorTest(ITestOutputHelper output) : MonolithMeshTes
         DefaultPolicy = UpdatePolicyKind.Continuous,
     };
 
-    private async Task<ImmutableList<string>> RunStartupPassAsync(StampedUpdater updater, TimeSpan floor)
+    /// <summary>Runs the startup pass and waits for the roll it is expected to produce — a positive
+    /// signal on the Patched stream, never a fixed delay.</summary>
+    private async Task<ImmutableList<string>> ExpectRollAsync(StampedUpdater updater, TimeSpan floor)
     {
-        var service = new SelfUpdateHostedService(
-            Mesh, new OneTagLister(), updater, Options(floor),
-            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>());
+        var service = NewService(updater, floor);
         await service.StartAsync(CancellationToken.None);
         try
         {
-            // Give the startup pass room to reach the roll decision either way. A patch that is
-            // going to happen has happened well inside this; a deferral never will.
+            await updater.Patched.FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(TestContext.Current.CancellationToken);
+            return updater.Tags;
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>Runs the startup pass and confirms NO roll happens. This is the one shape with no
+    /// positive signal to wait for — the sanctioned "wait to confirm nothing happened" case — so it
+    /// is the only place a bounded delay is correct.</summary>
+    private async Task<ImmutableList<string>> ExpectNoRollAsync(StampedUpdater updater, TimeSpan floor)
+    {
+        var service = NewService(updater, floor);
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
             await Task.Delay(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
             return updater.Tags;
         }
@@ -94,11 +113,15 @@ public class SelfUpdateRollFloorTest(ITestOutputHelper output) : MonolithMeshTes
         }
     }
 
+    private SelfUpdateHostedService NewService(StampedUpdater updater, TimeSpan floor) =>
+        new(Mesh, new OneTagLister(), updater, Options(floor),
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>());
+
     [Fact(Timeout = 60000)]
     public async Task AFreshRoll_DefersTheNextOne()
     {
         var updater = new StampedUpdater(DateTimeOffset.UtcNow.AddMinutes(-5));
-        var tags = await RunStartupPassAsync(updater, floor: TimeSpan.FromHours(1));
+        var tags = await ExpectNoRollAsync(updater, floor: TimeSpan.FromHours(1));
         tags.Should().BeEmpty(
             "the install rolled 5 minutes ago and the floor is an hour — rolling again would restart "
             + "the pod and drop every live circuit for a version it just took");
@@ -110,7 +133,7 @@ public class SelfUpdateRollFloorTest(ITestOutputHelper output) : MonolithMeshTes
         // The shape process uptime gets wrong: a pod that has just started (young process) on an
         // image rolled long ago (old stamp) must roll AT ONCE, not wait out the floor.
         var updater = new StampedUpdater(DateTimeOffset.UtcNow.AddHours(-9));
-        var tags = await RunStartupPassAsync(updater, floor: TimeSpan.FromHours(1));
+        var tags = await ExpectRollAsync(updater, floor: TimeSpan.FromHours(1));
         tags.Should().Equal([CandidateTag],
             "the last roll is older than the floor, so a freshly-restarted pod on an old image "
             + "must take the update immediately rather than waiting");
@@ -122,7 +145,7 @@ public class SelfUpdateRollFloorTest(ITestOutputHelper output) : MonolithMeshTes
         // A first-ever roll has no stamp to compare against. It must not be held: an install that
         // has never self-updated is the one most in need of the update.
         var updater = new StampedUpdater(null);
-        var tags = await RunStartupPassAsync(updater, floor: TimeSpan.FromHours(1));
+        var tags = await ExpectRollAsync(updater, floor: TimeSpan.FromHours(1));
         tags.Should().Equal([CandidateTag]);
     }
 
@@ -131,7 +154,7 @@ public class SelfUpdateRollFloorTest(ITestOutputHelper output) : MonolithMeshTes
     {
         // The opt-out an install with no restart cost (a single-user dev portal) can set.
         var updater = new StampedUpdater(DateTimeOffset.UtcNow.AddSeconds(-1));
-        var tags = await RunStartupPassAsync(updater, floor: TimeSpan.Zero);
+        var tags = await ExpectRollAsync(updater, floor: TimeSpan.Zero);
         tags.Should().Equal([CandidateTag]);
     }
 }


### PR DESCRIPTION
Closes #1778. **This is my regression from #1773** — I am fixing it, not reporting it.

## What I broke

#1773 renamed `SelfUpdateOptions.PollInterval` and removed the recurring poll. That left `SelfUpdate__PollInterval: "1.00:00:00"` in `deploy/aks/values.aks.yaml` — a deliberate **one-roll-per-day production throttle** — binding to nothing, while still reading like a live throttle to anyone opening the file.

The cause is specific: I grepped `.cs` for the renamed option, and grepped the charts only for the option I *deleted*. **A rename is exactly as breaking as a deletion for a `__`-bound key.**

Without pacing, **publication frequency is portal-restart frequency, one for one** — and each restart drops the live circuits of everyone using the portal.

## The floor

- `SelfUpdateOptions.MinRollInterval`, bound from `SelfUpdate:*` like the rest, **default 1 hour**.
- Checked at the roll decision: inside the floor, log and defer.
- A deferred roll is re-decided by the **next publication event**, exactly like an availability hold — the floor introduces **no timer**.

## 🚨 Restart-surviving state, and why not uptime

A successful roll **restarts the process**, so an in-memory "last rolled at" is empty exactly when the floor needs it. `IDeploymentUpdater` grows `LastRolledAtAsync`, answered in `MeshWeaver.SelfUpdate.Aks` by an **annotation the patch itself stamps on the Deployment**, and "never" by the platform's `DetectOnly` fallback (an install with no patcher cannot roll anyway).

**Not process uptime** — the tempting third option, wrong for **crash recovery**: a pod that comes back on an OLD image has a young process but an old deployment, and uptime would make it wait out a floor it satisfied hours ago, precisely when it most needs the newer image. The annotation gives the right answer. `AnOldStampRollsImmediately_TheCrashRecoveryCase` pins exactly that.

## 🚨 The value is 1 h, deliberately not the 24 h prod had

Restoring the prior number is **not** the neutral default it looks like. With hourly publication, a daily floor means a merged fix reaches prod the **next day** — strictly worse than the 3 h window the maintainer rejected. "Restore prior behaviour" would silently answer their complaint with "no".

Half the 2026-08-10 rationale for 24 h is also obsolete: adopt-before-compile took a prod roll from **80 compiles / 64.8 s to 0 compiles / 32.1 s**, leaving the restart cost as the only live argument — which is what this bounds.

| floor | restarts/day | a merged fix is visible |
|---|---|---|
| 24 h | ≤1 | next day (what prod had) |
| 6 h | ≤4 | same working day |
| **1 h** | ≤24 | **~1.5 h after merge** |

`values.aks.yaml` carries that trade in prose, so the number can be changed without re-deriving it. And the floor paces only the **automatic** cadence — `kubectl rollout restart` (startup pass takes the newest image) and a `main-cd.yml` dispatch both still apply an urgent fix immediately.

## Timing, verified rather than assumed

Prod runs `3.0.0-rc4.ci.4147` (commit `324e61a`), an **ancestor of #1773** — so the portals still carry the old poller and are still on the 24 h throttle. **The unpaced behaviour is not live yet**; it begins with the first post-#1773 image prod rolls onto, which is the deadline this wants to be inside.

## Verification

- Whole solution `-c Release -p:CIRun=true -warnaserror` → `0 Error(s)`.
- **18/18** self-update tests, including four new ones: fresh roll defers, old stamp rolls immediately (crash recovery), never-rolled is not held, zero floor opts out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjujCq1BsJkNKuZ4wXodo1