### PR TITLE
fix: re-drive a NodeType that never compiled and settles at Error (#1793)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -422,6 +422,7 @@ LIVE inputs differ from that stamp:
 | An edited / added / removed source | one fresh attempt |
 | Nothing — same framework, modules and sources | **no attempt**: the identical failure would reproduce |
 | The stamp is `null` (a failure from before this field, or an `Error` baked into a node file) | one fresh attempt — the migration |
+| The source set has not been established yet (`CurrentSourceVersions` unwritten) | **no attempt — it WAITS**: "not known yet" is not "no sources", and a compile driven from a set nobody established forms a verdict from evidence the mesh does not have |
 
 It is bounded three ways, and the first is the one that does the work:
 
@@ -433,6 +434,15 @@ It is bounded three ways, and the first is the one that does the work:
    moment (1) provably did not hold. Non-convergence is never quiet.
 3. **Terminal.** Past `MaxAutomaticFailureRedrives` the kickoff gives up for the hub's lifetime and
    says so, naming the type, its error and the remedy. An explicit Compile refunds the budget.
+
+The re-drive is **owner-driven, never caller-driven**. It fires from the type's OWN hub on facts the
+node already holds; no request, and no requester's identity, is an input. The compile runs as System
+and its activity row lands in the owning partition attributed to System — exactly as the first-build,
+recovery and framework-stale kickoffs have always done — and no user's `RequestedReleaseAt` /
+`RequestedReleaseBy` is touched, so nothing is misattributed. An unauthorized caller who merely
+activates the hub therefore gains no lever: the trigger is a property of the persisted record, and
+the three inputs that can move it (framework identity, installed modules, the type's own source
+nodes) are all writable only by principals who already hold that access.
 
 And when the re-drive **declines** — a type settled at `Error`/`Unavailable` whose verdict was formed
 under exactly the live inputs — the hub logs one warning per activation naming the type, its error

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -397,6 +397,53 @@ Anything else triggers a recompile. This makes a cold hub start **self-healing**
 | **MeshWeaver redeployed with a breaking change** | The cached DLL bound against the *old* framework surface (ABI-stale) | Rule 3 |
 | Module updated | The cached DLL may bind the replaced module's old ABI | Rule 4 |
 
+### A compile that FAILED is re-driven too — one attempt per set of inputs
+
+`HasUsableBuild` and its framework-stale twin both key on **assembly coordinates**, and a failed
+compile writes none: `ApplyCompileFailure` stamps neither `LatestAssembly{Collection,Path}` nor
+`CompiledFrameworkVersion`. For a NodeType that never compiled successfully *on this deployment*
+those stay null forever, so every automatic path used to skip it — the first-build kickoff needs a
+`null` status, the recovery kickoff needs `Compiling`, the framework-stale kickoff needs the
+coordinates, the release watcher needs a human, and the park registry's source-change auto-retry is
+in-memory (a failure that predates the process is not in it). Only a human pressing **Compile** got
+such a node out; a redeploy, a framework bump, a module update and a fix to the failing code reached
+none of them ([#1793](https://github.com/Systemorph/MeshWeaver/issues/1793); the fix written for
+fifteen types parked on memex-cloud could not reach the nodes it was written for).
+
+So a failure records the one thing it honestly can: **the inputs the verdict was formed from** —
+framework identity, installed-module fingerprint, and the source snapshot the compile consumed —
+folded into `NodeTypeDefinition.FailedBuildInputs`. The owner-side re-drive fires exactly when the
+LIVE inputs differ from that stamp:
+
+| What moved | Effect |
+|---|---|
+| A new framework (a redeploy, possibly carrying the fix) | one fresh attempt |
+| A module update | one fresh attempt |
+| An edited / added / removed source | one fresh attempt |
+| Nothing — same framework, modules and sources | **no attempt**: the identical failure would reproduce |
+| The stamp is `null` (a failure from before this field, or an `Error` baked into a node file) | one fresh attempt — the migration |
+
+It is bounded three ways, and the first is the one that does the work:
+
+1. **Structural.** The flip to `Pending` writes the live token **in the same update**, so the trigger
+   the re-drive fires on is false the instant it fires. A reconcile that can re-arm its own trigger
+   is the 257,000-version write-storm shape; the stamp forecloses it.
+2. **Loud.** A process-wide ledger (`NodeTypeCompileParkRegistry.RecordFailureRedrive`) logs an
+   **error naming the path** the moment a type is re-driven twice for the *same* inputs — i.e. the
+   moment (1) provably did not hold. Non-convergence is never quiet.
+3. **Terminal.** Past `MaxAutomaticFailureRedrives` the kickoff gives up for the hub's lifetime and
+   says so, naming the type, its error and the remedy. An explicit Compile refunds the budget.
+
+And when the re-drive **declines** — a type settled at `Error`/`Unavailable` whose verdict was formed
+under exactly the live inputs — the hub logs one warning per activation naming the type, its error
+and why nothing will retry it. That state is correct and bounded, and before that line it was also
+completely silent: nothing anywhere named a NodeType that is broken and will not be retried.
+
+> 🚨 `FailedBuildInputs` is **mesh-owned operational state**: exports strip it, imports preserve the
+> live node's value, and `ShippedNodeTypeStateTest` bans it from committed node files. An authored
+> token that happened to match the importing deployment's live inputs would suppress precisely the
+> retry it exists to grant.
+
 ### Framework-version freezing
 
 A compiled NodeType DLL references the MeshWeaver framework assemblies present

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-broken-node-type-can-recover-by-itself.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-broken-node-type-can-recover-by-itself.md
@@ -1,0 +1,27 @@
+---
+Name: A broken NodeType can recover by itself
+Category: Fix
+Description: A NodeType whose very first build failed is now rebuilt automatically when the platform, its modules or its code change — instead of staying broken until someone presses Compile.
+Icon: ArrowSync
+Order: -20260818
+---
+
+# A broken NodeType can recover by itself
+
+When a NodeType's build fails, the page it powers shows an error card instead of its content. That
+is meant to be temporary: fix the code, or deploy a platform version that fixes it, and the type
+rebuilds. For one particular kind of failure it was not temporary at all.
+
+If a NodeType had *never* built successfully on that installation — a fresh import, a first
+deployment, or a type whose failed state came in with the content — nothing would ever try again.
+Every automatic rebuild the platform performs was looking for traces that only a successful build
+leaves behind, and a failed build leaves none of them. So a new platform release, a module update
+and even a corrected source file all went past it, and the only way out was for someone to open the
+type and press Compile. Types stayed broken for days that way, including through the very release
+that contained their fix.
+
+A failed build now records what it was built against — the platform version, the installed modules
+and the exact source files it used. When any of those change, the type gets one fresh attempt on
+its own. A type that is simply broken is retried once and then left alone, with a clear line in the
+log naming it, what it failed on and that only a manual Compile will move it — so a recoverable
+failure recovers, and an unrecoverable one is visibly stuck rather than silently forgotten.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -695,6 +695,10 @@ internal static class NodeTypeCompilationHelpers
                 && def.CompilationStatus is CompilationStatus.Error or CompilationStatus.Unavailable
                 && string.IsNullOrEmpty(def.LatestAssemblyPath)
                 && !IsStaticOnlyNodeType(node, def)
+                // Same establishment gate as the re-drive: before the sources watcher has seeded a
+                // snapshot the re-drive is merely WAITING, not declining, and reporting that as
+                // "stuck" would cry wolf on every cold activation of a broken type.
+                && def.CurrentSourceVersions is not null
                 && !HasStaleFailureVerdict(def, guards.ModulesHash))
             .Take(1)
             .Subscribe(
@@ -1471,6 +1475,18 @@ internal static class NodeTypeCompilationHelpers
     /// never reached a verdict at all, so it is even less of a reason to stop trying than an
     /// Error. (<c>NodeTypeContractHandler.EnsureCompileDispatched</c> already re-drives it on the
     /// next REQUEST; this adds the activation-time path, under the same bound.)</para>
+    ///
+    /// <para>🚨 <b>Never re-drive from an UNESTABLISHED source set.</b> On a cold activation the
+    /// sources watcher has not written <see cref="NodeTypeDefinition.CurrentSourceVersions"/> yet,
+    /// so the source half of the live token is not "no sources" — it is "not known yet". Firing
+    /// there would (a) drive a compile from a set nobody established, which is the #1216 lesson
+    /// ("a compile driven from a set you did not establish produces verdicts about code from
+    /// evidence you do not have"), and (b) burn a second attempt for free, because the watcher's
+    /// first write changes the token and the type would be re-driven AGAIN one emission later. The
+    /// sources watcher always writes a snapshot for every type this predicate applies to — the
+    /// empty map when the queries match nothing — so this ORDERS the mechanism rather than
+    /// disabling it, and a mesh that cannot answer the source query degrades to no re-drive rather
+    /// than to a wrong verdict.</para>
     /// </summary>
     internal static bool HasStaleFailureVerdict(NodeTypeDefinition def, string? modulesHash) =>
         def.CompilationStatus is CompilationStatus.Error or CompilationStatus.Unavailable
@@ -1478,6 +1494,8 @@ internal static class NodeTypeCompilationHelpers
         // owns every case where coordinates DO exist.
         && string.IsNullOrEmpty(def.LatestAssemblyCollection)
         && string.IsNullOrEmpty(def.LatestAssemblyPath)
+        // The source set must be ESTABLISHED before it can be compared — see above.
+        && def.CurrentSourceVersions is not null
         && !string.Equals(
             def.FailedBuildInputs,
             BuildInputsToken(modulesHash, def.CurrentSourceVersions),

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -538,8 +538,184 @@ internal static class NodeTypeCompilationHelpers
                         "Framework-stale kickoff: Update failed for {HubPath}", hubPath));
             });
 
+
+        // 🚨 Failed-verdict re-drive kickoff (issue #1793) — the missing COMPLEMENT of the
+        // framework-stale kickoff above, and the reason a fix could never reach the nodes it was
+        // written for.
+        //
+        // A compile that FAILS writes no assembly coordinates at all: ApplyCompileFailure stamps
+        // neither LatestAssembly{Collection,Path} nor CompiledFrameworkVersion. For a NodeType that
+        // never compiled successfully on this deployment those are null FOREVER — and every
+        // automatic path keys off something that only exists after a first success:
+        //
+        //   firstBuildKickoff              needs CompilationStatus is null   → it is Error
+        //   recoveryKickoff                needs Compiling                   → it is Error
+        //   frameworkStaleKickoff          needs the assembly coordinates    → never written
+        //     (its own filter reads `Ok or Error`, so it INTENDS to cover this — it cannot,
+        //      because HasStaleFrameworkBuild delegates to fields a failure does not stamp)
+        //   InstallReleaseRequestWatcher   needs RequestedReleaseAt > LastReleaseRequestHandledAt
+        //                                                                    → only a human moves it
+        //   the sources watcher's parked auto-retry needs the IN-MEMORY park registry to hold this
+        //     path — a failure that predates this PROCESS is not in it, so a source fix after a
+        //     restart re-drives nothing either
+        //
+        // So only a human pressing Compile (or a Recycle) got such a node out; a redeploy, a
+        // framework bump, a module update and a fix to the failing code all reached none of them.
+        // Measured cost: NodeCompileShaping.AnchorIncludePath was written for 15 types parked on
+        // memex-cloud 2026-08-12 and, five days later, #1786 found near enough the same list still
+        // parked — the fix shipped and could not reach them.
+        //
+        // The trigger is the only thing a failure CAN honestly record: the INPUTS the verdict was
+        // formed from (framework identity + installed modules + source snapshot), stamped as
+        // NodeTypeDefinition.FailedBuildInputs. Live inputs differ from the stamp ⇒ this framework,
+        // these modules or these sources have never had their attempt ⇒ take exactly one.
+        //
+        // 🚨 Bounded three ways, because an unbounded re-drive on a genuinely broken type is a
+        // recompile storm on this hub's single-threaded action block:
+        //   1. STRUCTURAL, and the one that actually does the work — the flip to Pending stamps the
+        //      live token in the SAME Update, so the trigger this kickoff fires on is false the
+        //      instant it fires. A reconcile that feeds its own trigger is the #223 write-storm
+        //      shape; the stamp is what forecloses it.
+        //   2. LOUD — the process-wide ledger (NodeTypeCompileParkRegistry.RecordFailureRedrive)
+        //      logs an ERROR naming the path the moment it is re-driven twice for the SAME inputs,
+        //      i.e. the moment (1) provably did not hold. Non-convergence must never be quiet.
+        //   3. TERMINAL — past MaxAutomaticFailureRedrives the kickoff gives up for this hub's
+        //      lifetime and says so, naming the type and the remedy. An explicit Compile refunds it.
+        //
+        // Level-triggered, NOT Take(1): CurrentSourceVersions is written by the sources watcher
+        // AFTER activation, so the source half of the token is not final on the first emission — a
+        // one-shot would sample the pre-seed state and miss every source fix. Convergence comes
+        // from (1), not from the Rx operator.
+        var redriveGivenUp = false;
+        var failedVerdictKickoffSub = ownStream
+            .Where(node => node?.Content is NodeTypeDefinition def
+                && HasStaleFailureVerdict(def, guards.ModulesHash)
+                && !IsStaticOnlyNodeType(node, def))
+            // Cheap dedupe so an unrelated field edit does not re-enter the body while the flip is
+            // still in flight; correctness is the re-check inside the Update lambda, not this.
+            .DistinctUntilChanged(node =>
+            {
+                var d = (NodeTypeDefinition)node!.Content!;
+                return (d.CompilationStatus, BuildInputsToken(guards.ModulesHash, d.CurrentSourceVersions));
+            })
+            .Subscribe(
+                node =>
+                {
+                    if (redriveGivenUp)
+                        return;
+                    var def = (NodeTypeDefinition)node!.Content!;
+                    var liveInputs = BuildInputsToken(guards.ModulesHash, def.CurrentSourceVersions);
+                    var (forTheseInputs, total) =
+                        parkRegistry?.RecordFailureRedrive(hubPath, liveInputs) ?? (1, 1);
+
+                    if (forTheseInputs > 1)
+                        logger?.LogError(
+                            "Failed-verdict re-drive DID NOT CONVERGE for NodeType {HubPath}: this process has "
+                            + "already re-driven it for EXACTLY these compile inputs ({Inputs}) — attempt "
+                            + "{Attempt}. The flip to Pending stamps those inputs in the same write, so the "
+                            + "trigger cannot legitimately still be true; something is rewriting or dropping "
+                            + "FailedBuildInputs. Treat this as a write cycle, not as a slow compile.",
+                            hubPath, liveInputs, forTheseInputs);
+
+                    if (total > NodeTypeCompileParkRegistry.MaxAutomaticFailureRedrives)
+                    {
+                        redriveGivenUp = true;
+                        logger?.LogError(
+                            "Failed-verdict re-drive GIVING UP on NodeType {HubPath} after {Total} automatic "
+                            + "attempt(s) in this process (limit {Limit}). The type stays at "
+                            + "{Status} serving its recorded error and NOTHING will retry it automatically "
+                            + "until someone requests a build (the Compile button / a fresh release request), "
+                            + "which also refunds this budget. Last error: {Error}",
+                            hubPath, total, NodeTypeCompileParkRegistry.MaxAutomaticFailureRedrives,
+                            def.CompilationStatus, def.CompilationError ?? "(none recorded)");
+                        return;
+                    }
+
+                    logger?.LogInformation(
+                        "Failed-verdict re-drive: NodeType {HubPath} is settled at {Status} with no compiled "
+                        + "assembly, and its verdict was formed under different compile inputs than the live "
+                        + "ones (stamped '{Stamped}', live '{Live}') — flipping CompilationStatus=Pending for "
+                        + "ONE fresh attempt ({Attempt} of {Limit} in this process). Recorded error: {Error}",
+                        hubPath, def.CompilationStatus, def.FailedBuildInputs ?? "(never stamped)",
+                        liveInputs, total, NodeTypeCompileParkRegistry.MaxAutomaticFailureRedrives,
+                        def.CompilationError ?? "(none recorded)");
+
+                    // 🅿️ Un-park FIRST (in-memory + synchronous, so it happens-before the Pending
+                    // emission the compile watcher observes), exactly as the sources watcher's
+                    // parked auto-retry does — otherwise the parked short-circuit would swallow the
+                    // flip and re-settle it to Error. This does not weaken the park: the predicate
+                    // above is false for a type parked in THIS process under THESE inputs, so a
+                    // broken type whose inputs have not moved is never woken.
+                    parkRegistry?.Unpark(hubPath);
+                    var redriveAccess = hub.ServiceProvider.GetService<AccessService>();
+                    using var systemScope = redriveAccess?.ImpersonateAsSystem();
+                    workspace.GetMeshNodeStream().Update(curr =>
+                    {
+                        if (curr?.Content is not NodeTypeDefinition d) return curr!;
+                        // Never clobber an in-flight compile (a concurrent release request or
+                        // enrichment self-heal may already have flipped Pending/Compiling).
+                        if (d.CompilationStatus is CompilationStatus.Pending
+                                                or CompilationStatus.Compiling)
+                            return curr;
+                        // Re-check inside the lambda — a genuine compile may have settled between
+                        // the outer Where and this write.
+                        if (!HasStaleFailureVerdict(d, guards.ModulesHash)) return curr;
+                        return curr with
+                        {
+                            Content = d with
+                            {
+                                // 🚨 The bookkeeping and the flip land TOGETHER. Stamping the live
+                                // inputs here — not only in ApplyCompileFailure — is what makes the
+                                // re-drive unable to schedule another pass even if the compile
+                                // never writes back at all (process death mid-compile, the parked
+                                // re-settle, a poisoned content read).
+                                FailedBuildInputs = BuildInputsToken(
+                                    guards.ModulesHash, d.CurrentSourceVersions),
+                                CompilationStatus = CompilationStatus.Pending
+                            }
+                        };
+                    }).Subscribe(_ => { },
+                        ex => logger?.LogWarning(ex,
+                            "Failed-verdict re-drive: Update failed for {HubPath}", hubPath));
+                },
+                ex => logger?.LogWarning(ex,
+                    "Failed-verdict re-drive: own-stream subscription faulted for {HubPath} — a "
+                    + "never-compiled failure on this type will not be re-driven until the hub recycles",
+                    hubPath));
+
+        // 🚨 …and when the re-drive is deliberately DECLINED, say so ONCE. A type settled at a
+        // failure whose verdict was formed under exactly the live inputs is the give-up state of
+        // the mechanism above: correct, bounded — and, before this line, completely silent. Nothing
+        // anywhere named a NodeType that is broken and will not be retried, which is how thirteen
+        // parked types on memex-cloud went unnoticed between the fix that was written for them and
+        // the issue that rediscovered them. One line per hub lifetime, naming the type, the error
+        // and the remedy.
+        var stuckDiagnosticSub = ownStream
+            .Where(node => node?.Content is NodeTypeDefinition def
+                && def.CompilationStatus is CompilationStatus.Error or CompilationStatus.Unavailable
+                && string.IsNullOrEmpty(def.LatestAssemblyPath)
+                && !IsStaticOnlyNodeType(node, def)
+                && !HasStaleFailureVerdict(def, guards.ModulesHash))
+            .Take(1)
+            .Subscribe(
+                node =>
+                {
+                    var def = (NodeTypeDefinition)node!.Content!;
+                    logger?.LogWarning(
+                        "NodeType {HubPath} is STUCK at {Status} with no compiled assembly: its verdict was "
+                        + "formed under the compile inputs that are live now ({Inputs}), so the automatic "
+                        + "re-drive correctly declines and nothing will retry it until the framework, the "
+                        + "installed modules or its sources change — or someone requests a build. Error: {Error}",
+                        hubPath, def.CompilationStatus,
+                        def.FailedBuildInputs ?? "(never stamped)",
+                        def.CompilationError ?? "(none recorded)");
+                },
+                ex => logger?.LogDebug(ex,
+                    "Stuck-type diagnostic: own-stream subscription faulted for {HubPath}", hubPath));
+
         return new CompositeDisposable(
-            watcherSub, firstBuildKickoffSub, recoveryKickoffSub, frameworkStaleKickoffSub);
+            watcherSub, firstBuildKickoffSub, recoveryKickoffSub, frameworkStaleKickoffSub,
+            failedVerdictKickoffSub, stuckDiagnosticSub);
     }
 
     /// <summary>
@@ -912,6 +1088,10 @@ internal static class NodeTypeCompilationHelpers
                     // 🅿️ Deliberate retry → un-park so the explicit rebuild is allowed through
                     // the compile watcher's parked short-circuit (and the attempt budget resets).
                     parkRegistry?.Unpark(hubPath);
+                    // …and refund the AUTOMATIC re-drive budget (#1793): a human asking for a build
+                    // is the strongest signal that a give-up should be reconsidered, so a type that
+                    // exhausted its automatic attempts is eligible again after an explicit Compile.
+                    parkRegistry?.ResetFailureRedrives(hubPath);
                     logger?.LogInformation(
                         "[ReleaseRequestWatcher] {HubPath}: handling RequestedReleaseAt={Req} (force={Force}, lastHandled={Handled})",
                         hubPath, triggerAt,
@@ -1225,6 +1405,85 @@ internal static class NodeTypeCompilationHelpers
             || (guards is not null && !DependenciesValid(def, guards)));
 
     /// <summary>
+    /// The COMPILE INPUTS a verdict is formed from, as one comparable token — the framework
+    /// identity, the installed-module fingerprint, and the source snapshot
+    /// (see <see cref="NodeTypeDefinition.FailedBuildInputs"/>).
+    ///
+    /// <para>Pure and hub-free so the failure stamp
+    /// (<see cref="ApplyCompileFailure"/>) and the re-drive kickoff compute it the SAME way —
+    /// a token that two call sites derived differently would either never converge (a permanent
+    /// re-drive) or never fire (the hole this closes), and both failures are silent.</para>
+    ///
+    /// <para>Readable rather than a bare hash: an operator reading a stuck node's record can see
+    /// WHICH input the standing verdict was formed under. The source set is folded to
+    /// <c>count:sha256[0..16]</c> so the token stays a line rather than a kilobyte of paths.</para>
+    /// </summary>
+    internal static string BuildInputsToken(
+        string? modulesHash, IReadOnlyDictionary<string, long>? sources) =>
+        $"fw={FrameworkVersion};mod={modulesHash ?? "(none)"};src={SourceToken(sources)}";
+
+    /// <summary>The source snapshot folded to a short, order-insensitive token. A <c>null</c>
+    /// snapshot (the sources watcher has not seeded yet) is deliberately DISTINCT from an empty
+    /// one (the mesh answered "this type has no sources"): those are different facts, and
+    /// collapsing them would let an unseeded node read as a source-less one.</summary>
+    private static string SourceToken(IReadOnlyDictionary<string, long>? sources)
+    {
+        if (sources is null)
+            return "(unseeded)";
+        if (sources.Count == 0)
+            return "0";
+        var joined = string.Join(
+            "\n",
+            sources.OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                .Select(kv => $"{kv.Key}@{kv.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}"));
+        var digest = System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(joined));
+        return $"{sources.Count}:{Convert.ToHexString(digest)[..16].ToLowerInvariant()}";
+    }
+
+    /// <summary>
+    /// 🚨 True when a NodeType is sitting on a FAILURE VERDICT that the LIVE compile inputs have
+    /// moved past — the predicate the failed-verdict re-drive kickoff fires on (issue #1793).
+    ///
+    /// <para><b>Why it cannot be <see cref="HasStaleFrameworkBuild(NodeTypeDefinition, BuildGuards?)"/>.</b>
+    /// That twin needs <see cref="NodeTypeDefinition.LatestAssemblyCollection"/>,
+    /// <see cref="NodeTypeDefinition.LatestAssemblyPath"/> and
+    /// <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/> — all three written ONLY by a
+    /// successful compile. Its own filter already reads
+    /// <c>CompilationStatus is Ok or Error</c>, so it INTENDS to cover a failed type; it cannot,
+    /// because a type that never compiled successfully here has none of the coordinates it
+    /// delegates to. The harder case got the weaker treatment: a type that succeeded once and went
+    /// stale rebuilds automatically, a type that failed the first time never did.</para>
+    ///
+    /// <para>So this predicate is deliberately the COMPLEMENT: it applies exactly where the
+    /// framework-stale twin cannot — a settled failure with NO recorded assembly — and compares the
+    /// stamped verdict inputs against the live ones instead of comparing assembly coordinates.</para>
+    ///
+    /// <para><b>Bounded by construction.</b> The kickoff writes the live token into
+    /// <see cref="NodeTypeDefinition.FailedBuildInputs"/> in the same update that flips to
+    /// <see cref="CompilationStatus.Pending"/>, so this returns false immediately afterwards:
+    /// exactly one automatic attempt per distinct (framework, modules, sources) triple. A
+    /// <c>null</c> stamp — every node that failed before this field existed, and every node whose
+    /// Error was baked into a committed file — differs from any live token, which is precisely the
+    /// one-off recovery those nodes need.</para>
+    ///
+    /// <para><see cref="CompilationStatus.Unavailable"/> is included: it records that a compile
+    /// never reached a verdict at all, so it is even less of a reason to stop trying than an
+    /// Error. (<c>NodeTypeContractHandler.EnsureCompileDispatched</c> already re-drives it on the
+    /// next REQUEST; this adds the activation-time path, under the same bound.)</para>
+    /// </summary>
+    internal static bool HasStaleFailureVerdict(NodeTypeDefinition def, string? modulesHash) =>
+        def.CompilationStatus is CompilationStatus.Error or CompilationStatus.Unavailable
+        // NO usable build was ever recorded — the complement of HasStaleFrameworkBuild, which
+        // owns every case where coordinates DO exist.
+        && string.IsNullOrEmpty(def.LatestAssemblyCollection)
+        && string.IsNullOrEmpty(def.LatestAssemblyPath)
+        && !string.Equals(
+            def.FailedBuildInputs,
+            BuildInputsToken(modulesHash, def.CurrentSourceVersions),
+            StringComparison.Ordinal);
+
+    /// <summary>
     /// THE terminal stamp of a SUCCESSFUL compile — the exact field set
     /// <see cref="RunCompile"/>'s write-back has always applied, extracted as a pure function so
     /// the initial-bake batch driver (issue #1207, <c>NodeTypeBatchBake</c> in
@@ -1283,7 +1542,12 @@ internal static class NodeTypeCompilationHelpers
             CompiledDependencies = result.CompiledDependencies ?? def.CompiledDependencies,
             // Clear the consumed release-requester so a later System-only recompile doesn't
             // mis-attribute its release to a stale prior user.
-            RequestedReleaseBy = null
+            RequestedReleaseBy = null,
+            // 🚨 The standing FAILURE verdict is gone, so the inputs it was formed from must go
+            // with it (#1793). Leaving the token behind would make a LATER failure look like it
+            // had already had its automatic attempt under these inputs, and the type would sit
+            // broken with nothing due to retry it.
+            FailedBuildInputs = null
         };
 
     /// <summary>
@@ -1331,7 +1595,8 @@ internal static class NodeTypeCompilationHelpers
         NodeTypeDefinition def,
         NodeCompilationResult? result,
         Exception? error,
-        string? activityPath)
+        string? activityPath,
+        string? modulesHash = null)
         => def with
         {
             CompilationStatus = error is SourceDiscoveryUnavailableException or AddressRecyclingException
@@ -1343,6 +1608,14 @@ internal static class NodeTypeCompilationHelpers
                 : null,
             LastCompilationActivityPath = activityPath,
             CompiledSources = null,
+            // 🚨 RECORD WHAT THE VERDICT WAS FORMED FROM (#1793). This is the one durable fact a
+            // failure can leave behind — it writes no assembly coordinates and no framework stamp,
+            // which is exactly why every automatic re-drive used to skip a never-compiled failure
+            // forever. The source half is the snapshot the compile CONSUMED (the result's own set
+            // when it resolved one, else the node's live snapshot), so an edit that lands while a
+            // doomed compile is running still earns its own attempt.
+            FailedBuildInputs = BuildInputsToken(
+                modulesHash, result?.CompiledSources ?? def.CurrentSourceVersions),
             // Clear the consumed release-requester on failure too — the failed request is
             // done; a fresh request must re-stamp it.
             RequestedReleaseBy = null
@@ -1800,7 +2073,8 @@ internal static class NodeTypeCompilationHelpers
                         return curr with
                         {
                             Content = ApplyCompileFailure(
-                                def, outcome.Result, outcome.Error, resolvedActivityPath)
+                                def, outcome.Result, outcome.Error, resolvedActivityPath,
+                                hub.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash)
                         };
                     })
                     .Subscribe(

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompileParkRegistry.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompileParkRegistry.cs
@@ -64,6 +64,51 @@ public sealed class NodeTypeCompileParkRegistry
     public void RecordAttempt(string nodeTypePath) =>
         _attempts.AddOrUpdate(nodeTypePath, 1, (_, n) => n + 1);
 
+    // 🚨 #1793 — the AUTOMATIC failure re-drive ledger. Two counters, because the two failure
+    // shapes they bound are different questions:
+    //
+    //   _redrivesByInputs — how often THIS process re-drove a type for EXACTLY the same compile
+    //     inputs. The kickoff stamps the live inputs in the same write that flips Pending, so this
+    //     can only exceed 1 if something is rewriting that stamp — i.e. the re-drive is feeding
+    //     itself. That is the 257,000-version write-storm shape (#223), and it must be LOUD rather
+    //     than merely bounded: the second occurrence logs an ERROR naming the path.
+    //   _redriveTotals — how many automatic re-drives this process has issued for the type at all,
+    //     across every input change. The give-up bound: past it the type is left alone, loudly,
+    //     for a human to Compile.
+    private readonly ConcurrentDictionary<(string Path, string Inputs), int> _redrivesByInputs = new();
+    private readonly ConcurrentDictionary<string, int> _redriveTotals = new();
+
+    /// <summary>
+    /// How many automatic failure re-drives one NodeType may receive from a single process before
+    /// the framework stops trying and says so. A SAFETY VALVE, not the primary bound — the primary
+    /// bound is structural (one re-drive per distinct set of compile inputs, enforced by the stamp
+    /// the re-drive writes). This exists so that a stamp which somehow fails to stick converges on
+    /// a loud stop instead of a spin.
+    /// </summary>
+    public const int MaxAutomaticFailureRedrives = 5;
+
+    /// <summary>
+    /// Record an automatic failure re-drive of <paramref name="nodeTypePath"/> for the compile
+    /// inputs <paramref name="inputs"/> (<c>NodeTypeCompilationHelpers.BuildInputsToken</c>).
+    /// </summary>
+    /// <returns>
+    /// <c>ForTheseInputs</c> — how many times this process has now re-driven the type for exactly
+    /// these inputs; anything above 1 means the re-drive did not converge. <c>Total</c> — how many
+    /// automatic re-drives this process has issued for the type in total, compared against
+    /// <see cref="MaxAutomaticFailureRedrives"/>.
+    /// </returns>
+    public (int ForTheseInputs, int Total) RecordFailureRedrive(string nodeTypePath, string inputs)
+    {
+        var forTheseInputs = _redrivesByInputs.AddOrUpdate((nodeTypePath, inputs), 1, (_, n) => n + 1);
+        var total = _redriveTotals.AddOrUpdate(nodeTypePath, 1, (_, n) => n + 1);
+        return (forTheseInputs, total);
+    }
+
+    /// <summary>How many automatic failure re-drives this process has issued for the NodeType —
+    /// the observable proof that the recovery path is bounded.</summary>
+    public int GetFailureRedriveCount(string nodeTypePath) =>
+        _redriveTotals.GetValueOrDefault(nodeTypePath);
+
     /// <summary>
     /// Total real compile kick-offs for the NodeType since the last un-park. A parked
     /// (broken) type holds at its small attempt count rather than climbing on every
@@ -116,6 +161,19 @@ public sealed class NodeTypeCompileParkRegistry
     {
         _parked.TryRemove(nodeTypePath, out _);
         _failureCounts.TryRemove(nodeTypePath, out _);
+        // The automatic re-drive CONVERGED, so its budget is spent and returned: a type that
+        // breaks again later gets a fresh set of attempts rather than inheriting a used-up one.
+        ClearFailureRedrives(nodeTypePath);
+    }
+
+    /// <summary>Forget the automatic-re-drive ledger for one NodeType (a converged or deliberately
+    /// retried type starts clean).</summary>
+    private void ClearFailureRedrives(string nodeTypePath)
+    {
+        _redriveTotals.TryRemove(nodeTypePath, out _);
+        foreach (var key in _redrivesByInputs.Keys)
+            if (string.Equals(key.Path, nodeTypePath, StringComparison.Ordinal))
+                _redrivesByInputs.TryRemove(key, out _);
     }
 
     /// <summary>
@@ -129,6 +187,14 @@ public sealed class NodeTypeCompileParkRegistry
             _attempts.TryRemove(nodeTypePath, out _);
         _failureCounts.TryRemove(nodeTypePath, out _);
     }
+
+    /// <summary>
+    /// A DELIBERATE retry (the Compile button / a fresh release request) also returns the automatic
+    /// re-drive budget: a human asking for a build is the strongest possible signal that the
+    /// give-up should be reconsidered. Separate from <see cref="Unpark"/> so the automatic path
+    /// (which un-parks too) cannot refund its own budget.
+    /// </summary>
+    public void ResetFailureRedrives(string nodeTypePath) => ClearFailureRedrives(nodeTypePath);
 
     /// <summary>
     /// A compile reached a terminal FAILED state. Bound every failure path: a

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompileState.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompileState.cs
@@ -113,6 +113,9 @@ public record NodeTypeCompileState
     /// <summary>See <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/>.</summary>
     public string? CompiledFrameworkVersion { get; init; }
 
+    /// <summary>See <see cref="NodeTypeDefinition.FailedBuildInputs"/>.</summary>
+    public string? FailedBuildInputs { get; init; }
+
     /// <summary>The state projected from a NodeType definition — pure. Null in, null out.</summary>
     public static NodeTypeCompileState? FromDefinition(NodeTypeDefinition? definition) =>
         definition is null
@@ -138,6 +141,7 @@ public record NodeTypeCompileState
                 CompiledSources = definition.CompiledSources,
                 CurrentSourceVersions = definition.CurrentSourceVersions,
                 CompiledFrameworkVersion = definition.CompiledFrameworkVersion,
+                FailedBuildInputs = definition.FailedBuildInputs,
             };
 
     /// <summary>Whether NO compile machinery has recorded anything yet — a never-compiled,
@@ -151,7 +155,7 @@ public record NodeTypeCompileState
         && LastReleaseRequestHandledAt is null && ReleaseNotes is null
         && LatestAssemblyCollection is null && LatestAssemblyPath is null
         && CompiledSources is null && CurrentSourceVersions is null
-        && CompiledFrameworkVersion is null;
+        && CompiledFrameworkVersion is null && FailedBuildInputs is null;
 }
 
 /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -570,6 +570,46 @@ public record NodeTypeDefinition
     public System.Collections.Immutable.ImmutableSortedDictionary<string, string>? CompiledDependencies { get; init; }
 
     /// <summary>
+    /// 🚨 The COMPILE INPUTS the STANDING FAILURE VERDICT was formed from — the one thing a failed
+    /// compile can honestly record, and the field that makes a failure RECOVERABLE (issue #1793).
+    ///
+    /// <para><b>The hole it closes.</b> A failed compile writes no assembly coordinates at all:
+    /// <c>NodeTypeCompilationHelpers.ApplyCompileFailure</c> stamps neither
+    /// <see cref="LatestAssemblyCollection"/> / <see cref="LatestAssemblyPath"/> nor
+    /// <see cref="CompiledFrameworkVersion"/>. For a NodeType that never compiled successfully on
+    /// this deployment those are therefore null forever — and EVERY automatic re-drive keys off
+    /// something that only exists after a first success: the first-build kickoff needs
+    /// <c>CompilationStatus is null</c>, the recovery kickoff needs <c>Compiling</c>, the
+    /// framework-stale kickoff needs the assembly coordinates
+    /// (<c>NodeTypeCompilationHelpers.HasStaleFrameworkBuild</c>), and the release watcher needs a
+    /// human to move <see cref="RequestedReleaseAt"/>. So a redeploy, a framework bump, a module
+    /// update or a fix to the failing code reached none of them — which is why the fix written FOR
+    /// the fifteen types parked on memex-cloud could not reach the nodes it was written for.</para>
+    ///
+    /// <para><b>The shape.</b> An opaque, comparable token over the three inputs a verdict depends
+    /// on — the framework identity, the installed-module fingerprint, and the source snapshot the
+    /// compile consumed (<c>NodeTypeCompilationHelpers.BuildInputsToken</c>). The re-drive kickoff
+    /// fires exactly when the LIVE inputs differ from this stamp, which gives ONE automatic retry
+    /// per distinct set of inputs: a deployed framework, a module update, or an edited source each
+    /// earn a fresh attempt, and a type that is simply broken is retried once and then left alone
+    /// (loudly — see the give-up log in <c>InstallCompileWatcher</c>) instead of storming.</para>
+    ///
+    /// <para><b>Self-limiting by construction.</b> The kickoff stamps this field in the SAME write
+    /// that flips <see cref="CompilationStatus"/> to <see cref="Mesh.Services.CompilationStatus.Pending"/>,
+    /// so the re-drive's own bookkeeping makes its trigger false — a reconcile that fed itself is
+    /// the 257,000-version write-storm shape, and this is what forecloses it.</para>
+    ///
+    /// <para><c>null</c> = no failure verdict has been recorded here (a never-attempted type, a
+    /// successful one — <c>ApplyCompileSuccess</c> CLEARS it — or a node whose Error was baked into
+    /// a file by an export, which is precisely the population that must get its one retry).</para>
+    ///
+    /// <para>🚨 Runtime state: never author it into a node file. <c>ShippedNodeTypeStateTest</c>
+    /// bans it, because an authored token that happens to match the live inputs would suppress the
+    /// very retry this field exists to enable.</para>
+    /// </summary>
+    public string? FailedBuildInputs { get; init; }
+
+    /// <summary>
     /// 🚨 Round-trip buffer for content members this compiled shape does not declare —
     /// schema evolution: a property written by a NEWER build, or one removed since the
     /// JSON was persisted. Without this, System.Text.Json silently DROPS such members on

--- a/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
@@ -280,6 +280,11 @@ public static class PrebuiltAssemblySeeder
                                     LatestAssemblyCollection = location.Collection,
                                     LatestAssemblyPath = location.ContentPath,
                                     CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
+                                    // The adopted build retires any standing FAILURE verdict, so
+                                    // the inputs it was formed from go with it (#1793) — exactly as
+                                    // ApplyCompileSuccess does. A token left behind would describe a
+                                    // verdict this node no longer holds.
+                                    FailedBuildInputs = null,
                                     // The producer compiled exactly the sources it shipped beside
                                     // these bytes, so the snapshot IS the installed set. Leaving it
                                     // unset would leave IsDirty comparing an empty snapshot against

--- a/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
+++ b/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
@@ -14,6 +14,12 @@
          tracked for retirement separately from the (removed) Approvals grant. -->
     <InternalsVisibleTo Include="MeshWeaver.Hosting" />
     <InternalsVisibleTo Include="MeshWeaver.Hosting.Monolith.Test" />
+    <!-- OrleansCompileActivityAccessTest seeds a NodeType whose compile state is deliberately
+         "settled and nothing due", which means stamping FailedBuildInputs with the token the
+         framework itself computes (NodeTypeCompilationHelpers.BuildInputsToken). Re-deriving that
+         fold in the test is the one thing its own contract forbids — two call sites computing the
+         token differently either never converge or never fire, and both are silent. -->
+    <InternalsVisibleTo Include="MeshWeaver.Hosting.Orleans.Test" />
     <!-- The build-time packer calls DynamicMeshNodeAttributeGenerator directly. A prebuilt
          assembly MUST carry the same generated skeleton the runtime compiles (the
          MeshNodeProviderAttribute subclass + ConfigureHub wrapping the `configuration` lambda),

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -693,7 +693,8 @@ internal static class NodeTypeBatchBake
                             def, result!, typeNode.Version, activityPath: null, releasePath,
                             mesh.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash)
                         : NodeTypeCompilationHelpers.ApplyCompileFailure(
-                            def, result, error, activityPath: null))
+                            def, result, error, activityPath: null,
+                            mesh.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash))
                     // The batch driver has no Pending→Compiling flip to stamp this at, and the
                     // shared field-set deliberately does not touch it (the activation path owns it
                     // there). Written here so a per-type duration is derivable FROM THE MESH on both

--- a/src/MeshWeaver.Mesh.Contract/NodeTypeOperationalContent.cs
+++ b/src/MeshWeaver.Mesh.Contract/NodeTypeOperationalContent.cs
@@ -66,6 +66,11 @@ public static class NodeTypeOperationalContent
         "compiledSources",
         "currentSourceVersions",
         "compiledFrameworkVersion",
+        // #1793 — the inputs the standing FAILURE verdict was formed from. Operational for the
+        // same reason compiledFrameworkVersion is, and for one sharper one: an authored token that
+        // happened to match this deployment's live inputs would SUPPRESS the one automatic retry a
+        // never-compiled failure gets. Stripped on export, preserved from the live node on import.
+        "failedBuildInputs",
     };
 
     /// <summary>

--- a/test/MeshWeaver.Graph.Test/FailedVerdictRedriveTest.cs
+++ b/test/MeshWeaver.Graph.Test/FailedVerdictRedriveTest.cs
@@ -1,0 +1,372 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+using MeshWeaver.Compiler;
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 Issue #1793 — a NodeType that has NEVER compiled successfully and settles at
+/// <see cref="CompilationStatus.Error"/> must be reachable by an automatic re-drive.
+///
+/// <para><b>The hole.</b> <c>ApplyCompileFailure</c> writes no assembly coordinates and no
+/// framework stamp, so for such a type <see cref="NodeTypeDefinition.LatestAssemblyCollection"/>,
+/// <see cref="NodeTypeDefinition.LatestAssemblyPath"/> and
+/// <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/> are null forever — and every
+/// automatic path keys off one of them or off a state only a first success produces. The
+/// framework-stale kickoff's own filter reads <c>Ok or Error</c>, so it INTENDS to cover a failed
+/// type; it cannot, because <see cref="NodeTypeCompilationHelpers.HasStaleFrameworkBuild(NodeTypeDefinition, string?)"/>
+/// delegates to coordinates a failure never writes.</para>
+///
+/// <para>These are the PURE pins of the fix: the verdict-inputs token, the re-drive predicate
+/// built on it, the stamps that keep it truthful, and the ledger that bounds and exposes a
+/// re-drive which fails to converge. The end-to-end behaviour (a broken type actually recovering
+/// on a real mesh, and NOT looping while it stays broken) is pinned by
+/// <c>NeverCompiledFailureRedriveTest</c> in MeshWeaver.Hosting.Monolith.Test.</para>
+/// </summary>
+public class FailedVerdictRedriveTest
+{
+    private const string TypePath = "P/T";
+
+    private static NodeTypeDefinition NeverCompiledFailure(
+        string? failedInputs = null,
+        IReadOnlyDictionary<string, long>? currentSources = null,
+        CompilationStatus status = CompilationStatus.Error) => new()
+    {
+        Configuration = "config => config",
+        Sources = ["namespace:Source scope:subtree"],
+        CompilationStatus = status,
+        CompilationError = "CS0103: The name 'Nope' does not exist in the current context",
+        CurrentSourceVersions = currentSources,
+        FailedBuildInputs = failedInputs,
+    };
+
+    private static ImmutableDictionary<string, long> Sources(params (string Path, long Ticks)[] entries)
+    {
+        var map = ImmutableDictionary<string, long>.Empty;
+        foreach (var (path, ticks) in entries)
+            map = map.SetItem(path, ticks);
+        return map;
+    }
+
+    // ── The trigger fires exactly where the framework-stale twin cannot ──────────────────────
+
+    /// <summary>
+    /// The migration case, and the population #1786 measured: a node imported (or left behind) at
+    /// <c>Error</c> with NO verdict-inputs stamp at all. A null stamp differs from every live
+    /// token, so it earns exactly one automatic attempt — which is the whole point of the fix.
+    /// </summary>
+    [Fact]
+    public void NeverCompiledError_WithNoStamp_IsReDrivable()
+    {
+        var def = NeverCompiledFailure(currentSources: Sources(("P/T/Source/a", 1)));
+
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(def, modulesHash: null)
+            .Should().BeTrue(
+                "a failure verdict that records nothing about the inputs it was formed under must "
+                + "not be treated as already-attempted on this deployment");
+
+        // …and none of the paths that exist today can see it — the reason the fix is needed at all.
+        def.CompilationStatus.Should().NotBeNull("the first-build kickoff needs a null status");
+        def.CompilationStatus.Should().NotBe(CompilationStatus.Compiling, "the recovery kickoff needs Compiling");
+        NodeTypeCompilationHelpers.HasStaleFrameworkBuild(def, modulesHash: null)
+            .Should().BeFalse(
+                "the framework-stale kickoff delegates to assembly coordinates a failed compile "
+                + "never stamps — that is precisely why it could not cover this node");
+    }
+
+    /// <summary>The self-limiting property, stated directly: the token the re-drive stamps is the
+    /// token the trigger compares against, so the trigger is false the instant the re-drive
+    /// fires. A reconcile that can re-arm its own trigger is the #223 write-storm shape.</summary>
+    [Fact]
+    public void StampingTheLiveInputs_MakesTheTriggerFalse()
+    {
+        var sources = Sources(("P/T/Source/a", 1), ("P/T/Source/b", 2));
+        var def = NeverCompiledFailure(currentSources: sources);
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(def, "mod-1").Should().BeTrue();
+
+        var stamped = def with
+        {
+            FailedBuildInputs = NodeTypeCompilationHelpers.BuildInputsToken("mod-1", sources),
+        };
+
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(stamped, "mod-1")
+            .Should().BeFalse("the re-drive's own bookkeeping must not schedule another pass");
+    }
+
+    /// <summary>A new framework (the deploy that carries the fix) re-opens the attempt — one per
+    /// framework, which is what lets a shipped fix reach the nodes it was written for.</summary>
+    [Fact]
+    public void AVerdictFromAnotherFramework_IsReDrivable()
+    {
+        var sources = Sources(("P/T/Source/a", 1));
+        var fromAnotherImage = NeverCompiledFailure(
+            failedInputs: $"fw=0ldfr4me;mod=(none);src={TokenSourcePart("mod-x", sources)}",
+            currentSources: sources);
+
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(fromAnotherImage, modulesHash: null)
+            .Should().BeTrue("a new framework has never had its attempt at this type");
+    }
+
+    /// <summary>A module-only update moves the compile surface without moving the framework MVID —
+    /// the same reasoning <c>HasUsableBuild</c>'s modules-hash join encodes for successes.</summary>
+    [Fact]
+    public void AVerdictFromAnotherModuleSet_IsReDrivable()
+    {
+        var sources = Sources(("P/T/Source/a", 1));
+        var def = NeverCompiledFailure(
+            failedInputs: NodeTypeCompilationHelpers.BuildInputsToken("mod-OLD", sources),
+            currentSources: sources);
+
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(def, "mod-OLD").Should().BeFalse();
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(def, "mod-NEW")
+            .Should().BeTrue("a module update can be exactly the fix the failing compile needed");
+    }
+
+    /// <summary>
+    /// 🚨 "A fix to the failing code" — the case the issue names and the one the in-memory park
+    /// registry cannot cover, because a failure that predates this PROCESS is not in it.
+    /// </summary>
+    [Fact]
+    public void AnEditedSource_IsReDrivable_EvenWhenTheFrameworkDidNotMove()
+    {
+        var broken = Sources(("P/T/Source/a", 1));
+        var def = NeverCompiledFailure(
+            failedInputs: NodeTypeCompilationHelpers.BuildInputsToken(null, broken),
+            currentSources: broken);
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(def, null).Should().BeFalse();
+
+        var fixedUp = def with { CurrentSourceVersions = Sources(("P/T/Source/a", 2)) };
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(fixedUp, null)
+            .Should().BeTrue("an edit that may BE the fix must earn a fresh attempt");
+
+        var added = def with { CurrentSourceVersions = broken.SetItem("P/T/Source/b", 9) };
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(added, null)
+            .Should().BeTrue("an added source changes the compile unit");
+
+        var removed = def with { CurrentSourceVersions = ImmutableDictionary<string, long>.Empty };
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(removed, null)
+            .Should().BeTrue("a removed source changes the compile unit too");
+    }
+
+    /// <summary><see cref="CompilationStatus.Unavailable"/> records that the compile never reached
+    /// a verdict at all — even less of a reason to stop trying than an Error.</summary>
+    [Fact]
+    public void AnUndeterminedVerdict_IsReDrivenTheSameWay()
+    {
+        var def = NeverCompiledFailure(status: CompilationStatus.Unavailable);
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(def, null).Should().BeTrue();
+    }
+
+    // ── …and nowhere else ───────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(CompilationStatus.Ok)]
+    [InlineData(CompilationStatus.Pending)]
+    [InlineData(CompilationStatus.Compiling)]
+    public void OnlySettledFailures_AreReDriven(CompilationStatus? status)
+    {
+        var def = NeverCompiledFailure() with { CompilationStatus = status };
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(def, null)
+            .Should().BeFalse("re-driving a healthy or in-flight type is a recompile storm, not a recovery");
+    }
+
+    /// <summary>
+    /// The predicate is the strict COMPLEMENT of the framework-stale twin: a type carrying
+    /// assembly coordinates is that twin's business (and the enrichment self-heal's), and having
+    /// two kickoffs claim the same state is how a rebuild loop starts.
+    /// </summary>
+    [Fact]
+    public void AFailureLayeredOnAPriorGoodBuild_IsLeftToTheFrameworkStaleKickoff()
+    {
+        var def = NeverCompiledFailure() with
+        {
+            LatestAssemblyCollection = "assemblies",
+            LatestAssemblyPath = "P_T/v7.dll",
+            CompiledFrameworkVersion = "0ldfr4me",
+        };
+
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(def, null)
+            .Should().BeFalse("coordinates exist, so this is the framework-stale kickoff's case");
+        NodeTypeCompilationHelpers.HasStaleFrameworkBuild(def, modulesHash: null)
+            .Should().BeTrue("…and that kickoff does cover it");
+    }
+
+    // ── The token ───────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheToken_IsOrderInsensitive_AndSeparatesUnseededFromEmpty()
+    {
+        var a = NodeTypeCompilationHelpers.BuildInputsToken(
+            "m", Sources(("b", 2), ("a", 1)));
+        var b = NodeTypeCompilationHelpers.BuildInputsToken(
+            "m", Sources(("a", 1), ("b", 2)));
+        a.Should().Be(b, "dictionary enumeration order must never decide whether a type is re-driven");
+
+        NodeTypeCompilationHelpers.BuildInputsToken("m", null)
+            .Should().NotBe(NodeTypeCompilationHelpers.BuildInputsToken(
+                "m", ImmutableDictionary<string, long>.Empty),
+                "'the sources watcher has not seeded yet' and 'this type has no sources' are "
+                + "different facts — collapsing them would let an unseeded node read as source-less");
+
+        a.Should().Contain(NodeTypeCompilationHelpers.FrameworkVersion,
+            "an operator reading a stuck node must be able to see WHICH framework formed the verdict");
+    }
+
+    // ── The stamps stay truthful ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ApplyCompileFailure_StampsTheInputsTheVerdictWasFormedFrom()
+    {
+        var consumed = ImmutableDictionary<string, long>.Empty.Add("P/T/Source/a", 5);
+        var def = new NodeTypeDefinition
+        {
+            Configuration = "config => config",
+            CurrentSourceVersions = Sources(("P/T/Source/a", 5)),
+        };
+
+        var stamped = NodeTypeCompilationHelpers.ApplyCompileFailure(
+            def, new NodeCompilationResult(null, [], CompiledSources: consumed),
+            new CompilationException(TypePath, "CS0103 …"), activityPath: null, modulesHash: "mod-1");
+
+        stamped.FailedBuildInputs.Should().Be(
+            NodeTypeCompilationHelpers.BuildInputsToken("mod-1", consumed));
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(stamped, "mod-1")
+            .Should().BeFalse("the failure just had its attempt under exactly these inputs");
+    }
+
+    /// <summary>The consumed set may differ from the node's live snapshot when an edit lands
+    /// mid-compile; the stamp must describe what the compile actually saw, so the edit still
+    /// earns its own attempt.</summary>
+    [Fact]
+    public void ApplyCompileFailure_FallsBackToTheLiveSnapshot_WhenTheResultResolvedNone()
+    {
+        var live = Sources(("P/T/Source/a", 5));
+        var def = new NodeTypeDefinition { Configuration = "c", CurrentSourceVersions = live };
+
+        var stamped = NodeTypeCompilationHelpers.ApplyCompileFailure(
+            def, result: null, error: new InvalidOperationException("boom"),
+            activityPath: null, modulesHash: null);
+
+        stamped.FailedBuildInputs.Should().Be(NodeTypeCompilationHelpers.BuildInputsToken(null, live));
+    }
+
+    [Fact]
+    public void ApplyCompileSuccess_ClearsTheFailureVerdict()
+    {
+        var def = NeverCompiledFailure(
+            failedInputs: NodeTypeCompilationHelpers.BuildInputsToken(null, null));
+
+        var stamped = NodeTypeCompilationHelpers.ApplyCompileSuccess(
+            def,
+            new NodeCompilationResult("/cache/T.dll", [], Collection: "assemblies",
+                ContentPath: "P_T/v1.dll", Version: 1),
+            currentNodeVersion: 1, activityPath: null, releasePath: null);
+
+        stamped.FailedBuildInputs.Should().BeNull(
+            "a stale token would make a LATER failure look like it had already had its attempt, "
+            + "and the type would sit broken with nothing due to retry it");
+    }
+
+    // ── The bound, and its loud failure mode ────────────────────────────────────────────────
+
+    /// <summary>
+    /// The ledger is what turns non-convergence from silent into loud: re-driving the SAME inputs
+    /// twice can only happen if the stamp did not stick, and the caller logs an ERROR naming the
+    /// path on exactly that count.
+    /// </summary>
+    [Fact]
+    public void TheLedger_CountsPerInputs_AndPerType()
+    {
+        var registry = new NodeTypeCompileParkRegistry();
+        var first = NodeTypeCompilationHelpers.BuildInputsToken(null, Sources(("a", 1)));
+        var second = NodeTypeCompilationHelpers.BuildInputsToken(null, Sources(("a", 2)));
+
+        registry.RecordFailureRedrive(TypePath, first).Should().Be((1, 1));
+        registry.RecordFailureRedrive(TypePath, second).Should().Be((1, 2),
+            "a different input set is a legitimate fresh attempt, not a repeat");
+        registry.RecordFailureRedrive(TypePath, first).Should().Be((2, 3),
+            "re-driving the SAME inputs twice is the non-convergence signal");
+        registry.GetFailureRedriveCount(TypePath).Should().Be(3);
+        registry.GetFailureRedriveCount("P/Other").Should().Be(0,
+            "the ledger is per type — one broken type must not spend another's budget");
+    }
+
+    [Fact]
+    public void TheBudget_IsReturnedOnSuccess_AndOnADeliberateRetry()
+    {
+        var registry = new NodeTypeCompileParkRegistry();
+        var inputs = NodeTypeCompilationHelpers.BuildInputsToken(null, null);
+
+        for (var i = 0; i < NodeTypeCompileParkRegistry.MaxAutomaticFailureRedrives; i++)
+            registry.RecordFailureRedrive(TypePath, inputs);
+        registry.GetFailureRedriveCount(TypePath)
+            .Should().Be(NodeTypeCompileParkRegistry.MaxAutomaticFailureRedrives);
+
+        registry.OnCompileSucceeded(TypePath);
+        registry.GetFailureRedriveCount(TypePath).Should().Be(0,
+            "the re-drive converged, so a type that breaks again later starts with a full budget");
+
+        for (var i = 0; i < NodeTypeCompileParkRegistry.MaxAutomaticFailureRedrives; i++)
+            registry.RecordFailureRedrive(TypePath, inputs);
+        registry.ResetFailureRedrives(TypePath);
+        registry.GetFailureRedriveCount(TypePath).Should().Be(0,
+            "a human asking for a build is the strongest signal that a give-up should be reconsidered");
+    }
+
+    /// <summary>The give-up bound is a real cap, not a hint — the caller stops at it, so a broken
+    /// type cannot drive an unbounded sequence of Roslyn passes on the hub's action block.</summary>
+    [Fact]
+    public void TheBudget_IsFinite()
+    {
+        var registry = new NodeTypeCompileParkRegistry();
+        var overBudget = 0;
+        for (var i = 0; i < NodeTypeCompileParkRegistry.MaxAutomaticFailureRedrives + 3; i++)
+        {
+            // Each attempt uses DIFFERENT inputs — the structural bound cannot help here, so only
+            // the cap stands between a churning source set and an unbounded re-drive.
+            var (_, total) = registry.RecordFailureRedrive(
+                TypePath, NodeTypeCompilationHelpers.BuildInputsToken(null, Sources(("a", i))));
+            if (total > NodeTypeCompileParkRegistry.MaxAutomaticFailureRedrives)
+                overBudget++;
+        }
+        overBudget.Should().Be(3, "past the cap every further attempt must report as over budget");
+    }
+
+    // ── The operational-member contract ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The stamp is MESH-owned bookkeeping: export must strip it and an upsert must preserve the
+    /// live node's value. An authored token matching the importing deployment's live inputs would
+    /// suppress the one automatic retry this whole mechanism exists to grant.
+    /// </summary>
+    [Fact]
+    public void TheStamp_IsOperationalState()
+    {
+        // Contains(), not the collection assertion: the set is OrdinalIgnoreCase and the member
+        // is listed camelCased, so an equality-based collection check would miss it.
+        NodeTypeOperationalContent.MemberNames
+            .Contains(nameof(NodeTypeDefinition.FailedBuildInputs))
+            .Should().BeTrue(
+                "an authored failedBuildInputs would suppress the retry it is supposed to enable");
+
+        var state = NodeTypeCompileState.FromDefinition(
+            NeverCompiledFailure(failedInputs: "fw=x;mod=(none);src=0"));
+        state!.FailedBuildInputs.Should().Be("fw=x;mod=(none);src=0",
+            "the compile-state satellite must carry every masked member or it silently drops it");
+        state.IsEmpty.Should().BeFalse();
+        NodeTypeCompileState.FromDefinition(new NodeTypeDefinition())!.IsEmpty
+            .Should().BeTrue("a definition with no compile state at all is still empty");
+    }
+
+    private static string TokenSourcePart(string? modulesHash, IReadOnlyDictionary<string, long>? sources)
+    {
+        var token = NodeTypeCompilationHelpers.BuildInputsToken(modulesHash, sources);
+        return token[(token.IndexOf(";src=", StringComparison.Ordinal) + ";src=".Length)..];
+    }
+}

--- a/test/MeshWeaver.Graph.Test/FailedVerdictRedriveTest.cs
+++ b/test/MeshWeaver.Graph.Test/FailedVerdictRedriveTest.cs
@@ -158,8 +158,30 @@ public class FailedVerdictRedriveTest
     [Fact]
     public void AnUndeterminedVerdict_IsReDrivenTheSameWay()
     {
-        var def = NeverCompiledFailure(status: CompilationStatus.Unavailable);
+        var def = NeverCompiledFailure(
+            currentSources: Sources(("P/T/Source/a", 1)), status: CompilationStatus.Unavailable);
         NodeTypeCompilationHelpers.HasStaleFailureVerdict(def, null).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 🚨 Never re-drive from a source set nobody established. On a cold activation the sources
+    /// watcher has not written <see cref="NodeTypeDefinition.CurrentSourceVersions"/> yet, and
+    /// "not known yet" is not "no sources": compiling there forms a verdict from evidence the
+    /// mesh does not have (#1216), and the watcher's first write would immediately change the
+    /// token and burn a second attempt for free.
+    /// </summary>
+    [Fact]
+    public void AnUnestablishedSourceSet_Waits_RatherThanReDriving()
+    {
+        var unseeded = NeverCompiledFailure(currentSources: null);
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(unseeded, null)
+            .Should().BeFalse("the source set is not known yet — this is waiting, not declining");
+
+        // …and the moment the watcher seeds it — even with the EMPTY map, which is a real answer —
+        // the re-drive is due.
+        var seededEmpty = unseeded with { CurrentSourceVersions = ImmutableDictionary<string, long>.Empty };
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(seededEmpty, null)
+            .Should().BeTrue("an established (even empty) source set is an answer, so the attempt is due");
     }
 
     // ── …and nowhere else ───────────────────────────────────────────────────────────────────

--- a/test/MeshWeaver.Graph.Test/ShippedNodeTypeStateTest.cs
+++ b/test/MeshWeaver.Graph.Test/ShippedNodeTypeStateTest.cs
@@ -32,11 +32,18 @@ namespace MeshWeaver.Graph.Test;
 ///   <item>the release-request watcher requires <c>RequestedReleaseAt &gt;
 ///     LastReleaseRequestHandledAt</c> — and the export baked the two EQUAL.</item>
 /// </list>
-/// So the node parks on a foreign machine's error forever, and no later fix to the code, the
-/// sources, or the framework can reach it. The committed error text for
+/// So the node parked on a foreign machine's error forever, and no later fix to the code, the
+/// sources, or the framework could reach it. The committed error text for
 /// <c>Northwind/AnalyticsCatalog</c> named <c>OrderViews</c>/<c>SalesViews</c> — identifiers
 /// that occur nowhere in the configuration it shipped alongside; the configuration had long
 /// since been corrected, and the correction could never take effect.</para>
+///
+/// <para><b>#1793 narrowed that, and this guard is why it still matters.</b> A never-compiled
+/// failure now earns ONE automatic re-drive whenever the live compile inputs differ from the ones
+/// its verdict was formed under (<see cref="NodeTypeDefinition.FailedBuildInputs"/>). An authored
+/// file that carries a <c>failedBuildInputs</c> token matching the importing deployment would
+/// SUPPRESS exactly that retry — so the banned set covers it too, and the invariant below is
+/// unchanged: a committed node file carries no compile state at all.</para>
 ///
 /// <para><b>Why the check is fail-closed by NAME.</b> The banned set is derived from
 /// <see cref="NodeTypeDefinition"/> by reflection over the control plane's naming convention
@@ -67,6 +74,7 @@ public class ShippedNodeTypeStateTest
         "LatestRelease",     // LatestReleasePath
         "RequestedRelease",  // Path, At, Force, By
         "CurrentSource",     // CurrentSourceVersions
+        "Failed",            // FailedBuildInputs (#1793) — the standing failure verdict's inputs
     ];
 
     /// <summary>The banned members as they appear in JSON (camelCase), derived from the type.</summary>
@@ -119,6 +127,9 @@ public class ShippedNodeTypeStateTest
         Assert.Contains("latestAssemblyPath", BannedMembers);
         Assert.Contains("lastReleaseRequestHandledAt", BannedMembers);
         Assert.Contains("lastCompilationActivityPath", BannedMembers);
+        // #1793: an authored token matching this deployment's live inputs would suppress the one
+        // automatic retry a never-compiled failure gets — the exact shape this guard exists for.
+        Assert.Contains("failedBuildInputs", BannedMembers);
 
         // Authored members must NOT be swept up — the guard has to leave real content alone.
         Assert.DoesNotContain("configuration", BannedMembers);

--- a/test/MeshWeaver.Hosting.Monolith.Test/NeverCompiledFailureRedriveTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NeverCompiledFailureRedriveTest.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+using MeshWeaver.Compiler;
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 Repro + regression pin for issue #1793: a NodeType that has NEVER compiled successfully and
+/// settles at <see cref="CompilationStatus.Error"/> was unreachable by EVERY automatic re-drive.
+///
+/// <para><b>Why every path skipped it.</b> <c>ApplyCompileFailure</c> stamps neither
+/// <see cref="NodeTypeDefinition.LatestAssemblyCollection"/> /
+/// <see cref="NodeTypeDefinition.LatestAssemblyPath"/> nor
+/// <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/>, so for such a type all three stay
+/// null forever — and the first-build kickoff needs a <c>null</c> status, the recovery kickoff
+/// needs <c>Compiling</c>, the framework-stale kickoff needs those very coordinates, the release
+/// watcher needs a human to move <see cref="NodeTypeDefinition.RequestedReleaseAt"/>, and the
+/// sources watcher's parked auto-retry needs the IN-MEMORY park registry to still hold the path
+/// (a failure that predates the process is not in it). Only a human pressing Compile got the node
+/// out; a redeploy, a framework bump, a module update and a fix to the failing code all reached
+/// none of them. <c>NodeCompileShaping.AnchorIncludePath</c> was written for fifteen types parked
+/// on memex-cloud and, five days later, #1786 found near enough the same list still parked.</para>
+///
+/// <para><b>What is pinned here.</b> Three properties, each of which is a way the fix could be
+/// wrong: it must RECOVER a never-compiled failure without any user action; it must NOT loop on a
+/// type whose source genuinely cannot compile (an unbounded re-drive on the per-NodeType hub's
+/// single-threaded action block is the recompile-storm wedge); and its own bookkeeping must not
+/// re-arm its own trigger (the write-cycle shape of the 257,000-version <c>_Policy</c> storm).</para>
+///
+/// <para>The pure half — the verdict-inputs token, the predicate, the ledger — is
+/// <c>FailedVerdictRedriveTest</c> in MeshWeaver.Graph.Test.</para>
+/// </summary>
+public class NeverCompiledFailureRedriveTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override bool ShareMeshAcrossTests => true;
+
+    // Real Roslyn compiles (a failing one, then the automatic rebuild) — same shape and budget as
+    // FrameworkStaleProactiveRebuildTest.
+    protected override TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(90);
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(180);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGraph();
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    private NodeTypeCompileParkRegistry ParkRegistry =>
+        Mesh.ServiceProvider.GetRequiredService<NodeTypeCompileParkRegistry>();
+
+    /// <summary>
+    /// 🚨 THE #1793 REPRO — the exact record shape #1786 measured: a NodeType sitting at
+    /// <c>Error</c> with no assembly coordinates, no framework stamp, and no record of the inputs
+    /// the verdict was formed under (a compile that failed on another machine, an export that baked
+    /// the verdict into a file, or simply a failure that predates this field).
+    ///
+    /// <para>No instance is activated, no Compile is clicked, no release is requested. The type's
+    /// OWN hub must re-drive it exactly once and it must come back green.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task NeverCompiledErrorRecord_IsReDrivenAutomatically_AndRecovers()
+    {
+        var (typePath, baselineSucceededAt) = await CompileBaselineType("RedriveRecovers", GoodSource);
+        var workspace = Mesh.GetWorkspace();
+
+        await ForgeNeverCompiledFailure(typePath);
+
+        // The OWNER-side re-drive must rebuild it: back to Ok, with real assembly coordinates and a
+        // STRICTLY NEWER success timestamp (a replayed old Ok would prove nothing). Before the fix
+        // nothing re-drives this record at all, so this times out.
+        var recovered = await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath)
+                && d.CompiledFrameworkVersion == NodeTypeCompilationHelpers.FrameworkVersion
+                && d.LastCompileSucceededAt is { } s && s > baselineSucceededAt);
+        Output.WriteLine(
+            $"Automatically re-driven and recovered: {typePath} → Ok at "
+            + $"{((NodeTypeDefinition)recovered.Content!).LastCompileSucceededAt:O}");
+
+        // 🚨 …and it converged. A success clears the failure stamp (a stale one would make a LATER
+        // failure look like it had already had its attempt), and nothing re-drives a healthy type.
+        ((NodeTypeDefinition)recovered.Content!).FailedBuildInputs.Should().BeNull(
+            "a success retires the failure verdict, so its inputs must go with it");
+        await AssertNoFurtherCompileIsDriven(typePath, 15.Seconds(),
+            "a recovered type must not be re-driven again — the re-drive's own bookkeeping is what "
+            + "makes its trigger false, and a trigger that survives its own write is a write cycle");
+    }
+
+    /// <summary>
+    /// 🚨 THE BOUND. The same record shape as above, but on a type whose source CANNOT compile: it
+    /// gets its one automatic attempt, that attempt fails, and then it is left alone. An unbounded
+    /// retry on a genuinely broken type saturates the per-NodeType hub's single-threaded action
+    /// block — the wedge the park registry exists to prevent — so "recoverable when it can be" must
+    /// not cost "loudly stuck when it cannot".
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ABrokenSource_IsReDrivenExactlyOnce_AndThenLeftAlone()
+    {
+        var typePath = await CreateType("RedriveBounded", BrokenSource);
+        var workspace = Mesh.GetWorkspace();
+
+        // The first-build kickoff runs and Roslyn rejects it. The failure now RECORDS the inputs it
+        // was formed under, so the re-drive declines: it is the same framework, the same modules and
+        // the same sources that just failed.
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Error
+                && !string.IsNullOrEmpty(d.FailedBuildInputs));
+        Output.WriteLine($"{typePath} settled at Error with its verdict inputs recorded.");
+
+        ParkRegistry.GetFailureRedriveCount(typePath).Should().Be(0,
+            "a verdict formed under exactly the live inputs has already had its attempt — "
+            + "re-driving it would reproduce the identical failure");
+
+        // Now stage the pre-fix record (no stamp) so the re-drive DOES fire, and prove it fires
+        // exactly once: the attempt fails again, and nothing schedules another.
+        await ForgeNeverCompiledFailure(typePath);
+
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Error
+                && !string.IsNullOrEmpty(d.FailedBuildInputs));
+        var redrives = ParkRegistry.GetFailureRedriveCount(typePath);
+        redrives.Should().Be(1,
+            "exactly one automatic attempt per distinct set of compile inputs — the flip to Pending "
+            + "stamps those inputs in the same write, so the trigger cannot re-arm itself");
+        Output.WriteLine($"{typePath} re-driven {redrives}× and re-failed — now bounded.");
+
+        await AssertNoFurtherCompileIsDriven(typePath, 20.Seconds(),
+            "a type whose source cannot compile must back off after its one attempt instead of "
+            + "storming Roslyn on the hub's action block");
+        ParkRegistry.GetFailureRedriveCount(typePath).Should().Be(1,
+            "…and the ledger must still show exactly one, which is the observable proof of the bound");
+        ParkRegistry.IsParked(typePath).Should().BeTrue(
+            "the re-failed attempt re-parks the type, so its cached error is served without recompiling");
+    }
+
+    /// <summary>
+    /// 🚨 "a fix to the failing code" — the case the issue names, and the one no existing path
+    /// covers once the failure predates this PROCESS. The park registry's source-change auto-retry
+    /// is in-memory, so a restart empties it and a later edit re-drives nothing; here that state is
+    /// staged by un-parking the type before the edit lands.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task AFixedSource_ReDrivesAFailureThatPredatesThisProcess()
+    {
+        var typePath = await CreateType("RedriveSourceFix", BrokenSource);
+        var workspace = Mesh.GetWorkspace();
+        var sourcePath = $"{typePath}/Source/code";
+
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d && d.CompilationStatus == CompilationStatus.Error);
+
+        // 🚧 Stage "the failure predates this process": the in-memory park is what the sources
+        // watcher's ShouldRetryForSourceChange consults, and after a restart it holds nothing. With
+        // it cleared, the ONLY thing that can notice the fix is the durable verdict-inputs stamp.
+        ParkRegistry.Unpark(typePath);
+        ParkRegistry.IsParked(typePath).Should().BeFalse(
+            "the in-process park must be gone, or this test would pass through the pre-existing "
+            + "same-process retry path and pin nothing");
+
+        var typeId = typePath.Split('/')[^1];
+        await workspace.GetMeshNodeStream(sourcePath)
+            .Update(curr => curr is null ? curr! : curr with
+            {
+                Content = new CodeConfiguration { Code = GoodSource(typeId), Language = "csharp" }
+            })
+            .Should().Within(30.Seconds()).Emit();
+        Output.WriteLine($"Fixed the source at {sourcePath} — nothing else was touched.");
+
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath));
+        Output.WriteLine($"{typePath} recovered from the source fix with no Compile click.");
+    }
+
+    // ── staging ─────────────────────────────────────────────────────────────────────────────
+
+    private static string GoodSource(string typeId) => $$"""
+        public record {{typeId}} { public string Title { get; init; } = string.Empty; }
+        """;
+
+    /// <summary>Source Roslyn must reject — an unresolvable name, the CS0103 shape every parked
+    /// type on memex-cloud carried.</summary>
+    private static string BrokenSource(string typeId) => $$"""
+        public record {{typeId}} { public string Title { get; init; } = ThisSymbolDoesNotExist; }
+        """;
+
+    private async Task<string> CreateType(string prefix, Func<string, string> source)
+    {
+        var typeId = $"{prefix}{Guid.NewGuid():N}";
+        var typePath = $"type/{typeId}";
+
+        await MeshService.CreateNode(MeshNode.FromPath(typePath) with
+        {
+            Name = typeId,
+            NodeType = MeshNode.NodeTypePath,
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = $"config => config.WithContentType<{typeId}>()"
+            }
+        }).Should().Emit();
+        await MeshService.CreateNode(new MeshNode("code", $"{typePath}/Source")
+        {
+            NodeType = "Code",
+            Name = "code",
+            State = MeshNodeState.Active,
+            Content = new CodeConfiguration { Code = source(typeId), Language = "csharp" }
+        }).Should().Emit();
+        return typePath;
+    }
+
+    private async Task<(string Path, DateTimeOffset SucceededAt)> CompileBaselineType(
+        string prefix, Func<string, string> source)
+    {
+        var typePath = await CreateType(prefix, source);
+        await Mesh.Observe(new GetCompilationPathRequest(), o => o.WithTarget(new Address(typePath)))
+            .Should().Within(90.Seconds()).Emit();
+        var okNode = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(60.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && d.LastCompileSucceededAt is not null
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath));
+        var def = (NodeTypeDefinition)okNode.Content!;
+        Output.WriteLine(
+            $"Baseline compile Ok for {typePath} at {def.LastCompileSucceededAt!.Value:O}.");
+        return (typePath, def.LastCompileSucceededAt!.Value);
+    }
+
+    /// <summary>
+    /// Stamps the record shape a never-compiled failure leaves behind — and the shape #1786 found
+    /// baked into 8 shipped node files: <c>Error</c>, no assembly coordinates, no framework stamp,
+    /// and no record of the inputs the verdict was formed under. Nothing else is touched, and no
+    /// instance of the type is ever activated, so only the OWNER-side re-drive can act on it.
+    /// </summary>
+    private async Task ForgeNeverCompiledFailure(string typePath)
+    {
+        var workspace = Mesh.GetWorkspace();
+        // The park is in-memory and per-process; a record that arrived from elsewhere carries no
+        // park with it, so clear it here too or the staged state would not be the staged state.
+        ParkRegistry.Unpark(typePath);
+        var marker = $"FORGED-{Guid.NewGuid():N}";
+        await workspace.GetMeshNodeStream(typePath)
+            .Update(curr => curr.Content is NodeTypeDefinition d
+                ? curr with
+                {
+                    Content = d with
+                    {
+                        CompilationStatus = CompilationStatus.Error,
+                        CompilationError = marker,
+                        CompilationDiagnostics = null,
+                        LatestAssemblyCollection = null,
+                        LatestAssemblyPath = null,
+                        CompiledFrameworkVersion = null,
+                        CompiledSources = null,
+                        FailedBuildInputs = null,
+                    }
+                }
+                : curr)
+            .Should().Within(30.Seconds()).Emit();
+        // 🚧 Barrier: GetMeshNodeStream replays its latest snapshot, so without confirming the
+        // forge LANDED a later convergence Match could match the pre-forge state and pass with no
+        // re-drive at all — masking a disabled kickoff.
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(20.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Error
+                && d.CompilationError == marker
+                && string.IsNullOrEmpty(d.LatestAssemblyPath)
+                && d.FailedBuildInputs is null);
+        Output.WriteLine($"Forged the never-compiled Error record on {typePath} (marker {marker}).");
+    }
+
+    /// <summary>
+    /// The sanctioned bounded NEGATIVE observation for "nothing re-drives this": no transition into
+    /// <see cref="CompilationStatus.Pending"/> or <see cref="CompilationStatus.Compiling"/> within
+    /// the window. Not vacuous — the sibling assertions above prove the same subscription DOES see
+    /// the flip when the re-drive fires.
+    /// </summary>
+    private async Task AssertNoFurtherCompileIsDriven(string typePath, TimeSpan window, string because)
+    {
+        await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Where(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling)
+            .Should().NotEmit(window, because);
+        Output.WriteLine($"No further compile was driven for {typePath} within {window.TotalSeconds:F0}s.");
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansCompileActivityAccessTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansCompileActivityAccessTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
@@ -400,20 +401,53 @@ public class OrleansCompileActivityAccessTest(ITestOutputHelper output)
         // role on OtherUser/ — RestrictedAccessSiloConfigurator only grants
         // TestUser Admin on TestUser/_Access.
         //
-        // 🚨 Seed a SETTLED CompilationStatus (Error) so the System first-build
-        // kickoff cannot fire. The kickoff in InstallCompileWatcher fires on ANY
-        // grain activation when CompilationStatus is null — under System identity
-        // — and creates exactly one compile activity (the by-design behaviour that
-        // OrleansCompileActivityAccessTest.BackgroundActivation_…
-        // DoesNotLoopRecompiles pins as "exactly one"). That kickoff is
-        // INFRASTRUCTURE, orthogonal to user authorization: it would create an
-        // _Activity row here even though TestUser is denied, making the
-        // access-control invariant un-observable. Seeding a terminal status
-        // (CompilationStatus is non-null → kickoff needs null, recovery needs
-        // Compiling, release-watcher needs RequestedReleaseAt) means the ONLY
-        // path to a compile activity is the release-request — which requires
-        // TestUser's denied write to land. So "no activity row" cleanly proves
-        // the denial, with no race against the orthogonal kickoff.
+        // 🚨 Seed a compile record that is SETTLED **and has nothing due** — so no
+        // System-driven, activation-time kickoff can fire and the ONLY path to a
+        // compile activity is the release-request, which requires TestUser's denied
+        // write to land. That is what makes "no activity row" a clean proof of the
+        // denial rather than a race against orthogonal infrastructure.
+        //
+        // Those kickoffs are INFRASTRUCTURE, orthogonal to user authorization: they
+        // run on the type's OWN hub, under System, from facts the persisted record
+        // already holds — no request and no requester's identity is an input. They
+        // would create an _Activity row here even though TestUser is denied, making
+        // the access-control invariant un-observable. So each one is excluded by the
+        // record itself:
+        //
+        //   first-build      needs CompilationStatus null      → seeded Error
+        //   recovery         needs Compiling                   → seeded Error
+        //   framework-stale  needs assembly coordinates        → none seeded
+        //   release watcher  needs RequestedReleaseAt          → the denied write
+        //   failed-verdict   needs the LIVE compile inputs to differ from
+        //                    FailedBuildInputs (#1793)         → seeded EQUAL, below
+        //
+        // 🚨 A settled status ALONE stopped being sufficient with #1793. A failure
+        // that never compiled successfully used to be unreachable by every automatic
+        // path — which is the bug #1793 fixed — so it is now re-driven once whenever
+        // the framework, the installed modules or the type's sources differ from what
+        // the verdict was formed under. A seeded Error with no FailedBuildInputs is
+        // exactly the "imported from elsewhere, never attempted here" record that
+        // SHOULD be re-driven, so it no longer stages a quiet type.
+        //
+        // The honest replacement is a record that says what a locally-formed failure
+        // says: this verdict was reached HERE, under these very inputs. Then nothing
+        // is due, by the mechanism's own rule rather than by an accident of which
+        // fields the predicates happened to read. Two halves, and both are needed:
+        //   • CurrentSourceVersions = EMPTY — the type has no Source/ children, and
+        //     the sources watcher will write exactly that on activation, so seeding it
+        //     removes the window in which the snapshot is "not established yet" and
+        //     the watcher's first write would move the token.
+        //   • FailedBuildInputs = the token the framework itself computes for that
+        //     state. Derived through NodeTypeCompilationHelpers.BuildInputsToken, never
+        //     re-implemented here: a token two call sites compute differently either
+        //     never converges or never fires, and both failures are silent.
+        var siloServices = ((InProcessSiloHandle)Cluster.Silos[0]).SiloHost.Services;
+        var siloHubForToken = siloServices.GetRequiredService<IMessageHub>();
+        var noSources = (IReadOnlyDictionary<string, long>)
+            ImmutableDictionary<string, long>.Empty;
+        var settledInputs = NodeTypeCompilationHelpers.BuildInputsToken(
+            NodeTypeCompilationHelpers.ModulesHashOf(siloHubForToken), noSources);
+
         var typeId = $"NoEdit{Guid.NewGuid():N}";
         var typePath = $"OtherUser/{typeId}";
         var typeNode = MeshNode.FromPath(typePath) with
@@ -425,19 +459,19 @@ public class OrleansCompileActivityAccessTest(ITestOutputHelper output)
                 Description = "Negative — user lacks Edit, recompile must fail-closed",
                 Configuration = $"config => config.WithContentType<{typeId}>()",
                 CompilationStatus = CompilationStatus.Error,
-                CompilationError = "seeded terminal state (isolates access-control from the first-build kickoff)"
+                CompilationError = "seeded terminal state (isolates access-control from the compile kickoffs)",
+                CurrentSourceVersions = noSources,
+                FailedBuildInputs = settledInputs
             }
         };
         await SeedAsSystem(typeNode, ct);
+        Output.WriteLine(
+            $"Seeded {typePath} settled at Error with nothing due (inputs '{settledInputs}').");
 
         // As TestUser (no Edit on OtherUser/), attempt the Update.
         var client = GetClient($"no-edit-{Guid.NewGuid():N}", userId: "TestUser");
-        var siloMeshHub = ((InProcessSiloHandle)Cluster.Silos[0]).SiloHost.Services
-            .GetRequiredService<IMessageHub>();
-        var siloAccess = ((InProcessSiloHandle)Cluster.Silos[0]).SiloHost.Services
-            .GetRequiredService<IMessageHub>()
-            .ServiceProvider
-            .GetRequiredService<AccessService>();
+        var siloMeshHub = siloHubForToken;
+        var siloAccess = siloMeshHub.ServiceProvider.GetRequiredService<AccessService>();
 
         // Run the Update under TestUser's context and capture either an error
         // or a "no activity written" outcome.
@@ -492,8 +526,9 @@ public class OrleansCompileActivityAccessTest(ITestOutputHelper output)
             .Should().NotEmit(within: TimeSpan.FromSeconds(5),
                 because: "TestUser lacks Edit on OtherUser/; the write itself was denied " +
                     $"({updateException?.GetType().Name ?? "no exception"}), so no release-request " +
-                    "lands and — with the first-build kickoff suppressed by the seeded terminal " +
-                    "status — no compile activity row is ever created. Pin against the " +
+                    "lands and — with every System-driven kickoff excluded by a record that is " +
+                    "settled AND has nothing due (see the seeding comment) — no compile activity " +
+                    "row is ever created. Pin against the " +
                     "MessageHubConfiguration.cs:328-342 deletion (PostPipeline no longer stamps " +
                     "hub-self as principal).");
     }


### PR DESCRIPTION
Closes #1793.

## The gap

A compile that FAILS writes no assembly coordinates at all — `ApplyCompileFailure` stamps neither `LatestAssembly{Collection,Path}` nor `CompiledFrameworkVersion`. For a NodeType that never compiled successfully *on this deployment* those are null forever, and **every** automatic re-drive keys off something only a first success produces:

| path | requires | a never-succeeded `Error` node |
|---|---|---|
| first-build kickoff | `CompilationStatus is null` | ✗ it is `Error` |
| recovery kickoff | `CompilationStatus == Compiling` | ✗ |
| framework-stale kickoff | `HasStaleFrameworkBuild` → assembly coordinates + `CompiledFrameworkVersion` | ✗ a failure stamps none of them — and its own filter reads `Ok or Error`, so it *intends* to cover this |
| `InstallReleaseRequestWatcher` | `RequestedReleaseAt > LastReleaseRequestHandledAt` | ✗ only a human moves it |
| sources watcher's parked auto-retry | the **in-memory** park registry to hold the path | ✗ a failure that predates the process is not in it — so a source fix after a restart re-drives nothing either |
| enrichment self-heal (`ApplyStreamResult`) | `Ok/Error` **and** assembly coordinates | ✗ falls straight through to the "correct the code" overlay |
| pre-warm sweep (`WarmOne`) | activates the hub, then waits for `HasUsableBuild ‖ Error` | ✗ returns `CompileError` at once; the activation fires only the kickoffs above |
| `RebuildMissingBytes` | `BakeState.BytesMissing` (record claims a live-framework build) | ✗ classified `PreviouslyBroken` |

The one path that *does* re-drive it is the **batch** bake (`NodeTypeBatchBake.BakeOne` drives the compiler unconditionally) — but that is taken only on a readiness-gated bake pod / `PreWarm:BatchBake`, never on a serving pod's activation-driven sweep.

So only a human pressing **Compile** (or a Recycle) got such a node out. A redeploy, a framework bump, a module update and a fix to the failing code reached none of them — which is why `NodeCompileShaping.AnchorIncludePath`, written for the fifteen types it parked on memex-cloud 2026-08-12, could not reach them, and why #1786 found near enough the same list still parked five days later.

## The fix

A failure now records the one thing it honestly can: **the inputs the verdict was formed from** — framework identity + installed-module fingerprint + the source snapshot the compile consumed — folded into `NodeTypeDefinition.FailedBuildInputs`. A new owner-side kickoff fires exactly when the LIVE inputs differ from that stamp:

| What moved | Effect |
|---|---|
| A new framework (a redeploy, possibly carrying the fix) | one fresh attempt |
| A module update | one fresh attempt |
| An edited / added / removed source | one fresh attempt |
| Nothing — same framework, modules, sources | **no attempt**: the identical failure would reproduce |
| The stamp is `null` (every pre-existing parked node, and every `Error` baked into a node file) | one fresh attempt — the migration |

It is the strict **complement** of the framework-stale kickoff: it applies only where no assembly coordinates exist, so the two can never both claim the same state.

### Backoff / give-up

1. **STRUCTURAL** (the one that does the work) — the flip to `Pending` writes the live token **in the same `Update`**, so the trigger the re-drive fires on is false the instant it fires. A reconcile that can re-arm its own trigger is the 257,000-version `_Policy` write-storm shape; the stamp forecloses it. It is stamped at the flip as well as in `ApplyCompileFailure`, so it holds even when the compile never writes back at all (process death mid-compile, the parked re-settle, a poisoned content read).
2. **LOUD** — a process-wide ledger (`NodeTypeCompileParkRegistry.RecordFailureRedrive`) logs an **error naming the path** the moment a type is re-driven twice for the *same* inputs, i.e. the moment (1) provably did not hold.
3. **TERMINAL** — past `MaxAutomaticFailureRedrives` the kickoff gives up for the hub's lifetime and says so, naming the type, its error and the remedy. An explicit Compile refunds the budget.

And when the re-drive **declines** — a failure formed under exactly the live inputs — the hub logs one warning per activation naming the type, its error and why nothing will retry it. That state was correct and bounded before this change, and *completely silent*: nothing anywhere named a NodeType that is broken and will not be retried.

`FailedBuildInputs` is mesh-owned operational state — exports strip it, imports preserve the live node's value, and `ShippedNodeTypeStateTest` bans it from committed node files (an authored token matching the importing deployment would suppress precisely the retry it exists to grant).

`Unavailable` gets the same treatment: it records that a compile never reached a verdict at all, so it is even less of a reason to stop trying. (`EnsureCompileDispatched` already re-drives it on the next *request*; this adds the activation-time path under the same bound.)

## Tests — executed, and verified non-vacuous

`test/MeshWeaver.Graph.Test/FailedVerdictRedriveTest.cs` — 16 pure pins: the token (order-insensitive, unseeded ≠ empty), the predicate's truth table (null stamp / other framework / other modules / edited-added-removed source / `Unavailable` / only-settled-failures / left to the framework-stale twin), both stamps, the ledger, the finite budget, the operational-member contract.

`test/MeshWeaver.Hosting.Monolith.Test/NeverCompiledFailureRedriveTest.cs`:
- `NeverCompiledErrorRecord_IsReDrivenAutomatically_AndRecovers` — the #1786 record shape recovers with no user action, and is not re-driven again.
- `ABrokenSource_IsReDrivenExactlyOnce_AndThenLeftAlone` — a source that cannot compile gets exactly one attempt (ledger == 1), no further `Pending` flip in a bounded window, and re-parks.
- `AFixedSource_ReDrivesAFailureThatPredatesThisProcess` — the park is cleared first (emulating a restart), so only the durable stamp can notice the fix.

```
Passed!  - Failed: 0, Passed: 1274 - MeshWeaver.Graph.Test.dll
Passed!  - Failed: 0, Passed:   48 - MeshWeaver.Hosting.Monolith.Test.dll (compile-related filter, incl. the 3 new)
Passed!  - Failed: 0, Passed:  408 - MeshWeaver.PluginCatalog.Test.dll
Passed!  - Failed: 0, Passed:   34 - MeshWeaver.Documentation.Test.dll
```

**Control run** (AGENTS.md: a verification step that cannot fail is not a verification step) — with the new kickoff's `Where` neutered to `false`, the same three integration tests fail:

```
Failed!  - Failed: 3, Passed: 0, Total: 3, Duration: 4 m 32 s
  NeverCompiledFailureRedriveTest.ABrokenSource_IsReDrivenExactlyOnce_AndThenLeftAlone [FAIL]
  NeverCompiledFailureRedriveTest.AFixedSource_ReDrivesAFailureThatPredatesThisProcess [FAIL]
  NeverCompiledFailureRedriveTest.NeverCompiledErrorRecord_IsReDrivenAutomatically_AndRecovers [FAIL]
```

Docs: a new section in `Doc/Architecture/NodeTypeCompilation` and a What's New entry (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wVYniTKJ7Kuw7Hh425UPy