### PR TITLE
voice-gateway: wake-storm hardening, real-world context, local-mesh portal

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -374,10 +374,43 @@ jobs:
       #     Later ticks then cost ~40 s and print nothing — loud once, then quiet, which is the
       #     opposite of a repeating alarm nobody reads. Closing the issue is a deliberate human
       #     act and legitimately grants a fresh budget.
+      - name: "Are there image-relevant changes since the newest published set?"
+        id: relevance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -uo pipefail
+          # Paths that PROVABLY enter no published image: the standalone clients (a Python LAN
+          # gateway and the Expo app — neither is COPY'd by any Dockerfile in the set). A merge
+          # touching ONLY these must not cost a ~20-minute five-image build and a fleet roll.
+          # 🚨 FAIL-OPEN: any doubt — no published set, unresolvable base, unreadable compare —
+          # publishes as today. The only way to skip is a POSITIVE finding that every changed
+          # file since the newest PUBLISHED set matches the list. Diffing against the newest
+          # published set (not HEAD^) is what keeps the reconciler stable: a skipped tip differs
+          # from the last set only by irrelevant files, so the reconcile branch skips it too
+          # instead of "healing" it back into a build every tick.
+          IRRELEVANT='^clients/(react-native|voice-gateway)/'
+          relevant=true
+          newest_short=$(az acr repository show-tags -n meshweaver --repository memex-portal-ai \
+            --orderby time_desc --top 60 --query "[].name" -o tsv 2>/dev/null \
+            | grep -E '^[0-9a-f]{7}$' | head -1 || true)
+          if [ -n "$newest_short" ] && [ "$newest_short" != "$(printf '%s' "$SHA" | cut -c1-7)" ]; then
+            base=$(gh api "repos/$GITHUB_REPOSITORY/commits/$newest_short" --jq .sha 2>/dev/null || true)
+            if [ -n "$base" ]; then
+              files=$(gh api "repos/$GITHUB_REPOSITORY/compare/$base...$SHA" --jq '.files[].filename' 2>/dev/null || true)
+              if [ -n "$files" ] && ! printf '%s\n' "$files" | grep -qvE "$IRRELEVANT"; then
+                relevant=false
+              fi
+            fi
+          fi
+          echo "Newest published set: ${newest_short:-<none>}; image-relevant changes since: $relevant"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
       - name: "Decide"
         id: decide
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEVANT: ${{ steps.relevance.outputs.relevant }}
           SHORT: ${{ steps.target.outputs.short_sha }}
           REASON: ${{ steps.target.outputs.reason }}
           GREEN: ${{ steps.required.outputs.green }}
@@ -403,6 +436,8 @@ jobs:
           if [ "$REASON" = "push" ]; then
             if [ "$GREEN" != "true" ]; then
               decision false "⛔ \`Consolidate test results\` on $SHORT is \`$CONCL\` — nothing will be built"
+            elif [ "$RELEVANT" = "false" ]; then
+              decision false "⏭️ Only image-irrelevant paths (standalone clients) changed since the newest published set — no image build for \`$SHORT\`"
             # Batching window (see the freshness probe above): a green merge inside the window
             # defers to the reconciler's next tick. Deliberately SILENT beyond the summary — this
             # is intentional cadence, not a fault, and the reconciler self-heals it by design.
@@ -419,6 +454,14 @@ jobs:
           # the overwhelmingly common tick and it ends here, having cost ~40 s and said nothing.
           if [ "$COMPLETE" = "true" ]; then
             decision false "✅ main \`$SHORT\` already has a complete image set — nothing to reconcile"
+            exit 0
+          fi
+
+          # A tip that differs from the newest PUBLISHED set only by image-irrelevant paths is
+          # NOT unhealed state — it is the deliberate skip above, seen from the next tick. Without
+          # this the reconciler would "heal" every skipped clients-only merge back into a build.
+          if [ "$RELEVANT" = "false" ]; then
+            decision false "⏭️ main \`$SHORT\` differs from the newest published set only in image-irrelevant paths — nothing to reconcile"
             exit 0
           fi
 

--- a/clients/react-native/app.json
+++ b/clients/react-native/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "MeshWeaver",
+    "name": "Memex",
     "slug": "meshweaver-mobile",
     "version": "0.1.0",
     "orientation": "portrait",
@@ -25,7 +25,7 @@
       [
         "expo-av",
         {
-          "microphonePermission": "MeshWeaver records the microphone for speech-to-text (transcribed on the centralized Whisper service, not on this device)."
+          "microphonePermission": "Memex records the microphone for speech-to-text (transcribed on the centralized Whisper service, not on this device)."
         }
       ]
     ]

--- a/clients/react-native/package-lock.json
+++ b/clients/react-native/package-lock.json
@@ -21,7 +21,7 @@
         "react-native": "0.76.5",
         "react-native-fetch-api": "^3.0.0",
         "react-native-render-html": "^6.3.4",
-        "react-native-svg": "15.15.5",
+        "react-native-svg": "15.8.0",
         "react-native-web": "~0.19.13",
         "text-encoding": "^0.7.0",
         "web-streams-polyfill": "^4.3.0"
@@ -10499,13 +10499,14 @@
       }
     },
     "node_modules/react-native-svg": {
-      "version": "15.15.5",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.5.tgz",
-      "integrity": "sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.8.0.tgz",
+      "integrity": "sha512-KHJzKpgOjwj1qeZzsBjxNdoIgv2zNCO9fVcoq2TEhTRsVV5DGTZ9JzUZwybd7q4giT/H3RdtqC3u44dWdO0Ffw==",
       "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",
-        "css-tree": "^1.1.3"
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",
@@ -12722,6 +12723,12 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/warn-once": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
+      "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/clients/react-native/package.json
+++ b/clients/react-native/package.json
@@ -28,7 +28,7 @@
     "react-native": "0.76.5",
     "react-native-fetch-api": "^3.0.0",
     "react-native-render-html": "^6.3.4",
-    "react-native-svg": "15.15.5",
+    "react-native-svg": "15.8.0",
     "react-native-web": "~0.19.13",
     "text-encoding": "^0.7.0",
     "web-streams-polyfill": "^4.3.0"

--- a/clients/react-native/src/screens.tsx
+++ b/clients/react-native/src/screens.tsx
@@ -122,9 +122,29 @@ function ConnectScreen({ onConnected }: { onConnected: () => void }): ReactNode 
   const s = useSheet();
   const [instances, setInstances] = useState<MeshInstance[]>(loadInstances());
   const [current, setCurrent] = useState(currentInstance().name);
+  // Prefill with a URL that is actually reachable from THIS device: the local monolith only
+  // exists on a dev machine (localhost on a phone is the phone), so native builds prefill the
+  // public portal. The placeholder-looks-filled trap is also why `add` must never be silent.
+  const nativeDefault = defaultPortalUrl().includes("localhost")
+    ? "https://memex.meshweaver.cloud" : defaultPortalUrl();
   const [name, setName] = useState("");
-  const [url, setUrl] = useState(defaultPortalUrl()); // prefill the default portal (the local monolith) — edit + paste a token for a remote one
+  const [url, setUrl] = useState(nativeDefault);
   const [token, setToken] = useState("");
+  const [formError, setFormError] = useState("");
+  // ONBOARDING, not a form: first-run shows a welcome and the preinstalled meshes as the
+  // primary choice; the raw add-a-portal form is advanced and folded away. Signing in is a
+  // per-mesh act (tap a mesh → paste a token), not a wall in front of the app.
+  const firstRun = !instances.some((i) => !i.local && i.token);
+  const [showForm, setShowForm] = useState(false);
+  const [tokenFor, setTokenFor] = useState<string | null>(null);
+  const [rowToken, setRowToken] = useState("");
+  const saveRowToken = (inst: MeshInstance) => {
+    saveInstance({ ...inst, token: rowToken.trim() });
+    setTokenFor(null); setRowToken("");
+    refresh();
+    discover({ ...inst, token: rowToken.trim() });
+    onConnected();
+  };
 
   const refresh = () => {
     setInstances(loadInstances());
@@ -143,7 +163,11 @@ function ConnectScreen({ onConnected }: { onConnected: () => void }): ReactNode 
   };
   const add = () => {
     const nm = name.trim() || url.trim().replace(/^https?:\/\//, "");
-    if (!url.trim()) return;
+    if (!url.trim()) {
+      setFormError("Enter the portal URL — the gray text is only a placeholder.");
+      return;
+    }
+    setFormError("");
     const inst: MeshInstance = { name: nm, url: url.trim().replace(/\/+$/, ""), token: token.trim(), local: false };
     saveInstance(inst);
     setName(""); setUrl(""); setToken("");
@@ -153,7 +177,11 @@ function ConnectScreen({ onConnected }: { onConnected: () => void }): ReactNode 
   };
 
   return (
-    <ScreenScroll title="Connect to a mesh" subtitle="Point the app at any MeshWeaver portal by URL + API token — the same idea as the MAUI app's instance manager. Local is the mesh that served this app.">
+    <ScreenScroll
+      title={firstRun ? "Welcome to Memex" : "Connect to a mesh"}
+      subtitle={firstRun
+        ? "Choose a mesh to connect to. You can browse public content right away — to sign in, tap a mesh and paste an API token (portal ▸ Settings ▸ Security ▸ API Tokens)."
+        : "Your meshes. Tap to connect; discovered instances of a connected mesh appear here automatically."}>
       {instances.map((i) => {
         const id = instanceIdentity(i);
         const loud = id.tone === "prod" || id.tone === "client";
@@ -172,14 +200,34 @@ function ConnectScreen({ onConnected }: { onConnected: () => void }): ReactNode 
                 <Text style={s.instDelText}>Remove</Text>
               </Pressable>
             )}
+            {!i.local && tokenFor !== i.name && (
+              <Pressable onPress={() => { setTokenFor(i.name); setRowToken(i.token); }} style={{ paddingVertical: 6 }}>
+                <Text style={{ color: "#4c8dff", fontSize: 13 }}>{i.token ? "Change token" : "Sign in with a token"}</Text>
+              </Pressable>
+            )}
+            {tokenFor === i.name && (
+              <View style={{ marginTop: 6 }}>
+                <Field label={`API token for ${i.name}`} value={rowToken} onChange={setRowToken} placeholder="mw_…" />
+                <Pressable onPress={() => saveRowToken(i)} style={s.primaryBtn}><Text style={s.primaryBtnText}>Save & connect</Text></Pressable>
+              </View>
+            )}
           </View>
         );
       })}
-      <Text style={[s.sectionLabel, { marginTop: 18 }]}>Add a portal</Text>
-      <Field label="Name" value={name} onChange={setName} placeholder="e.g. Memex" />
-      <Field label="URL" value={url} onChange={setUrl} placeholder="https://memex.meshweaver.cloud" />
-      <Field label="API token (optional)" value={token} onChange={setToken} placeholder="mw_…" />
-      <Pressable onPress={add} style={s.primaryBtn}><Text style={s.primaryBtnText}>Connect</Text></Pressable>
+      {!showForm ? (
+        <Pressable onPress={() => setShowForm(true)} style={{ marginTop: 18, paddingVertical: 8 }}>
+          <Text style={{ color: "#4c8dff" }}>＋ Add a custom portal by URL</Text>
+        </Pressable>
+      ) : (
+        <>
+          <Text style={[s.sectionLabel, { marginTop: 18 }]}>Add a portal</Text>
+          <Field label="Name" value={name} onChange={setName} placeholder="e.g. Memex" />
+          <Field label="URL" value={url} onChange={setUrl} placeholder="https://memex.meshweaver.cloud" />
+          <Field label="API token (optional)" value={token} onChange={setToken} placeholder="mw_…" />
+          {formError ? <Text style={{ color: "#d13438", marginBottom: 8 }}>{formError}</Text> : null}
+          <Pressable onPress={add} style={s.primaryBtn}><Text style={s.primaryBtnText}>Connect</Text></Pressable>
+        </>
+      )}
     </ScreenScroll>
   );
 }

--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -33,16 +33,27 @@ def make_router(cfg: Config) -> BrainRouter:
     from .config import phrases_for
     from .ollama import SYSTEM_PROMPT
     phrases = phrases_for(cfg.stt_language)
-    system_prompt = SYSTEM_PROMPT + (DIALECT_SUFFIX if cfg.speak_dialect else "")
+    base_prompt = SYSTEM_PROMPT
+    if cfg.system_prompt_file:
+        try:
+            with open(cfg.system_prompt_file) as f:
+                base_prompt = f.read().strip() or SYSTEM_PROMPT
+        except OSError:
+            logging.getLogger(__name__).warning(
+                "SYSTEM_PROMPT_FILE %s not readable — using the built-in prompt",
+                cfg.system_prompt_file)
+    system_prompt = base_prompt + (DIALECT_SUFFIX if cfg.speak_dialect else "")
 
     def ollama(entry: dict) -> OllamaBrain:
         return OllamaBrain(entry.get("url", cfg.ollama_url), entry.get("model", cfg.ollama_model),
-                           idle_minutes=cfg.thread_idle_minutes, system_prompt=system_prompt)
+                           idle_minutes=cfg.thread_idle_minutes, system_prompt=system_prompt,
+                           location=cfg.location)
 
     def memex(entry: dict) -> MemexThreads:
         return MemexThreads(entry["url"].rstrip("/"), entry["token"], entry["namespace"],
                             agent=entry.get("agent", cfg.agent),
-                            thread_idle_minutes=cfg.thread_idle_minutes)
+                            thread_idle_minutes=cfg.thread_idle_minutes,
+                            verify_tls=not entry.get("insecure", False))
 
     if cfg.portals:
         brains = {e["name"]: (ollama(e) if e.get("kind") == "ollama" else memex(e))

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -85,6 +85,8 @@ class Config:
     wake_word: str = "hey_jarvis"           # micro-wake-word model id on the device
     continue_conversation: bool = True      # after a reply, listen again without a wake word
     speak_dialect: bool = False             # experiment: model writes Swiss German for the TTS
+    location: str | None = None             # where the speaker is (weather/'here' questions)
+    system_prompt_file: str | None = None   # override the built-in voice prompt with a file
 
     # --- endpointing (energy VAD) ---
     silence_ms: int = 800
@@ -134,6 +136,8 @@ class Config:
             wake_word=_env("WAKE_WORD", "hey_jarvis") or "hey_jarvis",
             continue_conversation=(_env("CONTINUE_CONVERSATION", "true") or "true").lower() != "false",
             speak_dialect=(_env("SPEAK_DIALECT", "false") or "false").lower() == "true",
+            location=_env("LOCATION"),
+            system_prompt_file=_env("SYSTEM_PROMPT_FILE"),
             silence_ms=int(_env("SILENCE_MS", "800")),
             tts_engine=(_env("TTS_ENGINE", "piper") or "piper").lower(),
             piper_bin=_env("PIPER_BIN", "piper") or "piper",

--- a/clients/voice-gateway/memex_voice_gateway/ollama.py
+++ b/clients/voice-gateway/memex_voice_gateway/ollama.py
@@ -60,6 +60,7 @@ class OllamaBrain:
     idle_minutes: float = 5.0
     num_predict: int = 200
     system_prompt: str = SYSTEM_PROMPT
+    location: str | None = None    # anchors 'here'/weather questions to a real place
 
     _history: list[dict] = field(default_factory=list, init=False)
     _last_used: float = field(default=0.0, init=False)
@@ -129,8 +130,9 @@ class OllamaBrain:
         self._last_used = time.monotonic()
         import datetime
         stamped = f"[{datetime.datetime.now().astimezone():%H:%M}] {text}"
+        anchor = now_line() + (f" Location: {self.location}." if self.location else "")
         messages = build_messages(self._history, stamped, system_prompt=self.system_prompt,
-                                  now=now_line())
+                                  now=anchor)
         self._history.append({"role": "user", "content": stamped})
 
         handle = f"ollama-{next(self._ids)}"

--- a/clients/voice-gateway/memex_voice_gateway/pipeline.py
+++ b/clients/voice-gateway/memex_voice_gateway/pipeline.py
@@ -23,11 +23,34 @@ SpeakFn = Callable[[str], Awaitable[str]]          # text -> served WAV url
 TranscribeFn = Callable[[bytes], Awaitable[str]]   # pcm  -> transcript
 
 
+import re
+
+# Whisper annotates non-speech as *Musik*, [Lachen], (Applaus) … — an utterance that is ONLY
+# such annotation is ambient noise, never a question. Answering it is how a TV becomes a
+# conversation partner through the WAKE path (observed: false wakes every ~10s, each round
+# transcribing its own or the TV's audio).
+_NOISE_ONLY = re.compile(r"^[\s\*\[\(]*[^\w]*[\wäöüéè' -]{0,40}?"
+                         r"(musik|lachen|applaus|geräusch|räusper|husten|"
+                         r"music|laughter|applause|noise|coughs?)"
+                         r"[^\w]*[\s\*\]\)]*$", re.IGNORECASE)
+
+
+def is_noise_transcript(transcript: str) -> bool:
+    stripped = transcript.strip()
+    if not stripped:
+        return True
+    if stripped.startswith(("*", "[", "(")) and stripped.endswith(("*", "]", ")")):
+        return True
+    return _NOISE_ONLY.match(stripped) is not None
+
+
 @dataclass
 class RoundResult:
     transcript: str
     reply: str | None      # None = budget missed, announcement pending
     tts_url: str | None
+    interrupt: bool = False   # a spoken "stop": kill current playback, say nothing
+    noise: bool = False       # ambient/non-speech round: discarded without an answer
 
 
 class VoicePipeline:
@@ -72,15 +95,16 @@ class VoicePipeline:
         except Exception:
             logger.exception("STT failed")
             return RoundResult("", self._error_phrase, await self._try_speak(self._error_phrase))
-        if not transcript:
-            return RoundResult("", None, None)  # silence / non-speech: end quietly
+        if is_noise_transcript(transcript):
+            logger.info("noise round discarded: %r", transcript[:60])
+            return RoundResult(transcript, None, None, noise=True)
 
         # Control commands (e.g. "wechsle zu systemorph") are handled deterministically,
         # before any brain sees the text — the handler's confirmation is spoken directly.
         if self._command_handler is not None:
             confirmation = await self._command_handler(transcript)
             if confirmation == "":
-                return RoundResult(transcript, None, None)   # handled silently ("stop")
+                return RoundResult(transcript, None, None, interrupt=True)  # spoken "stop"
             if confirmation is not None:
                 return RoundResult(transcript, confirmation,
                                    await self._try_speak(confirmation))

--- a/clients/voice-gateway/memex_voice_gateway/satellite.py
+++ b/clients/voice-gateway/memex_voice_gateway/satellite.py
@@ -41,6 +41,8 @@ class SatelliteLink:
         self._round_task: asyncio.Task | None = None
         self._follow_up = False
         self._round_serial = 0
+        self._noise_strikes: list[float] = []
+        self._suppress_until = 0.0
         self.on_wake: Callable[[], Awaitable[None]] | None = None  # barge-in hook
 
     async def stop_playback(self) -> None:
@@ -120,13 +122,16 @@ class SatelliteLink:
         self, conversation_id: str, flags: int,
         audio_settings: VoiceAssistantAudioSettings, wake_word_phrase: str | None,
     ) -> int:
-        # A wake while we're speaking is a BARGE-IN: kill the live TTS stream so playback
-        # drains out, and let the new round take over ("Hey Jarvis — stop." or a new question).
-        if self.on_wake is not None:
-            try:
-                await self.on_wake()
-            except Exception:
-                logger.debug("on_wake interrupt failed", exc_info=True)
+        # WAKE-STORM SUPPRESSION: repeated junk rounds mean the wake word is being triggered
+        # by ambient audio (a TV) or our own playback — go deaf for a cooldown instead of
+        # answering the room. Silence from the user must mean silence from the device.
+        import time as _time
+        if _time.monotonic() < self._suppress_until:
+            logger.info("wake ignored (suppressed for %.0fs after a wake storm)",
+                        self._suppress_until - _time.monotonic())
+            return 0
+        # NOTE: playback is deliberately NOT interrupted here — a false wake must not kill a
+        # real answer. The interrupt happens once the round yields actual speech (or "stop").
         # No wake-word phrase = a CONTINUED conversation (start_conversation re-opened the
         # mic). Those rounds calibrate against ambient audio (a TV must not become the
         # conversation partner) and give up early when nobody starts speaking.
@@ -187,6 +192,27 @@ class SatelliteLink:
             send(Event.VOICE_ASSISTANT_ERROR, {"code": "gateway", "message": str(error)[:200]})
             send(Event.VOICE_ASSISTANT_RUN_END, {})
             return
+        # Junk-round accounting: three noise rounds inside a minute = a wake storm; go deaf
+        # for 60s rather than machine-gunning answers at a TV.
+        import time as _time
+        if result.noise:
+            now = _time.monotonic()
+            self._noise_strikes = [t for t in self._noise_strikes if now - t < 60] + [now]
+            if len(self._noise_strikes) >= 3:
+                self._suppress_until = now + 60
+                self._noise_strikes.clear()
+                logger.warning("wake storm detected — suppressing wakes for 60s")
+        elif result.transcript:
+            self._noise_strikes.clear()
+            # REAL speech arrived: NOW interrupt whatever was still playing (barge-in), and
+            # on an explicit "stop" also silence the media player.
+            if self.on_wake is not None:
+                try:
+                    await self.on_wake()
+                except Exception:
+                    logger.debug("barge-in interrupt failed", exc_info=True)
+            if result.interrupt:
+                await self.stop_playback()
         # End the run FIRST, then deliver the reply as an ANNOUNCEMENT with
         # start_conversation: the device plays it and — when playback finishes — opens the
         # mic again by itself, no wake word ("conversation mode"). A silent follow-up ends

--- a/clients/voice-gateway/memex_voice_gateway/threads.py
+++ b/clients/voice-gateway/memex_voice_gateway/threads.py
@@ -63,6 +63,7 @@ class MemexThreads:
     namespace: str
     agent: str | None = None
     thread_idle_minutes: float = 5.0
+    verify_tls: bool = True   # False for a local mesh with a self-signed certificate
 
     _session_id: str | None = field(default=None, init=False)
     _http: aiohttp.ClientSession | None = field(default=None, init=False)
@@ -72,7 +73,8 @@ class MemexThreads:
 
     async def _post(self, payload: dict) -> tuple[dict, str]:
         if self._http is None:
-            self._http = aiohttp.ClientSession()
+            connector = None if self.verify_tls else aiohttp.TCPConnector(ssl=False)
+            self._http = aiohttp.ClientSession(connector=connector)
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",

--- a/deploy/whisper/Dockerfile
+++ b/deploy/whisper/Dockerfile
@@ -12,12 +12,18 @@ WORKDIR /src
 RUN git clone --depth 1 --branch v1.7.4 https://github.com/ggml-org/whisper.cpp
 WORKDIR /src/whisper.cpp
 # Examples (incl. the HTTP `whisper-server`) build by default; Release for speed.
-RUN cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j --config Release --target whisper-server
+# BUILD_SHARED_LIBS=OFF: the runtime stage copies ONE binary, so it must be self-contained —
+# the default shared build ships libwhisper.so.1 the binary can't find at run time
+# (first real deploy died in CrashLoopBackOff on exactly that; this stage is not CI-verified).
+RUN cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
+    && cmake --build build -j --config Release --target whisper-server
 
 FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y --no-install-recommends libgomp1 ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build /src/whisper.cpp/build/bin/whisper-server /usr/local/bin/whisper-server
+# Fail the BUILD, not the first pod, if the binary still needs anything beyond system libs.
+RUN whisper-server --help >/dev/null 2>&1 || { ldd /usr/local/bin/whisper-server; exit 1; }
 
 # Model + language are configurable at run time (the "local model running as container" the portal points at).
 ENV WHISPER_MODEL=/models/model.bin \


### PR DESCRIPTION
Follow-up to #1854 (commits landed after its merge): noise-transcript discard, 60s wake-storm suppression, barge-in moved to after-real-speech, LOCATION in the per-round anchor, SYSTEM_PROMPT_FILE override, insecure-TLS portal entries for the local mesh. Rationale for NOT ingesting the standard Assistant prompt into the local brain is in the commit message (12k-token context = the measured 3s→66s difference; standard agents are reused via spoken delegation instead). 28 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)