### PR TITLE
fix(test): AreaProbeTest's frames were queued onto another test's Rx trampoline — 26% flake

### DIFF
--- a/test/MeshWeaver.PluginTester.Test/AreaProbeTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/AreaProbeTest.cs
@@ -1,3 +1,5 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text.Json;
@@ -17,6 +19,10 @@ namespace MeshWeaver.PluginTester.Test;
 /// <c>No renderer is registered for area `Tests` on hub `Store`</c> — a gate failure that fired
 /// only on loaded CI runners (16 straight local runs, macOS and Linux, could not reproduce it)
 /// and redded three unrelated core PRs in one day.</para>
+///
+/// <para>The frames are pushed synchronously on subscribe (<see cref="FrameStream"/>), never
+/// scheduled — see that helper for why an enumerable-backed source made these tests depend on
+/// what the REST of the assembly was doing on the shared thread pool.</para>
 /// </summary>
 public class AreaProbeTest
 {
@@ -39,13 +45,54 @@ public class AreaProbeTest
         """{"areas":{"$Menu:Node":{"items":[{"label":"Request Approval","icon":"✅"},{"label":"Delete","icon":"🗑️"}]}}}""");
 
     /// <summary>
+    /// The synthetic stand-in for the live sync stream: pushes <paramref name="frames"/> to the
+    /// subscriber SYNCHRONOUSLY, during <c>Subscribe</c>, then completes — the same shape
+    /// <see cref="AreaProbe.ExecuteTestsArea"/> sees from
+    /// <c>GetRemoteStream&lt;JsonElement, LayoutAreaReference&gt;</c>.
+    ///
+    /// <para>🚨 NOT <c>new[]{ … }.ToObservable()</c>. That overload emits on
+    /// <c>SchedulerDefaults.Iteration</c> = <b>CurrentThreadScheduler</b>, and schedules its emit
+    /// loop as a SEPARATE work item — which <c>CurrentThreadScheduler</c> runs only if no
+    /// trampoline is already installed on the calling thread, and otherwise merely ENQUEUES behind
+    /// whatever that trampoline is doing. In this assembly a trampoline routinely IS installed:
+    /// <c>PluginGateRunner.RunPackages</c> composes the gate with <c>.ToObservable().Concat()</c>,
+    /// <c>PluginGateRunnerTest.RunGate</c> bridges it to a Task with <c>.FirstAsync().ToTask(…)</c>,
+    /// and completing that TaskCompletionSource runs the awaiting continuation INLINE on the
+    /// trampoline thread — a continuation which is the xUnit runner, which then runs the next test
+    /// class synchronously on that same stack. The frames then sit in a foreign queue that cannot
+    /// drain until the whole inlined runner stack unwinds, and <c>Timeout</c> wins with ZERO frames
+    /// delivered: 35 % of whole-assembly runs (0 % for the class alone, 0 % under 64 CPU hogs),
+    /// verdict <c>Tests area reported no verdict within 5s</c> at exactly 5000 ms with
+    /// <c>lastTransient</c> still null. Systemorph/MeshWeaver#1826.</para>
+    ///
+    /// <para>Pushing on subscribe removes the scheduler from the picture entirely, so these tests
+    /// assert on the CLASSIFICATION and never on a clock. <see cref="SyncFrames"/> implements
+    /// <see cref="IObservable{T}"/> directly rather than going through <c>Observable.Create</c>,
+    /// because every Rx <c>Producer</c>/<c>ObservableBase</c> subscribe path consults
+    /// <c>CurrentThreadScheduler</c> too — this one cannot.</para>
+    /// </summary>
+    private static IObservable<JsonElement> FrameStream(params JsonElement[] frames) =>
+        new SyncFrames(frames);
+
+    private sealed class SyncFrames(JsonElement[] frames) : IObservable<JsonElement>
+    {
+        public IDisposable Subscribe(IObserver<JsonElement> observer)
+        {
+            foreach (var frame in frames)
+                observer.OnNext(frame);
+            observer.OnCompleted();
+            return Disposable.Empty;
+        }
+    }
+
+    /// <summary>
     /// The regression pin: a not-found frame followed by the real table must be GREEN. Before the
     /// fix, Take(1) latched the not-found frame and the run failed without the tests ever running.
     /// </summary>
     [Fact]
     public async Task NotFoundFrame_ThenGreenTable_IsPassed()
     {
-        var frames = new[] { NotFound, GreenTable }.ToObservable();
+        var frames = FrameStream(NotFound, GreenTable);
 
         var verdict = await AreaProbe.ClassifyTestsFrames(frames, TimeSpan.FromSeconds(5))
             .FirstAsync().ToTask();
@@ -81,7 +128,7 @@ public class AreaProbeTest
     [Fact]
     public async Task MenuChromeFrame_ThenGreenTable_ReportsThePassSummary()
     {
-        var frames = new[] { MenuChromeOnly, GreenTable }.ToObservable();
+        var frames = FrameStream(MenuChromeOnly, GreenTable);
 
         var verdict = await AreaProbe.ClassifyTestsFrames(frames, TimeSpan.FromSeconds(5))
             .FirstAsync().ToTask();
@@ -113,5 +160,60 @@ public class AreaProbeTest
 
         Assert.Equal(CheckOutcome.Failed, verdict.Outcome);
         Assert.Contains("no verdict", verdict.Detail);
+    }
+
+    /// <summary>
+    /// The flake pin for Systemorph/MeshWeaver#1826: the synthetic frame source must deliver every
+    /// frame DURING <c>Subscribe</c>, even when the calling thread already sits inside somebody
+    /// else's <c>CurrentThreadScheduler</c> trampoline — the state xUnit leaves a thread in
+    /// whenever a sibling test completes a <c>ToTask()</c> bridge from inside one, because
+    /// <c>TrySetResult</c> runs the awaiting continuation (here: the whole runner) inline.
+    ///
+    /// <para>Runs on a dedicated thread so the trampoline state is KNOWN. This test's own thread
+    /// may already be inside a foreign trampoline — that is the very defect — which would defer
+    /// the body and leave the pin asserting nothing.</para>
+    ///
+    /// <para>Fails on the retired <c>new[]{ … }.ToObservable()</c> source, which schedules its
+    /// emit loop as a separate work item onto the ambient trampoline: zero frames and no verdict
+    /// at the point this asserts. It does no waiting at all, so there is no clock to tune.</para>
+    /// </summary>
+    [Fact]
+    public void Frames_ArriveDuringSubscribe_EvenInsideAForeignTrampoline()
+    {
+        var insideForeignTrampoline = false;
+        var framesSeenOnReturn = -1;
+        var verdictsSeenOnReturn = -1;
+        var verdicts = new List<AreaVerdict>();
+
+        var pin = new Thread(() =>
+            CurrentThreadScheduler.Instance.Schedule(() =>
+            {
+                // Schedule() on a clean thread INSTALLS a trampoline and runs this body inside it.
+                insideForeignTrampoline = !CurrentThreadScheduler.IsScheduleRequired;
+
+                var seen = new List<JsonElement>();
+                using (FrameStream(NotFound, GreenTable).Subscribe(seen.Add))
+                    framesSeenOnReturn = seen.Count;
+
+                using (AreaProbe
+                           .ClassifyTestsFrames(FrameStream(NotFound, GreenTable), TimeSpan.FromSeconds(5))
+                           .Subscribe(verdicts.Add))
+                    verdictsSeenOnReturn = verdicts.Count;
+            }))
+        {
+            IsBackground = true,
+            Name = "areaprobe-trampoline-pin",
+        };
+
+        pin.Start();
+        Assert.True(pin.Join(TimeSpan.FromSeconds(30)),
+            "the pin body performs no waiting at all — not finishing means it was queued, never run");
+
+        Assert.True(insideForeignTrampoline,
+            "the body must execute inside a live CurrentThreadScheduler trampoline, or it pins nothing");
+        Assert.Equal(2, framesSeenOnReturn);
+        Assert.Equal(1, verdictsSeenOnReturn);
+        Assert.Equal(CheckOutcome.Passed, verdicts[0].Outcome);
+        Assert.Equal("2/2 passed", verdicts[0].Detail);
     }
 }


### PR DESCRIPTION
Fixes #1826.

## The flake

`AreaProbeTest.NotFoundFrame_ThenGreenTable_IsPassed` and
`AreaProbeTest.MenuChromeFrame_ThenGreenTable_ReportsThePassSummary` fail whenever the
whole `MeshWeaver.PluginTester.Test` assembly runs. Part of the #1384 flake population.

| run shape | iterations | failures |
|---|---|---|
| single test method, no load | 30 | 0 |
| single test method, 64 CPU hogs | 40 | 0 |
| `-class AreaProbeTest`, no load | 20 | 0 |
| **whole assembly** | 70 | **18 (26 %)** |

CPU load is not the trigger. Running the rest of the assembly is.

## Mechanism

Instrumenting the test gave a 12/12 correlation: `CurrentThreadScheduler.IsScheduleRequired`
**false** at test entry ⇒ fail; **true** ⇒ pass. On the failing runs the verdict is
`Tests area reported no verdict within 5s` at exactly 5000 ms with `lastTransient` still
null — i.e. **not one frame was ever delivered**.

Both tests drove the seam with `new[]{ NotFound, GreenTable }.ToObservable()`, which emits on
`SchedulerDefaults.Iteration` = `CurrentThreadScheduler` and schedules its emit loop as a
*separate work item*. `CurrentThreadScheduler` runs that item only when no trampoline is
installed on the calling thread; otherwise it merely **enqueues behind whatever that trampoline
is doing**.

A trampoline routinely is installed. `Environment.StackTrace` captured on the failing runs:

```
AreaProbeTest.NotFoundFrame_ThenGreenTable_IsPassed()          ← our test, running here
  … 60 frames of Xunit.v3 runner …
  Task`1.TrySetResult / AwaitTaskContinuation.RunOrScheduleAction
PluginGateRunnerTest.CommercialPackage_InstallsAndGatesGreen()
PluginGateRunnerTest.RunGate(String repo)
  TaskCompletionSource`1.TrySetResult
  TaskObservableExtensions.ToTaskObserver`1.OnCompleted()       ← the ToTask() bridge completing…
  ObservableImpl.ConcatMany`1.ConcatManyOuterObserver.Drain()   ← …inside PluginGateRunner's
                                                                  .ToObservable().Concat() trampoline
```

1. `PluginGateRunner.RunPackages` composes the gate with `.ToObservable().Concat()` — the whole run executes inside one trampoline.
2. `PluginGateRunnerTest.RunGate` bridges it to a Task with `.FirstAsync().ToTask(…)`.
3. Completing that `TaskCompletionSource` runs the awaiting continuation **inline, on the trampoline thread** — and that continuation is the xUnit runner, which runs the next test class synchronously on the same stack.
4. `AreaProbeTest`'s frames are queued onto that foreign trampoline, which cannot drain until the whole inlined runner stack unwinds. `Timeout` wins.

That is why it is invisible in isolation and immune to CPU load: an ordering/inlining condition, not a timing one.

## Test defect, not a gate defect

The working hypothesis was cold-start cost landing inside the operator's 5 s budget. **Refuted:**

- The failing runs consume 0 ms of legitimate work — no frame is produced at all. Nothing is slow; something never runs, so a bigger budget only hangs longer.
- `AreaProbe.ClassifyTestsFrames` is deterministic and correct.
- The product path (`AreaProbe.ExecuteTestsArea` → `Frames()` → `GetRemoteStream<JsonElement, LayoutAreaReference>`) never uses a `CurrentThreadScheduler`-scheduled source; frames arrive on hub delivery threads, and `mw-plugin-test` passes its own `RenderTimeout`. **The five node-plugin repos that gate on `mw-plugin-test` are not exposed.**

The fault is that the test's *source* was scheduler-ambient — its delivery depended on what other tests were doing on the shared thread pool.

## The fix

Push the synthetic frames **synchronously on subscribe** — the same shape the live sync stream has — instead of scheduling them onto whatever trampoline owns the calling thread. `SyncFrames` implements `IObservable<JsonElement>` directly rather than going through `Observable.Create`, because every Rx `Producer`/`ObservableBase` subscribe path consults `CurrentThreadScheduler` too. No timeout was raised, no sleep or retry added; the two tests now assert on the classification and never on a clock.

New pin: `Frames_ArriveDuringSubscribe_EvenInsideAForeignTrampoline` installs a foreign
trampoline on a dedicated thread (this test's own thread may already be inside one — that is the
defect) and requires both frames *and* the verdict to have arrived by the time `Subscribe`
returns. It waits for nothing.

## Control

Same machine, same loop, same bin location, whole assembly, no artificial load:

| | iterations | failures |
|---|---|---|
| **before** (`origin/main`) | 70 | **18 (26 %)** |
| **after** (this change) | 60 | **0** |
| new pin against the retired `ToObservable()` source | — | fails deterministically, `Expected: 2 / Actual: 0` |

Release `-warnaserror` build clean; `MeshWeaver.PluginTester.Test` green 58/58 on all 60 runs.

## Overlap with #1822

**None at file level.** #1822 touches `Program.cs`, `GateAllowlist.cs`, `GateAllowlistTest.cs`,
`StartupFailureProcessTest.cs`, the README and three workflows; this PR touches only
`test/MeshWeaver.PluginTester.Test/AreaProbeTest.cs`. Either can merge first.

Worth noting for sequencing: #1822 adds a new test class to the same assembly, which changes the
concurrent-class population and so may perturb the *rate* at which the inlining window opens — it
neither causes nor fixes this defect, and after this change `AreaProbeTest` is immune either way.

## What's New

Skipped — test-only change with no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wVYniTKJ7Kuw7Hh425UPy
