### PR TITLE
fix: red-log incidents split by the fault's own text; a truncated window is reported

### DIFF
--- a/content/ai/Agent/LogTriage.md
+++ b/content/ai/Agent/LogTriage.md
@@ -21,10 +21,18 @@ an engineer can pick up cold — then hand it to the filer. You never open the i
 The incident node is your `MainNode` — **read it first** with `get`. It carries the evidence:
 
 - `category` — the .NET log category (e.g. `MeshWeaver.Data.MeshDataSource`)
-- `normalizedMessage` — the message with ids/guids/paths masked (this is what was fingerprinted)
+- `normalizedMessage` — the logged message with ids/guids/paths masked
+- `normalizedDetail` — **what was fingerprinted**: the exception's own message when the burst carried
+  one, otherwise the logged message. This is the text that makes this incident distinct from its
+  neighbours at the same log site — start here.
 - `exceptionType`, `topFrame` — the exception and the top application stack frame, when the burst had them
 - `occurrences`, `firstSeen`, `lastSeen`, `namespace`, `pods` — how much, how long, and where
-- `samples` — verbatim log lines
+- `samples` — verbatim log lines. These carry the **per-instance identity** the fingerprint masks out
+  (the node path, the tenant, the guid), so read them for the concrete case, not just the shape.
+- `variants` — normally `1`. Anything higher means this log site fanned out past the watcher's
+  per-site budget in one window and its bursts were **folded onto this one incident**. Then the
+  ticket is "this site reports N different things and the masking rule needs a case", not a single
+  defect — say so, and name the shapes you can see in `samples`.
 
 # How to triage
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
@@ -12,7 +12,10 @@ agent-written description of what is probably broken, filed in the repository th
                                 ▼
                        mw-log-watcher            (ns monitoring, its own PVC)
                           │ group lines into bursts
-                          │ fingerprint  =  hash(top app frame, exception)  — or hash(category, event id, exception) with no frame
+                          │ fingerprint  =  hash(WHERE, WHAT, WHICH)
+                          │     WHERE = top app frame, or (category, event id) with no frame
+                          │     WHAT  = exception type
+                          │     WHICH = masked exception message, or masked log message with no exception
                           │ queue to disk
                           ▼  POST /api/log-incidents   (Bearer, in-cluster)
                        Portal
@@ -42,13 +45,14 @@ GitHub App credential already live.
 ## One fault, one ticket
 
 The fingerprint (`StructuralLogIncidentIdentity.Compute`) identifies **the fault, not the reporter**.
-It is a `sha256` truncated to **16 hex characters** (the first 8 bytes) over one of two payloads,
-chosen by the burst itself:
+It is a `sha256` truncated to **16 hex characters** (the first 8 bytes) over three parts — *where*
+the fault is, *what* it is, and *which* one it is:
 
-| The burst names… | The identity is | Why |
+| Part | Value | Why |
 |---|---|---|
-| an application stack frame | `("frame", topFrame, exceptionType)` | the frame names the exact method that faulted — the most specific locator available |
-| no application frame | `("site", category, eventId, exceptionType)` | there is no location to key on, so the log site the code assigns is the locator |
+| **WHERE** | the top application stack frame — or `(category, eventId)` when the burst names no frame | the frame names the exact method that faulted; with no frame, the log site the code assigns is the only locator |
+| **WHAT** | the exception type, by simple name | the same method can fail two ways, and folding those hides the second bug behind the first one's ticket |
+| **WHICH** | the **masked exception message** — or the masked log message when there is no exception | inside one site there is nothing else left that says which fault this is |
 
 - **🚨 The reporting category is NOT in the identity when a frame is present.** The category names
   the class that *caught and printed* the fault, which is not where the fault is. One exception
@@ -56,17 +60,24 @@ chosen by the burst itself:
   2026-08-10 filed issues #1170 and #1171 for a single `ObjectDisposedException` raised at
   `SynchronizationStream<T>.OnCompleted()` during a single hub teardown, on one pod, at one instant,
   because `MessageHub` and `HostedHubsCollection` each logged it on the way out.
-- **🚨 The message text is NOT hashed, in either branch.** Earlier revisions folded a *normalized*
-  message (guids, timestamps, paths, quoted literals, hex blobs and bare numbers masked) into the
-  identity. That still fanned out: the varying subject sits in an arbitrary position that no masking
-  rule reliably anticipates, and one defect produced ~50 incidents. The message is still normalized
-  and *carried* on the report (`NormalizedMessage`), it just does not contribute to identity.
-- **The exception type is part of the identity in both branches** — the same method can fail two
-  ways, and folding those together would hide the second bug behind the first one's ticket. It is
-  compared on its **simple** name: `ex.ToString()` prints `System.ObjectDisposedException` while a
-  message interpolating `ex.GetType().Name` prints `ObjectDisposedException`, and one fault must not
-  fork on the caller's formatting. For the same reason the parser recovers the type from the message
-  text when the call site formatted the exception *into* it instead of passing it to the logger.
+- **🚨 The discriminating text is the EXCEPTION's message, never the reporter's prose** — and that
+  is what keeps #1170/#1171 folded while still splitting real defects. The two reporters worded
+  their own messages differently ("Error during shutdown of hub …" vs "Hub … disposal faulted") and
+  quoted the *same* exception message ("Cannot access a disposed object."). Only a burst carrying no
+  exception at all falls back to the logged message, because then it is the only text there is.
+- **🚨 Everything volatile is masked before hashing** (`LogLineParser.Normalize`): guids, timestamps,
+  paths, quoted literals, hex blobs, labelled identifiers, bare numbers — **and any token the
+  message itself uses as a path segment**. That last rule is what makes prose safe to hash at all:
+  a message's subject can sit anywhere (`target: Claims` after a label, `[PluginGating] Chess:`
+  before a colon), and no masking rule anticipates the next position. So this one does not guess —
+  it reads the subject *out of* the message, from the paths the message already spells out. `Chess`
+  is a path segment in `Chess/_Access/Public_Access`, therefore `Chess` anywhere in that message is
+  an identifier.
+- **The exception type is compared on its simple name**: `ex.ToString()` prints
+  `System.ObjectDisposedException` while a message interpolating `ex.GetType().Name` prints
+  `ObjectDisposedException`, and one fault must not fork on the caller's formatting. For the same
+  reason the parser recovers the type *and its message* from the message text when the call site
+  formatted the exception into it instead of passing it to the logger.
 - **The top frame excludes framework code** (`System.` / `Microsoft.` / `Npgsql.` / `Orleans.`
   prefixes are skipped) and drops its `in /path/file.cs:line NNN` suffix, so an unrelated edit above
   the faulting line does not fork the fingerprint into a second ticket.
@@ -74,12 +85,36 @@ chosen by the burst itself:
   pods are recorded on the incident instead — and so a defect every tenant hits opens one ticket
   rather than one per tenant.
 
-The direction of the remaining trade is deliberate: two genuinely different faults raised at the
-same frame with the same exception type collapse into one incident. An under-split incident is one
-ticket a human can split; an over-split one is fifty tickets nobody reads, and fifty is what
-production actually produced. What identity must *never* do is discard the fault site to make
-unrelated reporters agree — issues #1183 and #1184 (one logger, one event id, one exception type,
-two different health checks) are two code sites and stay two incidents.
+### The two cases this has to get right
+
+Both are measured, both from `memex-cloud` on 2026-08-17 (#1787), and
+`ProdRedLogFixtureTest` pins them on verbatim production lines:
+
+| Input | Result | Why |
+|---|---|---|
+| **3,894 lines of the SAME error** | **one** incident, `Occurrences = 3894` | everything that varies per occurrence — node paths, guids, counts, elapsed times — is masked out before hashing |
+| **13 lines of 13 DIFFERENT errors** | **one incident per distinct failure shape** | thirteen NodeTypes parked at `CompileError` share a category, an event id, an exception type *and* a top frame; only the compiler diagnostics differ, and those are now in the key. Two nodes failing *identically* still share one ticket and list each other in its evidence — that is one defect with two instances. |
+
+Before this, "same frame + same exception type" was the whole key, so all thirteen were **one**
+fingerprint and none of them was ticketed; #1786 had to be filed by hand.
+
+### The floor under "too fine": the per-site variant budget
+
+Masking cannot anticipate every message shape, and when it misses, one defect fans out into one
+ticket per subject — 2026-08-09 produced ~50 that way. So a log site that opens more than
+`MaxVariantsPerSite` (default **20**) distinct fingerprints *in one window* stops being N incidents
+and becomes **one**, keyed by `StructuralLogIncidentIdentity.ComputeSiteFold` and carrying
+`Variants = N`. The ticket then says "this site produced N shapes and the masking rule needs a case"
+instead of burying a human in tickets.
+
+The default sits deliberately between the two numbers production has produced: **13 stays 13**
+(each parked NodeType needs its own fix), **~50 folds**. The fold is per window and every
+fingerprint it produces is stable, so recurrences still deduplicate.
+
+The remaining trade is unchanged in direction: an under-split incident is one ticket a human can
+split, an over-split one is fifty nobody reads. What identity must *never* do is discard the fault
+site to make unrelated reporters agree — issues #1183 and #1184 (one logger, one event id, one
+exception type, two different health checks) are two code sites and stay two incidents.
 
 The fingerprint is also the incident's node id, so redelivery is idempotent by construction. That
 is what lets the watcher retry freely.
@@ -97,6 +132,38 @@ At-least-once, and deliberately so:
 
 A `4xx` other than `429` is permanent — a malformed or unauthorized report will not become valid by
 being resent — so it is dropped with an ERROR log rather than retried until the disk fills.
+
+## The watcher tickets its own blind spots
+
+🚨 **A watcher that cannot see is worse than no watcher, because it still reports "all quiet".** So
+every way this one can fail to read a window is itself a `LogIncidentReport` travelling the normal
+ingest path — landing in Postgres, which survives Loki being gone. All three dedup per namespace and
+carry no timestamps in their fingerprint, so a repeat raises an occurrence count instead of opening
+another ticket.
+
+| Condition | Detected by | Severity | What it means |
+|---|---|---|---|
+| Loki answered a long, continuously-watched window with **zero lines** | `LogPipelineGap.IsLostWindow` | Critical | the store lost that stretch — the query is unfiltered, so a running portal cannot be that quiet |
+| The query came back **at `QueryLimit`** | `LogPipelineGap.IsTruncated` | Error | the window was NOT fully read; the remainder is **deferred**, and while it lasts a noisy source crowds quieter errors out of the prefix that gets read |
+| The cursor was **floored by `MaxCatchUp`** | `WatcherState.CursorFor` returns the skipped stretch | Critical | the only path that LOSES evidence outright — that stretch will never be read |
+
+**🚨 Raising `QueryLimit` is not the fix for truncation.** The number in the watcher's log is a *cap*,
+not a count: on 2026-08-17 several consecutive `memex-cloud` windows reported exactly `5000` and
+nothing said so anywhere a verdict is read. A higher cap moves the ceiling; the finding is that one
+namespace out-talks its watcher, and the actionable number is the **backlog** the report carries —
+because a backlog that keeps growing ends at the `MaxCatchUp` floor, which is the row above that
+loses data for good.
+
+The per-window summary distinguishes the counts that used to be conflated:
+
+```
+memex-cloud: 5 distinct fingerprint(s) from 7 red burst(s) (2934 line(s) read)
+memex-cloud: 3 distinct fingerprint(s) from 41 red burst(s) (5000 line(s) read — TRUNCATED at the query limit)
+```
+
+The old line read `"1 distinct fingerprint(s) from 5000 red line(s)"` with `5000` bound to the
+**total** line count — the query returns every severity — so it looked like 5000 errors collapsing
+onto one ticket when it was 5000 lines of mostly `info:`.
 
 ## The incident lifecycle
 
@@ -238,6 +305,8 @@ stored.
 | `ColdStartLookback` | How far back a cursor-less start reads. Default 15 min — deliberately short, so a fresh install starts ticketing what happens next rather than replaying history into a hundred issues. |
 | `MaxCatchUp` | Cap on how far back the cursor may be dragged. Default 6 h. |
 | `IngestLag` | How far the window trails `now`. Default 30 s. |
+| `QueryLimit` | Max entries one Loki query may return. Default 5000. Hitting it is **reported as an incident** — see "The watcher tickets its own blind spots". Raising it is not the fix. |
+| `MaxVariantsPerSite` | How many distinct fingerprints one log site may open from one window before they fold onto a single site-level incident. Default 20 — above 13 (the parked-NodeType case, which must stay 13 tickets) and below ~50 (the 2026-08-09 fan-out, which must fold). `0` disables the fold. |
 | `StateDirectory` | **Must be a persistent volume.** On an `emptyDir` a restart replays the lookback window. |
 | `IgnoreCategories` | Category prefixes never ticketed. Prefer suppressing the incident in the portal, which keeps counting occurrences; this drops the lines entirely. |
 
@@ -266,7 +335,11 @@ Verify end to end:
 ```bash
 az aks command invoke -g <aks-resource-group> -n <aks-cluster> --command \
   "kubectl -n monitoring logs deploy/mw-log-watcher --tail=50"
-# Expect: "Loki: N red line(s) …" then "Reported <fingerprint> (<category>) — 200".
+# Expect: "Loki: N line(s) in <ns> …", then
+#         "<ns>: F distinct fingerprint(s) from B red burst(s) (N line(s) read)",
+#         then "Reported <fingerprint> (<category>) — 200".
+# 🚨 If that line ever says "TRUNCATED at the query limit", the window was not fully read — read
+#    the log-query-truncated-<ns> incident rather than raising QueryLimit.
 ```
 
 Then browse `Admin/_LogIncident` in the portal — every incident links to the ticket it opened and

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-every-distinct-production-error-gets-its-own-ticket.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-every-distinct-production-error-gets-its-own-ticket.md
@@ -1,0 +1,25 @@
+---
+Name: Every distinct production error gets its own ticket
+Category: Fix
+Description: The red-log watcher collapsed thousands of lines a minute onto one to three tickets — thirteen NodeTypes parked at CompileError were never reported at all. Distinct errors are now distinct incidents, and a window the watcher could not fully read says so instead of passing in silence.
+Icon: Sparkle
+Order: -20260817
+---
+
+# Every distinct production error gets its own ticket
+
+The incident list is supposed to hold one entry per distinct error a portal reports. It was holding
+one entry per *component*: the identity of an incident was built from where the fault was raised and
+what type it was, and nothing else — so thirteen NodeTypes failing to compile, each with its own
+compiler errors and its own fix, arrived at the same stack frame with the same exception type and
+became a single ticket. None of the thirteen was reported.
+
+An incident is now identified by the fault's own words as well: the exception's message, with
+everything that varies between occurrences masked out — node paths, ids, counts, elapsed times, and
+any name the message itself uses as a path. A thousand repeats of one error are still one entry with
+a rising count; two genuinely different errors are two entries with names you can tell apart. When
+one log source produces so many different shapes that the masking is clearly missing something, they
+fold into a single entry that says how many it stands for, rather than flooding the list.
+
+A window the watcher could not read completely now reports that as a finding of its own, as does a
+stretch skipped after a long outage. Silence from the log store is no longer mistaken for quiet.

--- a/src/MeshWeaver.Observability.Contract/BurstAggregator.cs
+++ b/src/MeshWeaver.Observability.Contract/BurstAggregator.cs
@@ -9,8 +9,30 @@ namespace MeshWeaver.Observability;
 public record LogLine(DateTimeOffset Timestamp, string? Namespace, string? Pod, string Line);
 
 /// <summary>
+/// What one window of log lines amounted to.
+///
+/// <para>The three numbers are reported separately on purpose. Before #1787 the watcher logged
+/// <c>"{Bursts} distinct fingerprint(s) from {Lines} red line(s)"</c> with <c>Lines</c> bound to the
+/// TOTAL line count — the query is deliberately unfiltered — so "1 distinct fingerprint from 5000
+/// red line(s)" read as a catastrophic collapse of 5000 errors when it was 5000 lines of every
+/// severity. A verdict nobody can interpret is not a verdict.</para>
+/// </summary>
+/// <param name="Reports">One report per distinct fingerprint, oldest first.</param>
+/// <param name="RedBursts">How many red (<c>fail:</c>/<c>crit:</c>) bursts were parsed — the number
+/// the fingerprint count should be compared against.</param>
+/// <param name="TotalLines">Every line the query returned, red or not.</param>
+/// <param name="FoldedSites">How many log sites exceeded the per-site variant budget and were
+/// collapsed onto a single site-level incident.</param>
+public record BurstAggregation(
+    ImmutableList<LogIncidentReport> Reports,
+    int RedBursts,
+    int TotalLines,
+    int FoldedSites);
+
+/// <summary>
 /// Turns a flat batch of log lines into one <see cref="LogIncidentReport"/> per distinct
-/// fingerprint — the step that collapses "ten thousand identical errors" into one ticketable fact.
+/// fingerprint — the step that collapses "ten thousand identical errors" into one ticketable fact,
+/// without collapsing thirteen different errors along with them.
 ///
 /// <para>Two groupings happen here, and they are different things:</para>
 /// <list type="number">
@@ -22,6 +44,27 @@ public record LogLine(DateTimeOffset Timestamp, string? Namespace, string? Pod, 
 /// count, the time span, the pods, and a bounded sample.</item>
 /// </list>
 ///
+/// <para>🚨 <b>The two real cases, and what this does with each</b> (both measured on memex-cloud,
+/// 2026-08-17):</para>
+/// <list type="bullet">
+/// <item><b>3,894 lines of the SAME error ⇒ ONE report</b> with <c>Occurrences = 3894</c>. The
+/// varying parts — node paths, guids, counts, durations — are masked before the identity is
+/// computed, so repetition cannot fan out.</item>
+/// <item><b>13 lines of 13 DIFFERENT errors ⇒ 13 reports.</b> Thirteen NodeTypes parked at
+/// <c>CompileError</c> share a category, an exception type and a top frame; only the compiler
+/// diagnostics differ, and those now reach the identity. Under the old rule they were one ticket,
+/// which is why #1786 had to be filed by hand.</item>
+/// </list>
+///
+/// <para>The bound on the second direction is <c>maxVariantsPerSite</c>: a log site that
+/// produces more distinct shapes than that in ONE window is treated as a message the masking failed
+/// to normalize, and its bursts fold onto a single site-level incident carrying
+/// <see cref="LogIncidentReport.Variants"/>. 13 is under the default budget and 50 (the 2026-08-09
+/// fan-out) is over it — deliberately, those are the two numbers production has actually produced.
+/// The fold is per WINDOW, so the worst case is one folded incident plus at most the budget's worth
+/// of fine-grained ones per site, all of them stably fingerprinted and therefore deduplicated across
+/// windows.</para>
+///
 /// <para>Pure and static — no state, no I/O — so the grouping is testable directly on a fixture of
 /// log lines.</para>
 /// </summary>
@@ -30,20 +73,30 @@ public static class BurstAggregator
     /// <summary>A header line plus the continuation lines that belong to it.</summary>
     private record RawBurst(DateTimeOffset Timestamp, string? Namespace, string? Pod, ImmutableList<string> Lines);
 
+    /// <summary>One parsed burst, with both identities it could be filed under.</summary>
+    private record KeyedBurst(RawBurst Raw, LogLineParser.ParsedBurst Parsed, string Fingerprint, string SiteFold);
+
     /// <summary>
-    /// Groups a batch into one report per fingerprint. <paramref name="ignoreCategories"/> drops
-    /// bursts whose category starts with any of the listed prefixes.
+    /// Groups a batch into one report per fingerprint.
     /// </summary>
-    public static ImmutableList<LogIncidentReport> Aggregate(
+    /// <param name="entries">The window's lines, oldest first.</param>
+    /// <param name="maxSamples">Evidence lines kept per report.</param>
+    /// <param name="maxSampleLength">Each evidence line is truncated to this many characters.</param>
+    /// <param name="ignoreCategories">Drops bursts whose category starts with any of these prefixes.</param>
+    /// <param name="maxVariantsPerSite">How many distinct fingerprints ONE log site may open in one
+    /// window before they are folded onto a single site-level incident. Zero or less disables the
+    /// fold.</param>
+    /// <returns>The reports plus the counts needed to read the verdict.</returns>
+    public static BurstAggregation Aggregate(
         IReadOnlyList<LogLine> entries,
         int maxSamples,
         int maxSampleLength,
-        IReadOnlyList<string>? ignoreCategories = null)
+        IReadOnlyList<string>? ignoreCategories = null,
+        int maxVariantsPerSite = 0)
     {
         ArgumentNullException.ThrowIfNull(entries);
 
-        var reports = new Dictionary<string, LogIncidentReport>(StringComparer.Ordinal);
-
+        var keyed = new List<KeyedBurst>();
         foreach (var raw in SplitBursts(entries))
         {
             if (LogLineParser.Parse(raw.Lines) is not { } parsed)
@@ -52,17 +105,38 @@ public static class BurstAggregator
                     parsed.Category.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) == true)
                 continue;
 
-            var fingerprint = LogLineParser.Fingerprint(parsed);
-            var sample = new LogSample(raw.Timestamp, raw.Pod, Truncate(
-                string.Join('\n', raw.Lines), maxSampleLength));
+            var burst = LogLineParser.ToBurst(parsed);
+            keyed.Add(new KeyedBurst(raw, parsed,
+                StructuralLogIncidentIdentity.Compute(burst),
+                StructuralLogIncidentIdentity.ComputeSiteFold(burst)));
+        }
+
+        var folded = FoldedSites(keyed, maxVariantsPerSite);
+        var variantsPerSite = folded.IsEmpty
+            ? ImmutableDictionary<string, int>.Empty
+            : keyed
+                .Where(b => folded.Contains(b.SiteFold))
+                .GroupBy(b => b.SiteFold, StringComparer.Ordinal)
+                .ToImmutableDictionary(
+                    g => g.Key,
+                    g => g.Select(b => b.Fingerprint).Distinct(StringComparer.Ordinal).Count(),
+                    StringComparer.Ordinal);
+
+        var reports = new Dictionary<string, LogIncidentReport>(StringComparer.Ordinal);
+        foreach (var burst in keyed)
+        {
+            var isFolded = folded.Contains(burst.SiteFold);
+            var fingerprint = isFolded ? burst.SiteFold : burst.Fingerprint;
+            var sample = new LogSample(burst.Raw.Timestamp, burst.Raw.Pod, Truncate(
+                string.Join('\n', burst.Raw.Lines), maxSampleLength));
 
             reports[fingerprint] = reports.TryGetValue(fingerprint, out var existing)
                 ? existing with
                 {
                     Occurrences = existing.Occurrences + 1,
-                    FirstSeen = raw.Timestamp < existing.FirstSeen ? raw.Timestamp : existing.FirstSeen,
-                    LastSeen = raw.Timestamp > existing.LastSeen ? raw.Timestamp : existing.LastSeen,
-                    Pods = raw.Pod is { Length: > 0 } pod && !existing.Pods.Contains(pod)
+                    FirstSeen = burst.Raw.Timestamp < existing.FirstSeen ? burst.Raw.Timestamp : existing.FirstSeen,
+                    LastSeen = burst.Raw.Timestamp > existing.LastSeen ? burst.Raw.Timestamp : existing.LastSeen,
+                    Pods = burst.Raw.Pod is { Length: > 0 } pod && !existing.Pods.Contains(pod)
                         ? existing.Pods.Add(pod)
                         : existing.Pods,
                     // Keep the LAST few lines: the most recent occurrence is the one a responder
@@ -72,22 +146,38 @@ public static class BurstAggregator
                 : new LogIncidentReport
                 {
                     Fingerprint = fingerprint,
-                    Category = parsed.Category,
-                    Severity = parsed.Severity,
-                    ExceptionType = parsed.ExceptionType,
-                    NormalizedMessage = parsed.NormalizedMessage,
-                    TopFrame = parsed.TopFrame,
-                    Namespace = raw.Namespace,
-                    Pods = raw.Pod is { Length: > 0 } p ? ImmutableList.Create(p) : ImmutableList<string>.Empty,
+                    Category = burst.Parsed.Category,
+                    Severity = burst.Parsed.Severity,
+                    ExceptionType = burst.Parsed.ExceptionType,
+                    NormalizedMessage = burst.Parsed.NormalizedMessage,
+                    NormalizedDetail = burst.Parsed.NormalizedDetail,
+                    TopFrame = burst.Parsed.TopFrame,
+                    Namespace = burst.Raw.Namespace,
+                    Pods = burst.Raw.Pod is { Length: > 0 } p ? ImmutableList.Create(p) : ImmutableList<string>.Empty,
                     Occurrences = 1,
-                    FirstSeen = raw.Timestamp,
-                    LastSeen = raw.Timestamp,
+                    Variants = isFolded ? variantsPerSite[burst.SiteFold] : 1,
+                    FirstSeen = burst.Raw.Timestamp,
+                    LastSeen = burst.Raw.Timestamp,
                     Samples = ImmutableList.Create(sample),
                 };
         }
 
-        return reports.Values.OrderBy(r => r.FirstSeen).ToImmutableList();
+        return new BurstAggregation(
+            reports.Values.OrderBy(r => r.FirstSeen).ToImmutableList(),
+            keyed.Count,
+            entries.Count,
+            folded.Count);
     }
+
+    /// <summary>The log sites whose distinct-fingerprint count exceeds the budget.</summary>
+    private static ImmutableHashSet<string> FoldedSites(IReadOnlyList<KeyedBurst> keyed, int maxVariantsPerSite) =>
+        maxVariantsPerSite <= 0
+            ? ImmutableHashSet<string>.Empty
+            : keyed
+                .GroupBy(b => b.SiteFold, StringComparer.Ordinal)
+                .Where(g => g.Select(b => b.Fingerprint).Distinct(StringComparer.Ordinal).Count() > maxVariantsPerSite)
+                .Select(g => g.Key)
+                .ToImmutableHashSet(StringComparer.Ordinal);
 
     /// <summary>
     /// Re-attaches each red header to the continuation lines that followed it. A line starts a new

--- a/src/MeshWeaver.Observability.Contract/ILogIncidentIdentity.cs
+++ b/src/MeshWeaver.Observability.Contract/ILogIncidentIdentity.cs
@@ -11,6 +11,9 @@ namespace MeshWeaver.Observability;
 /// <param name="NormalizedMessage">The message with ids, paths, numbers and labelled identifiers masked.</param>
 /// <param name="ExceptionType">The exception type name, when the burst carried one.</param>
 /// <param name="TopFrame">The top application stack frame, when the burst carried one.</param>
+/// <param name="NormalizedDetail">The masked text that discriminates WITHIN one fault site: the
+/// exception's own message when the burst carried an exception, else the logged message. Empty
+/// means "not supplied" and the identity falls back to <paramref name="NormalizedMessage"/>.</param>
 public record LogBurst(
     string Category,
     int EventId,
@@ -18,7 +21,8 @@ public record LogBurst(
     string Message,
     string NormalizedMessage,
     string? ExceptionType,
-    string? TopFrame);
+    string? TopFrame,
+    string NormalizedDetail = "");
 
 /// <summary>
 /// Decides what makes two red logs <b>the same incident</b> — the one question this subsystem got

--- a/src/MeshWeaver.Observability.Contract/LogIncidentReport.cs
+++ b/src/MeshWeaver.Observability.Contract/LogIncidentReport.cs
@@ -27,8 +27,23 @@ public record LogIncidentReport
     /// <summary>The exception type name, when the burst carried one.</summary>
     public string? ExceptionType { get; init; }
 
-    /// <summary>The message with volatile parts masked (what the fingerprint covers).</summary>
+    /// <summary>The logged message with volatile parts masked.</summary>
     public required string NormalizedMessage { get; init; }
+
+    /// <summary>
+    /// The masked text the fingerprint discriminates on within the fault site: the exception's own
+    /// message when the burst carried one, else the logged message. This is what tells thirteen
+    /// different compiler errors at one frame apart from each other.
+    /// </summary>
+    public string NormalizedDetail { get; init; } = string.Empty;
+
+    /// <summary>
+    /// How many distinct message shapes this report covers. Always <c>1</c> except when a log site
+    /// blew past the watcher's per-site variant budget in one window and its bursts were folded onto
+    /// a single site-level incident — then it is the number of shapes that were folded in, and the
+    /// ticket says so instead of opening that many tickets.
+    /// </summary>
+    public int Variants { get; init; } = 1;
 
     /// <summary>The top application stack frame, when the burst carried a stack trace.</summary>
     public string? TopFrame { get; init; }

--- a/src/MeshWeaver.Observability.Contract/LogLineParser.cs
+++ b/src/MeshWeaver.Observability.Contract/LogLineParser.cs
@@ -44,6 +44,14 @@ public static partial class LogLineParser
     /// line, or recovered from the message when the call site formatted the exception into it.</param>
     /// <param name="TopFrame">The top application stack frame, when present — where the fault IS,
     /// and therefore the incident's locator in preference to the reporting category.</param>
+    /// <param name="ExceptionMessage">The exception's OWN message — everything after
+    /// <c>Some.Type:</c> up to the first stack frame — read from the exception line, or from the
+    /// message when the call site formatted the exception into it. Null when the burst carries no
+    /// exception.</param>
+    /// <param name="NormalizedDetail">What the fingerprint discriminates on WITHIN a fault site:
+    /// the normalized <see cref="ExceptionMessage"/> when the burst carries an exception, otherwise
+    /// the normalized logged message. See <see cref="StructuralLogIncidentIdentity"/> for why the
+    /// exception's own text wins over the reporter's prose.</param>
     public record ParsedBurst(
         LogSeverity Severity,
         string Category,
@@ -51,7 +59,9 @@ public static partial class LogLineParser
         string Message,
         string NormalizedMessage,
         string? ExceptionType,
-        string? TopFrame);
+        string? TopFrame,
+        string? ExceptionMessage = null,
+        string NormalizedDetail = "");
 
     /// <summary>
     /// True when <paramref name="line"/> opens a red burst (<c>fail:</c> / <c>crit:</c>), with the
@@ -106,21 +116,72 @@ public static partial class LogLineParser
         // property of the caller's formatting, not of the fault, and it is half of why #1170 and
         // #1171 became two tickets for one ObjectDisposedException. Recover the type from the message
         // when no exception line exists; an own-line header always wins.
-        exceptionType ??= InlineException().Match(message) switch
+        string? exceptionMessage = null;
+        if (exceptionIndex >= 0)
         {
-            { Success: true } inline => inline.Groups["type"].Value,
-            _ => null,
-        };
+            exceptionMessage = ExceptionText(body, exceptionIndex);
+        }
+        else if (InlineException().Match(message) is { Success: true } inline)
+        {
+            exceptionType = inline.Groups["type"].Value;
+            // The exception's own words start right after the `Type: ` the regex consumed — the same
+            // text an own-line header would have carried, so both shapes yield the same detail.
+            exceptionMessage = message[(inline.Index + inline.Length)..].Trim();
+        }
+
+        var normalizedMessage = Normalize(message);
 
         return new ParsedBurst(
             severity,
             category,
             eventId,
             message,
-            Normalize(message),
+            normalizedMessage,
             exceptionType,
-            TopApplicationFrame(body));
+            TopApplicationFrame(body),
+            exceptionMessage,
+            // 🚨 The fault's OWN text wins over the reporter's prose. Two catch sites printing one
+            // unwinding exception word it differently ("Error during shutdown of hub …" vs "Hub …
+            // disposal faulted") but quote the SAME exception message, so keying on the exception
+            // text folds them — the property that stopped #1170/#1171 from being two tickets —
+            // while still telling thirteen different compiler errors apart. Only a burst with no
+            // exception at all falls back to the logged message, because then it is all there is.
+            exceptionMessage is { Length: > 0 } detail ? Normalize(detail) : normalizedMessage);
     }
+
+    /// <summary>
+    /// The exception's own message: the remainder of the exception line after <c>Some.Type:</c>,
+    /// plus the continuation lines up to the first stack frame.
+    ///
+    /// <para>Multi-line on purpose. A <c>CompilationException</c> puts every Roslyn diagnostic in
+    /// its message, and its FIRST line ("Compilation failed for '…'") normalizes to the same text
+    /// for every node — so a first-line-only rule would collapse thirteen parked NodeTypes back
+    /// onto one ticket, which is the defect this exists to fix (#1787). Bounded by
+    /// <see cref="MaxDetailLength"/> so one pathological exception cannot make every window's
+    /// hashing quadratic.</para>
+    /// </summary>
+    private static string ExceptionText(IReadOnlyList<string> body, int exceptionIndex)
+    {
+        var match = ExceptionLine().Match(body[exceptionIndex]);
+        var builder = new StringBuilder(body[exceptionIndex][match.Length..].TrimStart(' ', ':'));
+
+        for (var i = exceptionIndex + 1; i < body.Count && builder.Length < MaxDetailLength; i++)
+        {
+            if (StackFrame().IsMatch(body[i]))
+                break;
+            builder.Append('\n').Append(body[i]);
+        }
+
+        var text = builder.ToString().Trim();
+        return text.Length > MaxDetailLength ? text[..MaxDetailLength] : text;
+    }
+
+    /// <summary>
+    /// How much exception text may reach the fingerprint. Generous enough that a compiler's whole
+    /// diagnostic list fits (the ERRORS come first, before the warning tail), small enough that the
+    /// masking regexes stay cheap over thousands of lines per poll.
+    /// </summary>
+    private const int MaxDetailLength = 8000;
 
     /// <summary>
     /// The first <c>at …</c> stack frame belonging to application code. Framework and BCL frames
@@ -166,22 +227,97 @@ public static partial class LogLineParser
     {
         var masked = Guid().Replace(message, "{guid}");
         masked = Timestamp().Replace(masked, "{time}");
+        // Collected BEFORE the path rule eats them — see MaskSubjects.
+        var subjects = PathSegments(masked);
         masked = Path().Replace(masked, "{path}");
         masked = Quoted().Replace(masked, "'{value}'");
         masked = HexBlob().Replace(masked, "{hex}");
         masked = LabelledIdentifier().Replace(masked, "${label}: {id}");
+        masked = MaskSubjects(masked, subjects);
         masked = Number().Replace(masked, "{n}");
         return WhitespaceRun().Replace(masked, " ").Trim();
     }
+
+    /// <summary>
+    /// The distinct segments of every slash path in <paramref name="message"/> — the tokens the
+    /// message itself has told us are identifiers rather than prose.
+    /// </summary>
+    private static ImmutableHashSet<string> PathSegments(string message)
+    {
+        var segments = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+        foreach (Match match in Path().Matches(message))
+        {
+            foreach (var segment in match.Value.Split('/', '\\'))
+            {
+                // Placeholder names are excluded or a segment called "path" would rewrite the
+                // `{path}` this very method is about to produce.
+                if (segment.Length < 2 || !char.IsLetter(segment[0]) || segment.Contains('{')
+                    || PlaceholderNames.Contains(segment))
+                    continue;
+                segments.Add(segment);
+                if (segments.Count >= MaxSubjects)
+                    return segments.ToImmutable();
+            }
+        }
+        return segments.ToImmutable();
+    }
+
+    /// <summary>
+    /// Masks a token elsewhere in the message when that same token appears as a segment of a slash
+    /// path in it — <b>the message's own evidence that the token names an instance</b>.
+    ///
+    /// <para>🚨 This is what makes the message safe to hash at all. Round 4 of the fingerprint
+    /// (2026-08-09) produced ~22 incidents for ONE reconcile defect because the subject sat BEFORE
+    /// the colon — <c>[PluginGating] Chess: reconcile is NOT CONVERGING — rewrote
+    /// Chess/_Access/Public_Access …</c> — where a <c>label: value</c> rule cannot see it. No masking
+    /// rule can anticipate where the next message will put its subject, so this one does not try:
+    /// it reads the subject OUT of the message, from the paths the message already spells out.
+    /// <c>Chess</c> is a path segment, therefore <c>Chess</c> anywhere in that message is an
+    /// identifier, whatever position it occupies.</para>
+    ///
+    /// <para>Word-boundary and case-sensitive, so <c>Cession</c> does not swallow
+    /// <c>CessionData</c>, and bounded at <see cref="MaxSubjects"/> tokens. The failure direction is
+    /// over-collapsing (a prose word that happens to be a path segment), which costs one ticket a
+    /// human can split rather than fifty nobody reads.</para>
+    /// </summary>
+    private static string MaskSubjects(string message, ImmutableHashSet<string> subjects)
+    {
+        if (subjects.IsEmpty)
+            return message;
+
+        // Longest first, so a subject that is a prefix of another cannot shadow it.
+        var pattern = @"\b(?:"
+                      + string.Join('|', subjects.OrderByDescending(s => s.Length).Select(Regex.Escape))
+                      + @")\b";
+        return Regex.Replace(message, pattern, "{id}",
+            RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1));
+    }
+
+    /// <summary>How many path segments may become subjects. Bounds the constructed regex.</summary>
+    private const int MaxSubjects = 32;
+
+    /// <summary>The masks <see cref="Normalize"/> itself emits — never re-masked.</summary>
+    private static readonly ImmutableHashSet<string> PlaceholderNames =
+        ImmutableHashSet.Create<string>(StringComparer.Ordinal,
+            "path", "value", "guid", "time", "id", "hex", "n");
 
     /// <summary>
     /// The stable identity of a fault. Delegates to <see cref="StructuralLogIncidentIdentity"/> —
     /// there is ONE definition of "the same incident", and it lives behind
     /// <see cref="ILogIncidentIdentity"/> so a Code node can replace it without a redeploy.
     /// </summary>
-    public static string Fingerprint(ParsedBurst burst) => StructuralLogIncidentIdentity.Compute(
-        new LogBurst(burst.Category, burst.EventId, burst.Severity, burst.Message,
-            burst.NormalizedMessage, burst.ExceptionType, burst.TopFrame));
+    public static string Fingerprint(ParsedBurst burst) =>
+        StructuralLogIncidentIdentity.Compute(ToBurst(burst));
+
+    /// <summary>The identity function's input, as this parser saw the burst.</summary>
+    /// <param name="burst">The parsed burst.</param>
+    /// <returns>The <see cref="LogBurst"/> handed to <see cref="ILogIncidentIdentity"/>.</returns>
+    public static LogBurst ToBurst(ParsedBurst burst)
+    {
+        ArgumentNullException.ThrowIfNull(burst);
+        return new LogBurst(burst.Category, burst.EventId, burst.Severity, burst.Message,
+            burst.NormalizedMessage, burst.ExceptionType, burst.TopFrame, burst.NormalizedDetail);
+    }
 
     [GeneratedRegex(@"^(?<type>[A-Z][\w.]*(?:Exception|Error))(?::|\s*$)", RegexOptions.CultureInvariant)]
     private static partial Regex ExceptionLine();

--- a/src/MeshWeaver.Observability.Contract/LogLineParser.cs
+++ b/src/MeshWeaver.Observability.Contract/LogLineParser.cs
@@ -249,9 +249,11 @@ public static partial class LogLineParser
         {
             foreach (var segment in match.Value.Split('/', '\\'))
             {
-                // Placeholder names are excluded or a segment called "path" would rewrite the
-                // `{path}` this very method is about to produce.
-                if (segment.Length < 2 || !char.IsLetter(segment[0]) || segment.Contains('{')
+                // Word tokens only (letter-initial, all word characters) — that is what MaskSubjects
+                // can compare against, and it is the shape a bare subject actually takes (`Chess`,
+                // `Claims`, `Northwind`). Placeholder names are excluded or a segment called "path"
+                // would rewrite the `{path}` this very method is about to produce.
+                if (segment.Length < 2 || !char.IsLetter(segment[0]) || !IsWordToken(segment)
                     || PlaceholderNames.Contains(segment))
                     continue;
                 segments.Add(segment);
@@ -275,25 +277,61 @@ public static partial class LogLineParser
     /// <c>Chess</c> is a path segment, therefore <c>Chess</c> anywhere in that message is an
     /// identifier, whatever position it occupies.</para>
     ///
-    /// <para>Word-boundary and case-sensitive, so <c>Cession</c> does not swallow
-    /// <c>CessionData</c>, and bounded at <see cref="MaxSubjects"/> tokens. The failure direction is
-    /// over-collapsing (a prose word that happens to be a path segment), which costs one ticket a
-    /// human can split rather than fifty nobody reads.</para>
+    /// <para>Whole-token and case-sensitive, so <c>Cession</c> does not swallow <c>CessionData</c>,
+    /// and bounded at <see cref="MaxSubjects"/> tokens. The failure direction is over-collapsing (a
+    /// prose word that happens to be a path segment), which costs one ticket a human can split
+    /// rather than fifty nobody reads.</para>
+    ///
+    /// <para>🚨 Deliberately a linear scan over word tokens rather than a constructed
+    /// <c>\b(?:a|b|c)\b</c> regex. <see cref="Normalize"/> is on the ingest hot path, and a regex
+    /// built per message would be re-parsed on every call (the pattern cache is keyed by pattern
+    /// text) and would need a match timeout — whose expiry would throw straight through the
+    /// aggregator and wedge the poll, since a failed pass leaves the cursor put and the next tick
+    /// re-reads the very same window. A scan cannot time out, so there is nothing to catch.</para>
     /// </summary>
     private static string MaskSubjects(string message, ImmutableHashSet<string> subjects)
     {
         if (subjects.IsEmpty)
             return message;
 
-        // Longest first, so a subject that is a prefix of another cannot shadow it.
-        var pattern = @"\b(?:"
-                      + string.Join('|', subjects.OrderByDescending(s => s.Length).Select(Regex.Escape))
-                      + @")\b";
-        return Regex.Replace(message, pattern, "{id}",
-            RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1));
+        // A length window over the subjects, so the overwhelming majority of prose tokens are
+        // rejected without allocating the string the hash-set lookup would need.
+        var shortest = subjects.Min(s => s.Length);
+        var longest = subjects.Max(s => s.Length);
+
+        var result = new StringBuilder(message.Length);
+        var i = 0;
+        while (i < message.Length)
+        {
+            if (!IsWordChar(message[i]))
+            {
+                result.Append(message[i++]);
+                continue;
+            }
+
+            var start = i;
+            while (i < message.Length && IsWordChar(message[i]))
+                i++;
+
+            var token = message.AsSpan(start, i - start);
+            var isSubject = token.Length >= shortest && token.Length <= longest
+                            && subjects.Contains(token.ToString());
+            result.Append(isSubject ? "{id}" : token);
+        }
+        return result.ToString();
     }
 
-    /// <summary>How many path segments may become subjects. Bounds the constructed regex.</summary>
+    private static bool IsWordChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    private static bool IsWordToken(string value)
+    {
+        foreach (var c in value)
+            if (!IsWordChar(c))
+                return false;
+        return true;
+    }
+
+    /// <summary>How many path segments may become subjects. Bounds the lookup set.</summary>
     private const int MaxSubjects = 32;
 
     /// <summary>The masks <see cref="Normalize"/> itself emits — never re-masked.</summary>

--- a/src/MeshWeaver.Observability.Contract/StructuralLogIncidentIdentity.cs
+++ b/src/MeshWeaver.Observability.Contract/StructuralLogIncidentIdentity.cs
@@ -4,37 +4,44 @@ using System.Text;
 namespace MeshWeaver.Observability;
 
 /// <summary>
-/// The default identity: <b>the fault, not the reporter</b>.
+/// The default identity: <b>the fault, not the reporter</b> — located by frame or site, and
+/// discriminated by the fault's own text.
 ///
-/// <para>Two rules, and which one applies is decided by the burst itself:</para>
+/// <para>Three parts, and the first two are decided by the burst itself:</para>
 /// <list type="number">
-/// <item><b>The burst names an application frame</b> ⇒ the incident IS
-/// <c>(top application frame, exception type)</c>. The log category and event id are DISCARDED —
-/// they say who caught and printed the fault, not where it is. One exception unwinding through two
-/// catch sites is one defect however many of them log it.</item>
-/// <item><b>It names no application frame</b> ⇒ there is no location to key on, so the log SITE
-/// (category + event id) is the locator, plus the exception type when there is one. This is the
-/// #1002 rule, unchanged: a bare diagnostic is identified by the site the code assigns it.</item>
+/// <item><b>WHERE.</b> The burst names an application frame ⇒ the locator IS that frame, and the log
+/// category and event id are DISCARDED — they say who caught and printed the fault, not where it is.
+/// No frame ⇒ there is no location to key on, so the log SITE (category + event id) is the locator.
+/// This is the #1002 rule, unchanged.</item>
+/// <item><b>WHAT.</b> The exception type, by simple name.</item>
+/// <item><b>WHICH.</b> The normalized <i>detail</i>: the exception's OWN message when there is one,
+/// else the logged message. Masked first — guids, timestamps, paths, quoted literals, hex blobs,
+/// labelled identifiers, numbers, and any token the message itself uses as a path segment
+/// (<see cref="LogLineParser.Normalize"/>).</item>
 /// </list>
 ///
-/// <para>The message never participates, in either branch. That is the correction for four rounds
-/// of getting this wrong: every failure came from prose being part of the key, because a message
-/// embeds its subject in an arbitrary position (<c>target: Claims</c>, <c>[PluginGating] Chess:</c>)
-/// and no amount of masking anticipates the next shape.</para>
+/// <para>🚨 <b>Why the detail had to come back (#1787).</b> Without it, "same frame + same exception
+/// type" was the whole key, and on 2026-08-17 that mapped THIRTEEN NodeTypes parked at
+/// <c>CompileError</c> onto ONE fingerprint: every one of them throws <c>CompilationException</c>
+/// from <c>EmitPipeline.EmitCompilationToDirectory</c>, so thirteen independently-actionable
+/// compiler errors produced one ticket — and #1786 had to be filed by hand. Thousands of red lines
+/// per window were collapsing to one to three fingerprints; the contract is one triaged issue per
+/// distinct error.</para>
 ///
-/// <para>🚨 <b>Why the category had to go.</b> Keying on it split #1170 from #1171 — ONE
-/// <c>ObjectDisposedException</c> raised at <c>SynchronizationStream&lt;T&gt;.OnCompleted()</c>
-/// during one hub teardown on one pod at one instant, logged once by
-/// <c>MeshWeaver.Messaging.MessageHub</c> ("Error during shutdown of hub …") and once by
-/// <c>MeshWeaver.Messaging.HostedHubsCollection</c> ("Hub … disposal faulted"). Same fault, same
-/// frame, two reporters, two tickets. The frame is a strictly more specific locator than the
-/// category — it names the exact method — so dropping the category where a frame exists cannot
-/// merge anything the category was keeping apart for a good reason.</para>
+/// <para>🚨 <b>Why the detail is the EXCEPTION's message, not the reporter's.</b> That is the whole
+/// lesson of #1170/#1171: ONE <c>ObjectDisposedException</c> raised at
+/// <c>SynchronizationStream&lt;T&gt;.OnCompleted()</c> during one hub teardown, logged once by
+/// <c>MessageHub</c> ("Error during shutdown of hub …") and once by <c>HostedHubsCollection</c>
+/// ("Hub … disposal faulted"). The prose differs per reporter; the exception message
+/// ("Cannot access a disposed object.") does not. Keying on the fault's own words folds the
+/// reporters and still splits genuinely different faults. Only a burst with NO exception falls back
+/// to the logged message — there it is the only text there is.</para>
 ///
-/// <para>The remaining trade is deliberate and unchanged: two genuinely different faults raised at
-/// the same frame with the same exception type collapse into one incident. That is the SAFE
-/// direction — an under-split incident is one ticket a human can split, whereas an over-split one
-/// is fifty tickets nobody reads, and fifty was what production actually produced.</para>
+/// <para>Four earlier rounds fanned out because they hashed the reporter's prose with the subject
+/// still in it, in whatever position the message happened to put it. Masking now reads the subject
+/// out of the message rather than guessing at its position — see
+/// <c>LogLineParser.MaskSubjects</c> — and <see cref="ComputeSiteFold"/> bounds whatever that still
+/// misses.</para>
 ///
 /// <para>Override it by implementing <see cref="ILogIncidentIdentity"/> in a Code node; this stays
 /// the fallback when none is compiled.</para>
@@ -54,23 +61,51 @@ public sealed class StructuralLogIncidentIdentity : ILogIncidentIdentity
     public static string Compute(LogBurst burst)
     {
         ArgumentNullException.ThrowIfNull(burst);
+        return Hash(Payload(burst, Detail(burst)));
+    }
 
+    /// <summary>
+    /// The identity of a whole log SITE, with the detail deliberately dropped — the fold the
+    /// aggregator applies when one site produced more distinct details in a single window than the
+    /// configured budget allows.
+    ///
+    /// <para>This is the deliberate floor under the "too fine" direction. Masking cannot anticipate
+    /// every message shape, and the cost of guessing wrong is asymmetric: an under-split incident is
+    /// one ticket a human can split, an over-split one is fifty tickets nobody reads — and fifty is
+    /// what production actually produced on 2026-08-09. So a site that fans out past the budget
+    /// stops being N tickets and becomes ONE, whose body says how many shapes it covered.</para>
+    /// </summary>
+    /// <param name="burst">Any burst from the site being folded.</param>
+    /// <returns>A 16-hex-character token, distinct from every per-detail identity.</returns>
+    public static string ComputeSiteFold(LogBurst burst)
+    {
+        ArgumentNullException.ThrowIfNull(burst);
+        // The "fold" tag keeps this out of the per-detail namespace: a site fold and a genuine burst
+        // with an empty detail must never share a fingerprint.
+        return Hash("fold\n" + Payload(burst, ""));
+    }
+
+    private static string Payload(LogBurst burst, string detail)
+    {
         var fault = SimpleTypeName(burst.ExceptionType);
 
         // The branch tag ("frame"/"site") is part of the payload so the two rules can never collide
         // on a hash — a category that happens to read like a frame stays its own incident.
-        var payload = burst.TopFrame is { Length: > 0 } frame
-            ? $"frame\n{frame}\n{fault}"
-            // 🚨 No application frame — a bare diagnostic, or a fault whose whole stack is framework.
-            // The message contributes NOTHING here either: the subject sits in an arbitrary position
-            // (`[PluginGating] Chess:` puts it before the colon, where a `label: value` rule cannot
-            // see it), and masking only ever anticipates the shape you have already seen. Category +
-            // EventId identifies the log SITE, which is what the code itself asserts.
-            : $"site\n{burst.Category}\n{burst.EventId}\n{fault}";
-
-        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
-        return Convert.ToHexStringLower(hash.AsSpan(0, 8));
+        return burst.TopFrame is { Length: > 0 } frame
+            ? $"frame\n{frame}\n{fault}\n{detail}"
+            : $"site\n{burst.Category}\n{burst.EventId}\n{fault}\n{detail}";
     }
+
+    /// <summary>
+    /// The discriminating text. <see cref="LogBurst.NormalizedDetail"/> when the parser supplied one;
+    /// otherwise the normalized message, so a hand-built burst (or an older caller) still splits on
+    /// what it has rather than silently collapsing a whole site onto one ticket.
+    /// </summary>
+    private static string Detail(LogBurst burst) =>
+        burst.NormalizedDetail is { Length: > 0 } detail ? detail : burst.NormalizedMessage;
+
+    private static string Hash(string payload) =>
+        Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(payload)).AsSpan(0, 8));
 
     /// <summary>
     /// The exception type without its namespace. One fault reaches the watcher in two spellings —

--- a/src/MeshWeaver.Observability/LogIncident.cs
+++ b/src/MeshWeaver.Observability/LogIncident.cs
@@ -91,13 +91,13 @@ public record LogIncidentDraft
 public record LogIncident
 {
     /// <summary>
-    /// The node id, and the identity of "the same error happening again": a stable hash over the
-    /// FAULT — its top application frame and exception type — falling back to the log site
-    /// (category + event id) <b>plus the exception type</b> for a burst that names no frame. The
-    /// message never participates. The category participates ONLY in that no-frame fallback: when
-    /// a frame exists it locates the fault precisely, so who caught and printed it is irrelevant —
-    /// that is what stopped one fault from opening two tickets. See
-    /// <see cref="StructuralLogIncidentIdentity"/>.
+    /// The node id, and the identity of "the same error happening again": a stable hash over WHERE
+    /// the fault is (its top application frame, falling back to the log site — category + event id —
+    /// when the burst names no frame), WHAT it is (the exception type) and WHICH one it is (the
+    /// masked exception message, or the masked logged message for a burst with no exception). The
+    /// category participates ONLY in the no-frame fallback: when a frame exists it locates the fault
+    /// precisely, so who caught and printed it is irrelevant — that is what stopped one fault from
+    /// opening two tickets. See <see cref="StructuralLogIncidentIdentity"/>.
     /// </summary>
     [Browsable(false)]
     [Key]
@@ -118,11 +118,24 @@ public record LogIncident
     [Translation("de", "Ausnahme")]
     public string? ExceptionType { get; init; }
 
-    /// <summary>The message with volatile parts (ids, guids, paths, numbers) masked — what the
-    /// fingerprint is computed over, and the most readable one-line summary of the fault.</summary>
+    /// <summary>The message with volatile parts (ids, guids, paths, numbers) masked — the most
+    /// readable one-line summary of the fault.</summary>
     [Description("Message")]
     [Translation("de", "Meldung")]
     public string NormalizedMessage { get; init; } = string.Empty;
+
+    /// <summary>The masked text the fingerprint discriminates on: the exception's own message when
+    /// the burst carried one, else the logged message.</summary>
+    [Description("Detail")]
+    [Translation("de", "Detail")]
+    public string NormalizedDetail { get; init; } = string.Empty;
+
+    /// <summary>How many distinct message shapes this incident covers — <c>1</c> unless the log site
+    /// fanned out past the watcher's per-site budget and was folded onto one incident.</summary>
+    [Description("Variants")]
+    [Translation("de", "Varianten")]
+    [Editable(false)]
+    public int Variants { get; init; } = 1;
 
     /// <summary>The top application stack frame, when the burst carried a stack trace.</summary>
     [Description("Top frame")]

--- a/src/MeshWeaver.Observability/LogIncidentFiler.cs
+++ b/src/MeshWeaver.Observability/LogIncidentFiler.cs
@@ -193,6 +193,16 @@ public sealed class LogIncidentFiler(
         if (!incident.Pods.IsEmpty)
             sb.AppendLine(CultureInfo.InvariantCulture, $"| Pods | {string.Join(", ", incident.Pods.Select(p => $"`{p}`"))} |");
         sb.AppendLine(CultureInfo.InvariantCulture, $"| Occurrences | {incident.Occurrences} |");
+        if (incident.Variants > 1)
+        {
+            var folded = string.Create(CultureInfo.InvariantCulture,
+                $"| Message shapes | **{incident.Variants}** — ")
+                + "this log site fanned out past the watcher's per-site budget in one window, so its "
+                + "bursts were folded onto THIS one incident rather than opening that many tickets. "
+                + "The masking rule is not normalizing something in this message; the shapes are in "
+                + "the samples below. |";
+            sb.AppendLine(folded);
+        }
         sb.AppendLine(CultureInfo.InvariantCulture, $"| First seen | {Format(incident.FirstSeen)} |");
         sb.AppendLine(CultureInfo.InvariantCulture, $"| Last seen | {Format(incident.LastSeen)} |");
         if (route.Overridden)

--- a/src/MeshWeaver.Observability/LogIncidentFiler.cs
+++ b/src/MeshWeaver.Observability/LogIncidentFiler.cs
@@ -194,15 +194,12 @@ public sealed class LogIncidentFiler(
             sb.AppendLine(CultureInfo.InvariantCulture, $"| Pods | {string.Join(", ", incident.Pods.Select(p => $"`{p}`"))} |");
         sb.AppendLine(CultureInfo.InvariantCulture, $"| Occurrences | {incident.Occurrences} |");
         if (incident.Variants > 1)
-        {
-            var folded = string.Create(CultureInfo.InvariantCulture,
-                $"| Message shapes | **{incident.Variants}** — ")
-                + "this log site fanned out past the watcher's per-site budget in one window, so its "
-                + "bursts were folded onto THIS one incident rather than opening that many tickets. "
-                + "The masking rule is not normalizing something in this message; the shapes are in "
-                + "the samples below. |";
-            sb.AppendLine(folded);
-        }
+            sb.Append(CultureInfo.InvariantCulture, $"| Message shapes | **{incident.Variants}** — ")
+                .AppendLine(
+                    "this log site fanned out past the watcher's per-site budget in one window, so "
+                    + "its bursts were folded onto THIS one incident rather than opening that many "
+                    + "tickets. The masking rule is not normalizing something in this message; the "
+                    + "shapes are in the samples below. |");
         sb.AppendLine(CultureInfo.InvariantCulture, $"| First seen | {Format(incident.FirstSeen)} |");
         sb.AppendLine(CultureInfo.InvariantCulture, $"| Last seen | {Format(incident.LastSeen)} |");
         if (route.Overridden)

--- a/src/MeshWeaver.Observability/LogIncidentIngestService.cs
+++ b/src/MeshWeaver.Observability/LogIncidentIngestService.cs
@@ -101,6 +101,8 @@ public sealed class LogIncidentIngestService(
             Severity = report.Severity,
             ExceptionType = report.ExceptionType,
             NormalizedMessage = report.NormalizedMessage,
+            NormalizedDetail = report.NormalizedDetail,
+            Variants = Math.Max(1, report.Variants),
             TopFrame = report.TopFrame,
             Namespace = report.Namespace,
             Pods = report.Pods,
@@ -189,6 +191,9 @@ public sealed class LogIncidentIngestService(
             Samples = Trim(existing.Samples.AddRange(report.Samples), options.MaxSamples),
             // A recurrence can be MORE severe than the first sighting; never downgrade.
             Severity = report.Severity > existing.Severity ? report.Severity : existing.Severity,
+            // A site fold covers as many shapes as the WIDEST window has shown it to cover — a
+            // quieter window must not make the ticket understate what it is standing in for.
+            Variants = Math.Max(existing.Variants, Math.Max(1, report.Variants)),
         };
 
         return merged with { RequestedStatus = NextRequest(merged, options, lastSeen) };
@@ -293,14 +298,23 @@ public sealed class LogIncidentIngestService(
     /// <summary>
     /// The node's display name — what an admin sees in the incident list and what the fingerprint
     /// is recognisable by. Short by design; the full message lives in the content.
+    ///
+    /// <para>🚨 The detail is part of the name, not just the exception type. Thirteen NodeTypes
+    /// parked at <c>CompileError</c> are thirteen incidents that all carry
+    /// <c>CompilationException</c>, and naming them all
+    /// "MeshNodeCompilationService: CompilationException" would put thirteen indistinguishable rows
+    /// in the incident list — the split would exist and still be unreadable (#1787).</para>
     /// </summary>
     private static string Title(LogIncident incident)
     {
-        var subject = incident.ExceptionType is { Length: > 0 } ex
-            ? ex
-            : incident.NormalizedMessage;
-        if (subject.Length > 80)
-            subject = subject[..80].TrimEnd() + "…";
+        var detail = incident.NormalizedDetail is { Length: > 0 } d ? d : incident.NormalizedMessage;
+        var subject = incident.ExceptionType is { Length: > 0 } ex && !string.Equals(ex, detail, StringComparison.Ordinal)
+            ? $"{ex} — {detail}"
+            : detail;
+        // The detail can be multi-line (a compiler's diagnostic list); a display name cannot.
+        subject = subject.ReplaceLineEndings(" ").Trim();
+        if (subject.Length > 100)
+            subject = subject[..100].TrimEnd() + "…";
         var category = incident.Category.Split('.').LastOrDefault() ?? incident.Category;
         return $"{category}: {subject}";
     }

--- a/test/MeshWeaver.Observability.Test/BurstAggregatorTest.cs
+++ b/test/MeshWeaver.Observability.Test/BurstAggregatorTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using MeshWeaver.Observability;
 using Xunit;
 
@@ -13,6 +14,13 @@ public class BurstAggregatorTest
 
     private static LogLine Entry(string line, int second = 0, string pod = "memex-portal-abc") =>
         new(T0.AddSeconds(second), "memex", pod, line);
+
+    /// <summary>The reports out of an aggregation — the counts have their own tests below.</summary>
+    private static ImmutableList<LogIncidentReport> Reports(
+        IReadOnlyList<LogLine> entries, int maxSamples, int maxSampleLength,
+        IReadOnlyList<string>? ignoreCategories = null, int maxVariantsPerSite = 0) =>
+        BurstAggregator.Aggregate(entries, maxSamples, maxSampleLength, ignoreCategories, maxVariantsPerSite)
+            .Reports;
 
     private static IReadOnlyList<LogLine> OneFault(int second, string nodeId, string pod = "memex-portal-abc") =>
     [
@@ -30,7 +38,7 @@ public class BurstAggregatorTest
             .Concat(OneFault(9, "c0ffee00-1111-2222-3333-444455556666"))
             .ToList();
 
-        var reports = BurstAggregator.Aggregate(entries, maxSamples: 5, maxSampleLength: 2000);
+        var reports = Reports(entries, maxSamples: 5, maxSampleLength: 2000);
 
         reports.Should().HaveCount(1);
         var report = reports[0];
@@ -53,7 +61,7 @@ public class BurstAggregatorTest
             Entry("      Could not connect to the database", 3),
         ]);
 
-        var reports = BurstAggregator.Aggregate(entries, maxSamples: 5, maxSampleLength: 2000);
+        var reports = Reports(entries, maxSamples: 5, maxSampleLength: 2000);
 
         reports.Should().HaveCount(2);
         reports.Select(r => r.Category).Should().Contain("Memex.Portal.Startup");
@@ -68,7 +76,7 @@ public class BurstAggregatorTest
             .Concat(OneFault(4, "91bcd7e0-1234-4f88-9a01-bbccddeeff00", "memex-portal-bbb"))
             .ToList();
 
-        var reports = BurstAggregator.Aggregate(entries, maxSamples: 5, maxSampleLength: 2000);
+        var reports = Reports(entries, maxSamples: 5, maxSampleLength: 2000);
 
         // Same defect on two pods is ONE ticket — the pods ride along as evidence.
         reports.Should().HaveCount(1);
@@ -80,7 +88,7 @@ public class BurstAggregatorTest
     [Fact]
     public void Aggregate_AttachesTheStackTraceToItsHeader()
     {
-        var reports = BurstAggregator.Aggregate(
+        var reports = Reports(
             OneFault(0, "7a2f1c4e-9b3d-4a21-8f65-0c1d2e3f4a5b"),
             maxSamples: 5, maxSampleLength: 2000);
 
@@ -102,7 +110,7 @@ public class BurstAggregatorTest
             Entry("      All good now", 1),
         };
 
-        var reports = BurstAggregator.Aggregate(entries, maxSamples: 5, maxSampleLength: 2000);
+        var reports = Reports(entries, maxSamples: 5, maxSampleLength: 2000);
 
         reports.Should().ContainSingle();
         // The info: lines must not be swallowed into the red burst's evidence.
@@ -112,7 +120,7 @@ public class BurstAggregatorTest
     [Fact]
     public void Aggregate_IgnoresConfiguredCategories()
     {
-        var reports = BurstAggregator.Aggregate(
+        var reports = Reports(
             OneFault(0, "7a2f1c4e-9b3d-4a21-8f65-0c1d2e3f4a5b"),
             maxSamples: 5, maxSampleLength: 2000,
             ignoreCategories: ["MeshWeaver.Data."]);
@@ -127,12 +135,102 @@ public class BurstAggregatorTest
             .SelectMany(i => OneFault(i, $"{i:x8}-1111-2222-3333-444455556666"))
             .ToList();
 
-        var reports = BurstAggregator.Aggregate(entries, maxSamples: 3, maxSampleLength: 40);
+        var reports = Reports(entries, maxSamples: 3, maxSampleLength: 40);
 
         reports[0].Occurrences.Should().Be(20);
         reports[0].Samples.Should().HaveCount(3);
         // Kept samples are the LATEST ones — those correlate with the rest of the logs.
         reports[0].Samples[^1].Timestamp.Should().Be(T0.AddSeconds(19));
         reports[0].Samples.Should().OnlyContain(s => s.Line.Length <= 40 + "…[truncated]".Length);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The per-site variant budget — the floor under "too fine" (#1787)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// One site reporting <paramref name="distinct"/> different unmaskable subjects. Modelled on the
+    /// 2026-08-09 fan-out that produced ~50 incidents for ONE reconcile defect: a bare diagnostic, no
+    /// exception and no frame, whose varying subject is a plain word no masking rule can anticipate.
+    /// </summary>
+    private static List<LogLine> ManyShapesAtOneSite(int distinct) =>
+        Enumerable.Range(0, distinct)
+            .SelectMany(i => new[]
+            {
+                Entry("fail: PluginGating[0]", i),
+                // The subject is a bare WORD — no digits, no path, nothing Normalize masks. That is
+                // exactly the shape that defeated four earlier fingerprint rules.
+                Entry($"      reconcile is NOT CONVERGING — Widget{Word(i)} was rewritten again", i),
+            })
+            .ToList();
+
+    /// <summary>A distinct all-letters token per index — a digit would be masked as <c>{n}</c>.</summary>
+    private static string Word(int i) => $"{(char)('A' + i / 26)}{(char)('A' + i % 26)}";
+
+    /// <summary>
+    /// 13 different errors at one site is the #1787 case and MUST stay 13 tickets — every one of them
+    /// needs its own fix. It is under the watcher's default budget of 20 for exactly that reason.
+    /// </summary>
+    [Fact]
+    public void ThirteenShapesAtOneSite_StayThirteenIncidents()
+    {
+        var aggregation = BurstAggregator.Aggregate(
+            ManyShapesAtOneSite(13), maxSamples: 5, maxSampleLength: 2000,
+            maxVariantsPerSite: 20);
+
+        aggregation.Reports.Should().HaveCount(13);
+        aggregation.FoldedSites.Should().Be(0);
+        aggregation.Reports.Should().OnlyContain(r => r.Variants == 1);
+    }
+
+    /// <summary>
+    /// …and 50 is the fan-out that already burned us once. Past the budget the watcher stops
+    /// believing its own split: ONE incident, carrying the shape count, so a human is told the
+    /// masking rule needs a case instead of being handed fifty tickets nobody reads.
+    /// </summary>
+    [Fact]
+    public void FiftyShapesAtOneSite_FoldOntoOneIncident()
+    {
+        var aggregation = BurstAggregator.Aggregate(
+            ManyShapesAtOneSite(50), maxSamples: 5, maxSampleLength: 2000,
+            maxVariantsPerSite: 20);
+
+        aggregation.Reports.Should().ContainSingle();
+        aggregation.FoldedSites.Should().Be(1);
+
+        var folded = aggregation.Reports[0];
+        folded.Variants.Should().Be(50, "the ticket has to say how much it is standing in for");
+        folded.Occurrences.Should().Be(50);
+        folded.Category.Should().Be("PluginGating");
+    }
+
+    /// <summary>
+    /// A fold must not drag in an unrelated site. Only the site over budget collapses; the quiet one
+    /// beside it keeps its own ticket — otherwise a noisy component would swallow its neighbours,
+    /// which is the exact failure #1787 is about.
+    /// </summary>
+    [Fact]
+    public void AFoldedSite_DoesNotSwallowAQuietOne()
+    {
+        var entries = ManyShapesAtOneSite(50);
+        entries.AddRange(OneFault(60, "7a2f1c4e-9b3d-4a21-8f65-0c1d2e3f4a5b"));
+
+        var aggregation = BurstAggregator.Aggregate(
+            entries, maxSamples: 5, maxSampleLength: 2000, maxVariantsPerSite: 20);
+
+        aggregation.Reports.Should().HaveCount(2);
+        aggregation.Reports.Should().ContainSingle(r => r.Category == "MeshWeaver.Data.MeshDataSource")
+            .Which.Variants.Should().Be(1);
+    }
+
+    /// <summary>The budget is opt-in: zero disables the fold entirely.</summary>
+    [Fact]
+    public void WithoutABudget_NothingFolds()
+    {
+        var aggregation = BurstAggregator.Aggregate(
+            ManyShapesAtOneSite(50), maxSamples: 5, maxSampleLength: 2000, maxVariantsPerSite: 0);
+
+        aggregation.Reports.Should().HaveCount(50);
+        aggregation.FoldedSites.Should().Be(0);
     }
 }

--- a/test/MeshWeaver.Observability.Test/Fixtures/memex-cloud-2026-08-17-red-bursts.txt
+++ b/test/MeshWeaver.Observability.Test/Fixtures/memex-cloud-2026-08-17-red-bursts.txt
@@ -1,0 +1,80 @@
+fail: MeshWeaver.Graph.Configuration.MeshNodeCompilationService[0]
+      Failed to compile assembly for node MeshWeaver/samples/Graph/Data/Doc/Architecture/BusinessRules/Cession. Executed source queries (2):
+        - namespace:MeshWeaver/samples/Graph/Data/Doc/Architecture/BusinessRules/Cession/Source scope:subtree nodeType:Code
+        - namespace:MeshWeaver/samples/Graph/Data/Doc/Architecture/BusinessRules/Cession/Test scope:subtree nodeType:Code
+      Matched Code nodes (0):
+        (none) — the configuration lambda cannot reference types because no source files were included. Check that your Source Code nodes exist and that the NodeType's `sources` list points at them.
+
+      MeshWeaver.Compiler.CompilationException: Compilation failed for 'MeshWeaver/samples/Graph/Data/Doc/Architecture/BusinessRules/Cession':
+      CS0246 Error (line 58): The type or namespace name 'CessionData' could not be found (are you missing a using directive or an assembly reference?)
+      CS0246 Error (line 58): The type or namespace name 'Cashflow' could not be found (are you missing a using directive or an assembly reference?)
+      CS0103 Error (line 58): The name 'CessionSampleData' does not exist in the current context
+      CS0246 Error (line 58): The type or namespace name 'ExcessOfLossLayer' could not be found (are you missing a using directive or an assembly reference?)
+      CS0103 Error (line 58): The name 'CessionSampleData' does not exist in the current context
+      CS0103 Error (line 58): The name 'CessionResultsArea' does not exist in the current context
+      CS1591 Warning (line 32): Missing XML comment for publicly visible type or member 'MeshWeaver_samples_Graph_Data_Doc_Architecture_BusinessRules_CessionMeshNodeProviderAttribute'
+      CS1591 Warning (line 34): Missing XML comment for publicly visible type or member 'MeshWeaver_samples_Graph_Data_Doc_Architecture_BusinessRules_CessionMeshNodeProviderAttribute.Nodes'
+         at MeshWeaver.Compiler.EmitPipeline.EmitCompilationToDirectory(CSharpCompilation compilation, String nodeName, String nodePath, String releaseDir, CancellationToken ct) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Compiler/EmitPipeline.cs:line 114
+         at MeshWeaver.Graph.Configuration.MeshNodeCompilationService.<>c__DisplayClass49_0.<CompileAsyncCore>b__0(String releaseDir) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs:line 1648
+         at MeshWeaver.Compiler.EmitPipeline.EmitToDiskWithRetry(String cacheDirectory, String nodeName, Int32 maxAttempts, ILogger logger, Func`2 emitToReleaseDir) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Compiler/EmitPipeline.cs:line 358
+         at MeshWeaver.Graph.Configuration.MeshNodeCompilationService.CompileAsyncCore(CodeConfiguration codeFile, String hubConfiguration, IReadOnlyList`1 contentCollections, MeshNode node, String nodeName, CancellationToken ct) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs:line 1646
+         at MeshWeaver.Graph.Configuration.MeshNodeCompilationService.RunCompileAndEvict(CodeConfiguration codeFile, String hubConfiguration, IReadOnlyList`1 contentCollections, MeshNode node, String nodeName, CancellationToken ct) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs:line 1570
+         at MeshWeaver.Graph.Configuration.MeshNodeCompilationService.<>c__DisplayClass8_0`1.<<OnThreadPool>b__1>d.MoveNext() in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs:line 76
+info: MeshWeaver.Hosting.DynamicTypePreWarmerHostedService[0]
+      BatchBake: MeshWeaver/samples/Graph/Data/Doc/Architecture/BusinessRules/Cession → NoSources
+fail: MeshWeaver.Graph.Configuration.MeshNodeCompilationService[0]
+      Failed to compile assembly for node MeshWeaver/samples/Graph/Data/Northwind/Product. Executed source queries (2):
+        - namespace:MeshWeaver/samples/Graph/Data/Northwind/Product/Source scope:subtree nodeType:Code
+        - namespace:MeshWeaver/samples/Graph/Data/Northwind/Product/Test scope:subtree nodeType:Code
+      Matched Code nodes (2):
+        - MeshWeaver/samples/Graph/Data/Northwind/Product/Source/ProductContent
+        - MeshWeaver/samples/Graph/Data/Northwind/Product/Source/ProductNodeLayoutAreas
+
+      MeshWeaver.Compiler.CompilationException: Compilation failed for 'MeshWeaver/samples/Graph/Data/Northwind/Product':
+      CS0246 Error (line 51): The type or namespace name 'Supplier' could not be found (are you missing a using directive or an assembly reference?)
+      CS0246 Error (line 55): The type or namespace name 'Category' could not be found (are you missing a using directive or an assembly reference?)
+      CS0105 Warning (line 27): The using directive for 'System.ComponentModel' appeared previously in this namespace
+      CS0105 Warning (line 28): The using directive for 'System.ComponentModel.DataAnnotations' appeared previously in this namespace
+      CS0105 Warning (line 29): The using directive for 'MeshWeaver.Domain' appeared previously in this namespace
+      CS8632 Warning (line 93): The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+      CS1591 Warning (line 44): Missing XML comment for publicly visible type or member 'ProductContent.ProductId'
+      CS1591 Warning (line 206): Missing XML comment for publicly visible type or member 'MeshWeaver_samples_Graph_Data_Northwind_ProductMeshNodeProviderAttribute'
+         at MeshWeaver.Compiler.EmitPipeline.EmitCompilationToDirectory(CSharpCompilation compilation, String nodeName, String nodePath, String releaseDir, CancellationToken ct) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Compiler/EmitPipeline.cs:line 114
+         at MeshWeaver.Graph.Configuration.MeshNodeCompilationService.<>c__DisplayClass49_0.<CompileAsyncCore>b__0(String releaseDir) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs:line 1648
+         at MeshWeaver.Compiler.EmitPipeline.EmitToDiskWithRetry(String cacheDirectory, String nodeName, Int32 maxAttempts, ILogger logger, Func`2 emitToReleaseDir) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Compiler/EmitPipeline.cs:line 358
+         at MeshWeaver.Graph.Configuration.MeshNodeCompilationService.CompileAsyncCore(CodeConfiguration codeFile, String hubConfiguration, IReadOnlyList`1 contentCollections, MeshNode node, String nodeName, CancellationToken ct) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs:line 1646
+info: MeshWeaver.Hosting.DynamicTypePreWarmerHostedService[0]
+      BatchBake: MeshWeaver/samples/Graph/Data/Northwind/Product → CompileError
+fail: MeshWeaver.Graph.Configuration.MeshNodeCompilationService[0]
+      Failed to compile assembly for node MeshWeaver/samples/Graph/Data/SocialMedia/Post. Executed source queries (2):
+        - namespace:MeshWeaver/samples/Graph/Data/SocialMedia/Post/Source scope:subtree nodeType:Code
+        - namespace:MeshWeaver/samples/Graph/Data/SocialMedia/Post/Test scope:subtree nodeType:Code
+      Matched Code nodes (0):
+        (none) — the configuration lambda cannot reference types because no source files were included. Check that your Source Code nodes exist and that the NodeType's `sources` list points at them.
+
+      MeshWeaver.Compiler.CompilationException: Compilation failed for 'MeshWeaver/samples/Graph/Data/SocialMedia/Post':
+      CS0246 Error (line 58): The type or namespace name 'SocialMediaPost' could not be found (are you missing a using directive or an assembly reference?)
+      CS0246 Error (line 58): The type or namespace name 'Platform' could not be found (are you missing a using directive or an assembly reference?)
+      CS0103 Error (line 58): The name 'Platform' does not exist in the current context
+      CS1061 Error (line 58): 'LayoutDefinition' does not contain a definition for 'AddSocialMediaPostLayoutAreas' and no accessible extension method 'AddSocialMediaPostLayoutAreas' accepting a first argument of type 'LayoutDefinition' could be found (are you missing a using directive or an assembly reference?)
+      CS1591 Warning (line 32): Missing XML comment for publicly visible type or member 'MeshWeaver_samples_Graph_Data_SocialMedia_PostMeshNodeProviderAttribute'
+      CS1591 Warning (line 34): Missing XML comment for publicly visible type or member 'MeshWeaver_samples_Graph_Data_SocialMedia_PostMeshNodeProviderAttribute.Nodes'
+         at MeshWeaver.Compiler.EmitPipeline.EmitCompilationToDirectory(CSharpCompilation compilation, String nodeName, String nodePath, String releaseDir, CancellationToken ct) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Compiler/EmitPipeline.cs:line 114
+         at MeshWeaver.Graph.Configuration.MeshNodeCompilationService.<>c__DisplayClass49_0.<CompileAsyncCore>b__0(String releaseDir) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs:line 1648
+         at MeshWeaver.Compiler.EmitPipeline.EmitToDiskWithRetry(String cacheDirectory, String nodeName, Int32 maxAttempts, ILogger logger, Func`2 emitToReleaseDir) in /home/runner/work/MeshWeaver/MeshWeaver/src/MeshWeaver.Compiler/EmitPipeline.cs:line 358
+info: MeshWeaver.Hosting.DynamicTypePreWarmerHostedService[0]
+      BatchBake: MeshWeaver/samples/Graph/Data/SocialMedia/Post → NoSources
+fail: Polly[0]
+      Resilience event occurred. EventName: 'OnTimeout', Source: 'plugin-registry-standard//Standard-AttemptTimeout', Operation Key: '', Result: ''
+warn: Polly[3]
+      Execution attempt. Source: 'plugin-registry-standard//Standard-Retry', Operation Key: '', Result: 'The operation didn't complete within the allowed timeout of '00:00:10'.', Handled: 'True', Attempt: '0', Execution Time: 10018.8844ms
+fail: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[103]
+      Health check nodetype_bake with status Unhealthy completed after 0.7493ms with message 'NodeType bake in progress — enumerating dynamic NodeTypes'
+info: MeshWeaver.Hosting.DynamicTypePreWarmerHostedService[0]
+      Prebuilt assembly ADOPTED for AgenticPrimer/DiceGame at version 374 (framework sc2308d7c5e16fa71cc93f4a8ed20549f) — no compile needed
+fail: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[103]
+      Health check nodetype_bake with status Unhealthy completed after 0.0297ms with message 'NodeType bake in progress — enumerating dynamic NodeTypes'
+info: MeshWeaver.Hosting.DynamicTypePreWarmerHostedService[0]
+      Prebuilt assembly ADOPTED for Store/Order at version 1344 (framework sc2308d7c5e16fa71cc93f4a8ed20549f) — no compile needed
+fail: Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService[103]
+      Health check nodetype_bake with status Unhealthy completed after 0.0063ms with message 'NodeType bake in progress — enumerating dynamic NodeTypes'

--- a/test/MeshWeaver.Observability.Test/LogQueryTruncationTest.cs
+++ b/test/MeshWeaver.Observability.Test/LogQueryTruncationTest.cs
@@ -1,0 +1,103 @@
+using MeshWeaver.LogWatcher;
+using MeshWeaver.Observability;
+using Xunit;
+
+namespace MeshWeaver.Observability.Test;
+
+/// <summary>
+/// 🚨 <b>5000 IS A CAP, NOT A COUNT.</b>
+///
+/// <para>On 2026-08-17 the watcher logged <c>"memex-cloud: 1 distinct fingerprint(s) from 5000 red
+/// line(s)"</c> for several consecutive windows. Exactly 5000 every time, because that is
+/// <c>QueryLimit</c> — the window was never fully read. The truncation was handled correctly on the
+/// cursor (it resumes at the last line actually seen, so the remainder is deferred rather than
+/// dropped) and reported NOWHERE a verdict is read: one <c>LogWarning</c> in the watcher's own pod
+/// log, which is precisely the thing this subsystem exists to stop humans from having to grep.</para>
+///
+/// <para>These tests pin the two conditions as reportable facts. Raising the limit is not the fix
+/// and never was: while one namespace out-talks its watcher, a dominant noisy source crowds every
+/// quieter error out of the prefix that gets read, and that is the case where the quiet defect is
+/// the one that matters.</para>
+/// </summary>
+public class LogQueryTruncationTest
+{
+    private static readonly DateTimeOffset Start = new(2026, 8, 17, 19, 27, 30, TimeSpan.Zero);
+    private static readonly DateTimeOffset End = new(2026, 8, 17, 19, 28, 37, TimeSpan.Zero);
+
+    /// <summary>At the limit the window was not fully read — the measured 5000/5000 shape.</summary>
+    [Fact]
+    public void AtTheQueryLimit_IsTruncated()
+    {
+        LogPipelineGap.IsTruncated(5000, 5000).Should().BeTrue(
+            "Loki stops at the limit, so a result AT the limit is a prefix of the window, not the "
+            + "whole of it");
+        LogPipelineGap.IsTruncated(4752, 5000).Should().BeFalse(
+            "4752 of a possible 5000 is the whole window — the same production log shows both, and "
+            + "only one of them is a truncation");
+    }
+
+    /// <summary>A limit of zero means "unbounded"; it must not report every window as truncated.</summary>
+    [Fact]
+    public void NoLimit_IsNeverTruncated()
+    {
+        LogPipelineGap.IsTruncated(9_999, 0).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The report has to name the backlog, because the backlog is the actionable number: a backlog
+    /// that keeps growing ends at the <c>MaxCatchUp</c> floor, where the skipped stretch IS lost.
+    /// </summary>
+    [Fact]
+    public void TruncatedReport_NamesTheLimitAndTheBacklog()
+    {
+        // The read got as far as 19:27:52 — 45 s of the window never came back.
+        var reached = Start.AddSeconds(22);
+        var report = LogPipelineGap.TruncatedReport("memex-cloud", Start, End, reached, 5000);
+
+        report.Severity.Should().Be(LogSeverity.Error);
+        report.Namespace.Should().Be("memex-cloud");
+        report.NormalizedMessage.Should().Contain("5000")
+            .And.Contain("NOT fully read");
+        report.NormalizedMessage.Should().Contain("raising the limit only moves the cap",
+            "the ticket has to say what the fix is NOT, or the first responder raises QueryLimit");
+        report.Samples.Should().ContainSingle().Which.Line.Should().Contain("45s backlog");
+    }
+
+    /// <summary>
+    /// Per-namespace and timestamp-free, like every other judgement the watcher makes about its own
+    /// input: a namespace that truncates every minute is one rising incident, not one per minute.
+    /// </summary>
+    [Fact]
+    public void TruncatedReport_DedupsPerNamespace()
+    {
+        var first = LogPipelineGap.TruncatedReport("memex-cloud", Start, End, Start.AddSeconds(20), 5000);
+        var later = LogPipelineGap.TruncatedReport("memex-cloud", End, End.AddMinutes(1), End, 5000);
+
+        later.Fingerprint.Should().Be(first.Fingerprint);
+        LogPipelineGap.TruncatedReport("memex", Start, End, Start, 5000).Fingerprint
+            .Should().NotBe(first.Fingerprint, "a different namespace out-talks its watcher for its "
+                                               + "own reasons");
+        first.Fingerprint.Should().NotBe(LogPipelineGap.Report("memex-cloud", Start, End).Fingerprint,
+            "a truncated window and a lost window are different findings with different fixes");
+    }
+
+    /// <summary>
+    /// The one path that genuinely LOSES evidence: a cursor older than <c>MaxCatchUp</c> is dragged
+    /// forward and the skipped stretch is never read. It used to exist only as a <c>LogWarning</c>.
+    /// </summary>
+    [Fact]
+    public void SkippedWindowReport_IsCritical_AndNamesTheStretch()
+    {
+        var oldCursor = new DateTimeOffset(2026, 8, 17, 6, 0, 0, TimeSpan.Zero);
+        var floor = new DateTimeOffset(2026, 8, 17, 13, 30, 0, TimeSpan.Zero);
+
+        var report = LogPipelineGap.SkippedWindowReport("memex-cloud", oldCursor, floor);
+
+        report.Severity.Should().Be(LogSeverity.Critical,
+            "this stretch is unrecoverable — unlike a truncation, no later poll will read it");
+        report.NormalizedMessage.Should().Contain("never ticketed");
+        report.Samples.Should().ContainSingle().Which.Line.Should().Contain("450 minute");
+        report.Fingerprint.Should()
+            .NotBe(LogPipelineGap.TruncatedReport("memex-cloud", oldCursor, floor, floor, 5000).Fingerprint);
+    }
+}

--- a/test/MeshWeaver.Observability.Test/LokiQueryShapeTest.cs
+++ b/test/MeshWeaver.Observability.Test/LokiQueryShapeTest.cs
@@ -49,8 +49,8 @@ public class LokiQueryShapeTest
         // What the OLD filtered query returned — headers only.
         var headersOnly = new[] { whole[0] };
 
-        var fromWhole = BurstAggregator.Aggregate(whole, maxSamples: 5, maxSampleLength: 2000)[0];
-        var fromHeaders = BurstAggregator.Aggregate(headersOnly, maxSamples: 5, maxSampleLength: 2000)[0];
+        var fromWhole = BurstAggregator.Aggregate(whole, maxSamples: 5, maxSampleLength: 2000).Reports[0];
+        var fromHeaders = BurstAggregator.Aggregate(headersOnly, maxSamples: 5, maxSampleLength: 2000).Reports[0];
 
         // With the burst intact the incident identifies the actual defect…
         fromWhole.ExceptionType.Should().Be("System.InvalidOperationException");

--- a/test/MeshWeaver.Observability.Test/MeshWeaver.Observability.Test.csproj
+++ b/test/MeshWeaver.Observability.Test/MeshWeaver.Observability.Test.csproj
@@ -3,6 +3,12 @@
     <ProjectGuid>{c8a6e021-53fd-47b0-8e14-9f27d3b6a5c2}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Verbatim production log lines. ProdRedLogFixtureTest asserts the fingerprint split on the
+         REAL bursts that produced #1787, not on hand-invented ones — every earlier revision of the
+         identity function passed synthetic input and failed production. -->
+    <None Include="Fixtures\**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.Observability\MeshWeaver.Observability.csproj" />
     <!-- The in-cluster watcher: LogPipelineGapTest pins its judgement about its OWN input (a long
          window Loki answers with nothing is lost evidence, not silence worth trusting). -->

--- a/test/MeshWeaver.Observability.Test/ProdRedLogFixtureTest.cs
+++ b/test/MeshWeaver.Observability.Test/ProdRedLogFixtureTest.cs
@@ -1,0 +1,157 @@
+using System.Collections.Immutable;
+using MeshWeaver.Observability;
+using Xunit;
+
+namespace MeshWeaver.Observability.Test;
+
+/// <summary>
+/// 🚨 THE #1787 REGRESSION TEST, run on VERBATIM production lines.
+///
+/// <para><c>Fixtures/memex-cloud-2026-08-17-red-bursts.txt</c> is copied out of the <c>memex-cloud</c> portal
+/// pod on the day the defect was measured. That day the watcher reported
+/// <c>"memex-cloud: 1 distinct fingerprint(s) from 5000 red line(s)"</c> window after window, and
+/// **13 NodeTypes parked at <c>CompileError</c> were never ticketed** (#1786 had to be filed by
+/// hand). Every earlier revision of the identity function passed hand-written input and failed
+/// production, so these assertions run on the real thing.</para>
+///
+/// <para>The two cases the fix has to answer, both present in this fixture:</para>
+/// <list type="bullet">
+/// <item><b>Many lines of the SAME error ⇒ ONE incident.</b> The three health-check bursts differ
+/// only in an elapsed time and fold into one report with three occurrences.</item>
+/// <item><b>Few lines of DIFFERENT errors ⇒ one incident each.</b> The three compile failures share
+/// their category, their event id, their exception type AND their top application frame — the whole
+/// of the old identity — and are three separate defects.</item>
+/// </list>
+/// </summary>
+public class ProdRedLogFixtureTest
+{
+    private static readonly DateTimeOffset T0 = new(2026, 8, 17, 19, 27, 30, TimeSpan.Zero);
+    private const string Pod = "memex-portal-deployment-559ddb8f8-dbpx6";
+
+    /// <summary>The fixture as the collector would have handed it over: one entry per line.</summary>
+    private static ImmutableList<LogLine> Fixture()
+    {
+        // 🚨 `.txt`, not `.log` — the repo's .gitignore excludes `*.log`, so a fixture with that
+        // extension is silently untracked: green locally, MISSING on CI's clean checkout.
+        var path = Path.Combine(
+            AppContext.BaseDirectory, "Fixtures", "memex-cloud-2026-08-17-red-bursts.txt");
+        return File.ReadAllLines(path)
+            .Select((line, i) => new LogLine(T0.AddMilliseconds(i * 10), "memex-cloud", Pod, line))
+            .ToImmutableList();
+    }
+
+    private static ImmutableList<LogIncidentReport> Reports() =>
+        BurstAggregator.Aggregate(Fixture(), maxSamples: 5, maxSampleLength: 4000).Reports;
+
+    /// <summary>
+    /// The headline claim: three NodeTypes that failed to compile are three incidents, even though
+    /// the identity's old inputs are identical across all three.
+    /// </summary>
+    [Fact]
+    public void ThirteenParkedNodeTypes_AreNotOneTicket()
+    {
+        var compile = Reports()
+            .Where(r => r.Category == "MeshWeaver.Graph.Configuration.MeshNodeCompilationService")
+            .ToImmutableList();
+
+        // Everything the identity used to consist of is the same for all of them…
+        compile.Select(r => r.ExceptionType).Distinct().Should().ContainSingle()
+            .Which.Should().Be("MeshWeaver.Compiler.CompilationException");
+        compile.Select(r => r.TopFrame).Distinct().Should().ContainSingle()
+            .Which.Should().Be(
+                "MeshWeaver.Compiler.EmitPipeline.EmitCompilationToDirectory(CSharpCompilation compilation, "
+                + "String nodeName, String nodePath, String releaseDir, CancellationToken ct)");
+
+        // …so under the old rule this was ONE fingerprint. The compiler diagnostics are what differ,
+        // and they now reach the identity.
+        compile.Should().HaveCount(3,
+            "Cession, Northwind/Product and SocialMedia/Post fail with different compiler errors and "
+            + "need different fixes — one ticket for all of them is why #1786 was filed by hand");
+        compile.Select(r => r.Fingerprint).Distinct().Should().HaveCount(3);
+        compile.Should().OnlyContain(r => r.Occurrences == 1);
+    }
+
+    /// <summary>
+    /// The other direction, on the same fixture: a repeated diagnostic is ONE incident whose
+    /// occurrence count says how loud it was. This is the property a finer fingerprint must not lose,
+    /// and 3,894 lines of one error was the other measured case in #1787.
+    /// </summary>
+    [Fact]
+    public void RepeatsOfOneDiagnostic_AreOneTicket()
+    {
+        var health = Reports()
+            .Where(r => r.Category.EndsWith("DefaultHealthCheckService", StringComparison.Ordinal))
+            .ToImmutableList();
+
+        health.Should().ContainSingle(
+            "the three bursts differ only in an elapsed time, which is masked before hashing");
+        health[0].Occurrences.Should().Be(3);
+        health[0].NormalizedDetail.Should().NotContain("0.7493");
+    }
+
+    /// <summary>
+    /// The independently-actionable failures #1787 lists must each be their own incident: a compile
+    /// error, a Polly timeout and a failing health check are three different problems in one window.
+    /// </summary>
+    [Fact]
+    public void DifferentSubsystems_AreDifferentIncidents()
+    {
+        var reports = Reports();
+
+        reports.Select(r => r.Category).Distinct().Should().BeEquivalentTo(
+            new[]
+            {
+                "MeshWeaver.Graph.Configuration.MeshNodeCompilationService",
+                "Polly",
+                "Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService",
+            },
+            System.Text.Json.JsonSerializerOptions.Default);
+
+        // 3 compile + 1 Polly + 1 health check. The watcher reported ONE for this shape of window.
+        reports.Should().HaveCount(5);
+        reports.Select(r => r.Fingerprint).Should().OnlyHaveUniqueItems();
+    }
+
+    /// <summary>
+    /// The verdict line has to be readable. "1 distinct fingerprint(s) from 5000 red line(s)" bound
+    /// <c>Lines</c> to the TOTAL line count — the query is unfiltered — so it read as 5000 collapsing
+    /// errors when it was 5000 lines of every severity. Red bursts and total lines are separate now.
+    /// </summary>
+    [Fact]
+    public void TheAggregation_ReportsRedBurstsSeparatelyFromTotalLines()
+    {
+        var entries = Fixture();
+        var aggregation = BurstAggregator.Aggregate(entries, maxSamples: 5, maxSampleLength: 4000);
+
+        aggregation.TotalLines.Should().Be(entries.Count);
+        aggregation.RedBursts.Should().Be(7, "3 compile + 1 Polly + 3 health-check bursts are red");
+        aggregation.RedBursts.Should().BeLessThan(aggregation.TotalLines,
+            "the unfiltered query returns info: and warn: lines too — conflating the two is what made "
+            + "the production log unreadable");
+        aggregation.FoldedSites.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The per-node identity has to survive into the ticket, or splitting the incidents buys nothing:
+    /// a responder still has to know WHICH node is parked. It rides in the samples, verbatim.
+    /// </summary>
+    [Fact]
+    public void EachIncident_CarriesItsOwnNodePathInTheEvidence()
+    {
+        var compile = Reports()
+            .Where(r => r.Category == "MeshWeaver.Graph.Configuration.MeshNodeCompilationService")
+            .ToImmutableList();
+
+        var nodes = compile
+            .Select(r => string.Join('\n', r.Samples.Select(s => s.Line)))
+            .ToImmutableList();
+
+        nodes.Should().ContainSingle(s => s.Contains("BusinessRules/Cession", StringComparison.Ordinal));
+        nodes.Should().ContainSingle(s => s.Contains("Northwind/Product", StringComparison.Ordinal));
+        nodes.Should().ContainSingle(s => s.Contains("SocialMedia/Post", StringComparison.Ordinal));
+
+        // …while the fingerprint itself is free of it, so the same failure on another node folds in
+        // rather than opening a second ticket.
+        compile.Should().OnlyContain(r => !r.NormalizedDetail.Contains("Northwind"));
+    }
+}

--- a/test/MeshWeaver.Observability.Test/ProdRedLogFixtureTest.cs
+++ b/test/MeshWeaver.Observability.Test/ProdRedLogFixtureTest.cs
@@ -44,11 +44,12 @@ public class ProdRedLogFixtureTest
         BurstAggregator.Aggregate(Fixture(), maxSamples: 5, maxSampleLength: 4000).Reports;
 
     /// <summary>
-    /// The headline claim: three NodeTypes that failed to compile are three incidents, even though
-    /// the identity's old inputs are identical across all three.
+    /// The headline claim: NodeTypes that failed to compile are separate incidents, even though the
+    /// identity's old inputs are identical across all of them. The fixture carries three of the
+    /// thirteen bursts memex-cloud produced — enough to pin the split, small enough to read.
     /// </summary>
     [Fact]
-    public void ThirteenParkedNodeTypes_AreNotOneTicket()
+    public void ParkedNodeTypes_WithDifferentCompilerErrors_AreSeparateIncidents()
     {
         var compile = Reports()
             .Where(r => r.Category == "MeshWeaver.Graph.Configuration.MeshNodeCompilationService")

--- a/test/MeshWeaver.Observability.Test/StructuralIdentityTest.cs
+++ b/test/MeshWeaver.Observability.Test/StructuralIdentityTest.cs
@@ -11,9 +11,12 @@ namespace MeshWeaver.Observability.Test;
 public class StructuralIdentityTest
 {
     private static LogBurst Burst(string category, int eventId, string message,
-        string? exception = null, string? frame = null) =>
+        string? exception = null, string? frame = null, string? exceptionMessage = null) =>
         new(category, eventId, LogSeverity.Error, message,
-            LogLineParser.Normalize(message), exception, frame);
+            LogLineParser.Normalize(message), exception, frame,
+            exceptionMessage is { Length: > 0 } detail
+                ? LogLineParser.Normalize(detail)
+                : LogLineParser.Normalize(message));
 
     /// <summary>
     /// Round 3's failure: one ROUTER_TRAFFIC defect, reported once per target hub, produced ~50
@@ -241,24 +244,98 @@ public class StructuralIdentityTest
     }
 
     /// <summary>
-    /// A burst with neither exception nor frame is identified by its log SITE alone — the message
-    /// contributes nothing, so no wording change can fork it.
+    /// A burst with neither exception nor frame is identified by its log site AND its masked message —
+    /// the message is the only thing left that says WHICH fault it is.
+    ///
+    /// <para>🚨 The second half of this test used to assert the opposite: that "something else
+    /// entirely" at the same site was the SAME incident, because prose contributed nothing at all.
+    /// That is the rule #1787 measured in production and found indefensible — one log site became one
+    /// ticket no matter how many different things it reported, so thousands of red lines a window
+    /// collapsed onto one to three fingerprints and thirteen parked NodeTypes were never ticketed.
+    /// Volatile parts are still masked, so a COUNT changing cannot fork anything.</para>
     /// </summary>
     [Fact]
-    public void BareDiagnostics_AreIdentifiedByTheirLogSite()
+    public void BareDiagnostics_AreIdentifiedByTheirLogSiteAndMaskedMessage()
     {
         var a = StructuralLogIncidentIdentity.Compute(
             Burst("DynamicTypePreWarmer", 0, "REFUSING READINESS — 3 NodeType(s) regressed on this image"));
         var b = StructuralLogIncidentIdentity.Compute(
             Burst("DynamicTypePreWarmer", 0, "REFUSING READINESS — 17 NodeType(s) regressed on this image"));
 
-        b.Should().Be(a);
+        b.Should().Be(a, "the count is masked — the same diagnostic with a different number is the "
+                         + "same fault, and this is what keeps a storm to one ticket");
 
-        // …and the same holds for a wholly different wording at the same site: prose is not part of
-        // the key at all, which is the property four earlier rules lacked.
         StructuralLogIncidentIdentity.Compute(
                 Burst("DynamicTypePreWarmer", 0, "something else entirely"))
-            .Should().Be(a);
+            .Should().NotBe(a,
+                "a different thing reported by the same logger is a different fault — collapsing "
+                + "those was the #1787 defect: one site, one ticket, whatever it said");
+    }
+
+    /// <summary>
+    /// 🚨 THE #1787 CASE, in miniature: same category, same event id, same exception type, same top
+    /// frame — everything the identity used to consist of — and thirteen genuinely different faults.
+    /// The exception's OWN message is what tells them apart, and it is now what the identity keys on.
+    /// (<c>ProdRedLogFixtureTest</c> runs this on the verbatim production bursts.)
+    /// </summary>
+    [Fact]
+    public void SameFrameAndException_DifferentExceptionMessages_StayApart()
+    {
+        LogBurst Compile(string diagnostic) => Burst(
+            "MeshWeaver.Graph.Configuration.MeshNodeCompilationService", 0,
+            "Failed to compile assembly for node MeshWeaver/samples/Graph/Data/X.",
+            exception: "MeshWeaver.Compiler.CompilationException",
+            frame: "MeshWeaver.Compiler.EmitPipeline.EmitCompilationToDirectory(CSharpCompilation compilation)",
+            exceptionMessage: diagnostic);
+
+        var missingType = StructuralLogIncidentIdentity.Compute(
+            Compile("CS0246 Error (line 58): The type or namespace name 'Cashflow' could not be found"));
+        var missingMethod = StructuralLogIncidentIdentity.Compute(
+            Compile("CS1061 Error (line 58): 'LayoutDefinition' does not contain a definition for 'AddX'"));
+
+        missingMethod.Should().NotBe(missingType,
+            "a missing type and a missing extension method are two fixes, so two tickets");
+    }
+
+    /// <summary>
+    /// …and the counterweight: the SAME fault repeated is still one incident, however many times and
+    /// on however many nodes it fires. Everything that varies per occurrence is masked out of the
+    /// exception message before it is hashed.
+    /// </summary>
+    [Fact]
+    public void SameExceptionMessage_OnDifferentNodes_IsOneIncident()
+    {
+        LogBurst Compile(string node, string symbol) => Burst(
+            "MeshWeaver.Graph.Configuration.MeshNodeCompilationService", 0,
+            $"Failed to compile assembly for node MeshWeaver/samples/Graph/Data/{node}.",
+            exception: "MeshWeaver.Compiler.CompilationException",
+            frame: "MeshWeaver.Compiler.EmitPipeline.EmitCompilationToDirectory(CSharpCompilation compilation)",
+            exceptionMessage:
+            $"Compilation failed for 'MeshWeaver/samples/Graph/Data/{node}':\n"
+            + $"CS0246 Error (line 58): The type or namespace name '{symbol}' could not be found");
+
+        StructuralLogIncidentIdentity.Compute(Compile("SocialMedia/Post", "SocialMediaPost"))
+            .Should().Be(StructuralLogIncidentIdentity.Compute(Compile("SocialMedia/Profile", "SocialMediaProfile")),
+                "two nodes failing the same way is ONE defect with two instances — the node paths and "
+                + "the symbol names are masked, so the identity is the failure SHAPE");
+    }
+
+    /// <summary>
+    /// The site fold is a different key space from the per-detail one. Otherwise a folded site and a
+    /// burst that genuinely carries no detail would share an incident node.
+    /// </summary>
+    [Fact]
+    public void SiteFold_IsDistinctFromEveryPerDetailIdentity()
+    {
+        var burst = Burst("PluginGating", 0, "reconcile is NOT CONVERGING");
+
+        StructuralLogIncidentIdentity.ComputeSiteFold(burst)
+            .Should().NotBe(StructuralLogIncidentIdentity.Compute(burst));
+        StructuralLogIncidentIdentity.ComputeSiteFold(burst)
+            .Should().Be(StructuralLogIncidentIdentity.ComputeSiteFold(
+                    Burst("PluginGating", 0, "a completely different message")),
+                "the fold is the SITE's identity — that is what makes it one ticket");
+        StructuralLogIncidentIdentity.ComputeSiteFold(burst).Should().HaveLength(16);
     }
 
     [Fact]

--- a/tools/MeshWeaver.LogWatcher/LogPipelineGap.cs
+++ b/tools/MeshWeaver.LogWatcher/LogPipelineGap.cs
@@ -54,6 +54,7 @@ public static class LogPipelineGap
         new()
         {
             Fingerprint = $"log-pipeline-silent-window-{ns}",
+            NormalizedDetail = "Loki returned zero lines for a long, continuously-watched window.",
             Category = "MeshWeaver.LogWatcher.Pipeline",
             Severity = LogSeverity.Critical,
             NormalizedMessage =
@@ -71,5 +72,103 @@ public static class LogPipelineGap
                 null,
                 $"Loki query_range [{start:u}, {end:u}) — {(end - start).TotalMinutes:F0} minute(s), "
                 + "0 lines returned")),
+        };
+
+    /// <summary>
+    /// True when the query came back AT its entry limit — meaning the window was not fully read and
+    /// the remainder is, at this moment, <b>unseen</b>.
+    ///
+    /// <para>Loki returns at most <c>limit</c> entries, and the watcher's query is deliberately
+    /// unfiltered, so a busy namespace hits the cap on lines of every severity. The cursor is then
+    /// advanced only to the last line actually read, which makes the remainder <i>deferred</i>
+    /// rather than lost — but only as long as the watcher out-reads the namespace. It never used to
+    /// say any of this anywhere a human reads a verdict; on 2026-08-17 several consecutive windows
+    /// on memex-cloud reported exactly 5000 lines and nothing recorded that the number was a CAP.</para>
+    /// </summary>
+    /// <param name="lineCount">Lines the query returned.</param>
+    /// <param name="limit">The limit the query asked for.</param>
+    /// <returns>True when the window was truncated.</returns>
+    public static bool IsTruncated(int lineCount, int limit) => limit > 0 && lineCount >= limit;
+
+    /// <summary>
+    /// The incident for a truncated window.
+    ///
+    /// <para>🚨 <b>Raising the limit is not the fix and this report is not a nag.</b> Truncation
+    /// means one namespace is producing lines faster than the watcher reads them, so a dominant
+    /// noisy source can push every other error out of the sample the watcher actually looks at —
+    /// which is precisely the case where the QUIET defect is the one that matters. The actionable
+    /// number is the backlog (<paramref name="end"/> minus the cursor the read reached), because a
+    /// backlog that keeps growing ends at the <see cref="LogWatcherOptions.MaxCatchUp"/> floor,
+    /// where the skipped window IS lost (<see cref="SkippedWindowReport"/>).</para>
+    ///
+    /// <para>Per-namespace fingerprint, no timestamps: repeats are the same finding — this namespace
+    /// out-talks its watcher — so they fold into one incident with a rising occurrence count.</para>
+    /// </summary>
+    /// <param name="ns">The namespace whose window was truncated.</param>
+    /// <param name="start">The window's start.</param>
+    /// <param name="end">The window's intended end.</param>
+    /// <param name="reached">The timestamp the read actually reached — where the next poll resumes.</param>
+    /// <param name="limit">The entry limit that was hit.</param>
+    /// <returns>The report to queue.</returns>
+    public static LogIncidentReport TruncatedReport(
+        string ns, DateTimeOffset start, DateTimeOffset end, DateTimeOffset reached, int limit) =>
+        new()
+        {
+            Fingerprint = $"log-query-truncated-{ns}",
+            Category = "MeshWeaver.LogWatcher.Pipeline",
+            Severity = LogSeverity.Error,
+            NormalizedMessage =
+                $"Log query truncated for namespace '{ns}': Loki returned its full {limit}-entry limit, "
+                + "so the window was NOT fully read. The unread remainder is deferred to the next poll, "
+                + "not dropped — but while a namespace out-talks its watcher, a noisy source crowds "
+                + "quieter errors out of every sample, and a backlog that keeps growing eventually hits "
+                + "the MaxCatchUp floor, where the skipped window IS lost. Find and quieten the dominant "
+                + "source; raising the limit only moves the cap.",
+            NormalizedDetail = $"Loki returned its full {limit}-entry limit for this namespace.",
+            Namespace = ns,
+            Occurrences = 1,
+            FirstSeen = start,
+            LastSeen = end,
+            Samples = ImmutableList.Create(new LogSample(
+                end,
+                null,
+                $"Loki query_range [{start:u}, {end:u}) — {limit} entries returned (the limit); "
+                + $"resuming at {reached:u}, leaving a {(end - reached).TotalSeconds:F0}s backlog")),
+        };
+
+    /// <summary>
+    /// The incident for a window the watcher will never read: a cursor older than
+    /// <see cref="LogWatcherOptions.MaxCatchUp"/> is dragged forward, and everything between the old
+    /// cursor and the new floor is skipped for good.
+    ///
+    /// <para>This is the ONE path in the watcher that genuinely loses evidence rather than deferring
+    /// it, and until now it only said so in the watcher's own pod log — the exact "reported nowhere a
+    /// verdict is read" shape that #1787 is about. Critical, because red logs in that stretch were
+    /// never ticketed and never will be.</para>
+    /// </summary>
+    /// <param name="ns">The namespace whose cursor was floored.</param>
+    /// <param name="from">The old cursor — the start of the skipped stretch.</param>
+    /// <param name="to">The floor the cursor was dragged to — the end of it.</param>
+    /// <returns>The report to queue.</returns>
+    public static LogIncidentReport SkippedWindowReport(string ns, DateTimeOffset from, DateTimeOffset to) =>
+        new()
+        {
+            Fingerprint = $"log-window-skipped-{ns}",
+            Category = "MeshWeaver.LogWatcher.Pipeline",
+            Severity = LogSeverity.Critical,
+            NormalizedMessage =
+                $"Log window SKIPPED for namespace '{ns}': the cursor was older than the catch-up cap "
+                + "and was dragged forward, so red logs in the skipped stretch were never ticketed and "
+                + "cannot be recovered. Either the watcher was down for longer than MaxCatchUp, or it "
+                + "cannot keep up with this namespace's log volume.",
+            NormalizedDetail = "The cursor was floored by MaxCatchUp; the skipped stretch is unrecoverable.",
+            Namespace = ns,
+            Occurrences = 1,
+            FirstSeen = from,
+            LastSeen = to,
+            Samples = ImmutableList.Create(new LogSample(
+                to,
+                null,
+                $"Skipped [{from:u}, {to:u}) — {(to - from).TotalMinutes:F0} minute(s) never read")),
         };
 }

--- a/tools/MeshWeaver.LogWatcher/LogWatchWorker.cs
+++ b/tools/MeshWeaver.LogWatcher/LogWatchWorker.cs
@@ -80,7 +80,8 @@ public sealed class LogWatchWorker(
     private IObservable<Unit> Collect(string ns)
     {
         var now = DateTimeOffset.UtcNow;
-        var start = state.CursorFor(ns, now);
+        var cursor = state.CursorFor(ns, now);
+        var start = cursor.From;
         var end = now - options.IngestLag;
         if (end <= start)
             return Observable.Return(Unit.Default);
@@ -91,8 +92,15 @@ public sealed class LogWatchWorker(
 
         return loki.Query(ns, start, end, options.QueryLimit).SelectMany(entries =>
         {
-            var reports = BurstAggregator.Aggregate(
-                entries, options.MaxSamplesPerReport, options.MaxSampleLength, options.IgnoreCategories);
+            var aggregation = BurstAggregator.Aggregate(
+                entries, options.MaxSamplesPerReport, options.MaxSampleLength, options.IgnoreCategories,
+                options.MaxVariantsPerSite);
+            var reports = aggregation.Reports;
+
+            // 🚨 A stretch the cursor was dragged past is the ONE thing this watcher loses outright.
+            // Report it; a LogWarning in the watcher's own pod log is not a place any verdict is read.
+            if (cursor.SkippedFrom is { } skippedFrom)
+                reports = reports.Add(LogPipelineGap.SkippedWindowReport(ns, skippedFrom, start));
 
             // 🚨 REACHABLE BUT EMPTY over a LONG window WE WATCHED = the store lost that stretch.
             // Report it instead of accepting silence as good news. Both qualifiers matter: a short
@@ -118,27 +126,44 @@ public sealed class LogWatchWorker(
                 reports = reports.Add(LogPipelineGap.Report(ns, start, end));
             }
 
-            if (reports.Count > 0)
-                logger?.LogInformation(
-                    "{Namespace}: {Bursts} distinct fingerprint(s) from {Lines} red line(s)",
-                    ns, reports.Count, entries.Count);
-
             // Truncation guard: at the query limit the window was not fully read, so advancing the
             // cursor to `end` would skip the remainder. Advance only to the last line actually seen
             // and let the next tick pick up from there.
-            var truncated = entries.Count >= options.QueryLimit;
-            var cursor = truncated && entries.Count > 0
+            //
+            // 🚨 And REPORT it. "5000 lines" is a CAP, not a count: while it holds, the watcher is
+            // reading a prefix of the window, so a dominant noisy source crowds every quieter error
+            // out of the sample it ever looks at. Raising the limit is not the fix — the fix is
+            // finding what out-talks the watcher — so this travels the normal ingest path and becomes
+            // a ticket like any other finding (#1787).
+            var truncated = LogPipelineGap.IsTruncated(entries.Count, options.QueryLimit);
+            var resumeAt = truncated && entries.Count > 0
                 ? entries[^1].Timestamp
                 : end;
             if (truncated)
+            {
                 logger?.LogWarning(
-                    "{Namespace}: hit the {Limit}-entry query limit — resuming at {Cursor:u} instead of {End:u}",
-                    ns, options.QueryLimit, cursor.UtcDateTime, end.UtcDateTime);
+                    "{Namespace}: hit the {Limit}-entry query limit — resuming at {Cursor:u} instead of "
+                    + "{End:u}, leaving a {Backlog:F0}s backlog. The window was NOT fully read.",
+                    ns, options.QueryLimit, resumeAt.UtcDateTime, end.UtcDateTime,
+                    (end - resumeAt).TotalSeconds);
+                reports = reports.Add(
+                    LogPipelineGap.TruncatedReport(ns, start, end, resumeAt, options.QueryLimit));
+            }
+
+            if (reports.Count > 0)
+                logger?.LogInformation(
+                    "{Namespace}: {Fingerprints} distinct fingerprint(s) from {Bursts} red burst(s) "
+                    + "({Lines} line(s) read{Truncated}){Folded}",
+                    ns, reports.Count, aggregation.RedBursts, aggregation.TotalLines,
+                    truncated ? " — TRUNCATED at the query limit" : "",
+                    aggregation.FoldedSites > 0
+                        ? $"; {aggregation.FoldedSites} log site(s) folded past the per-site variant budget"
+                        : "");
 
             // Queue BEFORE the cursor moves: if the process dies between these two writes the
             // window is simply re-read, which the fingerprint makes harmless.
             return (reports.Count > 0 ? state.Enqueue(reports) : Observable.Return(Unit.Default))
-                .SelectMany(_ => state.Advance(ns, cursor));
+                .SelectMany(_ => state.Advance(ns, resumeAt));
         });
     }
 

--- a/tools/MeshWeaver.LogWatcher/LogWatcherOptions.cs
+++ b/tools/MeshWeaver.LogWatcher/LogWatcherOptions.cs
@@ -90,6 +90,23 @@ public sealed record LogWatcherOptions
     /// </summary>
     public TimeSpan SilentWindowAlarm { get; init; } = TimeSpan.FromMinutes(5);
 
+    /// <summary>
+    /// How many distinct fingerprints ONE log site (category + event id, or top frame + exception)
+    /// may open from a single window before they are folded onto one site-level incident.
+    ///
+    /// <para>🚨 This is the FLOOR under the "too fine" direction, not a tuning knob. The identity
+    /// discriminates on the fault's masked text, and masking cannot anticipate every message shape;
+    /// when it misses, one defect fans out into one ticket per subject — 2026-08-09 produced ~50
+    /// that way. Past this budget the watcher stops believing its own split and files ONE incident
+    /// carrying <c>Variants</c>, which says the masking rule needs a case rather than burying a
+    /// human in tickets.</para>
+    ///
+    /// <para>The default sits between the two numbers production has actually produced: the 13
+    /// NodeTypes parked at <c>CompileError</c> on 2026-08-17 stay 13 tickets (each needs its own
+    /// fix), and the ~50-way fan-out folds. Zero or less disables the fold entirely.</para>
+    /// </summary>
+    public int MaxVariantsPerSite { get; init; } = 20;
+
     /// <summary>Evidence lines sent per report.</summary>
     public int MaxSamplesPerReport { get; init; } = 5;
 

--- a/tools/MeshWeaver.LogWatcher/WatcherState.cs
+++ b/tools/MeshWeaver.LogWatcher/WatcherState.cs
@@ -64,25 +64,41 @@ public sealed class WatcherState(
     });
 
     /// <summary>
+    /// Where reading resumes for a namespace.
+    /// </summary>
+    /// <param name="From">The window's start.</param>
+    /// <param name="SkippedFrom">The cursor that was dragged forward, when
+    /// <see cref="LogWatcherOptions.MaxCatchUp"/> floored it — so the caller can REPORT the stretch
+    /// that will never be read. Null when nothing was skipped.</param>
+    public readonly record struct CursorStart(DateTimeOffset From, DateTimeOffset? SkippedFrom);
+
+    /// <summary>
     /// Where reading should resume for <paramref name="ns"/>. A cold start reads only
     /// <see cref="LogWatcherOptions.ColdStartLookback"/>; a cursor older than
     /// <see cref="LogWatcherOptions.MaxCatchUp"/> is dragged forward so one poll after a long
     /// outage cannot ask Loki for days of logs and time out on every attempt.
+    ///
+    /// <para>🚨 The floored case returns the skipped stretch as well, because that stretch is the
+    /// one thing this watcher can lose outright — and a loss that only ever appeared in the
+    /// watcher's own pod log is a loss nobody sees (#1787).</para>
     /// </summary>
-    public DateTimeOffset CursorFor(string ns, DateTimeOffset now)
+    /// <param name="ns">The namespace.</param>
+    /// <param name="now">The current time the window is derived from.</param>
+    /// <returns>The window start, and the skipped stretch when the cursor was floored.</returns>
+    public CursorStart CursorFor(string ns, DateTimeOffset now)
     {
         lock (gate)
         {
             if (!cursors.TryGetValue(ns, out var cursor))
-                return now - options.ColdStartLookback;
+                return new CursorStart(now - options.ColdStartLookback, null);
             var floor = now - options.MaxCatchUp;
             if (cursor >= floor)
-                return cursor;
+                return new CursorStart(cursor, null);
             logger?.LogWarning(
                 "Cursor for {Namespace} was {Cursor:u}, older than the {MaxCatchUp} catch-up cap — "
                 + "resuming at {Floor:u}. Red logs in the skipped window were NOT ticketed.",
                 ns, cursor.UtcDateTime, options.MaxCatchUp, floor.UtcDateTime);
-            return floor;
+            return new CursorStart(floor, cursor);
         }
     }
 


### PR DESCRIPTION
Fixes #1787.

Measured on `memex-cloud`, 2026-08-17: thousands of red lines per window collapsed onto **1–3
fingerprints**, and **13 NodeTypes parked at `CompileError` were never ticketed** — #1786 had to be
filed by hand. Two separate defects.

## 1. The fingerprint was too coarse

The identity was `(top app frame | log site) + exception type`, and nothing else. Every one of the 13
compile failures throws `CompilationException` from `EmitPipeline.EmitCompilationToDirectory`, so 13
independently-actionable compiler errors were **one** ticket.

The identity now also covers **the fault's own masked text** — the *exception's* message when the
burst carries one, else the logged message:

| Part | Value |
|---|---|
| WHERE | top application frame, or `(category, eventId)` with no frame *(unchanged)* |
| WHAT | exception type, simple name *(unchanged)* |
| **WHICH** | **masked exception message, or masked log message with no exception** *(new)* |

Choosing the *exception's* message rather than the reporter's prose is what keeps #1170/#1171 folded:
two catch sites word their own messages differently ("Error during shutdown of hub …" vs "Hub …
disposal faulted") and quote the **same** exception message.

`Normalize` gains the rule that makes prose safe to hash at all: **a token the message itself uses as
a path segment is masked everywhere in that message**. That reads the subject *out of* the message
instead of guessing at its position — which is exactly how round 4 fanned out ~22 ways on
`[PluginGating] Chess: … rewrote Chess/_Access/Public_Access`.

### What it does with the two real cases

| Input | Result |
|---|---|
| **3,894 lines of the SAME error** | **one** incident, `Occurrences = 3894` — everything per-occurrence (paths, guids, counts, elapsed times) is masked before hashing |
| **13 lines of 13 DIFFERENT errors** | **one incident per distinct failure shape**, each with a distinguishable name. Two nodes failing *identically* still share one ticket and list each other in the evidence — that is one defect with two instances, not two defects. |

### The floor under "too fine"

Masking cannot anticipate every message shape. A log site that opens more than
`MaxVariantsPerSite` (default **20**) distinct fingerprints **in one window** folds onto ONE
site-level incident carrying `Variants = N`, so the ticket reads "this site produced N shapes and the
masking rule needs a case" rather than burying a human. The default deliberately sits between the two
numbers production has produced: **13 stays 13**, the **~50-way 2026-08-09 fan-out folds**. Every
fingerprint it produces is stable, so recurrences still dedup across windows.

## 2. `5000` was a CAP, not a count — and said so nowhere

Truncation was already handled *correctly on the cursor* (it resumes at the last line actually read,
so the remainder is deferred, not dropped) and reported **only as a `LogWarning` in the watcher's own
pod log** — the one place this subsystem exists to stop humans from having to grep.

Every way the watcher can fail to read a window is now a `LogIncidentReport` on the normal ingest
path (dedup per namespace, no timestamps in the fingerprint):

| Condition | Severity | Meaning |
|---|---|---|
| zero lines over a long, continuously-watched window | Critical | *(existing)* the store lost that stretch |
| **query came back at `QueryLimit`** | **Error** | the window was NOT fully read; while it lasts a noisy source crowds quieter errors out of the prefix that gets read |
| **cursor floored by `MaxCatchUp`** | **Critical** | the only path that **loses** evidence outright — that stretch will never be read |

🚨 **The limit was deliberately NOT raised.** A higher cap moves the ceiling; the finding is that one
namespace out-talks its watcher, and the actionable number the report carries is the **backlog** —
because a backlog that keeps growing ends at the `MaxCatchUp` floor, which is the row that loses data.

The per-window summary also stopped conflating counts. It read
`"1 distinct fingerprint(s) from 5000 red line(s)"` with `5000` bound to the **total** line count (the
query is unfiltered), so it looked like 5000 errors collapsing when it was 5000 lines of mostly
`info:`. Now:

```
memex-cloud: 5 distinct fingerprint(s) from 7 red burst(s) (2934 line(s) read)
memex-cloud: 3 distinct fingerprint(s) from 41 red burst(s) (5000 line(s) read — TRUNCATED at the query limit)
```

## Tested on real captured data

`ProdRedLogFixtureTest` runs on **verbatim lines pulled from the `memex-cloud` portal pod** on the day
this was measured (`test/MeshWeaver.Observability.Test/Fixtures/memex-cloud-2026-08-17-red-bursts.txt`)
— three real compile failures, the real `Polly` timeout, the real repeated health-check. Every earlier
revision of this identity function passed hand-written input and failed production, so the regression
test is the production bursts. It asserts that the three compile reports share category, event id,
exception type **and** top frame — the whole of the old key — and are still three incidents.

145/145 green in `MeshWeaver.Observability.Test`; `MeshWeaver.Documentation.Test` green (doc + What's
New entry).

## Notes

- **Existing incident nodes keep their old fingerprints.** After this deploys, the collapsed
  compile incident stays as it is and the per-error incidents open fresh. That is inherent to changing
  an identity function; the old node can be suppressed or closed by hand.
- What's New entry included (`Category: Fix`): an admin browsing `Admin/_LogIncident` goes from one
  catch-all row to one row per defect, which is user-noticeable.
- `LogTriage`'s agent instructions were updated for the two new incident fields (`normalizedDetail`,
  `variants`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)