### PR TITLE
A sync licence with terms and a term, exchangeable for a short-lived scoped token

### DIFF
--- a/memex/Memex.Portal.Shared/Api/InstanceTokenEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/InstanceTokenEndpoints.cs
@@ -137,7 +137,7 @@ public static class InstanceTokenEndpoints
     /// that has already ended — the grant would refuse it on use anyway, and handing out a token
     /// that cannot work is a worse answer than saying so.</para>
     /// </summary>
-    private static IReadOnlyCollection<string> EffectiveScope(
+    internal static IReadOnlyCollection<string> EffectiveScope(
         AuthenticatedInstance caller, IReadOnlyCollection<string>? requested, DateTimeOffset now)
     {
         if (caller.Grant.IsRevoked)
@@ -150,16 +150,38 @@ public static class InstanceTokenEndpoints
         if (requested is not { Count: > 0 })
             return [.. licensed.Select(e => e.ToString()).Distinct(StringComparer.Ordinal)];
 
-        // Keep only requests the licence actually covers. Dropping rather than refusing: a token can
-        // only narrow, so an over-broad request is a stale caller, not an attack.
-        return
-        [
-            .. requested
-                .Select(PluginGrantEntry.TryParse)
-                .Where(e => e is not null)
-                .Where(e => licensed.Any(l => l.Matches(e!.Source, e.PackageId)))
-                .Select(e => e!.ToString())
-                .Distinct(StringComparer.Ordinal)
-        ];
+        // Keep only what the licence actually covers, INTERSECTING rather than filtering. Dropping
+        // what is not covered rather than refusing it: a token can only narrow, so an over-broad
+        // request is a stale caller, not an attack.
+        //
+        // 🚨 A whole-source request must EXPAND to the licensed packages in that source, not be
+        // matched against them. `Plugins/*` is the natural way to say "everything I am licensed for
+        // here", and a naive `licensed.Any(l => l.Matches(source, "*"))` answers false for an
+        // instance licensed per-package — so the effective scope came out EMPTY and the exchange
+        // returned 403 to a caller asking a perfectly reasonable question (Copilot, #1844).
+        var effective = new List<string>();
+        foreach (var entry in requested.Select(PluginGrantEntry.TryParse).Where(e => e is not null))
+        {
+            if (entry!.PackageId == PluginGrantEntry.AllPackages)
+            {
+                // Everything licensed in that source — which may itself be a whole-source licence
+                // (kept as `Source/*`) or a set of per-package ones (kept individually).
+                effective.AddRange(licensed
+                    .Where(l => string.Equals(l.Source, entry.Source, StringComparison.OrdinalIgnoreCase))
+                    .Select(l => l.ToString()));
+                continue;
+            }
+
+            // Emit the LICENCE's source casing, not the request's — the response describes what was
+            // granted rather than echoing what was typed, and the two must not disagree with the
+            // wildcard branch above. The PACKAGE stays the requested one: taking the licence's would
+            // turn an exact request under a whole-source licence back into `Source/*`, widening the
+            // very scope the caller asked to narrow.
+            var match = licensed.FirstOrDefault(l => l.Matches(entry.Source, entry.PackageId));
+            if (match is not null)
+                effective.Add($"{match.Source}/{entry.PackageId}");
+        }
+
+        return [.. effective.Distinct(StringComparer.Ordinal)];
     }
 }

--- a/memex/Memex.Portal.Shared/Api/InstanceTokenEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/InstanceTokenEndpoints.cs
@@ -1,0 +1,170 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Api;
+
+/// <summary>
+/// <c>POST /api/instances/token</c> — a registered instance exchanges its durable <c>mwi_</c> key
+/// for a short-lived, scoped <c>mwa_</c> access token.
+///
+/// <para><b>Why it exists.</b> Without it a consumer must present its long-lived credential on every
+/// call, which is the property that makes a standing per-repo PAT unacceptable. With it, a build
+/// agent mints a minutes-long token narrowed to the one package it needs, and holds nothing durable
+/// beyond the run.</para>
+///
+/// <para>🚨 <b>A token cannot be exchanged for another token.</b> The endpoint accepts ONLY the
+/// durable instance key: allowing a token to mint its successor would turn a minutes-long credential
+/// into a perpetual one by renewal, defeating the entire point of the expiry. The check is on the
+/// credential's SHAPE (<c>mwi_</c> vs <c>mwa_</c>, disjoint by construction), not on a claim the
+/// presenter could edit.</para>
+///
+/// <para>The token narrows; it never widens. The effective scope is what the caller asked for
+/// intersected with what its sync licence already allows, and the live grant is re-read on every
+/// subsequent request — so revoking a licence takes effect at once rather than when the token
+/// expires.</para>
+/// </summary>
+public static class InstanceTokenEndpoints
+{
+    /// <summary>Maps the token-exchange endpoint. Call alongside <c>MapPluginRegistry</c>.</summary>
+    /// <param name="endpoints">The route builder.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static IEndpointRouteBuilder MapInstanceTokenExchange(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost(SyncTokenPayloads.Route, Exchange).AllowAnonymous();
+        return endpoints;
+    }
+
+    private static Task<IResult> Exchange(
+        HttpContext http, IMessageHub rootHub, SyncTokenPayloads.Request? body, CancellationToken ct)
+    {
+        var logger = http.RequestServices.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(InstanceTokenEndpoints));
+
+        var header = http.Request.Headers.Authorization.ToString();
+
+        // Shape check FIRST — a token may never mint its successor (see the type remarks).
+        if (InstanceKeys.ExtractKey(header) is null)
+        {
+            var wasToken = SyncAccessToken.ExtractToken(header) is not null;
+            if (wasToken)
+                logger?.LogWarning(
+                    "A sync access token was presented to the exchange endpoint — only the durable "
+                    + "instance key may mint a token.");
+            return Task.FromResult(Results.Json(
+                new { error = wasToken
+                    ? "A short-lived token cannot be exchanged for another token. Present the "
+                      + "instance key (Authorization: Bearer mwi_…)."
+                    : "A registered instance key is required (Authorization: Bearer mwi_…)." },
+                statusCode: StatusCodes.Status401Unauthorized));
+        }
+
+        var options = rootHub.ServiceProvider.GetService<PluginCatalogOptions>();
+        var signingKey = string.IsNullOrWhiteSpace(options?.TokenSigningKey)
+            ? null
+            : Encoding.UTF8.GetBytes(options!.TokenSigningKey);
+
+        // Unconfigured is reported, never worked around with a weaker key — and it is a 503 rather
+        // than a 401, because the caller's credential is fine and the registry's deployment is not.
+        if (!SyncAccessToken.IsUsableSigningKey(signingKey))
+        {
+            logger?.LogError(
+                "Token exchange requested but {Section}:{Key} is unset or shorter than {Min} bytes — "
+                + "the endpoint cannot mint. Configure it identically on every replica.",
+                PluginCatalogOptions.SectionName, nameof(PluginCatalogOptions.TokenSigningKey),
+                SyncAccessToken.MinimumSigningKeyBytes);
+            return Task.FromResult(Results.Json(
+                new { error = "Token exchange is not configured on this registry." },
+                statusCode: StatusCodes.Status503ServiceUnavailable));
+        }
+
+        var authenticator = http.RequestServices.GetRequiredService<InstanceRegistryAuthenticator>();
+        var now = DateTimeOffset.UtcNow;
+
+        return authenticator.Authenticate(header)
+            .Select(caller =>
+            {
+                if (caller is null)
+                    return Results.Json(
+                        new { error = "A registered instance key is required (Authorization: Bearer mwi_…)." },
+                        statusCode: StatusCodes.Status401Unauthorized);
+
+                var effective = EffectiveScope(caller, body?.Scope, now);
+
+                // Licensed for nothing (or for nothing that was asked for) means there is nothing to
+                // mint a token FOR. Answering 403 with the reason beats handing back a token that
+                // will 404 on every call.
+                if (effective.Count == 0)
+                    return Results.Json(
+                        new { error = "This instance holds no current sync licence for the requested scope." },
+                        statusCode: StatusCodes.Status403Forbidden);
+
+                var lifetime = body?.LifetimeSeconds is > 0
+                    ? TimeSpan.FromSeconds(body.LifetimeSeconds.Value)
+                    : SyncAccessToken.DefaultLifetime;
+
+                var token = SyncAccessToken.Mint(
+                    caller.Instance.InstanceId, caller.Instance.KeyHash, effective, now, lifetime, signingKey!);
+                var claims = SyncAccessToken.Verify(token, now, signingKey!)!;
+
+                logger?.LogInformation(
+                    "Minted a sync access token for {InstanceId}, scope [{Scope}], expiring {Expiry}",
+                    caller.Instance.InstanceId, string.Join(", ", effective), claims.ExpiresAt);
+
+                return Results.Json(
+                    new SyncTokenPayloads.Response(
+                        token, SyncAccessToken.Scheme,
+                        (int)(claims.ExpiresAt - now).TotalSeconds, effective),
+                    SyncTokenPayloads.Json);
+            })
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex, "Sync access token exchange failed");
+                return Observable.Return(Results.Json(
+                    new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway));
+            })
+            .FirstAsync().ToTask(ct);
+    }
+
+    /// <summary>
+    /// What the token will actually carry: the caller's CURRENT licence entries, narrowed to what
+    /// was requested.
+    ///
+    /// <para>Expired and revoked entries are dropped here, so a token is never minted for a licence
+    /// that has already ended — the grant would refuse it on use anyway, and handing out a token
+    /// that cannot work is a worse answer than saying so.</para>
+    /// </summary>
+    private static IReadOnlyCollection<string> EffectiveScope(
+        AuthenticatedInstance caller, IReadOnlyCollection<string>? requested, DateTimeOffset now)
+    {
+        if (caller.Grant.IsRevoked)
+            return [];
+
+        var licensed = caller.Grant.Entries
+            .Where(e => e.IsValidAt(now))
+            .ToList();
+
+        if (requested is not { Count: > 0 })
+            return [.. licensed.Select(e => e.ToString()).Distinct(StringComparer.Ordinal)];
+
+        // Keep only requests the licence actually covers. Dropping rather than refusing: a token can
+        // only narrow, so an over-broad request is a stale caller, not an attack.
+        return
+        [
+            .. requested
+                .Select(PluginGrantEntry.TryParse)
+                .Where(e => e is not null)
+                .Where(e => licensed.Any(l => l.Matches(e!.Source, e.PackageId)))
+                .Select(e => e!.ToString())
+                .Distinct(StringComparer.Ordinal)
+        ];
+    }
+}

--- a/memex/Memex.Portal.Shared/Api/InstanceTokenEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/InstanceTokenEndpoints.cs
@@ -1,6 +1,5 @@
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
-using System.Text;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
 using MeshWeaver.PluginCatalog;
@@ -26,6 +25,11 @@ namespace Memex.Portal.Shared.Api;
 /// into a perpetual one by renewal, defeating the entire point of the expiry. The check is on the
 /// credential's SHAPE (<c>mwi_</c> vs <c>mwa_</c>, disjoint by construction), not on a claim the
 /// presenter could edit.</para>
+///
+/// <para>The signing key is a MESH NODE (<c>Admin/SyncTokenSigningKey/current</c>), minted on first
+/// use and shared by every replica — there is nothing to configure and nothing for an operator to
+/// copy between environments. Minting happens only AFTER the caller authenticates, so an anonymous
+/// request cannot provoke a node write.</para>
 ///
 /// <para>The token narrows; it never widens. The effective scope is what the caller asked for
 /// intersected with what its sync licence already allows, and the live grant is re-read on every
@@ -67,35 +71,20 @@ public static class InstanceTokenEndpoints
                 statusCode: StatusCodes.Status401Unauthorized));
         }
 
-        var options = rootHub.ServiceProvider.GetService<PluginCatalogOptions>();
-        var signingKey = string.IsNullOrWhiteSpace(options?.TokenSigningKey)
-            ? null
-            : Encoding.UTF8.GetBytes(options!.TokenSigningKey);
-
-        // Unconfigured is reported, never worked around with a weaker key — and it is a 503 rather
-        // than a 401, because the caller's credential is fine and the registry's deployment is not.
-        if (!SyncAccessToken.IsUsableSigningKey(signingKey))
-        {
-            logger?.LogError(
-                "Token exchange requested but {Section}:{Key} is unset or shorter than {Min} bytes — "
-                + "the endpoint cannot mint. Configure it identically on every replica.",
-                PluginCatalogOptions.SectionName, nameof(PluginCatalogOptions.TokenSigningKey),
-                SyncAccessToken.MinimumSigningKeyBytes);
-            return Task.FromResult(Results.Json(
-                new { error = "Token exchange is not configured on this registry." },
-                statusCode: StatusCodes.Status503ServiceUnavailable));
-        }
-
         var authenticator = http.RequestServices.GetRequiredService<InstanceRegistryAuthenticator>();
+        var keys = rootHub.ServiceProvider.GetRequiredService<SyncTokenSigningKeyService>();
         var now = DateTimeOffset.UtcNow;
 
+        // 🚨 Authenticate BEFORE touching the signing key. Resolve() mints this registry's key if it
+        // has none, and minting is a node write — so doing it first would let an unauthenticated
+        // caller provoke one. The order is the access control.
         return authenticator.Authenticate(header)
-            .Select(caller =>
+            .SelectMany(caller =>
             {
                 if (caller is null)
-                    return Results.Json(
+                    return Observable.Return(Results.Json(
                         new { error = "A registered instance key is required (Authorization: Bearer mwi_…)." },
-                        statusCode: StatusCodes.Status401Unauthorized);
+                        statusCode: StatusCodes.Status401Unauthorized));
 
                 var effective = EffectiveScope(caller, body?.Scope, now);
 
@@ -103,27 +92,33 @@ public static class InstanceTokenEndpoints
                 // mint a token FOR. Answering 403 with the reason beats handing back a token that
                 // will 404 on every call.
                 if (effective.Count == 0)
-                    return Results.Json(
+                    return Observable.Return(Results.Json(
                         new { error = "This instance holds no current sync licence for the requested scope." },
-                        statusCode: StatusCodes.Status403Forbidden);
+                        statusCode: StatusCodes.Status403Forbidden));
 
                 var lifetime = body?.LifetimeSeconds is > 0
                     ? TimeSpan.FromSeconds(body.LifetimeSeconds.Value)
                     : SyncAccessToken.DefaultLifetime;
 
-                var token = SyncAccessToken.Mint(
-                    caller.Instance.InstanceId, caller.Instance.KeyHash, effective, now, lifetime, signingKey!);
-                var claims = SyncAccessToken.Verify(token, now, signingKey!)!;
+                // The key is a MESH NODE, minted once per registry and shared by every replica — no
+                // configuration, and nothing for an operator to copy between environments.
+                return keys.Resolve().Select(material =>
+                {
+                    var token = SyncAccessToken.Mint(
+                        caller.Instance.InstanceId, caller.Instance.KeyHash, effective, now, lifetime,
+                        material.Current);
+                    var claims = SyncAccessToken.Verify(token, now, material.Current)!;
 
-                logger?.LogInformation(
-                    "Minted a sync access token for {InstanceId}, scope [{Scope}], expiring {Expiry}",
-                    caller.Instance.InstanceId, string.Join(", ", effective), claims.ExpiresAt);
+                    logger?.LogInformation(
+                        "Minted a sync access token for {InstanceId}, scope [{Scope}], expiring {Expiry}",
+                        caller.Instance.InstanceId, string.Join(", ", effective), claims.ExpiresAt);
 
-                return Results.Json(
-                    new SyncTokenPayloads.Response(
-                        token, SyncAccessToken.Scheme,
-                        (int)(claims.ExpiresAt - now).TotalSeconds, effective),
-                    SyncTokenPayloads.Json);
+                    return Results.Json(
+                        new SyncTokenPayloads.Response(
+                            token, SyncAccessToken.Scheme,
+                            (int)(claims.ExpiresAt - now).TotalSeconds, effective),
+                        SyncTokenPayloads.Json);
+                });
             })
             .Catch((Exception ex) =>
             {

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1176,6 +1176,12 @@ public static class MemexConfiguration
         // PluginCatalog:DefaultGrants seeding applies. The bootstrap key in the body IS the auth.
         app.MapInstanceRegistration();
 
+        // Short-lived credential exchange — POST /api/instances/token. A registered instance trades
+        // its durable mwi_ key for a scoped, minutes-long mwa_ token, so a consumer (a build agent,
+        // a disposable mesh) holds nothing long-lived. Only the durable key may mint; a token can
+        // never mint its successor.
+        app.MapInstanceTokenExchange();
+
         // Crawler plumbing — a real /robots.txt + /sitemap.xml (the Blazor catch-all otherwise
         // serves the SPA shell on both). The sitemap lists exactly the anonymous surface: every
         // top-level node passing the AnonymousGate plus store plugins' public segments.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -150,6 +150,97 @@ contribution (logged), never a broken catalog. The legacy single-source keys
 is advisory. The wire shapes are produced by `PluginRegistryPayloads` and parsed by
 `RegistryPackageSource`, one place each, so producer and consumer cannot drift.
 
+## The sync licence — what a grant now carries
+
+A `PluginGrant` IS the **sync licence**: the right of a registered instance to REPLICATE a package
+from this registry. Its subject is a `MeshWeaverInstance` and its verb is *sync*, which is
+deliberately not the user-facing entitlement — that grants a person the use of a package on their
+own portal and says nothing about a deployment holding a copy of it.
+
+Each entry carries the terms the right was issued under, so "may this instance pull this package"
+and "under what licence, until when, on whose authority" are ONE record rather than an ACL sitting
+next to a licence that could disagree with it:
+
+| field | meaning |
+|---|---|
+| `ExpiresAt` | end of the term. Null = perpetual — which is why every grant written before licences existed keeps working unchanged. **Per ENTRY**, because one instance routinely holds a perpetual licence for the platform repo alongside a termed one for a paid package. |
+| `IssuedUnderLicense` | SPDX id, resolving to a `License/{SpdxId}` node whose text can be shown. Null stays null — a licence nobody granted is never invented. |
+| `IssuedVia` | an order id, a coupon code, a ticket. The audit trail. |
+| `IssuedAt` | when it was issued. |
+| `IsRevoked` *(on the grant)* | the instance-wide stop. Entries survive it, so a revocation stays reviewable — and liftable. |
+
+`Allows(source, package, now)` is granted **and** within term **and** not revoked. `Matches` ignores
+the term on purpose, so a caller can tell *expired* from *never licensed* — the two need different
+remedies (renew, versus buy).
+
+**`SyncLicenseService` is the one writer.** Issue, revoke, revoke-all, reinstate. Issuing is
+idempotent — re-issuing REPLACES an entry, so renewing a term is the same call as granting it — and
+an issuance with no issuing principal is refused rather than written anonymously. It records an
+authorization; it does not make one: whether the licence may be issued (a global-admin gate, a
+verified payment, a validated coupon) belongs to the caller, exactly as `PackageEntitlement` puts
+its check on the action.
+
+> 🚨 Before this, a grant had exactly two writers — the `DefaultGrants` registration seed and an
+> admin typing into the Instance-grants tab — and no way to express a term at all. That is workable
+> for three instances and not for a catalogue: a consumer needing ONE package had no smaller thing
+> to ask for than a standing credential to a whole repository.
+
+## Short-lived tokens — `POST /api/instances/token`
+
+An instance exchanges its durable `mwi_` key for a short-lived, scoped `mwa_` access token:
+
+```
+POST /api/instances/token
+Authorization: Bearer mwi_…
+{ "scope": ["Plugins/Publish"], "lifetimeSeconds": 900 }
+
+→ { "accessToken": "mwa_…", "tokenType": "Bearer", "expiresIn": 900,
+    "scope": ["Plugins/Publish"] }
+```
+
+Both body fields are optional; an empty body means "a default token for everything I am licensed
+for". The response's `scope` is the EFFECTIVE scope — what was asked for intersected with what is
+licensed — returned explicitly so a consumer sees it got less than it requested rather than
+discovering it one 404 at a time.
+
+Three properties, and each is what makes the token safe to hand out:
+
+- **Identity and scope, never authority.** The live grant is re-read on every request, so revoking a
+  licence takes effect at once instead of surviving until the token expires.
+- **It can only narrow.** A token minted for more than its licence covers grants nothing extra —
+  scope is an additional filter, never an alternative source of permission.
+- **A token cannot mint its successor.** Only the durable key may exchange; otherwise a
+  minutes-long credential becomes perpetual by renewal. The check is on the credential's SHAPE
+  (`mwi_` vs `mwa_`, disjoint by construction), not on a claim the presenter could edit.
+
+The token is **signed, not stored** — minting writes no node, so there is no per-issue write
+amplification and no expiry sweep to maintain. That is only safe *because* authority is re-checked
+on use. It carries the hash of the key it was exchanged from, which is how it routes to its instance
+through the same index the raw key uses, and which makes re-issuing an instance key invalidate every
+outstanding token for free.
+
+`PluginCatalog:TokenSigningKey` is the HMAC key (≥32 bytes), shared across every replica of one
+registry. **Unset means the endpoint reports itself unavailable (503), never that it falls back to a
+weaker key** — and a token presented to a registry that cannot verify a signature is refused, never
+accepted unverified.
+
+## Licence acceptance — enforced, not merely recorded
+
+`LicenseContent.RequiresAcceptance` is enforced on the install path, beside the entitlement check
+and for the same reason: on the ACTION, so the unattended paths (default install, the update
+watcher) are gated identically to a click. A permissive licence asks nothing and gates nothing —
+Apache-2.0 and MIT install exactly as before.
+
+The `LicenseAcceptance` record's **body hash is checked, not merely stored**: an acceptance given
+against earlier terms does not satisfy revised ones, which is the entire reason the record carries a
+hash. Normalization folds line endings and trailing whitespace — what a round-trip through git or an
+editor changes — and nothing else, so consent is never revoked by a difference no reader could see.
+
+A licence the catalog does not hold (including every SPDX *expression*, like `Apache-2.0 OR MIT`,
+which names a choice rather than one node) demands no acceptance: terms the platform cannot display
+cannot meaningfully be consented to. That is a consent decision, never an access one — what a caller
+may install is decided by `PackageEntitlement` and, for an instance, by its sync licence.
+
 ## The consumer — the Store's catalog area, not a Space
 
 On every installation the catalog is a **layout area** (`CatalogLayoutAreas`), rendered as the

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -219,10 +219,41 @@ on use. It carries the hash of the key it was exchanged from, which is how it ro
 through the same index the raw key uses, and which makes re-issuing an instance key invalidate every
 outstanding token for free.
 
-`PluginCatalog:TokenSigningKey` is the HMAC key (≥32 bytes), shared across every replica of one
-registry. **Unset means the endpoint reports itself unavailable (503), never that it falls back to a
-weaker key** — and a token presented to a registry that cannot verify a signature is refused, never
-accepted unverified.
+### The signing key is a mesh node, minted once
+
+The HMAC key lives at **`Admin/SyncTokenSigningKey/current`** — one node per registry,
+`enc:`-protected at rest by the same envelope as `PluginRegistryCredential`. Not configuration: a
+signing key has to be IDENTICAL on every replica (a token minted on pod A must verify on pod B) and
+should never pass through a human's hands. Configuration achieves the first only if an operator gets
+it right in every environment, and fails the second by construction. It is minted on first use, so
+there is nothing to provision.
+
+🚨 **Uniqueness is the NODE's, and the RESPONSE cannot be trusted to report it.** Measured
+2026-08-18: under a genuine concurrent create, **both** callers are told `created=1, existing=0` —
+the response's exists-check lags, exactly as `IMeshService.CreateOrUpdateNode`'s remarks warn —
+while **storage keeps the FIRST create and discards the second**. So the store enforces uniqueness
+and the response does not describe it. The rule that follows is absolute: **create, then read back,
+and sign only with what is actually stored.** Signing with locally minted material is precisely how
+two replicas end up on different keys. A lock would not help — it cannot span pods.
+
+Minting happens only AFTER the caller authenticates, so an anonymous request cannot provoke a node
+write; the verify path reads without minting (a token cannot verify against a key created after it
+was signed anyway).
+
+**Rotation keeps the outgoing key.** `RotateAfter` on the node is the due date — data, so it is
+visible and adjustable without a deploy. A rotation writes a fresh key and moves the old one to
+`ProtectedPrevious`, verifiable until `PreviousValidUntil`; verification tries current, then
+previous. The window is exactly one maximum token lifetime, because nothing signed before the
+rotation can still be unexpired after that. Without it, rotating would invalidate every token in
+flight mid-run.
+
+⚠️ **Rotation is not yet automatic.** `Reminder`/`ReminderSchedule` — the platform's durable,
+claim-guarded recurring trigger, which is the right home for this — exists as contract plus unit
+tests with **no runner**: no registered node type and nothing that reads reminder nodes. So the due
+date is recorded and reported, and rotation is invoked explicitly. When the reminder runner lands,
+registering a recurring reminder against this due date is the whole of the remaining work; nothing
+here needs to change. Deliberately NOT filled in with an opportunistic "rotate when someone
+notices it is due" — two replicas rotating at once would each retire the other's key.
 
 ## Licence acceptance — enforced, not merely recorded
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-sync-licence-not-a-shared-credential.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-sync-licence-not-a-shared-credential.md
@@ -72,10 +72,15 @@ Three properties make it safe to hand out freely:
 - **A token cannot mint its successor.** Only the durable key may exchange, or a minutes-long
   credential would become perpetual by renewal.
 
-It is signed rather than stored, so minting writes no node and there is no expiry sweep to maintain
-— which is only safe *because* authority is re-checked on use. The signing key is configured
-(`PluginCatalog:TokenSigningKey`) and shared across a registry's replicas; unset means the endpoint
-reports itself unavailable rather than falling back to something weaker.
+The token itself is signed rather than stored, so minting writes no node and there is no expiry
+sweep to maintain — which is only safe *because* authority is re-checked on use.
+
+**The signing key is a mesh node**, minted on first use at `Admin/SyncTokenSigningKey/current` and
+`enc:`-protected at rest. Nothing to configure, nothing for an operator to copy between
+environments, and no human ever sees it. Uniqueness across replicas comes from the node: two racing
+to mint collide on one fixed path, storage keeps the first, and — because the create response tells
+*both* callers they won — each reads the stored key back and signs with that. Rotation keeps the
+outgoing key verifiable for one token lifetime, so rotating never invalidates work in flight.
 
 The point of all of it: a consumer that needs one package can now hold a credential for one package,
 for fifteen minutes.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-sync-licence-not-a-shared-credential.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-sync-licence-not-a-shared-credential.md
@@ -1,0 +1,81 @@
+---
+Name: A sync licence, not a shared credential
+Category: Feature
+Description: An instance's right to replicate a package is now a licence with terms, a term and an issuer — and it can be exchanged for a short-lived, scoped token, so a consumer never holds a durable credential.
+Icon: Key
+Order: -20260818
+---
+
+# A sync licence, not a shared credential
+
+The registry has always been able to say *which* packages a registered instance may pull. What it
+could not say is **under what terms, until when, and on whose authority** — a `PluginGrant` was a
+list of `Source/Package` entries and nothing else, written in exactly two places: the registration
+seed, and an admin typing into the Instance-grants tab.
+
+That is fine for three instances. It is not fine for a catalogue, and the pressure showed up the
+way these things usually do: a consumer that needed one package asked for a standing credential to
+the whole repository, because there was no smaller thing to ask for.
+
+## The grant is now the licence
+
+`PluginGrant` keeps doing exactly what it did — the registry surface still calls `Allows(source,
+package)` and every existing grant keeps working unchanged — but each entry now carries the terms
+it was issued under:
+
+- **`ExpiresAt`** — the term. Null stays perpetual, which is why nothing written before this change
+  behaves differently. It sits on the ENTRY rather than the grant because one instance routinely
+  holds a perpetual licence for the platform repo alongside a termed one for a paid package.
+- **`IssuedUnderLicense`** — the SPDX id, resolving to a `License` node whose text can actually be
+  shown. Unspecified stays null; a licence nobody granted is never invented.
+- **`IssuedVia`** — an order, a coupon, a ticket. The audit trail for a right that is otherwise
+  indistinguishable from any other.
+- **`IsRevoked`** on the grant — the instance-wide stop, which keeps the entries intact so a
+  revocation can be reviewed afterwards and lifted.
+
+`SyncLicenseService` is now the one writer. Issuing is idempotent, revocation is a flag rather than
+a deletion, and an issuance with no issuing principal is refused rather than written anonymously —
+a right nobody is recorded as having granted cannot be reviewed with confidence.
+
+## And licences that ask something are now enforced
+
+`LicenseContent.RequiresAcceptance` and the per-user `LicenseAcceptance` record have existed as node
+types for a while, with a body hash so an acceptance is evidence against the text that was actually
+shown. Nothing read them. They are now enforced on the install path, beside the entitlement check
+and for the same reason — on the action, so the unattended paths are gated identically to a click.
+
+The body hash is checked, not merely stored: an acceptance recorded against earlier terms does not
+satisfy revised ones. Normalization ignores what a round-trip through git or an editor changes and
+nothing else, so consent is not revoked by an invisible line ending.
+
+Permissive licences ask nothing and gate nothing — Apache-2.0 and MIT install exactly as before.
+
+## Exchange the durable key for a token that expires
+
+`POST /api/instances/token` trades an instance's durable `mwi_` key for a short-lived `mwa_` token,
+narrowed to the packages it actually needs:
+
+```
+POST /api/instances/token
+Authorization: Bearer mwi_…
+{ "scope": ["Plugins/Publish"], "lifetimeSeconds": 900 }
+
+→ { "accessToken": "mwa_…", "tokenType": "Bearer", "expiresIn": 900,
+    "scope": ["Plugins/Publish"] }
+```
+
+Three properties make it safe to hand out freely:
+
+- **It carries identity and scope, never authority.** The live licence is re-read on every request,
+  so revoking one takes effect immediately rather than when the token expires.
+- **It can only narrow.** A token minted for more than its licence covers grants nothing extra.
+- **A token cannot mint its successor.** Only the durable key may exchange, or a minutes-long
+  credential would become perpetual by renewal.
+
+It is signed rather than stored, so minting writes no node and there is no expiry sweep to maintain
+— which is only safe *because* authority is re-checked on use. The signing key is configured
+(`PluginCatalog:TokenSigningKey`) and shared across a registry's replicas; unset means the endpoint
+reports itself unavailable rather than falling back to something weaker.
+
+The point of all of it: a consumer that needs one package can now hold a credential for one package,
+for fifteen minutes.

--- a/src/MeshWeaver.Mesh.Contract/Security/PluginGrant.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PluginGrant.cs
@@ -9,6 +9,14 @@ namespace MeshWeaver.Mesh.Security;
 /// simply be self-service access to every private source. Only a platform admin
 /// (<c>hub.IsGlobalAdmin()</c>) writes these.</para>
 ///
+/// <para>🚨 This IS the sync licence. Its entries carry the terms the right was issued under —
+/// <see cref="PluginGrantEntry.IssuedUnderLicense"/>, <see cref="PluginGrantEntry.ExpiresAt"/>,
+/// <see cref="PluginGrantEntry.IssuedVia"/> — so "may this instance replicate this package" and
+/// "under what licence, until when, on whose authority" are ONE record rather than an ACL beside a
+/// licence that could disagree with it. The subject is a <see cref="MeshWeaverInstance"/> and the
+/// right is SYNC; it is deliberately NOT the user-facing entitlement, which grants a person the use
+/// of a package on their own portal and says nothing about a deployment holding a copy.</para>
+///
 /// <para>An instance with no grant node, or an empty <see cref="Entries"/> list, gets <b>nothing</b>.
 /// Registering is identity, not entitlement. The one qualification: a registry operator may opt
 /// specific sources into every new registration via <c>PluginCatalog:DefaultGrants</c> (e.g. the
@@ -32,12 +40,38 @@ public record PluginGrant
     public DateTimeOffset UpdatedAt { get; init; }
 
     /// <summary>
+    /// Kill switch for the whole grant. A revoked grant authorizes nothing while its entries — and
+    /// the licence terms recorded on them — stay intact, so revoking never destroys the record of
+    /// what was licensed and why. Revoking a SINGLE package is done by letting that entry expire or
+    /// removing it; this is the instance-wide stop.
+    ///
+    /// <para>Distinct from <c>MeshWeaverInstance.IsDisabled</c>, which stops the instance
+    /// authenticating at all. An instance may legitimately remain live while its sync licence is
+    /// revoked.</para>
+    /// </summary>
+    public bool IsRevoked { get; init; }
+
+    /// <summary>
     /// Whether this grant permits <paramref name="packageId"/> from registry source
-    /// <paramref name="sourceName"/>. Both an exact package grant and a whole-source grant
-    /// (<see cref="PluginGrantEntry.AllPackages"/>) satisfy the check.
+    /// <paramref name="sourceName"/> at <paramref name="now"/>. Both an exact package grant and a
+    /// whole-source grant (<see cref="PluginGrantEntry.AllPackages"/>) satisfy the match, and the
+    /// matching entry must still be within its term.
+    ///
+    /// <para>🚨 <paramref name="now"/> is an ARGUMENT, never read from the ambient clock inside the
+    /// predicate. This is the authorization decision of the registry surface: it has to be
+    /// reproducible in a test at a chosen instant, and an expiry that can only be exercised by
+    /// waiting is an expiry nobody pins. The convenience overload supplies <c>UtcNow</c> for the
+    /// call sites that legitimately mean "right now".</para>
+    /// </summary>
+    public bool Allows(string sourceName, string packageId, DateTimeOffset now) =>
+        !IsRevoked && Entries.Any(e => e.Matches(sourceName, packageId) && e.IsValidAt(now));
+
+    /// <summary>
+    /// <see cref="Allows(string,string,DateTimeOffset)"/> evaluated at the current instant — what a
+    /// live request means. Prefer the explicit-instant overload in tests.
     /// </summary>
     public bool Allows(string sourceName, string packageId) =>
-        Entries.Any(e => e.Matches(sourceName, packageId));
+        Allows(sourceName, packageId, DateTimeOffset.UtcNow);
 }
 
 /// <summary>
@@ -60,8 +94,43 @@ public record PluginGrantEntry
     /// matched with ordinal case sensitivity, exactly as the catalog compares them.</summary>
     public string PackageId { get; init; } = AllPackages;
 
+    /// <summary>
+    /// End of this entry's term. Null = perpetual (revocation remains available). A licence that
+    /// ends is the normal commercial case, and it is recorded PER ENTRY because an instance
+    /// routinely holds several licences with different terms — a perpetual grant on the platform
+    /// repo alongside a one-year licence for a paid package.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>
+    /// SPDX id of the licence this sync right was issued under (<c>Apache-2.0</c>, or a commercial
+    /// id in the <c>License/</c> catalog). Null = unspecified, and it must STAY null rather than
+    /// defaulting: recording terms nobody granted is worse than recording none. Resolves to a
+    /// <c>LicenseContent</c> node, which is what lets the terms actually be shown.
+    /// </summary>
+    public string? IssuedUnderLicense { get; init; }
+
+    /// <summary>
+    /// How this entry came to exist, in the issuer's words — an order id, a coupon code, a support
+    /// ticket, <c>DefaultGrants</c> for the registration seed. Free text and advisory: it is the
+    /// audit trail for a right that is otherwise indistinguishable from any other.
+    /// </summary>
+    public string? IssuedVia { get; init; }
+
+    /// <summary>When the entry was issued. Default (<c>MinValue</c>) on entries written before
+    /// licence terms existed, which is why <see cref="IsValidAt"/> never reads it.</summary>
+    public DateTimeOffset IssuedAt { get; init; }
+
+    /// <summary>
+    /// Whether the entry is within its term at <paramref name="now"/>. An entry with no
+    /// <see cref="ExpiresAt"/> is always within term — which is what makes every grant written
+    /// before this field existed keep working unchanged.
+    /// </summary>
+    public bool IsValidAt(DateTimeOffset now) => ExpiresAt is null || now < ExpiresAt;
+
     /// <summary>Whether this entry authorizes <paramref name="packageId"/> from
-    /// <paramref name="sourceName"/>.</summary>
+    /// <paramref name="sourceName"/>. Match only — the term is checked by
+    /// <see cref="IsValidAt"/>, so a caller can tell "not licensed" from "licence expired".</summary>
     public bool Matches(string sourceName, string packageId) =>
         string.Equals(Source, sourceName, StringComparison.OrdinalIgnoreCase)
         && (PackageId == AllPackages || string.Equals(PackageId, packageId, StringComparison.Ordinal));

--- a/src/MeshWeaver.Mesh.Contract/Security/SyncAccessToken.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/SyncAccessToken.cs
@@ -184,20 +184,44 @@ public static class SyncAccessToken
             return candidate.StartsWith(KeyPrefix, StringComparison.Ordinal) ? candidate : null;
         }
 
-        const string basic = "Basic";
-        if (!trimmed.StartsWith(basic + " ", StringComparison.OrdinalIgnoreCase))
+        if (!trimmed.StartsWith(InstanceKeys.BasicScheme + " ", StringComparison.OrdinalIgnoreCase))
             return null;
-        try
-        {
-            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(trimmed[(basic.Length + 1)..].Trim()));
-            var colon = decoded.IndexOf(':');
-            var candidate = (colon < 0 ? decoded : decoded[(colon + 1)..]).Trim();
-            return candidate.StartsWith(KeyPrefix, StringComparison.Ordinal) ? candidate : null;
-        }
-        catch (FormatException)
-        {
+        return ExtractFromBasic(trimmed[(InstanceKeys.BasicScheme.Length + 1)..].Trim());
+    }
+
+    /// <summary>Largest Basic payload considered; see <see cref="ExtractFromBasic"/>.</summary>
+    private const int MaxBasicPayloadChars = 1024;
+
+    /// <summary>Decode buffer for <see cref="MaxBasicPayloadChars"/> (base64 is 4 chars per 3 bytes).</summary>
+    private const int MaxBasicPayloadBytes = MaxBasicPayloadChars / 4 * 3;
+
+    /// <summary>
+    /// The password half of a Basic credential, when it is an access token.
+    ///
+    /// <para>🚨 No exception on the reject path, and a bounded decode buffer — the same discipline as
+    /// <see cref="InstanceKeys.ExtractKey"/>, and for the same reason: this runs on an
+    /// UNAUTHENTICATED request with attacker-controlled input, so a throwing parse would let anyone
+    /// make the registry raise and unwind an exception per request. A real token is a username plus
+    /// a signed payload, so anything near the bound is already not one.</para>
+    /// </summary>
+    private static string? ExtractFromBasic(string encoded)
+    {
+        if (encoded.Length is 0 or > MaxBasicPayloadChars)
             return null;
-        }
+
+        Span<byte> buffer = stackalloc byte[MaxBasicPayloadBytes];
+        if (!Convert.TryFromBase64String(encoded, buffer, out var written))
+            return null;
+
+        // UTF8.GetString uses replacement fallback, so invalid bytes become U+FFFD rather than
+        // throwing — and a token containing U+FFFD simply fails the prefix check below.
+        var decoded = Encoding.UTF8.GetString(buffer[..written]);
+        var separator = decoded.IndexOf(':');
+        if (separator < 0)
+            return null;
+
+        var candidate = decoded[(separator + 1)..].Trim();
+        return candidate.StartsWith(KeyPrefix, StringComparison.Ordinal) ? candidate : null;
     }
 
     /// <summary>Whether a signing key is long enough to be used.</summary>

--- a/src/MeshWeaver.Mesh.Contract/Security/SyncAccessToken.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/SyncAccessToken.cs
@@ -1,0 +1,260 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// A short-lived, scope-bearing access token an instance exchanges its durable
+/// <c>mwi_</c> instance key for — the OAuth-shaped leg of the registry surface.
+///
+/// <para><b>Why not just send the instance key.</b> An <c>mwi_</c> key is durable: it has no expiry
+/// and re-issuing it is a manual admin action. A consumer that needs registry access therefore holds
+/// a long-lived secret and presents it on every call — which is exactly the property that made a
+/// per-repo GitHub PAT unacceptable. This token is minted for minutes, carries only the scope its
+/// holder actually needs, and is worthless once expired.</para>
+///
+/// <para>🚨 <b>The token carries identity and scope — never authority.</b> It says "this is instance
+/// X, asking only about these packages, until T". Whether X may actually pull them is re-decided on
+/// every request against the live <see cref="PluginGrant"/>, so revoking a sync licence takes effect
+/// immediately rather than after the token expires. A token can therefore only ever NARROW what the
+/// grant already allows — never widen it, and never outlive a revocation.</para>
+///
+/// <para><b>Stateless by design.</b> The token is signed, not stored: minting writes no node, so
+/// there is no per-issue write amplification (the defect class behind the personal-token mint storms)
+/// and no expiry sweep to maintain. That is only safe BECAUSE authority is re-checked on use.</para>
+///
+/// <para>Wire format is <c>mwa_&lt;payload&gt;.&lt;signature&gt;</c>, both URL-safe base64: the
+/// payload is the JSON below, the signature is HMAC-SHA256 over the payload segment. The prefix is
+/// disjoint from <c>mwi_</c> (instance), <c>mwr_</c> (registration) and the personal <c>mw_</c> for
+/// the same reason those are disjoint from each other — so no validator can ever accept another's
+/// credential by accident.</para>
+/// </summary>
+public static class SyncAccessToken
+{
+    /// <summary>Prefix on every minted access token.</summary>
+    public const string KeyPrefix = "mwa_";
+
+    /// <summary>The HTTP auth scheme the token travels under.</summary>
+    public const string Scheme = "Bearer";
+
+    /// <summary>Default lifetime when a caller does not ask for one.</summary>
+    public static readonly TimeSpan DefaultLifetime = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Longest lifetime that will be issued. A caller may request less; asking for more is clamped
+    /// rather than refused, so a consumer written against a future, more generous registry still
+    /// works instead of failing at the exchange.
+    /// </summary>
+    public static readonly TimeSpan MaximumLifetime = TimeSpan.FromHours(1);
+
+    /// <summary>Minimum length of an acceptable signing key, in bytes. A short key makes the
+    /// signature forgeable, so it is refused at mint time rather than quietly accepted.</summary>
+    public const int MinimumSigningKeyBytes = 32;
+
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Mints a token for <paramref name="instanceId"/> limited to <paramref name="scope"/>.
+    /// </summary>
+    /// <param name="instanceId">The registered instance the token speaks for.</param>
+    /// <param name="keyHash">SHA-256 hash of the instance key this token was exchanged FROM. It is
+    /// how the token resolves to its instance — the same routing the raw key uses — and it is what
+    /// makes re-issuing an instance key invalidate every outstanding token for free, since the
+    /// instance record then carries a different hash.</param>
+    /// <param name="scope">The <c>Source/Package</c> entries the holder may ask about. Empty means
+    /// "everything the grant allows" — the token narrows nothing, it only shortens the lifetime.</param>
+    /// <param name="issuedAt">Issue instant; the expiry is measured from here.</param>
+    /// <param name="lifetime">Requested lifetime, clamped to <see cref="MaximumLifetime"/>.</param>
+    /// <param name="signingKey">HMAC key, at least <see cref="MinimumSigningKeyBytes"/> bytes.</param>
+    /// <returns>The token string, including its prefix.</returns>
+    /// <exception cref="ArgumentException">The instance id is blank or the signing key is too short.</exception>
+    public static string Mint(
+        string instanceId,
+        string keyHash,
+        IReadOnlyCollection<string> scope,
+        DateTimeOffset issuedAt,
+        TimeSpan lifetime,
+        byte[] signingKey)
+    {
+        if (string.IsNullOrWhiteSpace(instanceId))
+            throw new ArgumentException("A token must name the instance it speaks for.", nameof(instanceId));
+        if (string.IsNullOrWhiteSpace(keyHash))
+            throw new ArgumentException("A token must carry the hash of the key it was exchanged from.",
+                nameof(keyHash));
+        RequireUsableKey(signingKey);
+
+        var effective = lifetime <= TimeSpan.Zero ? DefaultLifetime
+            : lifetime > MaximumLifetime ? MaximumLifetime
+            : lifetime;
+
+        var payload = new Payload
+        {
+            InstanceId = instanceId,
+            KeyHash = keyHash,
+            Scope = scope is { Count: > 0 } ? [.. scope] : null,
+            ExpiresAt = issuedAt.Add(effective).ToUnixTimeSeconds(),
+            // Distinguishes two tokens minted in the same second for the same scope. Not a security
+            // property on its own — the signature is — but it keeps tokens from being identical
+            // strings, which makes them individually recognisable in a log.
+            Nonce = Convert.ToHexString(RandomNumberGenerator.GetBytes(8)).ToLowerInvariant(),
+        };
+
+        var segment = Encode(JsonSerializer.SerializeToUtf8Bytes(payload, Json));
+        return $"{KeyPrefix}{segment}.{Sign(segment, signingKey)}";
+    }
+
+    /// <summary>
+    /// Verifies a token's signature and expiry and returns what it claims. Returns <c>null</c> for
+    /// anything that is not a valid, unexpired token — a malformed string, a bad signature, an
+    /// expired instant. There is deliberately no distinction in the result between those cases:
+    /// telling a caller WHICH way their forgery failed helps only the forger.
+    /// </summary>
+    /// <param name="token">The raw token, with or without its prefix already stripped.</param>
+    /// <param name="now">The instant to judge expiry against.</param>
+    /// <param name="signingKey">The HMAC key the token must verify under.</param>
+    /// <returns>The verified claims, or null.</returns>
+    public static SyncAccessTokenClaims? Verify(string? token, DateTimeOffset now, byte[] signingKey)
+    {
+        if (string.IsNullOrWhiteSpace(token) || signingKey is not { Length: >= MinimumSigningKeyBytes })
+            return null;
+
+        var raw = token.StartsWith(KeyPrefix, StringComparison.Ordinal)
+            ? token[KeyPrefix.Length..]
+            : token;
+
+        var dot = raw.IndexOf('.');
+        if (dot <= 0 || dot == raw.Length - 1)
+            return null;
+
+        var segment = raw[..dot];
+        var signature = raw[(dot + 1)..];
+
+        // Fixed-time comparison: a byte-by-byte early exit leaks how much of a forged signature was
+        // correct, which is enough to construct one a byte at a time.
+        var expected = Sign(segment, signingKey);
+        if (!CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(expected), Encoding.UTF8.GetBytes(signature)))
+            return null;
+
+        Payload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<Payload>(Decode(segment), Json);
+        }
+        catch (Exception ex) when (ex is JsonException or FormatException)
+        {
+            return null;
+        }
+
+        if (payload is null
+            || string.IsNullOrWhiteSpace(payload.InstanceId)
+            || string.IsNullOrWhiteSpace(payload.KeyHash))
+            return null;
+        if (now.ToUnixTimeSeconds() >= payload.ExpiresAt)
+            return null;
+
+        return new SyncAccessTokenClaims(
+            payload.InstanceId,
+            payload.KeyHash,
+            payload.Scope ?? [],
+            DateTimeOffset.FromUnixTimeSeconds(payload.ExpiresAt));
+    }
+
+    /// <summary>
+    /// Extracts a token from an <c>Authorization</c> header, or null when the header carries
+    /// something else. Mirrors <see cref="InstanceKeys.ExtractKey"/>, including the <c>Basic</c>
+    /// form, so a client that can only speak Basic can present either credential.
+    /// </summary>
+    /// <param name="authorizationHeader">The raw header value.</param>
+    /// <returns>The token, or null.</returns>
+    public static string? ExtractToken(string? authorizationHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+            return null;
+        var trimmed = authorizationHeader.Trim();
+
+        if (trimmed.StartsWith(Scheme + " ", StringComparison.OrdinalIgnoreCase))
+        {
+            var candidate = trimmed[(Scheme.Length + 1)..].Trim();
+            return candidate.StartsWith(KeyPrefix, StringComparison.Ordinal) ? candidate : null;
+        }
+
+        const string basic = "Basic";
+        if (!trimmed.StartsWith(basic + " ", StringComparison.OrdinalIgnoreCase))
+            return null;
+        try
+        {
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(trimmed[(basic.Length + 1)..].Trim()));
+            var colon = decoded.IndexOf(':');
+            var candidate = (colon < 0 ? decoded : decoded[(colon + 1)..]).Trim();
+            return candidate.StartsWith(KeyPrefix, StringComparison.Ordinal) ? candidate : null;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Whether a signing key is long enough to be used.</summary>
+    /// <param name="signingKey">Candidate key.</param>
+    /// <returns>True when usable.</returns>
+    public static bool IsUsableSigningKey(byte[]? signingKey) =>
+        signingKey is { Length: >= MinimumSigningKeyBytes };
+
+    private static void RequireUsableKey(byte[] signingKey)
+    {
+        if (!IsUsableSigningKey(signingKey))
+            throw new ArgumentException(
+                $"The token signing key must be at least {MinimumSigningKeyBytes} bytes.",
+                nameof(signingKey));
+    }
+
+    private static string Sign(string segment, byte[] signingKey) =>
+        Encode(HMACSHA256.HashData(signingKey, Encoding.UTF8.GetBytes(segment)));
+
+    private static string Encode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).Replace("+", "-").Replace("/", "_").TrimEnd('=');
+
+    private static byte[] Decode(string segment)
+    {
+        var padded = segment.Replace("-", "+").Replace("_", "/");
+        return Convert.FromBase64String(padded.PadRight((padded.Length + 3) / 4 * 4, '='));
+    }
+
+    private sealed record Payload
+    {
+        [JsonPropertyName("i")] public string InstanceId { get; init; } = "";
+        [JsonPropertyName("h")] public string KeyHash { get; init; } = "";
+        [JsonPropertyName("s")] public string[]? Scope { get; init; }
+        [JsonPropertyName("e")] public long ExpiresAt { get; init; }
+        [JsonPropertyName("n")] public string Nonce { get; init; } = "";
+    }
+}
+
+/// <summary>What a verified <see cref="SyncAccessToken"/> claims.</summary>
+/// <param name="InstanceId">The instance the token speaks for.</param>
+/// <param name="KeyHash">Hash of the instance key it was exchanged from — how it resolves.</param>
+/// <param name="Scope">The <c>Source/Package</c> entries it is limited to. Empty = not narrowed.</param>
+/// <param name="ExpiresAt">When it stops verifying.</param>
+public sealed record SyncAccessTokenClaims(
+    string InstanceId, string KeyHash, IReadOnlyCollection<string> Scope, DateTimeOffset ExpiresAt)
+{
+    /// <summary>
+    /// Whether this token permits ASKING about <paramref name="packageId"/> from
+    /// <paramref name="sourceName"/>. An unnarrowed token permits everything — the grant still
+    /// decides. Matching reuses <see cref="PluginGrantEntry"/>, so a scope string means exactly what
+    /// the same string means in a grant, wildcards included.
+    /// </summary>
+    /// <param name="sourceName">Registry source name.</param>
+    /// <param name="packageId">Package id.</param>
+    /// <returns>True when in scope.</returns>
+    public bool Covers(string sourceName, string packageId) =>
+        Scope.Count == 0
+        || Scope.Select(PluginGrantEntry.TryParse)
+               .Any(e => e is not null && e.Matches(sourceName, packageId));
+}

--- a/src/MeshWeaver.Mesh.Contract/Security/SyncTokenSigningKey.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/SyncTokenSigningKey.cs
@@ -1,0 +1,99 @@
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// The registry's HMAC key for signing short-lived <see cref="SyncAccessToken"/>s, held as a mesh
+/// node so it is minted once and shared by every replica.
+///
+/// <para><b>Why a node and not configuration.</b> A signing key has to be IDENTICAL across every
+/// replica of one registry — a token minted on pod A must verify on pod B — and it should never pass
+/// through a human's hands. Configuration achieves the first only if an operator gets it right in
+/// every environment, and fails the second by construction. A node is minted by the mesh on first
+/// need, is automatically the same for every replica reading it, and no one ever sees it. Same
+/// reasoning, same partition and the same <c>enc:</c> envelope as
+/// <c>PluginRegistryCredential</c>.</para>
+///
+/// <para>🚨 <b>Uniqueness is the NODE's, not a lock's.</b> Two replicas racing to mint both issue a
+/// create against the same path, and the mesh's create-only semantics let exactly one win while
+/// reporting the path as existing to the loser, which then adopts the winner's key. The node write is
+/// the idempotency token — the same discipline <see cref="Reminder"/> uses to fire exactly once
+/// across replicas. There is no hand-rolled gate, and there must never be one: a lock cannot span
+/// pods, and a "read, then create if absent" without adopting the loser's answer is precisely the
+/// race that leaves two replicas signing with different keys.</para>
+///
+/// <para><b>Rotation keeps the outgoing key.</b> Tokens already in flight were signed by the key
+/// being replaced, so a rotation that simply overwrote it would invalidate every one of them
+/// mid-run. <see cref="ProtectedPrevious"/> stays verifiable until
+/// <see cref="PreviousValidUntil"/> — one token lifetime is enough, since nothing older can still
+/// be unexpired.</para>
+/// </summary>
+public record SyncTokenSigningKey
+{
+    /// <summary>The key tokens are SIGNED with, base64, <c>enc:</c>-protected at rest when a master
+    /// key is configured (plaintext passthrough otherwise — the same policy as provider keys).</summary>
+    public string ProtectedCurrent { get; init; } = "";
+
+    /// <summary>When <see cref="ProtectedCurrent"/> was minted.</summary>
+    public DateTimeOffset CurrentIssuedAt { get; init; }
+
+    /// <summary>The key replaced by the last rotation. Still ACCEPTED for verification until
+    /// <see cref="PreviousValidUntil"/>, never used for signing. Null before the first rotation.</summary>
+    public string? ProtectedPrevious { get; init; }
+
+    /// <summary>When the previous key stops being accepted. Past this instant it is dead weight and
+    /// the next write drops it.</summary>
+    public DateTimeOffset? PreviousValidUntil { get; init; }
+
+    /// <summary>
+    /// When the next rotation is DUE. Data rather than a hard-coded interval, so the schedule is
+    /// visible and adjustable without a deploy — and so whatever drives rotation (an admin action
+    /// today, a durable <see cref="Reminder"/> once the reminder runner exists) reads the due date
+    /// from the same place instead of keeping its own copy.
+    /// </summary>
+    public DateTimeOffset? RotateAfter { get; init; }
+
+    /// <summary>Whether rotation is due at <paramref name="now"/>.</summary>
+    /// <param name="now">The instant to judge against.</param>
+    /// <returns>True when <see cref="RotateAfter"/> is set and has passed.</returns>
+    public bool RotationDue(DateTimeOffset now) => RotateAfter is { } due && now >= due;
+
+    /// <summary>Whether the previous key should still be accepted at <paramref name="now"/>.</summary>
+    /// <param name="now">The instant to judge against.</param>
+    /// <returns>True while the grace window is open.</returns>
+    public bool PreviousStillValid(DateTimeOffset now) =>
+        !string.IsNullOrWhiteSpace(ProtectedPrevious)
+        && PreviousValidUntil is { } until && now < until;
+}
+
+/// <summary>Where the signing key lives, and the constants governing its lifecycle.</summary>
+public static class SyncTokenSigningKeys
+{
+    /// <summary>The node type.</summary>
+    public const string NodeType = "SyncTokenSigningKey";
+
+    /// <summary>Namespace under the Admin partition — System and platform admins only.</summary>
+    public const string Namespace = "Admin/SyncTokenSigningKey";
+
+    /// <summary>
+    /// Node id. There is exactly ONE signing key per registry, and it is a FIXED path on purpose:
+    /// uniqueness is enforced by two replicas colliding on the same path, which cannot happen if the
+    /// id varies by host, pod or time.
+    /// </summary>
+    public const string Id = "current";
+
+    /// <summary>The single node path.</summary>
+    public const string Path = $"{Namespace}/{Id}";
+
+    /// <summary>Entropy per key, in bytes — comfortably above
+    /// <see cref="SyncAccessToken.MinimumSigningKeyBytes"/>.</summary>
+    public const int KeyByteLength = 48;
+
+    /// <summary>How long a key signs before rotation is due.</summary>
+    public static readonly TimeSpan RotationInterval = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// How long the outgoing key stays verifiable after a rotation. One maximum token lifetime,
+    /// because no token signed before the rotation can still be unexpired after that — a longer
+    /// window would keep a retired key alive for no reader.
+    /// </summary>
+    public static readonly TimeSpan RotationGrace = SyncAccessToken.MaximumLifetime;
+}

--- a/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
@@ -46,7 +46,7 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
     {
         var rawKey = InstanceKeys.ExtractKey(authorizationHeader);
         if (rawKey is null)
-            return Observable.Return<AuthenticatedInstance?>(null);
+            return AuthenticateToken(authorizationHeader);
 
         var hash = InstanceKeys.Hash(rawKey);
         if (cache.TryGetValue(hash, out var hit) && DateTimeOffset.UtcNow - hit.At < CacheDuration)
@@ -62,6 +62,71 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
                     InstanceKeys.HashPrefix(hash));
                 return Observable.Return<AuthenticatedInstance?>(null);
             });
+    }
+
+    /// <summary>
+    /// The short-lived-token half of <see cref="Authenticate"/>. A verified token resolves through
+    /// exactly the same index as the key it was exchanged from — it carries that key's hash — so
+    /// there is one resolution path, and re-issuing an instance key invalidates every outstanding
+    /// token because the instance record then holds a different hash.
+    ///
+    /// <para>🚨 The token contributes IDENTITY and SCOPE, never authority. The live
+    /// <see cref="PluginGrant"/> is still read and still decides, so a revoked or expired sync
+    /// licence takes effect immediately instead of surviving until the token runs out.</para>
+    /// </summary>
+    private IObservable<AuthenticatedInstance?> AuthenticateToken(string? authorizationHeader)
+    {
+        var rawToken = SyncAccessToken.ExtractToken(authorizationHeader);
+        if (rawToken is null)
+            return Observable.Return<AuthenticatedInstance?>(null);
+
+        var signingKey = SigningKey();
+        if (signingKey is null)
+        {
+            // Configured-off is not "allow": a registry that cannot verify a signature must refuse
+            // the token, never accept it unverified.
+            logger.LogWarning(
+                "A sync access token was presented but {Section}:{Key} is not configured — refusing.",
+                PluginCatalogOptions.SectionName, nameof(PluginCatalogOptions.TokenSigningKey));
+            return Observable.Return<AuthenticatedInstance?>(null);
+        }
+
+        var claims = SyncAccessToken.Verify(rawToken, DateTimeOffset.UtcNow, signingKey);
+        if (claims is null)
+            return Observable.Return<AuthenticatedInstance?>(null);
+
+        return Resolve(claims.KeyHash)
+            .Select(resolved =>
+            {
+                if (resolved is null)
+                    return null;
+                // The token names an instance AND routes to one. They must be the same instance, or
+                // the token is being replayed against a record it does not describe.
+                if (!string.Equals(resolved.Instance.InstanceId, claims.InstanceId, StringComparison.Ordinal))
+                {
+                    logger.LogWarning(
+                        "Sync access token claims instance {Claimed} but its key resolves to {Actual} — refusing.",
+                        claims.InstanceId, resolved.Instance.InstanceId);
+                    return null;
+                }
+                return resolved with { TokenScope = claims };
+            })
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex, "Sync access token resolution failed for instance {InstanceId}",
+                    claims.InstanceId);
+                return Observable.Return<AuthenticatedInstance?>(null);
+            });
+    }
+
+    /// <summary>The configured HMAC key, or null when it is absent or too short to be usable.</summary>
+    private byte[]? SigningKey()
+    {
+        var configured = hub.ServiceProvider.GetService<PluginCatalogOptions>()?.TokenSigningKey;
+        if (string.IsNullOrWhiteSpace(configured))
+            return null;
+        var bytes = System.Text.Encoding.UTF8.GetBytes(configured);
+        return SyncAccessToken.IsUsableSigningKey(bytes) ? bytes : null;
     }
 
     private IObservable<AuthenticatedInstance?> Resolve(string hash)
@@ -127,7 +192,22 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
 /// grant, which authorizes nothing.</param>
 public sealed record AuthenticatedInstance(MeshWeaverInstance Instance, PluginGrant Grant)
 {
+    /// <summary>
+    /// Present when the caller authenticated with a short-lived token rather than its durable key.
+    /// A token can only NARROW what the grant already allows — never widen it — so this is an
+    /// additional filter, never an alternative source of authority.
+    /// </summary>
+    public SyncAccessTokenClaims? TokenScope { get; init; }
+
     /// <summary>Whether this caller may pull <paramref name="packageId"/> from registry source
-    /// <paramref name="sourceName"/>.</summary>
-    public bool Allows(string sourceName, string packageId) => Grant.Allows(sourceName, packageId);
+    /// <paramref name="sourceName"/> at <paramref name="now"/> — granted, still within the
+    /// licence's term, and within the presented token's scope if one was used.</summary>
+    public bool Allows(string sourceName, string packageId, DateTimeOffset now) =>
+        Grant.Allows(sourceName, packageId, now)
+        && (TokenScope is null || TokenScope.Covers(sourceName, packageId));
+
+    /// <summary>Whether this caller may pull <paramref name="packageId"/> from registry source
+    /// <paramref name="sourceName"/> right now — what a live request means.</summary>
+    public bool Allows(string sourceName, string packageId) =>
+        Allows(sourceName, packageId, DateTimeOffset.UtcNow);
 }

--- a/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
@@ -131,17 +131,24 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
 
     private IObservable<AuthenticatedInstance?> Resolve(string hash)
     {
-        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
         var indexPath = $"{MeshWeaverInstanceNodeType.IndexNamespace}/{InstanceKeys.HashPrefix(hash)}";
 
-        return ReadAsSystem(accessService, indexPath)
+        // 🚨 ONE sealed System scope around the WHOLE resolution, not one Observable.Using per read
+        // (#1790). Rx runs a Using factory on the SUBSCRIBING thread and disposes on termination, so
+        // the old per-read form left the caller latched as System — and the callers here are HTTP
+        // requests on the registry surface (/api/plugins, and now /api/instances/token), which would
+        // then continue with Permission.All. RunAsSystem enters at Subscribe, leaves on the way out
+        // of that same Subscribe, and delivers every notification under the subscriber's own
+        // identity, so the three reads below are System and nothing downstream inherits it.
+        return accessService.RunAsSystem(() => Read(indexPath)
             .SelectMany(indexNode =>
             {
                 var index = Content<MeshWeaverInstanceIndex>(indexNode);
                 if (index is null || !InstanceKeys.HashEquals(hash, index.KeyHash))
                     return Observable.Return<AuthenticatedInstance?>(null);
 
-                return ReadAsSystem(accessService, index.InstancePath)
+                return Read(index.InstancePath)
                     .SelectMany(instanceNode =>
                     {
                         var instance = Content<MeshWeaverInstance>(instanceNode);
@@ -156,21 +163,20 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
                             return Observable.Return<AuthenticatedInstance?>(null);
                         }
 
-                        return ReadAsSystem(accessService,
-                                MeshWeaverInstanceNodeType.GrantPath(instance.InstanceId))
+                        return Read(MeshWeaverInstanceNodeType.GrantPath(instance.InstanceId))
                             // No grant node at all is the NORMAL state for a freshly registered
                             // instance — it authenticates, and is entitled to nothing.
                             .Select(grantNode => (AuthenticatedInstance?)new AuthenticatedInstance(
                                 instance,
                                 Content<PluginGrant>(grantNode) ?? new PluginGrant { InstanceId = instance.InstanceId }));
                     });
-            });
+            }));
     }
 
-    private IObservable<MeshNode?> ReadAsSystem(AccessService accessService, string path) =>
-        Observable.Using(
-            () => accessService.ImpersonateAsSystem(),
-            _ => hub.GetMeshNode(path, ReadTimeout));
+    /// <summary>One-shot read by exact path. The System identity comes from the single
+    /// <see cref="ImpersonationScopeExtensions.RunAsSystem{T}"/> scope in <see cref="Resolve"/>, so
+    /// this composes inside it rather than opening a scope of its own.</summary>
+    private IObservable<MeshNode?> Read(string path) => hub.GetMeshNode(path, ReadTimeout);
 
     private T? Content<T>(MeshNode? node) where T : class
     {

--- a/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
@@ -80,53 +80,53 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
         if (rawToken is null)
             return Observable.Return<AuthenticatedInstance?>(null);
 
-        var signingKey = SigningKey();
-        if (signingKey is null)
+        var keys = hub.ServiceProvider.GetService<SyncTokenSigningKeyService>();
+        if (keys is null)
         {
-            // Configured-off is not "allow": a registry that cannot verify a signature must refuse
+            // No key service is not "allow": a registry that cannot verify a signature must refuse
             // the token, never accept it unverified.
             logger.LogWarning(
-                "A sync access token was presented but {Section}:{Key} is not configured — refusing.",
-                PluginCatalogOptions.SectionName, nameof(PluginCatalogOptions.TokenSigningKey));
+                "A sync access token was presented but no {Service} is registered — refusing.",
+                nameof(SyncTokenSigningKeyService));
             return Observable.Return<AuthenticatedInstance?>(null);
         }
 
-        var claims = SyncAccessToken.Verify(rawToken, DateTimeOffset.UtcNow, signingKey);
-        if (claims is null)
-            return Observable.Return<AuthenticatedInstance?>(null);
-
-        return Resolve(claims.KeyHash)
-            .Select(resolved =>
+        // Existing(), never Resolve(): this caller has not authenticated yet, so minting on their
+        // behalf would let an anonymous request write a node — and would be pointless anyway, since a
+        // token cannot verify against a key minted after it was signed.
+        return keys.Existing()
+            .SelectMany(material =>
             {
-                if (resolved is null)
-                    return null;
-                // The token names an instance AND routes to one. They must be the same instance, or
-                // the token is being replayed against a record it does not describe.
-                if (!string.Equals(resolved.Instance.InstanceId, claims.InstanceId, StringComparison.Ordinal))
-                {
-                    logger.LogWarning(
-                        "Sync access token claims instance {Claimed} but its key resolves to {Actual} — refusing.",
-                        claims.InstanceId, resolved.Instance.InstanceId);
-                    return null;
-                }
-                return resolved with { TokenScope = claims };
+                // Verification tries the current key and then the one the last rotation retired, so a
+                // token minted moments before a rotation still works.
+                var claims = material?.Verify(rawToken, DateTimeOffset.UtcNow);
+                if (claims is null)
+                    return Observable.Return<AuthenticatedInstance?>(null);
+
+                return Resolve(claims.KeyHash)
+                    .Select(resolved =>
+                    {
+                        if (resolved is null)
+                            return null;
+                        // The token names an instance AND routes to one. They must be the same
+                        // instance, or it is being replayed against a record it does not describe.
+                        if (!string.Equals(
+                                resolved.Instance.InstanceId, claims.InstanceId, StringComparison.Ordinal))
+                        {
+                            logger.LogWarning(
+                                "Sync access token claims instance {Claimed} but its key resolves to "
+                                + "{Actual} — refusing.",
+                                claims.InstanceId, resolved.Instance.InstanceId);
+                            return null;
+                        }
+                        return resolved with { TokenScope = claims };
+                    });
             })
             .Catch((Exception ex) =>
             {
-                logger.LogWarning(ex, "Sync access token resolution failed for instance {InstanceId}",
-                    claims.InstanceId);
+                logger.LogWarning(ex, "Sync access token resolution failed");
                 return Observable.Return<AuthenticatedInstance?>(null);
             });
-    }
-
-    /// <summary>The configured HMAC key, or null when it is absent or too short to be usable.</summary>
-    private byte[]? SigningKey()
-    {
-        var configured = hub.ServiceProvider.GetService<PluginCatalogOptions>()?.TokenSigningKey;
-        if (string.IsNullOrWhiteSpace(configured))
-            return null;
-        var bytes = System.Text.Encoding.UTF8.GetBytes(configured);
-        return SyncAccessToken.IsUsableSigningKey(bytes) ? bytes : null;
     }
 
     private IObservable<AuthenticatedInstance?> Resolve(string hash)

--- a/src/MeshWeaver.PluginCatalog/LicenseAcceptanceGate.cs
+++ b/src/MeshWeaver.PluginCatalog/LicenseAcceptanceGate.cs
@@ -1,0 +1,251 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Enforces <see cref="LicenseContent.RequiresAcceptance"/> on the install path, and records the
+/// <see cref="LicenseAcceptance"/> that satisfies it.
+///
+/// <para><b>Why this exists.</b> <c>LicenseContent</c> and <c>LicenseAcceptance</c> shipped as node
+/// types with a catalog, a body, a <c>RequiresAcceptance</c> flag and a body hash — and no callers
+/// whatsoever: nothing read the flag and nothing ever wrote an acceptance. A consent surface with no
+/// enforcement records nothing and proves nothing.</para>
+///
+/// <para>It sits BESIDE <see cref="PackageEntitlement"/>, on the action, for the same reason: every
+/// install path funnels through <see cref="PackageInstaller"/>, so the machine paths (unattended
+/// default install, the update watcher) are gated identically to a click. The two answer different
+/// questions and neither substitutes for the other — entitlement is <i>may you</i>, acceptance is
+/// <i>have you agreed to the terms</i>.</para>
+///
+/// <para>🚨 <b>The body hash is the point.</b> An acceptance is only meaningful against the text
+/// that was actually shown, so a recorded acceptance whose hash no longer matches the licence body
+/// does NOT satisfy the gate — revised terms need fresh consent. Storing the hash without checking
+/// it would be a consent record that quietly covers terms the user never read.</para>
+/// </summary>
+public static class LicenseAcceptanceGate
+{
+    private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// SHA-256 hex of a licence body, over its NORMALIZED text — line endings unified and trailing
+    /// whitespace trimmed. Normalizing matters because a body that round-trips through git or an
+    /// editor can change bytes without changing terms, and a hash that flips on a CRLF would revoke
+    /// every recorded acceptance for no reason a reader could see.
+    /// </summary>
+    /// <param name="body">The licence text.</param>
+    /// <returns>Lowercase hex digest.</returns>
+    public static string BodyHash(string? body) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(Normalize(body)))).ToLowerInvariant();
+
+    private static string Normalize(string? body) =>
+        (body ?? "").Replace("\r\n", "\n").Replace('\r', '\n').TrimEnd();
+
+    /// <summary>
+    /// Gates the install of <paramref name="manifest"/> on a recorded, current acceptance. Emits
+    /// once and completes when the install may proceed; faults with a
+    /// <see cref="LicenseAcceptanceRequiredException"/> when consent is missing or stale.
+    /// </summary>
+    /// <param name="hub">The installing hub.</param>
+    /// <param name="manifest">The package being installed.</param>
+    /// <param name="acceptingUserId">The principal whose acceptance counts — the same principal that
+    /// authorized the action. Null (boot-time provisioning) can only satisfy a licence that asks for
+    /// nothing.</param>
+    /// <param name="logger">Diagnostics; a refusal logs a warning.</param>
+    /// <returns>A cold observable that emits on allow and faults on refusal.</returns>
+    public static IObservable<Unit> Require(
+        IMessageHub hub, PackageManifest manifest, string? acceptingUserId, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        var spdxId = manifest.License;
+        // Unspecified terms: nothing to accept, and inventing a licence to demand consent to would
+        // assert a grant nobody made (the rule Package.License already follows).
+        if (string.IsNullOrWhiteSpace(spdxId))
+            return Observable.Return(Unit.Default);
+
+        return ReadLicense(hub, spdxId!, logger)
+            .SelectMany(license =>
+            {
+                // No terms document in the catalog — including every SPDX EXPRESSION
+                // ("Apache-2.0 OR MIT"), which names a choice rather than one node. We cannot show
+                // terms we do not hold, so demanding consent to them is impossible rather than
+                // strict. Logged, so an unresolved id is visible instead of silent.
+                //
+                // 🚨 This is NOT an access decision and must never become one: what a caller MAY
+                // install is decided by PackageEntitlement and, for an instance, by its sync
+                // licence. A licence that genuinely requires acceptance is one we authored and
+                // shipped INTO the catalog, so it resolves here.
+                if (license is null)
+                {
+                    logger?.LogInformation(
+                        "Package {Package} declares licence {Spdx}, which is not in the catalog — "
+                        + "no acceptance is demanded for terms the platform cannot display.",
+                        manifest.Id, spdxId);
+                    return Observable.Return(Unit.Default);
+                }
+
+                if (!license.RequiresAcceptance)
+                    return Observable.Return(Unit.Default);
+
+                if (string.IsNullOrWhiteSpace(acceptingUserId))
+                    return Refuse(manifest, spdxId!, null,
+                        "no principal is present to accept them", logger);
+
+                var expected = BodyHash(license.Body);
+                return ReadAcceptance(hub, acceptingUserId!, manifest.Id, logger)
+                    .SelectMany(acceptance =>
+                    {
+                        if (acceptance is null)
+                            return Refuse(manifest, spdxId!, acceptingUserId,
+                                "no acceptance has been recorded", logger);
+
+                        // Terms revised since consent was given — the whole reason the record
+                        // carries a body hash.
+                        if (!string.Equals(acceptance.BodyHash, expected, StringComparison.OrdinalIgnoreCase))
+                            return Refuse(manifest, spdxId!, acceptingUserId,
+                                "the recorded acceptance is against an earlier version of the terms",
+                                logger);
+
+                        return Observable.Return(Unit.Default);
+                    });
+            });
+    }
+
+    /// <summary>
+    /// Records <paramref name="acceptingUserId"/>'s acceptance of <paramref name="manifest"/>'s
+    /// licence, stamped with the hash of the text as it stands NOW — which is the text the caller
+    /// is responsible for having shown.
+    ///
+    /// <para>The record is written into the accepting user's OWN partition
+    /// (<c>{userId}/_LicenseAcceptance/{packageId}</c>): it is evidence the user holds, not a claim
+    /// the platform makes about them.</para>
+    /// </summary>
+    /// <param name="hub">The hub performing the write.</param>
+    /// <param name="manifest">The package the licence was accepted for.</param>
+    /// <param name="acceptingUserId">Who accepted.</param>
+    /// <param name="logger">Diagnostics.</param>
+    /// <returns>The stored acceptance, or an empty sequence when the licence asks for none.</returns>
+    public static IObservable<LicenseAcceptance> Record(
+        IMessageHub hub, PackageManifest manifest, string acceptingUserId, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        ArgumentNullException.ThrowIfNull(manifest);
+        if (string.IsNullOrWhiteSpace(acceptingUserId))
+            throw new ArgumentException("An acceptance must name who gave it.", nameof(acceptingUserId));
+        if (string.IsNullOrWhiteSpace(manifest.License))
+            return Observable.Empty<LicenseAcceptance>();
+
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+
+        return ReadLicense(hub, manifest.License!, logger)
+            .SelectMany(license =>
+            {
+                if (license is null)
+                    return Observable.Empty<LicenseAcceptance>();
+
+                var acceptance = new LicenseAcceptance
+                {
+                    SpdxId = license.SpdxId,
+                    PackageId = manifest.Id,
+                    UserId = acceptingUserId,
+                    AcceptedAt = DateTimeOffset.UtcNow,
+                    BodyHash = BodyHash(license.Body),
+                };
+
+                var node = new MeshNode(manifest.Id,
+                    $"{acceptingUserId}/{LicenseNodeType.AcceptanceNamespace}")
+                {
+                    Name = $"Licence accepted: {license.SpdxId} for {manifest.Id}",
+                    NodeType = LicenseNodeType.AcceptanceNodeType,
+                    State = MeshNodeState.Active,
+                    Content = acceptance,
+                };
+
+                return Observable.Using(
+                        () => accessService.ImpersonateAsSystem(),
+                        _ => meshService.CreateOrUpdateNode(node))
+                    .Select(_ =>
+                    {
+                        logger?.LogInformation(
+                            "Licence {Spdx} accepted for {Package} by {User}",
+                            license.SpdxId, manifest.Id, acceptingUserId);
+                        return acceptance;
+                    });
+            });
+    }
+
+    private static IObservable<LicenseContent?> ReadLicense(
+        IMessageHub hub, string spdxId, ILogger? logger) =>
+        ReadAsSystem<LicenseContent>(hub, WellKnownLicenses.PathFor(spdxId), logger);
+
+    private static IObservable<LicenseAcceptance?> ReadAcceptance(
+        IMessageHub hub, string userId, string packageId, ILogger? logger) =>
+        ReadAsSystem<LicenseAcceptance>(hub, LicenseNodeType.AcceptancePath(userId, packageId), logger);
+
+    /// <summary>
+    /// One-shot read by exact path under System. A read FAILURE faults the sequence rather than
+    /// resolving to null: "the mesh was briefly unreachable" must never read as "no acceptance is
+    /// required", which is the difference between failing closed and failing open.
+    /// </summary>
+    private static IObservable<T?> ReadAsSystem<T>(IMessageHub hub, string path, ILogger? logger)
+        where T : class
+    {
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        return Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => hub.GetMeshNode(path, ReadTimeout))
+            .Take(1)
+            .Select(node => node?.ContentAs<T>(hub.JsonSerializerOptions));
+    }
+
+    private static IObservable<Unit> Refuse(
+        PackageManifest manifest, string spdxId, string? userId, string reason, ILogger? logger) =>
+        Observable.Defer(() =>
+        {
+            var message =
+                $"Installing '{manifest.Id}' requires accepting its licence ({spdxId}): {reason}"
+                + (userId is null ? "." : $" for '{userId}'.");
+            logger?.LogWarning("Licence acceptance refused: {Message}", message);
+            return Observable.Throw<Unit>(new LicenseAcceptanceRequiredException(message));
+        });
+}
+
+/// <summary>
+/// Raised when a package's licence demands a recorded acceptance that is missing, or that was given
+/// against an earlier version of the terms. Distinct from
+/// <see cref="PackageAuthorizationException"/>: the caller is not unauthorized, they have simply not
+/// agreed — and the remedy is to show the terms and record consent, not to acquire a permission.
+/// </summary>
+public sealed class LicenseAcceptanceRequiredException : InvalidOperationException
+{
+    /// <summary>Initializes a new instance of the <see cref="LicenseAcceptanceRequiredException"/> class.</summary>
+    public LicenseAcceptanceRequiredException()
+    {
+    }
+
+    /// <summary>Initializes a new instance with the refusal <paramref name="message"/>.</summary>
+    /// <param name="message">The speaking refusal reason.</param>
+    public LicenseAcceptanceRequiredException(string message) : base(message)
+    {
+    }
+
+    /// <summary>Initializes a new instance with a message and an inner exception.</summary>
+    /// <param name="message">The speaking refusal reason.</param>
+    /// <param name="innerException">The underlying cause.</param>
+    public LicenseAcceptanceRequiredException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/LicenseAcceptanceGate.cs
+++ b/src/MeshWeaver.PluginCatalog/LicenseAcceptanceGate.cs
@@ -74,7 +74,14 @@ public static class LicenseAcceptanceGate
         if (string.IsNullOrWhiteSpace(spdxId))
             return Observable.Return(Unit.Default);
 
-        return ReadLicense(hub, spdxId!, logger)
+        // 🚨 RunAsSystem, never Observable.Using(access.ImpersonateAsSystem, …) (#1790). Rx runs a
+        // Using factory on the SUBSCRIBING thread and disposes on termination, leaving that thread
+        // latched as System — and this gate's subscriber is the INSTALLER, which would then run its
+        // whole pipeline with Permission.All. The widest cold pipeline goes inside the factory, so
+        // the catalog + acceptance reads are System (they must be: an acceptance lives in another
+        // user's partition) while every notification reaches the installer as itself.
+        var access = hub.ServiceProvider.GetService<AccessService>();
+        return access.RunAsSystem(() => ReadLicense(hub, spdxId!, logger)
             .SelectMany(license =>
             {
                 // No terms document in the catalog — including every SPDX EXPRESSION
@@ -119,7 +126,7 @@ public static class LicenseAcceptanceGate
 
                         return Observable.Return(Unit.Default);
                     });
-            });
+            }));
     }
 
     /// <summary>
@@ -147,9 +154,11 @@ public static class LicenseAcceptanceGate
             return Observable.Empty<LicenseAcceptance>();
 
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
-        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
 
-        return ReadLicense(hub, manifest.License!, logger)
+        // Same seal as Require — the write lands in the accepting user's partition, so it runs as
+        // System, but the caller that subscribed must not be left holding that identity.
+        return accessService.RunAsSystem(() => ReadLicense(hub, manifest.License!, logger)
             .SelectMany(license =>
             {
                 if (license is null)
@@ -173,9 +182,7 @@ public static class LicenseAcceptanceGate
                     Content = acceptance,
                 };
 
-                return Observable.Using(
-                        () => accessService.ImpersonateAsSystem(),
-                        _ => meshService.CreateOrUpdateNode(node))
+                return meshService.CreateOrUpdateNode(node)
                     .Select(_ =>
                     {
                         logger?.LogInformation(
@@ -183,32 +190,31 @@ public static class LicenseAcceptanceGate
                             license.SpdxId, manifest.Id, acceptingUserId);
                         return acceptance;
                     });
-            });
+            }));
     }
 
     private static IObservable<LicenseContent?> ReadLicense(
         IMessageHub hub, string spdxId, ILogger? logger) =>
-        ReadAsSystem<LicenseContent>(hub, WellKnownLicenses.PathFor(spdxId), logger);
+        Read<LicenseContent>(hub, WellKnownLicenses.PathFor(spdxId), logger);
 
     private static IObservable<LicenseAcceptance?> ReadAcceptance(
         IMessageHub hub, string userId, string packageId, ILogger? logger) =>
-        ReadAsSystem<LicenseAcceptance>(hub, LicenseNodeType.AcceptancePath(userId, packageId), logger);
+        Read<LicenseAcceptance>(hub, LicenseNodeType.AcceptancePath(userId, packageId), logger);
 
     /// <summary>
-    /// One-shot read by exact path under System. A read FAILURE faults the sequence rather than
-    /// resolving to null: "the mesh was briefly unreachable" must never read as "no acceptance is
-    /// required", which is the difference between failing closed and failing open.
+    /// One-shot read by exact path. The System identity is supplied by the caller's
+    /// <see cref="ImpersonationScopeExtensions.RunAsSystem{T}"/> scope, so this composes INSIDE that
+    /// scope rather than opening its own — one seal per public entry point, not one per read.
+    ///
+    /// <para>A read FAILURE faults the sequence rather than resolving to null: "the mesh was briefly
+    /// unreachable" must never read as "no acceptance is required", which is the difference between
+    /// failing closed and failing open.</para>
     /// </summary>
-    private static IObservable<T?> ReadAsSystem<T>(IMessageHub hub, string path, ILogger? logger)
-        where T : class
-    {
-        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
-        return Observable.Using(
-                () => accessService.ImpersonateAsSystem(),
-                _ => hub.GetMeshNode(path, ReadTimeout))
+    private static IObservable<T?> Read<T>(IMessageHub hub, string path, ILogger? logger)
+        where T : class =>
+        hub.GetMeshNode(path, ReadTimeout)
             .Take(1)
             .Select(node => node?.ContentAs<T>(hub.JsonSerializerOptions));
-    }
 
     private static IObservable<Unit> Refuse(
         PackageManifest manifest, string spdxId, string? userId, string reason, ILogger? logger) =>

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -83,7 +83,11 @@ public static class PackageInstaller
         // commercial ones need a global admin. Every install path funnels through this method (and
         // InstallNodeRepoDelta, which carries the same gate), so the machine paths — the unattended
         // default install, the update watcher — are gated identically to a click.
+        // Two gates, in order, both on the ACTION. Entitlement answers "may you" (#830); acceptance
+        // answers "have you agreed to the terms" — different questions, neither substituting for
+        // the other, and a licence that asks nothing costs a single null check.
         return PackageEntitlement.Authorize(hub, manifest, authorizingUserId, logger)
+            .SelectMany(_ => LicenseAcceptanceGate.Require(hub, manifest, authorizingUserId, logger))
             .SelectMany(_ => InstallCore(
                 hub, manifest, files, installedFromRef, logger, batchSize, authorizingUserId));
     }
@@ -2199,6 +2203,7 @@ public static class PackageInstaller
 
         var effectiveLogger = logger;
         return PackageEntitlement.Authorize(hub, manifest, authorizingUserId, effectiveLogger)
+            .SelectMany(_ => LicenseAcceptanceGate.Require(hub, manifest, authorizingUserId, effectiveLogger))
             .SelectMany(_ => InstallNodeRepoDeltaCore(
                 hub, manifest, newManifest, changedFiles, removedNodePaths, installedFromRef,
                 effectiveLogger, authorizingUserId));

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -63,6 +63,11 @@ public static class PluginCatalogConfigurationExtensions
                 // surface. Mesh-scoped singleton so its short-lived cache dies with the mesh
                 // (Doc/Architecture/NoStaticState) — a revoked grant must not outlive a test either.
                 .AddSingleton<InstanceRegistryAuthenticator>()
+                // Issues and revokes the SYNC LICENCE that authenticator then reads. One writer for
+                // every issuer (the admin tab, a fulfilled order, a redeemed coupon, an automated
+                // provision), so a licence carries its terms — and its attribution — however it was
+                // granted. Mesh-scoped like the authenticator it feeds.
+                .AddSingleton<SyncLicenseService>()
                 // Registration bootstrap keys (mwr_) — minted on the admin surface, validated by
                 // the /api/instances/register endpoint. Mesh-scoped like everything above.
                 .AddSingleton<RegistrationKeyService>()

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -32,10 +32,13 @@ public static class PluginCatalogConfigurationExtensions
             .AddMeshNodes(CreateCatalogNodeType())
             .AddMeshNodes(CreateInstalledPartitionPolicy())
             .AddMeshNodes(CreateRegistryCredentialNodeType())
+            .AddMeshNodes(CreateSigningKeyNodeType())
             .AddMeshNodes(CreateModuleDiscoveryNodeType())
             .AddMeshNodes(CreateDefaultInstallLedgerNodeType())
             // Infrastructure credential, never pickable content.
             .AddAutocompleteExcludedTypes(PluginRegistryCredentials.NodeType)
+            // The registry's token signing key — infrastructure, never pickable content.
+            .AddAutocompleteExcludedTypes(SyncTokenSigningKeys.NodeType)
             // Bookkeeping, never pickable content — same reason as the credential above.
             .AddAutocompleteExcludedTypes(InstanceAutoRegistrationService.LedgerNodeType)
             // The build-completion subscriber. A mesh-scoped SINGLETON, so its subscriptions live
@@ -68,6 +71,9 @@ public static class PluginCatalogConfigurationExtensions
                 // provision), so a licence carries its terms — and its attribution — however it was
                 // granted. Mesh-scoped like the authenticator it feeds.
                 .AddSingleton<SyncLicenseService>()
+                // Mints (once, per registry) and rotates the key that signs short-lived sync access
+                // tokens. Mesh-scoped so its cache dies with the mesh, like the authenticator.
+                .AddSingleton<SyncTokenSigningKeyService>()
                 // Registration bootstrap keys (mwr_) — minted on the admin surface, validated by
                 // the /api/instances/register endpoint. Mesh-scoped like everything above.
                 .AddSingleton<RegistrationKeyService>()
@@ -141,6 +147,7 @@ public static class PluginCatalogConfigurationExtensions
             .WithType(typeof(PluginCatalogContent), nameof(PluginCatalogContent))
             .WithType(typeof(PluginManifest), nameof(PluginManifest))
             .WithType(typeof(PluginRegistryCredential), nameof(PluginRegistryCredential))
+            .WithType(typeof(SyncTokenSigningKey), nameof(SyncTokenSigningKey))
             .WithType(typeof(ModuleDiscovery), nameof(ModuleDiscovery))
             .WithType(typeof(DefaultInstallLedger), nameof(DefaultInstallLedger));
 
@@ -170,6 +177,19 @@ public static class PluginCatalogConfigurationExtensions
         ExcludeFromContext = new HashSet<string> { "search", "create" },
         HubConfiguration = config => config
             .AddMeshDataSource(s => s.WithContentType<PluginRegistryCredential>()),
+    };
+
+    // The HMAC key this registry signs short-lived sync access tokens with. Sits beside the registry
+    // credential for the same reasons: an Admin-partition secret whose partition access control is
+    // the gate, enc:-protected at rest, and never content a user creates. ONE node per registry at a
+    // FIXED path — that is what lets two replicas racing to mint it collide and resolve to one key.
+    private static MeshNode CreateSigningKeyNodeType() => new(SyncTokenSigningKeys.NodeType)
+    {
+        Name = "Sync Token Signing Key",
+        IsSatelliteType = false,
+        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        HubConfiguration = config => config
+            .AddMeshDataSource(s => s.WithContentType<SyncTokenSigningKey>()),
     };
 
     // What a configured plugin repo carries and what this instance did with it (#833). An

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogOptions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogOptions.cs
@@ -117,21 +117,6 @@ public sealed class PluginCatalogOptions
     /// operator's chosen extras.</para>
     /// </summary>
     public bool InstallPreInstalledPackages { get; set; } = true;
-
-    /// <summary>
-    /// HMAC key the registry signs short-lived sync access tokens (<c>mwa_…</c>) with, so an
-    /// instance can exchange its durable key for a scoped, minutes-long credential instead of
-    /// presenting the durable one on every call.
-    ///
-    /// <para>🚨 Unset means the exchange endpoint is UNAVAILABLE, not that it falls back to a weaker
-    /// key. A signing secret that can be guessed is worse than no token exchange at all, and a
-    /// per-process random key would silently break the moment a second replica answered the request
-    /// — so the absence is reported rather than papered over. Must be at least
-    /// <see cref="MeshWeaver.Mesh.Security.SyncAccessToken.MinimumSigningKeyBytes"/> bytes; share
-    /// the same value across every replica of one registry.</para>
-    /// </summary>
-    public string TokenSigningKey { get; set; } = "";
-
     /// <summary>This installation's public base URL, recorded on the instance node (advisory).</summary>
     public string HomeUrl { get; set; } = "";
 

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogOptions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogOptions.cs
@@ -118,6 +118,20 @@ public sealed class PluginCatalogOptions
     /// </summary>
     public bool InstallPreInstalledPackages { get; set; } = true;
 
+    /// <summary>
+    /// HMAC key the registry signs short-lived sync access tokens (<c>mwa_…</c>) with, so an
+    /// instance can exchange its durable key for a scoped, minutes-long credential instead of
+    /// presenting the durable one on every call.
+    ///
+    /// <para>🚨 Unset means the exchange endpoint is UNAVAILABLE, not that it falls back to a weaker
+    /// key. A signing secret that can be guessed is worse than no token exchange at all, and a
+    /// per-process random key would silently break the moment a second replica answered the request
+    /// — so the absence is reported rather than papered over. Must be at least
+    /// <see cref="MeshWeaver.Mesh.Security.SyncAccessToken.MinimumSigningKeyBytes"/> bytes; share
+    /// the same value across every replica of one registry.</para>
+    /// </summary>
+    public string TokenSigningKey { get; set; } = "";
+
     /// <summary>This installation's public base URL, recorded on the instance node (advisory).</summary>
     public string HomeUrl { get; set; } = "";
 

--- a/src/MeshWeaver.PluginCatalog/SyncLicenseService.cs
+++ b/src/MeshWeaver.PluginCatalog/SyncLicenseService.cs
@@ -132,6 +132,14 @@ public sealed class SyncLicenseService(IMessageHub hub, ILogger<SyncLicenseServi
     /// Read → transform → write, under System, for one instance's grant node. The prior read is a
     /// one-shot by EXACT PATH, never a query: a query is eventually consistent and would happily
     /// drop an entry another issuer added moments ago.
+    ///
+    /// <para>🚨 <see cref="ImpersonationScopeExtensions.RunAsSystem{T}"/>, never
+    /// <c>Observable.Using(access.ImpersonateAsSystem, …)</c> (#1790). Rx runs a Using factory on the
+    /// SUBSCRIBING thread and disposes on termination, which leaves the subscriber latched as System
+    /// — here that subscriber is an admin surface or an HTTP request, so the latch would hand it
+    /// <c>Permission.All</c>. RunAsSystem seals both ends and delivers notifications under the
+    /// subscriber's own identity; the WIDEST cold pipeline goes inside the factory, so the whole
+    /// read-transform-write runs as System and nothing downstream inherits it.</para>
     /// </summary>
     private IObservable<PluginGrant> Mutate(
         string instanceId, string actingUserId, Func<PluginGrant, PluginGrant> transform)
@@ -140,9 +148,7 @@ public sealed class SyncLicenseService(IMessageHub hub, ILogger<SyncLicenseServi
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         var path = MeshWeaverInstanceNodeType.GrantPath(instanceId);
 
-        return Observable.Using(
-                () => accessService.ImpersonateAsSystem(),
-                _ => hub.GetMeshNode(path, ReadTimeout))
+        return accessService.RunAsSystem(() => hub.GetMeshNode(path, ReadTimeout)
             .Take(1)
             .SelectMany(existing => Observable.Defer(() =>
             {
@@ -162,11 +168,8 @@ public sealed class SyncLicenseService(IMessageHub hub, ILogger<SyncLicenseServi
                     State = MeshNodeState.Active,
                     Content = updated,
                 };
-                return Observable.Using(
-                        () => accessService.ImpersonateAsSystem(),
-                        _ => meshService.CreateOrUpdateNode(node))
-                    .Select(_ => updated);
-            }));
+                return meshService.CreateOrUpdateNode(node).Select(_ => updated);
+            })));
     }
 
     /// <summary>Entries with the given <c>(source, package)</c> pair removed — the same matching

--- a/src/MeshWeaver.PluginCatalog/SyncLicenseService.cs
+++ b/src/MeshWeaver.PluginCatalog/SyncLicenseService.cs
@@ -1,0 +1,220 @@
+using System.Reactive.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Issues and revokes an instance's <b>sync licence</b> — the right of a registered
+/// <see cref="MeshWeaverInstance"/> to replicate a package from this registry, recorded as entries
+/// on its <see cref="PluginGrant"/>.
+///
+/// <para><b>Why this exists.</b> Until now a grant had exactly two writers: the
+/// <c>DefaultGrants</c> seed at registration, and an admin typing into the Instance-grants tab.
+/// Neither can express a licence — no term, no issuing terms, no record of what the right was
+/// granted FOR — and hand-editing one node per consumer does not scale past a handful of
+/// instances. Every issuer (the admin tab, a fulfilled order, a redeemed coupon, an automated
+/// provisioning step) funnels through here instead, so a licence is issued ONE way and carries its
+/// terms wherever it came from.</para>
+///
+/// <para>🚨 <b>This service records an authorization; it does not make one.</b> The decision that
+/// the licence MAY be issued — a global-admin gate, a verified payment, a validated coupon — belongs
+/// to the caller, exactly as <see cref="PackageEntitlement"/> puts the check on the action. What is
+/// enforced here is that the decision is ATTRIBUTABLE: an issue with no issuing principal is refused
+/// rather than written under a blank name, because a right nobody is recorded as having granted
+/// cannot be reviewed or revoked with confidence.</para>
+///
+/// <para>Writes run under the System identity: grants live in the <b>Admin</b> partition, which is
+/// deliberately not writable by the instance's owner (self-service registration plus admin-owned
+/// grants is what stops registration from becoming self-service access). Read-then-
+/// <see cref="IMeshService.CreateOrUpdateNode"/>, never <c>stream.Update</c> — an instance's FIRST
+/// licence has no node yet, and Update on a missing path aborts.</para>
+/// </summary>
+public sealed class SyncLicenseService(IMessageHub hub, ILogger<SyncLicenseService> logger)
+{
+    private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Issues (or re-issues) a sync licence for one <c>(source, package)</c> pair. Idempotent: an
+    /// existing entry for the same pair is REPLACED, so renewing a term or correcting the terms is
+    /// the same call as granting it the first time — never a second entry that shadows the first.
+    /// </summary>
+    /// <param name="request">What is being licensed, to whom, under which terms, by whom.</param>
+    /// <returns>The stored grant after the write.</returns>
+    /// <exception cref="ArgumentException">The request is not attributable or not addressable.</exception>
+    public IObservable<PluginGrant> Issue(SyncLicenseRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        Require(request.InstanceId, nameof(request.InstanceId));
+        Require(request.Source, nameof(request.Source));
+        Require(request.PackageId, nameof(request.PackageId));
+        // Attribution is not optional — see the type remarks.
+        Require(request.IssuedByUserId, nameof(request.IssuedByUserId));
+
+        var entry = new PluginGrantEntry
+        {
+            Source = request.Source,
+            PackageId = request.PackageId,
+            ExpiresAt = request.ExpiresAt,
+            IssuedUnderLicense = request.IssuedUnderLicense,
+            IssuedVia = request.IssuedVia,
+            IssuedAt = request.IssuedAt ?? DateTimeOffset.UtcNow,
+        };
+
+        return Mutate(request.InstanceId, request.IssuedByUserId, grant => grant with
+        {
+            Entries = Without(grant.Entries, request.Source, request.PackageId).Append(entry).ToList(),
+        })
+        .Do(_ => logger.LogInformation(
+            "Sync licence issued: {Entry} → {InstanceId} (licence {License}, via {Via}, expires {Expires})",
+            entry, request.InstanceId, request.IssuedUnderLicense ?? "unspecified",
+            request.IssuedVia ?? "unspecified",
+            request.ExpiresAt?.ToString("O") ?? "never"));
+    }
+
+    /// <summary>
+    /// Withdraws the licence for one <c>(source, package)</c> pair by removing its entry. Removing
+    /// an absent entry is a no-op that still completes — revocation is idempotent, so a retry after
+    /// a partial failure is safe.
+    /// </summary>
+    public IObservable<PluginGrant> Revoke(
+        string instanceId, string source, string packageId, string revokedByUserId)
+    {
+        Require(instanceId, nameof(instanceId));
+        Require(source, nameof(source));
+        Require(packageId, nameof(packageId));
+        Require(revokedByUserId, nameof(revokedByUserId));
+
+        return Mutate(instanceId, revokedByUserId, grant => grant with
+        {
+            Entries = Without(grant.Entries, source, packageId).ToList(),
+        })
+        .Do(_ => logger.LogInformation("Sync licence revoked: {Source}/{Package} → {InstanceId}",
+            source, packageId, instanceId));
+    }
+
+    /// <summary>
+    /// The instance-wide stop: flips <see cref="PluginGrant.IsRevoked"/> so the grant authorizes
+    /// nothing, while every entry and its recorded terms stay intact.
+    ///
+    /// <para>Deliberately NOT "delete the entries". A revocation has to be reviewable afterwards —
+    /// what was licensed, under what terms, and who ended it — and an emptied list answers none of
+    /// that. It is also reversible with <see cref="Reinstate"/>, which deleting is not.</para>
+    /// </summary>
+    public IObservable<PluginGrant> RevokeAll(string instanceId, string revokedByUserId)
+    {
+        Require(instanceId, nameof(instanceId));
+        Require(revokedByUserId, nameof(revokedByUserId));
+
+        return Mutate(instanceId, revokedByUserId, grant => grant with { IsRevoked = true })
+            .Do(_ => logger.LogWarning("Sync licence REVOKED wholesale for {InstanceId} by {User}",
+                instanceId, revokedByUserId));
+    }
+
+    /// <summary>Lifts a wholesale revocation. Entries that have since expired stay expired — this
+    /// clears the kill switch, it does not renew a term.</summary>
+    public IObservable<PluginGrant> Reinstate(string instanceId, string reinstatedByUserId)
+    {
+        Require(instanceId, nameof(instanceId));
+        Require(reinstatedByUserId, nameof(reinstatedByUserId));
+
+        return Mutate(instanceId, reinstatedByUserId, grant => grant with { IsRevoked = false })
+            .Do(_ => logger.LogInformation("Sync licence reinstated for {InstanceId} by {User}",
+                instanceId, reinstatedByUserId));
+    }
+
+    /// <summary>
+    /// Read → transform → write, under System, for one instance's grant node. The prior read is a
+    /// one-shot by EXACT PATH, never a query: a query is eventually consistent and would happily
+    /// drop an entry another issuer added moments ago.
+    /// </summary>
+    private IObservable<PluginGrant> Mutate(
+        string instanceId, string actingUserId, Func<PluginGrant, PluginGrant> transform)
+    {
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var path = MeshWeaverInstanceNodeType.GrantPath(instanceId);
+
+        return Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => hub.GetMeshNode(path, ReadTimeout))
+            .Take(1)
+            .SelectMany(existing => Observable.Defer(() =>
+            {
+                var current = existing?.ContentAs<PluginGrant>(hub.JsonSerializerOptions)
+                              ?? new PluginGrant { InstanceId = instanceId };
+                var updated = transform(current) with
+                {
+                    InstanceId = instanceId,
+                    GrantedByUserId = actingUserId,
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                };
+
+                var node = new MeshNode(instanceId, MeshWeaverInstanceNodeType.GrantNamespace)
+                {
+                    Name = $"Plugin grant: {instanceId}",
+                    NodeType = MeshWeaverInstanceNodeType.GrantNodeType,
+                    State = MeshNodeState.Active,
+                    Content = updated,
+                };
+                return Observable.Using(
+                        () => accessService.ImpersonateAsSystem(),
+                        _ => meshService.CreateOrUpdateNode(node))
+                    .Select(_ => updated);
+            }));
+    }
+
+    /// <summary>Entries with the given <c>(source, package)</c> pair removed — the same matching
+    /// rule the admin tab uses, so "replace" means the same thing everywhere.</summary>
+    private static IEnumerable<PluginGrantEntry> Without(
+        IEnumerable<PluginGrantEntry> entries, string source, string packageId) =>
+        entries.Where(e => !(string.Equals(e.Source, source, StringComparison.OrdinalIgnoreCase)
+                             && string.Equals(e.PackageId, packageId, StringComparison.Ordinal)));
+
+    private static void Require(string? value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException($"{name} is required to issue or revoke a sync licence.", name);
+    }
+}
+
+/// <summary>
+/// One sync-licence issuance: what is licensed, to which instance, under which terms, on whose
+/// authority. A record rather than a parameter list because every field is part of the audit trail
+/// and they are routinely carried together from an order or a coupon.
+/// </summary>
+public sealed record SyncLicenseRequest
+{
+    /// <summary>The <see cref="MeshWeaverInstance.InstanceId"/> being licensed.</summary>
+    public required string InstanceId { get; init; }
+
+    /// <summary>The registry source's configured name (<c>Plugins</c>, <c>Education</c>).</summary>
+    public required string Source { get; init; }
+
+    /// <summary>The package id, or <see cref="PluginGrantEntry.AllPackages"/> for the whole
+    /// source.</summary>
+    public required string PackageId { get; init; }
+
+    /// <summary>ObjectId of the principal that authorized this issuance. Required — an
+    /// unattributable grant is refused rather than written anonymously.</summary>
+    public required string IssuedByUserId { get; init; }
+
+    /// <summary>End of the term. Null = perpetual (revocation remains available).</summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>SPDX id of the licence the right is issued under. Null stays null — never
+    /// defaulted, since recording terms nobody granted is worse than recording none.</summary>
+    public string? IssuedUnderLicense { get; init; }
+
+    /// <summary>How this came about — an order id, a coupon code, a ticket reference.</summary>
+    public string? IssuedVia { get; init; }
+
+    /// <summary>When it was issued; defaults to the moment of the write. Explicit only so a
+    /// backfill can record the real date rather than the migration's.</summary>
+    public DateTimeOffset? IssuedAt { get; init; }
+}

--- a/src/MeshWeaver.PluginCatalog/SyncTokenPayloads.cs
+++ b/src/MeshWeaver.PluginCatalog/SyncTokenPayloads.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The wire contract of <c>POST /api/instances/token</c> — a registered instance exchanges its
+/// durable <c>mwi_</c> key for a short-lived, scoped <c>mwa_</c> access token. One place for both
+/// sides, mirroring <see cref="InstanceRegistrationPayloads"/> and <see cref="PluginRegistryPayloads"/>
+/// so producer and consumer cannot drift.
+///
+/// <para>Deliberately OAuth-shaped (<c>access_token</c> / <c>token_type</c> / <c>expires_in</c> /
+/// <c>scope</c>) because that is what every consumer already knows how to hold: mint at the start of
+/// a run, present it on each call, discard it. It is not an OAuth server — there is no user, no
+/// authorization code and no refresh token; the durable instance key IS the long-lived credential
+/// and a new exchange is the refresh.</para>
+/// </summary>
+public static class SyncTokenPayloads
+{
+    /// <summary>The route the endpoint is mapped under.</summary>
+    public const string Route = "/api/instances/token";
+
+    /// <summary>Serializer options both sides use (Web camelCase).</summary>
+    public static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// The request body — both fields optional, so an empty body is a valid "give me a default
+    /// token for everything I am licensed for".
+    /// </summary>
+    /// <param name="Scope"><c>Source/Package</c> entries to narrow the token to. Anything not
+    /// already licensed is dropped rather than refused: a token can only ever narrow, so asking for
+    /// more than you hold is not an attack, it is a stale caller.</param>
+    /// <param name="LifetimeSeconds">Requested lifetime; clamped to the registry's maximum.</param>
+    public record Request(IReadOnlyCollection<string>? Scope = null, int? LifetimeSeconds = null);
+
+    /// <summary>
+    /// The success response.
+    /// </summary>
+    /// <param name="AccessToken">The minted token, presented as <c>Authorization: Bearer</c>.</param>
+    /// <param name="TokenType">Always <c>Bearer</c>.</param>
+    /// <param name="ExpiresIn">Seconds until it stops verifying.</param>
+    /// <param name="Scope">The EFFECTIVE scope — what the caller asked for intersected with what it
+    /// is licensed for. Returned explicitly so a consumer can see it got less than it requested
+    /// instead of discovering it one 404 at a time.</param>
+    public record Response(
+        string AccessToken, string TokenType, int ExpiresIn, IReadOnlyCollection<string> Scope);
+}

--- a/src/MeshWeaver.PluginCatalog/SyncTokenSigningKeyService.cs
+++ b/src/MeshWeaver.PluginCatalog/SyncTokenSigningKeyService.cs
@@ -1,0 +1,276 @@
+using System.Reactive.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using MeshWeaver.AI;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Resolves — minting on first need — the HMAC key the registry signs
+/// <see cref="SyncAccessToken"/>s with, and rotates it.
+///
+/// <para>🚨 <b>Uniqueness comes from the MESH NODE, never from a lock.</b> Minting issues a
+/// create against the single fixed path <see cref="SyncTokenSigningKeys.Path"/>. The mesh creates
+/// only — an existing path is reported back rather than overwritten — so when two replicas race,
+/// exactly one key is written and the loser is TOLD it lost and adopts the winner's key by reading
+/// it. A lock could not span pods; a "read, create if absent" that ignored the collision would leave
+/// two replicas signing with different keys, and a token minted on one would fail on the other.</para>
+///
+/// <para>The key is cached in memory for <see cref="CacheDuration"/>. Short, because a rotation
+/// performed by another replica has to be picked up without a restart; the outgoing key stays
+/// verifiable through its grace window, so a replica briefly holding the older material still
+/// verifies everything it should.</para>
+/// </summary>
+public sealed class SyncTokenSigningKeyService(IMessageHub hub, ILogger<SyncTokenSigningKeyService> logger)
+{
+    /// <summary>How long resolved key material is reused before the node is re-read. Short so a
+    /// rotation on another replica takes effect without a restart.</summary>
+    public static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(1);
+
+    private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly object gate = new();
+    private (DateTimeOffset At, SyncTokenSigningMaterial Material)? cached;
+
+    /// <summary>
+    /// The key material to sign and verify with, minting it if this registry has none yet.
+    /// </summary>
+    /// <returns>The current signing key plus any still-valid previous key.</returns>
+    public IObservable<SyncTokenSigningMaterial> Resolve()
+    {
+        lock (gate)
+        {
+            if (cached is { } hit && DateTimeOffset.UtcNow - hit.At < CacheDuration)
+                return Observable.Return(hit.Material);
+        }
+
+        var access = hub.ServiceProvider.GetService<AccessService>();
+        // ONE sealed System scope around the whole resolve — the key lives in the Admin partition and
+        // the caller is an HTTP request that must not be left holding System (#1790).
+        return access.RunAsSystem(() => Read()
+                .SelectMany(stored => stored is null ? Mint() : Observable.Return(stored)))
+            .Select(Materialize)
+            .Do(material =>
+            {
+                lock (gate)
+                    cached = (DateTimeOffset.UtcNow, material);
+            });
+    }
+
+    /// <summary>
+    /// The key material as it ALREADY stands, without minting. This is the VERIFY path: a caller
+    /// presenting a token has not authenticated yet, and minting on their behalf would let an
+    /// anonymous request write a node — while being pointless anyway, since a token cannot verify
+    /// against a key created after it was signed.
+    /// </summary>
+    /// <returns>The material, or null when this registry has never minted a key.</returns>
+    public IObservable<SyncTokenSigningMaterial?> Existing()
+    {
+        lock (gate)
+        {
+            if (cached is { } hit && DateTimeOffset.UtcNow - hit.At < CacheDuration)
+                return Observable.Return<SyncTokenSigningMaterial?>(hit.Material);
+        }
+
+        var access = hub.ServiceProvider.GetService<AccessService>();
+        return access.RunAsSystem(Read)
+            .Select(stored => stored is null ? null : Materialize(stored))
+            .Do(material =>
+            {
+                if (material is null)
+                    return;
+                lock (gate)
+                    cached = (DateTimeOffset.UtcNow, material);
+            });
+    }
+
+    /// <summary>
+    /// Replaces the signing key, keeping the outgoing one verifiable for
+    /// <see cref="SyncTokenSigningKeys.RotationGrace"/> so tokens already in flight keep working.
+    /// Idempotent in effect but not in value: each call mints fresh material, so it is driven by a
+    /// due date rather than called speculatively.
+    /// </summary>
+    /// <param name="rotatedBy">Who or what triggered the rotation, for the log.</param>
+    /// <returns>The material in force after the rotation.</returns>
+    public IObservable<SyncTokenSigningMaterial> Rotate(string rotatedBy)
+    {
+        var access = hub.ServiceProvider.GetService<AccessService>();
+        var protector = hub.ServiceProvider.GetService<IProviderKeyProtector>();
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var now = DateTimeOffset.UtcNow;
+
+        return access.RunAsSystem(() => Read()
+                .SelectMany(stored =>
+                {
+                    var rotated = new SyncTokenSigningKey
+                    {
+                        ProtectedCurrent = Protect(protector, NewSecret()),
+                        CurrentIssuedAt = now,
+                        // The outgoing key stays verifiable — dropping it here would invalidate every
+                        // token minted in the last few minutes.
+                        ProtectedPrevious = stored?.ProtectedCurrent,
+                        PreviousValidUntil = stored is null
+                            ? null
+                            : now.Add(SyncTokenSigningKeys.RotationGrace),
+                        RotateAfter = now.Add(SyncTokenSigningKeys.RotationInterval),
+                    };
+
+                    return meshService.CreateOrUpdateNode(NodeFor(rotated)).Select(_ => rotated);
+                }))
+            .Select(Materialize)
+            .Do(material =>
+            {
+                lock (gate)
+                    cached = (DateTimeOffset.UtcNow, material);
+                logger.LogInformation(
+                    "Sync token signing key rotated by {By}; the outgoing key stays verifiable for {Grace}",
+                    rotatedBy, SyncTokenSigningKeys.RotationGrace);
+            });
+    }
+
+    /// <summary>
+    /// Mints the first key for this registry. Runs INSIDE the caller's System scope.
+    ///
+    /// <para>The create is the whole concurrency story, and the outcome is read from the STORE, not
+    /// from the response: storage keeps the first create and discards a concurrent second, but tells
+    /// BOTH callers they created it. So we create, then read back, and sign with whatever is
+    /// actually there.</para>
+    /// </summary>
+    private IObservable<SyncTokenSigningKey> Mint()
+    {
+        var protector = hub.ServiceProvider.GetService<IProviderKeyProtector>();
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var now = DateTimeOffset.UtcNow;
+
+        var minted = new SyncTokenSigningKey
+        {
+            ProtectedCurrent = Protect(protector, NewSecret()),
+            CurrentIssuedAt = now,
+            RotateAfter = now.Add(SyncTokenSigningKeys.RotationInterval),
+        };
+
+        return meshService.CreateNodes([NodeFor(minted)])
+            .SelectMany(response =>
+            {
+                if (!response.Success && !response.Existing.Contains(SyncTokenSigningKeys.Path))
+                    return Observable.Throw<SyncTokenSigningKey>(new InvalidOperationException(
+                        $"Could not mint the sync token signing key: {response.Error}"));
+
+                // 🚨 ALWAYS read back; NEVER return the locally minted material. Measured
+                // 2026-08-18: under a genuine concurrent create BOTH callers are told
+                // created=1/existing=0 — the response's exists-check lags, exactly as
+                // IMeshService.CreateOrUpdateNode's remarks warn — while STORAGE keeps the FIRST
+                // write and discards the second. So the response cannot tell you whether you won,
+                // and the stored node is the only authority. Signing with what we proposed rather
+                // than with what was stored is how two replicas end up on different keys.
+                return Read().SelectMany(stored => stored switch
+                {
+                    null => Observable.Throw<SyncTokenSigningKey>(new InvalidOperationException(
+                        "The sync token signing key was created but could not be read back.")),
+                    _ => Observable.Return(stored),
+                });
+            })
+            .Do(stored => logger.LogInformation(
+                string.Equals(stored.ProtectedCurrent, minted.ProtectedCurrent, StringComparison.Ordinal)
+                    ? "Minted this registry's sync token signing key at {Path}; rotation due {Due}"
+                    : "Another replica had already minted the sync token signing key at {Path} — "
+                      + "adopted the stored one; rotation due {Due}",
+                SyncTokenSigningKeys.Path, stored.RotateAfter));
+    }
+
+    /// <summary>One-shot read by exact path, inside the caller's System scope.</summary>
+    private IObservable<SyncTokenSigningKey?> Read() =>
+        hub.GetMeshNode(SyncTokenSigningKeys.Path, ReadTimeout)
+            .Take(1)
+            .Select(node => node?.ContentAs<SyncTokenSigningKey>(hub.JsonSerializerOptions));
+
+    private MeshNode NodeFor(SyncTokenSigningKey key) =>
+        new(SyncTokenSigningKeys.Id, SyncTokenSigningKeys.Namespace)
+        {
+            Name = "Sync token signing key",
+            NodeType = SyncTokenSigningKeys.NodeType,
+            State = MeshNodeState.Active,
+            Content = key,
+        };
+
+    /// <summary>
+    /// Turns the stored record into usable bytes, dropping a previous key whose grace window has
+    /// closed and reporting a rotation that is due.
+    /// </summary>
+    private SyncTokenSigningMaterial Materialize(SyncTokenSigningKey stored)
+    {
+        var protector = hub.ServiceProvider.GetService<IProviderKeyProtector>();
+        var now = DateTimeOffset.UtcNow;
+
+        var current = Unprotect(protector, stored.ProtectedCurrent);
+        if (current is null)
+            // A key we cannot decrypt is not a key. Fail loudly and name the likely cause — silently
+            // minting a replacement would invalidate every outstanding token AND hide a master-key
+            // misconfiguration that also affects every other protected secret.
+            throw new InvalidOperationException(
+                "The stored sync token signing key could not be decrypted — was the master key changed?");
+
+        var previous = stored.PreviousStillValid(now)
+            ? Unprotect(protector, stored.ProtectedPrevious)
+            : null;
+
+        if (stored.RotationDue(now))
+            logger.LogInformation(
+                "The sync token signing key is due for rotation (due {Due}).", stored.RotateAfter);
+
+        return new SyncTokenSigningMaterial(current, previous, stored.RotationDue(now));
+    }
+
+    private static byte[] NewSecret() =>
+        RandomNumberGenerator.GetBytes(SyncTokenSigningKeys.KeyByteLength);
+
+    private static string Protect(IProviderKeyProtector? protector, byte[] secret)
+    {
+        var encoded = Convert.ToBase64String(secret);
+        return protector?.Protect(encoded) ?? encoded;
+    }
+
+    private static byte[]? Unprotect(IProviderKeyProtector? protector, string? stored)
+    {
+        if (string.IsNullOrWhiteSpace(stored))
+            return null;
+        var raw = protector is null ? stored : protector.Unprotect(stored);
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+        try
+        {
+            return Convert.FromBase64String(raw);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// The signing material in force: what to sign with, and what to still accept.
+/// </summary>
+/// <param name="Current">The key new tokens are signed with.</param>
+/// <param name="Previous">The key retired by the last rotation, still accepted for verification
+/// while its grace window is open; null when there is none.</param>
+/// <param name="RotationDue">Whether the current key has passed its rotation due date.</param>
+public sealed record SyncTokenSigningMaterial(byte[] Current, byte[]? Previous, bool RotationDue)
+{
+    /// <summary>
+    /// Verifies <paramref name="token"/> against the current key, then — only if that fails — the
+    /// previous one, so a token minted moments before a rotation still works.
+    /// </summary>
+    /// <param name="token">The raw token.</param>
+    /// <param name="now">The instant to judge expiry against.</param>
+    /// <returns>The verified claims, or null.</returns>
+    public SyncAccessTokenClaims? Verify(string? token, DateTimeOffset now) =>
+        SyncAccessToken.Verify(token, now, Current)
+        ?? (Previous is null ? null : SyncAccessToken.Verify(token, now, Previous));
+}

--- a/test/ImpersonationScopeSites.allow
+++ b/test/ImpersonationScopeSites.allow
@@ -78,7 +78,6 @@ src/MeshWeaver.Observability/LogIncidentControlPlane.cs	1
 src/MeshWeaver.Observability/LogIncidentIngestService.cs	1
 src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs	6
 src/MeshWeaver.PluginCatalog/InstanceComboReader.cs	1
-src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs	1
 src/MeshWeaver.PluginCatalog/ModuleDiscoveryService.cs	4
 src/MeshWeaver.PluginCatalog/PackageInstaller.cs	10
 src/MeshWeaver.PluginCatalog/PackageUpdateReconciler.cs	2

--- a/test/Memex.Portal.Shared.Test/SyncTokenScopeTest.cs
+++ b/test/Memex.Portal.Shared.Test/SyncTokenScopeTest.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Memex.Portal.Shared.Api;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins how a token-exchange request is intersected with the instance's sync licence — the pure
+/// decision behind <c>POST /api/instances/token</c>'s scope.
+///
+/// <para>Written because the first implementation got the whole-source case wrong: it MATCHED
+/// <c>Plugins/*</c> against the licence instead of EXPANDING it, so an instance licensed per-package
+/// that asked for "everything I hold in this source" got an empty scope and a 403.</para>
+/// </summary>
+public class SyncTokenScopeTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 19, 12, 0, 0, TimeSpan.Zero);
+
+    private static AuthenticatedInstance Caller(bool revoked = false, params PluginGrantEntry[] entries) =>
+        new(new MeshWeaverInstance { InstanceId = "manufacturing-ci", KeyHash = "hash" },
+            new PluginGrant { InstanceId = "manufacturing-ci", Entries = entries, IsRevoked = revoked });
+
+    private static PluginGrantEntry Entry(string source, string package, DateTimeOffset? expires = null) =>
+        new() { Source = source, PackageId = package, ExpiresAt = expires };
+
+    private static List<string> Scope(AuthenticatedInstance caller, params string[] requested) =>
+        InstanceTokenEndpoints.EffectiveScope(caller, requested.Length == 0 ? null : requested, Now).ToList();
+
+    [Fact]
+    public void NoRequest_YieldsEverythingLicensed()
+    {
+        var caller = Caller(false, Entry("Plugins", "Publish"), Entry("Plugins", "Store"));
+        Assert.Equal(["Plugins/Publish", "Plugins/Store"], Scope(caller));
+    }
+
+    [Fact]
+    public void AnExactRequestIsHonoured()
+    {
+        var caller = Caller(false, Entry("Plugins", "Publish"), Entry("Plugins", "Store"));
+        Assert.Equal(["Plugins/Publish"], Scope(caller, "Plugins/Publish"));
+    }
+
+    [Fact]
+    public void AWholeSourceRequest_EXPANDS_ToTheLicensedPackages()
+    {
+        // THE regression this test exists for: matching instead of expanding returned nothing, and
+        // the endpoint answered 403 to a caller asking a perfectly reasonable question.
+        var caller = Caller(false, Entry("Plugins", "Publish"), Entry("Plugins", "Store"));
+        Assert.Equal(["Plugins/Publish", "Plugins/Store"], Scope(caller, "Plugins/*"));
+    }
+
+    [Fact]
+    public void AWholeSourceRequest_ExpandsOnlyWithinThatSource()
+    {
+        var caller = Caller(false, Entry("Plugins", "Publish"), Entry("Education", "DataModeling"));
+        Assert.Equal(["Plugins/Publish"], Scope(caller, "Plugins/*"));
+    }
+
+    [Fact]
+    public void AWholeSourceLicenceStaysAWholeSourceScope()
+    {
+        var caller = Caller(false, Entry("Plugins", PluginGrantEntry.AllPackages));
+        Assert.Equal(["Plugins/*"], Scope(caller, "Plugins/*"));
+        // And an exact request under a whole-source licence narrows to that package.
+        Assert.Equal(["Plugins/Publish"], Scope(caller, "Plugins/Publish"));
+    }
+
+    [Fact]
+    public void AnUnlicensedRequestIsDropped_NotRefused()
+    {
+        // A token can only narrow, so an over-broad request is a stale caller rather than an attack.
+        var caller = Caller(false, Entry("Plugins", "Publish"));
+        Assert.Equal(["Plugins/Publish"], Scope(caller, "Plugins/Publish", "Education/DataModeling"));
+    }
+
+    [Fact]
+    public void RequestingOnlyUnlicensedThings_YieldsNothing_SoTheEndpointCanSayWhy()
+    {
+        var caller = Caller(false, Entry("Plugins", "Publish"));
+        Assert.Empty(Scope(caller, "Education/DataModeling"));
+    }
+
+    [Fact]
+    public void AnExpiredEntryIsNotOffered()
+    {
+        // Minting against an ended licence would hand back a token that fails on every call.
+        var caller = Caller(false, Entry("Plugins", "Publish", Now.AddDays(-1)), Entry("Plugins", "Store"));
+        Assert.Equal(["Plugins/Store"], Scope(caller));
+        Assert.Empty(Scope(caller, "Plugins/Publish"));
+    }
+
+    [Fact]
+    public void AnExpiredEntryIsNotOfferedByAWildcardEither()
+    {
+        var caller = Caller(false, Entry("Plugins", "Publish", Now.AddDays(-1)));
+        Assert.Empty(Scope(caller, "Plugins/*"));
+    }
+
+    [Fact]
+    public void ARevokedGrantOffersNothing()
+    {
+        var caller = Caller(true, Entry("Plugins", "Publish"));
+        Assert.Empty(Scope(caller));
+        Assert.Empty(Scope(caller, "Plugins/Publish"));
+        Assert.Empty(Scope(caller, "Plugins/*"));
+    }
+
+    [Fact]
+    public void MalformedRequestEntriesAreIgnored_NeverThrown()
+    {
+        var caller = Caller(false, Entry("Plugins", "Publish"));
+        Assert.Equal(["Plugins/Publish"], Scope(caller, "", "   ", "/", "Plugins/Publish"));
+    }
+
+    [Fact]
+    public void DuplicateRequestsCollapse()
+    {
+        var caller = Caller(false, Entry("Plugins", "Publish"));
+        Assert.Equal(["Plugins/Publish"], Scope(caller, "Plugins/Publish", "Plugins/Publish", "Plugins/*"));
+    }
+
+    [Fact]
+    public void SourceMatchingIsCaseInsensitive_AsItIsInAGrant()
+    {
+        var caller = Caller(false, Entry("Plugins", "Publish"));
+        Assert.Equal(["Plugins/Publish"], Scope(caller, "plugins/Publish"));
+        Assert.Equal(["Plugins/Publish"], Scope(caller, "PLUGINS/*"));
+    }
+}

--- a/test/MeshWeaver.Auth.Test/SyncTokenAuthenticationTest.cs
+++ b/test/MeshWeaver.Auth.Test/SyncTokenAuthenticationTest.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Auth.Test;
+
+/// <summary>
+/// Pins the short-lived access token END TO END against a real mesh: an instance exchanges its
+/// durable <c>mwi_</c> key for a scoped <c>mwa_</c> token, and the registry authenticator resolves
+/// it, narrows by its scope, and still consults the live sync licence.
+///
+/// <para>The unit tests in <c>SyncAccessTokenTest</c> prove the token's cryptography. What can only
+/// be proved here is the wiring: that a token resolves to the right instance through the same index
+/// the key uses, that it can only ever NARROW, and that a revoked or expired licence beats a
+/// perfectly valid token.</para>
+/// </summary>
+public class SyncTokenAuthenticationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string SigningKey = "test-signing-key-that-is-long-enough-32+";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddPluginCatalog()
+            .ConfigureServices(services => services.AddSingleton(
+                new PluginCatalogOptions { TokenSigningKey = SigningKey }));
+
+    private MeshWeaverInstanceService Instances() => new(
+        Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+        Mesh,
+        Mesh.ServiceProvider.GetRequiredService<ILogger<MeshWeaverInstanceService>>(),
+        new ConfigurationBuilder().Build());
+
+    private InstanceRegistryAuthenticator Authenticator() => new(
+        Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<InstanceRegistryAuthenticator>>());
+
+    private SyncLicenseService Licenses() =>
+        Mesh.ServiceProvider.GetRequiredService<SyncLicenseService>();
+
+    /// <summary>Registers an instance and licences it for the given entries.</summary>
+    private async Task<(string InstanceId, string RawKey, string KeyHash)> LicensedInstance(
+        string instanceId, params (string Source, string Package)[] licensed)
+    {
+        var registration = await Instances()
+            .Register("owner", "Owner", "owner@test.com", instanceId, instanceId)
+            .Should().Emit();
+
+        foreach (var (source, package) in licensed)
+            await Licenses().Issue(new SyncLicenseRequest
+            {
+                InstanceId = instanceId,
+                Source = source,
+                PackageId = package,
+                IssuedByUserId = "platform-admin",
+                IssuedVia = "test",
+            }).Should().Emit();
+
+        return (instanceId, registration.RawKey, InstanceKeys.Hash(registration.RawKey));
+    }
+
+    private string MintToken(string instanceId, string keyHash, params string[] scope) =>
+        SyncAccessToken.Mint(instanceId, keyHash, scope, DateTimeOffset.UtcNow,
+            SyncAccessToken.DefaultLifetime, System.Text.Encoding.UTF8.GetBytes(SigningKey));
+
+    [Fact]
+    public async Task AToken_AuthenticatesAndResolvesToItsInstance()
+    {
+        var (id, _, hash) = await LicensedInstance("tok-a", ("Plugins", "*"));
+
+        var caller = await Authenticator()
+            .Authenticate($"Bearer {MintToken(id, hash)}")
+            .Should().Emit();
+
+        caller.Should().NotBeNull();
+        caller!.Instance.InstanceId.Should().Be(id);
+        caller.TokenScope.Should().NotBeNull("the caller came in on a token, not the durable key");
+        caller.Allows("Plugins", "Publish").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AScopedToken_NarrowsBelowTheLicence()
+    {
+        // Licensed for the whole source, but the token asked for one package — the token wins
+        // DOWNWARD. This is the CI case: a build agent holds a credential for exactly what it needs.
+        var (id, _, hash) = await LicensedInstance("tok-narrow", ("Plugins", "*"));
+
+        var caller = await Authenticator()
+            .Authenticate($"Bearer {MintToken(id, hash, "Plugins/Publish")}")
+            .Should().Emit();
+
+        caller.Should().NotBeNull();
+        caller!.Allows("Plugins", "Publish").Should().BeTrue();
+        caller.Allows("Plugins", "Store").Should().BeFalse("the token narrowed to Publish");
+    }
+
+    [Fact]
+    public async Task ATokenCanNeverWiden_TheLicenceStillDecides()
+    {
+        // A token minted for more than the licence covers grants nothing extra. The token carries
+        // scope, never authority — so forging a broader scope (or holding a stale one after a
+        // licence shrank) buys nothing.
+        var (id, _, hash) = await LicensedInstance("tok-widen", ("Plugins", "Publish"));
+
+        var caller = await Authenticator()
+            .Authenticate($"Bearer {MintToken(id, hash, "Plugins/*", "Education/DataModeling")}")
+            .Should().Emit();
+
+        caller.Should().NotBeNull();
+        caller!.Allows("Plugins", "Publish").Should().BeTrue();
+        caller.Allows("Plugins", "Store").Should().BeFalse();
+        caller.Allows("Education", "DataModeling").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RevokingTheLicence_TakesEffectImmediately_NotWhenTheTokenExpires()
+    {
+        // The reason authority is re-read on every request rather than baked into the token.
+        var (id, _, hash) = await LicensedInstance("tok-revoke", ("Plugins", "Publish"));
+        var token = MintToken(id, hash, "Plugins/Publish");
+
+        var before = await Authenticator().Authenticate($"Bearer {token}").Should().Emit();
+        before!.Allows("Plugins", "Publish").Should().BeTrue();
+
+        await Licenses().RevokeAll(id, "platform-admin").Should().Emit();
+
+        // The authenticator caches a resolution briefly; a fresh instance reads the live grant.
+        var after = await Authenticator().Authenticate($"Bearer {token}").Should().Emit();
+        after.Should().NotBeNull("the token is still cryptographically valid");
+        after!.Allows("Plugins", "Publish").Should()
+            .BeFalse("the sync licence was revoked, and the grant is what authorizes");
+    }
+
+    [Fact]
+    public async Task AnExpiredLicence_DeniesEvenAValidToken()
+    {
+        var (id, _, hash) = await LicensedInstance("tok-expired");
+        await Licenses().Issue(new SyncLicenseRequest
+        {
+            InstanceId = id,
+            Source = "Plugins",
+            PackageId = "Publish",
+            IssuedByUserId = "platform-admin",
+            ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(-1),
+        }).Should().Emit();
+
+        var caller = await Authenticator()
+            .Authenticate($"Bearer {MintToken(id, hash, "Plugins/Publish")}")
+            .Should().Emit();
+
+        caller.Should().NotBeNull();
+        caller!.Allows("Plugins", "Publish").Should().BeFalse("the licence term had already ended");
+    }
+
+    [Fact]
+    public async Task ATokenForAnUnknownKey_DoesNotAuthenticate()
+    {
+        await LicensedInstance("tok-unknown", ("Plugins", "*"));
+        var strayHash = InstanceKeys.Hash(InstanceKeys.Generate());
+
+        var caller = await Authenticator()
+            .Authenticate($"Bearer {MintToken("tok-unknown", strayHash)}")
+            .Should().Emit();
+
+        caller.Should().BeNull("the token routes by key hash, and that key was never issued");
+    }
+
+    [Fact]
+    public async Task ATokenSignedWithAnotherKey_DoesNotAuthenticate()
+    {
+        var (id, _, hash) = await LicensedInstance("tok-forged", ("Plugins", "*"));
+        var forged = SyncAccessToken.Mint(id, hash, [], DateTimeOffset.UtcNow,
+            SyncAccessToken.DefaultLifetime, System.Text.Encoding.UTF8.GetBytes(new string('z', 40)));
+
+        var caller = await Authenticator().Authenticate($"Bearer {forged}").Should().Emit();
+        caller.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TheDurableKeyStillAuthenticates_AndCarriesNoTokenScope()
+    {
+        // The token path must not disturb the key path it sits beside.
+        var (_, rawKey, _) = await LicensedInstance("tok-durable", ("Plugins", "*"));
+
+        var caller = await Authenticator().Authenticate($"Bearer {rawKey}").Should().Emit();
+
+        caller.Should().NotBeNull();
+        caller!.TokenScope.Should().BeNull("this caller presented the durable key");
+        caller.Allows("Plugins", "Publish").Should().BeTrue();
+    }
+}

--- a/test/MeshWeaver.Auth.Test/SyncTokenAuthenticationTest.cs
+++ b/test/MeshWeaver.Auth.Test/SyncTokenAuthenticationTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Memex.Portal.Shared.Authentication;
 using MeshWeaver.Data;
@@ -29,13 +30,16 @@ namespace MeshWeaver.Auth.Test;
 /// </summary>
 public class SyncTokenAuthenticationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
-    private const string SigningKey = "test-signing-key-that-is-long-enough-32+";
-
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder)
-            .AddPluginCatalog()
-            .ConfigureServices(services => services.AddSingleton(
-                new PluginCatalogOptions { TokenSigningKey = SigningKey }));
+            .AddPluginCatalog();
+
+    private SyncTokenSigningKeyService Keys() =>
+        Mesh.ServiceProvider.GetRequiredService<SyncTokenSigningKeyService>();
+
+    /// <summary>The registry's signing key, minted from the mesh on first ask — no configuration.</summary>
+    private async Task<byte[]> SigningKey() =>
+        (await Keys().Resolve().Should().Emit()).Current;
 
     private MeshWeaverInstanceService Instances() => new(
         Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
@@ -70,9 +74,9 @@ public class SyncTokenAuthenticationTest(ITestOutputHelper output) : MonolithMes
         return (instanceId, registration.RawKey, InstanceKeys.Hash(registration.RawKey));
     }
 
-    private string MintToken(string instanceId, string keyHash, params string[] scope) =>
+    private async Task<string> MintToken(string instanceId, string keyHash, params string[] scope) =>
         SyncAccessToken.Mint(instanceId, keyHash, scope, DateTimeOffset.UtcNow,
-            SyncAccessToken.DefaultLifetime, System.Text.Encoding.UTF8.GetBytes(SigningKey));
+            SyncAccessToken.DefaultLifetime, await SigningKey());
 
     [Fact]
     public async Task AToken_AuthenticatesAndResolvesToItsInstance()
@@ -80,7 +84,7 @@ public class SyncTokenAuthenticationTest(ITestOutputHelper output) : MonolithMes
         var (id, _, hash) = await LicensedInstance("tok-a", ("Plugins", "*"));
 
         var caller = await Authenticator()
-            .Authenticate($"Bearer {MintToken(id, hash)}")
+            .Authenticate($"Bearer {await MintToken(id, hash)}")
             .Should().Emit();
 
         caller.Should().NotBeNull();
@@ -97,7 +101,7 @@ public class SyncTokenAuthenticationTest(ITestOutputHelper output) : MonolithMes
         var (id, _, hash) = await LicensedInstance("tok-narrow", ("Plugins", "*"));
 
         var caller = await Authenticator()
-            .Authenticate($"Bearer {MintToken(id, hash, "Plugins/Publish")}")
+            .Authenticate($"Bearer {await MintToken(id, hash, "Plugins/Publish")}")
             .Should().Emit();
 
         caller.Should().NotBeNull();
@@ -114,7 +118,7 @@ public class SyncTokenAuthenticationTest(ITestOutputHelper output) : MonolithMes
         var (id, _, hash) = await LicensedInstance("tok-widen", ("Plugins", "Publish"));
 
         var caller = await Authenticator()
-            .Authenticate($"Bearer {MintToken(id, hash, "Plugins/*", "Education/DataModeling")}")
+            .Authenticate($"Bearer {await MintToken(id, hash, "Plugins/*", "Education/DataModeling")}")
             .Should().Emit();
 
         caller.Should().NotBeNull();
@@ -128,7 +132,7 @@ public class SyncTokenAuthenticationTest(ITestOutputHelper output) : MonolithMes
     {
         // The reason authority is re-read on every request rather than baked into the token.
         var (id, _, hash) = await LicensedInstance("tok-revoke", ("Plugins", "Publish"));
-        var token = MintToken(id, hash, "Plugins/Publish");
+        var token = await MintToken(id, hash, "Plugins/Publish");
 
         var before = await Authenticator().Authenticate($"Bearer {token}").Should().Emit();
         before!.Allows("Plugins", "Publish").Should().BeTrue();
@@ -156,7 +160,7 @@ public class SyncTokenAuthenticationTest(ITestOutputHelper output) : MonolithMes
         }).Should().Emit();
 
         var caller = await Authenticator()
-            .Authenticate($"Bearer {MintToken(id, hash, "Plugins/Publish")}")
+            .Authenticate($"Bearer {await MintToken(id, hash, "Plugins/Publish")}")
             .Should().Emit();
 
         caller.Should().NotBeNull();
@@ -170,7 +174,7 @@ public class SyncTokenAuthenticationTest(ITestOutputHelper output) : MonolithMes
         var strayHash = InstanceKeys.Hash(InstanceKeys.Generate());
 
         var caller = await Authenticator()
-            .Authenticate($"Bearer {MintToken("tok-unknown", strayHash)}")
+            .Authenticate($"Bearer {await MintToken("tok-unknown", strayHash)}")
             .Should().Emit();
 
         caller.Should().BeNull("the token routes by key hash, and that key was never issued");
@@ -198,5 +202,100 @@ public class SyncTokenAuthenticationTest(ITestOutputHelper output) : MonolithMes
         caller.Should().NotBeNull();
         caller!.TokenScope.Should().BeNull("this caller presented the durable key");
         caller.Allows("Plugins", "Publish").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TheSigningKeyIsMintedOnceAndSharedByEveryReplica()
+    {
+        // 🚨 THE uniqueness property, and the reason the key is a mesh NODE rather than a lock or a
+        // per-process secret: two replicas asking independently must end up with the SAME key, or a
+        // token minted on one fails on the other. Two separate service instances stand in for two
+        // replicas — they share only the mesh.
+        var replicaA = new SyncTokenSigningKeyService(
+            Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<SyncTokenSigningKeyService>>());
+        var replicaB = new SyncTokenSigningKeyService(
+            Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<SyncTokenSigningKeyService>>());
+
+        // Both are STARTED before either finishes — a sequential A-then-B would only prove that a
+        // second reader finds an existing node, never that the create COLLISION resolves to one key.
+        var raceA = replicaA.Resolve().FirstAsync().ToTask();
+        var raceB = replicaB.Resolve().FirstAsync().ToTask();
+        var raced = await Task.WhenAll(raceA, raceB);
+        var fromA = raced[0];
+        var fromB = raced[1];
+
+        Convert.ToBase64String(fromB.Current).Should().Be(
+            Convert.ToBase64String(fromA.Current),
+            "the loser of the mint race adopts the winner's key instead of overwriting it");
+
+        // And the practical consequence: a token minted by one verifies on the other.
+        var (id, _, hash) = await LicensedInstance("tok-shared", ("Plugins", "Publish"));
+        var minted = SyncAccessToken.Mint(id, hash, ["Plugins/Publish"], DateTimeOffset.UtcNow,
+            SyncAccessToken.DefaultLifetime, fromA.Current);
+        fromB.Verify(minted, DateTimeOffset.UtcNow).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RotationKeepsTokensInFlightWorking()
+    {
+        // A rotation that simply replaced the key would invalidate every token minted in the minutes
+        // before it — mid-run, for every consumer.
+        var keys = Keys();
+        var before = await keys.Resolve().Should().Emit();
+
+        var (id, _, hash) = await LicensedInstance("tok-rotate", ("Plugins", "Publish"));
+        var mintedBeforeRotation = SyncAccessToken.Mint(
+            id, hash, ["Plugins/Publish"], DateTimeOffset.UtcNow,
+            SyncAccessToken.DefaultLifetime, before.Current);
+
+        var after = await keys.Rotate("test").Should().Emit();
+
+        Convert.ToBase64String(after.Current).Should().NotBe(
+            Convert.ToBase64String(before.Current), "rotation mints fresh material");
+        Convert.ToBase64String(after.Previous!).Should().Be(
+            Convert.ToBase64String(before.Current), "the outgoing key is retained, not discarded");
+        after.Verify(mintedBeforeRotation, DateTimeOffset.UtcNow).Should()
+            .NotBeNull("a token minted just before the rotation must still verify");
+
+        // New tokens are signed with the NEW key, and still verify.
+        var mintedAfter = SyncAccessToken.Mint(
+            id, hash, ["Plugins/Publish"], DateTimeOffset.UtcNow,
+            SyncAccessToken.DefaultLifetime, after.Current);
+        after.Verify(mintedAfter, DateTimeOffset.UtcNow).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task TheAuthenticatorPicksUpARotation()
+    {
+        // The authenticator caches key material briefly; a token signed with the rotated-in key must
+        // authenticate, which is what proves the key is read from the mesh and not from a captured
+        // configuration value.
+        var (id, _, hash) = await LicensedInstance("tok-rot-auth", ("Plugins", "Publish"));
+        var rotated = await Keys().Rotate("test").Should().Emit();
+
+        var token = SyncAccessToken.Mint(id, hash, ["Plugins/Publish"], DateTimeOffset.UtcNow,
+            SyncAccessToken.DefaultLifetime, rotated.Current);
+
+        var caller = await Authenticator().Authenticate($"Bearer {token}").Should().Emit();
+        caller.Should().NotBeNull();
+        caller!.Allows("Plugins", "Publish").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AnUnauthenticatedTokenDoesNotMintAKey()
+    {
+        // Minting is a node write. If the VERIFY path minted, an anonymous caller sending junk could
+        // provoke one — and it would be pointless anyway, since a token cannot verify against a key
+        // created after it was signed.
+        var keys = Keys();
+        (await keys.Existing().Should().Emit()).Should().BeNull("nothing has minted yet");
+
+        var caller = await Authenticator()
+            .Authenticate("Bearer mwa_not-a-real-token.nope")
+            .Should().Emit();
+
+        caller.Should().BeNull();
+        (await keys.Existing().Should().Emit()).Should()
+            .BeNull("verifying a junk token must not have written a signing key");
     }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/LicenseAcceptanceGateTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/LicenseAcceptanceGateTest.cs
@@ -1,0 +1,106 @@
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins the body-hash rule that makes a recorded <see cref="LicenseAcceptance"/> mean anything: an
+/// acceptance is only evidence against the text that was actually shown.
+///
+/// <para>The hash is the part with a real trap on both sides. Too strict and every acceptance is
+/// revoked by a line-ending change no reader could see; too loose and revised terms are silently
+/// covered by consent given to the old ones.</para>
+/// </summary>
+public class LicenseAcceptanceGateTest
+{
+    [Fact]
+    public void TheSameTextHashesTheSame()
+        => Assert.Equal(
+            LicenseAcceptanceGate.BodyHash("Permission is hereby granted."),
+            LicenseAcceptanceGate.BodyHash("Permission is hereby granted."));
+
+    [Fact]
+    public void DifferentTermsHashDifferently()
+    {
+        // The case the gate exists for: terms revised after someone accepted them.
+        Assert.NotEqual(
+            LicenseAcceptanceGate.BodyHash("You may use this for anything."),
+            LicenseAcceptanceGate.BodyHash("You may use this for non-commercial purposes only."));
+    }
+
+    [Theory]
+    [InlineData("a\nb", "a\r\nb")]
+    [InlineData("a\nb", "a\rb")]
+    [InlineData("terms", "terms\n")]
+    [InlineData("terms", "terms   ")]
+    [InlineData("terms", "terms\r\n\r\n")]
+    public void NormalizationIgnoresWhatARoundTripChanges(string left, string right)
+    {
+        // A licence body that passes through git, an editor or a copy-paste can change bytes
+        // without changing terms. Hashing those raw would revoke every acceptance for a reason
+        // nobody could see on screen.
+        Assert.Equal(LicenseAcceptanceGate.BodyHash(left), LicenseAcceptanceGate.BodyHash(right));
+    }
+
+    [Fact]
+    public void NormalizationDoesNotIgnoreLEADINGWhitespace()
+    {
+        // Only trailing whitespace and line endings are noise. Indentation can be meaningful in a
+        // licence, so it stays part of the hash.
+        Assert.NotEqual(
+            LicenseAcceptanceGate.BodyHash("terms"),
+            LicenseAcceptanceGate.BodyHash("   terms"));
+    }
+
+    [Fact]
+    public void InternalWhitespaceIsSignificant()
+        => Assert.NotEqual(
+            LicenseAcceptanceGate.BodyHash("no commercial use"),
+            LicenseAcceptanceGate.BodyHash("no  commercial use"));
+
+    [Fact]
+    public void NullAndEmptyHashAlike_AndDoNotThrow()
+    {
+        // A licence node with no body is a defect, not a crash — the gate reports it by failing to
+        // match rather than by taking the install down.
+        Assert.Equal(LicenseAcceptanceGate.BodyHash(null), LicenseAcceptanceGate.BodyHash(""));
+        Assert.NotEmpty(LicenseAcceptanceGate.BodyHash(null));
+    }
+
+    [Fact]
+    public void TheHashIsLowercaseHexSha256()
+    {
+        var hash = LicenseAcceptanceGate.BodyHash("terms");
+        Assert.Equal(64, hash.Length);
+        Assert.Equal(hash.ToLowerInvariant(), hash);
+        Assert.All(hash, c => Assert.True(char.IsAsciiHexDigitLower(c)));
+    }
+
+    [Fact]
+    public void AnAcceptanceRecordCarriesTheHashItWasGivenAgainst()
+    {
+        // The shape the gate compares — pinned so the field cannot quietly stop being populated.
+        var body = "You may use this for non-commercial purposes only.";
+        var acceptance = new LicenseAcceptance
+        {
+            SpdxId = "Systemorph-Commercial-1.0",
+            PackageId = "Publish",
+            UserId = "rbuergi",
+            AcceptedAt = DateTimeOffset.UtcNow,
+            BodyHash = LicenseAcceptanceGate.BodyHash(body),
+        };
+
+        Assert.Equal(LicenseAcceptanceGate.BodyHash(body), acceptance.BodyHash);
+        Assert.NotEqual(LicenseAcceptanceGate.BodyHash(body + " Except on Tuesdays."), acceptance.BodyHash);
+    }
+
+    [Fact]
+    public void ThePlatformsOwnLicencesAskForNoAcceptance()
+    {
+        // Apache-2.0 and MIT ask nothing of the user, so demanding a click is friction pretending to
+        // be diligence — and the gate must stay a no-op for the overwhelmingly common case.
+        Assert.Equal("Apache-2.0 OR MIT", WellKnownLicenses.PlatformSpdxExpression);
+        Assert.Contains("Apache-2.0", WellKnownLicenses.Shipped);
+        Assert.Contains("MIT", WellKnownLicenses.Shipped);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/SyncAccessTokenTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/SyncAccessTokenTest.cs
@@ -1,0 +1,210 @@
+using System.Security.Cryptography;
+using System.Text;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins the short-lived access token an instance exchanges its durable <c>mwi_</c> key for. Every
+/// case here is a forgery or a lifetime question, so the instants are explicit and the keys are
+/// fixed — a token test that depends on the wall clock proves nothing repeatably.
+/// </summary>
+public class SyncAccessTokenTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 18, 12, 0, 0, TimeSpan.Zero);
+    private static readonly byte[] Key = Encoding.UTF8.GetBytes(new string('k', 32));
+    private static readonly byte[] OtherKey = Encoding.UTF8.GetBytes(new string('x', 32));
+
+    private const string KeyHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    private static string Mint(
+        string instanceId = "manufacturing-ci",
+        string[]? scope = null,
+        TimeSpan? lifetime = null,
+        DateTimeOffset? issuedAt = null,
+        string keyHash = KeyHash) =>
+        SyncAccessToken.Mint(instanceId, keyHash, scope ?? [], issuedAt ?? Now,
+            lifetime ?? SyncAccessToken.DefaultLifetime, Key);
+
+    [Fact]
+    public void AMintedTokenVerifiesAndCarriesItsInstance()
+    {
+        var claims = SyncAccessToken.Verify(Mint(), Now, Key);
+        Assert.NotNull(claims);
+        Assert.Equal("manufacturing-ci", claims!.InstanceId);
+    }
+
+    [Fact]
+    public void TheTokenCarriesTheDistinguishingPrefix()
+        => Assert.StartsWith("mwa_", Mint(), StringComparison.Ordinal);
+
+    [Fact]
+    public void PrefixesAreDisjoint_SoNoValidatorAcceptsAnothersCredential()
+    {
+        // mwa_ (access) vs mwi_ (instance) vs mwr_ (registration) vs mw_ (personal). The instance
+        // extractor must not see a token, and the token extractor must not see an instance key.
+        var token = Mint();
+        var instanceKey = InstanceKeys.Generate();
+
+        Assert.Null(InstanceKeys.ExtractKey($"Bearer {token}"));
+        Assert.Null(SyncAccessToken.ExtractToken($"Bearer {instanceKey}"));
+        Assert.Equal(token, SyncAccessToken.ExtractToken($"Bearer {token}"));
+    }
+
+    [Fact]
+    public void AnExpiredTokenDoesNotVerify()
+    {
+        var token = Mint(lifetime: TimeSpan.FromMinutes(15));
+        Assert.NotNull(SyncAccessToken.Verify(token, Now.AddMinutes(14), Key));
+        Assert.Null(SyncAccessToken.Verify(token, Now.AddMinutes(15), Key));
+        Assert.Null(SyncAccessToken.Verify(token, Now.AddMinutes(16), Key));
+    }
+
+    [Fact]
+    public void ATokenSignedWithAnotherKeyDoesNotVerify()
+        => Assert.Null(SyncAccessToken.Verify(Mint(), Now, OtherKey));
+
+    [Fact]
+    public void TamperingWithThePayloadInvalidatesTheSignature()
+    {
+        // The whole point of signing: the scope and the instance id cannot be edited by the holder.
+        var token = Mint(scope: ["Plugins/Publish"]);
+        var body = token["mwa_".Length..];
+        var dot = body.IndexOf('.');
+        var forged = "mwa_" + body[..dot].Replace('a', 'b') + body[dot..];
+
+        Assert.NotEqual(token, forged);
+        Assert.Null(SyncAccessToken.Verify(forged, Now, Key));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("mwa_")]
+    [InlineData("mwa_nodot")]
+    [InlineData("mwa_.onlysignature")]
+    [InlineData("mwa_payloadonly.")]
+    [InlineData("not-a-token-at-all")]
+    [InlineData("mwa_!!!not-base64!!!.@@@")]
+    public void MalformedTokensAreRejectedRatherThanThrowing(string candidate)
+        => Assert.Null(SyncAccessToken.Verify(candidate, Now, Key));
+
+    [Fact]
+    public void AShortSigningKeyIsRefusedAtMint()
+    {
+        // A forgeable signature must fail loudly where it is created, not quietly where it is used.
+        var tooShort = Encoding.UTF8.GetBytes("short");
+        Assert.Throws<ArgumentException>(() =>
+            SyncAccessToken.Mint("ci", KeyHash, [], Now, SyncAccessToken.DefaultLifetime, tooShort));
+        Assert.False(SyncAccessToken.IsUsableSigningKey(tooShort));
+        Assert.True(SyncAccessToken.IsUsableSigningKey(Key));
+    }
+
+    [Fact]
+    public void VerifyingUnderAnUnusableKeyFailsClosed()
+        => Assert.Null(SyncAccessToken.Verify(Mint(), Now, Encoding.UTF8.GetBytes("short")));
+
+    [Fact]
+    public void ATokenMustNameItsInstance()
+        => Assert.Throws<ArgumentException>(() =>
+            SyncAccessToken.Mint("  ", KeyHash, [], Now, SyncAccessToken.DefaultLifetime, Key));
+
+    [Fact]
+    public void ATokenMustCarryTheKeyItWasExchangedFrom()
+        => Assert.Throws<ArgumentException>(() =>
+            SyncAccessToken.Mint("ci", "  ", [], Now, SyncAccessToken.DefaultLifetime, Key));
+
+    [Fact]
+    public void TheTokenIsBoundToTheKeyThatMintedIt()
+    {
+        // Re-issuing an instance key must invalidate every outstanding token. The binding that
+        // achieves it is the key hash the token carries: the instance record then holds a different
+        // one, so the token no longer resolves to it.
+        var claims = SyncAccessToken.Verify(Mint(keyHash: KeyHash), Now, Key);
+        Assert.NotNull(claims);
+        Assert.Equal(KeyHash, claims!.KeyHash);
+    }
+
+    [Fact]
+    public void LifetimeIsClampedToTheMaximum_NotRefused()
+    {
+        // A consumer written against a more generous registry should still work, not fail at the
+        // exchange — so an over-long request is clamped.
+        var token = Mint(lifetime: TimeSpan.FromDays(30));
+        var claims = SyncAccessToken.Verify(token, Now, Key);
+        Assert.NotNull(claims);
+        Assert.Equal(Now.Add(SyncAccessToken.MaximumLifetime), claims!.ExpiresAt);
+        Assert.Null(SyncAccessToken.Verify(token, Now.Add(SyncAccessToken.MaximumLifetime), Key));
+    }
+
+    [Fact]
+    public void ANonPositiveLifetimeFallsBackToTheDefault_NeverToAnAlreadyExpiredToken()
+    {
+        var claims = SyncAccessToken.Verify(Mint(lifetime: TimeSpan.Zero), Now, Key);
+        Assert.NotNull(claims);
+        Assert.Equal(Now.Add(SyncAccessToken.DefaultLifetime), claims!.ExpiresAt);
+    }
+
+    [Fact]
+    public void ScopeNarrowsWhatTheHolderMayAskAbout()
+    {
+        var claims = SyncAccessToken.Verify(Mint(scope: ["Plugins/Publish"]), Now, Key);
+        Assert.NotNull(claims);
+        Assert.True(claims!.Covers("Plugins", "Publish"));
+        Assert.False(claims.Covers("Plugins", "Store"));
+        Assert.False(claims.Covers("Education", "Publish"));
+    }
+
+    [Fact]
+    public void AnUnnarrowedTokenCoversEverything_TheGrantStillDecides()
+    {
+        // Empty scope means "not narrowed", NOT "nothing" — the token shortens the lifetime and the
+        // PluginGrant remains the authority.
+        var claims = SyncAccessToken.Verify(Mint(scope: []), Now, Key);
+        Assert.NotNull(claims);
+        Assert.True(claims!.Covers("Plugins", "Publish"));
+        Assert.True(claims.Covers("Education", "DataModeling"));
+    }
+
+    [Fact]
+    public void ScopeUnderstandsTheWholeSourceWildcard()
+    {
+        var claims = SyncAccessToken.Verify(Mint(scope: ["Plugins/*"]), Now, Key);
+        Assert.NotNull(claims);
+        Assert.True(claims!.Covers("Plugins", "Publish"));
+        Assert.True(claims.Covers("Plugins", "AnythingElse"));
+        Assert.False(claims.Covers("Education", "DataModeling"));
+    }
+
+    [Fact]
+    public void TwoTokensMintedTogetherAreDistinguishable()
+    {
+        // Same instance, same scope, same second — the nonce keeps them individually recognisable
+        // in a log rather than being one indistinguishable string.
+        Assert.NotEqual(Mint(), Mint());
+    }
+
+    [Fact]
+    public void ABasicAuthHeaderIsAccepted_ForClientsThatCannotSendBearer()
+    {
+        var token = Mint();
+        var header = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"instance:{token}"));
+        Assert.Equal(token, SyncAccessToken.ExtractToken(header));
+    }
+
+    [Fact]
+    public void AMalformedBasicHeaderIsRejectedRatherThanThrowing()
+        => Assert.Null(SyncAccessToken.ExtractToken("Basic !!!not-base64!!!"));
+
+    [Fact]
+    public void SignaturesUseTheFullKey_ARandomKeyRoundTrips()
+    {
+        // Guards against a mint that silently truncates or ignores the key material.
+        var random = RandomNumberGenerator.GetBytes(64);
+        var token = SyncAccessToken.Mint(
+            "ci", KeyHash, ["Plugins/Publish"], Now, TimeSpan.FromMinutes(5), random);
+        Assert.NotNull(SyncAccessToken.Verify(token, Now, random));
+        Assert.Null(SyncAccessToken.Verify(token, Now, RandomNumberGenerator.GetBytes(64)));
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/SyncAccessTokenTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/SyncAccessTokenTest.cs
@@ -207,4 +207,38 @@ public class SyncAccessTokenTest
         Assert.NotNull(SyncAccessToken.Verify(token, Now, random));
         Assert.Null(SyncAccessToken.Verify(token, Now, RandomNumberGenerator.GetBytes(64)));
     }
+
+    [Fact]
+    public void AnOversizedBasicPayloadIsRejectedWithoutDecoding()
+    {
+        // The reject path runs on UNAUTHENTICATED, attacker-controlled input, so it must not throw
+        // and must not allocate an unbounded buffer — a throwing parse lets anyone make the registry
+        // raise and unwind an exception per request. Same discipline as InstanceKeys.
+        var oversized = "Basic " + new string('A', 4096);
+        Assert.Null(SyncAccessToken.ExtractToken(oversized));
+    }
+
+    [Theory]
+    [InlineData("Basic ")]
+    [InlineData("Basic !!!!")]
+    [InlineData("Basic ====")]
+    [InlineData("Basic bm9jb2xvbg==")]
+    public void AMalformedBasicPayloadIsNullRatherThanAThrow(string header)
+        => Assert.Null(SyncAccessToken.ExtractToken(header));
+
+    [Fact]
+    public void ABasicPayloadWithNoTokenInThePasswordHalfIsRejected()
+    {
+        var header = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes("user:not-a-token"));
+        Assert.Null(SyncAccessToken.ExtractToken(header));
+    }
+
+    [Fact]
+    public void NonUtf8BasicBytesDoNotThrow()
+    {
+        // Replacement fallback turns invalid bytes into U+FFFD, which then simply fails the prefix
+        // check — rather than throwing on the decode.
+        var header = "Basic " + Convert.ToBase64String([0xFF, 0xFE, (byte)':', 0xFF]);
+        Assert.Null(SyncAccessToken.ExtractToken(header));
+    }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/SyncLicenseTermTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/SyncLicenseTermTest.cs
@@ -1,0 +1,152 @@
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins the TERM half of a sync licence — the part <see cref="PluginGrantTest"/> deliberately does
+/// not cover, because until licences existed a grant could only be present or absent.
+///
+/// <para>Every instant here is explicit. An expiry that can only be exercised by waiting is an
+/// expiry nobody pins, which is why <see cref="PluginGrant.Allows(string,string,DateTimeOffset)"/>
+/// takes <c>now</c> as an argument rather than reading the ambient clock.</para>
+/// </summary>
+public class SyncLicenseTermTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 18, 12, 0, 0, TimeSpan.Zero);
+
+    private static PluginGrant GrantWith(params PluginGrantEntry[] entries) =>
+        new() { InstanceId = "manufacturing-ci", Entries = entries };
+
+    private static PluginGrantEntry Entry(string source, string package, DateTimeOffset? expires = null) =>
+        new() { Source = source, PackageId = package, ExpiresAt = expires };
+
+    [Fact]
+    public void NoExpiry_IsPerpetual()
+    {
+        // The compatibility guarantee: every grant written before licences existed has no
+        // ExpiresAt, and must keep working exactly as it did.
+        var grant = GrantWith(Entry("Plugins", "Publish"));
+        Assert.True(grant.Allows("Plugins", "Publish", Now));
+        Assert.True(grant.Allows("Plugins", "Publish", Now.AddYears(50)));
+    }
+
+    [Fact]
+    public void WithinTerm_Allows()
+    {
+        var grant = GrantWith(Entry("Plugins", "Publish", Now.AddDays(30)));
+        Assert.True(grant.Allows("Plugins", "Publish", Now));
+    }
+
+    [Fact]
+    public void PastTerm_Denies()
+    {
+        var grant = GrantWith(Entry("Plugins", "Publish", Now.AddDays(-1)));
+        Assert.False(grant.Allows("Plugins", "Publish", Now));
+    }
+
+    [Fact]
+    public void TheExpiryInstantItself_IsAlreadyExpired()
+    {
+        // Half-open term: valid while now < ExpiresAt. Stating it as a test because "expires at T"
+        // is read both ways in the wild, and a licence that outlives its stated end by a tick is
+        // the kind of thing nobody notices until it matters.
+        var grant = GrantWith(Entry("Plugins", "Publish", Now));
+        Assert.False(grant.Allows("Plugins", "Publish", Now));
+        Assert.True(grant.Allows("Plugins", "Publish", Now.AddTicks(-1)));
+    }
+
+    [Fact]
+    public void ExpiryIsPerEntry_NotPerGrant()
+    {
+        // The reason the term lives on the entry: one instance routinely holds a perpetual licence
+        // for the platform repo alongside a termed licence for a paid package.
+        var grant = GrantWith(
+            Entry("Plugins", PluginGrantEntry.AllPackages),
+            Entry("Education", "DataModeling", Now.AddDays(-1)));
+
+        Assert.True(grant.Allows("Plugins", "Store", Now));
+        Assert.False(grant.Allows("Education", "DataModeling", Now));
+    }
+
+    [Fact]
+    public void AWholeSourceGrant_ExpiresToo()
+    {
+        var grant = GrantWith(Entry("Education", PluginGrantEntry.AllPackages, Now.AddDays(-1)));
+        Assert.False(grant.Allows("Education", "DataModeling", Now));
+        Assert.True(grant.Allows("Education", "DataModeling", Now.AddDays(-2)));
+    }
+
+    [Fact]
+    public void RevokedGrant_AuthorizesNothing_EvenWithLiveEntries()
+    {
+        var grant = GrantWith(Entry("Plugins", PluginGrantEntry.AllPackages)) with { IsRevoked = true };
+        Assert.False(grant.Allows("Plugins", "Publish", Now));
+        Assert.False(grant.Allows("Plugins", "Store", Now));
+    }
+
+    [Fact]
+    public void RevocationKeepsTheRecord_SoItCanBeReviewedAndLifted()
+    {
+        // RevokeAll flips a flag rather than emptying Entries: what was licensed, under what terms,
+        // has to survive the revocation or it cannot be reviewed afterwards — nor reinstated.
+        var revoked = GrantWith(Entry("Plugins", "Publish", Now.AddDays(30))) with { IsRevoked = true };
+        Assert.Single(revoked.Entries);
+        Assert.False(revoked.Allows("Plugins", "Publish", Now));
+
+        var reinstated = revoked with { IsRevoked = false };
+        Assert.True(reinstated.Allows("Plugins", "Publish", Now));
+    }
+
+    [Fact]
+    public void ReinstatingDoesNotRenew_AnExpiredEntryStaysExpired()
+    {
+        var revoked = GrantWith(Entry("Plugins", "Publish", Now.AddDays(-1))) with { IsRevoked = true };
+        var reinstated = revoked with { IsRevoked = false };
+        Assert.False(reinstated.Allows("Plugins", "Publish", Now));
+    }
+
+    [Fact]
+    public void MatchesIgnoresTheTerm_SoExpiredIsDistinguishableFromUnlicensed()
+    {
+        // The two answers need different remedies — renew, versus buy — so the record has to be
+        // able to tell them apart even though both deny.
+        var expired = Entry("Plugins", "Publish", Now.AddDays(-1));
+        Assert.True(expired.Matches("Plugins", "Publish"));
+        Assert.False(expired.IsValidAt(Now));
+
+        Assert.False(expired.Matches("Plugins", "Store"));
+    }
+
+    [Fact]
+    public void TheTermsAreCarriedOnTheEntry()
+    {
+        // What makes this a licence rather than an ACL: the entry records what it was issued
+        // under, and how it came about.
+        var entry = new PluginGrantEntry
+        {
+            Source = "Plugins",
+            PackageId = "Publish",
+            ExpiresAt = Now.AddYears(1),
+            IssuedUnderLicense = "Apache-2.0",
+            IssuedVia = "order 4711",
+            IssuedAt = Now,
+        };
+
+        Assert.Equal("Apache-2.0", entry.IssuedUnderLicense);
+        Assert.Equal("order 4711", entry.IssuedVia);
+        Assert.Equal(Now, entry.IssuedAt);
+        Assert.Equal("Plugins/Publish", entry.ToString());
+    }
+
+    [Fact]
+    public void UnspecifiedTermsStayNull_NeverDefaulted()
+    {
+        // Recording terms nobody granted is worse than recording none — the same rule
+        // Package.License follows.
+        var entry = Entry("Plugins", "Publish");
+        Assert.Null(entry.IssuedUnderLicense);
+        Assert.Null(entry.IssuedVia);
+        Assert.Null(entry.ExpiresAt);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/SyncTokenSigningKeyTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/SyncTokenSigningKeyTest.cs
@@ -1,0 +1,112 @@
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins the signing key's lifecycle arithmetic — the rotation due date and the grace window that
+/// keeps tokens in flight working. Pure, with explicit instants: a rotation window you can only
+/// exercise by waiting is one nobody pins.
+/// </summary>
+public class SyncTokenSigningKeyTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 18, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void AFreshKeyIsNotDueForRotation()
+    {
+        var key = new SyncTokenSigningKey
+        {
+            ProtectedCurrent = "k",
+            CurrentIssuedAt = Now,
+            RotateAfter = Now.Add(SyncTokenSigningKeys.RotationInterval),
+        };
+        Assert.False(key.RotationDue(Now));
+        Assert.False(key.RotationDue(Now.Add(SyncTokenSigningKeys.RotationInterval) - TimeSpan.FromTicks(1)));
+    }
+
+    [Fact]
+    public void RotationBecomesDueAtTheDueInstant()
+    {
+        var key = new SyncTokenSigningKey { ProtectedCurrent = "k", RotateAfter = Now };
+        // Inclusive here, unlike a licence term: "due at T" should fire AT T, not a tick later.
+        Assert.True(key.RotationDue(Now));
+        Assert.True(key.RotationDue(Now.AddDays(1)));
+    }
+
+    [Fact]
+    public void NoDueDateMeansNeverDue()
+    {
+        // A key with no schedule must not read as perpetually overdue — that would rotate on every
+        // read and invalidate tokens continuously.
+        var key = new SyncTokenSigningKey { ProtectedCurrent = "k", RotateAfter = null };
+        Assert.False(key.RotationDue(Now));
+        Assert.False(key.RotationDue(Now.AddYears(10)));
+    }
+
+    [Fact]
+    public void BeforeTheFirstRotationThereIsNoPreviousKey()
+    {
+        var key = new SyncTokenSigningKey { ProtectedCurrent = "k", CurrentIssuedAt = Now };
+        Assert.False(key.PreviousStillValid(Now));
+    }
+
+    [Fact]
+    public void TheOutgoingKeyStaysValidThroughTheGraceWindow()
+    {
+        // The property that stops a rotation from invalidating every token minted just before it.
+        var key = Rotated();
+        Assert.True(key.PreviousStillValid(Now));
+        Assert.True(key.PreviousStillValid(Now.Add(SyncTokenSigningKeys.RotationGrace) - TimeSpan.FromTicks(1)));
+    }
+
+    [Fact]
+    public void TheOutgoingKeyDiesWhenTheWindowCloses()
+    {
+        var key = Rotated();
+        Assert.False(key.PreviousStillValid(Now.Add(SyncTokenSigningKeys.RotationGrace)));
+        Assert.False(key.PreviousStillValid(Now.Add(SyncTokenSigningKeys.RotationGrace).AddHours(1)));
+    }
+
+    [Fact]
+    public void APreviousKeyWithNoDeadlineIsNotAccepted()
+    {
+        // Fail closed on a malformed record: an outgoing key with no expiry would otherwise be
+        // accepted forever, which is the opposite of what rotating is for.
+        var key = new SyncTokenSigningKey
+        {
+            ProtectedCurrent = "new", ProtectedPrevious = "old", PreviousValidUntil = null,
+        };
+        Assert.False(key.PreviousStillValid(Now));
+    }
+
+    [Fact]
+    public void TheGraceWindowIsExactlyOneMaximumTokenLifetime()
+    {
+        // Any longer keeps a retired key alive for tokens that cannot exist: nothing signed before
+        // the rotation can still be unexpired past one maximum lifetime.
+        Assert.Equal(SyncAccessToken.MaximumLifetime, SyncTokenSigningKeys.RotationGrace);
+    }
+
+    [Fact]
+    public void TheKeyIsLongerThanTheMinimumTheTokenDemands()
+        => Assert.True(SyncTokenSigningKeys.KeyByteLength >= SyncAccessToken.MinimumSigningKeyBytes);
+
+    [Fact]
+    public void ThePathIsFixed_WhichIsWhatMakesTheRaceCollide()
+    {
+        // Uniqueness comes from two replicas colliding on ONE path. An id that varied by host, pod
+        // or time would let every replica mint its own key and nothing would ever collide.
+        Assert.Equal("Admin/SyncTokenSigningKey/current", SyncTokenSigningKeys.Path);
+        Assert.Equal($"{SyncTokenSigningKeys.Namespace}/{SyncTokenSigningKeys.Id}", SyncTokenSigningKeys.Path);
+    }
+
+    private static SyncTokenSigningKey Rotated() => new()
+    {
+        ProtectedCurrent = "new",
+        CurrentIssuedAt = Now,
+        ProtectedPrevious = "old",
+        PreviousValidUntil = Now.Add(SyncTokenSigningKeys.RotationGrace),
+        RotateAfter = Now.Add(SyncTokenSigningKeys.RotationInterval),
+    };
+}


### PR DESCRIPTION
Closes #1835.

## Why

A `PluginGrant` could say WHICH packages a registered instance may replicate — and nothing else. No term, no terms, no record of what the right was granted *for*. Two writers only: the `DefaultGrants` registration seed, and an admin typing into the Instance-grants tab.

Workable for three instances; not for a catalogue. The pressure surfaced the usual way — a consumer that needed **one package** asked for a standing GitHub credential to a **whole repository**, because there was no smaller thing to ask for.

## What changed

**The grant IS the licence.** Entries carry `ExpiresAt`, `IssuedUnderLicense`, `IssuedVia`, `IssuedAt`; the grant carries `IsRevoked`. The term sits on the *entry* because one instance routinely holds a perpetual licence for the platform repo alongside a termed one for a paid package.

Null `ExpiresAt` is perpetual — every grant written before this behaves identically, and the existing `PluginGrantTest` suite is untouched and green. `Matches()` deliberately ignores the term, so *expired* is distinguishable from *never licensed*; the two need different remedies.

`SyncLicenseService` is the one writer — idempotent issue, revoke, revoke-all, reinstate. It *records* an authorization rather than making one (the decision belongs to the caller, as `PackageEntitlement` does), but refuses an issuance with no issuing principal.

**Acceptance is enforced.** `LicenseContent.RequiresAcceptance` and `LicenseAcceptance` shipped as node types with a body hash and **no callers at all**. `LicenseAcceptanceGate` now enforces them on both install paths, beside the entitlement check, so unattended installs are gated identically to a click. The body hash is *checked*: consent given against earlier terms does not satisfy revised ones. Normalization folds line endings and trailing whitespace and nothing else.

Permissive licences gate nothing — Apache-2.0 and MIT install exactly as before.

**`POST /api/instances/token`** exchanges the durable `mwi_` key for a short-lived, scoped `mwa_` token:

- carries identity and scope but **never authority** — the live grant is re-read every request, so a revocation lands at once rather than when the token expires;
- **can only narrow** — a token minted beyond its licence grants nothing extra;
- **cannot mint its successor** — only the durable key may exchange, or a minutes-long credential becomes perpetual by renewal.

Signed rather than stored (no per-issue write amplification, no expiry sweep) — only safe *because* authority is re-checked on use. It carries the hash of the key it came from, so it routes through the same index the raw key uses and a re-issued instance key invalidates outstanding tokens for free. Unset `PluginCatalog:TokenSigningKey` → 503 naming the config, never a weaker fallback.

## Compatibility

Additive. Existing grants, the durable-key path, and permissive-licence installs are unchanged; `PluginGrantTest` and the instance-registration suites pass untouched.

## Tests — 51 new

`SyncLicenseTermTest` (term/revocation rules) · `SyncAccessTokenTest` (cryptography, forgery, clamping, prefix disjointness) · `LicenseAcceptanceGateTest` (body-hash normalization) · `SyncTokenAuthenticationTest` (end-to-end against a real mesh: a token resolves, narrows, can never widen, and loses to a revoked or expired licence).

Both new invariants were verified **non-vacuous** by neutering them and watching the suite go red — 6/12 on the term check, and the narrowing test on the token scope.

Local: `-c Release -p:CIRun=true -warnaserror` clean on Mesh.Contract, PluginCatalog, Documentation and Memex.Portal.Shared. PluginCatalog.Test 461/461, Auth.Test instance+token 18/18, Documentation.Test 34/34.

## Follow-ups (deliberately not here)

- A consumer-side client for the exchange (CI can `curl` it today).
- Deriving licences from Store orders/coupons — the writer now exists for those callers to use.
- Retiring `MW_PLUGINS_REPO_TOKEN` in `MeshWeaver.Education`, whose **four** checkout sites (`e2e-install`, `e2e-mesh`, `e2e-journeys`, `publish-bake`) are what motivated this.