### PR TITLE
One apt-lock wait, shared — clients.yml had none that worked

### DIFF
--- a/.github/scripts/wait-for-apt.sh
+++ b/.github/scripts/wait-for-apt.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Wait until no apt/dpkg process is running, so a following `apt-get` (usually via
+# `playwright install --with-deps`) can take the lock instead of losing a race to the runner
+# image's own background apt (unattended-upgrades / the daily timer).
+#
+# 🚨 WAIT FOR THE HOLDER TO FINISH — do not "check the lock". The shape this replaced was
+#   sudo flock -w N /var/lib/apt/lists/lock true
+# which ACQUIRES the lock and releases it in the same breath, reserving nothing: the holder
+# re-takes it before playwright's apt-get gets there. Measured — after that wait reported the
+# lock free, the very next line still failed with
+#   E: Could not get lock /var/lib/apt/lists/lock. It is held by process 3014 (apt-get)
+# apt also locks with fcntl, which does not interoperate with flock, so that shape could not
+# have been reliable even without the release race. See #1843 / #1858.
+#
+# Bounded by the first argument (default 240s): it can wait, it cannot hang. Exits 0 either way —
+# a timed-out wait is not a reason to skip the install, which is bounded on its own.
+set -euo pipefail
+budget="${1:-240}"
+waited=0
+while [ "$waited" -lt "$budget" ]; do
+  pgrep -x apt-get >/dev/null 2>&1 || pgrep -f unattended-upgr >/dev/null 2>&1 || break
+  sleep 3
+  waited=$((waited + 3))
+done
+[ "$waited" -gt 0 ] && echo "waited ${waited}s for a competing apt to finish" >&2
+exit 0

--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -283,6 +283,6 @@ jobs:
       # not a broken download. ONE shared implementation, because two copies of this drift and the
       # copy that drifts is the one nobody notices until a shard reddens on an unrelated PR (#1843).
       - run: |
-          .github/scripts/wait-for-apt.sh
+          "$GITHUB_WORKSPACE/.github/scripts/wait-for-apt.sh"
           timeout --signal=TERM --kill-after=30 180 npx playwright install --with-deps chromium
       - run: npm run e2e # expo export --platform web → serve dist/ → drive headless Chromium

--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -280,9 +280,9 @@ jobs:
       # already converts a silent hang into a visible, re-runnable infra failure.
       # The apt wait is for the same reason as dotnet-test's: `--with-deps` shells out to apt-get,
       # and the runner's own background apt makes it exit 100 "Could not get lock" — contention,
-      # not a broken download. `flock … true` waits for that holder and releases immediately, so
-      # playwright takes the lock itself. Both bounds are hard: it can wait, it cannot hang.
+      # not a broken download. ONE shared implementation, because two copies of this drift and the
+      # copy that drifts is the one nobody notices until a shard reddens on an unrelated PR (#1843).
       - run: |
-          sudo flock -w 60 /var/lib/apt/lists/lock true 2>/dev/null || true
+          .github/scripts/wait-for-apt.sh
           timeout --signal=TERM --kill-after=30 180 npx playwright install --with-deps chromium
       - run: npm run e2e # expo export --platform web → serve dist/ → drive headless Chromium

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -650,7 +650,7 @@ jobs:
           # Wait for the runner's own background apt to finish before `--with-deps` shells out
           # to apt-get. Shared with clients.yml — the WHY (and why "check the lock" does not work)
           # lives in the script, so the two cannot drift apart. #1843 / #1858.
-          .github/scripts/wait-for-apt.sh "$APT_LOCK_WAIT"
+          "$GITHUB_WORKSPACE/.github/scripts/wait-for-apt.sh" "$APT_LOCK_WAIT"
           rc=0
           timeout --signal=TERM --kill-after=30 "$BROWSER_INSTALL_TIMEOUT" \
             npx --yes "playwright-core@${PLAYWRIGHT_VERSION}" install --with-deps --only-shell chromium || rc=$?

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -647,28 +647,10 @@ jobs:
           # deadlock). Bounded, like everything else here: it can wait, it cannot hang. `|| true`
           # because a timed-out wait is not a reason to skip the attempt — apt may well be free by
           # the time npx reaches it, and the attempt itself is bounded anyway.
-          # 🚨 WAIT FOR THE COMPETING PROCESS TO EXIT — not for a lock to be momentarily free.
-          #
-          # The previous shape was `flock -w N <lock> true`, which ACQUIRES the lock and releases
-          # it in the same breath. That reserves nothing: the runner image's background apt
-          # (unattended-upgrades / the daily timer) re-takes it before playwright's own apt-get
-          # gets there, so the wait returns "free" and the install fails anyway. Measured on this
-          # very branch — waiting on all three lock files still failed with
-          #   E: Could not get lock /var/lib/apt/lists/lock. It is held by process 3014 (apt-get)
-          # i.e. the same holder, immediately after our wait said the lock was available.
-          #
-          # apt also locks with fcntl, which does not interoperate with flock, so the earlier
-          # approach could not have worked reliably even without the release race.
-          #
-          # What actually settles it is the holder FINISHING. Bounded, like everything here: it
-          # can wait, it cannot hang.
-          waited=0
-          while [ "$waited" -lt "$APT_LOCK_WAIT" ]; do
-            pgrep -x apt-get >/dev/null 2>&1 || pgrep -f unattended-upgr >/dev/null 2>&1 || break
-            sleep 3
-            waited=$((waited + 3))
-          done
-          [ "$waited" -gt 0 ] && echo "waited ${waited}s for a competing apt to finish" >&2
+          # Wait for the runner's own background apt to finish before `--with-deps` shells out
+          # to apt-get. Shared with clients.yml — the WHY (and why "check the lock" does not work)
+          # lives in the script, so the two cannot drift apart. #1843 / #1858.
+          .github/scripts/wait-for-apt.sh "$APT_LOCK_WAIT"
           rc=0
           timeout --signal=TERM --kill-after=30 "$BROWSER_INSTALL_TIMEOUT" \
             npx --yes "playwright-core@${PLAYWRIGHT_VERSION}" install --with-deps --only-shell chromium || rc=$?


### PR DESCRIPTION
Follow-up to #1858, from its own review.

## What was still exposed

`clients.yml` runs the same `playwright install --with-deps` with the **old** shape:

```bash
sudo flock -w 60 /var/lib/apt/lists/lock true 2>/dev/null || true
```

That acquires the lock and releases it in the same breath — **it reserves nothing**, so the runner's background apt re-takes it before playwright's `apt-get` gets there. The fix landed in `dotnet-test.yml` while this workflow stayed exposed to identical contention.

And two copies of this logic drift. The copy that drifts is the one nobody notices, until a shard reddens on a PR whose diff cannot touch tests.

## The change

Extracted to **`.github/scripts/wait-for-apt.sh`**, used by both workflows.

The script carries the *why* — that checking a lock and releasing it loses the race (measured: the very next line still failed on the same holder), and that apt locks with **fcntl**, which does not interoperate with `flock` at all. Keeping the rationale in one place is the point: it cannot go stale in one copy while the other keeps it.

Bounded exactly as before (default 240 s; `dotnet-test` passes `APT_LOCK_WAIT`), and exits 0 either way — a timed-out wait is not a reason to skip an install that is bounded on its own.

Verified: both workflows YAML-parse, every `run:` block passes `bash -n`, and the script passes `bash -n`.

Refs #1843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFx1SsoKDhRKHdaJbQPEWQ