### PR TITLE
fix(test): prove the prebuilt-bundle skip from what Seed writes, not from MeshNode.Version

### DIFF
--- a/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
@@ -109,6 +109,22 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
     /// level-triggered property at the same time (a cleared / remounted / stale-restored assembly
     /// volume must re-seed, never be skipped on the record's word alone; that is the
     /// <see cref="BakeState.BytesMissing"/> trap).</para>
+    ///
+    /// <para>🚨 <b>"Seed did not run" is asserted on what Seed WRITES — never on
+    /// <see cref="MeshNode.Version"/>.</b> That counter is minted by the owner for EVERY writer,
+    /// and this node has others: its own per-node hub seeds
+    /// <see cref="NodeTypeDefinition.CurrentSourceVersions"/> from the sources watcher on first
+    /// activation, and that write lands on either side of the adoption patch depending on
+    /// scheduling. Keying the skip assertion on the counter therefore failed whenever the
+    /// framework's own write happened to land second — 1 in 31 whole-assembly runs, 0 in 60
+    /// class-only ones, always as <c>Expected value to be 2 … but found 3</c>, with the seeder
+    /// having correctly skipped in every one of them. The record Seed restamps
+    /// (<see cref="NodeTypeDefinition.LastCompileSucceededAt"/>,
+    /// <see cref="NodeTypeDefinition.LastCompiledVersion"/>,
+    /// <see cref="NodeTypeDefinition.LatestAssemblyPath"/>) and the assembly store's own contents
+    /// name the seeder specifically, so they say what the counter cannot.
+    /// <see cref="AConcurrentWriteToTheNodeDoesNotMakeTheNextSeedReAdopt"/> pins that
+    /// deterministically.</para>
     /// </summary>
     [Fact(Timeout = 120_000)]
     public async Task UnchangedBundle_SkipsWithoutRewriting_AndReSeedsWhenTheStoreLosesItsBytes()
@@ -130,10 +146,13 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
                 .ToTask(TestContext.Current.CancellationToken);
             first.Should().Be(1, "a type with no build yet must be adopted");
 
-            var afterFirst = await AdoptedNode(typePath);
-            var adoptedVersion = afterFirst.Version;
-            var adoptedAt = afterFirst
-                .ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!.LastCompileSucceededAt;
+            var adopted = (await AdoptedNode(typePath))
+                .ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!;
+            var adoptedAt = adopted.LastCompileSucceededAt;
+            // The store snapshot is the race-free half of "did Seed run": Seed uploads BEFORE it
+            // stamps the record, and the upload is a local filesystem write, so it is settled the
+            // moment the seeding observable emits.
+            var storeAfterFirst = StoreContents(typePath);
 
             // ── 2. Second boot, nothing changed: SKIPPED — but still COVERED. ─────────────────
             var second = await ShippedPrebuiltBundles.SeedAll(Mesh, dir, null)
@@ -144,14 +163,21 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
                 + "the signal that the CI bake lane works, so it must NOT collapse to 0 on a "
                 + "healthy steady-state boot");
 
-            var afterSecond = await CurrentNode(typePath);
-            afterSecond.Version.Should().Be(adoptedVersion,
-                "an already-adopted entry must not be re-stamped — the write is what activates "
-                + "the NodeType's per-node hub, and that activation is the whole cost being removed");
-            afterSecond.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!
-                .LastCompileSucceededAt.Should().Be(adoptedAt,
-                    "a re-adoption would restamp this timestamp; an unchanged one proves Seed "
-                    + "never ran");
+            StoreContents(typePath).Should().Equal(storeAfterFirst,
+                "an already-adopted entry must not be re-uploaded — the store write, the node "
+                + "write and the per-node hub activation they need are the whole cost being "
+                + "removed, and a re-adoption puts the bytes under a NEW (path, version) key");
+
+            var afterSecond = (await CurrentNode(typePath))
+                .ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!;
+            afterSecond.LastCompileSucceededAt.Should().Be(adoptedAt,
+                "a re-adoption would restamp this timestamp; an unchanged one proves Seed "
+                + "never ran");
+            afterSecond.LastCompiledVersion.Should().Be(adopted.LastCompiledVersion,
+                "Seed stamps the node version it read, which has moved on since the first "
+                + "adoption — an unchanged stamp is a second witness that Seed never ran");
+            afterSecond.LatestAssemblyPath.Should().Be(adopted.LatestAssemblyPath,
+                "a re-adoption uploads under a new store key and rewrites this");
 
             // ── 3. The positive control: the store loses its bytes ⇒ the next seed re-adopts. ──
             Directory.Delete(AssemblyStoreRoot, recursive: true);
@@ -161,21 +187,155 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
                 .ToTask(TestContext.Current.CancellationToken);
             third.Should().Be(1, "the entry is covered again — this time by actually re-adopting it");
 
+            // Wait for the RE-ADOPTION — the record Seed restamps — and not for a version bump:
+            // any writer moves the version, so a wait on one can be satisfied by a write that is
+            // not this seed's, and the assertion after it then reads a node the seed never touched.
             var afterThird = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
-                .Where(n => n is not null && n.Version > adoptedVersion)
+                .Select(n => n?.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions))
+                .Where(d => d is { LastCompileSucceededAt: not null }
+                    && d.LastCompileSucceededAt != adoptedAt)
                 .Take(1)
                 .Timeout(TimeSpan.FromSeconds(30))
                 .ToTask(TestContext.Current.CancellationToken);
-            afterThird!.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!
-                .LastCompileSucceededAt.Should().NotBe(adoptedAt,
-                    "the record may never be trusted over the store: a cleared assembly volume "
-                    + "leaves every record pristine over bytes that are gone, and a skip decided "
-                    + "on the record alone would leave the type permanently unbuilt");
+            afterThird!.LastCompileSucceededAt.Should().NotBe(adoptedAt,
+                "the record may never be trusted over the store: a cleared assembly volume "
+                + "leaves every record pristine over bytes that are gone, and a skip decided "
+                + "on the record alone would leave the type permanently unbuilt");
+            StoreContents(typePath).Should().NotBeEmpty(
+                "the re-adoption put the bytes back on the store the delete emptied");
         }
         finally
         {
             TryDelete(dir);
         }
+    }
+
+    /// <summary>
+    /// 🚨 THE CONCURRENT-WRITER PIN. The NodeType node the seeder stamps is NOT written by the
+    /// seeder alone: its own per-node hub seeds
+    /// <see cref="NodeTypeDefinition.CurrentSourceVersions"/> the first time the hub activates —
+    /// and the hub activates BECAUSE the seeder opened its stream, so the two writes are
+    /// concurrent by construction and land in either order.
+    ///
+    /// <para>That is why <see cref="MeshNode.Version"/> can never express "the seeder did not
+    /// run": it is one counter shared by every writer. Here the foreign write is made EXPLICIT
+    /// and awaited — the same field, on the same node, between two seeds — so the property under
+    /// test is pinned with no wall clock and no scheduling luck: an entry that is already on the
+    /// store is skipped no matter what else has touched its node, and the skip is decided on
+    /// <see cref="NodeTypeDefinition.LastCompiledVersion"/> plus the store's bytes
+    /// (<see cref="NodeTypeBakeStatus.Classify"/>).</para>
+    ///
+    /// <para>Non-vacuous by measurement, not by argument: with the retired
+    /// <see cref="MeshNode.Version"/> assertion put back into this test it fails <b>10 out of
+    /// 10</b> runs — <c>Expected value to be 3 … but found 4</c>, the same shape the flake
+    /// produced — while every field the seeder owns is unchanged; with the assertions below it
+    /// passes 10 out of 10. No wall clock is involved in either.</para>
+    ///
+    /// <para>The stand-in write edits <see cref="NodeTypeDefinition.Description"/> rather than
+    /// <c>CurrentSourceVersions</c> itself, deliberately: the watcher owns that field, and two
+    /// writers on ONE field would put a cross-hub merge conflict into the fixture — a second race,
+    /// in a test whose whole point is not to have one. Any foreign write moves the counter, which
+    /// is the entire property at issue.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AConcurrentWriteToTheNodeDoesNotMakeTheNextSeedReAdopt()
+    {
+        var typePath = $"{TestPartition}/ConcurrentlyWrittenThing";
+        await CreateNodeType("ConcurrentlyWrittenThing");
+
+        var dir = CreateBundleDirectory();
+        try
+        {
+            WriteBundle(
+                Path.Combine(dir, "concurrent.zip"),
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream([0x11, 0x22, 0x33])));
+
+            var first = await ShippedPrebuiltBundles.SeedAll(Mesh, dir, null)
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+            first.Should().Be(1, "a type with no build yet must be adopted");
+
+            var afterAdoption = await AdoptedNode(typePath);
+            var adopted = afterAdoption.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!;
+            var storeAfterAdoption = StoreContents(typePath);
+
+            // The foreign write, spelled out: a field the seeder never stamps, written under the
+            // same System identity the framework's own watchers write with.
+            var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+            await Observable.Using(
+                    () => access.ImpersonateAsSystem(),
+                    _ => Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+                        .Update(node => node with
+                        {
+                            Content = node.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)! with
+                            {
+                                Description = "bake fixture, touched by someone else",
+                            },
+                        }))
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(TestContext.Current.CancellationToken);
+
+            // 🚨 The fixture is only meaningful once that write has actually MOVED the counter the
+            // old assertion keyed on — Update emits the writer's optimistic snapshot, which still
+            // carries the pre-write version, so the owner's committed node is what proves it.
+            var bumped = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+                .Where(n => n is not null && n.Version > afterAdoption.Version)
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(TestContext.Current.CancellationToken);
+            bumped!.Version.Should().BeGreaterThan(afterAdoption.Version,
+                "without a moved counter this test cannot distinguish the fix from the bug");
+
+            var second = await ShippedPrebuiltBundles.SeedAll(Mesh, dir, null)
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+            second.Should().Be(1,
+                "the entry is still covered — the foreign write changed nothing the seeder stamps");
+
+            StoreContents(typePath).Should().Equal(storeAfterAdoption,
+                "a moved node version must not make the seeder re-upload: the skip is keyed on "
+                + "LastCompiledVersion and the store's bytes, never on MeshNode.Version");
+
+            var after = (await CurrentNode(typePath))
+                .ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!;
+            after.LastCompileSucceededAt.Should().Be(adopted.LastCompileSucceededAt,
+                "a re-adoption would restamp this; an unchanged one proves Seed never ran");
+            after.LastCompiledVersion.Should().Be(adopted.LastCompiledVersion,
+                "Seed stamps the node version it read — an unchanged stamp is the second witness");
+        }
+        finally
+        {
+            TryDelete(dir);
+        }
+    }
+
+    /// <summary>
+    /// One NodeType's files on the assembly store, relative and ordered — the race-free half of
+    /// "did Seed run". <see cref="PrebuiltAssemblySeeder.Seed"/> uploads BEFORE it stamps the
+    /// record, and the upload is a local filesystem write, so this is settled the moment the
+    /// seeding observable emits; the NODE, by contrast, is written through the owner and its
+    /// mirror may not have caught up, so a regression could otherwise read as a pass. A
+    /// re-adoption always lands a NEW file, because the store key carries the node version Seed
+    /// read and that version has moved on since the first adoption.
+    ///
+    /// <para>Scoped to the type: <see cref="MonolithMeshTestBase.AssemblyStoreRoot"/> is shared
+    /// by every <c>[Fact]</c> of this class (it is keyed by process + test class), so an
+    /// unscoped listing would also see a sibling test's builds.</para>
+    /// </summary>
+    private string[] StoreContents(string typePath)
+    {
+        // The store files each type under a directory named for its sanitized mesh path, so the
+        // leaf id is enough to scope the listing without duplicating that sanitization here.
+        var leaf = typePath[(typePath.LastIndexOf('/') + 1)..];
+        return Directory.Exists(AssemblyStoreRoot)
+            ? Directory.GetFiles(AssemblyStoreRoot, "*", SearchOption.AllDirectories)
+                .Select(f => Path.GetRelativePath(AssemblyStoreRoot, f))
+                .Where(f => f.Contains(leaf, StringComparison.Ordinal))
+                .OrderBy(f => f, StringComparer.Ordinal)
+                .ToArray()
+            : [];
     }
 
     /// <summary>The node once its adoption has landed.</summary>


### PR DESCRIPTION
Closes #1833.

`ShippedPrebuiltBundlesTest.UnchangedBundle_SkipsWithoutRewriting_AndReSeedsWhenTheStoreLosesItsBytes`
failed about one whole-assembly run in fifteen with

```
Expected value to be 2 because an already-adopted entry must not be re-stamped …, but found 3.
```

That is the boot-time bundle **adoption** path — the decision between `alreadyBaked=0` and a warm
start in #1814 — so the missing signal is worth more than a normal test flake.

## Mechanism (measured, not inferred)

Instrumenting the NodeType's mesh-node stream with the seeder's own fields makes the sequence
explicit. On a **passing** run:

```
 53 EMIT  v=3 status=Ok lcv=1 succAt=…234395 csv=0 cs=null
 53 MARK  after first SeedAll
 54 MARK  captured adoptedVersion=3
 55 MARK  second SeedAll -> 1
 55 MARK  afterSecond.Version=3          ← no emission in between: the seeder SKIPPED
 68 EMIT  v=4 status=Ok lcv=3 succAt=…256234 csv=0 cs=0   ← step 3's deliberate re-adoption
```

`Seed` read the node at **v1** — that is what it stamps as `LastCompiledVersion` and uses as the
assembly-store key — yet its write committed as **v3**. Something wrote v2 in between, and the
emission names it: `CurrentSourceVersions` went from absent to the empty snapshot. The seeder never
writes that field; `NodeTypeCompilationHelpers.InstallSourcesWatcher` does, on the per-NodeType
hub's **first activation** — an activation the seeder itself causes by opening the stream. The two
writes are concurrent by construction:

* watcher first → adoption lands at v3 → `adoptedVersion == 3` is final → pass
* adoption first → adoption lands at v2 → the watcher's write follows as v3 → `Expected 2 … found 3`

## Test defect, and the product decision it guards is correct

`MeshNode.Version` is a per-node counter the owner mints for **every** writer: it records that
someone wrote, never who. In every failing run the second `SeedAll` emitted nothing, the record the
seeder owns was untouched, and the assembly store was untouched — the skip happened. The skip is
already keyed correctly (`IsAlreadyCurrent` probes the store at `LastCompiledVersion`, explicitly
*not* at `node.Version`, which `IsAlreadyAdopted` documents as unsatisfiable by design).

**Not #1826.** That flake is a `CurrentThreadScheduler` trampoline starving a synthetic frame
source — a wall-clock timeout with zero frames delivered. Here nothing is starved: every awaited
value arrives within ~2 ms and the failure is a value comparison. Ruled out.

## The change

Assertions now name what `Seed` writes — `LastCompileSucceededAt`, `LastCompiledVersion`,
`LatestAssemblyPath`, and the type's files on the assembly store. The store snapshot is the
race-free half: Seed uploads *before* it stamps and the upload is a local filesystem write, so it is
settled the moment the seeding observable emits, whereas the node goes through the owner and its
mirror can lag — which would let a real regression read as a pass. Step 3's positive control waits
for the **re-adoption** rather than for `Version > adoptedVersion`, which any writer satisfies.

`AConcurrentWriteToTheNodeDoesNotMakeTheNextSeedReAdopt` pins the mechanism rather than a timing
budget: it performs the foreign write explicitly between two seeds, awaits proof the counter really
moved, and asserts the second seed still skips. It edits `Description` rather than
`CurrentSourceVersions` deliberately — the watcher owns that field, and two writers on one field
would put a cross-hub merge conflict into the fixture.

## Measured, this machine, whole-assembly Release runs of `MeshWeaver.PluginCatalog.Test`

| loop (whole assembly, Release, `MeshWeaver.PluginCatalog.Test`) | iterations | failures |
|---|---|---|
| **before** the fix | **31** (15 baseline + a 16-run matched control) | **1** |
| **after** the fix | **30** | **0** |
| class-only, before the fix | 60 | 0 |

At a ~3 % frequency that pair is under-powered on its own — 0/30 and 1/31 are not distinguishable —
so the **deterministic** pair is what carries the argument, on the same machine and the same
fixture, with no wall clock anywhere in it:

| `AConcurrentWriteToTheNodeDoesNotMakeTheNextSeedReAdopt` | iterations | failures |
|---|---|---|
| with the **retired** `MeshNode.Version` assertion put back | 10 | **10** |
| with the assertions this PR ships | 10 | **0** |

The retired assertion fails there with `Expected value to be 3 … but found 4` — the same shape the
flake produced — while every field the seeder owns is unchanged.

## Adjacent product defect — filed, not fixed here

The same instrumentation shows `cs=null` on the adoption emission while `csv=0`: the adoption's
patch is computed against the mirror's snapshot, which predates the watcher's write, so
`CompiledSources` is stamped from a `CurrentSourceVersions` that has not been published yet. Harmless
for a sourceless fixture; for a real type **with** sources it leaves `IsDirty == true`, and
`InstallReleaseRequestWatcher`'s "satisfied by the existing current build" branch requires
`!def.IsDirty` — so the next release request compiles the type that was just adopted. **#1834.**

## Notes

* Test-only change, no user-visible effect → no What's New entry.
* No overlap with **#1829** (`test/MeshWeaver.PluginTester.Test/AreaProbeTest.cs`) or **#1831**
  (`EmitPipeline` / `MeshDataSource` / `PackageInstaller` + `InstallReleaseOrderingTest`,
  `StaleStampRootBindingTest`): this touches only
  `test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs`, which none of them edits. No
  sequencing needed in either direction.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
