### PR TITLE
fix: the activity-log seal no longer latches system-security on the script thread (#1790)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-long-running-script-keeps-its-own-identity.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-long-running-script-keeps-its-own-identity.md
@@ -1,0 +1,23 @@
+---
+Name: A long-running script keeps its own identity
+Category: Fix
+Description: A script that logged past the activity window could silently continue as the system account; it now stays the user who submitted it.
+Icon: ShieldError
+Order: -20260818
+---
+
+# A long-running script keeps its own identity
+
+An activity log keeps only the newest slice of a run's output on the node itself and files the
+older lines away into a segment beside it. That filing step is a privileged write, and it was
+opening its system-identity scope on the thread that happened to be logging — the script's own
+thread — while closing it somewhere else entirely.
+
+The result was that a script which produced enough output to trigger the filing carried on as the
+system account for the rest of its run. Anything it read afterwards was read with system rights
+rather than the submitter's, which for a document export meant an embedded area the requester was
+not allowed to see could still be resolved into the exported file.
+
+The privileged scope is now opened and closed around the write alone, so nothing after it inherits
+the elevation. Scripts, exports and any other activity that outgrows the log window now read
+exactly what their submitter is allowed to read.

--- a/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
+++ b/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
@@ -366,26 +366,37 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
         _sealInFlight = true;
         // CreateOrUpdateNode (not CreateNode): a retried seal re-writes the SAME index with the same
         // content rather than failing on an existing path.
-        // Observable.Using holds the System scope across the COLD write's Subscribe — a plain `using`
-        // would have lapsed before the subscribe ran and the write would post context-null.
-        Observable.Using<MeshNode, IDisposable>(
-                () => _accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
-                _ => meshService.CreateOrUpdateNode(segmentNode))
-            .Subscribe(
-                _ =>
-                {
-                    lock (_publishLock)
+        //
+        // 🚨 #1790 — a SYNCHRONOUS using, never Observable.Using / RunAsSystem, for exactly the
+        // reason spelled out on the publish write above: impersonation is an AsyncLocal scope, and
+        // both reactive shapes open it on the SUBSCRIBING thread while disposing it on whichever
+        // thread the write terminates. This call site is on the same thread as that one — the seal
+        // runs inside PublishSnapshotLocked — so the latch it leaves behind runs the rest of the
+        // script as System. #1785 fixed the publish and split the seal out to #1790 rather than
+        // change it without a repro; ActivityLogSealIdentityTest is that repro.
+        //
+        // Sound here because the capture is synchronous: MeshService.CreateOrUpdateNode reads
+        // AccessService.Context on the CALLING thread and pins it onto the request (RequestedBy)
+        // and onto the delivery (PostOptions.WithAccessContext), so nothing re-reads the ambient
+        // afterwards. The Subscribe sits inside the block as well, which costs nothing and keeps
+        // the cold pipeline's synchronous prologue covered too.
+        using (_accessService?.ImpersonateAsSystem())
+            meshService.CreateOrUpdateNode(segmentNode)
+                .Subscribe(
+                    _ =>
                     {
-                        _sealedCount = firstOrdinal + take;
-                        _sealedSegments = index + 1;
-                        _sealInFlight = false;
-                    }
-                },
-                _ =>
-                {
-                    // Best-effort, like every other write on this path: the lines stay in the window
-                    // and the next flush retries them.
-                    lock (_publishLock) _sealInFlight = false;
-                });
+                        lock (_publishLock)
+                        {
+                            _sealedCount = firstOrdinal + take;
+                            _sealedSegments = index + 1;
+                            _sealInFlight = false;
+                        }
+                    },
+                    _ =>
+                    {
+                        // Best-effort, like every other write on this path: the lines stay in the window
+                        // and the next flush retries them.
+                        lock (_publishLock) _sealInFlight = false;
+                    });
     }
 }

--- a/test/MeshWeaver.AI.Test/ActivityLogSealIdentityTest.cs
+++ b/test/MeshWeaver.AI.Test/ActivityLogSealIdentityTest.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Reflection;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Kernel.Hub;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// #1790 — <c>ActivityLogLogger.SealOverflowLocked</c> must not leave <c>system-security</c>
+/// latched on the thread that issued the publish.
+///
+/// <para><b>The defect.</b> The seal wrote its overflow segment inside
+/// <c>Observable.Using(() =&gt; access.ImpersonateAsSystem(), _ =&gt; meshService.CreateOrUpdateNode(…))</c>.
+/// Impersonation is an <c>AsyncLocal</c> store/restore pair
+/// (<c>AccessService.AccessContextScope</c> saves the previous value and writes it back on
+/// <c>Dispose</c>). <c>Observable.Using</c> OPENS that scope on the SUBSCRIBING thread and DISPOSES
+/// it when the inner observable TERMINATES — for a cross-hub write, the owning hub's response
+/// thread. The two halves therefore land on different threads: the subscriber keeps
+/// <c>system-security</c> forever, and the terminating thread has the subscriber's captured
+/// "previous" identity written into its context.</para>
+///
+/// <para><b>Why the subscribing thread matters here.</b> <c>SealOverflowLocked</c> is called from
+/// <c>PublishSnapshotLocked</c>, and the FIRST publish of a script run is issued from the script's
+/// own thread (<c>Console.WriteLine</c> → <c>LoggerTextWriter</c> → <c>PublishSnapshotLocked</c>,
+/// inside <c>KernelExecutor.RunOnePass</c>). A latch there runs the rest of the script as System —
+/// which is how a <c>--render</c> export came to resolve embedded areas the submitting user may not
+/// read (the review finding on #1785, measured against
+/// <c>DocumentExportAreaAccessTest</c>). The publish write was fixed there; the seal was split out
+/// to #1790 rather than changed without a repro. This is that repro.</para>
+///
+/// <para><b>Why the assertion is the NEGATIVE one.</b> An identity leak has no failing operation to
+/// observe — the seal succeeds either way. The only thing that distinguishes the broken shape from
+/// the fixed one is what the CALLER's thread is left holding, so that is what is asserted, at the
+/// one moment it is observable: immediately after the publish returns and before the enclosing
+/// scope's own <c>Dispose</c> would paper over the latch by restoring the same value.</para>
+///
+/// <para><b>Non-vacuity.</b> Three guards, because "the identity is fine" also passes when the
+/// seal never ran. The tail-flush timer is cancelled up front, so the seal can only be issued
+/// from this thread; the counters are asserted UNTOUCHED immediately before the operation, so an
+/// early seal cannot silently turn it into a no-op; and the test then waits for those counters to
+/// advance, which happens only in the segment write's success callback. Reverting
+/// <c>SealOverflowLocked</c> to <c>Observable.Using</c> turns the identity assertion red on the
+/// first run.</para>
+/// </summary>
+[Collection("KernelTests")]
+public class ActivityLogSealIdentityTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const int DefaultTimeoutMs = 120000;
+    private const string OwnerPath = "rbuergi";
+    private const string CallerId = "alice";
+    private const string SystemId = "system-security";
+
+    [Fact(Timeout = DefaultTimeoutMs)]
+    public async Task SealingTheOverflow_LeavesTheCallersIdentityOnTheCallingThread()
+    {
+        var client = GetClient();
+        var access = client.ServiceProvider.GetRequiredService<AccessService>();
+        client.ServiceProvider.GetService<IMeshService>().Should().NotBeNull(
+            "the seal IS a mesh write — with no IMeshService resolvable from the logger's hub, "
+            + "SealOverflowLocked returns before it impersonates and this test asserts nothing");
+
+        var activityPath = await CreateActivity();
+        var logger = new ActivityLogLogger(client, activityPath);
+        ILogger asLogger = logger;
+
+        // The first append publishes immediately and stamps the throttle window; the next append
+        // to land inside that window arms the 100 ms tail-flush timer. Kill it: a timer-thread
+        // flush would seal on the TIMER thread, leaving this thread untouched and the assertion
+        // below trivially true. A disposed SerialDisposable also disposes every later assignment,
+        // so no tail flush can be armed again for the rest of the test.
+        var pendingFlush = PendingFlushOf(logger);
+        for (var i = 0; i < 100 && pendingFlush.Disposable is null; i++)
+            asLogger.LogInformation("arm {Index}", i);
+        pendingFlush.Disposable.Should().NotBeNull(
+            "the throttle must have armed a tail flush — if nothing is armed, cancelling it "
+            + "proves nothing and a timer could still steal the seal");
+        pendingFlush.Dispose();
+
+        // Fill the window past the seal threshold. Every one of these lands inside the throttle
+        // window, so none of them publishes and the tail flush that would is cancelled.
+        for (var i = 0; i < ActivityLog.MessageWindowLimit + 2; i++)
+            asLogger.LogInformation("line {Index}", i);
+
+        // Nothing may have sealed yet: SealOverflowLocked is a no-op while a seal is in flight, so
+        // an early seal (one of the appends above crossing the 100 ms throttle window on a heavily
+        // loaded machine) would make the operation under test do nothing and the assertion below
+        // vacuously true. Read synchronously, before the operation — a loud failure, never a
+        // silent pass.
+        SealedCountOf(logger).Should().Be(0, "no seal may have completed before the operation under test");
+        SealInFlightOf(logger).Should().BeFalse("no seal may have STARTED before the operation under test");
+
+        // ── The operation under test ────────────────────────────────────────────────────────
+        // Complete bypasses the throttle and publishes SYNCHRONOUSLY on this thread — the same
+        // shape as the script thread's own first publish. A real caller is ambient throughout.
+        using (access.SwitchAccessContext(new AccessContext { ObjectId = CallerId, Name = CallerId }))
+        {
+            logger.Complete(ActivityStatus.Succeeded);
+
+            access.Context?.ObjectId.Should().Be(CallerId,
+                "the seal's ImpersonateAsSystem scope must be closed by the call that opened it. "
+                + $"Observing '{SystemId}' here means the scope was opened on this thread and left "
+                + "to be disposed by the write's terminating thread — so every later statement on "
+                + "this thread, i.e. the rest of the script run, executes as System (#1790)");
+        }
+
+        // Non-vacuity: the counters only advance in the segment write's success callback, so this
+        // proves SealOverflowLocked really ran — and, since the only other publisher was cancelled
+        // above, that it ran on the thread the assertion was made on.
+        var sealedCount = await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .StartWith(0L)
+            .Select(_ => SealedCountOf(logger))
+            .Where(count => count > 0)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(60))
+            .ToTask(TestContext.Current.CancellationToken);
+        Output.WriteLine($"sealed {sealedCount} messages into the overflow segment");
+    }
+
+    /// <summary>
+    /// Materialises the Activity MeshNode the logger publishes to — same shape as
+    /// <c>ActivityTerminalSettleTest.CreateKernelSession</c>.
+    /// </summary>
+    private async Task<string> CreateActivity()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var activityNamespace = $"{OwnerPath}/_Activity";
+        var activityId = $"seal-{Guid.NewGuid():N}";
+        await meshService.CreateNode(new MeshNode(activityId, activityNamespace)
+        {
+            Name = "Seal-identity activity",
+            NodeType = "Activity",
+            MainNode = OwnerPath,
+            State = MeshNodeState.Active,
+            Content = new ActivityLog("ScriptExecution") { Status = ActivityStatus.Running }
+        }).Should().Within(30.Seconds()).Emit();
+        return $"{activityNamespace}/{activityId}";
+    }
+
+    /// <summary>
+    /// The logger's tail-flush handle. Private by design — the null guard turns a rename into a
+    /// loud failure rather than a silently vacuous test.
+    /// </summary>
+    private static SerialDisposable PendingFlushOf(ActivityLogLogger logger)
+        => (SerialDisposable)FieldOf(logger, "pendingFlush");
+
+    /// <summary>How many messages the logger has sealed away — advanced only by a successful
+    /// segment write.</summary>
+    private static int SealedCountOf(ActivityLogLogger logger)
+        => (int)FieldOf(logger, "_sealedCount");
+
+    /// <summary>Whether a segment write is outstanding — set as the seal subscribes, cleared by
+    /// whichever of its callbacks runs.</summary>
+    private static bool SealInFlightOf(ActivityLogLogger logger)
+        => (bool)FieldOf(logger, "_sealInFlight");
+
+    private static object FieldOf(ActivityLogLogger logger, string name)
+    {
+        var field = typeof(ActivityLogLogger)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull(
+            $"ActivityLogLogger.{name} is what this test reads — if it was renamed or retyped, "
+            + "update the test rather than losing the coverage");
+        return field!.GetValue(logger)!;
+    }
+}


### PR DESCRIPTION
Closes #1790.

## The latching mechanism, precisely

`ActivityLogLogger.SealOverflowLocked` wrote its overflow segment like this:

```csharp
Observable.Using<MeshNode, IDisposable>(
        () => _accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
        _ => meshService.CreateOrUpdateNode(segmentNode))
    .Subscribe(…);
```

It is **not** an un-disposed impersonation, and it is not an ambient captured on the wrong thread.
It is an **`AsyncLocal` scope whose store and restore land on two different threads**:

- `AccessService.ImpersonateAsSystem()` returns an `AccessContextScope`, which in its **constructor**
  saves `context.Value` and in `Dispose()` writes that saved value back
  (`src/MeshWeaver.Messaging.Hub/AccessService.cs`).
- Rx runs a `Using`'s resource factory on the **subscribing** thread and disposes the resource when
  the inner observable **terminates**. `meshService.CreateOrUpdateNode` is a cross-hub
  request/response, so it terminates on the owning hub's response thread.

So one Subscribe produced two defects at once:

| | |
|---|---|
| subscribing thread | `system-security` written and **never restored** — latched |
| terminating thread | the subscriber's captured "previous" identity written into *its* context |

**Why that thread matters.** `SealOverflowLocked` is called from `PublishSnapshotLocked`, and the
**first** publish of a script run is issued from the script's own thread (`Console.WriteLine` →
`LoggerTextWriter` → `PublishSnapshotLocked`, inside `KernelExecutor.RunOnePass`). A run that logged
past `ActivityLog.MessageWindowLimit` therefore continued **as System**, and a `--render` export then
resolved embedded areas the submitting user may not read.

That is not inferred — #1785 measured it on the publish write one line below, where the same shape
reddened `DocumentExportAreaAccessTest`. `RunAsSystem` (#1444) was tried there and failed the same
test: `ContainIdentity` restores the caller's identity around **notifications** only, never around
the `Subscribe` that opened the scope. #1785 fixed the publish and deliberately left the seal
byte-identical to main, because it had no repro. This PR is that repro plus the fix.

## The fix

A synchronous `using` around the call *and* its `Subscribe` — the same treatment #1785 applied to
the publish. Opened and closed on one thread, which is what makes it a scope at all.

It is sound because the capture is synchronous: `MeshService.CreateOrUpdateNode` reads
`AccessService.Context` **eagerly, on the calling thread**, and pins it onto the request
(`RequestedBy`) and onto the delivery (`PostOptions.WithAccessContext`), so nothing re-reads the
ambient at Subscribe or later. The issue asked for that to be checked before choosing the shape;
it holds, so no new seam is needed. (`MeshService` is the only `IMeshService` implementation.)

## The test asserts the NEGATIVE, and cannot pass vacuously

`ActivityLogSealIdentityTest.SealingTheOverflow_LeavesTheCallersIdentityOnTheCallingThread`
(`test/MeshWeaver.AI.Test`). An identity leak has no failing operation to observe — the seal
succeeds either way — so the assertion is on what the caller's thread is left holding, taken at the
one moment it is observable: right after the publish returns, before the enclosing scope's own
`Dispose` would paper over the latch by restoring the same value.

Three guards, because "the identity is fine" also passes when the seal never ran:

1. the 100 ms tail-flush timer is cancelled up front, so only this thread can issue the seal (a
   timer-thread seal would leave this thread untouched and the assertion trivially true);
2. the seal counters are asserted **untouched** immediately before the operation, so an early seal
   cannot silently turn `Complete()` into a no-op;
3. the test then waits for those counters to advance — which happens only in the segment write's
   success callback, proving the write really ran and really landed (`sealed 404 messages into the
   overflow segment`).

**Proof it is non-vacuous** — same test, `SealOverflowLocked` reverted to `origin/main`'s
`Observable.Using`, first run:

```
Failed MeshWeaver.AI.Test.ActivityLogSealIdentityTest.SealingTheOverflow_LeavesTheCallersIdentityOnTheCallingThread [1 s]
  Error Message:
   MeshWeaver.Reactive.Assertions.AssertionException : Expected value to be "alice" because the
   seal's ImpersonateAsSystem scope must be closed by the call that opened it. Observing
   'system-security' here means the scope was opened on this thread and left to be disposed by the
   write's terminating thread — so every later statement on this thread, i.e. the rest of the
   script run, executes as System (#1790), but found "system-security".
```

and with the fix restored:

```
Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1
```

## Verification

`dotnet build -c Release -warnaserror` — `MeshWeaver.Kernel.Hub`, `MeshWeaver.AI.Test`,
`MeshWeaver.Hosting.Monolith.Test`, `MeshWeaver.Kernel.Test`, `MeshWeaver.Documentation.Test`:
0 warnings, 0 errors.

| suite | result |
|---|---|
| `MeshWeaver.AI.Test` (full) | **1176 passed**, 0 failed, 5 skipped |
| `DocumentExportAreaAccessTest` (the test #1785's regression reddened) | 1 passed |
| `MeshWeaver.Kernel.Test` | 10 passed |
| `MeshWeaver.Documentation.Test` | 34 passed |

## Siblings found — reported, not fixed here

The same store-here/restore-there shape is widespread: `Observable.Using(access.ImpersonateAsSystem, …)`
and the framework helper `RunAsSystem`/`RunAsHub` both open the scope at Subscribe and close it at
termination. Severity is entirely a function of **which thread subscribes** — benign on a dedicated
background worker or a ThreadPool item (the pool resets `ExecutionContext`), serious on a thread that
keeps doing user work. A sweep of `src/` turned up, highest first:

- **`MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs:402`** — the auth bootstrap itself.
  `System` is latched on the **ASP.NET request thread** by the code that is supposed to be
  establishing the user's identity (`ExtractFromBearerToken` → `InvokeAsync` awaits it). Widest blast
  radius of the set.
- **`MeshWeaver.Graph/Configuration/ApiTokenNodeType.cs:109/:138`** — fire-and-forget `Subscribe`
  inside the `ValidateTokenRequest` handler leaves System on the ApiToken hub's action block. An
  authorization handler latching `Permission.All` is the scenario `ImpersonationScopeExtensions`'
  own doc-comment cites as having already reached an authorization decision once.
- **`MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs:193`** and
  **`MeshWeaver.Hosting.SignalR/SignalRConnectionRegistry.cs:123`** — `await …ToTask()` on the
  transport handshake thread; the rest of connection setup runs as System.
- **`MeshWeaver.Hosting/PathResolutionService.cs:606`** — on the hot path of every page load,
  subscribed from a Blazor circuit thread and from `RoutingServiceBase`.
- **`MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs:470`** (+ `PackageInstaller.cs:2624`),
  **`MeshWeaver.Graph/SpaceInviteService.cs:124`**, **`GroupInviteExtensions.cs:215`**,
  **`NotificationService.cs:111`** — `WithClickAction` handlers, i.e. layout-area hub action blocks.
- **`MeshWeaver.GitSync/GitHubActivityExtensions.cs:75`** — opens the System scope in the
  `SelectMany` continuation *immediately after* a permission verdict.

Lower-severity variants latch the **caller's own** identity rather than System
(`Markdown.Export/Html/LayoutAreaResolver.cs:192`, `Blazor/BlazorView.razor.cs:615`,
`Blazor/Services/BlazorAutocompleteService.cs:91`) — the latch is a no-op in effect, but the restore
still writes a foreign "previous" (often null) onto the terminating thread.

The structural item behind all of them is `ImpersonationScopeExtensions.RunAsSystem` / `RunAsHub`
themselves: if they also restored the subscriber's identity at the **end of Subscribe**, most of the
list would close at the root. That is a framework-wide change with its own blast radius and belongs
in its own issue, not bolted onto a one-call-site fix with a repro for that call site only.

**Not changed here** (named deliberately): `ActivityLogAppender.FlushClaimedSeal`, the other seal
implementation, opens no impersonation scope at all — it writes under whatever identity the append
ran as — so it does not carry this defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wVYniTKJ7Kuw7Hh425UPy
