### PR TITLE
Assert Orleans provisioning at both ends of the handover (#1798)

### DIFF
--- a/memex/aspire/Memex.Database.Migration/Migrations/OrleansClusteringSetup.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/OrleansClusteringSetup.cs
@@ -33,11 +33,52 @@ namespace Memex.Database.Migration.Migrations;
 /// </summary>
 public static class OrleansClusteringSetup
 {
+    /// <summary>
+    /// The nine membership query keys the clustering script inserts, and the four grain-storage
+    /// keys the persistence script inserts. These are the rows the silo's providers read back —
+    /// each grain-storage key with a <c>.Single()</c> — so they ARE the contract this step
+    /// delivers. Mirrored by <c>OrleansProvisioningGate</c> in the portal, which asserts the same
+    /// set at startup; the two lists must move together when the Orleans package version does.
+    /// </summary>
+    private static readonly string[] MembershipQueryKeys =
+    [
+        "UpdateIAmAlivetimeKey",
+        "InsertMembershipVersionKey",
+        "InsertMembershipKey",
+        "UpdateMembershipKey",
+        "MembershipReadRowKey",
+        "MembershipReadAllKey",
+        "DeleteMembershipTableEntriesKey",
+        "GatewaysQueryKey",
+        "CleanupDefunctSiloEntriesKey",
+    ];
+
+    private static readonly string[] GrainStorageQueryKeys =
+    [
+        "WriteToStorageKey",
+        "ReadFromStorageKey",
+        "ClearStorageKey",
+        "DeleteStorageKey",
+    ];
+
     public static async Task RunAsync(string orleansConnectionString, ILogger logger)
     {
         if (string.IsNullOrWhiteSpace(orleansConnectionString))
         {
-            logger.LogInformation("[OrleansClustering] No 'orleans' connection string — skipping (non-AdoNet clustering).");
+            // 🚨 WARNING, not Information, and the CONSEQUENCE is named. This step cannot see the
+            // portal's `Features:Orleans:Clustering` flag, so it genuinely cannot tell a
+            // legitimate skip (Azure-Tables / Localhost clustering) from the failure mode that
+            // rolled prod back (#1798): ConnectionStrings__orleans present on the PORTAL and
+            // absent from the MIGRATION's secret. What it CAN do is stop reporting the ambiguous
+            // case as routine. The red gate lives where the intent is unambiguous — the portal's
+            // OrleansProvisioningGate refuses to start when AdoNet is configured and these rows
+            // are missing. Producer reports; consumer asserts.
+            logger.LogWarning(
+                "[OrleansClustering] No 'orleans' connection string — SKIPPED, nothing provisioned. "
+                + "This is expected ONLY for non-AdoNet clustering (Azure Tables / Localhost). If "
+                + "this deployment's portal runs Features:Orleans:Clustering=AdoNet it will refuse "
+                + "to start: provision ConnectionStrings__orleans on the MIGRATION as well as the "
+                + "portal and re-run this container.");
             return;
         }
 
@@ -68,6 +109,65 @@ public static class OrleansClusteringSetup
             await cmd.ExecuteNonQueryAsync();
             logger.LogInformation("[OrleansClustering] Orleans persistence tables created.");
         }
+
+        await VerifyProvisionedAsync(conn, logger);
+    }
+
+    /// <summary>
+    /// POSTCONDITION: read back the <c>OrleansQuery</c> rows the silo's providers will load and
+    /// fail RED if any is missing. This is what turns the step's success line from a claim into a
+    /// measurement.
+    ///
+    /// <para>🚨 Both phases above gate on a MARKER TABLE (<c>orleansquery</c> /
+    /// <c>orleansstorage</c>) because their scripts use plain <c>CREATE</c> and cannot be re-run.
+    /// That gate answers "did something create this table?", never "is the table's CONTENT
+    /// complete" — so a script that died part-way leaves the marker present and every later run
+    /// reports "already present — nothing to do", forever, for a database that is missing rows the
+    /// silo requires. A gate that can pass on the wrong evidence is worse than no gate (AGENTS.md
+    /// → "a verification step that cannot fail is not a verification step"), and the failure it
+    /// would hide is precisely #1798's: a silo crash-looping on <c>Sequence contains no
+    /// elements</c>.</para>
+    ///
+    /// <para>Throwing here fails the migration container, which is the correct blast radius: the
+    /// portal's own <c>OrleansProvisioningGate</c> would otherwise refuse to start anyway, and a
+    /// red migration names the problem one step earlier and closer to the fix.</para>
+    /// </summary>
+    private static async Task VerifyProvisionedAsync(NpgsqlConnection conn, ILogger logger)
+    {
+        var required = MembershipQueryKeys.Concat(GrainStorageQueryKeys).ToArray();
+
+        await using var cmd = new NpgsqlCommand(
+            "SELECT querykey FROM orleansquery WHERE querykey = ANY(@keys)", conn);
+        cmd.Parameters.AddWithValue("keys", required);
+
+        var present = new HashSet<string>(StringComparer.Ordinal);
+        await using (var reader = await cmd.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+                present.Add(reader.GetString(0));
+        }
+
+        var missing = required.Where(k => !present.Contains(k)).ToArray();
+        if (missing.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"[OrleansClustering] Provisioning is INCOMPLETE: OrleansQuery is missing "
+                + $"{missing.Length} of {required.Length} required query keys "
+                + $"({string.Join(", ", missing)}). The marker tables exist, so the creation "
+                + "scripts were skipped as 'already present' — a previous run must have died "
+                + "part-way. The Orleans scripts use plain CREATE and cannot be re-run over a "
+                + "partial state: drop the affected Orleans tables in the 'orleans' database and "
+                + "re-run this migration. Refusing to report a successful migration for a "
+                + "database the silo cannot start against.");
+        }
+
+        // The signal the portal's gate asserts — specific to what this step provisioned, and
+        // COUNTED. "Database migration completed. Version: N" says nothing about Orleans; this
+        // line is what makes the difference observable.
+        logger.LogInformation(
+            "[OrleansClustering] provisioned OK: {Membership} membership + {Storage} grain-storage "
+            + "query keys present in OrleansQuery ({Total} total).",
+            MembershipQueryKeys.Length, GrainStorageQueryKeys.Length, required.Length);
     }
 
     /// <summary>

--- a/memex/aspire/Memex.Portal.Distributed/OrleansProvisioningGate.cs
+++ b/memex/aspire/Memex.Portal.Distributed/OrleansProvisioningGate.cs
@@ -1,0 +1,172 @@
+using System.Collections.Immutable;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace Memex.Portal.Distributed;
+
+/// <summary>
+/// Hard gate that runs once at portal startup when the silo is configured for AdoNet clustering:
+/// asserts that the <c>orleans</c> database actually carries the <c>OrleansQuery</c> rows the
+/// Orleans AdoNet providers read, and refuses to start the host if any are missing.
+///
+/// <para><b>Why this exists (#1798).</b> The portal already throws when
+/// <c>Features:Orleans:Clustering=AdoNet</c> and <c>ConnectionStrings:orleans</c> is unset — but
+/// that only proves the portal was TOLD where the database is. It says nothing about whether
+/// anything ever provisioned it. In the incident, the connection string was present on the
+/// PORTAL and absent from the MIGRATION's secret, so <c>OrleansClusteringSetup</c> logged
+/// "skipping" at Information and created nothing. The portal then started, and
+/// <c>AdoNetGrainStorage.Init</c> — which loads each of its query texts with
+/// <see cref="System.Linq.Enumerable.Single{T}(System.Collections.Generic.IEnumerable{T})"/> —
+/// threw <c>Sequence contains no elements</c> into a crash loop. That exception names no table,
+/// no key, no connection string and no container: it is the least actionable possible rendering
+/// of "the database was never provisioned", and prod was rolled back on it.</para>
+///
+/// <para>This gate is the consumer half of the pipeline rule that every step asserts its
+/// predecessor's signal: <c>OrleansClusteringSetup</c> (Memex.Database.Migration) emits a signal
+/// specific to what it provisioned (counted query keys, not "completed"), and this gate
+/// independently re-checks the same contract against the database the silo will actually
+/// use. Two checks of one contract — one at produce time, one at consume time — so a deployment
+/// where the two components disagree about whether Orleans is in play fails LOUDLY at startup
+/// naming exactly what to provision, instead of crash-looping on a LINQ exception.</para>
+///
+/// <para>Modelled on <see cref="DbVersionGate"/>, including its two hard-won behaviours: fail
+/// CLOSED on anything the database says, and RETHROW a cancellation of the host's own startup
+/// token (a rollout replacing the pod moments after it started is not a provisioning failure —
+/// issue #1183).</para>
+/// </summary>
+public sealed class OrleansProvisioningGate(
+    string orleansConnectionString,
+    bool requiresGrainStorage,
+    IHostApplicationLifetime lifetime,
+    ILogger<OrleansProvisioningGate> logger) : IHostedService
+{
+    /// <summary>
+    /// The nine <c>OrleansQuery</c> keys <c>AdoNetClusteringTable</c> loads at silo start. Taken
+    /// from the verbatim Orleans PostgreSQL clustering script the migration runs — keep the two
+    /// in step when the Orleans package version moves.
+    /// </summary>
+    public static readonly ImmutableArray<string> MembershipQueryKeys =
+    [
+        "UpdateIAmAlivetimeKey",
+        "InsertMembershipVersionKey",
+        "InsertMembershipKey",
+        "UpdateMembershipKey",
+        "MembershipReadRowKey",
+        "MembershipReadAllKey",
+        "DeleteMembershipTableEntriesKey",
+        "GatewaysQueryKey",
+        "CleanupDefunctSiloEntriesKey",
+    ];
+
+    /// <summary>
+    /// The four <c>OrleansQuery</c> keys <c>AdoNetGrainStorage.Init</c> loads — each with a
+    /// <c>.Single()</c>, which is why a missing row surfaces as <c>Sequence contains no
+    /// elements</c> rather than as anything that names the database. These back
+    /// <c>PubSubStore</c>; see the streaming-durability rationale on
+    /// <c>OrleansClusteringSetup</c> (Memex.Database.Migration).
+    /// </summary>
+    public static readonly ImmutableArray<string> GrainStorageQueryKeys =
+    [
+        "WriteToStorageKey",
+        "ReadFromStorageKey",
+        "ClearStorageKey",
+        "DeleteStorageKey",
+    ];
+
+    /// <summary>
+    /// The keys this deployment requires: always membership (clustering is on whenever this gate
+    /// is registered), plus grain storage when the silo also configures an AdoNet
+    /// <c>PubSubStore</c>. Both derive from the single <c>useAdoNetClustering</c> decision in
+    /// <c>Program.cs</c>, so the gate can never require more than the silo configures.
+    /// </summary>
+    public static ImmutableArray<string> RequiredKeys(bool requiresGrainStorage)
+        => requiresGrainStorage
+            ? [.. MembershipQueryKeys, .. GrainStorageQueryKeys]
+            : MembershipQueryKeys;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var required = RequiredKeys(requiresGrainStorage);
+        try
+        {
+            await using var conn = new NpgsqlConnection(orleansConnectionString);
+            await conn.OpenAsync(cancellationToken);
+
+            await using var cmd = new NpgsqlCommand(
+                "SELECT querykey FROM orleansquery WHERE querykey = ANY(@keys)", conn);
+            cmd.Parameters.AddWithValue("keys", required.ToArray());
+
+            var present = new HashSet<string>(StringComparer.Ordinal);
+            await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
+            {
+                while (await reader.ReadAsync(cancellationToken))
+                    present.Add(reader.GetString(0));
+            }
+
+            var missing = required.Where(k => !present.Contains(k)).ToArray();
+            if (missing.Length > 0)
+            {
+                logger.LogCritical(
+                    "Orleans AdoNet storage is configured but the 'orleans' database is not "
+                    + "provisioned: OrleansQuery is missing {MissingCount} of {RequiredCount} "
+                    + "required query keys ({Missing}). The db-migration container did not run "
+                    + "OrleansClusteringSetup — almost always because ConnectionStrings__orleans "
+                    + "is set on the PORTAL but not on the MIGRATION, where its absence is a "
+                    + "skip. Provision it on the migration and re-run it. Refusing to start the "
+                    + "portal (without this the silo crash-loops on 'Sequence contains no "
+                    + "elements' from AdoNetGrainStorage.Init, which names none of the above).",
+                    missing.Length, required.Length, string.Join(", ", missing));
+                lifetime.StopApplication();
+                return;
+            }
+
+            logger.LogInformation(
+                "Orleans provisioning check passed: all {Count} required OrleansQuery keys are "
+                + "present (membership{Storage}).",
+                required.Length, requiresGrainStorage ? " + grain storage" : "");
+        }
+        catch (PostgresException ex) when (ex.SqlState == "42P01")
+        {
+            // The OrleansQuery table itself is absent — the migration's Orleans phase never ran
+            // at all. This is the #1798 shape exactly.
+            logger.LogCritical(ex,
+                "Orleans AdoNet storage is configured but the 'orleans' database has no "
+                + "OrleansQuery table — OrleansClusteringSetup never ran. Set "
+                + "ConnectionStrings__orleans on the db-migration container and re-run it. "
+                + "Refusing to start the portal.");
+            lifetime.StopApplication();
+        }
+        catch (PostgresException ex) when (ex.SqlState == "3D000")
+        {
+            // The `orleans` DATABASE does not exist. Distinct from the table case: on managed
+            // Postgres the migration deliberately does not CREATE DATABASE, so this points at
+            // provisioning outside the migration rather than at the migration having skipped.
+            logger.LogCritical(ex,
+                "Orleans AdoNet storage is configured but the database named in "
+                + "ConnectionStrings:orleans does not exist. On managed Postgres the migration "
+                + "does not create it — declare it in the AppHost / provision it on the server. "
+                + "Refusing to start the portal.");
+            lifetime.StopApplication();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // 🚨 Host startup was aborted (shutdown raced startup) — that is not a provisioning
+            // verdict. Same lesson as DbVersionGate / issue #1183: honour the IHostedService
+            // cancellation contract instead of misreporting an ordinary shutdown as a critical
+            // failure to provision.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Any other connection / auth error — fail CLOSED, like DbVersionGate. A silo that
+            // cannot verify its clustering store must not join a cluster.
+            logger.LogCritical(ex,
+                "Orleans provisioning check failed unexpectedly against the 'orleans' database. "
+                + "Refusing to start the portal.");
+            lifetime.StopApplication();
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -381,6 +381,22 @@ builder.Services.AddHostedService<Memex.Portal.Distributed.DbVersionGate>();
 builder.Services.AddHealthChecks()
     .AddCheck<Memex.Portal.Distributed.DbVersionHealthCheck>("db_version");
 
+// The same shape, one dependency further out: DbVersionGate proves the MESH database is
+// migrated; this proves the ORLEANS database is provisioned. They are different databases,
+// provisioned by different phases, and #1798 is what happens when only the first is checked —
+// the portal held a valid ConnectionStrings:orleans (so the existing throw above was satisfied)
+// while the MIGRATION's secret lacked it, so OrleansClusteringSetup logged "skipping" and created
+// nothing. AdoNetGrainStorage.Init then died on `Sequence contains no elements`, which names no
+// table, key, or container. Registered ONLY when this silo actually uses AdoNet, and asking for
+// exactly the keys `useAdoNetClustering` causes it to configure, so the gate can never demand
+// more than the deployment uses.
+if (useAdoNetClustering)
+    builder.Services.AddHostedService(sp => new Memex.Portal.Distributed.OrleansProvisioningGate(
+        orleansConnectionString!,
+        requiresGrainStorage: configurePubSubStore is not null,
+        sp.GetRequiredService<IHostApplicationLifetime>(),
+        sp.GetRequiredService<ILogger<Memex.Portal.Distributed.OrleansProvisioningGate>>()));
+
 // Front-load dynamic NodeType compiles at startup so a fresh pod (every image roll /
 // self-update spins one up) doesn't make the first visitor of each type wait out a cold
 // Roslyn compile. The sweep is sequential, in dependency order, and RESUMES from the shared

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-a-silo-checks-its-orleans-database-before-starting.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-17-a-silo-checks-its-orleans-database-before-starting.md
@@ -1,0 +1,46 @@
+---
+Name: A silo checks its Orleans database before starting
+Category: Fix
+Description: A portal configured for AdoNet clustering now refuses to start — naming exactly what to provision — when the orleans database was never set up, instead of crash-looping on an exception that named nothing.
+Icon: DatabaseWarning
+Order: -20260817
+---
+
+# A silo checks its Orleans database before starting
+
+A portal that runs `Features:Orleans:Clustering=AdoNet` needs two databases: the mesh database
+the migration versions, and a separate `orleans` database holding cluster membership and the
+grain storage behind `PubSubStore`. Until now the portal only ever verified the first one.
+
+It did check that it had been *told* where the Orleans database is — startup throws when the
+connection string is missing. But being told where a database is says nothing about whether
+anything ever created it, and those are provisioned by two different containers. When the
+connection string was present on the portal and absent from the **migration**, the migration's
+Orleans phase logged "skipping" at Information and created nothing; the portal then started, and
+the first thing the AdoNet provider did was load its query texts with `.Single()` and throw
+`Sequence contains no elements` into a crash loop.
+
+That message names no table, no key, no connection string and no container — it is the least
+actionable possible rendering of "the database was never provisioned", and a production roll-out
+was reverted on it.
+
+Now both ends of that handover say what they mean:
+
+- The **migration** reads back the `OrleansQuery` rows it was supposed to create and reports them
+  counted — `9 membership + 4 grain-storage query keys present` — instead of reporting a generic
+  completion. If the rows are missing it fails red rather than claiming success, which also closes
+  a gap where a creation script that died part-way left its marker table behind and every later
+  run skipped it as "already present", forever.
+- The **portal** independently re-checks the same rows against the database its silo will actually
+  use, and refuses to start if any are missing — naming which keys are absent and which container
+  to provision.
+
+Two checks of one contract, one where it is produced and one where it is consumed. A deployment
+whose two halves disagree about whether Orleans is in play now fails loudly at startup, pointing at
+the fix, rather than looking healthy until the silo tries to use what is not there.
+
+The check only runs where it applies: it is registered solely when the silo genuinely uses AdoNet
+clustering, and it asks for exactly the keys that deployment's configuration causes it to read — so
+a portal on Azure Tables or Localhost clustering, or one with an in-memory pub-sub store, is
+unaffected. Like the existing database-version gate, it fails closed on anything the database says
+and stays silent when a rollout simply replaced the pod mid-startup.

--- a/test/Memex.Portal.Shared.Test/OrleansProvisioningGateTest.cs
+++ b/test/Memex.Portal.Shared.Test/OrleansProvisioningGateTest.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Distributed;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins <see cref="OrleansProvisioningGate"/> — the consume-side half of the Orleans provisioning
+/// contract (#1798). The produce side (<c>OrleansClusteringSetup.VerifyProvisionedAsync</c>)
+/// asserts the same key set before reporting success; these two independent checks of one contract
+/// are what makes "the migration skipped Orleans" impossible to discover only as a crash loop.
+/// </summary>
+public class OrleansProvisioningGateTest
+{
+    /// <summary>
+    /// A connection string nothing listens on — the gate gets connection-refused immediately on
+    /// loopback. Same device as <see cref="DbVersionGateTest"/>.
+    /// </summary>
+    private const string Unreachable =
+        "Host=127.0.0.1;Port=59322;Username=nobody;Password=nothing;Database=nowhere;Timeout=2";
+
+    private sealed class RecordingLifetime : IHostApplicationLifetime
+    {
+        public bool StopRequested { get; private set; }
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+        public void StopApplication() => StopRequested = true;
+    }
+
+    private static OrleansProvisioningGate Gate(RecordingLifetime lifetime, bool grainStorage = true)
+        => new(Unreachable, grainStorage, lifetime, NullLogger<OrleansProvisioningGate>.Instance);
+
+    /// <summary>
+    /// The gate's reason to exist: a silo that cannot VERIFY its clustering store must not join a
+    /// cluster. Failing open here would reproduce #1798 — the portal starts, and the first thing
+    /// the AdoNet provider does is throw a LINQ exception naming nothing.
+    /// </summary>
+    [Fact]
+    public async Task AnUnverifiableOrleansDatabase_FailsClosed()
+    {
+        var lifetime = new RecordingLifetime();
+
+        await Gate(lifetime).StartAsync(TestContext.Current.CancellationToken);
+
+        lifetime.StopRequested.Should().BeTrue(
+            "a silo configured for AdoNet clustering must refuse to start when it cannot confirm "
+            + "the orleans database is provisioned — otherwise the failure surfaces as a crash "
+            + "loop on 'Sequence contains no elements', which names no table, key or container");
+    }
+
+    /// <summary>
+    /// 🚨 The regression pin inherited from issue #1183 via <see cref="DbVersionGate"/>: a
+    /// cancellation of the HOST's startup token means shutdown raced startup (a rollout replacing
+    /// the pod), which is not a provisioning verdict. Folding it into the catch-all would log a
+    /// critical "refusing to start" for a process that was merely told to stop.
+    /// </summary>
+    [Fact]
+    public async Task AStartupAbortedByShutdown_Propagates_InsteadOfFailingTheGate()
+    {
+        var lifetime = new RecordingLifetime();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => Gate(lifetime).StartAsync(cts.Token));
+
+        lifetime.StopRequested.Should().BeFalse(
+            "an aborted startup is not a provisioning failure — the gate must not StopApplication "
+            + "for a host that is already tearing down");
+    }
+
+    /// <summary>
+    /// The gate asks for exactly what the silo configures. <c>requiresGrainStorage</c> tracks
+    /// whether <c>Program.cs</c> wired an AdoNet <c>PubSubStore</c>, so the gate can never demand
+    /// rows a deployment does not use — the shape that would turn a correct Localhost-PubSub
+    /// deployment into a startup refusal.
+    /// </summary>
+    [Fact]
+    public void RequiredKeys_TrackWhatTheSiloActuallyConfigures()
+    {
+        var membershipOnly = OrleansProvisioningGate.RequiredKeys(requiresGrainStorage: false);
+        var withStorage = OrleansProvisioningGate.RequiredKeys(requiresGrainStorage: true);
+
+        // Clustering is on whenever this gate is registered, so membership keys are always required.
+        Assert.Equal(OrleansProvisioningGate.MembershipQueryKeys, membershipOnly);
+
+        // A deployment with an in-memory PubSubStore never reads the grain-storage queries —
+        // demanding them would turn a correct Localhost-PubSub deployment into a startup refusal.
+        Assert.DoesNotContain(membershipOnly,
+            k => OrleansProvisioningGate.GrainStorageQueryKeys.Contains(k));
+
+        Assert.All(OrleansProvisioningGate.MembershipQueryKeys, k => Assert.Contains(k, withStorage));
+        Assert.All(OrleansProvisioningGate.GrainStorageQueryKeys, k => Assert.Contains(k, withStorage));
+
+        // The two key sets are disjoint — a duplicate would mean one list drifted into the other.
+        Assert.Equal(withStorage.Length, withStorage.Distinct().Count());
+    }
+
+    /// <summary>
+    /// 🚨 The four grain-storage keys are exactly the ones <c>AdoNetGrainStorage.Init</c> loads
+    /// with <c>.Single()</c>. That <c>.Single()</c> is why a missing row presents as
+    /// <c>Sequence contains no elements</c> instead of anything actionable, and it is the whole
+    /// reason this gate exists — so the set is pinned literally rather than being free to drift
+    /// with a refactor.
+    /// </summary>
+    [Fact]
+    public void TheGrainStorageKeys_AreTheOnesAdoNetGrainStorageLoadsWithSingle()
+    {
+        Assert.Equal(
+            new[]
+            {
+                "WriteToStorageKey",
+                "ReadFromStorageKey",
+                "ClearStorageKey",
+                "DeleteStorageKey",
+            },
+            OrleansProvisioningGate.GrainStorageQueryKeys);
+    }
+}


### PR DESCRIPTION
## What

A portal configured for `Features:Orleans:Clustering=AdoNet` needs a second database — `orleans` — provisioned by the **migration** container. The portal verified only that it had been *told* where that database is (the existing throw when `ConnectionStrings:orleans` is unset). It never verified that anything had created it.

In #1798 the connection string was present on the **portal** and absent from the **migration's** secret. `OrleansClusteringSetup` logged `skipping` at Information and created nothing; the portal started; `AdoNetGrainStorage.Init` loaded its query texts with `.Single()` and threw `Sequence contains no elements` into a crash loop. That message names no table, no key, no connection string and no container. Prod was rolled back on it.

## How — producer reports, consumer asserts

Each step emits a signal specific to what it did, and the next step asserts it. `Database migration completed. Version: 53` is the counter-example this fixes: true, and silent about Orleans.

**Migration (`OrleansClusteringSetup`)** reads back the `OrleansQuery` rows it was supposed to create and logs them **counted** — `9 membership + 4 grain-storage query keys` — throwing if any is missing.

That postcondition also closes a second hole. Both phases gate on a marker *table* (`orleansquery` / `orleansstorage`) because their scripts use plain `CREATE` and cannot be re-run. That gate answers *"did something create this table?"*, never *"is its content complete"* — so a script that died part-way leaves the marker behind and **every later run reports "already present — nothing to do", forever**, for a database missing rows the silo requires. A gate that can pass on the wrong evidence is worse than no gate.

**Portal (`OrleansProvisioningGate`, new)** independently re-checks the same rows against the database the silo will actually use, and refuses startup if any are missing — naming the missing keys and the container to provision. Modelled on `DbVersionGate`, including both of its hard-won behaviours:

- fail **closed** on anything the database says (a silo that cannot verify its clustering store must not join a cluster);
- **rethrow** a cancellation of the host's own startup token, so a rollout replacing the pod mid-startup is not misreported as a provisioning failure (#1183).

It distinguishes the two shapes it can find: `42P01` (no `OrleansQuery` table — the migration's Orleans phase never ran, the #1798 shape) from `3D000` (the database itself does not exist — on managed Postgres the migration deliberately does not `CREATE DATABASE`, so that points elsewhere).

## Blast radius

The gate is registered **only** when `useAdoNetClustering`, and asks for exactly the keys that decision causes the silo to configure (`requiresGrainStorage` tracks whether an AdoNet `PubSubStore` was wired). So it can never demand rows a deployment does not use — a portal on Azure Tables or Localhost clustering, or one with an in-memory pub-sub store, is unaffected.

## Tests

`OrleansProvisioningGateTest` (4): fails closed on an unverifiable database; propagates an aborted startup instead of tripping the gate; `RequiredKeys` tracks what the silo configures and the two key sets stay disjoint; and the four grain-storage keys are pinned literally — they are exactly the ones `AdoNetGrainStorage.Init` loads with `.Single()`, which is the whole reason this gate exists, so the set is not free to drift with a refactor.

## Verification

- `dotnet build -c Release -warnaserror` clean: `Memex.Portal.Distributed`, `Memex.Database.Migration`, `Memex.Portal.Shared.Test`.
- `Passed! - Failed: 0, Passed: 4` on the new tests.

(`-warnaserror` earned its keep here: it caught two `CS1574` crefs pointing at the migration project, which the portal only links a single source file from.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)