### PR TITLE
Access: SYSTEM-OWNED means a ONE-WAY GitSync, not "has a _GitSync"

### DIFF
--- a/src/MeshWeaver.GitSync/SystemOwnedAccessRetractionHandler.cs
+++ b/src/MeshWeaver.GitSync/SystemOwnedAccessRetractionHandler.cs
@@ -10,8 +10,14 @@ using Microsoft.Extensions.Logging;
 namespace MeshWeaver.GitSync;
 
 /// <summary>
-/// 🚨 THE MOMENT A PARTITION GAINS A <c>_GitSync</c> IT BECOMES SYSTEM-OWNED — so every privileged
-/// account grant on it is retracted, right there.
+/// 🚨 THE MOMENT A PARTITION GAINS A <b>ONE-WAY</b> <c>_GitSync</c> IT BECOMES SYSTEM-OWNED — so
+/// every privileged account grant on it is retracted, right there.
+///
+/// <para><b>A bijective sync is exempt</b>, and that is not a loophole: with <c>twoWay: true</c> a
+/// node edited on the server is preserved and committed back, so the mesh copy is the working copy
+/// and the people editing it must be able to write. Retracting there would leave a space that
+/// advertises two-way editing which only the importer may perform. One definition governs both
+/// this sweep and the write boundary: <c>AccessAssignmentGuard.IsSystemOwned</c>.</para>
 ///
 /// <para><b>The window this closes.</b> <c>AccessAssignmentGuard.IsForbiddenOnSystemOwned</c> makes
 /// it impossible to WRITE such a grant onto a space that is already system-owned, and
@@ -65,6 +71,20 @@ public sealed class SystemOwnedAccessRetractionHandler(
         var partition = AccessAssignmentGuard.PartitionOf(createdNode.Namespace ?? "");
         if (string.IsNullOrEmpty(partition))
             return Observable.Return(Unit.Default);
+
+        // 🚨 A BIJECTIVE sync does not make the space system-owned — there the mesh nodes ARE the
+        // working copy, server-side edits are preserved and committed back, and the people making
+        // them need write access. Sweeping their grants away the moment the sync is wired would
+        // make two-way editing unusable by everyone except the importer, which is the opposite of
+        // what wiring it asked for. Read the direction off the node whose creation triggered this,
+        // so the decision costs no extra probe and cannot disagree with the write boundary.
+        if (AccessAssignmentGuard.IsTwoWay(createdNode, hub.JsonSerializerOptions))
+        {
+            logger?.LogInformation(
+                "[SystemOwned] '{Partition}' syncs BIJECTIVELY — its mesh nodes are the working "
+                + "copy, so write grants stand and nothing is retracted.", partition);
+            return Observable.Return(Unit.Default);
+        }
 
         var accessFolder = $"{partition}/_Access";
 

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -1742,7 +1742,9 @@ public static class MeshExtensions
                             // carries no grants AT ALL — the framework repairing its own failed
                             // bookkeeping, not an authorization decision.
                             return RepairOwnerlessPartitionGrant(
-                                hub, partition, t.root.Node, systemOwned: t.sync is not null,
+                                hub, partition, t.root.Node,
+                                systemOwned: AccessAssignmentGuard.IsSystemOwned(
+                                    t.sync, hub.JsonSerializerOptions),
                                 persistence, meshService, accessService, logger);
 
                         var healRoot = rootUsable
@@ -1757,7 +1759,11 @@ public static class MeshExtensions
                         // The self-heal still does its job for a user's own partition, which is
                         // what it exists for; it just no longer fires on a SYSTEM-OWNED one, where
                         // the caller is a deployer and never the owner.
-                        var systemOwned = t.sync is not null;
+                        // ONE definition (AccessAssignmentGuard.IsSystemOwned): a BIJECTIVE
+                        // sync is not system-owned — there the mesh nodes are the working
+                        // copy, so its creator keeps the ordinary ownership of the space.
+                        var systemOwned = AccessAssignmentGuard.IsSystemOwned(
+                            t.sync, hub.JsonSerializerOptions);
                         var mintGrant = isRealCreator && !grantExists && !systemOwned;
                         if (isRealCreator && !grantExists && systemOwned)
                             logger.LogInformation(
@@ -3281,8 +3287,9 @@ public static class MeshExtensions
     }
 
     /// <summary>
-    /// Emits the rejection reason when the node is a privileged grant on a SYSTEM-OWNED (GitSynced)
-    /// partition, else <c>null</c>. See <see cref="AccessAssignmentGuard.IsForbiddenOnSystemOwned"/>
+    /// Emits the rejection reason when the node is a privileged grant on a SYSTEM-OWNED partition
+    /// — a ONE-WAY GitSync; a bijective one is the working copy and grants are legal there — else
+    /// <c>null</c>. See <see cref="AccessAssignmentGuard.IsForbiddenOnSystemOwned"/>
     /// for why that shape is refused.
     ///
     /// <para><b>The storage read is paid for only by the shape that can fail.</b> The pure checks
@@ -3317,7 +3324,9 @@ public static class MeshExtensions
         var partition = AccessAssignmentGuard.PartitionOf(scope);
         return ReadNodeAuthoritative(hub, persistence, $"{partition}/_GitSync")
             .Select(sync => AccessAssignmentGuard.IsForbiddenOnSystemOwned(
-                node, assignment, systemOwned: sync is not null, out var reason)
+                node, assignment,
+                systemOwned: AccessAssignmentGuard.IsSystemOwned(sync, hub.JsonSerializerOptions),
+                out var reason)
                 ? reason
                 : null);
     }

--- a/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using System.Text.Json;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 
@@ -176,9 +177,11 @@ public static class AccessAssignmentGuard
                && string.Equals(r.Role, Role.Admin.Id, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
-    /// 🚨 A SYSTEM-OWNED space grants nobody write access. A partition with a <c>_GitSync</c> is
-    /// rewritten from its repo on every sync, so the ONLY identity that may write it is the one the
-    /// importer runs as (<see cref="WellKnownUsers.System"/>). Any other Admin/Editor grant is an
+    /// 🚨 A SYSTEM-OWNED space grants nobody write access. A partition with a ONE-WAY
+    /// <c>_GitSync</c> is rewritten from its repo on every sync, so the ONLY identity that may
+    /// write it is the one the importer runs as (<see cref="WellKnownUsers.System"/>). A
+    /// <b>bijective</b> sync is a different contract and is NOT system-owned — see
+    /// <see cref="IsSystemOwned"/>. Any other Admin/Editor grant is an
     /// ownership claim over content the repo owns — and the change it enables is silently reverted
     /// by the next sync, which is the worst of both worlds.
     ///
@@ -198,8 +201,10 @@ public static class AccessAssignmentGuard
     /// <param name="node">The grant node, already normalised.</param>
     /// <param name="assignment">Its content, materialised by the caller through the typed accessor
     /// — never re-read here as raw JSON, which is how a typed content silently reads as empty.</param>
-    /// <param name="systemOwned">Whether the partition has a <c>_GitSync</c>. The caller reads it;
-    /// keeping it a parameter is what makes this predicate pure and unit-testable with no hub.</param>
+    /// <param name="systemOwned">Whether the partition is system-owned — a ONE-WAY <c>_GitSync</c>
+    /// (see <see cref="IsSystemOwned"/>); a bijective sync is NOT, because there the mesh nodes are
+    /// the working copy. The caller reads it; keeping it a parameter is what makes this predicate
+    /// pure and unit-testable with no hub.</param>
     public static bool IsForbiddenOnSystemOwned(
         MeshNode? node, AccessAssignment? assignment, bool systemOwned, out string reason)
     {
@@ -227,6 +232,69 @@ public static class AccessAssignmentGuard
                + "live edit by anyone else is reverted by the next sync. Grant Viewer as an "
                + "entitlement instead, or change the repo and sync it.";
         return true;
+    }
+
+    /// <summary>
+    /// 🚨 THE definition of SYSTEM-OWNED, and the reason it is not simply "has a <c>_GitSync</c>".
+    ///
+    /// <para>A sync has two directions, and they imply opposite ownership:</para>
+    /// <list type="bullet">
+    ///   <item><b>One-way</b> (<c>twoWay: false</c>, the default) — import is git-first: the repo
+    ///     overwrites the live node on every sync. The mesh copy is a PROJECTION, so a write by
+    ///     anyone other than the importer is silently reverted. That partition is system-owned and
+    ///     grants nobody write access.</item>
+    ///   <item><b>Bijective</b> (<c>twoWay: true</c>) — a node edited on the server since the last
+    ///     sync is PRESERVED and committed back. The mesh nodes ARE the working copy, editing them
+    ///     is the entire point, and refusing write grants there makes the feature unusable: the
+    ///     space advertises two-way editing that nobody but the importer may do.</item>
+    /// </list>
+    ///
+    /// <para>Keying on the existence of the config alone conflated the two. Measured on
+    /// memex.systemorph.com 2026-08-18: <c>Deployments</c> was configured <c>twoWay: true</c> and
+    /// its skill documented UI editing as "a first-class way of writing it", yet granting a second
+    /// person Editor was refused as an ownership claim. The only account that could use the
+    /// two-way sync was the one whose grant PREDATED this guard — every later grant was refused,
+    /// which is a rule that enforces itself only against newcomers.</para>
+    ///
+    /// <para>Reads <c>twoWay</c> SHAPE-TOLERANTLY: the config arrives typed on the hub that owns
+    /// it, as a <c>JsonObject</c> from the node builders, and as a <c>JsonElement</c> from
+    /// persistence. A bare <c>is JsonElement</c> test would read the typed form as "no twoWay" and
+    /// fail CLOSED — which is the safe direction, but silently reinstates the exact bug above.
+    /// Absence of the property means <c>false</c>, which is the documented default.</para>
+    /// </summary>
+    /// <param name="syncNode">The <c>{partition}/_GitSync</c> node, or null when there is none.</param>
+    /// <param name="options">The HUB's serializer options — never a hand-rolled instance.</param>
+    public static bool IsSystemOwned(MeshNode? syncNode, JsonSerializerOptions? options)
+        => syncNode is not null && !IsTwoWay(syncNode, options);
+
+    /// <summary>
+    /// Whether a sync config is bijective. Pure and total: an unreadable or absent
+    /// <c>twoWay</c> is <c>false</c>, matching <c>GitHubSyncConfig.TwoWay</c>'s own default.
+    /// </summary>
+    public static bool IsTwoWay(MeshNode? syncNode, JsonSerializerOptions? options)
+    {
+        if (syncNode?.Content is not { } content)
+            return false;
+        try
+        {
+            // Serialized as the CONCRETE runtime type — the object overload routes through the
+            // polymorphic converter, which adopts a foreign type into this hub's registry as a
+            // side effect of a read.
+            var element = content is JsonElement je
+                ? je
+                : JsonSerializer.SerializeToElement(content, content.GetType(), options);
+            return element.ValueKind == JsonValueKind.Object
+                   && element.TryGetProperty("twoWay", out var twoWay)
+                   && twoWay.ValueKind == JsonValueKind.True;
+        }
+        catch (JsonException)
+        {
+            return false;   // unreadable config → treat as one-way, i.e. keep the space protected
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
     }
 
     /// <summary>The partition a scope belongs to — its first segment. <c>Store/Plugin</c> → <c>Store</c>,

--- a/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
@@ -335,4 +335,94 @@ public class AccessAssignmentGuardTest
             Roles = [new RoleAssignment { Role = "" }, new RoleAssignment { Role = "Admin", Denied = true }]
         }).Should().BeFalse();
     }
+
+    // ─────────────── SYSTEM-OWNED means ONE-WAY, not "has a _GitSync" ───────────────
+
+    private static MeshNode SyncConfig(bool? twoWay) => new("_GitSync", "Deployments")
+    {
+        NodeType = "GitHubSyncConfig",
+        Content = twoWay is null
+            ? System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(
+                """{"$type":"GitHubSyncConfig","repositoryUrl":"https://github.com/o/r"}""")
+            : System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(
+                $$"""{"$type":"GitHubSyncConfig","repositoryUrl":"https://github.com/o/r","twoWay":{{(twoWay.Value ? "true" : "false")}}}"""),
+    };
+
+    /// <summary>No sync at all — an ordinary space, owned by whoever created it.</summary>
+    [Fact]
+    public void NoSyncConfig_IsNotSystemOwned()
+        => Assert.False(AccessAssignmentGuard.IsSystemOwned(null, null));
+
+    /// <summary>
+    /// A ONE-WAY sync IS system-owned: the repo overwrites the live node on every sync, so a write
+    /// by anyone but the importer is silently reverted.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(null)]     // absent → the documented default, which is one-way
+    public void OneWaySync_IsSystemOwned(bool? twoWay)
+        => Assert.True(AccessAssignmentGuard.IsSystemOwned(SyncConfig(twoWay), null));
+
+    /// <summary>
+    /// 🚨 A BIJECTIVE sync is NOT system-owned. With twoWay the server copy is preserved and
+    /// committed back, so the mesh nodes are the working copy and the people editing them must be
+    /// able to write. Measured on memex.systemorph.com 2026-08-18: `Deployments` was configured
+    /// twoWay:true and its own skill documented UI editing as first-class, yet granting a second
+    /// person Editor was refused — the only account that could use the feature was the one whose
+    /// grant predated the guard.
+    /// </summary>
+    [Fact]
+    public void BijectiveSync_IsNotSystemOwned()
+        => Assert.False(AccessAssignmentGuard.IsSystemOwned(SyncConfig(true), null));
+
+    /// <summary>
+    /// The whole point, end to end: the same Editor grant that a one-way sync refuses is ALLOWED
+    /// on a bijective one.
+    /// </summary>
+    [Fact]
+    public void EditorGrant_IsRefusedOnOneWay_AndAllowedOnBijective()
+    {
+        var node = GrantOf("Deployments/_Access/sglauser_Access", "sglauser", "Editor");
+
+        Assert.True(AccessAssignmentGuard.IsForbiddenOnSystemOwned(
+            node, Content(node),
+            AccessAssignmentGuard.IsSystemOwned(SyncConfig(false), null), out var reason));
+        Assert.Contains("SYSTEM-OWNED", reason);
+
+        Assert.False(AccessAssignmentGuard.IsForbiddenOnSystemOwned(
+            node, Content(node),
+            AccessAssignmentGuard.IsSystemOwned(SyncConfig(true), null), out _));
+    }
+
+    /// <summary>
+    /// Reading the flag must survive every shape the config arrives in — typed on its owning hub,
+    /// JsonElement from persistence. A shape test that missed would read a bijective config as
+    /// one-way and reinstate the refusal.
+    /// </summary>
+    [Fact]
+    public void TwoWay_IsReadFromAnyContentShape()
+    {
+        var fromJson = SyncConfig(true);
+        Assert.True(AccessAssignmentGuard.IsTwoWay(fromJson, null));
+
+        // The anonymous-object shape a node builder produces, serialized as its concrete type.
+        var typed = new MeshNode("_GitSync", "Deployments")
+        {
+            NodeType = "GitHubSyncConfig",
+            Content = new { twoWay = true, repositoryUrl = "https://github.com/o/r" },
+        };
+        Assert.True(AccessAssignmentGuard.IsTwoWay(typed, null));
+    }
+
+    /// <summary>An unreadable or contentless config keeps the space PROTECTED — fail closed.</summary>
+    [Fact]
+    public void UnreadableConfig_FailsClosed()
+    {
+        Assert.False(AccessAssignmentGuard.IsTwoWay(null, null));
+        var noContent = new MeshNode("_GitSync", "Deployments") { NodeType = "GitHubSyncConfig" };
+        Assert.False(AccessAssignmentGuard.IsTwoWay(noContent, null));
+        Assert.True(AccessAssignmentGuard.IsSystemOwned(noContent, null),
+            "a config we cannot read must leave the space system-owned, never open it up");
+    }
+
 }


### PR DESCRIPTION
A sync has two directions and they imply **opposite** ownership — but every enforcement point keyed on the mere existence of the config.

| | meaning | ownership |
|---|---|---|
| `twoWay: false` (default) | import is git-first; the repo overwrites the live node | **system-owned** — a write by anyone but the importer is silently reverted |
| `twoWay: true` | a node edited on the server since the last sync is **preserved and committed back** | the mesh nodes **are** the working copy — editing them is the point |

## The measurement

memex.systemorph.com, 2026-08-18: `Deployments` was configured `twoWay: true` and its own skill documented UI editing as *"a first-class way of writing it"* — yet granting a second person `Editor` was refused as an ownership claim:

```
AccessAssignment 'Deployments/_Access/sglauser_Access' would give 'sglauser' write access
to 'Deployments', which is SYSTEM-OWNED (it has Deployments/_GitSync …)
```

The only account that could use the two-way sync was the one whose grant **predated** the guard. A rule that enforces itself only against newcomers.

## The change

`AccessAssignmentGuard.IsSystemOwned` becomes the **one** definition, used by all four enforcement points — the write boundary (`SystemOwnedGrantRejection`), both `EnsurePartitionBootstrap` sites, and `SystemOwnedAccessRetractionHandler` — so the sweep can never retract a grant the boundary would have allowed.

- Reads `twoWay` **shape-tolerantly**: the config arrives typed on its owning hub and as a `JsonElement` from persistence. A bare `is JsonElement` test would read the typed form as one-way and silently reinstate the bug.
- **Fails closed**: an unreadable or absent flag leaves the space protected, matching `GitHubSyncConfig.TwoWay`'s own default.
- The retraction sweep reads the direction off the very node whose creation triggers it — no extra probe, and it cannot disagree with the write boundary.

## Scope

**No behaviour change for one-way syncs**, which is every sync on all three meshes as of today (53 configs; the single `twoWay: true` was set back to false before this PR).

7 new tests in `AccessAssignmentGuardTest`, all passing (48 in the class). The key one asserts the same `Editor` grant is refused on one-way and allowed on bijective.