### PR TITLE
fix(#1563,#1693,#1748): an unreachable hub degrades in 10s with an attributable answer, not 60s with none

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
+++ b/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
@@ -164,7 +164,23 @@ public static class ContentFileResolver
             // hub unchanged, so in-mesh callers (the deck export's SlideAssetInliner, a portal hub,
             // a test client) keep their identity byte-for-byte. GetMeshNode/GetMeshNodeOutcome and
             // every node-CRUD path already went this way (2c796d297); this read was the straggler.
-            return hub.NodeOperationIssuingHub().Observe(
+            // 🚨 …and BOUND IT. Without a budget of its own this read's only terminal is the hub's
+            // 60 s RequestTimeout, which is the framework's last-resort ceiling — the number that
+            // has to cover a cold NodeType compile — not a budget an HTTP request ever chose. When
+            // the owning hub is unreachable, still starting, or its reply is dropped in transit
+            // (MeshWeaver#1742), the caller therefore waited a full minute and answered 500 with the
+            // hub's own impatience ("No response received in hub … the target hub was not found"),
+            // which names neither the file nor what to do about it. Issues #1563 and #1693.
+            //
+            // ReadBudget.Default (10 s) is the SAME budget GetMeshNode has always defaulted to, and
+            // it errors with a typed HubUnreachableException — a TimeoutException subclass, so every
+            // transient-failure classifier keeps recognising it — which BlazorHostingExtensions
+            // .ContentFailure maps to a retryable 503 instead of a fail:-level 500. This is a READ:
+            // it is idempotent, it cancels nothing, and abandoning it costs only the answer (which
+            // is why the "never put a client-side ceiling on a mesh operation" rule in
+            // MeshService's remarks — about WRITES that keep running — does not apply here).
+            var issuingHub = hub.NodeOperationIssuingHub();
+            return issuingHub.Observe(
                     new GetDataRequest(new ContentCollectionReference(candidates)),
                     o =>
                     {
@@ -172,6 +188,8 @@ public static class ContentFileResolver
                         return caller is null ? o : o.WithAccessContext(caller);
                     })
                 .Take(1)
+                .FailIfNoFirstEmission(
+                    issuingHub, targetAddress.ToString() ?? string.Empty, "content collection config")
                 .Select(delivery =>
                 {
                     var configs = ReadCollectionConfigs(delivery);

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-hub-that-cannot-answer-says-so-in-seconds.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-hub-that-cannot-answer-says-so-in-seconds.md
@@ -1,0 +1,43 @@
+---
+Name: A hub that cannot answer says so in seconds
+Category: Fix
+Description: Reads whose target hub is unreachable, still starting, or broken now give up in ten seconds with a retryable answer, instead of holding the page for a full minute and then reporting a server error.
+Icon: Timer
+Order: -20260818
+---
+
+# A hub that cannot answer says so in seconds
+
+A cover image that would not load, a form field that spun and then popped an error, a video that
+never started — each of them, on a bad minute, took exactly **sixty seconds** to fail, and then
+failed as if the page were broken rather than as if something were temporarily away.
+
+Sixty seconds was never anybody's decision. It is the framework's last-resort reply ceiling, the
+number that has to be generous enough to cover a cold module compiling itself for the first time.
+A read that set no budget of its own simply inherited it — so an image fetch and a first-time
+compile were given the same patience, and when nothing came back the failure said only *"no
+response received"*, naming neither the file nor the node.
+
+Interactive reads now carry their **own** ten-second budget — the same one node reads have always
+used — and report in their own terms: *this node did not answer, within this budget, and here is
+what the two ends looked like while we waited*. The answer a browser gets is **503 Service
+Unavailable**, which means "ask again", instead of a 500 that means "this is broken". Caches and
+retries treat those very differently, and only one of them was true.
+
+Three related habits changed with it, all of them about telling apart facts that used to collapse
+into one:
+
+- **A hub that could not start** is now reported as *unavailable* — retry-worthy — rather than as an
+  unclassified fault. It is an availability fact about the target, and the next visit re-runs the
+  whole thing from scratch.
+- **A node that genuinely is not there** answers as a plain, immediate *not found*, identical to a
+  refusal, instead of a server error.
+- **A form field bound to a node that is slow to reach** now draws empty after the budget and
+  **keeps waiting**, so a value that arrives late still fills it in. Previously the field could wait
+  for the life of the page with nothing logged at all.
+
+There is one more fix underneath. When a module's hub failed to construct — a genuine bug in that
+module — the platform's own error handling dereferenced the missing hub and reported *"Object
+reference not set to an instance of an object"*, burying the real exception it had already written
+down a moment earlier. That report now names the module, its type, and where the actual cause is
+recorded.

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -549,13 +549,22 @@ public static class BlazorHostingExtensions
     /// model, the principal, AND proof the node exists. Echoing it handed that to the caller
     /// verbatim.</para>
     ///
-    /// <para><b>Why the fallback still needs this after the tri-state.</b> The two typed arms below
-    /// catch the classified refusals, but they are property patterns over
+    /// <para><b>Why the fallback still needs this after the tri-state.</b> The typed arms below
+    /// catch the classified failures, but they are property patterns over
     /// <see cref="DeliveryFailureException.Failure"/> — which is <c>null</c> for the string-only
-    /// constructors, and is <see cref="ErrorType.Unknown"/> / <see cref="ErrorType.NotFound"/> /
-    /// <see cref="ErrorType.Exception"/> for every failure a hub reports without classifying. All of
-    /// those fall through to <c>_</c>, still carrying a hub-authored message and still caller-
-    /// triggerable. So the suppression belongs on the fallback, not only on the refusal arms.</para>
+    /// constructors, and is <see cref="ErrorType.Unknown"/> / <see cref="ErrorType.Exception"/> for
+    /// every failure a hub reports without classifying. Those fall through to <c>_</c>, still
+    /// carrying a hub-authored message and still caller-triggerable. So the suppression belongs on
+    /// the fallback, not only on the refusal arms.</para>
+    ///
+    /// <para>🚨 <b>The fallback is the ALERTING arm, so nothing routine may reach it.</b> It logs at
+    /// <c>Error</c> — a <c>fail:</c> line the incident pipeline opens issues from. Three outcomes
+    /// used to land there that are not incidents at all, and each filed one:
+    /// a read that TIMED OUT (#1563 — the target hub never answered, after a full 60 s), an
+    /// ACTIVATION failure reported as an unclassified delivery failure (#1693), and a routing
+    /// <see cref="ErrorType.NotFound"/> for a node that simply is not there. Each now has its own
+    /// arm with the honest status and log level; the fallback is left for what it is meant for — a
+    /// fault nobody classified, which genuinely wants a human.</para>
     ///
     /// <para><b>Nothing is lost, it MOVES.</b> The detail goes to the server-side log, which is where
     /// diagnostics belong — a response body is not a log sink. Dropping it silently would be the
@@ -577,9 +586,36 @@ public static class BlazorHostingExtensions
             // No verdict reached — a degraded dependency, NOT a statement about this caller's rights.
             // Still fail closed (nothing is served), but 503 so the caller retries instead of caching
             // an absence that was never asserted.
-            case DeliveryFailureException { Failure.ErrorType: ErrorType.Unavailable }:
+            //
+            // 🚨 ShuttingDown lands here too, and that is the point of naming it: the owning hub was
+            // mid-recycle when the delivery arrived. ErrorType.ShuttingDown's own contract is
+            // "retry-worthy, never terminal", so answering 500 (or worse, 404) for a hub that will be
+            // back on the next probe is exactly the confident-wrong-answer this classification exists
+            // to prevent.
+            case DeliveryFailureException
+            {
+                Failure.ErrorType: ErrorType.Unavailable or ErrorType.ShuttingDown
+            }:
                 logger?.LogWarning(ex, "Content read could not be authorized for {Path}", path);
                 return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+            // The owning hub never answered inside the route's own read budget (ReadBudget /
+            // HubUnreachableException, issues #1563 + #1748), or any other read that timed out.
+            // Same fact as Unavailable above — no verdict was reached — so the same retryable 503,
+            // and Warning rather than Error: a single transient miss on a route a browser will
+            // simply re-request is not a fail:-level incident, and the message still names the hub
+            // and the budget so a RECURRING one is greppable. Before this the read burned the full
+            // 60 s RequestTimeout and then answered 500.
+            case TimeoutException:
+                logger?.LogWarning(ex, "Content read timed out for {Path}", path);
+                return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+            // The owning node/hub is not there — routing said so, immediately and authoritatively.
+            // 404, byte-identical to a refusal and to a miss, so no arm of this switch can be used
+            // as an existence oracle; Debug, because "you asked for something that does not exist"
+            // is a client fact, not a server incident. This used to fall through to the 500 + Error
+            // arm below, which alerted on every request for a deleted node.
+            case DeliveryFailureException { Failure.ErrorType: ErrorType.NotFound }:
+                logger?.LogDebug(ex, "Content read found no node for {Path}", path);
+                return Results.NotFound(ContentNotFound);
             default:
                 logger?.LogError(ex, "Content read failed for {Path}", path);
                 return Results.Problem(ContentError);

--- a/src/MeshWeaver.Hosting.Monolith/MonolithRoutingService.cs
+++ b/src/MeshWeaver.Hosting.Monolith/MonolithRoutingService.cs
@@ -72,22 +72,45 @@ internal class MonolithRoutingService(
     {
         var isShuttingDown = Mesh.IsDisposing;
         string errorMessage;
-        if (isShuttingDown)
-            errorMessage = $"Mesh is shutting down, cannot route to {address}";
-        else if (node is null)
-            errorMessage = $"No node found for address {address}";
-        else
-            errorMessage = $"No hub configuration for node '{node.Path}' (NodeType: {node.NodeType ?? "null"}). Ensure the node type is registered via AddGraph() or a custom builder extension.";
-
-        logger.LogWarning("No route found for {MessageType} → {Address}. Node: {NodePath}, NodeType: {NodeType}, Sender: {Sender}, ShuttingDown: {ShuttingDown}",
-            delivery.Message.GetType().Name, address, node?.Path, node?.NodeType, delivery.Sender, isShuttingDown);
-
         // 🚨 ShuttingDown, NOT Failed. Consumers with their own recovery machinery — chiefly
         // SynchronizationStream's keep-alive + change-feed resubscribe latch — key on THIS member
         // to ride the reject out instead of tearing down. Classifying a shutdown reject as Failed
         // makes it read as terminal, which is the CI 30003419841 wedge: erroring the sync stream on
         // this NACK killed the resubscribe latch and wedged every read of a mid-recycle NodeType.
-        var errorType = isShuttingDown ? ErrorType.ShuttingDown : ErrorType.NotFound;
+        ErrorType errorType;
+        if (isShuttingDown)
+        {
+            errorMessage = $"Mesh is shutting down, cannot route to {address}";
+            errorType = ErrorType.ShuttingDown;
+        }
+        else if (node is null)
+        {
+            errorMessage = $"No node found for address {address}";
+            errorType = ErrorType.NotFound;
+        }
+        else
+        {
+            // 🚨 THE NODE EXISTS — its HUB could not be built, which is not the same fact and must
+            // not be reported as one. An unregistered/uncompilable NodeType never reaches here (see
+            // CreateHub: it substitutes a NACK-fallback hub, which answers NotFound itself), so the
+            // only way to arrive with a non-null node and a null hub is that hub CONSTRUCTION
+            // failed — the configuration lambda threw and HostedHubsCollection.CreateHub logged the
+            // real exception and returned null — or creation is frozen by an ancestor's disposal.
+            // Both are availability facts about the target and both are retryable: the next access
+            // re-runs resolution and construction from scratch. Reported as NotFound they told the
+            // caller the node does not exist, which is the confident-wrong-answer the Orleans twin
+            // produced as a bare NullReferenceException (issue #1693).
+            errorMessage =
+                $"Hub construction returned no hub for node '{node.Path}' (NodeType: {node.NodeType ?? "null"}). "
+                + "The hub configuration threw — see the 'Failed to create hosted hub' entry logged "
+                + "immediately before this one, which carries the real exception — or hosted-hub creation "
+                + "is frozen because this host (or an ancestor) is disposing.";
+            errorType = ErrorType.Unavailable;
+        }
+
+        logger.LogWarning("No route found for {MessageType} → {Address}. Node: {NodePath}, NodeType: {NodeType}, Sender: {Sender}, ShuttingDown: {ShuttingDown}",
+            delivery.Message.GetType().Name, address, node?.Path, node?.NodeType, delivery.Sender, isShuttingDown);
+
         // The answer-once contract — see AnswerPolicy. 🚨 Read the ENVELOPE: this delivery came
         // through MeshBuilder's delivery.Package(...), so its payload is RawJson and the CLR-type
         // test this replaces could never match (#1485). It was also missing the [CanBeIgnored]

--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -486,6 +486,23 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                 // activation error so a later transient rejection doesn't surface an outdated cause.
                 activationFailures?.Clear(streamId);
             }
+            // 🚨 NULLABLE, and the `!` that used to sit on this call was a lie that cost a
+            // production diagnosis (issue #1693). GetHostedHub → HostedHubsCollection.CreateHub
+            // returns NULL on three real paths, every one of them reachable here:
+            //   • the hub CONFIGURATION threw — and Build runs every SyncBuildupAction inline, so
+            //     that covers a compiled NodeType's own configuration lambda, AddData's workspace
+            //     construction, and every ConfigureDefaultNodeHub overlay. CreateHub catches it,
+            //     logs "Failed to create hosted hub for address {Address}" WITH the real stack, and
+            //     returns null;
+            //   • the collection is disposing ("Preventing hub creation for address …");
+            //   • an ancestor froze creation ("Rejecting hosted hub creation for address …").
+            // Dereferencing that null threw a NullReferenceException, which the catch below then
+            // reported as the activation's cause — so the caller got
+            // "Hub activation failed for AdvancedBusinessRules: Object reference not set to an
+            // instance of an object.", a message that names nothing and points at no line, while
+            // the ACTUAL exception sat in a separate log entry milliseconds earlier. The Monolith
+            // twin has always been null-safe here (MonolithRoutingService: `createdHub?.Register…`);
+            // this is the same treatment plus a message that says which of the three it was.
             var hub = meshHub.GetHostedHub(address, config =>
             {
                 config = config.WithOwnNodeStream(ownNodeStream);
@@ -511,7 +528,21 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                             this.GetPrimaryKeyString());
                         TryDeactivateOnIdle();
                     }));
-            })!;
+            });
+
+            if (hub is null)
+            {
+                // Not a defect in THIS method — the cause is already logged with its stack by
+                // HostedHubsCollection. Report the fact in terms a caller can act on, and keep the
+                // retry-on-next-access semantics the rest of this method has: the next delivery
+                // re-runs resolution and hub construction from scratch.
+                var reason = HubConstructionFailureReason(node);
+                logger.LogError("[ACTIVATE] Grain {StreamId}: {Reason}", streamId, reason);
+                activationFailures?.Record(streamId, reason);
+                _hubReadyRaw.OnError(new InvalidOperationException(reason));
+                TryDeactivateOnIdle();
+                return;
+            }
 
             hub.RegisterForDisposal(_ => TryDeactivateOnIdle());
             _hub = hub;
@@ -533,6 +564,29 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
             TryDeactivateOnIdle();
         }
     }
+
+    /// <summary>
+    /// What a caller is told when hub CONSTRUCTION produced no hub —
+    /// <c>HostedHubsCollection.CreateHub</c> returned null (issue #1693).
+    ///
+    /// <para>Pure and <c>internal static</c> so the message contract is unit-testable without a
+    /// cluster, like <see cref="LongRunningOperationCapExceeded"/> and
+    /// <see cref="ComposeActivationSource"/>. That matters because the message IS the fix: the
+    /// previous code dereferenced the null and reported the resulting
+    /// <see cref="NullReferenceException"/> as the activation's cause, so the caller received
+    /// <c>"Hub activation failed for AdvancedBusinessRules: Object reference not set to an instance
+    /// of an object."</c> — a sentence that names nothing, points at no line, and hides the fact
+    /// that the REAL exception had already been logged with its stack a moment earlier. Naming the
+    /// node, its type, and where the real cause is written is the whole difference between an
+    /// unactionable alert and a diagnosis.</para>
+    /// </summary>
+    /// <param name="node">The node whose hub could not be constructed.</param>
+    /// <returns>The failure reason.</returns>
+    internal static string HubConstructionFailureReason(MeshNode node) =>
+        $"Hub construction returned no hub for {node.Path} (NodeType: {node.NodeType ?? "(null)"}). "
+        + "Either the hub configuration threw — see the 'Failed to create hosted hub' entry logged "
+        + "immediately before this one, which carries the real exception — or hosted-hub creation is "
+        + "frozen because this host (or an ancestor) is disposing.";
 
     /// <summary>
     /// Composes the per-emission "enrich with HubConfiguration" step as an
@@ -651,10 +705,28 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                 try { tcs.TrySetResult(hub.DeliverMessage(delivery)); }
                 catch (Exception ex) { tcs.TrySetException(ex); }
             },
+            // 🚨 CLASSIFY, at the one place that knows. Both arms used to take the UNCLASSIFIED
+            // Failed(string) overload, so the DeliveryFailure that reached the caller carried
+            // ErrorType.Unknown — indistinguishable from a handler blowing up, from a bad request,
+            // from anything. Callers therefore could not tell "the target could not START" (an
+            // availability fact, retryable — Orleans deactivates and the next access re-runs
+            // resolution from scratch) apart from a genuine defect, and mapped it to a 500 with a
+            // fail:-level log. That is issue #1693: one NullReferenceException inside
+            // AdvancedBusinessRules' activation was reported to the content route as an unclassified
+            // failure and alerted as if the ROUTE were broken.
+            //
+            // Unavailable is the member whose whole contract is "NO VERDICT WAS REACHED … retryable
+            // by construction", which is exactly what an activation fault is. ShuttingDown is the
+            // matching transient for the disposal race — the same classification
+            // MonolithRoutingService already mints for it, so the two hosting models agree, and the
+            // consumers with their own recovery machinery (SynchronizationStream's resubscribe
+            // latch) ride it out instead of tearing down.
             ex => tcs.TrySetResult(delivery.Failed(
-                $"Hub activation failed for {this.GetPrimaryKeyString()}: {ex.Message}")),
+                $"Hub activation failed for {this.GetPrimaryKeyString()}: {ex.Message}",
+                ErrorType.Unavailable)),
             () => tcs.TrySetResult(delivery.Failed(
-                $"Hub disposed before delivery for {this.GetPrimaryKeyString()}.")));
+                $"Hub disposed before delivery for {this.GetPrimaryKeyString()}.",
+                ErrorType.ShuttingDown)));
         return tcs.Task;
     }
 

--- a/src/MeshWeaver.Hosting/RoutingServiceBase.cs
+++ b/src/MeshWeaver.Hosting/RoutingServiceBase.cs
@@ -171,6 +171,15 @@ namespace MeshWeaver.Hosting
             using (delivery.AccessContext is null ? access?.ImpersonateAsSystem() : null)
                 Mesh.Post(new DeliveryFailure(delivery)
                 {
+                    // 🚨 Unavailable, not the default Unknown. Everything that faults the route
+                    // chain is an availability fact about the TARGET, not about this request:
+                    // path resolution stalled past its 30 s bound, or building the per-node hub
+                    // threw — which is the monolith's shape of the Orleans activation fault in
+                    // issue #1693, where a NullReferenceException inside a package root's
+                    // activation reached the content route as an unclassified failure and was
+                    // alerted as a route defect. Retry-worthy by construction: the next access
+                    // re-runs resolution and hub creation from scratch.
+                    ErrorType = ErrorType.Unavailable,
                     Message = ex.Message,
                     ExceptionType = ex.GetType().Name,
                     StackTrace = ex.StackTrace!

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeBindingExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeBindingExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -67,16 +68,62 @@ public static class MeshNodeBindingExtensions
     /// field is absent) so the caller's existing converter pipeline (<c>Hub.ConvertSingle</c> /
     /// <c>ConversionToValue</c>) deserializes it exactly as it would a <c>/data</c> value. Stays
     /// subscribed for the component lifetime — no <c>.Take(1)</c>.
+    ///
+    /// <para>🚨 <b>Bounded on the FIRST value only</b> (<see cref="ReadBudget"/>, 10 s). Two ways
+    /// this binding could previously produce a control that spins forever with nothing logged, both
+    /// seen in production:</para>
+    /// <list type="bullet">
+    ///   <item>the owning hub is unreachable / still starting, so the stream's hydrating
+    ///     <c>SubscribeRequest</c> burns the hub's whole 60 s <c>RequestTimeout</c> before the fault
+    ///     even reaches the view (Systemorph/MeshWeaver#1748 —
+    ///     <c>"No response received in hub cache/… → target Posts/RobertHaircuts"</c>);</item>
+    ///   <item>the node is genuinely ABSENT, in which case the <c>Where(node is not null)</c> below
+    ///     filters every emission and this observable never emits or errors AT ALL — no timeout, no
+    ///     log, a control that waits for the life of the circuit.</item>
+    /// </list>
+    ///
+    /// <para><b>It degrades rather than errors, deliberately.</b> An error would tear the
+    /// subscription down, and a hub that is merely slow — a cold NodeType compile legitimately
+    /// outruns any interactive budget — would then never populate the control at all. Instead the
+    /// budget emits the same <c>null</c> the binding emits for an absent field, so the control
+    /// draws, AND the subscription stays live so a late value replaces it. The degradation is
+    /// logged at Warning naming the node, the field and the budget — it is never silent.</para>
     /// </summary>
+    /// <param name="hub">The hub whose node stream is read.</param>
+    /// <param name="nodePath">The node to bind against.</param>
+    /// <param name="bindContent">Bind against the node's Content (true) or the whole node (false).</param>
+    /// <param name="subPath">Optional content sub-path the field pointer is nested under.</param>
+    /// <param name="reference">The field pointer.</param>
+    /// <param name="firstValueBudget">
+    /// How long to wait for the FIRST value before drawing the control with no value;
+    /// <see cref="ReadBudget.Default"/> when omitted. Only the first value is bounded — an idle,
+    /// healthy binding is never cut short.
+    /// </param>
+    /// <param name="scheduler">Clock for the budget — pass a <c>TestScheduler</c> to drive it in
+    /// virtual time.</param>
+    /// <returns>The live field stream.</returns>
     public static IObservable<object?> Bind(
-        IMessageHub hub, string nodePath, bool bindContent, string? subPath, JsonPointerReference reference)
+        IMessageHub hub, string nodePath, bool bindContent, string? subPath, JsonPointerReference reference,
+        TimeSpan? firstValueBudget = null,
+        IScheduler? scheduler = null)
     {
         var options = hub.JsonSerializerOptions;
         var pointer = Combine(subPath, reference.Pointer);
         return hub.GetMeshNodeStream(nodePath)
             .Where(node => node is not null)
             .Select(node => (object?)EvaluateField(BindingRoot(node, bindContent, options), pointer))
-            .DistinctUntilChanged(JsonElementValueComparer.Instance);
+            .DistinctUntilChanged(JsonElementValueComparer.Instance)
+            .DegradeIfNoFirstEmission(
+                fallback: null,
+                onDegraded: failure => ReadBudget.Logger(hub)?.LogWarning(
+                    "MeshNodeBinding: '{Field}' on {Path} has no value yet — drawing the control "
+                    + "empty and staying subscribed. {Reason}",
+                    pointer, nodePath, failure.Message),
+                reader: hub,
+                target: nodePath,
+                what: $"field '{pointer}'",
+                budget: firstValueBudget,
+                scheduler: scheduler);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/ReadBudget.cs
+++ b/src/MeshWeaver.Mesh.Contract/ReadBudget.cs
@@ -1,0 +1,292 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// A read whose owning hub never answered within the caller's budget. Derives from
+/// <see cref="TimeoutException"/> on purpose: every classifier in the framework
+/// (<c>AreaErrorClassifier.IsTransientHubFailure</c>,
+/// <c>MeshNodeStreamCache.IsTransientOwnerFailure</c>, <c>RoutingGrain.IsTransientFailure</c>)
+/// already treats a <see cref="TimeoutException"/> as a TRANSIENT owner miss worth a retry, and a
+/// brand-new exception type would have silently fallen out of all three — turning a retryable stall
+/// into a negative-cached "missing node".
+///
+/// <para>It carries the two facts a bare timeout does not: WHICH address never answered, and WHAT
+/// budget expired. Those are what let a caller answer "temporarily unavailable, retry" instead of
+/// "not found" or a generic 500.</para>
+/// </summary>
+public sealed class HubUnreachableException : TimeoutException
+{
+    /// <summary>Creates the exception.</summary>
+    /// <param name="message">The full diagnostic message (see <see cref="ReadBudget"/>).</param>
+    /// <param name="target">The address that never answered.</param>
+    /// <param name="budget">The budget that expired.</param>
+    /// <param name="innerException">The underlying cause, when there is one.</param>
+    public HubUnreachableException(string message, string target, TimeSpan budget, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Target = target;
+        Budget = budget;
+    }
+
+    /// <summary>The address whose hub never answered.</summary>
+    public string Target { get; }
+
+    /// <summary>The wall-clock budget that expired.</summary>
+    public TimeSpan Budget { get; }
+}
+
+/// <summary>
+/// 🚨 THE CALLER-SIDE BUDGET ON A READ WHOSE TARGET HUB MAY BE UNREACHABLE.
+///
+/// <para><b>The problem this exists for.</b> <c>MessageHub.Observe</c> bounds a request/response
+/// exchange with the hub's <c>RequestTimeout</c> — <b>60 s</b>, one value for the whole process.
+/// That is the framework's LAST-RESORT terminal, not a budget any particular read chose: it is the
+/// number that has to cover a cold NodeType compile as well as a same-process warm reply. When the
+/// target hub is unreachable, still starting, or its reply is dropped in transit, every caller that
+/// applied no budget of its own therefore waits the full minute and then reports the hub's own
+/// impatience — <c>"No response received in hub X within 00:01:00 … the target hub was not
+/// found"</c> — which names neither what was being read nor what to do about it. Three production
+/// incidents, one shape: Systemorph/MeshWeaver#1563, #1693, #1748.</para>
+///
+/// <para><b>The rule.</b> Same rule <c>MeshOperationOptions</c> states for writes, applied to
+/// reads: <i>a bound nested inside another bound must be able to fire FIRST, because it is the only
+/// one that knows WHICH read starved.</i> An interactive read seam — an HTTP endpoint, a GUI
+/// binding, anything with a human waiting — carries its own budget, strictly inside the hub's
+/// <c>RequestTimeout</c>, and reports the failure in its own terms.</para>
+///
+/// <para><b>The number is not new.</b> <see cref="Default"/> is 10 s — the budget
+/// <c>MeshNodeStreamExtensions.GetMeshNode</c> has always defaulted to, and the band every other
+/// interactive read in the GUI already uses (5–15 s across <c>NamedAreaView</c>,
+/// <c>ThreadChatView</c>, <c>NavigationService</c>, <c>MeshNodePickerView</c>). This type does not
+/// introduce a budget; it applies the existing one at the two seams that were missing it.</para>
+///
+/// <para>🚨 <b>READS ONLY.</b> A caller-side ceiling on a WRITE makes the caller abandon an
+/// operation that is still running — it cancels nothing, and the continuation outlives the caller's
+/// DI scope (MeshWeaver#1270 tried exactly that and got <c>ObjectDisposedException</c> on a
+/// thread-pool thread after the test had reported success). Everything here is for an idempotent
+/// read whose only effect is the answer; bound a write with the hub's <c>RequestTimeout</c>, which
+/// is enforced where the request actually lives.</para>
+///
+/// <para><b>Two dispositions, and choosing between them is the whole design decision</b> — see
+/// <see cref="FailIfNoFirstEmission{T}"/> (one-shot reads: ERROR) and
+/// <see cref="DegradeIfNoFirstEmission{T}"/> (live bindings: emit a fallback and KEEP TRYING).
+/// Neither ever completes empty: Rx's own <c>Timeout</c> overload that swaps in
+/// <c>Observable.Empty</c> passes a COMPLETION downstream, which a reader cannot tell apart from
+/// "there is genuinely nothing here" — the exact silent-failure shape this repo bans.</para>
+/// </summary>
+public static class ReadBudget
+{
+    /// <summary>
+    /// The default caller-side read budget: <b>10 seconds</b>. Deliberately identical to
+    /// <c>GetMeshNode</c>'s long-standing default so the framework has ONE interactive read budget
+    /// rather than a new one per call site, and comfortably inside the 60 s hub
+    /// <c>RequestTimeout</c> so this bound is the one that fires — and therefore the one that gets
+    /// to say which read starved.
+    /// </summary>
+    public static readonly TimeSpan Default = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Bounds the wait for <paramref name="source"/>'s FIRST notification and <b>errors</b> with a
+    /// <see cref="HubUnreachableException"/> when it does not arrive.
+    ///
+    /// <para>Only the FIRST notification is bounded. Once the source produces anything — a value or
+    /// its own error — the budget timer is unsubscribed and the source flows untouched, so a live
+    /// stream that legitimately sits idle afterwards is never cut short. (Rx's plain
+    /// <c>Timeout(TimeSpan)</c> applies BETWEEN consecutive elements and would fault exactly that
+    /// healthy idle stream; <see cref="Observable.Amb{TSource}(IObservable{TSource}, IObservable{TSource})"/>
+    /// is the shape the framework already uses for this in
+    /// <c>MessageHubGrain.BuildActivationChain</c>.)</para>
+    ///
+    /// <para>Use this for a ONE-SHOT read — a request/response exchange, an HTTP endpoint — where
+    /// the caller has to answer now and "no answer" is a real outcome it must report.</para>
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The read to bound.</param>
+    /// <param name="reader">The hub issuing the read; its pending-request snapshot goes in the
+    /// diagnostic. May be null when there is no hub to interrogate.</param>
+    /// <param name="target">The address expected to answer.</param>
+    /// <param name="what">A short description of the read, e.g. <c>"content collection config"</c>.</param>
+    /// <param name="budget">The budget; <see cref="Default"/> when omitted.</param>
+    /// <param name="scheduler">Clock for the budget — pass a <c>TestScheduler</c> to drive it in
+    /// virtual time (same seam as <c>MessageHubGrain.BuildActivationChain</c>).</param>
+    /// <returns>The bounded source.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The budget is not positive.</exception>
+    public static IObservable<T> FailIfNoFirstEmission<T>(
+        this IObservable<T> source,
+        IMessageHub? reader,
+        string target,
+        string what,
+        TimeSpan? budget = null,
+        IScheduler? scheduler = null)
+    {
+        var effective = Validate(budget);
+        return Observable.Amb(
+            source,
+            Observable.Timer(effective, scheduler ?? Scheduler.Default)
+                .SelectMany(_ => Observable.Throw<T>(
+                    Unreachable(reader, target, what, effective))));
+    }
+
+    /// <summary>
+    /// Bounds the wait for <paramref name="source"/>'s FIRST value and, when it does not arrive,
+    /// emits <paramref name="fallback"/> and <b>stays subscribed</b>.
+    ///
+    /// <para>This is the disposition for a LIVE binding, and the difference from
+    /// <see cref="FailIfNoFirstEmission{T}"/> is deliberate in both directions:</para>
+    /// <list type="bullet">
+    ///   <item><b>It does not error</b>, because an error tears the subscription down — and a hub
+    ///     that is merely slow (a cold NodeType compile legitimately outruns any interactive
+    ///     budget) would then never populate the control at all. Here the late value still lands
+    ///     and replaces the fallback.</item>
+    ///   <item><b>It does not complete</b>, for the same reason plus the empty-completion trap: a
+    ///     completed binding is indistinguishable from a field that has no more values.</item>
+    ///   <item><b>It is not silent.</b> <paramref name="onDegraded"/> fires with the same
+    ///     <see cref="HubUnreachableException"/> the failing disposition would have thrown, so the
+    ///     caller logs/surfaces WHICH node did not answer and within what budget. Emitting the
+    ///     fallback with no record is the silent-empty failure this repo bans.</item>
+    /// </list>
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The live read to bound.</param>
+    /// <param name="fallback">What to emit when nothing arrived in time — the "we have nothing
+    /// yet" value the consumer would render for an absent field.</param>
+    /// <param name="onDegraded">Called exactly once, with the attributable failure, when the
+    /// fallback is emitted. Never called when a real value arrived first.</param>
+    /// <param name="reader">The hub issuing the read (diagnostics only; may be null).</param>
+    /// <param name="target">The address expected to answer.</param>
+    /// <param name="what">A short description of the read.</param>
+    /// <param name="budget">The budget; <see cref="Default"/> when omitted.</param>
+    /// <param name="scheduler">Clock for the budget (virtual time in tests).</param>
+    /// <returns>The bounded source.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The budget is not positive.</exception>
+    public static IObservable<T> DegradeIfNoFirstEmission<T>(
+        this IObservable<T> source,
+        T fallback,
+        Action<HubUnreachableException> onDegraded,
+        IMessageHub? reader,
+        string target,
+        string what,
+        TimeSpan? budget = null,
+        IScheduler? scheduler = null)
+    {
+        var effective = Validate(budget);
+        return Observable.Create<T>(observer =>
+            {
+                // 0 = nothing has been emitted yet. Whoever flips it to 1 first wins: a real value
+                // cancels the degradation, and the degradation cannot fire twice.
+                var emitted = 0;
+                var subscription = source.Subscribe(
+                    value =>
+                    {
+                        Interlocked.Exchange(ref emitted, 1);
+                        observer.OnNext(value);
+                    },
+                    observer.OnError,
+                    observer.OnCompleted);
+                var timer = Observable.Timer(effective, scheduler ?? Scheduler.Default)
+                    .Subscribe(_ =>
+                    {
+                        if (Interlocked.CompareExchange(ref emitted, 1, 0) != 0)
+                            return;
+                        var failure = Unreachable(reader, target, what, effective);
+                        try
+                        {
+                            onDegraded(failure);
+                        }
+                        catch
+                        {
+                            // Reporting the degradation must never replace it: the consumer still
+                            // needs the fallback so its control draws instead of spinning.
+                        }
+                        observer.OnNext(fallback);
+                    });
+                return new CompositeDisposable(subscription, timer);
+            })
+            // The value path and the budget timer run on different threads; Rx's grammar requires
+            // serialized notifications, and the CAS above only guarantees the degradation is not
+            // DUPLICATED, not that it cannot interleave with an in-flight OnNext.
+            .Synchronize();
+    }
+
+    private static TimeSpan Validate(TimeSpan? budget)
+    {
+        var effective = budget ?? Default;
+        return effective > TimeSpan.Zero
+            ? effective
+            : throw new ArgumentOutOfRangeException(nameof(budget), effective,
+                "A read budget must be positive — a non-positive budget expires before the read is "
+                + "even posted, which reports 'unreachable' about a hub nobody asked.");
+    }
+
+    /// <summary>
+    /// The failure a lapsed budget produces, carrying everything needed to tell the three causes
+    /// apart WITHOUT re-running anything: the reader's own in-flight snapshot (our request still
+    /// pending ⇒ the reply never came), and whether the target hub exists in this process at all
+    /// (⇒ it never activated here, or it is owned by another silo and the reply was lost in
+    /// transit — MeshWeaver#1742).
+    /// </summary>
+    private static HubUnreachableException Unreachable(
+        IMessageHub? reader, string target, string what, TimeSpan budget)
+    {
+        var readerState = Describe(() => reader?.GetPendingRequestDiagnostics() ?? "<no reader hub>");
+        var targetState = Describe(() => DescribeTarget(reader, target));
+        return new HubUnreachableException(
+            $"Reading {what} from '{target}' gave up after {budget.TotalSeconds:F0}s — the owning hub "
+            + "never answered. This is NOT 'not found' and NOT a denial: no verdict was reached, so "
+            + $"the read is retryable. Reader: {readerState} {targetState}",
+            target,
+            budget);
+    }
+
+    private static string DescribeTarget(IMessageHub? reader, string target)
+    {
+        if (reader is null)
+            return "Target: <not probed — no reader hub>.";
+        if (string.Equals(reader.Address.ToString(), target, StringComparison.Ordinal))
+            return "Target: this hub itself.";
+        // HostedHubCreation.Never — a pure dictionary probe. Diagnosing a hub must never activate it.
+        return reader.GetHostedHub(new Address(target), HostedHubCreation.Never) is { } owner
+            ? $"Target: {owner.GetPendingRequestDiagnostics()}"
+            : $"Target: NO LOCAL HUB at '{target}' — it never activated in this process (or it is "
+              + "owned by another silo and the reply was lost in transit).";
+    }
+
+    private static string Describe(Func<string> probe)
+    {
+        try
+        {
+            return probe();
+        }
+        catch (Exception ex)
+        {
+            // Diagnostics run on the budget timer's thread, where the hub may already be torn down.
+            // A throw here would be an unobserved fault on a pool thread — precisely the class of
+            // failure this type exists to remove.
+            return $"<diagnostics unavailable: {ex.GetType().Name}>";
+        }
+    }
+
+    /// <summary>
+    /// The logger every read-budget degradation reports on, so one channel covers every seam.
+    /// </summary>
+    /// <param name="hub">The hub whose service provider owns the logger factory.</param>
+    /// <returns>The logger, or null when none can be resolved.</returns>
+    public static ILogger? Logger(IMessageHub? hub)
+    {
+        try
+        {
+            return hub?.ServiceProvider.GetService<ILoggerFactory>()
+                ?.CreateLogger("MeshWeaver.Mesh.ReadBudget");
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -1240,10 +1240,16 @@ public class MessageService : IMessageService
             if (!deferredDeliveries.TryRemove(delivery.Id, out var tracker)) return;
             tracker.TimeoutCts.Dispose();
             var stillClosed = string.Join(",", gates.Keys);
+            // 🚨 Unavailable, not the default Unknown. A hub that has not opened its init gates is
+            // still STARTING — the read reached no verdict and the same request will succeed once
+            // the gate opens, which is precisely ErrorType.Unavailable's contract ("no verdict was
+            // reached … retryable by construction"). Reported as Unknown it was indistinguishable
+            // from a handler defect, so every caller mapped it to a hard error instead of a retry.
             ReportFailure(delivery.WithProperty("Error",
-                $"Hub {Address} deferred {delivery.Message.GetType().Name} (id={delivery.Id}) for >{DeferralTimeout.TotalSeconds:F0}s "
-                + $"without opening init gates [{stillClosed}] — likely a stuck NodeType compile, "
-                + $"missing handler registration on the receiver, or a dependency that never initialised."));
+                    $"Hub {Address} deferred {delivery.Message.GetType().Name} (id={delivery.Id}) for >{DeferralTimeout.TotalSeconds:F0}s "
+                    + $"without opening init gates [{stillClosed}] — likely a stuck NodeType compile, "
+                    + $"missing handler registration on the receiver, or a dependency that never initialised."),
+                ErrorType.Unavailable);
         }, TaskScheduler.Default);
     }
 

--- a/test/MeshWeaver.Hosting.Blazor.Test/ContentFailureMappingTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ContentFailureMappingTest.cs
@@ -1,3 +1,5 @@
+using System;
+using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -70,11 +72,89 @@ public class ContentFailureMappingTest
     }
 
     /// <summary>
+    /// 🚨 A HUB THAT IS RECYCLING IS NOT A BROKEN ONE. <see cref="ErrorType.ShuttingDown"/>'s own
+    /// contract is "retry-worthy, never terminal" — routing mints it deliberately INSTEAD of
+    /// NotFound for a live-but-recycling address. Answering 500 (or 404) for a hub that will be back
+    /// on the next probe is the confident-wrong-answer the tri-state exists to prevent, so it joins
+    /// the retryable arm rather than the alerting fallback.
+    /// </summary>
+    [Fact]
+    public void ARecyclingHub_IsRetryable_NotAFailure()
+    {
+        var result = BlazorHostingExtensions.ContentFailure(
+            Failure(ErrorType.ShuttingDown, "Hub 'PrivateSpace' is shutting down. Rejecting now."),
+            logger: null, path: "PrivateSpace/secret.pdf");
+
+        result.Should().BeOfType<StatusCodeHttpResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    /// <summary>
+    /// 🚨 THE #1563 / #1748 ARM. A read that gave up because the owning hub never answered reached
+    /// no verdict either — same fact as <see cref="ErrorType.Unavailable"/>, same retryable 503.
+    /// Before the route carried a budget of its own this arrived only after the hub's full 60 s
+    /// <c>RequestTimeout</c> and fell through to the 500 + <c>fail:</c> fallback, which is how a
+    /// transient miss on one image became a filed production incident.
+    /// </summary>
+    [Fact]
+    public void AReadThatTimedOut_IsRetryable_NotAFailure()
+    {
+        var result = BlazorHostingExtensions.ContentFailure(
+            new HubUnreachableException(
+                "Reading content collection config from 'Skill' gave up after 10s",
+                target: "Skill", budget: TimeSpan.FromSeconds(10)),
+            logger: null, path: "Skill/content/og-card.png");
+
+        result.Should().BeOfType<StatusCodeHttpResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable,
+                "the hub never answered — that is an availability fact, and the same request "
+                + "succeeds once the target is back");
+    }
+
+    /// <summary>
+    /// A plain <see cref="TimeoutException"/> takes the same arm: the classification must key on the
+    /// FACT (a read that reached no verdict), not on this repo's own exception subclass, or a
+    /// timeout arriving from any other layer would quietly rejoin the alerting fallback.
+    /// </summary>
+    [Fact]
+    public void AnyTimeout_TakesTheSameRetryableArm()
+    {
+        var result = BlazorHostingExtensions.ContentFailure(
+            new TimeoutException("No response received in hub mesh/x within 00:01:00"),
+            logger: null, path: "Skill/content/og-card.png");
+
+        result.Should().BeOfType<StatusCodeHttpResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    /// <summary>
+    /// 🚨 ROUTING SAID THERE IS NO NODE — so answer as a miss, immediately, and with the SAME body a
+    /// refusal produces. This used to fall through to the 500 + Error fallback, which alerted on
+    /// every request for a node that had simply been deleted, AND made the response distinguishable
+    /// from a refusal: 500-vs-404 over a fully predictable URL scheme is an existence oracle in the
+    /// other direction. Both go away by putting absence on the arm that already means absence.
+    /// </summary>
+    [Fact]
+    public void ARoutingNotFound_AnswersAsAMissingFile_NotAsAServerFault()
+    {
+        var result = BlazorHostingExtensions.ContentFailure(
+            Failure(ErrorType.NotFound, "No node found at 'PrivateSpace'."),
+            logger: null, path: "PrivateSpace/secret.pdf");
+
+        var notFound = result.Should().BeOfType<NotFound<string>>().Which;
+        notFound.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        notFound.Value.Should().NotContain("PrivateSpace",
+            "the body stays the constant a refusal uses, so the two are byte-identical");
+    }
+
+    /// <summary>
     /// Fail closed either way: neither refusal arm serves anything, and neither is a 2xx.
     /// </summary>
     [Theory]
     [InlineData(ErrorType.Unauthorized)]
     [InlineData(ErrorType.Unavailable)]
+    [InlineData(ErrorType.ShuttingDown)]
+    [InlineData(ErrorType.NotFound)]
     public void NeitherRefusalArm_EverServes(ErrorType errorType)
     {
         var result = BlazorHostingExtensions.ContentFailure(
@@ -92,14 +172,13 @@ public class ContentFailureMappingTest
     /// 🚨 NO EXCEPTION TEXT IN THE BODY, on the arm that used to carry it. An unclassified failure
     /// still arrives holding the refusing hub's own diagnostic message — and the fallback arm is
     /// where every failure a hub reports WITHOUT classifying lands, including
-    /// <see cref="ErrorType.Unknown"/>, <see cref="ErrorType.NotFound"/> and a
+    /// <see cref="ErrorType.Unknown"/>, <see cref="ErrorType.Exception"/> and a
     /// <see cref="DeliveryFailureException"/> constructed with no <c>Failure</c> at all (the
     /// property patterns simply do not match those). Echoing it published the permission model, the
     /// principal and the node's existence to an anonymous caller over a public route.
     /// </summary>
     [Theory]
     [InlineData(ErrorType.Unknown)]
-    [InlineData(ErrorType.NotFound)]
     [InlineData(ErrorType.Exception)]
     [InlineData(ErrorType.Failed)]
     public void AnUnclassifiedFailure_NeverEchoesTheExceptionText(ErrorType errorType)

--- a/test/MeshWeaver.Hosting.Blazor.Test/ContentRouteUnreachableHubTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ContentRouteUnreachableHubTest.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// 🚨 <c>/api/content</c> MUST DEGRADE FAST AND TRUTHFULLY WHEN THE OWNING HUB CANNOT ANSWER —
+/// issues #1563 (the hub was unreachable) and #1693 (the hub threw during activation), driven over
+/// REAL HTTP against a REAL monolith mesh.
+///
+/// <para><b>What was broken, and it is one shape wearing three faces.</b> The route's
+/// collection-config read carried no budget of its own, so its only terminal was the hub's
+/// <c>RequestTimeout</c> — 60 s, the framework's last-resort ceiling. And the failures that DID
+/// come back fast were unclassified, so they landed on the route's fallback arm: HTTP 500 with a
+/// <c>fail:</c>-level log. Every one of the three cases below therefore ended as an alert that told
+/// an operator nothing and told the browser to give up:</para>
+/// <list type="bullet">
+///   <item><b>The hub throws while activating</b> — <c>"Hub activation failed for
+///     AdvancedBusinessRules: Object reference not set to an instance of an object."</c> (#1693).
+///     An availability fact about the target, reported as a defect in the route.</item>
+///   <item><b>The hub is still starting</b> and its init gates have not opened, so the delivery is
+///     parked and nobody answers for a minute (#1563 / #1748).</item>
+///   <item><b>Nothing resolves at that path</b> — which must stay a plain, immediate 404.</item>
+/// </list>
+///
+/// <para><b>What must hold now.</b> A degraded read answers <b>503</b> — retryable, because no
+/// verdict was reached and the same request will succeed once the target is back — and it does so
+/// in SECONDS, not in the hub's minute. A genuinely absent path stays 404. And the healthy path is
+/// untouched, which is the control that stops "make it fail fast" from becoming "make it fail".</para>
+///
+/// <para><b>Why the elapsed-time assertions are the point.</b> Status alone would pass against the
+/// old code plus a classification fix, while a real user still waited 60 s for a broken image. The
+/// bound asserted here is deliberately loose — an order of magnitude below the 60 s budget rather
+/// than a hair above the 10 s one — so it measures the fix without becoming a machine-speed
+/// flake.</para>
+/// </summary>
+public class ContentRouteUnreachableHubTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>A node whose hub builds and serves normally — the control.</summary>
+    private const string HealthySpace = "HealthySpace";
+
+    /// <summary>A node whose hub CONFIGURATION throws — the #1693 shape, reproduced exactly.</summary>
+    private const string BrokenSpace = "BrokenSpace";
+
+    /// <summary>A node whose hub comes up but never opens an init gate — the "still Starting" shape.</summary>
+    private const string StartingSpace = "StartingSpace";
+
+    private const string CoverFile = "cover.txt";
+    private const string CoverBody = "cover-bytes";
+
+    /// <summary>Header the test pipeline reads to stamp the request's identity (see BuildPortal).</summary>
+    private const string UserHeader = "X-Test-User";
+
+    /// <summary>
+    /// The wall-clock ceiling every assertion below uses. The bug produced 60 s; the route's own
+    /// budget is <see cref="ReadBudget.Default"/> (10 s). 25 s is comfortably above the budget plus
+    /// a cold monolith's activation and comfortably below the failure — it proves the fix without
+    /// pinning a machine-speed race.
+    /// </summary>
+    private static readonly TimeSpan WellUnderTheOldBudget = TimeSpan.FromSeconds(25);
+
+    /// <summary>
+    /// The ceiling for a failure the mesh reports IMMEDIATELY (a hub that could not be constructed,
+    /// a path that resolves to nothing). These must not even reach the read budget — if one does,
+    /// the classification regressed and the route is waiting where it should be answering.
+    /// </summary>
+    private static readonly TimeSpan Immediately = TimeSpan.FromSeconds(8);
+
+    private readonly string storageRoot = CreateStorageFixture();
+
+    private WebApplication? portal;
+    private HttpClient client = null!;
+
+    private static string CreateStorageFixture()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "unreachable-hub-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(Path.Combine(root, "content", HealthySpace));
+        File.WriteAllText(Path.Combine(root, "content", HealthySpace, CoverFile), CoverBody);
+        Directory.CreateDirectory(Path.Combine(root, "content", BrokenSpace));
+        File.WriteAllText(Path.Combine(root, "content", BrokenSpace, CoverFile), CoverBody);
+        Directory.CreateDirectory(Path.Combine(root, "content", StartingSpace));
+        File.WriteAllText(Path.Combine(root, "content", StartingSpace, CoverFile), CoverBody);
+        return root;
+    }
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                new MeshNode(HealthySpace) { Name = "Healthy Space", NodeType = "Markdown" },
+                new MeshNode(BrokenSpace) { Name = "Broken Space", NodeType = "Markdown" },
+                new MeshNode(StartingSpace) { Name = "Starting Space", NodeType = "Markdown" })
+            .ConfigureDefaultNodeHub(config =>
+            {
+                var address = config.Address.ToString();
+
+                // 🚨 THE #1693 REPRODUCTION, at the layer where it actually happened: a
+                // NullReferenceException thrown while the per-node hub's configuration is composed.
+                // MessageHubConfiguration.Build runs every SyncBuildupAction inline, so a compiled
+                // NodeType's own configuration lambda, the workspace construction AddData registers,
+                // and every ConfigureDefaultNodeHub overlay all execute inside hub construction —
+                // which is why a single null dereference anywhere in that chain becomes "hub
+                // activation failed" and nothing more specific.
+                if (address == BrokenSpace)
+                    throw new NullReferenceException("Object reference not set to an instance of an object.");
+
+                // A hub that BUILDS but never becomes ready: an initialization gate nothing ever
+                // opens, so every delivery to it is deferred. This is the "target hub is still
+                // Starting" case — the one where no failure is ever produced, so the CALLER'S budget
+                // is the only thing that can end the wait.
+                if (address == StartingSpace)
+                    return config.WithInitializationGate("NeverOpens");
+
+                return address == HealthySpace
+                    ? config.AddContentCollection(_ => new ContentCollectionConfig
+                    {
+                        Name = ContentCollectionsExtensions.DefaultCollectionName,
+                        SourceType = "FileSystem",
+                        BasePath = Path.Combine(storageRoot, "content", HealthySpace),
+                        Address = config.Address,
+                        ExposeInChildren = true,
+                        IsStatic = true,
+                    })
+                    : config;
+            });
+
+    /// <inheritdoc />
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        portal = BuildPortal();
+        await portal.StartAsync(TestContext.Current.CancellationToken);
+        client = portal.GetTestClient();
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        if (portal is not null)
+            await portal.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    /// <summary>
+    /// The portal's HTTP surface: the REAL <c>MapMeshWeaver()</c> endpoints over the test mesh,
+    /// preceded by the identity middleware production's <c>UserContextMiddleware</c> provides.
+    /// </summary>
+    private WebApplication BuildPortal()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.Services.AddSingleton(Mesh);
+
+        var app = builder.Build();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        app.Use(async (ctx, next) =>
+        {
+            var userId = ctx.Request.Headers[UserHeader].ToString();
+            accessService.SetContext(string.IsNullOrEmpty(userId)
+                ? new AccessContext { ObjectId = WellKnownUsers.Anonymous, Name = WellKnownUsers.Anonymous }
+                : TestUsers.Admin);
+            await next();
+        });
+        app.MapMeshWeaver();
+        return app;
+    }
+
+    private async Task<(HttpStatusCode Status, TimeSpan Elapsed)> GetAsync(string url)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add(UserHeader, TestUsers.Admin.ObjectId);
+        var started = Stopwatch.StartNew();
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        var elapsed = started.Elapsed;
+        Output.WriteLine($"GET {url} → {(int)response.StatusCode} in {elapsed.TotalSeconds:F2}s");
+        return (response.StatusCode, elapsed);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  The control — nothing below is worth anything if the healthy path regressed.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A reachable hub still serves its bytes, promptly. A read budget that also breaks the working
+    /// case is not a fix, and "fails fast" is trivially satisfiable by failing always.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AReachableHub_StillServesItsContent()
+    {
+        var (status, elapsed) = await GetAsync($"/api/content/{HealthySpace}/{CoverFile}");
+
+        status.Should().Be(HttpStatusCode.OK);
+        elapsed.Should().BeLessThan(Immediately);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  #1693 — the hub throws while activating.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 A hub that throws while activating is an AVAILABILITY failure of the TARGET, not a defect
+    /// in this route: the node exists, its hub blew up, and the next access re-runs construction
+    /// from scratch. So the honest answer is a retryable 503 — never the 500 + <c>fail:</c> alert
+    /// that filed #1693, and never a 404, which would tell a caller (and any cache between) that
+    /// content which demonstrably exists does not.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AHubThatThrowsWhileActivating_Answers503_NotAFailLevel500()
+    {
+        var (status, elapsed) = await GetAsync($"/api/content/{BrokenSpace}/{CoverFile}");
+
+        status.Should().Be(HttpStatusCode.ServiceUnavailable,
+            "the node is there and its hub could not be built — no verdict was reached, so the "
+            + "answer is 'retry', not 'this is broken' and not 'this does not exist'");
+        elapsed.Should().BeLessThan(Immediately,
+            "hub construction fails synchronously and the mesh reports it at once — this case must "
+            + "not even reach the read budget, let alone the hub's 60 s RequestTimeout");
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  #1563 / #1748 — the hub is still starting and nobody ever answers.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 THE ORIGINAL BUG. The target hub is up but not ready — its init gates have not opened — so
+    /// the delivery is parked and NO failure is ever produced. Nothing but the caller's own budget
+    /// can end that wait, and without one the route sat for the hub's full 60 s and then answered
+    /// 500 with <c>"No response received in hub … the target hub was not found"</c>.
+    ///
+    /// <para>The elapsed bound is the assertion that matters here: the status could be made right by
+    /// classification alone while a user still stared at a broken image for a minute.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AHubThatNeverBecomesReady_Answers503_WellInsideTheOldSixtySecondBudget()
+    {
+        var (status, elapsed) = await GetAsync($"/api/content/{StartingSpace}/{CoverFile}");
+
+        status.Should().Be(HttpStatusCode.ServiceUnavailable,
+            "the read reached no verdict — 503 tells the caller to retry, which is exactly what a "
+            + "still-starting hub deserves");
+        elapsed.Should().BeLessThan(WellUnderTheOldBudget,
+            "the whole point: the route now carries its own 10 s read budget instead of inheriting "
+            + "the hub's 60 s RequestTimeout as its only terminal");
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  Nothing there at all.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A path that resolves to no node is answered immediately, and as a plain 404 — the same body a
+    /// refusal produces, so no arm of the failure mapping can be used as an existence oracle over a
+    /// fully predictable URL scheme. Pinned alongside the degraded cases because "unreachable" and
+    /// "absent" are the two facts this change exists to keep apart.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task APathThatResolvesToNoNode_Is404_Immediately()
+    {
+        var (status, elapsed) = await GetAsync($"/api/content/NoSuchSpaceAnywhere/{CoverFile}");
+
+        status.Should().Be(HttpStatusCode.NotFound);
+        elapsed.Should().BeLessThan(Immediately,
+            "absence is known without asking any hub — it must never wait on a budget");
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/HubConstructionFailureReasonTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/HubConstructionFailureReasonTest.cs
@@ -1,0 +1,76 @@
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 THE #1693 DIAGNOSIS, pinned as a contract.
+///
+/// <para><b>What production actually said.</b> <c>"Hub activation failed for
+/// AdvancedBusinessRules: Object reference not set to an instance of an object."</c> — filed as an
+/// incident, and unactionable: no line, no node type, no hint that the real exception had already
+/// been written with its stack milliseconds earlier.</para>
+///
+/// <para><b>Where it came from.</b> <c>MessageHubGrain.CompleteActivation</c> called
+/// <c>meshHub.GetHostedHub(address, config)</c> and suppressed the nullability with <c>!</c>. That
+/// call returns NULL on three real paths — the configuration threw (and
+/// <c>HostedHubsCollection.CreateHub</c> caught it, logged <i>"Failed to create hosted hub for
+/// address {Address}"</i> WITH the stack, and returned null), the collection is disposing, or an
+/// ancestor froze creation. Dereferencing that null threw a <see cref="NullReferenceException"/>
+/// which the grain's own catch then reported as the CAUSE of the activation — a secondary failure
+/// masking the primary one. The Monolith twin has always been null-safe here
+/// (<c>MonolithRoutingService</c>: <c>createdHub?.RegisterForDisposal(...)</c>); the asymmetry is
+/// what made this Orleans-only.</para>
+///
+/// <para>Deleting the <c>!</c> is what makes the null check compiler-enforced under this repo's
+/// nullable + warnings-as-errors settings; this test pins the other half — that the message a
+/// caller receives is a diagnosis rather than a null dereference.</para>
+/// </summary>
+public class HubConstructionFailureReasonTest
+{
+    /// <summary>
+    /// It names the node and its type. That is the minimum needed to know WHICH package broke,
+    /// which is precisely what the bare NRE withheld.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TheReason_NamesTheNodeAndItsType()
+    {
+        var reason = MessageHubGrain.HubConstructionFailureReason(
+            new MeshNode("AdvancedBusinessRules") { NodeType = "Store/Plugin" });
+
+        reason.Should().Contain("AdvancedBusinessRules").And.Contain("Store/Plugin");
+        reason.Should().NotContain("Object reference not set",
+            "a null dereference inside the grain is a SECOND failure that masks the first — the "
+            + "message must describe hub construction, not the crash that reporting it caused");
+    }
+
+    /// <summary>
+    /// 🚨 It points at where the REAL exception is. The cause is caught, logged with its stack and
+    /// swallowed one layer down, so a reader who does not know that goes looking for a stack that
+    /// is not attached to anything — which is exactly how #1693 was triaged as a route defect.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TheReason_PointsAtTheLogEntryCarryingTheRealException()
+    {
+        var reason = MessageHubGrain.HubConstructionFailureReason(
+            new MeshNode("AdvancedBusinessRules") { NodeType = "Store/Plugin" });
+
+        reason.Should().Contain("Failed to create hosted hub",
+            "that is the verbatim HostedHubsCollection log entry that carries the actual stack");
+        reason.Should().Contain("disposing",
+            "the other reachable cause is a frozen/ disposing hub collection — a reader must be able "
+            + "to tell a broken configuration from a pod that is going away");
+    }
+
+    /// <summary>
+    /// A node with no NodeType still produces a readable sentence rather than a hole — the untyped
+    /// node is one of the shapes that reaches hub construction in the first place.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void AnUntypedNode_StillReadsAsASentence()
+    {
+        var reason = MessageHubGrain.HubConstructionFailureReason(new MeshNode("Orphan"));
+
+        reason.Should().Contain("Orphan").And.Contain("(null)");
+    }
+}

--- a/test/MeshWeaver.Layout.Test/ReadBudgetTest.cs
+++ b/test/MeshWeaver.Layout.Test/ReadBudgetTest.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Mesh;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// 🚨 THE CALLER-SIDE READ BUDGET — the seam behind issues #1563, #1693 and #1748, pinned in
+/// VIRTUAL TIME.
+///
+/// <para><b>The shape all three share.</b> A read whose target hub is unreachable, still starting,
+/// or whose reply is dropped in transit has no terminal of its own, so it inherits the hub's
+/// <c>RequestTimeout</c> — 60 s, the framework's last-resort ceiling — and then reports the hub's
+/// own impatience instead of what was being read. <see cref="ReadBudget"/> is the nested bound that
+/// fires first and therefore gets to say which read starved.</para>
+///
+/// <para><b>Why virtual time.</b> These are timeout tests; run against the wall clock they would
+/// either take a minute each or hang CI exactly the way the bug does. A
+/// <see cref="TestScheduler"/> drives the budget deterministically and instantly — the same seam
+/// <c>MessageHubGrain.BuildActivationChain</c> exposes for the identical reason.</para>
+///
+/// <para><b>What each disposition must NOT do</b> is as load-bearing as what it must: the failing
+/// one must ERROR rather than complete (an empty completion reads as "there is genuinely nothing
+/// here", which is Rx's own <c>Timeout(..., Observable.Empty)</c> trap), and the degrading one must
+/// stay SUBSCRIBED (an error would tear a live binding down, so a hub that is merely slow could
+/// never populate the control).</para>
+/// </summary>
+public class ReadBudgetTest
+{
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(10);
+    private const string Target = "Posts/RobertHaircuts";
+    private const string What = "field 'authorPath'";
+
+    private sealed record Observed<T>(List<T> Values, List<Exception> Errors, int Completions);
+
+    private static Observed<T> Record<T>(IObservable<T> source, TestScheduler scheduler, TimeSpan advance)
+    {
+        var values = new List<T>();
+        var errors = new List<Exception>();
+        var completions = 0;
+        using var subscription = source.Subscribe(values.Add, errors.Add, () => completions++);
+        scheduler.AdvanceBy(advance.Ticks);
+        return new Observed<T>(values, errors, completions);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  FailIfNoFirstEmission — the ONE-SHOT disposition (the content route, #1563 / #1693).
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 THE WHOLE POINT. A target that never answers must terminate the read at the CALLER'S
+    /// budget, not at the hub's 60 s ceiling — and the failure must name the target and the budget,
+    /// because "the read gave up" is only actionable if you know which read.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void ATargetThatNeverAnswers_FailsAtTheCallersBudget_NotTheHubs()
+    {
+        var scheduler = new TestScheduler();
+
+        var observed = Record(
+            Observable.Never<string>().FailIfNoFirstEmission(
+                reader: null, Target, What, Budget, scheduler),
+            scheduler,
+            Budget);
+
+        var failure = Assert.Single(observed.Errors);
+        var unreachable = Assert.IsType<HubUnreachableException>(failure);
+        unreachable.Target.Should().Be(Target);
+        unreachable.Budget.Should().Be(Budget);
+        unreachable.Message.Should().Contain(Target).And.Contain(What,
+            "a bare 'no response received in hub X' names neither the read nor the file — which is "
+            + "exactly why #1563 and #1748 were each filed as an unactionable single-occurrence alert");
+    }
+
+    /// <summary>
+    /// It is a <see cref="TimeoutException"/> BY INHERITANCE, and that is not cosmetic: every
+    /// transient-failure classifier in the framework keys on that type
+    /// (<see cref="AreaErrorClassifier.IsTransientHubFailure"/>,
+    /// <c>MeshNodeStreamCache.IsTransientOwnerFailure</c>, <c>RoutingGrain.IsTransientFailure</c>).
+    /// A brand-new exception type would have fallen out of all three at once, turning a retryable
+    /// stall into a negative-cached "missing node" — a strictly worse failure than the 60 s wait
+    /// this replaces.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TheFailure_StaysClassifiedAsATransientHubMiss()
+    {
+        var scheduler = new TestScheduler();
+
+        var observed = Record(
+            Observable.Never<string>().FailIfNoFirstEmission(
+                reader: null, Target, What, Budget, scheduler),
+            scheduler,
+            Budget);
+
+        var failure = Assert.Single(observed.Errors);
+        failure.Should().BeAssignableTo<TimeoutException>();
+        AreaErrorClassifier.IsTransientHubFailure(failure).Should().BeTrue(
+            "the retry/negative-cache classifiers must keep recognising a lapsed read budget as the "
+            + "transient owner miss it is");
+    }
+
+    /// <summary>
+    /// 🚨 IT ERRORS — it never completes empty. Rx's <c>Timeout(..., Observable.Empty)</c> passes a
+    /// COMPLETION downstream, which a reader cannot tell apart from "there is genuinely nothing
+    /// here"; a route would answer 404 for a hub that never spoke. The distinction has to survive to
+    /// the caller, so the degraded read is a terminal ERROR and nothing else.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TheFailedRead_NeverCompletesEmpty()
+    {
+        var scheduler = new TestScheduler();
+
+        var observed = Record(
+            Observable.Never<string>().FailIfNoFirstEmission(
+                reader: null, Target, What, Budget, scheduler),
+            scheduler,
+            Budget);
+
+        observed.Values.Should().BeEmpty();
+        observed.Completions.Should().Be(0,
+            "an empty completion is indistinguishable from 'no data' — the exact silent failure "
+            + "this budget exists to remove");
+        observed.Errors.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// Nothing fires one tick early: the budget is a deadline, not a hint. Pinning the boundary is
+    /// what stops a later "make the tests faster" edit from quietly turning a bound into a race.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TheBudget_DoesNotFireBeforeItElapses()
+    {
+        var scheduler = new TestScheduler();
+
+        var observed = Record(
+            Observable.Never<string>().FailIfNoFirstEmission(
+                reader: null, Target, What, Budget, scheduler),
+            scheduler,
+            Budget - TimeSpan.FromTicks(1));
+
+        observed.Errors.Should().BeEmpty();
+        observed.Completions.Should().Be(0);
+    }
+
+    /// <summary>
+    /// 🚨 ONLY THE FIRST EMISSION IS BOUNDED. Rx's plain <c>Timeout(TimeSpan)</c> applies BETWEEN
+    /// consecutive elements, so wiring it here would fault a perfectly healthy binding that simply
+    /// has nothing new to say — turning a fix for a stall into a new source of them. Once the source
+    /// speaks, the budget timer is gone and the stream flows untouched, however long the gaps.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void OnceTheSourceAnswers_TheBudgetIsGone_AndAnIdleStreamSurvives()
+    {
+        var scheduler = new TestScheduler();
+        var source = new Subject<string>();
+        var values = new List<string>();
+        var errors = new List<Exception>();
+
+        using var subscription = source
+            .FailIfNoFirstEmission(reader: null, Target, What, Budget, scheduler)
+            .Subscribe(values.Add, errors.Add);
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+        source.OnNext("first");
+        // Ten budgets' worth of silence — an idle live binding.
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(100).Ticks);
+        source.OnNext("late");
+
+        values.Should().Equal("first", "late");
+        errors.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The source's OWN terminal wins when it arrives first — a routing <c>NotFound</c>, a denial, a
+    /// hub NACK. The budget exists for the case where nothing arrives; it must never overwrite a
+    /// real answer with "the hub did not respond", which would erase the one classification the
+    /// caller can act on.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void ARealFailure_IsNotReplacedByTheBudgetsOne()
+    {
+        var scheduler = new TestScheduler();
+        var source = new Subject<string>();
+        var errors = new List<Exception>();
+
+        using var subscription = source
+            .FailIfNoFirstEmission(reader: null, Target, What, Budget, scheduler)
+            .Subscribe(_ => { }, errors.Add);
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+        source.OnError(new UnauthorizedAccessException("Access denied"));
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(100).Ticks);
+
+        Assert.Single(errors).Should().BeOfType<UnauthorizedAccessException>();
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  DegradeIfNoFirstEmission — the LIVE-BINDING disposition (the node picker, #1748).
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 THE BINDING DRAWS, AND KEEPS TRYING. A control bound to an unreachable node used to spin
+    /// for the hub's full 60 s (and, when the node was simply ABSENT, for the life of the circuit —
+    /// the <c>Where(node is not null)</c> filter means the stream never emits or errors at all).
+    /// Now the budget hands it the same "no value" it renders for an absent field, and the
+    /// subscription survives, so the late value still lands.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void ABindingThatGetsNothingInTime_DrawsEmpty_AndStillTakesTheLateValue()
+    {
+        var scheduler = new TestScheduler();
+        var source = new Subject<object?>();
+        var values = new List<object?>();
+        var errors = new List<Exception>();
+        var degradations = new List<HubUnreachableException>();
+
+        using var subscription = source
+            .DegradeIfNoFirstEmission<object?>(
+                fallback: null, degradations.Add, reader: null, Target, What, Budget, scheduler)
+            .Subscribe(values.Add, errors.Add);
+
+        scheduler.AdvanceBy(Budget.Ticks);
+        values.Should().Equal(new object?[] { null }, "the control must draw instead of spinning");
+        errors.Should().BeEmpty("an error would tear the binding down and the late value would never arrive");
+
+        source.OnNext("arrived-late");
+        values.Should().Equal(new object?[] { null, "arrived-late" },
+            "a cold NodeType compile legitimately outruns any interactive budget — the value must "
+            + "still replace the placeholder when it lands");
+    }
+
+    /// <summary>
+    /// …and it is NOT SILENT. Emitting the fallback with no record would make "the hub never
+    /// answered" indistinguishable from "this field is empty" — the same collapse the failing
+    /// disposition refuses. The report carries the identical typed failure, so whoever logs it names
+    /// the node and the budget.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TheDegradation_IsReportedOnce_WithTheSameAttributableFailure()
+    {
+        var scheduler = new TestScheduler();
+        var degradations = new List<HubUnreachableException>();
+
+        using var subscription = Observable.Never<object?>()
+            .DegradeIfNoFirstEmission<object?>(
+                fallback: null, degradations.Add, reader: null, Target, What, Budget, scheduler)
+            .Subscribe(_ => { });
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(120).Ticks);
+
+        var reported = Assert.Single(degradations);
+        reported.Target.Should().Be(Target);
+        reported.Budget.Should().Be(Budget);
+        reported.Message.Should().Contain(What);
+    }
+
+    /// <summary>
+    /// A binding that answers in time is untouched: no placeholder, no report. The degradation must
+    /// never race a healthy read — otherwise every slow-but-fine control would log a warning and
+    /// flash empty.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void AValueInTime_CancelsTheDegradationEntirely()
+    {
+        var scheduler = new TestScheduler();
+        var source = new Subject<object?>();
+        var values = new List<object?>();
+        var degradations = new List<HubUnreachableException>();
+
+        using var subscription = source
+            .DegradeIfNoFirstEmission<object?>(
+                fallback: null, degradations.Add, reader: null, Target, What, Budget, scheduler)
+            .Subscribe(values.Add);
+
+        scheduler.AdvanceBy((Budget - TimeSpan.FromSeconds(1)).Ticks);
+        source.OnNext("value");
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(120).Ticks);
+
+        values.Should().Equal("value");
+        degradations.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The degrading disposition never completes either — a completed binding tells the consumer
+    /// there will be no more values, which is precisely the opposite of "we are still waiting".
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TheDegradedBinding_StaysOpen()
+    {
+        var scheduler = new TestScheduler();
+
+        var observed = Record(
+            Observable.Never<object?>().DegradeIfNoFirstEmission<object?>(
+                fallback: null, _ => { }, reader: null, Target, What, Budget, scheduler),
+            scheduler,
+            TimeSpan.FromSeconds(120));
+
+        observed.Completions.Should().Be(0);
+        observed.Errors.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A reporting callback that throws must not swallow the placeholder it was reporting: the
+    /// consumer still needs a value to draw. Logging is a side effect of the degradation, never a
+    /// precondition for it.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void AThrowingReport_StillLetsTheControlDraw()
+    {
+        var scheduler = new TestScheduler();
+
+        var observed = Record(
+            Observable.Never<object?>().DegradeIfNoFirstEmission<object?>(
+                fallback: null,
+                _ => throw new InvalidOperationException("logger exploded"),
+                reader: null, Target, What, Budget, scheduler),
+            scheduler,
+            Budget);
+
+        observed.Values.Should().Equal(new object?[] { null });
+        observed.Errors.Should().BeEmpty();
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════
+    //  The budget itself.
+    // ════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The default is the framework's EXISTING interactive read budget, not a new number: 10 s is
+    /// what <c>GetMeshNode</c> has always defaulted to, and it must stay far below the 60 s hub
+    /// <c>RequestTimeout</c> — that inequality is what makes this the bound that fires, and
+    /// therefore the one that can say which read starved.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TheDefaultBudget_SitsWellInsideTheHubsRequestTimeout()
+    {
+        ReadBudget.Default.Should().Be(TimeSpan.FromSeconds(10));
+        ReadBudget.Default.Should().BeLessThan(TimeSpan.FromSeconds(60));
+    }
+
+    /// <summary>
+    /// A non-positive budget expires before the read is even posted, so it would report
+    /// "unreachable" about a hub nobody asked. Refused loudly rather than silently treated as
+    /// "immediately" — the zero-budget shape that leaked a pending SubscribeRequest in #1613.
+    /// </summary>
+    [Theory(Timeout = 30000)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ANonPositiveBudget_IsRefused(int seconds)
+    {
+        var budget = TimeSpan.FromSeconds(seconds);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Observable.Never<string>()
+            .FailIfNoFirstEmission(reader: null, Target, What, budget));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Observable.Never<object?>()
+            .DegradeIfNoFirstEmission<object?>(
+                fallback: null, _ => { }, reader: null, Target, What, budget));
+    }
+}


### PR DESCRIPTION
Closes #1563. Closes #1693. Closes #1748.

## One seam, two call sites, three alerts

All three issues are the same shape: **a read whose target hub is unreachable, still starting, or broken has no terminal of its own**, so it inherits `MessageHub.Observe`'s single global reply budget — the hub's `RequestTimeout`, **60 s** — and then reports the hub's own impatience (`"No response received in hub X … the target hub was not found"`) as a `fail:`-level 500.

That 60 s was never a decision any of these reads made. It is the framework's last-resort ceiling, sized so a cold NodeType compile can finish. An HTTP image fetch and a first-time module compile were being given the same patience.

**It is one seam with two unbounded call sites**, not three independent bugs:

| Issue | Call site | Symptom |
|---|---|---|
| #1563 | `ContentFileResolver.Resolve` — the `/api/content` collection-config `GetDataRequest` | 60 s, then 500 |
| #1693 | same call site | fast, but an *unclassified* failure → 500 + `fail:` |
| #1748 | `MeshNodeBindingExtensions.Bind` — the node-bound GUI binding | 60 s spinner, then an error modal |

Filed as three single-occurrence alerts; the value is in the shape.

## The budget, and why this number

**`ReadBudget.Default` is 10 s, and it is not a new number.** It is what `MeshNodeStreamExtensions.GetMeshNode` has defaulted to since it was written, and it is squarely inside the band every *other* interactive read in this repo already uses (5–15 s across `NamedAreaView`, `ThreadChatView`, `NavigationService`, `MeshNodePickerView`, `UcrLink`). This PR does not introduce a budget — it applies the existing one at the two seams that were missing it.

The rule is the one `MeshOperationOptions` already states for writes, applied to reads: *a bound nested inside another bound must be able to fire FIRST, because it is the only one that knows WHICH read starved.* The mesh's own structural budgets are all 30 s (path resolution, first-node resolution, deferral, mesh operations); the hub's 60 s is the outermost. A caller that waits past the mesh's worst-case self-report is waiting on something the mesh cannot see — a reply lost in transit (#1742) — and waiting longer cannot help.

🚨 **READS only.** A caller-side ceiling on a *write* makes the caller abandon an operation that is still running; #1270 tried exactly that and got `ObjectDisposedException` on a thread-pool thread after the tests had reported success. Everything here bounds an idempotent read whose only effect is the answer.

## Two dispositions — and choosing between them is the design decision

`ReadBudget` (new, `MeshWeaver.Mesh.Contract`) offers exactly two, because the honest answer differs by surface:

- **`FailIfNoFirstEmission`** — one-shot reads (the HTTP route). **Errors** with a typed `HubUnreachableException` naming the target, the budget, and both ends' in-flight state.
- **`DegradeIfNoFirstEmission`** — live bindings. Emits a fallback and **stays subscribed**, because an error tears the binding down and a hub that is merely *slow* (a cold compile legitimately outruns any interactive budget) would then never populate the control at all. It reports the identical typed failure through a callback, so it is never silent.

Two properties are load-bearing and pinned by test:

- **Neither ever completes empty.** Rx's own `Timeout(…, Observable.Empty)` passes a *completion* downstream, which a reader cannot tell apart from "there is genuinely nothing here" — a route would answer 404 for a hub that never spoke.
- **Only the FIRST emission is bounded.** Rx's plain `Timeout(TimeSpan)` applies *between consecutive elements* and would fault a perfectly healthy idle binding — turning a fix for a stall into a new source of them. `Observable.Amb` is the shape `MessageHubGrain.BuildActivationChain` already uses for exactly this.

`HubUnreachableException` derives from `TimeoutException` **on purpose**: `AreaErrorClassifier.IsTransientHubFailure`, `MeshNodeStreamCache.IsTransientOwnerFailure` and `RoutingGrain.IsTransientFailure` all key on that type, and a brand-new exception type would have fallen out of all three at once — turning a retryable stall into a negative-cached "missing node", which is strictly worse than the 60 s wait it replaces.

## Classify at the site that knows

Three failure sites reported `ErrorType.Unknown`, so callers could not tell "the target could not start" from "something is broken":

- `MessageHubGrain.DeliverMessage` — activation fault → `Unavailable`; disposal race → `ShuttingDown` (the same classification `MonolithRoutingService` already mints, so the two hosting models agree and `SynchronizationStream`'s resubscribe latch rides it out).
- `MessageService.ScheduleDeferralTimeout` — a hub that never opened its init gates → `Unavailable`.
- `RoutingServiceBase.NackRouteFailure` — a faulted route chain → `Unavailable`.
- `MonolithRoutingService.PostNotFound` — a node that exists whose **hub could not be built** is no longer reported as `NotFound`.

`ErrorType.Unavailable`'s own doc says it: *"NO VERDICT WAS REACHED … retryable by construction … collapsing that into a definitive negative is worse than a plain error, because it is actionable-looking."*

## The HTTP mapping

`ContentFailure` gains three arms, and the point is that **the 500 + `Error` fallback is the ALERTING arm** — the `fail:` line the incident pipeline files issues from. Three routine outcomes were landing there, and each filed one:

| Outcome | Was | Now |
|---|---|---|
| read timed out / recycling hub | 500 + `Error`, after 60 s | **503** + `Warning`, in 10 s |
| activation failed (unclassified) | 500 + `Error` | **503** + `Warning` |
| routing `NotFound` | 500 + `Error` | **404** + `Debug`, body byte-identical to a refusal |

503 is not cosmetic: it means *ask again*, which is true, and caches and retry logic treat it very differently from a 500. The 404 change also **closes an existence oracle in the other direction** — a missing node used to answer 500 while a refused one answered 404, which is distinguishable over a fully predictable URL scheme.

## #1693's NullReferenceException — found and fixed

The NRE is real and it is in the platform, not in `AdvancedBusinessRules`.

`MessageHubGrain.CompleteActivation` called `meshHub.GetHostedHub(address, config)!` — and **that `!` was a lie**. `HostedHubsCollection.CreateHub` returns `null` on three reachable paths:

1. the hub **configuration threw** — and `MessageHubConfiguration.Build` runs every `SyncBuildupAction` inline, so that covers a compiled NodeType's own configuration lambda, `AddData`'s workspace construction, and every `ConfigureDefaultNodeHub` overlay. `CreateHub` catches it, logs **`"Failed to create hosted hub for address {Address}"` with the real stack**, and returns null;
2. the collection is disposing;
3. an ancestor froze creation.

Dereferencing that null threw a `NullReferenceException`, which the grain's own catch then reported as *the cause of the activation* — a **secondary failure masking the primary one**. Hence the production line: `"Hub activation failed for AdvancedBusinessRules: Object reference not set to an instance of an object."` — a sentence that names nothing, points at no line, and hides the fact that the actual exception had been written with its stack milliseconds earlier.

The tell that clinched it: the **Monolith twin has always been null-safe here** (`MonolithRoutingService`: `createdHub?.RegisterForDisposal(...)`). The asymmetry is what made this Orleans-only.

Fixed: the `!` is deleted (so nullable + `-warnaserror` now *enforces* the check) and the report names the node, its type, and where the real stack is recorded. The underlying module bug — whatever threw inside `AdvancedBusinessRules`' configuration — is now diagnosable from one log line instead of invisible.

## Tests — executed, bounded, and proven non-vacuous

Timeout bugs demand bounded tests; an unbounded one hangs CI exactly the way the bug does.

**`ReadBudgetTest`** (14 cases, virtual time via `TestScheduler`, 1.3 s total) — fires at the budget and not a tick before; names target + budget; stays a `TimeoutException` for the classifiers; **errors rather than completing empty**; only bounds the first emission (an idle stream survives 10 budgets); a real failure is not overwritten by the budget's; the degrading form draws, keeps trying, takes the late value, reports once, never completes; a non-positive budget is refused.

**`ContentRouteUnreachableHubTest`** — real HTTP over a real monolith mesh, covering the three mandated cases:

```
GET /api/content/HealthySpace/cover.txt   → 200 in 0.27s   (the control)
GET /api/content/BrokenSpace/cover.txt    → 503 in 0.18s   (activation throws NRE — #1693)
GET /api/content/StartingSpace/cover.txt  → 503 in 10.0s   (init gates never open — was 60 s)
GET /api/content/NoSuchSpaceAnywhere/…    → 404 in 0.43s   (nothing resolves)
```

**Non-vacuity, measured.** With the two fixes reverted on the same machine:

```
Failed  AHubThatThrowsWhileActivating_Answers503_NotAFailLevel500 [248 ms]
        Expected ServiceUnavailable … but found NotFound.
        [Error] [MeshWeaver.Messaging.HostedHubsCollection] Failed to create hosted hub for address BrokenSpace
Failed  AHubThatNeverBecomesReady_Answers503_WellInsideTheOldSixtySecondBudget [30 s]
        (test timeout — the read was still waiting out the hub's 60 s RequestTimeout)
```

That second line *is* the bug, reproduced.

**`ContentFailureMappingTest`** — the new arms, incl. that a routing `NotFound` body stays byte-identical to a refusal. **`HubConstructionFailureReasonTest`** — the #1693 diagnosis names the node, its type, and the log entry carrying the real stack, and never says "Object reference not set".

## Suites run locally (Release, `-warnaserror`, all green)

| Suite | Result |
|---|---|
| MeshWeaver.Layout.Test | 448 passed |
| MeshWeaver.Hosting.Blazor.Test | 412 passed |
| MeshWeaver.Hosting.Monolith.Test | 747 passed, 3 skipped |
| MeshWeaver.Messaging.Hub.Test | 252 passed |
| MeshWeaver.Hosting.Test | 184 passed |
| MeshWeaver.Content.Test | 260 passed, 1 skipped |
| MeshWeaver.ContentCollections.Test | 30 passed |
| MeshWeaver.Documentation.Test | 34 passed |
| MeshWeaver.Hosting.Orleans.Test (routing / activation / broken-NodeType subset) | 24 passed |

## Deliberately NOT in scope

**#1613** is left alone — a change may be in flight there. Its maintainer thread is the evidence this PR leans on (a disposal path that cannot cancel an in-flight `SubscribeRequest` inside the teardown budget), and the rule it states — *a delivery parked behind init gates that are never opened is owed a terminal response* — is what `ScheduleDeferralTimeout`'s reclassification here makes actionable.

**#1742** (cross-silo replies riding a non-durable Orleans memory stream, so a reply can be silently dropped) is the *cause* of the 60 s waits in production and needs an infrastructure decision. This PR does not touch it; it makes the symptom degrade in 10 s with an attributable answer instead of a minute with none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wVYniTKJ7Kuw7Hh425UPy
