### PR TITLE
fix(#1758): publish a package's access BEFORE its content, not after it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-installed-packages-are-readable-on-arrival.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-installed-packages-are-readable-on-arrival.md
@@ -1,0 +1,35 @@
+---
+Name: A freshly installed package is readable the moment it appears
+Category: Fix
+Description: Landing on a new package's page right after it installed no longer showed "access denied" for the first few seconds — its public read is now published before its content.
+Icon: LockOpen
+Order: -20260818
+---
+
+# A freshly installed package is readable the moment it appears
+
+For a short window after a package finished installing, opening one of its pages — including the
+paywall landing that is meant to be public — could answer *"Access denied: you lack Read permission
+on '{Package}'"*. Refreshing a few seconds later worked, which is what made this so easy to dismiss
+as a hiccup.
+
+It was not a permissions bug. The package became **reachable** as soon as its root landed, but the
+grants that say *"everyone may read this"* were written at the very END of the install — after every
+content node, every type and every compile. On a busy instance that gap was measured at **12 to 17
+seconds**, during which the permission check was doing exactly the right thing with the information
+it had: the grants were simply not there yet.
+
+Publishing a partition's access is now a **phase of the install**, placed immediately after the
+package's root and before its first content node. A package can no longer be observable before it is
+readable — the window is gone rather than shortened.
+
+Two things deliberately did not change:
+
+- **Nothing was opened up.** A commercial package still installs gated, and a package that publishes
+  only some of its pages still gates the rest. Those gates are now written *before* the pages they
+  cover exist, so a protected page is protected from the moment it lands rather than a moment after.
+- **A package that ships its own access policy still wins.** Its policy is written in the same phase
+  and just ahead of the declared one, so the installer never overwrites it — not even briefly.
+
+The install also now checks its own work: if the partition somehow ends up unreadable, that is
+reported as an error naming the package instead of finishing quietly.

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -129,21 +129,38 @@ public static class PackageInstaller
 
         var options = hub.JsonSerializerOptions;
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
+        // 🚨 PUBLISH THE PARTITION BEFORE ITS CONTENT (#1758). A content package writes no
+        // partition ROOT of its own (every parsed node lands at `{partition}/{id}` or deeper), so
+        // there is nothing here to race and the shape can go first outright: the package's own
+        // root access satellites, then the manifest-declared shape, then everything else.
+        //
+        // It used to run after every content node. That is an ORDERING defect, not a permission
+        // one: the partition becomes reachable as soon as anything in it lands, readers arrive, and
+        // the permission fold correctly denies because the grants are simply not there yet.
+        var ownAccess = nodes.Where(n => IsPartitionAccessSatellite(n.Path, partition)).ToArray();
+        var content = nodes.Where(n => !IsPartitionAccessSatellite(n.Path, partition)).ToArray();
         return EnsurePartitionsProvisioned(hub, partition, InstalledPartition)
-            .SelectMany(_ => nodes
+            .SelectMany(_ => ownAccess
                 .Select(n => UpsertIfChanged(hub, persistence, n, options))
-                .ToObservable().Merge(batchSize).ToList())
+                .ToObservable().Concat().ToList())
+            .SelectMany(accessWrites => EnsureDeclaredAccess(
+                    hub, manifest, partition, logger, nodes.Select(n => n.Path))
+                .Select(_ => accessWrites))
+            .SelectMany(accessWrites => content
+                .Select(n => UpsertIfChanged(hub, persistence, n, options))
+                .ToObservable().Merge(batchSize).ToList()
+                .Select(contentWrites => (IList<bool>)accessWrites.Concat(contentWrites).ToList()))
             .SelectMany(writes =>
             {
                 var result = new InstallResult(nodes.Length, writes.Count(w => w));
                 logger?.LogInformation(
                     "Installed package {Id} v{Version}: {Written} written, {Unchanged} unchanged into {Partition} @ {Ref}",
                     manifest.Id, manifest.Version, result.Written, result.Unchanged, partition, installedFromRef);
-                // The declared-access shape lands BEFORE the roots are warmed: warming ACTIVATES
-                // each root hub, whose gating pass seeds the partition's access table — it must see
-                // the shape this package declares, not a partition nobody can read.
-                return EnsureDeclaredAccess(hub, manifest, partition, logger,
-                        nodes.Select(n => n.Path))
+                // The declared access was published as a PHASE before the first content node landed
+                // (see the note above). What stays here is its POST-CONDITION, read once and
+                // reported LOUDLY — an install that reports success while its partition is
+                // unreadable is exactly the failure this ordering exists to make impossible.
+                return VerifyDeclaredAccess(hub, manifest, partition, logger)
                     .SelectMany(_ => WriteInstalledRecord(
                         hub, manifest, installedFromRef, nodes.Length, authorizingUserId: authorizingUserId))
                     .SelectMany(_ => WarmInstalledRoots(hub, nodes, logger))
@@ -319,6 +336,94 @@ public static class PackageInstaller
     /// never fight over it.
     /// </summary>
     private const string WellKnownPublicSegment = "Public";
+
+    /// <summary>The well-known folder holding a scope's <c>AccessAssignment</c> grants.</summary>
+    private const string AccessFolder = AccessAssignmentGuard.AccessFolder;
+
+    /// <summary>
+    /// A node the PACKAGE itself ships that decides who may read its PARTITION ROOT — its own
+    /// <c>{partition}/_Policy</c>, or a grant under <c>{partition}/_Access/</c>. Pure.
+    ///
+    /// <para>These land in the same phase as <see cref="EnsureDeclaredAccess"/> and BEFORE it, so
+    /// create-only still means "the package's own shape wins" now that the phase runs before the
+    /// package's content (#1758). Written the other way round, a package declaring itself free
+    /// while SHIPPING a gated policy would be published wide open for the width of the install and
+    /// only closed again when its own policy node landed — trading a denial window for an exposure
+    /// window, which is the one trade this fix must never make.</para>
+    ///
+    /// <para>Deliberately the ROOT's satellites only. A child's shipped grant stays in the normal
+    /// satellite stage: it can only ever land after the child it anchors on, and until that child
+    /// exists there is nothing to expose.</para>
+    /// </summary>
+    internal static bool IsPartitionAccessSatellite(string path, string? partition) =>
+        !string.IsNullOrWhiteSpace(partition)
+        && (string.Equals(path, $"{partition}/{PartitionPolicyId}", StringComparison.Ordinal)
+            || path.StartsWith($"{partition}/{AccessFolder}/", StringComparison.Ordinal));
+
+    /// <summary>
+    /// The one node whose presence PROVES <see cref="EnsureDeclaredAccess"/> did its job for this
+    /// manifest — the fully-public shape's <c>{partition}/_Policy</c>, or the scoped shape's root
+    /// <c>Public</c> grant. <c>null</c> when the manifest declares nothing to publish (a commercial
+    /// package installs gated on purpose, so there is no marker and nothing to verify). Pure.
+    /// </summary>
+    internal static string? DeclaredAccessMarker(PackageManifest manifest, string? partition)
+    {
+        if (string.IsNullOrWhiteSpace(partition))
+            return null;
+        if (!manifest.PreInstalled && manifest.IsCommercial())
+            return null;
+        return !manifest.PreInstalled && DeclaredPublicSegments(manifest).Count > 0
+            ? $"{partition}/{AccessFolder}/{WellKnownUsers.Public}_Access"
+            : $"{partition}/{PartitionPolicyId}";
+    }
+
+    /// <summary>
+    /// Re-reads the marker <see cref="EnsureDeclaredAccess"/> was supposed to leave behind and
+    /// reports its ABSENCE as an error — the POST-CONDITION of the declared-access phase (#1758).
+    ///
+    /// <para>Deliberately a READ, never a second write pass: the scoped shape derives its child
+    /// walk from a subtree query it also writes into, and a step that re-derives from nodes it has
+    /// itself just written is how a reconcile comes to feed itself (#223, the 257,000-version
+    /// <c>_Policy</c> storm). One call site writes; this one only looks, and it cannot schedule
+    /// another pass because it never writes anything.</para>
+    ///
+    /// <para>Never fatal — the content is committed by the time this runs, and failing the install
+    /// would trade an unreadable partition for no partition at all. LOUD is the point: before this,
+    /// "published nothing" and "published correctly" were the same silent success. The poll is the
+    /// same bounded shape as the install's other visibility barriers (the marker is written through
+    /// the per-node hub, whose persist is debounced), and its expiry is the diagnosis, not a sleep.
+    /// </para>
+    /// </summary>
+    private static IObservable<Unit> VerifyDeclaredAccess(
+        IMessageHub hub, PackageManifest manifest, string? partition, ILogger? logger)
+    {
+        var marker = DeclaredAccessMarker(manifest, partition);
+        var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
+        if (marker is null || persistence is null)
+            return Observable.Return(Unit.Default);
+
+        return Observable
+            .Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+            .SelectMany(_ => persistence.Exists(marker))
+            .Where(exists => exists)
+            .FirstAsync()
+            .Timeout(DeclaredAccessVerifyBudget)
+            .Select(_ => Unit.Default)
+            .Catch((Exception exception) =>
+            {
+                logger?.LogError(exception,
+                    "[PackageInstaller] {Id} finished installing into {Partition} but its declared "
+                    + "access never converged — {Marker} is absent, so the partition is unreadable "
+                    + "to everyone the manifest declares may read it.",
+                    manifest.Id, partition, marker);
+                return Observable.Return(Unit.Default);
+            });
+    }
+
+    /// <summary>Bound on the declared-access post-condition poll. Its expiry is a DIAGNOSIS (the
+    /// error above), never a retry and never a delay anything waits on in the healthy case — the
+    /// marker is normally already there on the first probe.</summary>
+    private static readonly TimeSpan DeclaredAccessVerifyBudget = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Establishes the access a package's MANIFEST declares — the ONE access-establishment step of
@@ -633,16 +738,22 @@ public static class PackageInstaller
             var gated = GatedChildRoots(
                 children.Concat(installedPaths ?? []), partition, declared);
 
-            var shape = new List<MeshNode>
-            {
-                ViewerAssignment(partition, WellKnownUsers.Public, denied: false),
-                ViewerAssignment(partition, WellKnownUsers.Anonymous, denied: false),
-            };
+            // 🚨 DENIES FIRST, ROOT GRANTS LAST — the same rule EnsurePartitionPublicRead states
+            // for its heal sweep, and for the same reason: the root grant is what OPENS the
+            // partition and grants inherit strictly downward, so between the grant and a child's
+            // deny that child is publicly readable. Ordered this way an interrupted publication
+            // leaves the partition CLOSED, which is the safe half to fail on. It matters more now
+            // that this whole step runs BEFORE the package's content (#1758): the denies are
+            // established before the segments they gate even exist, so a gated child is born gated
+            // instead of being reachable until its deny catches up.
+            var shape = new List<MeshNode>();
             foreach (var child in gated)
             {
                 shape.Add(ViewerAssignment(child, WellKnownUsers.Public, denied: true));
                 shape.Add(ViewerAssignment(child, WellKnownUsers.Anonymous, denied: true));
             }
+            shape.Add(ViewerAssignment(partition, WellKnownUsers.Public, denied: false));
+            shape.Add(ViewerAssignment(partition, WellKnownUsers.Anonymous, denied: false));
 
             // Create-only, sequential; a failed write propagates (Upsert throws on !Success).
             return shape
@@ -2011,7 +2122,17 @@ public static class PackageInstaller
                 var stage2Root = stage2.Where(n => Order(n) == 2).ToArray();
                 var bulkInstances = stage2.Where(n => Order(n) == 3 && IsBulk(n)).ToArray();
                 var requestInstances = stage2.Where(n => Order(n) == 3 && !IsBulk(n)).ToArray();
-                var satellites = stage2.Where(n => Order(n) == 4).ToArray();
+                // The package's OWN root access satellites are HOISTED out of the satellite stage
+                // and written in the publication phase below, immediately before
+                // EnsureDeclaredAccess — so create-only still means "the package's shipped shape
+                // wins" now that the phase runs ahead of the content (#1758).
+                var partitionPath = manifest.TargetPartition ?? manifest.Id;
+                var hoistedAccess = stage2
+                    .Where(n => Order(n) == 4 && IsPartitionAccessSatellite(n.Path, partitionPath))
+                    .ToArray();
+                var satellites = stage2
+                    .Where(n => Order(n) == 4 && !IsPartitionAccessSatellite(n.Path, partitionPath))
+                    .ToArray();
                 // Only types updated through the debounced per-node path still need the Exists
                 // barrier; a bulk-written type is committed when its batch responds. (These paths
                 // already exist, so the barrier passes on its first probe — no 100 ms tail.)
@@ -2026,7 +2147,39 @@ public static class PackageInstaller
                             : Array.Empty<MeshNode>(),
                         current))
                     .SelectMany(rootWrites => Visible(root is null ? [] : [root.Path])
-                        .SelectMany(_ => BulkSave(bulkSources))
+                        // 🚨 THE PUBLICATION IS A PHASE, AND IT IS THIS ONE (#1758). It lands the
+                        // instant the root exists and BEFORE a single content node does, so
+                        // "installed" can never be observable before "readable".
+                        //
+                        // It used to run at the very END of the install — after every content node,
+                        // every type, the retype reconcile and the persisted poll. But a package
+                        // becomes REACHABLE the moment its root lands in stage 0 above: the path
+                        // resolves, readers arrive, and the paywall landing ({plugin}/Subscribe)
+                        // correctly DENIES because the grants that make a cover public are simply
+                        // not there yet. Measured on a fresh mesh: bursts of denials 12–17 s before
+                        // the partition's access shape was written (Store 17 s, Edu 12 s,
+                        // AgenticOffice 12 s) and ZERO denials after it. The permission fold was
+                        // innocent throughout — this is pure sequencing.
+                        //
+                        // Placed AFTER the root's own write and its visibility barrier, never
+                        // before: an access satellite is the partition's first CHILD create, and a
+                        // child create on a partition whose root is not yet persistence-visible
+                        // triggers the implicit partition bootstrap, whose generic Space root races
+                        // ours (see the stage-0 note above). Root, then access, then everything
+                        // else — which collapses the window from the whole content install to the
+                        // two or three access writes themselves.
+                        //
+                        // The paths this install is ABOUT to write are handed to EnsureDeclaredAccess,
+                        // so a scoped package's per-child DENIES are established BEFORE the children
+                        // they gate exist. That is strictly narrower than the old placement, where
+                        // every child sat ungated for the whole install; nothing here widens access.
+                        .SelectMany(_ => WriteAll(hoistedAccess, current))
+                        .SelectMany(accessWrites => EnsureDeclaredAccess(
+                                hub, manifest, partitionPath, logger, nodes.Select(n => n.Path))
+                            .Select(_ => accessWrites))
+                        .SelectMany(accessWrites => BulkSave(bulkSources)
+                            .Select(sourceWrites => (IList<(string Path, bool Wrote)>)accessWrites
+                                .Concat(sourceWrites).ToList()))
                         .SelectMany(sourceWrites => BulkSave(bulkTypes)
                             .SelectMany(typeBulkWrites => WriteAll(requestStage1, current)
                                 .Select(typeReqWrites => (IList<(string Path, bool Wrote)>)sourceWrites
@@ -2126,10 +2279,13 @@ public static class PackageInstaller
                     ? SeedPrebuiltAssemblies(hub, nodeTypePaths, logger)
                     : Observable.Return(0);
 
-                // Same order as the content path: publish the partition BEFORE warming its roots
-                // (activation's gating pass must see the declared shape).
-                return EnsureDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id,
-                        logger, nodes.Select(n => n.Path))
+                // The declared access was published as a PHASE before the first content node
+                // landed (see the note at that call site, #1758) — there is deliberately no second
+                // write pass here, so nothing can re-derive a shape from nodes it has itself just
+                // written. What stays is the phase's POST-CONDITION, read once and reported LOUDLY:
+                // an install that reports success while its partition is unreadable is the failure
+                // this whole ordering exists to make impossible, and it must never be silent.
+                return VerifyDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id, logger)
                     .SelectMany(_ => WriteInstalledRecord(
                         hub, manifest, installedFromRef, nodes.Length, moduleManifest, authorizingUserId))
                     // Adoption first (it can settle a release without compiling at all), then the
@@ -2296,7 +2452,16 @@ public static class PackageInstaller
                         }))
                     .ToObservable().Concat().Sum();
 
+        // 🚨 The declared access is re-asserted BEFORE the delta's writes, not after them (#1758).
+        // An UPDATE re-asserts it at all so a package that only just flipped its declaration (or
+        // whose policy was lost) converges on the next sync rather than waiting for a full
+        // re-install; running it FIRST means the re-asserted shape is in place before the nodes it
+        // governs land. A delta presupposes a prior install, so the partition root already exists
+        // and there is no bootstrap race to order around. Create-only, so this is free on the
+        // common path.
         return EnsurePartitionsProvisioned(hub, manifest.TargetPartition ?? manifest.Id, InstalledPartition)
+            .SelectMany(_ => EnsureDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id,
+                logger, nodes.Select(n => n.Path)))
             .SelectMany(_ => WriteAll(head))
             .SelectMany(headWrites => TypesVisible()
                 .SelectMany(_ => WriteAll(tail))
@@ -2333,13 +2498,12 @@ public static class PackageInstaller
                 var releases = releaseTargets.Length > 0
                     ? SeedThenRequestReleases(hub, releaseTargets, logger)
                     : Observable.Return(System.Reactive.Unit.Default);
-                // An UPDATE re-asserts the declared access too: a package that only just flipped
-                // its declaration (or whose policy was lost) must converge on the next sync rather
-                // than wait for a full re-install. Create-only, so an existing shape is untouched
-                // and this is free on the common path.
+                // The declared access was re-asserted BEFORE the writes (see the note at that call
+                // site, #1758). What stays here is its POST-CONDITION — a read, never a second
+                // write pass, so nothing can re-derive a shape from nodes it just wrote.
                 return releases
-                    .SelectMany(_ => EnsureDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id,
-                        logger, nodes.Select(n => n.Path)))
+                    .SelectMany(_ => VerifyDeclaredAccess(
+                        hub, manifest, manifest.TargetPartition ?? manifest.Id, logger))
                     .SelectMany(_ => WriteInstalledRecord(hub, manifest, installedFromRef,
                         newManifest.Files.Count, newManifest, authorizingUserId))
                     .SelectMany(_ => WarmInstalledRoots(hub, nodes, logger))

--- a/test/MeshWeaver.PluginCatalog.Test/InstallAccessOrderingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallAccessOrderingTest.cs
@@ -1,0 +1,396 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// THE ORDER OF AN INSTALL (#1758): a package must never be OBSERVABLE before it is READABLE.
+///
+/// <para>Measured on a fresh mesh before this pin existed: every
+/// <c>Access denied: user '…' lacks Read permission on '{Package}'</c> fired in a burst of 14,
+/// <b>12–17 seconds before</b> that package's partition access shape was written (Store 17 s,
+/// Edu 12 s, AgenticOffice 12 s), with zero denials after it. The permission fold was innocent
+/// throughout — the grants simply were not there yet. A package becomes reachable the moment its
+/// ROOT lands (stage 0 of the node-repo install), while <c>EnsureDeclaredAccess</c> ran at the very
+/// END: after every content node, every type, the retype reconcile and the persisted poll.</para>
+///
+/// <para>Consequence chain, and the reason this is a product defect rather than a test-timing one:
+/// an un-entitled viewer who lands on <c>{plugin}/Subscribe</c> inside that window is denied on a
+/// page that is by design public — so no coupon surface, so no entitlement, so no install step.
+/// Under CI load the window outlasts the caller's patience; on an idle laptop a retry hides it.
+/// Education's disposable-mesh e2e (<c>15-install-lands.spec.ts</c>) has been flake-listed on
+/// exactly this.</para>
+///
+/// <para><b>What is pinned here is ORDER, never duration.</b> Nothing sleeps, nothing polls for a
+/// window to close, nothing asserts that anything is fast. The primary pin is CLOCK-FREE: the
+/// install returns <see cref="InstallResult.WrittenPaths"/> in pipeline order, so the position of
+/// the partition's access node in that list IS the phase order. The stamp comparisons that follow
+/// are the same evidence the live investigation used (denial timestamps vs. <c>min(last_modified)</c>
+/// on the access table), reduced to the in-process case — and they compare two <b>acceptance</b>
+/// instants written by one strictly-sequential pipeline, never a duration against a budget.</para>
+///
+/// <para>Built on <see cref="MonolithMeshTestBase.ConfigureMeshBase"/>, NOT the default
+/// <c>ConfigureMesh</c>: the latter seeds a root-scope <c>Public → Admin</c> grant that would make
+/// every partition readable by everyone and void the "we did not widen anything" half.</para>
+/// </summary>
+public class InstallAccessOrderingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>A signed-in principal holding NOTHING — no role, no grant, anywhere.</summary>
+    private const string PlainUser = "ordering-plain-user";
+
+    /// <summary>The not-logged-in reader (the well-known Anonymous permission bucket).</summary>
+    private const string Anonymous = WellKnownUsers.Anonymous;
+
+    private const string PlatformAdmin = "ordering-admin";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddPluginCatalog()
+            .AddMeshNodes(AssignmentNodeFactory.UserRole(PlatformAdmin, "Admin", "Admin"));
+
+    /// <summary>The content children of the fully-public package — enough of them that the write
+    /// phase is a measurable stretch of the install rather than a single round trip.</summary>
+    private static readonly string[] FreeDocs =
+        Enumerable.Range(1, 12).Select(i => $"Doc{i:00}").ToArray();
+
+    private static readonly IReadOnlyList<RepoFile> Repo = BuildRepo();
+
+    private static List<RepoFile> BuildRepo()
+    {
+        var files = new List<RepoFile>
+        {
+            // FULLY PUBLIC (free, nothing declared) — the Store/Edu shape from the live
+            // measurement: the partition is published with a `_Policy · PublicRead = true`.
+            new("OrderPlug/index.json",
+                """
+                {"$type":"MeshNode","id":"OrderPlug","namespace":"","path":"OrderPlug",
+                 "mainNode":"OrderPlug","name":"Order Plug","nodeType":"Space","state":"Active",
+                 "content":{"$type":"PluginManifest","description":"Free for everyone.","price":0,
+                            "publicSegments":[]}}
+                """),
+            // SCOPED (free with declared publicSegments) — the cover-plus-gated-children shape.
+            new("OrderSegPlug/index.json",
+                """
+                {"$type":"MeshNode","id":"OrderSegPlug","namespace":"","path":"OrderSegPlug",
+                 "mainNode":"OrderSegPlug","name":"Order Seg Plug","nodeType":"Space","state":"Active",
+                 "content":{"$type":"PluginManifest","description":"Partially public.","price":0,
+                            "publicSegments":["Open"]}}
+                """),
+            new("OrderSegPlug/Open.json",
+                """
+                {"$type":"MeshNode","id":"Open","namespace":"OrderSegPlug","path":"OrderSegPlug/Open",
+                 "mainNode":"OrderSegPlug/Open","name":"Open","nodeType":"Markdown","state":"Active",
+                 "content":"# Open\n\nDeclared public — the cover surface."}
+                """),
+            new("OrderSegPlug/Hidden.json",
+                """
+                {"$type":"MeshNode","id":"Hidden","namespace":"OrderSegPlug","path":"OrderSegPlug/Hidden",
+                 "mainNode":"OrderSegPlug/Hidden","name":"Hidden","nodeType":"Markdown","state":"Active",
+                 "content":"# Hidden\n\nUndeclared — must be gated BEFORE it exists."}
+                """),
+            // A package that SHIPS ITS OWN _Policy. Its manifest says free, its policy says gated —
+            // a contradiction create-only resolves in the package's favour. That only stays true if
+            // the shipped satellite lands in the SAME phase as the declared shape and BEFORE it,
+            // which is what the clock-free pin below reads off WrittenPaths.
+            new("OrderOwnPolicy/index.json",
+                """
+                {"$type":"MeshNode","id":"OrderOwnPolicy","namespace":"","path":"OrderOwnPolicy",
+                 "mainNode":"OrderOwnPolicy","name":"Order Own Policy","nodeType":"Space","state":"Active",
+                 "content":{"$type":"PluginManifest","description":"Brings its own policy.","price":0}}
+                """),
+            new("OrderOwnPolicy/_Policy.json",
+                """
+                {"$type":"MeshNode","id":"_Policy","namespace":"OrderOwnPolicy",
+                 "path":"OrderOwnPolicy/_Policy","mainNode":"OrderOwnPolicy/_Policy",
+                 "name":"Access Policy","nodeType":"PartitionAccessPolicy","state":"Active",
+                 "content":{"$type":"PartitionAccessPolicy","publicRead":false,
+                            "redirectOnDenied":"OrderOwnPolicy/Subscribe"}}
+                """),
+        };
+        files.AddRange(FreeDocs.Select(id => new RepoFile(
+            $"OrderPlug/{id}.json",
+            $$"""
+              {"$type":"MeshNode","id":"{{id}}","namespace":"OrderPlug","path":"OrderPlug/{{id}}",
+               "mainNode":"OrderPlug/{{id}}","name":"{{id}}","nodeType":"Markdown","state":"Active",
+               "content":"# {{id}}\n\nContent that must not land before the partition is published."}
+              """)));
+        files.AddRange(FreeDocs.Select(id => new RepoFile(
+            $"OrderOwnPolicy/{id}.json",
+            $$"""
+              {"$type":"MeshNode","id":"{{id}}","namespace":"OrderOwnPolicy",
+               "path":"OrderOwnPolicy/{{id}}","mainNode":"OrderOwnPolicy/{{id}}","name":"{{id}}",
+               "nodeType":"Markdown","state":"Active","content":"# {{id}}"}
+              """)));
+        // A few children under the gated segment, so the scoped package's write phase is more than
+        // one node wide too.
+        files.AddRange(Enumerable.Range(1, 6).Select(i => new RepoFile(
+            $"OrderSegPlug/Hidden/Page{i:00}.json",
+            $$"""
+              {"$type":"MeshNode","id":"Page{{i:00}}","namespace":"OrderSegPlug/Hidden",
+               "path":"OrderSegPlug/Hidden/Page{{i:00}}","mainNode":"OrderSegPlug/Hidden/Page{{i:00}}",
+               "name":"Page{{i:00}}","nodeType":"Markdown","state":"Active","content":"# Page {{i}}"}
+              """)));
+        return files;
+    }
+
+    private static NodeRepoPackageSource Source()
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-install-ordering", Repo));
+        return new NodeRepoPackageSource(fetch, "https://github.com/acme/plugins");
+    }
+
+    /// <summary>Installs one package through the real listing and the real installer.</summary>
+    private async Task<InstallResult> Install(string id)
+    {
+        var source = Source();
+        var manifests = await source.ListPackages("HEAD")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+        var pkg = manifests.Single(m => m.Id == id);
+        var files = await source.FetchPackageFiles(pkg, "HEAD")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+        return await PackageInstaller.Install(
+                Mesh, pkg, files, "HEAD", authorizingUserId: PlatformAdmin)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(180)).ToTask();
+    }
+
+    /// <summary>Authoritative single-node read straight off storage (never the lagging index).</summary>
+    private Task<MeshNode?> Read(string path) =>
+        Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>()
+            .Read(path, Mesh.JsonSerializerOptions)
+            .Take(1).Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+    private async Task<MeshNode> Stored(string path)
+    {
+        var node = await Read(path);
+        node.Should().NotBeNull($"'{path}' must exist after the install");
+        return node!;
+    }
+
+    /// <summary>
+    /// THE CLOCK-FREE PIN. <see cref="InstallResult.WrittenPaths"/> is emitted in pipeline order, so
+    /// the position of the partition's <c>_Policy</c> in it IS the phase order — no timestamps, no
+    /// tolerance, no way for a fast machine to make it vacuous.
+    ///
+    /// <para>The package ships its own <c>_Policy</c>, which is what puts a partition-access node
+    /// into <c>WrittenPaths</c> at all (the installer's own writes are not package nodes and are not
+    /// counted there). Before the fix that satellite was in the LAST bucket, behind every one of the
+    /// twelve documents; the publication phase now writes it immediately after the root, in the same
+    /// phase as — and just before — the manifest-declared shape, so create-only still means the
+    /// package's own policy wins.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task PartitionAccess_IsWritten_BeforeAnyContentNode()
+    {
+        var result = await Install("OrderOwnPolicy");
+        var written = result.WrittenPaths.ToList();
+        Output.WriteLine("WrittenPaths: " + string.Join(", ", written));
+
+        var policyAt = written.IndexOf("OrderOwnPolicy/_Policy");
+        policyAt.Should().BeGreaterThanOrEqualTo(0,
+            "the package's own partition policy must be part of the install");
+
+        var contentAt = FreeDocs
+            .Select(doc => written.IndexOf($"OrderOwnPolicy/{doc}"))
+            .Where(i => i >= 0)
+            .ToList();
+        contentAt.Should().NotBeEmpty("the package's content must be part of the install");
+
+        policyAt.Should().BeLessThan(contentAt.Min(),
+            "a package must be READABLE before it is OBSERVABLE — the node that decides who may "
+            + "read the partition has to land in a phase BEFORE the content, not in the satellite "
+            + "bucket behind all of it (#1758). Its index here is the phase order, so a higher one "
+            + "means every content node was reachable-and-denied first");
+
+        // The end state is unchanged: create-only, so the SHIPPED policy is what survives.
+        var policy = await Stored("OrderOwnPolicy/_Policy");
+        var content = policy.ContentAs<PartitionAccessPolicy>(Mesh.JsonSerializerOptions);
+        content.Should().NotBeNull();
+        content!.PublicRead.Should().BeFalse(
+            "hoisting the shipped satellite into the publication phase must not let the installer's "
+            + "public-read policy overwrite it — that would trade a denial window for an EXPOSURE "
+            + "window, which is the one trade this fix must never make");
+        content.RedirectOnDenied.Should().Be("OrderOwnPolicy/Subscribe");
+    }
+
+    /// <summary>
+    /// The same ordering for the shape the live measurement actually caught: a free package with
+    /// nothing declared, published by the INSTALLER writing <c>{partition}/_Policy</c>. That node is
+    /// not a package node, so it cannot be read off <c>WrittenPaths</c> — the evidence is the pair of
+    /// acceptance stamps, exactly as the live investigation compared the denial timestamps against
+    /// <c>min(last_modified)</c> on the access table.
+    ///
+    /// <para>Before the fix this failed by the whole width of the content write: the policy was the
+    /// last thing the install did, so every one of the twelve documents was reachable-and-denied
+    /// first. On a laptop that is milliseconds per node; on the live mesh it was 12–17 seconds.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task FullyPublicPackage_IsPublished_BeforeItsFirstContentNodeLands()
+    {
+        var result = await Install("OrderPlug");
+        result.Written.Should().BeGreaterThan(0);
+
+        var policy = await Stored($"OrderPlug/{PackageInstaller.PartitionPolicyId}");
+        var root = await Stored("OrderPlug");
+        var contents = new List<MeshNode>();
+        foreach (var doc in FreeDocs)
+            contents.Add(await Stored($"OrderPlug/{doc}"));
+
+        var firstContent = contents.MinBy(n => n.CreatedDate)!;
+        Output.WriteLine(
+            $"root={root.CreatedDate:O}  policy={policy.CreatedDate:O}  "
+            + $"firstContent={firstContent.Path}@{firstContent.CreatedDate:O}  "
+            + $"lastContent={contents.MaxBy(n => n.CreatedDate)!.CreatedDate:O}");
+
+        policy.CreatedDate.Should().BeOnOrBefore(firstContent.CreatedDate,
+            "a package must be READABLE before it is OBSERVABLE — publishing the partition after "
+            + "its content has landed leaves every reader in the window denied on a page that is "
+            + "declared public (#1758). Content stamped first here means the declared-access step "
+            + "ran after the install, which is the defect");
+
+        // The root is the ONE write that legitimately precedes the publication: an access satellite
+        // is the partition's first child create, and a child create on a partition whose root is
+        // not yet persistence-visible triggers the implicit partition bootstrap (whose generic Space
+        // root races the installer's own). Root, then access, then everything else.
+        root.CreatedDate.Should().BeOnOrBefore(policy.CreatedDate,
+            "the partition root must land before its access satellites, or the bootstrap heal races "
+            + "the installer's root");
+
+        // …and nothing was widened: the declared shape is exactly what it was, for everyone.
+        foreach (var identity in new[] { PlainUser, Anonymous })
+        {
+            await Mesh.GetEffectivePermissions("OrderPlug", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p.HasFlag(Permission.Read),
+                    $"'{identity}' must read a free package's partition");
+            await Mesh.GetEffectivePermissions($"OrderPlug/{FreeDocs[0]}", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p.HasFlag(Permission.Read),
+                    $"'{identity}' must read a free package's content");
+        }
+    }
+
+    /// <summary>
+    /// The same ordering for the SCOPED shape, plus the half that must not be traded away for it:
+    /// a gated child is gated BEFORE it exists, and the root grant that opens the cover is the LAST
+    /// write of the publication rather than its first.
+    ///
+    /// <para>🚨 This is the trap in moving an access step earlier. The root grant inherits strictly
+    /// downward, so writing it before the child denies would make every gated child publicly
+    /// readable for as long as the publication takes — trading a denial window for a PAYWALL
+    /// window. Denies first, root grants last: an interrupted publication leaves the partition
+    /// closed, which is the safe half to fail on.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ScopedPackage_GatesEveryChild_BeforeTheChildLands_AndOpensTheCoverLast()
+    {
+        var result = await Install("OrderSegPlug");
+        result.Written.Should().BeGreaterThan(0);
+
+        var hiddenDeny = await Stored("OrderSegPlug/Hidden/_Access/Public_Access");
+        var hiddenAnonDeny = await Stored("OrderSegPlug/Hidden/_Access/Anonymous_Access");
+        var rootGrant = await Stored("OrderSegPlug/_Access/Public_Access");
+        var hidden = await Stored("OrderSegPlug/Hidden");
+        var open = await Stored("OrderSegPlug/Open");
+
+        Output.WriteLine(
+            $"hiddenDeny={hiddenDeny.CreatedDate:O}  rootGrant={rootGrant.CreatedDate:O}  "
+            + $"hidden={hidden.CreatedDate:O}  open={open.CreatedDate:O}");
+
+        hiddenDeny.CreatedDate.Should().BeOnOrBefore(hidden.CreatedDate,
+            "the deny that gates an undeclared segment must be established before the segment "
+            + "exists — a child that lands first is reachable under the root grant until its own "
+            + "deny catches up (#1758)");
+        hiddenAnonDeny.CreatedDate.Should().BeOnOrBefore(hidden.CreatedDate,
+            "the same holds for the Anonymous half of the pair");
+
+        rootGrant.CreatedDate.Should().BeOnOrAfter(hiddenDeny.CreatedDate,
+            "the root grant OPENS the partition and inherits downward — writing it before the "
+            + "child denies would publish gated content for the width of the publication");
+        rootGrant.CreatedDate.Should().BeOnOrBefore(open.CreatedDate,
+            "the cover must still be readable before the package's content is observable");
+
+        // The deny is not weaker: an un-entitled signed-in viewer and an anonymous one still see
+        // the cover and the declared segment, and still cannot see the undeclared one.
+        foreach (var identity in new[] { PlainUser, Anonymous })
+        {
+            await Mesh.GetEffectivePermissions("OrderSegPlug", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p.HasFlag(Permission.Read),
+                    $"'{identity}' must read the cover of a scoped-public package");
+            await Mesh.GetEffectivePermissions("OrderSegPlug/Open", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p.HasFlag(Permission.Read),
+                    $"'{identity}' must read the declared public segment");
+            await Mesh.GetEffectivePermissions("OrderSegPlug/Hidden", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p == Permission.None,
+                    $"'{identity}' must NOT read an undeclared segment — moving the publication "
+                    + "earlier must never widen it");
+            await Mesh.GetEffectivePermissions("OrderSegPlug/Hidden/Page01", identity)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(p => p == Permission.None,
+                    $"'{identity}' must NOT read a page under an undeclared segment either");
+        }
+    }
+
+    /// <summary>
+    /// The phase's POST-CONDITION is a real node, per declared shape — the thing
+    /// <c>VerifyDeclaredAccess</c> reads back so that "published nothing" and "published correctly"
+    /// stop being the same silent success. Pure; no mesh.
+    /// </summary>
+    [Theory]
+    [InlineData(0d, null, false, new string[0], "P/_Policy")]
+    [InlineData(null, null, true, new[] { "Open" }, "P/_Policy")]      // preInstalled ⇒ fully public
+    [InlineData(0d, null, false, new[] { "Open" }, "P/_Access/Public_Access")]
+    [InlineData(25d, null, false, new string[0], null)]                 // priced ⇒ nothing published
+    [InlineData(null, "sales@acme.test", false, new string[0], null)]   // contact-sales ⇒ likewise
+    public void DeclaredAccessMarker_NamesTheNodeThePublicationMustLeaveBehind(
+        double? price, string? contactEmail, bool preInstalled, string[] segments, string? expected)
+    {
+        var manifest = new PackageManifest
+        {
+            Id = "P",
+            Price = (decimal?)price,
+            ContactEmail = contactEmail,
+            PreInstalled = preInstalled,
+            PublicSegments = [.. segments],
+        };
+
+        PackageInstaller.DeclaredAccessMarker(manifest, "P").Should().Be(expected);
+        PackageInstaller.DeclaredAccessMarker(manifest, partition: null)
+            .Should().BeNull("there is nothing to verify without a partition");
+    }
+
+    /// <summary>
+    /// Only the PARTITION ROOT's own access satellites are hoisted into the publication phase. A
+    /// child's shipped grant is not: it can only ever land after the child it anchors on, and until
+    /// that child exists there is nothing to expose. Pure.
+    /// </summary>
+    [Theory]
+    [InlineData("P/_Policy", "P", true)]
+    [InlineData("P/_Access/Public_Access", "P", true)]
+    [InlineData("P/Child/_Access/Public_Access", "P", false)]
+    [InlineData("P/Child/_Policy", "P", false)]
+    [InlineData("P/Doc", "P", false)]
+    [InlineData("P", "P", false)]
+    [InlineData("Other/_Policy", "P", false)]
+    [InlineData("P/_Policy", null, false)]
+    public void PartitionAccessSatellite_IsTheRootsOwn_NeverAChilds(
+        string path, string? partition, bool expected) =>
+        PackageInstaller.IsPartitionAccessSatellite(path, partition).Should().Be(expected);
+}


### PR DESCRIPTION
Closes #1758.

## The defect: sequencing, not permissions

A package becomes **reachable** the moment its ROOT lands — stage 0 of the node-repo install: the path resolves, readers arrive. `EnsureDeclaredAccess` — the step that writes `{partition}/_Policy · PublicRead` or the root `Public`/`Anonymous` Viewer grants — ran at the very **END** of the install, after every content node, every type, the retype reconcile and the persisted poll.

So there was a window in which the paywall landing that is *by design* public correctly **denied**. Measured on a fresh mesh (issue #1758): bursts of 14 `Access denied: user '…' lacks Read permission on '{Package}'`, **12–17 s before** that package's access shape was written (Store 17 s, Edu 12 s, AgenticOffice 12 s), and **zero** denials after it. The permission fold was innocent throughout.

Consequence chain: denied on `{Course}/Subscribe` ⇒ no coupon surface ⇒ never entitled ⇒ the cover legitimately offers no install step ⇒ education's `15-install-lands.spec.ts:488` fails. A retry hides it on an idle laptop; under CI load the window outlasts the caller's patience.

## The fix — one phase, moved

`EnsureDeclaredAccess` is now a **phase** placed immediately after the root's write **and its persistence-visibility barrier**, and before the first content node. Root → access → everything else. The same move on all three install paths (node-repo full, node-repo delta, content install).

It is placed after the root deliberately, never before: an access satellite is the partition's first CHILD create, and a child create on a partition whose root is not yet persistence-visible triggers the implicit partition bootstrap, whose generic `Space` root races the installer's own. That is why the window collapses to the two or three access writes rather than to zero.

What remains at the tail is the phase's **post-condition** (`VerifyDeclaredAccess`): a bounded READ of the marker the phase must have left behind, reported as an ERROR naming the package. Before this, "published nothing" and "published correctly" were the same silent success.

## The two traps, and how they are avoided

**Never widen access.** No deny got weaker; two things got *stricter*:

- **Denies first, root grants last** inside the scoped shape. The root grant OPENS the partition and inherits strictly downward, so writing it first would have published every gated child for the width of the publication — trading a denial window for a **paywall** window. Ordered this way a gated child is **born gated** (its deny is established before the segment exists) and an interrupted publication leaves the partition **closed**.
- **A package's own root access satellites** (`{p}/_Policy`, `{p}/_Access/*`) are hoisted into the same phase, just *ahead* of the declared shape, so create-only still means the shipped policy wins — never briefly overwritten by the installer's public read. `PreInstalled` is untouched; the commercial branch still writes nothing.

**Never feed a reconcile its own writes.** The tail step is a **read**, not a second write pass — it cannot schedule another pass because it writes nothing. `EnsureScopedPublicRead` still derives its child walk from one `.Take(1)` query unioned with the paths the install is about to write; there is exactly one writing call site per install, as before.

## Tests — ORDER, never duration

`test/MeshWeaver.PluginCatalog.Test/InstallAccessOrderingTest.cs` (16 cases). Nothing sleeps, nothing polls for a window to close, nothing asserts that anything is fast.

The **primary pin is clock-free**: `InstallResult.WrittenPaths` is emitted in pipeline order, so the index of the partition's access node in it *is* the phase order.

### Non-vacuity — the same tests against an unmodified `PackageInstaller`

Baseline = `origin/main`'s installer plus only the two pure internals the test names, so the ordering assertions are the only thing under test:

```
Failed  PartitionAccess_IsWritten_BeforeAnyContentNode
  Expected 13 to be less than 1 because a package must be READABLE before it is
  OBSERVABLE — the node that decides who may read the partition has to land in a
  phase BEFORE the content, not in the satellite bucket behind all of it (#1758).
  WrittenPaths: OrderOwnPolicy, OrderOwnPolicy/Doc01, … OrderOwnPolicy/Doc12,
                OrderOwnPolicy/_Policy

Failed  FullyPublicPackage_IsPublished_BeforeItsFirstContentNodeLands
  root=…37.7364500Z  policy=…37.7405650Z  firstContent=OrderPlug/Doc01@…37.7396120Z

Failed  ScopedPackage_GatesEveryChild_BeforeTheChildLands_AndOpensTheCoverLast
  hiddenDeny=…36.4103840Z  rootGrant=…36.4089380Z  hidden=…36.3996290Z

Failed!  - Failed: 3, Passed: 13, Total: 16
```

With the fix, on the same machine:

```
Passed  FullyPublicPackage_IsPublished_BeforeItsFirstContentNodeLands
  root=…11.2744180Z  policy=…11.2809650Z  firstContent=OrderPlug/Doc01@…11.2812710Z
Test Run Successful.  Total tests: 16  Passed: 16
```

(`WrittenPaths` with the fix: `OrderOwnPolicy, OrderOwnPolicy/_Policy, Doc01 …` — index 1, not 13.)

## Suites run locally, Release + `-warnaserror`

| suite | result |
|---|---|
| MeshWeaver.PluginCatalog.Test | **425 passed**, 0 failed |
| MeshWeaver.Graph.Test | **1296 passed**, 0 failed |
| MeshWeaver.Hosting.Monolith.Test | **752 passed**, 0 failed, 3 skipped |
| MeshWeaver.Documentation.Test | 37 passed |
| MeshWeaver.AccessControl.Test | 29 passed |

Build: `0 Warning(s), 0 Error(s)` for every touched project and its dependents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)