### PR TITLE
fix(#1789): make a routing back-pressure line self-sufficient

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-diagnostics-say-which-episode-they-belong-to.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-diagnostics-say-which-episode-they-belong-to.md
@@ -1,0 +1,23 @@
+---
+Name: Diagnostics say which episode they belong to
+Category: Fix
+Description: A routing overload warning now identifies which episode it belongs to, so a repeat is recognisable as a new event rather than the same one continuing.
+Icon: Sparkle
+Order: -20260817
+---
+
+# Diagnostics say which episode they belong to
+
+When the server reported that message routing was falling behind, it printed the
+same headline numbers every time and left the "recovered after" line to say how
+long it lasted. If that second line never arrived — which is exactly what happens
+when the condition does not clear — there was no way to tell a repeat apart from
+a single event still going.
+
+Each report now carries its own identity, so two reports are visibly two events
+or visibly one, and the recovery line is no longer the only thing that can answer
+the question. The recovery line also ships at a level that reaches the log store,
+instead of one that can be filtered away.
+
+Nothing about how routing behaves has changed — only what the diagnostics let an
+operator conclude.

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -91,6 +91,26 @@ internal class RoutingGrain(
     private int saturationReported;
 
     /// <summary>
+    /// Identity of THIS activation, and the episode counter within it — the pair that makes a single
+    /// saturation line self-sufficient (issue #1789).
+    ///
+    /// <para>🚨 <b>Why a log line needs an identity.</b> <see cref="ReportSaturation"/> latches: the
+    /// only writer of <c>0</c> to <see cref="saturationReported"/> is <see cref="ReportDrained"/>, so
+    /// two crossing lines from ONE activation are impossible without a clear between them. On
+    /// 2026-08-17 a pod emitted two crossings ten minutes apart with NO clear line, and answering
+    /// "was this one episode or two?" required knowing whether the grain had been recycled — which
+    /// nothing logged, because <c>RoutingGrain</c> has no lifecycle overrides. The question was
+    /// unanswerable from the evidence, and it was the question that mattered.</para>
+    ///
+    /// <para>With both stamped on every line it is answerable from the Critical channel alone:
+    /// <b>different activation ⇒ the grain was recycled</b>; <b>same activation, higher episode ⇒
+    /// the previous episode really did drain</b>; and the same activation+episode never appears
+    /// twice, by the latch.</para>
+    /// </summary>
+    private readonly string activationId = Guid.NewGuid().ToString("N")[..8];
+    private int saturationEpisode;
+
+    /// <summary>
     /// UTC ticks at which the current saturation episode began, so <see cref="ReportDrained"/> can
     /// say how long it lasted. Written under the same latch that gates the report, read only by the
     /// clearing report — a plain <see cref="Volatile"/> pair is sufficient and costs the hot dispatch
@@ -237,18 +257,27 @@ internal class RoutingGrain(
     {
         if (inFlight < SaturationThreshold) return;
         if (Interlocked.Exchange(ref saturationReported, 1) == 1) return;
-        Volatile.Write(ref saturationSinceTicks, DateTime.UtcNow.Ticks);
+        var startedUtc = DateTime.UtcNow;
+        Volatile.Write(ref saturationSinceTicks, startedUtc.Ticks);
+        var episode = Interlocked.Increment(ref saturationEpisode);
         var (destinations, deepest) = orderedDispatcher.QueueSnapshot();
         logger.LogCritical(
-            "[ROUTE] Routing back-pressure: {InFlight} route dispatches in flight (reporting threshold {Threshold}); "
+            "[ROUTE] Routing back-pressure [{ActivationId}#{Episode} started {StartedUtc:O}]: "
+            + "{InFlight} route dispatches in flight (reporting threshold {Threshold}); "
             + "stream destinations queued {Destinations}, deepest per-destination queue {Deepest}, routing pool subscribing {PoolInFlight}. "
             + "Latest dispatch target {Address} — the address that happened to cross the threshold, NOT a diagnosis. "
             + "A slot is held from dispatch until the leg terminates, INCLUDING the unbounded wait for a ThreadPool "
             + "thread before the leg's own timeouts start, so a CPU-starved silo raises this with nothing stuck. "
             + "A deepest queue of 1 or more means legs are blocked behind a leg (head-of-line on one destination); "
-            + "0 means nothing is waiting on anything, so read it as load and check the 'cleared after' line "
-            + "for how long it really lasted.",
-            inFlight, SaturationThreshold, destinations, deepest, routingPool.CurrentInFlight, addressPath);
+            + "0 means nothing is waiting on anything, so read it as load. "
+            + "🚨 Deepest is sampled AT THE CROSSING, so like the in-flight count it is partly an artefact of the "
+            + "threshold: with N destinations sharing the backlog it is ~InFlight/N whatever is wrong. "
+            + "READ THE EPISODE STAMP, not the depth: a later line with a HIGHER episode on this activation means "
+            + "this episode drained; a line with a DIFFERENT activation id means the grain was recycled; and if "
+            + "neither a clear nor a higher episode ever follows, the in-flight count never fell below half the "
+            + "threshold — which means a leg never terminated and its slot leaked, not that the silo was busy.",
+            activationId, episode, startedUtc, inFlight, SaturationThreshold,
+            destinations, deepest, routingPool.CurrentInFlight, addressPath);
     }
 
     private void ReportDrained(int inFlight)
@@ -260,10 +289,21 @@ internal class RoutingGrain(
         // silo absorbed, minutes is a leg that really was not completing. Without it, five reports
         // in eighteen seconds (prod, 2026-08-10) read as one permanent wedge when they were in fact
         // five separate crossings — each one drained below half the threshold in between.
+        //
+        // 🚨 WARNING, not Information — a permanent level change with a cost/value argument, not a
+        // debugging tweak (AGENTS.md). This line is one HALF of a signal whose other half is
+        // Critical; at Information the two halves ride independently-filterable channels and the
+        // pair cannot be reconstructed. On 2026-08-17 that is exactly what happened: the crossing
+        // lines survived, the clear did not, and "did this episode ever end?" — the whole question —
+        // became unanswerable. It is deliberately NOT raised to Critical: the red-log ticketing path
+        // files an incident per Critical fingerprint, so a Critical "cleared" line would file a
+        // ticket for a RECOVERY and invert the signal. Warning ships reliably and tickets nothing.
+        // The episode stamp below is what actually makes the pair reconstructible; the level only
+        // makes sure both halves arrive.
         var lasted = since == 0 ? TimeSpan.Zero : DateTime.UtcNow - new DateTime(since, DateTimeKind.Utc);
-        logger.LogInformation(
-            "[ROUTE] Routing back-pressure cleared after {ElapsedMs} ms — {InFlight} route(s) in flight",
-            (long)lasted.TotalMilliseconds, inFlight);
+        logger.LogWarning(
+            "[ROUTE] Routing back-pressure [{ActivationId}#{Episode}] cleared after {ElapsedMs} ms — {InFlight} route(s) in flight",
+            activationId, Volatile.Read(ref saturationEpisode), (long)lasted.TotalMilliseconds, inFlight);
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #1789. **Diagnostics only — routing behaviour is untouched, and this does not fix the underlying leak.**

## The problem this fixes

`RoutingGrain`'s saturation report is one half of a signal, and the halves cannot be reconstructed from each other. `ReportSaturation` latches:

```csharp
ReportSaturation: if (Interlocked.Exchange(ref saturationReported, 1) == 1) return;  // fires only 0→1
ReportDrained:    if (Interlocked.Exchange(ref saturationReported, 0) == 0) return;  // fires only 1→0, then logs
```

`saturationReported` is written to `0` **only** by `ReportDrained`, which logs immediately after winning that exchange. So two crossing lines from one activation are impossible without a clear between them.

On 2026-08-17 a `memex-cloud` pod emitted two crossings ten minutes apart with **no clear line**. Answering the only question that mattered — *was this one episode or two?* — required knowing whether the grain had been recycled, and **nothing logged that**, because `RoutingGrain` has no lifecycle overrides. The evidence could not distinguish "the episode never ended" from "the clear line was lost", and those imply different defects.

## What changes

- **Every line carries `{ActivationId}#{Episode}` and the episode start time.** Different activation id ⇒ the grain was recycled. Same activation, higher episode ⇒ the previous episode really did drain. Same activation+episode twice ⇒ impossible, by the latch. Answerable from the Critical channel alone.
- **The guidance no longer points at a line that can be impossible to emit.** It told the reader to *"check the 'cleared after' line for how long it really lasted"* — but `ReportDrained` requires `inFlight <= 32`, so when in-flight slots leak the clear can **never** fire. The advice was unreachable precisely in the failure it was meant to explain. It now states what a missing clear means, and warns that `deepest` is sampled **at the crossing** — with N destinations it is ~`InFlight/N` whatever is wrong, the same latch artefact the code already documents for the constant `64`. (`deepest = 33` twice in prod is that artefact, not a frozen queue.)
- **`ReportDrained` moves `Information` → `Warning`.** Permanent and justified, not a debugging tweak: *the two halves of one signal must ship on the same channel, or the pair cannot be reconstructed* — and `Information` is the channel that was lost. Deliberately **not** `Critical`: red-log ticketing files an incident per Critical fingerprint, so a Critical "cleared" line would file a ticket for a **recovery** and invert the signal.

## What this does NOT do

It does not fix the leak. `IoPool.SubscribeThroughPool` registers `_poolCts.Token.Register(inner.Dispose)` for a leg cancelled **after** subscribe completed, and *disposing a subscription emits nothing* — so `.Finally` never runs, the in-flight slot leaks, and the destination FIFO strands permanently. That is a second instance of the class [the same file already fixed](https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs) for the setup-cancellation path. Fixing it changes teardown semantics for **every** `SubscribeThroughPool` caller and interacts with `IoPool.Drain()`'s join reasoning, so it is a design call tracked on #1789, not a patch here.

## Testing

**No new test, deliberately.** The change is diagnostic text plus a counter; an assertion on log wording would be brittle without pinning anything real. The invariant it leans on — the latch — is already exercised by `RoutingBackpressureShapeTest`, which drives `OrderedRouteDispatcher` directly.

- `MeshWeaver.Hosting.Orleans` built `-c Release -warnaserror`, 0 errors.
- `RoutingBackpressureShapeTest` + `RoutingGrainStreamPostBoundTest` + `RoutingGrainTurnIsolationTest`: **6/6 passed**.
- `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest`: **2/2 passed**.

The real verification is the authorised prod re-roll: the [probe protocol](https://github.com/Systemorph/MeshWeaver/issues/1789#issuecomment-5319613088) is on the issue, posted **before** the roll so a quiet roll cannot be read as an all-clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)