### PR TITLE
A source version must change when the source changes

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -494,7 +494,11 @@ internal class MeshNodeCompilationService(
                 .Where(n => !string.IsNullOrEmpty(n.Path))
                 .Aggregate(
                     ImmutableDictionary<string, long>.Empty,
-                    (acc, n) => acc.SetItem(n.Path, n.LastModified.UtcTicks)));
+                    // One rule for both snapshots — see NodeTypeDefinition.SourceVersionOf.
+                    // A raw .LastModified.UtcTicks here records 1601 for any source with no
+                    // real timestamp, which compares equal across an edit and hides the
+                    // change from IsDirty forever (#1836).
+                    (acc, n) => acc.SetItem(n.Path, NodeTypeDefinition.SourceVersionOf(n))));
 
     /// <summary>
     /// Resolves the source set for a compile run. When the caller hands in a

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -666,14 +666,15 @@ internal static class NodeTypeCompilationHelpers
             .Switch()
             .Select(sources =>
             {
-                // Fold the full current set → path → LastModified.UtcTicks. Same
-                // version field CompiledSources is keyed on, so IsDirty compares
-                // like-for-like (empty set → empty snapshot → IsDirty=false when
-                // CompiledSources is also empty).
+                // Fold the full current set → path → NodeTypeDefinition.SourceVersionOf.
+                // Same rule CompiledSources is keyed on, so IsDirty compares like-for-like
+                // (empty set → empty snapshot → IsDirty=false when CompiledSources is also
+                // empty). Keying on the raw timestamp is what let an un-timestamped source
+                // record 1601 on both sides and never read as changed (#1836).
                 var snap = System.Collections.Immutable.ImmutableDictionary<string, long>.Empty;
                 foreach (var n in sources)
                     if (!string.IsNullOrEmpty(n.Path))
-                        snap = snap.SetItem(n.Path!, n.LastModified.UtcTicks);
+                        snap = snap.SetItem(n.Path!, NodeTypeDefinition.SourceVersionOf(n));
                 return (IReadOnlyDictionary<string, long>)snap;
             }),
                 snapshot =>

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -2,6 +2,7 @@
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Services.LanguageServer;
 
@@ -465,6 +466,47 @@ public record NodeTypeDefinition
     /// always sees authoritative content, not the index-lagged query result.</para>
     /// </summary>
     public IReadOnlyDictionary<string, long>? CurrentSourceVersions { get; init; }
+
+    /// <summary>
+    /// <see cref="DateTime"/> ticks for <c>1601-01-01</c> — the FILETIME epoch, and the value
+    /// .NET returns from <c>FileInfo.LastWriteTimeUtc</c> for a file that DOES NOT EXIST
+    /// (it does not throw). A node stamped with it has no real modification time.
+    ///
+    /// <para>🚨 This is not a curiosity: a source stamped 1601 records the SAME version before
+    /// and after an edit, so <see cref="IsDirty"/> compares equal, no recompile is ever
+    /// scheduled, and the type serves its previous assembly forever while every status field
+    /// says <c>Ok</c>. Measured on memex 2026-08-18 (Systemorph/MeshWeaver#1836): an
+    /// <c>Edu/Module</c> change imported, logged "Recompiling", minted a fresh release — and
+    /// ran the old code, because six of its fourteen sources carried this value on BOTH sides
+    /// of the comparison.</para>
+    /// </summary>
+    public const long UnknownSourceVersionTicks = 504911232000000000L;
+
+    /// <summary>
+    /// The per-source version key for the <see cref="CompiledSources"/> /
+    /// <see cref="CurrentSourceVersions"/> snapshots: the node's modification time when it has
+    /// a real one, else its <see cref="MeshNode.Version"/>.
+    ///
+    /// <para>The fallback is the point. <c>Version</c> is the owning hub's monotonic
+    /// persistence counter — bumped by every write — so it CHANGES when the source changes,
+    /// which is the only property the staleness comparison actually needs. Falling back to it
+    /// turns an un-timestamped source from permanently-invisible into ordinarily comparable.</para>
+    ///
+    /// <para>Both snapshots MUST fold through this one function — the compiler's
+    /// (<c>MeshNodeCompilationService.DiscoverSourceVersionSnapshot</c>) and the watcher's
+    /// (<c>NodeTypeCompilationHelpers</c>) — or the two sides key differently and every type
+    /// reads as permanently dirty, which is the same outage with the opposite sign.</para>
+    ///
+    /// <para>Nodes carrying a real timestamp are unaffected. A node stored with the 1601 stamp
+    /// re-keys to its Version, so it differs from the recorded snapshot exactly ONCE,
+    /// recompiles, and both sides then agree — a single self-healing compile per affected
+    /// type, not a recompile storm.</para>
+    /// </summary>
+    /// <param name="node">A source (Code) node of the NodeType.</param>
+    public static long SourceVersionOf(MeshNode node) =>
+        node.LastModified.UtcTicks > UnknownSourceVersionTicks
+            ? node.LastModified.UtcTicks
+            : node.Version;
 
     /// <summary>
     /// <c>true</c> iff <see cref="CurrentSourceVersions"/> differs from

--- a/src/MeshWeaver.Hosting/Persistence/FileSystemStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/FileSystemStorageAdapter.cs
@@ -157,11 +157,19 @@ public class FileSystemStorageAdapter : IStorageAdapter
             node = node with { MainNode = mainNodePath };
         }
 
-        // Use file system last modified time if not specified
+        // Use file system last modified time if not specified.
+        //
+        // 🚨 ONLY when the file is actually there. FileInfo.LastWriteTimeUtc for a file that
+        // does not exist returns 1601-01-01 (the FILETIME epoch) rather than throwing, so an
+        // unstattable path silently stamps the node with a timestamp that is not a time. That
+        // value then becomes the node's source version, compares EQUAL to itself across every
+        // later edit, and the NodeType it belongs to never recompiles again while reporting
+        // compilationStatus Ok — measured on memex 2026-08-18 (#1836). Now: stamp the real
+        // mtime when there is one, else stamp NOW, which is both honest ("we observed this
+        // node at this moment") and comparable.
         if (node.LastModified == default)
         {
-            var fileInfo = new FileInfo(filePath);
-            node = node with { LastModified = new DateTimeOffset(fileInfo.LastWriteTimeUtc, TimeSpan.Zero) };
+            node = node with { LastModified = FileTimestamps.ObservedAt(filePath) };
         }
 
         // Merge companion index.md content into JSON-sourced nodes that have no content

--- a/src/MeshWeaver.Hosting/Persistence/FileTimestamps.cs
+++ b/src/MeshWeaver.Hosting/Persistence/FileTimestamps.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+
+namespace MeshWeaver.Hosting.Persistence;
+
+/// <summary>
+/// The one way a node's <c>LastModified</c> is derived from a file on disk.
+///
+/// <para>🚨 <c>FileInfo.LastWriteTimeUtc</c> DOES NOT THROW for a file that is not there — it
+/// returns <c>1601-01-01</c>, the FILETIME zero. Adopting that as a modification time stamps the
+/// node with a value that is not a time, and because it is stable it then compares EQUAL to
+/// itself across every subsequent edit. For a Code node that is fatal downstream: the per-source
+/// version snapshots behind <c>NodeTypeDefinition.IsDirty</c> record 1601 on both sides, the
+/// NodeType never recompiles again, and it serves its previous assembly while every status field
+/// reads <c>Ok</c> (Systemorph/MeshWeaver#1836).</para>
+///
+/// <para>The exposure was per-FILE, not per-writer: within one import, paths that were stat-able
+/// got real ticks and paths that were not got 1601 — which is why it looked like it tracked
+/// GitSync. Three parsers and the filesystem adapter derived the stamp independently and only
+/// <c>MarkdownFileParser</c> guarded; this helper exists so they cannot drift apart again.</para>
+/// </summary>
+public static class FileTimestamps
+{
+    /// <summary>
+    /// The modification time to record for a node backed by <paramref name="filePath"/>: the
+    /// file's real last-write time when it is actually on disk, else NOW — which is both honest
+    /// (the node is being written at this moment) and, unlike 1601, comparable.
+    /// </summary>
+    public static DateTimeOffset ObservedAt(string filePath)
+    {
+        var fileInfo = new FileInfo(filePath);
+        return fileInfo.Exists
+            ? new DateTimeOffset(fileInfo.LastWriteTimeUtc, TimeSpan.Zero)
+            : DateTimeOffset.UtcNow;
+    }
+}

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/AgentFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/AgentFileParser.cs
@@ -96,9 +96,8 @@ public class AgentFileParser : IFileFormatParser
             ? content.Substring(yamlBlock.Span.End + 1).TrimStart('\r', '\n')
             : content;
 
-        // Get file last modified time
-        var fileInfo = new FileInfo(filePath);
-        var lastModified = new DateTimeOffset(fileInfo.LastWriteTimeUtc, TimeSpan.Zero);
+        // Get file last modified time — never 1601 for a missing file (see FileTimestamps).
+        var lastModified = FileTimestamps.ObservedAt(filePath);
 
         // Build AgentConfiguration from frontmatter + markdown body. Node-level metadata
         // (name, description, icon, group, order) lives on the MeshNode below — NOT

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/CSharpFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/CSharpFileParser.cs
@@ -75,8 +75,9 @@ public partial class CSharpFileParser : IFileFormatParser
         // node (still CodeConfiguration content, still folded into the parent compile).
         var nodeType = metadata.GetValueOrDefault("NodeType") ?? "Code";
 
-        var fileInfo = new FileInfo(filePath);
-        var lastModified = new DateTimeOffset(fileInfo.LastWriteTimeUtc, TimeSpan.Zero);
+        // Never adopt 1601 for a file that is not there — see FileTimestamps. These nodes are a
+        // NodeType's COMPILE INPUTS, so a stamp that cannot change is what freezes its assembly.
+        var lastModified = FileTimestamps.ObservedAt(filePath);
 
         var node = new MeshNode(nodeId, ns)
         {

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
@@ -174,10 +174,7 @@ public partial class MarkdownFileParser : IFileFormatParser
         DateTimeOffset lastModified;
         try
         {
-            var fileInfo = new FileInfo(filePath);
-            lastModified = fileInfo.Exists
-                ? new DateTimeOffset(fileInfo.LastWriteTimeUtc, TimeSpan.Zero)
-                : DateTimeOffset.UtcNow;
+            lastModified = FileTimestamps.ObservedAt(filePath);
         }
         catch
         {

--- a/test/MeshWeaver.Hosting.Test/SourceVersionMustChangeTests.cs
+++ b/test/MeshWeaver.Hosting.Test/SourceVersionMustChangeTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins Systemorph/MeshWeaver#1836: a source whose node carries no real modification time must
+/// still read as CHANGED when it changes.
+///
+/// <para><c>FileInfo.LastWriteTimeUtc</c> returns <c>1601-01-01</c> — it does not throw — for a
+/// file that does not exist, so an unstattable path stamped that value onto the node as a real
+/// timestamp. It then became the node's source version, compared EQUAL to itself across every
+/// later edit, and the NodeType never recompiled again while every status field said
+/// <c>Ok</c>. Measured on memex 2026-08-18: an <c>Edu/Module</c> change imported, logged
+/// "Recompiling", minted a fresh release — and ran the old code, because six of its fourteen
+/// sources carried 1601 on BOTH sides of the comparison.</para>
+/// </summary>
+public class SourceVersionMustChangeTests
+{
+    private static MeshNode Source(string id, DateTimeOffset lastModified, long version) =>
+        new(id, "T/Source") { NodeType = "Code", LastModified = lastModified, Version = version };
+
+    private static readonly DateTimeOffset NoRealTimestamp =
+        new(new DateTime(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+    /// <summary>The constant IS the FILETIME epoch — the value .NET hands back for a missing file.</summary>
+    [Fact]
+    public void UnknownSourceVersion_IsTheFileTimeEpoch()
+    {
+        Assert.Equal(NodeTypeDefinition.UnknownSourceVersionTicks, NoRealTimestamp.UtcTicks);
+        // And it is exactly what a non-existent file reports, which is the whole trap.
+        var missing = new System.IO.FileInfo(
+            System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"mw-absent-{Guid.NewGuid():N}"));
+        Assert.False(missing.Exists);
+        Assert.Equal(NoRealTimestamp.UtcDateTime, missing.LastWriteTimeUtc);
+    }
+
+    /// <summary>A node with a real mtime keys on it — unchanged behaviour for the healthy case.</summary>
+    [Fact]
+    public void RealTimestamp_IsUsedAsTheSourceVersion()
+    {
+        var when = new DateTimeOffset(2026, 8, 18, 11, 38, 12, TimeSpan.Zero);
+        Assert.Equal(when.UtcTicks, NodeTypeDefinition.SourceVersionOf(Source("a", when, version: 7)));
+    }
+
+    /// <summary>
+    /// No real mtime → key on <c>Version</c>, the owning hub's monotonic write counter. That is
+    /// the only field guaranteed to move when the source moves.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]      // default(DateTimeOffset)
+    [InlineData(1601)]   // FileInfo.LastWriteTimeUtc for a file that is not there
+    public void NoRealTimestamp_FallsBackToTheNodeVersion(int year)
+    {
+        var stamp = year == 0 ? default : NoRealTimestamp;
+        Assert.Equal(42, NodeTypeDefinition.SourceVersionOf(Source("a", stamp, version: 42)));
+    }
+
+    /// <summary>
+    /// THE REGRESSION. An edit lands on a source with no real timestamp: the node's Version bumps,
+    /// its LastModified does not. Keyed the old way both snapshots read 1601 and <c>IsDirty</c> was
+    /// false — the change was invisible and no recompile was ever scheduled.
+    /// </summary>
+    [Fact]
+    public void EditToAnUntimestampedSource_IsVisibleToIsDirty()
+    {
+        var before = Source("EduCourseNavigationProvider", NoRealTimestamp, version: 1);
+        var after = Source("EduCourseNavigationProvider", NoRealTimestamp, version: 2);
+
+        // What the old fold recorded: identical on both sides, so the edit vanished.
+        Assert.Equal(before.LastModified.UtcTicks, after.LastModified.UtcTicks);
+
+        var def = new NodeTypeDefinition
+        {
+            CompiledSources = Snapshot(before),
+            CurrentSourceVersions = Snapshot(after),
+        };
+        Assert.True(def.IsDirty, "an edited source must read as dirty even with no usable timestamp");
+    }
+
+    /// <summary>The converse: no edit, no dirt. The fallback must not make every type permanently dirty.</summary>
+    [Fact]
+    public void UnchangedUntimestampedSource_IsNotDirty()
+    {
+        var node = Source("EduCourseNavigationProvider", NoRealTimestamp, version: 1);
+        var def = new NodeTypeDefinition
+        {
+            CompiledSources = Snapshot(node),
+            CurrentSourceVersions = Snapshot(node),
+        };
+        Assert.False(def.IsDirty);
+    }
+
+    /// <summary>
+    /// The migration is ONE self-healing compile: a snapshot recorded the old way (raw 1601) differs
+    /// from the same unchanged source keyed the new way, so the type recompiles exactly once and
+    /// then converges instead of storming.
+    /// </summary>
+    [Fact]
+    public void LegacySnapshot_RecompilesOnceThenConverges()
+    {
+        var node = Source("EduCourseNavigationProvider", NoRealTimestamp, version: 9);
+        var legacy = new Dictionary<string, long> { [node.Path] = node.LastModified.UtcTicks };
+
+        var firstPass = new NodeTypeDefinition
+        {
+            CompiledSources = legacy,
+            CurrentSourceVersions = Snapshot(node),
+        };
+        Assert.True(firstPass.IsDirty, "the legacy 1601 snapshot must re-key and trigger one compile");
+
+        // That compile re-records CompiledSources through the same rule — and it settles.
+        var afterCompile = firstPass with { CompiledSources = Snapshot(node) };
+        Assert.False(afterCompile.IsDirty, "and then it must settle — one heal, not a storm");
+    }
+
+    /// <summary>
+    /// The mint site. A parser handed a path that is not on disk must not adopt 1601 as the
+    /// node's modification time.
+    ///
+    /// <para>This is the half that matters most, and it is why fixing the storage adapter alone
+    /// was not enough: the adapter only stamps <c>if (node.LastModified == default)</c>, and a
+    /// parser that already stamped 1601 puts that guard permanently out of reach — 1601 is not
+    /// default, so the adapter never corrects it. <c>.cs</c> files are exactly the ones whose
+    /// timestamps drive a NodeType's compile.</para>
+    /// </summary>
+    [Fact]
+    public void MissingFile_IsNeverStampedWithTheFileTimeEpoch()
+    {
+        var absent = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), $"mw-absent-{Guid.NewGuid():N}.cs");
+        Assert.False(System.IO.File.Exists(absent));
+
+        var stamped = MeshWeaver.Hosting.Persistence.FileTimestamps.ObservedAt(absent);
+
+        Assert.NotEqual(NoRealTimestamp, stamped);
+        Assert.True(stamped.UtcTicks > NodeTypeDefinition.UnknownSourceVersionTicks,
+            "a node written now was modified now — never 1601, which cannot change and so "
+            + "freezes the NodeType's assembly");
+    }
+
+    /// <summary>A file that IS there keeps its real mtime — the helper must not paper over reality.</summary>
+    [Fact]
+    public void ExistingFile_KeepsItsRealModificationTime()
+    {
+        var path = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), $"mw-present-{Guid.NewGuid():N}.cs");
+        System.IO.File.WriteAllText(path, "// x");
+        try
+        {
+            var expected = new DateTimeOffset(
+                new System.IO.FileInfo(path).LastWriteTimeUtc, TimeSpan.Zero);
+            Assert.Equal(expected,
+                MeshWeaver.Hosting.Persistence.FileTimestamps.ObservedAt(path));
+        }
+        finally { System.IO.File.Delete(path); }
+    }
+
+    // The fold under test, applied exactly as both snapshot producers apply it.
+    private static Dictionary<string, long> Snapshot(params MeshNode[] nodes)
+    {
+        var d = new Dictionary<string, long>();
+        foreach (var n in nodes)
+            d[n.Path] = NodeTypeDefinition.SourceVersionOf(n);
+        return d;
+    }
+}


### PR DESCRIPTION
Fixes #1836.

`FileInfo.LastWriteTimeUtc` **does not throw** for a file that is not there — it returns `1601-01-01`, the FILETIME zero. Three parsers and the filesystem adapter each derived a node's `LastModified` from that call independently, and only `MarkdownFileParser` checked `Exists`. So whenever a path could not be stat'd, the node was stamped with a value that is not a time.

That value becomes the node's entry in the per-source version snapshots behind `NodeTypeDefinition.IsDirty`. **1601 compares equal to 1601**, so an edit records the same version before and after: the comparison is satisfied, no recompile is scheduled, and the NodeType serves its previous assembly indefinitely while every status field reads `Ok`.

## What this looked like in production

Measured on memex, 2026-08-18, deploying a change to `Edu/Module`:

| check | result |
|---|---|
| the mesh's own copy of the changed source | new content, 55 test cases registered |
| `git_hub_sync update` | `Imported (3 node(s))`, `Recompiling 3 NodeType(s)` |
| an explicit compile | `Compile SUCCEEDED`, real release `…-DWMuR-8E`, artifact `v1163` |
| `Edu/Module` → `latestAssemblyPath` | `v1152` — the previous day's |
| the rendered `Tests` area, on three instances | **54/54** — the pre-change count |

Every operator-visible signal said success and the deployed code never changed. Six of the type's fourteen sources carried `504911232000000000` (= 1601-01-01) on **both** sides of the comparison.

Verified stale across a type-hub recycle, an instance recycle, and a **cold third instance** — which is what distinguishes this from a hub caching an old assembly, the known failure it superficially resembles (prior occurrence 2026-08-12, where recycling both hubs *was* the remedy).

The exposure is per-**file**, not per-writer: within one import, paths that were stat-able got real ticks and paths that were not got 1601 — which is why it looked like it tracked GitSync and did not. Confirmed independently on a second mesh (memex.systemorph.com) by @meshweaver-plugins-d0, whose `Hosting` package gave the discriminating case: a **new** type compiled fine (`CompiledSources` empty ⇒ dirty regardless) while a **changed** one went invisible. That proved scheduling was healthy and the comparison was not.

## Two halves, both needed

**1 — Stop minting it.** `FileTimestamps.ObservedAt` is now the single derivation: the real mtime when the file is on disk, else `UtcNow` (honest — the node is being written now — and, unlike 1601, comparable). All four sites route through it.

Fixing only the adapter would not have worked: it stamps just `if (node.LastModified == default)`, and a parser that already wrote 1601 puts that guard **permanently out of reach**, since `1601 != default`. `.cs` files are precisely the ones whose timestamps drive a compile.

**2 — Make the comparison robust anyway.** `NodeTypeDefinition.SourceVersionOf` is the one rule both snapshots fold through: the modification time when it is above the FILETIME epoch, else the node's `Version` — the owning hub's monotonic write counter, the only field guaranteed to move when the source moves. Both producers call it (`MeshNodeCompilationService.DiscoverSourceVersionSnapshot` and the sources watcher's fold); they must not diverge, or every type reads permanently dirty — the same outage with the opposite sign.

Deliberately **not** "an unknown version forces a recompile". That is correct on the first pass and never converges: the post-compile `CompiledSources` re-records the same unknown and the type is dirty again immediately — a permanent recompile loop on every affected type. The `Version` fallback heals in exactly one compile and settles.

## Migration

None. Meshes already holding 1601 self-heal: the source re-keys to its `Version`, differs from the recorded snapshot **once**, recompiles, and agrees thereafter. Sources with real timestamps are unaffected — same value as before.

## Tests

`SourceVersionMustChangeTests` — 9 cases, including:

- `UnknownSourceVersion_IsTheFileTimeEpoch` — asserts the constant against a genuinely absent file, so the magic number is pinned to the behaviour it comes from
- `EditToAnUntimestampedSource_IsVisibleToIsDirty` — the regression
- `LegacySnapshot_RecompilesOnceThenConverges` — heals once, does not storm
- `MissingFile_IsNeverStampedWithTheFileTimeEpoch` / `ExistingFile_KeepsItsRealModificationTime` — the mint site

Proved non-vacuous: reverting the `SourceVersionOf` fallback fails 4 of them.

Green: `MeshWeaver.Hosting.Test` 193/193 · the compile/release/prewarm/bake `MeshWeaver.Hosting.Monolith.Test` selection 17/17 · build clean under warnings-as-errors.

## Verification after deploy

@meshweaver-plugins-d0 has `Hosting/BackupStore` on memex.systemorph.com lined up as the end-to-end check — no dependents, every source on the placeholder, and predicted to go stale on its next content change. Under this fix it should recompile exactly once and then settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WBLnrSdT1Mc7BJuSaQJzB