### PR TITLE
fix: give every agent round the current date/time, in the viewer's zone

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -496,8 +496,9 @@ public class AgentChatClient : IAgentChat
 
     /// <summary>
     /// Appends the DYNAMIC per-round context block to <paramref name="messageText"/> — the current
-    /// application context (node IDENTITY as JSON) plus any attached content (text inlined, binary
-    /// returned) — and returns the binary attachments. This is the single source of truth shared by
+    /// date/time in the viewer's zone (<see cref="CurrentTimeContext"/>), the current application
+    /// context (node IDENTITY as JSON), and any attached content (text inlined, binary returned) —
+    /// and returns the binary attachments. This is the single source of truth shared by
     /// BOTH the non-streaming <see cref="BuildMessageWithContextAsync"/> path and the streaming
     /// <see cref="GetStreamingResponseAsync(IReadOnlyCollection{ChatMessage}, CancellationToken)"/>
     /// path, so the streaming chat ships the same context/attachments the user set (contextPath +
@@ -508,6 +509,16 @@ public class AgentChatClient : IAgentChat
     /// </summary>
     private async Task<ImmutableList<DataContent>> AppendContextAndAttachmentsAsync(StringBuilder messageText)
     {
+        // 🕰️ WHAT DAY IS IT (#1651). Nothing else in the pipeline told the agent, so every model
+        // answered "what day is today" — and every relative expression a scheduling agent computes
+        // off it — from its training priors. It belongs HERE, in the per-round block, and NOT in
+        // the agent's instructions: agents are built once and cached while a thread lives for days,
+        // so an instruction-time date goes stale and is then confidently wrong in exactly the way
+        // this fixes. Rendered in the viewer's own zone (never .ToLocalTime(), which in the UTC
+        // deployment container is a no-op) plus the ISO-8601 `Z` instant for anything the agent
+        // feeds back into a tool. See CurrentTimeContext.
+        messageText.Append(CurrentTimeContext.Describe(DateTimeOffset.UtcNow, ResolveViewerZoneId()));
+
         // Dynamic part: context (changes per navigation)
         if (Context != null)
         {
@@ -620,6 +631,29 @@ public class AgentChatClient : IAgentChat
         }
 
         return binaryAttachments;
+    }
+
+    /// <summary>
+    /// The zone the round's date/time block is rendered in — the SUBMITTER's named IANA zone.
+    ///
+    /// <para>Resolution order mirrors the user-identity block below, and for the same reason: by
+    /// the time a round's prompt is composed the agent runs asynchronously on the agent hub, where
+    /// the ambient <c>AccessContext</c> has usually been reset to null or to an impersonated System
+    /// principal. The DURABLE identity captured at submit time
+    /// (<c>ThreadExecutionContext.UserAccessContext</c>, rebuilt by the round-dispatch watcher from
+    /// the <c>ThreadMessage.SubmitterTimeZoneId</c> rider) is therefore the primary source; the live
+    /// request/circuit context is the fallback for the in-process paths that still have one.</para>
+    ///
+    /// <para>Null when nothing knows the viewer's zone — <see cref="CurrentTimeContext.Describe"/>
+    /// then renders UTC and says so. It must never fall back to the server's zone: the deployment
+    /// container runs UTC, so that "fallback" is both a lie and a no-op.</para>
+    /// </summary>
+    private string? ResolveViewerZoneId()
+    {
+        var fromSubmitter = ExecutionContext?.UserAccessContext?.TimeZoneId;
+        if (!string.IsNullOrWhiteSpace(fromSubmitter))
+            return fromSubmitter;
+        return hub.ServiceProvider.GetService<AccessService>().ViewerZoneId();
     }
 
     private async Task<(string Text, ImmutableList<DataContent> BinaryAttachments)> BuildMessageWithContextAsync(IReadOnlyCollection<ChatMessage> messages, string? agentName = null)

--- a/src/MeshWeaver.AI/CurrentTimeContext.cs
+++ b/src/MeshWeaver.AI/CurrentTimeContext.cs
@@ -1,0 +1,100 @@
+using System.Globalization;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// The "what day is it" block shipped into EVERY agent round's context — the anchor an agent
+/// needs before it can resolve a single relative expression ("today", "tomorrow", "next Tuesday",
+/// "clear my Friday"). Without it a model answers from its training priors, confidently and
+/// wrong (#1651: the Executive Assistant answered Wednesday 6 August on Friday 14 August).
+///
+/// <para><b>Why this is PER ROUND, never in the agent's instructions.</b> Agents are built once
+/// and cached (<c>ChatClientAgentFactory</c>), and a thread lives for days — a date baked into
+/// the cached instruction text is stale the moment the clock rolls past midnight, which is worse
+/// than no date at all because it is confidently wrong in exactly the same way. So the block is
+/// composed on the round, beside the application context and attachments
+/// (<c>AgentChatClient.AppendContextAndAttachmentsAsync</c>), which both the streaming and the
+/// non-streaming path share.</para>
+///
+/// <para><b>🕰️ Two clocks, deliberately, because they answer two different questions.</b>
+/// Every stored instant is UTC, and the deployment container's process zone IS UTC — so
+/// <c>.ToLocalTime()</c> / <c>.LocalDateTime</c> are no-ops wearing a disguise and are never
+/// used here. The viewer's wall clock comes from their named IANA zone
+/// (<see cref="AccessContext.TimeZoneId"/>) through the one display seam,
+/// <see cref="DisplayTimeExtensions.ToDisplayTime(DateTimeOffset, string?)"/>, so DST is applied
+/// per-region rather than as a fixed offset:
+/// <list type="bullet">
+///   <item><description><b>The user's local date</b> answers "what day is today" for a HUMAN, and
+///   is the anchor every relative expression must be resolved against. Near midnight the UTC date
+///   and the user's date are DIFFERENT days — that is the whole reason the zone has to ride
+///   along.</description></item>
+///   <item><description><b>The UTC instant, ISO-8601 with the trailing <c>Z</c></b>, is what the
+///   agent may feed back into a tool, a node field or a calendar entry. A zone-less string is
+///   re-parsed in the SERVER's zone on the way back, which silently shifts it.</description></item>
+/// </list>
+/// An unknown or unset zone degrades to UTC and SAYS SO — never to the server's zone, which looks
+/// right in CI and is wrong in Zurich.</para>
+///
+/// <para>The formatter is <b>pure</b>: it takes the instant and the zone id as arguments and
+/// touches no hub, no circuit, and no ambient <c>CultureInfo</c> — the caller captures the zone
+/// once, on the round. Text is model-facing, so it is invariant English by design (the same rule
+/// that keeps tool-parameter descriptions untranslated); that also makes it deterministic to
+/// test. See <c>CurrentTimeContextTest</c>.</para>
+/// </summary>
+public static class CurrentTimeContext
+{
+    /// <summary>The markdown heading the block opens with — shared with the tests so they cannot drift.</summary>
+    public const string Heading = "# Current Date and Time";
+
+    /// <summary>
+    /// Renders the per-round date/time block for a viewer in <paramref name="timeZoneId"/>.
+    /// </summary>
+    /// <param name="utcNow">The current instant. Converted to UTC before anything is rendered, so
+    /// a caller that passes a non-UTC offset still gets the correct instant on both clocks.</param>
+    /// <param name="timeZoneId">The viewer's named IANA zone (e.g. <c>Europe/Zurich</c>), normally
+    /// <see cref="AccessContext.TimeZoneId"/>. Null, empty, or an id this host cannot resolve →
+    /// the block renders UTC and says the zone is unknown. Never a fixed offset (DST would then be
+    /// wrong half the year).</param>
+    /// <returns>A markdown block ending in a blank line, ready to append to the round's context.</returns>
+    public static string Describe(DateTimeOffset utcNow, string? timeZoneId)
+    {
+        var utc = utcNow.ToUniversalTime();
+        var zone = DisplayTimeExtensions.ResolveZone(timeZoneId);
+        var local = DisplayTimeExtensions.ToDisplayTime(utc, timeZoneId);
+
+        // The zone LABEL is the resolved zone's own id, never the caller's string: an id this host
+        // cannot resolve falls back to UTC, and echoing the unresolvable name would claim a
+        // conversion that did not happen.
+        var zoneLine = zone is null
+            ? $"- **Local time now:** {local.ToString("HH:mm", CultureInfo.InvariantCulture)} " +
+              "(UTC — the user's time zone is not known, so this may not be their wall clock)"
+            : $"- **Local time now:** {local.ToString("HH:mm", CultureInfo.InvariantCulture)} " +
+              $"({zone.Id}, UTC{local.ToString("zzz", CultureInfo.InvariantCulture)})";
+
+        return $"""
+                {Heading}
+
+                - **Today (the user's local date):** {local.DayOfWeek}, {local.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}
+                {zoneLine}
+                - **Now, UTC (machine-readable):** `{Iso(utc)}`
+
+                Resolve every relative expression — "today", "tomorrow", "next Tuesday", "this Friday",
+                "in two weeks" — against the user's LOCAL date above. Never answer the date from memory.
+                When you WRITE a timestamp (a tool argument, a node field, a calendar entry) use ISO-8601
+                with the trailing `Z` or an explicit offset; a zone-less string is re-read in the server's
+                zone and silently shifts. Do NOT convert dates that are not instants — a policy inception,
+                an as-of date, a due date or a birthday is the same calendar day in every zone.
+
+
+                """;
+    }
+
+    /// <summary>
+    /// The machine-facing form of an instant: ISO-8601, seconds precision, explicit trailing
+    /// <c>Z</c>. Anything an agent may hand back to a tool goes through here — a zone-less string
+    /// re-parses in the server's zone on the way back.
+    /// </summary>
+    public static string Iso(DateTimeOffset instant) =>
+        instant.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+}

--- a/src/MeshWeaver.AI/HubThreadExtensions.cs
+++ b/src/MeshWeaver.AI/HubThreadExtensions.cs
@@ -45,7 +45,7 @@ public static class HubThreadExtensions
     /// (<c>AccessService.Context</c>) or the per-circuit fallback (<c>CircuitContext</c>). The
     /// captured <c>(ObjectId, Name)</c> is stamped onto the pending <see cref="ThreadMessage"/>
     /// (<see cref="ThreadMessage.SubmitterObjectId"/> / <see cref="ThreadMessage.SubmitterName"/> /
-    /// <see cref="ThreadMessage.SubmitterLocale"/>)
+    /// <see cref="ThreadMessage.SubmitterLocale"/> / <see cref="ThreadMessage.SubmitterTimeZoneId"/>)
     /// so the round-dispatch watcher can rebuild the identity AFTER every later async boundary
     /// (its own <c>.Subscribe</c> continuation + the AI streaming continuations) has wiped the
     /// AsyncLocal. This is "capture the identity when computing the submit patch" — the data
@@ -55,6 +55,12 @@ public static class HubThreadExtensions
     /// user-facing string a round emits is resolved off the round's context, so a rebuilt context
     /// without the language renders English for a German user (#948). The language is part of the
     /// identity, and this is the one place it is reliably live.</para>
+    ///
+    /// <para>🕰️ …and their <see cref="AccessContext.TimeZoneId"/>, for the same reason one step on:
+    /// the agent round ships the current date/time into its context so relative expressions
+    /// ("tomorrow", "clear my Friday") have an anchor, and that anchor is only the USER's day if
+    /// their zone rides along. A rebuilt context without it degrades every viewer to UTC — silently,
+    /// and wrongly by a whole day for anyone whose evening is UTC's next morning (#1651).</para>
     ///
     /// <para><b>The first REAL USER wins, not the first non-null context.</b> The request-scoped
     /// <c>Context</c> frequently holds a NON-user principal at the submit boundary — a hub-shaped
@@ -69,15 +75,15 @@ public static class HubThreadExtensions
     /// <para>Returns all-null when no real user identity is live at all — the watcher then falls
     /// back to the thread owner derived from the node, NEVER hub-self and never System.</para>
     /// </summary>
-    private static (string? ObjectId, string? Name, string? Locale) CaptureSubmitter(this IMessageHub hub)
+    private static (string? ObjectId, string? Name, string? Locale, string? TimeZoneId) CaptureSubmitter(this IMessageHub hub)
     {
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var ctx = IsRealUser(accessService?.Context) ? accessService!.Context
             : IsRealUser(accessService?.CircuitContext) ? accessService!.CircuitContext
             : null;
         if (ctx is null)
-            return (null, null, null);
-        return (ctx.ObjectId, string.IsNullOrEmpty(ctx.Name) ? ctx.ObjectId : ctx.Name, ctx.Locale);
+            return (null, null, null, null);
+        return (ctx.ObjectId, string.IsNullOrEmpty(ctx.Name) ? ctx.ObjectId : ctx.Name, ctx.Locale, ctx.TimeZoneId);
 
         // A submitter is a PERSON. Hub addresses (sync/, mesh/, node/, activity/, portal/) and the
         // well-known System identity are infrastructure credentials — never a submitter.
@@ -161,7 +167,7 @@ public static class HubThreadExtensions
         // Capture the submitter's identity NOW — synchronous, live AsyncLocal — and persist it on the
         // pending message (below) so the round-dispatch watcher can rebuild it AFTER the async boundary
         // wipes the AsyncLocal. See ThreadMessage.SubmitterObjectId / AccessContextPropagation.md.
-        var (submitterObjectId, submitterName, submitterLocale) = hub.CaptureSubmitter();
+        var (submitterObjectId, submitterName, submitterLocale, submitterTimeZoneId) = hub.CaptureSubmitter();
 
         // 🎯 The thread's COMPOSER is the single source of truth for the round's sticky
         // selection (agent / model / harness / context). Seed it from the supplied composer
@@ -204,7 +210,8 @@ public static class HubThreadExtensions
                         harness: harness,
                         submitterObjectId: submitterObjectId,
                         submitterName: submitterName,
-                        submitterLocale: submitterLocale))
+                        submitterLocale: submitterLocale,
+                        submitterTimeZoneId: submitterTimeZoneId))
             }
             : baseThread; // empty thread — no round
         threadNode = threadNode with { Content = seededThread };
@@ -335,7 +342,7 @@ public static class HubThreadExtensions
         if (string.IsNullOrWhiteSpace(userText))
             return;
 
-        var (submitterObjectId, submitterName, submitterLocale) = hub.CaptureSubmitter();
+        var (submitterObjectId, submitterName, submitterLocale, submitterTimeZoneId) = hub.CaptureSubmitter();
         var userMessage = ThreadInput.CreateUserMessage(
             userText ?? string.Empty,
             createdBy: createdBy,
@@ -347,7 +354,8 @@ public static class HubThreadExtensions
             harness: harness,
             submitterObjectId: submitterObjectId,
             submitterName: submitterName,
-            submitterLocale: submitterLocale);
+            submitterLocale: submitterLocale,
+            submitterTimeZoneId: submitterTimeZoneId);
         try
         {
             ThreadInput.AppendUserInput(hub.GetWorkspace(), threadPath, userMessage);
@@ -400,7 +408,7 @@ public static class HubThreadExtensions
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.AI.HubThreadExtensions");
         var msgId = Guid.NewGuid().ToString("N")[..8];
-        var (submitterObjectId, submitterName, submitterLocale) = hub.CaptureSubmitter();
+        var (submitterObjectId, submitterName, submitterLocale, submitterTimeZoneId) = hub.CaptureSubmitter();
 
         hub.GetWorkspace().GetMeshNodeStream(threadPath).Update(node =>
         {
@@ -425,7 +433,8 @@ public static class HubThreadExtensions
                 harness: c.Harness,
                 submitterObjectId: submitterObjectId,
                 submitterName: submitterName,
-                submitterLocale: submitterLocale);
+                submitterLocale: submitterLocale,
+                submitterTimeZoneId: submitterTimeZoneId);
 
             return node with
             {

--- a/src/MeshWeaver.AI/Thread.cs
+++ b/src/MeshWeaver.AI/Thread.cs
@@ -575,6 +575,25 @@ public record ThreadMessage
     public string? SubmitterLocale { get; init; }
 
     /// <summary>
+    /// The submitter's <see cref="AccessContext.TimeZoneId"/> — their preferred display zone as a
+    /// named IANA id (<c>Europe/Zurich</c>, <c>America/New_York</c>, …) — captured alongside
+    /// <see cref="SubmitterObjectId"/> at submit time. Null OR EMPTY when the submitter has no zone
+    /// preference; the value is copied verbatim from <see cref="AccessContext.TimeZoneId"/>, whose
+    /// own contract is null/empty/unresolvable → display in UTC.
+    ///
+    /// <para><b>🕰️ Why the ZONE has to ride on the message too.</b> Exactly the argument that put
+    /// <see cref="SubmitterLocale"/> here (#948), one presentation preference over: the
+    /// round-dispatch watcher rebuilds the round's <see cref="AccessContext"/> from this rider
+    /// because its Throttle/Subscribe continuation has no live identity, and an ambient context it
+    /// might instead observe is the thread hub's owner injection — <c>{ObjectId, Name}</c> only, no
+    /// presentation preferences. Without the rider the round knows WHO the user is and not WHEN
+    /// they are, so the agent's date anchor silently degrades to UTC for every viewer and "today"
+    /// is the wrong day for anyone west of Greenwich after their afternoon (#1651). Never a fixed
+    /// offset — a named zone is what makes DST apply per region.</para>
+    /// </summary>
+    public string? SubmitterTimeZoneId { get; init; }
+
+    /// <summary>
     /// Completed tool calls from this message's execution.
     /// Populated when execution finishes, used for post-execution inspection.
     /// </summary>

--- a/src/MeshWeaver.AI/ThreadInput.cs
+++ b/src/MeshWeaver.AI/ThreadInput.cs
@@ -38,6 +38,10 @@ public static class ThreadInput
     /// alongside <paramref name="submitterObjectId"/> so the rebuilt round context can render
     /// user-facing text in the submitter's language. See
     /// <see cref="ThreadMessage.SubmitterLocale"/>.</param>
+    /// <param name="submitterTimeZoneId">The submitter's <see cref="AccessContext.TimeZoneId"/> — a
+    /// named IANA zone — captured alongside <paramref name="submitterObjectId"/> so the rebuilt
+    /// round context can anchor the agent's "today" in the user's own day rather than UTC's. See
+    /// <see cref="ThreadMessage.SubmitterTimeZoneId"/>.</param>
     public static ThreadMessage CreateUserMessage(
         string text,
         string? createdBy = null,
@@ -49,7 +53,8 @@ public static class ThreadInput
         string? harness = null,
         string? submitterObjectId = null,
         string? submitterName = null,
-        string? submitterLocale = null) =>
+        string? submitterLocale = null,
+        string? submitterTimeZoneId = null) =>
         new()
         {
             Role = "user",
@@ -64,6 +69,7 @@ public static class ThreadInput
             SubmitterObjectId = submitterObjectId,
             SubmitterName = submitterName,
             SubmitterLocale = submitterLocale,
+            SubmitterTimeZoneId = submitterTimeZoneId,
             Timestamp = DateTime.UtcNow,
             Type = ThreadMessageType.ExecutedInput,
             // User cells don't have a streaming lifecycle — Submitted on creation.

--- a/src/MeshWeaver.AI/ThreadSubmission.cs
+++ b/src/MeshWeaver.AI/ThreadSubmission.cs
@@ -783,7 +783,12 @@ internal static class ThreadSubmissionServer
                 // 🌍 The submitter's LANGUAGE rides on the same rider as their identity. Every
                 // user-facing string this round emits is resolved off AccessContext.Locale, so a
                 // context rebuilt without it renders English for every viewer (#948).
-                Locale = submitter.SubmitterLocale
+                Locale = submitter.SubmitterLocale,
+                // 🕰️ …and their ZONE, for the same reason: the round ships the current date/time
+                // into the agent's context as the anchor for every relative expression, and that
+                // anchor is only the USER's day if their named IANA zone came along. A context
+                // rebuilt without it silently anchors every viewer to UTC (#1651).
+                TimeZoneId = submitter.SubmitterTimeZoneId
             };
         // 🌍 …and when the identity came from an AMBIENT context above, that context is
         // locale-less BY CONSTRUCTION: the thread hub's OWNER-INJECTION (ThreadExecution) stamps
@@ -796,6 +801,13 @@ internal static class ThreadSubmissionServer
                  && string.IsNullOrEmpty(userCtx.Locale)
                  && !string.IsNullOrEmpty(submitter?.SubmitterLocale))
             userCtx = userCtx with { Locale = submitter.SubmitterLocale };
+        // 🕰️ The ZONE is filled in independently of the language — the two preferences are set
+        // separately on the profile, so a user can easily have one and not the other, and folding
+        // them into one condition would drop the zone whenever the locale happened to be present.
+        if (userCtx is not null
+            && string.IsNullOrEmpty(userCtx.TimeZoneId)
+            && !string.IsNullOrEmpty(submitter?.SubmitterTimeZoneId))
+            userCtx = userCtx with { TimeZoneId = submitter.SubmitterTimeZoneId };
 
         var fellBackToCreatedBy = false;
         // Resolution: thread content's CreatedBy → wrapping node's CreatedBy → null.

--- a/src/MeshWeaver.Documentation/Data/GUI/DisplayTimes.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/DisplayTimes.md
@@ -137,6 +137,34 @@ public static string DisplayStamp(DateTimeOffset instant, string? zoneId) =>
 
 ---
 
+# The agent's clock is a viewer of this seam too
+
+An **agent prompt** is not a render path, and it needs the same two clocks for the same reasons.
+Until #1651 nothing told an agent the date at all, so every model answered "what day is today" from
+its training priors — and so did every relative expression a scheduling agent computes off that
+anchor ("tomorrow", "next Tuesday afternoon", "clear my Friday"). A wrong anchor books meetings on
+wrong days while nothing looks broken.
+
+`CurrentTimeContext.Describe(instant, zoneId)` (MeshWeaver.AI) renders the block, and
+`AgentChatClient.AppendContextAndAttachmentsAsync` appends it to the **per-round** context — beside
+the application context and attachments, shared by the streaming and non-streaming paths. Three
+things about it are load-bearing:
+
+- **Per round, never in the instructions.** Agents are built once and cached while a thread lives
+  for days, so a date baked into instruction text is stale after midnight — confidently wrong in
+  exactly the way the fix removes.
+- **Both clocks, labelled.** The user's local date answers "what day is today" for a human; the
+  ISO-8601 `Z` instant is what the agent may hand back to a tool (see *Machine-facing output* above).
+  The block also tells the agent NOT to convert calendar facts.
+- **The zone comes from the identity, and has to RIDE there.** By the time a round's prompt is
+  composed the agent runs on the agent hub, where the ambient `AccessContext` is typically null or
+  an impersonated System principal. So `AccessContext.TimeZoneId` is captured at the submit boundary
+  onto `ThreadMessage.SubmitterTimeZoneId` and rebuilt by the round-dispatch watcher — the same
+  carrier, and the same argument, as `SubmitterLocale` (#948). Without it every viewer silently
+  anchors to UTC.
+
+---
+
 # Why this has its own page
 
 The seam shipped with 7 render sites converted. An audit two weeks later found **15 more still

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-agents-know-what-day-it-is.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-agents-know-what-day-it-is.md
@@ -1,0 +1,27 @@
+---
+Name: Agents know what day it is
+Category: Fix
+Description: Every agent turn now carries today's date and time — in your own time zone — so "tomorrow", "next Tuesday" and "what day is today" are answered from the clock instead of the model's memory.
+Icon: CalendarClock
+Order: -20260818
+---
+
+# Agents know what day it is
+
+Ask an assistant what day it is and it used to answer from whatever its training data suggested —
+confidently, and often days off. Nothing in the pipeline ever told it the date, and it had no clock
+to consult, so there was no way for it to be right.
+
+Every turn now ships the current date and time as part of the agent's context. That matters well
+beyond the question itself: a scheduling or mail assistant resolves "tomorrow", "next Tuesday
+afternoon" or "clear my Friday" against an anchor date, and a wrong anchor books meetings on wrong
+days without anything looking broken.
+
+The date is shown in **your** time zone, taken from your profile, so "today" is your day rather than
+UTC's — which are genuinely different days for anyone whose evening falls after midnight in London.
+Alongside it the agent gets the same moment in UTC, in the machine-readable form it should use when
+it writes a timestamp back into a calendar entry or a document.
+
+Because the clock is stamped on each turn rather than baked into an assistant when it is first
+loaded, a conversation you come back to next week gets next week's date — not the date it was
+started on.

--- a/test/MeshWeaver.AI.Test/AttachmentContextTest.cs
+++ b/test/MeshWeaver.AI.Test/AttachmentContextTest.cs
@@ -449,4 +449,99 @@ public class AttachmentContextTest : MonolithMeshTestBase
         assembledPrompt.Should().NotContain("You are **Assistant**",
             "Assistant's instructions should NOT be present when Researcher was selected via @reference");
     }
+
+    // ── #1651: every round must carry the current date/time ─────────────────────────────
+
+    /// <summary>The block's "Today" line as the formatter renders it — line-ending agnostic.</summary>
+    private static string TodayLine(DateTimeOffset instant, string? zoneId) =>
+        CurrentTimeContext.Describe(instant, zoneId)
+            .Replace("\r\n", "\n")
+            .Split('\n')
+            .First(l => l.StartsWith("- **Today", StringComparison.Ordinal));
+
+    /// <summary>
+    /// #1651 — the agent must be TOLD what day it is. Nothing in the round pipeline injected the
+    /// current date, so every model answered "what day is today" — and every relative expression a
+    /// scheduling agent computes off it ("tomorrow", "clear my Friday") — from its training priors:
+    /// on Friday 2026-08-14 the Executive Assistant confidently answered "Mittwoch, der 6. August".
+    ///
+    /// <para>This pins the block onto the PER-ROUND context, beside the application context and
+    /// attachments, and NOT into the agent's cached instructions — those are built once while a
+    /// thread lives for days, so an instruction-time date goes stale and is then wrong in exactly
+    /// the way this fixes. It also pins the ZONE: the rendered date is the VIEWER's, resolved
+    /// through the display seam from their named IANA zone, never <c>.ToLocalTime()</c> (a no-op in
+    /// the UTC deployment container). Asia/Tokyo is UTC+9 with no DST, so a silent UTC fallback
+    /// cannot pass this by accident on a UTC host.</para>
+    /// </summary>
+    [Fact]
+    public async Task PromptAssembly_ShipsTheCurrentDate_InTheViewersZone()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (agentChat, factory) = await SetupAgentChatAsync(ct);
+
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var previousContext = access.CircuitContext;
+        access.SetHostIdentity((previousContext ?? TestUsers.Admin) with { TimeZoneId = "Asia/Tokyo" });
+
+        string? assembledPrompt;
+        var before = DateTimeOffset.UtcNow;
+        DateTimeOffset after;
+        try
+        {
+            await foreach (var _ in agentChat.GetResponseAsync(
+                [new ChatMessage(ChatRole.User, "What day is today?")], ct)) { }
+            after = DateTimeOffset.UtcNow;
+            assembledPrompt = GetLastUserMessageText(factory.AllCapturedMessages);
+        }
+        finally
+        {
+            access.SetHostIdentity(previousContext);
+        }
+
+        assembledPrompt.Should().NotBeNullOrEmpty();
+        assembledPrompt.Should().Contain(CurrentTimeContext.Heading,
+            "every round must carry the current date/time — without it the model answers from priors (#1651)");
+        assembledPrompt.Should().Contain("Asia/Tokyo",
+            "the block names the zone it converted into, so a silent UTC fallback is visible");
+
+        // Compare against the formatter's OWN output rather than re-deriving a date here, so the
+        // prompt and CurrentTimeContextTest cannot drift. Both ends of the round's wall-clock
+        // window are accepted, so a run that straddles midnight in Tokyo still matches one of them.
+        var expected = new[] { TodayLine(before, "Asia/Tokyo"), TodayLine(after, "Asia/Tokyo") };
+        expected.Any(e => assembledPrompt!.Contains(e, StringComparison.Ordinal)).Should().BeTrue(
+            "the date must be the VIEWER's local date (Asia/Tokyo), not UTC's and not the server's — "
+            + $"expected one of [{string.Join(" | ", expected)}]");
+    }
+
+    /// <summary>
+    /// The STREAMING path ships the same block — it folds the round context into its SYSTEM message
+    /// rather than into the user turn, so a regression there would be invisible to the non-streaming
+    /// assertion above (#1651). Asserted on the machine-facing UTC instant, which is zone-independent
+    /// and therefore says nothing about whatever identity a shared-mesh sibling test left behind.
+    /// </summary>
+    [Fact]
+    public async Task Streaming_ShipsTheCurrentDate()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (agentChat, factory) = await SetupAgentChatAsync(ct);
+
+        var before = DateTimeOffset.UtcNow;
+        await foreach (var _ in agentChat.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "What day is today?")], ct)) { }
+        var after = DateTimeOffset.UtcNow;
+
+        factory.AllCapturedMessages.Should().NotBeEmpty();
+        var assembled = string.Join("\n", factory.AllCapturedMessages.Select(MessageText));
+
+        assembled.Should().Contain(CurrentTimeContext.Heading,
+            "the STREAMING prompt must carry the current date/time too");
+        // The ISO-8601 `Z` instant is what the agent may feed back into a tool — it must be NOW,
+        // in UTC, with the zone stated. A zone-less or remembered date would fail this.
+        var expected = new[] { before, after }.Select(t => "`" + CurrentTimeContext.Iso(t)[..13]).ToArray();
+        expected.Any(e => assembled.Contains(e, StringComparison.Ordinal)).Should().BeTrue(
+            "the machine-facing instant must be the CURRENT UTC hour — "
+            + $"expected one of [{string.Join(" | ", expected)}]");
+        assembled.Should().Contain("Z`",
+            "machine-facing output stays UTC and SAYS so — a zone-less string re-parses in the server's zone");
+    }
 }

--- a/test/MeshWeaver.AI.Test/CurrentTimeContextTest.cs
+++ b/test/MeshWeaver.AI.Test/CurrentTimeContextTest.cs
@@ -1,0 +1,239 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Globalization;
+using MeshWeaver.AI;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Unit coverage for <see cref="CurrentTimeContext"/> — the per-round date/time block that gives
+/// every agent an anchor for "what day is today" and for every relative expression computed off it
+/// (#1651). The formatter is PURE (instant + zone id in, markdown out), so all of this runs with no
+/// hub, no circuit and no mesh.
+///
+/// <para>What each case is guarding, because the failure mode is silence:</para>
+/// <list type="bullet">
+///   <item><description><b>Both DST directions.</b> A hard-coded offset passes one and fails the
+///   other — the whole reason the seam uses named IANA zones. Zurich is UTC+2 in July and UTC+1 in
+///   January; New York is UTC−4 in July and UTC−5 in January, on different switch dates, so the two
+///   regions together also pin that DST is applied PER REGION rather than globally.</description></item>
+///   <item><description><b>The date rollover.</b> An instant late in the UTC evening is already
+///   TOMORROW in Zurich, and an instant early in the UTC morning is still YESTERDAY in New York.
+///   This is the case that reads as an off-by-one rather than as a timezone bug — and it is exactly
+///   the case a calendar agent gets wrong when it books "tomorrow".</description></item>
+///   <item><description><b>Zone null / unresolvable → UTC, and SAYS so.</b> Never the server's
+///   zone: the deployment container runs UTC, so a server-local fallback looks right in CI and is
+///   wrong in Zurich. An unresolvable id must not be echoed either — printing a zone name the
+///   conversion did not use claims a localization that never happened.</description></item>
+///   <item><description><b>Invariant English, never the ambient culture.</b> The block is
+///   model-facing (the same rule that keeps tool-parameter descriptions untranslated), and a render
+///   hops schedulers where an AsyncLocal culture would not survive anyway.</description></item>
+/// </list>
+/// </summary>
+public class CurrentTimeContextTest
+{
+    private const string Zurich = "Europe/Zurich";
+    private const string NewYork = "America/New_York";
+
+    private static DateTimeOffset Utc(string iso) =>
+        DateTimeOffset.Parse(iso, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+
+    // ── DST, both directions, two regions ────────────────────────────────────────────────
+
+    [Fact]
+    public void Summer_Zurich_rendersCEST_UtcPlusTwo()
+    {
+        var block = CurrentTimeContext.Describe(Utc("2026-07-20T14:32:00Z"), Zurich);
+
+        Assert.Contains("- **Today (the user's local date):** Monday, 2026-07-20", block, StringComparison.Ordinal);
+        Assert.Contains("- **Local time now:** 16:32 (Europe/Zurich, UTC+02:00)", block, StringComparison.Ordinal);
+        Assert.Contains("`2026-07-20T14:32:00Z`", block, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Winter_Zurich_rendersCET_UtcPlusOne()
+    {
+        // Same wall-clock UTC as the summer case: an implementation with a hard-coded +02:00
+        // passes that one and fails this one.
+        var block = CurrentTimeContext.Describe(Utc("2026-01-20T14:32:00Z"), Zurich);
+
+        Assert.Contains("- **Today (the user's local date):** Tuesday, 2026-01-20", block, StringComparison.Ordinal);
+        Assert.Contains("- **Local time now:** 15:32 (Europe/Zurich, UTC+01:00)", block, StringComparison.Ordinal);
+        Assert.Contains("`2026-01-20T14:32:00Z`", block, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Summer_NewYork_rendersEDT_UtcMinusFour()
+    {
+        var block = CurrentTimeContext.Describe(Utc("2026-07-20T14:32:00Z"), NewYork);
+
+        Assert.Contains("- **Today (the user's local date):** Monday, 2026-07-20", block, StringComparison.Ordinal);
+        Assert.Contains("- **Local time now:** 10:32 (America/New_York, UTC-04:00)", block, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Winter_NewYork_rendersEST_UtcMinusFive()
+    {
+        var block = CurrentTimeContext.Describe(Utc("2026-01-20T14:32:00Z"), NewYork);
+
+        Assert.Contains("- **Today (the user's local date):** Tuesday, 2026-01-20", block, StringComparison.Ordinal);
+        Assert.Contains("- **Local time now:** 09:32 (America/New_York, UTC-05:00)", block, StringComparison.Ordinal);
+    }
+
+    // ── The date rollover — the case that reads as an off-by-one ─────────────────────────
+
+    [Fact]
+    public void LateUtcEvening_isAlreadyTomorrow_inZurich()
+    {
+        // 23:30 UTC on the 29th is 01:30 on the 30th in Zurich. An agent that anchored on the UTC
+        // date would book "tomorrow" a full day early.
+        var block = CurrentTimeContext.Describe(Utc("2026-07-29T23:30:00Z"), Zurich);
+
+        Assert.Contains("- **Today (the user's local date):** Thursday, 2026-07-30", block, StringComparison.Ordinal);
+        Assert.Contains("- **Local time now:** 01:30 (Europe/Zurich, UTC+02:00)", block, StringComparison.Ordinal);
+        // …while the machine-facing instant stays on the UTC calendar, unshifted.
+        Assert.Contains("`2026-07-29T23:30:00Z`", block, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EarlyUtcMorning_isStillYesterday_inNewYork()
+    {
+        // The mirror image, west of Greenwich: 02:30 UTC on Monday the 20th is 22:30 on Sunday the
+        // 19th in New York. "What day is today" is a different DAY, not merely a different hour.
+        var block = CurrentTimeContext.Describe(Utc("2026-07-20T02:30:00Z"), NewYork);
+
+        Assert.Contains("- **Today (the user's local date):** Sunday, 2026-07-19", block, StringComparison.Ordinal);
+        Assert.Contains("- **Local time now:** 22:30 (America/New_York, UTC-04:00)", block, StringComparison.Ordinal);
+        Assert.Contains("`2026-07-20T02:30:00Z`", block, StringComparison.Ordinal);
+    }
+
+    // ── Unknown zone → UTC, and it says so ───────────────────────────────────────────────
+
+    [Fact]
+    public void NullZone_staysUtc_andSaysTheZoneIsUnknown()
+    {
+        var block = CurrentTimeContext.Describe(Utc("2026-07-20T14:32:00Z"), null);
+
+        // Unchanged — NOT converted into the host/server zone.
+        Assert.Contains("- **Today (the user's local date):** Monday, 2026-07-20", block, StringComparison.Ordinal);
+        Assert.Contains("- **Local time now:** 14:32 (UTC — the user's time zone is not known", block, StringComparison.Ordinal);
+        Assert.Contains("`2026-07-20T14:32:00Z`", block, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmptyZone_staysUtc()
+    {
+        var block = CurrentTimeContext.Describe(Utc("2026-01-20T14:32:00Z"), "   ");
+
+        Assert.Contains("- **Local time now:** 14:32 (UTC — the user's time zone is not known", block, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnresolvableZone_staysUtc_andDoesNotEchoTheBogusId()
+    {
+        var block = CurrentTimeContext.Describe(Utc("2026-07-20T14:32:00Z"), "Mars/Olympus_Mons");
+
+        Assert.Contains("- **Local time now:** 14:32 (UTC — the user's time zone is not known", block, StringComparison.Ordinal);
+        Assert.DoesNotContain("Mars/Olympus_Mons", block, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullZoneRendering_isIdenticalToRenderingTheUtcZoneExplicitly()
+    {
+        // Pins "degrades to UTC" as a VALUE, not just as prose: whatever the host's own zone is,
+        // the local clock for an unknown viewer is the UTC clock.
+        var instant = Utc("2026-07-20T14:32:00Z");
+        var unknown = CurrentTimeContext.Describe(instant, null);
+        var explicitUtc = CurrentTimeContext.Describe(instant, "UTC");
+
+        Assert.Contains("- **Today (the user's local date):** Monday, 2026-07-20", unknown, StringComparison.Ordinal);
+        Assert.Contains("- **Today (the user's local date):** Monday, 2026-07-20", explicitUtc, StringComparison.Ordinal);
+        Assert.Contains("14:32", unknown, StringComparison.Ordinal);
+        Assert.Contains("14:32", explicitUtc, StringComparison.Ordinal);
+    }
+
+    // ── Machine-facing output stays UTC and says so ──────────────────────────────────────
+
+    [Fact]
+    public void Iso_normalisesToUtc_withTheTrailingZ()
+    {
+        // A non-UTC offset in → the same INSTANT out, in UTC, with an explicit Z. A zone-less
+        // string would re-parse in the server's zone on the way back.
+        Assert.Equal("2026-07-20T14:32:00Z",
+            CurrentTimeContext.Iso(new DateTimeOffset(2026, 7, 20, 16, 32, 0, TimeSpan.FromHours(2))));
+        Assert.Equal("2026-01-20T14:32:00Z",
+            CurrentTimeContext.Iso(new DateTimeOffset(2026, 1, 20, 9, 32, 0, TimeSpan.FromHours(-5))));
+    }
+
+    [Fact]
+    public void Describe_normalisesANonUtcInstant_onBothClocks()
+    {
+        // 16:32+02:00 IS 14:32Z — the caller's offset must not leak into either rendering.
+        var block = CurrentTimeContext.Describe(
+            new DateTimeOffset(2026, 7, 20, 16, 32, 0, TimeSpan.FromHours(2)), NewYork);
+
+        Assert.Contains("- **Local time now:** 10:32 (America/New_York, UTC-04:00)", block, StringComparison.Ordinal);
+        Assert.Contains("`2026-07-20T14:32:00Z`", block, StringComparison.Ordinal);
+    }
+
+    // ── Model-facing text: invariant English, never the ambient culture ──────────────────
+
+    [Fact]
+    public void Rendering_isInvariantEnglish_underAGermanAmbientCulture()
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        var previousUiCulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            // de-DE would otherwise give "Montag", "20.07.2026" and a comma decimal — and a round
+            // hops schedulers, so an ambient culture is never a legitimate source anyway.
+            var german = new CultureInfo("de-DE");
+            CultureInfo.CurrentCulture = german;
+            CultureInfo.CurrentUICulture = german;
+
+            var block = CurrentTimeContext.Describe(Utc("2026-07-20T14:32:00Z"), Zurich);
+
+            Assert.Contains("Monday, 2026-07-20", block, StringComparison.Ordinal);
+            Assert.DoesNotContain("Montag", block, StringComparison.Ordinal);
+            Assert.Contains("16:32 (Europe/Zurich, UTC+02:00)", block, StringComparison.Ordinal);
+            Assert.Equal("2026-07-20T14:32:00Z", CurrentTimeContext.Iso(Utc("2026-07-20T14:32:00Z")));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+            CultureInfo.CurrentUICulture = previousUiCulture;
+        }
+    }
+
+    // ── Shape: the heading and the standing guidance the agent acts on ───────────────────
+
+    [Fact]
+    public void Block_opensWithItsHeading_andCarriesTheAnchoringGuidance()
+    {
+        var block = CurrentTimeContext.Describe(Utc("2026-08-14T10:46:00Z"), Zurich);
+
+        Assert.StartsWith(CurrentTimeContext.Heading, block, StringComparison.Ordinal);
+        // Ends on a blank line so it cannot run into the next context block. Compared line-ending
+        // agnostically: the raw string literal picks up whatever the checkout wrote.
+        Assert.EndsWith("\n\n", block.Replace("\r\n", "\n"), StringComparison.Ordinal);
+        Assert.Contains("against the user's LOCAL date above", block, StringComparison.Ordinal);
+        Assert.Contains("Never answer the date from memory", block, StringComparison.Ordinal);
+        Assert.Contains("ISO-8601", block, StringComparison.Ordinal);
+        // Calendar facts are NOT instants — converting one shifts data and corrupts joins.
+        Assert.Contains("Do NOT convert dates that are not instants", block, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheReportedIssue_wouldNowBeAnswerable()
+    {
+        // #1651 verbatim: the round was submitted 2026-08-14T10:46Z — a FRIDAY — and the agent
+        // answered "Mittwoch, der 6. August 2026". With the block in context the correct answer is
+        // sitting in the prompt, in the submitter's own zone.
+        var block = CurrentTimeContext.Describe(Utc("2026-08-14T10:46:00Z"), Zurich);
+
+        Assert.Contains("Friday, 2026-08-14", block, StringComparison.Ordinal);
+        Assert.Contains("12:46 (Europe/Zurich, UTC+02:00)", block, StringComparison.Ordinal);
+    }
+}

--- a/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
@@ -186,7 +186,10 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
         // watcher's Throttle/Subscribe continuation has no live AccessContext (#948).
         var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
         var previousContext = access.CircuitContext;
-        access.SetHostIdentity((previousContext ?? TestUsers.Admin) with { Locale = "de" });
+        // 🕰️ …and in a zone, captured on the SAME rider for the same reason: the agent round ships
+        // the current date/time as the anchor for every relative expression, and that anchor is only
+        // the user's day if their named IANA zone survived the hop (#1651).
+        access.SetHostIdentity((previousContext ?? TestUsers.Admin) with { Locale = "de", TimeZoneId = "Europe/Zurich" });
         try
         {
             client.SubmitMessage(threadPath, "hello", modelName: StaleModel, createdBy: TestUser);
@@ -213,6 +216,10 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
         userCell.SubmitterLocale.Should().Be("de",
             "the submit boundary must capture the submitter's language onto the message — it is the "
             + "only carrier that survives the watcher's Throttle/Subscribe hop (#948)");
+        userCell.SubmitterTimeZoneId.Should().Be("Europe/Zurich",
+            "the submitter's ZONE rides on the same carrier — without it the round's rebuilt context "
+            + "knows WHO the user is but not WHEN they are, and the agent's date anchor silently "
+            + "degrades to UTC for every viewer (#1651)");
         // The failure must SPEAK — and speak the SUBMITTER's language: it comes from the
         // localization catalog resolved off the round's own AccessContext.Locale, not a hard-coded
         // English literal, and it names the requested model.


### PR DESCRIPTION
Closes #1651.

## The bug

Nothing in the agent pipeline injected the current date, and no plugin exposes a clock — so a model
could not answer "what day is today" except from its training priors. The issue records the
Executive Assistant answering **"Mittwoch, der 6. August 2026"** on Friday **2026-08-14**, with
`toolCalls: []`: it made no attempt to retrieve the date because there was nothing to call and
nothing in its context to read.

The visible question is the small half. This is the calendar/mail agent: every relative expression
it is instructed to resolve — "tomorrow", "next Tuesday afternoon", "clear my Friday" — is computed
off an anchor date it did not have. A wrong anchor books meetings on wrong days while nothing looks
broken.

## The fix

`CurrentTimeContext.Describe(instant, zoneId)` renders the block;
`AgentChatClient.AppendContextAndAttachmentsAsync` appends it to the **per-round** context — the one
builder the streaming and non-streaming paths share — beside the application context and
attachments. What the model now receives:

```
# Current Date and Time

- **Today (the user's local date):** Friday, 2026-08-14
- **Local time now:** 12:46 (Europe/Zurich, UTC+02:00)
- **Now, UTC (machine-readable):** `2026-08-14T10:46:00Z`

Resolve every relative expression … against the user's LOCAL date above. Never answer the date
from memory. When you WRITE a timestamp … use ISO-8601 with the trailing `Z` … Do NOT convert
dates that are not instants — a policy inception, an as-of date, a due date or a birthday is the
same calendar day in every zone.
```

**Per round, never in the instructions.** Agents are built once and cached (`ChatClientAgentFactory`)
while a thread lives for days, so a date baked into instruction text is stale the moment the clock
passes midnight — confidently wrong in exactly the way this removes. This also follows the issue's
own recommendation of injection over a `GetCurrentTime` tool: every agent needs the anchor
implicitly, and a tool only helps if the model decides to call it (here it confidently didn't).

## Time-zone correctness — which clock, and why two of them

Every stored instant is UTC and the deployment container's process zone **is** UTC, so
`.ToLocalTime()` / `.LocalDateTime` are no-ops wearing a disguise. Neither appears in this change.
The block therefore carries two clocks, deliberately, because they answer two different questions:

| | Source | For |
|---|---|---|
| **The user's local date + time** | `AccessContext.TimeZoneId` through `DisplayTimeExtensions.ToDisplayTime` — a **named IANA zone**, so DST applies per region | the human question ("what day is today") and the anchor every relative expression resolves against |
| **The instant, ISO-8601 with the trailing `Z`** | `DateTimeOffset.UtcNow` | anything the agent may feed back into a tool, a node field or a calendar entry — a zone-less string re-parses in the **server's** zone on the way back |

Near midnight these are different **days**, which is the entire reason the zone has to be known.
An unknown, empty, or unresolvable zone degrades to **UTC and says so** ("the user's time zone is not
known, so this may not be their wall clock") — never to the server's zone, which looks right in CI
and is wrong in Zurich. An unresolvable id is not echoed either: printing a zone name the conversion
did not use would claim a localization that never happened.

The block also instructs the model **not** to convert calendar facts. A policy inception, an as-of
date, a due date or a birthday is the same calendar day in every zone; converting one shifts data
and corrupts joins.

### The zone has to RIDE on the identity (the half that would otherwise fail silently)

By the time a round's prompt is composed the agent runs asynchronously on the agent hub, where the
ambient `AccessContext` has usually been reset to null or to an impersonated System principal — which
is why the round-dispatch watcher already rebuilds the round's identity from a rider on the pending
message. That rider carried `SubmitterObjectId` / `SubmitterName` / `SubmitterLocale` and not the
zone, so reading `TimeZoneId` off the rebuilt context would have returned null for everyone and the
whole feature would have degraded to UTC — silently, and green in every test that did not look.

So the zone now rides the same carrier, on exactly the argument that put the locale there (#948):

- `AccessContext.TimeZoneId` → `ThreadMessage.SubmitterTimeZoneId`, captured in
  `HubThreadExtensions.CaptureSubmitter` at the submit boundary (the one moment the identity is
  reliably live) and threaded through `ThreadInput.CreateUserMessage`.
- `ThreadSubmissionServer` rebuilds it onto the round's `AccessContext`. Filled in **independently**
  of the locale — the two are separate profile preferences, and folding them into one condition
  would drop the zone whenever the locale happened to be present.
- `AgentChatClient.ResolveViewerZoneId()` prefers that durable submitter zone and falls back to the
  live request/circuit context (`AccessService.ViewerZoneId()`) for the in-process paths that still
  have one.

Scope note: the *language* is deliberately left alone. The locale plumbing already exists (#948) and
adding "User locale: de" to a block about time would not change how a date resolves.

## Tests

`CurrentTimeContextTest` — 15 cases, formatter kept **pure** (instant + zone in, markdown out), so it
runs with no hub, no circuit and no mesh:

| Case | Pins |
|---|---|
| `Summer_Zurich_rendersCEST_UtcPlusTwo` | `2026-07-20 14:32Z` → **16:32**, UTC+02:00 |
| `Winter_Zurich_rendersCET_UtcPlusOne` | `2026-01-20 14:32Z` → **15:32**, UTC+01:00 — a hard-coded offset passes the first and fails this |
| `Summer_NewYork_rendersEDT_UtcMinusFour` / `Winter_NewYork_rendersEST_UtcMinusFive` | a second region on different switch dates — DST is per region, not global |
| `LateUtcEvening_isAlreadyTomorrow_inZurich` | `2026-07-29 23:30Z` → the DATE becomes **2026-07-30** — the case that reads as an off-by-one rather than a timezone bug |
| `EarlyUtcMorning_isStillYesterday_inNewYork` | the mirror image west of Greenwich: `2026-07-20 02:30Z` → Sunday **2026-07-19** |
| `NullZone_staysUtc_andSaysTheZoneIsUnknown`, `EmptyZone_staysUtc`, `UnresolvableZone_staysUtc_andDoesNotEchoTheBogusId`, `NullZoneRendering_isIdenticalToRenderingTheUtcZoneExplicitly` | unchanged UTC, never the server's zone; the bogus id is not echoed |
| `Iso_normalisesToUtc_withTheTrailingZ`, `Describe_normalisesANonUtcInstant_onBothClocks` | machine-facing output stays UTC and says so |
| `Rendering_isInvariantEnglish_underAGermanAmbientCulture` | model-facing text never reads `CultureInfo.Current*` ("Montag" would be the tell) |
| `Block_opensWithItsHeading_andCarriesTheAnchoringGuidance`, `TheReportedIssue_wouldNowBeAnswerable` | the standing guidance, and the issue's own instant rendering as `Friday, 2026-08-14` |

**Non-vacuity, measured**: replacing the seam with a hard-coded `+02:00` offset fails **5 of the 15**
(the winter rows, both New York rows, and the non-UTC-input row). Reverted, all 15 pass.

`AttachmentContextTest.PromptAssembly_ShipsTheCurrentDate_InTheViewersZone` and
`.Streaming_ShipsTheCurrentDate` pin the block onto the **real** assembled prompt on both paths
(Asia/Tokyo, UTC+9 with no DST, so a silent UTC fallback cannot pass by accident on a UTC host).
`ModelSubstitutionTest` pins the submitter rider end to end through the real submission watcher.

## Verification

```
dotnet build src/MeshWeaver.AI -c Release -warnaserror        → 0 Warning(s), 0 Error(s)

CurrentTimeContextTest                     Passed: 15,  Failed: 0
AttachmentContextTest (whole class)        Passed: 10,  Failed: 0
ModelSubstitutionTest                      Passed:  2,  Failed: 0
MeshWeaver.AI.Test (full)                  Passed: 1192, Failed: 0, Skipped: 5 (pre-existing env-gated)
MeshWeaver.Threading.Test (full)           Passed: 133, Failed: 0
MeshWeaver.Documentation.Test (full)       Passed: 34,  Failed: 0
```

Docs: a "What's New" entry (`Category: Fix`), and a new section in `Doc/GUI/DisplayTimes` — an agent
prompt is not a render path but it is a viewer of the same seam, and the next person auditing that
page should find it listed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wVYniTKJ7Kuw7Hh425UPy