### PR TITLE
fix: an impersonation scope no longer latches onto the thread that opened it (#1790)

### DIFF
--- a/src/MeshWeaver.Blazor/BlazorView.razor.cs
+++ b/src/MeshWeaver.Blazor/BlazorView.razor.cs
@@ -605,23 +605,17 @@ public class BlazorView<TViewModel, TView> : ComponentBase, IAsyncDisposable
     /// Runs <paramref name="source"/> with the durable circuit user (<see cref="ResolveCircuitUser"/>)
     /// re-established on the HUB <see cref="AccessService"/> — the SAME instance <c>Hub.GetQuery</c> /
     /// <c>Hub.GetMeshNodeStream(path).Update()</c> read to attribute reads/writes. The identity is
-    /// resolved and switched at SUBSCRIBE (inside the <c>Observable.Using</c> resource factory) and held
-    /// for the whole subscription, so the synced-query / IIoPool hops the source fans out across all
-    /// carry it. Use to wrap any mesh READ a view subscribes after an Rx hop (picker, skill, completions).
+    /// resolved and switched at SUBSCRIBE (the <c>RunAs</c> resolver overload runs on the subscribing
+    /// thread) and held across the whole synchronous Subscribe, so the synced-query / IIoPool hops the
+    /// source fans out across capture it. Use to wrap any mesh READ a view subscribes after an Rx hop
+    /// (picker, skill, completions).
+    ///
+    /// <para>🚨 <c>RunAs</c>, never <c>Observable.Using</c> (#1790): the latter disposes the scope on
+    /// whichever thread the source terminates, which leaves the circuit's own thread switched to the
+    /// resolved user indefinitely and writes that thread's previous identity onto a foreign one.</para>
     /// </summary>
     protected IObservable<T> RunUnderCircuitUser<T>(IObservable<T> source)
-    {
-        var hubAccess = Hub.ServiceProvider.GetService<AccessService>();
-        return Observable.Using(
-            () =>
-            {
-                var user = ResolveCircuitUser();
-                return user is not null && hubAccess is not null
-                    ? hubAccess.SwitchAccessContext(user)
-                    : (IDisposable)System.Reactive.Disposables.Disposable.Empty;
-            },
-            _ => source);
-    }
+        => Hub.ServiceProvider.GetService<AccessService>().RunAs(ResolveCircuitUser, () => source);
 
     /// <summary>
     /// Writes the mesh node at <paramref name="path"/> under the durable circuit user. Use from deferred

--- a/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
@@ -397,12 +397,20 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
         // the user resolves as ANONYMOUS → RLS returns empty → blank "portal is down" for every
         // authenticated user (chronic token-forwarding failure, prod 2026-06-18). Run it as System
         // (Permission.All — NOT ImpersonateAsHub, whose hub address has no Read on the token node).
-        // Observable.Using holds the impersonation across the cold Observe's Subscribe.
+        //
+        // 🚨 RunAsSystem, never Observable.Using (#1790). The impersonation is DELIBERATE and stays
+        // — what must not stay is the AsyncLocal write. Observable.Using opens the scope on the
+        // SUBSCRIBING thread, which here is the ASP.NET REQUEST thread (InvokeAsync subscribes this
+        // through .ToTask()), and disposes it when the ApiToken hub answers — a different thread.
+        // The request thread was therefore left holding `system-security` for the rest of the
+        // pipeline: the `existing.Email == userContext.Email` reuse branch just below reads that
+        // latched context, so a token whose record carries no email matched the System context's
+        // null email and the whole request ran with Permission.All. RunAsSystem keeps the scope
+        // across the cold Observe's Subscribe (where the post is stamped) and leaves it on the way
+        // out of that same Subscribe.
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        return Observable.Using<ValidateTokenResponse?, IDisposable>(
-                () => accessService?.ImpersonateAsSystem()
-                      ?? System.Reactive.Disposables.Disposable.Empty,
-                _ => hub.Observe(
+        return accessService.RunAsSystem(
+                () => hub.Observe(
                         new ValidateTokenRequest(rawToken),
                         o => o.WithTarget(tokenAddress))
                     .Select(d => (ValidateTokenResponse?)d.Message))

--- a/src/MeshWeaver.Blazor/Services/BlazorAutocompleteService.cs
+++ b/src/MeshWeaver.Blazor/Services/BlazorAutocompleteService.cs
@@ -1,4 +1,3 @@
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Blazor.Components.Monaco;
 using MeshWeaver.Blazor.Infrastructure;
@@ -81,22 +80,19 @@ public class BlazorAutocompleteService(
     /// <summary>
     /// Subscribes <paramref name="source"/> with the durable circuit user re-established on the HUB
     /// <see cref="AccessService"/> (the same singleton the mesh query's RLS reads). The identity is
-    /// switched at SUBSCRIBE and held for the whole subscription via <see cref="Observable.Using{TResult,TResource}(System.Func{TResource},System.Func{TResource,System.IObservable{TResult}})"/>, so
-    /// every IIoPool / synced-query hop the query fans out across carries it. Mirrors
+    /// resolved and switched at SUBSCRIBE and held across the whole synchronous Subscribe via
+    /// <see cref="ImpersonationScopeExtensions.RunAs{T}(MeshWeaver.Messaging.AccessService?,System.Func{MeshWeaver.Messaging.AccessContext?},System.Func{System.IObservable{T}})"/>,
+    /// so every IIoPool / synced-query hop the query fans out across captures it. Mirrors
     /// <c>BlazorView.RunUnderCircuitUser</c> for the shared (non-component) autocomplete service.
+    ///
+    /// <para>🚨 <c>RunAs</c>, never <c>Observable.Using</c> (#1790): the latter disposes the scope on
+    /// whichever thread the query terminates, leaving this thread switched to the resolved user and
+    /// writing its previous identity onto a foreign one.</para>
     /// </summary>
     private IObservable<T> RunUnderCircuitUser<T>(IObservable<T> source)
     {
         var hubAccess = portalApplication.Hub.ServiceProvider.GetService<AccessService>();
-        return Observable.Using(
-            () =>
-            {
-                var user = ResolveCircuitUser(hubAccess);
-                return user is not null && hubAccess is not null
-                    ? hubAccess.SwitchAccessContext(user)
-                    : (IDisposable)Disposable.Empty;
-            },
-            _ => source);
+        return hubAccess.RunAs(() => ResolveCircuitUser(hubAccess), () => source);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessContextPropagation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessContextPropagation.md
@@ -372,9 +372,9 @@ A `SynchronizationStream.OnNext` that unconditionally stamps `ImpersonateAsHub(H
 
 ### 🚨 An impersonation scope must not ESCAPE the operation it was opened for
 
-`accessService.RunAsSystem(work)` — **not** a hand-written `Observable.Using(access.ImpersonateAsSystem, _ => work)` — wherever the scoped observable is **returned to a caller**.
+`accessService.RunAsSystem(work)` — **not** a hand-written `Observable.Using(access.ImpersonateAsSystem, _ => work)` — at **every** site, whether the scoped observable is returned to a caller or subscribed on the spot.
 
-The hand-written idiom is correct for the work itself and leaks everywhere after it:
+The hand-written idiom is correct for the work itself and leaks in two directions at once — forwards onto what the subscriber composes, and BACKWARDS onto the thread that subscribed:
 
 ```csharp
 // ❌ the scope escapes: Rx forwards OnNext to the subscriber BEFORE Using disposes its resource,
@@ -392,11 +392,33 @@ Because those primitives also **re-stamp** the captured identity around their ow
 
 **It is an authorization concern, not only an audit one.** `AccessControlPipeline.HandleGetPermission` carries the scar: `SecurityService`'s bootstrap-time system scope leaked past its using-block onto the action-block thread, and trusting the ambient there returned `Permission.All` for **every** caller, anonymous included. That call site defends itself by resolving the identity explicitly; `RunAsSystem` fixes the class at the source so the next one does not have to know Rx's disposal order.
 
+#### …and the other direction: the SUBSCRIBING thread keeps the identity (#1790)
+
+Impersonation is an `AsyncLocal` store/restore pair, so both halves must land on ONE logical flow. `Observable.Using` runs its resource factory on the **subscribing** thread and disposes the resource when the inner observable **terminates** — for a cross-hub request/response, the owning hub's response thread. Nothing ever disposes it on the subscriber, so:
+
+```csharp
+// ❌ opens on THIS thread, closes on the hub's response thread
+Observable.Using(access.ImpersonateAsSystem, _ => hub.Observe(request)).Subscribe(...);
+// …everything after this line on this thread runs as system-security
+```
+
+Measured consequences, all silent:
+
+- **The auth bootstrap.** `UserContextMiddleware.ValidateTokenViaHub` subscribes on the ASP.NET **request** thread. The latch left the request running with `Permission.All`, and `InvokeAsync`'s `existing.Email == userContext.Email` reuse branch then adopted the System context as the caller's own.
+- **A script run.** `ActivityLogLogger`'s first publish is issued from the script's own thread; the latch made the rest of the script System, and a `--render` export resolved embedded areas the submitting user may not read.
+
+`RunAsSystem` / `RunAsHub` / `RunAs` open the scope at Subscribe and close it on the way **out of that same Subscribe**. That still covers the work: everything a cold pipeline does eagerly happens inside `Subscribe` — the factory runs, the primitives eager-capture the identity, the post is stamped, and any scheduled continuation captures the `ExecutionContext` as it stands right then. A captured `ExecutionContext` is an immutable snapshot, so restoring the subscribing flow afterwards cannot un-elevate work already scheduled.
+
+🚨 `ContainIdentity` does **not** close this half — it restores around NOTIFICATIONS, never around the Subscribe that opened the scope. Where the capture is genuinely synchronous, a plain `using` around the call **and its `Subscribe`** is equally correct (`ActivityLogLogger`).
+
+The second half of the leak — the caller's *previous* identity being written onto the terminating thread, which is an identity **injection** into a hub action block, not a cleanup — is closed inside `AccessService` itself: a scope's restore is thread-affine, so a dispose on a flow that never carried its store writes nothing. `ImpersonationScopeSiteRatchetGuard` + `test/ImpersonationScopeSites.allow` keep the inventory of sites still written the old way from growing.
+
 | API | Use it for |
 |---|---|
-| `access.RunAsSystem(work)` | A system read/write whose result a caller composes on. Enters the scope at Subscribe (so the cold work is covered), delivers every notification under the **subscriber's** identity. |
+| `access.RunAsSystem(work)` | A system read/write, returned to a caller or subscribed on the spot. Enters the scope at Subscribe (so the cold work is covered), LEAVES it on the way out of that Subscribe, and delivers every notification under the **subscriber's** identity. |
 | `access.RunAsHub(hub, work)` | The same seal for a hub identity. |
-| `source.ContainIdentity(access)` | Sealing an **already-composed** chain — several system calls where the caller builds on the LAST one's emission. |
+| `access.RunAs(identity, work)` / `access.RunAs(resolver, work)` | The same seal for an explicit identity the caller carries — an export rendering as the requesting user, a Blazor view re-establishing the durable circuit user. The resolver overload reads the identity on the subscribing thread. |
+| `source.ContainIdentity(access)` | Sealing an **already-composed** chain — several system calls where the caller builds on the LAST one's emission. Forward direction only. |
 
 🚨 **It never invents an identity.** What is restored is exactly what was ambient at Subscribe: a real user for a user-driven flow, `system-security` for a genuinely system-initiated one, and **nothing at all** when the subscriber had no identity — so a background worker that never had a user is not fail-closed by adopting it. The only behaviour that changes is the defect: a caller who *had* an identity, silently continuing as System.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-privileged-work-hands-your-identity-back.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-privileged-work-hands-your-identity-back.md
@@ -1,0 +1,30 @@
+---
+Name: Privileged work hands your identity back
+Category: Fix
+Description: Sign-in, page routing, installs and invitations briefly run with system rights; those rights no longer stay behind on the thread that asked for them.
+Icon: ShieldKeyhole
+Order: -20260818
+---
+
+# Privileged work hands your identity back
+
+Some steps genuinely have to run as the system rather than as you. Checking an API token is the
+clearest example: it is what turns a token into an identity, so at the moment it runs there is no
+identity yet to run as. The same is true of resolving which page a URL points at, installing a
+package into a shared catalogue, or writing an invitation into somebody else's space.
+
+Those steps were switching to the system account correctly — and then leaving it switched on. The
+switch was released when the privileged work *finished*, which happens on a different thread from
+the one that started it, so the thread that asked was left holding system rights for everything it
+did next. For a signed-in request that meant the rest of the request ran with more rights than the
+person had; in one path a token that carried no e-mail address could even be adopted as the
+caller's own identity for the remainder of the request.
+
+The same mismatch worked in the other direction too: the release wrote the *asking* user's identity
+onto whichever background thread happened to finish the work, handing a shared worker a principal
+that had nothing to do with what it was processing.
+
+Both halves are closed. A privileged step now covers exactly the work it was opened for and returns
+the calling thread to the identity it had, and a release can no longer take effect anywhere the
+switch was never applied. Nothing about who may do what has changed — token validation, routing,
+installs and invitations still run with the rights they need — only how far those rights travel.

--- a/src/MeshWeaver.Graph/Configuration/ApiTokenNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ApiTokenNodeType.cs
@@ -104,11 +104,17 @@ public static class ApiTokenNodeType
         // ApiToken node) and the validator would return "Token not found" for
         // every request. The hash-compare further down is the actual
         // authentication step; the System scope only covers this one read.
+        //
+        // 🚨 RunAsSystem, never Observable.Using (#1790). This handler runs ON the ApiToken hub's
+        // action block; Observable.Using would open the System scope on that thread and dispose it
+        // on whichever thread the cross-hub read terminates, leaving the action block holding
+        // `system-security` and the responder holding a foreign "previous". RunAsSystem opens and
+        // closes the scope inside one synchronous Subscribe — the whole composition below sits
+        // INSIDE the work factory, so nothing about the emission-time behaviour changes.
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
         var hubAddress = hub.Address.ToString();
-        Observable.Using(
-            () => accessService.ImpersonateAsSystem(),
-            _ => hub.GetMeshNode(hubAddress, TimeSpan.FromSeconds(10)))
+        accessService.RunAsSystem(
+            () => hub.GetMeshNode(hubAddress, TimeSpan.FromSeconds(10))
             .SelectMany(node =>
             {
                 if (node == null)
@@ -130,14 +136,13 @@ public static class ApiTokenNodeType
 
                     // Cross-hub one-shot read for the actual token node — GetDataRequest
                     // routes to the owning per-node hub via the mesh. Re-impersonate
-                    // as System for this read too: the AsyncLocal context that the
-                    // outer Observable.Using set may not be alive when the SelectMany
-                    // continuation re-subscribes downstream, and the actual token
-                    // node sits at "{userId}/ApiToken/{hashPrefix}" which RLS gates
-                    // on the owning user's identity.
-                    tokenNodeObs = Observable.Using(
-                        () => accessService.ImpersonateAsSystem(),
-                        _ => hub.GetMeshNode(index.TokenPath, TimeSpan.FromSeconds(10)));
+                    // as System for this read too: the AsyncLocal context the OUTER
+                    // scope set is not alive on the thread this SelectMany continuation
+                    // re-subscribes from, and the actual token node sits at
+                    // "{userId}/ApiToken/{hashPrefix}" which RLS gates on the owning
+                    // user's identity.
+                    tokenNodeObs = accessService.RunAsSystem(
+                        () => hub.GetMeshNode(index.TokenPath, TimeSpan.FromSeconds(10)));
                 }
                 else
                 {
@@ -183,7 +188,7 @@ public static class ApiTokenNodeType
                     hub.Post(response, o => o.ResponseFor(request));
                     return Unit.Default;
                 });
-            })
+            }))
             .Subscribe(
                 _ => { },
                 // A THROWN fault (GetMeshNode timeout, storage error, routing failure) means the

--- a/src/MeshWeaver.Graph/GroupInviteExtensions.cs
+++ b/src/MeshWeaver.Graph/GroupInviteExtensions.cs
@@ -212,9 +212,14 @@ public static class GroupInviteExtensions
 
         // Both writes land in the Admin partition → system identity, constructed inside the scope. Both are
         // upserts keyed by a deterministic id/slug, so a re-invite overwrites rather than duplicating.
-        return Observable.Using(accessService.ImpersonateAsSystem, _ => Observable.Defer(() =>
+        // 🚨 RunAsSystem, never Observable.Using (#1790): impersonation is an AsyncLocal
+        // store/restore pair, and Observable.Using splits the two across threads — the caller who
+        // subscribes is left running as System, and the write's terminating thread is handed the
+        // caller's identity. RunAsSystem opens the scope across the cold writes' Subscribe (where
+        // each eager-captures its identity) and closes it on the way out of that same Subscribe.
+        return accessService.RunAsSystem(() =>
                 EventSubscriptionOps.CreateSubscription(meshService, subscription)
-                    .SelectMany(_ => meshService.CreateOrUpdateNode(invitation))))
+                    .SelectMany(_ => meshService.CreateOrUpdateNode(invitation)))
             .Select(_ => GroupInviteOutcome.Invited);
     }
 

--- a/src/MeshWeaver.Graph/NotificationService.cs
+++ b/src/MeshWeaver.Graph/NotificationService.cs
@@ -108,9 +108,13 @@ public static class NotificationService
         var access = hub.ServiceProvider.GetRequiredService<AccessService>();
         var category = type.ToCategory();
 
-        return Observable.Using(
-            access.ImpersonateAsSystem,
-            _ => ReadSettings(hub, recipient).SelectMany(settings =>
+        // 🚨 RunAsSystem, never Observable.Using (#1790): impersonation is an AsyncLocal
+        // store/restore pair, and Observable.Using splits the two across threads — the caller who
+        // subscribes is left running as System, and the write's terminating thread is handed the
+        // caller's identity. RunAsSystem opens the scope across the cold writes' Subscribe (where
+        // each eager-captures its identity) and closes it on the way out of that same Subscribe.
+        return access.RunAsSystem(
+            () => ReadSettings(hub, recipient).SelectMany(settings =>
             {
                 // The two channels are independent — isolate each with Catch so a transient email
                 // fault can't suppress the bell write (or vice versa).

--- a/src/MeshWeaver.Graph/SpaceInviteService.cs
+++ b/src/MeshWeaver.Graph/SpaceInviteService.cs
@@ -121,9 +121,14 @@ public sealed class SpaceInviteService(
         // Both writes land in the Admin partition → system identity, constructed inside the scope.
         // Both are upserts keyed by a deterministic id/slug, so a re-invite overwrites rather than
         // duplicating. The existing InvitationEmailSender emails the Pending invitation.
-        return Observable.Using(accessService.ImpersonateAsSystem, _ => Observable.Defer(() =>
+        // 🚨 RunAsSystem, never Observable.Using (#1790): impersonation is an AsyncLocal
+        // store/restore pair, and Observable.Using splits the two across threads — the caller who
+        // subscribes is left running as System, and the write's terminating thread is handed the
+        // caller's identity. RunAsSystem opens the scope across the cold writes' Subscribe (where
+        // each eager-captures its identity) and closes it on the way out of that same Subscribe.
+        return accessService.RunAsSystem(() =>
                 EventSubscriptionOps.CreateSubscription(meshService, subscription)
-                    .SelectMany(_ => meshService.CreateOrUpdateNode(invitation))))
+                    .SelectMany(_ => meshService.CreateOrUpdateNode(invitation)))
             .Select(_ =>
             {
                 logger?.LogInformation("Invited {Email} to {Space} ({Role}); grant scheduled on sign-up", email, spacePath, role);

--- a/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
@@ -190,12 +190,16 @@ public sealed class GrpcConnectionRegistry : IDisposable, IParticipantPresence
         }
 
         var tokenAddress = new Address("ApiToken", ValidateTokenRequest.HashToken(rawToken)[..12]);
-        return Observable.Using(
+        return accessService.RunAsSystem(
+                // 🚨 RunAsSystem, never Observable.Using (#1790): the impersonation is an AsyncLocal
+                // scope, and Observable.Using opens it on the SUBSCRIBING thread while disposing it
+                // on whichever thread the inner observable terminates. RunAsSystem opens and closes
+                // it inside one synchronous Subscribe, so the handshake thread is not left holding
+                // `system-security` and the responding thread is handed no foreign "previous".
                 // Token validation is the auth bootstrap — it runs BEFORE any identity exists, so it
                 // must run as System (Permission.All) or the never-null guard fail-closes the post.
-                () => accessService.ImpersonateAsSystem(),
                 // 🚨 Issued on the transport's PORTAL hub, never on the root mesh hub — see TransportHub.
-                _ => TransportHub.Observe(new ValidateTokenRequest(rawToken), o => o.WithTarget(tokenAddress))
+                () => TransportHub.Observe(new ValidateTokenRequest(rawToken), o => o.WithTarget(tokenAddress))
                         .Select(d => d.Message as ValidateTokenResponse))
             .Take(1)
             // Completed-empty = the request produced NO verdict at all (unroutable ApiToken hub) —

--- a/src/MeshWeaver.Hosting.SignalR/SignalRConnectionRegistry.cs
+++ b/src/MeshWeaver.Hosting.SignalR/SignalRConnectionRegistry.cs
@@ -120,12 +120,16 @@ public sealed class SignalRConnectionRegistry : IDisposable
         }
 
         var tokenAddress = new Address("ApiToken", ValidateTokenRequest.HashToken(rawToken)[..12]);
-        return Observable.Using(
+        return accessService.RunAsSystem(
+                // 🚨 RunAsSystem, never Observable.Using (#1790): the impersonation is an AsyncLocal
+                // scope, and Observable.Using opens it on the SUBSCRIBING thread while disposing it
+                // on whichever thread the inner observable terminates. RunAsSystem opens and closes
+                // it inside one synchronous Subscribe, so the handshake thread is not left holding
+                // `system-security` and the responding thread is handed no foreign "previous".
                 // Token validation is the auth bootstrap — it runs BEFORE any identity exists, so it
                 // must run as System (Permission.All) or the never-null guard fail-closes the post.
-                () => accessService.ImpersonateAsSystem(),
                 // 🚨 Issued on the transport's PORTAL hub, never on the root mesh hub — see TransportHub.
-                _ => TransportHub.Observe(new ValidateTokenRequest(rawToken), o => o.WithTarget(tokenAddress))
+                () => TransportHub.Observe(new ValidateTokenRequest(rawToken), o => o.WithTarget(tokenAddress))
                         .Select(d => d.Message as ValidateTokenResponse))
             .Take(1)
             // Completed-empty = the request produced NO verdict at all (unroutable ApiToken hub) —

--- a/src/MeshWeaver.Hosting/PathResolutionService.cs
+++ b/src/MeshWeaver.Hosting/PathResolutionService.cs
@@ -592,20 +592,25 @@ internal class PathResolutionService : IPathResolver, IDisposable
             UserId = WellKnownUsers.System,
         };
 
-        // Observable.Using ensures the ImpersonateAsSystem scope is opened on
-        // Subscribe AND disposed when the inner observable completes — keeping
-        // the AsyncLocal Context = system-security alive for the lifetime of
-        // the query (the PG provider may capture context lazily on its first
-        // emission, well past the chaining call).
+        // RunAsSystem opens the ImpersonateAsSystem scope on Subscribe — so the query is ISSUED
+        // as system-security, and any ExecutionContext the provider captures while subscribing
+        // (an IIoPool hop, a scheduled continuation) carries that identity forward as an
+        // immutable snapshot — and closes it again on the way out of that same Subscribe.
+        //
+        // 🚨 Never Observable.Using here (#1790). This is the hot path of EVERY page load, called
+        // from the caller's own thread; Observable.Using would leave `system-security` latched on
+        // it (the query terminates on a storage/pool thread, which is where it would dispose) and
+        // hand that thread the caller's "previous" identity. A resolver on the render path must
+        // hand back the thread exactly as it found it.
+        //
         // Routing is a SIMPLE PATH LOOKUP — never a synced subscription.
         // We take only the FIRST emission (the Initial snapshot of which path
         // prefixes exist) and dispose. No fan-out, no ongoing watching, no
         // change deltas. If the resolver later needs to track new nodes, the
         // caller re-asks; the cache that wraps this method invalidates on
         // CreateNode/DeleteNode events.
-        return Observable.Using(
-            () => _accessService?.ImpersonateAsSystem() ?? System.Reactive.Disposables.Disposable.Empty,
-            _ => _queryCore.Query<MeshNode>(request, _hub.JsonSerializerOptions))
+        return _accessService.RunAsSystem(
+            () => _queryCore.Query<MeshNode>(request, _hub.JsonSerializerOptions))
             .Where(change => change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
             .Take(1)
             .Select<QueryResultChange<MeshNode>, AddressResolution?>(change =>

--- a/src/MeshWeaver.Markdown.Export/Html/LayoutAreaResolver.cs
+++ b/src/MeshWeaver.Markdown.Export/Html/LayoutAreaResolver.cs
@@ -1,4 +1,3 @@
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
 using HtmlAgilityPack;
@@ -182,19 +181,25 @@ public static class LayoutAreaResolver
         IMessageHub hub,
         DocumentHtmlOptions options,
         AccessContext? caller)
-        // 🚨 Observable.Using, NOT Defer + `using var`. With `using var` the caller scope is
-        // disposed when the FACTORY returns — before anything subscribes to the observable it
-        // built — so the area stream was created under the caller's identity but SUBSCRIBED and
-        // rendered without it. That is the bug shape AccessContextPropagation.md is about: the
-        // owner's read gate is evaluated on the subscription, so a caller denied the embedded
-        // content could have received it in their export (and the notice text would resolve in the
-        // wrong language). Observable.Using ties the scope to the SUBSCRIPTION's lifetime instead.
-        => Observable.Using(
-            () => (caller is not null
-                       ? hub.ServiceProvider.GetService<AccessService>()?.SwitchAccessContext(caller)
-                       : null)
-                  ?? Disposable.Empty,
-            _ =>
+        // 🚨 RunAs, NOT Defer + `using var`, and NOT Observable.Using.
+        //
+        // With `using var` the caller scope would be disposed when the FACTORY returns — before
+        // anything subscribes to the observable it built — so the area stream would be created
+        // under the caller's identity but SUBSCRIBED and rendered without it. That is the bug shape
+        // AccessContextPropagation.md is about: the owner's read gate is evaluated on the
+        // subscription, so a caller denied the embedded content could have received it in their
+        // export (and the notice text would resolve in the wrong language).
+        //
+        // Observable.Using ties the scope to the SUBSCRIPTION's lifetime, which covers the read
+        // gate — but it opens the scope on the SUBSCRIBING thread and disposes it on whichever
+        // thread the render terminates (#1790), latching the caller onto the export thread and
+        // writing its "previous" identity onto a foreign one. RunAs keeps the scope across the
+        // whole synchronous Subscribe — the stream is created AND subscribed inside it, and any
+        // ExecutionContext the render captures there carries the identity onward — and leaves it
+        // on the way out.
+        => hub.ServiceProvider.GetService<AccessService>().RunAs(
+            caller,
+            () =>
             {
                 var reference = new LayoutAreaReference(target.Area) { Id = target.Id ?? string.Empty };
                 var stream = hub.GetWorkspace()

--- a/src/MeshWeaver.Messaging.Hub/AccessService.cs
+++ b/src/MeshWeaver.Messaging.Hub/AccessService.cs
@@ -38,6 +38,22 @@ public class AccessService
     private readonly AsyncLocal<AccessContext?> context = new();
 
     /// <summary>
+    /// Marks WHICH <see cref="AccessContextScope"/> most recently wrote <see cref="context"/> on
+    /// the current logical flow. It exists so a scope can tell "I am the value that is installed
+    /// here" from "this is somebody else's thread", and it is an <c>AsyncLocal</c> for exactly the
+    /// same reason <see cref="context"/> is: it must travel with an <c>await</c> continuation and
+    /// must NOT travel to an unrelated thread.
+    ///
+    /// <para>🚨 This is what makes <see cref="AccessContextScope.Dispose"/> thread-affine — see the
+    /// remarks there. Without it, a scope opened on one thread and disposed on another WRITES the
+    /// first thread's "previous" identity into the second thread's context. That is not a lost
+    /// restore, it is an identity INJECTION: the disposing thread is typically a hub action block
+    /// or a transport handshake thread, and it is handed a principal that has nothing to do with
+    /// the message it is processing.</para>
+    /// </summary>
+    private readonly AsyncLocal<object?> scopeMarker = new();
+
+    /// <summary>
     /// Per-circuit user context, scoped via AsyncLocal.
     /// Set by CircuitAccessHandler at the start of each Blazor inbound activity
     /// and cleared in its finally block. This ensures each circuit's events
@@ -312,18 +328,67 @@ public class AccessService
         });
     }
 
+    /// <summary>
+    /// The store/restore pair behind <see cref="SwitchAccessContext"/>,
+    /// <see cref="ImpersonateAsHub"/> and <see cref="ImpersonateAsSystem"/>.
+    ///
+    /// <para>🚨 <b>The restore is THREAD-AFFINE, and that is the whole point.</b> Impersonation is
+    /// an <c>AsyncLocal</c> write: it mutates the CURRENT logical flow and nothing else. The
+    /// idiomatic reactive shape
+    /// <c>Observable.Using(access.ImpersonateAsSystem, _ =&gt; crossHubCall())</c> therefore splits
+    /// the pair across two threads — Rx runs the resource factory on the SUBSCRIBING thread and
+    /// disposes the resource when the inner observable TERMINATES, which for a cross-hub
+    /// request/response is the owning hub's response thread. An unconditional
+    /// <c>SetContext(previous)</c> in <see cref="Dispose"/> then writes the SUBSCRIBER's previous
+    /// identity onto a thread that never had it: a hub action block, a gRPC/SignalR handshake
+    /// thread, an ASP.NET request thread. Restoring an identity somewhere it was never installed
+    /// is an identity injection, not a cleanup.</para>
+    ///
+    /// <para>So the restore runs only where this scope's store is actually ours to undo:</para>
+    /// <list type="bullet">
+    ///   <item><description>the flow still carries our marker — the normal synchronous
+    ///   <c>using</c>, and an <c>await</c> continuation, whose ExecutionContext carries both the
+    ///   context and the marker forward; or</description></item>
+    ///   <item><description>we are back on the thread that opened the scope — which covers the
+    ///   case where a NESTED scope opened inside our block was never disposed (it overwrote the
+    ///   marker), and where <c>CarryAccessContext</c>'s per-callback scope must still clamp the
+    ///   thread back on the way out of a subscriber callback.</description></item>
+    /// </list>
+    ///
+    /// <para>Neither condition holds on a foreign terminating thread, so the write simply does not
+    /// happen there. Note what this does NOT fix: the SUBSCRIBING thread of the reactive shape is
+    /// still left holding the impersonated identity, because nothing disposes the scope on it. Only
+    /// the call site can close that half — see <c>ImpersonationScopeExtensions.RunAsSystem</c>,
+    /// which opens and closes the scope inside one synchronous <c>Subscribe</c>.</para>
+    /// </summary>
     private sealed class AccessContextScope : IDisposable
     {
         private readonly AccessService service;
         private readonly AccessContext? previousAsyncLocal;
+        private readonly object? previousMarker;
+        private readonly int openedOnThreadId;
 
         public AccessContextScope(AccessService service, AccessContext? newContext)
         {
             this.service = service;
             previousAsyncLocal = service.context.Value;
+            previousMarker = service.scopeMarker.Value;
+            openedOnThreadId = Environment.CurrentManagedThreadId;
+            service.scopeMarker.Value = this;
             service.SetContext(newContext);
         }
 
-        public void Dispose() => service.SetContext(previousAsyncLocal);
+        public void Dispose()
+        {
+            // Ours to undo? Either the flow still carries our marker, or we are back on the thread
+            // that opened it (a nested undisposed scope overwrote the marker — restoring is still
+            // correct there, and is what keeps the per-callback clamp honest).
+            if (!ReferenceEquals(service.scopeMarker.Value, this)
+                && openedOnThreadId != Environment.CurrentManagedThreadId)
+                return;
+
+            service.scopeMarker.Value = previousMarker;
+            service.SetContext(previousAsyncLocal);
+        }
     }
 }

--- a/src/MeshWeaver.Messaging.Hub/ImpersonationScopeExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/ImpersonationScopeExtensions.cs
@@ -4,9 +4,10 @@ namespace MeshWeaver.Messaging;
 
 /// <summary>
 /// 🚨 THE framework's impersonation boundary: a scope that <b>cannot escape the operation it was
-/// opened for</b>.
+/// opened for</b> — neither forwards, onto what the subscriber composes, nor backwards, onto the
+/// thread that subscribed.
 ///
-/// <para><b>The defect this closes (issue #1444).</b> The idiomatic system read/write is
+/// <para><b>The first defect this closes (issue #1444).</b> The idiomatic system read/write is
 /// <c>Observable.Using(() =&gt; access.ImpersonateAsSystem(), _ =&gt; work)</c>, and it is correct for
 /// <i>the work itself</i>. It is not self-contained. Rx forwards <c>OnNext</c> to the subscriber
 /// <b>before</b> <c>Using</c> disposes its resource, so everything the subscriber composes on that
@@ -17,35 +18,61 @@ namespace MeshWeaver.Messaging;
 /// so the System identity does not merely survive one hop — it is <b>re-acquired</b> at every hop
 /// after it.</para>
 ///
-/// <para><b>This is not hypothetical, and it has already reached an authorization decision.</b>
-/// <c>AccessControlPipeline.HandleGetPermission</c> carries a comment describing exactly this shape:
-/// <c>SecurityService</c>'s bootstrap-time <c>ImpersonateAsSystem</c> leaked past its using-block
-/// onto the action-block thread, and trusting the ambient there "returned <c>Permission.All</c> for
-/// every caller — including anonymous deliveries". That call site defends itself by resolving the
-/// identity explicitly instead of reading the ambient. This type fixes the same class at the SOURCE,
-/// so the next call site does not have to know Rx's disposal order to be safe.</para>
+/// <para><b>The second defect, and why <c>Observable.Using</c> is gone from here (issue #1790).</b>
+/// Impersonation is an <c>AsyncLocal</c> store/restore pair, so it must be opened and closed on ONE
+/// logical flow. <c>Observable.Using</c> opens it on the SUBSCRIBING thread and disposes it when the
+/// inner observable TERMINATES — for a cross-hub request/response, the owning hub's response thread.
+/// The two halves land on different threads: <b>the subscriber keeps <c>system-security</c>
+/// latched</b> for everything it does next, and the terminating thread is handed the subscriber's
+/// captured "previous" identity. <see cref="ContainIdentity{T}"/> does not close that half — it
+/// restores around NOTIFICATIONS, never around the <c>Subscribe</c> that opened the scope — which is
+/// why this type now opens and closes the scope inside one synchronous <c>Subscribe</c> instead.
+/// Measured, not reasoned: the seal in <c>ActivityLogLogger</c> latched System onto the script
+/// thread and a <c>--render</c> export then resolved embedded areas the submitting user may not
+/// read.</para>
 ///
-/// <para><b>What it does NOT do: invent an identity.</b> <see cref="ContainIdentity{T}"/> restores
-/// exactly what was ambient at Subscribe — a real user for a user-driven flow, <c>system-security</c>
-/// for a genuinely system-initiated one, and <b>nothing at all</b> when the subscriber had no
-/// identity. That last case is deliberate and is what makes adopting this safe at an existing call
-/// site: a background worker with no ambient context keeps whatever the framework leaves it (the
-/// documented <c>restoreNullCapture: false</c> behaviour of read pipelines), so the only behaviour
-/// that changes is the one the defect describes — a caller who HAD an identity, silently continuing
-/// as System.</para>
+/// <para><b>Why closing at the end of Subscribe still covers the work.</b> Everything a cold
+/// pipeline does eagerly happens INSIDE <c>Subscribe</c>: the factory runs, the framework primitives
+/// capture <see cref="AccessService.Context"/> at their call site, the post is stamped, and any
+/// scheduled continuation captures the ExecutionContext as it stands right then — impersonated. The
+/// restore afterwards mutates only the subscribing flow's own context; an ExecutionContext already
+/// captured is an immutable snapshot and keeps the System identity. So the work runs as System, and
+/// the caller's thread is handed back exactly what it had.</para>
+///
+/// <para><b>What it does NOT do: invent an identity.</b> The restore puts back exactly what was
+/// ambient at Subscribe — a real user for a user-driven flow, <c>system-security</c> for a genuinely
+/// system-initiated one, and <b>nothing at all</b> when the subscriber had no identity. That last
+/// case is deliberate and is what makes adopting this safe at an existing call site: a background
+/// worker with no ambient context keeps whatever the framework leaves it (the documented
+/// <c>restoreNullCapture: false</c> behaviour of read pipelines), so the only behaviour that changes
+/// is the one the defects describe.</para>
+///
+/// <para><b>Neither half is hypothetical, and one has already reached an authorization decision.</b>
+/// <c>AccessControlPipeline.HandleGetPermission</c> carries a comment describing exactly the first
+/// shape: <c>SecurityService</c>'s bootstrap-time <c>ImpersonateAsSystem</c> leaked past its
+/// using-block onto the action-block thread, and trusting the ambient there "returned
+/// <c>Permission.All</c> for every caller — including anonymous deliveries". That call site defends
+/// itself by resolving the identity explicitly instead of reading the ambient. This type fixes the
+/// class at the SOURCE, so the next call site does not have to know Rx's disposal order to be
+/// safe.</para>
 /// </summary>
 public static class ImpersonationScopeExtensions
 {
     /// <summary>
-    /// Runs <paramref name="work"/> under the well-known System identity with the scope SEALED: the
-    /// impersonation is entered at Subscribe (so the cold reads/writes the factory yields carry the
-    /// system context — the <c>Observable.Using</c>, never <c>Defer</c>-plus-<c>using</c>, rule),
-    /// and every notification that reaches the subscriber is delivered under the subscriber's OWN
-    /// identity, so nothing composed downstream inherits System.
+    /// Runs <paramref name="work"/> under the well-known System identity with the scope SEALED at
+    /// both ends: the impersonation is entered at Subscribe (so the cold reads/writes the factory
+    /// yields carry the system context), <b>left on the way out of that same Subscribe</b> (so the
+    /// subscribing thread is never latched — issue #1790), and every notification that reaches the
+    /// subscriber is delivered under the subscriber's OWN identity, so nothing composed downstream
+    /// inherits System (issue #1444).
     ///
     /// <para>Prefer this over a hand-written <c>Observable.Using(access.ImpersonateAsSystem, …)</c>
-    /// at every site that RETURNS the scoped observable to a caller — returning it is precisely what
-    /// turns a scope into an inheritance.</para>
+    /// at EVERY site — both the ones that return the scoped observable to a caller (returning it is
+    /// precisely what turns a scope into an inheritance) and the fire-and-forget
+    /// <c>….Subscribe(…)</c> ones (which is where the thread latch bites).</para>
+    ///
+    /// <para>Compose the WIDEST cold pipeline inside <paramref name="work"/>. Everything inside it
+    /// keeps today's emission-time behaviour exactly; the seal applies at the boundary only.</para>
     ///
     /// <para>A null <paramref name="access"/> (minimal test hosts) runs the work unimpersonated —
     /// deferred, so it stays cold.</para>
@@ -56,9 +83,7 @@ public static class ImpersonationScopeExtensions
     public static IObservable<T> RunAsSystem<T>(this AccessService? access, Func<IObservable<T>> work) =>
         access is null
             ? Observable.Defer(work)
-            : Observable
-                .Using(access.ImpersonateAsSystem, _ => Observable.Defer(work))
-                .ContainIdentity(access);
+            : new SubscribeScopedObservable<T>(access, access.ImpersonateAsSystem, work);
 
     /// <summary>
     /// Runs <paramref name="work"/> as <paramref name="hub"/>'s own identity, sealed exactly as
@@ -72,9 +97,48 @@ public static class ImpersonationScopeExtensions
         this AccessService? access, IMessageHub hub, Func<IObservable<T>> work) =>
         access is null
             ? Observable.Defer(work)
-            : Observable
-                .Using(() => access.ImpersonateAsHub(hub), _ => Observable.Defer(work))
-                .ContainIdentity(access);
+            : new SubscribeScopedObservable<T>(access, () => access.ImpersonateAsHub(hub), work);
+
+    /// <summary>
+    /// Runs <paramref name="work"/> as an EXPLICIT identity the caller has already resolved — the
+    /// <see cref="AccessService.SwitchAccessContext"/> shape — sealed exactly as
+    /// <see cref="RunAsSystem{T}"/> is.
+    ///
+    /// <para>Use it where the identity is a value the caller carries rather than System: an export
+    /// rendering an embedded area as the requesting user, a Blazor view re-establishing the durable
+    /// circuit user for a mesh read it subscribes after an Rx hop. A null
+    /// <paramref name="identity"/> runs the work unswitched (deferred, still cold) — nothing is
+    /// invented.</para>
+    /// </summary>
+    /// <typeparam name="T">What the scoped operation emits.</typeparam>
+    /// <param name="access">The access service, or null on a host without one.</param>
+    /// <param name="identity">The identity to run under; null runs the work unswitched.</param>
+    /// <param name="work">The cold operation to run under <paramref name="identity"/>.</param>
+    public static IObservable<T> RunAs<T>(
+        this AccessService? access, AccessContext? identity, Func<IObservable<T>> work) =>
+        access is null || identity is null
+            ? Observable.Defer(work)
+            : new SubscribeScopedObservable<T>(access, () => access.SwitchAccessContext(identity), work);
+
+    /// <summary>
+    /// The overload that resolves the identity AT SUBSCRIBE rather than at composition — for a
+    /// caller whose identity lives in an <c>AsyncLocal</c> that is only reliable on the subscribing
+    /// thread (<c>BlazorView.ResolveCircuitUser</c>). Same seal as
+    /// <see cref="RunAs{T}(MeshWeaver.Messaging.AccessService?,MeshWeaver.Messaging.AccessContext?,System.Func{System.IObservable{T}})"/>;
+    /// a resolver returning null runs the work unswitched.
+    /// </summary>
+    /// <typeparam name="T">What the scoped operation emits.</typeparam>
+    /// <param name="access">The access service, or null on a host without one.</param>
+    /// <param name="resolveIdentity">Resolves the identity on the subscribing thread; may return null.</param>
+    /// <param name="work">The cold operation to run under the resolved identity.</param>
+    public static IObservable<T> RunAs<T>(
+        this AccessService? access, Func<AccessContext?> resolveIdentity, Func<IObservable<T>> work) =>
+        access is null
+            ? Observable.Defer(work)
+            : new SubscribeScopedObservable<T>(
+                access,
+                () => resolveIdentity() is { } identity ? access.SwitchAccessContext(identity) : null,
+                work);
 
     /// <summary>
     /// Seals an ALREADY-COMPOSED <paramref name="source"/>: every notification is delivered to the
@@ -84,6 +148,12 @@ public static class ImpersonationScopeExtensions
     /// <para>Use this where the impersonated region is not one call — a chain of system writes whose
     /// LAST emission is what the caller composes on. Sealing the chain's boundary is what stops the
     /// caller inheriting it.</para>
+    ///
+    /// <para>🚨 It seals the FORWARD direction only. It opens no scope, so it has nothing to restore
+    /// on the subscribing thread — if the chain it wraps opens an impersonation with
+    /// <c>Observable.Using</c>, that thread stays latched. Use <see cref="RunAsSystem{T}"/> /
+    /// <see cref="RunAsHub{T}"/> / <see cref="RunAs{T}(MeshWeaver.Messaging.AccessService?,MeshWeaver.Messaging.AccessContext?,System.Func{System.IObservable{T}})"/>,
+    /// which own both ends.</para>
     ///
     /// <para>The restore is per-notification (entered on <c>OnNext</c>/<c>OnError</c>/
     /// <c>OnCompleted</c>, disposed as the callback returns), so nothing is left behind on the
@@ -109,6 +179,37 @@ public static class ImpersonationScopeExtensions
             return caller is null
                 ? source.Subscribe(observer)
                 : AccessContextCaptureExtensions.SubscribeRestoring(source, observer, access, caller);
+        }
+    }
+
+    /// <summary>
+    /// The seal itself: ONE synchronous <c>Subscribe</c> that opens the impersonation, composes and
+    /// subscribes the work inside it, and leaves it on the way out — on the same thread, always.
+    ///
+    /// <para>Deliberately NOT <c>Observable.Using</c>, which would defer the dispose to whichever
+    /// thread the inner observable terminates on (#1790). Deliberately not <c>Defer</c> + a plain
+    /// <c>using</c> around the factory either: that would close the scope before anything SUBSCRIBED
+    /// to what the factory built, so the read/write would be issued unimpersonated (the bug shape
+    /// <c>AccessContextPropagation.md</c> is about). Subscribe is the one boundary that is both — the
+    /// moment the cold work actually starts, and a synchronous call frame we own.</para>
+    /// </summary>
+    private sealed class SubscribeScopedObservable<T>(
+        AccessService access, Func<IDisposable?> openScope, Func<IObservable<T>> work) : IObservable<T>
+    {
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            // Read the caller BEFORE impersonating — this is the last moment the ambient context is
+            // reliably theirs, and it is what every notification is delivered under.
+            var caller = access.Context;
+            using (openScope())
+            {
+                var source = work();
+                // A null caller passes through unwrapped: clamping to null here would fail-close a
+                // background flow that never had a user. Same rule as ContainIdentity.
+                return caller is null
+                    ? source.Subscribe(observer)
+                    : AccessContextCaptureExtensions.SubscribeRestoring(source, observer, access, caller);
+            }
         }
     }
 }

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -467,7 +467,12 @@ public static class CatalogLayoutAreas
             .ToObservable()
             .Concat();
 
-        Observable.Using(() => accessService.ImpersonateAsSystem(), _ => install)
+        // 🚨 RunAsSystem, never Observable.Using (#1790). A click action subscribes on the Blazor
+        // circuit's own thread; Observable.Using would leave `system-security` latched there for
+        // everything the circuit does next, and hand the install's terminating thread the clicking
+        // user's identity. RunAsSystem opens the scope across the cold install's Subscribe — where
+        // every write eager-captures its identity — and closes it on the way out of it.
+        accessService.RunAsSystem(() => install)
             .Subscribe(
                 _ => { },
                 // The failing package is already named above; this records that the CLICK did not

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -2621,9 +2621,11 @@ public static class PackageInstaller
                 + "run as System because Plugins/_Policy denies it to every ordinary caller."));
 
         var recordPath = $"{InstalledPartition}/{packageId}";
-        return Observable.Using(
-                () => accessService.ImpersonateAsSystem(),
-                _ => meshService.DeleteNode(recordPath))
+        // 🚨 RunAsSystem, never Observable.Using (#1790) — and doubly so for a method that RETURNS
+        // the scoped observable: with Observable.Using the scope is opened on whatever thread the
+        // caller subscribes from and disposed on the delete's terminating thread, so the caller is
+        // left running as System and the terminating thread is handed the caller's identity.
+        return accessService.RunAsSystem(() => meshService.DeleteNode(recordPath))
             .Take(1)
             // DeleteNode faults on a missing node rather than answering false, so a value here IS a
             // removal — the caller's error path reports the absent-record case.

--- a/test/ImpersonationScopeSites.allow
+++ b/test/ImpersonationScopeSites.allow
@@ -1,0 +1,88 @@
+# ImpersonationScopeSites.allow — the identity-latch ratchet (#1790).
+#
+# Each line is a file that still opens an impersonation scope inside `Observable.Using`:
+#
+#     Observable.Using(() => access.ImpersonateAsSystem(), _ => work)
+#
+# Impersonation is an AsyncLocal store/restore pair. Rx runs the resource factory on the
+# SUBSCRIBING thread and disposes the resource when the inner observable TERMINATES — for a
+# cross-hub call, the owning hub's response thread. The subscriber is therefore left running as
+# the impersonated identity: an ASP.NET request that continues with Permission.All, a script run
+# that resolves areas its user may not read, a hub action block holding system-security.
+#
+# The second half of that leak — the caller's "previous" identity being written onto the
+# terminating thread — is closed inside AccessService itself (the scope's restore is thread-affine
+# now), so it does NOT need a per-site fix. What is left at each line below is the subscribing-
+# thread latch, and only the call site can close that.
+#
+# TO FIX A SITE:  access.RunAsSystem(() => work)  /  RunAsHub(hub, () => work)  /
+#                 RunAs(identity, () => work)     — ImpersonationScopeExtensions.
+#                 Put the WIDEST cold pipeline inside the work factory; the emission-time
+#                 behaviour is then unchanged and only the boundary is sealed.
+#                 Where the capture is genuinely synchronous, a plain `using` around the call AND
+#                 its Subscribe is equally correct (see ActivityLogLogger).
+#
+# 🚨 THIS LIST MAY ONLY SHRINK. Fixing a site means LOWERING or DELETING its line. A new file or a
+# raised count fails ImpersonationScopeSiteRatchetGuard — adding a line is not a fix.
+#
+# Scope: src/, memex/, tools/ (production code). test/ and samples/ are out of scope: a latch there
+# costs test isolation, not a user's permissions.
+#
+# format: <path>	<count>
+
+memex/Memex.Client/Prefs/PreferencesService.cs	2
+memex/Memex.Client/Services/DeviceOnboarding.cs	1
+memex/Memex.Portal.Shared/Api/SeoEndpoints.cs	1
+memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs	1
+memex/Memex.Portal.Shared/Authentication/BootstrapController.cs	1
+memex/Memex.Portal.Shared/Authentication/DevAuthController.cs	2
+memex/Memex.Portal.Shared/Authentication/InvitationService.cs	2
+memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs	3
+memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs	1
+memex/Memex.Portal.Shared/Authentication/UserOnboardingService.cs	3
+memex/Memex.Portal.Shared/Email/InvitationEmailSender.cs	2
+memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs	1
+memex/Memex.Portal.Shared/Models/ModelProviderService.cs	1
+memex/Memex.Portal.Shared/Pages/Onboarding.razor	1
+memex/Memex.Portal.Shared/Settings/InboxSettingsTab.cs	1
+src/MeshWeaver.AI.OpenAI/OpenAICompatibleModelSync.cs	1
+src/MeshWeaver.AI/ChatClientCredentialResolver.cs	2
+src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs	1
+src/MeshWeaver.GitSync/GitHubSyncService.cs	2
+src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs	4
+src/MeshWeaver.Graph/Configuration/CellSurfaceAssemblyProvider.cs	2
+src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs	2
+src/MeshWeaver.Graph/Configuration/NodeTypeCompilationActivity.cs	2
+src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs	3
+src/MeshWeaver.Graph/Configuration/NodeTypeCompileState.cs	1
+src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs	1
+src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs	1
+src/MeshWeaver.Graph/Configuration/PartitionDropPostDeletionHandler.cs	1
+src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs	1
+src/MeshWeaver.Graph/Configuration/WebhookEventNodeType.cs	1
+src/MeshWeaver.Graph/DeckSlidesCache.cs	1
+src/MeshWeaver.Graph/MeshDataSource.cs	1
+src/MeshWeaver.Graph/MeshNodeExtensions.cs	6
+src/MeshWeaver.Graph/NodeTypeReleaseExtensions.cs	1
+src/MeshWeaver.Graph/StaticRepoImporter.cs	1
+src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs	1
+src/MeshWeaver.Hosting/MeshNodeStreamCache.cs	1
+src/MeshWeaver.Hosting/NodeUpdatePipeline.cs	1
+src/MeshWeaver.InstanceSync/InstanceSyncCoordinator.cs	1
+src/MeshWeaver.InstanceSync/InstanceSyncService.cs	1
+src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs	1
+src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs	1
+src/MeshWeaver.Mail.MicrosoftGraph/EmailInboundProcessor.cs	2
+src/MeshWeaver.Mesh.Contract/MeshExtensions.cs	1
+src/MeshWeaver.Observability/LogIncidentControlPlane.cs	1
+src/MeshWeaver.Observability/LogIncidentIngestService.cs	1
+src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs	6
+src/MeshWeaver.PluginCatalog/InstanceComboReader.cs	1
+src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs	1
+src/MeshWeaver.PluginCatalog/ModuleDiscoveryService.cs	4
+src/MeshWeaver.PluginCatalog/PackageInstaller.cs	10
+src/MeshWeaver.PluginCatalog/PackageUpdateReconciler.cs	2
+src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs	1
+src/MeshWeaver.PluginCatalog/RegistrationKeyService.cs	1
+src/MeshWeaver.Teams/TeamsInboundProcessor.cs	1
+tools/MeshWeaver.PluginTester/PluginGateRunner.cs	1

--- a/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance ratchet for the identity-latch defect class (#1790): the shape
+/// <c>Observable.Using(() =&gt; access.ImpersonateAsSystem(), _ =&gt; work)</c> — or the same with
+/// <c>ImpersonateAsHub</c> / <c>SwitchAccessContext</c> — may not appear at a NEW site.
+///
+/// <para><b>Why the shape is a defect and not a style.</b> Impersonation is an <c>AsyncLocal</c>
+/// store/restore pair. Rx runs <c>Using</c>'s resource factory on the SUBSCRIBING thread and
+/// disposes the resource when the inner observable TERMINATES — for a cross-hub request/response,
+/// the owning hub's response thread. The store and the restore therefore land on different threads,
+/// and the subscriber is left running as the impersonated identity: an ASP.NET request that
+/// continues with <c>Permission.All</c>, a script run whose remaining statements resolve areas the
+/// submitting user may not read, a hub action block that keeps <c>system-security</c>.</para>
+///
+/// <para><b>The fix at a site</b> is <c>access.RunAsSystem(() =&gt; work)</c> /
+/// <c>RunAsHub(hub, …)</c> / <c>RunAs(identity, …)</c> (<c>ImpersonationScopeExtensions</c>), which
+/// opens the scope at Subscribe — so the cold work is still issued impersonated, and anything it
+/// schedules captures that ExecutionContext — and closes it again on the way OUT of that same
+/// Subscribe. Compose the widest cold pipeline inside the <c>work</c> factory and the emission-time
+/// behaviour is unchanged. Where the capture is genuinely synchronous, a plain <c>using</c> around
+/// the call and its <c>Subscribe</c> is equally correct (<c>ActivityLogLogger</c>).</para>
+///
+/// <para><b>Why the file is seeded rather than empty.</b> The shape was the framework's idiom for
+/// two years; <see cref="AllowFileName"/> is the inventory of what still carries it, so that the
+/// NEXT one fails here instead of being discovered in production. The
+/// <see cref="MeshWeaver.Messaging.AccessService"/> fix already closes the second half of the leak
+/// at every listed site — a scope disposed on a thread that never opened it now writes nothing, so
+/// no foreign identity is injected anywhere — which is why the remaining entries are debt rather
+/// than live incidents. What is left at each of them is the subscribing-thread latch, and that only
+/// the call site can close.</para>
+///
+/// <para><b>The ratchet may only SHRINK.</b> A new file, a raised count, or a raised TOTAL is a
+/// failure. A line that has become stale (its site was fixed) is reported, not failed: two PRs
+/// closing sites concurrently would otherwise red <c>main</c> on whichever merged second, and a
+/// gate that punishes the direction it is asking for teaches people to stop shrinking. Delete the
+/// stale line and lower <see cref="TotalBudget"/> in the same change.</para>
+/// </summary>
+public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
+{
+    /// <summary>
+    /// The seeded inventory's size. Per-file entries stop a new site in a file that already carries
+    /// the shape; this stops the list as a WHOLE from growing — including by the trick of adding a
+    /// new file's line. Lower it whenever you delete or lower an entry.
+    /// </summary>
+    private const int TotalBudget = 98;
+
+    /// <summary>Production roots. <c>test/</c> and <c>samples/</c> are deliberately out of scope —
+    /// the leak there costs test isolation, not a user's permissions, and listing 21 more entries
+    /// would bury the ones that matter.</summary>
+    private static readonly string[] ScannedRoots = ["src", "memex", "tools"];
+
+    private const string Marker = "Observable.Using";
+
+    /// <summary>The identity-scope factories. All three return an <see cref="IDisposable"/> whose
+    /// Dispose writes an <c>AsyncLocal</c>, which is what makes them thread-affine.</summary>
+    private static readonly string[] ScopeFactories = ["Impersonate", "SwitchAccessContext"];
+
+    private const string AllowFileName = "ImpersonationScopeSites.allow";
+
+    private static readonly string[] ExcludedSegments =
+        ["bin", "obj", "node_modules", "TestResults", ".git", ".vs", "dist"];
+
+    [Fact]
+    public void NoNewSiteOpensAnImpersonationScopeInsideObservableUsing()
+    {
+        var root = FindRepoRoot();
+        var allowed = ReadAllowFile(Path.Combine(root, "test", AllowFileName));
+        var found = Scan(root);
+
+        var failures = new List<string>();
+
+        foreach (var (file, count) in found.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            if (!allowed.TryGetValue(file, out var budget))
+                failures.Add(
+                    $"  NEW SITE   {file} ({count}) — replace Observable.Using(…Impersonate…) with "
+                    + "AccessService.RunAsSystem/RunAsHub/RunAs, or a synchronous `using` around the "
+                    + "call and its Subscribe. Do NOT add a line to " + AllowFileName + ".");
+            else if (count > budget)
+                failures.Add(
+                    $"  MORE       {file} ({count} > {budget} allowed) — a site was ADDED to a file "
+                    + "that already carries the shape.");
+        }
+
+        var total = allowed.Values.Sum();
+        if (total > TotalBudget)
+            failures.Add(
+                $"  TOTAL      {total} allowances > {TotalBudget} budgeted — the inventory GREW. "
+                + "Adding a line to " + AllowFileName + " is not a fix.");
+
+        // Stale entries are reported, never failed: shrinking is the direction this guard exists to
+        // encourage, and failing on it would red main whenever two PRs close sites concurrently.
+        foreach (var (file, budget) in allowed.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            var count = found.GetValueOrDefault(file, 0);
+            if (count < budget)
+                output.WriteLine(
+                    $"STALE (please tidy): {file} — {count} found, {budget} allowed. "
+                    + $"{(count == 0 ? "Delete the line" : $"Lower it to {count}")} and lower "
+                    + $"TotalBudget by {budget - count}.");
+        }
+
+        Assert.True(failures.Count == 0,
+            "The identity-latch shape `Observable.Using(() => access.Impersonate…(), _ => work)` "
+            + "opens an AsyncLocal scope on the SUBSCRIBING thread and disposes it on whichever "
+            + "thread the work terminates — leaving the subscriber running as the impersonated "
+            + "identity (#1790). Use ImpersonationScopeExtensions.RunAsSystem/RunAsHub/RunAs.\n"
+            + string.Join("\n", failures));
+    }
+
+    /// <summary>
+    /// Non-vacuity, pinned in the same run: the scanner must actually SEE the shape. The seeded
+    /// allow file is non-empty, so a scanner that silently matched nothing — a renamed marker, a
+    /// masking bug that blanked every file — would report every entry as STALE rather than pass;
+    /// this states the expectation directly so the failure names the scanner instead of the tree.
+    /// </summary>
+    [Fact]
+    public void TheScannerFindsTheShapeItIsRatcheting()
+    {
+        var root = FindRepoRoot();
+        var found = Scan(root);
+
+        Assert.True(found.Count > 0,
+            "The scanner found no occurrence of the shape anywhere under "
+            + string.Join(", ", ScannedRoots)
+            + ". Either every site was migrated — in which case empty "
+            + AllowFileName + " and delete this assertion — or the scanner is broken, which would "
+            + "make the ratchet above pass on no evidence.");
+
+        // The doc comments in ImpersonationScopeExtensions and AccessService QUOTE the shape. A
+        // scanner that counted them would ratchet against prose, so prove the masking works.
+        var seam = Path.Combine(root, "src", "MeshWeaver.Messaging.Hub", "ImpersonationScopeExtensions.cs");
+        Assert.True(File.Exists(seam), "the seam file must exist for this check to mean anything");
+        Assert.True(File.ReadAllText(seam).Contains("Observable.Using(access.ImpersonateAsSystem"),
+            "the seam's remarks must still quote the shape — otherwise this check proves nothing");
+        Assert.False(found.ContainsKey(Path.Combine("src", "MeshWeaver.Messaging.Hub", "ImpersonationScopeExtensions.cs")
+                .Replace(Path.DirectorySeparatorChar, '/')),
+            "the scanner counted a DOC COMMENT as a call site — comment masking is broken, and every "
+            + "count in the allow file is therefore unreliable.");
+    }
+
+    private static Dictionary<string, int> Scan(string root) =>
+        ScannedRoots
+            .Select(r => Path.Combine(root, r))
+            .Where(Directory.Exists)
+            .SelectMany(dir => Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
+            .Where(f => Path.GetExtension(f) is ".cs" or ".razor")
+            .Where(f => !IsExcluded(root, f))
+            .Select(f => (Relative: Relative(root, f), Count: CountSites(f)))
+            .Where(x => x.Count > 0)
+            .ToDictionary(x => x.Relative, x => x.Count, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Occurrences of <see cref="Marker"/> whose FIRST argument — the resource factory — names one
+    /// of <see cref="ScopeFactories"/>. Comments and string literals are masked first: the seam's
+    /// own remarks quote the shape verbatim, and counting prose would make the ratchet meaningless.
+    /// </summary>
+    private static int CountSites(string path)
+    {
+        string text;
+        try { text = File.ReadAllText(path); }
+        catch (IOException) { return 0; } // a file a concurrent build is writing is not evidence
+
+        if (!text.Contains(Marker, StringComparison.Ordinal)) return 0;
+
+        var code = MaskCommentsAndStrings(text);
+        var count = 0;
+        var at = 0;
+        while ((at = code.IndexOf(Marker, at, StringComparison.Ordinal)) >= 0)
+        {
+            var open = code.IndexOf('(', at + Marker.Length);
+            at += Marker.Length;
+            if (open < 0) continue;
+            var firstArg = FirstArgument(code, open);
+            if (ScopeFactories.Any(f => firstArg.Contains(f, StringComparison.Ordinal)))
+                count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>The text between <paramref name="openParen"/> and the first comma at its own nesting
+    /// depth (or the matching close paren) — i.e. the call's first argument.</summary>
+    private static string FirstArgument(string code, int openParen)
+    {
+        var depth = 0;
+        for (var i = openParen; i < code.Length; i++)
+        {
+            switch (code[i])
+            {
+                case '(' or '[' or '{':
+                    depth++;
+                    break;
+                case ')' or ']' or '}':
+                    if (--depth == 0) return code[(openParen + 1)..i];
+                    break;
+                case ',' when depth == 1:
+                    return code[(openParen + 1)..i];
+            }
+        }
+
+        return code[(openParen + 1)..];
+    }
+
+    /// <summary>
+    /// Blanks comment and string-literal characters, preserving offsets and newlines, so the scan
+    /// sees code only. Handles line/block comments, ordinary, verbatim and raw string literals, and
+    /// character literals — enough that a doc comment containing <c>Plugins/*</c> does not swallow
+    /// the next thousand lines (which is exactly what a naive scanner did).
+    /// </summary>
+    private static string MaskCommentsAndStrings(string text)
+    {
+        var masked = new StringBuilder(text);
+        var i = 0;
+        var n = text.Length;
+
+        void Blank(int from, int to)
+        {
+            for (var k = from; k < to && k < n; k++)
+                if (text[k] != '\n')
+                    masked[k] = ' ';
+        }
+
+        while (i < n)
+        {
+            var c = text[i];
+            var next = i + 1 < n ? text[i + 1] : '\0';
+
+            if (c == '/' && next == '/')
+            {
+                var end = text.IndexOf('\n', i);
+                end = end < 0 ? n : end;
+                Blank(i, end);
+                i = end;
+            }
+            else if (c == '/' && next == '*')
+            {
+                var end = text.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                end = end < 0 ? n : end + 2;
+                Blank(i, end);
+                i = end;
+            }
+            else if (c == '"' && i + 2 < n && text[i + 1] == '"' && text[i + 2] == '"')
+            {
+                var end = text.IndexOf("\"\"\"", i + 3, StringComparison.Ordinal);
+                end = end < 0 ? n : end + 3;
+                Blank(i, end);
+                i = end;
+            }
+            else if (c == '@' && next == '"')
+            {
+                i = MaskVerbatim(text, masked, i + 1, Blank);
+            }
+            else if (c == '$' && next == '@' && i + 2 < n && text[i + 2] == '"')
+            {
+                Blank(i, i + 2);
+                i = MaskVerbatim(text, masked, i + 2, Blank);
+            }
+            else if (c is '"' or '\'')
+            {
+                var quote = c;
+                Blank(i, i + 1);
+                i++;
+                while (i < n && text[i] != quote && text[i] != '\n')
+                {
+                    var step = text[i] == '\\' ? 2 : 1;
+                    Blank(i, i + step);
+                    i += step;
+                }
+
+                if (i < n && text[i] == quote) { Blank(i, i + 1); i++; }
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        return masked.ToString();
+    }
+
+    /// <summary>Masks a verbatim string starting at its opening quote; <c>""</c> is an escaped quote.</summary>
+    private static int MaskVerbatim(string text, StringBuilder masked, int quote, Action<int, int> blank)
+    {
+        var n = text.Length;
+        blank(quote, quote + 1);
+        var i = quote + 1;
+        while (i < n)
+        {
+            if (text[i] == '"')
+            {
+                if (i + 1 < n && text[i + 1] == '"') { blank(i, i + 2); i += 2; continue; }
+                blank(i, i + 1);
+                return i + 1;
+            }
+
+            blank(i, i + 1);
+            i++;
+        }
+
+        return n;
+    }
+
+    /// <summary>
+    /// <c>relative/path.cs&lt;TAB&gt;count</c>, one per line; <c>#</c> starts a comment.
+    /// </summary>
+    private static Dictionary<string, int> ReadAllowFile(string path)
+    {
+        Assert.True(File.Exists(path),
+            $"{AllowFileName} is missing — without it this guard cannot tell a pre-existing site "
+            + "from a new one and would report every occurrence as a failure. Restore it from git "
+            + "rather than regenerating it: a regenerated file would silently bless whatever is in "
+            + "the tree, which is the one thing a ratchet must never do.");
+
+        return File.ReadAllLines(path)
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0 && !l.StartsWith('#'))
+            .Select(l => l.Split('\t', StringSplitOptions.TrimEntries))
+            .ToDictionary(parts => parts[0], parts => int.Parse(parts[1]), StringComparer.Ordinal);
+    }
+
+    private static string Relative(string root, string path) =>
+        Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/');
+
+    private static bool IsExcluded(string root, string path) =>
+        Relative(root, path).Split('/').Any(s => ExcludedSegments.Contains(s, StringComparer.OrdinalIgnoreCase));
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+               ?? throw new InvalidOperationException(
+                   "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NotificationDispatchIdentityLatchTest.cs
+++ b/test/MeshWeaver.Graph.Test/NotificationDispatchIdentityLatchTest.cs
@@ -1,0 +1,111 @@
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// #1790, tiers 2–3 — a service that RETURNS a system-scoped observable to a caller who subscribes
+/// it from their own thread. <see cref="NotificationService.Dispatch"/> is the representative shape
+/// (the click-action sites — plugin install, space/group invite, install-record removal — are all
+/// the same one): the writes must run as System because the notification lands in the RECIPIENT's
+/// partition, which the acting user has no rights on, but the acting user's thread must be handed
+/// back untouched.
+///
+/// <para><b>The defect.</b> <c>Observable.Using(access.ImpersonateAsSystem, _ =&gt; writes)</c> opens
+/// the AsyncLocal scope on whichever thread the CALLER subscribes from — a Blazor circuit, a hub
+/// handler, a click action — and disposes it when the writes terminate, on the owning partition
+/// hub's thread. So the caller kept <c>system-security</c> and the hub thread was handed the
+/// caller's identity. Nothing failed; the notification was written either way. That is why the
+/// assertion below is about the THREAD, not about the outcome.</para>
+///
+/// <para><b>Non-vacuity.</b> The dispatch is awaited and the recipient's bell node asserted present
+/// in the same test, so a "fix" that stopped impersonating (and therefore stopped writing into a
+/// partition the caller cannot touch) fails here rather than passing quietly. Reverting
+/// <c>ImpersonationScopeExtensions</c> to its <c>Observable.Using</c> form turns the identity
+/// assertion red.</para>
+/// </summary>
+public class NotificationDispatchIdentityLatchTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Recipient = "latch_recipient";
+    private const string SystemId = "system-security";
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+    private System.Text.Json.JsonSerializerOptions Json => Mesh.JsonSerializerOptions;
+
+    private static readonly AccessContext Actor = new()
+    {
+        ObjectId = "granting_admin",
+        Name = "Granting Admin",
+        Email = "granting_admin@acme.com",
+    };
+
+    [Fact(Timeout = 120000)]
+    public async Task DispatchingANotification_LeavesTheActorsIdentityOnTheCallingThread()
+    {
+        using (Access.ImpersonateAsSystem())
+            await MeshService.CreateNode(new MeshNode(Recipient)
+            {
+                NodeType = "User",
+                Name = Recipient,
+                Content = new User { Email = $"{Recipient}@acme.com", FullName = Recipient },
+            }).Should().Emit();
+
+        string? identityRightAfterSubscribe;
+
+        using (Access.SwitchAccessContext(Actor))
+        {
+            Access.Context?.ObjectId.Should().Be("granting_admin",
+                "the premise: the acting user is ambient on this thread before the dispatch");
+
+            // ToTask() subscribes SYNCHRONOUSLY here — the moment the scope is opened — and the
+            // writes terminate on the recipient partition's hub thread, which is the moment the old
+            // shape would have disposed it. Read the identity in between.
+            var dispatch = NotificationService.Dispatch(
+                    Mesh,
+                    recipient: Recipient,
+                    mainNodePath: Recipient,
+                    title: "You've been given access to LatchSpace",
+                    message: "You now have Editor access to \"LatchSpace\".",
+                    type: NotificationType.AccessGranted,
+                    targetNodePath: "LatchSpace",
+                    createdBy: Actor.ObjectId)
+                .Timeout(60.Seconds())
+                .ToTask(TestContext.Current.CancellationToken);
+
+            identityRightAfterSubscribe = Access.Context?.ObjectId;
+
+            await dispatch;
+        }
+
+        identityRightAfterSubscribe.Should().NotBe(SystemId,
+            "a service that runs its own writes as System must not hand the caller an elevated "
+            + "thread. Observing 'system-security' here means everything the caller does after the "
+            + "click — further writes, permission checks, the next render — runs with Permission.All "
+            + "(#1790)");
+        identityRightAfterSubscribe.Should().Be("granting_admin",
+            "and it is the actor's own identity that must come back, not merely 'not System'");
+
+        // Non-vacuity: the write really happened, into a partition the actor has no rights on — so
+        // the impersonation was genuinely in force for the work.
+        await Mesh.GetWorkspace()
+            .GetQuery($"latch-notif|{Recipient}",
+                $"path:{Recipient}/_Notification scope:children nodeType:Notification")
+            .Where(nodes => (nodes ?? []).Any(n =>
+                n.ContentAs<Notification>(Json) is { NotificationType: NotificationType.AccessGranted }))
+            .FirstAsync().Timeout(60.Seconds());
+
+        Access.Context?.ObjectId.Should().BeNull(
+            "and the enclosing scope restores the thread to what the test host left it");
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/ImpersonationScopeThreadAffinityTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/ImpersonationScopeThreadAffinityTest.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// #1790 — impersonation is an <c>AsyncLocal</c> store/restore pair, so the two halves must land on
+/// ONE logical flow. <c>Observable.Using(() =&gt; access.ImpersonateAsSystem(), _ =&gt; crossHubCall())</c>
+/// splits them across two threads: Rx runs the resource factory on the SUBSCRIBING thread and
+/// disposes the resource when the inner observable TERMINATES — for a cross-hub request/response,
+/// the owning hub's response thread.
+///
+/// <para><b>Two distinct leaks, and they need two distinct fixes.</b></para>
+/// <list type="number">
+///   <item><description><b>The subscriber keeps <c>system-security</c> latched.</b> Nothing disposes
+///   the scope on that thread, so every later statement on it runs elevated. Only the CALL SITE can
+///   close this — <see cref="ImpersonationScopeExtensions.RunAsSystem{T}"/> opens and closes the
+///   scope inside one synchronous <c>Subscribe</c>.</description></item>
+///   <item><description><b>The terminating thread is handed a foreign "previous".</b> The scope's
+///   <c>Dispose</c> writes the SUBSCRIBER's prior identity into a thread that never had it — a hub
+///   action block, a transport handshake thread, an ASP.NET request thread. That is an identity
+///   INJECTION, not a cleanup, and it is closed inside <see cref="AccessService"/> itself, so it
+///   holds for every call site including the ones still written the old way.</description></item>
+/// </list>
+///
+/// <para><b>Why the assertions are the NEGATIVE ones.</b> An identity leak has no failing operation
+/// to observe — the work succeeds either way. The only thing that distinguishes the broken shape
+/// from the fixed one is what each thread is left holding, so that is what is asserted.</para>
+///
+/// <para><b>Why a suppressed-flow thread.</b> <c>Thread.Start</c> and <c>Task.Run</c> both CAPTURE
+/// the caller's <c>ExecutionContext</c>, which would hand the "foreign" thread the subscriber's
+/// AsyncLocals and make it a poor model of a hub action block. <see cref="OnAForeignThread"/>
+/// suppresses the flow so the thread starts with a genuinely empty context — exactly what a hub
+/// thread has before its delivery pipeline stamps one.</para>
+/// </summary>
+public class ImpersonationScopeThreadAffinityTest
+{
+    private static readonly AccessContext Alice = new() { ObjectId = "alice", Name = "Alice" };
+    private static readonly AccessContext Bob = new() { ObjectId = "bob", Name = "Bob" };
+
+    private const string System = "system-security";
+
+    // ── Leak 2: the terminating thread ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The premise, pinned across threads. <see cref="SystemScopeDoesNotEscapeTest"/> pins the
+    /// SAME-thread case (where <c>Using</c> disposes correctly); this pins the cross-thread one,
+    /// which is the shape every cross-hub call actually has. The latch is asserted as STILL PRESENT
+    /// for the raw idiom — the <see cref="AccessService"/> fix deliberately does not invent a
+    /// dispose on a thread nothing disposed on, so the raw idiom stays unsafe and the seal below is
+    /// the answer.
+    /// </summary>
+    [Fact]
+    public void TheRawIdiomLatchesTheImpersonatedIdentityOnTheSubscribingThread()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        var terminatesElsewhere = new Subject<int>();
+        using var subscription = Observable
+            .Using(access.ImpersonateAsSystem, _ => terminatesElsewhere)
+            .Subscribe(_ => { });
+
+        access.Context?.ObjectId.Should().Be(System,
+            "Observable.Using opened the scope on THIS thread and nothing will dispose it here — "
+            + "the inner observable terminates on someone else's thread. Every later statement on "
+            + "this thread therefore runs as System (#1790). This is why the raw idiom must be "
+            + "replaced at the call site, not merely made polite on the far end");
+    }
+
+    /// <summary>
+    /// 🚨 The <see cref="AccessService"/> half: a scope disposed on a thread that never had its
+    /// store must write NOTHING. Before the fix this test reads "alice" on a thread that has never
+    /// heard of Alice — the subscriber's previous identity injected into a hub thread.
+    /// </summary>
+    [Fact]
+    public void ARawIdiomDisposalOnAForeignThreadInjectsNothingIntoIt()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        var terminatesElsewhere = new Subject<int>();
+        using var subscription = Observable
+            .Using(access.ImpersonateAsSystem, _ => terminatesElsewhere)
+            .Subscribe(_ => { });
+
+        string? foreignBefore = null;
+        string? foreignAfter = null;
+        var terminatedThere = false;
+
+        OnAForeignThread(() =>
+        {
+            foreignBefore = access.Context?.ObjectId;
+            // Completing here is what makes Observable.Using dispose the impersonation scope —
+            // on THIS thread, which never opened it.
+            terminatesElsewhere.OnCompleted();
+            terminatedThere = true;
+            foreignAfter = access.Context?.ObjectId;
+        });
+
+        terminatedThere.Should().BeTrue(
+            "non-vacuity: the disposal must actually have been triggered on the foreign thread — "
+            + "an assertion about a scope that was never disposed proves nothing");
+        foreignBefore.Should().BeNull(
+            "the model must be honest: a hub action block starts with no ambient identity, so the "
+            + "flow-suppressed thread must too — if this is non-null the thread inherited the "
+            + "subscriber's context and is not a foreign thread at all");
+        foreignAfter.Should().BeNull(
+            "the scope's store never happened on THIS thread, so its restore must not happen here "
+            + "either. Writing the subscriber's 'previous' identity onto a hub/transport thread is "
+            + "an identity injection: the next thing that thread does reads a principal that has "
+            + "nothing to do with the message it is processing (#1790)");
+    }
+
+    // ── Leak 1: the subscribing thread ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The seam half. Same cross-thread termination, but through
+    /// <see cref="ImpersonationScopeExtensions.RunAsSystem{T}"/>: the subscribing thread is handed
+    /// back exactly what it had. Against the pre-fix seam (which was <c>Observable.Using</c> +
+    /// <c>ContainIdentity</c>) this reads "system-security" — <c>ContainIdentity</c> restores around
+    /// NOTIFICATIONS only, never around the Subscribe that opened the scope.
+    /// </summary>
+    [Fact]
+    public void RunAsSystemLeavesTheSubscribersOwnIdentityOnTheSubscribingThread()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        var terminatesElsewhere = new Subject<int>();
+        var subscribedUnder = (string?)null;
+
+        using var subscription = access
+            .RunAsSystem(() => Observable.Defer(() =>
+            {
+                subscribedUnder = access.Context?.ObjectId;
+                return terminatesElsewhere;
+            }))
+            .Subscribe(_ => { });
+
+        subscribedUnder.Should().Be(System,
+            "non-vacuity: the scope must still COVER the work — a seal that fixed the thread by not "
+            + "impersonating at all would trade an escalation for a fail-closed read");
+        access.Context?.ObjectId.Should().Be("alice",
+            "the impersonation was established FOR that read and must not outlive the Subscribe "
+            + "that opened it. Observing 'system-security' here means the rest of this thread's "
+            + "work — the rest of an HTTP request, of a script run, of a hub handler — executes "
+            + "with Permission.All (#1790)");
+    }
+
+    /// <summary>The same guarantee for the hub-identity and explicit-identity overloads.</summary>
+    [Fact]
+    public void EveryRunAsOverloadLeavesTheSubscribingThreadAsItFoundIt()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        var explicitIdentitySawBob = false;
+        using (access.RunAs(Bob, () => Observable.Defer(() =>
+               {
+                   explicitIdentitySawBob = access.Context?.ObjectId == "bob";
+                   return new Subject<int>();
+               })).Subscribe(_ => { }))
+        {
+            explicitIdentitySawBob.Should().BeTrue("RunAs(identity) must switch for the work");
+            access.Context?.ObjectId.Should().Be("alice", "…and switch back on the way out");
+        }
+
+        var resolverRanOnTheSubscribingThread = false;
+        var resolvedIdentitySawBob = false;
+        using (access.RunAs(
+                   () =>
+                   {
+                       // The resolver overload exists precisely so the identity can be read on the
+                       // SUBSCRIBING thread (BlazorView.ResolveCircuitUser reads AsyncLocals).
+                       resolverRanOnTheSubscribingThread = access.Context?.ObjectId == "alice";
+                       return Bob;
+                   },
+                   () => Observable.Defer(() =>
+                   {
+                       resolvedIdentitySawBob = access.Context?.ObjectId == "bob";
+                       return new Subject<int>();
+                   })).Subscribe(_ => { }))
+        {
+            resolverRanOnTheSubscribingThread.Should().BeTrue(
+                "the resolver must run BEFORE the switch, on the subscribing thread — resolving it "
+                + "after would read the identity we are about to install");
+            resolvedIdentitySawBob.Should().BeTrue("RunAs(resolver) must switch for the work");
+            access.Context?.ObjectId.Should().Be("alice", "…and switch back on the way out");
+        }
+    }
+
+    /// <summary>
+    /// The other end of the seal: a <see cref="ImpersonationScopeExtensions.RunAsSystem{T}"/>
+    /// pipeline that terminates on a foreign thread must leave that thread untouched too — nothing
+    /// is disposed there at all any more.
+    /// </summary>
+    [Fact]
+    public void RunAsSystemTouchesNothingOnTheTerminatingThread()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        var terminatesElsewhere = new Subject<int>();
+        using var subscription = access
+            .RunAsSystem(() => (IObservable<int>)terminatesElsewhere)
+            .Subscribe(_ => { });
+
+        string? foreignAfter = null;
+        var terminatedThere = false;
+        OnAForeignThread(() =>
+        {
+            terminatesElsewhere.OnCompleted();
+            terminatedThere = true;
+            foreignAfter = access.Context?.ObjectId;
+        });
+
+        terminatedThere.Should().BeTrue("non-vacuity: the termination must have happened there");
+        foreignAfter.Should().BeNull("the seal disposes on the subscribing thread and nowhere else");
+    }
+
+    /// <summary>
+    /// 🚨 The property the whole fix rests on, and the one that would make it a trade rather than a
+    /// fix if it did not hold: closing the scope at the end of <c>Subscribe</c> must NOT un-elevate
+    /// work that was already scheduled inside it. An <c>ExecutionContext</c> captured while the
+    /// scope was open is an immutable snapshot; restoring the subscribing flow afterwards cannot
+    /// reach into it. This is what lets a query provider capture lazily on a pooled thread and still
+    /// read <c>system-security</c>.
+    /// </summary>
+    [Fact]
+    public void WorkScheduledInsideTheScopeStillRunsAsSystemAfterTheThreadIsRestored()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        string? seenByAFlowedContinuation = null;
+        Thread? flowed = null;
+
+        using var subscription = access
+            .RunAsSystem(() => Observable.Defer(() =>
+            {
+                // Models an IIoPool / scheduler hop taken while subscribing: the ExecutionContext
+                // is captured HERE, inside the scope.
+                flowed = new Thread(() => seenByAFlowedContinuation = access.Context?.ObjectId)
+                {
+                    IsBackground = true
+                };
+                flowed.Start();
+                return new Subject<int>();
+            }))
+            .Subscribe(_ => { });
+
+        flowed.Should().NotBeNull("non-vacuity: the hop must have been taken inside the scope");
+        flowed!.Join(TimeSpan.FromSeconds(30)).Should().BeTrue("the flowed continuation must finish");
+
+        seenByAFlowedContinuation.Should().Be(System,
+            "a captured ExecutionContext is a snapshot — the restore on the subscribing thread "
+            + "creates a NEW context for that thread and cannot rewrite one already taken. If this "
+            + "were not so, sealing the scope would fail-close every provider that reads the "
+            + "identity lazily off a pooled thread");
+        access.Context?.ObjectId.Should().Be("alice", "and the subscribing thread is still restored");
+    }
+
+    // ── The cases thread-affinity must NOT break ────────────────────────────────────────────────
+
+    /// <summary>
+    /// The overwhelmingly common shape: open and close on one thread. Thread-affinity must be
+    /// invisible here.
+    /// </summary>
+    [Fact]
+    public void ASynchronousScopeStillRestoresExactlyAsBefore()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        using (access.ImpersonateAsSystem())
+            access.Context?.ObjectId.Should().Be(System);
+
+        access.Context?.ObjectId.Should().Be("alice");
+
+        // Nested, in order — each restores to its enclosing identity, not to null or the default.
+        using (access.SwitchAccessContext(Bob))
+        {
+            using (access.ImpersonateAsSystem())
+                access.Context?.ObjectId.Should().Be(System);
+            access.Context?.ObjectId.Should().Be("bob");
+        }
+
+        access.Context?.ObjectId.Should().Be("alice");
+    }
+
+    /// <summary>
+    /// A scope that spans an <c>await</c> is ONE logical flow even when the continuation resumes on
+    /// another thread: the ExecutionContext carries both the context and the scope marker forward,
+    /// so the restore is still ours to make. Thread-affinity that keyed on the thread id alone
+    /// would silently stop restoring here — which is why the marker exists.
+    /// </summary>
+    [Fact]
+    public async Task AScopeSpanningAnAwaitStillRestores()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        int threadInside;
+        using (access.ImpersonateAsSystem())
+        {
+            await Task.Yield();
+            await Task.Run(() => { }, TestContext.Current.CancellationToken);
+            threadInside = Environment.CurrentManagedThreadId;
+            access.Context?.ObjectId.Should().Be(System,
+                "the impersonation flows with the continuation — that is what AsyncLocal is for");
+        }
+
+        access.Context?.ObjectId.Should().Be("alice",
+            $"the scope was disposed on thread {threadInside} inside the same logical flow, so the "
+            + "restore is ours to make even if the physical thread changed");
+    }
+
+    /// <summary>
+    /// 🚨 The case that decides the marker is not sufficient on its own.
+    /// <c>AccessContextCaptureExtensions</c> wraps every subscriber callback in a
+    /// <see cref="AccessService.SwitchAccessContext"/> scope and documents that "AsyncLocal is
+    /// touched ONLY for the duration of the callback". If the callback opens an impersonation that
+    /// is never disposed on this thread (exactly what a nested <c>Observable.Using</c> does), the
+    /// marker no longer names the outer scope — so the outer restore must fall back to the thread
+    /// it was opened on, or the leaked identity would outlive the callback.
+    /// </summary>
+    [Fact]
+    public void AnUndisposedNestedScopeDoesNotStrandTheEnclosingOne()
+    {
+        var access = new AccessService();
+        access.SetContext(Alice);
+
+        using (access.SwitchAccessContext(Bob))
+        {
+            // Deliberately never disposed on this thread — the nested-Observable.Using shape.
+            _ = access.ImpersonateAsSystem();
+            access.Context?.ObjectId.Should().Be(System);
+        }
+
+        access.Context?.ObjectId.Should().Be("alice",
+            "the enclosing scope must still clamp the thread back on the way out. Anything else "
+            + "would turn CarryAccessContext's per-callback scope into a leak of its own — the "
+            + "opposite of what it exists for");
+    }
+
+    /// <summary>
+    /// Runs <paramref name="action"/> on a thread whose <c>ExecutionContext</c> is genuinely empty —
+    /// the model of a hub action block or a transport handshake thread. Flow suppression is what
+    /// makes it honest: both <c>Thread.Start</c> and <c>Task.Run</c> would otherwise capture the
+    /// caller's AsyncLocals and the "foreign" thread would silently be the subscriber's own flow.
+    /// </summary>
+    private static void OnAForeignThread(Action action)
+    {
+        Exception? failure = null;
+        Thread thread;
+        using (ExecutionContext.SuppressFlow())
+        {
+            thread = new Thread(() =>
+            {
+                try { action(); }
+                catch (Exception ex) { failure = ex; }
+            })
+            { IsBackground = true };
+            thread.Start();
+        }
+
+        thread.Join(TimeSpan.FromSeconds(30)).Should().BeTrue(
+            "the foreign thread must finish — a timeout here means the termination wedged, not that "
+            + "the identity is fine");
+        if (failure is not null)
+            throw failure;
+    }
+}

--- a/test/MeshWeaver.Security.Test/AuthBootstrapIdentityLatchTest.cs
+++ b/test/MeshWeaver.Security.Test/AuthBootstrapIdentityLatchTest.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Security.Cryptography;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Blazor.Infrastructure;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// #1790, tier 1 — the AUTH BOOTSTRAP. <c>UserContextMiddleware.ValidateTokenViaHub</c> deliberately
+/// runs as System: it is what turns a raw Bearer token into a user identity, so by construction the
+/// caller is unauthenticated, and without <c>Permission.All</c> the never-null post guard
+/// fail-closes and every authenticated user sees a blank portal (prod 2026-06-18, issue #637). The
+/// impersonation is correct. What was not correct is that it never came back.
+///
+/// <para><b>The defect.</b> The validation was composed as
+/// <c>Observable.Using(() =&gt; access.ImpersonateAsSystem(), _ =&gt; hub.Observe(…))</c>. Impersonation
+/// is an <c>AsyncLocal</c> store/restore pair; Rx runs the resource factory on the SUBSCRIBING
+/// thread and disposes the resource when the inner observable TERMINATES — here, when the ApiToken
+/// hub answers, on a hub thread. The subscribing thread is the ASP.NET REQUEST thread
+/// (<c>InvokeAsync</c> bridges this stream with <c>.ToTask()</c>), so it was left holding
+/// <c>system-security</c> for the remainder of the request.</para>
+///
+/// <para><b>Why that is an escalation and not an untidiness.</b> Immediately after the bridge,
+/// <c>InvokeAsync</c> reads <c>userService.Context</c> into <c>existing</c> and reuses it when
+/// <c>existing.Email == userContext.Email</c>. The latched System context has a null Email, so a
+/// token record carrying no email matched it — and the request proceeded with the System context
+/// set as the caller's own. The blast radius is every request that presents a Bearer token.</para>
+///
+/// <para><b>Why the assertion is the NEGATIVE one.</b> Validation succeeds either way; the only
+/// observable difference is what the calling thread is left holding. So that is what is asserted, at
+/// the one moment it is observable — after <c>.ToTask()</c> has subscribed (which is when the scope
+/// is opened) and before the response arrives (which is when the old shape would have disposed it,
+/// on someone else's thread).</para>
+///
+/// <para><b>Non-vacuity.</b> The response is asserted SUCCESSFUL in the same test: the token node is
+/// readable only under the System scope, so a "fix" that simply stopped impersonating would turn the
+/// verdict into a failure here rather than pass quietly. Reverting
+/// <c>ImpersonationScopeExtensions</c> to its <c>Observable.Using</c> form turns the identity
+/// assertion red on the first run.</para>
+/// </summary>
+public class AuthBootstrapIdentityLatchTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static readonly TimeSpan StepTimeout = 30.Seconds();
+
+    private const string TokenOwner = "token-owner";
+    private const string SystemId = "system-security";
+
+    private static readonly AccessContext Caller = new()
+    {
+        ObjectId = "alice",
+        Name = "Alice",
+        Email = "alice@example.com",
+    };
+
+    [Fact]
+    public async Task ValidatingABearerToken_LeavesTheRequestThreadsOwnIdentityBehind()
+    {
+        var rawToken = await CreateApiToken();
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        string? identityRightAfterSubscribe;
+        ValidateTokenResponse? response;
+
+        using (access.SwitchAccessContext(Caller))
+        {
+            access.Context?.ObjectId.Should().Be("alice",
+                "the premise: this thread carries a real caller BEFORE the bootstrap runs, exactly "
+                + "as an ASP.NET request thread does");
+
+            // ToTask() subscribes SYNCHRONOUSLY on this thread and returns — which is precisely the
+            // shape UserContextMiddleware.InvokeAsync uses, and the moment the scope is opened.
+            var validation = UserContextMiddleware
+                .ValidateTokenViaHub(rawToken, Mesh)
+                .FirstAsync()
+                .Timeout(StepTimeout)
+                .ToTask(TestContext.Current.CancellationToken);
+
+            // ── The assertion. Read BEFORE awaiting: the response has not arrived, so under the old
+            // shape nothing has disposed the scope and this thread is still impersonated.
+            identityRightAfterSubscribe = access.Context?.ObjectId;
+
+            response = await validation;
+        }
+
+        identityRightAfterSubscribe.Should().NotBe(SystemId,
+            "the auth bootstrap's System scope must not outlive the Subscribe that opened it. "
+            + "Observing 'system-security' here means the ASP.NET request thread runs the REST of "
+            + "the request with Permission.All — including InvokeAsync's `existing.Email == "
+            + "userContext.Email` reuse branch, which then adopts the System context as the "
+            + "caller's own (#1790)");
+        identityRightAfterSubscribe.Should().Be("alice",
+            "and it must be the caller's own identity that is handed back — not merely 'not System'");
+
+        response.Should().NotBeNull("non-vacuity: the validation must have produced a verdict");
+        response!.Success.Should().BeTrue(
+            "non-vacuity, and the half that matters: the token node is readable only under the "
+            + "System scope, so a green identity assertion with a FAILED verdict would mean the "
+            + "impersonation had simply been dropped — trading an escalation for a portal outage. "
+            + "Error was: " + (response.Error ?? "(none)"));
+        response.UserId.Should().Be(TokenOwner);
+
+        access.Context?.ObjectId.Should().Be("alice",
+            "and the enclosing scope still restores normally afterwards");
+    }
+
+    /// <summary>
+    /// Mints an ApiToken node at <c>ApiToken/{hashPrefix}</c> — the address
+    /// <see cref="UserContextMiddleware.ValidateTokenViaHub"/> targets. <c>MainNode</c> is the owning
+    /// user, so the validating read is permitted for the OWNER and for System, and denied to the
+    /// caller in the test — which is what makes the success assertion above evidence that the
+    /// impersonation really ran.
+    /// </summary>
+    private async Task<string> CreateApiToken()
+    {
+        var rawToken = ValidateTokenRequest.TokenPrefix
+                       + Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
+        var hash = ValidateTokenRequest.HashToken(rawToken);
+
+        await NodeFactory.CreateNode(new MeshNode(hash[..12], "ApiToken")
+        {
+            Name = "Auth-bootstrap latch token",
+            NodeType = ApiTokenNodeType.NodeType,
+            MainNode = TokenOwner,
+            Content = new ApiToken
+            {
+                TokenHash = hash,
+                UserId = TokenOwner,
+                UserName = "Token Owner",
+                UserEmail = $"{TokenOwner}@example.com",
+                Label = "latch",
+                CreatedAt = DateTimeOffset.UtcNow,
+                Roles = ["Editor"],
+            }
+        }).Should().Within(StepTimeout).Emit();
+
+        return rawToken;
+    }
+}


### PR DESCRIPTION
Closes the framework-wide identity-latch class audited on #1790 — the half that #1820 fixed at one
call site (`ActivityLogLogger.SealOverflowLocked`), fixed at the SEAM plus the audited high-severity
sites.

## The defect

`AccessService.ImpersonateAsSystem()` returns a scope that stores `context.Value` (an
`AsyncLocal<AccessContext?>`) in its constructor and writes it back in `Dispose()`. Used as

```csharp
Observable.Using(() => access.ImpersonateAsSystem(), _ => someCrossHubCall()).Subscribe(...)
```

Rx runs the resource factory on the **subscribing** thread and disposes the resource when the inner
observable **terminates** — for a cross-hub request/response, the owning hub's response thread. So
the pair lands on two threads and leaks in **both directions**:

1. **The subscribing thread keeps the impersonated identity.** Nothing disposes the scope there.
2. **The terminating thread is handed the subscriber's "previous" identity.** That is an identity
   *injection* into a hub action block / transport handshake thread, not a cleanup.

## What this PR does

**1 — `AccessService`: the restore is now THREAD-AFFINE.** A scope records a marker
(`AsyncLocal<object?>`) and the thread it was opened on, and `Dispose` writes only when the flow
still carries that marker (the synchronous `using`, and an `await` continuation, whose
ExecutionContext carries it forward) **or** we are back on the opening thread (which keeps
`CarryAccessContext`'s per-callback clamp honest when a nested scope was left undisposed). Neither
holds on a foreign terminating thread, so **leak 2 is closed for every call site in the repo**,
including the ~98 still written the old way. The new restore fires on a strict subset of the cases
the old one did, so it can never be worse than today.

**2 — `ImpersonationScopeExtensions`: the seam no longer uses `Observable.Using`.**
`RunAsSystem` / `RunAsHub` / the new `RunAs(identity, …)` / `RunAs(resolver, …)` open the scope at
Subscribe, compose **and subscribe** the work inside it, and leave it on the way out of that same
synchronous `Subscribe`. This closes leak 1 at every seam adopter.

> ⚠️ #1785's note that `RunAsSystem` "measured RED" at the #1790 site was accurate **against the old
> seam**: `ContainIdentity` restores around NOTIFICATIONS only, never around the Subscribe that
> opened the scope, and `RunAsSystem` was `Observable.Using` + `ContainIdentity`. That is exactly
> what changed here. Its 8 existing tests (`SystemScopeDoesNotEscapeTest`) are unchanged and green.

Closing at end-of-Subscribe still covers the work: everything a cold pipeline does eagerly happens
inside `Subscribe` — the factory runs, the write primitives eager-capture the identity, the post is
stamped, and any scheduled continuation captures the `ExecutionContext` as it stands right then. A
captured `ExecutionContext` is an immutable snapshot, so the restore cannot un-elevate work already
scheduled. That property is pinned by
`WorkScheduledInsideTheScopeStillRunsAsSystemAfterTheThreadIsRestored`.

**3 — The audited sites**, migrated with the widest cold pipeline moved INSIDE the `work` factory so
emission-time behaviour is unchanged and only the boundary is sealed:

| Site | Verdict |
|---|---|
| `Blazor/Infrastructure/UserContextMiddleware.ValidateTokenViaHub` | **fixed** — latched System onto the ASP.NET **request** thread |
| `Graph/Configuration/ApiTokenNodeType` ×2 | **fixed** — latched the ApiToken hub's action block |
| `Hosting.Grpc/GrpcConnectionRegistry`, `Hosting.SignalR/SignalRConnectionRegistry` | **fixed** — transport handshake threads |
| `Hosting/PathResolutionService` | **fixed** — hot path of every page load |
| `PluginCatalog/CatalogLayoutAreas` (click action), `PluginCatalog/PackageInstaller.RemoveInstalledRecord` | **fixed** |
| `Graph/SpaceInviteService`, `Graph/GroupInviteExtensions`, `Graph/NotificationService` | **fixed** |
| `Markdown.Export/Html/LayoutAreaResolver`, `Blazor/BlazorView.RunUnderCircuitUser`, `Blazor/Services/BlazorAutocompleteService.RunUnderCircuitUser` | **fixed** (via `RunAs`) |
| `GitSync/GitHubActivityExtensions:75` | **no defect to fix here** — it already calls `accessService.RunAsSystem(runActivity)`; the seam fix closes it with no edit. Same for the 7 other existing seam adopters (`InstanceSyncService`, `ModuleDiscoveryService`, `SystemOwnedAccessRetractionHandler`, `EventSubscriptionRunner`, `AccessGrantNotifier`, `StaticRepoImporter`, `MeshExtensions`). |
| `Kernel.Hub/ActivityLogLogger` | **not touched** — #1820 owns that file. |

**The auth bootstrap's impersonation is preserved exactly.** Running token validation as System is
deliberate and correct (#637, prod 2026-06-18); only the leak is removed, and the integration test
asserts the verdict is still `Success` so a "fix" that silently stopped impersonating fails loudly.

While reading it, one concrete escalation fell out: after the latch, `InvokeAsync` reads
`userService.Context` into `existing` and reuses it when `existing.Email == userContext.Email`. The
latched System context has a null `Email`, so a token record carrying no e-mail matched it and the
request proceeded with the System context set as the caller's own.

**4 — Regression guard.** `ImpersonationScopeSiteRatchetGuard` +
`test/ImpersonationScopeSites.allow` scan `src/`, `memex/`, `tools/` for
`Observable.Using(…Impersonate…/…SwitchAccessContext…)` (comments and string literals masked, so the
seam's own remarks are not counted). A NEW file, a raised per-file count, or a raised TOTAL fails.
A line that has become stale is **reported, not failed** — failing on the direction the guard is
asking for would red `main` whenever two PRs close sites concurrently (and #1820 is in flight on one
of the listed files).

## Tests — every one proven non-vacuous

`test/MeshWeaver.Messaging.Hub.Test/ImpersonationScopeThreadAffinityTest.cs` (9),
`test/MeshWeaver.Security.Test/AuthBootstrapIdentityLatchTest.cs` (tier 1),
`test/MeshWeaver.Graph.Test/NotificationDispatchIdentityLatchTest.cs` (tiers 2–3).

Every one asserts the NEGATIVE — what the calling thread is left holding, and that the terminating
thread received nothing — because the operation succeeds either way. Non-vacuity was measured by
re-implementing the two fixed methods the pre-fix way (`Observable.Using` + `ContainIdentity`, and
an unconditional `Dispose`) and re-running: **5 of the 9 unit tests and both integration tests go
red**, with exactly the intended messages. The 4 that stay green are the ones pinning behaviour that
must NOT change (the raw idiom's latch, the synchronous restore, the `await`-spanning restore).
