### PR TITLE
Refs #1753: an empty Messages projection could not say which failure it was

### DIFF
--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -236,20 +236,28 @@ internal static class ThreadExecution
             // when the polymorphic $type doesn't resolve it stays a JsonElement, and `as` → null
             // flip-flops Status StartingExecution↔null, defeating DistinctUntilChanged(Status) and
             // re-firing the claim (mitigated by the idempotent CAS, but still wrong).
-            .Select(n => new { Node = n, Status = n.ContentAs<MeshThread>(parentHub.JsonSerializerOptions)?.Status })
-            .DistinctUntilChanged(x => x.Status)
-            .Where(x => x.Status == ThreadExecutionStatus.StartingExecution)
-            .Select(x => x.Node)
+            //
+            // 🚨 …and read it EXACTLY ONCE, carrying the recovered instance forward. This used to
+            // read the content twice — `ContentAs` here to decide whether to ENTER the
+            // StartingExecution branch, then `node.Content is not MeshThread` inside the
+            // subscriber to decide whether to ABORT it — and the two reads do not agree by
+            // construction: `ContentAs` recovers a degraded JsonElement (the whole reason it is
+            // used above), the raw type test does not. A node whose $type failed to resolve
+            // therefore passed the filter and then hit `return` on "thread node has no MeshThread
+            // content" WITHOUT rolling the claim back, parking the thread at StartingExecution
+            // with no cell — the orphaned-claim shape of #539, whose recovery
+            // (InitializeThreadLifecycle) runs ONLY on hub ACTIVATION, while
+            // DistinctUntilChanged(Status) guarantees the live claim is never observed again.
+            // One read cannot disagree with itself, and the Where below already guarantees a
+            // non-null thread, so the self-contradictory abort branch is gone rather than fixed.
+            .Select(n => new { Node = n, Thread = n.ContentAs<MeshThread>(parentHub.JsonSerializerOptions) })
+            .DistinctUntilChanged(x => x.Thread?.Status)
+            .Where(x => x.Thread?.Status == ThreadExecutionStatus.StartingExecution)
             .Subscribe(
-                node =>
+                x =>
                 {
-                    if (node?.Content is not MeshThread thread)
-                    {
-                        logger?.LogWarning(
-                            "[ExecRoundWatcher] thread node has no MeshThread content for {ThreadPath}",
-                            threadPath);
-                        return;
-                    }
+                    var node = x.Node;
+                    var thread = x.Thread!;
 
                     // 🚨 Thread execution ALWAYS runs under the thread owner's
                     // identity. The cache stream's emission scheduler doesn't

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-claimed-chat-round-cannot-park-on-a-degraded-read.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-claimed-chat-round-cannot-park-on-a-degraded-read.md
@@ -1,0 +1,22 @@
+---
+Name: A claimed chat round cannot park on a degraded read
+Category: Fix
+Description: The dispatcher that starts a chat round now reads the thread's content once instead of twice, so a round can no longer be claimed and then silently abandoned.
+Icon: ShieldCheckmark
+Order: -20260818
+---
+
+# A claimed chat round cannot park on a degraded read
+
+Starting a chat round is a two-step handshake: the thread is first *claimed*, and a moment later the
+claim is *committed* into a real round with a visible answer cell. The code that performs the second
+step used to read the thread's stored content twice — once to decide the round was ready to start,
+and again to actually start it. The two reads did not use the same rule, so in the case where the
+stored content arrives in a degraded form the first read succeeded and the second one gave up.
+
+When that happened the thread was left claimed but never started: the message stayed queued, no
+answer cell appeared, and nothing recovered it until the thread was next opened from cold. To the
+person who pressed send, the conversation simply sat there.
+
+The dispatcher now reads the content once and carries that single result through, so the two halves
+of the decision cannot disagree and the abandoning branch no longer exists.

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansThreadStreamingTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansThreadStreamingTest.cs
@@ -75,8 +75,10 @@ public class OrleansThreadStreamingTest(ITestOutputHelper output) : OrleansTestB
     /// "content was never readable" and "the round never dispatched" produce the IDENTICAL
     /// observation — an empty message list — so the 45 s timeout in #1753 could not say which of
     /// the two had happened. <see cref="MeshNodeContentExtensions.ContentAs{T}"/> recovers the
-    /// degraded shape (and logs when it genuinely cannot); <see cref="Shape"/> records what
-    /// arrived, and the control-plane counters say how far the round got.</para>
+    /// degraded shape; when it genuinely cannot, the diagnosis lands in the ASSERTION MESSAGE
+    /// rather than in a log this suite would then have to be reading — <see cref="Shape"/> names
+    /// what did arrive and <see cref="Status"/> reads <c>(unreadable)</c>. The control-plane
+    /// counters say how far the round got.</para>
     /// </summary>
     private sealed record ThreadControlPlane(
         string Shape,

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansThreadStreamingTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansThreadStreamingTest.cs
@@ -22,6 +22,7 @@ using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Orleans.Hosting;
 using Orleans.TestingHost;
 using Xunit;
@@ -60,13 +61,60 @@ public class OrleansThreadStreamingTest(ITestOutputHelper output) : OrleansTestB
     /// </summary>
     private IObservable<T?> GetHubContent<T>(IMessageHub client, string path) where T : class
         => client.GetWorkspace().GetMeshNodeStream(path)
-            .Select(node =>
-            {
-                if (node?.Content is T typed) return typed;
-                if (node?.Content is JsonElement contentJe)
-                    return contentJe.Deserialize<T>(client.JsonSerializerOptions);
-                return null;
-            });
+            .Select(node => node.ContentAs<T>(client.JsonSerializerOptions));
+
+    /// <summary>
+    /// The thread node's CONTROL-PLANE state, projected off its live stream — what every
+    /// assertion in this class actually waits on, in a shape a TIMEOUT can explain.
+    ///
+    /// <para>🚨 <c>node.Content as MeshThread</c> was the trap-door AGENTS.md forbids ("Read
+    /// <c>node.Content</c> in WHATEVER shape it arrives"): content is a typed instance on the
+    /// owning hub but reaches a CLIENT mirror as a <see cref="JsonElement"/> whenever the
+    /// polymorphic <c>$type</c> does not resolve against that hub's registry, and <c>as</c>
+    /// silently yields null. Folded through <c>?? ImmutableList&lt;string&gt;.Empty</c> that made
+    /// "content was never readable" and "the round never dispatched" produce the IDENTICAL
+    /// observation — an empty message list — so the 45 s timeout in #1753 could not say which of
+    /// the two had happened. <see cref="MeshNodeContentExtensions.ContentAs{T}"/> recovers the
+    /// degraded shape (and logs when it genuinely cannot); <see cref="Shape"/> records what
+    /// arrived, and the control-plane counters say how far the round got.</para>
+    /// </summary>
+    private sealed record ThreadControlPlane(
+        string Shape,
+        ThreadExecutionStatus? Status,
+        IReadOnlyList<string> Messages,
+        int Pending,
+        int Ingested,
+        int UserIds)
+    {
+        public static ThreadControlPlane Of(MeshNode? node, JsonSerializerOptions options)
+        {
+            var shape = node is null ? "(no node)" : node.Content?.GetType().Name ?? "(null content)";
+            var thread = node.ContentAs<MeshThread>(options);
+            return thread is null
+                ? new ThreadControlPlane(shape, null, [], 0, 0, 0)
+                : new ThreadControlPlane(shape, thread.Status, thread.Messages,
+                    thread.PendingUserMessages.Count, thread.IngestedMessageIds.Count,
+                    thread.UserMessageIds.Count);
+        }
+
+        // Rendered verbatim into the assertion's "Last of N emission(s) was: …" line, so a
+        // timeout NAMES the stage the round stopped at: content unreadable (Status=(unreadable)),
+        // the submit never landed (pending=0 userIds=0), the claim was never made (status=Idle
+        // pending=1), or the claim was made and the _Exec commit never came back
+        // (status=StartingExecution pending=1 messages=[]) — the orphaned-claim shape #539
+        // recovers only on hub REACTIVATION, never on a live hub.
+        public override string ToString() =>
+            $"content={Shape} status={Status?.ToString() ?? "(unreadable)"} " +
+            $"messages=[{string.Join(",", Messages)}] pending={Pending} " +
+            $"ingested={Ingested} userIds={UserIds}";
+    }
+
+    /// <summary>
+    /// The thread node's <see cref="ThreadControlPlane"/> on every emission of its live stream.
+    /// </summary>
+    private IObservable<ThreadControlPlane> ThreadStates(IMessageHub client, string threadPath)
+        => client.GetWorkspace().GetMeshNodeStream(threadPath)
+            .Select(node => ThreadControlPlane.Of(node, client.JsonSerializerOptions));
 
     /// <summary>
     /// Verifies that response text streams to the message node during execution.
@@ -84,23 +132,16 @@ public class OrleansThreadStreamingTest(ITestOutputHelper output) : OrleansTestB
         var threadPath = response.Message.Node!.Path!;
         Output.WriteLine($"Thread: {threadPath}");
 
-        // Project the thread's message-id list off the live stream.
-        var messageIds = client.GetWorkspace()
-            .GetMeshNodeStream(threadPath)
-            .Select(node =>
-            {
-                
-                return (node?.Content as MeshThread)?.Messages
-                       ?? (IReadOnlyList<string>)System.Collections.Immutable.ImmutableList<string>.Empty;
-            });
+        // Project the thread's control-plane state off the live stream.
+        var threadStates = ThreadStates(client, threadPath);
 
         // Submit via workspace extension
         client.SubmitMessage(
             threadPath,
             "Tell me something",
             contextPath: ContextPath);
-        var msgIds = await messageIds.Should().Within(45.Seconds()).Match(ids => ids.Count >= 2);
-        var responseMsgId = msgIds[1];
+        var committed = await threadStates.Should().Within(45.Seconds()).Match(s => s.Messages.Count >= 2);
+        var responseMsgId = committed.Messages[1];
         Output.WriteLine($"Response message: {responseMsgId}");
 
         // Wait for the response message to gain text.
@@ -135,8 +176,7 @@ public class OrleansThreadStreamingTest(ITestOutputHelper output) : OrleansTestB
         using var _ = workspace.GetMeshNodeStream(threadPath)
             .Subscribe(node =>
             {
-                
-                var thread = node?.Content as MeshThread;
+                var thread = node.ContentAs<MeshThread>(client.JsonSerializerOptions);
                 if (thread != null)
                 {
                     var msg = $"Thread: IsExecuting={thread.IsExecuting}, Status={thread.ExecutionStatus ?? "(null)"}, Messages={thread.Messages.Count}, ActiveMsg={thread.ActiveMessageId ?? "(null)"}";
@@ -145,14 +185,8 @@ public class OrleansThreadStreamingTest(ITestOutputHelper output) : OrleansTestB
                 }
             });
 
-        // Project the thread's message-id list off the live stream.
-        var messageIds = workspace.GetMeshNodeStream(threadPath)
-            .Select(node =>
-            {
-                
-                return (node?.Content as MeshThread)?.Messages
-                       ?? (IReadOnlyList<string>)System.Collections.Immutable.ImmutableList<string>.Empty;
-            });
+        // Project the thread's control-plane state off the live stream.
+        var threadStates = ThreadStates(client, threadPath);
 
         // Submit message via workspace extension
         Output.WriteLine("2. Submitting message...");
@@ -163,7 +197,8 @@ public class OrleansThreadStreamingTest(ITestOutputHelper output) : OrleansTestB
         Output.WriteLine("3. Message submitted successfully");
 
         // Wait for 2 message IDs
-        var msgIds = await messageIds.Should().Within(45.Seconds()).Match(ids => ids.Count >= 2);
+        var committed = await threadStates.Should().Within(45.Seconds()).Match(s => s.Messages.Count >= 2);
+        var msgIds = committed.Messages;
         Output.WriteLine($"4. Messages appeared: [{string.Join(", ", msgIds)}]");
         var responseMsgId = msgIds[1];
         var responsePath = $"{threadPath}/{responseMsgId}";
@@ -226,15 +261,9 @@ public class OrleansThreadStreamingTest(ITestOutputHelper output) : OrleansTestB
         Output.WriteLine("2. Message submitted");
 
         // 3. Wait for 2 messages (user + response)
-        var msgIds = await workspace.GetMeshNodeStream(threadPath)
-            .Select(node =>
-            {
-
-                return (node?.Content as MeshThread)?.Messages
-                       ?? (IReadOnlyList<string>)System.Collections.Immutable.ImmutableList<string>.Empty;
-            })
-            .Should().Within(30.Seconds()).Match(ids => ids.Count >= 2);
-        var responseMsgId = msgIds[1];
+        var committed = await ThreadStates(client, threadPath)
+            .Should().Within(30.Seconds()).Match(s => s.Messages.Count >= 2);
+        var responseMsgId = committed.Messages[1];
         var responsePath = $"{threadPath}/{responseMsgId}";
         Output.WriteLine($"3. Response message: {responseMsgId}");
 
@@ -243,7 +272,7 @@ public class OrleansThreadStreamingTest(ITestOutputHelper output) : OrleansTestB
         var msgWithDelegation = await workspace.GetMeshNodeStream(responsePath)
             .Select(node =>
             {
-                var msg = node?.Content as ThreadMessage;
+                var msg = node.ContentAs<ThreadMessage>(client.JsonSerializerOptions);
                 if (msg != null)
                     Output.WriteLine($"  [STREAM] text={msg.Text?.Length ?? 0}ch, toolCalls={msg.ToolCalls.Count}, delegations={msg.ToolCalls.Count(c => !string.IsNullOrEmpty(c.DelegationPath))}");
                 return msg;
@@ -276,7 +305,6 @@ public class OrleansThreadStreamingTest(ITestOutputHelper output) : OrleansTestB
     public async Task LayoutArea_ReceivesUpdateThreadMessageContent_ViaLayoutStream()
     {
         var client = GetUniqueClient();
-        var workspace = client.GetWorkspace();
 
         // 1. Create thread + submit message
         var createResp = await client.Observe(new CreateNodeRequest(ThreadNodeType.BuildThreadNode(ContextPath, "Layout stream test")), o => o.WithTarget(new Address(ContextPath)))
@@ -291,11 +319,9 @@ public class OrleansThreadStreamingTest(ITestOutputHelper output) : OrleansTestB
         Output.WriteLine("2. Submitted");
 
         // 2. Wait for response message to appear
-        var msgIds = await workspace.GetMeshNodeStream(threadPath)
-            .Select(node => (node?.Content as MeshThread)?.Messages
-                             ?? (IReadOnlyList<string>)System.Collections.Immutable.ImmutableList<string>.Empty)
-            .Should().Within(30.Seconds()).Match(ids => ids.Count >= 2);
-        var responseMsgId = msgIds[1];
+        var committed = await ThreadStates(client, threadPath)
+            .Should().Within(30.Seconds()).Match(s => s.Messages.Count >= 2);
+        var responseMsgId = committed.Messages[1];
         var responsePath = $"{threadPath}/{responseMsgId}";
         Output.WriteLine($"3. Response: {responseMsgId}");
 
@@ -470,7 +496,31 @@ public class StreamingSiloConfigurator : ISiloConfigurator, IHostConfigurator
     public void Configure(ISiloBuilder siloBuilder)
     {
         siloBuilder.ConfigureMeshWeaverServer()
-            .AddMemoryGrainStorageAsDefault();
+            .AddMemoryGrainStorageAsDefault()
+            // 🚨 Surface SILO-side framework logs through ITestOutputHelper, exactly as the
+            // canonical TestSiloConfigurator does. This class was the only Orleans suite
+            // without it, and that is why #1753's failure report carried the test's own three
+            // WriteLines and NOTHING else: every diagnostic the round emits on the way to a
+            // wedge — "[ExecRoundWatcher] thread node has no MeshThread content",
+            // "[SubmissionWatcher] claim Update failed", "[ThreadSubmission] Response cell
+            // creation failed", "[ThreadExec] Init observation faulted … re-establishing" —
+            // is written silo-side and was being discarded. A timeout with no logs is not
+            // evidence that nothing was logged.
+            //
+            // 🚨 Warning+ ONLY, with the Orleans/Microsoft/System runtime chatter at Error.
+            // AddXUnitLogger deliberately sets no filters (levels are appsettings-driven), but
+            // the TestCluster silo host does not read this project's appsettings — unfiltered it
+            // emits ~150 Information lines of Orleans startup per test. That volume is not free:
+            // xunit buffers captured output for EVERY test whether or not it is printed, and this
+            // suite's flakes are load-dependent races that extra logging on the hot path is known
+            // to MASK (see .github/workflows/flake-repro.yml). Warning+ costs nothing in a healthy
+            // run — nothing is emitted — and is exactly the band the wedge diagnostics live in.
+            .ConfigureLogging(logging => logging
+                .AddXUnitLogger()
+                .SetMinimumLevel(LogLevel.Warning)
+                .AddFilter("Orleans", LogLevel.Error)
+                .AddFilter("Microsoft", LogLevel.Error)
+                .AddFilter("System", LogLevel.Error));
     }
 
     public void Configure(IHostBuilder hostBuilder)


### PR DESCRIPTION
`Refs #1753` — deliberately **not** a closing keyword. The cause is still unknown; this makes the
next occurrence name it, and fixes the one thing in the path I could prove wrong by reading.

## I could not reproduce it, and the CI history says why

Before writing a line I surveyed every run of *MeshWeaver Build and Test* since the test was
introduced (2026-07-02, PR #145) — **all 3762 runs**, day-by-day, because the runs API silently
truncates a `status=failure` query at 1000. `ResponseText_StreamsToMessageNode` has failed
**exactly once in its lifetime**: run 32030673408 on 2026-08-17, the one #1753 was filed from. (That
run does not even appear under `status=failure` — it was re-run, the retry passed, and its final
conclusion is `success`.)

At that rate no local budget produces a repro, and it didn't:

| where | shape | executions of the target test | #1753 signature |
|---|---|---|---|
| this laptop, branch base | isolated bin per process, 10 procs × 30 iters, `DOTNET_PROCESSOR_COUNT=2` | 300 | **0** |
| this laptop, **with this change** | *identical* harness | 300 | **0** |
| this laptop, branch base | 40 solo + 20 full-class + 60 under 10-way load + 300 shared-bin blitz | 420 | **0** |
| this laptop, with this change | 300 shared-bin blitz + one full 165-test assembly run | 301 | **0** |
| **real 4-vCPU GitHub runner** (`flake-repro.yml`, `mode: rate`, run 32123362302) | 8 × the whole `MeshWeaver.Hosting.Orleans.Test` assembly, on `main` | 8 | **0** |

That is the control the flake rules ask for, run on the same machine with the change reverted
(`.worktrees/ctrl-1753` at this branch's base commit). **Both sides are 0/300, so neither number is
evidence about the race** — they are evidence that this change does not itself break or perturb the
suite.

The failures the local loops *did* produce are harness artefacts, classified rather than counted:
2 test-host kills under the memory pressure of ten concurrent Orleans clusters (base), and 3
`Node already exists at path: TestUser/_Thread/streaming-text-test-XXXX` (change) — the thread id
carries only 4 hex chars of entropy from the title, and my loop re-runs 30 times against one
persistent file-system store. CI extracts a fresh tarball per shard and runs the assembly once, so
that collision cannot happen there. Neither is the #1753 shape (a clean 45 s assertion failure).

The run 32123362302 log shows 8/8 iterations red — every one of them
`OrleansMarkdownExportTest.ExportPdf_RoundTrips_AsTypedResponse`, which fails in that workflow
because it does not install Playwright. The target test passed all 8.

## What the change does

### 1. The projection stops destroying the evidence (the substance)

`OrleansThreadStreamingTest.cs:93` was the raw-`as` trap-door AGENTS.md forbids:

```csharp
return (node?.Content as MeshThread)?.Messages
       ?? (IReadOnlyList<string>)ImmutableList<string>.Empty;
```

Content is a typed instance on the owning hub, but reaches a **client** mirror as a `JsonElement`
whenever the polymorphic `$type` does not resolve against that hub's registry — and `as` then yields
`null`. Folded through `?? Empty`, **"the content was never readable" and "the round never
dispatched" produce the identical observation**, which is exactly why the 45 s timeout could say
nothing beyond `[] (0 item(s))`.

It is now a `ThreadControlPlane` record read through `ContentAs`, whose `ToString` is rendered
verbatim into the assertion library's own *"Last of N emission(s) was: …"* line:

```
content=Thread status=Idle messages=[7cee26f3,ba9a0ed8] pending=0 ingested=1 userIds=1
```

which separates the four candidates on sight:

| what the line says | what stopped |
|---|---|
| `status=(unreadable)` | content never materialised — the #1753 candidate (2) |
| `pending=0 userIds=0` | the submit write never landed on the owner |
| `status=Idle pending=1` | the submission watcher never claimed |
| `status=StartingExecution pending=1 messages=[]` | the claim was made and the `_Exec` commit never came back — the orphaned-claim shape of #539, whose recovery runs only on hub **activation** |

**Proven non-vacuous**, the way this repo pins a diagnostic: I made the predicate unreachable
(`>= 99`), ran it, and read the message — the line above is the real output, against `[] (0 item(s))`
before. The predicate, the 45 s budget and the `[Fact(Timeout = 60000)]` are all unchanged. Nothing
is slept, retried, or relaxed.

The file's three sibling projections used the same trap-door and are converted with it, as #1753
asks.

### 2. The suite's silo logs stop going nowhere

`StreamingSiloConfigurator` was the only Orleans configurator that never called `AddXUnitLogger` —
which is why the #1753 report carried the test's three `WriteLine`s and **zero framework
diagnostics**. Grepping the whole failing job log for `SubmissionWatcher|ExecRoundWatcher|
ThreadSubmission|ThreadExec|AppendUserInput` returns nothing. A timeout with no logs was not
evidence that nothing was logged.

Added at **Warning+ only**, with Orleans/Microsoft/System at Error: the TestCluster silo host does
not read this project's `appsettings.json`, and unfiltered it emits ~150 Information lines of Orleans
startup per test — volume xunit buffers for *every* test, and volume that
[`flake-repro.yml`](.github/workflows/flake-repro.yml) documents as able to **mask** exactly this
class of race. Warning+ is the band the wedge messages live in and emits nothing in a healthy run.

### 3. The one product change: read the thread once, not twice

`ThreadExecution.InstallExecRoundWatcher` read the node's content **twice**, with two different
rules:

```csharp
.Select(n => new { Node = n, Status = n.ContentAs<MeshThread>(...)?.Status })   // tolerant: ENTER
.Where(x => x.Status == ThreadExecutionStatus.StartingExecution)
.Subscribe(node => {
    if (node?.Content is not MeshThread thread)                                  // intolerant: ABORT
    { logger?.LogWarning("[ExecRoundWatcher] thread node has no MeshThread content …"); return; }
```

They cannot agree by construction — `ContentAs` recovers a degraded `JsonElement` (the whole reason
the comment three lines above says to use it), the raw type test does not. A node whose `$type`
failed to resolve therefore **passed the filter and then abandoned the round**, and the abort path
does not roll the claim back: the thread parks at `StartingExecution` with no cell, which is the
orphaned-claim shape `OrphanedStartingExecutionRecoveryTest` documents for #539 — recovered **only
on hub activation**, while `DistinctUntilChanged(Status)` guarantees the live claim is never observed
again.

It now reads once and carries the recovered instance forward; `Where` already guarantees a non-null
thread, so the self-contradictory branch is **deleted rather than fixed**. This is hardening on a
latent path — I have no evidence it is what bit #1753, and the PR does not claim it is.

## Verification

`-c Release -p:CIRun=true -warnaserror`, clean. Executed locally:

- `MeshWeaver.Hosting.Orleans.Test` — 165/165
- `MeshWeaver.Threading.Test` — 133/133 (incl. `OrphanedStartingExecutionRecoveryTest`)
- `MeshWeaver.AI.Test` — 1180/1180, 5 skipped
- `MeshWeaver.Documentation.Test` — 34/34 (What's New + doc-link integrity)

## What's New

`Category: Fix` — the round-dispatcher change is a user-noticeable failure mode (send a message, the
conversation sits there), described as the capability rather than as an incident, since no user
report is attached to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
