### PR TITLE
memex-voice-gateway: ESPHome voice satellite → agent threads, no Home Assistant

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -633,6 +633,17 @@ jobs:
         set -euo pipefail
         sudo mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
         sudo chown "$(id -u):$(id -g)" "$PLAYWRIGHT_BROWSERS_PATH"
+        # 🚨 APT MUST WAIT ON ITS OWN LOCKS — the flock below closes only PART of the race.
+        # The background apt (apt-daily / unattended-upgrades) takes and RELEASES the lists lock
+        # once per source, so flock can succeed in a release gap and the apt-get that playwright
+        # itself spawns still loses the very next acquisition. Observed on run 32165453521
+        # (shard 5, twice in a row): every attempt failed instantly with "Could not get lock
+        # /var/lib/apt/lists/lock. It is held by process N (apt-get)" while the flock had
+        # returned at once — the attempts were 22s apart, not APT_LOCK_WAIT apart.
+        # DPkg::Lock::Timeout makes EVERY apt invocation (including the ones npx spawns, which
+        # no external flock can wrap) wait up to 300s for the lock itself, removing the window
+        # entirely. Bounded, so it cannot hang; the per-attempt timeout still caps the whole run.
+        echo 'DPkg::Lock::Timeout "300";' | sudo tee /etc/apt/apt.conf.d/99ci-lock-timeout >/dev/null
         ok=0
         for attempt in 1 2 3; do
           # 🚨 WAIT FOR APT BEFORE EACH ATTEMPT. `--with-deps` shells out to apt-get, and the

--- a/clients/react-native/src/connection.ts
+++ b/clients/react-native/src/connection.ts
@@ -73,8 +73,51 @@ const SEED_VERSION = 1;
 export const KNOWN_INSTANCES: MeshInstance[] = [
   { name: "memex.localhost (k8s)", url: "https://memex.localhost:8443", token: "", local: false, icon: "☸", color: "#d29922", kind: "Local · k8s" },
   { name: "memex", url: "https://memex.meshweaver.cloud", token: "", local: false, icon: "☁️", color: "#4c8dff", kind: "Prod" },
-  { name: "systemorph", url: "https://memex.systemorph.com", token: "", local: false, icon: "🏢", color: "#6a4c93", kind: "Prod" },
 ];
+
+/**
+ * Discover the fleet from a connected mesh: instances are MESH NODES (nodeType
+ * `Hosting/Deployment`, populated in the mesh's Deployments space), so the connect list is
+ * data on the mesh — this app is public and carries no environment inventory of its own.
+ * Best-effort by design: no Hosting plugin, no permission, or offline all yield [].
+ */
+export async function discoverInstances(from: MeshInstance): Promise<MeshInstance[]> {
+  try {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (from.token) headers.Authorization = `Bearer ${from.token}`;
+    const search = await fetch(`${from.url}/api/mesh/search`, {
+      method: "POST", headers,
+      body: JSON.stringify({ query: "nodeType:Hosting/Deployment scope:subtree" }),
+    });
+    if (!search.ok) return [];
+    const results: Array<{ path?: string; name?: string }> = ((await search.json()) as any)?.results ?? [];
+    const found: MeshInstance[] = [];
+    for (const r of results.slice(0, 20)) {
+      if (!r.path) continue;
+      const got = await fetch(`${from.url}/api/mesh/get`, {
+        method: "POST", headers, body: JSON.stringify({ path: `@${r.path}` }),
+      });
+      if (!got.ok) continue;
+      const host: string | undefined = ((await got.json()) as any)?.content?.host;
+      if (!host) continue;
+      found.push({ name: r.name ?? host, url: `https://${host}`, token: "", local: false, kind: "Prod" });
+    }
+    return found;
+  } catch {
+    return [];
+  }
+}
+
+/** Merge discovered instances into the saved list — an existing entry (its token, edits) always wins. */
+export function mergeDiscovered(discovered: MeshInstance[]): MeshInstance[] {
+  const existing = read<MeshInstance[]>(INSTANCES_KEY) ?? [];
+  const byName = new Map(existing.map((i) => [i.name, i]));
+  const byUrl = new Set(existing.map((i) => i.url));
+  for (const d of discovered) if (!byName.has(d.name) && !byUrl.has(d.url)) byName.set(d.name, d);
+  const merged = [...byName.values()];
+  write(INSTANCES_KEY, merged);
+  return merged;
+}
 
 /**
  * Idempotently add the known environments to the saved-instances list on first run (versioned, so

--- a/clients/react-native/src/connection.ts
+++ b/clients/react-native/src/connection.ts
@@ -73,6 +73,7 @@ const SEED_VERSION = 1;
 export const KNOWN_INSTANCES: MeshInstance[] = [
   { name: "memex.localhost (k8s)", url: "https://memex.localhost:8443", token: "", local: false, icon: "☸", color: "#d29922", kind: "Local · k8s" },
   { name: "memex", url: "https://memex.meshweaver.cloud", token: "", local: false, icon: "☁️", color: "#4c8dff", kind: "Prod" },
+  { name: "systemorph", url: "https://memex.systemorph.com", token: "", local: false, icon: "🏢", color: "#6a4c93", kind: "Prod" },
 ];
 
 /**

--- a/clients/react-native/src/screens.tsx
+++ b/clients/react-native/src/screens.tsx
@@ -3,7 +3,7 @@
 // mesh): Voice (speech), Connect (remote instances), Profile, Settings.
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { View, Text, TextInput, Pressable, ScrollView, StyleSheet } from "react-native";
-import { loadInstances, saveInstance, removeInstance, setCurrentInstance, currentInstance, defaultPortalUrl, instanceIdentity, type MeshInstance } from "./connection";
+import { loadInstances, saveInstance, removeInstance, setCurrentInstance, currentInstance, defaultPortalUrl, instanceIdentity, discoverInstances, mergeDiscovered, type MeshInstance } from "./connection";
 import { useStyles, useTheme, type Palette } from "./theme";
 
 const useSheet = () => useStyles(makeStyles);
@@ -130,13 +130,25 @@ function ConnectScreen({ onConnected }: { onConnected: () => void }): ReactNode 
     setInstances(loadInstances());
     setCurrent(currentInstance().name);
   };
-  const select = (n: string) => { setCurrentInstance(n); setCurrent(n); onConnected(); };
+  // The fleet is data ON the mesh (Hosting/Deployment nodes): after pointing at a portal,
+  // quietly pull its deployment directory into the switcher. Best-effort, never blocking.
+  const discover = (inst: MeshInstance) => {
+    discoverInstances(inst).then((d) => { if (d.length) { mergeDiscovered(d); refresh(); } }).catch(() => {});
+  };
+  const select = (n: string) => {
+    setCurrentInstance(n); setCurrent(n);
+    const inst = loadInstances().find((i) => i.name === n);
+    if (inst && !inst.local) discover(inst);
+    onConnected();
+  };
   const add = () => {
     const nm = name.trim() || url.trim().replace(/^https?:\/\//, "");
     if (!url.trim()) return;
-    saveInstance({ name: nm, url: url.trim().replace(/\/+$/, ""), token: token.trim(), local: false });
+    const inst: MeshInstance = { name: nm, url: url.trim().replace(/\/+$/, ""), token: token.trim(), local: false };
+    saveInstance(inst);
     setName(""); setUrl(""); setToken("");
     refresh();
+    discover(inst);
     onConnected();
   };
 

--- a/clients/voice-gateway/.gitignore
+++ b/clients/voice-gateway/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.egg-info/
+.pytest_cache/
+.env

--- a/clients/voice-gateway/Dockerfile
+++ b/clients/voice-gateway/Dockerfile
@@ -1,0 +1,19 @@
+# memex-voice-gateway — ESPHome voice satellite ↔ MeshWeaver threads, no Home Assistant.
+FROM python:3.12-slim
+
+# piper-tts brings the `piper` CLI + onnxruntime; the voice model is fetched at runtime
+# by the entrypoint (kept out of the image, same policy as deploy/whisper).
+RUN pip install --no-cache-dir piper-tts
+
+WORKDIR /app
+COPY pyproject.toml ./
+COPY memex_voice_gateway ./memex_voice_gateway
+RUN pip install --no-cache-dir .
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# TTS file server the satellite fetches audio from — must be reachable on the LAN.
+EXPOSE 8200
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/clients/voice-gateway/README.md
+++ b/clients/voice-gateway/README.md
@@ -1,0 +1,91 @@
+# memex-voice-gateway
+
+Wires an **ESPHome voice satellite** (built for the
+[FutureProofHomes Satellite1](https://github.com/FutureProofHomes/Satellite1-ESPHome)) directly to
+**MeshWeaver agent threads** — no Home Assistant required. One container on any always-on LAN box.
+
+```
+Satellite1 (wake word on-device, XMOS AEC)
+   │ mic audio (ESPHome native API, this gateway dials the device)
+   ▼
+memex-voice-gateway
+   ├─ endpointing (energy VAD)                          [vad.py]
+   ├─ STT  → POST {MEMEX_URL}/api/speech/transcribe     [stt.py]   Swiss German Whisper container
+   ├─ chat → /mcp start_thread / submit_message          [threads.py]  one conversation ≈ one thread
+   └─ TTS  → Piper (de_DE) served over HTTP              [tts.py]   device plays the URL
+```
+
+**Latency reality (measured 2026-08-18):** a memex thread round takes ~60–70 s wall clock —
+dispatch/startup, not generation. The gateway therefore answers inline only when the reply lands
+within `REPLY_BUDGET_S`; otherwise it speaks a short holding phrase, ends the voice run, and
+delivers the real answer as an **announcement** when it arrives. If platform dispatch gets faster,
+the same code starts answering inline — nothing to change.
+
+## Quick start
+
+1. **Mint a token**: memex portal → Settings ▸ Security ▸ API Tokens → label `voice-gateway`.
+   The gateway acts as *you* on the mesh — anyone who talks to the speaker does too.
+2. **Get the device's API encryption key** from your Satellite1's ESPHome config (`api: encryption:`).
+3. Create `.env` next to `docker-compose.yml`:
+
+   ```env
+   SATELLITE_HOST=192.168.1.42
+   SATELLITE_PSK=<the device's api encryption key>
+   MEMEX_TOKEN=mw_…
+   MEMEX_NAMESPACE=<your user id>
+   GATEWAY_HOST=192.168.1.10        # THIS machine's LAN IP — the satellite fetches TTS audio here
+   ```
+
+4. `docker compose up --build -d`, say the wake word, ask something.
+
+## The Voice agent
+
+Point `MEMEX_AGENT` at a **lean** agent (short instructions, `chat` model tier, at most the Mesh
+Get/Search plugin). The platform's default assistant carries ~12k tokens of context into every
+round — fine in the portal, wasteful when the reply is one spoken sentence.
+
+## Coexisting with Home Assistant
+
+The device accepts multiple ESPHome API clients, so HA can own the satellite's **sensors, music
+and multi-room audio** while this gateway owns **voice** — but only ONE client may subscribe as
+the voice assistant. If you run HA alongside: do **not** assign the satellite to an Assist
+pipeline there. (Apple Music on the satellite = HA + Music Assistant; Siri cannot run on the
+device — but an Apple Shortcut on your phone can call the same thread API.)
+
+## Configuration reference
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `SATELLITE_HOST` / `SATELLITE_PORT` | — / `6053` | the device's LAN address |
+| `SATELLITE_PSK` | — | ESPHome API encryption key (`SATELLITE_PASSWORD` for legacy auth) |
+| `MEMEX_URL` | `https://memex.meshweaver.cloud` | the mesh |
+| `MEMEX_TOKEN` | — | `mw_…` bearer token |
+| `MEMEX_NAMESPACE` | — | where threads are created (`{ns}/_Thread/…`) |
+| `MEMEX_AGENT` | `Voice` | agent name; empty = platform default |
+| `GATEWAY_HOST` / `GATEWAY_PORT` | — / `8200` | LAN address the satellite fetches TTS from |
+| `STT_LANGUAGE` | `de` | `de` transcribes Swiss German OUT as Standard German |
+| `REPLY_BUDGET_S` | `10` | wait this long before acking with the holding phrase |
+| `ANNOUNCE_BUDGET_S` | `240` | keep polling this long, then announce the answer |
+| `THREAD_IDLE_MINUTES` | `5` | follow-up questions reuse the same thread within this window |
+| `HOLD_PHRASE` / `ERROR_PHRASE` | German defaults | what the speaker says meanwhile / on failure |
+| `PIPER_VOICE` / `PIPER_VOICE_URL` | thorsten-medium | High German TTS voice |
+
+## Development
+
+```bash
+pip install -e .[dev]
+pytest
+```
+
+The device protocol follows the same `aioesphomeapi` surface Home Assistant's ESPHome
+integration uses (`subscribe_voice_assistant` in API-audio mode, `send_voice_assistant_event`,
+announcements with a media-player fallback). The thread and STT clients are unit-tested against
+the live-verified wire shapes; the device leg needs a real satellite to verify end-to-end.
+
+## Speech model license
+
+The default STT model behind `/api/speech/transcribe` is a derivative of
+[Flurin17/whisper-large-v3-turbo-swiss-german](https://huggingface.co/Flurin17/whisper-large-v3-turbo-swiss-german)
+(**CC BY-NC 4.0 — non-commercial use only**). A personal home assistant is non-commercial use;
+for anything commercial, point the whisper container at a permissively licensed model
+(see `deploy/whisper/README.md`).

--- a/clients/voice-gateway/README.md
+++ b/clients/voice-gateway/README.md
@@ -38,6 +38,30 @@ the same code starts answering inline — nothing to change.
 
 4. `docker compose up --build -d`, say the wake word, ask something.
 
+## All-local mode (Mac)
+
+Every leg is pluggable, so the gateway also runs **fully local** — no cloud in the loop, and
+(since the Swiss German Whisper model is CC BY-NC) the unambiguously non-commercial setup:
+
+| Leg | Mesh-hosted (default) | Local |
+|---|---|---|
+| STT | `{MEMEX_URL}/api/speech/transcribe` | `STT_URL=http://127.0.0.1:8090/inference` — whisper.cpp with the same Swiss German GGML |
+| Brain | `BRAIN=memex` (agent threads) | `BRAIN=ollama` + `OLLAMA_MODEL=qwen3.6` (or any pulled model) |
+| TTS | Piper (container) | `TTS_ENGINE=say` — macOS built-in voices (`SAY_VOICE=Anna`) |
+
+```bash
+brew install whisper-cpp ollama
+mkdir -p ~/models/whisper && curl -fSL -o ~/models/whisper/ggml-swiss-german-turbo-q5_0.bin \
+  https://github.com/Systemorph/MeshWeaver/releases/download/voice-model-swiss-german/ggml-swiss-german-turbo-q5_0.bin
+pip install -e .
+SATELLITE_HOST=… SATELLITE_PSK=… GATEWAY_HOST=<this Mac's LAN IP> ./run-local.sh
+```
+
+Mix and match freely — e.g. local STT with the memex-thread brain is the best of both while
+the mesh's whisper container isn't deployed. (Apple Intelligence as a brain would need a small
+Swift helper around the Foundation Models framework — it has no HTTP API; Ollama is the
+practical local brain today.)
+
 ## The Voice agent
 
 Point `MEMEX_AGENT` at a **lean** agent (short instructions, `chat` model tier, at most the Mesh

--- a/clients/voice-gateway/docker-compose.yml
+++ b/clients/voice-gateway/docker-compose.yml
@@ -1,0 +1,20 @@
+# memex-voice-gateway — fill in the four secrets/addresses in .env (see README).
+services:
+  voice-gateway:
+    build: .
+    restart: unless-stopped
+    network_mode: host   # the satellite must reach the TTS server; host networking keeps URLs simple
+    environment:
+      SATELLITE_HOST: "${SATELLITE_HOST}"          # the Satellite1's LAN IP or mDNS name
+      SATELLITE_PSK: "${SATELLITE_PSK:-}"          # the device's ESPHome API encryption key
+      MEMEX_URL: "${MEMEX_URL:-https://memex.meshweaver.cloud}"
+      MEMEX_TOKEN: "${MEMEX_TOKEN}"                # mw_… token (Settings ▸ Security ▸ API Tokens)
+      MEMEX_NAMESPACE: "${MEMEX_NAMESPACE}"        # thread namespace, e.g. your user id
+      MEMEX_AGENT: "${MEMEX_AGENT:-Voice}"
+      GATEWAY_HOST: "${GATEWAY_HOST}"              # THIS machine's LAN IP (satellite fetches TTS here)
+      STT_LANGUAGE: "de"
+    volumes:
+      - piper-voices:/voices
+
+volumes:
+  piper-voices:

--- a/clients/voice-gateway/entrypoint.sh
+++ b/clients/voice-gateway/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Fetch the Piper voice on first start (≈60 MB, kept in the /voices volume).
+# High German out: the Swiss German Whisper fine-tune transcribes dialect INTO Standard
+# German, and the assistant answers in Standard German.
+VOICE="${PIPER_VOICE:-/voices/de_DE-thorsten-medium.onnx}"
+VOICE_URL="${PIPER_VOICE_URL:-https://huggingface.co/rhasspy/piper-voices/resolve/main/de/de_DE/thorsten/medium/de_DE-thorsten-medium.onnx}"
+if [ ! -f "$VOICE" ]; then
+    mkdir -p "$(dirname "$VOICE")"
+    echo "Fetching Piper voice → $VOICE"
+    python -c "import urllib.request,sys; urllib.request.urlretrieve('$VOICE_URL', '$VOICE')"
+    python -c "import urllib.request; urllib.request.urlretrieve('$VOICE_URL.json', '$VOICE.json')"
+fi
+
+exec memex-voice-gateway

--- a/clients/voice-gateway/memex_voice_gateway/__init__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__init__.py
@@ -1,0 +1,3 @@
+"""memex-voice-gateway: an ESPHome voice satellite wired directly to MeshWeaver threads."""
+
+__version__ = "0.1.0"

--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -10,7 +10,7 @@ import re
 import aiohttp
 
 from . import stt
-from .config import Config
+from .config import Config, phrases_for
 from .ollama import OllamaBrain
 from .pipeline import VoicePipeline
 from .router import BrainRouter
@@ -23,11 +23,21 @@ SENTENCE_END = re.compile(r"[.!?…][\"')\]]*\s")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 
 
+DIALECT_SUFFIX = (
+    " Antworte auf Schweizerdeutsch (Züritüütsch), schreibe den Dialekt phonetisch aus."
+)
+
+
 def make_router(cfg: Config) -> BrainRouter:
     """One router over all configured brains — PORTALS entries, else the legacy single brain."""
+    from .config import phrases_for
+    from .ollama import SYSTEM_PROMPT
+    phrases = phrases_for(cfg.stt_language)
+    system_prompt = SYSTEM_PROMPT + (DIALECT_SUFFIX if cfg.speak_dialect else "")
+
     def ollama(entry: dict) -> OllamaBrain:
         return OllamaBrain(entry.get("url", cfg.ollama_url), entry.get("model", cfg.ollama_model),
-                           idle_minutes=cfg.thread_idle_minutes)
+                           idle_minutes=cfg.thread_idle_minutes, system_prompt=system_prompt)
 
     def memex(entry: dict) -> MemexThreads:
         return MemexThreads(entry["url"].rstrip("/"), entry["token"], entry["namespace"],
@@ -38,11 +48,11 @@ def make_router(cfg: Config) -> BrainRouter:
         brains = {e["name"]: (ollama(e) if e.get("kind") == "ollama" else memex(e))
                   for e in cfg.portals}
         active = next((e["name"] for e in cfg.portals if e.get("default")), cfg.portals[0]["name"])
-        return BrainRouter(brains, active)
+        return BrainRouter(brains, active, phrases=phrases)
     if cfg.brain == "ollama":
-        return BrainRouter({"lokal": ollama({})}, "lokal")
+        return BrainRouter({"lokal": ollama({})}, "lokal", phrases=phrases)
     return BrainRouter({"memex": memex({"url": cfg.memex_url, "token": cfg.memex_token,
-                                        "namespace": cfg.namespace})}, "memex")
+                                        "namespace": cfg.namespace})}, "memex", phrases=phrases)
 
 
 def make_tts(cfg: Config):
@@ -112,6 +122,8 @@ async def run() -> None:
         command_handler=router.handle_command,
         stream_text=router.stream_text,
         stream_speak=stream_speak,
+        hold_phrase_for=router.describe_hold,
+        answer_to_template=phrases_for(cfg.stt_language)["answer_to"],
     )
     link = SatelliteLink(cfg, pipeline)
 

--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -114,6 +114,12 @@ async def run() -> None:
         stream_speak=stream_speak,
     )
     link = SatelliteLink(cfg, pipeline)
+
+    async def barge_in() -> None:
+        await server.interrupt_streams()
+        await link.stop_playback()
+
+    link.on_wake = barge_in
     try:
         await link.run_forever()
     finally:

--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -1,0 +1,66 @@
+"""Entry point: wire config → STT → threads → TTS → satellite, then run forever."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+
+import aiohttp
+
+from . import stt
+from .config import Config
+from .pipeline import VoicePipeline
+from .satellite import SatelliteLink
+from .threads import MemexThreads
+from .tts import PiperTts, TtsFileServer
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+
+async def run() -> None:
+    cfg = Config.from_env()
+    http = aiohttp.ClientSession()
+    threads = MemexThreads(cfg.memex_url, cfg.memex_token, cfg.namespace,
+                           agent=cfg.agent, thread_idle_minutes=cfg.thread_idle_minutes)
+    piper = PiperTts(cfg.piper_bin, cfg.piper_voice)
+    server = TtsFileServer(cfg.gateway_host, cfg.gateway_port)
+    await server.start()
+
+    async def speak(text: str) -> str:
+        return server.add(await piper.synthesize(text))
+
+    link: SatelliteLink | None = None
+
+    async def announce(url: str, text: str) -> None:
+        if link is not None:
+            await link.announce(url, text)
+
+    pipeline = VoicePipeline(
+        transcribe=functools.partial(stt.transcribe, http, cfg.memex_url, cfg.memex_token,
+                                     path=cfg.stt_path, language=cfg.stt_language,
+                                     sample_rate=cfg.sample_rate),
+        ask=threads.ask,
+        await_reply=threads.await_reply,
+        speak=speak,
+        announce=announce,
+        reply_budget_s=cfg.reply_budget_s,
+        announce_budget_s=cfg.announce_budget_s,
+        hold_phrase=cfg.hold_phrase,
+        error_phrase=cfg.error_phrase,
+    )
+    link = SatelliteLink(cfg, pipeline)
+    try:
+        await link.run_forever()
+    finally:
+        await server.stop()
+        await threads.close()
+        await http.close()
+
+
+def main() -> None:
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -12,6 +12,7 @@ from . import stt
 from .config import Config
 from .ollama import OllamaBrain
 from .pipeline import VoicePipeline
+from .router import BrainRouter
 from .satellite import SatelliteLink
 from .threads import MemexThreads
 from .tts import PiperTts, SayTts, TtsFileServer
@@ -19,15 +20,26 @@ from .tts import PiperTts, SayTts, TtsFileServer
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 
 
-def make_brain(cfg: Config):
-    """Returns (ask, await_reply, close) for the configured brain."""
+def make_router(cfg: Config) -> BrainRouter:
+    """One router over all configured brains — PORTALS entries, else the legacy single brain."""
+    def ollama(entry: dict) -> OllamaBrain:
+        return OllamaBrain(entry.get("url", cfg.ollama_url), entry.get("model", cfg.ollama_model),
+                           idle_minutes=cfg.thread_idle_minutes)
+
+    def memex(entry: dict) -> MemexThreads:
+        return MemexThreads(entry["url"].rstrip("/"), entry["token"], entry["namespace"],
+                            agent=entry.get("agent", cfg.agent),
+                            thread_idle_minutes=cfg.thread_idle_minutes)
+
+    if cfg.portals:
+        brains = {e["name"]: (ollama(e) if e.get("kind") == "ollama" else memex(e))
+                  for e in cfg.portals}
+        active = next((e["name"] for e in cfg.portals if e.get("default")), cfg.portals[0]["name"])
+        return BrainRouter(brains, active)
     if cfg.brain == "ollama":
-        brain = OllamaBrain(cfg.ollama_url, cfg.ollama_model,
-                            idle_minutes=cfg.thread_idle_minutes)
-        return brain.ask, brain.await_reply, brain.close
-    threads = MemexThreads(cfg.memex_url, cfg.memex_token, cfg.namespace,
-                           agent=cfg.agent, thread_idle_minutes=cfg.thread_idle_minutes)
-    return threads.ask, threads.await_reply, threads.close
+        return BrainRouter({"lokal": ollama({})}, "lokal")
+    return BrainRouter({"memex": memex({"url": cfg.memex_url, "token": cfg.memex_token,
+                                        "namespace": cfg.namespace})}, "memex")
 
 
 def make_tts(cfg: Config):
@@ -39,7 +51,7 @@ def make_tts(cfg: Config):
 async def run() -> None:
     cfg = Config.from_env()
     http = aiohttp.ClientSession()
-    ask, await_reply, close_brain = make_brain(cfg)
+    router = make_router(cfg)
     tts = make_tts(cfg)
     server = TtsFileServer(cfg.gateway_host, cfg.gateway_port)
     await server.start()
@@ -56,21 +68,22 @@ async def run() -> None:
     pipeline = VoicePipeline(
         transcribe=functools.partial(stt.transcribe, http, cfg.stt_url, cfg.stt_token,
                                      language=cfg.stt_language, sample_rate=cfg.sample_rate),
-        ask=ask,
-        await_reply=await_reply,
+        ask=router.ask,
+        await_reply=router.await_reply,
         speak=speak,
         announce=announce,
         reply_budget_s=cfg.reply_budget_s,
         announce_budget_s=cfg.announce_budget_s,
         hold_phrase=cfg.hold_phrase,
         error_phrase=cfg.error_phrase,
+        command_handler=router.handle_command,
     )
     link = SatelliteLink(cfg, pipeline)
     try:
         await link.run_forever()
     finally:
         await server.stop()
-        await close_brain()
+        await router.close()
         await http.close()
 
 

--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
+import re
 
 import aiohttp
 
@@ -15,7 +16,9 @@ from .pipeline import VoicePipeline
 from .router import BrainRouter
 from .satellite import SatelliteLink
 from .threads import MemexThreads
-from .tts import PiperTts, SayTts, TtsFileServer
+from .tts import PiperTts, SayTts, TtsFileServer, split_wav
+
+SENTENCE_END = re.compile(r"[.!?…][\"')\]]*\s")
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 
@@ -59,6 +62,36 @@ async def run() -> None:
     async def speak(text: str) -> str:
         return server.add(await tts.synthesize(text))
 
+    async def stream_speak(chunks) -> str:
+        """Speak a live text stream: open a chunked-WAV session (the device starts playing
+        the URL immediately), synthesize sentence-by-sentence as pieces arrive, close on end.
+        Both `say` (forced LEI16@22050) and the piper medium voices emit 22.05 kHz."""
+        stream, url = server.open_stream(sample_rate=22050)
+
+        async def feed() -> None:
+            buffer = ""
+
+            async def speak_piece(text: str) -> None:
+                pcm, _ = split_wav(await tts.synthesize(text))
+                await stream.push(pcm)
+
+            try:
+                async for piece in chunks:
+                    buffer += piece
+                    while (match := SENTENCE_END.search(buffer)) is not None:
+                        sentence, buffer = buffer[:match.end()].strip(), buffer[match.end():]
+                        if sentence:
+                            await speak_piece(sentence)
+                if buffer.strip():
+                    await speak_piece(buffer.strip())
+            except Exception:
+                logging.getLogger(__name__).exception("streaming synthesis failed")
+            finally:
+                await stream.close()
+
+        asyncio.create_task(feed())
+        return url
+
     link: SatelliteLink | None = None
 
     async def announce(url: str, text: str) -> None:
@@ -77,6 +110,8 @@ async def run() -> None:
         hold_phrase=cfg.hold_phrase,
         error_phrase=cfg.error_phrase,
         command_handler=router.handle_command,
+        stream_text=router.stream_text,
+        stream_speak=stream_speak,
     )
     link = SatelliteLink(cfg, pipeline)
     try:

--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -1,4 +1,4 @@
-"""Entry point: wire config → STT → threads → TTS → satellite, then run forever."""
+"""Entry point: wire config → STT → brain → TTS → satellite, then run forever."""
 
 from __future__ import annotations
 
@@ -10,25 +10,42 @@ import aiohttp
 
 from . import stt
 from .config import Config
+from .ollama import OllamaBrain
 from .pipeline import VoicePipeline
 from .satellite import SatelliteLink
 from .threads import MemexThreads
-from .tts import PiperTts, TtsFileServer
+from .tts import PiperTts, SayTts, TtsFileServer
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+
+def make_brain(cfg: Config):
+    """Returns (ask, await_reply, close) for the configured brain."""
+    if cfg.brain == "ollama":
+        brain = OllamaBrain(cfg.ollama_url, cfg.ollama_model,
+                            idle_minutes=cfg.thread_idle_minutes)
+        return brain.ask, brain.await_reply, brain.close
+    threads = MemexThreads(cfg.memex_url, cfg.memex_token, cfg.namespace,
+                           agent=cfg.agent, thread_idle_minutes=cfg.thread_idle_minutes)
+    return threads.ask, threads.await_reply, threads.close
+
+
+def make_tts(cfg: Config):
+    if cfg.tts_engine == "say":
+        return SayTts(cfg.say_voice)
+    return PiperTts(cfg.piper_bin, cfg.piper_voice)
 
 
 async def run() -> None:
     cfg = Config.from_env()
     http = aiohttp.ClientSession()
-    threads = MemexThreads(cfg.memex_url, cfg.memex_token, cfg.namespace,
-                           agent=cfg.agent, thread_idle_minutes=cfg.thread_idle_minutes)
-    piper = PiperTts(cfg.piper_bin, cfg.piper_voice)
+    ask, await_reply, close_brain = make_brain(cfg)
+    tts = make_tts(cfg)
     server = TtsFileServer(cfg.gateway_host, cfg.gateway_port)
     await server.start()
 
     async def speak(text: str) -> str:
-        return server.add(await piper.synthesize(text))
+        return server.add(await tts.synthesize(text))
 
     link: SatelliteLink | None = None
 
@@ -37,11 +54,10 @@ async def run() -> None:
             await link.announce(url, text)
 
     pipeline = VoicePipeline(
-        transcribe=functools.partial(stt.transcribe, http, cfg.memex_url, cfg.memex_token,
-                                     path=cfg.stt_path, language=cfg.stt_language,
-                                     sample_rate=cfg.sample_rate),
-        ask=threads.ask,
-        await_reply=threads.await_reply,
+        transcribe=functools.partial(stt.transcribe, http, cfg.stt_url, cfg.stt_token,
+                                     language=cfg.stt_language, sample_rate=cfg.sample_rate),
+        ask=ask,
+        await_reply=await_reply,
         speak=speak,
         announce=announce,
         reply_budget_s=cfg.reply_budget_s,
@@ -54,7 +70,7 @@ async def run() -> None:
         await link.run_forever()
     finally:
         await server.stop()
-        await threads.close()
+        await close_brain()
         await http.close()
 
 

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -1,0 +1,88 @@
+"""Gateway configuration — one flat dataclass, filled from environment variables.
+
+Every knob has a default except the four that identify YOUR satellite and YOUR mesh:
+SATELLITE_HOST, SATELLITE_PSK (or SATELLITE_PASSWORD), MEMEX_URL, MEMEX_TOKEN.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+
+def _env(name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name, default)
+    return value if value not in ("", None) else default
+
+
+@dataclass
+class Config:
+    # --- the satellite (ESPHome native API, LAN) ---
+    satellite_host: str = ""
+    satellite_port: int = 6053
+    satellite_psk: str | None = None        # noise encryption key (preferred)
+    satellite_password: str | None = None   # legacy plaintext API password
+
+    # --- the mesh ---
+    memex_url: str = "https://memex.meshweaver.cloud"
+    memex_token: str = ""                   # mw_… API token (Settings ▸ Security ▸ API Tokens)
+    namespace: str = ""                     # thread namespace, e.g. your user id
+    agent: str | None = "Voice"             # lean spoken-answer agent; None = platform default
+
+    # --- speech ---
+    stt_path: str = "/api/speech/transcribe"
+    stt_language: str = "de"                # "de" transcribes Swiss German OUT as Standard German
+    sample_rate: int = 16000                # the satellite streams 16 kHz mono s16le
+
+    # --- conversation pacing ---
+    reply_budget_s: float = 10.0            # wait this long for the agent before acking
+    announce_budget_s: float = 240.0        # keep polling this long, then announce the answer
+    thread_idle_minutes: float = 5.0        # reuse the same thread within this window
+    hold_phrase: str = "Ich schaue nach. Einen Moment bitte."
+    error_phrase: str = "Entschuldigung, das hat gerade nicht geklappt."
+
+    # --- endpointing (energy VAD) ---
+    silence_ms: int = 800
+    max_utterance_s: float = 15.0
+    min_utterance_s: float = 0.4
+
+    # --- TTS (Piper) + the URL the satellite fetches audio from ---
+    piper_bin: str = "piper"
+    piper_voice: str = "/voices/de_DE-thorsten-medium.onnx"
+    gateway_host: str = ""                  # LAN IP of THIS gateway, reachable by the satellite
+    gateway_port: int = 8200
+
+    extra: dict = field(default_factory=dict)
+
+    @staticmethod
+    def from_env() -> "Config":
+        cfg = Config(
+            satellite_host=_env("SATELLITE_HOST") or "",
+            satellite_port=int(_env("SATELLITE_PORT", "6053")),
+            satellite_psk=_env("SATELLITE_PSK"),
+            satellite_password=_env("SATELLITE_PASSWORD"),
+            memex_url=(_env("MEMEX_URL", "https://memex.meshweaver.cloud") or "").rstrip("/"),
+            memex_token=_env("MEMEX_TOKEN") or "",
+            namespace=_env("MEMEX_NAMESPACE") or "",
+            agent=_env("MEMEX_AGENT", "Voice"),
+            stt_language=_env("STT_LANGUAGE", "de") or "de",
+            reply_budget_s=float(_env("REPLY_BUDGET_S", "10")),
+            announce_budget_s=float(_env("ANNOUNCE_BUDGET_S", "240")),
+            thread_idle_minutes=float(_env("THREAD_IDLE_MINUTES", "5")),
+            hold_phrase=_env("HOLD_PHRASE", Config.hold_phrase) or Config.hold_phrase,
+            error_phrase=_env("ERROR_PHRASE", Config.error_phrase) or Config.error_phrase,
+            silence_ms=int(_env("SILENCE_MS", "800")),
+            piper_bin=_env("PIPER_BIN", "piper") or "piper",
+            piper_voice=_env("PIPER_VOICE", Config.piper_voice) or Config.piper_voice,
+            gateway_host=_env("GATEWAY_HOST") or "",
+            gateway_port=int(_env("GATEWAY_PORT", "8200")),
+        )
+        missing = [n for n, v in (
+            ("SATELLITE_HOST", cfg.satellite_host),
+            ("MEMEX_TOKEN", cfg.memex_token),
+            ("MEMEX_NAMESPACE", cfg.namespace),
+            ("GATEWAY_HOST", cfg.gateway_host),
+        ) if not v]
+        if missing:
+            raise SystemExit(f"Missing required environment variables: {', '.join(missing)}")
+        return cfg

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -54,6 +54,9 @@ class Config:
     hold_phrase: str = "Ich schaue nach. Einen Moment bitte."
     error_phrase: str = "Entschuldigung, das hat gerade nicht geklappt."
 
+    # --- multiple brains (optional) — see router.py; overrides the single-brain fields ---
+    portals: list = field(default_factory=list)   # PORTALS: JSON list of named targets
+
     # --- wake word (activated on the device if none is) ---
     wake_word: str = "hey_jarvis"           # micro-wake-word model id on the device
 
@@ -74,6 +77,9 @@ class Config:
 
     @staticmethod
     def from_env() -> "Config":
+        import json
+        portals_raw = _env("PORTALS")
+        portals = json.loads(portals_raw) if portals_raw else []
         memex_url = (_env("MEMEX_URL", "https://memex.meshweaver.cloud") or "").rstrip("/")
         memex_token = _env("MEMEX_TOKEN") or ""
         stt_url = _env("STT_URL") or f"{memex_url}/api/speech/transcribe"
@@ -107,9 +113,10 @@ class Config:
             say_voice=_env("SAY_VOICE", "Anna") or "Anna",
             gateway_host=_env("GATEWAY_HOST") or "",
             gateway_port=int(_env("GATEWAY_PORT", "8200")),
+            portals=portals,
         )
         required = [("SATELLITE_HOST", cfg.satellite_host), ("GATEWAY_HOST", cfg.gateway_host)]
-        if cfg.brain == "memex":
+        if not cfg.portals and cfg.brain == "memex":
             required += [("MEMEX_TOKEN", cfg.memex_token), ("MEMEX_NAMESPACE", cfg.namespace)]
         missing = [name for name, value in required if not value]
         if missing:

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -54,6 +54,9 @@ class Config:
     hold_phrase: str = "Ich schaue nach. Einen Moment bitte."
     error_phrase: str = "Entschuldigung, das hat gerade nicht geklappt."
 
+    # --- wake word (activated on the device if none is) ---
+    wake_word: str = "hey_jarvis"           # micro-wake-word model id on the device
+
     # --- endpointing (energy VAD) ---
     silence_ms: int = 800
     max_utterance_s: float = 15.0
@@ -96,6 +99,7 @@ class Config:
             thread_idle_minutes=float(_env("THREAD_IDLE_MINUTES", "5")),
             hold_phrase=_env("HOLD_PHRASE", Config.hold_phrase) or Config.hold_phrase,
             error_phrase=_env("ERROR_PHRASE", Config.error_phrase) or Config.error_phrase,
+            wake_word=_env("WAKE_WORD", "hey_jarvis") or "hey_jarvis",
             silence_ms=int(_env("SILENCE_MS", "800")),
             tts_engine=(_env("TTS_ENGINE", "piper") or "piper").lower(),
             piper_bin=_env("PIPER_BIN", "piper") or "piper",

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -1,7 +1,16 @@
 """Gateway configuration — one flat dataclass, filled from environment variables.
 
-Every knob has a default except the four that identify YOUR satellite and YOUR mesh:
-SATELLITE_HOST, SATELLITE_PSK (or SATELLITE_PASSWORD), MEMEX_URL, MEMEX_TOKEN.
+Three pluggable legs, each independently local or mesh-hosted:
+
+  BRAIN=memex   agent threads over /mcp (needs MEMEX_TOKEN + MEMEX_NAMESPACE)   [default]
+  BRAIN=ollama  a local model via Ollama (OLLAMA_URL / OLLAMA_MODEL)
+
+  STT_URL       full transcription endpoint. Default: {MEMEX_URL}/api/speech/transcribe.
+                Point it at a local whisper.cpp server instead (http://127.0.0.1:8090/inference)
+                — both speak multipart file+language → {"text": …}.
+
+  TTS_ENGINE=piper  the Piper CLI (container default)
+  TTS_ENGINE=say    macOS's built-in `say` (zero setup on a Mac; SAY_VOICE, e.g. "Anna")
 """
 
 from __future__ import annotations
@@ -23,21 +32,25 @@ class Config:
     satellite_psk: str | None = None        # noise encryption key (preferred)
     satellite_password: str | None = None   # legacy plaintext API password
 
-    # --- the mesh ---
+    # --- the brain ---
+    brain: str = "memex"                    # "memex" (agent threads) | "ollama" (local model)
     memex_url: str = "https://memex.meshweaver.cloud"
     memex_token: str = ""                   # mw_… API token (Settings ▸ Security ▸ API Tokens)
     namespace: str = ""                     # thread namespace, e.g. your user id
     agent: str | None = "Voice"             # lean spoken-answer agent; None = platform default
+    ollama_url: str = "http://127.0.0.1:11434"
+    ollama_model: str = "qwen3.6"
 
-    # --- speech ---
-    stt_path: str = "/api/speech/transcribe"
+    # --- speech-to-text ---
+    stt_url: str = ""                       # default derived: {memex_url}/api/speech/transcribe
+    stt_token: str | None = None            # bearer for the STT endpoint; None = unauthenticated
     stt_language: str = "de"                # "de" transcribes Swiss German OUT as Standard German
     sample_rate: int = 16000                # the satellite streams 16 kHz mono s16le
 
     # --- conversation pacing ---
-    reply_budget_s: float = 10.0            # wait this long for the agent before acking
+    reply_budget_s: float = 10.0            # wait this long for the answer before acking
     announce_budget_s: float = 240.0        # keep polling this long, then announce the answer
-    thread_idle_minutes: float = 5.0        # reuse the same thread within this window
+    thread_idle_minutes: float = 5.0        # reuse the conversation within this window
     hold_phrase: str = "Ich schaue nach. Einen Moment bitte."
     error_phrase: str = "Entschuldigung, das hat gerade nicht geklappt."
 
@@ -46,9 +59,11 @@ class Config:
     max_utterance_s: float = 15.0
     min_utterance_s: float = 0.4
 
-    # --- TTS (Piper) + the URL the satellite fetches audio from ---
+    # --- text-to-speech + the URL the satellite fetches audio from ---
+    tts_engine: str = "piper"               # "piper" | "say" (macOS)
     piper_bin: str = "piper"
     piper_voice: str = "/voices/de_DE-thorsten-medium.onnx"
+    say_voice: str = "Anna"                 # macOS German voice
     gateway_host: str = ""                  # LAN IP of THIS gateway, reachable by the satellite
     gateway_port: int = 8200
 
@@ -56,15 +71,25 @@ class Config:
 
     @staticmethod
     def from_env() -> "Config":
+        memex_url = (_env("MEMEX_URL", "https://memex.meshweaver.cloud") or "").rstrip("/")
+        memex_token = _env("MEMEX_TOKEN") or ""
+        stt_url = _env("STT_URL") or f"{memex_url}/api/speech/transcribe"
+        # The mesh endpoint needs the bearer; a local whisper.cpp server does not.
+        stt_token = _env("STT_TOKEN") or (memex_token if stt_url.startswith(memex_url) else None)
         cfg = Config(
             satellite_host=_env("SATELLITE_HOST") or "",
             satellite_port=int(_env("SATELLITE_PORT", "6053")),
             satellite_psk=_env("SATELLITE_PSK"),
             satellite_password=_env("SATELLITE_PASSWORD"),
-            memex_url=(_env("MEMEX_URL", "https://memex.meshweaver.cloud") or "").rstrip("/"),
-            memex_token=_env("MEMEX_TOKEN") or "",
+            brain=(_env("BRAIN", "memex") or "memex").lower(),
+            memex_url=memex_url,
+            memex_token=memex_token,
             namespace=_env("MEMEX_NAMESPACE") or "",
             agent=_env("MEMEX_AGENT", "Voice"),
+            ollama_url=(_env("OLLAMA_URL", "http://127.0.0.1:11434") or "").rstrip("/"),
+            ollama_model=_env("OLLAMA_MODEL", "qwen3.6") or "qwen3.6",
+            stt_url=stt_url,
+            stt_token=stt_token,
             stt_language=_env("STT_LANGUAGE", "de") or "de",
             reply_budget_s=float(_env("REPLY_BUDGET_S", "10")),
             announce_budget_s=float(_env("ANNOUNCE_BUDGET_S", "240")),
@@ -72,17 +97,19 @@ class Config:
             hold_phrase=_env("HOLD_PHRASE", Config.hold_phrase) or Config.hold_phrase,
             error_phrase=_env("ERROR_PHRASE", Config.error_phrase) or Config.error_phrase,
             silence_ms=int(_env("SILENCE_MS", "800")),
+            tts_engine=(_env("TTS_ENGINE", "piper") or "piper").lower(),
             piper_bin=_env("PIPER_BIN", "piper") or "piper",
             piper_voice=_env("PIPER_VOICE", Config.piper_voice) or Config.piper_voice,
+            say_voice=_env("SAY_VOICE", "Anna") or "Anna",
             gateway_host=_env("GATEWAY_HOST") or "",
             gateway_port=int(_env("GATEWAY_PORT", "8200")),
         )
-        missing = [n for n, v in (
-            ("SATELLITE_HOST", cfg.satellite_host),
-            ("MEMEX_TOKEN", cfg.memex_token),
-            ("MEMEX_NAMESPACE", cfg.namespace),
-            ("GATEWAY_HOST", cfg.gateway_host),
-        ) if not v]
+        required = [("SATELLITE_HOST", cfg.satellite_host), ("GATEWAY_HOST", cfg.gateway_host)]
+        if cfg.brain == "memex":
+            required += [("MEMEX_TOKEN", cfg.memex_token), ("MEMEX_NAMESPACE", cfg.namespace)]
+        missing = [name for name, value in required if not value]
         if missing:
             raise SystemExit(f"Missing required environment variables: {', '.join(missing)}")
+        if cfg.brain not in ("memex", "ollama"):
+            raise SystemExit(f"BRAIN must be 'memex' or 'ollama', not '{cfg.brain}'")
         return cfg

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -24,6 +24,30 @@ def _env(name: str, default: str | None = None) -> str | None:
     return value if value not in ("", None) else default
 
 
+# What the SPEAKER says in its own voice (holding, errors, switch confirmations) — chosen by
+# the configured language; every instruction and prompt in this repo stays English.
+PHRASES: dict[str, dict[str, str]] = {
+    "en": {"hold": "Let me check. One moment please.",
+           "error": "Sorry, that did not work.",
+           "connected": "Connected to {name}.",
+           "unknown": "I don't know {target}. Available: {names}.",
+           "delegated": "Started a {agent} thread on {portal}. You can review it there.",
+           "no_mesh": "No mesh portal is configured for threads."},
+    "de": {"hold": "Ich schaue nach. Einen Moment bitte.",
+           "error": "Entschuldigung, das hat gerade nicht geklappt.",
+           "connected": "Verbunden mit {name}.",
+           "unknown": "Ich kenne {target} nicht. Verfügbar: {names}.",
+           "delegated": "Thread mit {agent} auf {portal} gestartet. Du kannst ihn dort anschauen.",
+           "no_mesh": "Es ist kein Portal für Threads konfiguriert."},
+}
+PHRASES["en"]["answer_to"] = "Answering your question: {question} —"
+PHRASES["de"]["answer_to"] = "Antwort auf deine Frage: {question} —"
+
+
+def phrases_for(language: str) -> dict[str, str]:
+    return PHRASES.get((language or "en").split("-")[0].lower(), PHRASES["en"])
+
+
 @dataclass
 class Config:
     # --- the satellite (ESPHome native API, LAN) ---
@@ -51,8 +75,8 @@ class Config:
     reply_budget_s: float = 10.0            # wait this long for the answer before acking
     announce_budget_s: float = 240.0        # keep polling this long, then announce the answer
     thread_idle_minutes: float = 5.0        # reuse the conversation within this window
-    hold_phrase: str = "Ich schaue nach. Einen Moment bitte."
-    error_phrase: str = "Entschuldigung, das hat gerade nicht geklappt."
+    hold_phrase: str = ""                   # default: PHRASES[stt_language]["hold"]
+    error_phrase: str = ""                  # default: PHRASES[stt_language]["error"]
 
     # --- multiple brains (optional) — see router.py; overrides the single-brain fields ---
     portals: list = field(default_factory=list)   # PORTALS: JSON list of named targets
@@ -60,6 +84,7 @@ class Config:
     # --- wake word (activated on the device if none is) ---
     wake_word: str = "hey_jarvis"           # micro-wake-word model id on the device
     continue_conversation: bool = True      # after a reply, listen again without a wake word
+    speak_dialect: bool = False             # experiment: model writes Swiss German for the TTS
 
     # --- endpointing (energy VAD) ---
     silence_ms: int = 800
@@ -104,10 +129,11 @@ class Config:
             reply_budget_s=float(_env("REPLY_BUDGET_S", "10")),
             announce_budget_s=float(_env("ANNOUNCE_BUDGET_S", "240")),
             thread_idle_minutes=float(_env("THREAD_IDLE_MINUTES", "5")),
-            hold_phrase=_env("HOLD_PHRASE", Config.hold_phrase) or Config.hold_phrase,
-            error_phrase=_env("ERROR_PHRASE", Config.error_phrase) or Config.error_phrase,
+            hold_phrase=_env("HOLD_PHRASE") or phrases_for(_env("STT_LANGUAGE", "de") or "de")["hold"],
+            error_phrase=_env("ERROR_PHRASE") or phrases_for(_env("STT_LANGUAGE", "de") or "de")["error"],
             wake_word=_env("WAKE_WORD", "hey_jarvis") or "hey_jarvis",
             continue_conversation=(_env("CONTINUE_CONVERSATION", "true") or "true").lower() != "false",
+            speak_dialect=(_env("SPEAK_DIALECT", "false") or "false").lower() == "true",
             silence_ms=int(_env("SILENCE_MS", "800")),
             tts_engine=(_env("TTS_ENGINE", "piper") or "piper").lower(),
             piper_bin=_env("PIPER_BIN", "piper") or "piper",

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -59,6 +59,7 @@ class Config:
 
     # --- wake word (activated on the device if none is) ---
     wake_word: str = "hey_jarvis"           # micro-wake-word model id on the device
+    continue_conversation: bool = True      # after a reply, listen again without a wake word
 
     # --- endpointing (energy VAD) ---
     silence_ms: int = 800
@@ -106,6 +107,7 @@ class Config:
             hold_phrase=_env("HOLD_PHRASE", Config.hold_phrase) or Config.hold_phrase,
             error_phrase=_env("ERROR_PHRASE", Config.error_phrase) or Config.error_phrase,
             wake_word=_env("WAKE_WORD", "hey_jarvis") or "hey_jarvis",
+            continue_conversation=(_env("CONTINUE_CONVERSATION", "true") or "true").lower() != "false",
             silence_ms=int(_env("SILENCE_MS", "800")),
             tts_engine=(_env("TTS_ENGINE", "piper") or "piper").lower(),
             piper_bin=_env("PIPER_BIN", "piper") or "piper",

--- a/clients/voice-gateway/memex_voice_gateway/ollama.py
+++ b/clients/voice-gateway/memex_voice_gateway/ollama.py
@@ -22,15 +22,32 @@ SYSTEM_PROMPT = (
     "Du bist ein Sprachassistent auf einem Lautsprecher. Deine Antworten werden vorgelesen: "
     "Antworte in höchstens zwei kurzen Sätzen, ohne Markdown, Listen, Code oder Links. "
     "Antworte in der Sprache der Frage; Schweizerdeutsch kommt als Standarddeutsch an — "
-    "antworte auf Standarddeutsch. Gib direkt die Antwort, keine Erklärung des Vorgehens."
+    "antworte auf Standarddeutsch. Gib direkt die Antwort, keine Erklärung des Vorgehens. "
+    "Jede Nutzernachricht beginnt mit ihrer Uhrzeit in eckigen Klammern — nutze sie, um "
+    "zeitliche Abstände im Gespräch richtig einzuordnen."
 )
+
+_WEEKDAYS = ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"]
+_MONTHS = ["Januar", "Februar", "März", "April", "Mai", "Juni", "Juli",
+           "August", "September", "Oktober", "November", "Dezember"]
+
+
+def now_line(now=None) -> str:
+    """The current wall-clock, spoken-German style — a local model has NO clock of its own,
+    and a voice assistant unmoored from real time answers 'heute' questions wrongly."""
+    import datetime
+    now = now or datetime.datetime.now().astimezone()
+    return (f"Aktuelle Zeit: {_WEEKDAYS[now.weekday()]}, {now.day}. "
+            f"{_MONTHS[now.month - 1]} {now.year}, {now:%H:%M} Uhr.")
 
 
 def build_messages(history: list[dict], text: str, system_prompt: str = SYSTEM_PROMPT,
-                   max_turns: int = 8) -> list[dict]:
-    """System prompt + the last `max_turns` exchanges + the new user message."""
+                   max_turns: int = 8, now: str | None = None) -> list[dict]:
+    """System prompt (+ the real-time anchor) + the last `max_turns` exchanges + the new
+    user message. History user entries carry their [HH:MM] stamps from ask()."""
+    system = system_prompt if now is None else f"{system_prompt}\n\n{now}"
     trimmed = history[-2 * max_turns:]
-    return [{"role": "system", "content": system_prompt}, *trimmed,
+    return [{"role": "system", "content": system}, *trimmed,
             {"role": "user", "content": text}]
 
 
@@ -107,8 +124,10 @@ class OllamaBrain:
         if self._history and (time.monotonic() - self._last_used) > self.idle_minutes * 60:
             self._history = []
         self._last_used = time.monotonic()
-        messages = build_messages(self._history, text)
-        self._history.append({"role": "user", "content": text})
+        import datetime
+        stamped = f"[{datetime.datetime.now().astimezone():%H:%M}] {text}"
+        messages = build_messages(self._history, stamped, now=now_line())
+        self._history.append({"role": "user", "content": stamped})
 
         handle = f"ollama-{next(self._ids)}"
         self._chunks[handle] = asyncio.Queue()

--- a/clients/voice-gateway/memex_voice_gateway/ollama.py
+++ b/clients/voice-gateway/memex_voice_gateway/ollama.py
@@ -19,26 +19,28 @@ from dataclasses import dataclass, field
 import aiohttp
 
 SYSTEM_PROMPT = (
-    "Du bist ein Sprachassistent auf einem Lautsprecher. Deine Antworten werden vorgelesen: "
-    "Antworte in höchstens zwei kurzen Sätzen, ohne Markdown, Listen, Code oder Links. "
-    "Antworte in der Sprache der Frage; Schweizerdeutsch kommt als Standarddeutsch an — "
-    "antworte auf Standarddeutsch. Gib direkt die Antwort, keine Erklärung des Vorgehens. "
-    "Jede Nutzernachricht beginnt mit ihrer Uhrzeit in eckigen Klammern — nutze sie, um "
-    "zeitliche Abstände im Gespräch richtig einzuordnen."
+    "You are a voice assistant on a smart speaker. Everything you write is read aloud by "
+    "text-to-speech: answer in at most two short sentences — no markdown, lists, code, or "
+    "links. Reply in the language you were addressed in; Swiss German arrives transcribed "
+    "as Standard German — reply in Standard German. Give the answer directly, not the "
+    "process; ask a follow-up question only when the request is genuinely ambiguous. Each "
+    "user message starts with its wall-clock time in brackets — use it to judge the time "
+    "gaps in the conversation."
 )
 
-_WEEKDAYS = ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"]
-_MONTHS = ["Januar", "Februar", "März", "April", "Mai", "Juni", "Juli",
-           "August", "September", "Oktober", "November", "Dezember"]
+_WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+_MONTHS = ["January", "February", "March", "April", "May", "June", "July",
+           "August", "September", "October", "November", "December"]
 
 
 def now_line(now=None) -> str:
-    """The current wall-clock, spoken-German style — a local model has NO clock of its own,
-    and a voice assistant unmoored from real time answers 'heute' questions wrongly."""
+    """The current wall-clock — a local model has NO clock of its own, and a voice
+    assistant unmoored from real time answers 'today' questions wrongly. Model-facing, so
+    English regardless of the spoken language."""
     import datetime
     now = now or datetime.datetime.now().astimezone()
-    return (f"Aktuelle Zeit: {_WEEKDAYS[now.weekday()]}, {now.day}. "
-            f"{_MONTHS[now.month - 1]} {now.year}, {now:%H:%M} Uhr.")
+    return (f"Current time: {_WEEKDAYS[now.weekday()]}, {now.day} "
+            f"{_MONTHS[now.month - 1]} {now.year}, {now:%H:%M}.")
 
 
 def build_messages(history: list[dict], text: str, system_prompt: str = SYSTEM_PROMPT,
@@ -57,6 +59,7 @@ class OllamaBrain:
     model: str
     idle_minutes: float = 5.0
     num_predict: int = 200
+    system_prompt: str = SYSTEM_PROMPT
 
     _history: list[dict] = field(default_factory=list, init=False)
     _last_used: float = field(default=0.0, init=False)
@@ -126,7 +129,8 @@ class OllamaBrain:
         self._last_used = time.monotonic()
         import datetime
         stamped = f"[{datetime.datetime.now().astimezone():%H:%M}] {text}"
-        messages = build_messages(self._history, stamped, now=now_line())
+        messages = build_messages(self._history, stamped, system_prompt=self.system_prompt,
+                                  now=now_line())
         self._history.append({"role": "user", "content": stamped})
 
         handle = f"ollama-{next(self._ids)}"

--- a/clients/voice-gateway/memex_voice_gateway/ollama.py
+++ b/clients/voice-gateway/memex_voice_gateway/ollama.py
@@ -44,10 +44,15 @@ class OllamaBrain:
     _history: list[dict] = field(default_factory=list, init=False)
     _last_used: float = field(default=0.0, init=False)
     _tasks: dict[str, asyncio.Task] = field(default_factory=dict, init=False)
+    _chunks: dict[str, asyncio.Queue] = field(default_factory=dict, init=False)
     _ids: itertools.count = field(default_factory=itertools.count, init=False)
     _http: aiohttp.ClientSession | None = field(default=None, init=False)
 
-    async def _chat(self, messages: list[dict]) -> str:
+    async def _chat(self, messages: list[dict], handle: str | None = None) -> str:
+        """One completion; when `handle` names a chunk queue, STREAM pieces into it as they
+        arrive — the voice pipeline speaks them sentence-by-sentence while generation runs."""
+        if handle is not None:
+            return await self._chat_streaming(messages, handle)
         if self._http is None:
             self._http = aiohttp.ClientSession()
         # keep_alive holds the model in RAM between questions — without it, Ollama unloads
@@ -70,6 +75,33 @@ class OllamaBrain:
                 data = await response.json()
         return (data.get("message") or {}).get("content", "").strip()
 
+    async def _chat_streaming(self, messages: list[dict], handle: str) -> str:
+        if self._http is None:
+            self._http = aiohttp.ClientSession()
+        payload = {"model": self.model, "messages": messages, "stream": True,
+                   "think": False, "keep_alive": "60m",
+                   "options": {"num_predict": self.num_predict}}
+        queue = self._chunks[handle]
+        pieces: list[str] = []
+        import json as _json
+        try:
+            async with self._http.post(f"{self.base_url}/api/chat", json=payload,
+                                       timeout=aiohttp.ClientTimeout(total=300)) as response:
+                response.raise_for_status()
+                async for line in response.content:
+                    if not line.strip():
+                        continue
+                    data = _json.loads(line)
+                    piece = (data.get("message") or {}).get("content", "")
+                    if piece:
+                        pieces.append(piece)
+                        await queue.put(piece)
+                    if data.get("done"):
+                        break
+        finally:
+            await queue.put(None)
+        return "".join(pieces).strip()
+
     async def ask(self, text: str) -> str:
         """Start generating; returns a handle usable with await_reply (pipeline contract)."""
         if self._history and (time.monotonic() - self._last_used) > self.idle_minutes * 60:
@@ -78,14 +110,29 @@ class OllamaBrain:
         messages = build_messages(self._history, text)
         self._history.append({"role": "user", "content": text})
 
+        handle = f"ollama-{next(self._ids)}"
+        self._chunks[handle] = asyncio.Queue()
+
         async def generate() -> str:
-            reply = await self._chat(messages)
+            reply = await self._chat(messages, handle=handle)
             self._history.append({"role": "assistant", "content": reply})
             return reply
 
-        handle = f"ollama-{next(self._ids)}"
         self._tasks[handle] = asyncio.create_task(generate())
         return handle
+
+    def stream_text(self, handle: str):
+        """Async iterator over the reply's text pieces as they are generated, or None."""
+        queue = self._chunks.get(handle)
+        if queue is None:
+            return None
+
+        async def drain():
+            while (piece := await queue.get()) is not None:
+                yield piece
+            self._chunks.pop(handle, None)
+
+        return drain()
 
     async def await_reply(self, handle: str, budget_s: float) -> str | None:
         task = self._tasks.get(handle)
@@ -96,6 +143,7 @@ class OllamaBrain:
         except asyncio.TimeoutError:
             return None      # generation keeps running; the announce path retries this handle
         self._tasks.pop(handle, None)
+        self._chunks.pop(handle, None)   # nobody streamed this round — drop the piece queue
         return reply
 
     async def close(self) -> None:

--- a/clients/voice-gateway/memex_voice_gateway/ollama.py
+++ b/clients/voice-gateway/memex_voice_gateway/ollama.py
@@ -1,0 +1,106 @@
+"""A local model as the brain, via Ollama's /api/chat.
+
+Implements the same two-phase surface as MemexThreads (`ask` → handle, `await_reply` with a
+budget), so the pipeline — including the holding-phrase + announce path — is identical for a
+local model and a mesh agent. Generation runs in a background task; a budget miss leaves it
+running and the announce poll picks the answer up when it lands.
+
+Conversation history lives in-process (this brain has no thread node) and resets after the
+same idle window a mesh thread would.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import time
+from dataclasses import dataclass, field
+
+import aiohttp
+
+SYSTEM_PROMPT = (
+    "Du bist ein Sprachassistent auf einem Lautsprecher. Deine Antworten werden vorgelesen: "
+    "Antworte in höchstens zwei kurzen Sätzen, ohne Markdown, Listen, Code oder Links. "
+    "Antworte in der Sprache der Frage; Schweizerdeutsch kommt als Standarddeutsch an — "
+    "antworte auf Standarddeutsch. Gib direkt die Antwort, keine Erklärung des Vorgehens."
+)
+
+
+def build_messages(history: list[dict], text: str, system_prompt: str = SYSTEM_PROMPT,
+                   max_turns: int = 8) -> list[dict]:
+    """System prompt + the last `max_turns` exchanges + the new user message."""
+    trimmed = history[-2 * max_turns:]
+    return [{"role": "system", "content": system_prompt}, *trimmed,
+            {"role": "user", "content": text}]
+
+
+@dataclass
+class OllamaBrain:
+    base_url: str
+    model: str
+    idle_minutes: float = 5.0
+    num_predict: int = 200
+
+    _history: list[dict] = field(default_factory=list, init=False)
+    _last_used: float = field(default=0.0, init=False)
+    _tasks: dict[str, asyncio.Task] = field(default_factory=dict, init=False)
+    _ids: itertools.count = field(default_factory=itertools.count, init=False)
+    _http: aiohttp.ClientSession | None = field(default=None, init=False)
+
+    async def _chat(self, messages: list[dict]) -> str:
+        if self._http is None:
+            self._http = aiohttp.ClientSession()
+        # keep_alive holds the model in RAM between questions — without it, Ollama unloads
+        # after ~5 min idle and the next wake pays the full model load (measured: 15s cold
+        # vs 0.4s warm for qwen3.6 on an M5 Max).
+        payload = {"model": self.model, "messages": messages, "stream": False,
+                   "think": False, "keep_alive": "60m",
+                   "options": {"num_predict": self.num_predict}}
+        async with self._http.post(f"{self.base_url}/api/chat", json=payload,
+                                   timeout=aiohttp.ClientTimeout(total=300)) as response:
+            if response.status == 400:
+                # Older Ollama / non-thinking model rejecting "think" — retry without it.
+                del payload["think"]
+                async with self._http.post(f"{self.base_url}/api/chat", json=payload,
+                                           timeout=aiohttp.ClientTimeout(total=300)) as retry:
+                    retry.raise_for_status()
+                    data = await retry.json()
+            else:
+                response.raise_for_status()
+                data = await response.json()
+        return (data.get("message") or {}).get("content", "").strip()
+
+    async def ask(self, text: str) -> str:
+        """Start generating; returns a handle usable with await_reply (pipeline contract)."""
+        if self._history and (time.monotonic() - self._last_used) > self.idle_minutes * 60:
+            self._history = []
+        self._last_used = time.monotonic()
+        messages = build_messages(self._history, text)
+        self._history.append({"role": "user", "content": text})
+
+        async def generate() -> str:
+            reply = await self._chat(messages)
+            self._history.append({"role": "assistant", "content": reply})
+            return reply
+
+        handle = f"ollama-{next(self._ids)}"
+        self._tasks[handle] = asyncio.create_task(generate())
+        return handle
+
+    async def await_reply(self, handle: str, budget_s: float) -> str | None:
+        task = self._tasks.get(handle)
+        if task is None:
+            return None
+        try:
+            reply = await asyncio.wait_for(asyncio.shield(task), timeout=budget_s)
+        except asyncio.TimeoutError:
+            return None      # generation keeps running; the announce path retries this handle
+        self._tasks.pop(handle, None)
+        return reply
+
+    async def close(self) -> None:
+        for task in self._tasks.values():
+            task.cancel()
+        if self._http is not None:
+            await self._http.close()
+            self._http = None

--- a/clients/voice-gateway/memex_voice_gateway/pipeline.py
+++ b/clients/voice-gateway/memex_voice_gateway/pipeline.py
@@ -44,8 +44,12 @@ class VoicePipeline:
         hold_phrase: str,
         error_phrase: str,
         command_handler: Callable[[str], Awaitable[str | None]] | None = None,
+        stream_text: Callable[[str], object | None] | None = None,
+        stream_speak: Callable[[object], Awaitable[str]] | None = None,
     ) -> None:
         self._command_handler = command_handler
+        self._stream_text = stream_text
+        self._stream_speak = stream_speak
         self._transcribe = transcribe
         self._ask = ask
         self._await_reply = await_reply
@@ -77,11 +81,23 @@ class VoicePipeline:
 
         try:
             thread_path = await self._ask(transcript)
+
+            # Streaming path: a brain that streams text + a streaming TTS session mean the
+            # device starts PLAYING while generation is still running — the URL blocks until
+            # the first spoken sentence lands, then sentences flow as the model writes them.
+            if self._stream_text is not None and self._stream_speak is not None:
+                chunks = self._stream_text(thread_path)
+                if chunks is not None:
+                    url = await self._stream_speak(chunks)
+                    logger.info("round: %r → streaming reply", transcript)
+                    return RoundResult(transcript, None, url)
+
             reply = await self._await_reply(thread_path, self._reply_budget_s)
         except Exception:
             logger.exception("thread submission failed")
             return RoundResult(transcript, self._error_phrase,
                                await self._try_speak(self._error_phrase))
+        logger.info("round: %r → %r", transcript, (reply or "")[:120])
 
         if reply is not None:
             return RoundResult(transcript, reply, await self._try_speak(reply))

--- a/clients/voice-gateway/memex_voice_gateway/pipeline.py
+++ b/clients/voice-gateway/memex_voice_gateway/pipeline.py
@@ -46,10 +46,14 @@ class VoicePipeline:
         command_handler: Callable[[str], Awaitable[str | None]] | None = None,
         stream_text: Callable[[str], object | None] | None = None,
         stream_speak: Callable[[object], Awaitable[str]] | None = None,
+        hold_phrase_for: Callable[[str], str] | None = None,
+        answer_to_template: str | None = None,
     ) -> None:
         self._command_handler = command_handler
         self._stream_text = stream_text
         self._stream_speak = stream_speak
+        self._hold_phrase_for = hold_phrase_for
+        self._answer_to_template = answer_to_template
         self._transcribe = transcribe
         self._ask = ask
         self._await_reply = await_reply
@@ -104,17 +108,24 @@ class VoicePipeline:
         if reply is not None:
             return RoundResult(transcript, reply, await self._try_speak(reply))
 
-        # Budget missed: hold phrase now, real answer as an announcement when it lands.
-        task = asyncio.create_task(self._announce_when_ready(thread_path))
+        # Budget missed: acknowledge the SUBMISSION (naming the portal — answers can be
+        # highly async), and deliver the real answer later, prefixed with which question it
+        # belongs to, so out-of-order arrivals stay attributable.
+        task = asyncio.create_task(self._announce_when_ready(thread_path, transcript))
         self._background.add(task)
         task.add_done_callback(self._background.discard)
-        return RoundResult(transcript, None, await self._try_speak(self._hold_phrase))
+        hold = (self._hold_phrase_for(thread_path) if self._hold_phrase_for
+                else self._hold_phrase)
+        return RoundResult(transcript, None, await self._try_speak(hold))
 
-    async def _announce_when_ready(self, thread_path: str) -> None:
+    async def _announce_when_ready(self, thread_path: str, transcript: str) -> None:
         try:
             reply = await self._await_reply(thread_path, self._announce_budget_s)
             if reply is None:
                 reply = self._error_phrase
+            if self._answer_to_template:
+                question = transcript if len(transcript) <= 60 else transcript[:57] + "…"
+                reply = f"{self._answer_to_template.format(question=question)} {reply}"
             url = await self._speak(reply)
             await self._announce(url, reply)
         except Exception:

--- a/clients/voice-gateway/memex_voice_gateway/pipeline.py
+++ b/clients/voice-gateway/memex_voice_gateway/pipeline.py
@@ -75,6 +75,8 @@ class VoicePipeline:
         # before any brain sees the text — the handler's confirmation is spoken directly.
         if self._command_handler is not None:
             confirmation = await self._command_handler(transcript)
+            if confirmation == "":
+                return RoundResult(transcript, None, None)   # handled silently ("stop")
             if confirmation is not None:
                 return RoundResult(transcript, confirmation,
                                    await self._try_speak(confirmation))

--- a/clients/voice-gateway/memex_voice_gateway/pipeline.py
+++ b/clients/voice-gateway/memex_voice_gateway/pipeline.py
@@ -1,0 +1,100 @@
+"""The voice round, orchestrated: audio → STT → thread → reply (now or announced later).
+
+Measured reality on memex (2026-08-18): a thread round takes ~60–70 s wall clock even for a
+trivial question — the time is dispatch/startup, not generation. So the pipeline's PRIMARY
+shape is: try to answer within `reply_budget_s`; on a miss, speak a short holding phrase, end
+the voice run (freeing the device), keep polling in the background, and deliver the real
+answer as an ANNOUNCEMENT when it lands. If the platform's dispatch latency improves, the
+same code simply starts answering inline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+# Narrow protocol the satellite link implements — kept as callables so the pipeline is
+# unit-testable with plain fakes and never imports aioesphomeapi.
+SpeakFn = Callable[[str], Awaitable[str]]          # text -> served WAV url
+TranscribeFn = Callable[[bytes], Awaitable[str]]   # pcm  -> transcript
+
+
+@dataclass
+class RoundResult:
+    transcript: str
+    reply: str | None      # None = budget missed, announcement pending
+    tts_url: str | None
+
+
+class VoicePipeline:
+    def __init__(
+        self,
+        *,
+        transcribe: TranscribeFn,
+        ask: Callable[[str], Awaitable[str]],                 # text -> thread path
+        await_reply: Callable[[str, float], Awaitable[str | None]],
+        speak: SpeakFn,
+        announce: Callable[[str, str], Awaitable[None]],      # (url, text) -> None
+        reply_budget_s: float,
+        announce_budget_s: float,
+        hold_phrase: str,
+        error_phrase: str,
+    ) -> None:
+        self._transcribe = transcribe
+        self._ask = ask
+        self._await_reply = await_reply
+        self._speak = speak
+        self._announce = announce
+        self._reply_budget_s = reply_budget_s
+        self._announce_budget_s = announce_budget_s
+        self._hold_phrase = hold_phrase
+        self._error_phrase = error_phrase
+        self._background: set[asyncio.Task] = set()
+
+    async def run(self, pcm: bytes) -> RoundResult:
+        """One voice round. Returns what to speak NOW; may schedule a later announcement."""
+        try:
+            transcript = await self._transcribe(pcm)
+        except Exception:
+            logger.exception("STT failed")
+            return RoundResult("", self._error_phrase, await self._try_speak(self._error_phrase))
+        if not transcript:
+            return RoundResult("", None, None)  # silence / non-speech: end quietly
+
+        try:
+            thread_path = await self._ask(transcript)
+            reply = await self._await_reply(thread_path, self._reply_budget_s)
+        except Exception:
+            logger.exception("thread submission failed")
+            return RoundResult(transcript, self._error_phrase,
+                               await self._try_speak(self._error_phrase))
+
+        if reply is not None:
+            return RoundResult(transcript, reply, await self._try_speak(reply))
+
+        # Budget missed: hold phrase now, real answer as an announcement when it lands.
+        task = asyncio.create_task(self._announce_when_ready(thread_path))
+        self._background.add(task)
+        task.add_done_callback(self._background.discard)
+        return RoundResult(transcript, None, await self._try_speak(self._hold_phrase))
+
+    async def _announce_when_ready(self, thread_path: str) -> None:
+        try:
+            reply = await self._await_reply(thread_path, self._announce_budget_s)
+            if reply is None:
+                reply = self._error_phrase
+            url = await self._speak(reply)
+            await self._announce(url, reply)
+        except Exception:
+            logger.exception("late announcement failed")
+
+    async def _try_speak(self, text: str) -> str | None:
+        try:
+            return await self._speak(text)
+        except Exception:
+            logger.exception("TTS failed")
+            return None

--- a/clients/voice-gateway/memex_voice_gateway/pipeline.py
+++ b/clients/voice-gateway/memex_voice_gateway/pipeline.py
@@ -43,7 +43,9 @@ class VoicePipeline:
         announce_budget_s: float,
         hold_phrase: str,
         error_phrase: str,
+        command_handler: Callable[[str], Awaitable[str | None]] | None = None,
     ) -> None:
+        self._command_handler = command_handler
         self._transcribe = transcribe
         self._ask = ask
         self._await_reply = await_reply
@@ -64,6 +66,14 @@ class VoicePipeline:
             return RoundResult("", self._error_phrase, await self._try_speak(self._error_phrase))
         if not transcript:
             return RoundResult("", None, None)  # silence / non-speech: end quietly
+
+        # Control commands (e.g. "wechsle zu systemorph") are handled deterministically,
+        # before any brain sees the text — the handler's confirmation is spoken directly.
+        if self._command_handler is not None:
+            confirmation = await self._command_handler(transcript)
+            if confirmation is not None:
+                return RoundResult(transcript, confirmation,
+                                   await self._try_speak(confirmation))
 
         try:
             thread_path = await self._ask(transcript)

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -27,6 +27,8 @@ class Brain(Protocol):
     async def close(self) -> None: ...
 
 
+_STOP = re.compile(r"^\s*(?:stop|stopp|halt|sei still|ruhe|schweig|genug)[.!]?\s*$", re.IGNORECASE)
+
 _SWITCH = re.compile(
     r"^\s*(?:switch to|connect to|go to|wechsle zu|wechsel zu|verbinde mit|verbinde dich mit|"
     r"gang uf|verbind mit|geh zu)\s+(?P<target>[\wäöüéè .-]+?)[.!?]?\s*$",
@@ -57,7 +59,10 @@ class BrainRouter:
         return None
 
     async def handle_command(self, transcript: str) -> str | None:
-        """Returns the spoken confirmation when the transcript was a switch command."""
+        """Returns the spoken confirmation when the transcript was a command;
+        empty string = handled silently (say nothing)."""
+        if _STOP.match(transcript.strip()):
+            return ""     # barge-in already stopped playback at wake; just end quietly
         spoken = parse_switch_command(transcript)
         if spoken is None:
             return None

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -1,0 +1,81 @@
+"""Multiple brains, one wake word — and a spoken command to switch between them.
+
+`PORTALS` (JSON) declares a named list of targets — mesh portals (memex, systemorph, a
+customer instance) and/or a local model:
+
+    PORTALS='[
+      {"name":"memex","url":"https://memex.meshweaver.cloud","token":"mw_…","namespace":"rbuergi","agent":"Voice"},
+      {"name":"systemorph","url":"https://memex.systemorph.com","token":"mw_…","namespace":"rbuergi","agent":"Voice"},
+      {"name":"lokal","kind":"ollama","model":"qwen3.6"}
+    ]'
+
+Switching is a DETERMINISTIC spoken command matched before the brain ever sees the text
+("switch to systemorph", "wechsle zu memex", "verbinde mit lokal", "gang uf systemorph") —
+regex, not a tool call, so it works identically on every brain and cannot be mis-refused
+by a model. The confirmation is spoken back; everything else flows to the ACTIVE brain.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Awaitable, Callable, Protocol
+
+
+class Brain(Protocol):
+    async def ask(self, text: str) -> str: ...
+    async def await_reply(self, handle: str, budget_s: float) -> str | None: ...
+    async def close(self) -> None: ...
+
+
+_SWITCH = re.compile(
+    r"^\s*(?:switch to|connect to|go to|wechsle zu|wechsel zu|verbinde mit|verbinde dich mit|"
+    r"gang uf|verbind mit|geh zu)\s+(?P<target>[\wäöüéè .-]+?)[.!?]?\s*$",
+    re.IGNORECASE,
+)
+
+
+def parse_switch_command(transcript: str) -> str | None:
+    """The raw target phrase of a spoken switch command, or None."""
+    match = _SWITCH.match(transcript.strip())
+    return match.group("target").strip() if match else None
+
+
+class BrainRouter:
+    def __init__(self, brains: dict[str, Brain], active: str) -> None:
+        if active not in brains:
+            raise ValueError(f"active brain {active!r} not among {list(brains)}")
+        self._brains = brains
+        self.active = active
+
+    def resolve(self, spoken: str) -> str | None:
+        """Match a spoken target against the configured names, forgivingly."""
+        wanted = spoken.lower().strip()
+        for name in self._brains:
+            lowered = name.lower()
+            if wanted == lowered or wanted.startswith(lowered) or lowered.startswith(wanted):
+                return name
+        return None
+
+    async def handle_command(self, transcript: str) -> str | None:
+        """Returns the spoken confirmation when the transcript was a switch command."""
+        spoken = parse_switch_command(transcript)
+        if spoken is None:
+            return None
+        name = self.resolve(spoken)
+        if name is None:
+            return f"Ich kenne {spoken} nicht. Verfügbar: {', '.join(self._brains)}."
+        self.active = name
+        return f"Verbunden mit {name}."
+
+    async def ask(self, text: str) -> str:
+        return f"{self.active}::{await self._brains[self.active].ask(text)}"
+
+    async def await_reply(self, handle: str, budget_s: float) -> str | None:
+        # The handle is stamped with its brain so a late announce still polls the brain
+        # that produced it, even if the active brain changed meanwhile.
+        name, _, inner = handle.partition("::")
+        return await self._brains[name].await_reply(inner, budget_s)
+
+    async def close(self) -> None:
+        for brain in self._brains.values():
+            await brain.close()

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -42,12 +42,56 @@ def parse_switch_command(transcript: str) -> str | None:
     return match.group("target").strip() if match else None
 
 
+_DELEGATE = re.compile(
+    r"^\s*(?:frag|frage|ask)\s+(?:den|die|das|the)?\s*(?P<agent>[a-zA-Zäöü]+)[:,]?\s+"
+    r"(?:nach\s+|about\s+|to\s+)?(?P<task>.{4,})$",
+    re.IGNORECASE,
+)
+_DELEGATE_THREAD = re.compile(
+    r"^\s*(?:starte\s+(?:einen\s+)?thread|start\s+a\s+thread)[:,]?\s+(?P<task>.{4,})$",
+    re.IGNORECASE,
+)
+
+# Spoken agent names → the standard agents on the mesh. The gate keeps ordinary sentences
+# that happen to start with "ask …" from being swallowed as delegations.
+KNOWN_AGENTS = {"assistant": "Assistant", "researcher": "Researcher", "worker": "Worker",
+                "tutor": "Tutor", "voice": "Voice"}
+
+_DEFAULT_PHRASES = {
+    "hold": "Let me check. One moment please.",
+    "connected": "Connected to {name}.",
+    "unknown": "I don't know {target}. Available: {names}.",
+    "delegated": "Started a {agent} thread on {portal}. You can review it there.",
+    "no_mesh": "No mesh portal is configured for threads.",
+    "submitted": "Submitted to {portal}. I will tell you when the answer arrives.",
+}
+
+
 class BrainRouter:
-    def __init__(self, brains: dict[str, Brain], active: str) -> None:
+    def __init__(self, brains: dict[str, Brain], active: str,
+                 phrases: dict[str, str] | None = None,
+                 mesh_brains: set[str] | None = None) -> None:
         if active not in brains:
             raise ValueError(f"active brain {active!r} not among {list(brains)}")
         self._brains = brains
         self.active = active
+        self._phrases = {**_DEFAULT_PHRASES, **(phrases or {})}
+        self._mesh = mesh_brains if mesh_brains is not None else {
+            n for n, b in brains.items() if hasattr(b, "delegate")}
+
+    def _mesh_target(self) -> str | None:
+        """The portal delegations go to: the active brain when it is a mesh, else the first mesh."""
+        if self.active in self._mesh:
+            return self.active
+        return next(iter(self._mesh), None)
+
+    def describe_hold(self, handle: str) -> str:
+        """What to say when the answer will come later — mesh submissions are ACKNOWLEDGED
+        by portal name, because their answers can arrive highly asynchronously."""
+        name, _, _ = handle.partition("::")
+        if name in self._mesh:
+            return self._phrases["submitted"].format(portal=name)
+        return self._phrases["hold"]
 
     def resolve(self, spoken: str) -> str | None:
         """Match a spoken target against the configured names, forgivingly."""
@@ -63,14 +107,33 @@ class BrainRouter:
         empty string = handled silently (say nothing)."""
         if _STOP.match(transcript.strip()):
             return ""     # barge-in already stopped playback at wake; just end quietly
+
+        # Delegation: launch a real thread for a STANDARD agent on the mesh and leave the
+        # work to be evaluated THERE — the speaker only confirms the submission.
+        delegated = _DELEGATE_THREAD.match(transcript.strip())
+        agent_name: str | None = None
+        if delegated is None:
+            match = _DELEGATE.match(transcript.strip())
+            if match and match.group("agent").lower() in KNOWN_AGENTS:
+                delegated = match
+                agent_name = KNOWN_AGENTS[match.group("agent").lower()]
+        if delegated is not None:
+            target = self._mesh_target()
+            if target is None:
+                return self._phrases["no_mesh"]
+            await self._brains[target].delegate(delegated.group("task").strip(), agent_name)  # type: ignore[attr-defined]
+            return self._phrases["delegated"].format(agent=agent_name or "Assistant",
+                                                     portal=target)
+
         spoken = parse_switch_command(transcript)
         if spoken is None:
             return None
         name = self.resolve(spoken)
         if name is None:
-            return f"Ich kenne {spoken} nicht. Verfügbar: {', '.join(self._brains)}."
+            return self._phrases["unknown"].format(target=spoken,
+                                                   names=", ".join(self._brains))
         self.active = name
-        return f"Verbunden mit {name}."
+        return self._phrases["connected"].format(name=name)
 
     async def ask(self, text: str) -> str:
         return f"{self.active}::{await self._brains[self.active].ask(text)}"

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -76,6 +76,12 @@ class BrainRouter:
         name, _, inner = handle.partition("::")
         return await self._brains[name].await_reply(inner, budget_s)
 
+    def stream_text(self, handle: str):
+        """The producing brain's live text stream for this handle, or None (brain doesn't stream)."""
+        name, _, inner = handle.partition("::")
+        stream = getattr(self._brains[name], "stream_text", None)
+        return stream(inner) if stream else None
+
     async def close(self) -> None:
         for brain in self._brains.values():
             await brain.close()

--- a/clients/voice-gateway/memex_voice_gateway/satellite.py
+++ b/clients/voice-gateway/memex_voice_gateway/satellite.py
@@ -1,0 +1,143 @@
+"""The LAN link to the ESPHome voice satellite (e.g. FutureProofHomes Satellite1).
+
+Speaks the same aioesphomeapi surface Home Assistant uses: `subscribe_voice_assistant`
+(API-audio mode — the handler returns port 0), `send_voice_assistant_event` for the
+RUN/STT/TTS event sequence that drives the device's LEDs and player, and
+`send_voice_assistant_announcement_await_response` (with a media-player fallback) for
+answers that outlive the voice run.
+
+The device is the SERVER — this gateway dials it on the LAN, so it can run beside a Home
+Assistant that owns the satellite's sensors and media, as long as only ONE of them
+subscribes as the voice assistant (leave the device unassigned in HA's Assist).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aioesphomeapi import APIClient
+from aioesphomeapi.model import VoiceAssistantAudioSettings, VoiceAssistantEventType as Event
+
+from .config import Config
+from .pipeline import VoicePipeline
+from .vad import Endpointer
+
+logger = logging.getLogger(__name__)
+
+
+class SatelliteLink:
+    def __init__(self, cfg: Config, pipeline: VoicePipeline) -> None:
+        self.cfg = cfg
+        self.pipeline = pipeline
+        self.client = APIClient(
+            cfg.satellite_host, cfg.satellite_port,
+            cfg.satellite_password, noise_psk=cfg.satellite_psk,
+        )
+        self._endpointer: Endpointer | None = None
+        self._utterance_done = asyncio.Event()
+        self._media_player_key: int | None = None
+        self._round_task: asyncio.Task | None = None
+
+    # --- lifecycle -------------------------------------------------------------------
+
+    async def run_forever(self) -> None:
+        backoff = 2.0
+        while True:
+            try:
+                await self.client.connect(login=True)
+                info = await self.client.device_info()
+                logger.info("connected to %s (%s)", info.name, self.cfg.satellite_host)
+                await self._find_media_player()
+                unsubscribe = self.client.subscribe_voice_assistant(
+                    handle_start=self._handle_start,
+                    handle_stop=self._handle_stop,
+                    handle_audio=self._handle_audio,
+                )
+                backoff = 2.0
+                try:
+                    while self.client._connection is not None:  # noqa: SLF001 — liveness probe
+                        await asyncio.sleep(5)
+                finally:
+                    unsubscribe()
+            except Exception as error:
+                logger.warning("satellite link lost (%s); retrying in %.0fs", error, backoff)
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 60)
+
+    async def _find_media_player(self) -> None:
+        entities, _ = await self.client.list_entities_services()
+        for entity in entities:
+            if type(entity).__name__ == "MediaPlayerInfo":
+                self._media_player_key = entity.key
+                return
+
+    # --- voice assistant callbacks ----------------------------------------------------
+
+    async def _handle_start(
+        self, conversation_id: str, flags: int,
+        audio_settings: VoiceAssistantAudioSettings, wake_word_phrase: str | None,
+    ) -> int:
+        logger.info("wake (%s)", wake_word_phrase or "button")
+        self._endpointer = Endpointer(
+            sample_rate=self.cfg.sample_rate,
+            silence_ms=self.cfg.silence_ms,
+            max_utterance_s=self.cfg.max_utterance_s,
+            min_utterance_s=self.cfg.min_utterance_s,
+        )
+        self._utterance_done.clear()
+        self._round_task = asyncio.create_task(self._run_round())
+        return 0  # 0 = stream microphone audio over the API connection (no UDP)
+
+    async def _handle_audio(self, data: bytes) -> None:
+        endpointer = self._endpointer
+        if endpointer is not None and endpointer.feed(data):
+            self._utterance_done.set()
+
+    async def _handle_stop(self, *_args) -> None:
+        self._utterance_done.set()
+
+    # --- the round ---------------------------------------------------------------------
+
+    async def _run_round(self) -> None:
+        send = self.client.send_voice_assistant_event
+        send(Event.VOICE_ASSISTANT_RUN_START, {})
+        send(Event.VOICE_ASSISTANT_STT_START, {})
+        try:
+            await asyncio.wait_for(self._utterance_done.wait(),
+                                   timeout=self.cfg.max_utterance_s + 5)
+        except asyncio.TimeoutError:
+            pass
+        pcm = self._endpointer.audio if self._endpointer else b""
+        self._endpointer = None
+
+        try:
+            result = await self.pipeline.run(pcm)
+            if result.transcript:
+                send(Event.VOICE_ASSISTANT_STT_END, {"text": result.transcript})
+            if result.tts_url:
+                send(Event.VOICE_ASSISTANT_TTS_START, {"text": result.reply or ""})
+                send(Event.VOICE_ASSISTANT_TTS_END, {"url": result.tts_url})
+        except Exception as error:
+            logger.exception("voice round failed")
+            send(Event.VOICE_ASSISTANT_ERROR, {"code": "gateway", "message": str(error)[:200]})
+        finally:
+            send(Event.VOICE_ASSISTANT_RUN_END, {})
+
+    # --- late answers --------------------------------------------------------------------
+
+    async def announce(self, url: str, text: str) -> None:
+        """Deliver a late answer. Prefers the voice-assistant announcement (waits for
+        playback), falls back to a media-player announcement command."""
+        announce_api = getattr(self.client, "send_voice_assistant_announcement_await_response", None)
+        if announce_api is not None:
+            try:
+                await announce_api(url, 60.0, text)
+                return
+            except Exception:
+                logger.debug("announcement API failed; falling back to media player", exc_info=True)
+        if self._media_player_key is not None:
+            self.client.media_player_command(
+                self._media_player_key, media_url=url, announcement=True)
+        else:
+            logger.error("no announcement path available — reply dropped: %s", text[:100])

--- a/clients/voice-gateway/memex_voice_gateway/satellite.py
+++ b/clients/voice-gateway/memex_voice_gateway/satellite.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Awaitable, Callable
 
 from aioesphomeapi import APIClient
 from aioesphomeapi.model import VoiceAssistantAudioSettings, VoiceAssistantEventType as Event
@@ -38,6 +39,20 @@ class SatelliteLink:
         self._utterance_done = asyncio.Event()
         self._media_player_key: int | None = None
         self._round_task: asyncio.Task | None = None
+        self._follow_up = False
+        self._round_serial = 0
+        self.on_wake: Callable[[], Awaitable[None]] | None = None  # barge-in hook
+
+    async def stop_playback(self) -> None:
+        """Stop whatever the media player is doing — the device half of a barge-in."""
+        if self._media_player_key is None:
+            return
+        try:
+            from aioesphomeapi.model import MediaPlayerCommand
+            self.client.media_player_command(self._media_player_key,
+                                             command=MediaPlayerCommand.STOP)
+        except Exception:
+            logger.debug("media stop failed", exc_info=True)
 
     # --- lifecycle -------------------------------------------------------------------
 
@@ -105,12 +120,27 @@ class SatelliteLink:
         self, conversation_id: str, flags: int,
         audio_settings: VoiceAssistantAudioSettings, wake_word_phrase: str | None,
     ) -> int:
-        logger.info("wake (%s)", wake_word_phrase or "button")
+        # A wake while we're speaking is a BARGE-IN: kill the live TTS stream so playback
+        # drains out, and let the new round take over ("Hey Jarvis — stop." or a new question).
+        if self.on_wake is not None:
+            try:
+                await self.on_wake()
+            except Exception:
+                logger.debug("on_wake interrupt failed", exc_info=True)
+        # No wake-word phrase = a CONTINUED conversation (start_conversation re-opened the
+        # mic). Those rounds calibrate against ambient audio (a TV must not become the
+        # conversation partner) and give up early when nobody starts speaking.
+        follow_up = not wake_word_phrase
+        logger.info("wake (%s)", wake_word_phrase or "follow-up")
+        self._follow_up = follow_up
+        self._round_serial += 1
         self._endpointer = Endpointer(
             sample_rate=self.cfg.sample_rate,
             silence_ms=self.cfg.silence_ms,
             max_utterance_s=self.cfg.max_utterance_s,
             min_utterance_s=self.cfg.min_utterance_s,
+            calibrate_ms=400 if follow_up else 0,
+            onset_timeout_s=5.0 if follow_up else 0,
         )
         self._utterance_done.clear()
         self._round_task = asyncio.create_task(self._run_round())
@@ -129,6 +159,7 @@ class SatelliteLink:
     # --- the round ---------------------------------------------------------------------
 
     async def _run_round(self) -> None:
+        serial = self._round_serial
         send = self.client.send_voice_assistant_event
         send(Event.VOICE_ASSISTANT_RUN_START, {})
         send(Event.VOICE_ASSISTANT_STT_START, {})
@@ -137,8 +168,15 @@ class SatelliteLink:
                                    timeout=self.cfg.max_utterance_s + 5)
         except asyncio.TimeoutError:
             pass
-        pcm = self._endpointer.audio if self._endpointer else b""
-        self._endpointer = None
+        endpointer, self._endpointer = self._endpointer, None
+        pcm = endpointer.audio if endpointer else b""
+        # A follow-up that never paused (TV, music) or never started (silence) is not
+        # addressed to the assistant: end the conversation quietly instead of answering it.
+        if self._follow_up and endpointer is not None and endpointer.ended_by_cap:
+            logger.info("follow-up discarded (%s) — conversation ends",
+                        "continuous audio" if endpointer.speech_seen else "silence")
+            send(Event.VOICE_ASSISTANT_RUN_END, {})
+            return
 
         try:
             result = await self.pipeline.run(pcm)
@@ -154,10 +192,15 @@ class SatelliteLink:
         # mic again by itself, no wake word ("conversation mode"). A silent follow-up ends
         # the chain via the pipeline's quiet empty-transcript path.
         send(Event.VOICE_ASSISTANT_RUN_END, {})
-        if result.tts_url:
+        # SUPERSEDED replies are dropped, not queued: if another wake started meanwhile,
+        # playing this answer late would drain a stale backlog at the listener (observed
+        # with a TV feeding rounds faster than they played).
+        if result.tts_url and serial == self._round_serial:
             await self.announce(result.tts_url, result.reply or "",
                                 start_conversation=self.cfg.continue_conversation
                                 and bool(result.transcript))
+        elif result.tts_url:
+            logger.info("reply superseded by a newer round — not played")
 
     # --- late answers --------------------------------------------------------------------
 

--- a/clients/voice-gateway/memex_voice_gateway/satellite.py
+++ b/clients/voice-gateway/memex_voice_gateway/satellite.py
@@ -144,24 +144,34 @@ class SatelliteLink:
             result = await self.pipeline.run(pcm)
             if result.transcript:
                 send(Event.VOICE_ASSISTANT_STT_END, {"text": result.transcript})
-            if result.tts_url:
-                send(Event.VOICE_ASSISTANT_TTS_START, {"text": result.reply or ""})
-                send(Event.VOICE_ASSISTANT_TTS_END, {"url": result.tts_url})
         except Exception as error:
             logger.exception("voice round failed")
             send(Event.VOICE_ASSISTANT_ERROR, {"code": "gateway", "message": str(error)[:200]})
-        finally:
             send(Event.VOICE_ASSISTANT_RUN_END, {})
+            return
+        # End the run FIRST, then deliver the reply as an ANNOUNCEMENT with
+        # start_conversation: the device plays it and — when playback finishes — opens the
+        # mic again by itself, no wake word ("conversation mode"). A silent follow-up ends
+        # the chain via the pipeline's quiet empty-transcript path.
+        send(Event.VOICE_ASSISTANT_RUN_END, {})
+        if result.tts_url:
+            await self.announce(result.tts_url, result.reply or "",
+                                start_conversation=self.cfg.continue_conversation
+                                and bool(result.transcript))
 
     # --- late answers --------------------------------------------------------------------
 
-    async def announce(self, url: str, text: str) -> None:
-        """Deliver a late answer. Prefers the voice-assistant announcement (waits for
-        playback), falls back to a media-player announcement command."""
+    async def announce(self, url: str, text: str, start_conversation: bool = False) -> None:
+        """Deliver a reply. Prefers the voice-assistant announcement (waits for playback;
+        `start_conversation` re-opens the mic when it ends), falls back to a media-player
+        announcement command."""
         announce_api = getattr(self.client, "send_voice_assistant_announcement_await_response", None)
         if announce_api is not None:
             try:
-                await announce_api(url, 60.0, text)
+                try:
+                    await announce_api(url, 120.0, text, start_conversation=start_conversation)
+                except TypeError:
+                    await announce_api(url, 120.0, text)   # older aioesphomeapi: no kwarg
                 return
             except Exception:
                 logger.debug("announcement API failed; falling back to media player", exc_info=True)

--- a/clients/voice-gateway/memex_voice_gateway/satellite.py
+++ b/clients/voice-gateway/memex_voice_gateway/satellite.py
@@ -54,6 +54,7 @@ class SatelliteLink:
                     handle_stop=self._handle_stop,
                     handle_audio=self._handle_audio,
                 )
+                await self._ensure_wake_word()
                 backoff = 2.0
                 try:
                     while self.client._connection is not None:  # noqa: SLF001 — liveness probe
@@ -72,6 +73,32 @@ class SatelliteLink:
                 self._media_player_key = entity.key
                 return
 
+    async def _ensure_wake_word(self) -> None:
+        """Activate a wake word if none is active.
+
+        Modern ESPHome voice firmware hands wake-word selection to the API client (HA
+        normally does this), so a factory-fresh device can sit with NO active wake word —
+        it hears nothing and no voice run ever starts. The configuration request is only
+        answered on the connection that holds the voice-assistant subscription, so this
+        must run here, not from a side channel.
+        """
+        try:
+            conf = await self.client.get_voice_assistant_configuration(timeout=10)
+        except Exception:
+            logger.info("device does not answer wake-word configuration (older firmware) — skipping")
+            return
+        available = [w.id for w in conf.available_wake_words]
+        active = list(conf.active_wake_words)
+        logger.info("wake words available=%s active=%s", available, active)
+        if active or not available:
+            return
+        wanted = self.cfg.wake_word
+        chosen = wanted if wanted in available else available[0]
+        if wanted and wanted not in available:
+            logger.warning("WAKE_WORD %r not on the device; using %r", wanted, chosen)
+        await self.client.set_voice_assistant_configuration(active_wake_words=[chosen])
+        logger.info("activated wake word %r", chosen)
+
     # --- voice assistant callbacks ----------------------------------------------------
 
     async def _handle_start(
@@ -89,7 +116,9 @@ class SatelliteLink:
         self._round_task = asyncio.create_task(self._run_round())
         return 0  # 0 = stream microphone audio over the API connection (no UDP)
 
-    async def _handle_audio(self, data: bytes) -> None:
+    async def _handle_audio(self, data: bytes, data2: bytes | None = None) -> None:
+        # Two channels on devices with MULTI_CHANNEL_AUDIO (the XMOS sends processed + raw);
+        # channel 0 (`data`) is the echo-cancelled one — feed only that.
         endpointer = self._endpointer
         if endpointer is not None and endpointer.feed(data):
             self._utterance_done.set()

--- a/clients/voice-gateway/memex_voice_gateway/stt.py
+++ b/clients/voice-gateway/memex_voice_gateway/stt.py
@@ -1,8 +1,10 @@
-"""Speech-to-text against the mesh's centralized Whisper container.
+"""Speech-to-text over HTTP — one client for both hosting modes.
 
-The portal exposes `POST /api/speech/transcribe` (Bearer auth, multipart, ≤25 MB) in front of
-the cluster-internal whisper.cpp server — see Doc/Architecture/CentralizedSpeech. We wrap the
-raw satellite PCM in a WAV header and post it; the reply is `{"text": …, "language": …}`.
+The mesh's `POST /api/speech/transcribe` (Bearer auth, in front of the cluster-internal
+whisper.cpp — Doc/Architecture/CentralizedSpeech) and a LOCAL whisper.cpp server's
+`POST /inference` speak the same multipart contract: `file` + `language`
+(+ `response_format=json`, which the mesh accepts and ignores) → `{"text": …}`.
+So the gateway just points STT_URL at whichever one it uses.
 """
 
 from __future__ import annotations
@@ -24,11 +26,10 @@ def wav_from_pcm(pcm: bytes, sample_rate: int = 16000, channels: int = 1) -> byt
 
 async def transcribe(
     session: aiohttp.ClientSession,
-    base_url: str,
-    token: str,
+    url: str,
+    token: str | None,
     pcm: bytes,
     *,
-    path: str = "/api/speech/transcribe",
     language: str = "de",
     sample_rate: int = 16000,
 ) -> str:
@@ -37,11 +38,10 @@ async def transcribe(
     form.add_field("file", wav_from_pcm(pcm, sample_rate), filename="utterance.wav",
                    content_type="audio/wav")
     form.add_field("language", language)
-    async with session.post(
-        f"{base_url}{path}", data=form,
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=aiohttp.ClientTimeout(total=60),
-    ) as response:
+    form.add_field("response_format", "json")
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    async with session.post(url, data=form, headers=headers,
+                            timeout=aiohttp.ClientTimeout(total=60)) as response:
         response.raise_for_status()
         payload = await response.json(content_type=None)
         return (payload.get("text") or "").strip()

--- a/clients/voice-gateway/memex_voice_gateway/stt.py
+++ b/clients/voice-gateway/memex_voice_gateway/stt.py
@@ -1,0 +1,47 @@
+"""Speech-to-text against the mesh's centralized Whisper container.
+
+The portal exposes `POST /api/speech/transcribe` (Bearer auth, multipart, ≤25 MB) in front of
+the cluster-internal whisper.cpp server — see Doc/Architecture/CentralizedSpeech. We wrap the
+raw satellite PCM in a WAV header and post it; the reply is `{"text": …, "language": …}`.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import aiohttp
+
+
+def wav_from_pcm(pcm: bytes, sample_rate: int = 16000, channels: int = 1) -> bytes:
+    """Minimal RIFF/WAVE wrapper for 16-bit PCM."""
+    byte_rate = sample_rate * channels * 2
+    block_align = channels * 2
+    header = b"RIFF" + struct.pack("<I", 36 + len(pcm)) + b"WAVE"
+    header += b"fmt " + struct.pack("<IHHIIHH", 16, 1, channels, sample_rate, byte_rate, block_align, 16)
+    header += b"data" + struct.pack("<I", len(pcm))
+    return header + pcm
+
+
+async def transcribe(
+    session: aiohttp.ClientSession,
+    base_url: str,
+    token: str,
+    pcm: bytes,
+    *,
+    path: str = "/api/speech/transcribe",
+    language: str = "de",
+    sample_rate: int = 16000,
+) -> str:
+    """Returns the transcript text; raises on transport errors, empty text on silence."""
+    form = aiohttp.FormData()
+    form.add_field("file", wav_from_pcm(pcm, sample_rate), filename="utterance.wav",
+                   content_type="audio/wav")
+    form.add_field("language", language)
+    async with session.post(
+        f"{base_url}{path}", data=form,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=aiohttp.ClientTimeout(total=60),
+    ) as response:
+        response.raise_for_status()
+        payload = await response.json(content_type=None)
+        return (payload.get("text") or "").strip()

--- a/clients/voice-gateway/memex_voice_gateway/threads.py
+++ b/clients/voice-gateway/memex_voice_gateway/threads.py
@@ -1,0 +1,160 @@
+"""The memex thread surface, spoken over MCP streamable HTTP.
+
+The mesh's `/mcp` endpoint takes plain JSON-RPC POSTs with a Bearer token: `initialize`
+(capture `Mcp-Session-Id`), `notifications/initialized`, then `tools/call`. Responses arrive
+as JSON or as a single-event SSE body — both are handled. This mirrors the framing already
+proven by education/scripts/upload-videos.py.
+
+Thread lifecycle (verified against live nodes, 2026-08-18):
+  start_thread → {"status":"Started","threadPath":…}; the agent runs asynchronously.
+  The thread node's content lists message ids in `messages`; children only materialize at
+  round end as ThreadMessage nodes ({"role":"assistant","text":…,"status":"Completed"}).
+  A failed dispatch leaves no assistant child but writes the failure into `summary`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass, field
+
+import aiohttp
+
+
+class McpError(RuntimeError):
+    pass
+
+
+def parse_tool_result(body: str) -> str:
+    """Extract the tool's text payload from a JSON or single-event SSE response body."""
+    for line in body.splitlines():
+        if line.startswith("data:"):
+            body = line[5:].strip()
+            break
+    result = json.loads(body)
+    if "error" in result:
+        raise McpError(json.dumps(result["error"]))
+    parts = result.get("result", {}).get("content", [])
+    if result.get("result", {}).get("isError"):
+        raise McpError(parts[0].get("text", "tool error") if parts else "tool error")
+    return parts[0].get("text", "") if parts else json.dumps(result)
+
+
+def extract_reply(thread_json: str, known_ids: set[str]) -> tuple[list[str], str | None]:
+    """From a thread node's JSON: (new message ids, dispatch-failure summary or None).
+
+    The summary is only a failure signal while no assistant reply exists AND nothing is
+    pending — a completed round always carries its reply as a message child.
+    """
+    node = json.loads(thread_json)
+    content = node.get("content") or {}
+    ids = [m for m in content.get("messages", []) if m not in known_ids]
+    pending = content.get("pendingUserMessages") or {}
+    summary = content.get("summary")
+    failure = summary if (not ids and not pending and summary) else None
+    return ids, failure
+
+
+@dataclass
+class MemexThreads:
+    base_url: str
+    token: str
+    namespace: str
+    agent: str | None = None
+    thread_idle_minutes: float = 5.0
+
+    _session_id: str | None = field(default=None, init=False)
+    _http: aiohttp.ClientSession | None = field(default=None, init=False)
+    _thread_path: str | None = field(default=None, init=False)
+    _known_ids: set[str] = field(default_factory=set, init=False)
+    _last_used: float = field(default=0.0, init=False)
+
+    async def _post(self, payload: dict) -> tuple[dict, str]:
+        if self._http is None:
+            self._http = aiohttp.ClientSession()
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if self._session_id:
+            headers["Mcp-Session-Id"] = self._session_id
+        async with self._http.post(
+            f"{self.base_url}/mcp", json=payload, headers=headers,
+            timeout=aiohttp.ClientTimeout(total=120),
+        ) as response:
+            body = await response.text()
+            if response.status >= 400:
+                raise McpError(f"HTTP {response.status}: {body[:300]}")
+            return dict(response.headers), body
+
+    async def _ensure_session(self) -> None:
+        if self._session_id:
+            return
+        head, _ = await self._post({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2025-03-26", "capabilities": {},
+                       "clientInfo": {"name": "memex-voice-gateway", "version": "0.1"}},
+        })
+        self._session_id = head.get("Mcp-Session-Id") or head.get("mcp-session-id")
+        await self._post({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    async def call(self, tool: str, arguments: dict) -> str:
+        await self._ensure_session()
+        try:
+            _, body = await self._post({"jsonrpc": "2.0", "id": 9, "method": "tools/call",
+                                        "params": {"name": tool, "arguments": arguments}})
+        except McpError:
+            # One re-init retry: the server may have expired the session between wake words.
+            self._session_id = None
+            await self._ensure_session()
+            _, body = await self._post({"jsonrpc": "2.0", "id": 9, "method": "tools/call",
+                                        "params": {"name": tool, "arguments": arguments}})
+        return parse_tool_result(body)
+
+    async def _snapshot_ids(self, thread_path: str) -> set[str]:
+        node = json.loads(await self.call("get", {"path": f"@{thread_path}"}))
+        return set((node.get("content") or {}).get("messages", []))
+
+    async def ask(self, text: str) -> str:
+        """Submit an utterance; returns the thread path. Reuses a recent thread for context."""
+        fresh = self._thread_path and (time.monotonic() - self._last_used) < self.thread_idle_minutes * 60
+        if fresh and self._thread_path:
+            self._known_ids = await self._snapshot_ids(self._thread_path)
+            args: dict = {"threadPath": self._thread_path, "message": text}
+            if self.agent:
+                args["agentName"] = self.agent
+            await self.call("submit_message", args)
+        else:
+            args = {"namespacePath": self.namespace, "message": text}
+            if self.agent:
+                args["agentName"] = self.agent
+            started = json.loads(await self.call("start_thread", args))
+            self._thread_path = started["threadPath"]
+            self._known_ids = set()
+        self._last_used = time.monotonic()
+        return self._thread_path  # type: ignore[return-value]
+
+    async def await_reply(self, thread_path: str, budget_s: float,
+                          poll_interval_s: float = 1.5) -> str | None:
+        """Poll until an assistant reply (or a dispatch failure) lands; None on budget miss."""
+        deadline = time.monotonic() + budget_s
+        while time.monotonic() < deadline:
+            thread_json = await self.call("get", {"path": f"@{thread_path}"})
+            new_ids, failure = extract_reply(thread_json, self._known_ids)
+            for message_id in new_ids:
+                child = json.loads(await self.call("get", {"path": f"@{thread_path}/{message_id}"}))
+                content = child.get("content") or {}
+                self._known_ids.add(message_id)
+                if content.get("role") == "assistant" and content.get("text"):
+                    return content["text"]
+            if failure:
+                return failure
+            await asyncio.sleep(poll_interval_s)
+        return None
+
+    async def close(self) -> None:
+        if self._http is not None:
+            await self._http.close()
+            self._http = None

--- a/clients/voice-gateway/memex_voice_gateway/threads.py
+++ b/clients/voice-gateway/memex_voice_gateway/threads.py
@@ -117,6 +117,16 @@ class MemexThreads:
         node = json.loads(await self.call("get", {"path": f"@{thread_path}"}))
         return set((node.get("content") or {}).get("messages", []))
 
+    async def delegate(self, text: str, agent: str | None = None) -> str:
+        """Fire-and-forget: launch a NEW thread for a standard agent (Assistant, Researcher,
+        …) and return its path. Deliberately does NOT become the voice conversation thread —
+        the task runs and is evaluated in the portal, not read aloud."""
+        args: dict = {"namespacePath": self.namespace, "message": text}
+        if agent or self.agent:
+            args["agentName"] = agent or self.agent
+        started = json.loads(await self.call("start_thread", args))
+        return started["threadPath"]
+
     async def ask(self, text: str) -> str:
         """Submit an utterance; returns the thread path. Reuses a recent thread for context."""
         fresh = self._thread_path and (time.monotonic() - self._last_used) < self.thread_idle_minutes * 60

--- a/clients/voice-gateway/memex_voice_gateway/tts.py
+++ b/clients/voice-gateway/memex_voice_gateway/tts.py
@@ -69,15 +69,77 @@ class SayTts:
                 pass
 
 
+def split_wav(wav: bytes) -> tuple[bytes, int]:
+    """(pcm, sample_rate) out of a RIFF/WAVE blob — walks the chunks, no fixed 44-byte guess."""
+    if wav[:4] != b"RIFF" or wav[8:12] != b"WAVE":
+        raise ValueError("not a RIFF/WAVE blob")
+    rate, offset = 16000, 12
+    while offset + 8 <= len(wav):
+        cid = wav[offset:offset + 4]
+        size = int.from_bytes(wav[offset + 4:offset + 8], "little")
+        if cid == b"fmt ":
+            rate = int.from_bytes(wav[offset + 12:offset + 16], "little")
+        elif cid == b"data":
+            return wav[offset + 8:offset + 8 + size], rate
+        offset += 8 + size + (size & 1)
+    raise ValueError("no data chunk")
+
+
+def streaming_wav_header(sample_rate: int, channels: int = 1) -> bytes:
+    """A WAV header that promises 'read until EOF' — sizes maxed, for chunked streaming."""
+    import struct
+    byte_rate = sample_rate * channels * 2
+    header = b"RIFF" + struct.pack("<I", 0xFFFFFFFF) + b"WAVE"
+    header += b"fmt " + struct.pack("<IHHIIHH", 16, 1, channels, sample_rate, byte_rate, channels * 2, 16)
+    header += b"data" + struct.pack("<I", 0xFFFFFFFF - 44)
+    return header
+
+
+class StreamingWav:
+    """One in-flight streamed utterance: PCM sentences arrive on a queue while the device
+    is already playing the URL. `close()` ends the stream (and the playback)."""
+
+    def __init__(self, sample_rate: int) -> None:
+        self.sample_rate = sample_rate
+        self.queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+
+    async def push(self, pcm: bytes) -> None:
+        await self.queue.put(pcm)
+
+    async def close(self) -> None:
+        await self.queue.put(None)
+
+
 class TtsFileServer:
-    """Serves synthesized WAVs at /tts/{id}.wav from memory, expiring after `ttl_s`."""
+    """Serves synthesized WAVs at /tts/{id}.wav from memory, expiring after `ttl_s` —
+    and chunked live streams at /tts-stream/{id}.wav (see StreamingWav)."""
 
     def __init__(self, host: str, port: int, ttl_s: float = 300.0) -> None:
         self.host = host
         self.port = port
         self.ttl_s = ttl_s
         self._files: dict[str, tuple[float, bytes]] = {}
+        self._streams: dict[str, StreamingWav] = {}
         self._runner: web.AppRunner | None = None
+
+    def open_stream(self, sample_rate: int) -> tuple[StreamingWav, str]:
+        stream = StreamingWav(sample_rate)
+        stream_id = secrets.token_urlsafe(8)
+        self._streams[stream_id] = stream
+        return stream, f"http://{self.host}:{self.port}/tts-stream/{stream_id}.wav"
+
+    async def _handle_stream(self, request: web.Request) -> web.StreamResponse:
+        stream = self._streams.pop(request.match_info["id"], None)
+        if stream is None:
+            return web.Response(status=404)
+        response = web.StreamResponse(headers={"Content-Type": "audio/wav"})
+        response.enable_chunked_encoding()
+        await response.prepare(request)
+        await response.write(streaming_wav_header(stream.sample_rate))
+        while (pcm := await stream.queue.get()) is not None:
+            await response.write(pcm)
+        await response.write_eof()
+        return response
 
     def add(self, wav: bytes) -> str:
         now = time.monotonic()
@@ -95,6 +157,7 @@ class TtsFileServer:
     async def start(self) -> None:
         app = web.Application()
         app.router.add_get("/tts/{id}.wav", self._handle)
+        app.router.add_get("/tts-stream/{id}.wav", self._handle_stream)
         self._runner = web.AppRunner(app)
         await self._runner.setup()
         site = web.TCPSite(self._runner, "0.0.0.0", self.port)

--- a/clients/voice-gateway/memex_voice_gateway/tts.py
+++ b/clients/voice-gateway/memex_voice_gateway/tts.py
@@ -120,13 +120,21 @@ class TtsFileServer:
         self.ttl_s = ttl_s
         self._files: dict[str, tuple[float, bytes]] = {}
         self._streams: dict[str, StreamingWav] = {}
+        self._live: set[StreamingWav] = set()
         self._runner: web.AppRunner | None = None
 
     def open_stream(self, sample_rate: int) -> tuple[StreamingWav, str]:
         stream = StreamingWav(sample_rate)
         stream_id = secrets.token_urlsafe(8)
         self._streams[stream_id] = stream
+        self._live.add(stream)
         return stream, f"http://{self.host}:{self.port}/tts-stream/{stream_id}.wav"
+
+    async def interrupt_streams(self) -> None:
+        """Barge-in: close every live stream so its playback drains out within a second."""
+        for stream in list(self._live):
+            await stream.close()
+        self._live.clear()
 
     async def _handle_stream(self, request: web.Request) -> web.StreamResponse:
         stream = self._streams.pop(request.match_info["id"], None)
@@ -136,9 +144,12 @@ class TtsFileServer:
         response.enable_chunked_encoding()
         await response.prepare(request)
         await response.write(streaming_wav_header(stream.sample_rate))
-        while (pcm := await stream.queue.get()) is not None:
-            await response.write(pcm)
-        await response.write_eof()
+        try:
+            while (pcm := await stream.queue.get()) is not None:
+                await response.write(pcm)
+            await response.write_eof()
+        finally:
+            self._live.discard(stream)
         return response
 
     def add(self, wav: bytes) -> str:

--- a/clients/voice-gateway/memex_voice_gateway/tts.py
+++ b/clients/voice-gateway/memex_voice_gateway/tts.py
@@ -34,6 +34,41 @@ class PiperTts:
         return wav
 
 
+class SayTts:
+    """macOS's built-in `say` — zero-setup local TTS (voice e.g. "Anna" for German).
+
+    Writes a 16-bit 22.05 kHz WAV to a temp file (say has no stdout mode) and returns
+    its bytes; the temp file is removed immediately.
+    """
+
+    def __init__(self, voice: str = "Anna") -> None:
+        self.voice = voice
+
+    @staticmethod
+    def build_args(voice: str, out_path: str) -> list[str]:
+        return ["say", "-v", voice, "-o", out_path, "--data-format=LEI16@22050", "-f", "-"]
+
+    async def synthesize(self, text: str) -> bytes:
+        import os
+        import tempfile
+        fd, path = tempfile.mkstemp(suffix=".wav")
+        os.close(fd)
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *self.build_args(self.voice, path),
+                stdin=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+            _, err = await process.communicate(text.encode())
+            if process.returncode != 0:
+                raise RuntimeError(f"say failed ({process.returncode}): {err.decode()[:200]}")
+            with open(path, "rb") as f:
+                return f.read()
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+
 class TtsFileServer:
     """Serves synthesized WAVs at /tts/{id}.wav from memory, expiring after `ttl_s`."""
 

--- a/clients/voice-gateway/memex_voice_gateway/tts.py
+++ b/clients/voice-gateway/memex_voice_gateway/tts.py
@@ -1,0 +1,71 @@
+"""Text-to-speech (Piper) plus the tiny HTTP server the satellite fetches audio from.
+
+The ESPHome voice pipeline delivers TTS as a URL in the TTS_END event; the device's media
+player then streams it. So the gateway synthesizes with the Piper CLI and serves the WAV from
+memory for a short TTL. High German out (`de_DE` voices) — the assistant *understands*
+Schwiizerdütsch (the Whisper fine-tune transcribes it to Standard German) and answers in
+Standard German.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+
+from aiohttp import web
+
+
+class PiperTts:
+    def __init__(self, piper_bin: str, voice_path: str) -> None:
+        self.piper_bin = piper_bin
+        self.voice_path = voice_path
+
+    async def synthesize(self, text: str) -> bytes:
+        process = await asyncio.create_subprocess_exec(
+            self.piper_bin, "--model", self.voice_path, "--output_file", "-",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        wav, err = await process.communicate(text.encode())
+        if process.returncode != 0 or not wav:
+            raise RuntimeError(f"piper failed ({process.returncode}): {err.decode()[:300]}")
+        return wav
+
+
+class TtsFileServer:
+    """Serves synthesized WAVs at /tts/{id}.wav from memory, expiring after `ttl_s`."""
+
+    def __init__(self, host: str, port: int, ttl_s: float = 300.0) -> None:
+        self.host = host
+        self.port = port
+        self.ttl_s = ttl_s
+        self._files: dict[str, tuple[float, bytes]] = {}
+        self._runner: web.AppRunner | None = None
+
+    def add(self, wav: bytes) -> str:
+        now = time.monotonic()
+        self._files = {k: v for k, v in self._files.items() if now - v[0] < self.ttl_s}
+        file_id = secrets.token_urlsafe(8)
+        self._files[file_id] = (now, wav)
+        return f"http://{self.host}:{self.port}/tts/{file_id}.wav"
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        entry = self._files.get(request.match_info["id"])
+        if entry is None:
+            return web.Response(status=404)
+        return web.Response(body=entry[1], content_type="audio/wav")
+
+    async def start(self) -> None:
+        app = web.Application()
+        app.router.add_get("/tts/{id}.wav", self._handle)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, "0.0.0.0", self.port)
+        await site.start()
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None

--- a/clients/voice-gateway/memex_voice_gateway/vad.py
+++ b/clients/voice-gateway/memex_voice_gateway/vad.py
@@ -1,0 +1,81 @@
+"""End-of-utterance detection over the satellite's 16 kHz mono s16le stream.
+
+Energy-based endpointing with an adaptive noise floor — no model, no native deps, fully
+unit-testable. The device's XMOS pipeline already gives us clean, echo-cancelled audio, so a
+simple RMS gate is enough to find the end of speech; swap in a model VAD later if dialect
+pauses prove too long for a fixed silence window.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+
+
+def rms(frame: bytes) -> float:
+    """Root mean square of a 16-bit little-endian PCM frame. Empty frame → 0."""
+    n = len(frame) // 2
+    if n == 0:
+        return 0.0
+    samples = struct.unpack(f"<{n}h", frame[: n * 2])
+    return (sum(s * s for s in samples) / n) ** 0.5
+
+
+@dataclass
+class Endpointer:
+    """Feed PCM chunks; `done` flips true one silence-window after speech ended.
+
+    The threshold adapts: the noise floor is the running minimum of recent frame energy,
+    and speech is anything a fixed factor above it. This survives both a quiet room and a
+    fan next to the mic without per-site tuning.
+    """
+
+    sample_rate: int = 16000
+    silence_ms: int = 800
+    max_utterance_s: float = 15.0
+    min_utterance_s: float = 0.4
+    speech_factor: float = 3.0
+    floor_init: float = 150.0
+
+    def __post_init__(self) -> None:
+        self._buffer = bytearray()
+        self._noise_floor = self.floor_init
+        self._speech_seen = False
+        self._silence_bytes = 0
+        self._speech_bytes = 0
+        self.done = False
+
+    @property
+    def audio(self) -> bytes:
+        return bytes(self._buffer)
+
+    def _bytes_per_ms(self) -> float:
+        return self.sample_rate * 2 / 1000.0
+
+    def feed(self, chunk: bytes) -> bool:
+        """Accumulate a chunk; returns True once the utterance is complete."""
+        if self.done or not chunk:
+            return self.done
+        self._buffer.extend(chunk)
+
+        level = rms(chunk)
+        # Track the floor down fast, up slowly — a shout must not raise it.
+        if level < self._noise_floor:
+            self._noise_floor = max(1.0, 0.5 * self._noise_floor + 0.5 * level)
+        else:
+            self._noise_floor = 0.995 * self._noise_floor + 0.005 * level
+
+        if level > self._noise_floor * self.speech_factor:
+            self._speech_seen = True
+            self._speech_bytes += len(chunk)
+            self._silence_bytes = 0
+        elif self._speech_seen:
+            self._silence_bytes += len(chunk)
+
+        long_enough = self._speech_bytes >= self.min_utterance_s * self.sample_rate * 2
+        silent_long = self._silence_bytes >= self.silence_ms * self._bytes_per_ms()
+        too_long = len(self._buffer) >= self.max_utterance_s * self.sample_rate * 2
+
+        if (self._speech_seen and long_enough and silent_long) or too_long:
+            self.done = True
+        return self.done

--- a/clients/voice-gateway/memex_voice_gateway/vad.py
+++ b/clients/voice-gateway/memex_voice_gateway/vad.py
@@ -36,6 +36,8 @@ class Endpointer:
     min_utterance_s: float = 0.4
     speech_factor: float = 3.0
     floor_init: float = 150.0
+    calibrate_ms: int = 0       # treat the first N ms as ambient (TV, music) — floor, not speech
+    onset_timeout_s: float = 0  # 0 = off; else end early when no speech starts in time
 
     def __post_init__(self) -> None:
         self._buffer = bytearray()
@@ -44,6 +46,8 @@ class Endpointer:
         self._silence_bytes = 0
         self._speech_bytes = 0
         self.done = False
+        self.ended_by_cap = False   # True = closed by max duration, NOT by a silence gap
+        self.speech_seen = False
 
     @property
     def audio(self) -> bytes:
@@ -59,6 +63,11 @@ class Endpointer:
         self._buffer.extend(chunk)
 
         level = rms(chunk)
+        # Ambient calibration window (follow-up rounds): whatever is audible right when the
+        # mic opens — a TV, music — is the FLOOR, not speech; only louder-than-that counts.
+        if len(self._buffer) <= self.calibrate_ms * self._bytes_per_ms():
+            self._noise_floor = max(self._noise_floor, level)
+            return self.done
         # Track the floor down fast, up slowly — a shout must not raise it.
         if level < self._noise_floor:
             self._noise_floor = max(1.0, 0.5 * self._noise_floor + 0.5 * level)
@@ -75,7 +84,11 @@ class Endpointer:
         long_enough = self._speech_bytes >= self.min_utterance_s * self.sample_rate * 2
         silent_long = self._silence_bytes >= self.silence_ms * self._bytes_per_ms()
         too_long = len(self._buffer) >= self.max_utterance_s * self.sample_rate * 2
+        no_onset = (self.onset_timeout_s > 0 and not self._speech_seen
+                    and len(self._buffer) >= self.onset_timeout_s * self.sample_rate * 2)
 
-        if (self._speech_seen and long_enough and silent_long) or too_long:
+        if (self._speech_seen and long_enough and silent_long) or too_long or no_onset:
             self.done = True
+            self.ended_by_cap = too_long or no_onset
+            self.speech_seen = self._speech_seen
         return self.done

--- a/clients/voice-gateway/pyproject.toml
+++ b/clients/voice-gateway/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "memex-voice-gateway"
+version = "0.1.0"
+description = "Standalone voice gateway: an ESPHome voice satellite (e.g. FutureProofHomes Satellite1) wired directly to MeshWeaver agent threads — no Home Assistant required."
+requires-python = ">=3.11"
+dependencies = [
+    "aioesphomeapi>=30.0",
+    "aiohttp>=3.9",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8", "pytest-asyncio>=0.23"]
+
+[project.scripts]
+memex-voice-gateway = "memex_voice_gateway.__main__:main"
+
+[tool.setuptools.packages.find]
+include = ["memex_voice_gateway*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/clients/voice-gateway/run-local.sh
+++ b/clients/voice-gateway/run-local.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# All-local run on a Mac: whisper.cpp STT + Ollama brain + macOS `say` TTS.
+# Prereqs: brew install whisper-cpp ollama; the Swiss German GGML in ~/models/whisper/
+# (from the voice-model-swiss-german release); an Ollama model pulled (default qwen3.6).
+# Required env: SATELLITE_HOST, SATELLITE_PSK, GATEWAY_HOST (this Mac's LAN IP).
+set -e
+
+WHISPER_MODEL="${WHISPER_MODEL:-$HOME/models/whisper/ggml-swiss-german-turbo-q5_0.bin}"
+WHISPER_PORT="${WHISPER_PORT:-8090}"
+
+if ! curl -sf "http://127.0.0.1:${WHISPER_PORT}/" >/dev/null 2>&1; then
+    echo "Starting whisper-server on :${WHISPER_PORT} (${WHISPER_MODEL})"
+    whisper-server -m "$WHISPER_MODEL" --port "$WHISPER_PORT" --host 127.0.0.1 &
+    sleep 2
+fi
+
+export BRAIN="${BRAIN:-ollama}"
+export OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.6}"
+export STT_URL="${STT_URL:-http://127.0.0.1:${WHISPER_PORT}/inference}"
+export TTS_ENGINE="${TTS_ENGINE:-say}"
+export SAY_VOICE="${SAY_VOICE:-Anna}"
+
+exec python -m memex_voice_gateway

--- a/clients/voice-gateway/tests/test_ollama.py
+++ b/clients/voice-gateway/tests/test_ollama.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from memex_voice_gateway.ollama import SYSTEM_PROMPT, OllamaBrain, build_messages
+
+
+def test_build_messages_prepends_system_and_trims_history():
+    history = [{"role": "user", "content": f"q{i}"} for i in range(30)]
+    messages = build_messages(history, "neu", max_turns=2)
+    assert messages[0] == {"role": "system", "content": SYSTEM_PROMPT}
+    assert len(messages) == 1 + 4 + 1  # system + last 2*2 history + new user message
+    assert messages[-1] == {"role": "user", "content": "neu"}
+
+
+def test_budget_miss_leaves_generation_running_and_second_wait_succeeds():
+    async def scenario():
+        brain = OllamaBrain("http://unused", "test-model")
+        release = asyncio.Event()
+
+        async def slow_chat(messages):
+            await release.wait()
+            return "Die Antwort."
+
+        brain._chat = slow_chat  # inject a fake transport
+        handle = await brain.ask("Frage?")
+        assert await brain.await_reply(handle, 0.05) is None  # budget missed, still running
+        release.set()
+        reply = await brain.await_reply(handle, 1.0)          # announce path retries the handle
+        assert reply == "Die Antwort."
+        assert brain._history[-1] == {"role": "assistant", "content": "Die Antwort."}
+        await brain.close()
+
+    asyncio.run(scenario())
+
+
+def test_history_resets_after_idle_window():
+    async def scenario():
+        brain = OllamaBrain("http://unused", "test-model", idle_minutes=0)
+
+        async def chat(messages):
+            return "ok"
+
+        brain._chat = chat
+        first = await brain.ask("erste Frage")
+        await brain.await_reply(first, 1.0)
+        brain._last_used -= 1  # idle_minutes=0 → any elapsed time exceeds the window
+        await brain.ask("zweite Frage")
+        assert [m["content"] for m in brain._history] == ["zweite Frage"]
+        await brain.close()
+
+    asyncio.run(scenario())

--- a/clients/voice-gateway/tests/test_ollama.py
+++ b/clients/voice-gateway/tests/test_ollama.py
@@ -16,7 +16,7 @@ def test_budget_miss_leaves_generation_running_and_second_wait_succeeds():
         brain = OllamaBrain("http://unused", "test-model")
         release = asyncio.Event()
 
-        async def slow_chat(messages):
+        async def slow_chat(messages, handle=None):
             await release.wait()
             return "Die Antwort."
 
@@ -36,7 +36,7 @@ def test_history_resets_after_idle_window():
     async def scenario():
         brain = OllamaBrain("http://unused", "test-model", idle_minutes=0)
 
-        async def chat(messages):
+        async def chat(messages, handle=None):
             return "ok"
 
         brain._chat = chat

--- a/clients/voice-gateway/tests/test_ollama.py
+++ b/clients/voice-gateway/tests/test_ollama.py
@@ -44,7 +44,16 @@ def test_history_resets_after_idle_window():
         await brain.await_reply(first, 1.0)
         brain._last_used -= 1  # idle_minutes=0 → any elapsed time exceeds the window
         await brain.ask("zweite Frage")
-        assert [m["content"] for m in brain._history] == ["zweite Frage"]
+        assert [m["content"].split("] ", 1)[1] for m in brain._history] == ["zweite Frage"]
         await brain.close()
 
     asyncio.run(scenario())
+
+
+def test_real_time_anchor_in_messages():
+    import datetime
+    from memex_voice_gateway.ollama import now_line
+    stamp = now_line(datetime.datetime(2026, 8, 18, 21, 30))
+    assert stamp == "Aktuelle Zeit: Dienstag, 18. August 2026, 21:30 Uhr."
+    messages = build_messages([], "[21:30] Frage", now=stamp)
+    assert stamp in messages[0]["content"] and messages[0]["role"] == "system"

--- a/clients/voice-gateway/tests/test_ollama.py
+++ b/clients/voice-gateway/tests/test_ollama.py
@@ -54,6 +54,6 @@ def test_real_time_anchor_in_messages():
     import datetime
     from memex_voice_gateway.ollama import now_line
     stamp = now_line(datetime.datetime(2026, 8, 18, 21, 30))
-    assert stamp == "Aktuelle Zeit: Dienstag, 18. August 2026, 21:30 Uhr."
+    assert stamp == "Current time: Tuesday, 18 August 2026, 21:30."
     messages = build_messages([], "[21:30] Frage", now=stamp)
     assert stamp in messages[0]["content"] and messages[0]["role"] == "system"

--- a/clients/voice-gateway/tests/test_pipeline.py
+++ b/clients/voice-gateway/tests/test_pipeline.py
@@ -1,0 +1,80 @@
+import asyncio
+
+from memex_voice_gateway.pipeline import VoicePipeline
+
+
+def make_pipeline(**overrides):
+    calls = {"announced": [], "spoken": []}
+
+    async def transcribe(pcm):
+        return overrides.get("transcript", "wie spät ist es")
+
+    async def ask(text):
+        return "u/_Thread/t1"
+
+    async def await_reply(path, budget):
+        return overrides.get("reply", "Es ist drei Uhr.")
+
+    async def speak(text):
+        calls["spoken"].append(text)
+        return f"http://gw/tts/{len(calls['spoken'])}.wav"
+
+    async def announce(url, text):
+        calls["announced"].append(text)
+
+    pipeline = VoicePipeline(
+        transcribe=overrides.get("transcribe", transcribe),
+        ask=overrides.get("ask", ask),
+        await_reply=overrides.get("await_reply", await_reply),
+        speak=speak, announce=announce,
+        reply_budget_s=0.05, announce_budget_s=0.2,
+        hold_phrase="Moment bitte.", error_phrase="Fehler.",
+    )
+    return pipeline, calls
+
+
+def test_inline_reply_within_budget():
+    pipeline, calls = make_pipeline()
+    result = asyncio.run(pipeline.run(b"pcm"))
+    assert result.reply == "Es ist drei Uhr."
+    assert result.tts_url and calls["spoken"] == ["Es ist drei Uhr."]
+    assert calls["announced"] == []
+
+
+def test_budget_miss_holds_then_announces():
+    attempts = []
+
+    async def slow_reply(path, budget):
+        attempts.append(budget)
+        if len(attempts) == 1:
+            return None            # inline budget missed
+        return "Die Antwort."      # background poll succeeds
+
+    async def scenario():
+        pipeline, calls = make_pipeline(await_reply=slow_reply)
+        result = await pipeline.run(b"pcm")
+        assert result.reply is None
+        assert calls["spoken"] == ["Moment bitte."]
+        await asyncio.gather(*pipeline._background)
+        return calls
+
+    calls = asyncio.run(scenario())
+    assert calls["announced"] == ["Die Antwort."]
+    assert calls["spoken"] == ["Moment bitte.", "Die Antwort."]
+
+
+def test_empty_transcript_ends_quietly():
+    pipeline, calls = make_pipeline(transcript="")
+    result = asyncio.run(pipeline.run(b"pcm"))
+    assert result.reply is None and result.tts_url is None
+    assert calls["spoken"] == [] and calls["announced"] == []
+
+
+def test_stt_failure_speaks_error_phrase():
+    async def broken(pcm):
+        raise RuntimeError("stt down")
+
+    pipeline, calls = make_pipeline(transcribe=broken)
+    result = asyncio.run(pipeline.run(b"pcm"))
+    assert result.reply == "Fehler."
+    assert calls["spoken"] == ["Fehler."]

--- a/clients/voice-gateway/tests/test_router.py
+++ b/clients/voice-gateway/tests/test_router.py
@@ -38,7 +38,7 @@ def test_switch_and_routing_with_stamped_handles():
         handle = await router.ask("frage eins")
         assert handle == "memex::h-memex"
 
-        assert await router.handle_command("wechsle zu lokal") == "Verbunden mit lokal."
+        assert await router.handle_command("wechsle zu lokal") == "Connected to lokal."
         assert router.active == "lokal"
         await router.ask("frage zwei")
         assert local.asked == ["frage zwei"]
@@ -57,3 +57,26 @@ def test_resolve_is_forgiving():
     assert router.resolve("Systemorph") == "systemorph"
     assert router.resolve("system") == "systemorph"
     assert router.resolve("nothing") is None
+
+
+def test_delegation_to_a_standard_agent():
+    async def scenario():
+        class MeshBrain(FakeBrain):
+            def __init__(self):
+                super().__init__("memex")
+                self.delegated = []
+
+            async def delegate(self, text, agent=None):
+                self.delegated.append((agent, text))
+                return "u/_Thread/task-1"
+
+        mesh, local = MeshBrain(), FakeBrain("lokal")
+        router = BrainRouter({"lokal": local, "memex": mesh}, "lokal")
+        reply = await router.handle_command("Frag den Researcher nach dem Wetter von morgen")
+        assert "Researcher" in reply and "memex" in reply
+        assert mesh.delegated == [("Researcher", "dem Wetter von morgen")]
+        assert await router.handle_command("Fragen kostet nichts") is None  # not a delegation
+        assert router.describe_hold("memex::x").startswith("Submitted to memex")
+        assert router.describe_hold("lokal::x") == "Let me check. One moment please."
+
+    asyncio.run(scenario())

--- a/clients/voice-gateway/tests/test_router.py
+++ b/clients/voice-gateway/tests/test_router.py
@@ -1,0 +1,59 @@
+import asyncio
+
+from memex_voice_gateway.router import BrainRouter, parse_switch_command
+
+
+def test_parse_switch_variants():
+    assert parse_switch_command("Wechsle zu Systemorph.") == "Systemorph"
+    assert parse_switch_command("switch to memex") == "memex"
+    assert parse_switch_command("Verbinde mit lokal!") == "lokal"
+    assert parse_switch_command("gang uf systemorph") == "systemorph"
+    assert parse_switch_command("Wie viele Kantone hat die Schweiz?") is None
+    assert parse_switch_command("Wechsle zu was auch immer du willst bitte jetzt") \
+        == "was auch immer du willst bitte jetzt"
+
+
+class FakeBrain:
+    def __init__(self, tag):
+        self.tag = tag
+        self.asked = []
+
+    async def ask(self, text):
+        self.asked.append(text)
+        return f"h-{self.tag}"
+
+    async def await_reply(self, handle, budget_s):
+        return f"{self.tag} answered {handle}"
+
+    async def close(self):
+        pass
+
+
+def test_switch_and_routing_with_stamped_handles():
+    async def scenario():
+        memex, local = FakeBrain("memex"), FakeBrain("lokal")
+        router = BrainRouter({"memex": memex, "lokal": local}, "memex")
+
+        assert await router.handle_command("Wie spät ist es?") is None
+        handle = await router.ask("frage eins")
+        assert handle == "memex::h-memex"
+
+        assert await router.handle_command("wechsle zu lokal") == "Verbunden mit lokal."
+        assert router.active == "lokal"
+        await router.ask("frage zwei")
+        assert local.asked == ["frage zwei"]
+
+        # a handle from BEFORE the switch still polls the brain that produced it
+        assert await router.await_reply(handle, 1.0) == "memex answered h-memex"
+
+        unknown = await router.handle_command("wechsle zu atlantis")
+        assert "atlantis" in unknown and "memex" in unknown
+
+    asyncio.run(scenario())
+
+
+def test_resolve_is_forgiving():
+    router = BrainRouter({"systemorph": FakeBrain("s"), "memex": FakeBrain("m")}, "memex")
+    assert router.resolve("Systemorph") == "systemorph"
+    assert router.resolve("system") == "systemorph"
+    assert router.resolve("nothing") is None

--- a/clients/voice-gateway/tests/test_streaming.py
+++ b/clients/voice-gateway/tests/test_streaming.py
@@ -1,0 +1,71 @@
+import asyncio
+
+import aiohttp
+import pytest
+
+from memex_voice_gateway.ollama import OllamaBrain
+from memex_voice_gateway.stt import wav_from_pcm
+from memex_voice_gateway.tts import TtsFileServer, split_wav, streaming_wav_header
+
+
+def test_split_wav_round_trip():
+    pcm = b"\x01\x02" * 800
+    got, rate = split_wav(wav_from_pcm(pcm, sample_rate=22050))
+    assert got == pcm and rate == 22050
+
+
+def test_streaming_header_shape():
+    header = streaming_wav_header(22050)
+    assert header[:4] == b"RIFF" and header[8:12] == b"WAVE" and len(header) == 44
+
+
+@pytest.mark.asyncio
+async def test_stream_endpoint_plays_chunks_as_they_arrive():
+    server = TtsFileServer("127.0.0.1", 8391)
+    await server.start()
+    try:
+        stream, url = server.open_stream(sample_rate=22050)
+
+        async def feed():
+            await stream.push(b"AA" * 100)
+            await asyncio.sleep(0.05)
+            await stream.push(b"BB" * 100)
+            await stream.close()
+
+        task = asyncio.create_task(feed())
+        async with aiohttp.ClientSession() as http:
+            async with http.get(url.replace("127.0.0.1:8391", "127.0.0.1:8391")) as response:
+                assert response.status == 200
+                body = await response.read()
+        await task
+        assert body[:4] == b"RIFF"
+        assert body[44:] == b"AA" * 100 + b"BB" * 100
+
+        # a stream id is single-use
+        async with aiohttp.ClientSession() as http:
+            async with http.get(url) as response:
+                assert response.status == 404
+    finally:
+        await server.stop()
+
+
+def test_ollama_stream_text_drains_generated_pieces():
+    async def scenario():
+        brain = OllamaBrain("http://unused", "test-model")
+
+        async def fake_streaming(messages, handle):
+            queue = brain._chunks[handle]
+            for piece in ["Die Schweiz ", "hat 26 ", "Kantone."]:
+                await queue.put(piece)
+            await queue.put(None)
+            return "Die Schweiz hat 26 Kantone."
+
+        brain._chat_streaming = fake_streaming
+        handle = await brain.ask("Frage?")
+        stream = brain.stream_text(handle)
+        pieces = [piece async for piece in stream]
+        assert "".join(pieces) == "Die Schweiz hat 26 Kantone."
+        assert await brain.await_reply(handle, 1.0) == "Die Schweiz hat 26 Kantone."
+        await brain.close()
+
+    asyncio.run(scenario())

--- a/clients/voice-gateway/tests/test_stt.py
+++ b/clients/voice-gateway/tests/test_stt.py
@@ -1,0 +1,15 @@
+import struct
+
+from memex_voice_gateway.stt import wav_from_pcm
+
+
+def test_wav_header_fields():
+    pcm = b"\x01\x02" * 1600  # 100 ms at 16 kHz mono s16le
+    wav = wav_from_pcm(pcm, sample_rate=16000)
+    assert wav[:4] == b"RIFF" and wav[8:12] == b"WAVE"
+    assert struct.unpack("<I", wav[4:8])[0] == 36 + len(pcm)
+    fmt = struct.unpack("<IHHIIHH", wav[16:36])
+    assert fmt == (16, 1, 1, 16000, 32000, 2, 16)
+    assert wav[36:40] == b"data"
+    assert struct.unpack("<I", wav[40:44])[0] == len(pcm)
+    assert wav[44:] == pcm

--- a/clients/voice-gateway/tests/test_threads.py
+++ b/clients/voice-gateway/tests/test_threads.py
@@ -1,0 +1,61 @@
+import json
+
+import pytest
+
+from memex_voice_gateway.threads import McpError, extract_reply, parse_tool_result
+
+
+def rpc_result(text: str) -> str:
+    return json.dumps({"jsonrpc": "2.0", "id": 9,
+                       "result": {"content": [{"type": "text", "text": text}]}})
+
+
+def test_parse_plain_json_result():
+    assert parse_tool_result(rpc_result("hello")) == "hello"
+
+
+def test_parse_sse_wrapped_result():
+    body = "event: message\ndata: " + rpc_result("hello") + "\n\n"
+    assert parse_tool_result(body) == "hello"
+
+
+def test_parse_rpc_error_raises():
+    body = json.dumps({"jsonrpc": "2.0", "id": 9, "error": {"code": -32000, "message": "nope"}})
+    with pytest.raises(McpError):
+        parse_tool_result(body)
+
+
+def test_parse_tool_level_error_raises():
+    body = json.dumps({"jsonrpc": "2.0", "id": 9,
+                       "result": {"isError": True,
+                                  "content": [{"type": "text", "text": "agent exploded"}]}})
+    with pytest.raises(McpError, match="agent exploded"):
+        parse_tool_result(body)
+
+
+# --- extract_reply: fixtures mirror live thread nodes observed on memex 2026-08-18 ---
+
+def thread_node(messages, pending=None, summary=None) -> str:
+    content = {"$type": "Thread", "messages": messages,
+               "pendingUserMessages": pending or {}}
+    if summary is not None:
+        content["summary"] = summary
+    return json.dumps({"$type": "MeshNode", "content": content})
+
+
+def test_new_message_ids_are_reported():
+    new_ids, failure = extract_reply(thread_node(["u1", "a1"]), known_ids={"u1"})
+    assert new_ids == ["a1"] and failure is None
+
+
+def test_dispatch_failure_surfaces_via_summary():
+    node = thread_node(["u1"], summary="Selected agent 'Voice' was not found")
+    new_ids, failure = extract_reply(node, known_ids={"u1"})
+    assert new_ids == [] and "not found" in failure
+
+
+def test_pending_round_suppresses_stale_summary():
+    pending = {"u2": {"role": "user", "text": "next question"}}
+    node = thread_node(["u1"], pending=pending, summary="an old digest")
+    _, failure = extract_reply(node, known_ids={"u1"})
+    assert failure is None

--- a/clients/voice-gateway/tests/test_vad.py
+++ b/clients/voice-gateway/tests/test_vad.py
@@ -1,0 +1,47 @@
+import math
+import struct
+
+from memex_voice_gateway.vad import Endpointer, rms
+
+
+def tone(ms: int, amplitude: int = 8000, rate: int = 16000) -> bytes:
+    n = rate * ms // 1000
+    return struct.pack(f"<{n}h", *(int(amplitude * math.sin(i / 5)) for i in range(n)))
+
+
+def silence(ms: int, rate: int = 16000) -> bytes:
+    return b"\x00\x00" * (rate * ms // 1000)
+
+
+def feed_chunks(endpointer: Endpointer, audio: bytes, chunk_ms: int = 20) -> bool:
+    step = 16000 * 2 * chunk_ms // 1000
+    done = False
+    for offset in range(0, len(audio), step):
+        done = endpointer.feed(audio[offset:offset + step])
+        if done:
+            break
+    return done
+
+
+def test_rms_of_silence_is_zero():
+    assert rms(silence(20)) == 0.0
+    assert rms(b"") == 0.0
+
+
+def test_speech_then_silence_ends_the_utterance():
+    endpointer = Endpointer(silence_ms=400)
+    audio = silence(200) + tone(800) + silence(1000)
+    assert feed_chunks(endpointer, audio) is True
+    assert len(endpointer.audio) > 0
+
+
+def test_pure_silence_only_ends_at_max_duration():
+    endpointer = Endpointer(silence_ms=400, max_utterance_s=1.0)
+    assert feed_chunks(endpointer, silence(900)) is False
+    assert feed_chunks(endpointer, silence(300)) is True  # crosses max_utterance_s
+
+
+def test_too_short_speech_does_not_end_early():
+    endpointer = Endpointer(silence_ms=300, min_utterance_s=0.5)
+    # 100 ms of speech is below the minimum, so trailing silence must NOT end the round yet.
+    assert feed_chunks(endpointer, silence(100) + tone(100) + silence(500)) is False


### PR DESCRIPTION
## What

`clients/voice-gateway/` — a standalone LAN container wiring an ESPHome voice satellite (FutureProofHomes Satellite1) **directly to memex agent threads**:

```
Satellite1 (wake word on-device) ──ESPHome API──► gateway
  ├─ endpointing (energy VAD, adaptive noise floor)
  ├─ STT  → POST /api/speech/transcribe   (the centralized Swiss German Whisper)
  ├─ chat → /mcp start_thread / submit_message   (one conversation ≈ one thread)
  └─ TTS  → Piper de_DE, served over HTTP; device plays the URL
```

Replies inside `REPLY_BUDGET_S` are spoken inline; slower rounds get a holding phrase and the real answer delivered later via `send_voice_assistant_announcement_await_response` (media-player fallback). Coexists with a Home Assistant that owns the satellite's sensors/music — only the voice-assistant subscription must be exclusive.

## Verified

- **16 unit tests green** (`pip install -e .[dev] && pytest` in `clients/voice-gateway/`) — VAD endpointing, WAV framing, MCP result/SSE parsing, thread-reply extraction (fixtures mirror live nodes), pipeline budget hit/miss/error paths.
- **Thread + STT protocol smoke-tested against live memex** (2026-08-18): submit 0.4 s; lean chat-tier `Voice` agent replied *"Die Hauptstadt der Schweiz ist Bern."* in **3.4 s** wall. Cold starts / the default assistant run ~60–70 s — which is why the announce path exists.
- The device leg mirrors HA's exact `aioesphomeapi` usage (`subscribe_voice_assistant` API-audio mode, `send_voice_assistant_event` sequence) and needs a real satellite for e2e — flagged in the README.

## Notes

- Found while testing: newly created Agent nodes don't reach the roster cache until a recycle — filed as #1853 with the workaround.
- The default STT model's CC BY-NC 4.0 scope is stated in the README (personal, non-commercial), pointing at `deploy/whisper/README.md` for the commercial swap.
- No CI wiring for the Python tests in this PR — happy to add a small job if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)