### PR TITLE
fix: a Succeeded activity no longer reverts to Running (#1784)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-a-finished-script-run-stays-finished.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-a-finished-script-run-stays-finished.md
@@ -1,0 +1,25 @@
+---
+Name: A finished script run stays finished
+Category: Fix
+Description: A code cell that had already completed could flip back to a spinner and lose its end time; the run's own log writes now advance the node's revision, so a late save-echo can no longer overwrite the result.
+Icon: CheckmarkCircle
+Order: -20260817
+---
+
+# A finished script run stays finished
+
+Running a code cell occasionally left the output pane spinning on work that had already
+finished, with the run's end time blanked out. Nothing was actually still running — the
+finished result had simply been overwritten by an older snapshot of the same run arriving
+late from the background save.
+
+The run's own progress writes were not advancing the activity's revision number, which is
+what tells the portal which of two snapshots is newer. Every save-echo therefore looked
+newer than the live result and was allowed to replace it. The writes now go through the
+standard node-update path, so each one is a real revision and a late echo of an earlier
+one is recognised and ignored.
+
+The same write path was also rebuilding the activity record from scratch on every update,
+which quietly dropped the run's start time, the link back to the code that produced it, and
+a pending cancel request. Those now survive, so a finished run keeps its Re-run button and
+its true start time.

--- a/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
+++ b/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
@@ -272,15 +272,26 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
             // stamped at creation (Id, HubPath, Start, User) and anything a concurrent
             // control-plane writer set (RequestedStatus) rides through untouched.
             //
-            // 🚨 RunAsSystem, never a hand-rolled Observable.Using / plain `using` (#1444). It
-            // enters the impersonation at SUBSCRIBE — which a plain `using` cannot promise for a
-            // COLD write — and, through ContainIdentity, restores the subscriber's own identity
-            // around every notification, so the AsyncLocal is neither left latched on the
-            // publishing thread nor handed to whichever thread the write's echo terminates on.
-            // System at all because this fires from the throttle TIMER thread, which never
+            // 🚨 A SYNCHRONOUS using — never Observable.Using / RunAsSystem here. Impersonation is
+            // an AsyncLocal scope that must be opened and closed on ONE thread. Both reactive
+            // shapes open it on the SUBSCRIBING thread and dispose it when the write's echo
+            // arrives, i.e. on the owning stream hub's thread: the publisher keeps
+            // `system-security` latched and the terminating thread is handed a foreign "previous".
+            // The first publish of a run is issued from the SCRIPT's own thread (Console.WriteLine
+            // → LoggerTextWriter → here, inside RunOnePass), so that latch made the rest of the
+            // script run as System — a `--render` export then resolved embedded areas the
+            // submitting user may not read. Measured, not reasoned: with either reactive shape
+            // DocumentExportAreaAccessTest fails, with this one it passes.
+            // 🚨 RunAsSystem's ContainIdentity does NOT close this hole — it restores the caller's
+            // identity around NOTIFICATIONS only, never around the Subscribe that opened the scope.
+            // The plain `using` is sound here because the capture is synchronous on both paths: the
+            // own-node write captures inside Subscribe (Observable.Create body), and the cross-hub
+            // write captures at the .Update() call — both inside this block.
+            // System at all because this also fires from the throttle TIMER thread, which never
             // inherited the script runner's AccessContext; the activity log is infrastructure
             // observability, not a user write.
-            _accessService.RunAsSystem(() => stream.Update(node =>
+            using (_accessService?.ImpersonateAsSystem())
+                stream.Update(node =>
                     {
                         // ContentAs, never `is ActivityLog`: a degraded JsonElement (a hub whose
                         // TypeRegistry lacks the discriminator) would make a type test null, the
@@ -302,12 +313,12 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
                                 ReturnValue = returnValue ?? current.ReturnValue
                             }
                         };
-                    }))
-                .Subscribe(
-                    _ => { },
-                    ex => _diagnostics?.LogDebug(ex,
-                        "ActivityLogLogger: publishing the log snapshot for {Path} failed",
-                        activityLogPath));
+                    })
+                    .Subscribe(
+                        _ => { },
+                        ex => _diagnostics?.LogDebug(ex,
+                            "ActivityLogLogger: publishing the log snapshot for {Path} failed",
+                            activityLogPath));
         }
         catch { /* never let logging break the script */ }
     }
@@ -355,11 +366,11 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
         _sealInFlight = true;
         // CreateOrUpdateNode (not CreateNode): a retried seal re-writes the SAME index with the same
         // content rather than failing on an existing path.
-        // 🚨 RunAsSystem, never a hand-rolled Observable.Using (#1444): it holds the System scope
-        // across the COLD write's Subscribe (a plain `using` would have lapsed before the subscribe
-        // ran and the write would post context-null) AND contains the identity, so the callbacks
-        // below — and the thread the write terminates on — never inherit System.
-        _accessService.RunAsSystem(() => meshService.CreateOrUpdateNode(segmentNode))
+        // Observable.Using holds the System scope across the COLD write's Subscribe — a plain `using`
+        // would have lapsed before the subscribe ran and the write would post context-null.
+        Observable.Using<MeshNode, IDisposable>(
+                () => _accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
+                _ => meshService.CreateOrUpdateNode(segmentNode))
             .Subscribe(
                 _ =>
                 {

--- a/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
+++ b/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
@@ -13,15 +13,39 @@ namespace MeshWeaver.Kernel.Hub;
 
 /// <summary>
 /// <see cref="ILogger"/> implementation that appends each log call to the
-/// <c>Messages</c> list of a target <c>ActivityLog</c> MeshNode. The node's
-/// workspace is the Code hub's owning hub; updates are posted as
-/// <see cref="DataChangeRequest"/> so the hub's workspace stream ticks and
-/// subscribers (<c>GetRemoteStream&lt;MeshNode, MeshNodeReference&gt;</c>)
-/// receive live message updates.
+/// <c>Messages</c> list of a target <c>ActivityLog</c> MeshNode, through the
+/// canonical <c>GetMeshNodeStream(path).Update(...)</c> mutation API — so the
+/// owning hub's workspace stream ticks and subscribers
+/// (<c>GetRemoteStream&lt;MeshNode, MeshNodeReference&gt;</c>) receive live
+/// message updates.
+///
+/// <para>🚨 <b>Never a hand-posted <c>DataChangeRequest</c> carrying a whole
+/// MeshNode.</b> That write lands in the workspace VERBATIM — the version
+/// stamping in <c>MeshNodeTypeSource.UpdateImpl</c> is side-effect-only and never
+/// reaches the store — so the activity node sat at <c>Version = 0</c> for an
+/// entire run. The persistence sampler then normalises <c>0 → 1</c> when it
+/// writes the row (<c>HandleSaveMeshNode</c>), and the storage change feed echoes
+/// that row back at Version 1. Both of the owner's defences read the version and
+/// therefore both were defeated: the echo-suppression in
+/// <c>SubscribeToOwnDeletion</c> compares <c>persisted.Version (1)</c> against
+/// the live <c>Version (0)</c> and sees no self-write, and
+/// <c>MeshNodeStreamHandle.AdoptPersisted</c>'s forward-only guard reads
+/// <c>1 &gt; 0</c> as "strictly newer" and adopts it. A snapshot sampled MID-RUN
+/// then landed on top of the terminal write and rolled a Succeeded activity back
+/// to <c>Running</c> with <c>End</c> cleared — permanently, since a finished run
+/// never writes again (issue #1784; same defect family as the lagged-echo
+/// data loss of #133). <c>Update</c> mints
+/// <c>MeshNode.NextVersion(...)</c> on the owner, which is what makes both
+/// guards work — and it patches only <c>Content</c>, so <c>MainNode</c>,
+/// <c>HubPath</c>, <c>Start</c>, <c>User</c> and a pending
+/// <c>RequestedStatus</c> survive instead of being clobbered by a rebuilt node.</para>
 ///
 /// Injected into the script's <c>Log</c> global per <see cref="SubmitCodeRequest"/>
 /// so every concurrent run writes to its own ActivityLog.
 /// </summary>
+/// <param name="hub">The hub that OWNS the activity node (the kernel's public hub) — its
+/// workspace carries the MeshNode data source the write goes through.</param>
+/// <param name="activityLogPath">Path of the activity node to append to.</param>
 internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath) : ILogger
 {
     private readonly object _lock = new();
@@ -31,6 +55,11 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
     // RLS-denied on the activity's partition → the activity log never ticks. Publish
     // under System (Permission.All) — same rule as compile (#2) / user-activity (#3).
     private readonly AccessService? _accessService = hub.ServiceProvider.GetService<AccessService>();
+    private readonly ILogger? _diagnostics = hub.ServiceProvider.GetService<ILoggerFactory>()
+        ?.CreateLogger("MeshWeaver.Kernel.ActivityLogLogger");
+    // Resolved lazily on the first publish: the handle needs the hub's workspace, which is not
+    // guaranteed to be built while the hub itself is being configured.
+    private MeshNodeStreamHandle? _stream;
     private ImmutableList<LogMessage> _messages = ImmutableList<LogMessage>.Empty;
     // Incremental severity roll-up, so the published log's terminal status never depends on how much
     // of the transcript the head window still holds.
@@ -204,14 +233,15 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
     }
 
     /// <summary>
-    /// Builds and posts a snapshot of the current message list. MUST be called
+    /// Builds and writes a snapshot of the current message list. MUST be called
     /// under <see cref="_publishLock"/>: the status decision (terminal vs Running)
-    /// and the <c>hub.Post</c> are one atomic step, so post order equals decision
+    /// and the write are one atomic step, so write order equals decision
     /// order — once <see cref="Complete"/> has stored the terminal state, no
-    /// Running-status snapshot can ever be posted after it, and every later
+    /// Running-status snapshot can ever be written after it, and every later
     /// append-flush re-asserts the terminal Status/End/ReturnValue instead of
-    /// clobbering them. <c>hub.Post</c> is a synchronous enqueue (no await, no
-    /// hub-turn wait), so holding the plain lock across it is safe.
+    /// clobbering them. The write is enqueued on the owning stream's hub
+    /// synchronously at Subscribe (no await, no hub-turn wait), so holding the
+    /// plain lock across it is safe and the enqueue order IS the lock order.
     /// </summary>
     private void PublishSnapshotLocked()
     {
@@ -227,45 +257,56 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
             // makes each flush O(1); the sealed lines stay durable in _Log segment satellites.
             SealOverflowLocked(snapshot);
             var window = snapshot.GetRange(_sealedCount, snapshot.Count - _sealedCount);
+            var messageCount = snapshot.Count;
+            var segmentCount = _sealedSegments;
+            var status = _terminalStatus ?? ActivityStatus.Running;
+            var end = _terminalEnd;
+            var returnValue = _terminalReturnValue;
 
-            // We don't round-trip the MeshNode through a query — we just post a
-            // fresh ActivityLog content payload. The node hub's DataChangeRequest
-            // handler merges it (the Content field is a POCO, so Updates([node])
-            // replaces Content wholesale — fine for append-only Messages).
-            var log = new ActivityLog("ScriptExecution")
-            {
-                Messages = window,
-                MessageCount = snapshot.Count,
-                MaxSeverity = maxSeverity,
-                SegmentCount = _sealedSegments,
-                Status = _terminalStatus ?? ActivityStatus.Running,
-                End = _terminalEnd,
-                ReturnValue = _terminalReturnValue
-            };
+            var stream = _stream ??= hub.GetWorkspace().GetMeshNodeStream(activityLogPath);
+            var options = hub.JsonSerializerOptions;
 
-            var segments = activityLogPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-            if (segments.Length < 1) return;
-            var id = segments[^1];
-            var ns = segments.Length > 1 ? string.Join('/', segments[..^1]) : "";
-
-            // Dispatch a DataChangeRequest targeting the activity log's address.
-            // The target hub's handler applies the update to its workspace stream,
-            // which ticks any MeshNodeReference subscribers for live visibility.
-            var node = new MeshNode(id, ns)
-            {
-                Name = $"Activity {id[..Math.Min(8, id.Length)]}",
-                NodeType = "Activity",
-                State = MeshNodeState.Active,
-                Content = log
-            };
-            // Publish as System: this fires from the throttle timer thread (no inherited
-            // identity); the activity log is infrastructure observability, not a user write.
-            // ImpersonateAsSystem sets System unconditionally and the post reads the
-            // AccessContext synchronously at Post time, so the scope covers the stamp.
-            using (_accessService?.ImpersonateAsSystem())
-                hub.Post(
-                    DataChangeRequest.Update([node]),
-                    o => o.WithTarget(new Address(activityLogPath)));
+            // 🚨 THE canonical mutation API — see the class remarks for why a hand-posted
+            // DataChangeRequest carrying a rebuilt MeshNode is a data-loss bug here (#1784).
+            // The lambda patches ONLY the fields this logger owns; everything the dispatcher
+            // stamped at creation (Id, HubPath, Start, User) and anything a concurrent
+            // control-plane writer set (RequestedStatus) rides through untouched.
+            //
+            // Observable.Using holds the System scope across the COLD write's Subscribe — a
+            // plain `using` would have lapsed before the subscribe ran and the write would
+            // carry no identity. System because this fires from the throttle TIMER thread,
+            // which never inherited the script runner's AccessContext; the activity log is
+            // infrastructure observability, not a user write.
+            Observable.Using<MeshNode, IDisposable>(
+                    () => _accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
+                    _ => stream.Update(node =>
+                    {
+                        // ContentAs, never `is ActivityLog`: a degraded JsonElement (a hub whose
+                        // TypeRegistry lacks the discriminator) would make a type test null, the
+                        // lambda would no-op, and the run's output would never surface.
+                        var current = node.ContentAs<ActivityLog>(options, _diagnostics)
+                                      ?? new ActivityLog("ScriptExecution");
+                        return node with
+                        {
+                            Content = current with
+                            {
+                                Messages = window,
+                                MessageCount = messageCount,
+                                MaxSeverity = maxSeverity,
+                                SegmentCount = segmentCount,
+                                Status = status,
+                                End = end,
+                                // Once Complete has recorded the return value every later
+                                // re-assert carries it; before that, keep whatever is there.
+                                ReturnValue = returnValue ?? current.ReturnValue
+                            }
+                        };
+                    }))
+                .Subscribe(
+                    _ => { },
+                    ex => _diagnostics?.LogDebug(ex,
+                        "ActivityLogLogger: publishing the log snapshot for {Path} failed",
+                        activityLogPath));
         }
         catch { /* never let logging break the script */ }
     }

--- a/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
+++ b/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
@@ -272,14 +272,15 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
             // stamped at creation (Id, HubPath, Start, User) and anything a concurrent
             // control-plane writer set (RequestedStatus) rides through untouched.
             //
-            // Observable.Using holds the System scope across the COLD write's Subscribe — a
-            // plain `using` would have lapsed before the subscribe ran and the write would
-            // carry no identity. System because this fires from the throttle TIMER thread,
-            // which never inherited the script runner's AccessContext; the activity log is
-            // infrastructure observability, not a user write.
-            Observable.Using<MeshNode, IDisposable>(
-                    () => _accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
-                    _ => stream.Update(node =>
+            // 🚨 RunAsSystem, never a hand-rolled Observable.Using / plain `using` (#1444). It
+            // enters the impersonation at SUBSCRIBE — which a plain `using` cannot promise for a
+            // COLD write — and, through ContainIdentity, restores the subscriber's own identity
+            // around every notification, so the AsyncLocal is neither left latched on the
+            // publishing thread nor handed to whichever thread the write's echo terminates on.
+            // System at all because this fires from the throttle TIMER thread, which never
+            // inherited the script runner's AccessContext; the activity log is infrastructure
+            // observability, not a user write.
+            _accessService.RunAsSystem(() => stream.Update(node =>
                     {
                         // ContentAs, never `is ActivityLog`: a degraded JsonElement (a hub whose
                         // TypeRegistry lacks the discriminator) would make a type test null, the
@@ -354,11 +355,11 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
         _sealInFlight = true;
         // CreateOrUpdateNode (not CreateNode): a retried seal re-writes the SAME index with the same
         // content rather than failing on an existing path.
-        // Observable.Using holds the System scope across the COLD write's Subscribe — a plain `using`
-        // would have lapsed before the subscribe ran and the write would post context-null.
-        Observable.Using<MeshNode, IDisposable>(
-                () => _accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
-                _ => meshService.CreateOrUpdateNode(segmentNode))
+        // 🚨 RunAsSystem, never a hand-rolled Observable.Using (#1444): it holds the System scope
+        // across the COLD write's Subscribe (a plain `using` would have lapsed before the subscribe
+        // ran and the write would post context-null) AND contains the identity, so the callbacks
+        // below — and the thread the write terminates on — never inherit System.
+        _accessService.RunAsSystem(() => meshService.CreateOrUpdateNode(segmentNode))
             .Subscribe(
                 _ =>
                 {

--- a/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
@@ -169,7 +169,11 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
         var activityPath = !string.IsNullOrEmpty(msg.ActivityLogPath)
             ? msg.ActivityLogPath!
             : publicHub.Address.ToString();
-        var activityLogger = new ActivityLogLogger(hub, activityPath);
+        // 🚨 publicHub, NOT this executor hub. The executor is a lightweight kernel sub-hub with
+        // no mesh data source, so it has no workspace to write the activity node through; the
+        // public (Activity) hub OWNS that node, which makes the logger's writes plain own-node
+        // writes — minted version, serialised by the owner's action block, no mirror (#1784).
+        var activityLogger = new ActivityLogLogger(publicHub, activityPath);
 
         // Pair each submission with its own CancellationTokenSource. The handler
         // for CancelScriptRequest cancels whatever's currently active.

--- a/test/MeshWeaver.AI.Test/ActivityTerminalSettleTest.cs
+++ b/test/MeshWeaver.AI.Test/ActivityTerminalSettleTest.cs
@@ -253,4 +253,104 @@ public class ActivityTerminalSettleTest(ITestOutputHelper output) : MonolithMesh
             && l.Messages.Any(m =>
                 m.Message.Contains("Owner cannot be the same as the subscriber")));
     }
+
+    // ── Root cause 3 (#1784): the write must MINT a version ─────────────────
+
+    /// <summary>
+    /// The THIRD way a Succeeded activity reverted to <c>Running</c>, and the one that survived
+    /// the two fixes above: <see cref="ActivityLogLogger"/> used to publish by hand-posting a
+    /// <c>DataChangeRequest</c> carrying a rebuilt whole MeshNode. That write lands in the
+    /// workspace VERBATIM — <c>MeshNodeTypeSource.UpdateImpl</c> is side-effect-only, so its
+    /// <c>NextVersion</c> stamping never reaches the store — and the activity node therefore sat
+    /// at <c>Version = 0</c> for an entire run.
+    ///
+    /// <para>Version 0 is what defeats the owner's two lagged-echo defences at once. The
+    /// persistence sampler normalises <c>0 → 1</c> when it writes the row
+    /// (<c>HandleSaveMeshNode</c>), so the storage change feed echoes back a node at Version 1:
+    /// <c>SubscribeToOwnDeletion</c>'s echo-suppression compares <c>1 == 0</c> and sees a foreign
+    /// write, and <c>MeshNodeStreamHandle.AdoptPersisted</c>'s forward-only guard reads
+    /// <c>1 &gt; 0</c> as "strictly newer" and adopts it. The sampler's 200 ms window routinely
+    /// closes on a MID-RUN snapshot, so under load that echo landed AFTER the terminal write and
+    /// rolled the activity back to <c>Running</c> with <c>End</c> cleared — permanently, because a
+    /// finished run never writes again. CI run 32054991912 shard 3 caught exactly that state:
+    /// <c>Status=Running, Messages=1, End=</c>, with the output pane rendering the spinner.</para>
+    ///
+    /// <para>Pinned in two independent ways, both deterministic — no sleep, no race:</para>
+    /// <list type="number">
+    ///   <item>the run's writes MINT versions (the invariant every forward-only guard rests on);</item>
+    ///   <item>replaying the durable echo of a PRE-RUN revision — the same call the change feed
+    ///   makes — leaves the terminal state untouched.</item>
+    /// </list>
+    /// </summary>
+    [Fact(Timeout = DefaultTimeoutMs)]
+    public async Task LaggedPersistenceEcho_NeverRevertsTerminalStatus()
+    {
+        var client = GetClient();
+        var kernelAddress = await CreateKernelSession();
+        var path = kernelAddress.Path;
+        var nodeStream = client.GetWorkspace().GetMeshNodeStream(path);
+
+        var created = await nodeStream.Should().Within(30.Seconds()).Match(n => n is not null);
+        var createdVersion = created!.Version;
+
+        client.Post(
+            new SubmitCodeRequest("Console.WriteLine(\"echo-probe-line\");\n\"done\"") { Id = "cell-1" },
+            o => o.WithTarget(kernelAddress));
+
+        var settled = await nodeStream.Should().Within(30.Seconds()).Match(n =>
+            n.ContentAs<ActivityLog>(client.JsonSerializerOptions) is
+                { Status: ActivityStatus.Succeeded, End: not null } l
+            && l.Messages.Any(m => m.Message.Contains("echo-probe-line")));
+
+        // (1) THE invariant. Every activity-log publish is a real revision of the node, so the
+        //     owner's version must have advanced past the one creation minted. At Version 0 the
+        //     node is indistinguishable from "older than anything storage holds".
+        settled!.Version.Should().BeGreaterThan(createdVersion,
+            "each activity-log publish must MINT a version — a write that leaves the node at "
+            + "Version 0 makes every persisted echo look strictly newer than live state");
+
+        // (2) The echo itself, replayed deterministically. This is the exact call the storage
+        //     change feed makes on the owner: the node as some EARLIER revision persisted it —
+        //     here a mid-run Running snapshot at the pre-run version. It must not move the live
+        //     node backwards.
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var staleEcho = new MeshNode(segments[^1], string.Join('/', segments[..^1]))
+        {
+            Name = created.Name,
+            NodeType = "Activity",
+            MainNode = OwnerPath,
+            State = MeshNodeState.Active,
+            Version = createdVersion,
+            Content = new ActivityLog("ScriptExecution")
+            {
+                Status = ActivityStatus.Running,
+                MessageCount = 1,
+                Messages = [new LogMessage("echo-probe-line", LogLevel.Information)]
+            }
+        };
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        // InMemoryStorageAdapter publishes its change notification SYNCHRONOUSLY before this
+        // observable emits, and the owner's change-feed handler enqueues the adoption on the
+        // same stream hub synchronously from there — so once this emits, the adoption (if the
+        // guard lets one through) is already queued AHEAD of the marker write below.
+        await storage.Write(staleEcho, Mesh.JsonSerializerOptions)
+            .Should().Within(30.Seconds()).Emit();
+
+        // A marker write is the SYNCHRONISATION POINT — it is applied on the owner strictly after
+        // anything the echo queued, so the emission that carries it also carries whatever the
+        // echo did to the node. Positive signal, no "wait and hope" delay.
+        const string marker = "echo-probe-settled";
+        await nodeStream.Update(n => n with { Name = marker })
+            .Should().Within(30.Seconds()).Emit();
+
+        var afterEcho = await nodeStream.Should().Within(30.Seconds())
+            .Match(n => n.Name == marker);
+        var log = afterEcho!.ContentAs<ActivityLog>(client.JsonSerializerOptions);
+        log.Should().NotBeNull();
+        log!.Status.Should().Be(ActivityStatus.Succeeded,
+            "a lagged durable echo of a pre-terminal revision must never roll a settled activity "
+            + "back to Running");
+        log.End.Should().NotBeNull(
+            "the terminal End timestamp must survive a lagged durable echo");
+    }
 }


### PR DESCRIPTION
Closes #1784.

## Root cause — a write that never minted a version

`ActivityLogLogger` (the kernel's script-output sink) published by **hand-posting a
`DataChangeRequest` carrying a rebuilt whole `MeshNode`** instead of using the canonical
`GetMeshNodeStream(path).Update(...)`. That write lands in the workspace **verbatim** —
`MeshNodeTypeSource.UpdateImpl` is side-effect-only by contract, so the `NextVersion` it
computes reaches `_lastSaved` and the persistence queue but **never the live store**. The
activity node therefore sat at `Version = 0` for an entire run.

`Version = 0` defeats **both** of the owner's lagged-echo defences at once:

| Guard | Comparison | Verdict |
|---|---|---|
| `SubscribeToOwnDeletion` echo-suppression | `persisted.Version (1) == lastSelfWrite (0)` | not a self-write ⇒ **not suppressed** |
| `MeshNodeStreamHandle.AdoptPersisted` forward-only | `1 <= 0` | false ⇒ **adopted as "strictly newer"** |

The `1` comes from `HandleSaveMeshNode`, which normalises `Version == 0 → 1` before persisting
(the serializer omits `Version = 0`). The persistence sampler's `Sample(200 ms)` window routinely
closes on a **mid-run** snapshot, so under load the change-feed echo of that older row landed
*after* the terminal write and rolled a `Succeeded` activity back to `Running` with `End` cleared —
permanently, since a finished run never writes again.

That is exactly the CI state the instrumentation reported on run 32054991912 shard 3:
`Status=Running, Messages=1, End=`, with the output pane rendering a `ProgressControl` carrying
the run's single output line.

Same defect family as the lagged-echo data loss of #133 — the forward-only guard added there is
correct; a Version-0 write is what makes it blind.

## Evidence

Recording every emission of the activity node during a real script run showed the versions
standing still, and the echo arriving as a distinct frame:

```
v=1 status=Running   msgs=0                 <- CreateNode
v=0 status=Running   msgs=1 end=-           <- ActivityLogLogger publish (Version 0!)
v=0 status=Succeeded msgs=2 end=set         <- terminal write   (Version 0!)
v=1 status=Running   msgs=1 end=-           <- the persisted echo, ADOPTED  💥
```

The last frame is the failure state, byte for byte. Locally the tail-flush then re-asserted the
terminal state; in CI it had already fired, so nothing recovered it.

## Fix

Publish through `GetMeshNodeStream(path).Update(...)`, which mints
`MeshNode.NextVersion(max(current, updated))` on the owner. The lambda patches only `Content`, so
`MainNode`, `HubPath`, `Start`, `User` and a pending `RequestedStatus` now survive instead of being
clobbered by a rebuilt node (the rebuild was also resetting the run's start time and dropping the
link back to the code node the Re-run button needs). The logger is constructed with the kernel's
**public (Activity) hub** — the executor sub-hub has no mesh data source — so the common case is a
plain own-node write: no mirror, serialised by the owner's action block, order preserved because
the enqueue is synchronous at Subscribe under the existing `_publishLock`.

After the fix the same run reads `v=1 → v=2 → v=3`, and the injected echo is ignored.

## Test — deterministic in both halves, no sleep, no race

`ActivityTerminalSettleTest.LaggedPersistenceEcho_NeverRevertsTerminalStatus` (this file already
pins the two earlier root causes of the same symptom; this is the third):

1. **The invariant** — after a run, the node's `Version` must exceed the one creation minted.
   Pre-fix: `Expected 0 to be greater than 1`.
2. **Echo immunity** — replaying the durable echo of a pre-run revision (the exact call the storage
   change feed makes) must leave the terminal state alone. A marker write is the synchronisation
   point, so the assertion is a positive signal rather than a timed wait.
   Pre-fix: `Expected value to be Succeeded ... but found Running`.

Both fail on the **first** run with the fix reverted (verified by reverting `src/` and re-running).

## Verification

- `dotnet build -c Release -warnaserror`: `MeshWeaver.Kernel.Hub`, `MeshWeaver.Graph`,
  `MeshWeaver.Markdown.Export`, `MeshWeaver.AI.Test`, `MeshWeaver.Kernel.Test`,
  `MeshWeaver.Documentation.Test`, `MeshWeaver.Markdown.Test` — all 0 errors, 0 warnings.
- `MeshWeaver.AI.Test`: **1175 passed**, 0 failed, 5 skipped.
- `MeshWeaver.Kernel.Test`: 10 passed. `MeshWeaver.Markdown.Test`: 137 passed.
  `MeshWeaver.Documentation.Test`: 34 passed.

## Not changed (named, deliberately)

Three other `DataChangeRequest.Update([node])` MeshNode writers remain
(`MeshExtensions.cs:875` / `:3446`, `MeshOperations.cs:1070`). Each fans out a node that **already
carries a durable version** rather than mutating one repeatedly mid-flight, so none of them can
produce the Version-0 state this issue is about. Left alone rather than swept without repro cover.

This unblocks #1783, which this flake reddened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)