### PR TITLE
fix: stop re-adopting prebuilt bundles that are already on the store

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -223,16 +223,36 @@ behaves exactly as today.
 pipeline, **after** the static repo import settles (the nodes a bundle names must exist) and
 **before** [the sweep](/Doc/Architecture/NodeTypeCompilation) probes the assembly store:
 
-1. every `*.zip` under `prebuilt/` (override: `PreWarm:PrebuiltDirectory`) is read with
-   `BundleReader` — the one codec shared with the registry bundle client;
+1. every `*.zip` under `prebuilt/` (override: `PreWarm:PrebuiltDirectory`) has its **manifest** read
+   with `BundleReader.ReadManifest` — a few KB at a known entry, **no assembly decompressed**;
 2. the bundle's framework MVID is checked **once** against the running process; a mismatch declines
    the whole bundle, loudly;
 3. one enumeration of the mesh's NodeType nodes filters the entries down to types this deployment
    actually holds (an image ships one content set; a mesh serves a subset) — no per-missing-path
-   waits;
-4. each remaining entry is adopted through `PrebuiltAssemblySeeder.Seed`: the bytes land in the
-   assembly store under the node's **current** version, and the record is stamped exactly as a
-   successful compile stamps it.
+   waits. The enumerated **nodes** are kept, not just their paths: they carry the record that
+   answers step 4;
+4. each remaining entry is asked whether adopting it would change anything —
+   `PrebuiltAssemblySeeder.IsAlreadyAdopted`, which defers to the same `NodeTypeBakeStatus.Classify`
+   the sweep's probe uses, plus one store probe at the record's `LastCompiledVersion`. An entry the
+   store already backs is **skipped entirely**;
+5. only the **deviating** entries are extracted (`BundleReader.Read(stream, nodePaths)`) and adopted
+   through `PrebuiltAssemblySeeder.Seed`: the bytes land in the assembly store under the node's
+   version and the record is stamped exactly as a successful compile stamps it.
+
+> 🚨 **Step 4 is not an optimisation detail — adoption is expensive.** `Seed` opens the type's own
+> mesh-node stream, which **activates its per-node hub**, then re-uploads the bytes and writes the
+> node. Before the skip, memex-cloud re-adopted all 43 of its assemblies on every boot — 43
+> activations, 43 uploads, 43 writes, **13.5 s of a 101 s warm-up** — to establish that nothing had
+> changed since the previous pod did the same. The framework identity is an API-surface hash and is
+> stable across internal-only merges, so that is the *common* roll. It also grew the assembly cache
+> by a whole generation per boot: `Seed` stamps the version it read *before* its own write, so each
+> re-adoption uploaded the same bytes under a new key that nothing ever read.
+
+The skip stays **level-triggered on the store**: the record's claim is believed only when a probe
+confirms the bytes are still at that key, so a cleared, remounted or stale-restored assembly volume
+re-seeds exactly as before (`BakeState.BytesMissing`). The reported count is `adopted +
+already-current`, so the coverage signal below does not collapse to zero on a healthy steady-state
+boot.
 
 The sweep's store probe (`NodeTypeBakeStatus`) then classifies each adopted type `Baked` — for fully
 covered shipped content the boot log reads `pending=0` and no Roslyn runs. Everything here is

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-faster-portal-startup.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-faster-portal-startup.md
@@ -1,0 +1,23 @@
+---
+Name: Faster portal startup
+Category: Fix
+Description: Restarting a portal no longer re-adopts pre-built code that was already in place.
+Icon: Sparkle
+Order: -20260817
+---
+
+# Faster portal startup
+
+Every time a portal started, it re-installed all of the pre-built code that ships with it — even
+when that code was already in place and unchanged from the previous start. Reinstalling each piece
+meant waking up the component that owns it, re-uploading its compiled bytes and re-saving its
+record, so a large portal spent a noticeable part of every startup confirming that nothing had
+changed.
+
+The portal now reads each package's index first and only re-installs the pieces that actually
+differ. A restart where nothing changed does none of that work. Startup is correspondingly quicker
+and quieter, and the shared code cache stops accumulating a fresh copy of every component on each
+restart.
+
+Nothing is skipped on trust: if the compiled bytes are genuinely missing — after the code cache is
+cleared, remounted or restored from a backup — that piece is re-installed exactly as before.

--- a/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
@@ -75,6 +75,104 @@ public static class PrebuiltAssemblySeeder
     public static string? LiveFrameworkIdentityWarning => NodeTypeCompilationHelpers.FrameworkVersionWarning;
 
     /// <summary>
+    /// Whether adopting this bundle entry would CHANGE ANYTHING — i.e. whether the NodeType's own
+    /// record already names exactly the build the seed would stamp, with the bytes still behind it.
+    ///
+    /// <para>🚨 The counterpart to <see cref="DeclineReason(string?)"/>, and the reason both are
+    /// public: <c>DeclineReason</c> answers "must we NOT adopt", this answers "need we adopt at
+    /// all". Without it every boot re-adopts every bundle entry it holds — and adoption is not
+    /// cheap bookkeeping: <see cref="Seed"/> opens the type's own mesh-node stream (which ACTIVATES
+    /// its per-node hub), re-uploads the assembly bytes to the shared store, and writes the node.
+    /// Measured on memex-cloud 2026-08-17, that was 43 hub activations, 43 uploads and 43 writes —
+    /// <b>13.5 s of a 101 s boot</b> — establishing that nothing had changed since the previous pod
+    /// did exactly the same thing. Framework identity is an API-SURFACE hash, deliberately stable
+    /// across internal-only merges, so the overwhelmingly common roll finds its own bytes already
+    /// on the share.</para>
+    ///
+    /// <para><b>Pure, and level-triggered on the store.</b> The caller resolves
+    /// <paramref name="storeHasBytes"/> by probing the store at the record's
+    /// <see cref="NodeTypeDefinition.LastCompiledVersion"/> and passes the answer in, so this
+    /// function does no I/O. That split is the same one <see cref="NodeTypeBakeStatus.Classify"/>
+    /// makes, for the same reason: a record can claim a build whose bytes were cleared, remounted
+    /// or restored away from under it (<see cref="BakeState.BytesMissing"/>), and a skip decided on
+    /// the record alone would leave that type permanently unbuilt. Record AND bytes ⇒ skip;
+    /// anything else ⇒ seed.</para>
+    ///
+    /// <para><b>"Already built" is NOT re-decided here.</b> It delegates to
+    /// <see cref="NodeTypeBakeStatus.Classify"/> — the one definition of that in the framework, and
+    /// the very function the pre-warmer's store probe applies to this same type moments later. A
+    /// second, hand-rolled notion of "current" beside it would be a rule that can drift from the
+    /// one that actually decides whether anything gets compiled, and the two disagreeing is how a
+    /// type gets skipped by the seeder AND skipped by the bake. So the contract is exactly: <b>skip
+    /// precisely what the bake would call <see cref="BakeState.Baked"/></b>.</para>
+    ///
+    /// <para>🚨 Note in particular what this does NOT compare: the NodeType MeshNode's CURRENT
+    /// version. <see cref="Seed"/> uploads and stamps the version it read BEFORE its own write, and
+    /// that write bumps the node — so after any adoption <c>LastCompiledVersion</c> is permanently
+    /// one behind <c>node.Version</c>, and a naive equality check is unsatisfiable. That mismatch
+    /// is also why today's unconditional re-adoption uploads the SAME bytes under a NEW store key
+    /// every boot: the assembly cache grows a fresh generation per pod start with nothing ever
+    /// reading the old ones. Whether a build is stale with respect to its SOURCES is
+    /// <c>CompiledSources</c>/<c>CurrentSourceVersions</c>'s question, answered by the compile
+    /// watcher, and it is deliberately not re-asked here.</para>
+    ///
+    /// <para>The one conjunct this adds on top of the bake's own verdict is the bundle's DEPENDENCY
+    /// RECORD (#1707 slice 2): an entry whose record differs from the stamped one would REPLACE
+    /// that stamp, so it is a real change and must not be mistaken for a no-op. A legacy bundle
+    /// carrying no record stamps none, and therefore cannot change one either.</para>
+    /// </summary>
+    /// <param name="definition">The NodeType's persisted definition.</param>
+    /// <param name="storeHasBytes">Whether the assembly store resolved bytes for this type's
+    /// <see cref="NodeTypeDefinition.LastCompiledVersion"/> — the caller's already-resolved probe,
+    /// so this function never does I/O.</param>
+    /// <param name="bundleDependencies">The bundle entry's dependency record, or null for a
+    /// legacy bundle.</param>
+    /// <param name="liveFrameworkMvid">Framework identity to compare against; defaults to the live
+    /// one. Injected so a test can stage a framework roll without rebuilding the framework — the
+    /// same seam <see cref="DeclineReason(string?, string)"/> exposes.</param>
+    /// <param name="liveDependencyIdOf">Live dependency-id resolver, passed through to
+    /// <see cref="NodeTypeBakeStatus.Classify"/>.</param>
+    /// <param name="liveToolchainId">Live toolchain id, passed through to
+    /// <see cref="NodeTypeBakeStatus.Classify"/>.</param>
+    public static bool IsAlreadyAdopted(
+        NodeTypeDefinition definition,
+        bool storeHasBytes,
+        IReadOnlyDictionary<string, string>? bundleDependencies,
+        string? liveFrameworkMvid = null,
+        Func<string, string?>? liveDependencyIdOf = null,
+        string? liveToolchainId = null)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        return StampWouldMatch(definition.CompiledDependencies, bundleDependencies)
+            && NodeTypeBakeStatus.Classify(
+                definition,
+                storeHasBytes,
+                liveFrameworkMvid ?? LiveFrameworkMvid,
+                liveDependencyIdOf,
+                liveToolchainId) is BakeState.Baked;
+    }
+
+    /// <summary>
+    /// Whether re-stamping <paramref name="bundle"/> would leave <paramref name="stamped"/>
+    /// unchanged. A legacy bundle (null) stamps nothing, so it always would.
+    /// </summary>
+    private static bool StampWouldMatch(
+        IReadOnlyDictionary<string, string>? stamped,
+        IReadOnlyDictionary<string, string>? bundle)
+    {
+        if (bundle is null)
+            return true;
+        if (stamped is null || stamped.Count != bundle.Count)
+            return false;
+        foreach (var (key, value) in bundle)
+            if (!stamped.TryGetValue(key, out var current)
+                || !string.Equals(current, value, StringComparison.Ordinal))
+                return false;
+        return true;
+    }
+
+    /// <summary>
     /// Seeds <paramref name="assemblyBytes"/> as the build for <paramref name="nodeTypePath"/>.
     ///
     /// <para>Cold: the write runs on Subscribe. Emits <c>true</c> when the assembly was adopted and

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -228,6 +228,47 @@ public static class ShippedPrebuiltBundles
             return seeds.Concat().Aggregate(0, (total, adopted) => total + adopted);
         });
 
+    /// <summary>
+    /// What one seeding pass did, split by the only distinction that matters operationally:
+    /// assemblies this pass actually ADOPTED (bytes uploaded, record stamped, the type's hub
+    /// activated to do it) versus assemblies that were ALREADY CURRENT and therefore cost nothing.
+    ///
+    /// <para>The split has to be reported, not just acted on. <c>deploy/aks/values.aks.yaml</c>
+    /// makes the boot coverage report the replacement for the retired bake readiness gate — "an
+    /// identity mismatch declines every bundle wholesale and shows up as a coverage collapse in the
+    /// logs on the FIRST pod of a bad roll". A skip-when-current optimisation that reported only
+    /// the newly-adopted count would drive that number to zero on every healthy steady-state boot
+    /// and destroy the signal. <see cref="Covered"/> is therefore what callers see, and the log
+    /// names both halves.</para>
+    /// </summary>
+    private readonly record struct SeedTally(int Adopted, int AlreadyCurrent)
+    {
+        /// <summary>Assemblies this bundle has BACKED on the store — adopted now or already there.
+        /// This is the coverage number; it is unchanged by the skip optimisation.</summary>
+        public int Covered => Adopted + AlreadyCurrent;
+
+        public static SeedTally operator +(SeedTally left, SeedTally right) =>
+            new(left.Adopted + right.Adopted, left.AlreadyCurrent + right.AlreadyCurrent);
+    }
+
+    /// <summary>
+    /// The NodeType nodes this mesh holds, as one snapshot: the PATHS (which types exist at all)
+    /// and, when the snapshot came from the mesh-wide enumeration, the NODES themselves.
+    ///
+    /// <para>The nodes are what make the deviation check possible — a node carries its
+    /// <see cref="MeshNode.Version"/> and its <see cref="NodeTypeDefinition"/>, which together are
+    /// the entire record half of "has this bundle entry already been adopted". They come for free:
+    /// the boot path already ran this exact query for the paths and threw the rest away.</para>
+    ///
+    /// <para>An EMPTY <see cref="Nodes"/> map means "no record snapshot available", and the
+    /// deviation check then answers "deviates" for everything — the install/push caller
+    /// (<see cref="SeedForTypes"/>) supplies paths rather than a query, and it is called precisely
+    /// when content just changed, so re-adopting is the right answer there anyway.</para>
+    /// </summary>
+    private sealed record TypeSnapshot(
+        ImmutableHashSet<string> Paths,
+        ImmutableDictionary<string, MeshNode> Nodes);
+
     /// <summary>The shared seeding core: the bundle files <paramref name="enumerateBundles"/>
     /// resolves (on the pool's blocking leg), through the one bundle pipeline.
     /// <paramref name="typePathFilter"/> replaces the mesh-wide NodeType enumeration when the
@@ -252,23 +293,36 @@ public static class ShippedPrebuiltBundles
             }
             var accessService = mesh.ServiceProvider.GetService<AccessService>();
             var pool = mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>().Get("prebuilt:files");
+            var store = mesh.ServiceProvider.GetService<IAssemblyStore>() ?? NullAssemblyStore.Instance;
             var startedAt = DateTimeOffset.UtcNow;
 
             // ONE enumeration of the NodeType nodes this mesh actually holds — the filter that
             // keeps a bundle for content this deployment never imported (an image ships one
             // content set; a mesh serves a subset) from parking the boot on per-path waits for
             // nodes that do not exist. A caller-supplied set (install/push) skips the query.
-            var existingPaths = typePathFilter is not null
-                ? Observable.Return(typePathFilter)
+            //
+            // 🚨 The NODES are kept, not just their paths. The same snapshot then answers the far
+            // more valuable question — "has this entry already been adopted?" — from the record it
+            // was already carrying. Keeping it costs nothing; throwing it away cost 43 hub
+            // activations and 13.5 s on every memex-cloud boot.
+            var snapshot = typePathFilter is not null
+                ? Observable.Return(new TypeSnapshot(
+                    typePathFilter, ImmutableDictionary<string, MeshNode>.Empty))
                 : meshService!
                     .Query<MeshNode>(MeshQueryRequest
                         .FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
                     .Take(1)
                     .Timeout(EnumerationBudget)
-                    .Select(change => change.Items
-                        .Where(n => !string.IsNullOrEmpty(n.Path))
-                        .Select(n => n.Path!)
-                        .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase));
+                    .Select(change =>
+                    {
+                        var nodes = change.Items
+                            .Where(n => !string.IsNullOrEmpty(n.Path))
+                            .GroupBy(n => n.Path!, StringComparer.OrdinalIgnoreCase)
+                            .ToImmutableDictionary(
+                                g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+                        return new TypeSnapshot(
+                            nodes.Keys.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase), nodes);
+                    });
 
             // 🚨 System-scoped end-to-end: reading NodeType records across every partition and
             // stamping adopted builds is framework infrastructure, exactly like the sweep this
@@ -286,15 +340,21 @@ public static class ShippedPrebuiltBundles
                                 return Observable.Return(0);
                             }
 
-                            return existingPaths
+                            return snapshot
                                 .SelectMany(existing => bundles
-                                    .Select(bundle => SeedBundle(mesh, pool, bundle, existing, logger))
+                                    .Select(bundle => SeedBundle(
+                                        mesh, pool, store, bundle, existing, logger))
                                     .Concat()
-                                    .Aggregate(0, (total, adopted) => total + adopted))
-                                .Do(adopted => logger?.LogInformation(
-                                    "ShippedPrebuiltBundles: adopted {Adopted} prebuilt assembly(ies) "
-                                    + "from {Bundles} shipped bundle(s) under {Directory} in {Elapsed}",
-                                    adopted, bundles.Count, dir, DateTimeOffset.UtcNow - startedAt));
+                                    .Aggregate(default(SeedTally), (total, one) => total + one))
+                                .Do(tally => logger?.LogInformation(
+                                    "ShippedPrebuiltBundles: {Covered} prebuilt assembly(ies) from "
+                                    + "{Bundles} shipped bundle(s) under {Directory} are backed by "
+                                    + "the assembly store — {Adopted} adopted now, {Current} already "
+                                    + "current and skipped WITHOUT activating their NodeType hubs — "
+                                    + "in {Elapsed}",
+                                    tally.Covered, bundles.Count, dir, tally.Adopted,
+                                    tally.AlreadyCurrent, DateTimeOffset.UtcNow - startedAt))
+                                .Select(tally => tally.Covered);
                         }))
                 // The seeding is an optimisation in front of the sweep — a fault here must degrade
                 // to "compile as today", never hold or fail the boot. Loud, so an operator can see
@@ -308,36 +368,46 @@ public static class ShippedPrebuiltBundles
                 });
         });
 
-    /// <summary>One bundle: read, gate on the framework MVID once, seed every payload whose
-    /// NodeType exists on this mesh. Emits the adopted count; folds its own faults to 0.</summary>
-    private static IObservable<int> SeedBundle(
+    /// <summary>
+    /// One bundle: read its MANIFEST, gate on the framework MVID once, and seed only the entries
+    /// that actually deviate from what the mesh already records and the store already holds.
+    ///
+    /// <para>🚨 <b>Manifest first, payload last.</b> The manifest is a few KB naming every entry's
+    /// node path and dependency record; the assemblies are the bundle's entire weight. Reading the
+    /// manifest alone is enough to answer the whole adoption question, so a bundle whose types are
+    /// all current is answered without decompressing a single assembly — on top of the per-type hub
+    /// activation and store upload that <see cref="PrebuiltAssemblySeeder.Seed"/> would cost.</para>
+    ///
+    /// <para>Emits the tally; folds its own faults to zero.</para>
+    /// </summary>
+    private static IObservable<SeedTally> SeedBundle(
         IMessageHub mesh,
         IIoPool pool,
+        IAssemblyStore store,
         string bundlePath,
-        ImmutableHashSet<string> existingTypePaths,
+        TypeSnapshot snapshot,
         ILogger? logger)
         => pool
-            .InvokeBlocking(_ => Plugin.Packaging.BundleReader.Read(File.ReadAllBytes(bundlePath)))
-            .SelectMany(payload =>
+            .InvokeBlocking(_ => Plugin.Packaging.BundleReader.ReadManifest(bundlePath))
+            .SelectMany(manifest =>
             {
-                var (manifest, assemblies) = payload;
                 if (PrebuiltAssemblySeeder.DeclineReason(manifest?.FrameworkMvid) is { } reason)
                 {
                     logger?.LogInformation(
                         "ShippedPrebuiltBundles: bundle {Bundle} DECLINED whole: {Reason} — "
                         + "the sweep compiles instead", Path.GetFileName(bundlePath), reason);
-                    return Observable.Return(0);
+                    return Observable.Return(default(SeedTally));
                 }
-                if (assemblies.Count == 0)
+                if (manifest!.Assemblies is not { Count: > 0 } assemblies)
                 {
                     logger?.LogWarning(
                         "ShippedPrebuiltBundles: bundle {Bundle} carries no assemblies (or no "
                         + "readable manifest) — nothing to adopt", Path.GetFileName(bundlePath));
-                    return Observable.Return(0);
+                    return Observable.Return(default(SeedTally));
                 }
 
                 var present = assemblies
-                    .Where(a => existingTypePaths.Contains(a.NodePath))
+                    .Where(a => snapshot.Paths.Contains(a.NodePath))
                     .ToList();
                 if (present.Count < assemblies.Count)
                     logger?.LogDebug(
@@ -346,34 +416,136 @@ public static class ShippedPrebuiltBundles
                         + "serves a subset)",
                         Path.GetFileName(bundlePath), assemblies.Count - present.Count);
                 if (present.Count == 0)
-                    return Observable.Return(0);
+                    return Observable.Return(default(SeedTally));
 
+                // Sequential (Concat, never Merge) for the same reason NodeTypeBakeStatus.Probe is:
+                // the store is typically a shared network volume or blob container, and a fan-out
+                // of lookups across every type at startup is the cold burst this whole mechanism
+                // exists to remove. Each probe is a glob or a blob-exists.
                 return present
-                    .Select(a => PrebuiltAssemblySeeder
-                        .Seed(mesh, a.NodePath, a.Assembly, a.Pdb, manifest!.FrameworkMvid, logger,
-                            a.Dependencies)
-                        .Take(1)
-                        .Timeout(SeedBudget)
-                        .Catch<bool, Exception>(ex =>
-                        {
-                            logger?.LogWarning(ex,
-                                "ShippedPrebuiltBundles: seeding {NodePath} from {Bundle} did not "
-                                + "complete — the sweep compiles it instead",
-                                a.NodePath, Path.GetFileName(bundlePath));
-                            return Observable.Return(false);
-                        }))
+                    .Select(entry => IsAlreadyCurrent(store, snapshot, mesh, entry, logger)
+                        .Select(current => (Entry: entry, Current: current)))
                     .Concat()
-                    .Count(adopted => adopted)
-                    .Do(adopted => logger?.LogInformation(
-                        "ShippedPrebuiltBundles: bundle {Bundle}: adopted {Adopted}/{Present} "
-                        + "prebuilt assembly(ies)",
-                        Path.GetFileName(bundlePath), adopted, present.Count));
+                    .ToList()
+                    .SelectMany(checks =>
+                    {
+                        var deviating = checks
+                            .Where(c => !c.Current)
+                            .Select(c => c.Entry.NodePath)
+                            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+                        var alreadyCurrent = checks.Count - deviating.Count;
+
+                        if (deviating.IsEmpty)
+                        {
+                            logger?.LogDebug(
+                                "ShippedPrebuiltBundles: bundle {Bundle}: all {Current} NodeType(s) "
+                                + "already carry this build and the store holds their bytes — no "
+                                + "assembly read, no hub activated, no write",
+                                Path.GetFileName(bundlePath), alreadyCurrent);
+                            return Observable.Return(new SeedTally(0, alreadyCurrent));
+                        }
+
+                        return pool
+                            .InvokeBlocking(_ => Plugin.Packaging.BundleReader
+                                .ReadFile(bundlePath, deviating))
+                            .SelectMany(payload => SeedPayloads(
+                                mesh, bundlePath, manifest.FrameworkMvid,
+                                payload.Assemblies, alreadyCurrent, logger));
+                    });
             })
-            .Catch<int, Exception>(ex =>
+            .Catch<SeedTally, Exception>(ex =>
             {
                 logger?.LogWarning(ex,
                     "ShippedPrebuiltBundles: bundle {Bundle} could not be read — skipped "
                     + "(the sweep compiles instead)", Path.GetFileName(bundlePath));
-                return Observable.Return(0);
+                return Observable.Return(default(SeedTally));
             });
+
+    /// <summary>
+    /// Whether this bundle entry is ALREADY on the store under the record the mesh already holds,
+    /// so seeding it would change nothing.
+    ///
+    /// <para>Two witnesses, and both are required. The RECORD
+    /// (<see cref="PrebuiltAssemblySeeder.IsAlreadyAdopted"/>, which defers to
+    /// <see cref="NodeTypeBakeStatus.Classify"/>) says the last adoption stamped exactly what this
+    /// entry would stamp; the STORE says the bytes are still there. Trusting the record alone is
+    /// the <see cref="BakeState.BytesMissing"/> trap — a cleared, remounted or partially-restored
+    /// assembly volume leaves every record pristine over bytes that are gone, and a skip decided on
+    /// it would leave those types permanently unbuilt.</para>
+    ///
+    /// <para>Fails SAFE: no node, unreadable content, no recorded version, or a store that throws
+    /// all answer "not current", so the entry is seeded exactly as it is today.</para>
+    /// </summary>
+    private static IObservable<bool> IsAlreadyCurrent(
+        IAssemblyStore store,
+        TypeSnapshot snapshot,
+        IMessageHub mesh,
+        Plugin.Packaging.BundleReader.AssemblyRef entry,
+        ILogger? logger)
+    {
+        if (!snapshot.Nodes.TryGetValue(entry.NodePath, out var node))
+            return Observable.Return(false);
+
+        // .ContentAs, never a cast: the enumeration crosses hubs, and a NodeTypeDefinition that
+        // arrives as an untyped JsonElement (a TypeRegistry without the discriminator) would read
+        // as null under `is` and silently re-seed everything.
+        var definition = node.ContentAs<NodeTypeDefinition>(mesh.JsonSerializerOptions);
+        if (definition is null)
+            return Observable.Return(false);
+
+        // 🚨 Probe at LastCompiledVersion, never at node.Version — that is the key the bytes were
+        // uploaded under, and the key NodeTypeBakeStatus.ProbeOne will ask about in a moment. (The
+        // two differ by design: Seed stamps the version it read BEFORE its own write, and that
+        // write bumps the node.) No recorded version means no key to ask about, which Classify
+        // already reads as NeverBuilt — resolved here as "not current", so it is seeded.
+        if (definition.LastCompiledVersion is not { } version || version < 0)
+            return Observable.Return(false);
+
+        return store
+            .TryGetAssemblyPath(entry.NodePath, version)
+            .Take(1)
+            .Select(path => PrebuiltAssemblySeeder.IsAlreadyAdopted(
+                definition,
+                storeHasBytes: !string.IsNullOrEmpty(path),
+                entry.Dependencies,
+                liveDependencyIdOf: NodeTypeCompilationHelpers.DependencyIdResolverOf(mesh),
+                liveToolchainId: NodeTypeCompilationHelpers.ProcessToolchainId))
+            .Catch<bool, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "ShippedPrebuiltBundles: assembly store lookup failed for {NodePath} — "
+                    + "re-seeding it (an unreadable store must never read as 'already there')",
+                    entry.NodePath);
+                return Observable.Return(false);
+            });
+    }
+
+    /// <summary>Seed the extracted payloads — the unchanged half of the pipeline.</summary>
+    private static IObservable<SeedTally> SeedPayloads(
+        IMessageHub mesh,
+        string bundlePath,
+        string? frameworkMvid,
+        IReadOnlyList<Plugin.Packaging.BundleReader.Payload> assemblies,
+        int alreadyCurrent,
+        ILogger? logger)
+        => assemblies
+            .Select(a => PrebuiltAssemblySeeder
+                .Seed(mesh, a.NodePath, a.Assembly, a.Pdb, frameworkMvid, logger, a.Dependencies)
+                .Take(1)
+                .Timeout(SeedBudget)
+                .Catch<bool, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "ShippedPrebuiltBundles: seeding {NodePath} from {Bundle} did not "
+                        + "complete — the sweep compiles it instead",
+                        a.NodePath, Path.GetFileName(bundlePath));
+                    return Observable.Return(false);
+                }))
+            .Concat()
+            .Count(adopted => adopted)
+            .Select(adopted => new SeedTally(adopted, alreadyCurrent))
+            .Do(tally => logger?.LogInformation(
+                "ShippedPrebuiltBundles: bundle {Bundle}: adopted {Adopted}/{Deviating} "
+                + "prebuilt assembly(ies); {Current} were already current",
+                Path.GetFileName(bundlePath), tally.Adopted, assemblies.Count, tally.AlreadyCurrent));
 }

--- a/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
@@ -95,22 +95,42 @@ public static class BundleReader
     public static (Manifest? Manifest, IReadOnlyList<Payload> Assemblies) Read(byte[] bundle)
     {
         using var buffer = new MemoryStream(bundle, writable: false);
-        using var archive = new ZipArchive(buffer, ZipArchiveMode.Read);
+        return Read(buffer);
+    }
 
-        var manifestEntry = archive.GetEntry(NuGetPackageWriter.ManifestEntry);
-        if (manifestEntry is null)
-            return (null, []);
+    /// <summary>
+    /// <see cref="Read(byte[])"/> over a STREAM, optionally extracting only the node paths
+    /// <paramref name="nodePaths"/> names.
+    ///
+    /// <para>🚨 Both parameters exist to keep bytes OUT of memory that nobody is going to use. A
+    /// bundle's assemblies are the whole of its weight, and a consumer that has already adopted
+    /// them needs none of it: reading a file as a stream avoids holding the compressed archive,
+    /// and the filter avoids materialising decompressed assemblies the caller will discard. The
+    /// boot-time seeder (<c>ShippedPrebuiltBundles</c>) asks
+    /// <see cref="ReadManifest(string)"/> first and comes back here for the DEVIATING subset only
+    /// — on a steady-state boot that subset is empty and this is never called at all.</para>
+    ///
+    /// <para><paramref name="nodePaths"/> <c>null</c> extracts everything, which is what a
+    /// consumer holding a freshly-downloaded bundle wants.</para>
+    /// </summary>
+    /// <param name="bundle">The archive, positioned at its start.</param>
+    /// <param name="nodePaths">Node paths to extract, or null for all of them.</param>
+    /// <returns>The manifest (null when the archive carries none) and the payloads found.</returns>
+    public static (Manifest? Manifest, IReadOnlyList<Payload> Assemblies) Read(
+        Stream bundle, IReadOnlySet<string>? nodePaths = null)
+    {
+        using var archive = new ZipArchive(bundle, ZipArchiveMode.Read, leaveOpen: true);
 
-        Manifest? manifest;
-        using (var stream = manifestEntry.Open())
-            manifest = JsonSerializer.Deserialize<Manifest>(stream, Json);
-
+        var manifest = ManifestOf(archive);
         if (manifest?.Assemblies is null)
             return (manifest, []);
 
         var payloads = new List<Payload>();
         foreach (var reference in manifest.Assemblies)
         {
+            if (nodePaths is not null && !nodePaths.Contains(reference.NodePath))
+                continue;
+
             var dll = archive.GetEntry($"{NuGetPackageWriter.AssemblyFolder}/{reference.Assembly}");
 
             if (dll is null)
@@ -129,10 +149,63 @@ public static class BundleReader
     }
 
     /// <summary>
-    /// Extracts the manifest and the MODULE closure files it names (#1664) — the module half of the
-    /// same bundle <see cref="Read"/> serves NodeType assemblies from.
+    /// The bundle's MANIFEST alone — every assembly's node path, dependency record and the
+    /// framework identity, WITHOUT decompressing a single assembly.
     ///
-    /// <para>Manifest-driven like <see cref="Read"/>, for the same reason: the manifest is the
+    /// <para>This is what makes "load the manifest, then touch only what deviates" possible. The
+    /// manifest is a few KB of JSON at a known entry; the assemblies it describes are megabytes.
+    /// A consumer can therefore decide the whole adoption question — is this bundle for our
+    /// framework, which of its types does this mesh hold, which of those are already on the
+    /// store — before paying for any of the payload.</para>
+    /// </summary>
+    /// <param name="bundle">The archive, positioned at its start.</param>
+    /// <returns>The manifest, or null when the archive carries none.</returns>
+    public static Manifest? ReadManifest(Stream bundle)
+    {
+        using var archive = new ZipArchive(bundle, ZipArchiveMode.Read, leaveOpen: true);
+        return ManifestOf(archive);
+    }
+
+    /// <summary>
+    /// <see cref="ReadManifest(Stream)"/> for a bundle on disk — opened for sequential read and
+    /// closed again, so the file's bytes never sit in the managed heap.
+    /// </summary>
+    /// <param name="bundlePath">Path to the bundle file.</param>
+    /// <returns>The manifest, or null when the archive carries none.</returns>
+    public static Manifest? ReadManifest(string bundlePath)
+    {
+        using var file = File.OpenRead(bundlePath);
+        return ReadManifest(file);
+    }
+
+    /// <summary>
+    /// <see cref="Read(Stream, IReadOnlySet{string})"/> for a bundle on disk.
+    /// </summary>
+    /// <param name="bundlePath">Path to the bundle file.</param>
+    /// <param name="nodePaths">Node paths to extract, or null for all of them.</param>
+    /// <returns>The manifest (null when the archive carries none) and the payloads found.</returns>
+    public static (Manifest? Manifest, IReadOnlyList<Payload> Assemblies) ReadFile(
+        string bundlePath, IReadOnlySet<string>? nodePaths = null)
+    {
+        using var file = File.OpenRead(bundlePath);
+        return Read(file, nodePaths);
+    }
+
+    private static Manifest? ManifestOf(ZipArchive archive)
+    {
+        var manifestEntry = archive.GetEntry(NuGetPackageWriter.ManifestEntry);
+        if (manifestEntry is null)
+            return null;
+
+        using var stream = manifestEntry.Open();
+        return JsonSerializer.Deserialize<Manifest>(stream, Json);
+    }
+
+    /// <summary>
+    /// Extracts the manifest and the MODULE closure files it names (#1664) — the module half of the
+    /// same bundle <see cref="Read(byte[])"/> serves NodeType assemblies from.
+    ///
+    /// <para>Manifest-driven like <see cref="Read(byte[])"/>, for the same reason: the manifest is the
     /// producer's statement of which files belong to the module, and enumerating
     /// <see cref="NuGetPackageWriter.ModuleFolder"/> instead would adopt any stray entry a future
     /// writer happens to place there. A file the manifest names but the archive lacks is FATAL here,

--- a/src/MeshWeaver.Plugin.Packaging/BundleWriter.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleWriter.cs
@@ -14,7 +14,7 @@ namespace MeshWeaver.Plugin.Packaging;
 /// producer and a consumer cannot drift. Producers: the CI bake (<c>mw-plugin-test
 /// --bake-output</c>, which persists what the content gate just compiled) and, later, the registry
 /// bundle lane. Consumers: <c>PluginBundleClient</c> (HTTP) and the boot-time shipped-bundle
-/// seeder — all of them go through <see cref="BundleReader.Read"/>.</para>
+/// seeder — all of them go through <see cref="BundleReader.Read(byte[])"/>.</para>
 ///
 /// <para>A bundle is deliberately NOT a nupkg: it carries no content, no nuspec, no dependency
 /// graph — only compiled bytes and the identity they are pinned to. The framework MVID in the

--- a/test/MeshWeaver.Graph.Test/PrebuiltAssemblySeederGateTest.cs
+++ b/test/MeshWeaver.Graph.Test/PrebuiltAssemblySeederGateTest.cs
@@ -1,4 +1,5 @@
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Services;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -54,6 +55,103 @@ public class PrebuiltAssemblySeederGateTest
         Assert.NotNull(PrebuiltAssemblySeeder.DeclineReason(live[..8]));
         Assert.NotNull(PrebuiltAssemblySeeder.DeclineReason(live.ToUpperInvariant()));
     }
+
+    // ── IsAlreadyAdopted: the "need we adopt at all" half ────────────────────────────────────────
+    //
+    // DeclineReason answers "must we NOT adopt"; IsAlreadyAdopted answers "would adopting change
+    // anything". Without the second, every boot re-adopts every bundle entry it holds — and
+    // adoption is not bookkeeping: it activates the type's per-node hub, re-uploads the bytes and
+    // writes the node. On memex-cloud 2026-08-17 that was 43 activations / 43 uploads / 43 writes,
+    // 13.5 s of a 101 s boot, to establish that nothing had changed.
+    //
+    // "Already built" delegates to NodeTypeBakeStatus.Classify — the one definition of that in the
+    // framework — so the seeder skips PRECISELY what the bake would call Baked. A too-permissive
+    // answer here does NOT degrade to "a bit stale": it silently skips an adoption that was needed.
+
+    private static NodeTypeDefinition Adopted() => new()
+    {
+        CompilationStatus = CompilationStatus.Ok,
+        LastCompiledVersion = 7,
+        CompiledFrameworkVersion = PrebuiltAssemblySeeder.LiveFrameworkMvid,
+        LatestAssemblyCollection = "nodetype-cache",
+        LatestAssemblyPath = "Some/Type/v7-abc.dll",
+    };
+
+    [Fact]
+    public void AnAdoptedRecordWhoseBytesAreOnTheStoreNeedsNoReAdoption() =>
+        Assert.True(PrebuiltAssemblySeeder.IsAlreadyAdopted(Adopted(), storeHasBytes: true, null));
+
+    [Fact]
+    public void AClearedStoreReAdopts() =>
+        // 🚨 The BytesMissing trap: the record is pristine and the bytes are gone (a cleared,
+        // remounted or stale-restored assembly volume). Skipping on the record's word alone would
+        // leave the type permanently unbuilt — the decision must stay level-triggered on the store.
+        Assert.False(PrebuiltAssemblySeeder.IsAlreadyAdopted(Adopted(), storeHasBytes: false, null));
+
+    [Fact]
+    public void AnotherFrameworksStampReAdoptsWhenTheStoreHasNothing() =>
+        Assert.False(PrebuiltAssemblySeeder.IsAlreadyAdopted(
+            Adopted() with { CompiledFrameworkVersion = "deadbeefdeadbeefdeadbeefdeadbeef" },
+            storeHasBytes: false, null));
+
+    [Fact]
+    public void ARecordSittingAtErrorReAdopts() =>
+        // PreviouslyBroken beats every other state in Classify, bytes or no bytes.
+        Assert.False(PrebuiltAssemblySeeder.IsAlreadyAdopted(
+            Adopted() with { CompilationStatus = CompilationStatus.Error },
+            storeHasBytes: true, null));
+
+    [Fact]
+    public void ARecordWithNoAssemblyCoordinatesReAdopts()
+    {
+        Assert.False(PrebuiltAssemblySeeder.IsAlreadyAdopted(
+            Adopted() with { LatestAssemblyPath = null }, storeHasBytes: true, null));
+        Assert.False(PrebuiltAssemblySeeder.IsAlreadyAdopted(
+            Adopted() with { LatestAssemblyCollection = null }, storeHasBytes: true, null));
+        Assert.False(PrebuiltAssemblySeeder.IsAlreadyAdopted(
+            Adopted() with { LastCompiledVersion = null }, storeHasBytes: true, null));
+    }
+
+    [Fact]
+    public void ADifferentDependencyRecordReAdopts()
+    {
+        // The bundle would REPLACE CompiledDependencies, so this is not a no-op — a rebuilt module
+        // closure has to land even though the framework identity and the bytes are untouched
+        // (#1707 slice 2). This is the one conjunct IsAlreadyAdopted adds on top of Classify.
+        var stamped = Adopted() with
+        {
+            CompiledDependencies = System.Collections.Immutable.ImmutableSortedDictionary
+                .CreateRange(StringComparer.Ordinal,
+                    [new KeyValuePair<string, string>("Custom.Module", "mvid:one")]),
+        };
+
+        Assert.True(PrebuiltAssemblySeeder.IsAlreadyAdopted(
+            stamped, true, new Dictionary<string, string> { ["Custom.Module"] = "mvid:one" }));
+        Assert.False(PrebuiltAssemblySeeder.IsAlreadyAdopted(
+            stamped, true, new Dictionary<string, string> { ["Custom.Module"] = "mvid:two" }));
+        Assert.False(PrebuiltAssemblySeeder.IsAlreadyAdopted(
+            stamped, true, new Dictionary<string, string>
+            {
+                ["Custom.Module"] = "mvid:one",
+                ["Other.Module"] = "mvid:three",
+            }));
+        // A record the bundle would ADD where none is stamped is still a change.
+        Assert.False(PrebuiltAssemblySeeder.IsAlreadyAdopted(
+            Adopted(), true, new Dictionary<string, string> { ["Custom.Module"] = "mvid:one" }));
+    }
+
+    [Fact]
+    public void ALegacyBundleWithNoDependencyRecordStampsNothingAndSoChangesNothing() =>
+        // Seed leaves any prior stamp untouched for a legacy bundle, so a stamped record is not
+        // evidence that re-seeding would differ.
+        Assert.True(PrebuiltAssemblySeeder.IsAlreadyAdopted(
+            Adopted() with
+            {
+                CompiledDependencies = System.Collections.Immutable.ImmutableSortedDictionary
+                    .CreateRange(StringComparer.Ordinal,
+                        [new KeyValuePair<string, string>("Custom.Module", "mvid:one")]),
+            },
+            storeHasBytes: true, null));
 
     [Fact]
     public void DeclineReasonNamesBothIdentities()

--- a/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
@@ -90,6 +90,111 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
         }
     }
 
+    /// <summary>
+    /// 🚨 THE STEADY-STATE BOOT: a bundle whose types are already adopted must cost NOTHING —
+    /// no assembly read, no store upload, no node write, and above all no per-NodeType hub
+    /// activation — while still reporting the same COVERAGE.
+    ///
+    /// <para>Measured on memex-cloud 2026-08-17 (pod <c>…-dbpx6</c>, 19:22:51→19:23:05): 43
+    /// assemblies re-adopted from 18 bundles, <b>13.5 s of a 101 s boot</b>, at ~300 ms per entry
+    /// — one per-node hub activation + one store upload + one node write each — establishing that
+    /// nothing had changed since the previous pod did exactly the same thing. The framework
+    /// identity is an API-surface hash and is deliberately stable across internal-only merges, so
+    /// this is the COMMON roll, not an edge case.</para>
+    ///
+    /// <para>The three steps are one story on purpose, and step 3 is what makes step 2 an honest
+    /// assertion rather than a race: a skip is the absence of a write, so it can only be proven
+    /// against a stream that demonstrably WOULD have shown one. Clearing the store and watching
+    /// the very next seed re-adopt supplies exactly that positive control — and pins the
+    /// level-triggered property at the same time (a cleared / remounted / stale-restored assembly
+    /// volume must re-seed, never be skipped on the record's word alone; that is the
+    /// <see cref="BakeState.BytesMissing"/> trap).</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task UnchangedBundle_SkipsWithoutRewriting_AndReSeedsWhenTheStoreLosesItsBytes()
+    {
+        var typePath = $"{TestPartition}/SteadyStateThing";
+        await CreateNodeType("SteadyStateThing");
+
+        var dir = CreateBundleDirectory();
+        try
+        {
+            WriteBundle(
+                Path.Combine(dir, "steady.zip"),
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream([0xAB, 0xCD, 0xEF])));
+
+            // ── 1. First boot: the bundle is adopted, exactly as before. ──────────────────────
+            var first = await ShippedPrebuiltBundles.SeedAll(Mesh, dir, null)
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+            first.Should().Be(1, "a type with no build yet must be adopted");
+
+            var afterFirst = await AdoptedNode(typePath);
+            var adoptedVersion = afterFirst.Version;
+            var adoptedAt = afterFirst
+                .ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!.LastCompileSucceededAt;
+
+            // ── 2. Second boot, nothing changed: SKIPPED — but still COVERED. ─────────────────
+            var second = await ShippedPrebuiltBundles.SeedAll(Mesh, dir, null)
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+            second.Should().Be(1,
+                "coverage is unchanged by the skip — deploy/aks/values.aks.yaml makes this count "
+                + "the signal that the CI bake lane works, so it must NOT collapse to 0 on a "
+                + "healthy steady-state boot");
+
+            var afterSecond = await CurrentNode(typePath);
+            afterSecond.Version.Should().Be(adoptedVersion,
+                "an already-adopted entry must not be re-stamped — the write is what activates "
+                + "the NodeType's per-node hub, and that activation is the whole cost being removed");
+            afterSecond.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!
+                .LastCompileSucceededAt.Should().Be(adoptedAt,
+                    "a re-adoption would restamp this timestamp; an unchanged one proves Seed "
+                    + "never ran");
+
+            // ── 3. The positive control: the store loses its bytes ⇒ the next seed re-adopts. ──
+            Directory.Delete(AssemblyStoreRoot, recursive: true);
+
+            var third = await ShippedPrebuiltBundles.SeedAll(Mesh, dir, null)
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+            third.Should().Be(1, "the entry is covered again — this time by actually re-adopting it");
+
+            var afterThird = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+                .Where(n => n is not null && n.Version > adoptedVersion)
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(TestContext.Current.CancellationToken);
+            afterThird!.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!
+                .LastCompileSucceededAt.Should().NotBe(adoptedAt,
+                    "the record may never be trusted over the store: a cleared assembly volume "
+                    + "leaves every record pristine over bytes that are gone, and a skip decided "
+                    + "on the record alone would leave the type permanently unbuilt");
+        }
+        finally
+        {
+            TryDelete(dir);
+        }
+    }
+
+    /// <summary>The node once its adoption has landed.</summary>
+    private Task<MeshNode> AdoptedNode(string typePath) =>
+        Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Where(n => n?.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)
+                ?.CompilationStatus == CompilationStatus.Ok)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken)!;
+
+    /// <summary>The node as it stands right now.</summary>
+    private Task<MeshNode> CurrentNode(string typePath) =>
+        Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Where(n => n is not null)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken)!;
+
     /// <summary>#1707 slice 3: install/push-time consumption is scoped to the CALLER's types —
     /// the mesh-wide enumeration is the boot path's business only.</summary>
     [Fact(Timeout = 120_000)]


### PR DESCRIPTION
Boot-time bundle adoption re-installed **every** prebuilt assembly on **every** start, whether or
not anything had changed. Each re-adoption opens the NodeType's own mesh-node stream — which
**activates its per-node hub** — re-uploads the assembly bytes to the shared store, and writes the
node. This makes the seeder read the bundle **manifest first** and touch only the entries that
actually deviate.

## The measurement (memex-cloud, pod `…-dbpx6`, 2026-08-17 19:22 UTC)

I pulled the real boot log rather than re-deriving it. Attribution of the 101 s warm-up:

| phase | span | cost |
|---|---|---|
| wait for the static repo import to settle | 19:22:47.4 → 19:22:51.5 | ~4 s |
| **`ShippedPrebuiltBundles` — 43 assemblies from 18 bundles** | 19:22:51.5 → 19:23:05.0 | **13.5 s** |
| NodeType enumeration + 282-type store probe | 19:23:05.0 → 19:23:11.8 | ~6.8 s |
| `BuildProtocol` chunk bookkeeping (38 chunks) + 17 compiles | 19:23:11.8 → 19:24:28.4 | ~76.6 s |

The seeding phase is a steady ~300 ms per entry — one hub activation + one store upload + one node
write each — and on this boot **all 43 were already on the share**: the pre-warmer that runs
immediately afterwards reported `alreadyBaked=265`, which includes every one of them. The framework
identity (`sc2308d7…`) is an API-surface hash, deliberately stable across internal-only merges, so
this is the *common* roll, not an edge case.

### 🚨 One correction to the brief, on the evidence

The premise "282 NodeType hubs are instantiated at every boot" is **not** what the log shows. 282 is
the number of NodeTypes *enumerated*; 265 of them are reported `AlreadyBaked` **without any hub
being activated** — `DynamicTypePreWarmer.WarmPending` already skips activation for anything the
store probe finds. The activations at boot are roughly **43 (this seeding) + 38 (`Admin/Build`
chunks) + 17 (pending compiles) ≈ 100**, not 282. The spirit of the brief holds — most of that
~100 is spent establishing that nothing changed — but the 43 fixed here are the ones in the
*always-on* path, and the rest are reported separately rather than folded in here.

## What changed

**The deviation key is one that already exists**, not a new sidecar: `NodeTypeBakeStatus.Classify`
— the very function the pre-warmer's store probe applies to the same type moments later. The seeder
now skips **precisely what the bake would call `Baked`**, plus one bundle-specific conjunct (the
entry's dependency record must equal the stamped one, or adoption would *replace* that stamp).

- `BundleReader.ReadManifest(path)` reads the few-KB manifest **without decompressing any
  assembly**; `Read(stream, nodePaths)` then extracts only the deviating subset. On a steady-state
  boot the subset is empty and the payload is never read at all.
- `PrebuiltAssemblySeeder.IsAlreadyAdopted(...)` — pure, public, the counterpart to the existing
  `DeclineReason`: that one answers *must we NOT adopt*, this answers *need we adopt at all*.
- The decision stays **level-triggered on the store**: the record's claim is only believed when a
  probe confirms the bytes are still at that key. A cleared / remounted / stale-restored assembly
  volume re-seeds exactly as today — that is `BakeState.BytesMissing`, and skipping on the record's
  word alone would leave those types permanently unbuilt.

### Two things this deliberately does NOT do

- **It does not compare the node's current version.** `Seed` stamps the version it read *before* its
  own write, and that write bumps the node — so `LastCompiledVersion` is permanently one behind
  `node.Version` and an equality check is unsatisfiable. (My first attempt used one; the new test
  caught it.) Whether a build is stale *with respect to its sources* is
  `CompiledSources`/`CurrentSourceVersions`' question, answered by the compile watcher, and is
  deliberately not re-asked here.
- **It changes no eager/lazy semantics.** Nothing that used to be compiled at boot now isn't; this
  only stops redoing work that was provably already done. The behavioural question is discussed
  below and is *not* part of this PR.

### Side effect worth naming: the assembly cache stops growing per boot

Because each re-adoption uploaded under `node.Version` and then bumped it, every boot wrote a
**fresh copy of every bundled assembly under a new store key**, which nothing ever read. That is a
contributor to the accumulation `deploy/aks/values.aks.yaml` documents (7817 DLLs / 93 generations /
3.2 GB on 2026-08-12). Skipping the no-op adoption stops it at the source.

## Numbers

Local A/B, same worktree, 43 assemblies across 18 bundles (prod's exact distribution), 3 runs each:

| | baseline (`origin/main`) | with this change |
|---|---|---|
| cold seed (nothing adopted yet) | 2871 / 1858 / 1835 ms | 1696 / 1720 / 1788 ms |
| **steady-state re-seed** | **726 / 411 / 305 ms** | **7 / 7 / 7 ms** |
| steady-state re-seed (again) | 453 / 288 / 387 ms | **3 / 4 / 3 ms** |
| coverage reported | 43 every run | 43 every run |

Cold is unchanged (inside baseline noise — an earlier single sample suggested a regression and did
not survive repetition). Steady state is ~390 ms → ~5 ms, and does **zero** hub activations, store
uploads, node writes and assembly decompressions.

Prod equivalent: the 13.5 s / 43 activations / 43 uploads phase becomes 18 manifest reads + 43 store
probes. The local harness is a filesystem store + in-memory persistence, so the absolute numbers do
not transfer — the removed *work* does.

## The coverage signal is preserved on purpose

`deploy/aks/values.aks.yaml` makes the boot coverage report the replacement for the retired bake
readiness gate: *"an identity mismatch declines every bundle wholesale and shows up as a coverage
collapse in the logs on the FIRST pod of a bad roll"*. Reporting only newly-adopted assemblies would
drive that number to 0 on every healthy boot and destroy the signal. The returned count is therefore
`Covered` = adopted + already-current, and the log names both halves:

```
ShippedPrebuiltBundles: 43 prebuilt assembly(ies) from 18 shipped bundle(s) under … are backed by
the assembly store — 0 adopted now, 43 already current and skipped WITHOUT activating their
NodeType hubs — in 00:00:00.4
```

## Tests

- `ShippedPrebuiltBundlesTest.UnchangedBundle_SkipsWithoutRewriting_AndReSeedsWhenTheStoreLosesItsBytes`
  — three steps as one story. Step 3 (clear the store, watch the next seed re-adopt) is the
  **positive control** that makes step 2 honest: a skip is the *absence* of a write, so it can only
  be proven against a stream that demonstrably would have shown one.
- `PrebuiltAssemblySeederGateTest` — 8 new pure cases, one per rule (cleared store, another
  framework, `Error`, missing coordinates, dependency-record add/change/superset, legacy bundle).

`SeedForTypes` (install/push) is unchanged: it supplies paths rather than a query, so it has no
record snapshot and skips nothing — and it runs precisely when content just changed.

## Build

`-c Release -p:CIRun=true -warnaserror` clean on `MeshWeaver.Plugin.Packaging`, `MeshWeaver.Graph`,
`MeshWeaver.Hosting`, `MeshWeaver.Plugin.Build`, `MeshWeaver.PluginCatalog`, `Memex.Portal.Shared`
and both touched test projects.

---

## Not in this PR — reported for a decision

1. **memex-cloud runs `PreWarm__DynamicTypes: "true"`**, drifted from the committed chart default of
   `"false"`. That default already *is* "no pre-bake on the instance; compile when a user reaches
   the place", with a long documented rationale. The drift is where the other **76.6 s** of the boot
   lives (38 `Admin/Build` chunks + 17 compiles). Reconciling it needs no code — and a `helm upgrade`
   would revert it anyway.
2. **`BuildProtocolDriver.BakeAsMaster` plans chunks over `definitions.Keys`** (all 282 types → 38
   chunks) rather than the pending set (17 types → ~6 chunks), so ~32 chunks are opened, claimed and
   given a fresh `Admin/Build/<pkg>/_Activity/<guid>` node every boot for namespaces with nothing to
   build.
3. **`Admin/Build/*` content reads as an untyped `JsonElement`** on the reading hub (`BuildState` is
   registered in `MeshNodeExtensions` but evidently not there) — 3–4 warnings per chunk per boot, and
   it is why `could not open chunk AgenticPrimer` burned a 15 s `GrantWindow` on this boot.
4. **`MonotonicWriteGuard` `Version=0` on `Admin/Partition/Doc`** — a second instance of the #1784/
   #1785 defect, located at `MeshExtensions.cs:3440-3450` (`RunPostCreationHandlersObs` writes
   `SpaceNodeType`'s additional nodes via a raw `persistence.Write` + hand-posted
   `DataChangeRequest`). #1785's body explicitly named this call site as a survivor. Not the same
   root as the seeding, so not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
