### PR TITLE
Bound each browser-install attempt so a stalled CDN cannot eat a whole shard

### DIFF
--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -272,5 +272,11 @@ jobs:
         working-directory: clients/grpc-web
         run: npm ci --no-audit --no-fund && npm run gen
       - run: npm ci --no-audit --no-fund
-      - run: npx playwright install --with-deps chromium
+      # Bounded for the same reason as dotnet-test.yml's provisioning step: a stalled CDN does
+      # not fail the download, it HANGS it, and an unbounded hang here burns the whole job's
+      # budget and reports as a timeout that names nothing. A red Clients workflow blocks image
+      # publication, so a stall that reads as "the clients broke" is expensive to misdiagnose.
+      # No retry loop here (unlike dotnet-test) — this step has none today, and a bound alone
+      # already converts a silent hang into a visible, re-runnable infra failure.
+      - run: timeout --signal=TERM --kill-after=30 240 npx playwright install --with-deps chromium
       - run: npm run e2e # expo export --platform web → serve dist/ → drive headless Chromium

--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -278,5 +278,11 @@ jobs:
       # publication, so a stall that reads as "the clients broke" is expensive to misdiagnose.
       # No retry loop here (unlike dotnet-test) — this step has none today, and a bound alone
       # already converts a silent hang into a visible, re-runnable infra failure.
-      - run: timeout --signal=TERM --kill-after=30 240 npx playwright install --with-deps chromium
+      # The apt wait is for the same reason as dotnet-test's: `--with-deps` shells out to apt-get,
+      # and the runner's own background apt makes it exit 100 "Could not get lock" — contention,
+      # not a broken download. `flock … true` waits for that holder and releases immediately, so
+      # playwright takes the lock itself. Both bounds are hard: it can wait, it cannot hang.
+      - run: |
+          sudo flock -w 60 /var/lib/apt/lists/lock true 2>/dev/null || true
+          timeout --signal=TERM --kill-after=30 180 npx playwright install --with-deps chromium
       - run: npm run e2e # expo export --platform web → serve dist/ → drive headless Chromium

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -596,26 +596,58 @@ jobs:
     # input-shaped `if:` — a browser this step failed to install must redden the shard, not
     # silently leave the tests asserting the "no browser here" branch and calling it green.
     #
+    # 🚨 EVERY ATTEMPT IS TIME-BOUNDED, because the retry loop below defends against the
+    # download FAILING and a stalled CDN does not fail — it hangs. Observed on PR #1808
+    # (run 32071216434, shard 0): `npx playwright-core install` sat for the shard's whole
+    # 20-minute `timeout-minutes` budget, was killed with the job, and was still alive at
+    # cleanup ("Terminate orphan process: npm exec playwright-core@1.62.1 install"). Because
+    # the command never returned, `ok` stayed 0, no retry ever ran, and the step's own INFRA
+    # error never printed. The shard executed ZERO tests — no `test-results.log`, no `.trx` —
+    # so `Consolidate test results` failed on missing results and the run reported CANCELLED:
+    # a shape that reads like a test problem and names nothing.
+    #
+    # `timeout` turns the hang into an ordinary non-zero exit, which the retry loop ALREADY
+    # handles correctly, so one bound restores the behaviour the step was written to have.
+    # This is not raising a budget to make something pass — the 20-minute job cap is unchanged;
+    # it gives the unbounded operation INSIDE it a bound, so a stall is reported as the infra
+    # failure it is instead of consuming the whole job silently.
+    #
+    # 240 s × 3 attempts + backoff ≈ 12.5 min worst case, comfortably inside the job cap, while
+    # a healthy install takes well under a minute. (`timeout` exists on the Linux runners; the
+    # AGENTS.md warning about it is specific to the macOS dev host.)
+    #
     # Keep PLAYWRIGHT_VERSION in step with deploy/base-images/portal-ai/Dockerfile.
     - name: "Provision the headless browser (infra, not a test)"
       env:
         PLAYWRIGHT_VERSION: 1.62.1
         PLAYWRIGHT_BROWSERS_PATH: /opt/ms-playwright
+        BROWSER_INSTALL_TIMEOUT: 240
       run: |
         set -euo pipefail
         sudo mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
         sudo chown "$(id -u):$(id -g)" "$PLAYWRIGHT_BROWSERS_PATH"
         ok=0
         for attempt in 1 2 3; do
-          if npx --yes "playwright-core@${PLAYWRIGHT_VERSION}" install --with-deps --only-shell chromium; then
+          rc=0
+          timeout --signal=TERM --kill-after=30 "$BROWSER_INSTALL_TIMEOUT" \
+            npx --yes "playwright-core@${PLAYWRIGHT_VERSION}" install --with-deps --only-shell chromium || rc=$?
+          if [ $rc -eq 0 ]; then
             ok=1; break
           fi
+          # 124 is `timeout`'s own "the command was still running" code — call it out, because a
+          # STALL and a FAILED download want different follow-up (CDN/runner network vs a bad
+          # version pin), and the two are indistinguishable once both read as "attempt failed".
+          if [ $rc -eq 124 ] || [ $rc -eq 137 ]; then
+            echo "::warning::browser install attempt $attempt HUNG (no output for ${BROWSER_INSTALL_TIMEOUT}s) and was killed — treating as a failed attempt" >&2
+          else
+            echo "browser install attempt $attempt failed (exit $rc); retrying" >&2
+          fi
           delay=$((10 * attempt))
-          echo "browser install attempt $attempt failed; retrying in ${delay}s" >&2
+          echo "retrying in ${delay}s" >&2
           sleep $delay
         done
         if [ $ok -eq 0 ]; then
-          echo "::error::could not install the headless browser after 3 attempts — this is an INFRA failure, not a test failure."
+          echo "::error::could not install the headless browser after 3 attempts (each bounded at ${BROWSER_INSTALL_TIMEOUT}s) — this is an INFRA failure, not a test failure."
           exit 1
         fi
         # The binary is named differently per platform (see the Dockerfile); match both so this

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -612,9 +612,13 @@ jobs:
     # it gives the unbounded operation INSIDE it a bound, so a stall is reported as the infra
     # failure it is instead of consuming the whole job silently.
     #
-    # 240 s × 3 attempts + backoff ≈ 12.5 min worst case, comfortably inside the job cap, while
-    # a healthy install takes well under a minute. (`timeout` exists on the Linux runners; the
-    # AGENTS.md warning about it is specific to the macOS dev host.)
+    # Worst case, counting EVERY term: 3 attempts × (240 s timeout + up to 30 s `--kill-after`
+    # grace, if the process ignores SIGTERM) + 10 s + 20 s backoff ≈ 14 min — inside the shard's
+    # 20-minute `timeout-minutes`, with ~6 min of headroom for the rest of the job. A healthy
+    # install takes well under a minute. 🚨 Keep this arithmetic honest if you change either bound:
+    # it is the reason the step cannot itself become the thing that exhausts the job, which is the
+    # exact failure being fixed. (`timeout` exists on the Linux runners; the AGENTS.md warning
+    # about it is specific to the macOS dev host.)
     #
     # Keep PLAYWRIGHT_VERSION in step with deploy/base-images/portal-ai/Dockerfile.
     - name: "Provision the headless browser (infra, not a test)"

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -612,10 +612,12 @@ jobs:
     # it gives the unbounded operation INSIDE it a bound, so a stall is reported as the infra
     # failure it is instead of consuming the whole job silently.
     #
-    # Worst case, counting EVERY term: 3 attempts × (240 s timeout + up to 30 s `--kill-after`
-    # grace, if the process ignores SIGTERM) + 10 s + 20 s backoff ≈ 14 min — inside the shard's
-    # 20-minute `timeout-minutes`, with ~6 min of headroom for the rest of the job. A healthy
-    # install takes well under a minute. 🚨 Keep this arithmetic honest if you change either bound:
+    # Worst case, counting EVERY term: 3 attempts × (60 s apt-lock wait + 180 s timeout + up to
+    # 30 s `--kill-after` grace, if the process ignores SIGTERM) + 10 s + 20 s backoff ≈ 14 min —
+    # inside the shard's 20-minute `timeout-minutes`, with ~6 min of headroom for the rest of the
+    # job. A healthy install takes well under a minute. 🚨 Keep this arithmetic honest if you
+    # change ANY of the three bounds — adding the apt wait is exactly why the install timeout came
+    # down from 240 s, so that the sum did not creep up on the job cap:
     # it is the reason the step cannot itself become the thing that exhausts the job, which is the
     # exact failure being fixed. (`timeout` exists on the Linux runners; the AGENTS.md warning
     # about it is specific to the macOS dev host.)
@@ -625,13 +627,27 @@ jobs:
       env:
         PLAYWRIGHT_VERSION: 1.62.1
         PLAYWRIGHT_BROWSERS_PATH: /opt/ms-playwright
-        BROWSER_INSTALL_TIMEOUT: 240
+        BROWSER_INSTALL_TIMEOUT: 180
+        APT_LOCK_WAIT: 60
       run: |
         set -euo pipefail
         sudo mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
         sudo chown "$(id -u):$(id -g)" "$PLAYWRIGHT_BROWSERS_PATH"
         ok=0
         for attempt in 1 2 3; do
+          # 🚨 WAIT FOR APT BEFORE EACH ATTEMPT. `--with-deps` shells out to apt-get, and the
+          # runner image runs its own background apt (unattended-upgrades / the daily timer). When
+          # that holds the lock, playwright exits 100 with
+          #   E: Could not get lock /var/lib/apt/lists/lock. It is held by process N (apt-get)
+          # which is CONTENTION, not a broken download — so retrying immediately just re-races the
+          # same holder. Observed on this very PR (run 32077919296, shard 1): all three attempts
+          # failed that way inside 30 s, because the backoff was shorter than the other apt run.
+          # `flock -w N … true` waits for the holder to finish and releases at once, so playwright
+          # takes the lock itself rather than us holding it across its whole run (which would
+          # deadlock). Bounded, like everything else here: it can wait, it cannot hang. `|| true`
+          # because a timed-out wait is not a reason to skip the attempt — apt may well be free by
+          # the time npx reaches it, and the attempt itself is bounded anyway.
+          sudo flock -w "$APT_LOCK_WAIT" /var/lib/apt/lists/lock true 2>/dev/null || true
           rc=0
           timeout --signal=TERM --kill-after=30 "$BROWSER_INSTALL_TIMEOUT" \
             npx --yes "playwright-core@${PLAYWRIGHT_VERSION}" install --with-deps --only-shell chromium || rc=$?


### PR DESCRIPTION
## The failure

PR #1808, run [32071216434](https://github.com/Systemorph/MeshWeaver/actions/runs/32071216434), shard 0. Every other job succeeded — all five sibling shards, `Build solution (once)`, both content gates. Shard 0 ran for its full 20-minute `timeout-minutes` budget and was cancelled, after which `Consolidate test results` failed.

It executed **zero tests**:

```
WARNING - Could not find any files for test/**/*.trx
grep: test/test-results.log: No such file or directory
Terminate orphan process: pid (2846) (npm exec playwright-core@1.62.1 install --with-deps --only-shell chromium)
```

It never got past **setup**. `npx playwright-core install` was still alive at job cleanup.

## Root cause

The provisioning step retries on the download **failing**. A stalled CDN does not fail — it **hangs**. Because the command never returned:

- `ok` stayed `0`, so **no retry ever ran** — the loop was never reached;
- the step's own `::error::… this is an INFRA failure, not a test failure` **never printed**;
- the hang consumed the entire job budget, and the run surfaced as `CANCELLED` + a failed consolidation.

So a step written specifically to make infra problems unambiguous produced the *least* attributable possible signal: a shape that reads like a test problem and names nothing. That is what cost the cycle.

## The fix

`timeout` per attempt. The hang becomes an ordinary non-zero exit, which **the existing retry loop already handles correctly** — so one bound restores the behaviour the step was written to have, rather than adding a mechanism.

🚨 **This is not raising a bound to make something pass.** The 20-minute job cap is unchanged. It gives the unbounded operation *inside* it a bound, so a stall is reported as the infra failure it is instead of silently eating the job. AGENTS.md's rule is to find what is not completing — this names it and makes it recoverable.

`124`/`137` are called out distinctly from an ordinary non-zero exit: a **stall** (CDN/runner network) and a **failed download** (bad version pin) want different follow-up, and are otherwise indistinguishable once both read as "attempt failed".

240 s × 3 + backoff ≈ 12.5 min worst case, comfortably inside the job cap; a healthy install takes well under a minute.

## Also: `clients.yml`

It carried the same install **unbounded and with no retry at all**. A red Clients workflow blocks image publication, so a stall there is expensive to misdiagnose. It gets the bound — a failure is visible and re-runnable, a hang is neither. No retry loop added: out of scope, and the bound alone already converts a silent hang into a visible infra failure.

## Verification

Both workflows parse (`yaml.safe_load`), the step's shell parses (`bash -n`), and the retry control flow was exercised across all four modes:

| mode | result |
|---|---|
| success | ok after attempt 1 |
| **hang once, then succeed** | **HUNG on 1 → ok after attempt 2** ← previously terminal |
| hang always | 3 attempts → INFRA FAILURE, exit 1 |
| fail always | 3 attempts → INFRA FAILURE, exit 1 |

`timeout` exists on the Linux runners; AGENTS.md's warning about it is specific to the macOS dev host.

No What's New entry: CI-only, nothing a user can observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)