### PR TITLE
The forge barrier waited to SEE a state designed to be overwritten

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/NeverCompiledFailureRedriveTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NeverCompiledFailureRedriveTest.cs
@@ -256,7 +256,7 @@ public class NeverCompiledFailureRedriveTest(ITestOutputHelper output) : Monolit
         // park with it, so clear it here too or the staged state would not be the staged state.
         ParkRegistry.Unpark(typePath);
         var marker = $"FORGED-{Guid.NewGuid():N}";
-        await workspace.GetMeshNodeStream(typePath)
+        var forged = await workspace.GetMeshNodeStream(typePath)
             .Update(curr => curr.Content is NodeTypeDefinition d
                 ? curr with
                 {
@@ -277,14 +277,24 @@ public class NeverCompiledFailureRedriveTest(ITestOutputHelper output) : Monolit
         // 🚧 Barrier: GetMeshNodeStream replays its latest snapshot, so without confirming the
         // forge LANDED a later convergence Match could match the pre-forge state and pass with no
         // re-drive at all — masking a disabled kickoff.
+        //
+        // 🚨 The barrier waits on the VERSION, not on seeing the forged content. The forged record
+        // is what TRIGGERS the re-drive, so it is transient by construction: the kickoff can
+        // recompile and overwrite it — marker gone, FailedBuildInputs filled — before this
+        // subscription observes it, and then the barrier times out on a forge that landed
+        // perfectly. That is a race the test loses more often the FASTER the product is, and it is
+        // load-sensitive on CI: this helper is used by all three tests in this file, which is why
+        // they fail in rotation (#1843 — observed on main and on three unrelated PRs).
+        //
+        // Version is monotonic and cannot be overwritten away, so waiting for it proves the write
+        // landed without requiring anyone to catch a state designed to be replaced.
+        var forgedVersion = forged.Version;
         await workspace.GetMeshNodeStream(typePath)
             .Should().Within(20.Seconds())
-            .Match(n => n.Content is NodeTypeDefinition d
-                && d.CompilationStatus == CompilationStatus.Error
-                && d.CompilationError == marker
-                && string.IsNullOrEmpty(d.LatestAssemblyPath)
-                && d.FailedBuildInputs is null);
-        Output.WriteLine($"Forged the never-compiled Error record on {typePath} (marker {marker}).");
+            .Match(n => n.Version >= forgedVersion);
+        Output.WriteLine(
+            $"Forged the never-compiled Error record on {typePath} (marker {marker}, "
+            + $"version {forgedVersion}).");
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes the test that has been blocking every PR in the repo (#1843).

## The race

`ForgeNeverCompiledFailure` writes a "never compiled" `Error` record, then waits up to 20 s to **observe that exact record** — marker set, `FailedBuildInputs` null:

```csharp
await workspace.GetMeshNodeStream(typePath)
    .Should().Within(20.Seconds())
    .Match(n => … d.CompilationError == marker && d.FailedBuildInputs is null);
```

But that record is **what triggers the re-drive**. It is transient by construction: the kickoff can recompile and overwrite it before this subscription observes it — and the barrier then times out on a forge that landed perfectly.

**A race the test loses more often the *faster* the product is**, and much more likely under CI load.

## The failure output says precisely this

```
Expected the observable to emit a value matching the predicate within 20s, but it did not.
Last of 4 emission(s) was: … CompilationStatus = Error,
CompilationError = Compilation failed: … CS0103 … 'ThisSymbolDoesNotExist' …
```

The marker is gone and the **real** compile error is in its place — the forged record had already been replaced by the re-drive's own result.

## Why it looks like several different flaky tests

The helper is used by **all three** tests in the file, so they fail in rotation rather than one failing consistently. Observed on `main` at `2cbe0521f` (**before** today's scheduler merge) and on three unrelated PRs — #1838, #1841, #1845 — blocking each of them.

## The fix

Wait for the node's **Version** to reach the forge's write. Version is monotonic and cannot be overwritten away, so it proves the write landed without requiring anyone to catch a state that exists to be replaced. The barrier keeps its purpose: a later `Match` still cannot match pre-forge state.

## Verification, honestly

**Not reproducible locally** — the tests pass 3/3 here both with and without the change, because the race needs the load that makes the re-drive land inside the observation gap. The diagnosis is from the failure output above; CI is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFx1SsoKDhRKHdaJbQPEWQ