### PR TITLE
Wait for the competing apt to FINISH — a momentary lock check reserves nothing

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -647,7 +647,16 @@ jobs:
           # deadlock). Bounded, like everything else here: it can wait, it cannot hang. `|| true`
           # because a timed-out wait is not a reason to skip the attempt — apt may well be free by
           # the time npx reaches it, and the attempt itself is bounded anyway.
-          sudo flock -w "$APT_LOCK_WAIT" /var/lib/apt/lists/lock true 2>/dev/null || true
+          # 🚨 EVERY lock apt takes, not just the lists one. The observed failure is
+          #   E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process N (apt-get)
+          # and `lists/lock` is a DIFFERENT lock — it guards the package-list download, while
+          # dpkg/lock-frontend guards the install itself. Waiting only on lists/lock let the
+          # install race straight into the frontend lock and fail all three attempts, which is
+          # what has been reddening shards on PRs whose diff cannot touch tests at all (#1843).
+          for lk in /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock; do
+            [ -e "$lk" ] || continue
+            sudo flock -w "$APT_LOCK_WAIT" "$lk" true 2>/dev/null || true
+          done
           rc=0
           timeout --signal=TERM --kill-after=30 "$BROWSER_INSTALL_TIMEOUT" \
             npx --yes "playwright-core@${PLAYWRIGHT_VERSION}" install --with-deps --only-shell chromium || rc=$?

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -628,7 +628,7 @@ jobs:
         PLAYWRIGHT_VERSION: 1.62.1
         PLAYWRIGHT_BROWSERS_PATH: /opt/ms-playwright
         BROWSER_INSTALL_TIMEOUT: 180
-        APT_LOCK_WAIT: 60
+        APT_LOCK_WAIT: 240
       run: |
         set -euo pipefail
         sudo mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
@@ -647,16 +647,28 @@ jobs:
           # deadlock). Bounded, like everything else here: it can wait, it cannot hang. `|| true`
           # because a timed-out wait is not a reason to skip the attempt — apt may well be free by
           # the time npx reaches it, and the attempt itself is bounded anyway.
-          # 🚨 EVERY lock apt takes, not just the lists one. The observed failure is
-          #   E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process N (apt-get)
-          # and `lists/lock` is a DIFFERENT lock — it guards the package-list download, while
-          # dpkg/lock-frontend guards the install itself. Waiting only on lists/lock let the
-          # install race straight into the frontend lock and fail all three attempts, which is
-          # what has been reddening shards on PRs whose diff cannot touch tests at all (#1843).
-          for lk in /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock; do
-            [ -e "$lk" ] || continue
-            sudo flock -w "$APT_LOCK_WAIT" "$lk" true 2>/dev/null || true
+          # 🚨 WAIT FOR THE COMPETING PROCESS TO EXIT — not for a lock to be momentarily free.
+          #
+          # The previous shape was `flock -w N <lock> true`, which ACQUIRES the lock and releases
+          # it in the same breath. That reserves nothing: the runner image's background apt
+          # (unattended-upgrades / the daily timer) re-takes it before playwright's own apt-get
+          # gets there, so the wait returns "free" and the install fails anyway. Measured on this
+          # very branch — waiting on all three lock files still failed with
+          #   E: Could not get lock /var/lib/apt/lists/lock. It is held by process 3014 (apt-get)
+          # i.e. the same holder, immediately after our wait said the lock was available.
+          #
+          # apt also locks with fcntl, which does not interoperate with flock, so the earlier
+          # approach could not have worked reliably even without the release race.
+          #
+          # What actually settles it is the holder FINISHING. Bounded, like everything here: it
+          # can wait, it cannot hang.
+          waited=0
+          while [ "$waited" -lt "$APT_LOCK_WAIT" ]; do
+            pgrep -x apt-get >/dev/null 2>&1 || pgrep -f unattended-upgr >/dev/null 2>&1 || break
+            sleep 3
+            waited=$((waited + 3))
           done
+          [ "$waited" -gt 0 ] && echo "waited ${waited}s for a competing apt to finish" >&2
           rc=0
           timeout --signal=TERM --kill-after=30 "$BROWSER_INSTALL_TIMEOUT" \
             npx --yes "playwright-core@${PLAYWRIGHT_VERSION}" install --with-deps --only-shell chromium || rc=$?


### PR DESCRIPTION
## My first attempt was wrong, and this PR's own CI proved it

I first changed the wait to cover `dpkg/lock-frontend` as well as `lists/lock`. That still failed — on this branch:

```
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 3014 (apt-get)
```

The **same holder**, immediately after our wait reported the lock free.

## The flaw is the approach, not the lock name

```bash
sudo flock -w "$APT_LOCK_WAIT" /var/lib/apt/lists/lock true   # acquire … and release
```

It acquires the lock and releases it in the same breath, so **it reserves nothing**. The runner image's background apt (unattended-upgrades / the daily timer) re-takes it before playwright's own `apt-get` gets there. apt also locks with **fcntl**, which does not interoperate with `flock`, so this shape could not have been reliable even without the release race.

## What actually settles it

Wait for the **holder to finish**:

```bash
waited=0
while [ "$waited" -lt "$APT_LOCK_WAIT" ]; do
  pgrep -x apt-get >/dev/null 2>&1 || pgrep -f unattended-upgr >/dev/null 2>&1 || break
  sleep 3
  waited=$((waited + 3))
done
```

Bounded exactly as before — it can wait, it cannot hang. Budget **60 s → 240 s**, because an unattended-upgrade run routinely outlasts a minute and the old bound expired while the holder was still working.

## Why it's worth fixing

Today, on PRs whose diff **cannot** affect tests: #1850 four shards, #1849 three shards (twice), #1841 three shards — `infra=4` each, **zero** test failures between them. Every one a re-run. That is how a team learns to re-run reflexively, and it is the erosion tracked in #1843.

Verified: YAML parses; every `run:` block passes `bash -n`. The real proof is this PR's own shards.

Refs #1843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFx1SsoKDhRKHdaJbQPEWQ