### PR TITLE
fix(#1814): the bake published to an address no portal read — restore the portal's canonical surface + guard the equality

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1153,6 +1153,78 @@ jobs:
           echo "BAKE_DIR=$BAKE" >> "$GITHUB_ENV"
           echo "baked identity: $(cat "$BAKE/framework-mvid.txt")"
           ls -l "$BAKE"/*.zip
+      # ─────────── THE ADDRESS CHECK — publish only to an address the portal actually reads ───────────
+      # 🚨 The framework identity is an ADDRESS, and until now NOTHING in this pipeline could observe
+      # that the producer and the consumer disagree about it. The bake publishes under the identity
+      # ITS host (mw-plugin-test) resolves; a portal only ever looks under the identity IT resolves.
+      # When the two differ the bundles are published, intact, to a directory no pod will ever open —
+      # so every publication-side check passes, this job goes green, and the pods compile everything
+      # at boot exactly as if the bake lane did not exist.
+      #
+      # That is not hypothetical. CD run 32063444385 baked release 3.0.0-rc4.ci.4201 (commit 493e1992)
+      # under sda0843abd6db4fc7e37cc3f838079265 while both prod pods asked for
+      # s944d7fd0bbf81f4b40b85a7a74296263 and logged "no CI-published bundles for framework identity".
+      # The first pod of that deploy compiled 269 NodeTypes over 10 m 29 s (+1598 MB working set); the
+      # second adopted from what the FIRST had compiled, not from CI. During that window ~12 instance
+      # hubs latched a compilation-fallback card and served it to anonymous visitors for two hours —
+      # every course cover on memex.meshweaver.cloud. Issue #1814.
+      #
+      # The cause was one host losing eight canonical assemblies from its surface manifest, which no
+      # amount of publication-side checking can see. A one-line comparison of the two VALUES can, and
+      # this is it. It runs BEFORE the publish on purpose: a bake nobody can adopt must fail the
+      # release rather than be filed under an address nobody reads. The release marker is then never
+      # written, so the deployment gate (#1754) holds too — fail-safe in both directions.
+      #
+      # 🚨 --platform linux/amd64 on BOTH pulls, out loud. The identity is per-architecture (the same
+      # four reference assemblies differ between the amd64 and arm64 legs of one multi-arch image), so
+      # a multi-arch image carries two identities and comparing across legs would be meaningless. Every
+      # AKS node is amd64 and the bake above already pins amd64; this pins the portal side to match.
+      # (An arm64 install — memex.localhost — resolves the OTHER identity and compiles locally; that is
+      # the second, independent way to mint an unread address, and publishing a second copy under it to
+      # "cover" it is forbidden: a bake is adoptable only when its producer ran the consumer's binaries.)
+      #
+      # The comparison is done by the bake image's own `framework-identity` verb, which resolves the
+      # identity of ANOTHER directory from that directory's meshweaver-surface.manifest and assemblies
+      # as FILES — nothing is loaded, so one container answers for the other image's /app. It refuses
+      # to answer for a directory with no usable manifest rather than degrading to the fallback
+      # identity: two manifest-less hosts of one commit resolve the SAME fallback, and a comparison
+      # that passes on degraded input would be a check that cannot fail.
+      - name: "Assert the bake's identity is the one the PROMOTED PORTAL IMAGE resolves"
+        env:
+          BAKE_IMAGE: ${{ env.ACR }}/mw-plugin-test:${{ needs.gate.outputs.staging_tag }}
+          PORTAL_IMAGE: ${{ env.ACR }}/memex-portal-ai:${{ needs.gate.outputs.staging_tag }}
+        run: |
+          set -euo pipefail
+          BAKED="$(tr -d '[:space:]' < "$BAKE_DIR/framework-mvid.txt")"
+          echo "the bake published under: $BAKED"
+          # The STAGING tag is this run's exact, immutable image — `main`/`latest` are moving
+          # pointers a concurrent CD run can re-aim mid-job, which would compare this bake against
+          # somebody else's build.
+          docker pull --quiet --platform linux/amd64 "$PORTAL_IMAGE"
+          STAGE="$RUNNER_TEMP/portal-image"
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE"
+          cid="$(docker create --platform linux/amd64 "$PORTAL_IMAGE")"
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+          # /app is ~306 MB (it is the app, not the base image), so copying it whole is cheap and
+          # uses nothing but `docker cp` — no tar wildcard flags that differ between tar flavours.
+          docker cp "$cid:/app" "$STAGE"
+          if [ ! -s "$STAGE/app/meshweaver-surface.manifest" ]; then
+            echo "::error::the promoted portal image ships no /app/meshweaver-surface.manifest, so it resolves the stamp/MVID FALLBACK identity and can adopt NO bake at all. That is the #1699 shape (the manifest missing from the publish output). Fix the image — do not publish a bake it cannot read."
+            exit 1
+          fi
+          echo "portal /app: $(ls "$STAGE/app"/MeshWeaver.*.dll | wc -l) MeshWeaver assemblies, $(wc -l < "$STAGE/app/meshweaver-surface.manifest") manifest lines"
+          # `--init` so a crashed tester exits instead of spinning as an unkillable PID 1 (#1741).
+          # The verb prints the portal's identity, compares it with the bake's, and on a mismatch
+          # names the canonical assemblies whose absence caused it — the actual defect in #1814 was
+          # eight of them, not "a hash that differs".
+          docker run --rm --init --platform linux/amd64 -v "$STAGE/app:/portal:ro" \
+            --entrypoint /app/mw-plugin-test "$BAKE_IMAGE" \
+            framework-identity /portal --expect "$BAKED"
+          {
+            echo "### 🔑 Bake address verified"
+            echo "- \`$BAKED\` — resolved by BOTH the bake host and the promoted \`memex-portal-ai\` image (linux/amd64)"
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: "Publish bundles to every portal target"
         env:
           BAKE_PUBLISH_TARGETS: ${{ vars.BAKE_PUBLISH_TARGETS }}

--- a/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+++ b/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
@@ -45,7 +45,57 @@
          one to the reference set, so `MeshWeaver.Import.dll` in Modules:Assemblies IS the
          declaration. It is listed FIRST there — the reference set is composed from the installed
          modules, so it must precede anything that compiles against it. The bits ship via the
-         modules/<Name>/ closure layout in MeshModulesPublish.targets. -->
+         modules/<Name>/ closure layout in MeshModulesPublish.targets.
+
+         🚨 …BUT THE COMPILE REFERENCE STAYS, WITH Private="false" — REMOVING IT TOOK THE SITE DOWN
+         (#1814). The framework build identity is the hash over the CANONICAL content-surface set
+         (FrameworkBuildIdentity.ContentSurfaceAssemblies), and each member's contribution is read
+         out of meshweaver-surface.manifest, which Directory.Build.props writes from
+         @(ReferencePathWithRefAssemblies) — a host's COMPILE references. So dropping this
+         ProjectReference dropped EIGHT canonical names (MeshWeaver.Import + its private
+         MeshWeaver.DataSetReader* / MeshWeaver.DataStructures closure) out of this image's manifest,
+         where they then hash as "absent" while the bake host (mw-plugin-test, which still references
+         them) hashes a real surface id. Two identities from ONE commit: CD baked release
+         3.0.0-rc4.ci.4201 under sda0843abd6db4fc7e37cc3f838079265 while both prod pods asked for
+         s944d7fd0bbf81f4b40b85a7a74296263. The bundles were published, intact, to an address nobody
+         reads — so every publication-side check passed, the bake job reported success, and the first
+         pod of each deploy Roslyn-compiled 269 types (10 m 29 s, +1598 MB) as if no bake existed.
+         That window is what let ~12 instance hubs latch a compilation-fallback card and serve it to
+         anonymous visitors for two hours.
+
+         Private="false" ExcludeAssets="runtime" PrivateAssets="all" is what keeps BOTH properties
+         true at once: the references restore the manifest entries (and therefore this image's
+         identity), while the bits stay OUT of the app publish root — modules/MeshWeaver.Import/ remains the only place
+         they ship, the closure lane's app-root refusal stays armed, TRUSTED_PLATFORM_ASSEMBLIES
+         still does not contain any of them, and CompileReferences.ComposeWithModules remains the one
+         thing that makes MeshWeaver.Import visible to in-mesh source. Nothing in this project's own
+         code uses any of it: these are SURFACE declarations.
+
+         🚨 ALL EIGHT are declared, not just the entry assembly, and that is measured rather than
+         defensive: Private/ExcludeAssets govern the DIRECT reference only, so declaring Import alone
+         still copied its seven transitive project outputs (and CsvHelper) into the app root —
+         re-shipping exactly what the module lane removed and pruning modules/MeshWeaver.Import/ down
+         to one file. Declaring each of the eight directly suppresses every copy: verified with a
+         from-clean Release build (CIRun=true, non-incremental) — manifest 54 to 62 lines and ZERO
+         new DLLs in bin/. The set is the canonical closure, so it is exactly what
+         FrameworkBuildIdentityTest.CanonicalContentSurface_IsRecordedByEverySurfaceManifestHost
+         checks — delete any one of them and that test goes red naming it, which is the check that
+         did not exist when this broke.
+
+         🚨 PrivateAssets="all" keeps the declaration PRIVATE TO THIS PROJECT, and that is measured
+         too: without it the references flow to everything that references this portal, and
+         test/Memex.Portal.Shared.Test (which does) copied MeshWeaver.Import.dll into its own bin
+         root — where the closure lane's prune then dropped it from modules/MeshWeaver.Import/ as a
+         same-relative-path duplicate. Eight ImportModuleLayoutTest cases went red on exactly that.
+         A surface declaration is this host's business; nothing downstream should inherit it. -->
+    <ProjectReference Include="..\..\..\src\MeshWeaver.Import\MeshWeaver.Import.csproj" Private="false" ExcludeAssets="runtime" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\src\MeshWeaver.DataSetReader\MeshWeaver.DataSetReader.csproj" Private="false" ExcludeAssets="runtime" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\src\MeshWeaver.DataSetReader.Csv\MeshWeaver.DataSetReader.Csv.csproj" Private="false" ExcludeAssets="runtime" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\src\MeshWeaver.DataSetReader.Excel\MeshWeaver.DataSetReader.Excel.csproj" Private="false" ExcludeAssets="runtime" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\src\MeshWeaver.DataSetReader.Excel.BinaryFormat\MeshWeaver.DataSetReader.Excel.BinaryFormat.csproj" Private="false" ExcludeAssets="runtime" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\src\MeshWeaver.DataSetReader.Excel.OpenXmlFormat\MeshWeaver.DataSetReader.Excel.OpenXmlFormat.csproj" Private="false" ExcludeAssets="runtime" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\src\MeshWeaver.DataSetReader.Excel.Utils\MeshWeaver.DataSetReader.Excel.Utils.csproj" Private="false" ExcludeAssets="runtime" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\src\MeshWeaver.DataStructures\MeshWeaver.DataStructures.csproj" Private="false" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Ship nuget.config into the image so the runtime `#r "nuget:..."` resolver can

--- a/src/MeshWeaver.Compiler/FrameworkBuildIdentity.cs
+++ b/src/MeshWeaver.Compiler/FrameworkBuildIdentity.cs
@@ -84,6 +84,20 @@ public static class FrameworkBuildIdentity
     /// the closure from the csproj graph and fails naming the drift when the tester's references
     /// change without this list following.
     ///
+    /// <para>🚨 <b>…AND EVERY OTHER MANIFEST HOST MUST RECORD THE SAME SET</b> (#1814). The list is
+    /// derived from the bake host, but the identity is only useful if the CONSUMERS resolve the same
+    /// value — and a canonical assembly a host does not COMPILE against gets no manifest line there
+    /// and hashes as <see cref="AbsentMarker"/>, forking that host's identity while its binaries stay
+    /// byte-identical. Moving <c>MeshWeaver.Import</c> and its private closure — eight names — out of
+    /// the portals' compile graphs into the runtime module lane did exactly that on 2026-08-17: the
+    /// bake published to an address no pod opened, every publication-side check passed, and the first
+    /// pod of each deploy recompiled 269 types while instance hubs latched fault cards.
+    /// <c>FrameworkBuildIdentityTest.CanonicalContentSurface_IsRecordedByEverySurfaceManifestHost</c>
+    /// pins the other side of that equality, and CD compares the two resolved VALUES before
+    /// publishing (<c>mw-plugin-test framework-identity … --expect …</c>, built on
+    /// <see cref="ResolveIdentityForDirectory"/>). Fix a failure by giving the host its compile
+    /// reference back — never by shrinking this list, which would under-invalidate.</para>
+    ///
     /// <para>🚨 <b>MOVING THE BAKE/GATE CLI INTO A NEW PROJECT SILENTLY CHANGES THE FRAMEWORK
     /// IDENTITY.</b> This list is anchored to <c>tools/MeshWeaver.PluginTester</c>'s reference
     /// closure, and the identity is the hash over these assemblies' surface-manifest pairs — an
@@ -259,12 +273,24 @@ public static class FrameworkBuildIdentity
     public static string ComputeSurfaceIdentity(
         IReadOnlyDictionary<string, string> surfaceByName,
         Func<string, string?> implMvidOf)
+        => ComputeSurfaceIdentity(surfaceByName, implMvidOf, FullMvidAssemblies);
+
+    /// <summary>
+    /// <see cref="ComputeSurfaceIdentity(IReadOnlyDictionary{string,string},Func{string,string?})"/>
+    /// with the full-MVID membership supplied explicitly — the form a resolution for a FOREIGN
+    /// host uses, where the toolchain closure has to be computed from THAT host's binaries rather
+    /// than from this process's (see <see cref="ResolveIdentityForDirectory"/>).
+    /// </summary>
+    public static string ComputeSurfaceIdentity(
+        IReadOnlyDictionary<string, string> surfaceByName,
+        Func<string, string?> implMvidOf,
+        IReadOnlyCollection<string> fullMvidAssemblies)
     {
         var text = new StringBuilder();
         foreach (var name in ContentSurfaceAssemblies)
         {
             string id;
-            if (FullMvidAssemblies.Contains(name))
+            if (fullMvidAssemblies.Contains(name))
                 id = implMvidOf(name)
                      ?? (surfaceByName.TryGetValue(name, out var surface) ? surface : AbsentMarker);
             else
@@ -445,6 +471,126 @@ public static class FrameworkBuildIdentity
         if (loaded is not null)
             return loaded.ManifestModule.ModuleVersionId.ToString("N");
         var candidate = Path.Combine(AppContext.BaseDirectory, simpleName + ".dll");
+        if (!File.Exists(candidate))
+            return null;
+        try
+        {
+            using var stream = File.OpenRead(candidate);
+            using var pe = new System.Reflection.PortableExecutable.PEReader(stream);
+            var md = pe.GetMetadataReader();
+            return md.GetGuid(md.GetModuleDefinition().Mvid).ToString("N");
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    // ── Resolving ANOTHER host's identity, from its binaries alone ─────────────────────────────
+
+    /// <summary>
+    /// 🚨 The identity a host whose application binaries live in <paramref name="appDirectory"/>
+    /// resolves — the SAME computation <see cref="ResolveProcessIdentityWithDiagnostics"/> performs
+    /// for its own base directory, expressed over a DIRECTORY so one process can answer it for
+    /// another's shipped binaries without loading a single assembly.
+    ///
+    /// <para>This exists because the identity is an ADDRESS: a bake publishes its bundles under the
+    /// identity its own host resolves, and a portal only ever looks under the identity IT resolves.
+    /// Nothing in the publication path could previously observe that the two disagree, which is
+    /// exactly how issue #1814 shipped — CD baked under <c>sda0843ab…</c> while both prod pods asked
+    /// for <c>s944d7fd…</c>, the bundles sat intact on the volume under an address nobody read, the
+    /// bake job reported success, and the first pod of every deploy recompiled 269 types
+    /// (10 m 29 s, +1598 MB) as though no bake existed. With this, CI can compare the two VALUES and
+    /// fail red — see the "the identity the bake publishes must be the identity the shipped portal
+    /// resolves" step in <c>main-cd.yml</c>.</para>
+    ///
+    /// <para>🚨 The comparison is only meaningful for the SAME ARCHITECTURE. The manifest records
+    /// reference-assembly hashes of a specific build, and the same four reference assemblies differ
+    /// between the amd64 and arm64 legs of one multi-arch image (see Directory.Build.props), so a
+    /// multi-arch image carries two identities. Callers must extract both directories for one
+    /// platform; the CI guard pins <c>--platform linux/amd64</c> out loud for that reason.</para>
+    ///
+    /// <para><b>Fails loudly rather than degrading.</b> A directory with no usable surface manifest
+    /// yields a null identity plus a diagnostic, never a fallback value: two manifest-less
+    /// directories built from the same commit would resolve the SAME fallback and a guard comparing
+    /// them would report a match having verified nothing.</para>
+    /// </summary>
+    /// <param name="appDirectory">The host's application directory — the one holding
+    /// <see cref="SurfaceManifestFileName"/> beside its assemblies (a container's <c>/app</c>).</param>
+    /// <returns>The resolved surface identity, or null with <c>Problem</c> naming why not.</returns>
+    public static (string? Identity, string? Problem) ResolveIdentityForDirectory(string appDirectory)
+    {
+        if (!Directory.Exists(appDirectory))
+            return (null, $"'{appDirectory}' does not exist or is not a directory");
+
+        var manifestPath = Path.Combine(appDirectory, SurfaceManifestFileName);
+        string manifestText;
+        try
+        {
+            if (!File.Exists(manifestPath))
+                return (null,
+                    $"'{manifestPath}' is missing — this host ships no surface manifest and "
+                    + "therefore resolves the stamp/MVID FALLBACK identity, which no bake may be "
+                    + "published under");
+            manifestText = File.ReadAllText(manifestPath);
+        }
+        catch (Exception ex)
+        {
+            return (null, $"'{manifestPath}' could not be read ({ex.GetType().Name}: {ex.Message})");
+        }
+
+        var pairs = ParseSurfaceManifest(manifestText);
+        if (pairs.Count == 0)
+            return (null, $"'{manifestPath}' holds no usable '<name>=<hash>' pairs");
+
+        var fullMvid = ComputeToolchainClosure(
+            ToolchainRoots, name => ReferencedMeshWeaverAssembliesInDirectory(appDirectory, name));
+        return (
+            ComputeSurfaceIdentity(pairs, name => ImplMvidInDirectory(appDirectory, name), fullMvid),
+            null);
+    }
+
+    /// <summary>
+    /// The canonical assemblies a directory's surface manifest does NOT record — the exact quantity
+    /// that made two hosts of one commit resolve different identities in #1814, since an unrecorded
+    /// canonical assembly hashes as <see cref="AbsentMarker"/>. Reported by name so a failing guard
+    /// says WHICH references a host lost rather than only that two hashes differ.
+    /// </summary>
+    public static ImmutableArray<string> CanonicalAssembliesAbsentFrom(
+        IReadOnlyDictionary<string, string> surfaceByName) =>
+        [.. ContentSurfaceAssemblies.Where(n => !surfaceByName.ContainsKey(n))];
+
+    /// <summary>An assembly's MeshWeaver.* AssemblyRef simple names read from the DLL in
+    /// <paramref name="directory"/> — metadata only, nothing loaded, so it answers for a FOREIGN
+    /// host's binaries. Missing/unreadable resolves empty, exactly as the process-level walk does
+    /// (the name still joins the closure; its MVID then resolves <see cref="AbsentMarker"/>).</summary>
+    private static IEnumerable<string> ReferencedMeshWeaverAssembliesInDirectory(
+        string directory, string simpleName)
+    {
+        var candidate = Path.Combine(directory, simpleName + ".dll");
+        if (!File.Exists(candidate))
+            return [];
+        try
+        {
+            using var stream = File.OpenRead(candidate);
+            using var pe = new System.Reflection.PortableExecutable.PEReader(stream);
+            var md = pe.GetMetadataReader();
+            return md.AssemblyReferences
+                .Select(h => md.GetString(md.GetAssemblyReference(h).Name))
+                .Where(n => !string.IsNullOrEmpty(n))
+                .ToList();
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    /// <summary>An assembly's implementation MVID read from the DLL in
+    /// <paramref name="directory"/> — metadata only, nothing loaded.</summary>
+    private static string? ImplMvidInDirectory(string directory, string simpleName)
+    {
+        var candidate = Path.Combine(directory, simpleName + ".dll");
         if (!File.Exists(candidate))
             return null;
         try

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -210,6 +210,81 @@ Manifest-less CI processes (test hosts) fall back to the commit identity `g<sha>
 (`MeshWeaver.Compiler.dll` — single-file attributable, which is what lets a packer read it without
 loading anything). The commit stamp doubles as provenance everywhere.
 
+### 🚨 …and both hosts must RECORD the same canonical set — the address check (#1814)
+
+The rule above is about the *bytes*. There is a second way for two hosts of one commit to resolve
+different identities, and it has nothing to do with bytes: **a canonical assembly that one host's
+surface manifest does not record at all.** `ComputeSurfaceIdentity` hashes every name in
+`ContentSurfaceAssemblies`, and a name the manifest has no line for contributes the literal
+`absent`. So a host that stops *compiling against* an assembly stops recording it — and forks its
+identity away from every other host — while its binaries are otherwise identical.
+
+That is what took memex.meshweaver.cloud's course covers down for two hours on 2026-08-17. The
+sequence, measured:
+
+* `feat: Excel/CSV import becomes its own module` (`82481e024`, merged 18:46 that evening) moved
+  `MeshWeaver.Import` and its private closure — `MeshWeaver.DataSetReader{,.Csv,.Excel,
+  .Excel.BinaryFormat,.Excel.OpenXmlFormat,.Excel.Utils}` and `MeshWeaver.DataStructures`, **eight
+  canonical names** — out of both portals' compile reference graphs into the `modules/<Name>/`
+  runtime lane. Correct on its own terms: the module lane still contributes `MeshWeaver.Import` to
+  the in-mesh compile reference set.
+* The manifest is written from `@(ReferencePathWithRefAssemblies)` — a host's **compile**
+  references — so those eight lines vanished from the portal's manifest only. `mw-plugin-test`,
+  the bake host, still referenced them.
+* Measured on the shipped images of `3.0.0-rc4.ci.4276`, both `--platform linux/amd64`:
+
+  | image | manifest | resolves |
+  |---|---|---|
+  | `mw-plugin-test` (bakes) | 38 lines | `s7293e54297ec28e213bd82f30d59e709` |
+  | `memex-portal-ai` (runs) | 54 lines | `sa6d587a25d64d11774f22348664bca0c` |
+
+  The **29 shared entries had byte-identical hashes**. Presence, not drift, was the entire
+  difference — and the net line counts (38 vs 54) hide it, because the portal legitimately carries
+  25 Blazor/Orleans/hosting names that are outside the canonical set by design.
+* Consequence: every bake was published, intact, under an address no pod ever opened. Publication
+  succeeded, the CD job was green, `check-release-availability.sh` passed — and each deploy's first
+  pod logged `compiled=269 alreadyBaked=0` and spent 10 m 29 s (+1598 MB working set) recompiling
+  what CI had already compiled. During that window ~12 instance hubs latched a compilation-fallback
+  card and served it to anonymous visitors long after the compile finished.
+
+**Two checks now stand where nothing stood.**
+
+1. **Offline, at PR time.** `CanonicalContentSurface_IsRecordedByEverySurfaceManifestHost`
+   (`FrameworkBuildIdentityTest`) recomputes, from the csproj graph, the compile closure of **every** project
+   that sets `MeshWeaverSurfaceManifest=true` and fails naming any canonical assembly a host does
+   not record. `CanonicalList_MatchesTheTesterClosure` had always pinned one side of that equality;
+   this pins the other, which is the half whose absence let a one-line-per-host change ship.
+2. **On the artifact, at release time.** `main-cd`'s `publish-bake` job resolves the identity of the
+   **promoted `memex-portal-ai` image** and compares it with the identity the bake published under,
+   **before** publishing. The comparison runs the bake image's own `framework-identity` verb:
+
+   ```
+   mw-plugin-test framework-identity <app-dir> [--expect <identity>]
+   ```
+
+   which resolves the identity of *another* host's `/app` from that directory's manifest and
+   assemblies as **files** — nothing is loaded, so one container answers for another image. It
+   refuses to answer for a directory with no usable manifest rather than degrading to the fallback
+   identity: two manifest-less hosts of one commit resolve the same fallback, and a comparison that
+   passes on degraded input is a check that cannot fail. On a mismatch it prints the canonical
+   assemblies the target does not record, because "the hashes differ" is not actionable and the real
+   defect was eight named assemblies.
+
+Both pulls pin `--platform linux/amd64`, out loud: the identity is per-architecture, so comparing
+across legs would be meaningless. That per-arch split is the *second* independent way to mint an
+unread address — `memex.localhost` is arm64 while the CI bake publishes amd64 — and the same guard
+covers it, because it compares the values two concrete hosts resolve.
+
+🚨 **The fix direction is always "give the host the reference back", never "shrink the canonical
+list".** Removing a name would make the two hosts agree by making the identity blind to that
+assembly's surface — an under-invalidation, which is how a portal ends up adopting NodeType
+assemblies compiled against a framework that has since shifted underneath them: a silent
+`TypeLoadException` inside an ALC at activation, the failure mode with no diagnostic and no overlay.
+`Memex.Portal.Distributed` therefore declares the eight as compile-only references
+(`Private="false" ExcludeAssets="runtime" PrivateAssets="all"`): the manifest records them, while
+the bits still ship only via `modules/MeshWeaver.Import/` and nothing downstream inherits the
+declaration.
+
 ## The image: `prebuilt/` beside the app
 
 `Memex.Portal.Distributed.csproj` accepts `-p:PrebuiltBakeDir=<dir>`: the bundle zips are laid into

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-deploys-adopt-the-prebuilt-content-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-deploys-adopt-the-prebuilt-content-again.md
@@ -1,0 +1,36 @@
+---
+Name: Deploys adopt prebuilt content again
+Category: Fix
+Description: CI's compiled content was being published to an address no portal ever read, so the first pod of every deploy recompiled everything — for ten minutes, while pages showed an error card.
+Icon: TopSpeed
+Order: -20260818
+---
+
+# Deploys adopt prebuilt content again
+
+CI compiles the platform's shipped content once, on release, so that a portal starting up can
+simply load the result instead of running the compiler itself. That saves about ten minutes on
+every pod start — and since 2026-08-17 it had quietly stopped working.
+
+Nothing failed. The compile ran, the bundles were published, the release went out green. They were
+just filed under the wrong name: the machine that compiles them and the portal that loads them had
+begun disagreeing about which build of the framework they were talking about, so the portal looked
+for something under a name that was never written, found nothing, and compiled all 269 content
+types itself.
+
+That is the ten-minute window in which the covers of every course on
+[memex.meshweaver.cloud](https://memex.meshweaver.cloud) served an error card to anonymous
+visitors for two hours on the evening of 2026-08-17. The card outlived the window that caused it;
+the window is now gone.
+
+The disagreement came from a genuinely good change made hours earlier — moving the Excel/CSV
+import stack out of the portal into its own module. Eight
+assemblies left the portal's compiled reference list as a result, and that list is exactly what
+each side uses to describe "which framework is this". Two descriptions, two names, one release.
+
+The portal now declares those eight again, purely as a description of the framework it was built
+against — the module keeps shipping the actual code, so nothing about the import module changed.
+
+More importantly, release builds now **compare the two names out loud** and fail if they differ,
+naming which assemblies caused it. A publication that nothing can read used to look exactly like a
+successful one from the outside. It no longer does.

--- a/test/MeshWeaver.Graph.Test/FrameworkBuildIdentityTest.cs
+++ b/test/MeshWeaver.Graph.Test/FrameworkBuildIdentityTest.cs
@@ -348,6 +348,207 @@ public class FrameworkBuildIdentityTest
             .Should().Be("s22825f5");
     }
 
+
+    // ---- the identity must be the SAME on every host that resolves it (#1814) -------------------
+
+    [Fact]
+    public void CanonicalContentSurface_IsRecordedByEverySurfaceManifestHost()
+    {
+        // 🚨 THE PIN FOR #1814. The identity is an ADDRESS: the bake publishes bundles under the
+        // identity ITS host resolves and a portal only ever looks under the identity IT resolves. A
+        // canonical assembly that is absent from one host's manifest hashes as AbsentMarker THERE and
+        // as a real surface id on the other, so the two hosts of ONE commit resolve two identities and
+        // every bake lands at an address nobody reads — silently: publication succeeds, the job is
+        // green, and the pods simply compile everything at boot.
+        //
+        // That is exactly what happened. `feat: Excel/CSV import becomes its own module` (82481e024,
+        // merged 2026-08-17 18:46) moved MeshWeaver.Import and its private closure — MeshWeaver.
+        // DataSetReader{,.Csv,.Excel,.Excel.BinaryFormat,.Excel.OpenXmlFormat,.Excel.Utils} and
+        // MeshWeaver.DataStructures, EIGHT canonical names — out of both portals' COMPILE reference
+        // graphs into the modules/<Name>/ runtime lane. The surface manifest is written from
+        // @(ReferencePathWithRefAssemblies), so those eight lines vanished from the image's manifest
+        // while mw-plugin-test kept them. Measured on the shipped images of release 3.0.0-rc4.ci.4276
+        // (both linux/amd64): mw-plugin-test resolved s7293e54297ec28e213bd82f30d59e709 and
+        // memex-portal-ai resolved sa6d587a25d64d11774f22348664bca0c — the value the live pods logged.
+        // The 29 SHARED manifest entries had byte-identical hashes; presence, not drift, was the whole
+        // difference. Two hours of every course cover serving a compilation-fallback card followed.
+        //
+        // CanonicalList_MatchesTheTesterClosure pins one side of that equality. This pins the other,
+        // and it is the check whose absence let a one-line-per-host change take the site down.
+        var root = FindRepositoryRoot();
+        Assert.SkipWhen(root is null,
+            "repository tree not reachable from the test bin — closure pin runs in-repo only");
+
+        var hosts = SurfaceManifestHosts(root!);
+        hosts.Should().HaveCountGreaterThan(1,
+            "the invariant is about hosts AGREEING — a run that found one project (or none) has "
+            + "verified nothing, so a broken discovery must not read as a pass");
+
+        var missingByHost = hosts.ToDictionary(
+            host => Path.GetRelativePath(root!, host),
+            host =>
+            {
+                var closure = ProjectClosure(host);
+                return FrameworkBuildIdentity.ContentSurfaceAssemblies
+                    .Where(name => !closure.Contains(name))
+                    .ToList();
+            },
+            StringComparer.Ordinal);
+
+        missingByHost.Values.SelectMany(m => m).Should().BeEmpty(
+            "every host that ships a surface manifest resolves the framework identity, so each must "
+            + "record EVERY canonical content-surface assembly — a missing one hashes as 'absent' "
+            + "there and forks that host's identity away from the bake's. Missing per host: "
+            + string.Join(" | ", missingByHost
+                .Where(kv => kv.Value.Count > 0)
+                .Select(kv => $"{kv.Key}: {string.Join(", ", kv.Value)}"))
+            + ". Fix by giving the host the compile reference back (Private=\"false\" "
+            + "ExcludeAssets=\"runtime\" keeps the bits out of its app closure — that is how "
+            + "Memex.Portal.Distributed references MeshWeaver.Import) — never by shrinking "
+            + "ContentSurfaceAssemblies, which would under-invalidate and let a portal adopt "
+            + "NodeType assemblies compiled against a framework that has shifted underneath them.");
+    }
+
+    // ---- resolving ANOTHER host's identity from its binaries (the CI address check) --------------
+
+    [Fact]
+    public void ResolveIdentityForDirectory_MatchesTheProcessComputationForTheSameInputs()
+    {
+        // The verb CI runs (`mw-plugin-test framework-identity <app-dir>`) must answer for a FOREIGN
+        // /app exactly what that host answers for itself — otherwise the guard compares its own
+        // arithmetic, not the two hosts.
+        var dir = StageAppDirectory(FrameworkBuildIdentity.ContentSurfaceAssemblies);
+        try
+        {
+            var (identity, problem) = FrameworkBuildIdentity.ResolveIdentityForDirectory(dir);
+            problem.Should().BeNull();
+            identity.Should().NotBeNull().And.MatchRegex("^s[0-9a-f]{32}$");
+
+            // Recomputed independently from the same directory: manifest pairs for everything, the
+            // toolchain closure's members by implementation MVID read off the staged DLLs.
+            var pairs = FrameworkBuildIdentity.ParseSurfaceManifest(
+                File.ReadAllText(Path.Combine(dir, FrameworkBuildIdentity.SurfaceManifestFileName)));
+            var closure = FrameworkBuildIdentity.ComputeToolchainClosure(
+                FrameworkBuildIdentity.ToolchainRoots, name => ReferencedInDirectory(dir, name));
+            identity.Should().Be(FrameworkBuildIdentity.ComputeSurfaceIdentity(
+                pairs, name => MvidInDirectory(dir, name), closure));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveIdentityForDirectory_ForksWhenOneCanonicalAssemblyIsUnrecorded()
+    {
+        // #1814 in miniature: same binaries, one manifest missing a canonical name. The two hosts
+        // MUST resolve different identities (that is the mechanism working correctly) and the
+        // absence must be REPORTABLE by name — "the hashes differ" is not an actionable failure.
+        var complete = StageAppDirectory(FrameworkBuildIdentity.ContentSurfaceAssemblies);
+        var reduced = StageAppDirectory(
+            FrameworkBuildIdentity.ContentSurfaceAssemblies.Where(n => n != "MeshWeaver.Import"));
+        try
+        {
+            var (whole, _) = FrameworkBuildIdentity.ResolveIdentityForDirectory(complete);
+            var (partial, _) = FrameworkBuildIdentity.ResolveIdentityForDirectory(reduced);
+            whole.Should().NotBeNull();
+            partial.Should().NotBeNull().And.NotBe(whole,
+                "a host that does not record a canonical assembly is a different surface reality — "
+                + "it must never share the bake's address");
+
+            var pairs = FrameworkBuildIdentity.ParseSurfaceManifest(
+                File.ReadAllText(Path.Combine(reduced, FrameworkBuildIdentity.SurfaceManifestFileName)));
+            FrameworkBuildIdentity.CanonicalAssembliesAbsentFrom(pairs)
+                .Should().Equal("MeshWeaver.Import");
+            FrameworkBuildIdentity.CanonicalAssembliesAbsentFrom(
+                    FrameworkBuildIdentity.ParseSurfaceManifest(
+                        File.ReadAllText(Path.Combine(complete, FrameworkBuildIdentity.SurfaceManifestFileName))))
+                .Should().BeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(complete, recursive: true);
+            Directory.Delete(reduced, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveIdentityForDirectory_RefusesToAnswerWithoutAUsableManifest()
+    {
+        // 🚨 A guard that cannot fail is not a guard. If a manifest-less directory degraded to the
+        // stamp/MVID fallback, two manifest-less hosts of one commit would resolve the SAME value and
+        // the CI comparison would report a match having proven nothing. So: no identity, and a
+        // diagnostic that says which file is missing.
+        var dir = Path.Combine(Path.GetTempPath(), "mw-nomanifest-dir-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var (identity, problem) = FrameworkBuildIdentity.ResolveIdentityForDirectory(dir);
+            identity.Should().BeNull();
+            problem.Should().Contain(FrameworkBuildIdentity.SurfaceManifestFileName);
+
+            File.WriteAllText(
+                Path.Combine(dir, FrameworkBuildIdentity.SurfaceManifestFileName), "not-a-pair\n\n");
+            var (stillNone, unusable) = FrameworkBuildIdentity.ResolveIdentityForDirectory(dir);
+            stillNone.Should().BeNull();
+            unusable.Should().NotBeNullOrEmpty();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveIdentityForDirectory_ReportsAMissingDirectory()
+    {
+        var (identity, problem) = FrameworkBuildIdentity.ResolveIdentityForDirectory(
+            Path.Combine(Path.GetTempPath(), "mw-absent-" + Guid.NewGuid().ToString("N")));
+        identity.Should().BeNull();
+        problem.Should().NotBeNullOrEmpty();
+    }
+
+    /// <summary>Stages an /app-shaped directory: this test host's MeshWeaver assemblies (so the
+    /// toolchain closure and its MVIDs resolve for real) plus a surface manifest recording exactly
+    /// <paramref name="recorded"/>.</summary>
+    private static string StageAppDirectory(IEnumerable<string> recorded)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-appdir-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        foreach (var dll in Directory.EnumerateFiles(AppContext.BaseDirectory, "MeshWeaver.*.dll"))
+            File.Copy(dll, Path.Combine(dir, Path.GetFileName(dll)), overwrite: true);
+        File.WriteAllText(
+            Path.Combine(dir, FrameworkBuildIdentity.SurfaceManifestFileName),
+            string.Join('\n', recorded.Select(n => $"{n}=surface-of-{n}")));
+        return dir;
+    }
+
+    private static IEnumerable<string> ReferencedInDirectory(string directory, string simpleName)
+    {
+        var candidate = Path.Combine(directory, simpleName + ".dll");
+        if (!File.Exists(candidate))
+            return [];
+        using var stream = File.OpenRead(candidate);
+        using var pe = new System.Reflection.PortableExecutable.PEReader(stream);
+        var md = pe.GetMetadataReader();
+        return md.AssemblyReferences
+            .Select(h => md.GetString(md.GetAssemblyReference(h).Name))
+            .Where(n => !string.IsNullOrEmpty(n))
+            .ToList();
+    }
+
+    private static string? MvidInDirectory(string directory, string simpleName)
+    {
+        var candidate = Path.Combine(directory, simpleName + ".dll");
+        if (!File.Exists(candidate))
+            return null;
+        using var stream = File.OpenRead(candidate);
+        using var pe = new System.Reflection.PortableExecutable.PEReader(stream);
+        var md = pe.GetMetadataReader();
+        return md.GetGuid(md.GetModuleDefinition().Mvid).ToString("N");
+    }
+
     // ---- helpers -------------------------------------------------------------------------------
 
     private static string? LoadedMvidOf(string simpleName) =>
@@ -383,6 +584,14 @@ public class FrameworkBuildIdentityTest
         return null;
     }
 
+    /// <summary>
+    /// A project's transitive COMPILE closure by simple name, read from the csproj graph.
+    /// <para>Two details are load-bearing rather than tidiness: XML comments are stripped first (a
+    /// commented-out ProjectReference is not a reference — samples/Northwind/MeshWeaver.Northwind.Domain
+    /// carries one), and a reference marked <c>ReferenceOutputAssembly="false"</c> is skipped, because
+    /// it contributes no compile reference and therefore no surface-manifest line. Both would
+    /// otherwise make this walk claim a host records an assembly it does not.</para>
+    /// </summary>
     private static HashSet<string> ProjectClosure(string startProject)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -396,11 +605,40 @@ public class FrameworkBuildIdentityTest
                 continue;
             names.Add(Path.GetFileNameWithoutExtension(project));
             var directory = Path.GetDirectoryName(project)!;
-            foreach (Match m in Regex.Matches(
-                File.ReadAllText(project), "ProjectReference Include=\"([^\"]+)\""))
+            var text = Regex.Replace(File.ReadAllText(project), "<!--.*?-->", string.Empty,
+                RegexOptions.Singleline);
+            foreach (Match element in Regex.Matches(text, "<ProjectReference\\b(?<attrs>[^>]*)>",
+                         RegexOptions.Singleline))
+            {
+                var attrs = element.Groups["attrs"].Value;
+                if (Regex.IsMatch(attrs, "ReferenceOutputAssembly\\s*=\\s*\"false\"",
+                        RegexOptions.IgnoreCase))
+                    continue;
+                var include = Regex.Match(attrs, "Include\\s*=\\s*\"(?<path>[^\"]+)\"");
+                if (!include.Success)
+                    continue;
                 stack.Push(Path.GetFullPath(
-                    Path.Combine(directory, m.Groups[1].Value.Replace('\\', '/'))));
+                    Path.Combine(directory, include.Groups["path"].Value.Replace('\\', '/'))));
+            }
         }
         return names;
     }
+
+    /// <summary>Every project that opts into a surface manifest — i.e. every host that RESOLVES the
+    /// framework build identity and must therefore agree with the others about it.</summary>
+    private static IReadOnlyList<string> SurfaceManifestHosts(string repositoryRoot) =>
+        // 🚨 The exclusions match the path RELATIVE to the root. Filtering the absolute path threw
+        // every file away when the checkout itself lives under .worktrees/<name> — a sibling git
+        // worktree, which is how every session of this repo works — and the test then "passed" over
+        // an empty host set. The HaveCountGreaterThan(1) assertion above is what caught it; keep
+        // both, since a discovery that silently finds nothing is the failure mode here.
+        [.. Directory.EnumerateFiles(repositoryRoot, "*.csproj", SearchOption.AllDirectories)
+            .Where(p => !Path.GetRelativePath(repositoryRoot, p)
+                .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .Any(segment => segment is ".worktrees" or "bin" or "obj" or "node_modules"))
+            .Where(p => Regex.IsMatch(
+                Regex.Replace(File.ReadAllText(p), "<!--.*?-->", string.Empty, RegexOptions.Singleline),
+                "<MeshWeaverSurfaceManifest>\\s*true\\s*</MeshWeaverSurfaceManifest>",
+                RegexOptions.IgnoreCase))
+            .OrderBy(p => p, StringComparer.Ordinal)];
 }

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -56,6 +56,8 @@ try
 {
     if (args.Length > 0 && args[0] == "compile")
         return RunCompile(args[1..]);
+    if (args.Length > 0 && args[0] == "framework-identity")
+        return RunFrameworkIdentity(args[1..]);
     return await RunGate(args);
 }
 catch (Exception ex)
@@ -121,6 +123,113 @@ static int RunCompile(string[] args)
         $"compile: {bake.Types.Count(t => t.Success)}/{bake.Types.Length} NodeType(s) compiled, "
         + $"{bake.Bundles.Length} bundle(s), framework={bake.FrameworkIdentity}");
     return bake.ExitCode;
+}
+
+// 🚨 THE `framework-identity` VERB — the ADDRESS CHECK (#1814).
+//
+//     mw-plugin-test framework-identity <app-dir> [--expect <identity>]
+//
+// Prints the framework build identity a host whose binaries live in <app-dir> resolves, reading
+// that directory's meshweaver-surface.manifest and assemblies as FILES — nothing is loaded, so one
+// container can answer the question for another image's /app.
+//
+// The identity is an ADDRESS: a bake publishes its bundles under the identity ITS host resolves and
+// a portal only ever looks under the identity IT resolves. Before this verb nothing in the pipeline
+// could observe that the two disagree — CD run 32063444385 baked release 3.0.0-rc4.ci.4201 under
+// `sda0843abd6db4fc7e37cc3f838079265` while both prod pods asked for
+// `s944d7fd0bbf81f4b40b85a7a74296263`, the bundles sat intact on the shared volume under an address
+// nobody read, the bake job reported SUCCESS, and the first pod of every deploy recompiled 269
+// types (10 m 29 s, +1598 MB working set) as though no bake had ever run. `--expect` turns that
+// into a red step: it compares and, on a mismatch, names the canonical assemblies each side's
+// manifest is missing — the actual defect in #1814 was eight of them, not a hash that "just
+// differs".
+//
+// 🚨 SAME ARCHITECTURE ONLY. Reference-assembly bytes differ between the amd64 and arm64 legs of one
+// multi-arch image, so an image carries two identities; extract both directories for ONE platform
+// (CI pins --platform linux/amd64). That per-arch split is the second, independent way to mint an
+// address nobody reads: memex.localhost is arm64 while the CI bake publishes linux/amd64.
+static int RunFrameworkIdentity(string[] args)
+{
+    string? appDirectory = null;
+    string? expected = null;
+    for (var i = 0; i < args.Length; i++)
+    {
+        switch (args[i])
+        {
+            case "--expect" when i + 1 < args.Length:
+                expected = args[++i].Trim();
+                break;
+            case "--expect":
+                Console.Error.WriteLine($"Option '{args[i]}' requires a value.");
+                return 2;
+            case "--help" or "-h":
+                Console.WriteLine(
+                    "usage: mw-plugin-test framework-identity <app-dir> [--expect <identity>]");
+                return 0;
+            default:
+                if (args[i].StartsWith('-') || appDirectory is not null)
+                {
+                    Console.Error.WriteLine($"Unknown argument '{args[i]}'. Try --help.");
+                    return 2;
+                }
+                appDirectory = args[i];
+                break;
+        }
+    }
+    if (appDirectory is null)
+    {
+        Console.Error.WriteLine(
+            "framework-identity: <app-dir> is required (the host's application directory — the one "
+            + "holding meshweaver-surface.manifest beside its assemblies; a container's /app).");
+        return 2;
+    }
+
+    var full = Path.GetFullPath(appDirectory);
+    var (identity, problem) = FrameworkBuildIdentity.ResolveIdentityForDirectory(full);
+    if (identity is null)
+    {
+        // 🚨 Never degrade to a fallback identity here. Two manifest-less directories built from the
+        // same commit resolve the SAME fallback, so a comparison over them would report a match
+        // having verified nothing — the "verification step that cannot fail" shape.
+        Console.Error.WriteLine($"framework-identity: cannot resolve an identity for '{full}' — {problem}");
+        return 1;
+    }
+
+    Console.WriteLine(identity);
+    if (expected is null || expected.Length == 0)
+        return 0;
+    if (string.Equals(expected, identity, StringComparison.Ordinal))
+    {
+        Console.Error.WriteLine(
+            $"framework-identity: MATCH — '{full}' resolves {identity}, the identity the bake "
+            + "published under. Its bundles are addressed to this host.");
+        return 0;
+    }
+
+    var pairs = FrameworkBuildIdentity.ParseSurfaceManifest(
+        File.ReadAllText(Path.Combine(full, FrameworkBuildIdentity.SurfaceManifestFileName)));
+    var absent = FrameworkBuildIdentity.CanonicalAssembliesAbsentFrom(pairs);
+    Console.Error.WriteLine(
+        $"framework-identity: MISMATCH — the bake published under '{expected}' but '{full}' "
+        + $"resolves '{identity}'. Bundles published under an identity this host never asks for are "
+        + "INERT: the pods compile everything at boot exactly as if no bake had run, and nothing "
+        + "else in the pipeline reports it (issue #1814).");
+    Console.Error.WriteLine(
+        absent.Length == 0
+            ? "  Both manifests record every canonical content-surface assembly, so the difference is "
+              + "in the recorded HASHES — different binaries (a different architecture, or hosts built "
+              + "from different commits). Check that both were taken with the same --platform and from "
+              + "the same release."
+            : "  This host's surface manifest does not record these canonical content-surface "
+              + $"assemblies, so each hashes as '{FrameworkBuildIdentity.AbsentMarker}' here while the "
+              + "bake host records a real surface hash for it:\n    - "
+              + string.Join("\n    - ", absent)
+              + "\n  A canonical assembly leaves a host's manifest when it leaves that host's COMPILE "
+              + "reference graph (@(ReferencePathWithRefAssemblies)) — e.g. a ProjectReference removed "
+              + "in favour of a runtime module lane. Either give this host the compile reference back "
+              + "(Private=\"false\" keeps the bits out of its app closure) or remove the assembly from "
+              + "FrameworkBuildIdentity.ContentSurfaceAssemblies — never leave the two hosts disagreeing.");
+    return 1;
 }
 
 // The GATE verb (`mw-plugin-test <repo-root>`). A LOCAL FUNCTION rather than bare top-level


### PR DESCRIPTION
Fixes **defect A** of #1814 (the bake/portal framework-identity mismatch). It does **not** close the issue: defects B/C — the fault card latching on an instance hub, the deterministic cross-hub `Conflict` retry, and the three-way-broken cross-process notify path (#1440, #1816) — are untouched and still worth fixing on their own.

## What was actually wrong

The RCA in #1814 got as far as "the two images ship different surface manifests — 38 lines vs 54". The *net* gap is a red herring. Measured on the shipped images of `3.0.0-rc4.ci.4276` (commit `b9b319f`), both extracted with `--platform linux/amd64`:

| image | manifest | resolves |
|---|---|---|
| `mw-plugin-test` (what the BAKE runs in) | 38 lines | `s7293e54297ec28e213bd82f30d59e709` |
| `memex-portal-ai` (what PROD runs) | 54 lines | `sa6d587a25d64d11774f22348664bca0c` |

The **29 shared entries have byte-identical hashes** — reference assemblies *are* reproducible across build invocations, so the "4 of 37 differ" data point in `Directory.Build.props` is not what bit us. The portal's 25 extra names are Blazor/Orleans/hosting, outside `ContentSurfaceAssemblies` **by design**.

The difference is **presence**. The tester records **9** names the portal does not, and **8 are canonical**:

`MeshWeaver.Import`, `MeshWeaver.DataSetReader`, `.Csv`, `.Excel`, `.Excel.BinaryFormat`, `.Excel.OpenXmlFormat`, `.Excel.Utils`, `MeshWeaver.DataStructures`

(the 9th, `MeshWeaver.Hosting.Monolith`, is excluded from the canonical set on purpose). Each hashes as `absent` on the portal and as a real surface id on the bake host, so **two hosts of one commit resolve two identities**.

### Why they left

`82481e024` — *"feat: Excel/CSV import becomes its own module"*, merged **2026-08-17 18:46, about two hours before the outage** — moved `MeshWeaver.Import` and its private closure out of **both portals' compile reference graphs** into the `modules/<Name>/` lane. The surface manifest is written from `@(ReferencePathWithRefAssemblies)` — a host's *compile* references — so the eight lines vanished from the image's manifest only.

The module change is correct on its own terms and is **kept**. `Import` is the first closure-lane flip that touched a canonical name; that is why this broke now and not on any earlier flip.

## The fix

`Memex.Portal.Distributed` declares the eight again as **compile-only** references:

```xml
<ProjectReference Include="…MeshWeaver.Import.csproj"
                  Private="false" ExcludeAssets="runtime" PrivateAssets="all" />
```

The manifest records them; the bits still ship **only** via `modules/MeshWeaver.Import/`; TPA still excludes them, so `ComposeWithModules` remains the one thing that makes `Import` visible to in-mesh source; and nothing downstream inherits the declaration. All three knobs are measured, not defensive:

- declaring `Import` alone still copied its **seven transitive outputs (and CsvHelper)** into the app root — re-shipping exactly what the module lane removed;
- without `PrivateAssets="all"` the reference reached `Memex.Portal.Shared.Test` (which references the portal) and pruned `modules/MeshWeaver.Import/` down to one file — **8 `ImportModuleLayoutTest` cases red**.

**Before:** portal manifest 54 lines, identity ≠ bake. **After:** 62 lines, identity == bake, **zero** new DLLs in `bin/`.

### What this deliberately does *not* do

- **Not** making the identity stable across deploys. Per #1814 and `Directory.Build.props`: Graph's MVID covers only Graph's own compile inputs while a NodeType's reference set is the whole TPA, so the identity must keep moving on real surface changes. Stabilising it trades a slow deploy for a silent `TypeLoadException` inside an ALC at activation.
- **Not** shrinking `ContentSurfaceAssemblies` to make the hosts agree. Same under-invalidation, different hat — and it is the tempting "fix" when the new test goes red, so both the test message and the doc say so explicitly.

## The guard — the durable half

**1. Offline, at PR time.** `FrameworkBuildIdentityTest.CanonicalContentSurface_IsRecordedByEverySurfaceManifestHost` recomputes, from the csproj graph, the compile closure of **every** project setting `MeshWeaverSurfaceManifest=true` and fails naming each canonical assembly a host does not record. `CanonicalList_MatchesTheTesterClosure` had always pinned one side of the equality; this pins the other — the half whose absence let a one-line-per-host change take the site down. (The closure walk now strips XML comments and honours `ReferenceOutputAssembly="false"`, both of which the repo actually contains.)

**2. On the artifact, at release time.** `main-cd`'s `publish-bake` resolves the identity of the **promoted `memex-portal-ai` image** and compares it with the identity the bake published under, **before** publishing — so a bake nobody can adopt fails the release rather than being filed under an unread address. The release marker is then never written, so the deployment gate (#1754) holds too: fail-safe in both directions. Both pulls pin `--platform linux/amd64` **out loud**, which covers the **second, independent** cause named in #1814: `memex.localhost` is arm64 while CI publishes amd64.

The comparison is a new verb on the bake image itself:

```
mw-plugin-test framework-identity <app-dir> [--expect <identity>]
```

built on `FrameworkBuildIdentity.ResolveIdentityForDirectory`, which reads another host's manifest and assemblies as **files** (metadata only, nothing loaded), so one container answers for another image's `/app`. It **refuses** to answer for a directory with no usable manifest rather than degrading to the stamp/MVID fallback — two manifest-less hosts of one commit resolve the *same* fallback, and a comparison that passes on degraded input is a check that cannot fail. On a mismatch it names the canonical assemblies the target does not record, because the real defect was eight named assemblies, not "a hash that differs".

> One guard covers every producer: the satellite repos (`Plugins`, `Education`, `Reinsurance`, `SocialMedia`) bake in the same `mw-plugin-test` image, so their bundles were mis-addressed in exactly the same way and are fixed by the same manifest restoration. Giving `node-repo-publish-bake.yml` its own portal-image input is a sensible follow-up, not a prerequisite.

## Non-vacuity — real output

**The unit test, against the shipped `csproj`** (fix reverted):

```
Expected collection to be empty … Missing per host:
  memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj:
  MeshWeaver.DataSetReader, MeshWeaver.DataSetReader.Csv, MeshWeaver.DataSetReader.Excel,
  MeshWeaver.DataSetReader.Excel.BinaryFormat, MeshWeaver.DataSetReader.Excel.OpenXmlFormat,
  MeshWeaver.DataSetReader.Excel.Utils, MeshWeaver.DataStructures, MeshWeaver.Import
Failed!  - Failed: 1, Passed: 0
```

With the fix: `Passed! - Failed: 0, Passed: 22`.

**The verb, against the REAL promoted images** (`docker cp` of `/app` — exactly what the CI step does):

```
mw-plugin-test  (the BAKE host)  → s7293e54297ec28e213bd82f30d59e709
memex-portal-ai (what PROD runs) → sa6d587a25d64d11774f22348664bca0c
framework-identity: MISMATCH … This host's surface manifest does not record these canonical
content-surface assemblies … - MeshWeaver.DataSetReader … - MeshWeaver.Import
exit 1
```

Against locally built hosts **with** the fix: `MATCH`, exit 0, `s44766eef1093873a087144ad029919e8` on both.

**Cross-check that the offline resolver is telling the truth:** it computes `sa6d587a25d64d11774f22348664bca0c` for `memex-portal-ai` — the identity memex logged live after today's 13:56 roll. The offline computation reproduces the running portal's exactly.

The vacuity guard on the guard earned its keep too: the host-discovery initially found **zero** projects (the checkout lives under `.worktrees/`, and the exclusion matched the absolute path), and `HaveCountGreaterThan(1)` failed rather than passing over an empty set.

## Verification

- Release + `-warnaserror`, 0 warnings / 0 errors: `MeshWeaver.Compiler`, `MeshWeaver.PluginTester`, `Memex.Portal.Distributed`, `Memex.Portal.Monolith`, and the three test projects.
- `MeshWeaver.Graph.Test` **1270/1270** · `Memex.Portal.Shared.Test` **407/407** (including all 8 `ImportModuleLayoutTest` cases) · `MeshWeaver.Documentation.Test` **37/37**.

## Is a roll safe after this lands?

**Yes for defect A, with one honest caveat.** This restores `alreadyBaked` on the first pod of a deploy, which removes the ~10-minute compile window that produced the latching. It does **not** fix the latching itself (defect B) — so if a fault card is ever raised again by some other cause, it will still stick until the instance is recycled. Fixing that is still the highest-value follow-up.

**Interaction with #1834** (adoption stamps `CompiledSources` from a field its own activation is still publishing): read against the code, it should **not** be load-bearing for this roll. `CurrentSourceVersions` is a persisted `NodeTypeDefinition` field and the sources watcher's write is idempotent (no-ops when the snapshot already matches), so on a mesh where a type has compiled before — memex-cloud, every one of them — the mirror snapshot already carries it and the seeder's stamp is correct. #1834's exposed population is content whose node has **no persisted `CurrentSourceVersions` yet**: a fresh package install, a git push, a first boot after a static-repo import, CI's disposable meshes. The caveat: for the types whose **sources changed in the release being rolled**, the watcher does write a fresh snapshot at activation, and those specific types can still be recompiled by #1834's stale stamp. So the expected first-pod result after this lands is **`compiled≈(types whose sources changed) alreadyBaked≈(the rest)`** — a handful, not 269. Reaching a clean `compiled=0` needs #1834 as well.

Refs #1814. Does not close it.