### PR TITLE
fix: content indexing that is switched off must answer, not throw

### DIFF
--- a/src/MeshWeaver.AI/Plugins/ChunkNavigation.cs
+++ b/src/MeshWeaver.AI/Plugins/ChunkNavigation.cs
@@ -45,6 +45,10 @@ public static class ChunkNavigation
     /// <param name="limit">Max chunk hits returned (1..200).</param>
     public static IObservable<string> SearchChunks(
         IServiceProvider services, string query, string? scopePath, int limit = 20) =>
+        // The RAW registrations, deliberately: ContentChunkSearch itself recognises the inert
+        // stand-ins an unconfigured deployment resolves, and answers with the {count:0, message}
+        // envelope carrying THEIR reason — an actionable line naming what to configure, rather than
+        // the generic "no chunk store" a pre-nulled pair would produce.
         ContentChunkSearch.Search(
                 services.GetService<IChunkedContentVectorStore>(),
                 services.GetService<IChunkEmbedder>(),
@@ -73,9 +77,9 @@ public static class ChunkNavigation
     public static IObservable<string> GetChunk(
         IServiceProvider services, string collectionPath, string filePath, int chunkIndex)
     {
-        var store = services.GetService<IChunkedContentVectorStore>();
+        var store = services.GetActiveChunkStore();
         if (store is null)
-            return Observable.Return(NotAvailableEnvelope());
+            return Observable.Return(NotAvailableEnvelope(services));
 
         if (string.IsNullOrWhiteSpace(collectionPath))
             return Observable.Return(Hint("'collectionPath' is required."));
@@ -119,12 +123,12 @@ public static class ChunkNavigation
                 }));
     }
 
-    private static string NotAvailableEnvelope() =>
+    private static string NotAvailableEnvelope(IServiceProvider services) =>
         new JsonObject
         {
             ["count"] = 0,
             ["results"] = new JsonArray(),
-            ["message"] = "Content chunk indexing is not enabled in this host — no chunk store is configured.",
+            ["message"] = services.ReasonOff(),
         }.ToJsonString();
 
     private static string Hint(string message) =>

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexSettingsTab.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexSettingsTab.cs
@@ -53,10 +53,12 @@ public static class ContentIndexSettingsTab
     {
         IReadOnlyList<SettingsMenuItemDefinition> none = Array.Empty<SettingsMenuItemDefinition>();
 
-        // The tab exists only where the pipeline is wired (embeddings + vector store configured). The
-        // observer is a mesh singleton registered exactly when AddContentIndexingPipeline ran — its
-        // absence means indexing is inert on this server, so don't surface the tab at all.
-        if (host.Hub.ServiceProvider.GetService<ContentIndexingObserver>() is null)
+        // The tab exists only where the pipeline is wired AND configured. Probe the STORE, not
+        // ContentIndexingObserver: the observer's registration deliberately THROWS its actionable
+        // configuration message on an unconfigured deployment (it is the reindex ACTION's entry point),
+        // so probing it would fault this menu provider instead of hiding the tab. GetActiveChunkStore is
+        // null both when the pipeline was never wired and when it is wired but inert.
+        if (host.Hub.ServiceProvider.GetActiveChunkStore() is null)
             return Observable.Return(none);
 
         var tab = new SettingsMenuItemDefinition(
@@ -82,7 +84,12 @@ public static class ContentIndexSettingsTab
 
     internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack, MeshNode? node)
     {
-        var observer = host.Hub.ServiceProvider.GetService<ContentIndexingObserver>();
+        // Same probe as GetTab — resolving the observer on an inert deployment throws by design, so the
+        // "is indexing active?" question is asked of the store and the observer is only resolved after
+        // the answer is yes.
+        var observer = host.Hub.ServiceProvider.GetActiveChunkStore() is null
+            ? null
+            : host.Hub.ServiceProvider.GetService<ContentIndexingObserver>();
         var spacePath = node?.Path ?? "";
         var collectionPath = $"{spacePath}/content";
 
@@ -210,6 +217,7 @@ public static class ContentIndexSettingsTab
     /// <summary>Runs the content search for the current query and renders the tool-call line + hit rows.</summary>
     private static IObservable<UiControl?> BuildExploreResults(LayoutAreaHost host, string collectionPath, string? query)
     {
+        // Raw registrations: ContentChunkSearch recognises an inert stand-in and renders ITS reason.
         var store = host.Hub.ServiceProvider.GetService<IChunkedContentVectorStore>();
         var embedder = host.Hub.ServiceProvider.GetService<IChunkEmbedder>();
         return ContentChunkSearch
@@ -272,7 +280,7 @@ public static class ContentIndexSettingsTab
         var collection = parts[0];
         var file = parts[1];
 
-        var store = host.Hub.ServiceProvider.GetService<IChunkedContentVectorStore>();
+        var store = host.Hub.ServiceProvider.GetActiveChunkStore();
         if (store is null)
             return Observable.Return((UiControl?)Controls.Stack.WithWidth("100%"));
 

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingPipelineExtensions.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingPipelineExtensions.cs
@@ -56,8 +56,22 @@ public static class ContentIndexingPipelineExtensions
                     sp.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem),
                     sp.GetService<ILogger<TextExtractor>>()));
 
-            services.AddSingleton(storeFactory);
-            services.AddSingleton(embedderFactory);
+            // The store + embedder honour the SAME resolve-time gate as the observer below. They used to
+            // be registered unconditionally, which made the gate a half-measure: every consumer that
+            // resolves IChunkedContentVectorStore (search_chunks, the Document blocks view, the settings
+            // tab's explorer) ran the CONCRETE factory on an unconfigured deployment and got that
+            // factory's missing-dependency exception — memex's `search_chunks` failing with
+            // "The requested service 'IEmbeddingProvider' has not been registered" (#1642) instead of
+            // the documented {count:0, message} envelope. Inert stand-ins keep resolution total, and
+            // ContentIndexAvailability maps them back to the null every consumer already branches on.
+            services.AddSingleton<IChunkedContentVectorStore>(sp =>
+                enabledWhen is null || enabledWhen(sp)
+                    ? storeFactory(sp)
+                    : new InertChunkedContentVectorStore(InactiveReason));
+            services.AddSingleton<IChunkEmbedder>(sp =>
+                enabledWhen is null || enabledWhen(sp)
+                    ? embedderFactory(sp)
+                    : new InertChunkEmbedder(InactiveReason));
             if (summarizerFactory is not null)
                 services.AddSingleton(summarizerFactory);
             if (imageDescriberFactory is not null)
@@ -96,10 +110,7 @@ public static class ContentIndexingPipelineExtensions
                         sp.GetRequiredService<IMessageHub>(),
                         sp.GetRequiredService<ContentIndexingService>(),
                         sp.GetService<ILogger<ContentIndexingObserver>>())
-                    : throw new InvalidOperationException(
-                        "Content indexing is not active on this deployment: the pipeline's activation " +
-                        "condition is false (typically no mesh database connection string or no " +
-                        "Embedding:Endpoint/Embedding:ApiKey configuration). Configure both to index content."));
+                    : throw new InvalidOperationException(InactiveReason));
             services.AddSingleton<IContentUploadObserver>(sp =>
                 enabledWhen is null || enabledWhen(sp)
                     ? sp.GetRequiredService<ContentIndexingObserver>()
@@ -110,6 +121,17 @@ public static class ContentIndexingPipelineExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Why the pipeline is inert on an unconfigured deployment — one sentence, naming what to configure.
+    /// It is the message of the reindex entry point's refusal AND the <c>Reason</c> the inert store /
+    /// embedder carry into the <c>search_chunks</c> "indexing is off" envelope, so an operator reads the
+    /// same actionable line wherever the capability is missing.
+    /// </summary>
+    public const string InactiveReason =
+        "Content indexing is not active on this deployment: the pipeline's activation condition is " +
+        "false (typically no mesh database connection string, or no embedding provider — " +
+        "Embedding:Endpoint plus Embedding:ApiKey for the cloud provider). Configure both to index content.";
 
     /// <summary>
     /// The disabled-pipeline stand-in on the upload seam: uploads proceed, nothing indexes.

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/DocumentLayoutAreas.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/DocumentLayoutAreas.cs
@@ -186,7 +186,10 @@ public static class DocumentLayoutAreas
     private static IObservable<UiControl?> BuildBlockPanel(
         LayoutAreaHost host, Document document, string nodePath, int index, string terms)
     {
-        var store = host.Hub.ServiceProvider.GetService<IChunkedContentVectorStore>();
+        // GetActiveChunkStore, never GetService: on a deployment where the pipeline is wired but not
+        // configured the registration resolves an inert stand-in, and this view must read that as
+        // "not enabled" — the same branch as "never wired".
+        var store = host.Hub.ServiceProvider.GetActiveChunkStore();
         if (store is null)
             return Observable.Return((UiControl?)Controls.Markdown(
                 "_Content indexing is not enabled on this server._"));
@@ -282,7 +285,7 @@ public static class DocumentLayoutAreas
         // Load the deep-linked chunk's stored provenance (page + on-page box) so the viewer marks the exact
         // region — precise and independent of whether the chunk text can be re-found by string match. When
         // the store/chunk/position is absent the viewer falls back to the verbatim text highlight (terms).
-        var store = host.Hub.ServiceProvider.GetService<IChunkedContentVectorStore>();
+        var store = host.Hub.ServiceProvider.GetActiveChunkStore();
         var provenance = store is null
             ? Observable.Return<ContentChunk?>(null)
             : store.GetChunk(document.CollectionPath, document.FilePath, index)

--- a/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgreSqlContentIndexingExtensions.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgreSqlContentIndexingExtensions.cs
@@ -91,12 +91,18 @@ public static class PostgreSqlContentIndexingExtensions
         => sp.GetService<IConfiguration>()?.GetConnectionString("memex")
            ?? sp.GetService<NpgsqlDataSource>()?.ConnectionString;
 
+    /// <summary>
+    /// The resolve-time activation gate: a mesh database to hold the chunks, and a registered
+    /// <see cref="IEmbeddingProvider"/> to embed them.
+    ///
+    /// <para>The provider's PRESENCE is the configuration signal — <c>TryAddEmbeddingProvider</c>
+    /// registers one exactly when <c>Embedding:Endpoint</c> (plus <c>Embedding:ApiKey</c> for the cloud
+    /// default) is set, and returns null otherwise. Re-testing those two keys here was therefore
+    /// redundant for the cloud provider and WRONG for the local one: an Ollama/OpenAI-compatible
+    /// endpoint legitimately has no API key, so a correctly configured on-host deployment registered a
+    /// provider and then had indexing held inert by a key it does not use.</para>
+    /// </summary>
     private static bool IsConfigured(IServiceProvider sp)
-    {
-        var configuration = sp.GetService<IConfiguration>();
-        return !string.IsNullOrWhiteSpace(MeshConnectionString(sp))
-            && !string.IsNullOrWhiteSpace(configuration?["Embedding:Endpoint"])
-            && !string.IsNullOrWhiteSpace(configuration?["Embedding:ApiKey"])
-            && sp.GetService<IEmbeddingProvider>() is not null;
-    }
+        => !string.IsNullOrWhiteSpace(MeshConnectionString(sp))
+           && sp.GetService<IEmbeddingProvider>() is not null;
 }

--- a/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgresContentIndexingModuleAttribute.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgresContentIndexingModuleAttribute.cs
@@ -15,11 +15,12 @@ namespace MeshWeaver.ContentCollections.Indexing.PostgreSql;
 ///
 /// <para><b>Activation is decided at RESOLVE time, not install time</b>: a module has no
 /// <c>IConfiguration</c> when its attribute folds in, so the pipeline registers with the
-/// <c>enabledWhen</c> gate — active only when the mesh database connection resolves AND
-/// <c>Embedding:Endpoint</c>/<c>Embedding:ApiKey</c> are configured AND an
-/// <see cref="IEmbeddingProvider"/> is registered. Unconfigured deployments (e.g. the FileSystem
-/// monolith) stay inert: uploads proceed unindexed and content autocomplete settles empty —
-/// never a missing-store error.</para>
+/// <c>enabledWhen</c> gate — active only when the mesh database connection resolves AND an
+/// <see cref="IEmbeddingProvider"/> is registered (which <c>AddEmbeddings</c> does exactly when
+/// <c>Embedding:Endpoint</c>, plus <c>Embedding:ApiKey</c> for the cloud provider, is configured).
+/// Unconfigured deployments (e.g. the FileSystem monolith) stay inert THROUGHOUT: uploads proceed
+/// unindexed, content autocomplete settles empty, and the chunk store/embedder resolve inert
+/// stand-ins so <c>search_chunks</c> answers "indexing is off" — never a missing-store error.</para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly)]
 public sealed class PostgresContentIndexingModuleAttribute : MeshNodeProviderAttribute

--- a/src/MeshWeaver.ContentCollections.Indexing/ContentChunkSearch.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/ContentChunkSearch.cs
@@ -27,8 +27,10 @@ namespace MeshWeaver.ContentCollections.Indexing;
 ///
 /// <para>Reactive + cold: every method returns an <see cref="IObservable{T}"/> that embeds + reads the
 /// store on subscribe. The store + embedder are passed in (resolved by the caller from DI); when content
-/// indexing is not wired into a host they are null and the engine emits a result whose
-/// <see cref="ContentSearchResult.Message"/> explains why, never throwing.</para>
+/// indexing is OFF — never wired into the host (null) or wired but not configured for this deployment
+/// (an <see cref="IInertContentIndex"/> stand-in) — the engine emits a result whose
+/// <see cref="ContentSearchResult.Message"/> says so, never throwing. A capability that is switched off
+/// must SAY it is switched off: an opaque error here sends the next caller hunting a data bug.</para>
 /// </summary>
 public static class ContentChunkSearch
 {
@@ -70,9 +72,8 @@ public static class ContentChunkSearch
         ContentSearchResult Empty(string message) =>
             new(text, ns, scope, limit, Array.Empty<ChunkHit>(), toolCall, message);
 
-        if (store is null || embedder is null)
-            return Observable.Return(Empty(
-                "Content chunk indexing is not enabled in this host — no chunk store is configured."));
+        if (ContentIndexAvailability.IsOff(store, embedder))
+            return Observable.Return(Empty(ContentIndexAvailability.ReasonOff(store, embedder)));
         if (string.IsNullOrWhiteSpace(text))
             return Observable.Return(Empty("Pass query text (free-text terms) to search content chunks."));
         if (string.IsNullOrWhiteSpace(ns))
@@ -103,9 +104,8 @@ public static class ContentChunkSearch
             new(text, NormalizePath(anchorPath), ContentSearchScope.AncestorsAndSelf, limit,
                 Array.Empty<ChunkHit>(), toolCall, message);
 
-        if (store is null || embedder is null)
-            return Observable.Return(Empty(
-                "Content chunk indexing is not enabled in this host — no chunk store is configured."));
+        if (ContentIndexAvailability.IsOff(store, embedder))
+            return Observable.Return(Empty(ContentIndexAvailability.ReasonOff(store, embedder)));
         if (string.IsNullOrWhiteSpace(text))
             return Observable.Return(Empty("Pass a non-empty 'query' to search content chunks."));
 

--- a/src/MeshWeaver.ContentCollections.Indexing/InertContentIndex.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/InertContentIndex.cs
@@ -1,0 +1,144 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reactive;
+using System.Reactive.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.ContentCollections.Indexing;
+
+/// <summary>
+/// Marks the stand-ins the content-indexing pipeline registers when the deployment is NOT configured
+/// for indexing (no vector store connection, no embedding provider). Every consumer of the indexing
+/// services tests for this state and answers "the capability is off" — it must never surface as an
+/// exception.
+///
+/// <para><b>Why a stand-in and not "no registration".</b> Whether the deployment is configured can
+/// only be decided at RESOLVE time (a boot-loaded module has no <c>IConfiguration</c> when it folds
+/// in), so the services ARE registered and the gate lives in the factory. The obvious shape — a
+/// factory returning <c>null</c> so <c>GetService</c> answers null — does not work on the container
+/// MeshWeaver actually runs: Autofac REFUSES a delegate registration that returns null and throws
+/// <c>"An exception was thrown while activating λ:T"</c> out of <c>GetService</c>. An inert INSTANCE
+/// is therefore the only shape in which "registered but switched off" can be resolved at all.</para>
+/// </summary>
+public interface IInertContentIndex
+{
+    /// <summary>
+    /// Why content indexing is off on this deployment, phrased for a tool caller or a page — it is
+    /// carried into the <c>search_chunks</c> envelope's <c>message</c>, so it must name what to
+    /// configure rather than merely stating that nothing was found.
+    /// </summary>
+    string Reason { get; }
+}
+
+/// <summary>
+/// The switched-off <see cref="IChunkedContentVectorStore"/>: every read answers the empty result and
+/// every write is dropped, so nothing throws and nothing is silently half-indexed. Resolved only via
+/// <see cref="ContentIndexAvailability.GetActiveChunkStore"/>, which maps it back to null for the
+/// callers that branch on "no store".
+/// </summary>
+public sealed class InertChunkedContentVectorStore(string reason)
+    : IChunkedContentVectorStore, IInertContentIndex
+{
+    /// <inheritdoc />
+    public string Reason { get; } = reason;
+
+    /// <inheritdoc />
+    public IObservable<string?> GetFileHash(string collectionPath, string filePath) =>
+        Observable.Return<string?>(null);
+
+    /// <inheritdoc />
+    public IObservable<Unit> ReplaceFileChunks(
+        string collectionPath, string filePath, IReadOnlyList<ContentChunk> chunks) =>
+        Observable.Return(Unit.Default);
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<ContentChunk>> Search(string collectionPath, float[] query, int topK) =>
+        Observable.Return<IReadOnlyList<ContentChunk>>(Array.Empty<ContentChunk>());
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<ContentChunk>> SearchSubtree(
+        string collectionPathPrefix, float[] query, int topK) =>
+        Observable.Return<IReadOnlyList<ContentChunk>>(Array.Empty<ContentChunk>());
+
+    /// <inheritdoc />
+    public IObservable<ContentChunk?> GetChunk(string collectionPath, string filePath, int chunkIndex) =>
+        Observable.Return<ContentChunk?>(null);
+
+    /// <inheritdoc />
+    public IObservable<int> GetChunkCount(string collectionPath, string filePath) =>
+        Observable.Return(0);
+}
+
+/// <summary>
+/// The switched-off <see cref="IChunkEmbedder"/>. It never embeds: every caller resolves it through
+/// <see cref="ContentIndexAvailability.GetActiveChunkEmbedder"/> (null when inert) or tests for
+/// <see cref="IInertContentIndex"/> first, so reaching <see cref="Embed"/> would mean a caller skipped
+/// the availability check — which must fail loudly rather than return a zero vector that ranks as a
+/// silent, meaningless similarity.
+/// </summary>
+public sealed class InertChunkEmbedder(string reason) : IChunkEmbedder, IInertContentIndex
+{
+    /// <inheritdoc />
+    public string Reason { get; } = reason;
+
+    /// <inheritdoc />
+    public IObservable<float[]> Embed(string text) =>
+        Observable.Throw<float[]>(new InvalidOperationException(Reason));
+
+    /// <inheritdoc />
+    public int Dimensions => 0;
+}
+
+/// <summary>
+/// Resolves the content-indexing services in the ONE shape every consumer already branches on:
+/// a live service, or <c>null</c> when the deployment is not configured for content indexing.
+/// </summary>
+public static class ContentIndexAvailability
+{
+    /// <summary>
+    /// The fallback message for the "indexing is off" envelope, used when no inert stand-in carried a
+    /// deployment-specific <see cref="IInertContentIndex.Reason"/> (e.g. the pipeline was never wired
+    /// into this host at all).
+    /// </summary>
+    public const string NotEnabledMessage =
+        "Content chunk indexing is not enabled in this host — no chunk store is configured.";
+
+    /// <summary>
+    /// The live chunk store, or null when content indexing is off (never wired, or wired but not
+    /// configured — see <see cref="IInertContentIndex"/>).
+    /// </summary>
+    public static IChunkedContentVectorStore? GetActiveChunkStore(this IServiceProvider services) =>
+        Active(services.GetService<IChunkedContentVectorStore>());
+
+    /// <summary>
+    /// The live chunk embedder, or null when content indexing is off — the counterpart to
+    /// <see cref="GetActiveChunkStore"/>.
+    /// </summary>
+    public static IChunkEmbedder? GetActiveChunkEmbedder(this IServiceProvider services) =>
+        Active(services.GetService<IChunkEmbedder>());
+
+    /// <summary>
+    /// The reason indexing is off on this host, read from whichever registered service is an inert
+    /// stand-in — the line a tool envelope or a page shows instead of "no results".
+    /// </summary>
+    public static string ReasonOff(this IServiceProvider services) =>
+        ReasonOff(services.GetService<IChunkedContentVectorStore>(), services.GetService<IChunkEmbedder>());
+
+    /// <summary>The reason indexing is off, from whichever of the two services is an inert stand-in.</summary>
+    public static string ReasonOff(IChunkedContentVectorStore? store, IChunkEmbedder? embedder) =>
+        (store as IInertContentIndex)?.Reason
+        ?? (embedder as IInertContentIndex)?.Reason
+        ?? NotEnabledMessage;
+
+    /// <summary>
+    /// Whether the pair can actually answer a search: false only when both are present and neither is an
+    /// inert stand-in — which is exactly when the caller may dereference them, hence the
+    /// <see cref="NotNullWhenAttribute"/> pair.
+    /// </summary>
+    public static bool IsOff(
+        [NotNullWhen(false)] IChunkedContentVectorStore? store,
+        [NotNullWhen(false)] IChunkEmbedder? embedder) =>
+        store is null or IInertContentIndex || embedder is null or IInertContentIndex;
+
+    private static T? Active<T>(T? service) where T : class =>
+        service is IInertContentIndex ? null : service;
+}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-content-search-says-when-it-is-switched-off.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-content-search-says-when-it-is-switched-off.md
@@ -1,0 +1,25 @@
+---
+Name: Content search says when it is switched off
+Category: Fix
+Description: On a deployment without an embedding provider, searching indexed content now answers "indexing is not active here, configure this" instead of failing with an opaque error.
+Icon: Search
+Order: -20260818
+---
+
+# Content search says when it is switched off
+
+Content indexing is optional: a deployment that has no embedding provider configured simply does
+not index anything. That was always the intent, but asking for indexed content on such a
+deployment did not say so — the `search_chunks` tool failed with a bare "An error occurred", and
+the Space settings page could fault the same way. An outage and a switched-off capability looked
+identical, so the natural next step was to go hunting for missing data.
+
+Now every content-search surface answers the way it documents: an empty result carrying one line
+that says content indexing is not active on this deployment and names the settings to configure.
+The chunk viewer on a Document node and the Content Indexing settings tab make the same
+distinction rather than erroring.
+
+This is about the message, not the capability: where indexing is configured nothing changes, and
+where it is not, configuring an embedding endpoint is still what turns it on. One related fix
+comes with it — a deployment using a local, key-less embedding endpoint was being held inert by a
+check for an API key it does not use, and now indexes normally.

--- a/test/MeshWeaver.AI.Test/ContentIndexingOffToolTest.cs
+++ b/test/MeshWeaver.AI.Test/ContentIndexingOffToolTest.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Plugins;
+using MeshWeaver.ContentCollections.Indexing;
+using MeshWeaver.ContentCollections.Indexing.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// #1642 — the <c>search_chunks</c> / <c>get_chunk</c> tools against a mesh where the content-indexing
+/// pipeline IS wired but the deployment is NOT configured for it (no embedding provider). That is memex's
+/// exact shape: the module is listed in <c>Modules:Assemblies</c>, so <c>AddContentIndexingPipeline</c>
+/// runs, while <c>Embedding:Endpoint</c>/<c>Embedding:ApiKey</c> are unset so no
+/// <c>IEmbeddingProvider</c> is registered.
+///
+/// <para>The tools' documented contract is explicit: <i>"When content indexing isn't enabled in this host,
+/// returns a <c>{count:0, message:…}</c> envelope rather than erroring."</i> Before the fix the store's
+/// registration was NOT gated, so resolving it ran the concrete factory, whose first act
+/// (<c>GetRequiredService&lt;IEmbeddingProvider&gt;()</c>) threw — and the MCP caller saw
+/// "An error occurred invoking 'search_chunks'", a capability outage that reads as a data bug.</para>
+///
+/// <para>The store/embedder factories here THROW exactly like the pgvector ones do on an unconfigured
+/// deployment, so the test fails if anything on the read path resolves them.</para>
+/// </summary>
+public class ContentIndexingOffToolTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static CancellationToken Ct => new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token;
+
+    /// <summary>The stand-in for "this deployment has no embedding provider" — the exact failure #1642 reported.</summary>
+    private static InvalidOperationException Unconfigured() =>
+        new("The requested service 'MeshWeaver.Hosting.Embeddings.IEmbeddingProvider' has not been registered.");
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddContentIndexingPipeline(
+                storeFactory: _ => throw Unconfigured(),
+                embedderFactory: _ => throw Unconfigured(),
+                enabledWhen: _ => false);
+
+    private Task<string> Run(IObservable<string> op) =>
+        op.FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+
+    [Fact(Timeout = 60000)]
+    public void UnconfiguredPipeline_ResolvingTheStore_DoesNotThrow()
+    {
+        var store = Mesh.ServiceProvider.GetService<IChunkedContentVectorStore>();
+        store.Should().BeAssignableTo<IInertContentIndex>(
+            "a wired-but-unconfigured pipeline must resolve an inert stand-in — the concrete factory " +
+            "(which needs an IEmbeddingProvider) must never run");
+        Mesh.ServiceProvider.GetActiveChunkStore().Should().BeNull(
+            "the availability helper maps the stand-in back to the null every consumer branches on");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task SearchChunks_Anchored_ReturnsEmptyEnvelopeWithMessage()
+    {
+        var json = await Run(ChunkNavigation.SearchChunks(
+            Mesh.ServiceProvider, "accrued benefit obligation", TestPartition));
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("count").GetInt32().Should().Be(0);
+        doc.RootElement.GetProperty("results").GetArrayLength().Should().Be(0);
+        var message = doc.RootElement.GetProperty("message").GetString();
+        message.Should().Contain("not active on this deployment",
+            "a switched-off capability must say it is switched off, not fail opaquely");
+        message.Should().Contain("Embedding:Endpoint",
+            "the message must name what to configure — otherwise the next reader hunts a data bug");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task SearchChunks_NamespaceGrammar_ReturnsEmptyEnvelopeWithMessage()
+    {
+        var json = await Run(ChunkNavigation.SearchChunks(
+            Mesh.ServiceProvider,
+            $"namespace:{TestPartition}/content scope:subtree accrued benefit obligation",
+            scopePath: null));
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("count").GetInt32().Should().Be(0);
+        doc.RootElement.GetProperty("message").GetString().Should().Contain("Embedding:Endpoint");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task GetChunk_ReturnsNotAvailableEnvelope()
+    {
+        var json = await Run(ChunkNavigation.GetChunk(
+            Mesh.ServiceProvider, $"{TestPartition}/content", "docs/note.txt", 0));
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("count").GetInt32().Should().Be(0);
+        doc.RootElement.TryGetProperty("text", out _).Should().BeFalse(
+            "an unavailable index must not hand back chunk text");
+        doc.RootElement.GetProperty("message").GetString().Should().Contain("not active on this deployment");
+    }
+}

--- a/test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test/IndexingBootPackTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test/IndexingBootPackTest.cs
@@ -1,10 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
+using MeshWeaver.ServiceProvider;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -19,6 +24,21 @@ namespace MeshWeaver.ContentCollections.Indexing.PostgreSql.Test;
 /// </summary>
 public class IndexingBootPackTest
 {
+    /// <summary>
+    /// The module's registrations behind the container the portal actually runs — Autofac. This is not
+    /// a detail: Autofac REFUSES a delegate registration that returns null (it throws
+    /// "An exception was thrown while activating λ:T" out of <c>GetService</c>), so the
+    /// "resolves to nothing when the capability is off" contract cannot be expressed as a
+    /// null-returning factory and only this container proves the inert stand-in works.
+    /// </summary>
+    private static IServiceProvider UnconfiguredProvider()
+    {
+        var services = InstallModule();
+        // An empty configuration — no connection string, no embeddings: the gate must hold.
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        return services.CreateMeshWeaverServiceProvider();
+    }
+
     private static IServiceCollection InstallModule()
     {
         var serviceConfigs = new List<Func<IServiceCollection, IServiceCollection>>();
@@ -61,5 +81,77 @@ public class IndexingBootPackTest
         var ex = Assert.Throws<InvalidOperationException>(
             () => provider.GetRequiredService<Graph.ContentIndexingObserver>());
         Assert.Contains("Embedding:Endpoint", ex.Message);
+    }
+
+    // ── #1642: an unconfigured deployment must ANSWER "indexing is off", never throw ──
+
+    [Fact]
+    public void Unconfigured_ChunkStoreAndEmbedder_ResolveInert_NeverThrow()
+    {
+        var provider = UnconfiguredProvider();
+        using var disposable = provider as IDisposable;
+
+        // The regression: this resolution used to run the CONCRETE pgvector factory, whose first act is
+        // GetRequiredService<IEmbeddingProvider>() — unregistered on an unconfigured deployment — so
+        // every consumer (search_chunks, the Document blocks view, the settings tab) got
+        // "The requested service 'IEmbeddingProvider' has not been registered" instead of an answer.
+        var store = provider.GetService<IChunkedContentVectorStore>();
+        var embedder = provider.GetService<IChunkEmbedder>();
+
+        Assert.IsAssignableFrom<IInertContentIndex>(store);
+        Assert.IsAssignableFrom<IInertContentIndex>(embedder);
+
+        // …and the availability helper maps the stand-ins back to the null every consumer branches on.
+        Assert.Null(provider.GetActiveChunkStore());
+        Assert.Null(provider.GetActiveChunkEmbedder());
+    }
+
+    [Fact]
+    public async Task Unconfigured_ChunkSearch_ReturnsEmptyEnvelopeNamingWhatToConfigure()
+    {
+        var provider = UnconfiguredProvider();
+        using var disposable = provider as IDisposable;
+        var store = provider.GetService<IChunkedContentVectorStore>();
+        var embedder = provider.GetService<IChunkEmbedder>();
+
+        // Both query shapes the tool accepts: anchored at a node path, and the namespace: grammar.
+        foreach (var (query, anchor) in new[]
+                 {
+                     ("accrued benefit obligation", "part/Space"),
+                     ("namespace:part/Space/content scope:subtree accrued benefit obligation", null),
+                 })
+        {
+            var result = await ContentChunkSearch.Search(store, embedder, query, anchor)
+                .FirstAsync().ToTask(TestContext.Current.CancellationToken);
+            var json = ContentChunkSearch.ToJson(result);
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.Equal(0, doc.RootElement.GetProperty("count").GetInt32());
+            Assert.Empty(doc.RootElement.GetProperty("results").EnumerateArray());
+            var message = doc.RootElement.GetProperty("message").GetString();
+            // A capability that is switched off must SAY so, and name what to configure — an opaque
+            // failure sends the next reader hunting a data bug.
+            Assert.Contains("not active on this deployment", message);
+            Assert.Contains("Embedding:Endpoint", message);
+        }
+    }
+
+    [Fact]
+    public async Task Unconfigured_ChunkSearch_NeverEmbeds()
+    {
+        var provider = UnconfiguredProvider();
+        using var disposable = provider as IDisposable;
+
+        // The inert embedder faults if it is ever asked to embed — reaching it would mean a caller
+        // skipped the availability check and ranked a meaningless zero vector. The search must settle
+        // on the "off" envelope without touching it.
+        var result = await ContentChunkSearch.Search(
+                provider.GetService<IChunkedContentVectorStore>(),
+                provider.GetService<IChunkEmbedder>(),
+                "anything at all", "part/Space")
+            .FirstAsync().ToTask(TestContext.Current.CancellationToken);
+
+        Assert.Empty(result.Hits);
+        Assert.NotNull(result.Message);
     }
 }

--- a/test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test.csproj
+++ b/test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test.csproj
@@ -8,6 +8,11 @@
     <ProjectReference Include="..\..\src\MeshWeaver.ContentCollections.Indexing\MeshWeaver.ContentCollections.Indexing.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.ContentCollections.Indexing.PostgreSql\MeshWeaver.ContentCollections.Indexing.PostgreSql.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.PostgreSql\MeshWeaver.Hosting.PostgreSql.csproj" />
+    <!-- CreateMeshWeaverServiceProvider: the Autofac container the portal runs, which the boot-pack
+         test resolves the pipeline through (a plain ServiceCollection.BuildServiceProvider tolerates a
+         null-returning factory that Autofac refuses, so it cannot prove the inert-when-unconfigured
+         contract). -->
+    <ProjectReference Include="..\..\src\MeshWeaver.ServiceProvider\MeshWeaver.ServiceProvider.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/MeshWeaver.ContentCollections.Indexing.Test/InertContentIndexTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Test/InertContentIndexTest.cs
@@ -1,0 +1,88 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Indexing.Test;
+
+/// <summary>
+/// The "content indexing is switched off" contract at the engine level (#1642). A deployment can have the
+/// pipeline WIRED and still not be CONFIGURED for it; the services then resolve
+/// <see cref="IInertContentIndex"/> stand-ins rather than the concrete store/embedder, and every search
+/// surface must answer the documented <c>{count:0, message:…}</c> envelope carrying the stand-in's reason —
+/// never an exception, and never a bare "no results" that reads as missing data.
+/// </summary>
+public class InertContentIndexTest
+{
+    private const string Reason = "Content indexing is not active on this deployment: configure Embedding:Endpoint.";
+
+    private readonly InertChunkedContentVectorStore _store = new(Reason);
+    private readonly InertChunkEmbedder _embedder = new(Reason);
+    private readonly FakeEmbedder _liveEmbedder = new();
+    private readonly InMemoryChunkedContentVectorStore _liveStore = new();
+
+    private static async Task<ContentSearchResult> Anchored(
+        IChunkedContentVectorStore? store, IChunkEmbedder? embedder) =>
+        await ContentChunkSearch.Search(store, embedder, "benefit obligation", "ACME/content", 20)
+            .FirstAsync().ToTask();
+
+    private static async Task<ContentSearchResult> Grammar(
+        IChunkedContentVectorStore? store, IChunkEmbedder? embedder) =>
+        await ContentChunkSearch.Search(
+                store, embedder, "namespace:ACME/content scope:subtree benefit obligation", null, 20)
+            .FirstAsync().ToTask();
+
+    [Fact]
+    public void IsOff_TrueForNullAndForInert_FalseOnlyWhenBothAreLive()
+    {
+        Assert.True(ContentIndexAvailability.IsOff(null, null));
+        Assert.True(ContentIndexAvailability.IsOff(_store, _liveEmbedder));
+        Assert.True(ContentIndexAvailability.IsOff(_liveStore, _embedder));
+        Assert.False(ContentIndexAvailability.IsOff(_liveStore, _liveEmbedder));
+    }
+
+    [Fact]
+    public void ReasonOff_PrefersTheStandIns_Reason_OverTheGenericFallback()
+    {
+        Assert.Equal(Reason, ContentIndexAvailability.ReasonOff(_store, _liveEmbedder));
+        Assert.Equal(Reason, ContentIndexAvailability.ReasonOff(_liveStore, _embedder));
+        // Nothing registered at all (the pipeline was never wired) has no deployment-specific reason.
+        Assert.Equal(ContentIndexAvailability.NotEnabledMessage,
+            ContentIndexAvailability.ReasonOff(null, null));
+    }
+
+    [Fact]
+    public async Task Search_WithInertServices_ReturnsTheReason_InBothQueryShapes()
+    {
+        foreach (var result in new[] { await Anchored(_store, _embedder), await Grammar(_store, _embedder) })
+        {
+            Assert.Empty(result.Hits);
+            Assert.Equal(Reason, result.Message);
+            // The tool envelope the MCP/agent surface actually returns.
+            var json = ContentChunkSearch.ToJson(result);
+            Assert.Contains("\"count\":0", json);
+            Assert.Contains(Reason, json);
+        }
+    }
+
+    [Fact]
+    public async Task Search_WithInertServices_NeverEmbeds()
+    {
+        // The inert embedder faults if asked to embed — reaching it would mean the availability check was
+        // skipped and a meaningless zero vector got ranked. Both query shapes must settle before that.
+        Assert.NotNull((await Anchored(_liveStore, _embedder)).Message);
+        Assert.NotNull((await Grammar(_liveStore, _embedder)).Message);
+    }
+
+    [Fact]
+    public async Task InertStore_AnswersEveryReadEmptily_AndDropsWrites()
+    {
+        Assert.Null(await _store.GetFileHash("ACME/content", "a.txt").FirstAsync().ToTask());
+        Assert.Equal(0, await _store.GetChunkCount("ACME/content", "a.txt").FirstAsync().ToTask());
+        Assert.Null(await _store.GetChunk("ACME/content", "a.txt", 0).FirstAsync().ToTask());
+        Assert.Empty(await _store.Search("ACME/content", [1f], 5).FirstAsync().ToTask());
+        Assert.Empty(await _store.SearchSubtree("ACME", [1f], 5).FirstAsync().ToTask());
+        // A write completes (uploads proceed) and stores nothing.
+        await _store.ReplaceFileChunks("ACME/content", "a.txt", []).FirstAsync().ToTask();
+        Assert.Equal(0, await _store.GetChunkCount("ACME/content", "a.txt").FirstAsync().ToTask());
+    }
+}


### PR DESCRIPTION
## What was broken

`search_chunks` on memex answered **"An error occurred invoking 'search_chunks'"** — against the tool's own documented contract:

> *"When content indexing isn't enabled in this host, returns a `{count:0, message:…}` envelope rather than erroring."*

A switched-off capability and an outage looked identical, which sends the next reader hunting a data bug. Reproduced live on `memex.meshweaver.cloud` on 2026-08-18 (both a `namespace:`-targeted and an anchored query).

## Root cause — the `enabledWhen` gate was a half-measure

`AddContentIndexingPipeline` gates the upload observer and the autocomplete provider on `enabledWhen`, but registered the **store and embedder factories unconditionally**. So every read-path consumer that resolves `IChunkedContentVectorStore` ran the concrete pgvector factory, whose first act is `sp.GetRequiredService<IEmbeddingProvider>()` — unregistered on a deployment with no embedding configuration. That is exactly the frame in the incident's stack trace (`PostgreSqlContentIndexingExtensions.<>c__1.<AddPostgreSqlContentIndexing>b__1_0`).

The `IsConfigured` guard added earlier stopped the *pipeline* from running; it never stopped the *store* from being resolved, and search resolves the store.

The same shape hit a second surface: `ContentIndexSettingsTab.GetTab` probed `GetService<ContentIndexingObserver>() is null` as its "is indexing active?" test, but that registration deliberately **throws** its actionable message when inactive — so on an unconfigured deployment the Space settings menu provider faulted instead of hiding the tab.

### Why the obvious fix does not work

A factory returning `null` (so `GetService` answers null, which is what all six consumers already branch on) **is refused by Autofac**, the container MeshWeaver actually runs — it throws `"An exception was thrown while activating λ:T"` straight out of `GetService`. Measured against the pinned Autofac 9.3.2 / Autofac.Extensions.DependencyInjection 11.0.2, and now pinned by a test that resolves through `CreateMeshWeaverServiceProvider` rather than `ServiceCollection.BuildServiceProvider` (which tolerates the null and would have proved nothing).

## The fix

- **`InertChunkedContentVectorStore` / `InertChunkEmbedder`** (`IInertContentIndex`), carrying the reason indexing is off. The pipeline resolves these when `enabledWhen` is false, so resolution is **total** — no consumer, present or future, can trip a factory that needs an embedding provider.
- **`ContentIndexAvailability`** maps a stand-in back to the `null` every consumer already branches on (`GetActiveChunkStore` / `GetActiveChunkEmbedder`), and `ContentChunkSearch` recognises it directly — so the envelope carries an **actionable** line naming what to configure instead of a bare "no chunk store".
- The settings tab probes the **store**, not the observer; the reindex action keeps its loud, actionable refusal (that is an action, not a probe).
- `IsConfigured` no longer re-tests `Embedding:Endpoint` / `Embedding:ApiKey`. The presence of a registered `IEmbeddingProvider` **is** that signal (`TryAddEmbeddingProvider` registers one exactly when the options suffice), and re-testing the API key held indexing inert on a correctly configured **local** endpoint — Ollama / OpenAI-compatible legitimately has no key, as `VectorSearch.md` documents.

## What this does NOT fix — #1642 must stay open

**memex has no embedding configuration at all**, so content indexing there is legitimately off. After this PR it will *say so* instead of erroring; it will not start working. Evidence, from tracked config only:

- The code path is wired: the AKS image `memex-portal-ai` is published from `memex/aspire/Memex.Portal.Distributed`, whose `Program.cs:160-161` does `Configuration.GetSection("Embedding").Get<EmbeddingOptions>()` → `AddEmbeddings(...)` → `TryAddEmbeddingProvider`. The module is listed (`appsettings.json` → `Modules:Assemblies` → `MeshWeaver.ContentCollections.Indexing.PostgreSql.dll`).
- The chart templates the keys: `deploy/helm/templates/memex-portal/config.yaml:181-183` (`Embedding__Provider/Endpoint/Model`) and `secrets.yaml:56-58` (`Embedding__ApiKey`, conditional).
- **No tracked values file supplies them** — not `deploy/helm/values.yaml`, `deploy/aks/values.aks.yaml`, nor `memex-cloud` / `memex` / `atioz` `values.gate.yaml` / `values.ha.yaml` / `values.replica.yaml` / `portal-patch.json`. `Embedding__Endpoint` therefore renders `""` → `CreateEmbeddingProvider` returns null → **no `IEmbeddingProvider`** → the gate is correctly false. `secretproviderclass.yaml` (Key Vault) lists no embedding secret either.
- Not verifiable from the repo: `memex-cloud/deploy.sh` passes an out-of-band `values.memexcloud.yaml` that has never been committed, and inline `kubectl set env` overrides are a pattern this deployment uses. Reading the live ConfigMap would settle it; no live mesh was touched for this PR.

**To turn the capability on**, set for the memex portal (and mirror under `config.memex_migration`, which sizes the pgvector column):

| Setting | Where |
|---|---|
| `config.memex_portal.Embedding__Endpoint` | Helm values → `memex-portal-config` ConfigMap |
| `config.memex_portal.Embedding__Model` | same |
| `config.memex_portal.Embedding__Provider` | same — omit for the Azure Foundry default, `Ollama` for on-host |
| `secrets.memex_portal.Embedding__ApiKey` | `memex-portal-secrets` Secret (required for Azure Foundry; not needed for a local endpoint after this PR) |

So: **this PR closes the contract violation; #1642 stays open for the deployment change.**

## Tests (all executed, all green)

| Suite | Result |
|---|---|
| `MeshWeaver.ContentCollections.Indexing.Test` (incl. new `InertContentIndexTest`) | 59/59 |
| `MeshWeaver.ContentCollections.Indexing.PostgreSql.Test` (incl. new `IndexingBootPackTest` cases) | 11/11 |
| `MeshWeaver.ContentCollections.Indexing.Graph.Test` | 32/32 |
| `MeshWeaver.AI.Test` (incl. new `ContentIndexingOffToolTest`) | 1179 passed, 0 failed |
| `MeshWeaver.Documentation.Test` | 34/34 |

- `ContentIndexingOffToolTest` drives the real entry points (`ChunkNavigation.SearchChunks` / `GetChunk` — what the MCP tool and the agent plugin both call) on a mesh whose pipeline is **wired but unconfigured**, with store/embedder factories that throw exactly like the pgvector ones. Both query shapes (anchored + `namespace:` grammar) must return `{count:0, message}` naming `Embedding:Endpoint`.
- `IndexingBootPackTest` installs the module the `Modules:Assemblies` way and resolves through **Autofac**, pinning both that resolution does not throw and that the stand-ins map to null.
- **Non-vacuity verified**: reverting only the registration change turns the new tests red with the issue's exact failure — `System.InvalidOperationException : An exception was thrown while activating λ:…IChunkedContentVectorStore ---- Autofac.Core.DependencyResolutionException`.

Builds clean with CI's flags (`-c Release -warnaserror`) for every touched project and its dependents.

Refs #1642 (do not close on merge — the deployment config is still missing).
