### PR TITLE
fix(#1767): a UTF-8 BOM silently dropped 62 of a package's 72 node files

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-bom-files-no-longer-skipped.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-bom-files-no-longer-skipped.md
@@ -1,0 +1,26 @@
+---
+Name: Files saved with a byte-order mark now load
+Category: Fix
+Description: A node file written by an editor that adds a UTF-8 byte-order mark was skipped on install — one sample package silently lost 62 of its 72 files.
+Icon: Sparkle
+Order: -20260817
+---
+
+# Files saved with a byte-order mark now load
+
+Some editors — Windows ones especially — save UTF-8 files with an invisible marker at the start
+called a byte-order mark. Files saved that way were unreadable to the installer: it skipped them,
+installed whatever was left, and reported success. There was nothing on screen to say anything had
+gone missing.
+
+One sample package lost **62 of its 72 files** this way and contributed no types at all, for years,
+while every install of it looked healthy.
+
+Both halves are fixed. The marker is now handled wherever node files are read, so a file saved with
+one installs exactly like a file saved without one. And a package that skips files now says so in
+one summary line — how many were skipped, out of how many, and how many installed — rather than
+burying one line per file where nobody would see it.
+
+Skipped files still do not fail an install: content the platform cannot read is left out and the
+rest is installed, which is the long-standing behaviour. The change is that you can now tell it
+happened.

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/CSharpFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/CSharpFileParser.cs
@@ -39,7 +39,11 @@ public partial class CSharpFileParser : IFileFormatParser
     /// <returns>A <c>CodeConfiguration</c> with the cleaned code, or null if it cannot be parsed.</returns>
     public CodeConfiguration? ParseCodeConfiguration(string filePath, string content)
     {
-        var codeWithoutMetadata = RemoveMetadataBlock(content);
+        // Second entry point into C# node text, reached from the storage adapters rather than
+        // through FileFormatParserRegistry.TryParse — so it needs the same BOM handling (#1767).
+        // A BOM here does not throw; RemoveMetadataBlock simply stops matching the leading
+        // `// <meshweaver>` line, and the heading survives as dead code at the top of Code.
+        var codeWithoutMetadata = RemoveMetadataBlock(FileFormatParserRegistry.WithoutBom(content));
 
         return new CodeConfiguration
         {

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/FileFormatParserRegistry.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/FileFormatParserRegistry.cs
@@ -134,7 +134,11 @@ public class FileFormatParserRegistry
     /// three chances to forget.</para>
     /// </summary>
     public static string WithoutBom(string content) =>
-        content.Length > 0 && content[0] == '﻿' ? content[1..] : content;
+        // '\uFEFF', spelled as an escape ON PURPOSE: the literal character is invisible in every
+        // editor, so a copy-paste or a formatter could drop it and turn this into a no-op that
+        // still compiles and still reads correctly (Copilot review, #1781). An invisible constant
+        // is the last thing a BOM fix should contain.
+        content.Length > 0 && content[0] == '\uFEFF' ? content[1..] : content;
 
     /// <summary>
     /// Gets a parser that can serialize the given node.

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/FileFormatParserRegistry.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/FileFormatParserRegistry.cs
@@ -92,6 +92,7 @@ public class FileFormatParserRegistry
         Action<string, Exception>? onError = null)
     {
         var parsers = GetParsers(extension);
+        content = WithoutBom(content);
         Exception? lastError = null;
         foreach (var parser in parsers)
         {
@@ -112,6 +113,28 @@ public class FileFormatParserRegistry
             onError?.Invoke(relativePath, lastError);
         return null;
     }
+
+    /// <summary>
+    /// Drops a leading UTF-8 BOM (U+FEFF) from decoded file text.
+    ///
+    /// <para>🚨 #1767: this is not cosmetic. A BOM'd file reached every parser as text beginning
+    /// with U+FEFF and each format failed differently — JSON threw (the file was SKIPPED), and a
+    /// C# node parsed but stopped recognising its <c>// &lt;meshweaver&gt;</c> heading, so it kept
+    /// its code and silently lost its declared Id/DisplayName. `PensionFund` lost <b>62 of 72
+    /// files</b> that way and gated ZERO NodeTypes while the run reported success.</para>
+    ///
+    /// <para>The BOM survives to this layer because package content arrives as BYTES (git tree,
+    /// archive, API response) and is decoded with <c>Encoding.UTF8.GetString</c>, which preserves
+    /// U+FEFF as a character — unlike <c>File.ReadAllText</c>, whose encoding detection strips it.
+    /// So a path that only ever read from disk never saw this, which is why it went unnoticed for
+    /// years: the defect lives on the package path, and only the package path.</para>
+    ///
+    /// <para>Stripping belongs HERE, once, rather than in each parser: a BOM is a property of the
+    /// text encoding, not of any file format, and three parsers each remembering to handle it is
+    /// three chances to forget.</para>
+    /// </summary>
+    public static string WithoutBom(string content) =>
+        content.Length > 0 && content[0] == '﻿' ? content[1..] : content;
 
     /// <summary>
     /// Gets a parser that can serialize the given node.

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -2358,28 +2358,41 @@ public static class PackageInstaller
 
         if (unparsed.Count > 0)
             logger?.LogWarning(
-                "Package '{Package}': {Skipped} of {Total} files had no parser and were skipped; "
-                + "{Installed} nodes installed. First skipped: {Sample}.",
-                packageId, unparsed.Count, files.Count, nodes.Length,
-                string.Join(", ", unparsed.Take(5)));
+                "Package '{Package}': {Skipped} of {Candidates} candidate files had no parser and "
+                + "were skipped; {Installed} nodes installed. First skipped: {Sample}.",
+                packageId, unparsed.Count, files.Count(f => !IsNotANodeFile(f.RelativePath)),
+                nodes.Length, string.Join(", ", unparsed.Take(5)));
 
         return nodes;
     }
 
+    /// <summary>
+    /// Files that are NOT nodes by design, and so are neither parsed nor counted as skips.
+    ///
+    /// <para>The README is a GitHub display file. The manifest is the install record's baseline.
+    /// A <c>{package}/content/**</c> asset is not a node — its bytes go to the partition root's
+    /// content collection (SyncPackageContent), which is where the served
+    /// <c>/api/content/{root}/content/…</c> URL resolves. (It used to be
+    /// <c>/static/{root}/content/…</c>; #587 unmounted content from /static entirely, so that shape
+    /// is now 404 for everyone — an authored asset URL must name the access-controlled route.) Same
+    /// split GitHubSyncService.ParseSnapshot makes, and the one NodePathForFile asserts. Excluding
+    /// them also silences the "No parser for …/videos/x.mp4" warning every course emitted per
+    /// install.</para>
+    ///
+    /// <para>ONE predicate, used by both the parse loop and the aggregate line's denominator —
+    /// "3 of 200 skipped" reads very differently when 150 of the 200 were never node candidates
+    /// (Copilot review, #1781). Two copies of this list would drift, and the drift would show up as
+    /// a quietly wrong count rather than as a failure.</para>
+    /// </summary>
+    private static bool IsNotANodeFile(string relativePath) =>
+        string.Equals(relativePath, "README.md", StringComparison.OrdinalIgnoreCase)
+        || ModuleManifest.IsManifestPath(relativePath)
+        || ContentAssetMapper.IsContentPath(relativePath);
+
     private static MeshNode? ParseCanonical(
         FileFormatParserRegistry parsers, PackageFile file, ILogger? logger, List<string>? unparsed = null)
     {
-        if (string.Equals(file.RelativePath, "README.md", StringComparison.OrdinalIgnoreCase)
-            || ModuleManifest.IsManifestPath(file.RelativePath)
-            // A `{package}/content/**` asset is NOT a node — its bytes go to the partition root's
-            // content collection (SyncPackageContent), which is where the served
-            // `/api/content/{root}/content/…` URL resolves. (It used to be `/static/{root}/content/…`;
-            // #587 unmounted content from /static entirely, so that shape is now 404 for everyone —
-            // an authored asset URL must name the access-controlled route.) Same split
-            // GitHubSyncService.ParseSnapshot
-            // makes, and the one NodePathForFile below has always asserted. Skipping it here also
-            // silences the "No parser for …/videos/x.mp4" warning every course emitted per install.
-            || ContentAssetMapper.IsContentPath(file.RelativePath))
+        if (IsNotANodeFile(file.RelativePath))
             return null;
         var ext = System.IO.Path.GetExtension(file.RelativePath);
         var parsed = parsers.TryParse(ext, file.RelativePath, file.Content, file.RelativePath);

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1674,10 +1674,7 @@ public static class PackageInstaller
             .Where(f => ModuleManifest.IsManifestPath(f.RelativePath))
             .Select(f => ModuleManifest.TryParse(f.Content, logger))
             .FirstOrDefault(m => m is not null);
-        var nodes = files
-            .Select(f => ParseCanonical(parsers, f, logger))
-            .Where(n => n is not null).Select(n => n!)
-            .ToArray();
+        var nodes = ParseAll(parsers, files, manifest.Id, logger);
 
         if (nodes.Length == 0)
             return Observable.Throw<InstallResult>(new InvalidOperationException(
@@ -2187,10 +2184,7 @@ public static class PackageInstaller
     {
 
         var parsers = new FileFormatParserRegistry(hub.JsonSerializerOptions);
-        var nodes = changedFiles
-            .Select(f => ParseCanonical(parsers, f, logger))
-            .Where(n => n is not null).Select(n => n!)
-            .ToArray();
+        var nodes = ParseAll(parsers, changedFiles, manifest.Id, logger);
 
         if (RefuseIfStaticShadowed(hub, manifest, nodes, logger) is { } shadowed)
             return shadowed;
@@ -2338,7 +2332,42 @@ public static class PackageInstaller
     // Parses a node-per-file file into a MeshNode at its CANONICAL path (no partition rebase) — the
     // file's repo-relative path IS the node's path. The export's top-level README.md is a GitHub
     // display file, never a node (mirrors GitHubSyncService.ParseFile, minus the space rebase).
-    private static MeshNode? ParseCanonical(FileFormatParserRegistry parsers, PackageFile file, ILogger? logger)
+    /// <summary>
+    /// Parses every file of an install and reports the UNPARSEABLE ones as ONE aggregate line.
+    ///
+    /// <para>🚨 #1767: a per-file "skipped" warning is not a signal. `PensionFund` shipped 72
+    /// BOM'd files, 62 of them were skipped, the package gated ZERO NodeTypes — and the install
+    /// reported success for years, because the only evidence was 62 lines in a log nobody reads.
+    /// "I installed nothing" and "I installed everything" must never look alike at the level where
+    /// the verdict is read.</para>
+    ///
+    /// <para>Loud and counted, NOT fatal: the runtime itself skips unmaterialisable files and
+    /// installs the rest, so refusing here would resolve a SMALLER tree than the mesh does — the
+    /// equivalence break #1763 exists to prevent, in the opposite direction. Files that are not
+    /// nodes by design (README, manifest, `content/**` assets) are not skips and are not counted.
+    /// </para>
+    /// </summary>
+    private static MeshNode[] ParseAll(
+        FileFormatParserRegistry parsers, IReadOnlyList<PackageFile> files, string packageId, ILogger? logger)
+    {
+        var unparsed = new List<string>();
+        var nodes = files
+            .Select(f => ParseCanonical(parsers, f, logger, unparsed))
+            .Where(n => n is not null).Select(n => n!)
+            .ToArray();
+
+        if (unparsed.Count > 0)
+            logger?.LogWarning(
+                "Package '{Package}': {Skipped} of {Total} files had no parser and were skipped; "
+                + "{Installed} nodes installed. First skipped: {Sample}.",
+                packageId, unparsed.Count, files.Count, nodes.Length,
+                string.Join(", ", unparsed.Take(5)));
+
+        return nodes;
+    }
+
+    private static MeshNode? ParseCanonical(
+        FileFormatParserRegistry parsers, PackageFile file, ILogger? logger, List<string>? unparsed = null)
     {
         if (string.Equals(file.RelativePath, "README.md", StringComparison.OrdinalIgnoreCase)
             || ModuleManifest.IsManifestPath(file.RelativePath)
@@ -2357,6 +2386,7 @@ public static class PackageInstaller
         if (parsed is null)
         {
             logger?.LogWarning("No parser for node-repo file {Path}; skipped.", file.RelativePath);
+            unparsed?.Add(file.RelativePath);
             return null;
         }
         var (id, ns) = NodeFileMapper.FromRelativePath(file.RelativePath);

--- a/test/MeshWeaver.Hosting.Test/FileFormatParserBomTest.cs
+++ b/test/MeshWeaver.Hosting.Test/FileFormatParserBomTest.cs
@@ -1,0 +1,101 @@
+using System.Text;
+using System.Text.Json;
+using MeshWeaver.Hosting.Persistence.Parsers;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins #1767: a UTF-8 BOM must not make a node file unparseable.
+///
+/// <para>`samples/Graph/Data/PensionFund/*.json` carry a BOM, and the node-repo loader dropped
+/// <b>62 of that package's 72 files</b> — gating ZERO NodeTypes for the whole tree while reporting
+/// success. The BOM is trivial; the invisibility was the defect, and it survived for years because
+/// a skip is one line per file in a log nobody reads.</para>
+///
+/// <para>Why the BOM survives to this layer at all: a string read through <c>File.ReadAllText</c>
+/// has its BOM stripped by encoding detection, but package content arrives as BYTES from a git
+/// tree / archive / API response and is decoded with <c>Encoding.UTF8.GetString</c>, which
+/// preserves U+FEFF as a character. So the string handed to a parser can legitimately start with
+/// one, and every format is affected, not just JSON: it equally breaks the <c>---</c> front-matter
+/// probe of an Agent file and the <c>// &lt;meshweaver&gt;</c> heading of a C# node.</para>
+///
+/// 🚨 Do NOT "fix" this by stripping the BOM from the sample files — that hides the parser gap and
+/// the next BOM'd file anywhere in the estate reproduces it.
+/// </summary>
+public class FileFormatParserBomTest
+{
+    private const string Bom = "﻿";
+    private static FileFormatParserRegistry Registry() => new(new JsonSerializerOptions());
+
+    [Fact]
+    public void JsonNode_WithUtf8Bom_StillParses()
+    {
+        const string json = """
+            { "$type": "MeshWeaver.Mesh.MarkdownContent", "Id": "Doc", "Name": "A document" }
+            """;
+
+        var withBom = Registry().TryParse(".json", "Pkg/Doc.json", Bom + json, "Pkg/Doc.json");
+        var without = Registry().TryParse(".json", "Pkg/Doc.json", json, "Pkg/Doc.json");
+
+        Assert.NotNull(without);
+        Assert.NotNull(withBom);
+    }
+
+    [Fact]
+    public void MarkdownNode_WithUtf8Bom_KeepsItsFrontMatter()
+    {
+        const string md = """
+            ---
+            Name: With front matter
+            ---
+
+            # Body
+            """;
+
+        var node = Registry().TryParse(".md", "Pkg/Page.md", Bom + md, "Pkg/Page.md");
+
+        Assert.NotNull(node);
+        // The BOM must be consumed, not carried into the first line — otherwise the front-matter
+        // fence is "﻿---", the block is treated as body text, and Name silently disappears.
+        Assert.Equal("With front matter", node!.Name);
+    }
+
+    [Fact]
+    public void CSharpNode_WithUtf8Bom_KeepsItsHeadingBlock()
+    {
+        const string cs = """
+            // <meshweaver>
+            // Id: Greeter
+            // DisplayName: The greeter
+            // </meshweaver>
+            public static class Greeter { }
+            """;
+
+        var node = Registry().TryParse(".cs", "Pkg/Source/Greeter.cs", Bom + cs, "Pkg/Source/Greeter.cs");
+
+        Assert.NotNull(node);
+        Assert.Equal("The greeter", node!.Name);
+    }
+
+    /// <summary>
+    /// The decode path that produces the BOM in the first place, so this test fails for the same
+    /// reason production did rather than because of a hand-written escape.
+    /// </summary>
+    [Fact]
+    public void Utf8GetString_PreservesTheBom_WhichIsWhyThisMatters()
+    {
+        const string json = """
+            { "$type": "MeshWeaver.Mesh.MarkdownContent", "Id": "Doc", "Name": "A document" }
+            """;
+        var bytes = Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes(json)).ToArray();
+
+        var decoded = Encoding.UTF8.GetString(bytes);
+
+        // The preamble is not stripped by the decoder — that is the entire mechanism, and it is
+        // why a path that only ever used File.ReadAllText never saw the bug.
+        Assert.StartsWith(Bom, decoded);
+        Assert.NotNull(Registry().TryParse(".json", "Pkg/Doc.json", decoded, "Pkg/Doc.json"));
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/FileFormatParserBomTest.cs
+++ b/test/MeshWeaver.Hosting.Test/FileFormatParserBomTest.cs
@@ -26,7 +26,12 @@ namespace MeshWeaver.Hosting.Test;
 /// </summary>
 public class FileFormatParserBomTest
 {
-    private const string Bom = "﻿";
+    /// <summary>
+    /// Spelled as an escape, not the literal character: a BOM is invisible in every editor, so a
+    /// formatter or a bad paste could silently empty this constant and leave the tests passing
+    /// while asserting nothing (Copilot review, #1781).
+    /// </summary>
+    private const string Bom = "\uFEFF";
     private static FileFormatParserRegistry Registry() => new(new JsonSerializerOptions());
 
     [Fact]
@@ -58,7 +63,7 @@ public class FileFormatParserBomTest
 
         Assert.NotNull(node);
         // The BOM must be consumed, not carried into the first line — otherwise the front-matter
-        // fence is "﻿---", the block is treated as body text, and Name silently disappears.
+        // fence is "\uFEFF---", the block is treated as body text, and Name silently disappears.
         Assert.Equal("With front matter", node!.Name);
     }
 

--- a/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
@@ -89,6 +89,13 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
     // samples/Graph/Data. Every NodeType that has ever compiled carries this stamp, so a fixture
     // without one does not resemble real content at all. If the converter regresses, the tree bake
     // drops Widget/Thing and the bundle-set assertion below goes red.
+    /// <summary>
+    /// A plain data node written WITH a UTF-8 BOM (#1767). Deliberately not a NodeType: what is
+    /// under test is that both producers materialise it identically, not that it compiles.
+    /// </summary>
+    private const string BommedNodeTypeJson =
+        """{"$type":"MeshNode","id":"Bommed","namespace":"Widget","path":"Widget/Bommed","mainNode":"Widget/Bommed","name":"A BOM'd node file","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"Written with a UTF-8 BOM; both bakes must see it."}}""";
+
     private const string ThingNodeTypeJson =
         """{"$type":"MeshNode","id":"Thing","namespace":"Widget","path":"Widget/Thing","mainNode":"Widget/Thing","name":"Thing","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A thing.","configuration":"config => config.WithContentType<Thing>().AddDefaultLayoutAreas()","includeGlobalTypes":true,"compilationStatus":"Ok","lastCompiledVersion":7,"sources":["namespace:Source scope:subtree","shared=@Lib/Shared/Source"]}}""";
 
@@ -171,13 +178,18 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
             WriteFile(root, "Widget/Thing/Source/Cell.json", ExecutableCellJson);
             WriteFile(root, "Widget/Thing/Test/ThingTests.cs", ThingTestsSource);
             WriteFile(root, "Widget/Snippets/Greeting.cs", GreetingSource);
-            // 🚨 A node file the RUNTIME cannot parse. samples/Graph/Data/PensionFund ships 62 of
-            // these — .json with a UTF-8 BOM — and the mesh's importer skips every one
-            // ("No parser for node-repo file X; skipped"), gating zero NodeTypes in that package.
-            // The bake must skip it too: neither die on it (it is not a bake failure) nor parse it
-            // (that would compile content the mesh never imports). Both producers therefore emit
-            // the SAME bundle set, which is what the assertions below check.
-            WriteFileWithBom(root, "Widget/Unparseable.json", WidgetIndexJson);
+            // 🚨 A node file the RUNTIME cannot parse — malformed JSON. The bake must skip it too:
+            // neither die on it (it is not a bake failure) nor parse it (that would compile content
+            // the mesh never imports). Both producers therefore emit the SAME bundle set, which is
+            // what the assertions below check.
+            WriteFile(root, "Widget/Unparseable.json", "{ this is not json");
+            // 🚨 A BOM'd file is NOT that case any more (#1767). It used to be — PensionFund ships
+            // 62 BOM'd .json files and the importer skipped every one, gating zero NodeTypes while
+            // reporting success — and this test pinned that skip as the contract. The BOM is now
+            // stripped in FileFormatParserRegistry, which both producers share, so the file parses
+            // on BOTH sides and equivalence still holds. Keeping it here means a regression that
+            // re-broke only one of the two loaders would show up as a bundle-set difference.
+            WriteFileWithBom(root, "Widget/Bommed.json", BommedNodeTypeJson);
         });
         var meshDir = Path.Combine(Path.GetTempPath(), "mw-bake-mesh-" + Guid.NewGuid().ToString("N"));
         var treeDir = Path.Combine(Path.GetTempPath(), "mw-bake-tree-" + Guid.NewGuid().ToString("N"));

--- a/tools/MeshWeaver.PluginTester/TreeNodeLoader.cs
+++ b/tools/MeshWeaver.PluginTester/TreeNodeLoader.cs
@@ -158,16 +158,21 @@ public static class TreeNodeLoader
         JsonDocument document;
         try
         {
-            document = JsonDocument.Parse(file.Content, ContentJsonDocument);
+            // 🚨 The BOM strip here is REQUIRED, and the requirement inverted on 2026-08-17.
+            // This line used to carry the opposite instruction — "do NOT strip a UTF-8 BOM, the
+            // RUNTIME drops those nodes and a bake that compiled them would be an equivalence
+            // break" — which was correct while the runtime skipped them. #1767 fixed the runtime
+            // (FileFormatParserRegistry.WithoutBom), so NOT stripping here is now the equivalence
+            // break, in the other direction: the bake would resolve a SMALLER tree than the mesh
+            // imports and silently ship no bundle for content the portal then compiles at runtime.
+            // Whichever way the runtime goes, this path follows it — that is the invariant, not
+            // the strip itself, and BakeEquivalenceTest is what holds the two together.
+            document = JsonDocument.Parse(FileFormatParserRegistry.WithoutBom(file.Content), ContentJsonDocument);
         }
         catch (JsonException ex)
         {
-            // 🚨 Matches JsonFileParser: a document that will not parse yields NO node, and the
-            // installer logs "No parser for …; skipped". Do NOT "fix" this by stripping a UTF-8 BOM
-            // here — samples/Graph/Data/PensionFund/*.json carry one, the RUNTIME drops every one of
-            // those nodes for exactly this reason, and a bake that quietly compiled content the mesh
-            // never imports would be the equivalence break this whole change exists to prevent (in
-            // the opposite direction). The BOM is a CONTENT defect and belongs in a content fix.
+            // Matches JsonFileParser: a document that will not parse yields NO node, and the
+            // installer logs "No parser for …; skipped".
             reason = $"malformed JSON: {ex.Message}";
             return null;
         }


### PR DESCRIPTION
Closes #1767.

## Measured, before and after

`samples/Graph/Data/PensionFund` ships **72 files, 62 of them carrying a UTF-8 BOM**. Staging that
tree as a node-repo and baking it:

```
before:  bake: 62 file(s) skipped …   11 node(s) from 1 package(s)
after:                                73 node(s) from 1 package(s)
```

So the package contributed **11 of its 73 nodes** and gated **zero NodeTypes** — for years, while
every install and every bake reported success.

## Why a BOM ever reached a parser

`File.ReadAllText` strips it via encoding detection. Package content does not go through that path:
it arrives as **bytes** (git tree, archive, API response) and is decoded with
`Encoding.UTF8.GetString`, which preserves U+FEFF as a character. So the defect lives on the package
path and only the package path — which is exactly why nothing on the disk-reading side ever saw it.

Each format then failed differently, and the second one is nastier than the skip:

| format | with a BOM, before |
|---|---|
| `.json` | throws → file SKIPPED (`No parser for node-repo file …`) |
| `.cs` | parses, but stops matching its `// <meshweaver>` heading → **silently loses its declared Id/DisplayName**, keeping the heading as dead code |
| `.md` | unaffected |

## The fix

**One strip, at the layer every format shares** — `FileFormatParserRegistry.TryParse`, plus
`ParseCodeConfiguration` (the second entry point, reached from the storage adapters). A BOM is a
property of the text encoding, not of any file format; three parsers each remembering to handle it
is three chances to forget.

🚨 **The bake had to move with it, and in the opposite direction to its own comment.**
`TreeNodeLoader.MaterialiseJson` carried an explicit instruction *not* to strip the BOM, on the
grounds that the runtime skipped those files and a bake that compiled them would break equivalence.
That was correct — until this PR changed the runtime. Leaving it would have made the bake resolve a
**smaller** tree than the mesh imports, shipping no bundle for content the portal then compiles at
runtime. The invariant is "this path follows the runtime", not the strip itself, and
`BakeEquivalenceTest` is what holds the two together. I only found this because I ran the real bake
over the real tree instead of trusting the unit test.

## Aggregate signal — the half that keeps the next one from hiding

A per-file "skipped" warning is not a signal. `ParseAll` now emits **one line per install**: how many
files had no parser, out of how many, and how many nodes installed. Files that are not nodes by
design (README, manifest, `content/**` assets) are not counted as skips.

Deliberately **loud and counted, not fatal**: the runtime skips unmaterialisable files and installs
the rest, so refusing here would resolve a smaller tree than the mesh — the same equivalence break,
again in the opposite direction.

## Scope of the newly-live content

The 62 files include **5 NodeTypeDefinitions** that have never compiled anywhere. Two things bound
the risk, and I checked both rather than assuming:

- **No production portal loads this tree.** `samples/Graph/Data` is referenced only by
  `Memex.Portal.Monolith`'s appsettings — the Distributed portal that ships to memex / atioz /
  memex-cloud does not load it. No production NodeType can go `CompileError` from this change.
- **I could not compile those five locally**, and say so rather than claim a green: they need
  `MeshWeaver.BusinessRules.Generator` from the mesh-local feed, and that project no longer exists in
  this repo. Their sources and configs are present and coherent (`Source/` children,
  `config => config.WithContentType<T>()…`), but "coherent" is not "compiles". The pre-prod NodeType
  sweep is the gate that would catch them.

## Tests

`FileFormatParserBomTest` (new, 4 cases) covers JSON, markdown front matter, the C# heading block,
and the `Encoding.UTF8.GetString` decode that produces the BOM in the first place — so it fails for
the same reason production did rather than because of a hand-written escape. **Verified failing
before the fix: 3 of 4 red**, including the C# case asserting the heading is lost.

`BakeEquivalenceTest` updated: its "unparseable" case was a BOM'd file, which is no longer
unparseable, so it now uses malformed JSON — and a BOM'd file stays in the fixture to pin the NEW
behaviour, where a regression that re-broke only one of the two loaders shows up as a bundle-set
difference.

Suites: `MeshWeaver.PluginTester.Test` 57/57, `MeshWeaver.Hosting.Test` 184/184,
`MeshWeaver.PluginCatalog.Test` (see checks), Documentation guards 2/2. Release `-warnaserror` clean
on every touched project.

**Not done, per the issue's own instruction:** the BOMs are NOT stripped from the sample files. That
would hide the parser gap and the next BOM'd file anywhere in the estate would reproduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
