### PR TITLE
fix(plugin-tester): a startup failure must exit, not spin at 100% CPU forever

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1075,7 +1075,14 @@ jobs:
           fi
           cp -R "$GITHUB_WORKSPACE/plugins-repo/$m" "$STAGE/"
         done
-        cp "$GITHUB_WORKSPACE/plugins-repo/plugin-gate.allow" "$STAGE/" 2>/dev/null || true
+        # The ratchet is REQUIRED, and its absence is reported here rather than left to the tester
+        # (#1741): `--allow` at a path that does not exist is a configuration error, and a `|| true`
+        # that swallowed the failed copy only moved the report one process further away.
+        if [ ! -f "$GITHUB_WORKSPACE/plugins-repo/plugin-gate.allow" ]; then
+          echo "::error::plugins-repo/plugin-gate.allow is missing — the known-debt ratchet this gate is configured with cannot be read, and a gate that cannot read its input must not look like one that passed. Commit the file (EMPTY = no known debt)."
+          exit 1
+        fi
+        cp "$GITHUB_WORKSPACE/plugins-repo/plugin-gate.allow" "$STAGE/"
         echo "gating: $VITAL_MODULES"
         # plugin-gate.allow is the plugins repo's known-debt ratchet: listed failures are
         # tolerated, NEW failures fail this PR. Same one-way contract the plugins CI uses, so the

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -220,7 +220,18 @@ jobs:
               -e DOTNET_DbgMiniDumpType=2
               -e DOTNET_DbgMiniDumpName=/coredumps/%e-%p.dmp)
           fi
-          docker run --rm -v "$REPO_MOUNT:/repo" "${DUMP_ARGS[@]}" \
+          # 🚨 `--init` is not cosmetic: without it the tester is the container's PID 1, and a
+          # PID-namespace init with SIG_DFL for SIGABRT is SIGNAL_UNKILLABLE — the kernel DISCARDS
+          # the signal the .NET runtime raises to end a crashed process. `abort()` then falls
+          # through to its trap instruction, the runtime's SIGTRAP handler returns to the very
+          # instruction that trapped, and the process SPINS at 100% CPU forever instead of exiting
+          # (#1741: two such containers "Up" 36 and 57 minutes each, having printed one exception
+          # in their first second). On CI that reads as a hang and burns the job's whole timeout
+          # rather than reporting the crash. With `--init` the tool runs as PID 2 under tini and a
+          # crash exits 134 immediately. The tester itself no longer lets an exception escape
+          # `Main`, but this covers what a `catch` cannot — a stack overflow, an OOM abort, an
+          # unhandled throw on a background thread.
+          docker run --rm --init -v "$REPO_MOUNT:/repo" "${DUMP_ARGS[@]}" \
             --entrypoint /app/mw-plugin-test "$IMAGE" /repo \
             "${ALLOW_ARGS[@]}"
       - name: Upload core dumps (if the gate crashed)

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -363,7 +363,9 @@ jobs:
         id: identity
         run: |
           set -euo pipefail
-          line=$(docker run --rm --entrypoint /app/mw-plugin-test "${{ steps.image.outputs.ref }}" \
+          # `--init` so a crashed tester exits instead of spinning as an unkillable PID 1 (#1741);
+          # this step would otherwise hang the job on a one-line diagnostic.
+          line=$(docker run --rm --init --entrypoint /app/mw-plugin-test "${{ steps.image.outputs.ref }}" \
             --print-framework-identity)
           identity="${line#*identity=}"
           identity="${identity%% *}"
@@ -441,7 +443,11 @@ jobs:
           chmod 777 "$BAKE"
           ALLOW_ARGS=()
           [ -n "${ALLOW_FILE:-}" ] && ALLOW_ARGS=(--allow "/repo/${ALLOW_FILE}")
-          docker run --rm -v "$REPO_MOUNT:/repo" -v "$BAKE:/bake" \
+          # `--init` for the same reason as the gate's run (#1741): as a container's PID 1 the
+          # tester cannot be killed by the SIGABRT its own runtime raises on a crash — the kernel
+          # discards the signal (SIGNAL_UNKILLABLE) and the process spins at 100% CPU instead of
+          # exiting. Under tini it is PID 2 and a crash exits 134 at once.
+          docker run --rm --init -v "$REPO_MOUNT:/repo" -v "$BAKE:/bake" \
             --entrypoint /app/mw-plugin-test "${{ steps.image.outputs.ref }}" /repo \
             "${ALLOW_ARGS[@]}" \
             --bake-output /bake --source-sha "$GITHUB_SHA"

--- a/test/MeshWeaver.PluginTester.Test/GateAllowlistTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/GateAllowlistTest.cs
@@ -52,6 +52,59 @@ public class GateAllowlistTest
         Assert.Contains("line 1", ex.Message);
     }
 
+    // ── a ratchet that is not there ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A MISSING allow file is a configuration error, not an empty ratchet (#1741). Substituting
+    /// an empty list would be the STRICTER verdict — with no entries every failure is new — so it
+    /// could never turn a red run green; it would instead make the gate's configuration
+    /// unverifiable, since <c>known-debt allowlist: 0 entr(ies)</c> would mean either "the ratchet
+    /// is empty" or "the gate never found the ratchet you passed". An empty ratchet has two honest
+    /// spellings: an empty FILE, or omitting <c>--allow</c>.
+    /// </summary>
+    [Fact]
+    public void Load_ThrowsAnActionableMessage_WhenTheFileIsMissing()
+    {
+        var missing = Path.Combine(
+            Path.GetTempPath(), $"no-such-ratchet-{Guid.NewGuid():N}.allow");
+
+        var ex = Assert.Throws<FileNotFoundException>(() => GateAllowlist.Load(missing));
+
+        // Not the framework's bare "Could not find file": the flag, the resolved path, and how an
+        // empty ratchet is actually spelled.
+        Assert.Contains("--allow", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(missing, ex.Message, StringComparison.Ordinal);
+        Assert.Contains("empty file", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>An EMPTY file is a legitimate ratchet — it is how "no known debt" is recorded,
+    /// and it must load as an empty list rather than as an error.</summary>
+    [Fact]
+    public void Load_ReadsAnEmptyFile_AsAnEmptyRatchet()
+    {
+        var file = Path.Combine(Path.GetTempPath(), $"empty-ratchet-{Guid.NewGuid():N}.allow");
+        File.WriteAllText(file, "");
+        try
+        {
+            Assert.Empty(GateAllowlist.Load(file).Entries);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    /// <summary>The diagnostic path resolver must never throw on the very path it is describing —
+    /// an empty <c>--allow</c> value would otherwise blow up inside the error message.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Describe_DegradesToTheRawText_WhenThePathCannotBeResolved(string path)
+    {
+        Assert.Equal(path, GateAllowlist.Describe(path));
+        Assert.Contains("--allow", GateAllowlist.MissingFileMessage(path), StringComparison.Ordinal);
+    }
+
     // ── classification ───────────────────────────────────────────────────────────────────────
 
     private static GateReport Report(params PackageResult[] packages) => new([.. packages]);

--- a/test/MeshWeaver.PluginTester.Test/StartupFailureProcessTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/StartupFailureProcessTest.cs
@@ -1,0 +1,169 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// The gate binary's STARTUP-FAILURE contract, asserted on the real process rather than on a
+/// method — because the defect these pin (#1741) is not in any method's return value, it is that
+/// the process never ends.
+///
+/// <para>🚨 Why a process test and why every wait here is BOUNDED. Every consumer runs this
+/// binary as a container's PID 1 (<c>docker run … --entrypoint /app/mw-plugin-test</c>). An
+/// exception escaping <c>Main</c> there does not terminate the process: the runtime prints the
+/// trace and calls <c>abort()</c>, whose SIGABRT the kernel DISCARDS for a PID-namespace init with
+/// the default disposition (<c>SIGNAL_UNKILLABLE</c>); <c>abort()</c> falls through to its trap
+/// instruction, the runtime's SIGTRAP handler returns to the instruction that trapped, and the
+/// main thread re-traps forever. Measured 2026-08-17: two containers "Up" 36 and 57 minutes at
+/// ~100% CPU, whose entire output was one <see cref="FileNotFoundException"/> printed in their
+/// first second. On CI that reads as a HANG — the job burns its whole timeout and reports nothing
+/// about the bad argument that caused it.</para>
+///
+/// <para>So an unbounded <c>WaitForExit()</c> here would reproduce the bug rather than catch it:
+/// the test would hang exactly as CI does. Every wait carries <see cref="ExitBudget"/>, and
+/// blowing it FAILS the test naming the spin.</para>
+/// </summary>
+public class StartupFailureProcessTest
+{
+    /// <summary>
+    /// How long the tool gets to fail and exit. Deliberately generous — the assertion is
+    /// "terminates at all", not "terminates in N ms", and a tight bound would turn a loaded CI box
+    /// into a flake. The bug it catches is unbounded, so any finite budget catches it.
+    /// </summary>
+    private static readonly TimeSpan ExitBudget = TimeSpan.FromSeconds(60);
+
+    // ── the missing --allow file ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MissingAllowFile_ExitsNonZero_NamingTheFlagAndThePath()
+    {
+        var missing = Path.Combine(
+            Path.GetTempPath(), $"mw-plugin-test-no-such-ratchet-{Guid.NewGuid():N}.allow");
+        Assert.False(File.Exists(missing), "the fixture path must not exist");
+
+        var run = Run("/nonexistent-repo-root", "--allow", missing);
+
+        Assert.Equal(2, run.ExitCode);
+        // The flag that named it, and the path it looked for — the two facts the raw
+        // FileNotFoundException stack trace made the reader dig for.
+        Assert.Contains("--allow", run.Output, StringComparison.Ordinal);
+        Assert.Contains(missing, run.Output, StringComparison.Ordinal);
+        // …and how "no known debt" is actually spelled, so the message is actionable.
+        Assert.Contains("empty file", run.Output, StringComparison.Ordinal);
+        // Nothing escaped Main: no unhandled-exception banner, no stack frames.
+        Assert.DoesNotContain("Unhandled exception", run.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MalformedAllowFile_ExitsNonZero_NamingTheOffendingLine()
+    {
+        var file = Path.Combine(
+            Path.GetTempPath(), $"mw-plugin-test-malformed-{Guid.NewGuid():N}.allow");
+        File.WriteAllText(file, "Claims flakiness\n");   // 'flakiness' is not a check name
+        try
+        {
+            var run = Run("/nonexistent-repo-root", "--allow", file);
+
+            Assert.Equal(2, run.ExitCode);
+            Assert.Contains("malformed", run.Output, StringComparison.Ordinal);
+            Assert.Contains("line 1", run.Output, StringComparison.Ordinal);
+            Assert.DoesNotContain("Unhandled exception", run.Output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    // ── the guard itself: an UNANTICIPATED startup throw ─────────────────────────────────────
+
+    /// <summary>
+    /// The other half of #1741, and the half that generalises: a bad <c>--compile-timeout</c>
+    /// value throws <see cref="FormatException"/> out of <c>double.Parse</c>. Before the guard
+    /// that escaped <c>Main</c> and spun the container exactly like the missing allow file did —
+    /// same defect, different argument. It must now be a printed error and an exit code.
+    /// </summary>
+    [Fact]
+    public void UnparseableTimeout_ExitsNonZero_WithAFatalMessageRatherThanEscapingMain()
+    {
+        var run = Run("/nonexistent-repo-root", "--compile-timeout", "not-a-number");
+
+        Assert.NotEqual(0, run.ExitCode);
+        Assert.Contains("FATAL", run.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Unhandled exception", run.Output, StringComparison.Ordinal);
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────────────────
+
+    private sealed record RunResult(int ExitCode, string Output);
+
+    /// <summary>
+    /// Runs the gate binary that sits beside this test assembly (the ProjectReference copies its
+    /// apphost, deps.json and runtimeconfig.json into this output directory) and returns its exit
+    /// code plus stdout+stderr, waiting at most <see cref="ExitBudget"/>.
+    /// </summary>
+    private static RunResult Run(params string[] arguments)
+    {
+        var exe = Path.Combine(
+            AppContext.BaseDirectory,
+            OperatingSystem.IsWindows() ? "mw-plugin-test.exe" : "mw-plugin-test");
+        Assert.True(
+            File.Exists(exe),
+            $"the gate binary is not beside the test assembly ('{exe}') — the ProjectReference to "
+            + "tools/MeshWeaver.PluginTester should copy it; without it this test verifies nothing.");
+
+        var info = new ProcessStartInfo(exe)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = AppContext.BaseDirectory,
+        };
+        foreach (var argument in arguments)
+            info.ArgumentList.Add(argument);
+
+        // Event-based reads, not ReadToEnd(): a child that filled a redirected pipe could not
+        // exit, which would look like the very hang under test.
+        var output = new StringBuilder();
+        using var process = new Process { StartInfo = info };
+        process.OutputDataReceived += (_, e) => Append(output, e.Data);
+        process.ErrorDataReceived += (_, e) => Append(output, e.Data);
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        if (!process.WaitForExit(ExitBudget))
+        {
+            var text = Text(output);
+            process.Kill(entireProcessTree: true);
+            Assert.Fail(
+                $"'{Path.GetFileName(exe)} {string.Join(' ', arguments)}' had not exited after "
+                + $"{ExitBudget.TotalSeconds:N0}s — this is the #1741 spin: a failure that does not "
+                + "become an exit code leaves the process alive (and, as a container's PID 1, "
+                + $"unkillable by its own abort) burning a CPU core. Output so far:\n{text}");
+        }
+        // The bounded wait above does not flush the async readers; this one does, and cannot block
+        // indefinitely because the process has already exited.
+        process.WaitForExit();
+        return new RunResult(process.ExitCode, Text(output));
+    }
+
+    private static void Append(StringBuilder builder, string? line)
+    {
+        if (line is null)
+            return;
+        lock (builder)
+            builder.AppendLine(line);
+    }
+
+    private static string Text(StringBuilder builder)
+    {
+        lock (builder)
+            return builder.ToString();
+    }
+}

--- a/tools/MeshWeaver.PluginTester/GateAllowlist.cs
+++ b/tools/MeshWeaver.PluginTester/GateAllowlist.cs
@@ -47,8 +47,49 @@ public sealed record GateAllowlist(IReadOnlyList<AllowEntry> Entries)
         return new GateAllowlist(entries);
     }
 
-    /// <summary>Loads and parses the allow file at <paramref name="path"/>.</summary>
-    public static GateAllowlist Load(string path) => Parse(File.ReadLines(path));
+    /// <summary>
+    /// Loads and parses the allow file at <paramref name="path"/>. A file that is not there
+    /// throws with <see cref="MissingFileMessage"/> as its message rather than the framework's
+    /// bare "Could not find file" — the caller is a CLI whose job is to turn that into one
+    /// actionable line and an exit code.
+    /// </summary>
+    public static GateAllowlist Load(string path) =>
+        File.Exists(path)
+            ? Parse(File.ReadLines(path))
+            : throw new FileNotFoundException(MissingFileMessage(path), path);
+
+    /// <summary>
+    /// The one-line, actionable account of an <c>--allow</c> path that is not there: the flag that
+    /// named it, the path it resolved to, and how an empty ratchet is actually spelled.
+    ///
+    /// <para>🚨 A MISSING ratchet is a configuration error, not an empty one, and the gate refuses
+    /// to run rather than substituting an empty list. Substituting would be the STRICTER reading —
+    /// with no entries every failure is a new failure, so it could never turn a red run green — but
+    /// it would make the gate's own configuration unverifiable: the run's
+    /// <c>known-debt allowlist: 0 entr(ies)</c> line would then mean either "the ratchet is empty"
+    /// or "the gate never found the ratchet you passed", and nothing in the run could tell those
+    /// apart. That is the shape the node-repo CI policy exists to forbid — a gate that cannot read
+    /// its input must not look like a gate that passed. An empty ratchet has two honest spellings,
+    /// an EMPTY FILE at that path or omitting <c>--allow</c> altogether (which the reusable
+    /// <c>node-repo-gate.yml</c> already does when a repo configures no allow file); a path that
+    /// does not exist is neither.</para>
+    /// </summary>
+    /// <param name="path">The path as it was given on the command line.</param>
+    public static string MissingFileMessage(string path) =>
+        $"mw-plugin-test: --allow named '{path}', which does not exist (resolved to "
+        + $"'{Describe(path)}'). The allow file is the known-debt ratchet; spell an EMPTY ratchet "
+        + "either as an empty file at that path or by omitting --allow entirely — never as a path "
+        + "that is not there, or nothing can tell 'no known debt' from 'the gate never read the "
+        + "ratchet'.";
+
+    /// <summary>
+    /// <paramref name="path"/> resolved against the current directory for a diagnostic, degrading
+    /// to the raw text when it cannot be resolved (an empty or otherwise invalid path) — a message
+    /// about a bad path must never itself throw on that same bad path.
+    /// </summary>
+    /// <param name="path">The path as it was given on the command line.</param>
+    public static string Describe(string path) =>
+        string.IsNullOrWhiteSpace(path) ? path : Path.GetFullPath(path);
 
     private static string StripComment(string line) =>
         line.IndexOf('#') is var i && i >= 0 ? line[..i] : line;

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -34,8 +34,35 @@ using MeshWeaver.Compiler;
 // Everything BELOW this block is the GATE (`mw-plugin-test <root>`), which legitimately stands up a
 // mesh because rendering a layout area and executing a `Tests` area are runtime behaviours. The two
 // used to be one code path wearing two names, which is how the mesh-driven bake stayed invisible.
-if (args.Length > 0 && args[0] == "compile")
-    return RunCompile(args[1..]);
+//
+// 🚨 NOTHING MAY THROW OUT OF `Main` — an escaping exception does not end this process, it SPINS it
+// (#1741). Every consumer runs this binary as a container's PID 1 (`docker run … --entrypoint
+// /app/mw-plugin-test`). The runtime's unhandled-exception path prints the trace and then calls
+// `abort()`, which `raise()`s SIGABRT at the process — but a PID-namespace init with SIG_DFL for
+// that signal is `SIGNAL_UNKILLABLE`, so the kernel DISCARDS it (kernel/signal.c,
+// `sig_task_ignored`). `raise()` returns, `abort()` falls through to its `ABORT_INSTRUCTION` trap,
+// the runtime's own SIGTRAP handler is still installed and returns to the very instruction that
+// trapped — and the main thread re-traps forever. Measured 2026-08-17: two containers "Up" for 36
+// and 57 minutes at ~100% CPU each, having printed one FileNotFoundException in their first second;
+// the same image run with `--init` (so the tool is PID 2) exits 134 immediately.
+//
+// So every failure below turns into a MESSAGE and an EXIT CODE. This guard is the backstop for the
+// ones nobody anticipated — it prints the whole exception, so nothing is hidden, and returns
+// non-zero so the container dies instead of burning a CI runner until the job timeout fires and
+// reports a "hang" rather than a bad argument. (The consumers ALSO pass `docker run --init` now,
+// which covers the crashes a `catch` cannot reach — a stack overflow, an OOM abort, an unhandled
+// throw on a background thread.)
+try
+{
+    if (args.Length > 0 && args[0] == "compile")
+        return RunCompile(args[1..]);
+    return await RunGate(args);
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"mw-plugin-test: FATAL — {ex}");
+    return 70; // EX_SOFTWARE: distinct from 0 (green), 1 (gate red) and 2 (bad usage).
+}
 
 static int RunCompile(string[] args)
 {
@@ -96,109 +123,137 @@ static int RunCompile(string[] args)
     return bake.ExitCode;
 }
 
-string? root = null;
-var compileTimeout = TimeSpan.FromMinutes(5);
-var renderTimeout = TimeSpan.FromMinutes(2);
-var allowlist = GateAllowlist.Empty;
-var allowApplied = false;
-string? reportPath = null;
-string? bakeOutput = null;
-string? sourceSha = null;
-
-for (var i = 0; i < args.Length; i++)
+// The GATE verb (`mw-plugin-test <repo-root>`). A LOCAL FUNCTION rather than bare top-level
+// statements so the guard above can wrap it: top-level statements are the body of `Main` itself,
+// and anything thrown from them escapes the process (see the #1741 note above).
+static async Task<int> RunGate(string[] args)
 {
-    switch (args[i])
+    string? root = null;
+    var compileTimeout = TimeSpan.FromMinutes(5);
+    var renderTimeout = TimeSpan.FromMinutes(2);
+    var allowlist = GateAllowlist.Empty;
+    var allowApplied = false;
+    string? reportPath = null;
+    string? bakeOutput = null;
+    string? sourceSha = null;
+
+    for (var i = 0; i < args.Length; i++)
     {
-        case "--compile-timeout" when i + 1 < args.Length:
-            compileTimeout = TimeSpan.FromSeconds(
-                double.Parse(args[++i], CultureInfo.InvariantCulture));
-            break;
-        case "--render-timeout" when i + 1 < args.Length:
-            renderTimeout = TimeSpan.FromSeconds(
-                double.Parse(args[++i], CultureInfo.InvariantCulture));
-            break;
-        case "--allow" when i + 1 < args.Length:
-            allowlist = GateAllowlist.Load(args[++i]);
-            allowApplied = true;
-            break;
-        case "--report" when i + 1 < args.Length:
-            reportPath = args[++i];
-            break;
-        case "--bake-output" when i + 1 < args.Length:
-            bakeOutput = args[++i];
-            break;
-        case "--source-sha" when i + 1 < args.Length:
-            sourceSha = args[++i];
-            break;
-        // A value-taking option as the LAST argument would otherwise fall through to the default
-        // case as "Unknown argument" — a misleading message for a missing value.
-        case "--compile-timeout" or "--render-timeout" or "--allow" or "--report"
-            or "--bake-output" or "--source-sha":
-            Console.Error.WriteLine($"Option '{args[i]}' requires a value. Try --help.");
-            return 2;
-        // Diagnostic: print the framework build identity this process resolves — the exact value
-        // the bake keys bundles to and the seeder gates on (#1660 WS3). One line, `identity=<id>
-        // provenance=<g<sha> | (unstamped)>`, then exit 0. Lets CI steps and operators verify
-        // "would this build's bake be adoptable by that image?" without standing up a mesh, and
-        // is what the surface-identity proof script drives.
-        case "--print-framework-identity":
+        switch (args[i])
         {
-            var provenance = MeshWeaver.Compiler.FrameworkBuildIdentity
-                .StampedIdentityOf(typeof(MeshWeaver.Compiler.FrameworkBuildIdentity).Assembly);
-            Console.WriteLine(
-                $"identity={MeshWeaver.Graph.Configuration.PrebuiltAssemblySeeder.LiveFrameworkMvid} "
-                + $"provenance={provenance ?? "(unstamped)"}");
-            return 0;
-        }
-        case "--help" or "-h":
-            Console.WriteLine(
-                "usage: mw-plugin-test <repo-root> [--compile-timeout <s>] [--render-timeout <s>] "
-                + "[--allow <file>] [--report <file>] [--bake-output <dir>] [--source-sha <sha>] "
-                + "[--print-framework-identity]");
-            return 0;
-        default:
-            if (args[i].StartsWith('-') || root is not null)
+            case "--compile-timeout" when i + 1 < args.Length:
+                compileTimeout = TimeSpan.FromSeconds(
+                    double.Parse(args[++i], CultureInfo.InvariantCulture));
+                break;
+            case "--render-timeout" when i + 1 < args.Length:
+                renderTimeout = TimeSpan.FromSeconds(
+                    double.Parse(args[++i], CultureInfo.InvariantCulture));
+                break;
+            // A ratchet the gate cannot read is a CONFIGURATION error, and it is refused here —
+            // before a mesh is built — with the flag, the resolved path and the two honest
+            // spellings of "no known debt". See GateAllowlist.MissingFileMessage for why a missing
+            // file is NOT silently read as an empty list even though that is the stricter verdict.
+            case "--allow" when i + 1 < args.Length:
             {
-                Console.Error.WriteLine($"Unknown argument '{args[i]}'. Try --help.");
-                return 2;
+                var allowPath = args[++i];
+                if (!File.Exists(allowPath))
+                {
+                    Console.Error.WriteLine(GateAllowlist.MissingFileMessage(allowPath));
+                    return 2;
+                }
+                try
+                {
+                    allowlist = GateAllowlist.Load(allowPath);
+                }
+                catch (FormatException ex)
+                {
+                    Console.Error.WriteLine(
+                        $"mw-plugin-test: --allow file '{GateAllowlist.Describe(allowPath)}' is "
+                        + $"malformed — {ex.Message}");
+                    return 2;
+                }
+                allowApplied = true;
+                break;
             }
-            root = args[i];
-            break;
+            case "--report" when i + 1 < args.Length:
+                reportPath = args[++i];
+                break;
+            case "--bake-output" when i + 1 < args.Length:
+                bakeOutput = args[++i];
+                break;
+            case "--source-sha" when i + 1 < args.Length:
+                sourceSha = args[++i];
+                break;
+            // A value-taking option as the LAST argument would otherwise fall through to the default
+            // case as "Unknown argument" — a misleading message for a missing value.
+            case "--compile-timeout" or "--render-timeout" or "--allow" or "--report"
+                or "--bake-output" or "--source-sha":
+                Console.Error.WriteLine($"Option '{args[i]}' requires a value. Try --help.");
+                return 2;
+            // Diagnostic: print the framework build identity this process resolves — the exact value
+            // the bake keys bundles to and the seeder gates on (#1660 WS3). One line, `identity=<id>
+            // provenance=<g<sha> | (unstamped)>`, then exit 0. Lets CI steps and operators verify
+            // "would this build's bake be adoptable by that image?" without standing up a mesh, and
+            // is what the surface-identity proof script drives.
+            case "--print-framework-identity":
+            {
+                var provenance = MeshWeaver.Compiler.FrameworkBuildIdentity
+                    .StampedIdentityOf(typeof(MeshWeaver.Compiler.FrameworkBuildIdentity).Assembly);
+                Console.WriteLine(
+                    $"identity={MeshWeaver.Graph.Configuration.PrebuiltAssemblySeeder.LiveFrameworkMvid} "
+                    + $"provenance={provenance ?? "(unstamped)"}");
+                return 0;
+            }
+            case "--help" or "-h":
+                Console.WriteLine(
+                    "usage: mw-plugin-test <repo-root> [--compile-timeout <s>] [--render-timeout <s>] "
+                    + "[--allow <file>] [--report <file>] [--bake-output <dir>] [--source-sha <sha>] "
+                    + "[--print-framework-identity]");
+                return 0;
+            default:
+                if (args[i].StartsWith('-') || root is not null)
+                {
+                    Console.Error.WriteLine($"Unknown argument '{args[i]}'. Try --help.");
+                    return 2;
+                }
+                root = args[i];
+                break;
+        }
     }
-}
 
-var options = new GateOptions
-{
-    RepoRoot = root ?? ".",
-    CompileTimeout = compileTimeout,
-    RenderTimeout = renderTimeout,
-    BakeOutputDirectory = bakeOutput,
-    SourceSha = sourceSha,
-};
+    var options = new GateOptions
+    {
+        RepoRoot = root ?? ".",
+        CompileTimeout = compileTimeout,
+        RenderTimeout = renderTimeout,
+        BakeOutputDirectory = bakeOutput,
+        SourceSha = sourceSha,
+    };
 
-Console.WriteLine($"mw-plugin-test: gating node repos under '{Path.GetFullPath(options.RepoRoot)}'");
-if (allowApplied)
-    Console.WriteLine($"known-debt allowlist: {allowlist.Entries.Count} entr(ies)");
-var report = await PluginGateRunner.Run(options).FirstAsync().ToTask();
-if (reportPath is not null)
-{
-    // Written for EVERY completed run — red, green, or fatal — and before any allowlist verdict:
-    // the combo verifier folds the raw evidence itself, and a missing report must only ever mean
-    // "the tester never completed", not "the run was red".
-    var fullReportPath = Path.GetFullPath(reportPath);
-    var reportDir = Path.GetDirectoryName(fullReportPath);
-    if (!string.IsNullOrEmpty(reportDir))
-        Directory.CreateDirectory(reportDir);
-    File.WriteAllText(
-        fullReportPath,
-        JsonSerializer.Serialize(report.ToRunReport(), InstanceComboAssembler.Json));
-    Console.WriteLine($"structured report written to '{fullReportPath}'");
+    Console.WriteLine($"mw-plugin-test: gating node repos under '{Path.GetFullPath(options.RepoRoot)}'");
+    if (allowApplied)
+        Console.WriteLine($"known-debt allowlist: {allowlist.Entries.Count} entr(ies)");
+    var report = await PluginGateRunner.Run(options).FirstAsync().ToTask();
+    if (reportPath is not null)
+    {
+        // Written for EVERY completed run — red, green, or fatal — and before any allowlist verdict:
+        // the combo verifier folds the raw evidence itself, and a missing report must only ever mean
+        // "the tester never completed", not "the run was red".
+        var fullReportPath = Path.GetFullPath(reportPath);
+        var reportDir = Path.GetDirectoryName(fullReportPath);
+        if (!string.IsNullOrEmpty(reportDir))
+            Directory.CreateDirectory(reportDir);
+        File.WriteAllText(
+            fullReportPath,
+            JsonSerializer.Serialize(report.ToRunReport(), InstanceComboAssembler.Json));
+        Console.WriteLine($"structured report written to '{fullReportPath}'");
+    }
+    if (!allowApplied)
+    {
+        report.WriteSummary(Console.Out);
+        return report.ExitCode;
+    }
+    var verdict = GateVerdict.Evaluate(report, allowlist);
+    report.WriteSummary(Console.Out, verdict);
+    return report.FatalError is null && verdict.Success ? 0 : 1;
 }
-if (!allowApplied)
-{
-    report.WriteSummary(Console.Out);
-    return report.ExitCode;
-}
-var verdict = GateVerdict.Evaluate(report, allowlist);
-report.WriteSummary(Console.Out, verdict);
-return report.FatalError is null && verdict.Success ? 0 : 1;

--- a/tools/MeshWeaver.PluginTester/README.md
+++ b/tools/MeshWeaver.PluginTester/README.md
@@ -48,3 +48,41 @@ empty in production, so that test — not the speed — is the point. See
 The framework build identity resolves from the `meshweaver-surface.manifest` packed beside the
 binaries — equal by construction with the portals' identity (see
 `Doc/Architecture/CiContentBake`), which is what makes the bundles this tool produces adoptable.
+
+## Exit codes — and why nothing may throw out of `Main`
+
+| code | meaning |
+|---|---|
+| `0` | green |
+| `1` | the gate ran and something failed (or an allow entry went stale) |
+| `2` | bad usage / bad configuration — an unknown argument, an option with no value, an `--allow` path that does not exist or does not parse |
+| `70` | an unanticipated failure; the whole exception is printed above it |
+
+🚨 **An exception must never escape `Main` (#1741).** Every consumer runs this binary as a
+container's PID 1 (`docker run … --entrypoint /app/mw-plugin-test`). There, an unhandled exception
+does not end the process — the runtime prints the trace and calls `abort()`, whose SIGABRT the
+kernel **discards** for a PID-namespace init with the default disposition (`SIGNAL_UNKILLABLE`);
+`abort()` falls through to its trap instruction, the runtime's SIGTRAP handler returns to the
+instruction that trapped, and the main thread re-traps forever. Measured 2026-08-17: two containers
+"Up" 36 and 57 minutes at ~100% CPU each, whose entire output was one `FileNotFoundException`
+printed in their first second. On CI that reads as a **hang**, burning the job's whole timeout and
+reporting nothing about the bad argument that caused it.
+
+So every failure becomes a message plus an exit code, `Program.cs` carries a top-level guard for the
+ones nobody anticipated, and the workflows pass **`docker run --init`** — which covers what a
+`catch` cannot reach (a stack overflow, an OOM abort, an unhandled throw on a background thread).
+`StartupFailureProcessTest` pins all of this on the real process, with a bounded wait: an unbounded
+one would reproduce the bug instead of catching it.
+
+## `--allow` — a MISSING ratchet is a configuration error, not an empty one
+
+`--allow <file>` names the known-debt ratchet. A path that does not exist is refused (exit `2`) with
+one actionable line rather than read as an empty list. Substituting an empty list would be the
+*stricter* verdict — with no entries every failure is a new failure, so it could never turn a red run
+green — but it would make the gate's own configuration unverifiable: `known-debt allowlist: 0
+entr(ies)` would then mean either "the ratchet is empty" or "the gate never found the ratchet you
+passed", and nothing in the run could tell those apart. That is the shape the node-repo CI policy
+exists to forbid: *a gate that cannot read its input must not look like a gate that passed.*
+
+An empty ratchet has two honest spellings — an **empty file** at that path, or **omitting `--allow`**
+(which the reusable `node-repo-gate.yml` already does when a repo configures no allow file).


### PR DESCRIPTION
Closes #1741.

`mw-plugin-test` is the gate five repos' CI depends on (MeshWeaver.Plugins, .SocialMedia, .Reinsurance, .Manufacturing, .Education). Two containers on one machine each burned **a full CPU core for over half an hour** having printed nothing but a startup crash in their first second.

## What was actually holding the process open — measured, not guessed

Every consumer runs this binary as a **container's PID 1** (`docker run … --entrypoint /app/mw-plugin-test`). An exception escaping `Main` there does **not** end the process:

1. The runtime prints the trace and calls `abort()`, which `raise()`s SIGABRT at itself.
2. A PID-namespace init whose disposition for that signal is `SIG_DFL` is `SIGNAL_UNKILLABLE`, so the kernel **discards** the signal (`kernel/signal.c`, `sig_task_ignored`). Confirmed from `/proc/<pid>/status` inside the container: `SigCgt: …44de` — bit 4 (SIGTRAP) set, **bit 5 (SIGABRT) clear**, and `NSpid: … 1`.
3. `raise()` returns, so `abort()` falls through to its `ABORT_INSTRUCTION` trap. The runtime's SIGTRAP handler *is* still installed and returns to the instruction that trapped.
4. The main thread re-traps forever. Signature: one thread at 99% CPU, `/proc/<pid>/task/<tid>/syscall` = `running` on every sample (never in a syscall), ~4× more **system** than user time, voluntary context switches flat — i.e. fault-driven, not a syscall loop.

**Control experiment, same image, same arguments:**

| run | result |
|---|---|
| `docker run … mw-plugin-test /repo --allow /repo/plugin-gate.allow` | `Up`, **99.59% CPU**, still running 57 minutes later |
| `docker run --init …` (tool becomes PID 2 under tini) | **exited, code 134, immediately** |

On CI this reads as a *hang*: the job burns its whole timeout and reports nothing about the bad argument. That is a materially worse diagnosis than "bad argument".

## Fix 1 — nothing may throw out of `Main`

The gate body moves into a `RunGate` local function behind a top-level guard. The guard **prints the whole exception** (nothing is hidden or swallowed) and returns `70`, so the container dies. Exit codes are now `0` green / `1` gate red / `2` bad usage or configuration / `70` unanticipated fatal, documented in the tool's README.

This is a translation, not a `catch`-and-continue: turning a failure into a message plus an exit code is the entry-point's job, and it is exactly what was missing.

**Belt and braces at the layer a `catch` cannot reach:** the workflows now pass `docker run --init` (`node-repo-gate.yml`, `node-repo-publish-bake.yml` ×2). A stack overflow, an OOM abort, or an unhandled throw on a background thread cannot be caught in managed code — under tini they still terminate the container instead of spinning it.

## Fix 2 — a missing `--allow` file is a clean, actionable refusal

Before any host is built, naming the flag, the resolved path and the fix:

```
mw-plugin-test: --allow named '/repo/plugin-gate.allow', which does not exist (resolved to
'/repo/plugin-gate.allow'). The allow file is the known-debt ratchet; spell an EMPTY ratchet
either as an empty file at that path or by omitting --allow entirely — never as a path that is
not there, or nothing can tell 'no known debt' from 'the gate never read the ratchet'.
```

exit `2`. A malformed line gets the same treatment (previously a `FormatException` out of `Main` — the *same* spin wearing a different argument).

### Why a missing allow file stays FATAL

The issue asks whether it should be fatal at all, since "no allow file" plausibly means "no known debt". I looked at how the file is used and kept it fatal:

- Reading a missing file as an **empty** ratchet is the *stricter* verdict — with no entries every failure is a new failure — so it could never turn a red run green. Safety is not the objection.
- The objection is **verifiability**. The run would print `known-debt allowlist: 0 entr(ies)`, which would then mean either "the ratchet is empty" *or* "the gate never found the ratchet you passed", with nothing in the run able to tell them apart. That is precisely the shape the node-repo CI policy exists to forbid: *a gate that cannot read its input must not look like a gate that passed.*
- An empty ratchet already has two honest spellings — an **empty file** (this repo's own `.github/doc-gate.allow` is 0 bytes), or **omitting `--allow`**, which `node-repo-gate.yml` already does when a repo configures no allow file. A path that is not there is neither.

Consistent with that, `dotnet-test.yml`'s plugin-gate step stops hiding the same thing behind `cp … 2>/dev/null || true` and reports the missing ratchet itself.

## Tests

`test/MeshWeaver.PluginTester.Test/StartupFailureProcessTest.cs` drives the **real binary** as a child process — the defect is not in any method's return value, it is that the process never ends:

- `MissingAllowFile_ExitsNonZero_NamingTheFlagAndThePath`
- `MalformedAllowFile_ExitsNonZero_NamingTheOffendingLine`
- `UnparseableTimeout_ExitsNonZero_WithAFatalMessageRatherThanEscapingMain` (the guard itself)

**Every wait is bounded** (60 s, then `Kill(entireProcessTree)` + a failure naming the spin) — an unbounded `WaitForExit()` would reproduce the bug instead of catching it, hanging CI exactly the way the bug does. Reads are event-based so a full pipe cannot masquerade as the hang under test.

Plus pure tests on the ratchet itself: `Load_ThrowsAnActionableMessage_WhenTheFileIsMissing`, `Load_ReadsAnEmptyFile_AsAnEmptyRatchet` (an empty file stays a legitimate ratchet), `Describe_DegradesToTheRawText_WhenThePathCannotBeResolved` (the message must not throw on the bad path it is describing).

**Non-vacuity proven by reverting the fix.** With `Program.cs` restored to `main` and everything else in place, all three process tests fail — `Expected: 2 / Actual: 134`, and `String: "Unhandled exception. System.FormatException…" / Not found: "FATAL"`. With the fix they pass in 30–110 ms each.

## Verification

- `dotnet build -c Release -p:CIRun=true -warnaserror` clean for `MeshWeaver.PluginTester`, `MeshWeaver.PluginTester.Test` and `MeshWeaver.Documentation.Test` (0 warnings, 0 errors).
- `MeshWeaver.PluginTester.Test`: **64/64 passed**.
- `MeshWeaver.Documentation.Test` workflow guards (`PlatformBakeLaneGuard`, `UpstreamBuildGateGuard`): **13/13 passed** — the three workflow edits are clean.
- End-to-end against a locally built `mw-plugin-test` image, **as PID 1, without `--init`**: exits in ~1 s with code `2` and the message above; `--compile-timeout not-a-number` exits `70` with `mw-plugin-test: FATAL — System.FormatException: …`.

## Not a What's New entry

Pure CI/developer tooling with no user-visible effect in any portal.

## ⚠️ Unrelated pre-existing flake, for the maintainer

While running the suite I hit `AreaProbeTest.MenuChromeFrame_ThenGreenTable_ReportsThePassSummary` failing intermittently. **It is not caused by this change** — a clean A/B on the same machine gives **1 failure in 5** runs *with* the new tests and **1 in 5** *without* them, and a control run of the suite minus the new class under artificial CPU load reproduces it.

Diagnosis for whoever picks it up: the verdict is `Tests area reported no verdict within 5s` with `lastTransient == null`, i.e. the operator's 5 s `Timeout` fires before a synchronous two-element in-memory observable delivers anything. In the failing runs this test is the **first** `AreaProbeTest` to execute and takes ~5 s, while `NotFoundFrame_ThenGreenTable_IsPassed` — identical shape, same static `GreenTable` frame — completes in **1 ms** right afterwards. That is a cold-start signature (first-use JIT / `RegexOptions.Compiled` emit / Rx init) landing *inside* the operator's own timeout budget on a loaded box. Happy to open a separate issue if you want it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wVYniTKJ7Kuw7Hh425UPy
