### PR TITLE
feat: opt OpenRouter chat requests into prompt caching

### DIFF
--- a/src/MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.csproj
+++ b/src/MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Memex.Portal.Shared.Test" />
+    <InternalsVisibleTo Include="MeshWeaver.AI.Test" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MeshWeaver.AI.OpenAI/OpenAIChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI.OpenAI/OpenAIChatClientAgentFactory.cs
@@ -1,4 +1,5 @@
 using System.ClientModel;
+using System.ClientModel.Primitives;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
@@ -155,9 +156,10 @@ public class OpenAIChatClientAgentFactory(
             throw new InvalidOperationException(
                 $"ApiKey is missing for model '{modelName}'. Configure a ModelProvider node (Provider 'OpenAI') or set OpenAI:ApiKey in config.");
 
+        var promptCache = OpenRouterPromptCachePolicy.AppliesTo(endpoint);
         logger.LogInformation(
-            "[OpenAI] Creating chat client model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
-            modelName, endpoint ?? "(default api.openai.com)", source, Fingerprint(apiKey));
+            "[OpenAI] Creating chat client model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint} promptCache={PromptCache}",
+            modelName, endpoint ?? "(default api.openai.com)", source, Fingerprint(apiKey), promptCache);
 
         var clientOptions = new OpenAIClientOptions
         {
@@ -167,6 +169,10 @@ public class OpenAIChatClientAgentFactory(
         };
         if (!string.IsNullOrEmpty(endpoint))
             clientOptions.Endpoint = new Uri(endpoint);
+        // OpenRouter: opt into prompt caching (Anthropic/Qwen need explicit breakpoints;
+        // everyone else ignores the field). See OpenRouterPromptCachePolicy.
+        if (promptCache)
+            clientOptions.AddPolicy(new OpenRouterPromptCachePolicy(), PipelinePosition.PerCall);
 
         var client = new OpenAIClient(new ApiKeyCredential(apiKey), clientOptions);
         return client.GetChatClient(modelName).AsIChatClient();

--- a/src/MeshWeaver.AI.OpenAI/OpenRouterPromptCachePolicy.cs
+++ b/src/MeshWeaver.AI.OpenAI/OpenRouterPromptCachePolicy.cs
@@ -1,0 +1,106 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace MeshWeaver.AI.OpenAI;
+
+/// <summary>
+/// Pipeline policy that opts every OpenRouter chat-completion request into prompt caching by
+/// injecting OpenRouter's top-level <c>"cache_control": {"type": "ephemeral"}</c> field into the
+/// outgoing request body.
+///
+/// <para>Providers with automatic caching (OpenAI, DeepSeek, Grok, Groq, Gemini 2.5, …) ignore the
+/// field, but providers that require EXPLICIT cache breakpoints (Anthropic, Qwen) get none without
+/// it — so a multi-round agent turn on an <c>anthropic/*</c> model re-pays the full re-sent prefix
+/// (tool schemas + system prompt + history) at 1× input price on every round. With the top-level
+/// field OpenRouter places the breakpoint at the last cacheable block itself, which caches that
+/// whole prefix incrementally: ~1.25× write on the per-round delta, ~0.1× read on everything
+/// before it. Below the model's minimum cacheable size the provider simply doesn't cache (no
+/// error), so injecting is always safe.</para>
+///
+/// <para>The resulting cache reads come back in the standard OpenAI usage shape
+/// (<c>prompt_tokens_details.cached_tokens</c>), which the Microsoft.Extensions.AI adapter already
+/// surfaces as <c>AdditionalCounts["InputTokenDetails.CachedTokenCount"]</c> — picked up unchanged
+/// by <c>UsageTokens.SplitCache</c> and the whole token-accounting pipeline behind it.</para>
+///
+/// <para>The typed OpenAI SDK cannot express this OpenRouter extension field, hence the rewrite at
+/// the transport pipeline — the sanctioned <see cref="PipelinePolicy"/> extension point. Attached
+/// per-call (before the retry policy) by <see cref="OpenAIChatClientAgentFactory"/>, and ONLY for
+/// endpoints where <see cref="AppliesTo"/> says the host is OpenRouter: other OpenAI-compatible
+/// gateways may reject an unknown top-level field.</para>
+/// </summary>
+public sealed class OpenRouterPromptCachePolicy : PipelinePolicy
+{
+    /// <inheritdoc />
+    public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    {
+        Apply(message);
+        ProcessNext(message, pipeline, currentIndex);
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    {
+        Apply(message);
+        await ProcessNextAsync(message, pipeline, currentIndex).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// True when <paramref name="endpoint"/> targets OpenRouter (<c>openrouter.ai</c> or a
+    /// subdomain) — the only gateway documented to accept the top-level <c>cache_control</c>
+    /// extension. Null / relative / unparsable endpoints (including the SDK-default
+    /// api.openai.com case) are not OpenRouter.
+    /// </summary>
+    public static bool AppliesTo(string? endpoint)
+    {
+        if (string.IsNullOrEmpty(endpoint) || !Uri.TryCreate(endpoint, UriKind.Absolute, out var uri))
+            return false;
+        return uri.Host.Equals("openrouter.ai", StringComparison.OrdinalIgnoreCase)
+            || uri.Host.EndsWith(".openrouter.ai", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Rewrites the request body of chat-completion POSTs in place; leaves every other request
+    /// (and any body <see cref="TryAddCacheControl"/> declines) untouched.
+    /// </summary>
+    private static void Apply(PipelineMessage message)
+    {
+        var request = message.Request;
+        if (request.Content is null
+            || !string.Equals(request.Method, "POST", StringComparison.OrdinalIgnoreCase)
+            || request.Uri is not { } uri
+            || !uri.AbsolutePath.EndsWith("/chat/completions", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        using var buffer = new MemoryStream();
+        request.Content.WriteTo(buffer, CancellationToken.None);
+        var body = Encoding.UTF8.GetString(buffer.GetBuffer(), 0, (int)buffer.Length);
+        if (TryAddCacheControl(body) is { } rewritten)
+            request.Content = BinaryContent.Create(BinaryData.FromString(rewritten));
+    }
+
+    /// <summary>
+    /// Adds <c>"cache_control": {"type": "ephemeral"}</c> at the top level of a JSON request body.
+    /// Returns the rewritten body, or null when no rewrite should happen: the body already carries
+    /// a top-level <c>cache_control</c> (a caller's explicit choice wins), isn't a JSON object, or
+    /// doesn't parse — never break a request we don't understand.
+    /// </summary>
+    internal static string? TryAddCacheControl(string requestBody)
+    {
+        JsonNode? root;
+        try
+        {
+            root = JsonNode.Parse(requestBody);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        if (root is not JsonObject obj || obj.ContainsKey("cache_control"))
+            return null;
+        obj["cache_control"] = new JsonObject { ["type"] = "ephemeral" };
+        return obj.ToJsonString();
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-openrouter-prompt-caching.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-openrouter-prompt-caching.md
@@ -1,0 +1,26 @@
+---
+Name: OpenRouter threads now cache their prompts
+Category: Feature
+Description: Chat requests through OpenRouter now opt into prompt caching, so long agent threads on models like Claude re-read their context at the cached rate instead of paying full input price every round — and the cached share shows up in the thread's token chip.
+Icon: TopSpeed
+Order: -20260818
+---
+
+# OpenRouter threads now cache their prompts
+
+Every round of an agent thread re-sends the same large prefix to the model: the
+agent's instructions, its tool documentation, and the whole conversation so far.
+Some providers cache that prefix on their own, but several of the models you can
+run through OpenRouter — Anthropic's Claude among them — only cache when the
+request explicitly asks for it. Ours never did, so those threads paid full input
+price for the same prefix on every single round.
+
+Now every chat request sent through an OpenRouter provider opts into prompt
+caching. After the first round, the model re-reads the unchanged prefix at the
+provider's reduced cache rate — roughly a tenth of the normal input price on
+Claude — which adds up quickly on long, tool-heavy threads. Providers that cache
+automatically are unaffected, and short prompts below the provider's minimum
+cacheable size simply keep behaving as before.
+
+You can see it working: the thread's token chip and usage breakdown now show how
+much of the input was served from cache.

--- a/test/MeshWeaver.AI.Test/OpenRouterPromptCachePolicyTest.cs
+++ b/test/MeshWeaver.AI.Test/OpenRouterPromptCachePolicyTest.cs
@@ -89,7 +89,8 @@ public class OpenRouterPromptCachePolicyTest
             Transport = new HttpClientPipelineTransport(new HttpClient(handler))
         };
         options.AddPolicy(new OpenRouterPromptCachePolicy(), PipelinePosition.PerCall);
-        var client = new OpenAIClient(new ApiKeyCredential("test-key"), options);
+        // Hermetic: the Transport above is a stub handler, so this client can never call out.
+        var client = new OpenAIClient(new ApiKeyCredential("test-key"), options); // local-only-guard:allow
         var chat = client.GetChatClient("anthropic/claude-sonnet-4.5");
 
         var completion = await chat.CompleteChatAsync(new UserChatMessage("hello"));

--- a/test/MeshWeaver.AI.Test/OpenRouterPromptCachePolicyTest.cs
+++ b/test/MeshWeaver.AI.Test/OpenRouterPromptCachePolicyTest.cs
@@ -1,0 +1,125 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.OpenAI;
+using OpenAI;
+using OpenAI.Chat;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Tests <see cref="OpenRouterPromptCachePolicy"/>: the endpoint gate (only OpenRouter hosts get
+/// the policy), the JSON rewrite (top-level <c>cache_control</c> injected exactly once, bodies we
+/// don't understand left alone), and — through a real <see cref="OpenAIClient"/> pipeline over a
+/// stub <see cref="HttpMessageHandler"/> — that the wire body OpenRouter would receive actually
+/// carries the field. No network.
+/// </summary>
+public class OpenRouterPromptCachePolicyTest
+{
+    // ── AppliesTo: only OpenRouter hosts ─────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://openrouter.ai/api/v1", true)]
+    [InlineData("https://OPENROUTER.AI/api/v1", true)]
+    [InlineData("https://gateway.openrouter.ai/api/v1", true)]
+    [InlineData("https://api.openai.com/v1", false)]
+    [InlineData("https://api.groq.com/openai/v1", false)]
+    // Host must END with .openrouter.ai — a lookalike prefix is not OpenRouter.
+    [InlineData("https://openrouter.ai.evil.example/v1", false)]
+    [InlineData("not a uri", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void AppliesTo_MatchesOnlyOpenRouterHosts(string? endpoint, bool expected)
+    {
+        OpenRouterPromptCachePolicy.AppliesTo(endpoint).Should().Be(expected);
+    }
+
+    // ── TryAddCacheControl: the JSON rewrite ─────────────────────────────────
+
+    [Fact]
+    public void TryAddCacheControl_AddsTopLevelEphemeralField_PreservingBody()
+    {
+        var body = """{"model":"anthropic/claude-sonnet-4.5","messages":[{"role":"user","content":"hi"}]}""";
+
+        var rewritten = OpenRouterPromptCachePolicy.TryAddCacheControl(body);
+
+        rewritten.Should().NotBeNull();
+        var node = JsonNode.Parse(rewritten!)!.AsObject();
+        node["cache_control"]!["type"]!.GetValue<string>().Should().Be("ephemeral");
+        node["model"]!.GetValue<string>().Should().Be("anthropic/claude-sonnet-4.5");
+        node["messages"]!.AsArray().Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void TryAddCacheControl_ExistingCacheControl_LeavesBodyAlone()
+    {
+        // A caller's explicit choice (e.g. a 1h TTL) must win over our default.
+        var body = """{"model":"m","cache_control":{"type":"ephemeral","ttl":"1h"},"messages":[]}""";
+
+        OpenRouterPromptCachePolicy.TryAddCacheControl(body).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("not json at all")]
+    [InlineData("[1,2,3]")]
+    [InlineData("\"just a string\"")]
+    public void TryAddCacheControl_UnrecognisedBody_LeavesBodyAlone(string body)
+    {
+        OpenRouterPromptCachePolicy.TryAddCacheControl(body).Should().BeNull();
+    }
+
+    // ── Through the real pipeline: the wire body carries the field ───────────
+
+    [Fact]
+    public async Task ChatCompletionRequest_ThroughPipeline_CarriesTopLevelCacheControl()
+    {
+        var handler = new CapturingHandler();
+        var options = new OpenAIClientOptions
+        {
+            Endpoint = new Uri("https://openrouter.ai/api/v1"),
+            Transport = new HttpClientPipelineTransport(new HttpClient(handler))
+        };
+        options.AddPolicy(new OpenRouterPromptCachePolicy(), PipelinePosition.PerCall);
+        var client = new OpenAIClient(new ApiKeyCredential("test-key"), options);
+        var chat = client.GetChatClient("anthropic/claude-sonnet-4.5");
+
+        var completion = await chat.CompleteChatAsync(new UserChatMessage("hello"));
+
+        completion.Value.Content[0].Text.Should().Be("ok");
+        handler.Body.Should().NotBeNull();
+        var sent = JsonNode.Parse(handler.Body!)!.AsObject();
+        sent["cache_control"]!["type"]!.GetValue<string>().Should().Be("ephemeral");
+        sent["model"]!.GetValue<string>().Should().Be("anthropic/claude-sonnet-4.5");
+    }
+
+    /// <summary>Captures the outgoing wire body and answers a minimal valid chat completion.</summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private const string CannedResponse =
+            """
+            {"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"anthropic/claude-sonnet-4.5",
+             "choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+             "usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}
+            """;
+
+        public string? Body;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Body = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(CannedResponse, Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}


### PR DESCRIPTION
## What

OpenRouter chat-completion requests now opt into prompt caching by injecting OpenRouter's top-level `"cache_control": {"type": "ephemeral"}` field at the transport pipeline.

## Why

Providers that require **explicit** cache breakpoints (Anthropic, Qwen) got no caching at all through our OpenAI-compatible path — every round of a multi-round agent turn re-paid the full re-sent prefix (tool schemas + system prompt + history) at 1× input price. With the top-level field, OpenRouter places the breakpoint at the last cacheable block itself, caching the prefix incrementally: ~1.25× write on the per-round delta, ~0.1× read on everything before it. Providers with automatic caching ignore the field; below the model's minimum cacheable size the provider simply doesn't cache — injecting is always safe.

## How

- `OpenRouterPromptCachePolicy` — a `System.ClientModel` `PipelinePolicy` (the SDK's sanctioned request-interception point, since the typed OpenAI SDK cannot express this OpenRouter extension field). Rewrites only `POST …/chat/completions` bodies; leaves alone anything unparseable, non-object, or already carrying a top-level `cache_control` (a caller's explicit choice wins).
- Attached per-call by `OpenAIChatClientAgentFactory`, gated to `openrouter.ai` hosts only — other OpenAI-compatible gateways may reject an unknown top-level field.
- No read-side change needed: cache reads arrive in the standard OpenAI usage shape (`prompt_tokens_details.cached_tokens`), which the M.E.AI adapter surfaces as `InputTokenDetails.CachedTokenCount` and `UsageTokens.SplitCache` already parses — the thread token chip and cost accounting light up on their own.

## Tests

`OpenRouterPromptCachePolicyTest` (15 tests, all green): endpoint gate incl. lookalike-host rejection, JSON rewrite semantics, and a real `OpenAIClient` pipeline over a stub `HttpMessageHandler` asserting the wire body OpenRouter would receive carries the field.

What's New entry included (`Category: Feature`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)