### PR TITLE
fix(layout): read the string binding values the docs actually document (#1657, #1658)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-documented-layout-values-now-apply.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-documented-layout-values-now-apply.md
@@ -1,0 +1,23 @@
+---
+Name: Documented layout values now actually apply
+Category: Fix
+Description: A CSS length like "8px" or a lowercase alignment like "center" — both straight from the layout docs — used to be dropped silently; they now bind as written.
+Icon: Bug
+Order: -20260818
+---
+
+# Documented layout values now actually apply
+
+The layout documentation has always shown stack gaps as CSS lengths (`"8px"`, `"1rem"`) and
+alignments as lowercase words (`"start"`, `"center"`, `"end"`). Following it did not work: the
+client-side conversion parsed a gap as a plain integer and an alignment with an exact-case match, so
+both of those documented values failed to convert, were replaced by the default, and left an error
+line in the log on every render.
+
+Sizes now accept a CSS unit — `px`, `%`, `rem`, `em` and the rest of the CSS set — and alignment and
+orientation words are matched without regard to case. Numbers are read the same way everywhere in the
+world: `"1.5"` is one-and-a-half whether or not the server happens to sit in a comma-decimal locale.
+
+A value that genuinely cannot be read no longer throws mid-render. It falls back to the property's
+default, which is what a viewer already saw, without tearing down the live binding for the rest of the
+page.

--- a/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
+++ b/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
@@ -456,7 +456,7 @@ public static class LayoutClientExtensions
         // "1.5rem" yields 1.5 rather than a guessed 24. px is the unit every framework example uses and the
         // one these numeric slots are already denominated in; the other units are accepted so a
         // hand-authored node degrades to a plausible number instead of to nothing.
-        var number = StripCssUnit(s);
+        var number = StripCssUnit(s);   // a span into s — no allocation
 
         // Parse INVARIANT, never CurrentCulture. These strings arrive off the wire as JSON or CSS, where
         // "1.5" always means one-and-a-half; `double.Parse("1.5")` on a comma-decimal thread reads 15.
@@ -479,11 +479,12 @@ public static class LayoutClientExtensions
 
     /// <summary>
     /// Returns <paramref name="s"/> with a trailing CSS unit removed ("8px" → "8", "-4px" → "-4",
-    /// "1.5rem" → "1.5", "50%" → "50"), or unchanged when it carries none.
+    /// "1.5rem" → "1.5", "50%" → "50"), or unchanged when it carries none. Stays a span the whole way —
+    /// the number is handed straight to the span TryParse overloads, so the render path allocates nothing.
     /// </summary>
-    private static string StripCssUnit(string s)
+    private static ReadOnlySpan<char> StripCssUnit(ReadOnlySpan<char> s)
     {
-        var span = s.AsSpan().Trim();
+        var span = s.Trim();
         var digits = span.Length;
         while (digits > 0 && !char.IsAsciiDigit(span[digits - 1]) && span[digits - 1] != '.')
             digits--;
@@ -491,7 +492,7 @@ public static class LayoutClientExtensions
         // keeps the tolerance narrow: "8 apples" and "auto" stay unreadable (→ the default) rather than
         // silently becoming 8 and 0.
         return digits > 0 && digits < span.Length && IsCssUnit(span[digits..])
-            ? span[..digits].ToString()
+            ? span[..digits]
             : s;
     }
 
@@ -499,16 +500,27 @@ public static class LayoutClientExtensions
     /// The CSS length and percentage units a bound layout value may carry. `px` and `%` are what the
     /// framework's controls and docs actually emit; the rest are the CSS spec's remaining length units,
     /// listed so a hand-authored `"1.5rem"` / `"2em"` / `"50vh"` reads the same way. Units are
-    /// case-insensitive in CSS ("8PX" is legal), hence the normalization before the match.
+    /// case-insensitive in CSS ("8PX" is legal), hence the fold before the match — done in a stack
+    /// buffer rather than via ToString(), because this sits on the render path and a per-binding
+    /// allocation there is per-frame GC pressure.
     /// </summary>
-    private static bool IsCssUnit(ReadOnlySpan<char> unit) =>
-        unit.ToString().ToLowerInvariant() switch
+    private static bool IsCssUnit(ReadOnlySpan<char> unit)
+    {
+        // Every unit below is at most four characters; the length cap is also what bounds the buffer.
+        if (unit.Length is 0 or > MaxCssUnitLength)
+            return false;
+        Span<char> lower = stackalloc char[MaxCssUnitLength];
+        unit.ToLowerInvariant(lower);
+        return lower[..unit.Length] switch
         {
             "%" or "px" or "rem" or "em" or "ex" or "ch" or "cap" or "ic" or "lh" or "rlh" => true,
             "vw" or "vh" or "vmin" or "vmax" or "vi" or "vb" => true,
             "cm" or "mm" or "q" or "in" or "pt" or "pc" or "fr" => true,
             _ => false
         };
+    }
+
+    private const int MaxCssUnitLength = 4;
 
     /// <summary>
     /// Reads an integral magnitude, accepting a fractional one by truncating it — the same thing
@@ -516,12 +528,19 @@ public static class LayoutClientExtensions
     /// slot behaves like 1.5 in an `int` slot instead of vanishing. Out of range yields <c>false</c>
     /// (→ the default), never an OverflowException thrown out of a render.
     /// </summary>
-    private static bool TryReadIntegral(string s, long min, long max, out long value)
+    private static bool TryReadIntegral(ReadOnlySpan<char> s, long min, long max, out long value)
     {
         if (!long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
         {
+            // The exact parse failed, so this is a fractional magnitude ("1.5rem"). Range-check it as a
+            // double BEFORE truncating — and cap at 2^53, past which a double no longer represents
+            // integers exactly: `(double)long.MaxValue` rounds UP, so a `d > max` test alone lets a value
+            // one ulp too large through and the cast then wraps to long.MinValue rather than failing.
+            // Nothing that size is a layout length; refusing it is the honest answer.
+            const double exactIntegerLimit = 9007199254740992d; // 2^53
             if (!double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var d)
-                || double.IsNaN(d) || double.IsInfinity(d) || d < min || d > max)
+                || double.IsNaN(d) || double.IsInfinity(d)
+                || Math.Abs(d) > exactIntegerLimit || d < min || d > max)
             {
                 value = 0;
                 return false;

--- a/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
+++ b/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Linq;
+﻿using System.Globalization;
+using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -241,6 +242,9 @@ public static class LayoutClientExtensions
     /// <paramref name="conversion"/> when provided, or the hub's JSON serializer and built-in
     /// type coercion otherwise. Handles <see cref="System.Text.Json.JsonElement"/>,
     /// <see cref="System.Text.Json.Nodes.JsonObject"/>, strings, and numeric types.
+    /// A raw string is read tolerantly — enums case-insensitively, numerics with a CSS unit suffix
+    /// stripped and the invariant culture — and an unreadable one yields <paramref name="defaultValue"/>
+    /// rather than throwing out of the render.
     /// </summary>
     /// <typeparam name="T">The target type to produce.</typeparam>
     /// <param name="hub">The hub whose JSON serializer options are used for deserialization.</param>
@@ -269,7 +273,7 @@ public static class LayoutClientExtensions
             JsonNode node => node.Deserialize<T>(hub.JsonSerializerOptions),
             // ReSharper restore ExpressionIsAlwaysNull
             T t => t,
-            string s => ConvertString<T>(s),
+            string s => hub.ConvertString(s, defaultValue),
             _ => ConvertNullableOrNumericValue(value, defaultValue)
         };
     }
@@ -422,25 +426,129 @@ public static class LayoutClientExtensions
         return s != null;
     }
 
-    private static T ConvertString<T>(string s)
+    /// <summary>
+    /// Parses a raw string binding value into <typeparamref name="T"/>. TOTAL by design: every form the
+    /// layout layer legitimately emits (a mis-cased enum literal, a CSS length) converts, and anything
+    /// genuinely unreadable degrades to <paramref name="defaultValue"/> instead of throwing.
+    /// </summary>
+    private static T? ConvertString<T>(this IMessageHub hub, string s, T? defaultValue)
     {
         var targetType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+        // Case-INSENSITIVE, mirroring the enum branch of GetDataBoundValue above — this is the same fix,
+        // on the sibling path that was missed. The lowercase form is not a mistake to tolerate, it is the
+        // DOCUMENTED one: Stack.md's configuration table lists `"start"`, `"center"`, `"end"` for
+        // WithHorizontalAlignment/WithVerticalAlignment while the CLR members are PascalCase, so a bare
+        // (case-sensitive) Enum.Parse rejects exactly what the docs tell an author to write — issue #1658,
+        // HorizontalAlignment "center" in Area Play/5.
         if (targetType.IsEnum)
-            return (T)Enum.Parse(targetType, s);
-        return Type.GetTypeCode(targetType) switch
+            return Enum.TryParse(targetType, s, ignoreCase: true, out var parsedEnum)
+                ? (T)parsedEnum!
+                : Unreadable(hub, s, defaultValue);
+
+        // The skin properties carrying sizes are `object?`, and every example in the framework's own docs
+        // fills them with a CSS length — Stack.md lists `"8px"`, `"1rem"`, `"16px"` for WithVerticalGap /
+        // WithHorizontalGap — while the Blazor view binds them into `int?` (LayoutStackView's
+        // VerticalGap/HorizontalGap, px-valued for FluentStack). So a bare int.Parse throws on the
+        // documented call site — issue #1657, "8px" in Area Play/4. Strip the unit and read the magnitude.
+        //
+        // No unit CONVERSION happens: there is no root font size and no containing box on this path, so
+        // "1.5rem" yields 1.5 rather than a guessed 24. px is the unit every framework example uses and the
+        // one these numeric slots are already denominated in; the other units are accepted so a
+        // hand-authored node degrades to a plausible number instead of to nothing.
+        var number = StripCssUnit(s);
+
+        // Parse INVARIANT, never CurrentCulture. These strings arrive off the wire as JSON or CSS, where
+        // "1.5" always means one-and-a-half; `double.Parse("1.5")` on a comma-decimal thread reads 15.
+        object? converted = Type.GetTypeCode(targetType) switch
         {
-            TypeCode.Int32 => (T)(object)int.Parse(s),
-            TypeCode.Double => (T)(object)double.Parse(s),
-            TypeCode.Single => (T)(object)float.Parse(s),
-            TypeCode.Boolean => (T)(object)bool.Parse(s),
-            TypeCode.Int64 => (T)(object)long.Parse(s),
-            TypeCode.Int16 => (T)(object)short.Parse(s),
-            TypeCode.Byte => (T)(object)byte.Parse(s),
-            TypeCode.Char => (T)(object)char.Parse(s),
-            TypeCode.DateTime => (T)(object)DateTime.Parse(s),
-            _ => throw new InvalidOperationException($"Cannot convert {s} to {typeof(T)}")
+            TypeCode.Int32 => TryReadIntegral(number, int.MinValue, int.MaxValue, out var i32) ? (object)(int)i32 : null,
+            TypeCode.Int64 => TryReadIntegral(number, long.MinValue, long.MaxValue, out var i64) ? (object)i64 : null,
+            TypeCode.Int16 => TryReadIntegral(number, short.MinValue, short.MaxValue, out var i16) ? (object)(short)i16 : null,
+            TypeCode.Byte => TryReadIntegral(number, byte.MinValue, byte.MaxValue, out var u8) ? (object)(byte)u8 : null,
+            TypeCode.Double => double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out var dbl) ? dbl : null,
+            TypeCode.Single => float.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out var flt) ? flt : null,
+            TypeCode.Boolean => bool.TryParse(s, out var b) ? b : null,
+            TypeCode.Char => s.Length == 1 ? s[0] : null,
+            TypeCode.DateTime => DateTime.TryParse(s, out var dt) ? dt : null,
+            _ => null
         };
 
+        return converted is null ? Unreadable(hub, s, defaultValue) : (T)converted;
+    }
+
+    /// <summary>
+    /// Returns <paramref name="s"/> with a trailing CSS unit removed ("8px" → "8", "-4px" → "-4",
+    /// "1.5rem" → "1.5", "50%" → "50"), or unchanged when it carries none.
+    /// </summary>
+    private static string StripCssUnit(string s)
+    {
+        var span = s.AsSpan().Trim();
+        var digits = span.Length;
+        while (digits > 0 && !char.IsAsciiDigit(span[digits - 1]) && span[digits - 1] != '.')
+            digits--;
+        // The suffix must be a RECOGNISED unit, and there must be a number in front of it. That is what
+        // keeps the tolerance narrow: "8 apples" and "auto" stay unreadable (→ the default) rather than
+        // silently becoming 8 and 0.
+        return digits > 0 && digits < span.Length && IsCssUnit(span[digits..])
+            ? span[..digits].ToString()
+            : s;
+    }
+
+    /// <summary>
+    /// The CSS length and percentage units a bound layout value may carry. `px` and `%` are what the
+    /// framework's controls and docs actually emit; the rest are the CSS spec's remaining length units,
+    /// listed so a hand-authored `"1.5rem"` / `"2em"` / `"50vh"` reads the same way. Units are
+    /// case-insensitive in CSS ("8PX" is legal), hence the normalization before the match.
+    /// </summary>
+    private static bool IsCssUnit(ReadOnlySpan<char> unit) =>
+        unit.ToString().ToLowerInvariant() switch
+        {
+            "%" or "px" or "rem" or "em" or "ex" or "ch" or "cap" or "ic" or "lh" or "rlh" => true,
+            "vw" or "vh" or "vmin" or "vmax" or "vi" or "vb" => true,
+            "cm" or "mm" or "q" or "in" or "pt" or "pc" or "fr" => true,
+            _ => false
+        };
+
+    /// <summary>
+    /// Reads an integral magnitude, accepting a fractional one by truncating it — the same thing
+    /// <see cref="ConvertDoubleToInteger{T}"/> already does for a bound double, so "1.5rem" in an `int`
+    /// slot behaves like 1.5 in an `int` slot instead of vanishing. Out of range yields <c>false</c>
+    /// (→ the default), never an OverflowException thrown out of a render.
+    /// </summary>
+    private static bool TryReadIntegral(string s, long min, long max, out long value)
+    {
+        if (!long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+        {
+            if (!double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var d)
+                || double.IsNaN(d) || double.IsInfinity(d) || d < min || d > max)
+            {
+                value = 0;
+                return false;
+            }
+            value = (long)Math.Truncate(d);
+        }
+        return value >= min && value <= max;
+    }
+
+    /// <summary>
+    /// Reports a string the conversion could not read and yields <paramref name="defaultValue"/>.
+    /// </summary>
+    /// <remarks>
+    /// Degrading rather than throwing is what the neighbouring <c>ConvertJson</c> and
+    /// <c>GetDataBoundValue</c> already do, and it is what this path needs: <c>ConvertSingle</c> is called
+    /// from <c>DataBind</c>'s <c>Select</c>, so a throw does not just drop one value — it faults the
+    /// observable and kills the binding for the lifetime of the view.
+    /// Logged at Debug, matching <c>GetDataBoundValue</c>: this runs on the render path, where one bad
+    /// literal must not become a per-frame `fail` line (the storm the Icon branch of ConvertSingle was
+    /// fixed for). Nothing is hidden that was previously visible — <c>BlazorView.DataBind</c> caught the
+    /// throw and applied the default anyway, so the outcome is unchanged and only the noise is gone.
+    /// </remarks>
+    private static T? Unreadable<T>(IMessageHub hub, string s, T? defaultValue)
+    {
+        hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Layout.ConvertString")
+            .LogDebug("ConvertString<{Type}> could not read '{Value}' — using default", typeof(T).Name, s);
+        return defaultValue;
     }
 
     private static T? ConvertJson<T>(this IMessageHub hub, JsonElement? value, Func<object?, T?, T?>? conversion, T? defaultValue = default(T))

--- a/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Globalization;
 using System.Text.Json;
 using MeshWeaver.Fixture;
 using MeshWeaver.Layout.Client;
@@ -541,5 +542,211 @@ public class LayoutClientExtensionsTest(ITestOutputHelper output) : HubTestBase(
         var result = hub.ConvertSingle<Icon>(icon, null);
 
         result.Should().BeSameAs(icon);
+    }
+
+    // ---- Issues #1657 / #1658: a raw STRING binding value must be read the way the layout layer -----
+    // (and its own documentation) actually writes one. Both defects lived in ConvertString<T>, reached
+    // from ConvertSingle's `string s =>` arm, which BlazorView.DataBind calls with no conversion:
+    //   #1658  Enum.Parse(targetType, s) is case-SENSITIVE → ArgumentException on "center", while
+    //          Stack.md's configuration table documents `"start"` / `"center"` / `"end"` for
+    //          WithHorizontalAlignment. Observed in prod on Area Play/5.
+    //   #1657  int.Parse(s) → FormatException on "8px", while Stack.md documents `"8px"` / `"1rem"` /
+    //          `"16px"` for WithVerticalGap / WithHorizontalGap — which LayoutStackView binds into
+    //          `int?`. Observed in prod on Area Play/4 (10 occurrences in 12 s).
+    // Both threw out to DataBind, which logged `fail` and applied the default, so the documented value
+    // was DROPPED on every render. The conversion must now read them, and stay TOTAL: an unreadable
+    // string degrades to the default rather than faulting the DataBind observable.
+
+    [Fact]
+    public void ConvertSingle_LowerCaseEnumString_ResolvesCaseInsensitively()
+    {
+        var hub = GetHost();
+
+        var result = hub.ConvertSingle<HorizontalAlignment>("center", null);
+
+        result.Should().Be(HorizontalAlignment.Center,
+            "the docs teach the lowercase form; a case-sensitive Enum.Parse rejected it (#1658)");
+    }
+
+    [Fact]
+    public void ConvertSingle_MixedCaseEnumString_ResolvesCaseInsensitively()
+    {
+        var hub = GetHost();
+
+        hub.ConvertSingle<HorizontalAlignment>("sTaRt", null).Should().Be(HorizontalAlignment.Start);
+        hub.ConvertSingle<Orientation>("horizontal", null).Should().Be(Orientation.Horizontal);
+    }
+
+    [Fact]
+    public void ConvertSingle_ExactCaseEnumString_StillResolves()
+    {
+        var hub = GetHost();
+
+        hub.ConvertSingle<HorizontalAlignment>("End", null).Should().Be(HorizontalAlignment.End);
+    }
+
+    [Fact]
+    public void ConvertSingle_LowerCaseEnumString_ToNullableEnum_Resolves()
+    {
+        // The skin properties are object? and the views bind them into nullable enums.
+        var hub = GetHost();
+
+        hub.ConvertSingle<HorizontalAlignment?>("center", null).Should().Be(HorizontalAlignment.Center);
+    }
+
+    [Fact]
+    public void ConvertSingle_UnknownEnumString_ReturnsDefaultInsteadOfThrowing()
+    {
+        var hub = GetHost();
+
+        var result = hub.ConvertSingle("not-an-alignment", null, HorizontalAlignment.Right);
+
+        result.Should().Be(HorizontalAlignment.Right,
+            "a genuinely unknown literal degrades to the default — a throw would fault the DataBind stream");
+    }
+
+    [Fact]
+    public void ConvertSingle_PxString_ToInt_StripsTheUnit()
+    {
+        var hub = GetHost();
+
+        var result = hub.ConvertSingle<int>("8px", null);
+
+        result.Should().Be(8, "\"8px\" is the documented WithHorizontalGap value and threw FormatException (#1657)");
+    }
+
+    [Fact]
+    public void ConvertSingle_PxString_ToNullableInt_StripsTheUnit()
+    {
+        // LayoutStackView's VerticalGap/HorizontalGap are int? — the exact prod binding.
+        var hub = GetHost();
+
+        hub.ConvertSingle<int?>("16px", null).Should().Be(16);
+    }
+
+    [Fact]
+    public void ConvertSingle_NegativePxString_ToInt_KeepsTheSign()
+    {
+        var hub = GetHost();
+
+        hub.ConvertSingle<int>("-4px", null).Should().Be(-4);
+    }
+
+    [Fact]
+    public void ConvertSingle_PercentString_ToInt_StripsTheUnit()
+    {
+        var hub = GetHost();
+
+        hub.ConvertSingle<int>("50%", null).Should().Be(50);
+    }
+
+    [Fact]
+    public void ConvertSingle_RemString_ToDouble_KeepsTheMagnitude()
+    {
+        var hub = GetHost();
+
+        hub.ConvertSingle<double>("1.5rem", null).Should().Be(1.5,
+            "the magnitude is read as authored — no root font size exists on this path, so no unit conversion is invented");
+    }
+
+    [Fact]
+    public void ConvertSingle_FractionalCssLength_ToInt_Truncates()
+    {
+        // Same rule ConvertDoubleToInteger already applies to a bound double: 1.5 in an int slot is 1.
+        var hub = GetHost();
+
+        hub.ConvertSingle<int>("1.5rem", null).Should().Be(1);
+    }
+
+    [Fact]
+    public void ConvertSingle_UpperCaseCssUnit_StripsTheUnit()
+    {
+        // CSS units are case-insensitive.
+        var hub = GetHost();
+
+        hub.ConvertSingle<int>("12PX", null).Should().Be(12);
+    }
+
+    [Fact]
+    public void ConvertSingle_PlainNumberString_ToInt_StillWorks()
+    {
+        // Regression: the unit-stripping must not disturb a plain number.
+        var hub = GetHost();
+
+        hub.ConvertSingle<int>("42", null).Should().Be(42);
+    }
+
+    [Fact]
+    public void ConvertSingle_DecimalString_ParsesInvariant_OnACommaDecimalThread()
+    {
+        // These strings arrive off the wire as JSON or CSS, where "1.5" is always one-and-a-half.
+        // double.Parse(CurrentCulture) on a comma-decimal thread reads it as 15.
+        var hub = GetHost();
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            hub.ConvertSingle<double>("1.5", null).Should().Be(1.5);
+            hub.ConvertSingle<double>("1.5rem", null).Should().Be(1.5);
+            hub.ConvertSingle<int>("8px", null).Should().Be(8);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    [Fact]
+    public void ConvertSingle_UnitOnlyKeyword_ReturnsDefaultInsteadOfThrowing()
+    {
+        // "auto"/"none" are legal CSS for a string slot but meaningless in a numeric one.
+        var hub = GetHost();
+
+        hub.ConvertSingle("auto", null, 7).Should().Be(7);
+        hub.ConvertSingle("none", null, 7).Should().Be(7);
+    }
+
+    [Fact]
+    public void ConvertSingle_UnrecognisedSuffix_ReturnsDefault_SoTheToleranceStaysNarrow()
+    {
+        // Only a RECOGNISED CSS unit is stripped: "8 apples" must not quietly become 8.
+        var hub = GetHost();
+
+        hub.ConvertSingle("8 apples", null, 7).Should().Be(7);
+        hub.ConvertSingle("8apples", null, 7).Should().Be(7);
+    }
+
+    [Fact]
+    public void ConvertSingle_UnreadableNumericString_ReturnsDefaultInsteadOfThrowing()
+    {
+        var hub = GetHost();
+
+        hub.ConvertSingle("not-a-number", null, 99).Should().Be(99);
+    }
+
+    [Fact]
+    public void ConvertSingle_UnsupportedTargetType_ReturnsDefaultInsteadOfThrowing()
+    {
+        // Previously an InvalidOperationException ("Cannot convert ... to ...") thrown from inside
+        // DataBind's Select, which faults the observable and kills the binding for the view's lifetime.
+        var hub = GetHost();
+        var fallback = Guid.NewGuid();
+
+        hub.ConvertSingle("whatever", null, fallback).Should().Be(fallback);
+    }
+
+    [Fact]
+    public void ConvertSingle_BooleanAndDateTimeStrings_StillParse()
+    {
+        // Regression: the non-numeric branches keep working, and stop throwing on a bad value.
+        var hub = GetHost();
+
+        hub.ConvertSingle<bool>("true", null).Should().BeTrue();
+        hub.ConvertSingle<bool>("TRUE", null).Should().BeTrue();
+        hub.ConvertSingle("not-a-bool", null, true).Should().BeTrue("an unreadable bool degrades to the default");
+        hub.ConvertSingle<DateTime>("2026-08-16T08:32:47Z", null).ToUniversalTime()
+            .Should().Be(new DateTime(2026, 8, 16, 8, 32, 47, DateTimeKind.Utc));
+        hub.ConvertSingle<char>("x", null).Should().Be('x');
     }
 }

--- a/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
@@ -698,6 +698,18 @@ public class LayoutClientExtensionsTest(ITestOutputHelper output) : HubTestBase(
     }
 
     [Fact]
+    public void ConvertSingle_AbsurdlyLargeCssLength_ReturnsDefault_NeverAWrappedNumber()
+    {
+        // A fractional magnitude is truncated through a double, so the range check has to happen in
+        // double space — where (double)long.MaxValue rounds UP. Without the 2^53 cap the cast wraps and
+        // this returns long.MinValue: a wrong number, silently, instead of the default.
+        var hub = GetHost();
+
+        hub.ConvertSingle("9223372036854775808.5px", null, 7L).Should().Be(7L);
+        hub.ConvertSingle("1e30px", null, 7).Should().Be(7);
+    }
+
+    [Fact]
     public void ConvertSingle_UnitOnlyKeyword_ReturnsDefaultInsteadOfThrowing()
     {
         // "auto"/"none" are legal CSS for a string slot but meaningless in a numeric one.


### PR DESCRIPTION
Closes #1657
Closes #1658

Both defects live in the same private method — `LayoutClientExtensions.ConvertString<T>(string)`, reached from `ConvertSingle`'s `string s =>` arm, which `BlazorView.DataBind` calls with no conversion — so they are fixed together.

## What was wrong, and why it is not a "model misconfiguration"

Both issues suggest the offending value might be an authoring mistake. It is not: **both values are what the framework's own documentation tells an author to write.**

`src/MeshWeaver.Documentation/Data/GUI/ContainerControl/Stack.md`, the Stack configuration reference:

| Method | Purpose | Example values |
|---|---|---|
| `WithVerticalGap(gap)` | Space between items on the vertical axis | `"8px"`, `"1rem"`, `"16px"` |
| `WithHorizontalGap(gap)` | Space between items on the horizontal axis | `"8px"`, `"1rem"`, `"16px"` |
| `WithHorizontalAlignment(align)` | Cross-axis or main-axis horizontal alignment | `"start"`, `"center"`, `"end"` |

…and its "Right-Aligned Button Group" pattern is literally `.WithHorizontalGap("8px").WithHorizontalAlignment("end")`. `"8px"` appears 209 times and `"%"` 138 times across the layout layer and its docs.

The skin properties (`LayoutStackSkin.HorizontalGap`, `.HorizontalAlignment`, …) are `object?`, so the string survives to the client, where `LayoutStackView` binds the gaps into `int?` and the alignments into an enum. There `ConvertString` did:

```csharp
if (targetType.IsEnum)
    return (T)Enum.Parse(targetType, s);          // #1658 — case-SENSITIVE
return Type.GetTypeCode(targetType) switch
{
    TypeCode.Int32 => (T)(object)int.Parse(s),    // #1657 — no unit, and CurrentCulture
    ...
    _ => throw new InvalidOperationException($"Cannot convert {s} to {typeof(T)}")
};
```

So the documented value threw, `BlazorView.DataBind` caught it, logged `fail:` and applied the default — **on every render**. The value was silently dropped and the log filled up.

`GetDataBoundValue<T>` in the same file already carried the case-insensitive, non-throwing enum fix (from the 2026-06-21 DataGrid render crash). `ConvertString` is the sibling path that was missed — #1658 is that same fix, applied where it belongs.

## Before / after

Measured by running the new tests against `origin/main`'s `ConvertString` (17 of the 19 new cases fail, with the *exact* exception texts from the two issues) and then against the fix:

| input | target | before | after |
|---|---|---|---|
| `"center"` | `HorizontalAlignment` | `ArgumentException: Requested value 'center' was not found.` | `Center` |
| `"sTaRt"` | `HorizontalAlignment` | `ArgumentException: Requested value 'sTaRt' was not found.` | `Start` |
| `"center"` | `HorizontalAlignment?` | `ArgumentException` | `Center` |
| `"8px"` | `int` | `FormatException: The input string '8px' was not in a correct format.` | `8` |
| `"16px"` | `int?` | `FormatException` | `16` |
| `"-4px"` | `int` | `FormatException` | `-4` |
| `"50%"` | `int` | `FormatException` | `50` |
| `"12PX"` | `int` | `FormatException` | `12` |
| `"1.5rem"` | `double` | `FormatException` | `1.5` |
| `"1.5rem"` | `int` | `FormatException` | `1` (truncated) |
| `"1.5"` on a `de-DE` thread | `double` | **`15`** | `1.5` |
| `"42"` | `int` | `42` | `42` (unchanged) |
| `"End"` | `HorizontalAlignment` | `End` | `End` (unchanged) |
| `"auto"` / `"8 apples"` / `"not-a-number"` | `int` | `FormatException` | the caller's default |
| `"whatever"` | `Guid` | `InvalidOperationException` | the caller's default |

The `de-DE` row is a third, unreported bug the fix removes: `double.Parse(s)` used `CurrentCulture`, so a comma-decimal server read `"1.5"` as **fifteen**. These strings come off the wire as JSON or CSS, where the decimal point is invariant.

## The change

`src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs`

1. **Enums parse case-insensitively** (`Enum.TryParse(..., ignoreCase: true)`), matching `GetDataBoundValue`.
2. **A trailing CSS unit is stripped before parsing** — `StripCssUnit` + `IsCssUnit`. The suffix must be a *recognised* CSS length/percentage unit (`px`, `%`, `rem`, `em`, `ex`, `ch`, `cap`, `ic`, `lh`, `rlh`, `vw`, `vh`, `vmin`, `vmax`, `vi`, `vb`, `cm`, `mm`, `q`, `in`, `pt`, `pc`, `fr`, case-insensitively) with a number in front of it, which is what keeps the tolerance narrow: `"8 apples"` and `"auto"` stay unreadable rather than quietly becoming `8` and `0`.
   **No unit conversion is invented.** There is no root font size and no containing box on this path, so `"1.5rem"` yields `1.5`, not a guessed `24`. `px` is the unit every framework example uses and the one these numeric slots are already denominated in; the rest are accepted so a hand-authored node degrades to a plausible number instead of to nothing. A fractional magnitude in an integer slot is truncated — exactly what `ConvertDoubleToInteger` already does for a bound `double`.
3. **Numbers parse with `CultureInfo.InvariantCulture`.**
4. **The method is now total: an unreadable value logs at Debug and returns `defaultValue` instead of throwing.**

### Why degrade rather than throw (the judgement call the issue asks for)

Consistent with both neighbours: `ConvertJson` logs and returns `defaultValue`, and `GetDataBoundValue` catches, logs at Debug and returns `default`. This path needs it more than either — `ConvertSingle` is called from `DataBind`'s `Select`, so a throw does not just drop one value, it **faults the observable and kills the binding for the lifetime of the view**.

This hides nothing that was previously visible: `BlazorView.DataBind` already caught the throw and applied the same default, so the *outcome* is unchanged for a genuinely bad value — only the per-render `fail:` line goes away, which is the storm the two issues are reporting. Debug rather than Error because this runs on the render path, the same reasoning that fixed the `Icon` branch of `ConvertSingle`.

## Tests

`test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs` — 19 new cases in a new section. Each is pinned non-vacuous: reverting only the `src` change makes 17 of them fail (the other two, `ConvertSingle_ExactCaseEnumString_StillResolves` and `ConvertSingle_PlainNumberString_ToInt_StillWorks`, are deliberate regression guards that must pass both ways).

- `ConvertSingle_LowerCaseEnumString_ResolvesCaseInsensitively`
- `ConvertSingle_MixedCaseEnumString_ResolvesCaseInsensitively`
- `ConvertSingle_ExactCaseEnumString_StillResolves`
- `ConvertSingle_LowerCaseEnumString_ToNullableEnum_Resolves`
- `ConvertSingle_UnknownEnumString_ReturnsDefaultInsteadOfThrowing`
- `ConvertSingle_PxString_ToInt_StripsTheUnit`
- `ConvertSingle_PxString_ToNullableInt_StripsTheUnit`
- `ConvertSingle_NegativePxString_ToInt_KeepsTheSign`
- `ConvertSingle_PercentString_ToInt_StripsTheUnit`
- `ConvertSingle_RemString_ToDouble_KeepsTheMagnitude`
- `ConvertSingle_FractionalCssLength_ToInt_Truncates`
- `ConvertSingle_UpperCaseCssUnit_StripsTheUnit`
- `ConvertSingle_PlainNumberString_ToInt_StillWorks`
- `ConvertSingle_DecimalString_ParsesInvariant_OnACommaDecimalThread`
- `ConvertSingle_UnitOnlyKeyword_ReturnsDefaultInsteadOfThrowing`
- `ConvertSingle_UnrecognisedSuffix_ReturnsDefault_SoTheToleranceStaysNarrow`
- `ConvertSingle_UnreadableNumericString_ReturnsDefaultInsteadOfThrowing`
- `ConvertSingle_UnsupportedTargetType_ReturnsDefaultInsteadOfThrowing`
- `ConvertSingle_BooleanAndDateTimeStrings_StillParse`

```
$ dotnet build test/MeshWeaver.Layout.Test/MeshWeaver.Layout.Test.csproj -c Release -warnaserror
Build succeeded.
    0 Warning(s)
    0 Error(s)

$ dotnet test test/MeshWeaver.Layout.Test/MeshWeaver.Layout.Test.csproj -c Release --no-build
Passed!  - Failed:     0, Passed:   453, Skipped:     0, Total:   453, Duration: 25 s

$ dotnet test test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj -c Release --no-build
Passed!  - Failed:     0, Passed:    34, Skipped:     0, Total:    34, Duration: 2 s
```

Pre-fix control run (src reverted, tests kept):

```
Failed!  - Failed:    17, Passed:    41, Skipped:     0, Total:    58
  ConvertSingle_PxString_ToInt_StripsTheUnit
    System.FormatException : The input string '8px' was not in a correct format.
  ConvertSingle_LowerCaseEnumString_ResolvesCaseInsensitively
    System.ArgumentException : Requested value 'center' was not found.
  ConvertSingle_DecimalString_ParsesInvariant_OnACommaDecimalThread
    Expected value to be 1,5, but found 15.
```

## Also

A What's New entry (`Category: Fix`), since an author following the layout docs will now see their gaps and alignments actually take effect.
