### PR TITLE
fix: the About page and What's New are reachable again (#1817)

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/PlatformUpdateChipView.razor
+++ b/memex/Memex.Portal.Shared/SelfUpdate/PlatformUpdateChipView.razor
@@ -1,6 +1,8 @@
 @using System.Reactive.Disposables
 @using Microsoft.FluentUI.AspNetCore.Components.Icons.Regular
 @using MeshWeaver.Mesh.Services
+@using MeshWeaver.Graph.Configuration
+@using Memex.Portal.Shared.Settings
 @implements IDisposable
 @inject IMessageHub Hub
 @inject AccessService Access
@@ -125,7 +127,7 @@
         if (chip.Action == PlatformUpdateChipAction.Refresh)
             Navigation.Refresh(forceReload: true);
         else
-            Navigation.NavigateTo("/_settings/GlobalSettings/About");
+            Navigation.NavigateTo(GlobalSettingsNodeType.TabHref(AboutSettingsTab.TabId));
     }
 
     public void Dispose()

--- a/memex/Memex.Portal.Shared/Settings/AboutSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/AboutSettingsTab.cs
@@ -35,7 +35,10 @@ namespace Memex.Portal.Shared.Settings;
 /// </summary>
 public static class AboutSettingsTab
 {
-    /// <summary>The tab id under <c>/_settings/GlobalSettings</c>.</summary>
+    /// <summary>
+    /// The tab id — the trailing segment of the tab's deep link, built with
+    /// <see cref="GlobalSettingsNodeType.TabHref"/> (<c>/_Setting/GlobalSettings/About</c>).
+    /// </summary>
     public const string TabId = "About";
 
     /// <summary>Data id the plugin grid binds to (rows published via <c>host.UpdateData</c>).</summary>

--- a/memex/Memex.Portal.Shared/Settings/WhatsNewSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/WhatsNewSettingsTab.cs
@@ -30,7 +30,10 @@ namespace Memex.Portal.Shared.Settings;
 /// </summary>
 public static class WhatsNewSettingsTab
 {
-    /// <summary>The tab id under <c>/_settings/GlobalSettings</c>.</summary>
+    /// <summary>
+    /// The tab id — the trailing segment of the tab's deep link, built with
+    /// <see cref="GlobalSettingsNodeType.TabHref"/> (<c>/_Setting/GlobalSettings/WhatsNew</c>).
+    /// </summary>
     public const string TabId = "WhatsNew";
 
     /// <summary>The documentation namespace holding per-entry release-note nodes (served under <c>Doc/</c>).</summary>

--- a/src/MeshWeaver.Blazor.Portal/Components/UserProfile.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Components/UserProfile.razor.cs
@@ -6,6 +6,7 @@ using System.Reactive.Threading.Tasks;
 using System.Security.Claims;
 using MeshWeaver.Blazor.Infrastructure;
 using MeshWeaver.Blazor.Portal.Authentication;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Components;
@@ -160,16 +161,19 @@ public partial class UserProfile : ComponentBase
         if (!string.IsNullOrEmpty(userId))
             Navigation.NavigateTo($"/User/{userId}/Settings");
         else
-            Navigation.NavigateTo("/_settings");
+            Navigation.NavigateTo(GlobalSettingsNodeType.SettingsHref);
     }
 
     // Platform info lives in the ungated global-settings tabs; the user menu is where users find
-    // "About" / "What's New" (a regular user's Settings goes to their own User node, not here). Tab
-    // ids are literals here because those tabs live in the higher Memex.Portal.Shared layer — this
-    // (framework) project can't reference them; the ids ("About"/"WhatsNew") are stable.
-    private void NavigateToWhatsNew() => Navigation.NavigateTo("/_settings/GlobalSettings/WhatsNew");
+    // "About" / "What's New" (a regular user's Settings goes to their own User node, not here). The
+    // tab IDS stay literals — those tabs live in the higher Memex.Portal.Shared layer, which this
+    // (framework) project can't reference, and the ids ("About"/"WhatsNew") are stable. The ROUTE
+    // around them is not a literal: it is derived from the registered node path, because four call
+    // sites once spelled that path as plural lowercase "_settings" and every one of them 404'd
+    // (#1817).
+    private void NavigateToWhatsNew() => Navigation.NavigateTo(GlobalSettingsNodeType.TabHref("WhatsNew"));
 
-    private void NavigateToAbout() => Navigation.NavigateTo("/_settings/GlobalSettings/About");
+    private void NavigateToAbout() => Navigation.NavigateTo(GlobalSettingsNodeType.TabHref("About"));
 
     private void Logout()
     {

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-about-page-reachable.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-about-page-reachable.md
@@ -1,0 +1,16 @@
+---
+Name: About and What's New open again
+Category: Fix
+Description: The profile menu and the build chip now open the About and What's New pages instead of "Page not found".
+Icon: Sparkle
+Order: -20260818
+---
+
+# About and What's New open again
+
+Choosing **About** or **What's New** from the profile menu — or clicking the version chip in the
+top bar to ask what build you are running — landed on a "Page not found" card. The pages were fine;
+every link to them pointed at an address the platform does not serve.
+
+Those links now come from the settings page's own registered address rather than being spelled out
+by hand, so all of them open, and a future link cannot quietly point somewhere that does not exist.

--- a/src/MeshWeaver.Graph/Configuration/GlobalSettingsNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/GlobalSettingsNodeType.cs
@@ -21,6 +21,35 @@ public static class GlobalSettingsNodeType
     public const string SettingsPath = "_Setting";
 
     /// <summary>
+    /// Application href of the global settings page itself. Use this — never a literal — for any
+    /// in-app link to Settings.
+    ///
+    /// <para>🚨 The registered path is <c>_Setting</c> — SINGULAR, capital S. Four call sites
+    /// independently hand-wrote the plural lowercase form (<c>_settings</c>, with a leading slash)
+    /// and every one of them 404'd with <i>"does not match any registered address pattern"</i>,
+    /// which is what made the About and What's New pages unreachable from the profile menu (#1817).
+    /// That form is not merely a typo to accept as an alias: lowercase <c>_settings</c> is a
+    /// reserved satellite/schema segment in the cross-schema Postgres/Snowflake routing, an
+    /// unrelated meaning. <c>GlobalSettingsRouteLiteralGuard</c> fails the build on a new one — and
+    /// it is why this paragraph names the bad spelling without its leading slash.</para>
+    /// </summary>
+    public const string SettingsHref = "/" + SettingsPath;
+
+    /// <summary>
+    /// Application href of ONE global-settings tab — <c>/_Setting/GlobalSettings/{tabId}</c> — built
+    /// through <see cref="LayoutAreaReference.ToHref(object)"/> so the URL shape comes from the same
+    /// place the settings menu's own links come from and the two cannot drift.
+    /// </summary>
+    /// <param name="tabId">
+    /// The tab's id, which is the settings menu entry's node id (<c>About</c>, <c>WhatsNew</c>,
+    /// <c>ApiTokens</c>, …). Tab ids are declared one layer up (Memex.Portal.Shared), so this method
+    /// takes the id rather than enumerating them.
+    /// </param>
+    public static string TabHref(string tabId) =>
+        "/" + new LayoutAreaReference(GlobalSettingsLayoutArea.GlobalSettingsArea) { Id = tabId }
+            .ToHref(SettingsPath);
+
+    /// <summary>
     /// Registers the built-in "GlobalSettings" MeshNode on the mesh builder
     /// and creates the singleton _Setting node.
     /// </summary>

--- a/src/MeshWeaver.Graph/GlobalSettingsLayoutArea.cs
+++ b/src/MeshWeaver.Graph/GlobalSettingsLayoutArea.cs
@@ -15,7 +15,9 @@ namespace MeshWeaver.Graph;
 
 /// <summary>
 /// Global settings page with Splitter layout: left NavMenu + right content pane.
-/// URL pattern: /_settings/GlobalSettings/{tabId}
+/// URL pattern: /_Setting/GlobalSettings/{tabId} — the node path is
+/// <see cref="GlobalSettingsNodeType.SettingsPath"/>, and in-app links are built with
+/// <see cref="GlobalSettingsNodeType.TabHref"/> rather than spelled out (#1817).
 /// Tabs are registered via <see cref="GlobalSettingsMenuItemsExtensions.AddGlobalSettingsMenuItems(MeshWeaver.Messaging.MessageHubConfiguration, MeshWeaver.Mesh.GlobalSettingsMenuItemProvider[])"/>.
 /// Follows the same pattern as <see cref="SettingsLayoutArea"/> for node settings.
 /// </summary>

--- a/src/MeshWeaver.Mesh.Contract/GlobalSettingsMenuItemDefinition.cs
+++ b/src/MeshWeaver.Mesh.Contract/GlobalSettingsMenuItemDefinition.cs
@@ -9,7 +9,7 @@ namespace MeshWeaver.Mesh;
 /// Contributed by providers registered via config.AddGlobalSettingsMenuItems().
 /// Unlike <see cref="SettingsMenuItemDefinition"/>, these are node-independent (platform-wide).
 /// </summary>
-/// <param name="Id">Tab identifier for URL routing (/_settings/GlobalSettings/{Id})</param>
+/// <param name="Id">Tab identifier for URL routing (/_Setting/GlobalSettings/{Id})</param>
 /// <param name="Label">Display text in the NavMenu sidebar</param>
 /// <param name="ContentBuilder">Delegate that builds the tab's content pane</param>
 /// <param name="Group">Optional group name for NavGroupControl (null = top-level item)</param>

--- a/test/Memex.Portal.Shared.Test/GlobalSettingsNavigationRouteTest.cs
+++ b/test/Memex.Portal.Shared.Test/GlobalSettingsNavigationRouteTest.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Settings;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Every in-app link to the global settings page must land on a path the mesh actually registers.
+///
+/// <para>It did not: the settings node is registered at <c>_Setting</c>
+/// (<see cref="GlobalSettingsNodeType.SettingsPath"/>) while four call sites navigated to the plural
+/// lowercase form (<c>_settings</c>), so the About page and What's New answered <i>"Page not found:
+/// does not match any registered address pattern"</i> from the profile menu and the build chip
+/// (#1817). Nothing failed — no exception, no log, no test — because the two halves lived in
+/// different projects and nothing had ever compared them.</para>
+///
+/// <para>So this test compares them, for the WHOLE family rather than the one string that was
+/// reported: it takes each settings tab the portal actually seeds
+/// (<see cref="PlatformSettingsTabAreas.Seeds"/> — About, What's New, Privacy, Invitations, Inbox,
+/// Updates, Published, Token Usage) plus the compiled API-tokens tab, builds that tab's link exactly
+/// as the portal does, and resolves it through the real <see cref="MeshWeaver.Mesh.Services.IPathResolver"/>
+/// on a live mesh. A new tab is covered the moment it is seeded, and a future rename of the settings
+/// node breaks here instead of in the browser.</para>
+///
+/// <para>The resolution is asserted the way navigation consumes it — prefix = the settings node,
+/// then <c>ParseAreaAndId</c> on the remainder — because a link can resolve to a node and still
+/// address the wrong area, which renders a blank pane rather than a 404.</para>
+/// </summary>
+public class GlobalSettingsNavigationRouteTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// Every tab a settings link can point at. Read from the seeds themselves (not a copy) so the
+    /// list cannot go stale, plus <see cref="ApiTokensSettingsTab"/>, which still registers through
+    /// the compiled provider lane.
+    /// </summary>
+    private static IEnumerable<string> TabIds =>
+        PlatformSettingsTabAreas.Seeds.Select(s => s.Id).Append(ApiTokensSettingsTab.TabId);
+
+    [Fact]
+    public async Task EverySettingsTabLink_ResolvesToTheGlobalSettingsNodeAndItsArea()
+    {
+        var offenders = new List<string>();
+
+        foreach (var tabId in TabIds)
+        {
+            var href = GlobalSettingsNodeType.TabHref(tabId);
+            var resolution = await PathResolver.ResolveNavigationPath(href).Should().Emit();
+
+            if (resolution is null)
+            {
+                offenders.Add($"{tabId,-14} → {href} does not match any registered address pattern");
+                continue;
+            }
+
+            var (area, id) = LayoutAreaMarkdownParser.ParseAreaAndId(resolution.Remainder);
+            if (resolution.Prefix.Trim('/') != GlobalSettingsNodeType.SettingsPath
+                || area != GlobalSettingsLayoutArea.GlobalSettingsArea
+                || id != tabId)
+            {
+                offenders.Add(
+                    $"{tabId,-14} → {href} resolved to node '{resolution.Prefix}' area '{area}' id '{id}'");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "A settings tab link does not address the registered settings node + area. The node is "
+            + $"'{GlobalSettingsNodeType.SettingsPath}' and the area is "
+            + $"'{GlobalSettingsLayoutArea.GlobalSettingsArea}' — build links with "
+            + "GlobalSettingsNodeType.TabHref so they cannot drift from the registration (#1817):\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>The bare Settings link (the profile menu's fallback for a user with no user node).</summary>
+    [Fact]
+    public async Task SettingsHref_ResolvesToTheGlobalSettingsNodeItself()
+    {
+        var resolution = await PathResolver
+            .ResolveNavigationPath(GlobalSettingsNodeType.SettingsHref).Should().Emit();
+
+        Assert.NotNull(resolution);
+        Assert.Equal(GlobalSettingsNodeType.SettingsPath, resolution!.Prefix.Trim('/'));
+        Assert.True(string.IsNullOrEmpty(resolution.Remainder),
+            $"'{GlobalSettingsNodeType.SettingsHref}' must resolve to the node exactly, "
+            + $"but left remainder '{resolution.Remainder}'.");
+    }
+
+    /// <summary>
+    /// The negative control, and the reason this bug was invisible: the retired plural/lowercase
+    /// spelling resolves to NOTHING. It is not an alias, and it must never become one — lowercase
+    /// <c>_settings</c> is a reserved satellite/schema segment in the cross-schema Postgres/Snowflake
+    /// routing, so accepting it here would collide with an unrelated meaning. Without this case the
+    /// test above could pass on a resolver that happily matched anything.
+    /// </summary>
+    [Fact]
+    public async Task TheRetiredPluralSpelling_ResolvesToNothing()
+    {
+        var retired = "/_" + "settings/GlobalSettings/" + AboutSettingsTab.TabId;
+
+        var resolution = await PathResolver.ResolveNavigationPath(retired).Should().Emit();
+
+        Assert.True(resolution is null,
+            $"'{retired}' resolved to '{resolution?.Prefix}' — the plural/lowercase spelling is a "
+            + "reserved schema segment, not a second name for the settings node.");
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/GlobalSettingsRouteLiteralGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/GlobalSettingsRouteLiteralGuard.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard: no source file may hand-write a <c>/_settings…</c> URL. The global settings
+/// page is registered at <c>_Setting</c> (singular, capital S —
+/// <c>GlobalSettingsNodeType.SettingsPath</c>), so every <c>/_settings/…</c> literal is a link to a
+/// path that does not exist and answers <i>"does not match any registered address pattern"</i>.
+///
+/// <para>This is not style policing — it is the exact defect of #1817, and the reason it needs a
+/// guard rather than a one-time fix is that it PROPAGATED: the About page and What's New were
+/// unreachable from the profile menu for months, #1791 then copied the literal into the build chip,
+/// and the profile menu's bare Settings fallback carried a fourth copy nobody had noticed (the issue
+/// reports three sites; there were four). A fifth is one keystroke away, and nothing else fails when
+/// it happens: the page renders "Page not found" and no test, build or log names the cause.</para>
+///
+/// <para>The needle is deliberately CASE-SENSITIVE and requires the leading slash, which makes it
+/// exact rather than approximate:</para>
+/// <list type="bullet">
+///   <item><c>"_settings"</c> WITHOUT a slash is a legitimate reserved satellite/schema segment in
+///     the cross-schema Postgres/Snowflake routing (<c>PostgreSqlCrossSchemaQueryProvider</c>,
+///     <c>SearchableSchemasUpdater</c>) — an unrelated meaning, and untouched by this guard.</item>
+///   <item><c>/_Settings</c> (capital S, plural) is the per-user notification-settings satellite
+///     (<c>NotificationSettingsPaths.SettingsSegment</c>) — a real path, and untouched too.</item>
+/// </list>
+///
+/// <para>The fix for a failure here is never to suppress it, and never to re-spell the literal
+/// correctly by hand: build the link from <c>GlobalSettingsNodeType.SettingsHref</c> /
+/// <c>GlobalSettingsNodeType.TabHref(tabId)</c>, which derive it from the registered path.</para>
+/// </summary>
+public class GlobalSettingsRouteLiteralGuard
+{
+    /// <summary>Repo-root directories that hold hand-authored source and mesh node content.</summary>
+    private static readonly string[] ScannedRoots =
+        ["src", "test", "samples", "content", "memex", "clients"];
+
+    /// <summary>Extensions a human authors a navigation target in. An allow-list, as in the NUL guard.</summary>
+    private static readonly HashSet<string> TextExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".cs", ".razor", ".cshtml", ".ts", ".tsx", ".js", ".jsx", ".html", ".md", ".json"
+    };
+
+    private static readonly string[] ExcludedSegments =
+        ["bin", "obj", "node_modules", "TestResults", ".git", ".vs", "dist"];
+
+    /// <summary>
+    /// Assembled from parts so this file can name the offending shape without tripping its own scan
+    /// (the same trick <c>NoLiteralNulInSourceGuard</c> uses for the NUL character).
+    /// </summary>
+    private static string Needle => "/_" + "settings";
+
+    [Fact]
+    public void NoSourceFileHandWritesTheUnregisteredSettingsRoute()
+    {
+        var root = FindRepoRoot();
+        var self = typeof(GlobalSettingsRouteLiteralGuard).Name + ".cs";
+
+        var offenders = ScannedRoots
+            .Select(r => Path.Combine(root, r))
+            .Where(Directory.Exists)
+            .SelectMany(dir => Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
+            .Where(f => TextExtensions.Contains(Path.GetExtension(f)))
+            .Where(f => !IsExcluded(root, f))
+            .Where(f => !string.Equals(Path.GetFileName(f), self, StringComparison.Ordinal))
+            .SelectMany(f => Hits(root, f))
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            $"A '{Needle}' URL is hand-written in source. The global settings node is registered at "
+            + "'_Setting' (GlobalSettingsNodeType.SettingsPath), so this link 404s with \"does not "
+            + "match any registered address pattern\" — that is #1817, which reached four call "
+            + "sites because each one copied the literal. Build the link from "
+            + "GlobalSettingsNodeType.SettingsHref / .TabHref(tabId) instead. Offending lines:\n"
+            + string.Join("\n", offenders));
+    }
+
+    /// <summary>Every <c>root</c>-relative <c>file:line</c> in <paramref name="path"/> holding the needle.</summary>
+    private static IEnumerable<string> Hits(string root, string path)
+    {
+        string[] lines;
+        try
+        {
+            lines = File.ReadAllLines(path);
+        }
+        catch (IOException)
+        {
+            yield break; // a file being written by a concurrent build is not evidence of anything
+        }
+
+        for (var i = 0; i < lines.Length; i++)
+            if (lines[i].Contains(Needle, StringComparison.Ordinal))
+                yield return $"  {Path.GetRelativePath(root, path)}:{i + 1}: {lines[i].Trim()}";
+    }
+
+    private static bool IsExcluded(string root, string path) =>
+        Path.GetRelativePath(root, path)
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Any(segment => ExcludedSegments.Contains(segment, StringComparer.OrdinalIgnoreCase));
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
Closes #1817.

## What was mismatched

The global settings node is registered at **`_Setting`** — singular, capital S
(`GlobalSettingsNodeType.SettingsPath`). Every in-app link to it was hand-written as the plural
lowercase form, which resolves to nothing, so the profile menu's **About** and **What's New**
entries and the build chip's "what am I running?" click all landed on
*"Page not found: does not match any registered address pattern."*

Verified against the live resolver on a test mesh:

```
/_Setting/GlobalSettings/About  → node '_Setting', area 'GlobalSettings', id 'About'   ✅
<plural lowercase form>/About   → (no match)                                           ❌
```

## The real call-site count is FOUR, not three

The issue names three; the profile menu's bare Settings fallback carried a fourth copy nobody had
noticed. The guard test below, run against the unfixed tree, named all four:

| site | link |
|---|---|
| `UserProfile.NavigateToSettings` | the bare Settings path (anonymous fallback) |
| `UserProfile.NavigateToWhatsNew` | `…/GlobalSettings/WhatsNew` |
| `UserProfile.NavigateToAbout` | `…/GlobalSettings/About` |
| `PlatformUpdateChipView.Activate` | `…/GlobalSettings/About` (added by #1791, by copying the literal) |

Plus **four doc comments** teaching the wrong spelling — `AboutSettingsTab`, `WhatsNewSettingsTab`,
`GlobalSettingsLayoutArea`, `GlobalSettingsMenuItemDefinition`. Those are where the next author
would have copied it from, so they are corrected too.

## Why the call sites, and not the registration

The registration is one line against four call sites, so "change the fewer side" pointed the other
way — but the plural lowercase spelling **cannot** become this node's name: it is a reserved
satellite/schema segment in the cross-schema Postgres/Snowflake routing
(`PostgreSqlCrossSchemaQueryProvider`, `SnowflakeCrossSchemaQueryProvider`,
`SearchableSchemasUpdater`), an unrelated meaning rather than an alias. Accepting both spellings
would collide with it.

Nothing external is owed either spelling: `SettingsPath` is referenced by nothing but its own
constant, and no *working* bookmark to the broken form can exist — it has never resolved.

So the links now **derive** from the constant instead of repeating it:

- `GlobalSettingsNodeType.SettingsHref` — the page itself,
- `GlobalSettingsNodeType.TabHref(tabId)` — one tab, built through
  `LayoutAreaReference.ToHref` so the URL shape comes from the same place the settings menu's own
  links come from and the two cannot drift.

## Sibling mismatches found

- **The other tabs were equally unreachable from any such link** — the broken segment is the shared
  prefix, so Privacy / Invitations / Inbox / Updates / Published / Token Usage / API Tokens would
  have 404'd the same way. They only escaped because nothing hard-links them: the settings NavMenu
  builds its hrefs from the live hub address. The new test now covers all nine.
- **A third spelling is in active use, and it works:** `PortalLayoutBase.NavigateToSettings` and
  `clients/portal-next/HeaderMenus.tsx` navigate to `/GlobalSettings` — the NodeType-definition
  node's own path, which carries the `HubConfiguration` and therefore also serves the area. Measured
  side effects, **left alone** as out of scope: the settings page has two addresses, from that one
  the menu's tab links come out as `/GlobalSettings/GlobalSettings/{tab}`, and `/GlobalSettings/About`
  addresses a non-existent *area* named `About` (a blank pane, not a 404). Nothing links it today.

## Tests

**`GlobalSettingsNavigationRouteTest`** (`test/Memex.Portal.Shared.Test`) — the family test. It reads
the tab ids from `PlatformSettingsTabAreas.Seeds` themselves (so a new tab is covered the moment it
is seeded), builds each link exactly as the portal does, and resolves it through the real
`IPathResolver` on a live mesh — asserting node **and** area **and** tab id, because a link can
resolve to a node and still address the wrong area, which renders a blank pane rather than a 404.
Plus the bare Settings link, and a negative control pinning that the retired spelling resolves to
nothing (without it the family test could pass on a resolver that matched anything).

**Non-vacuous:** reproducing the pre-fix literal in the helpers — registration untouched at
`_Setting`, exactly the shipped bug — fails all nine with the production message:

```
  WhatsNew       → …/GlobalSettings/WhatsNew does not match any registered address pattern
  About          → …/GlobalSettings/About does not match any registered address pattern
  Invitations    → … (and Inbox, UpdatePolicy, PublishedToTheWeb, TokenUsage, Privacy, ApiTokens)
```

**`GlobalSettingsRouteLiteralGuard`** (`test/MeshWeaver.Documentation.Test`) — the propagation guard,
because a *fix* does not stop a fifth copy. It fails on any hand-written link with the bad segment.
Against the unfixed tree it named all four call sites and all four stale comments. The needle is
case-sensitive and requires the leading slash, which keeps it exact: the unslashed reserved
schema-segment lists and the per-user `_Settings` notification satellite are both untouched.

## Runs

```
MeshWeaver.Documentation.Test   35/35     passed  (Release)
Memex.Portal.Shared.Test        407/407   passed  (Release)  — incl. the 3 new tests
MeshWeaver.Graph.Test           1255/1255 passed  (Release)
```

All touched projects build clean with CI's flags (`-c Release -p:CIRun=true -warnaserror`),
0 warnings / 0 errors.

Not addressed here (the issue's own "separate, smaller" section): the chip's version-string length
and showing the deployment time — both are UX changes to the chip, not this route bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wVYniTKJ7Kuw7Hh425UPy