### PR TITLE
feat: a node page publishes its own icon to the browser tab

### DIFF
--- a/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
+++ b/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
@@ -129,7 +129,7 @@ public static class SeoResolver
         ExtractImage(node) ?? $"/api/og/{node.Path}";
 
     /// <summary>The one media type that tells every consumer "this icon scales losslessly".</summary>
-    private const string SvgMediaType = "image/svg+xml";
+    private const string SvgMediaType = MeshNodeImageHelper.SvgMediaType;
 
     /// <summary>
     /// 🚨 THE PAGE'S OWN ICON — the node's icon, so a node page identifies itself rather than the
@@ -186,8 +186,9 @@ public static class SeoResolver
             ? SvgMediaType
             : null;
 
-    private static string SvgDataUri(string svg) =>
-        "data:" + SvgMediaType + "," + Uri.EscapeDataString(svg);
+    // One encoding rule for the whole product: the head, the tab and the app all carry an inline
+    // <svg> icon the same way (MeshNodeImageHelper.SvgDataUri).
+    private static string SvgDataUri(string svg) => MeshNodeImageHelper.SvgDataUri(svg);
 
     /// <summary>
     /// A string member of the node's content, by camelCase JSON name. Content arrives here in two

--- a/src/MeshWeaver.Blazor/Pages/ApplicationPage.razor
+++ b/src/MeshWeaver.Blazor/Pages/ApplicationPage.razor
@@ -14,6 +14,18 @@
 <FluentDesignTheme @bind-Mode="@Mode" StorageName="theme" />
 
 <PageTitle>@PageTitle</PageTitle>
+@if (TabIcon is { } tabIcon)
+{
+    @* The NODE's own icon in the browser tab. Declared here — inside HeadOutlet, which App.razor
+       places AFTER its site-wide favicon — so it outranks that one: an icon later in the head wins
+       over an earlier one of equal rank, which is the same ordering SeoHead relies on for the
+       crawler-facing head. Unlike SeoHead this runs in the CIRCUIT, so it also covers the pages a
+       crawler never sees (every authenticated page) and re-emits on each in-circuit navigation
+       instead of only on the initial HTTP response. *@
+    <HeadContent>
+        <link rel="icon" href="@tabIcon.Href" type="@tabIcon.Type" />
+    </HeadContent>
+}
 <CascadingValue Value="@Mode" Name="ThemeMode">
     @*
         Rule enforced here: every branch renders a descriptive text label.

--- a/src/MeshWeaver.Blazor/Pages/ApplicationPage.razor.cs
+++ b/src/MeshWeaver.Blazor/Pages/ApplicationPage.razor.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
+using MeshWeaver.Graph;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -63,6 +64,15 @@ public partial class ApplicationPage : ComponentBase, IDisposable
     public string? Path { get; set; } = "";
 
     private string? PageTitle { get; set; } = "";
+
+    /// <summary>
+    /// The node's own icon, published to the browser tab through <c>&lt;link rel="icon"&gt;</c> —
+    /// so a tab strip full of pages is readable, instead of the same portal favicon repeated.
+    /// Resolved next to <see cref="PageTitle"/> from the SAME navigation context, and therefore
+    /// swapped on every in-circuit navigation; null while no node is resolved (loading, Not Found,
+    /// an area page with no node), which leaves the site-wide favicon in place.
+    /// </summary>
+    private IconLink? TabIcon { get; set; }
 
     /// <summary>Catches any route parameters not explicitly declared; passed through to the layout area as additional options.</summary>
     [Parameter(CaptureUnmatchedValues = true)]
@@ -238,6 +248,7 @@ public partial class ApplicationPage : ComponentBase, IDisposable
         if (context is null)
         {
             PageTitle = IsLoading ? "Loading..." : "Page Not Found";
+            TabIcon = null;
             PreRenderedHtml = null;
             return;
         }
@@ -277,6 +288,10 @@ public partial class ApplicationPage : ComponentBase, IDisposable
         PageTitle = context.Node?.Name
             ?? context.Address.Segments.LastOrDefault()
             ?? context.Address.Type;
+
+        // …and the node's own icon for the tab, resolved exactly as the app resolves it everywhere
+        // else (MeshNodeImageHelper.ResolveIconLink → ResolveNodeIcon), so tab and app agree.
+        TabIcon = context.Node is { } node ? MeshNodeImageHelper.ResolveIconLink(node) : null;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
@@ -411,6 +411,15 @@ So a "Local" tab is unmistakable next to Test/Prod, the portal supports two opti
 
 These are implemented in `memex/Memex.Portal.Shared/App.razor`: when `Portal:InstanceName` is set it emits an inline-SVG data-URI favicon (a rounded-square badge with the initial) and a small `MutationObserver` that pins the tab title to the instance name. Unset → the standard `favicon.ico` and `Memex Portal` title. Set `Portal__InstanceName: "Local"` in your overlay so your local tab is obvious at a glance.
 
+🚨 **On a node page the NODE's icon wins over the badge, by design.** `ApplicationPage` publishes the
+node's own icon into the head from inside `HeadOutlet`, which App.razor places *after* the badge —
+and a later icon of equal rank outranks an earlier one, the same ordering `SeoHead` relies on. The
+environment stays unmistakable through the **title**, which the `MutationObserver` pins to the
+instance name on every page including node pages; the icon is what tells your open tabs apart. The
+badge still shows on every non-node page (login, search, onboarding, welcome). If an instance ever
+needs the badge to win everywhere, move that `<link rel="icon">` below `<SeoHead />` — precedence
+here is document order, nothing else.
+
 ---
 
 ## 13. Optional (advanced): home-wide access with a real cheap domain

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-your-browser-tabs-tell-themselves-apart.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-your-browser-tabs-tell-themselves-apart.md
@@ -1,0 +1,31 @@
+---
+Name: Your browser tabs tell themselves apart
+Category: Feature
+Description: Every node page now shows its own icon in the browser tab — the same mark the portal draws for it in the tree and on its cards — so a row of open tabs is readable instead of a row of identical portal favicons.
+Icon: TabDesktop
+Order: -20260818
+---
+
+# Your browser tabs tell themselves apart
+
+Work in this portal for an hour and you have eight tabs open. Until now all eight
+wore the same portal favicon, and the tab strip narrowed each title to two or three
+words — so finding the thread you were just in meant clicking through them.
+
+Each of those pages already had a mark of its own. The portal drew it in the tree,
+in menus, on every card. The browser tab was the one place it never reached.
+
+Now it does. **A node page publishes its own icon to the tab**, and it is the same
+icon the app shows you everywhere else: the node's own, else the glyph of its type —
+a document for a page, a chat bubble for a thread, a robot for an agent — and for a
+thread, the identicon unique to it. Nothing is invented for the tab; if the app
+shows a mark for a page, that is the mark the tab shows.
+
+It follows you as you navigate. The icon is resolved from the same page context that
+sets the tab title, so it swaps the moment you move to another node rather than only
+on a fresh page load — and it applies to every page you can see, not just the public
+ones that link previews already covered.
+
+One limitation worth naming: Safari began supporting scalable tab icons in Safari 26.
+On Safari 18 and older the tab keeps the portal favicon exactly as before — nothing
+gets worse there, it just does not get better.

--- a/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
+++ b/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Mesh;
 using DomainIcon = MeshWeaver.Domain.Icon;
@@ -30,6 +31,18 @@ public enum IconRenderKind
 /// <param name="Kind">The element the value has to be rendered with.</param>
 /// <param name="Value">The icon value — a URL, inline svg markup, or a text glyph, per <paramref name="Kind"/>.</param>
 public readonly record struct RenderableIcon(IconRenderKind Kind, string Value);
+
+/// <summary>
+/// An icon ready to hang off a <c>&lt;link rel="icon"&gt;</c>: a value an <c>href</c> can carry,
+/// plus the media type to declare with it.
+/// </summary>
+/// <param name="Href">A URL the portal already serves (a shipped glyph, an access-controlled
+/// content file), or an inline <c>data:</c> URI for an icon whose value is MARKUP rather than a
+/// location (raw <c>&lt;svg&gt;</c>, a text glyph).</param>
+/// <param name="Type">The media type to declare, or null when the value alone does not pin one
+/// down — declaring the WRONG type is worse than declaring none, because a browser ranking several
+/// icons by type would then rank this one on a lie.</param>
+public readonly record struct IconLink(string Href, string? Type);
 
 /// <summary>
 /// Helper for resolving and classifying a mesh node's icon for rendering. Resolves
@@ -274,6 +287,108 @@ public static class MeshNodeImageHelper
         var insertAt = idx + "<svg".Length;
         return svg.Insert(insertAt,
             $" style=\"width: {pixels}px; height: {pixels}px; display: block;\"");
+    }
+
+    /// <summary>The one media type that tells a browser "this icon scales losslessly".</summary>
+    public const string SvgMediaType = "image/svg+xml";
+
+    /// <summary>
+    /// 🚨 THE NODE'S ICON, READY FOR THE BROWSER TAB — a node page identifies itself in the tab
+    /// strip rather than wearing the same portal favicon as every other page.
+    ///
+    /// <para>Resolution is <see cref="ResolveNodeIcon"/>, i.e. EXACTLY what the app already renders
+    /// for the node in the tree, the menus and its cards (own icon → the shipped glyph of that name
+    /// → the NodeType default → a neutral box). Nothing is synthesised beyond putting a value an
+    /// <c>href</c> cannot carry into a form it can: an inline <c>&lt;svg&gt;</c> identicon and a text
+    /// glyph travel as <c>data:</c> URIs because they are MARKUP, not locations — the same mechanism
+    /// the per-instance favicon uses. So the tab and the app can never disagree about what a node
+    /// looks like.</para>
+    ///
+    /// <para>Total, like <see cref="ResolveNodeIcon"/>: every node resolves to something, so a tab
+    /// never silently keeps the previous page's icon.</para>
+    /// </summary>
+    /// <param name="node">The node whose page is being shown.</param>
+    public static IconLink ResolveIconLink(MeshNode node) =>
+        IconLinkFor(ResolveNodeIcon(node));
+
+    /// <summary>
+    /// The <c>&lt;link rel="icon"&gt;</c> form of one icon value, classified the same way the
+    /// rendered icon is (<see cref="ResolveRenderable"/>) so the two cannot drift apart.
+    /// </summary>
+    /// <param name="icon">The icon value — any of the four forms (URL, inline svg, glyph, Fluent name).</param>
+    /// <param name="fallback">The icon to fall back to when <paramref name="icon"/> cannot be
+    /// rendered; the neutral box glyph when omitted.</param>
+    public static IconLink IconLinkFor(string? icon, string? fallback = null)
+    {
+        var renderable = ResolveRenderable(icon, fallback);
+        return renderable.Kind switch
+        {
+            IconRenderKind.InlineSvg => new IconLink(SvgDataUri(renderable.Value), SvgMediaType),
+            IconRenderKind.Glyph => new IconLink(SvgDataUri(GlyphSvg(renderable.Value)), SvgMediaType),
+            _ => new IconLink(renderable.Value, MediaTypeOfUrl(renderable.Value)),
+        };
+    }
+
+    /// <summary>Inline <c>&lt;svg&gt;</c> markup as a <c>data:</c> URI — percent-encoded rather than
+    /// base64 so the markup stays readable in view-source and the URI stays short.</summary>
+    public static string SvgDataUri(string svg) =>
+        "data:" + SvgMediaType + "," + Uri.EscapeDataString(svg);
+
+    /// <summary>
+    /// A text glyph (an emoji) wrapped in an SVG that draws it, because no <c>href</c> can carry a
+    /// character. Only the FIRST grapheme cluster is drawn — a multi-codepoint emoji is one cluster,
+    /// while an icon field holding a whole word would otherwise overflow the canvas.
+    /// </summary>
+    private static string GlyphSvg(string glyph)
+    {
+        var cluster = glyph.Length == 0
+            ? glyph
+            : glyph[..StringInfo.GetNextTextElementLength(glyph)];
+        return "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 32 32\">"
+               + "<text x=\"16\" y=\"17\" text-anchor=\"middle\" dominant-baseline=\"central\" "
+               + "font-size=\"28\">" + XmlEscape(cluster) + "</text></svg>";
+    }
+
+    /// <summary>Escapes the five XML markup characters so a glyph like <c>R&amp;D</c> still yields
+    /// well-formed SVG.</summary>
+    private static string XmlEscape(string text) => text
+        .Replace("&", "&amp;", StringComparison.Ordinal)
+        .Replace("<", "&lt;", StringComparison.Ordinal)
+        .Replace(">", "&gt;", StringComparison.Ordinal)
+        .Replace("\"", "&quot;", StringComparison.Ordinal)
+        .Replace("'", "&apos;", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The media type an icon URL pins down by itself, or null when it does not. A content-route URL
+    /// carries the file's extension, so this covers the authored cases; anything unrecognised is
+    /// declared as nothing rather than guessed at.
+    /// </summary>
+    private static string? MediaTypeOfUrl(string url)
+    {
+        if (url.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        {
+            var mime = url["data:".Length..];
+            var end = mime.IndexOfAny([';', ',']);
+            mime = end < 0 ? mime : mime[..end];
+            return mime.StartsWith("image/", StringComparison.OrdinalIgnoreCase) ? mime : null;
+        }
+
+        // A query string is legitimate on a content URL, so match the extension before it — and only
+        // within the last SEGMENT, or a dotted directory ("ACME/My.Space/content/logo") would read as
+        // an extension and get a made-up media type.
+        var path = url.Split('?')[0];
+        var file = path[(path.LastIndexOf('/') + 1)..];
+        var dot = file.LastIndexOf('.');
+        return dot < 0 ? null : file[(dot + 1)..].ToLowerInvariant() switch
+        {
+            "svg" => SvgMediaType,
+            "png" => "image/png",
+            "ico" => "image/x-icon",
+            "jpg" or "jpeg" => "image/jpeg",
+            "gif" => "image/gif",
+            "webp" => "image/webp",
+            _ => null,
+        };
     }
 
     /// <summary>

--- a/test/MeshWeaver.Graph.Test/MeshNodeImageHelperTest.cs
+++ b/test/MeshWeaver.Graph.Test/MeshNodeImageHelperTest.cs
@@ -1,3 +1,4 @@
+using System.Xml.Linq;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
 using Xunit;
@@ -238,4 +239,116 @@ public class MeshNodeImageHelperTest
     public void NeitherIconNorFallback_StillYieldsTheNeutralGlyph(string? icon, string? fallback)
         => MeshNodeImageHelper.ResolveRenderable(icon, fallback)
             .Should().Be(new RenderableIcon(IconRenderKind.Image, "/static/NodeTypeIcons/box.svg"));
+
+    /// <summary>
+    /// The browser tab is a <c>&lt;link rel="icon"&gt;</c>, so every icon form has to come out as
+    /// something an <c>href</c> can carry — otherwise the tab silently keeps the site-wide favicon
+    /// and a tab strip full of pages stays unreadable. A URL travels as itself, with the media type
+    /// its extension pins down.
+    /// </summary>
+    [Theory]
+    [InlineData("/static/NodeTypeIcons/document.svg", "image/svg+xml")]
+    [InlineData("/api/content/ACME/Space/content/logo.png", "image/png")]
+    [InlineData("/api/content/ACME/Space/content/logo.PNG", "image/png")]
+    [InlineData("/api/content/ACME/Space/content/cover.jpeg", "image/jpeg")]
+    [InlineData("https://example.com/mark.svg", "image/svg+xml")]
+    [InlineData("data:image/png;base64,abc", "image/png")]
+    [InlineData("/api/content/ACME/Space/content/logo.svg?v=3", "image/svg+xml")]
+    public void IconLinkFor_AUrl_TravelsAsItself_WithItsOwnMediaType(string icon, string expectedType)
+        => MeshNodeImageHelper.IconLinkFor(icon)
+            .Should().Be(new IconLink(icon, expectedType));
+
+    /// <summary>
+    /// A type we cannot pin down is declared as NOTHING rather than guessed at — a browser ranking
+    /// several icons by type must never be told a wrong one.
+    /// </summary>
+    [Theory]
+    [InlineData("/api/content/ACME/Space/content/mark")]
+    [InlineData("/api/content/ACME/Space/content/mark.weird")]
+    // A dotted DIRECTORY is not an extension — reading one as ".Space" would declare a made-up type.
+    [InlineData("/api/content/ACME/My.Space/content/mark")]
+    public void IconLinkFor_AnUnknownExtension_DeclaresNoType(string icon)
+        => MeshNodeImageHelper.IconLinkFor(icon)
+            .Should().Be(new IconLink(icon, null));
+
+    /// <summary>
+    /// Inline <c>&lt;svg&gt;</c> is MARKUP, not a location — every thread carries one
+    /// (<c>ThreadIconGenerator</c>) — so it has to become a data URI. An <c>href</c> pointing at raw
+    /// svg text is exactly the broken-image case <see cref="MeshNodeImageHelper.ResolveRenderable"/>
+    /// exists to prevent.
+    /// </summary>
+    [Fact]
+    public void IconLinkFor_InlineSvg_BecomesADataUri()
+    {
+        const string svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\"></svg>";
+
+        var link = MeshNodeImageHelper.IconLinkFor(svg);
+
+        link.Type.Should().Be("image/svg+xml");
+        link.Href.Should().StartWith("data:image/svg+xml,");
+        Uri.UnescapeDataString(link.Href["data:image/svg+xml,".Length..])
+            .Should().Be(svg, "the node's icon travels byte for byte — only its transport changes");
+    }
+
+    /// <summary>
+    /// A text glyph cannot be an <c>href</c> either, so it is drawn INTO an svg. Without this an
+    /// emoji-iconed node fell back to the portal favicon, which is the very sameness this fixes.
+    /// </summary>
+    [Theory]
+    [InlineData("🎯")]
+    [InlineData("➕")]
+    public void IconLinkFor_AGlyph_IsDrawnIntoAnSvgDataUri(string glyph)
+    {
+        var link = MeshNodeImageHelper.IconLinkFor(glyph);
+
+        link.Type.Should().Be("image/svg+xml");
+        var svg = Uri.UnescapeDataString(link.Href["data:image/svg+xml,".Length..]);
+        svg.Should().StartWith("<svg").And.EndWith("</svg>").And.Contain(glyph);
+    }
+
+    /// <summary>Only the first grapheme cluster is drawn: an icon field holding a word would
+    /// otherwise run off the canvas, and a multi-codepoint emoji must stay ONE glyph.</summary>
+    [Theory]
+    [InlineData("R&D", "R")]
+    [InlineData("hello", "h")]
+    [InlineData("👨‍👩‍👧‍👦", "👨‍👩‍👧‍👦")]
+    public void IconLinkFor_AGlyph_DrawsOneClusterAndEscapesIt(string glyph, string expected)
+    {
+        var svg = Uri.UnescapeDataString(
+            MeshNodeImageHelper.IconLinkFor(glyph).Href["data:image/svg+xml,".Length..]);
+
+        // The markup must be well-formed even for a glyph containing XML characters.
+        XDocument.Parse(svg).Root!.Value.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The tab shows what the app shows: <see cref="MeshNodeImageHelper.ResolveIconLink"/> is
+    /// <see cref="MeshNodeImageHelper.ResolveNodeIcon"/>, so a node with no icon of its own reads as
+    /// its NodeType rather than falling back to the portal favicon.
+    /// </summary>
+    [Fact]
+    public void ResolveIconLink_NoOwnIcon_UsesTheNodeTypeGlyph()
+        => MeshNodeImageHelper.ResolveIconLink(new MeshNode("Page", "ACME") { NodeType = "Markdown" })
+            .Should().Be(new IconLink("/static/NodeTypeIcons/document.svg", "image/svg+xml"));
+
+    /// <summary>A typeless node still resolves — total, so a tab never keeps the PREVIOUS page's
+    /// icon after navigating.</summary>
+    [Fact]
+    public void ResolveIconLink_IsTotal_EvenForATypelessIconlessNode()
+        => MeshNodeImageHelper.ResolveIconLink(new MeshNode("Page", "ACME"))
+            .Should().Be(new IconLink("/static/NodeTypeIcons/box.svg", "image/svg+xml"));
+
+    /// <summary>A <c>content:</c> icon resolves through the ACCESS-CONTROLLED content route (issue
+    /// #587), never <c>/static/storage</c> — the tab must not be a way around a partition's policy.</summary>
+    [Fact]
+    public void ResolveIconLink_AContentIcon_UsesTheAccessControlledRoute()
+    {
+        var node = new MeshNode("Space", "ACME") { NodeType = "Space", Icon = "content:logo.svg" };
+
+        var link = MeshNodeImageHelper.ResolveIconLink(node);
+
+        link.Type.Should().Be("image/svg+xml");
+        link.Href.Should().StartWith("/api/content/").And.EndWith("logo.svg");
+        link.Href.Should().NotContain("/static/storage");
+    }
 }

--- a/test/MeshWeaver.Portal.E2E.Test/TabFaviconTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/TabFaviconTest.cs
@@ -1,0 +1,116 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// Browser proof that a node page puts its OWN icon in the browser tab — the one thing no unit test
+/// can show, because the tab icon is not in the HTTP response at all.
+///
+/// <para><b>Why a real browser is the only witness.</b> The portal's interactive components render
+/// with prerendering off, so the initial HTML carries the site-wide <c>favicon.ico</c> and an EMPTY
+/// title; both the title and the icon are filled in by the circuit, through <c>HeadOutlet</c>. A
+/// curl of a node page therefore shows no node icon even when the feature works perfectly — and
+/// equally would show none if it were broken. Only a connected circuit distinguishes the two.</para>
+///
+/// <para>Two behaviours are pinned: the icon a page publishes is the node's own (resolved exactly as
+/// the app resolves it everywhere else, so a node with no icon of its own reads as its TYPE), and it
+/// SWAPS on an in-circuit navigation rather than only on a fresh page load — the whole point being a
+/// tab strip you can read, which a favicon that only updates on F5 would not deliver.</para>
+///
+/// Drives the real portal — Skips unless E2E is enabled (see <see cref="PortalFixture"/>).
+/// </summary>
+[Collection("portal-e2e")]
+public class TabFaviconTest(PortalFixture fixture)
+{
+    /// <summary>Reads the LAST declared <c>rel="icon"</c> — the one a browser resolves the tab from,
+    /// and the position the feature depends on (App.razor declares the site favicon before
+    /// <c>HeadOutlet</c> precisely so the page's own icon outranks it).</summary>
+    private const string LastIconHrefJs = """
+        () => {
+          const links = [...document.querySelectorAll('link[rel~="icon"]')];
+          const last = links[links.length - 1];
+          return last ? last.getAttribute('href') : null;
+        }
+        """;
+
+    [Fact]
+    public async Task ANodePage_PublishesItsOwnIcon_AndSwapsItOnInCircuitNavigation()
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+        await using var context = await fixture.NewAuthenticatedContextAsync();
+        var token = await fixture.MintTokenAsync(context);
+
+        // A page carrying NO icon of its own: it must read as its NodeType (a document), never as the
+        // portal favicon — that sameness is the defect this fixes.
+        var plainPath = await SeedAsync(context, token, "Tab icon — plain (e2e)", icon: null);
+        // …and one whose icon is a GLYPH: a value no href can carry, so it only reaches the tab if it
+        // is drawn into an svg. Authored icons are the case a user notices first.
+        var glyphPath = await SeedAsync(context, token, "Tab icon — glyph (e2e)", icon: "🎯");
+
+        (await fixture.WaitUntilReadableAsync(context, token, plainPath, TimeSpan.FromSeconds(30)))
+            .Should().BeTrue("the seeded page must be readable before the UI is driven");
+        (await fixture.WaitUntilReadableAsync(context, token, glyphPath, TimeSpan.FromSeconds(30)))
+            .Should().BeTrue("the seeded page must be readable before the UI is driven");
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync($"{fixture.BaseUrl}/{plainPath}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 60_000 });
+        page.Url.Should().NotContain("/login");
+
+        // The circuit fills the head in; wait for the icon to stop being the site-wide favicon.
+        await WaitForIconAsync(page, "/static/NodeTypeIcons/document.svg");
+        (await IconHrefAsync(page)).Should().Be("/static/NodeTypeIcons/document.svg",
+            "a page with no icon of its own reads as its NodeType, not as the portal");
+
+        // An IN-CIRCUIT navigation (no page load): the tab icon has to follow the page, the same way
+        // the tab title already does.
+        await page.EvaluateAsync("path => Blazor.navigateTo(path, false)", $"/{glyphPath}");
+
+        var glyphIcon = await WaitForIconAsync(page, "image/svg+xml");
+        Uri.UnescapeDataString(glyphIcon).Should().Contain("🎯",
+            "the node's authored glyph is drawn into the tab icon, and it swapped without a page load");
+    }
+
+    /// <summary>Waits until the resolved tab icon contains <paramref name="expected"/>, then returns it.</summary>
+    private static async Task<string> WaitForIconAsync(IPage page, string expected)
+    {
+        await page.WaitForFunctionAsync(
+            """
+            expected => {
+              const links = [...document.querySelectorAll('link[rel~="icon"]')];
+              const last = links[links.length - 1];
+              return !!last && (last.getAttribute('href') || '').includes(expected);
+            }
+            """,
+            expected,
+            new PageWaitForFunctionOptions { Timeout = 60_000 });
+        return await IconHrefAsync(page);
+    }
+
+    private static async Task<string> IconHrefAsync(IPage page) =>
+        await page.EvaluateAsync<string>(LastIconHrefJs) ?? "";
+
+    /// <summary>Seeds a markdown page in the signed-in user's writable partition; returns its path.</summary>
+    private async Task<string> SeedAsync(IBrowserContext context, string token, string name, string? icon)
+    {
+        var id = $"tab{Guid.NewGuid():N}"[..14];
+        var partition = fixture.UserPartition;
+        var path = $"{partition}/{id}";
+        var iconField = icon is null ? "" : $"""
+              "icon": "{icon}",
+            """;
+        await fixture.CreateNodeAsync(context, token, $$"""
+            {
+              "id": "{{id}}",
+              "namespace": "{{partition}}",
+              "name": "{{name}}",
+              "nodeType": "Markdown",
+              "mainNode": "{{path}}",
+            {{iconField}}
+              "content": { "$type": "MarkdownContent", "content": "# Tab icon (e2e)\n\nA page whose tab shows its own icon.\n" }
+            }
+            """);
+        return path;
+    }
+}


### PR DESCRIPTION
## What

Every browser tab wore the same portal favicon. Now a node page publishes **its own icon** to the tab — the same mark the portal already draws for it in the tree, in menus and on cards.

`SeoHead` began lifting the node's icon into the head on 2026-08-11, but only for **anonymous** requests and only on the **initial HTTP response**. So every authenticated page (in practice: all of them) and every in-circuit navigation kept the generic favicon.

`ApplicationPage` now publishes it from inside the circuit, right next to the `PageTitle` it already sets from the same navigation context:

- covers authenticated pages, not just the public ones a crawler sees;
- **swaps on in-circuit navigation**, not only on a full page load;
- declared inside `HeadOutlet` — which `App.razor` places *after* its site-wide favicon — so the page's icon outranks it, the same ordering `SeoHead` relies on.

Resolution is `MeshNodeImageHelper.ResolveNodeIcon`, i.e. exactly what the app renders everywhere else (own icon → shipped glyph of that name → NodeType default → neutral box), so the tab and the app cannot disagree. **Nothing is synthesised**: the only transformation is putting a value an `href` cannot carry into a form it can — inline `<svg>` (every thread's identicon) and text glyphs travel as `data:` URIs, the mechanism the per-instance favicon already uses.

## Scope decisions

- **The node's own icon, as-is** — no per-node colour tinting or synthesised badge. Tabs differ by type, and by node wherever an icon is authored (threads already carry identicons).
- **No PNG rasterizer.** caniuse: Safari supports SVG favicons from **Safari 26**; every version through 18.7 does not and keeps `favicon.ico` exactly as today — nothing regresses, it just does not improve there. A rasterizer (`Svg.Skia` + a permission-checked `/api/favicon/{path}.png`) would buy only Safari ≤18.7, so it stays a clean follow-up if that turns out to matter.
- On an instance with `Portal:InstanceName` set (local installs), the **node icon now wins over the amber badge on node pages**; the environment stays unmistakable through the title, which the existing `MutationObserver` pins to the instance name on every page. Documented in `LocalColimaMac.md` §12, including the one-line change to flip the precedence back.

## Verification

🚨 **The tab icon is not in the HTTP response at all** — interactive components render with prerendering off, so the initial HTML carries `favicon.ico` and an *empty* title; both are filled in by the circuit. A curl shows no node icon whether the feature works or is broken, so only a real browser distinguishes the two.

- `test/MeshWeaver.Portal.E2E.Test/TabFaviconTest` (opt-in, self-skips in CI) drives a real portal in Chromium and pins both behaviours: a page with no icon of its own reads as its **NodeType**, and an authored glyph icon appears **after an in-circuit `Blazor.navigateTo`** — green against a local monolith.
- `MeshNodeImageHelperTest` table-tests the resolution: URL passthrough with the media type its extension pins down (and *no* type when it pins none), inline `<svg>` → `data:` URI byte-for-byte, glyph → drawn into an svg (one grapheme cluster, XML-escaped), `content:` refs through the **access-controlled** content route, totality for a typeless node. 83 passed.
- `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` green after the doc edits.
- `-c Release -warnaserror`: MeshWeaver.Graph (also `--no-incremental`), MeshWeaver.Blazor, Memex.Portal.Shared, MeshWeaver.Graph.Test, MeshWeaver.Documentation.Test, MeshWeaver.Portal.E2E.Test — 0 warnings, 0 errors.

## What's New

`2026-08-18-your-browser-tabs-tell-themselves-apart.md` (Category: Feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)