### PR TITLE
fix: a compile in flight must not read as a finished build (#1811 is #890, not an ordering race)

### DIFF
--- a/src/MeshWeaver.Compiler/EmitPipeline.cs
+++ b/src/MeshWeaver.Compiler/EmitPipeline.cs
@@ -173,7 +173,10 @@ public static class EmitPipeline
     ///   <item><c>canary=REFERENCES</c> — pristine emits, shared does not: the poison travels
     ///     with the reference instances (or the symbols Roslyn caches on their
     ///     <c>AssemblyMetadata</c>), and scoping the set per-mesh is on the right axis.</item>
-    ///   <item><c>canary=BELOW-ROSLYN</c> — neither emits: brand-new references and freshly
+    ///   <item><c>canary=DIVERGENT</c> — neither emits, but they died in DIFFERENT frames. The
+    ///     two legs run identical source, so two different faults are not evidence of one
+    ///     process-wide fault; both sites are named and the below-Roslyn claim is withheld.</item>
+    ///   <item><c>canary=BELOW-ROSLYN</c> — neither emits, IN THE SAME FRAME: brand-new references and freshly
     ///     parsed source still cannot emit, so nothing about the reference set explains it. The
     ///     broken state is under Roslyn (CLR heap / JIT / GC) and no reference-set change can fix
     ///     it. Roslyn keeps no cross-emit state — the metadata writer's indices are per-emit, its
@@ -233,18 +236,73 @@ public static class EmitPipeline
                 + "— the shared reference set cannot emit, but the pristine control could not be "
                 + "BUILT, so this says nothing about whether the reference set is the cause";
 
-        var pristine = EmitCanary(() => pristineRefs);
+        return Verdict(shared, EmitCanary(() => pristineRefs));
+    }
 
-        return pristine.StartsWith("OK", StringComparison.Ordinal)
-            ? $"canary=REFERENCES shared:{shared} pristine:{pristine} — the same source emits fine "
+    /// <summary>
+    /// Reduces the two canary legs to the one-line verdict. Pure — no Roslyn, no process state —
+    /// so every branch is unit-testable (<c>EmitCanaryVerdictTest</c>).
+    ///
+    /// <para>🚨 <b><c>BELOW-ROSLYN</c> requires the two legs to have died in the SAME frame</b>,
+    /// not merely to have both failed. Both legs run the SAME source; the only difference is the
+    /// reference set. So "shared threw and pristine threw" is the evidence for a process-wide
+    /// fault only when it is the SAME fault — and until the throw site was recorded
+    /// (<see cref="ThrowSite"/>) nothing checked that. Every <see cref="NullReferenceException"/>
+    /// in .NET carries the identical message, so an unrelated NRE in the pristine leg (a
+    /// reference that could not be read, an OOM surfacing as a null, a probe-side bug) read as a
+    /// confirmation and the probe answered its most expensive branch — *"the broken state is
+    /// below Roslyn (CLR heap / JIT / GC) … capture a core dump"* — on a coincidence of wording.
+    /// When the sites differ the verdict is <c>DIVERGENT</c>: both sites are named and the strong
+    /// claim is withheld, exactly as <c>INCONCLUSIVE</c> withholds it when the control never
+    /// ran.</para>
+    /// </summary>
+    /// <param name="shared">Leg 1's outcome token — the same reference set as the failed compile.</param>
+    /// <param name="pristine">Leg 2's outcome token — brand-new references.</param>
+    internal static string Verdict(string shared, string pristine)
+    {
+        if (pristine.StartsWith("OK", StringComparison.Ordinal))
+            return $"canary=REFERENCES shared:{shared} pristine:{pristine} — the same source emits fine "
                 + "against BRAND-NEW references but fails against the shared set ⇒ the poison "
                 + "travels with the MetadataReference instances / the Roslyn symbols cached on "
-                + "them (reference-set scoping is the right axis)"
-            : $"canary=BELOW-ROSLYN shared:{shared} pristine:{pristine} — a trivial compilation "
-                + "with BRAND-NEW references and freshly parsed source cannot emit either ⇒ "
-                + "nothing about the reference set explains this; the broken state is below "
-                + "Roslyn (CLR heap / JIT / GC), so no reference-set change can fix it — "
-                + "capture a core dump and re-run with tiering disabled";
+                + "them (reference-set scoping is the right axis)";
+
+        var sharedSite = SiteOf(shared);
+        var pristineSite = SiteOf(pristine);
+        if (sharedSite is null || pristineSite is null
+            || !string.Equals(sharedSite, pristineSite, StringComparison.Ordinal))
+            return $"canary=DIVERGENT shared:{shared} pristine:{pristine} — both legs failed, but "
+                + "NOT in the same way (shared died at "
+                + $"'{sharedSite ?? "an unrecorded site"}', pristine at '{pristineSite ?? "an unrecorded site"}'), "
+                + "and the two legs run identical source. Two different faults are not evidence of "
+                + "one process-wide fault, so the below-Roslyn verdict is withheld — COMPARE THE "
+                + "TWO SITES: one corruption can surface a frame apart, but two unrelated faults "
+                + "look exactly like this as well, and only the sites tell them apart. Start with "
+                + "whichever site is not the emit itself";
+
+        return $"canary=BELOW-ROSLYN shared:{shared} pristine:{pristine} — a trivial compilation "
+            + "with BRAND-NEW references and freshly parsed source cannot emit either, and BOTH "
+            + $"legs died in the same frame ({sharedSite}) ⇒ nothing about the reference set "
+            + "explains this; the broken state is below Roslyn (CLR heap / JIT / GC), so no "
+            + "reference-set change can fix it — capture a core dump and re-run with tiering "
+            + "disabled";
+    }
+
+    /// <summary>
+    /// The <c>Type.Method</c> frame out of a leg token shaped
+    /// <c>THREW {Type} at {Site}: {Message}</c>, or <c>null</c> when the leg did not throw or
+    /// recorded no site (a <c>DIAGNOSTICS(...)</c> outcome, or a token from an older shape).
+    /// </summary>
+    private static string? SiteOf(string leg)
+    {
+        const string marker = " at ";
+        if (!leg.StartsWith("THREW ", StringComparison.Ordinal))
+            return null;
+        var at = leg.IndexOf(marker, StringComparison.Ordinal);
+        if (at < 0)
+            return null;
+        var colon = leg.IndexOf(':', at);
+        var site = (colon < 0 ? leg[(at + marker.Length)..] : leg[(at + marker.Length)..colon]).Trim();
+        return string.IsNullOrEmpty(site) || site == "(no stack)" ? null : site;
     }
 
     /// <summary>
@@ -277,7 +335,49 @@ public static class EmitPipeline
         }
         catch (Exception probeError)
         {
-            return $"THREW {probeError.GetType().Name}: {probeError.Message}";
+            return $"THREW {probeError.GetType().Name} at {ThrowSite(probeError)}: {probeError.Message}";
+        }
+    }
+
+    /// <summary>
+    /// The frame an exception was thrown FROM, as <c>Type.Method</c> — the discriminator the
+    /// canary's verdict is decided on.
+    ///
+    /// <para>🚨 Why the verdict cannot be decided on the message. Both legs reduced their outcome
+    /// to <c>"THREW {Type}: {Message}"</c>, and <c>BELOW-ROSLYN</c> was claimed whenever the
+    /// pristine leg <i>also threw anything at all</i>. "Object reference not set to an instance of
+    /// an object." is the same string for every <see cref="NullReferenceException"/> in .NET, so
+    /// two throws from completely different code read as the same fault — and the verdict that
+    /// follows ("the broken state is below Roslyn (CLR heap / JIT / GC) … capture a core dump")
+    /// is the most expensive one this probe can hand triage. That is the same defect the
+    /// <c>INCONCLUSIVE</c> branch exists to avoid, one step further in: a probe must not answer
+    /// its scariest branch on evidence it never checked. With the site recorded, "both legs died
+    /// in the SAME frame" is a fact rather than an inference.</para>
+    ///
+    /// <para>Never throws and never returns null — it runs on an already-failing path (see the
+    /// "cannot fail into the fault path it is diagnosing" note on
+    /// <see cref="ProbeSharedEmitState"/>), so an unavailable stack degrades to
+    /// <c>(no stack)</c>.</para>
+    /// </summary>
+    internal static string ThrowSite(Exception error)
+    {
+        try
+        {
+            // TargetSite is the throwing method itself and survives a stack trace the runtime
+            // could not materialize; the first stack frame is the fallback for the rare
+            // TargetSite-less throw.
+            var method = error.TargetSite;
+            if (method is not null)
+                return $"{method.DeclaringType?.Name ?? "?"}.{method.Name}";
+            var firstFrame = error.StackTrace?
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .FirstOrDefault()?
+                .Trim();
+            return string.IsNullOrEmpty(firstFrame) ? "(no stack)" : firstFrame;
+        }
+        catch
+        {
+            return "(no stack)";
         }
     }
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-compile-in-flight-no-longer-reads-as-a-finished-build.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-compile-in-flight-no-longer-reads-as-a-finished-build.md
@@ -1,0 +1,37 @@
+---
+Name: A compile in flight no longer reads as a finished build
+Category: Fix
+Description: The two gates the package installer orders its root recycle against read a NodeType the way their consumers do, so a just-written type that is still compiling can no longer be mistaken for one with a loadable build.
+Icon: ArrowSync
+Order: -20260818
+---
+
+# A compile in flight no longer reads as a finished build
+
+Installing a package retypes its partition root, then recycles that root so the hub which comes
+back binds the package's own configuration instead of the placeholder. The recycle has to wait for
+the root's in-package NodeType to actually produce a build — recycle too early and the fresh hub
+binds the fallback configuration for its whole lifetime, which is what "No renderer is registered
+for area `Tests` on hub `Store`" looks like from the outside.
+
+The two predicates that decide when that wait is over — `HasLoadableBuild` and the settle gate
+behind `AwaitCompilationSettled` — asked `node.Content is not NodeTypeDefinition`, a CLR type test
+whose "this is not a NodeType at all" escape answers *yes, go ahead*. That escape also fires for a
+NodeType node whose content arrived un-materialized, as raw JSON rather than the CLR record — which
+is the normal shape for a node that just crossed a sync stream or was **just created**, i.e.
+precisely the node the installer wrote a moment earlier. In that shape a type that was still
+compiling answered "loadable", and the wait ended before the build existed.
+
+The tell was visible inside a single fold: the installer read the definition with `ContentAs` on
+one line and called `HasLoadableBuild` on the next, so the two halves could report "still
+compiling" and "loadable" about the same snapshot, and the second one is what settled the wait.
+Both predicates now read the definition the way their consumers read it, so a gate and its
+consumer can no longer disagree about one node. Same defect and same fix as the instance-side
+settle predicate before it.
+
+The emit canary that runs when Roslyn *throws* during a compile got the other half of this
+treatment: it now records **where** each of its two probe compiles died, and only reports the
+process-level "below Roslyn" verdict when both died in the same frame. Every
+`NullReferenceException` in .NET carries the same message, so comparing messages let two unrelated
+faults read as one process-wide fault — and that verdict is the one that sends an investigation
+after a core dump.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
@@ -72,7 +72,7 @@ internal static class NodeTypeContractHandler
         var workspace = hub.GetWorkspace();
         EnsureCompileDispatched(hub, workspace)
             .SelectMany(_ => workspace.GetMeshNodeStream()
-                .AwaitCompilationSettled()
+                .AwaitCompilationSettled(hub.JsonSerializerOptions)
                 .Take(1))
             .Timeout(SettleBudget)
             .SelectMany(node =>

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1694,7 +1694,7 @@ public static class MeshDataSourceExtensions
         // LatestReleasePath + ReleaseNotes — the explicit release's
         // notes-carrying write gets clobbered last-write-wins).
         workspace.GetMeshNodeStream()
-            .AwaitCompilationSettled()
+            .AwaitCompilationSettled(hub.JsonSerializerOptions)
             .Take(1)
             .Subscribe(ownNode =>
             {
@@ -1809,11 +1809,37 @@ public static class MeshDataSourceExtensions
     /// the mesh hub that leaks if the test times out before its response lands).
     /// Non-NodeType nodes pass through unchanged so this is safe to chain on any
     /// MeshNode stream.
+    ///
+    /// <para>🚨 <b>Read the definition the way its CONSUMER reads it</b> — hence the
+    /// <paramref name="options"/>. The predicate used to pattern-match
+    /// <c>node.Content is not NodeTypeDefinition</c>, a CLR type test whose "not a NodeType at
+    /// all" escape answers SETTLED. That escape also fires for a NodeType node whose Content
+    /// arrived UN-MATERIALIZED (a <see cref="JsonElement"/> / <c>JsonNode</c> mirror snapshot —
+    /// the normal shape for a node that just crossed a sync stream or was just created), so a
+    /// Pending/Compiling type in that shape was admitted as settled and the caller acted on a
+    /// pre-compile snapshot. <c>ContentAs</c> recovers every shape, which is exactly what the
+    /// downstream consumer uses, so the gate and the consumer can no longer disagree. Same defect,
+    /// same fix as <c>NodeTypeEnrichmentHelpers.IsCompileSettled</c>
+    /// (<c>CompileSettlePredicateTest</c>); pinned here by <c>LoadableBuildPredicateTest</c>.</para>
     /// </summary>
-    public static IObservable<MeshNode> AwaitCompilationSettled(this IObservable<MeshNode> source)
-        => source.Where(node => node?.Content is not NodeTypeDefinition def
+    /// <param name="source">The NodeType's MeshNode stream.</param>
+    /// <param name="options">The reading hub's <c>JsonSerializerOptions</c> — what resolves a
+    /// mirror snapshot's <c>$type</c> back into a <see cref="NodeTypeDefinition"/>.</param>
+    public static IObservable<MeshNode> AwaitCompilationSettled(
+        this IObservable<MeshNode> source, JsonSerializerOptions options)
+        => source.Where(node => IsCompilationSettled(node, options));
+
+    /// <summary>
+    /// The predicate behind <see cref="AwaitCompilationSettled"/>, as a pure function of one
+    /// emission — unit-testable with no hub and no stream.
+    /// </summary>
+    public static bool IsCompilationSettled(this MeshNode? node, JsonSerializerOptions options)
+    {
+        var def = node.ContentAs<NodeTypeDefinition>(options);
+        return def is null
             || (def.CompilationStatus != CompilationStatus.Compiling
-                && def.CompilationStatus != CompilationStatus.Pending));
+                && def.CompilationStatus != CompilationStatus.Pending);
+    }
 
     /// <summary>
     /// Holds a NodeType MeshNode stream until the type is settled AND is not advertising a build
@@ -1836,7 +1862,14 @@ public static class MeshDataSourceExtensions
     /// still bound the wait (a type that can never produce a loadable build would otherwise hold
     /// forever) and degrade rather than fail.</para>
     ///
-    /// <para>Non-NodeType nodes answer <c>true</c>, so this is safe to ask about any MeshNode.</para>
+    /// <para>Non-NodeType nodes answer <c>true</c>, so this is safe to ask about any MeshNode —
+    /// and that pass-through is decided by <c>ContentAs</c>, never by a CLR type test. A NodeType
+    /// node whose Content arrived un-materialized IS a NodeType node; reading it with
+    /// <c>Content is not NodeTypeDefinition</c> answered "loadable" for a type that was still
+    /// COMPILING, which is the one answer this predicate exists to withhold — the installer then
+    /// recycles the retyped root before its in-package type has a build, and the hub that comes
+    /// back binds the fallback configuration for its whole lifetime. See
+    /// <see cref="AwaitCompilationSettled"/> for the full note.</para>
     ///
     /// <para>🚨 Deliberately a NULL caller of the modules-hash join (#1664 step 11): this is a
     /// pure <see cref="MeshNode"/> predicate with no hub in scope, so it cannot resolve the mesh's
@@ -1846,13 +1879,18 @@ public static class MeshDataSourceExtensions
     /// hash-decisive gates are the kickoff/enrichment paths, which all pass the live hash.</para>
     /// </summary>
     /// <param name="node">The NodeType MeshNode to judge.</param>
+    /// <param name="options">The reading hub's <c>JsonSerializerOptions</c> — what resolves a
+    /// mirror snapshot's <c>$type</c> back into a <see cref="NodeTypeDefinition"/>.</param>
     /// <returns>False only while the node is mid-compile or is advertising an unloadable build.</returns>
-    public static bool HasLoadableBuild(this MeshNode? node)
-        => node?.Content is not NodeTypeDefinition def
+    public static bool HasLoadableBuild(this MeshNode? node, JsonSerializerOptions options)
+    {
+        var def = node.ContentAs<NodeTypeDefinition>(options);
+        return def is null
             || (def.CompilationStatus != CompilationStatus.Compiling
                 && def.CompilationStatus != CompilationStatus.Pending
                 && (string.IsNullOrEmpty(def.LatestAssemblyPath)
-                    || NodeTypeCompilationHelpers.HasUsableBuild(node, def)));
+                    || NodeTypeCompilationHelpers.HasUsableBuild(node!, def)));
+    }
 
     /// <summary>
     /// Stream form of <see cref="HasLoadableBuild"/> — holds a NodeType MeshNode stream until the
@@ -1860,9 +1898,11 @@ public static class MeshDataSourceExtensions
     /// the wait: a type that can never produce a loadable build would otherwise hold forever.
     /// </summary>
     /// <param name="source">The NodeType's MeshNode stream.</param>
+    /// <param name="options">The reading hub's <c>JsonSerializerOptions</c>.</param>
     /// <returns>The same stream, filtered to loadable-build emissions.</returns>
-    public static IObservable<MeshNode> AwaitLoadableBuild(this IObservable<MeshNode> source)
-        => source.Where(node => node.HasLoadableBuild());
+    public static IObservable<MeshNode> AwaitLoadableBuild(
+        this IObservable<MeshNode> source, JsonSerializerOptions options)
+        => source.Where(node => node.HasLoadableBuild(options));
 
     // StartCompile relocated to NodeTypeCompilationHelpers.RunCompile so the
     // per-NodeType-hub auto-watcher and the CreateReleaseRequest handler share

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -921,7 +921,12 @@ public static class PackageInstaller
                 var inFlight = def?.CompilationStatus
                     is CompilationStatus.Pending or CompilationStatus.Compiling;
                 var compiled = state.Compiled || inFlight;
-                var loadable = node.HasLoadableBuild();
+                // …and the SAME options here. HasLoadableBuild used to read the node with a CLR
+                // type test, so on an un-materialized emission it answered "loadable" for the very
+                // in-flight compile `inFlight` (one line up, on the same node) had just reported —
+                // the two halves of this fold disagreeing about one snapshot, which settles the
+                // wait early and recycles the root before its type has a build.
+                var loadable = node.HasLoadableBuild(options);
                 var parked = !inFlight
                     && !ReleaseRequestOutstanding(def)
                     && parkRegistry?.IsParked(declaredType) == true;
@@ -1096,7 +1101,7 @@ public static class PackageInstaller
                 .Where(node => node is not null)
                 .Take(1)
                 .Timeout(RootTypeProbeTimeout)
-                .Select(node => node.HasLoadableBuild())
+                .Select(node => node.HasLoadableBuild(hub.JsonSerializerOptions))
                 .Catch<bool, Exception>(_ => Observable.Return(false))
                 .Do(loadable =>
                 {

--- a/test/MeshWeaver.Graph.Test/EmitCanaryVerdictTest.cs
+++ b/test/MeshWeaver.Graph.Test/EmitCanaryVerdictTest.cs
@@ -1,0 +1,125 @@
+using MeshWeaver.Compiler;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Unit contract for <see cref="EmitPipeline.Verdict"/> — the one line the emit canary hands CI
+/// triage when a Roslyn <c>Emit</c> THROWS instead of returning diagnostics (#890).
+///
+/// <para><b>The bug this pins.</b> The verdict was decided on whether each leg's token started
+/// with <c>OK</c>, and nothing else. So <c>BELOW-ROSLYN</c> — *"the broken state is below Roslyn
+/// (CLR heap / JIT / GC) … capture a core dump and re-run with tiering disabled"*, the most
+/// expensive answer this probe can give — was claimed whenever the pristine leg ALSO threw
+/// anything at all. Both legs reduced their outcome to <c>THREW {Type}: {Message}</c>, and every
+/// <see cref="NullReferenceException"/> in .NET carries the identical message, so two throws from
+/// completely unrelated code were indistinguishable from one process-wide fault. That is the same
+/// defect the <c>INCONCLUSIVE</c> branch already exists to avoid — a probe answering its scariest
+/// branch on evidence it never checked.</para>
+///
+/// <para>The legs run IDENTICAL source and differ only in their reference set, so "the same fault"
+/// is a checkable claim once the throw SITE is recorded: same frame ⇒ BELOW-ROSLYN, different
+/// frames ⇒ <c>DIVERGENT</c>, which names both sites and withholds the strong claim.</para>
+/// </summary>
+public class EmitCanaryVerdictTest
+{
+    private const string Nre = "NullReferenceException";
+    private const string SameMessage = "Object reference not set to an instance of an object.";
+
+    private static string Threw(string site, string type = Nre, string message = SameMessage)
+        => $"THREW {type} at {site}: {message}";
+
+    [Fact]
+    public void PristineEmits_IsAlwaysTheReferenceSetVerdict()
+    {
+        var verdict = EmitPipeline.Verdict(Threw("MetadataWriter.GetConsolidatedTypeParameters"), "OK");
+
+        verdict.Should().StartWith("canary=REFERENCES",
+            "the same source emits against brand-new references and not against the shared set — "
+            + "that is the whole discriminator, and it does not depend on any site");
+    }
+
+    [Fact]
+    public void BothLegsDieInTheSameFrame_IsBelowRoslyn()
+    {
+        const string site = "MetadataWriter.GetConsolidatedTypeParameters";
+
+        var verdict = EmitPipeline.Verdict(Threw(site), Threw(site));
+
+        verdict.Should().StartWith("canary=BELOW-ROSLYN",
+            "identical source, brand-new references, and the SAME throwing frame is what makes "
+            + "'this process is broken under Roslyn' an observation rather than a guess");
+        verdict.Should().Contain(site,
+            "triage acts on the frame, so the verdict has to name it");
+    }
+
+    /// <summary>
+    /// 🚨 The regression this file exists for. Two unrelated NREs read as one fault because their
+    /// messages are byte-identical, and the probe answered BELOW-ROSLYN on that coincidence.
+    /// </summary>
+    [Fact]
+    public void TwoDifferentFaults_AreNotOneProcessWideFault()
+    {
+        var verdict = EmitPipeline.Verdict(
+            Threw("MetadataWriter.GetConsolidatedTypeParameters"),
+            Threw("MetadataReference.CreateFromFile"));
+
+        verdict.Should().StartWith("canary=DIVERGENT",
+            "the two legs run identical source, so failing in DIFFERENT frames is evidence of two "
+            + "separate faults — sending triage after a CLR heap bug here costs a core-dump hunt "
+            + "for a fault that is sitting in the second site");
+        verdict.Should().Contain("MetadataWriter.GetConsolidatedTypeParameters",
+            "both sites are the evidence and both must be printed");
+        verdict.Should().Contain("MetadataReference.CreateFromFile",
+            "…including the one that is NOT the emit");
+        verdict.Should().NotContain("BELOW-ROSLYN",
+            "the strong claim is withheld, never softened in place");
+    }
+
+    [Fact]
+    public void AnUnrecordedSite_WithholdsTheStrongClaimToo()
+    {
+        // A leg whose throw carried no usable frame, and a leg that failed with diagnostics rather
+        // than a throw: in neither case has "the same frame" been observed.
+        EmitPipeline.Verdict(Threw("MetadataWriter.GetConsolidatedTypeParameters"),
+                $"THREW {Nre} at (no stack): {SameMessage}")
+            .Should().StartWith("canary=DIVERGENT",
+                "'(no stack)' is an absence of evidence, and absence of evidence may not be read "
+                + "as a match");
+
+        EmitPipeline.Verdict(Threw("MetadataWriter.GetConsolidatedTypeParameters"),
+                "DIAGNOSTICS(CS0246)")
+            .Should().StartWith("canary=DIVERGENT",
+                "a pristine leg that produced compile DIAGNOSTICS did not reproduce the shared "
+                + "leg's throw at all");
+    }
+
+    [Fact]
+    public void ThrowSite_NamesTheThrowingMethod_AndNeverThrowsItself()
+    {
+        Exception captured;
+        try
+        {
+            ThrowFromHere();
+            throw new InvalidOperationException("unreachable");
+        }
+        catch (InvalidOperationException ex)
+        {
+            captured = ex;
+        }
+
+        EmitPipeline.ThrowSite(captured).Should().Be(
+            $"{nameof(EmitCanaryVerdictTest)}.{nameof(ThrowFromHere)}",
+            "the site is Type.Method of the frame that threw — the discriminator the verdict "
+            + "compares the two legs on");
+
+        // An exception that was never thrown has neither TargetSite nor a stack. The probe runs on
+        // an already-failing path, so it must degrade rather than fault.
+        EmitPipeline.ThrowSite(new InvalidOperationException("never thrown"))
+            .Should().Be("(no stack)",
+                "a diagnostic that throws while diagnosing destroys the evidence it exists to keep");
+    }
+
+    private static void ThrowFromHere()
+        => throw new InvalidOperationException("probe");
+}

--- a/test/MeshWeaver.Graph.Test/LoadableBuildPredicateTest.cs
+++ b/test/MeshWeaver.Graph.Test/LoadableBuildPredicateTest.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Unit contract for <see cref="MeshDataSourceExtensions.HasLoadableBuild"/> and
+/// <see cref="MeshDataSourceExtensions.IsCompilationSettled"/> — the two gates the package
+/// installer orders its root recycle and its root warm against.
+///
+/// <para><b>The bug this pins.</b> Both predicates decided everything on
+/// <c>node.Content is not NodeTypeDefinition</c>, a CLR type test whose "this is not a NodeType at
+/// all" escape answers <c>true</c> — settled, loadable, go ahead. That escape also fires for a
+/// NodeType node whose Content arrived UN-MATERIALIZED (a <see cref="JsonElement"/> or
+/// <see cref="JsonNode"/> mirror snapshot — the normal shape for a node that just crossed a sync
+/// stream or was just created, which is precisely a node the installer wrote seconds ago). In that
+/// shape a type that was still COMPILING answered "loadable", and the caller acted on it.</para>
+///
+/// <para><b>Why it is user-visible.</b>
+/// <c>PackageInstaller.MayPublishIntoRoot</c> reads the definition with <c>ContentAs</c> one line
+/// above and <c>HasLoadableBuild</c> one line below — so the two halves of ONE fold disagreed about
+/// ONE snapshot: <c>inFlight</c> said "still compiling", <c>loadable</c> said "loadable", and
+/// <c>loadable</c> is the term that settles the wait. <c>SettleRetypedRoot</c> then recycles the
+/// retyped package root BEFORE its in-package NodeType has a build, and the hub that comes back
+/// binds the fallback configuration for its whole lifetime — "No renderer is registered for area
+/// <c>Tests</c> on hub <c>Store</c>", the plugin-gate RED the recycle ordering exists to prevent.
+/// The same escape lets <c>WarmInstalledRoots</c> warm a root against an unloadable type.</para>
+///
+/// <para>Same defect, same fix, same test shape as <see cref="CompileSettlePredicateTest"/> — one
+/// predicate over. Both now read the definition the way their consumers read it
+/// (<c>ContentAs</c>), so a gate and its consumer can no longer disagree about one node.</para>
+/// </summary>
+public class LoadableBuildPredicateTest
+{
+    private const string NodeTypePath = "type/LoadableProbe";
+
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerOptions.Default);
+
+    private static NodeTypeDefinition Def(
+        CompilationStatus? status,
+        string? assemblyPath = null,
+        string? assemblyCollection = null,
+        string? frameworkVersion = null) => new()
+    {
+        Description = "loadable-build probe",
+        Configuration = "config => config",
+        CompilationStatus = status,
+        LatestAssemblyPath = assemblyPath,
+        LatestAssemblyCollection = assemblyCollection,
+        CompiledFrameworkVersion = frameworkVersion,
+    };
+
+    private static MeshNode Typed(NodeTypeDefinition def)
+        => new(NodeTypePath) { Version = 3, Content = def };
+
+    /// <summary>The same node as it arrives on a sync-stream mirror / straight after creation:
+    /// Content un-materialized, as raw JSON rather than the CLR type.</summary>
+    private static MeshNode AsJsonElement(NodeTypeDefinition def)
+        => new(NodeTypePath) { Version = 3, Content = JsonSerializer.SerializeToElement(def, Options) };
+
+    /// <summary>The DOM twin of the above — node builders assign JsonObject content.</summary>
+    private static MeshNode AsJsonObject(NodeTypeDefinition def)
+        => new(NodeTypePath) { Version = 3, Content = JsonSerializer.SerializeToNode(def, Options)! };
+
+    [Theory]
+    [InlineData(CompilationStatus.Pending)]
+    [InlineData(CompilationStatus.Compiling)]
+    public void InFlightCompile_IsNeitherSettledNorLoadable_WhateverShapeContentArrivesIn(
+        CompilationStatus status)
+    {
+        var inFlight = Def(status);
+
+        // Baseline: with typed content both predicates have always been right.
+        Typed(inFlight).HasLoadableBuild(Options).Should().BeFalse(
+            "a type that is mid-compile has no build an instance could bind to");
+        Typed(inFlight).IsCompilationSettled(Options).Should().BeFalse(
+            "Pending/Compiling is the definition of not settled");
+
+        // 🚨 The defect: the identical node, un-materialized, must reach the identical verdict.
+        // Before the fix the CLR type test fell through to the "not a NodeType at all" escape and
+        // answered TRUE — the installer recycled the root while this very compile was running.
+        AsJsonElement(inFlight).HasLoadableBuild(Options).Should().BeFalse(
+            "an un-materialized JsonElement mirror snapshot is the SAME state — a CLR type test "
+            + "must not turn an in-flight compile into a loadable build");
+        AsJsonElement(inFlight).IsCompilationSettled(Options).Should().BeFalse(
+            "…and the settle gate must not admit it either");
+
+        AsJsonObject(inFlight).HasLoadableBuild(Options).Should().BeFalse(
+            "the JsonObject shape a node builder assigns is the same state again");
+        AsJsonObject(inFlight).IsCompilationSettled(Options).Should().BeFalse(
+            "…and likewise for the settle gate");
+    }
+
+    /// <summary>
+    /// The state a node repo COMMITS: <c>compilationStatus: Ok</c> with assembly coordinates from
+    /// some other machine's framework. It is not loadable here, and saying otherwise is what pins
+    /// the fallback configuration onto the instance for its hub's lifetime.
+    /// </summary>
+    [Fact]
+    public void CommittedStaleStamp_IsNotLoadable_WhateverShapeContentArrivesIn()
+    {
+        var stale = Def(
+            CompilationStatus.Ok,
+            assemblyPath: "/cache/type_LoadableProbe_deadbeef/type_LoadableProbe.dll",
+            assemblyCollection: "assemblies",
+            frameworkVersion: "a-framework-this-process-has-never-run");
+
+        Typed(stale).HasLoadableBuild(Options).Should().BeFalse(
+            "a settled Ok whose CompiledFrameworkVersion is not this framework's advertises a "
+            + "build this process cannot load");
+        AsJsonElement(stale).HasLoadableBuild(Options).Should().BeFalse(
+            "and the un-materialized snapshot of that very node is the same claim");
+        AsJsonObject(stale).HasLoadableBuild(Options).Should().BeFalse(
+            "…in the DOM shape too");
+    }
+
+    /// <summary>
+    /// The pass-throughs the gates are documented to have, which the ContentAs read must preserve:
+    /// a node that genuinely is not a NodeType, and a terminal state with nothing built.
+    /// </summary>
+    [Fact]
+    public void NonNodeTypeContent_AndSettledStatesWithNothingBuilt_StillPassThrough()
+    {
+        var notATypeNode = new MeshNode("some/markdown")
+        {
+            Version = 1,
+            Content = new MarkdownProbeContent("hello"),
+        };
+        notATypeNode.HasLoadableBuild(Options).Should().BeTrue(
+            "asking a non-NodeType node is safe and answers yes — that pass-through is the whole "
+            + "reason the CLR type test was there, and it has to survive the fix");
+        notATypeNode.IsCompilationSettled(Options).Should().BeTrue(
+            "…same for the settle gate");
+
+        ((MeshNode?)null).HasLoadableBuild(Options).Should().BeTrue("nothing to judge");
+
+        var neverCompiled = Def(status: null);
+        Typed(neverCompiled).HasLoadableBuild(Options).Should().BeTrue(
+            "no assembly coordinates at all is a settled answer — 'nothing built', not a stale build");
+        AsJsonElement(neverCompiled).HasLoadableBuild(Options).Should().BeTrue(
+            "…and the shape it arrives in does not change that");
+
+        var failed = Def(CompilationStatus.Error);
+        Typed(failed).HasLoadableBuild(Options).Should().BeTrue(
+            "a genuinely failed compile wrote no assembly fields, so it too is settled");
+        AsJsonElement(failed).HasLoadableBuild(Options).Should().BeTrue(
+            "…in either shape");
+        AsJsonElement(failed).IsCompilationSettled(Options).Should().BeTrue(
+            "Error is a terminal state — the settle gate must not hold for a compile that is over");
+    }
+
+    /// <summary>Content that is a record of some other shape entirely — the "not a NodeType"
+    /// pass-through, exercised with something that really does serialize.</summary>
+    private sealed record MarkdownProbeContent(string Text);
+}

--- a/test/MeshWeaver.PluginCatalog.Test/InstallReleaseOrderingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallReleaseOrderingTest.cs
@@ -141,12 +141,21 @@ public class InstallReleaseOrderingTest(ITestOutputHelper output) : MonolithMesh
             .Select(n => n.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions))
             .Where(def => def?.CompilationStatus is CompilationStatus.Ok or CompilationStatus.Error)
             .FirstAsync().Timeout(StepTimeout).ToTask();
-        frontDef!.CompilationStatus.Should().Be(CompilationStatus.Ok,
-            $"the root's own type must compile or there is no recycle to order around; error: {frontDef.CompilationError}");
-
+        // Print the ORDER before asserting anything about it. An ordering test that fails without
+        // naming the sequence it saw costs a full investigation per sighting (#1811), and the
+        // precondition below is exactly where the reader is left with nothing: it fires BEFORE the
+        // stamps are read, so without this the trx shows a compile error and no ordering evidence
+        // at all — which is how this test's one recorded failure got filed as an ordering race.
         var recycles = _rootRecycles.ToArray();
-        foreach (var r in recycles)
-            Output.WriteLine($"root recycle observed at {r:O}");
+        Output.WriteLine(recycles.Length == 0
+            ? "root recycles observed: NONE"
+            : $"root recycles observed: {string.Join(", ", recycles.Select(r => r.ToString("O")))}");
+
+        frontDef!.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            "the root's own type must compile or there is no recycle to order around — and THIS "
+            + "assertion is about the mesh's compiler, not about ordering: "
+            + $"{ClassifyCompileFailure(frontDef.CompilationError)}");
+
         recycles.Should().NotBeEmpty(
             "the retyped root must be recycled — SettleRetypedRoot is what this ordering is about");
 
@@ -174,6 +183,33 @@ public class InstallReleaseOrderingTest(ITestOutputHelper output) : MonolithMesh
             + "GetMeshNode('<packageRoot>')), so the deferred types' releases must not be issued "
             + "until the installer's own recycle of that root has settled — but no recycle was "
             + $"observed between {front:O} and {widget:O} (#1732)");
+    }
+
+    /// <summary>
+    /// Turns the failed compile's recorded error into a sentence that says WHICH defect this is,
+    /// so the reader does not have to re-derive it from a Roslyn stack.
+    ///
+    /// <para>The precondition above fails for two completely different reasons and they need
+    /// completely different owners. A Roslyn <b>diagnostic</b> means this fixture's C# stopped
+    /// compiling — the test's own problem. An emit-phase <b>fault</b> (Roslyn THREW; the compile
+    /// pipeline stamps its two-leg canary verdict onto the message) means the mesh could not emit
+    /// at all, which is <b>#890</b> — a process-level condition this test merely observed, and
+    /// nothing about install-vs-recycle ordering. The one recorded failure of this test
+    /// (run 32069247537, shard 4, on a docs-only branch) was the second kind and was filed as the
+    /// first, which is the entire cost this line exists to remove.</para>
+    /// </summary>
+    private static string ClassifyCompileFailure(string? compilationError)
+    {
+        if (string.IsNullOrWhiteSpace(compilationError))
+            return "the compile reported no error text at all";
+        // The canary verdict is stamped only on an emit-phase THROW (EmitPipeline's catch around
+        // compilation.Emit), so its presence IS the discriminator — no string-matching on
+        // exception names.
+        return compilationError.Contains("canary=", StringComparison.Ordinal)
+            ? "Roslyn THREW while emitting rather than reporting diagnostics — this is #890 "
+              + "(a process-level emit fault), NOT an ordering race, and this test only observed "
+              + $"it. Verdict + error: {compilationError}"
+            : $"the fixture's own C# failed to compile: {compilationError}";
     }
 
     /// <summary>

--- a/test/MeshWeaver.PluginCatalog.Test/StaleStampRootBindingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/StaleStampRootBindingTest.cs
@@ -240,7 +240,7 @@ public class StaleStampRootBindingTest(ITestOutputHelper output) : MonolithMeshT
 
         var type = await Mesh.GetWorkspace().GetMeshNodeStream($"{id}/Front")
             .Where(n => n?.Content is NodeTypeDefinition).FirstAsync().Timeout(StepTimeout).ToTask();
-        type.HasLoadableBuild().Should().BeFalse(
+        type.HasLoadableBuild(Mesh.JsonSerializerOptions).Should().BeFalse(
             "the fixture is only meaningful while the type genuinely cannot produce a loadable "
             + "build — if this flips, the test has stopped covering the deterministic window");
 
@@ -313,7 +313,7 @@ public class StaleStampRootBindingTest(ITestOutputHelper output) : MonolithMeshT
             .Match(n => n.Content is NodeTypeDefinition d
                 && d.CompilationStatus == CompilationStatus.Ok
                 && !string.IsNullOrEmpty(d.LatestAssemblyPath)
-                && n.HasLoadableBuild());
+                && n.HasLoadableBuild(Mesh.JsonSerializerOptions));
         Output.WriteLine($"rebuild settled at +{sw.ElapsedMilliseconds}ms");
 
         // …and the ROOT's hub must be bound to that rebuilt configuration. Its `Tests` area only


### PR DESCRIPTION
Closes #1811.

## What #1811 actually is: not an ordering race

The issue reasons from "same code, different outcome" to "a race in install-vs-recycle
ordering". The shard log says otherwise. `InstallReleaseOrderingTest` failed on its own
**precondition** — line 144, `frontDef.CompilationStatus.Should().Be(Ok)` — because the mesh's
Roslyn `Emit` **threw** while compiling `Kit/Front`:

```
NullReferenceException
  at NamedTypeSymbol.Microsoft.Cci.ITypeDefinitionMember.get_ContainingTypeDefinition()
  at Microsoft.Cci.MetadataWriter.<GetConsolidatedTypeParameters>g__getConsolidatedTypeParameters
  at MeshWeaver.Compiler.EmitPipeline.EmitCompilationToDirectory
[canary=BELOW-ROSLYN shared:THREW NullReferenceException … pristine:THREW NullReferenceException …]
```

That is **#890**, verbatim signature and verbatim canary verdict. Neither ordering assertion in
the test was ever reached: no recycle timestamp, no release stamp, no comparison. The docs-only
branch is not evidence of a race — it is evidence that the failure had nothing to do with the
diff *or* with the test's subject.

**Measurements** (macOS host, `DOTNET_PROCESSOR_COUNT=4`, this branch's base):

| run shape | iterations | `InstallReleaseOrderingTest` failures |
|---|---|---|
| the test alone, in a loop | **60** | **0** |
| the whole `MeshWeaver.PluginCatalog.Test` assembly (408 tests), in a loop | **12** (4 896 test executions) | **0** |
| CI, `MeshWeaver Build and Test`, last 200 runs | 200 | **1** — the occurrence in this issue |

Zero `canary=` emit faults reproduced locally in any of those, which matches #890's own recorded
finding that an isolated loop does not reach this class. The one local flake the 12-run sweep did
surface is a *different* test (`ShippedPrebuiltBundlesTest.UnchangedBundle_…`, 3/12 ≈ 25 %) —
noted here so it is not lost, not addressed by this PR.

I also ran the hypothesis that our own cancellation of a running `Compilation.Emit`
(`BoundLeg`'s `CancellationDisposable`, which trips on every unsubscribe — including a mesh
teardown, of which a 408-test process does hundreds) corrupts Roslyn's process-wide state: a
harness doing 6 866 emits with **10 221 mid-flight cancellations** and 17 087 interleaved canary
emits poisoned nothing. That hypothesis is dead; recording it so nobody re-runs it.

So: **product defect, not a test defect — but the product defect is #890, not ordering.** What
this PR ships is what the investigation actually found on the way, each of which is a real,
independently-testable defect.

## 1. A compile in flight could read as a finished build (product)

`HasLoadableBuild` and the predicate behind `AwaitCompilationSettled` decided everything on
`node.Content is not NodeTypeDefinition` — a CLR type test whose "this is not a NodeType at all"
escape answers **yes, go ahead**. That escape also fires for a NodeType node whose content
arrived UN-MATERIALIZED (a `JsonElement`/`JsonNode` mirror snapshot — the normal shape for a node
that just crossed a sync stream **or was just created**, i.e. exactly the node the installer wrote
a moment earlier). In that shape a *still-compiling* type answered "loadable".

The tell sits inside one fold in `PackageInstaller.MayPublishIntoRoot`:

```csharp
var def      = node.ContentAs<NodeTypeDefinition>(options);   // "still compiling"
var inFlight = def?.CompilationStatus is Pending or Compiling;
var loadable = node.HasLoadableBuild();                       // "loadable"  ← settles the wait
```

Two halves of one fold disagreeing about one snapshot, and the second one is the term that ends
the wait. `SettleRetypedRoot` then recycles the retyped package root **before its in-package type
has a build**, and the hub that comes back binds the fallback configuration for its whole
lifetime — "No renderer is registered for area `Tests` on hub `Store`", the plugin-gate RED this
ordering exists to prevent. The same escape lets `WarmInstalledRoots` warm a root against an
unloadable type.

Both predicates now read the definition the way their consumers read it (`ContentAs`, options
threaded through) — the same defect and the same fix as `NodeTypeEnrichmentHelpers.IsCompileSettled`
before them, one predicate over.

## 2. `canary=BELOW-ROSLYN` was claimed on evidence nobody checked (diagnostics for #890)

The emit canary runs two legs — same source, shared references vs brand-new ones — and both
reduced to `THREW {Type}: {Message}`. The verdict then read *any* pristine throw as confirmation.
Every `NullReferenceException` in .NET carries the identical message, so two **unrelated** faults
were indistinguishable from one process-wide fault — and BELOW-ROSLYN is the most expensive
answer this probe can hand triage (*"the broken state is below Roslyn (CLR heap / JIT / GC) …
capture a core dump and re-run with tiering disabled"*), which is where #890's investigation
currently stands.

Each leg now records **where** it threw, and BELOW-ROSLYN requires both legs to have died in the
**same frame**. When they differ the verdict is `canary=DIVERGENT`, which names both sites and
withholds the strong claim — exactly as `INCONCLUSIVE` already withholds it when the control
never ran. This is the same rule that branch was written for, one step further in: a probe must
not answer its scariest branch on evidence it never checked.

## 3. The test names what it saw (test)

The issue asks for it directly: *"an ordering test that fails without printing the order it saw
costs a full investigation every sighting."* The recycle timestamps are now printed **before** the
precondition (which is where the reader was left with nothing), and the precondition classifies
its own failure: a Roslyn *diagnostic* is the fixture's own C#; an emit-phase *fault* — detected
by the canary verdict the compile pipeline stamps, not by string-matching an exception name — says
so and names #890. No bound was raised, no assertion loosened, nothing retried.

## Verification

- **Non-vacuity control**: with the two product changes reverted to their old bodies (signatures
  kept so the tests still compile), **5 of the 9 new unit tests fail**; with the fix, 0 of 9.
- `MeshWeaver.Graph.Test` — 1264 tests green.
- `MeshWeaver.PluginCatalog.Test` — full assembly green.
- `MeshWeaver.Hosting.Monolith.Test` — full assembly green.
- Full solution `dotnet build -c Release -p:CIRun=true -warnaserror` — 0 errors, 0 warnings.

## What this does NOT do

It does not fix #890. Nothing here would have made the 2026-08-17 run green: `Kit/Front` failed
to emit twice, 59 ms apart, and no ordering change can compile a type on a process whose Roslyn
emit is throwing. #890 stays open and this PR makes its next occurrence cheaper to read rather
than cheaper to ignore.

One datapoint for #890 worth recording separately: in that run **407 of 408 tests in the same
process passed**, and the poisoned compile was the *last* test to run. "One Roslyn Emit poisons
the whole process" (the issue title) is not what this occurrence shows — the poisoning appeared
at the end of a 111 s run and only two compile attempts were left to observe it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wVYniTKJ7Kuw7Hh425UPy
