### PR TITLE
fix(tokens): never write a zero-token usage satellite

### DIFF
--- a/src/MeshWeaver.AI/TokenUsage.cs
+++ b/src/MeshWeaver.AI/TokenUsage.cs
@@ -129,11 +129,25 @@ public static class TokenUsageNodeType
     /// <c>Where(...).Timeout</c> read), so it can land shortly AFTER the terminal status.
     ///
     /// <para>Two NON-poisoning phases (rounds run serially per thread, so this read-modify-write is
-    /// race-free): (1) create-only EnsureExists via <see cref="IMeshService.CreateNode"/> (a mesh-targeted
+    /// race-free): (1) create-only via <see cref="IMeshService.CreateNode"/> (a mesh-targeted
     /// CreateNodeRequest — never a point GetMeshNodeStream read of an absent node, which would trip the
-    /// MeshNodeStreamCache storm breaker); then (2) accumulate via the OWNER's authoritative
-    /// <c>GetMeshNodeStream(path).Update</c> on the now-existing node, which reads the live current
-    /// value and adds this round's tokens (exact across rounds, unlike a lagged CQRS query read).</para>
+    /// MeshNodeStreamCache storm breaker) of a satellite ALREADY CARRYING this round's counts; then
+    /// (2) — <b>only when that create reported the node already existed</b> — accumulate via the
+    /// OWNER's authoritative <c>GetMeshNodeStream(path).Update</c>, which reads the live current value
+    /// and adds this round's tokens (exact across rounds, unlike a lagged CQRS query read).</para>
+    ///
+    /// <para>🚨 <b>Phase 1 must never write a ZERO-token satellite</b> (#1812). It used to create the
+    /// node with all counters at zero and let phase 2 add the round's tokens on top, which published a
+    /// durable, readable, all-zero satellite in the window between the two writes — measured at ~60 ms
+    /// on an idle box, unbounded under load. Every reader saw it: the GUI's <c>ThreadTokenChip</c>
+    /// rendered <c>↑0 ↓0 · $0</c> for that window, and the token tests observed it as their FIRST
+    /// emission and then had to out-wait it (CI run 32070434174 timed out on exactly that snapshot,
+    /// <c>InputTokens = 0</c>, with the correct value landing after the assertion's budget). Worse, the
+    /// 15 s cap below fails OPEN, so a phase 2 that never lands leaves those zeros as the PERMANENT
+    /// record of a round that did consume tokens. Seeding the create with the round's counts removes
+    /// the intermediate outright: the first round is one atomic write that is correct the instant it is
+    /// visible, and only rounds 2+ pay for a read-modify-write. It costs nothing to do it this way —
+    /// the create already had to carry a content instance.</para>
     /// </summary>
     public static IObservable<System.Reactive.Unit> RecordUsage(
         IMessageHub hub, string threadPath, string? userId,
@@ -176,27 +190,43 @@ public static class TokenUsageNodeType
         //   • the untargeted CreateOrUpdateNodeRequest never reaches HandleCreateOrUpdateNodeRequest (it
         //     lives on the MESH hub — IMeshService.CreateNode targets hub.GetMeshHub().Address), so from
         //     this per-node thread hub the satellite was never created at all.
-        // Phase 1: EnsureExists via meshService.CreateNode of a ZERO-token satellite — CREATE-ONLY, so an
-        //   existing satellite (round 2+) is left untouched (CreateNode throws NodeAlreadyExists → caught
-        //   → continue). meshService.CreateNode posts a CreateNodeRequest TARGETED at the mesh hub and is
-        //   NOT a point-read, so it neither mis-routes nor poisons. It guarantees the node + its owning
-        //   per-node hub exist before the accumulate.
-        // Phase 2: accumulate via the OWNER's authoritative stream.Update — the node now exists, so the
-        //   read-modify-write reads the LIVE current value and adds this round's tokens. Race-free (rounds
-        //   are serial per thread) and EXACT across rounds (the cumulative invariant), unlike a lagged
-        //   CQRS query read which could miss a prior round's write.
+        // Phase 1: CREATE-ONLY via meshService.CreateNode, of a satellite already carrying THIS ROUND'S
+        //   counts — so an existing satellite (round 2+) is left untouched (CreateNode throws
+        //   NodeAlreadyExists → caught → phase 2). meshService.CreateNode posts a CreateNodeRequest
+        //   TARGETED at the mesh hub and is NOT a point-read, so it neither mis-routes nor poisons.
+        //   🚨 The counts go in HERE, not in a follow-up write (#1812): a create seeded with zeros
+        //   publishes a durable all-zero satellite until phase 2 lands, and that intermediate is
+        //   readable by everyone (the GUI chip renders it; the token tests saw it as their first
+        //   emission and timed out out-waiting it). On the first round this branch is now the WHOLE
+        //   write — atomic, correct the instant it is visible, and immune to the fail-open cap below.
+        // Phase 2: reached ONLY when the create said the node already exists. Accumulate via the OWNER's
+        //   authoritative stream.Update — the node demonstrably exists, so the read-modify-write reads
+        //   the LIVE current value and adds this round's tokens. Race-free (rounds are serial per
+        //   thread) and EXACT across rounds (the cumulative invariant), unlike a lagged CQRS query read
+        //   which could miss a prior round's write. Running it on the create's SUCCESS path too would
+        //   double-count, which is precisely why the zero seed existed.
         var freshNode = new MeshNode(key, ns)
         {
             Name = model,
             NodeType = NodeType,
             State = MeshNodeState.Active,
             MainNode = threadPath,
-            Content = new TokenUsage { UserId = userId, ThreadId = threadPath, Model = model },
+            Content = new TokenUsage
+            {
+                UserId = userId,
+                ThreadId = threadPath,
+                Model = model,
+                InputTokens = inTok,
+                OutputTokens = outTok,
+                CacheReadTokens = cacheReadTok,
+                CacheWriteTokens = cacheWriteTok,
+            },
         };
 
         return meshService.CreateNode(freshNode)
+            // TRUE = we created it, so this round's counts are already durable and phase 2 must NOT run.
             .Select(_ => true)
-            // Already exists (every round after the first for this model) → keep going to the accumulate.
+            // Already exists (every round after the first for this model) → FALSE, go accumulate.
             // A DIFFERENT failure (e.g. RLS) must NOT fall through to Phase 2: .Update on a node that was
             // never created would re-open the absent-node point-access this fix exists to avoid. Rethrow
             // so the terminal Catch fails the usage write open without touching the stream.
@@ -205,18 +235,34 @@ public static class TokenUsageNodeType
                 && ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase)
                     ? Observable.Return(false)
                     : Observable.Throw<bool>(ex))
-            .SelectMany(_ => hub.GetWorkspace().GetMeshNodeStream(usagePath)
-                .Update(node =>
-                {
-                    var cur = node.ContentAs<TokenUsage>(hub.JsonSerializerOptions, logger)
-                              ?? new TokenUsage { UserId = userId, ThreadId = threadPath, Model = model };
-                    return node with { Content = cur.Add(inTok, outTok, cacheReadTok, cacheWriteTok) };
-                }))
-            .Select(_ => System.Reactive.Unit.Default)
+            .SelectMany(alreadyDurable => alreadyDurable
+                ? Observable.Return(System.Reactive.Unit.Default)
+                : hub.GetWorkspace().GetMeshNodeStream(usagePath)
+                    .Update(node =>
+                    {
+                        var cur = node.ContentAs<TokenUsage>(hub.JsonSerializerOptions, logger)
+                                  ?? new TokenUsage { UserId = userId, ThreadId = threadPath, Model = model };
+                        return node with { Content = cur.Add(inTok, outTok, cacheReadTok, cacheWriteTok) };
+                    })
+                    .Select(_ => System.Reactive.Unit.Default))
             // Subscribed as an INDEPENDENT side effect (NOT chained before the terminal status write),
             // so it can never block the round. Still cap + fail open as basic hygiene: a wedged create
             // or accumulate resolves to a no-op rather than leaking a live subscription.
-            .Timeout(TimeSpan.FromSeconds(15), Observable.Return(System.Reactive.Unit.Default))
+            //
+            // 🚨 Fail open LOUDLY. This used to swap in a bare Observable.Return, so a cap that fired
+            // completed the chain SUCCESSFULLY and logged nothing at all — the round's tokens were gone
+            // from accounting with no trace, and "phase 2 landed late" was indistinguishable from
+            // "phase 2 never landed" for anyone reading the satellite afterwards. Defer so the warning
+            // fires only when the cap actually trips, not when the chain is built.
+            .Timeout(TimeSpan.FromSeconds(15), Observable.Defer(() =>
+            {
+                logger?.LogWarning(
+                    "[TokenUsage] RecordUsage TIMED OUT after 15s for {Path} (model {ModelId}) — "
+                    + "in={InputTokens} out={OutputTokens} cacheRead={CacheReadTokens} "
+                    + "cacheWrite={CacheWriteTokens} were NOT recorded",
+                    usagePath, model, inTok, outTok, cacheReadTok, cacheWriteTok);
+                return Observable.Return(System.Reactive.Unit.Default);
+            }))
             .Catch((Exception ex) =>
             {
                 logger?.LogWarning(ex, "[TokenUsage] RecordUsage failed for {Path}", usagePath);

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-token-usage-never-shows-zero.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-token-usage-never-shows-zero.md
@@ -1,0 +1,20 @@
+---
+Name: Token usage no longer flashes zero
+Category: Fix
+Description: A thread's token chip now shows the real counts the moment they exist, instead of briefly reading 0 tokens and $0.
+Icon: Sparkle
+Order: -20260818
+---
+
+# Token usage no longer flashes zero
+
+After a chat round finished, the token chip on a thread could briefly show `↑0 ↓0 · $0` before
+snapping to the real numbers. That was not a display delay — the usage record was genuinely written
+twice: once empty, and again a moment later with the round's counts.
+
+The empty write is gone. A round's token counts are now saved in a single step, so the chip shows
+the true figures as soon as the record exists. This also closes a rarer and worse case: if that
+second write was lost — under heavy load it could be abandoned after 15 seconds, silently — the
+zeros became the permanent record of a round that really had consumed tokens. There is no longer a
+second write to lose on a thread's first round with a model, and when one is abandoned it now says
+so in the log instead of failing quietly.

--- a/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
@@ -308,6 +308,14 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
     /// unrelated PR (#1703, 2026-08-17): the round lost the race and the read errored inside a
     /// second with <c>No node found at …/_Usage/…</c> — an error, not a timeout, so no amount of
     /// waiting could have saved it. Same defect #1040 fixed in <c>ThreadTokenUsageTest</c>.</para>
+    ///
+    /// <para>🚨 <b>Do not switch this to the node stream</b> (#1812). That issue proposed it, on the
+    /// theory that an all-zero <c>TokenUsage</c> CI once timed out on was a stale CQRS projection.
+    /// Measured, it is not: this query and <c>GetMeshNodeStream(usagePath)</c> resolve within ±13 ms
+    /// of each other, and the point stream is the SLOWER of the two once its cold per-node hub
+    /// activation is counted. The zeros were the node's authoritative value — <c>RecordUsage</c>'s
+    /// phase 1 wrote them — so an authoritative read returned the same zeros. Fixed on the write
+    /// side; pinned by <c>ThreadTokenUsageTest.UsageSatelliteIsNeverObservableWithZeroTokens</c>.</para>
     /// </summary>
     private async Task<TokenUsage> WaitForUsage(string threadPath, string modelKey, Func<TokenUsage, bool> predicate, int timeoutMs)
     {

--- a/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
@@ -146,6 +146,67 @@ public class ThreadTokenUsageTest : AITestBase
         usage.ThreadId.Should().Be(threadPath);
     }
 
+    // ─── The satellite is never observable with zero tokens (#1812) ───
+
+    /// <summary>
+    /// A round that consumed tokens must NEVER publish a readable all-zero <see cref="TokenUsage"/>
+    /// satellite — not even for a moment. Every emission that carries the node carries the counts.
+    ///
+    /// <para>This is the defect behind #1812, and it was a WRITE-side one.
+    /// <c>TokenUsageNodeType.RecordUsage</c> used to write in two phases whose FIRST phase created
+    /// the satellite with all four counters at zero and whose second added the round's tokens on
+    /// top. That published a durable, readable, all-zero record in the window between them —
+    /// measured at ~60 ms idle on this suite, unbounded under load. It was not a stale index view of
+    /// a value already written; it was the node's real value, so an "authoritative" point read
+    /// returned the same zeros.</para>
+    ///
+    /// <para>Two things went wrong with it, and only the second was ever noticed:
+    /// the GUI's <c>ThreadTokenChip</c> renders that window as <c>↑0 ↓0 · $0</c>; and a reader
+    /// waiting for the counts had to out-wait an intermediate that carried the right model and the
+    /// wrong numbers. CI run 32070434174 lost that wait — it reported
+    /// <c>Last of 1 emission(s) … InputTokens = 0</c> after 10 s, which reads as a lagging reader and
+    /// is really a premature writer. And because the write chain's 15 s cap fails OPEN, a phase 2
+    /// that never lands leaves those zeros as the PERMANENT record of a round that did cost money.
+    /// </para>
+    ///
+    /// <para>The watcher is opened BEFORE the round so it is live across every write the satellite
+    /// receives: the underlying query re-runs on each change with no debounce, so a durable zero
+    /// state cannot slip past it. Pre-fix this failed on the first emission, every run.</para>
+    /// </summary>
+    [Fact]
+    public async Task UsageSatelliteIsNeverObservableWithZeroTokens()
+    {
+        var threadPath = await SeedThread();
+        var client = GetClient();
+
+        var gate = new Lock();
+        var zeroSnapshots = new List<TokenUsage>();
+
+        // Live from before the round — see the summary: this must see every state the node passes
+        // through, not just the one it settles on.
+        var settled = ObserveUsage(threadPath, "usage_model")
+            .Do(u =>
+            {
+                if (u.InputTokens == 0 && u.OutputTokens == 0
+                    && u.CacheReadTokens == 0 && u.CacheWriteTokens == 0)
+                    lock (gate) zeroSnapshots.Add(u);
+            })
+            .Should().Within(TimeSpan.FromSeconds(20))
+            .Match(u => u.InputTokens == InTokens && u.OutputTokens == OutTokens);
+
+        client.SubmitMessage(threadPath, "hello", modelName: "usage-model", createdBy: TestUser);
+
+        await settled;
+
+        List<TokenUsage> observedZeros;
+        lock (gate) observedZeros = [.. zeroSnapshots];
+        observedZeros.Should().BeEmpty(
+            "a round that consumed {0} in / {1} out tokens must never publish a readable all-zero "
+            + "usage satellite — the GUI chip renders that window as $0, and if the follow-up write "
+            + "never lands (RecordUsage's cap fails open) the zeros become the permanent record",
+            InTokens, OutTokens);
+    }
+
     // ─── Cumulative across rounds (pins the round-dispatch reset hole) ───
 
     [Fact]
@@ -388,8 +449,8 @@ public class ThreadTokenUsageTest : AITestBase
             .Match(m => predicate(m!)))!;
 
     /// <summary>
-    /// Watches the per-model <see cref="TokenUsage"/> satellite at
-    /// <c>{threadPath}/_Usage/{modelKey}</c> until it matches <paramref name="predicate"/>.
+    /// The live per-model <see cref="TokenUsage"/> satellite at <c>{threadPath}/_Usage/{modelKey}</c>,
+    /// as every emission the reader can observe (nulls — "not there yet" — filtered out).
     ///
     /// <para>🚨 Through the LIVE CHILDREN QUERY of <c>{threadPath}/_Usage</c> — byte for byte the
     /// primitive <c>ThreadTokenChip</c> binds to in the portal — and never a point
@@ -398,8 +459,11 @@ public class ThreadTokenUsageTest : AITestBase
     /// deliberately NOT chained before the round's terminal status write; a watcher can therefore be
     /// in place before the node exists. A point read of an absent node answers with an authoritative
     /// routing NotFound and TERMINATES the stream with an error — it cannot wait for a node to
-    /// appear. The children query starts from the (possibly empty) collection and re-emits when the
-    /// node lands, which is the only shape that serves this ordering.</para>
+    /// appear, and worse, that NotFound opens MeshNodeStreamCache's storm-breaker window on the very
+    /// path RecordUsage is about to write, which fast-fails the WRITE too. The children query starts
+    /// from the (possibly empty) collection and re-emits when the node lands, which is the only shape
+    /// that serves this ordering. Listing children is exactly the use AGENTS.md sanctions for a
+    /// query.</para>
     ///
     /// <para>That mismatch was #1040's largest blocker: at
     /// <c>DOTNET_PROCESSOR_COUNT=4 -parallel collections</c> three of this class's tests failed
@@ -407,11 +471,21 @@ public class ThreadTokenUsageTest : AITestBase
     /// scheduling merely let the create win the race.
     /// <see cref="UsageWatchedFromBeforeTheRound_ArrivesWhenTheSatelliteIsCreated"/> pins the losing
     /// ordering deterministically.</para>
+    ///
+    /// <para>🚨 <b>Do NOT "fix" a slow usage read by switching this to the node stream</b> (#1812).
+    /// That issue proposed it, on the theory that the all-zero <c>TokenUsage</c> CI once timed out on
+    /// was a stale CQRS projection. Measured, it is not: with both readers racing the same round,
+    /// this query and <c>GetMeshNodeStream(usagePath)</c> resolve within ±13 ms of each other, and
+    /// the point stream is the SLOWER of the two once its cold per-node hub activation is counted.
+    /// The zeros were not a lagged view of a written value — they WERE the node's authoritative
+    /// value, because <c>RecordUsage</c>'s phase 1 wrote them. An authoritative read would have
+    /// returned the same zeros. The defect was on the write side and is fixed there; see
+    /// <see cref="UsageSatelliteIsNeverObservableWithZeroTokens"/>, which pins it.</para>
     /// </summary>
-    private async Task<TokenUsage> WaitForUsage(string threadPath, string modelKey, Func<TokenUsage, bool> predicate, int timeoutMs)
+    private IObservable<TokenUsage> ObserveUsage(string threadPath, string modelKey)
     {
         var usagePath = $"{threadPath}/{TokenUsageNodeType.SatelliteSegment}/{modelKey}";
-        return (await Mesh.GetQuery(
+        return Mesh.GetQuery(
                 $"usage:{threadPath}",
                 $"path:{threadPath}/{TokenUsageNodeType.SatelliteSegment} scope:children "
                 + $"nodeType:{TokenUsageNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
@@ -419,9 +493,16 @@ public class ThreadTokenUsageTest : AITestBase
                 .FirstOrDefault(n => string.Equals(n.Path, usagePath, StringComparison.OrdinalIgnoreCase))
                 .ContentAs<TokenUsage>(Mesh.JsonSerializerOptions))
             .Where(u => u is not null)
-            .Should().Within(TimeSpan.FromMilliseconds(timeoutMs))
-            .Match(u => predicate(u!)))!;
+            .Select(u => u!);
     }
+
+    /// <summary>
+    /// Watches <see cref="ObserveUsage"/> until it matches <paramref name="predicate"/>.
+    /// </summary>
+    private Task<TokenUsage> WaitForUsage(string threadPath, string modelKey, Func<TokenUsage, bool> predicate, int timeoutMs)
+        => ObserveUsage(threadPath, modelKey)
+            .Should().Within(TimeSpan.FromMilliseconds(timeoutMs))
+            .Match(predicate);
 
     // ─── Fake usage-reporting chat client ───
 

--- a/test/MeshWeaver.Threading.Test/DelegationSubThreadUsageTest.cs
+++ b/test/MeshWeaver.Threading.Test/DelegationSubThreadUsageTest.cs
@@ -143,6 +143,14 @@ public class DelegationSubThreadUsageTest(ITestOutputHelper output) : MonolithMe
         //    the "wait until the sub-thread settles" hop this used to make first — which was itself
         //    unsound, since Thread.IsExecuting is false for the INITIAL Idle state as well as for a
         //    finished round (the same defect fixed in OrleansSubThreadAutoResumeTest).
+        //
+        //    🚨 Do NOT switch this to the node stream (#1812). That issue proposed it, on the theory
+        //    that an all-zero TokenUsage CI once timed out on was a stale CQRS projection. Measured,
+        //    it is not: this query and GetMeshNodeStream(usagePath) resolve within ±13 ms of each
+        //    other, and the point stream is the SLOWER of the two once its cold per-node hub
+        //    activation is counted. The zeros were the node's authoritative value — RecordUsage's
+        //    phase 1 wrote them — so an authoritative read returned the same zeros. Fixed on the
+        //    write side; pinned by ThreadTokenUsageTest.UsageSatelliteIsNeverObservableWithZeroTokens.
         var usagePath = $"{subThreadPath}/{TokenUsageNodeType.SatelliteSegment}/{UsageModelKey}";
         var usage = (await Mesh.GetQuery(
                 $"usage:{subThreadPath}",


### PR DESCRIPTION
Closes #1812.

## What CI saw, and what it actually was

```
ThreadTokenUsageTest.ErrorRound_KeysUsageAndCellByActualModel_NotRequestedAlias [FAIL]
  Expected the observable to emit a value matching the predicate within 10s.
  Last of 1 emission(s) was:
    TokenUsage { Model = usage-error-resolved, InputTokens = 0, OutputTokens = 0, … }
```

`TokenUsageNodeType.RecordUsage` wrote the per-(thread, model) satellite in **two phases whose first
phase created it with all four counters at zero** and whose second added the round's counts on top.
That published a **durable, readable, all-zero record** in the window between them. It is not a
display delay and not a stale projection — it is a value that was really written.

**Measured on this suite** (probe racing both readers over the same round, then discarded):

| | first emission carrying the satellite | value settles |
|---|---|---|
| before | `InputTokens = 0` — **8/8 completed rounds** | ~60 ms later |
| after | `InputTokens = 137` — **16/16 rounds** | — |

Everyone downstream saw those zeros: the GUI's `ThreadTokenChip` renders that window as
`↑0 ↓0 · $0`, and a reader waiting for the counts had to out-wait an intermediate that carried the
right model and the wrong numbers. Under CI load that wait lost.

## The fix

Phase 1 now creates the satellite **already carrying this round's counts**, and phase 2 runs **only
when the create reported the node already existed** (rounds 2+, where accumulating is the point).
The first round becomes one atomic write that is correct the instant it is visible — there is no
intermediate to observe and no second write to lose. It costs nothing: the create already had to
carry a content instance.

That last part matters beyond the flake. The chain's 15 s cap **fails open**, so a phase 2 that
never landed left those zeros as the **permanent** record of a round that did consume tokens. The
cap also swapped in a bare `Observable.Return`, so it completed the chain *successfully* and logged
**nothing at all** — "landed late" and "never landed" were indistinguishable afterwards. It now logs
a warning naming the path, the model and the counts it dropped.

## Why the issue's prescribed fix is not applied

#1812 diagnosed this as the test reading through a lagged CQRS query and prescribed switching to
`GetMeshNodeStream(usagePath)`. **Measured, that is not the mechanism, and the switch would not have
helped.** Racing both readers over the same round, the children query and the point stream resolve
**within ±13 ms of each other**, and the point stream is the **slower** of the two once its cold
per-node hub activation is counted (~55 ms vs ~5 ms). The zeros were not a lagged view of a written
value — they *were* the node's authoritative value, so an authoritative read returned the same zeros.

So the read primitive is left alone. A point read of an *absent* satellite errors out and trips
`MeshNodeStreamCache`'s storm breaker on the very path the write is about to use, which is #1040 and
the red shard in #1703. All three usage readers gain a note recording that measurement, because
"switch it to the node stream" is exactly the change the issue invites.

## Reproduction and control (same machine, 18 cores)

The end-to-end 10 s overrun needs CI load and did **not** reproduce locally — 40 runs of the class
under 32 CPU hogs and 72 concurrent-mesh runs were both clean, matching the issue's own note. So the
defect is pinned **deterministically** instead, by the mechanism rather than the budget:

| measurement | before | after |
|---|---|---|
| `UsageSatelliteIsNeverObservableWithZeroTokens` (new) | **5/5 FAIL** | **30/30 pass** |
| `ThreadTokenUsageTest`, the 9 pre-existing tests, 6 concurrent meshes + 16 CPU hogs | 120 runs, 0 failed | 120 runs, 0 failed |
| `CancelledRound_…` alone, 8 concurrent meshes | — | 120 runs, 0 failed |
| `MeshWeaver.AI.Test` full suite | — | 1176 passed, 0 failed |
| `MeshWeaver.Threading.Test` full suite | — | 133 passed, 0 failed |

One unrelated failure appeared in an earlier 72-run sweep (`CancelledRound_…`, *"emitted nothing at
all"* — the satellite never became visible at all). It is not a regression from this change and
cannot be: the create happens at the same moment in both trees, so this fix makes the satellite
carry its counts *at* the instant the previously-zero node became visible, never later. Any wait
that passed before still passes; the old writer needed that instant **plus** a second write. The
targeted 120-run and 120-vs-120 sweeps above found it in neither tree.

## The new test

`UsageSatelliteIsNeverObservableWithZeroTokens` opens the watcher **before** the round, so it is
live across every write the satellite receives (the query re-runs per change, no debounce), and
asserts no emission ever carried all-zero counts. Against the old writer it fails on the first
emission, every run — a mechanism pin, not a timing budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wVYniTKJ7Kuw7Hh425UPy