### PR TITLE
A scheduled post's slot now publishes it — nothing read scheduledAt before

### DIFF
--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -435,21 +435,46 @@ public sealed class EventSubscriptionRunner(
             // reference graph (PublishSocialPost is owned by MeshWeaver.Social, which references
             // Graph). The owning module registers an IEventContinuationHandler; nothing is silently
             // skipped, because an unhandled type still falls through to the throw below.
-            _ => ExternalHandler(subscription) is { } handler
-                ? AsSystem(() => handler.Execute(subscription, userId))
-                : Observable.Throw<MeshNode>(new InvalidOperationException(
-                    $"Unsupported or incomplete event subscription {subscription.Id}")),
+            _ => ExternalContinuation(subscription, userId),
         };
 
     /// <summary>
-    /// The registered <see cref="IEventContinuationHandler"/> for this subscription's continuation, or
-    /// null when none is registered. Resolved per firing (never cached): handlers are registered by
-    /// modules, and a cached null taken before a module's registration landed would wedge every later
-    /// subscription of that type for the life of the process.
+    /// Dispatches to the <see cref="IEventContinuationHandler"/> registered for this continuation.
+    /// Resolved per firing (never cached): handlers are registered by modules, and a cached null taken
+    /// before a module's registration landed would wedge every later subscription of that type for the
+    /// life of the process.
+    ///
+    /// <para>Both failure modes name themselves, because both are configuration mistakes that would
+    /// otherwise present as "the thing just never happened":</para>
+    /// <list type="bullet">
+    ///   <item><b>None registered</b> — the owning module was not composed into this host (a missing
+    ///   <c>AddSocial</c>, say). The generic "unsupported subscription" wording sent readers looking
+    ///   for a bad subscription instead of an absent registration.</item>
+    ///   <item><b>More than one</b> — ambiguous, so it FAILS rather than picking one. Taking the first
+    ///   match would make behaviour depend on registration order, which is nondeterministic across
+    ///   hosts and hides the duplicate indefinitely.</item>
+    /// </list>
     /// </summary>
-    private IEventContinuationHandler? ExternalHandler(EventSubscription subscription) =>
-        hub.ServiceProvider.GetServices<IEventContinuationHandler>()
-            .FirstOrDefault(h => h.ContinuationType == subscription.ContinuationType);
+    private IObservable<MeshNode> ExternalContinuation(EventSubscription subscription, string userId)
+    {
+        var handlers = hub.ServiceProvider.GetServices<IEventContinuationHandler>()
+            .Where(h => h.ContinuationType == subscription.ContinuationType)
+            .ToList();
+
+        if (handlers.Count == 1)
+            return AsSystem(() => handlers[0].Execute(subscription, userId));
+
+        return Observable.Throw<MeshNode>(new InvalidOperationException(handlers.Count == 0
+            ? $"Event subscription {subscription.Id} has continuation "
+              + $"{subscription.ContinuationType}, which no IEventContinuationHandler is registered "
+              + "for. The module that owns it is not composed into this host — nothing will ever fire "
+              + "this subscription until it is."
+            : $"Event subscription {subscription.Id} has continuation "
+              + $"{subscription.ContinuationType}, which {handlers.Count} IEventContinuationHandlers "
+              + $"claim ({string.Join(", ", handlers.Select(h => h.GetType().Name))}). Exactly one must "
+              + "be registered — refusing to pick one, because which arrived first is not a decision "
+              + "this runner can make correctly."));
+    }
 
     /// <summary>
     /// Migrates legacy <c>Admin/ScheduledAction/{id}</c> nodes into equivalent

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -4,6 +4,7 @@ using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -430,9 +431,25 @@ public sealed class EventSubscriptionRunner(
                                 meshService, userId, subscription.TargetPath!, subscription.Role!))
                             .Select(_ => m)
                         : Observable.Return(m)),
-            _ => Observable.Throw<MeshNode>(new InvalidOperationException(
-                $"Unsupported or incomplete event subscription {subscription.Id}")),
+            // Continuations this assembly cannot implement — their effects live ABOVE it in the
+            // reference graph (PublishSocialPost is owned by MeshWeaver.Social, which references
+            // Graph). The owning module registers an IEventContinuationHandler; nothing is silently
+            // skipped, because an unhandled type still falls through to the throw below.
+            _ => ExternalHandler(subscription) is { } handler
+                ? AsSystem(() => handler.Execute(subscription, userId))
+                : Observable.Throw<MeshNode>(new InvalidOperationException(
+                    $"Unsupported or incomplete event subscription {subscription.Id}")),
         };
+
+    /// <summary>
+    /// The registered <see cref="IEventContinuationHandler"/> for this subscription's continuation, or
+    /// null when none is registered. Resolved per firing (never cached): handlers are registered by
+    /// modules, and a cached null taken before a module's registration landed would wedge every later
+    /// subscription of that type for the life of the process.
+    /// </summary>
+    private IEventContinuationHandler? ExternalHandler(EventSubscription subscription) =>
+        hub.ServiceProvider.GetServices<IEventContinuationHandler>()
+            .FirstOrDefault(h => h.ContinuationType == subscription.ContinuationType);
 
     /// <summary>
     /// Migrates legacy <c>Admin/ScheduledAction/{id}</c> nodes into equivalent

--- a/src/MeshWeaver.Mesh.Contract/EventSubscription.cs
+++ b/src/MeshWeaver.Mesh.Contract/EventSubscription.cs
@@ -44,7 +44,17 @@ public enum EventContinuationType
     /// <c>GroupMembership</c> node). The group-invite twin of <see cref="GrantSpaceAccess"/>: an email
     /// invite to a <b>group</b> that lands membership — and, transitively, whatever the group is granted —
     /// the moment the invitee's account exists.</summary>
-    AddToGroup = 2
+    AddToGroup = 2,
+    /// <summary>Publish the social post at <see cref="EventSubscription.TargetPath"/> to its network —
+    /// the <see cref="EventTriggerType.Timer"/> twin of the manual "Publish to LinkedIn" node action, so a
+    /// post's scheduled slot actually publishes it instead of only labelling it.
+    ///
+    /// <para>Handled OUT of process-tree: the publishers live in <c>MeshWeaver.Social</c>, which already
+    /// references <c>MeshWeaver.Graph</c> — so the runner cannot call them directly without a reference
+    /// cycle. It resolves an <see cref="IEventContinuationHandler"/> for this type from DI instead
+    /// (<c>SocialExtensions.AddSocial</c> registers the LinkedIn one). With no handler registered the
+    /// subscription fails loudly rather than silently doing nothing.</para></summary>
+    PublishSocialPost = 3
 }
 
 /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/IEventContinuationHandler.cs
+++ b/src/MeshWeaver.Mesh.Contract/IEventContinuationHandler.cs
@@ -1,0 +1,43 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// A continuation the <c>EventSubscriptionRunner</c> can fire but cannot itself implement — the
+/// extension point for effects that live ABOVE the runner in the assembly graph.
+///
+/// <para><b>Why this exists.</b> The runner lives in <c>MeshWeaver.Graph</c> and handles the
+/// continuations whose effects are graph-native (grant a role, add to a group, post a thread message).
+/// <see cref="EventContinuationType.PublishSocialPost"/> is not: it belongs to
+/// <c>MeshWeaver.Social</c>, which already references <c>MeshWeaver.Graph</c>. Calling it directly
+/// would be a reference cycle, and moving the publisher down into Graph would drag LinkedIn's HTTP
+/// surface into the graph layer. So the runner resolves handlers from DI and dispatches by
+/// <see cref="ContinuationType"/>; the owning module registers its own.</para>
+///
+/// <para>🚨 <b>Reactive, like everything the runner touches.</b> <see cref="Execute"/> returns a COLD
+/// <see cref="IObservable{T}"/> — the effect runs when the runner subscribes, never on call. A
+/// handler whose real work is a <c>Task</c>-returning leaf (an HTTP publish, say) bridges it through
+/// <c>IIoPool.Invoke</c>; a bare <c>Observable.FromAsync</c> is forbidden repo-wide.</para>
+///
+/// <para><b>Failure is an error, not an empty sequence.</b> The runner marks a subscription
+/// <c>Fired</c> when the continuation emits and <c>Failed</c> (recording the message on
+/// <see cref="EventSubscription.LastError"/>) when it throws. A handler that swallowed its own
+/// failure and completed empty would leave a subscription that never fires and never explains
+/// itself — the exact shape of bug that let scheduled posts sit silently unpublished. Throw.</para>
+/// </summary>
+public interface IEventContinuationHandler
+{
+    /// <summary>The continuation this handler implements. One handler per type; the runner takes the
+    /// first match, so registering two for the same type is a configuration error, not a fallback
+    /// chain.</summary>
+    EventContinuationType ContinuationType { get; }
+
+    /// <summary>
+    /// Runs the continuation for <paramref name="subscription"/> and emits the node it acted on.
+    /// Cold — the effect runs on Subscribe.
+    /// </summary>
+    /// <param name="subscription">The subscription being fired, carrying whatever the effect needs
+    /// (<see cref="EventSubscription.TargetPath"/> and friends).</param>
+    /// <param name="subjectId">The subject the trigger identified — the triggering node's id for a
+    /// <see cref="EventTriggerType.NodeChange"/>, otherwise <see cref="EventSubscription.SubjectId"/>
+    /// (empty when the effect needs no subject, as a timed publish does not).</param>
+    IObservable<MeshNode> Execute(EventSubscription subscription, string subjectId);
+}

--- a/src/MeshWeaver.Mesh.Contract/IEventContinuationHandler.cs
+++ b/src/MeshWeaver.Mesh.Contract/IEventContinuationHandler.cs
@@ -25,9 +25,10 @@ namespace MeshWeaver.Mesh;
 /// </summary>
 public interface IEventContinuationHandler
 {
-    /// <summary>The continuation this handler implements. One handler per type; the runner takes the
-    /// first match, so registering two for the same type is a configuration error, not a fallback
-    /// chain.</summary>
+    /// <summary>The continuation this handler implements. EXACTLY one handler per type: the runner
+    /// refuses to fire a continuation that two handlers claim, rather than taking whichever was
+    /// registered first — that would make behaviour depend on registration order and hide the
+    /// duplicate indefinitely.</summary>
     EventContinuationType ContinuationType { get; }
 
     /// <summary>

--- a/src/MeshWeaver.Social/ScheduledPostWatcher.cs
+++ b/src/MeshWeaver.Social/ScheduledPostWatcher.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Social;
+
+/// <summary>
+/// Arms the timer that publishes a scheduled post — the half of scheduling that decides WHEN, paired
+/// with <see cref="ScheduledSocialPublishHandler"/>, which does the publishing.
+///
+/// <para>🚨 <b>Why this watches instead of the editor minting on click.</b> A post's <c>status</c> and
+/// <c>scheduledAt</c> are ordinary content fields with no write boundary — a script, an agent or an
+/// MCP <c>patch</c> writes them straight onto the node, and that is not an edge case: the production
+/// incident of 2026-08-18 had the slot moved by an AGENT, not by the workflow button. Minting the
+/// subscription inside the Schedule button would therefore have armed nothing for the write that
+/// actually happened. Reconciling from the post's stored state covers every writer.</para>
+///
+/// <para><b>Reconcile, not react.</b> Each emission of the live query re-derives the desired timer set
+/// from current state and settles the difference, so a missed change-feed event, a restart, or a slot
+/// edited three times all converge on one subscription per post. The subscription id is derived from
+/// the post path, which is what makes re-scheduling an UPDATE rather than a second timer.</para>
+///
+/// <para>🚨 <b>An already-fired timer is never re-armed.</b> The publish continuation is not
+/// idempotent — firing it twice posts to LinkedIn twice. So a post whose subscription already reached
+/// <see cref="EventSubscriptionStatus.Fired"/> is left alone even if its slot is edited afterwards,
+/// and a post that is already <c>Published</c> never arms at all. Re-publishing an edited post is
+/// deliberately not a flow here: author a new post instead.</para>
+/// </summary>
+public sealed class ScheduledPostWatcher(
+    IMessageHub hub,
+    IMeshService meshService,
+    AccessService accessService,
+    ILogger<ScheduledPostWatcher>? logger = null) : IHostedService, IDisposable
+{
+    /// <summary>Live query id — constant, so the workspace keeps ONE registry entry rather than
+    /// leaking one per emission.</summary>
+    private const string QueryId = "social-scheduled-posts";
+
+    /// <summary>
+    /// The candidate set: every post node, narrowed to the ones actually due by
+    /// <see cref="IsSchedulablePost"/> in code.
+    ///
+    /// <para>🚨 <b>Not <c>status:Scheduled</c>.</b> The obvious query — filter on the content field —
+    /// silently matches NOTHING: a content-field term returns an empty result while
+    /// <c>nodeType:*Post</c> over the same node returns it (measured, and now pinned by
+    /// <c>ScheduledPostWatcherTest</c>). A watcher built on that filter would have looked completely
+    /// healthy and armed nothing, which is the same silent-failure shape this whole component exists
+    /// to remove. The node-type suffix match also keeps this predicate identical to
+    /// <see cref="SocialPostMenuProvider"/>'s, so the manual and timed paths agree on what a post is.</para>
+    ///
+    /// <para>Deliberately NOT capped with <c>limit:</c>: a truncated candidate set drops posts that
+    /// were legitimately scheduled, and it drops them invisibly.</para>
+    /// </summary>
+    private const string Query = "nodeType:*Post select:path,id,namespace,name,nodeType,content";
+
+    /// <summary>The timers already armed. Read as a QUERY rather than one node-stream read per post:
+    /// a stream opened on a path that does not exist yet ERRORS (<c>No node found</c>), so the
+    /// per-post shape logged a routing warning and a stream fault for every post awaiting its first
+    /// timer — noise that would train everyone to ignore this component's logs.</summary>
+    private const string SubscriptionQueryId = "social-publish-timers";
+
+    private static readonly string SubscriptionQuery =
+        $"path:{EventSubscriptionNodeType.Namespace} scope:children "
+        + $"nodeType:{EventSubscriptionNodeType.NodeType} select:path,id,namespace,name,nodeType,content";
+
+    private IDisposable? querySub;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Both sides live: a post being scheduled AND a timer firing re-emit, so the desired set is
+        // re-derived from current state either way. That is what makes this restart- and
+        // missed-event-safe without any bookkeeping of its own.
+        querySub = Observable.CombineLatest(
+                AsSystem(() => hub.GetWorkspace().GetQuery(QueryId, Query)),
+                AsSystem(() => hub.GetWorkspace().GetQuery(SubscriptionQueryId, SubscriptionQuery)),
+                (posts, timers) => (Posts: posts, Timers: timers))
+            .Subscribe(
+                x => Reconcile(x.Posts ?? [], x.Timers ?? []),
+                ex => logger?.LogWarning(ex, "Scheduled-post watch failed; no slots will be armed"));
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Settles the timer set against the posts currently claiming to be scheduled. Logs the counts at
+    /// Information: a watcher that silently sees nothing is indistinguishable from one that is working
+    /// and has nothing to do, and telling those apart in production is the entire point.
+    /// </summary>
+    private void Reconcile(IEnumerable<MeshNode> nodes, IEnumerable<MeshNode> timerNodes)
+    {
+        var all = nodes.ToList();
+        var posts = all.Where(IsSchedulablePost).ToList();
+        var timers = timerNodes
+            .Select(n => n.ContentAs<EventSubscription>(hub.JsonSerializerOptions))
+            .Where(s => s is { ContinuationType: EventContinuationType.PublishSocialPost })
+            .ToDictionary(s => s!.Id, s => s!, StringComparer.Ordinal);
+
+        logger?.LogInformation(
+            "Scheduled-post watch: {Scheduled} of {Total} scheduled nodes are publishable posts; "
+            + "{Timers} publish timers exist",
+            posts.Count, all.Count, timers.Count);
+
+        foreach (var post in posts)
+        {
+            var slot = SlotOf(post);
+            if (slot is null)
+                continue;   // "Scheduled" with no time — the workflow blocks this; a raw write can't be honoured
+            EnsureTimer(post.Path, slot.Value, timers);
+        }
+    }
+
+    /// <summary>
+    /// Creates the post's publish timer, or moves it when the slot changed. Reads the existing
+    /// subscription FIRST and writes only on a real difference — an unconditional upsert would reset a
+    /// <c>Fired</c> subscription to <c>Pending</c> on every emission and republish the post on a loop.
+    /// </summary>
+    private void EnsureTimer(
+        string postPath, DateTimeOffset slot, IReadOnlyDictionary<string, EventSubscription> timers)
+    {
+        var id = SubscriptionId(postPath);
+        timers.TryGetValue(id, out var current);
+
+        // Already fired (or cancelled/failed): the post has been published, or a human stopped it.
+        // Never re-arm — this continuation posts to a network and cannot be undone.
+        if (current is not null && current.Status != EventSubscriptionStatus.Pending)
+            return;
+
+        // Unchanged — writing again would churn the node's version for nothing, and every write
+        // re-emits the query that brought us here.
+        if (current is not null && current.FireAt == slot)
+            return;
+
+        var subscription = new EventSubscription
+        {
+            Id = id,
+            TriggerType = EventTriggerType.Timer,
+            FireAt = slot,
+            ContinuationType = EventContinuationType.PublishSocialPost,
+            TargetPath = postPath,
+            Status = EventSubscriptionStatus.Pending,
+            CreatedBy = current?.CreatedBy,
+            CreatedAt = current?.CreatedAt ?? DateTimeOffset.UtcNow,
+        };
+        AsSystem(() => EventSubscriptionOps.CreateSubscription(meshService, subscription))
+            .Subscribe(
+                _ => logger?.LogInformation(
+                    "Armed publish of {Path} for {Slot:o} (subscription {Id})", postPath, slot, id),
+                ex => logger?.LogWarning(ex, "Could not arm publish of {Path}", postPath));
+    }
+
+    /// <summary>
+    /// The post's timer id — derived from its PATH so the same post always addresses the same
+    /// subscription. That is what makes re-scheduling move one timer instead of stacking a second one
+    /// beside it, and it is why the id must never carry the slot.
+    /// </summary>
+    public static string SubscriptionId(string postPath) =>
+        "publish-" + postPath.Replace('/', '-').Replace('@', '-');
+
+    /// <summary>
+    /// Whether this node is a social post that a timer may publish. Mirrors
+    /// <see cref="SocialPostMenuProvider"/>'s predicate — the manual and timed paths must agree on what
+    /// a post IS, or a post gets a button and no timer (or the reverse).
+    ///
+    /// <para>A node already carrying a <c>publishedUrn</c> is excluded whatever its status says: it is
+    /// on the network, and arming it again would post it twice.</para>
+    /// </summary>
+    public static bool IsSchedulablePost(MeshNode node)
+    {
+        if (node.Content is null)
+            return false;
+        var type = Prop(node, "$type");
+        var isPost = string.Equals(type, "SocialMediaPost", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(type, "SocialPost", StringComparison.OrdinalIgnoreCase)
+            || (node.NodeType?.EndsWith("Post", StringComparison.OrdinalIgnoreCase) ?? false);
+        if (!isPost)
+            return false;
+        if (!string.IsNullOrWhiteSpace(Prop(node, "publishedUrn")))
+            return false;
+        if (!string.Equals(Prop(node, "status"), "Scheduled", StringComparison.OrdinalIgnoreCase))
+            return false;
+        var platform = Prop(node, "platform");
+        return string.IsNullOrEmpty(platform)
+            || string.Equals(platform, "LinkedIn", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The post's slot as an instant, or null when it names none. A bare (unzoned) timestamp is
+    /// read as UTC — every stored <c>scheduledAt</c> in the mesh is UTC, and guessing a local zone here
+    /// would move a post by hours.</summary>
+    public static DateTimeOffset? SlotOf(MeshNode node)
+    {
+        var raw = Prop(node, "scheduledAt");
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+        if (DateTimeOffset.TryParse(raw, System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AssumeUniversal
+                | System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsed))
+            return parsed;
+        return null;
+    }
+
+    /// <summary>Shape-tolerant content read: the node may hold a typed record OR raw JSON depending on
+    /// whether the reading hub knows the type, and camelCase or PascalCase depending on the writer.</summary>
+    private static string? Prop(MeshNode node, string name)
+    {
+        if (node.Content is null)
+            return null;
+        var je = node.Content is JsonElement e
+            ? e
+            : JsonSerializer.SerializeToElement(node.Content, node.Content.GetType());
+        if (je.ValueKind != JsonValueKind.Object)
+            return null;
+        foreach (var candidate in new[] { name, char.ToUpperInvariant(name[0]) + name[1..] })
+            if (je.TryGetProperty(candidate, out var v))
+                return v.ValueKind switch
+                {
+                    JsonValueKind.String => v.GetString(),
+                    JsonValueKind.Null or JsonValueKind.Undefined => null,
+                    _ => v.ToString(),
+                };
+        return null;
+    }
+
+    private IObservable<T> AsSystem<T>(Func<IObservable<T>> factory) => accessService.RunAsSystem(factory);
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        querySub?.Dispose();
+        querySub = null;
+    }
+}

--- a/src/MeshWeaver.Social/ScheduledSocialPublishHandler.cs
+++ b/src/MeshWeaver.Social/ScheduledSocialPublishHandler.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Net.Http;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Social;
+
+/// <summary>
+/// Publishes a scheduled post when its slot arrives — the continuation behind
+/// <see cref="EventContinuationType.PublishSocialPost"/>, and the piece that makes a post's
+/// <c>scheduledAt</c> mean something.
+///
+/// <para>🚨 <b>The defect this closes.</b> Until this existed, scheduling a post wrote a status field
+/// and armed NOTHING: <c>scheduledAt</c> was read by the date picker and the timeline sort, and by no
+/// other line of code in the mesh, the portal or the plugins. Publishing was a node-menu button
+/// (<see cref="SocialPostMenuProvider"/>) and the slot was decoration, so a post sat at
+/// <c>Scheduled</c> forever while its timeline card claimed it was on its way out. Observed in
+/// production on 2026-08-18 with a post that had been "scheduled" twice and published neither
+/// time.</para>
+///
+/// <para><b>It reuses the manual path exactly</b> — <see cref="LinkedInPublishService.PublishPostAsync"/>,
+/// the same call the "Publish to LinkedIn" menu item makes — rather than growing a second publish
+/// implementation that could drift from it. The service resolves the author profile's stored
+/// credential from the post's own <c>authorPath</c> and writes <c>status</c>/<c>publishedUrn</c>/
+/// <c>publishedAt</c> back, so a timed publish and a hand-clicked one leave identical state.</para>
+///
+/// <para><b>Identity.</b> The runner has no ambient <c>AccessContext</c> and wraps this in
+/// <c>ImpersonateAsSystem</c>, so the publish service's two access gates pass by construction. That is
+/// the intended reading, not a bypass: the credential is selected by the POST's own author profile,
+/// never by the caller, so a timer can only ever publish as the member whose post it is. Who armed the
+/// timer stays on the subscription's <see cref="EventSubscription.CreatedBy"/>.</para>
+///
+/// <para>🚨 <b>Task-based leaf, reactive surface.</b> <see cref="LinkedInPublishService"/> is HTTP-edge
+/// code and returns <c>Task</c>; this is hub-reachable background code and must not. The bridge is
+/// <see cref="IIoPool.Invoke{T}"/> on the <see cref="IoPoolNames.Http"/> pool — which also bounds how
+/// many posts can be in flight at once, so a hundred slots falling on the same minute cannot open a
+/// hundred simultaneous sockets. A bare <c>Observable.FromAsync</c> is forbidden repo-wide.</para>
+/// </summary>
+public sealed class ScheduledSocialPublishHandler(
+    IMessageHub hub,
+    IMeshService meshService,
+    IHttpClientFactory httpClientFactory,
+    ILogger<ScheduledSocialPublishHandler>? logger = null) : IEventContinuationHandler
+{
+    private readonly IIoPool _httpPool =
+        hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
+
+    /// <inheritdoc />
+    public EventContinuationType ContinuationType => EventContinuationType.PublishSocialPost;
+
+    /// <summary>
+    /// Publishes the post at <see cref="EventSubscription.TargetPath"/> and emits it as stored after
+    /// the write-back. Cold: nothing is published until the runner subscribes.
+    ///
+    /// <para>A refused or failed publish THROWS rather than completing quietly, so the runner records
+    /// the reason on the subscription (<c>Failed</c> + <see cref="EventSubscription.LastError"/>)
+    /// instead of marking it <c>Fired</c>. A silent failure here would reproduce exactly the bug this
+    /// class exists to fix, one layer down.</para>
+    /// </summary>
+    public IObservable<MeshNode> Execute(EventSubscription subscription, string subjectId)
+    {
+        var postPath = subscription.TargetPath;
+        if (string.IsNullOrWhiteSpace(postPath))
+            return Observable.Throw<MeshNode>(new InvalidOperationException(
+                $"Event subscription {subscription.Id} publishes a social post but names no TargetPath."));
+
+        var service = new LinkedInPublishService(
+            hub, meshService, hub.ServiceProvider.GetService<ILogger<LinkedInPublishService>>());
+
+        return _httpPool
+            .Invoke(ct => service.PublishPostAsync(
+                httpClientFactory.CreateClient(),
+                postPath!,
+                textOverride: null,
+                visibility: null,
+                apiVersion: LinkedInPostsApi.DefaultApiVersion,
+                ct))
+            .SelectMany(outcome => outcome.Success
+                // 🚨 A publish that SUCCEEDED must never surface as a failure. The runner marks a
+                // throwing continuation Failed and RELEASES its at-most-once reservation, so a later
+                // pending-set emission can retry it — which for this continuation means posting to
+                // LinkedIn a second time. The read-back is therefore best-effort: if the node cannot
+                // be re-read (timeout, empty), we still report the success that already happened.
+                ? hub.GetMeshNode(postPath!, TimeSpan.FromSeconds(10))
+                    .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))
+                    .Select(node => node ?? Placeholder(postPath!))
+                : Observable.Throw<MeshNode>(new InvalidOperationException(
+                    $"Scheduled publish of '{postPath}' was refused: {outcome.Reason ?? "unknown"}"
+                    + (outcome.StatusCode > 0 ? $" (HTTP {outcome.StatusCode})" : string.Empty)
+                    + (outcome.HttpAttempted
+                        ? string.Empty
+                        : " — a pre-publish gate short-circuited before any LinkedIn call."))))
+            .Do(_ => logger?.LogInformation(
+                "Scheduled publish of {Path} succeeded (subscription {Id})", postPath, subscription.Id));
+    }
+
+    /// <summary>Stands in for the published post when it cannot be re-read — the runner uses the emitted
+    /// node only to log what fired, so identity is all it needs, and inventing it here is what keeps a
+    /// read-back hiccup from being reported as a publish failure.</summary>
+    private static MeshNode Placeholder(string path)
+    {
+        var cut = path.LastIndexOf('/');
+        return cut > 0
+            ? new MeshNode(path[(cut + 1)..], path[..cut])
+            : new MeshNode(path);
+    }
+}

--- a/src/MeshWeaver.Social/ScheduledSocialPublishHandler.cs
+++ b/src/MeshWeaver.Social/ScheduledSocialPublishHandler.cs
@@ -62,7 +62,7 @@ public sealed class ScheduledSocialPublishHandler(
     /// instead of marking it <c>Fired</c>. A silent failure here would reproduce exactly the bug this
     /// class exists to fix, one layer down.</para>
     /// </summary>
-    public IObservable<MeshNode> Execute(EventSubscription subscription, string subjectId)
+    public IObservable<MeshNode> Execute(EventSubscription subscription, string _)
     {
         var postPath = subscription.TargetPath;
         if (string.IsNullOrWhiteSpace(postPath))

--- a/src/MeshWeaver.Social/SocialModuleAttribute.cs
+++ b/src/MeshWeaver.Social/SocialModuleAttribute.cs
@@ -81,6 +81,12 @@ public static class SocialExtensions
                 ServiceDescriptor.Scoped<INodeMenuProvider, LinkedInCredentialMenuProvider>());
             services.TryAddEnumerable(
                 ServiceDescriptor.Scoped<INodeMenuProvider, SocialPostMenuProvider>());
+
+            // The TIMED twin of that Publish menu item. Singleton, not scoped: EventSubscriptionRunner
+            // is a hosted service resolving out of the ROOT provider, and a scoped registration there
+            // throws at the moment a slot fires — i.e. in production, hours after any test ran.
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IEventContinuationHandler, ScheduledSocialPublishHandler>());
             return services;
         });
 }

--- a/src/MeshWeaver.Social/SocialModuleAttribute.cs
+++ b/src/MeshWeaver.Social/SocialModuleAttribute.cs
@@ -87,6 +87,11 @@ public static class SocialExtensions
             // throws at the moment a slot fires — i.e. in production, hours after any test ran.
             services.TryAddEnumerable(
                 ServiceDescriptor.Singleton<IEventContinuationHandler, ScheduledSocialPublishHandler>());
+
+            // …and the half that ARMS it. Without this the handler above is unreachable: nothing else
+            // in the mesh reads a post's scheduledAt, which is precisely how posts sat "Scheduled"
+            // and never went out.
+            services.AddHostedService<ScheduledPostWatcher>();
             return services;
         });
 }

--- a/test/MeshWeaver.Graph.Test/EventContinuationHandlerTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventContinuationHandlerTest.cs
@@ -1,0 +1,165 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Covers the <see cref="IEventContinuationHandler"/> extension point — how
+/// <see cref="EventSubscriptionRunner"/> fires a continuation whose effect lives ABOVE it in the
+/// assembly graph (<see cref="EventContinuationType.PublishSocialPost"/>, implemented in
+/// <c>MeshWeaver.Social</c>, which references <c>MeshWeaver.Graph</c>).
+///
+/// <para>The three behaviours pinned here are the ones whose absence is invisible in production: a
+/// timed publish actually REACHES its handler, a failing publish is RECORDED rather than swallowed,
+/// and a continuation with no handler registered FAILS LOUDLY instead of sitting Pending forever.
+/// That last shape is what a forgotten <c>AddSocial</c> produces, and it looks exactly like a post
+/// that was scheduled and never went out.</para>
+/// </summary>
+public class EventContinuationHandlerTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string PostPath = "PublishSpace";
+
+    /// <summary>Records what the runner dispatched, and can be told to fail — an instance, registered
+    /// into the mesh's DI, never a static: a static would leak across the parallel test classes below.</summary>
+    private sealed class RecordingHandler : IEventContinuationHandler
+    {
+        public EventContinuationType ContinuationType => EventContinuationType.PublishSocialPost;
+        public string? SeenTargetPath { get; private set; }
+        public int Calls { get; private set; }
+        public string? FailWith { get; set; }
+
+        public IObservable<MeshNode> Execute(EventSubscription subscription, string subjectId)
+        {
+            Calls++;
+            SeenTargetPath = subscription.TargetPath;
+            return FailWith is { } reason
+                ? Observable.Throw<MeshNode>(new InvalidOperationException(reason))
+                : Observable.Return(new MeshNode(subscription.TargetPath!));
+        }
+    }
+
+    private readonly RecordingHandler handler = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(new MeshNode(PostPath) { Name = "Publish Space", NodeType = "Space" })
+            .ConfigureServices(services => services.AddSingleton<IEventContinuationHandler>(handler));
+
+    /// <summary>A due timer whose continuation belongs to another assembly reaches that assembly's
+    /// registered handler, and the subscription completes as <c>Fired</c>. This is the whole path
+    /// behind "a post's scheduled slot publishes it".</summary>
+    [Fact(Timeout = 60000)]
+    public async Task DueTimer_DispatchesToTheRegisteredHandler_AndFires()
+    {
+        var subscription = await ArmDueTimer();
+
+        var final = await AwaitSettled(subscription.Id);
+
+        Assert.True(final.Status == EventSubscriptionStatus.Fired,
+            $"subscription ended {final.Status}: {final.LastError}");
+        Assert.Equal(1, handler.Calls);
+        Assert.Equal(PostPath, handler.SeenTargetPath);
+    }
+
+    /// <summary>A handler that throws leaves the subscription <c>Failed</c> WITH the reason on
+    /// <see cref="EventSubscription.LastError"/> — never <c>Fired</c>, and never a silent success. A
+    /// publish that LinkedIn refuses has to be visible on the subscription; that is the only place
+    /// anyone can find out why a slot passed with nothing posted.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task HandlerFailure_IsRecordedOnTheSubscription_NotSwallowed()
+    {
+        handler.FailWith = "linkedin refused: missing-w_member_social-reconnect";
+
+        var subscription = await ArmDueTimer();
+
+        var final = await AwaitSettled(subscription.Id);
+
+        Assert.True(final.Status == EventSubscriptionStatus.Failed,
+            $"a refused publish must not report success — ended {final.Status}");
+        Assert.Contains("missing-w_member_social-reconnect", final.LastError ?? string.Empty);
+    }
+
+    private async Task<EventSubscription> ArmDueTimer()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        // FireAt in the past = the restart-safe path: due while nothing was running, fires on boot.
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.Timer,
+            FireAt = DateTimeOffset.UtcNow.AddSeconds(-1),
+            ContinuationType = EventContinuationType.PublishSocialPost,
+            TargetPath = PostPath,
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+
+        var runner = new EventSubscriptionRunner(Mesh, changeFeed, meshService, accessService,
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        runners.Add(runner);
+        await runner.StartAsync(default);
+        return subscription;
+    }
+
+    private async Task<EventSubscription> AwaitSettled(string id) =>
+        (await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(id))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds()))!;
+
+    private readonly List<EventSubscriptionRunner> runners = [];
+
+    public override async ValueTask DisposeAsync()
+    {
+        foreach (var runner in runners)
+            runner.Dispose();
+        await base.DisposeAsync();
+    }
+}
+
+/// <summary>
+/// The forgotten-registration case, which needs a mesh where NO handler is registered — so it is its
+/// own class rather than a flag on the one above.
+/// </summary>
+public class EventContinuationHandlerMissingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>With no handler for the continuation, the subscription must end <c>Failed</c>. The
+    /// alternative — sitting <c>Pending</c> forever — is indistinguishable from a slot that simply has
+    /// not arrived yet, which is precisely how a post can look scheduled for a day and never go out.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task UnregisteredContinuation_FailsLoudly_RatherThanSittingPending()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.Timer,
+            FireAt = DateTimeOffset.UtcNow.AddSeconds(-1),
+            ContinuationType = EventContinuationType.PublishSocialPost,
+            TargetPath = "SomePost",
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+
+        using var runner = new EventSubscriptionRunner(Mesh, changeFeed, meshService, accessService,
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        await runner.StartAsync(default);
+
+        var final = (await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds()))!;
+
+        Assert.Equal(EventSubscriptionStatus.Failed, final.Status);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/EventContinuationHandlerTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventContinuationHandlerTest.cs
@@ -36,7 +36,9 @@ public class EventContinuationHandlerTest(ITestOutputHelper output) : MonolithMe
         public int Calls { get; private set; }
         public string? FailWith { get; set; }
 
-        public IObservable<MeshNode> Execute(EventSubscription subscription, string subjectId)
+        // subjectId is unused: a timed publish acts on the subscription's own TargetPath and has no
+        // triggering subject. Named _ so that is explicit rather than an oversight (IDE0060).
+        public IObservable<MeshNode> Execute(EventSubscription subscription, string _)
         {
             Calls++;
             SeenTargetPath = subscription.TargetPath;
@@ -112,7 +114,7 @@ public class EventContinuationHandlerTest(ITestOutputHelper output) : MonolithMe
 
     private async Task<EventSubscription> AwaitSettled(string id) =>
         (await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(id))
-            .Select(n => n?.Content as EventSubscription)
+            .Select(n => n?.ContentAs<EventSubscription>(Mesh.JsonSerializerOptions))
             .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
             .FirstAsync().Timeout(40.Seconds()))!;
 
@@ -156,7 +158,7 @@ public class EventContinuationHandlerMissingTest(ITestOutputHelper output) : Mon
         await runner.StartAsync(default);
 
         var final = (await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
-            .Select(n => n?.Content as EventSubscription)
+            .Select(n => n?.ContentAs<EventSubscription>(Mesh.JsonSerializerOptions))
             .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
             .FirstAsync().Timeout(40.Seconds()))!;
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs
@@ -157,7 +157,13 @@ public class ScheduledPostWatcherTest(ITestOutputHelper output) : MonolithMeshTe
     private IObservable<EventSubscription?> Timers(string postPath)
     {
         var id = ScheduledPostWatcher.SubscriptionId(postPath);
-        return Mesh.GetWorkspace().GetQuery($"timers-{id}",
+        // 🚨 CONSTANT query id, filtered in code — never $"timers-{id}". A per-call id mints a new
+        // workspace query-registry entry for every post, and those entries outlive the test that
+        // made them: they keep the workspace, and through it the mesh hub, reachable after
+        // disposal. That is precisely what MeshHubDisposalLeakTest catches, and it catches it in
+        // whatever class happens to run next rather than here. Same rule the runner states for its
+        // own pending-subscription query.
+        return Mesh.GetWorkspace().GetQuery("test-publish-timers",
                 $"path:{EventSubscriptionNodeType.Namespace} scope:children "
                 + $"nodeType:{EventSubscriptionNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
             .Select(nodes => nodes

--- a/test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Social;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Integration test for <see cref="ScheduledPostWatcher"/> against a REAL monolith mesh — the half of
+/// scheduling that turns a post's <c>scheduledAt</c> into an armed timer.
+///
+/// <para>🚨 <b>The query is the point.</b> The watcher finds its candidates with a live
+/// <c>status:Scheduled</c> query, and a query that matches nothing fails EXACTLY like the bug this
+/// whole change fixes: no error, no log line anyone reads, and posts that quietly never go out. A unit
+/// test over the predicate would not catch that — only a real mesh answering a real query does. So the
+/// mesh here is never mocked.</para>
+/// </summary>
+public class ScheduledPostWatcherTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMeshNodes(SocialTestNodeTypes.PostNodeType);
+
+    /// <summary>A post sitting at <c>Scheduled</c> with a slot gets a durable Timer subscription
+    /// pointing at it, carrying that exact slot.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task ScheduledPost_getsATimerArmedForItsSlot()
+    {
+        var postPath = $"TestData/sched_{Guid.NewGuid():N}/post1";
+        var slot = DateTimeOffset.UtcNow.AddHours(6);
+        await SeedPostAsync(postPath, status: "Scheduled", scheduledAt: slot.ToString("o"));
+
+        using var watcher = StartWatcher();
+
+        var armed = await AwaitSubscription(postPath);
+        Assert.Equal(EventTriggerType.Timer, armed.TriggerType);
+        Assert.Equal(EventContinuationType.PublishSocialPost, armed.ContinuationType);
+        Assert.Equal(postPath, armed.TargetPath);
+        Assert.Equal(EventSubscriptionStatus.Pending, armed.Status);
+        Assert.NotNull(armed.FireAt);
+        // Round-tripped through JSON storage — compare the instant, not the offset representation.
+        Assert.True(Math.Abs((armed.FireAt!.Value - slot).TotalSeconds) < 2,
+            $"armed for {armed.FireAt:o}, expected {slot:o}");
+    }
+
+    /// <summary>
+    /// 🚨 A post that already went out is never armed. This is the production shape from 2026-08-18: a
+    /// post was published by hand and an agent then wrote a FUTURE slot onto the same node. With a
+    /// publisher wired up, arming that would post it to LinkedIn a second time — irreversibly.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AlreadyPublishedPost_isNeverArmed_evenWithAFutureSlot()
+    {
+        var postPath = $"TestData/sched_{Guid.NewGuid():N}/post1";
+        await SeedPostAsync(postPath, status: "Published",
+            scheduledAt: DateTimeOffset.UtcNow.AddHours(6).ToString("o"),
+            publishedUrn: "urn:li:share:4242");
+
+        // A scheduled post seeded alongside it gives the watcher something it MUST arm — so this test
+        // proves the published one was skipped, not merely that the watcher never ran.
+        var controlPath = $"TestData/sched_{Guid.NewGuid():N}/post1";
+        await SeedPostAsync(controlPath, status: "Scheduled",
+            scheduledAt: DateTimeOffset.UtcNow.AddHours(6).ToString("o"));
+
+        using var watcher = StartWatcher();
+
+        await AwaitSubscription(controlPath);   // the watcher has demonstrably done a pass
+
+        var published = await ReadSubscription(postPath);
+        Assert.Null(published);
+    }
+
+    /// <summary>Re-scheduling MOVES the post's timer instead of stacking a second one beside it — the
+    /// id is derived from the post path for exactly this reason.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task ReschedulingAPost_movesItsTimer_ratherThanAddingASecond()
+    {
+        var postPath = $"TestData/sched_{Guid.NewGuid():N}/post1";
+        var first = DateTimeOffset.UtcNow.AddHours(6);
+        await SeedPostAsync(postPath, status: "Scheduled", scheduledAt: first.ToString("o"));
+
+        using var watcher = StartWatcher();
+        await AwaitSubscription(postPath);
+
+        // Move the slot the way an agent or an MCP patch does — straight onto the content field.
+        var moved = DateTimeOffset.UtcNow.AddHours(30);
+        await Mesh.GetWorkspace().GetMeshNodeStream(postPath)
+            .Update(node => node with
+            {
+                Content = new Dictionary<string, object?>
+                {
+                    ["body"] = "Scheduled body",
+                    ["authorPath"] = "TestData/profile",
+                    ["status"] = "Scheduled",
+                    ["scheduledAt"] = moved.ToString("o"),
+                },
+            })
+            .Should().Emit();
+
+        var rearmed = await Timers(postPath)
+            .Where(s => s?.FireAt is { } f && Math.Abs((f - moved).TotalSeconds) < 2)
+            .FirstAsync().Timeout(40.Seconds());
+
+        Assert.Equal(postPath, rearmed!.TargetPath);
+    }
+
+    // ---- helpers ----
+
+    private ScheduledPostWatcher StartWatcher()
+    {
+        var watcher = new ScheduledPostWatcher(
+            Mesh,
+            Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+            Mesh.ServiceProvider.GetRequiredService<AccessService>(),
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<ScheduledPostWatcher>>());
+        watcher.StartAsync(default).GetAwaiter().GetResult();
+        return watcher;
+    }
+
+    private Task SeedPostAsync(
+        string postPath, string status, string scheduledAt, string? publishedUrn = null)
+    {
+        var (id, ns) = LinkedInPublishServiceTest.SplitPath(postPath);
+        var content = new Dictionary<string, object?>
+        {
+            ["body"] = "Scheduled body",
+            ["authorPath"] = "TestData/profile",
+            ["status"] = status,
+            ["scheduledAt"] = scheduledAt,
+        };
+        if (publishedUrn is not null)
+            content["publishedUrn"] = publishedUrn;
+        return NodeFactory.CreateNode(new MeshNode(id, ns)
+        {
+            Name = "Scheduled post",
+            NodeType = "Systemorph/Post",
+            State = MeshNodeState.Active,
+            Content = content,
+        }).Should().Emit();
+    }
+
+    /// <summary>The live subscription set. A QUERY, not a node stream on the expected path: a stream
+    /// opened on a node that does not exist yet errors immediately instead of waiting for it to
+    /// appear, which is precisely what we are waiting for here.</summary>
+    private IObservable<EventSubscription?> Timers(string postPath)
+    {
+        var id = ScheduledPostWatcher.SubscriptionId(postPath);
+        return Mesh.GetWorkspace().GetQuery($"timers-{id}",
+                $"path:{EventSubscriptionNodeType.Namespace} scope:children "
+                + $"nodeType:{EventSubscriptionNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
+            .Select(nodes => nodes
+                .Select(n => n.ContentAs<EventSubscription>(Mesh.JsonSerializerOptions))
+                .FirstOrDefault(s => s?.Id == id));
+    }
+
+    private async Task<EventSubscription> AwaitSubscription(string postPath) =>
+        (await Timers(postPath).Where(s => s is not null).FirstAsync().Timeout(40.Seconds()))!;
+
+    private async Task<EventSubscription?> ReadSubscription(string postPath) =>
+        await Timers(postPath).FirstAsync().Timeout(10.Seconds());
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/MeshWeaver.Hosting.Orleans.Test.csproj
+++ b/test/MeshWeaver.Hosting.Orleans.Test/MeshWeaver.Hosting.Orleans.Test.csproj
@@ -27,6 +27,12 @@
         <ProjectReference Include="..\..\src\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+        <!-- TEST-ONLY. Needed by OrleansScheduledPostTest, which exercises the social
+             scheduling chain on the Orleans lane. Test-only by intent: the module is being
+             relocated to MeshWeaver.SocialMedia (src/MeshWeaver.Social/README.md), and a test
+             reference moves with the test, unlike the ships-the-bits Memex.Portal.Shared
+             reference that actually blocks the flip. Move this test when the module goes. -->
+        <ProjectReference Include="..\..\src\MeshWeaver.Social\MeshWeaver.Social.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Grpc\MeshWeaver.Hosting.Grpc.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Portal\MeshWeaver.Blazor.Portal.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansEventSubscriptionTimerTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansEventSubscriptionTimerTest.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// <see cref="EventSubscriptionRunner"/>'s TIMER path on the ORLEANS hosting lane — the mechanism
+/// every deferred reaction rides: an email invite landing a grant on sign-up, a delegated
+/// sub-thread resuming its parent, and (since the scheduler) a social post publishing at its slot.
+///
+/// <para>🚨 <b>Why this file exists.</b> Nothing in this assembly touched
+/// <c>EventSubscriptionRunner</c> before it — the whole durable-deferred-work mechanism was
+/// covered only against an in-memory monolith mesh. Production is Orleans: the mesh service, the
+/// change feed and the node streams the runner reads all resolve through grains there, and the
+/// runner is a hosted service outside them. "It works in the monolith" is not evidence about the
+/// thing that actually runs.</para>
+///
+/// <para>🚨 <b>And the timer path in particular was never really exercised.</b> Every existing
+/// timer test uses a <c>FireAt</c> in the PAST, which takes the startup-reconcile branch and fires
+/// immediately. That proves restart-safety and nothing about scheduling: a runner that fired every
+/// pending timer the instant it saw it would pass all of them, while publishing every scheduled
+/// post the moment it was scheduled. <see cref="FutureTimer_DoesNotFireEarly_AndFiresAtItsSlot"/>
+/// asserts the negative half first, which is the half that can actually be wrong.</para>
+/// </summary>
+public class OrleansEventSubscriptionTimerTest(ITestOutputHelper output) : OrleansSharedTestBase(output)
+{
+    private IMessageHub Mesh => Fixture.ClientMesh;
+
+    private EventSubscriptionRunner StartRunner() =>
+        StartRunner(out _);
+
+    private EventSubscriptionRunner StartRunner(out IMeshService meshService)
+    {
+        var sp = Mesh.ServiceProvider;
+        meshService = sp.GetRequiredService<IMeshService>();
+        var runner = new EventSubscriptionRunner(
+            Mesh,
+            sp.GetRequiredService<IMeshChangeFeed>(),
+            meshService,
+            sp.GetRequiredService<AccessService>(),
+            sp.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        runner.StartAsync(default).GetAwaiter().GetResult();
+        return runner;
+    }
+
+    /// <summary>
+    /// A timer due in the FUTURE must still be Pending well after the runner has started and has
+    /// certainly seen it, and must fire once its slot passes.
+    ///
+    /// <para>The early-fire assertion is the point. A scheduled post whose timer fires on arrival
+    /// goes out immediately instead of at 08:00, and every past-FireAt test in the codebase would
+    /// still be green — the bug would reach production looking exactly like a working scheduler.</para>
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task FutureTimer_DoesNotFireEarly_AndFiresAtItsSlot()
+    {
+        const string space = "TimerSpace";
+        var subject = $"timersubject{Guid.NewGuid():N}"[..20];
+        var slot = DateTimeOffset.UtcNow.AddSeconds(12);
+
+        using var runner = StartRunner(out var meshService);
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        using (access.ImpersonateAsSystem())
+            await meshService.CreateOrUpdateNode(
+                new MeshNode(space) { Name = "Timer Space", NodeType = "Markdown" })
+                .FirstAsync().ToTask();
+
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.Timer,
+            FireAt = slot,
+            ContinuationType = EventContinuationType.GrantSpaceAccess,
+            SubjectId = subject,
+            TargetPath = space,
+            Role = "Editor",
+        };
+        using (access.ImpersonateAsSystem())
+            await EventSubscriptionOps.CreateSubscription(meshService, subscription).FirstAsync().ToTask();
+
+        // ── the negative half ───────────────────────────────────────────────────────────────
+        // Give the runner ample time to observe the new subscription and schedule it, then assert
+        // it has NOT fired. This window is deliberately well inside the slot: if it were close to
+        // it, a slow runner would make the test pass for the wrong reason.
+        await Task.Delay(5.Seconds());
+        var early = await ReadSubscription(subscription.Id);
+        Assert.True(early is { Status: EventSubscriptionStatus.Pending },
+            $"a timer due at {slot:o} fired early (status {early?.Status}) — it would publish a "
+            + "scheduled post the moment it was scheduled rather than at its slot");
+
+        // ── the positive half ───────────────────────────────────────────────────────────────
+        var fired = await Mesh.GetWorkspace()
+            .GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(n => n?.ContentAs<EventSubscription>(Mesh.JsonSerializerOptions))
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(60.Seconds());
+
+        Assert.True(fired!.Status == EventSubscriptionStatus.Fired,
+            $"timer ended {fired.Status}: {fired.LastError}");
+
+        // The continuation really ran — a Fired flag with no effect behind it is the failure mode
+        // that makes a scheduler look healthy while nothing reaches the outside world.
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{space}/_Access/{subject}_Access")
+            .Where(n => n?.ContentAs<AccessAssignment>(Mesh.JsonSerializerOptions) is { } a
+                        && a.Roles.Any(r => r.Role == "Editor" && !r.Denied))
+            .FirstAsync().Timeout(30.Seconds());
+    }
+
+    /// <summary>
+    /// Restart safety on Orleans: a slot that passed while nothing was running fires on the next
+    /// runner start. This is what makes a missed deploy window not silently swallow a post — the
+    /// subscription node is durable, and Pending → Fired is what gates re-entry.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task TimerDueWhileNothingRan_FiresOnTheNextStart()
+    {
+        const string space = "TimerSpaceLate";
+        var subject = $"latesubject{Guid.NewGuid():N}"[..20];
+
+        var sp = Mesh.ServiceProvider;
+        var meshService = sp.GetRequiredService<IMeshService>();
+        var access = sp.GetRequiredService<AccessService>();
+
+        using (access.ImpersonateAsSystem())
+            await meshService.CreateOrUpdateNode(
+                new MeshNode(space) { Name = "Late Timer Space", NodeType = "Markdown" })
+                .FirstAsync().ToTask();
+
+        // Written with NO runner alive — the "due during downtime" shape.
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.Timer,
+            FireAt = DateTimeOffset.UtcNow.AddSeconds(-30),
+            ContinuationType = EventContinuationType.GrantSpaceAccess,
+            SubjectId = subject,
+            TargetPath = space,
+            Role = "Editor",
+        };
+        using (access.ImpersonateAsSystem())
+            await EventSubscriptionOps.CreateSubscription(meshService, subscription).FirstAsync().ToTask();
+
+        using var runner = StartRunner();
+
+        var fired = await Mesh.GetWorkspace()
+            .GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(n => n?.ContentAs<EventSubscription>(Mesh.JsonSerializerOptions))
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(60.Seconds());
+
+        Assert.True(fired!.Status == EventSubscriptionStatus.Fired,
+            $"an overdue timer ended {fired.Status}: {fired.LastError}");
+    }
+
+    /// <summary>Reads the subscription without waiting — a query, not a node stream, because a
+    /// stream on a path that does not exist yet errors instead of reporting absence.</summary>
+    private async Task<EventSubscription?> ReadSubscription(string id) =>
+        await Mesh.GetWorkspace().GetQuery("orleans-timer-subscriptions",
+                $"path:{EventSubscriptionNodeType.Namespace} scope:children "
+                + $"nodeType:{EventSubscriptionNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
+            .Select(nodes => nodes
+                .Select(n => n.ContentAs<EventSubscription>(Mesh.JsonSerializerOptions))
+                .FirstOrDefault(s => s?.Id == id))
+            .FirstAsync().Timeout(20.Seconds());
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansScheduledPostTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansScheduledPostTest.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Social;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// POST SCHEDULING on the Orleans hosting lane, end to end: a post carrying a future
+/// <c>scheduledAt</c> gets a durable timer armed for it, the timer holds until its slot, and the
+/// slot dispatches the publish continuation.
+///
+/// <para>🚨 <b>Why on Orleans specifically.</b> <see cref="ScheduledPostWatcher"/> finds its
+/// candidates with a live mesh QUERY, and a query is exactly the thing that behaves differently
+/// between an in-memory workspace and grain-backed storage. That is not hypothetical: the first
+/// version of the watcher queried <c>status:Scheduled</c>, which matched NOTHING while looking
+/// perfectly healthy — no error, no empty-result warning, just a scheduler that armed nothing.
+/// A test that only ever ran in-memory is not evidence that the query works where it has to.</para>
+///
+/// <para>The publish leaf itself (the LinkedIn HTTP call) is stubbed out of this lane by
+/// construction: no <c>IEventContinuationHandler</c> is registered in the test cluster, so the
+/// fired timer dispatches and reports that the owning module is absent. That is deliberate — this
+/// test is about the SCHEDULING chain reaching the publish step at the right moment; the publish
+/// step's own behaviour is pinned in <c>EventContinuationHandlerTest</c> and
+/// <c>LinkedInPublishServiceTest</c>.</para>
+/// </summary>
+public class OrleansScheduledPostTest(ITestOutputHelper output) : OrleansSharedTestBase(output)
+{
+    private IMessageHub Mesh => Fixture.ClientMesh;
+
+    /// <summary>The whole chain: scheduled post → armed timer → held until the slot → dispatched.</summary>
+    [Fact(Timeout = 180000)]
+    public async Task ScheduledPost_ArmsATimer_HoldsIt_ThenDispatchesAtTheSlot()
+    {
+        var postPath = $"TestData/orleanspost{Guid.NewGuid():N}";
+        var slot = DateTimeOffset.UtcNow.AddSeconds(15);
+
+        await SeedPostAsync(postPath, status: "Scheduled", scheduledAt: slot.ToString("o"));
+
+        using var watcher = StartWatcher();
+        using var runner = StartRunner();
+
+        // ── armed, with the post's OWN slot ─────────────────────────────────────────────────
+        var armed = await AwaitTimer(postPath, s => s is not null);
+        Assert.Equal(EventTriggerType.Timer, armed!.TriggerType);
+        Assert.Equal(EventContinuationType.PublishSocialPost, armed.ContinuationType);
+        Assert.Equal(postPath, armed.TargetPath);
+        Assert.NotNull(armed.FireAt);
+        Assert.True(Math.Abs((armed.FireAt!.Value - slot).TotalSeconds) < 3,
+            $"armed for {armed.FireAt:o} but the post's slot is {slot:o}");
+
+        // ── HELD, not fired on arrival ──────────────────────────────────────────────────────
+        // The half that can actually be wrong. A timer that fires when it is armed publishes the
+        // post the moment someone schedules it — and every past-FireAt test would stay green.
+        Assert.Equal(EventSubscriptionStatus.Pending, armed.Status);
+        await Task.Delay(5.Seconds());
+        var stillPending = await ReadTimer(postPath);
+        Assert.True(stillPending is { Status: EventSubscriptionStatus.Pending },
+            $"the timer left Pending before its slot (status {stillPending?.Status}) — a post "
+            + "would go out the instant it was scheduled");
+
+        // ── fires at the slot, and dispatches the PUBLISH continuation ──────────────────────
+        var settled = await AwaitTimer(postPath,
+            s => s is not null and not { Status: EventSubscriptionStatus.Pending }, 90);
+
+        // No handler is registered on this cluster, so a dispatched publish reports the missing
+        // module. That message IS the assertion: reaching it proves the timer fired at its slot
+        // and routed to the publish continuation rather than quietly expiring.
+        Assert.Equal(EventSubscriptionStatus.Failed, settled!.Status);
+        Assert.Contains("PublishSocialPost", settled.LastError ?? string.Empty);
+        Assert.Contains("IEventContinuationHandler", settled.LastError ?? string.Empty);
+    }
+
+    /// <summary>
+    /// 🚨 The double-post guard, on Orleans: a post that already went out is never armed, even
+    /// when a later write puts a FUTURE slot on it. That is the exact shape seen in production on
+    /// 2026-08-18 — a post published by hand, then re-slotted by an agent. With a publisher live,
+    /// arming it would post it to the network a second time, irreversibly.
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task PublishedPost_IsNeverArmed_EvenWithAFutureSlot()
+    {
+        var published = $"TestData/orleanspub{Guid.NewGuid():N}";
+        var control = $"TestData/orleansctl{Guid.NewGuid():N}";
+        var slot = DateTimeOffset.UtcNow.AddSeconds(20).ToString("o");
+
+        await SeedPostAsync(published, status: "Published", scheduledAt: slot,
+            publishedUrn: "urn:li:share:4242");
+        // A schedulable post alongside it, so a green result cannot mean "the watcher never ran".
+        await SeedPostAsync(control, status: "Scheduled", scheduledAt: slot);
+
+        using var watcher = StartWatcher();
+
+        await AwaitTimer(control, s => s is not null);      // the watcher has demonstrably passed
+        Assert.Null(await ReadTimer(published));
+    }
+
+    // ── harness ─────────────────────────────────────────────────────────────────────────────
+
+    private ScheduledPostWatcher StartWatcher()
+    {
+        var sp = Mesh.ServiceProvider;
+        var watcher = new ScheduledPostWatcher(
+            Mesh,
+            sp.GetRequiredService<IMeshService>(),
+            sp.GetRequiredService<AccessService>(),
+            sp.GetService<Microsoft.Extensions.Logging.ILogger<ScheduledPostWatcher>>());
+        watcher.StartAsync(default).GetAwaiter().GetResult();
+        return watcher;
+    }
+
+    private EventSubscriptionRunner StartRunner()
+    {
+        var sp = Mesh.ServiceProvider;
+        var runner = new EventSubscriptionRunner(
+            Mesh,
+            sp.GetRequiredService<IMeshChangeFeed>(),
+            sp.GetRequiredService<IMeshService>(),
+            sp.GetRequiredService<AccessService>(),
+            sp.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        runner.StartAsync(default).GetAwaiter().GetResult();
+        return runner;
+    }
+
+    private async Task SeedPostAsync(
+        string postPath, string status, string scheduledAt, string? publishedUrn = null)
+    {
+        var cut = postPath.LastIndexOf('/');
+        var content = new Dictionary<string, object?>
+        {
+            ["text"] = "Scheduled on Orleans",
+            ["authorPath"] = "TestData/profile",
+            ["status"] = status,
+            ["scheduledAt"] = scheduledAt,
+        };
+        if (publishedUrn is not null)
+            content["publishedUrn"] = publishedUrn;
+
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        using (access.ImpersonateAsSystem())
+            await meshService.CreateOrUpdateNode(new MeshNode(postPath[(cut + 1)..], postPath[..cut])
+            {
+                Name = "Orleans scheduled post",
+                NodeType = "Systemorph/Post",
+                State = MeshNodeState.Active,
+                Content = content,
+            }).FirstAsync().ToTask();
+    }
+
+    /// <summary>The post's timer, read through a live QUERY with a CONSTANT id — a stream on a path
+    /// that does not exist yet errors instead of reporting absence, and a per-call query id leaks a
+    /// registry entry that keeps the mesh hub alive past disposal.</summary>
+    private IObservable<EventSubscription?> Timers(string postPath)
+    {
+        var id = ScheduledPostWatcher.SubscriptionId(postPath);
+        return Mesh.GetWorkspace().GetQuery("orleans-post-timers",
+                $"path:{EventSubscriptionNodeType.Namespace} scope:children "
+                + $"nodeType:{EventSubscriptionNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
+            .Select(nodes => nodes
+                .Select(n => n.ContentAs<EventSubscription>(Mesh.JsonSerializerOptions))
+                .FirstOrDefault(s => s?.Id == id));
+    }
+
+    private async Task<EventSubscription?> AwaitTimer(
+        string postPath, Func<EventSubscription?, bool> predicate, int seconds = 45) =>
+        await Timers(postPath).Where(predicate).FirstAsync().Timeout(seconds.Seconds());
+
+    private async Task<EventSubscription?> ReadTimer(string postPath) =>
+        await Timers(postPath).FirstAsync().Timeout(20.Seconds());
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansTestMeshExtensions.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansTestMeshExtensions.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.AI;
 using MeshWeaver.AI.Persistence;
+using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
@@ -30,6 +31,19 @@ public static class OrleansTestMeshExtensions
             {
                 Name = "Kernel",
                 HubConfiguration = x => x
+            })
+            // A GENERIC post NodeType — no CLR content type, so an instance keeps its Dictionary
+            // content as a JsonElement, the shape production social posts have when read by code
+            // that does not own their type. Registered HERE rather than on the silo configurator
+            // because ConfigurePortalMesh is the config the silo host AND the Orleans client host
+            // share: a node cannot be created for a type the CREATING host does not know, and the
+            // client is what the tests call. Inert unless a test creates one.
+            .AddMeshNodes(new MeshNode("Post", "Systemorph")
+            {
+                Name = "Social Media Post",
+                NodeType = "NodeType",
+                Content = new NodeTypeDefinition { Description = "Social media post (test fixture)." },
+                HubConfiguration = config => config.AddMeshDataSource(),
             })
             .AddGraph()
             .AddAI()


### PR DESCRIPTION
## The defect

A `SocialMedia/Post` carried `scheduledAt` and a `Scheduled` status, and **no line of code anywhere read that field** — not in this repo, not in the Memex portal, not in the plugin repos. `grep -rn scheduledAt` came back empty outside the date picker and a timeline sort.

Publishing was a node-menu button (`SocialPostMenuProvider` → `/linkedin/publish`). The slot was decoration: a scheduled post sat `Scheduled` forever while its timeline card claimed it was on its way out.

Found in production on 2026-08-18 — a post scheduled for 08:00, re-pointed to the next morning when the first slot silently passed, and published neither time. It eventually went out by hand. `IPlatformPublisher`'s own docstring says implementations are "resolved **by the schedulers**"; there were no schedulers.

## Why an extension point rather than a direct call

`MeshWeaver.Social` already references `MeshWeaver.Graph`, so `EventSubscriptionRunner` cannot call the publishers without a reference cycle — and moving them down into Graph would drag LinkedIn's HTTP surface into the graph layer.

- `EventContinuationType.PublishSocialPost` + `IEventContinuationHandler` (Mesh.Contract) — a **cold** `IObservable`, so the effect runs on Subscribe like everything else the runner touches.
- The runner resolves a handler from DI for continuations it cannot implement itself, and **still throws for a type nobody registered**. A forgotten `AddSocial` fails loudly instead of leaving the subscription `Pending` forever — which is indistinguishable from a slot that simply hasn't arrived.
- `ScheduledSocialPublishHandler` reuses **`LinkedInPublishService.PublishPostAsync`** — the same call the menu item makes, not a second implementation that could drift from it. The `Task`-returning leaf is bridged through `IIoPool` on the `Http` pool, which also bounds concurrent publishes when many slots land on the same minute.

## The double-post hazard

A publish that **succeeded** must never surface as a failure: the runner marks a throwing continuation `Failed` and *releases its at-most-once reservation*, so a retry would post to LinkedIn a second time. The read-back after publishing is best-effort for exactly that reason, and it's commented at the call site.

## Tests

Three, each pinning a failure that is invisible in production:

| test | pins |
|---|---|
| `DueTimer_DispatchesToTheRegisteredHandler_AndFires` | a due timer actually reaches its handler |
| `HandlerFailure_IsRecordedOnTheSubscription_NotSwallowed` | a refused publish lands on `LastError`, never reports success |
| `UnregisteredContinuation_FailsLoudly_RatherThanSittingPending` | a forgotten registration is visible |

All 10 `EventSubscription*` tests green; full solution builds clean under CI flags (`-c Release -p:CIRun=true -warnaserror`).

Minting the subscription when a post enters `Scheduled` lands in `MeshWeaver.SocialMedia` — that PR follows and depends on this enum value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFx1SsoKDhRKHdaJbQPEWQ