### PR TITLE
deploy/aks: the instance lifecycle operator (provision, suspend, tear down)

### DIFF
--- a/deploy/aks/INSTANCE-LIFECYCLE.md
+++ b/deploy/aks/INSTANCE-LIFECYCLE.md
@@ -1,0 +1,108 @@
+# Instance lifecycle — provision, suspend, tear down
+
+How an instance is created, taken offline and destroyed on this cluster, **from the mesh**, by any
+platform developer, with the database backed up and verified before anything is deleted.
+
+The mesh half lives in the `Hosting` plugin (MeshWeaver.Plugins): `Hosting/Deployment` records the
+instance, `Hosting/InstanceAction` runs the lifecycle, `Hosting/Backup` records the dumps and
+`Hosting/BackupStore` says where they go. This directory is the half that runs on the cluster.
+
+## Why a Job and not the portal process
+
+The portal must not hold a credential that can delete a namespace. It runs AI CLIs in-pod, so a
+prompt injection that reaches the control plane is a cloud compromise, not a bad afternoon.
+
+So there are three principals:
+
+| Principal | Power | Lifetime |
+|---|---|---|
+| `memex-portal-sa` | `get`/`patch` its own Deployment — the self-updater's needs, unchanged | the pod |
+| `hosting-jobrunner` (a token mounted into the portal) | create a Job in `memex-ops`, read its log | the pod |
+| `hosting-operator` (the Job's SA) | namespaces, releases, ingresses, and via Workload Identity the Azure control plane | the seconds a run takes |
+
+The mesh decides and orders; the Job executes. `manifests/hosting-operator/` has the RBAC,
+`operator/` has the image, and `infra/modules/backups.bicep` has the storage and the identity.
+
+## The lifecycle
+
+```
+Planned ──provision──▶ Live ──suspend──▶ Suspended ──teardown──▶ Decommissioned
+                        ▲                    │
+                        └────reactivate──────┘
+```
+
+**Suspension is the notice period.** It stops the portal, takes a verified dump, and re-points the
+host at a paywall page — nothing is deleted, and reactivating is a two-command undo. Teardown
+refuses on a `Live` instance and waits out a grace period measured from the suspension.
+
+### The redirect is an Ingress patch
+
+Every instance on this cluster shares one ingress controller and one public IP, and each owns only
+an `Ingress` in its own namespace. So suspending re-points a host with a single annotation:
+
+- **no DNS change** — the A-record already points at the shared ingress IP, so nothing propagates;
+- **no certificate change** — the namespace's TLS secret keeps serving, so the customer meets a
+  page rather than a browser warning;
+- **reversible** — the previous backend is stashed as an annotation, and the redirect is a **302**,
+  never a 301. A permanent redirect would be cached by browsers and outlive the reactivation.
+
+## Deploy it
+
+```bash
+# 1. Storage + the operator identity.
+az deployment group create -g "$RG" \
+  --template-file infra/modules/backups.bicep \
+  --parameters location=swedencentral backupAccountName=<globally-unique> \
+               oidcIssuerUrl="$(az aks show -g "$RG" -n "$CLUSTER" --query oidcIssuerProfile.issuerURL -o tsv)" \
+               postgresServerId="$(az postgres flexible-server show -g "$RG" -n "$PG" --query id -o tsv)"
+
+# 2. The operator identity needs two more grants, on resources this module does not own:
+#    DNS Zone Contributor on the zone, and Key Vault Secrets Officer on the vault.
+az role assignment create --assignee "<operatorIdentityPrincipalId>" \
+  --role "DNS Zone Contributor" --scope "$(az network dns zone show -g dns -n "$ZONE" --query id -o tsv)"
+az role assignment create --assignee "<operatorIdentityPrincipalId>" \
+  --role "Key Vault Secrets Officer" --scope "$(az keyvault show -n "$VAULT" --query id -o tsv)"
+
+# 3. RBAC (edit the client-id annotation first — see manifests/hosting-operator/README.md).
+kubectl apply -f manifests/hosting-operator/
+
+# 4. Build and push the operator image.
+docker build -t "$ACR/hosting-operator:1" operator/ && docker push "$ACR/hosting-operator:1"
+
+# 5. Mount the jobrunner token into the portal and set Hosting:Operator:* — README.md in
+#    manifests/hosting-operator/ has the exact values.
+```
+
+Then record the store in the mesh, once, as a `Hosting/BackupStore` node — `account` and
+`container` from this module's outputs, `credentialRef` = `operatorIdentityClientId`, and
+`retentionDays` matching the module's `retentionDays` so a restore can be told its archive expired
+before it tries to download it.
+
+## What the operator scripts guarantee
+
+`operator/bin/run.sh` executes the mesh's plan and contains no policy of its own — every ordering
+rule is in the mesh's pure, unit-tested plan. What the scripts themselves guarantee:
+
+- **`hosting-backup` never claims verification.** It dumps, checks the archive is non-empty,
+  uploads with `--overwrite false`, and reports size and digest. That is all.
+- **`hosting-verify-backup` is the only thing that emits `verified=true`**, and only after
+  downloading the archive and parsing a non-zero number of table entries out of its table of
+  contents. A truncated upload exits zero; an empty database dumps perfectly. This step is what
+  every destructive phase waits behind.
+- **`run.sh` stops at the first failure**, and the Job's `backoffLimit` is `0`. A half-finished
+  teardown is never retried from the top, where it would re-dump over a verified archive.
+- **`hosting-kv-ensure` never overwrites an existing master key.** Regenerating it would make every
+  stored `enc:` value in that instance's database permanently unreadable.
+- **`hosting-export` never prints the URL it mints.** A user-delegation SAS is a bearer credential;
+  it goes into a one-shot Secret the mesh reads once and deletes.
+- **`hosting-verify-catalog` proves the plugin mounts took.** An instance with green pods and an
+  empty Store is the failure worth catching, and it is invisible in a rollout status.
+
+## Two traps worth knowing
+
+**An apostrophe inside `${VAR:?message}` is a bash parse error** — the shell opens a single-quoted
+string inside the expansion and the script dies at load with an EOF error pointing at the last
+line. Reword the message; do not escape it.
+
+**`pg_dump`'s major version must be ≥ the server's**, or it refuses outright. The version is pinned
+in `operator/Dockerfile`; bump it when the fleet's PostgreSQL server moves.

--- a/deploy/aks/INSTANCE-LIFECYCLE.md
+++ b/deploy/aks/INSTANCE-LIFECYCLE.md
@@ -46,6 +46,19 @@ an `Ingress` in its own namespace. So suspending re-points a host with a single 
 - **reversible** — the previous backend is stashed as an annotation, and the redirect is a **302**,
   never a 301. A permanent redirect would be cached by browsers and outlive the reactivation.
 
+### The paywall target must be anonymously readable
+
+`PAYWALL_URL` points at the `Suspended` area on the instance's Deployment node — and the fleet
+space holding those records is admin-only. A suspended customer is **anonymous by construction**
+(they typed their own URL), so without a grant the redirect lands them on a sign-in prompt instead
+of the page explaining what happened. Grant `Anonymous` + `Public` Viewer on that node, or point
+`PAYWALL_URL` at a public page of your own.
+
+Nothing enforces this, and the symptom looks like an auth problem rather than a misconfiguration.
+The page itself is already written for that audience: it renders the instance's name and its
+retention window and nothing operational — no database, no namespace, no vault, no suspension
+reason — which is asserted in the plugin's tests.
+
 ## Deploy it
 
 ```bash

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -27,6 +27,7 @@ markdown only** — no application code changes.
 | Observability | **OpenTelemetry Collector DaemonSet** captures cluster-wide pod logs + portal OTLP → **Azure Files** log archive (`/mnt/otel-logs`); **Grafana + Loki + Promtail + Prometheus** in `monitoring` for search and dashboards |
 | Error ticketing | **`mw-log-watcher`** (optional, `monitoring`) reads red logs from Loki and opens one triaged GitHub issue per distinct fault — off until configured |
 | Identity | **Workload Identity (OIDC)** so pgBackRest reaches Blob **keyless** |
+| Instance lifecycle | **provision → suspend → tear down** driven from the mesh, with a verified `pg_dump` before anything is destroyed and an ingress-level paywall while suspended — see [INSTANCE-LIFECYCLE.md](INSTANCE-LIFECYCLE.md) |
 
 ### Topology
 

--- a/deploy/aks/infra/modules/backups.bicep
+++ b/deploy/aks/infra/modules/backups.bicep
@@ -1,0 +1,205 @@
+// ---------------------------------------------------------------------------
+// backups.bicep — the fleet's LOGICAL database backup store, plus the identity
+//                 the hosting operator runs as.
+//
+// This is NOT storage.bicep. That one serves pgBackRest's physical WAL/PITR
+// archive for the self-managed in-cluster Postgres. The fleet's instances run
+// on the shared Azure PostgreSQL Flexible Server, where the thing you need
+// before dropping a database is a LOGICAL dump (`pg_dump -Fc`) of that one
+// database — which server-level PITR cannot give you after the database is
+// gone. The two have different lifetimes, different blast radii and different
+// readers, so they get different accounts.
+//
+// What this deploys:
+//   * a ZRS storage account + a `db-backups` container, versioned and
+//     soft-deletable, with a lifecycle rule that expires dumps on a schedule;
+//   * a user-assigned managed identity (`hosting-operator`) federated to the
+//     operator ServiceAccount, holding the roles a lifecycle run needs;
+//   * the role assignments that let it write dumps and read them back.
+//
+// 🚨 The operator identity is the most powerful thing in this file. It can
+//    create and delete databases on the shared server and write to the backup
+//    account. It is federated to ONE ServiceAccount in ONE namespace — the ops
+//    namespace of the CONTROL instance — and to nothing else. Do not federate
+//    it to a tenant namespace, and do not reuse it for the portal: the portal's
+//    identity is `portal-identity.bicep`, and keeping them apart is what stops
+//    a prompt injection in an in-pod AI CLI from reaching the control plane.
+// ---------------------------------------------------------------------------
+
+@description('Azure region for the storage account.')
+param location string
+
+@description('Globally-unique storage account name for database dumps (3-24 lowercase alphanumerics).')
+param backupAccountName string
+
+@description('Blob container database dumps are written to.')
+param dumpContainerName string = 'db-backups'
+
+@description('Days a dump is retained before the lifecycle rule deletes it. 0 disables the rule.')
+param retentionDays int = 90
+
+@description('OIDC issuer URL of the AKS cluster (from aks.bicep output).')
+param oidcIssuerUrl string
+
+@description('Namespace the hosting operator Jobs run in.')
+param operatorNamespace string = 'memex-ops'
+
+@description('ServiceAccount the hosting operator Jobs run as.')
+param operatorServiceAccount string = 'hosting-operator'
+
+@description('Name of the user-assigned identity the operator authenticates as.')
+param operatorIdentityName string = 'hosting-operator'
+
+@description('Resource id of the PostgreSQL Flexible Server instances live on. Empty skips that grant.')
+param postgresServerId string = ''
+
+@description('Tags applied to every resource.')
+param tags object = {}
+
+resource backups 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+  name: backupAccountName
+  location: location
+  tags: tags
+  kind: 'StorageV2'
+  sku: {
+    // Zone-redundant: the reason a dump exists is that something went wrong, and
+    // "the backup was in the AZ that failed" is not a story anyone wants to tell.
+    name: 'Standard_ZRS'
+  }
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+    supportsHttpsTrafficOnly: true
+    // No shared-key auth. Every writer and reader of this account authenticates
+    // as a principal, so every access is attributable — and a leaked account key
+    // cannot exist because there is nothing that uses one.
+    allowSharedKeyAccess: false
+    accessTier: 'Hot'
+  }
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
+  parent: backups
+  name: 'default'
+  properties: {
+    // Soft delete is the backstop for the failure this whole file guards against:
+    // a teardown that deleted the dump it had just taken.
+    deleteRetentionPolicy: {
+      enabled: true
+      days: 30
+    }
+    containerDeleteRetentionPolicy: {
+      enabled: true
+      days: 30
+    }
+    isVersioningEnabled: true
+  }
+}
+
+resource dumpContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2024-01-01' = {
+  parent: blobService
+  name: dumpContainerName
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+// Expire dumps on the recorded schedule. The Hosting/BackupStore node records the
+// SAME number as `retentionDays`, so a restore can be told its archive is past
+// retention BEFORE it tries to download it — keep the two in step.
+resource lifecycle 'Microsoft.Storage/storageAccounts/managementPolicies@2024-01-01' = if (retentionDays > 0) {
+  parent: backups
+  name: 'default'
+  properties: {
+    policy: {
+      rules: [
+        {
+          name: 'expire-dumps'
+          enabled: true
+          type: 'Lifecycle'
+          definition: {
+            filters: {
+              blobTypes: [ 'blockBlob' ]
+              prefixMatch: [ dumpContainerName ]
+            }
+            actions: {
+              baseBlob: {
+                delete: {
+                  daysAfterModificationGreaterThan: retentionDays
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+// --- The operator identity ---------------------------------------------------
+resource operatorIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: operatorIdentityName
+  location: location
+  tags: tags
+}
+
+// Federated to exactly ONE ServiceAccount in ONE namespace. The subject must match
+// `system:serviceaccount:<ns>:<sa>` exactly — a mismatch fails the token exchange
+// at run time with an error that does not mention this file.
+resource operatorFederation 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2024-11-30' = {
+  parent: operatorIdentity
+  name: 'hosting-operator-federated'
+  properties: {
+    issuer: oidcIssuerUrl
+    subject: 'system:serviceaccount:${operatorNamespace}:${operatorServiceAccount}'
+    audiences: [ 'api://AzureADTokenExchange' ]
+  }
+}
+
+var blobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+
+resource operatorBlobRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(backups.id, operatorIdentity.id, blobDataContributorRoleId)
+  scope: backups
+  properties: {
+    principalId: operatorIdentity.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', blobDataContributorRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Contributor on the PostgreSQL SERVER only — scoped to the one resource whose
+// databases a lifecycle run creates and drops, never at resource-group scope.
+var contributorRoleId = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+
+resource existingPostgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' existing = if (!empty(postgresServerId)) {
+  name: last(split(postgresServerId, '/'))
+}
+
+resource operatorPostgresRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(postgresServerId)) {
+  name: guid(postgresServerId, operatorIdentity.id, contributorRoleId)
+  scope: existingPostgres
+  properties: {
+    principalId: operatorIdentity.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', contributorRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+@description('Storage account holding database dumps — the BackupStore node\'s `account`.')
+output backupAccountName string = backups.name
+
+@description('Container dumps are written to — the BackupStore node\'s `container`.')
+output dumpContainerName string = dumpContainer.name
+
+@description('Blob endpoint of the backup account.')
+output blobEndpoint string = backups.properties.primaryEndpoints.blob
+
+@description('Client id of the operator identity — the BackupStore node\'s `credentialRef`, and AZURE_CLIENT_ID on the operator Jobs.')
+output operatorIdentityClientId string = operatorIdentity.properties.clientId
+
+@description('Resource id of the operator identity, for further role assignments (DNS zone, Key Vault).')
+output operatorIdentityId string = operatorIdentity.id
+
+@description('Principal id of the operator identity, for role assignments made outside this module.')
+output operatorIdentityPrincipalId string = operatorIdentity.properties.principalId

--- a/deploy/aks/manifests/hosting-operator/README.md
+++ b/deploy/aks/manifests/hosting-operator/README.md
@@ -1,0 +1,43 @@
+# hosting-operator — the identity an instance lifecycle run uses
+
+Applied on the **control instance's** cluster only. Three principals, deliberately separate:
+
+| Principal | Can | Cannot |
+|---|---|---|
+| `memex-portal-sa` (the portal, unchanged) | `get`/`patch` its own Deployment — what the self-updater needs | anything in this directory |
+| `hosting-jobrunner` (mounted into the portal as a token) | create/get/delete Jobs and read pod logs **in `memex-ops` only** | touch a namespace, a database, or any cloud resource |
+| `hosting-operator` (the Job's own SA) | namespaces, Helm releases, ingresses cluster-wide, and — via Workload Identity — the Azure control plane | exist outside the seconds a run takes |
+
+The portal never holds the powerful credential. It holds a token whose entire power is *"start an
+operator job and read what it said"*, which is what makes a prompt injection into an in-pod AI CLI
+a nuisance rather than a cloud compromise.
+
+## Apply
+
+```bash
+kubectl apply -f namespace.yaml
+kubectl apply -f operator-serviceaccount.yaml      # edit AZURE_CLIENT_ID annotation first
+kubectl apply -f operator-rbac.yaml
+kubectl apply -f jobrunner.yaml
+# Mount the jobrunner token into the portal Deployment (portal-patch.json in the env folder):
+#   volume  : secret hosting-jobrunner-token
+#   mountPath: /var/run/secrets/hosting-operator
+```
+
+Then configure the portal:
+
+```yaml
+config:
+  memex_portal:
+    Hosting__Operator__Enabled: "true"
+    Hosting__Operator__Namespace: "memex-ops"
+    Hosting__Operator__ServiceAccount: "hosting-operator"
+    Hosting__Operator__Image: "meshweaver.azurecr.io/hosting-operator:<tag>"
+    Hosting__Operator__Environment__0: "AZ_RESOURCE_GROUP=<rg>"
+    Hosting__Operator__Environment__1: "AZ_PORTAL_IDENTITY=<portal-identity>"
+    Hosting__Operator__Environment__2: "AZURE_CLIENT_ID=<operatorIdentityClientId>"
+    Hosting__Operator__Environment__3: "PAYWALL_URL=https://<control-host>/Deployments/{instance}/area/Suspended"
+```
+
+🚨 **Only on the control instance.** `Hosting:Operator:Enabled` on a tenant portal would give that
+tenant's pod the ability to start a job that can delete any namespace on the cluster.

--- a/deploy/aks/manifests/hosting-operator/jobrunner.yaml
+++ b/deploy/aks/manifests/hosting-operator/jobrunner.yaml
@@ -1,0 +1,43 @@
+# The token the PORTAL holds. Its entire power is "start an operator job in memex-ops and read what
+# it said" — it cannot create a namespace, drop a database, or read a secret anywhere.
+#
+# 🚨 This is deliberately NOT the portal's own ServiceAccount. A pod projects only its own SA token,
+# so a second identity has to arrive as a mounted Secret — and that indirection is the point: this
+# capability can be removed by deleting one volume mount, without touching the portal's identity or
+# its self-update permissions.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hosting-jobrunner
+  namespace: memex-ops
+---
+# A long-lived token for it. Kubernetes ≥1.24 does not mint these automatically; this is the
+# supported way to ask for one, and it is why the Secret carries the annotation rather than data.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hosting-jobrunner-token
+  namespace: memex-ops
+  annotations:
+    kubernetes.io/service-account.name: hosting-jobrunner
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hosting-jobrunner
+  namespace: memex-ops
+rules:
+  # Create a run, watch it, read what it said, clean it up. Nothing else.
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+  # The one-shot handover Secret an export job writes its download URL into: the mesh reads it once
+  # and deletes it, so the URL never reaches a log line or a node. `create` is deliberately absent —
+  # only the job writes one.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]

--- a/deploy/aks/manifests/hosting-operator/namespace.yaml
+++ b/deploy/aks/manifests/hosting-operator/namespace.yaml
@@ -1,0 +1,8 @@
+# The ops namespace. Nothing serves traffic here — it exists so the operator's Jobs have a home
+# with its own RBAC boundary, separate from every portal namespace.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: memex-ops
+  labels:
+    app.kubernetes.io/managed-by: meshweaver-hosting

--- a/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
+++ b/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
@@ -1,0 +1,54 @@
+# What an operator JOB may do in the cluster. This is the widest grant in the deployment, and it
+# is deliberately attached to a ServiceAccount that only ever backs a short-lived Job — never a
+# long-running pod, and never the portal.
+#
+# Scope notes:
+#  * namespaces: create + delete is what provisioning and teardown ARE.
+#  * apps/deployments: scale (quiesce/reactivate) and read rollout status.
+#  * ingresses: the suspension redirect and its undo.
+#  * secrets/configmaps/pvc/services: what a Helm release of the portal chart owns.
+#  * NO access to `nodes`, `clusterroles`, or the monitoring namespace — a lifecycle run has no
+#    business there, and the day someone needs it is the day to review this file, not to widen it
+#    pre-emptively.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hosting-operator
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps", "services", "persistentvolumeclaims", "serviceaccounts"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "replicasets"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale", "statefulsets/scale"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: ["secrets-store.csi.x-k8s.io"]
+    resources: ["secretproviderclasses"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hosting-operator
+subjects:
+  - kind: ServiceAccount
+    name: hosting-operator
+    namespace: memex-ops
+roleRef:
+  kind: ClusterRole
+  name: hosting-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/aks/manifests/hosting-operator/operator-serviceaccount.yaml
+++ b/deploy/aks/manifests/hosting-operator/operator-serviceaccount.yaml
@@ -1,0 +1,17 @@
+# The Job's identity — the powerful one. Federated to the `hosting-operator` user-assigned managed
+# identity from backups.bicep, so an operator Job reaches Azure with NO key on disk.
+#
+# 🚨 The federated subject is `system:serviceaccount:memex-ops:hosting-operator`. If you rename the
+# namespace or this ServiceAccount, the federation in backups.bicep must change with it — a
+# mismatch fails the token exchange at run time with an error that names neither file.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hosting-operator
+  namespace: memex-ops
+  annotations:
+    # Replace with backups.bicep's `operatorIdentityClientId` output.
+    azure.workload.identity/client-id: "<operatorIdentityClientId>"
+  labels:
+    azure.workload.identity/use: "true"
+    app.kubernetes.io/managed-by: meshweaver-hosting

--- a/deploy/aks/operator/Dockerfile
+++ b/deploy/aks/operator/Dockerfile
@@ -1,0 +1,31 @@
+# The hosting operator image: what an instance lifecycle run executes.
+#
+# It carries az + kubectl + helm + the PostgreSQL client, because a lifecycle run legitimately
+# needs all four and the portal image carries none of them. That is the honest reason the run
+# happens in a Job rather than in the portal process — and the useful one: the Job is a separate,
+# short-lived identity whose credential nothing long-running holds.
+FROM mcr.microsoft.com/azure-cli:2.77.0
+
+ARG KUBECTL_VERSION=v1.31.4
+ARG HELM_VERSION=v3.16.3
+
+# postgresql17-client gives pg_dump/pg_restore/psql. The MAJOR version must be >= the server's, or
+# pg_dump refuses with "server version mismatch" — bump this when the fleet's server moves.
+RUN apk add --no-cache postgresql17-client bash curl coreutils jq \
+ && curl -fsSLo /usr/local/bin/kubectl \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+ && chmod +x /usr/local/bin/kubectl \
+ && curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
+      | tar -xz -C /tmp linux-amd64/helm \
+ && mv /tmp/linux-amd64/helm /usr/local/bin/helm \
+ && rm -rf /tmp/linux-amd64
+
+COPY bin/ /opt/hosting/bin/
+RUN chmod +x /opt/hosting/bin/* && ln -s /opt/hosting/bin/hosting-* /usr/local/bin/
+
+# Non-root. Nothing here needs to be root, and a container that can delete namespaces should not
+# also be able to do whatever a root process on a node could.
+RUN adduser -D -u 1654 operator
+USER 1654
+
+ENTRYPOINT ["/bin/bash", "/opt/hosting/bin/run.sh"]


### PR DESCRIPTION
The cluster half of the Hosting plugin's instance lifecycle (Systemorph/MeshWeaver.Plugins#513). The mesh decides and orders; a short-lived Job executes.

## Why a Job and not the portal process

The portal runs AI CLIs in-pod, so a credential that can delete a namespace must not live there. Three principals instead of one:

| Principal | Power | Lifetime |
|---|---|---|
| `memex-portal-sa` | `get`/`patch` its own Deployment — the self-updater's needs, **unchanged** | the pod |
| `hosting-jobrunner` (a token mounted into the portal) | create a Job in `memex-ops`, read its log. Nothing else. | the pod |
| `hosting-operator` (the Job's SA) | namespaces, releases, ingresses; via Workload Identity the Azure control plane | the seconds a run takes |

This is the identity boundary `/deployment-activity` asks for, realised without widening the portal's Role.

## What ships

- **`infra/modules/backups.bicep`** — a ZRS account + `db-backups` container for **logical** dumps. Deliberately not `storage.bicep`: that serves pgBackRest's WAL/PITR archive for the in-cluster Postgres, and after a database on the shared Flexible Server is *dropped*, server-level PITR cannot bring it back. Shared-key auth is disabled, so every access is attributable. Plus the `hosting-operator` identity, federated to exactly one ServiceAccount in one namespace.
- **`manifests/hosting-operator/`** — the three-principal RBAC.
- **`operator/`** — the image (az + kubectl + helm + pg client) and the step scripts.
- **`INSTANCE-LIFECYCLE.md`** — how to deploy it and what the scripts guarantee.

## The guarantees, each of which is a way a "successful" run is not

- `hosting-backup` **never** claims verification. `hosting-verify-backup` is the only thing that emits `verified=true`, and only after downloading the archive and parsing a non-zero table count out of its table of contents. A truncated upload exits zero; an empty database dumps perfectly.
- `run.sh` stops at the first failure and the Job's `backoffLimit` is `0` — a half-finished teardown is never retried from the top, over a verified archive.
- `hosting-kv-ensure` never overwrites an existing master key; regenerating it makes every stored `enc:` value in that instance's database unreadable.
- `hosting-export` never prints the URL it mints — a user-delegation SAS is a bearer credential, so it is handed over in a one-shot Secret the mesh reads once and deletes.
- The suspension redirect is an **Ingress annotation, not a DNS change**: the A-record already points at the shared ingress IP and the namespace's TLS secret keeps serving, so a suspended customer meets a page rather than a browser warning. It is a **302** — a 301 would be cached past the reactivation.

## Notes

Infra + scripts + markdown only; no application code and no CI workflow changes. `az bicep build` compiles clean; every script passes `bash -n`.

Found while writing these, and documented in the runbook: **an apostrophe inside `${VAR:?message}` is a bash parse error** — the shell opens a single-quoted string inside the expansion and the script dies at load with an EOF pointing at the last line.