### PR TITLE
CI: clients.yml still had the apt flock no-op — one wait, two callers

### DIFF
--- a/.github/scripts/wait-for-apt.sh
+++ b/.github/scripts/wait-for-apt.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Wait for a competing apt on this runner to FINISH — bounded.
+#
+# The runner image runs its own background apt (unattended-upgrades / the daily timer). While it
+# holds the lock, `playwright install --with-deps` shells out to apt-get and exits 100 with
+#   E: Could not get lock /var/lib/apt/lists/lock. It is held by process N (apt-get)
+# which is CONTENTION, not a broken download, so retrying immediately just re-races the same holder.
+#
+# 🚨 TWO THINGS THIS DELIBERATELY DOES NOT DO, both measured on real runs (#1855, #1858):
+#   • It does not `flock` the lock file. flock(1) takes a BSD lock; apt and dpkg take POSIX fcntl
+#     locks on those same files, and on Linux those are independent lock spaces — so the flock is
+#     granted instantly against a lock apt is actively holding. In run 32166749364 the three
+#     install attempts were separated by the retry backoff alone (10s, 20s), never by the 60s the
+#     wait claimed, while one apt-get held the lock throughout.
+#   • It does not wait for the lock to be momentarily FREE. A momentary check reserves nothing:
+#     the background apt re-takes it before playwright's own apt-get gets there, which is why a
+#     wait on the lock files still failed with the same holder immediately after reporting it free.
+# What settles it is the holding PROCESS exiting. That is what this waits for.
+#
+# Usage: wait-for-apt.sh [budget-seconds]
+set -euo pipefail
+
+budget="${1:-180}"
+interval=3
+
+if ! command -v pgrep >/dev/null 2>&1; then
+  # Never silent: a wait that cannot run must say so, or its absence is indistinguishable from
+  # "apt was free" — which is how the flock version hid for as long as it did.
+  echo "::warning::pgrep is not available — cannot wait for a competing apt; continuing (the caller's step is bounded)" >&2
+  exit 0
+fi
+
+busy() {
+  pgrep -x apt-get >/dev/null 2>&1 ||
+  pgrep -x apt >/dev/null 2>&1 ||
+  pgrep -x dpkg >/dev/null 2>&1 ||
+  pgrep -f unattended-upgr >/dev/null 2>&1
+}
+
+waited=0
+while [ "$waited" -lt "$budget" ] && busy; do
+  [ "$waited" -eq 0 ] && echo "a competing apt is running — waiting up to ${budget}s for it to finish" >&2
+  sleep "$interval"
+  waited=$((waited + interval))
+done
+
+if [ "$waited" -gt 0 ]; then
+  if busy; then
+    # Reported, not fatal: apt may still finish before the caller reaches it, and every caller
+    # bounds its own attempt. But a run that failed AFTER a full wait must be distinguishable from
+    # one that never waited — the distinction the flock version destroyed.
+    echo "::warning::a competing apt is STILL running after ${budget}s; continuing anyway" >&2
+  else
+    echo "waited ${waited}s for a competing apt to finish" >&2
+  fi
+fi

--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -282,7 +282,15 @@ jobs:
       # and the runner's own background apt makes it exit 100 "Could not get lock" — contention,
       # not a broken download. Same shared script, so this copy cannot drift from that one again.
       # Both bounds are hard: it can wait, it cannot hang.
+      #
+      # 🚨 The install bound is 420s, not 180s, because 180 was BELOW what this step actually
+      # costs. Unlike dotnet-test's, this install is the FULL chromium (the e2e drives a real
+      # browser, not `--only-shell`) plus its apt dependencies, and two independent runs measured
+      # ~185s: main's own run 32180959535 and 32170659820 both died at exactly `exit code 124`
+      # — `timeout` killing a healthy install a few seconds short. A bound that the normal path
+      # exceeds is not a hang detector, it is a flake generator, and it reports as the very
+      # "infra failure" wording that trains people to re-run rather than look.
       - run: |
           "$GITHUB_WORKSPACE/.github/scripts/wait-for-apt.sh" 180
-          timeout --signal=TERM --kill-after=30 180 npx playwright install --with-deps chromium
+          timeout --signal=TERM --kill-after=30 420 npx playwright install --with-deps chromium
       - run: npm run e2e # expo export --platform web → serve dist/ → drive headless Chromium

--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -280,9 +280,9 @@ jobs:
       # already converts a silent hang into a visible, re-runnable infra failure.
       # The apt wait is for the same reason as dotnet-test's: `--with-deps` shells out to apt-get,
       # and the runner's own background apt makes it exit 100 "Could not get lock" — contention,
-      # not a broken download. `flock … true` waits for that holder and releases immediately, so
-      # playwright takes the lock itself. Both bounds are hard: it can wait, it cannot hang.
+      # not a broken download. Same shared script, so this copy cannot drift from that one again.
+      # Both bounds are hard: it can wait, it cannot hang.
       - run: |
-          sudo flock -w 60 /var/lib/apt/lists/lock true 2>/dev/null || true
+          "$GITHUB_WORKSPACE/.github/scripts/wait-for-apt.sh" 180
           timeout --signal=TERM --kill-after=30 180 npx playwright install --with-deps chromium
       - run: npm run e2e # expo export --platform web → serve dist/ → drive headless Chromium

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -662,13 +662,11 @@ jobs:
           #
           # What actually settles it is the holder FINISHING. Bounded, like everything here: it
           # can wait, it cannot hang.
-          waited=0
-          while [ "$waited" -lt "$APT_LOCK_WAIT" ]; do
-            pgrep -x apt-get >/dev/null 2>&1 || pgrep -f unattended-upgr >/dev/null 2>&1 || break
-            sleep 3
-            waited=$((waited + 3))
-          done
-          [ "$waited" -gt 0 ] && echo "waited ${waited}s for a competing apt to finish" >&2
+          # ONE implementation, called from here and from clients.yml — the two copies of this
+          # wait are what let #1858 fix this file while the identical `flock` no-op stayed in
+          # clients.yml. $GITHUB_WORKSPACE, not a relative path: the clients job runs with a
+          # working-directory where `.github/…` does not exist.
+          "$GITHUB_WORKSPACE/.github/scripts/wait-for-apt.sh" "$APT_LOCK_WAIT"
           rc=0
           timeout --signal=TERM --kill-after=30 "$BROWSER_INSTALL_TIMEOUT" \
             npx --yes "playwright-core@${PLAYWRIGHT_VERSION}" install --with-deps --only-shell chromium || rc=$?


### PR DESCRIPTION
**Superseded in part by #1858, which landed while this was open — this is now the half that PR did not cover, plus de-duplication.**

#1858 fixed the apt wait in `dotnet-test.yml`. The identical line in `clients.yml` is untouched:

```bash
sudo flock -w 60 /var/lib/apt/lists/lock true 2>/dev/null || true
```

It waits for nothing. `flock(1)` takes a BSD `flock()` lock; apt and dpkg take POSIX `fcntl()` record locks on those same files, and on Linux those are independent lock spaces — so it is granted instantly against a lock apt is actively holding. That copy is why the RN web e2e job keeps failing the way `dotnet-test` used to.

## Why a script instead of a second inline copy

Two copies of one wait is precisely what let #1858 fix one file and leave the other broken. This ships **one** script and calls it from both places, so they cannot drift again.

The semantics are **#1858's**, not this branch's earlier ones — I dropped mine in favour of theirs. Waiting for the lock to be momentarily free reserves nothing: the background apt re-takes it before playwright's `apt-get` gets there, which is exactly what that PR measured after a lock-file wait had reported the lock free. What settles it is the holding **process** exiting. Broadened slightly to `apt` and `dpkg` alongside `apt-get` and unattended-upgrades, since any of them holds the same lock.

## Details that decide whether this is a fix or another no-op

- **It degrades loudly.** No `pgrep`, or a competing apt still running when the budget expires, is reported as a warning. A wait that cannot run must say so — its silence is indistinguishable from "apt was free", which is how the `flock` version survived this long.
- **`$GITHUB_WORKSPACE`, not a repo-relative path.** The clients job sets `working-directory: clients/react-native`, where `.github/…` does not resolve.

## Testing

Stubbed `pgrep` and exercised all four branches:

| Case | Result |
|---|---|
| nothing competing | returns at once |
| holder runs past the budget | waits it out, warns it is *still* running |
| holder exits mid-wait | returns then, reports how long it waited |
| `pgrep` absent | loud skip, never a silent fail-open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)