### PR TITLE
The re-drive barrier was satisfied by a REPLAYED pre-forge emission

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/NeverCompiledFailureRedriveTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NeverCompiledFailureRedriveTest.cs
@@ -38,6 +38,15 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 ///
 /// <para>The pure half — the verdict-inputs token, the predicate, the ledger — is
 /// <c>FailedVerdictRedriveTest</c> in MeshWeaver.Graph.Test.</para>
+///
+/// <para>🚨 <b>The bounded assertions here are not self-certifying.</b> Every observation runs over
+/// <c>GetMeshNodeStream</c>, a <c>Replay(1)</c> mirror that hands each new subscription the snapshot
+/// it already holds and keeps nothing before it — so an assertion can be satisfied by a REPLAY of
+/// state that predates the thing it is claiming about, and it then passes for the wrong reason
+/// forever. <see cref="RedriveObservation"/> is the vocabulary that closes it (a version watermark,
+/// with the process ledger as the primary bound); <c>RedriveObservationReplayTest</c> is what proves
+/// it, by constructing the replay and pinning BOTH halves — the shape this file used to have
+/// accepting it, and this one refusing it while still accepting the genuine case.</para>
 /// </summary>
 public class NeverCompiledFailureRedriveTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -70,14 +79,17 @@ public class NeverCompiledFailureRedriveTest(ITestOutputHelper output) : Monolit
         var (typePath, baselineSucceededAt) = await CompileBaselineType("RedriveRecovers", GoodSource);
         var workspace = Mesh.GetWorkspace();
 
-        await ForgeNeverCompiledFailure(typePath);
+        var forgeWatermark = await ForgeNeverCompiledFailure(typePath);
 
         // The OWNER-side re-drive must rebuild it: back to Ok, with real assembly coordinates and a
-        // STRICTLY NEWER success timestamp (a replayed old Ok would prove nothing). Before the fix
-        // nothing re-drives this record at all, so this times out.
+        // STRICTLY NEWER success timestamp (a replayed old Ok would prove nothing) at a revision
+        // STRICTLY past the forge, so the mirror's Replay(1) hand-off of the pre-forge snapshot
+        // cannot satisfy it either. Before the fix nothing re-drives this record at all, so this
+        // times out.
         var recovered = await workspace.GetMeshNodeStream(typePath)
             .Should().Within(90.Seconds())
-            .Match(n => n.Content is NodeTypeDefinition d
+            .Match(n => RedriveObservation.IsPastWatermark(n, forgeWatermark)
+                && n.Content is NodeTypeDefinition d
                 && d.CompilationStatus == CompilationStatus.Ok
                 && !string.IsNullOrEmpty(d.LatestAssemblyPath)
                 && d.CompiledFrameworkVersion == NodeTypeCompilationHelpers.FrameworkVersion
@@ -90,7 +102,7 @@ public class NeverCompiledFailureRedriveTest(ITestOutputHelper output) : Monolit
         // failure look like it had already had its attempt), and nothing re-drives a healthy type.
         ((NodeTypeDefinition)recovered.Content!).FailedBuildInputs.Should().BeNull(
             "a success retires the failure verdict, so its inputs must go with it");
-        await AssertNoFurtherCompileIsDriven(typePath, 15.Seconds(),
+        await AssertNoFurtherCompileIsDriven(typePath, recovered.Version, 15.Seconds(),
             "a recovered type must not be re-driven again — the re-drive's own bookkeeping is what "
             + "makes its trigger false, and a trigger that survives its own write is a write cycle");
     }
@@ -124,20 +136,30 @@ public class NeverCompiledFailureRedriveTest(ITestOutputHelper output) : Monolit
 
         // Now stage the pre-fix record (no stamp) so the re-drive DOES fire, and prove it fires
         // exactly once: the attempt fails again, and nothing schedules another.
-        await ForgeNeverCompiledFailure(typePath);
+        var forgeWatermark = await ForgeNeverCompiledFailure(typePath);
 
-        await workspace.GetMeshNodeStream(typePath)
+        // 🚨 ANCHORED on the forge. Without the version clause this Match is satisfied by the
+        // mirror's Replay(1) hand-off of the PRE-forge record — which, for a type that cannot
+        // compile, is byte-identical to the record the re-drive re-settles at (Error, inputs
+        // stamped). The test would then believe it had watched the re-drive fire and re-fail having
+        // observed only state that predates the forge, and every bound below it would be anchored
+        // in the past. The forge nulls FailedBuildInputs, so a record carrying it again at a
+        // revision past the forge can only be the re-drive's own verdict.
+        var reFailed = await workspace.GetMeshNodeStream(typePath)
             .Should().Within(90.Seconds())
-            .Match(n => n.Content is NodeTypeDefinition d
+            .Match(n => RedriveObservation.IsPastWatermark(n, forgeWatermark)
+                && n.Content is NodeTypeDefinition d
                 && d.CompilationStatus == CompilationStatus.Error
                 && !string.IsNullOrEmpty(d.FailedBuildInputs));
         var redrives = ParkRegistry.GetFailureRedriveCount(typePath);
         redrives.Should().Be(1,
             "exactly one automatic attempt per distinct set of compile inputs — the flip to Pending "
             + "stamps those inputs in the same write, so the trigger cannot re-arm itself");
-        Output.WriteLine($"{typePath} re-driven {redrives}× and re-failed — now bounded.");
+        Output.WriteLine(
+            $"{typePath} re-driven {redrives}× and re-failed at v{reFailed.Version} "
+            + $"(forge watermark v{forgeWatermark}) — now bounded.");
 
-        await AssertNoFurtherCompileIsDriven(typePath, 20.Seconds(),
+        await AssertNoFurtherCompileIsDriven(typePath, reFailed.Version, 20.Seconds(),
             "a type whose source cannot compile must back off after its one attempt instead of "
             + "storming Roslyn on the hub's action block");
         ParkRegistry.GetFailureRedriveCount(typePath).Should().Be(1,
@@ -249,12 +271,21 @@ public class NeverCompiledFailureRedriveTest(ITestOutputHelper output) : Monolit
     /// and no record of the inputs the verdict was formed under. Nothing else is touched, and no
     /// instance of the type is ever activated, so only the OWNER-side re-drive can act on it.
     /// </summary>
-    private async Task ForgeNeverCompiledFailure(string typePath)
+    /// <returns>
+    /// The WATERMARK every later observation must be anchored on: the version the forge write was
+    /// based on. Any emission at or below it is the mirror replaying pre-forge state.
+    /// </returns>
+    private async Task<long> ForgeNeverCompiledFailure(string typePath)
     {
         var workspace = Mesh.GetWorkspace();
         // The park is in-memory and per-process; a record that arrived from elsewhere carries no
         // park with it, so clear it here too or the staged state would not be the staged state.
         ParkRegistry.Unpark(typePath);
+        // Read what the mirror is currently replaying, purely as EVIDENCE: it is logged next to the
+        // version Update hands back, and on every run the two are the same number. That equality is
+        // the whole defect in #1850's `>=` bound, measured on the real mesh rather than argued.
+        var beforeForge = await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(30.Seconds()).Emit();
         var marker = $"FORGED-{Guid.NewGuid():N}";
         var forged = await workspace.GetMeshNodeStream(typePath)
             .Update(curr => curr.Content is NodeTypeDefinition d
@@ -286,29 +317,57 @@ public class NeverCompiledFailureRedriveTest(ITestOutputHelper output) : Monolit
         // load-sensitive on CI: this helper is used by all three tests in this file, which is why
         // they fail in rotation (#1843 — observed on main and on three unrelated PRs).
         //
-        // Version is monotonic and cannot be overwritten away, so waiting for it proves the write
-        // landed without requiring anyone to catch a state designed to be replaced.
-        var forgedVersion = forged.Version;
-        await workspace.GetMeshNodeStream(typePath)
+        // 🚨 …and the bound is STRICT (>), which #1850's `>=` was not — the deeper race, and it is
+        // not a race at all but a structural vacuity. `Update` on a foreign path is UpdateRemote,
+        // which emits `update(current)`: the OPTIMISTIC LOCAL snapshot, carrying the PRE-write
+        // Version, because the forge lambda rewrites Content only. `>= forged.Version` is therefore
+        // a bound the mirror is ALREADY sitting on, and Replay(1) satisfies it instantly with the
+        // pre-forge snapshot — the barrier passed whether or not the write landed, and every
+        // observation downstream of it was anchored before the forge. RedriveObservationReplayTest
+        // constructs that replay and pins both halves: `>=` accepting it, `>` refusing it.
+        //
+        // 🚨 WHOSE version is this? The OWNER's, and it is a strict LOWER BOUND, not a receipt.
+        // MeshNode.Version is minted by the owning per-node hub for EVERY writer
+        // (MeshNode.NextVersion = current + 1) — #1833 is a test that flaked on assuming it tracks
+        // the caller's own write. So `> watermark` claims exactly one thing: the owner has
+        // committed at least one revision past the state this write was diffed against, so no
+        // later emission can be that state replayed. It deliberately does NOT claim "my forge
+        // landed" — the write's own completion above establishes that, and that the RE-DRIVE fired
+        // is established by the ledger, never by catching a state designed to be replaced.
+        var watermark = forged.Version;
+        var landed = await workspace.GetMeshNodeStream(typePath)
             .Should().Within(20.Seconds())
-            .Match(n => n.Version >= forgedVersion);
+            .Match(n => RedriveObservation.IsPastWatermark(n, watermark));
         Output.WriteLine(
-            $"Forged the never-compiled Error record on {typePath} (marker {marker}, "
-            + $"version {forgedVersion}).");
+            $"Forged the never-compiled Error record on {typePath} (marker {marker}); "
+            + $"the mirror was replaying v{beforeForge.Version}, Update handed back v{watermark} "
+            + $"(the SAME revision — so the old '>= {watermark}' bound was already satisfied), "
+            + $"owner then moved to v{landed.Version}.");
+        return watermark;
     }
 
     /// <summary>
-    /// The sanctioned bounded NEGATIVE observation for "nothing re-drives this": no transition into
-    /// <see cref="CompilationStatus.Pending"/> or <see cref="CompilationStatus.Compiling"/> within
-    /// the window. Not vacuous — the sibling assertions above prove the same subscription DOES see
-    /// the flip when the re-drive fires.
+    /// The sanctioned bounded NEGATIVE observation for "nothing re-drives this", with TWO
+    /// independent witnesses — see <see cref="RedriveObservation"/> for why one is not enough.
+    ///
+    /// <para><b>Primary: the LEDGER.</b> <c>NodeTypeCompileParkRegistry</c> counts events —
+    /// <c>RecordFailureRedrive</c> per automatic kickoff, <c>RecordAttempt</c> per real Roslyn
+    /// dispatch. Counters cannot be replayed or conflated, and — decisively for a type that cannot
+    /// compile — they can tell a re-drive that ran and re-failed apart from the record it started
+    /// from, which are byte-identical.</para>
+    ///
+    /// <para><b>Corroboration: the stream</b>, anchored at <paramref name="watermark"/> so the
+    /// mirror's <c>Replay(1)</c> hand-off of the snapshot the window OPENED on cannot read as a
+    /// fresh drive. Unanchored, this half was satisfiable by a replay in both directions: tripped
+    /// by a stale <c>Pending</c>, and passed by a whole <c>Pending → Compiling → Error</c> cycle
+    /// that fitted between the claim and <c>NotEmit</c>'s pool-scheduled attach.</para>
     /// </summary>
-    private async Task AssertNoFurtherCompileIsDriven(string typePath, TimeSpan window, string because)
+    private async Task AssertNoFurtherCompileIsDriven(
+        string typePath, long watermark, TimeSpan window, string because)
     {
-        await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
-            .Where(n => n?.Content is NodeTypeDefinition d
-                && d.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling)
-            .Should().NotEmit(window, because);
-        Output.WriteLine($"No further compile was driven for {typePath} within {window.TotalSeconds:F0}s.");
+        var observed = await RedriveObservation
+            .OpenWindow(ParkRegistry, typePath, watermark)
+            .AssertNothingWasDriven(Mesh.GetWorkspace().GetMeshNodeStream(typePath), window, because);
+        Output.WriteLine($"No further compile was driven — {observed}.");
     }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/RedriveObservation.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/RedriveObservation.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+
+using MeshWeaver.Compiler;
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 The observation vocabulary for the automatic-re-drive tests (<see
+/// cref="NeverCompiledFailureRedriveTest"/>), factored out for one reason: a NEGATIVE assertion
+/// cannot be trusted on the word of the test that uses it. These predicates are fed a CONSTRUCTED
+/// replay by <c>RedriveObservationReplayTest</c>, which pins both halves — the old shape accepting
+/// it, and this one rejecting it while still accepting the genuine case.
+///
+/// <para><b>The defect this exists to close.</b> <c>workspace.GetMeshNodeStream(path)</c> is a
+/// <c>Replay(1)</c> mirror (<c>MeshNodeStreamCache</c> — <c>new ReplaySubject&lt;MeshNode&gt;(1)</c>
+/// per entry). Two consequences, and every re-drive assertion trips over one of them:</para>
+/// <list type="number">
+///   <item><description><b>A new subscription is handed the snapshot the mirror ALREADY holds.</b>
+///     So a bound of the form "wait for <c>Version &gt;= X</c>" where <c>X</c> is a version the
+///     mirror already has is satisfied by that hand-off and proves nothing at all. That is exactly
+///     what the forge barrier did: <c>GetMeshNodeStream(path).Update(...)</c> is <c>UpdateRemote</c>,
+///     which emits <c>update(current)</c> — the OPTIMISTIC LOCAL snapshot, carrying the PRE-write
+///     <see cref="MeshNode.Version"/>, because the update lambda only rewrites <c>Content</c>. The
+///     barrier therefore waited for a version the stream was already sitting on.</description></item>
+///   <item><description><b>Only the LATEST snapshot survives the hand-off.</b> Everything that
+///     happened between the moment the caller decided to observe and the moment the pool-scheduled
+///     <c>Subscribe</c> attaches is collapsed into one value. A complete re-drive —
+///     <c>Pending → Compiling → Error</c> — fits in that gap, and a state-shaped "nothing was
+///     driven" assertion then passes having watched nothing at all.</description></item>
+/// </list>
+///
+/// <para><b>🚨 Whose version is the watermark?</b> The OWNER's, and it is a strict LOWER BOUND, not
+/// a receipt. <see cref="MeshNode.Version"/> is minted by the owning per-node hub for EVERY writer
+/// (<see cref="MeshNode.NextVersion"/> = <c>current + 1</c>) — issue #1833 is a test that flaked on
+/// assuming it tracks the caller's own write, and it does not. So <c>Version &gt; watermark</c>
+/// claims exactly one thing: the owner has committed at least one revision past the snapshot the
+/// caller was looking at, so this emission cannot be that snapshot replayed. It deliberately does
+/// NOT claim "my write landed" — that claim belongs to the LEDGER below, which counts EVENTS.</para>
+///
+/// <para><b>The ledger is the PRIMARY bound.</b> <see cref="NodeTypeCompileParkRegistry"/> counts
+/// what actually happened in this process: <c>RecordFailureRedrive</c> on every automatic re-drive
+/// kickoff, <c>RecordAttempt</c> on every real Roslyn dispatch (<c>RunCompile</c>). A counter cannot
+/// be replayed, cannot be conflated, and — unlike the node's state — can tell "the re-drive ran and
+/// re-failed" apart from "I was handed the pre-forge snapshot back", which for a broken type are
+/// byte-identical records. The stream observation stays as corroboration, anchored so a replay
+/// cannot trip it either way.</para>
+/// </summary>
+internal static class RedriveObservation
+{
+    /// <summary>
+    /// The forge barrier's bound: has the owner committed a revision STRICTLY past
+    /// <paramref name="watermark"/>? Strict, because <c>&gt;=</c> is satisfied by the replayed
+    /// snapshot the watermark was read from — the whole defect.
+    /// </summary>
+    public static bool IsPastWatermark(MeshNode? node, long watermark)
+        => node is { } n && n.Version > watermark;
+
+    /// <summary>
+    /// A compile drive that is NEW relative to <paramref name="watermark"/> — the emission the
+    /// negative assertion forbids. The version clause is what stops the mirror's hand-off of the
+    /// snapshot the window OPENED on from reading as a fresh drive.
+    /// </summary>
+    public static bool IsFreshCompileDrive(MeshNode? node, long watermark)
+        => node is { } n
+            && n.Version > watermark
+            && n.Content is NodeTypeDefinition d
+            && d.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling;
+
+    /// <summary>
+    /// Opens a "nothing further is driven" window: captures the ledger AND the watermark at the
+    /// caller's own point in the timeline, which is the moment the claim is about. Capturing at
+    /// SUBSCRIBE time instead — which is what a bare <c>NotEmit</c> does, on a pool thread — is how
+    /// a whole re-drive fits between the claim and its evidence.
+    /// </summary>
+    public static RedriveWindow OpenWindow(
+        NodeTypeCompileParkRegistry ledger, string typePath, long watermark)
+        => new(ledger, typePath, watermark,
+            ledger.GetFailureRedriveCount(typePath), ledger.GetCompileAttemptCount(typePath));
+}
+
+/// <summary>
+/// An open "nothing further is driven" observation window — see <see cref="RedriveObservation"/>.
+/// </summary>
+/// <param name="Ledger">The process-wide re-drive / compile-attempt ledger.</param>
+/// <param name="TypePath">The NodeType the claim is about.</param>
+/// <param name="Watermark">The node version the window opened on.</param>
+/// <param name="RedrivesAtOpen">Automatic re-drives recorded when the window opened.</param>
+/// <param name="AttemptsAtOpen">Real Roslyn dispatches recorded when the window opened.</param>
+internal sealed record RedriveWindow(
+    NodeTypeCompileParkRegistry Ledger,
+    string TypePath,
+    long Watermark,
+    int RedrivesAtOpen,
+    int AttemptsAtOpen)
+{
+    /// <summary>
+    /// Closes the window and asserts nothing was driven inside it. Two independent witnesses,
+    /// because neither alone is sound: the LEDGER (primary — events, unreplayable, uncollapsible)
+    /// and the anchored stream observation (corroboration — catches a drive that reached the node
+    /// but somehow never reached the ledger).
+    /// </summary>
+    /// <returns>A one-line summary of what the window observed, for the test's output.</returns>
+    public async Task<string> AssertNothingWasDriven(
+        IObservable<MeshNode> stream, TimeSpan window, string because)
+    {
+        await stream
+            .Where(n => RedriveObservation.IsFreshCompileDrive(n, Watermark))
+            .Should().NotEmit(window, because);
+
+        var redrives = Ledger.GetFailureRedriveCount(TypePath);
+        var attempts = Ledger.GetCompileAttemptCount(TypePath);
+        redrives.Should().Be(RedrivesAtOpen,
+            $"{because} — the automatic re-drive ledger for {TypePath} must not move inside the "
+            + "window, and it is the PRIMARY bound: a re-drive that started and re-settled between "
+            + "the claim and the mirror's Replay(1) hand-off leaves the node in a state that is "
+            + "byte-identical to the one the window opened on, so only a counter can see it");
+        attempts.Should().Be(AttemptsAtOpen,
+            $"{because} — and no real Roslyn dispatch (NodeTypeCompilationHelpers.RunCompile → "
+            + $"RecordAttempt) may happen for {TypePath} inside the window either");
+
+        return $"nothing driven for {TypePath} in {window.TotalSeconds:F0}s "
+            + $"(watermark v{Watermark}; re-drives {redrives}, attempts {attempts} — both unchanged)";
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/RedriveObservationReplayTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/RedriveObservationReplayTest.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Reactive.Assertions;
+using Xunit;
+
+using MeshWeaver.Compiler;
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 THE NON-VACUITY PROOF for <see cref="NeverCompiledFailureRedriveTest"/>'s bounded assertions.
+///
+/// <para><b>Why this file has to exist.</b> A negative assertion that already passes for the wrong
+/// reason still passes after it is fixed, so "the suite is green" is evidence of nothing. The only
+/// way to know an assertion means something is to CONSTRUCT the state it must reject and watch it
+/// reject it — and to watch the shape it replaces ACCEPT it. Both halves are here, on the real
+/// predicates (<see cref="RedriveObservation"/>), against the real ledger
+/// (<see cref="NodeTypeCompileParkRegistry"/>).</para>
+///
+/// <para><b>The replay is not a metaphor — it is the mirror.</b> <c>MeshNodeStreamCache</c> backs
+/// every <c>GetMeshNodeStream(path)</c> entry with <c>new ReplaySubject&lt;MeshNode&gt;(1)</c>, so
+/// these tests use exactly that type. A new subscription is handed the one snapshot the mirror
+/// holds; everything before it is gone.</para>
+///
+/// <para>No mesh, no hub, no Roslyn: deterministic and sub-second, which is what lets it be the
+/// evidence for a suite whose own timing is the thing under suspicion.</para>
+/// </summary>
+public class RedriveObservationReplayTest(ITestOutputHelper output)
+{
+    private const string TypePath = "type/RedriveProbe";
+    private const string Inputs = "fw=1.0|mods=abc|src=42";
+
+    private static MeshNode Node(
+        long version, CompilationStatus status, string? failedInputs, string? error = null) =>
+        MeshNode.FromPath(TypePath) with
+        {
+            NodeType = MeshNode.NodeTypePath,
+            State = MeshNodeState.Active,
+            Version = version,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = "config => config",
+                CompilationStatus = status,
+                CompilationError = error,
+                FailedBuildInputs = failedInputs,
+            }
+        };
+
+    private static NodeTypeDefinition Def(MeshNode node) => (NodeTypeDefinition)node.Content!;
+
+    // ── half 1 + 2 for the FORGE BARRIER ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE BUG, DEMONSTRATED. <c>ForgeNeverCompiledFailure</c>'s barrier waited for
+    /// <c>n.Version &gt;= forged.Version</c>, where <c>forged</c> is what
+    /// <c>GetMeshNodeStream(path).Update(...)</c> returned. That node is <c>UpdateRemote</c>'s
+    /// OPTIMISTIC LOCAL snapshot — <c>update(current)</c> — and the forge lambda rewrites only
+    /// <c>Content</c>, so it carries the PRE-write version. The bound is therefore a version the
+    /// mirror is already sitting on, and the <c>Replay(1)</c> hand-off satisfies it with the
+    /// PRE-FORGE snapshot: the barrier passes whether or not the write ever landed, and every
+    /// assertion downstream of it is anchored before the forge.
+    /// </summary>
+    [Fact]
+    public async Task TheOldForgeBarrier_IsSatisfiedByTheReplayedPreForgeSnapshot()
+    {
+        var mirror = new ReplaySubject<MeshNode>(1);
+        var preForge = Node(version: 7, CompilationStatus.Error, failedInputs: Inputs,
+            error: "CS0103: The name 'ThisSymbolDoesNotExist' does not exist");
+        mirror.OnNext(preForge);
+
+        // What Update hands back: the same node with forged Content — and the SAME Version,
+        // because the lambda never touches it and the owner's mint is not in this emission.
+        var forgedOptimistic = preForge with
+        {
+            Content = Def(preForge) with
+            {
+                CompilationStatus = CompilationStatus.Error,
+                CompilationError = "FORGED-marker",
+                FailedBuildInputs = null,
+                LatestAssemblyPath = null,
+                CompiledFrameworkVersion = null,
+            }
+        };
+        forgedOptimistic.Version.Should().Be(preForge.Version,
+            "UpdateRemote emits update(current); the forge lambda rewrites Content only, so the "
+            + "returned node carries the PRE-write version — the owner's mint is not in it");
+        output.WriteLine(
+            $"Update returned version {forgedOptimistic.Version}; the mirror already holds "
+            + $"version {preForge.Version}. The old bound is '>= {forgedOptimistic.Version}'.");
+
+        // ── the shape on main ──
+        var accepted = await mirror.Should().Within(2.Seconds())
+            .Match(n => n.Version >= forgedOptimistic.Version);
+
+        // It accepted the PRE-FORGE snapshot: the forge's marker is absent and the pre-forge
+        // FailedBuildInputs is still there — this node predates the write the barrier is for.
+        accepted.Version.Should().Be(preForge.Version);
+        Def(accepted).CompilationError.Should().NotBe("FORGED-marker",
+            "the bound was satisfied by the replayed PRE-FORGE snapshot, not by the forge");
+        Def(accepted).FailedBuildInputs.Should().Be(Inputs,
+            "the forge nulls FailedBuildInputs — this record still carries the pre-forge stamp, so "
+            + "it is the state the mirror was already holding");
+        output.WriteLine(
+            "OLD BARRIER ACCEPTED the replay: version " + accepted.Version
+            + ", CompilationError='" + Def(accepted).CompilationError
+            + "', FailedBuildInputs='" + Def(accepted).FailedBuildInputs + "' — no forge in it.");
+
+        // ── the shape that replaces it: STRICTLY past the watermark ──
+        var watermark = preForge.Version;
+        Func<Task> rejects = async () => await mirror.Should().Within(500.Milliseconds())
+            .Match(n => RedriveObservation.IsPastWatermark(n, watermark));
+        await rejects.Should().ThrowAsync<AssertionException>(
+            "the replayed pre-forge snapshot IS the watermark, so a strict bound must refuse it");
+        output.WriteLine($"NEW BARRIER REJECTED the same replay (watermark v{watermark}).");
+
+        // …and it still accepts the genuine case: the OWNER mints NextVersion(current).
+        var ownerCommitted = Node(version: MeshNode.NextVersion(preForge.Version),
+            CompilationStatus.Pending, failedInputs: Inputs);
+        mirror.OnNext(ownerCommitted);
+        var genuine = await mirror.Should().Within(5.Seconds())
+            .Match(n => RedriveObservation.IsPastWatermark(n, watermark));
+        genuine.Version.Should().Be(8);
+        output.WriteLine($"NEW BARRIER ACCEPTED the genuine owner-minted revision v{genuine.Version}.");
+    }
+
+    // ── half 1 + 2 for the NEGATIVE ASSERTION ───────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE BUG, DEMONSTRATED — the negative assertion this time.
+    /// <c>AssertNoFurtherCompileIsDriven</c> claimed "nothing re-drove this type" on the strength
+    /// of one thing: no <c>Pending</c>/<c>Compiling</c> value arriving on the mirror. But the
+    /// window the test MEANS opens where the caller stands; the window a bare <c>NotEmit</c>
+    /// OBSERVES opens when its <c>SubscribeOn(TaskPoolScheduler)</c> attach lands — and
+    /// <c>Replay(1)</c> collapses everything in between into a single snapshot. A complete
+    /// re-drive (<c>Pending → Compiling → Error</c>) fits in that gap, and for a type whose source
+    /// cannot compile the state it re-settles at is byte-identical to the state the window opened
+    /// on. The assertion then passes having watched the exact thing it forbids.
+    /// </summary>
+    [Fact]
+    public async Task TheOldNegativeAssertion_IsSatisfiedByAReplayThatHidesAWholeReDrive()
+    {
+        var ledger = new NodeTypeCompileParkRegistry();
+        var mirror = new ReplaySubject<MeshNode>(1);
+
+        // The type has already had its one bounded attempt: Error, inputs stamped, parked.
+        ledger.RecordFailureRedrive(TypePath, Inputs);
+        ledger.RecordAttempt(TypePath);
+        var settled = Node(version: 9, CompilationStatus.Error, failedInputs: Inputs,
+            error: "CS0103: The name 'ThisSymbolDoesNotExist' does not exist");
+        mirror.OnNext(settled);
+
+        // t0 — the window OPENS. This is where the mesh test stands: it has just been handed
+        // `settled` by its Match and is about to claim nothing further is driven.
+        var window = RedriveObservation.OpenWindow(ledger, TypePath, settled.Version);
+
+        // t0+ε — a COMPLETE, UNBOUNDED re-drive: the kickoff records it, RunCompile dispatches
+        // Roslyn, the node runs Pending → Compiling → Error. Exactly what the assertion forbids.
+        // All of it lands before either subscriber attaches, so Replay(1) keeps only the last —
+        // and the last is indistinguishable from `settled`.
+        ledger.RecordFailureRedrive(TypePath, Inputs);
+        ledger.RecordAttempt(TypePath);
+        mirror.OnNext(Node(10, CompilationStatus.Pending, failedInputs: Inputs));
+        mirror.OnNext(Node(11, CompilationStatus.Compiling, failedInputs: Inputs));
+        var reSettled = Node(12, CompilationStatus.Error, failedInputs: Inputs,
+            error: "CS0103: The name 'ThisSymbolDoesNotExist' does not exist");
+        mirror.OnNext(reSettled);
+
+        // ── the shape on main: the state filter alone, no anchor, no ledger ──
+        await mirror
+            .Where(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling)
+            .Should().NotEmit(1.Seconds(),
+                "the shape on main — this PASSES, and a full re-drive just happened");
+        output.WriteLine(
+            "OLD NEGATIVE ASSERTION PASSED while the ledger recorded re-drive "
+            + $"{ledger.GetFailureRedriveCount(TypePath)} and attempt "
+            + $"{ledger.GetCompileAttemptCount(TypePath)} — a FALSE GREEN on the bound that keeps a "
+            + "permanently-broken NodeType out of an unbounded retry loop.");
+
+        // ── the shape that replaces it, over the SAME mirror in the SAME state ──
+        Func<Task> rejects = () => window.AssertNothingWasDriven(
+            mirror, 1.Seconds(), "a re-failed type must be left alone");
+        var thrown = await rejects.Should().ThrowAsync<AssertionException>(
+            "the ledger moved inside the window, and the ledger is the primary bound");
+        output.WriteLine("NEW NEGATIVE ASSERTION REJECTED the same replay: " + thrown.Which.Message);
+    }
+
+    /// <summary>
+    /// …and the replacement still ACCEPTS the genuine case — a quiet window over a mirror that is
+    /// replaying a settled snapshot and a ledger that does not move. Without this half the fix
+    /// could be "assert false", which rejects the replay and everything else with it.
+    /// </summary>
+    [Fact]
+    public async Task TheNewNegativeAssertion_AcceptsAQuietWindow()
+    {
+        var ledger = new NodeTypeCompileParkRegistry();
+        var mirror = new ReplaySubject<MeshNode>(1);
+
+        ledger.RecordFailureRedrive(TypePath, Inputs);
+        ledger.RecordAttempt(TypePath);
+        var settled = Node(version: 12, CompilationStatus.Error, failedInputs: Inputs);
+        mirror.OnNext(settled);
+
+        var window = RedriveObservation.OpenWindow(ledger, TypePath, settled.Version);
+        var summary = await window.AssertNothingWasDriven(
+            mirror, 1.Seconds(), "a re-failed type must be left alone");
+        output.WriteLine("NEW NEGATIVE ASSERTION ACCEPTED the quiet window: " + summary);
+    }
+
+    /// <summary>
+    /// The anchor is not decoration either: a re-drive that DOES reach the mirror inside the window
+    /// is caught by the stream half on its own, so the two witnesses are genuinely independent
+    /// (a drive that never made it to the ledger would still be caught).
+    /// </summary>
+    [Fact]
+    public async Task TheNewNegativeAssertion_CatchesADriveThatOnlyTheMirrorSaw()
+    {
+        var ledger = new NodeTypeCompileParkRegistry();
+        var mirror = new ReplaySubject<MeshNode>(1);
+        var settled = Node(version: 12, CompilationStatus.Error, failedInputs: Inputs);
+        mirror.OnNext(settled);
+
+        var window = RedriveObservation.OpenWindow(ledger, TypePath, settled.Version);
+        // A fresh drive lands on the node and NOTHING is recorded in the ledger.
+        mirror.OnNext(Node(13, CompilationStatus.Pending, failedInputs: null));
+
+        Func<Task> rejects = () => window.AssertNothingWasDriven(
+            mirror, 1.Seconds(), "a re-failed type must be left alone");
+        var thrown = await rejects.Should().ThrowAsync<ObservableAssertionException>(
+            "the stream half must catch a drive the ledger never saw");
+        output.WriteLine("Stream half REJECTED an unledgered drive: " + thrown.Which.Message);
+    }
+
+    /// <summary>
+    /// …and the anchor does not make the stream half blind: the version clause rejects only the
+    /// replay of the snapshot the window OPENED on, never a genuinely newer one. Pinned by feeding
+    /// the predicate both directly.
+    /// </summary>
+    [Fact]
+    public void TheWatermarkRejectsOnlyTheReplay()
+    {
+        var settled = Node(version: 12, CompilationStatus.Compiling, failedInputs: null);
+        RedriveObservation.IsFreshCompileDrive(settled, watermark: 12).Should().BeFalse(
+            "this IS the snapshot the window opened on, handed back by Replay(1)");
+        RedriveObservation.IsFreshCompileDrive(
+            Node(13, CompilationStatus.Compiling, failedInputs: null), watermark: 12)
+            .Should().BeTrue("a strictly newer revision is a genuine fresh drive");
+        RedriveObservation.IsFreshCompileDrive(
+            Node(13, CompilationStatus.Error, failedInputs: Inputs), watermark: 12)
+            .Should().BeFalse("a newer revision that is not a compile drive is not one");
+    }
+}


### PR DESCRIPTION
Closes #1866.

`NeverCompiledFailureRedriveTest`'s bounded assertions were anchored on a barrier that a **replayed** emission satisfies, so the assertion pinning the automatic re-drive's **bound** — `ABrokenSource_IsReDrivenExactlyOnce_AndThenLeftAlone`, which is what keeps a permanently-broken NodeType out of an unbounded retry loop on the per-NodeType hub's single-threaded action block — could pass without observing anything.

#1825 added the test; #1850 fixed the *first* race in the same barrier (it waited to *see* a record that is transient by construction). This is the second one it left behind.

## The defect — not a race, an identity

```csharp
var forgedVersion = forged.Version;                       // ← what Update() returned
await workspace.GetMeshNodeStream(typePath)
    .Should().Within(20.Seconds())
    .Match(n => n.Version >= forgedVersion);
```

- `Update` on a foreign path is `UpdateRemote`, which emits **`update(current)`** — the *optimistic local snapshot*; the queue "does NOT wait for the patch's echo from the owner". The forge lambda rewrites `Content` only, so the returned node carries the **pre-write** `Version`.
- `GetMeshNodeStream(path)` is a **`Replay(1)`** mirror (`new ReplaySubject<MeshNode>(1)` per cache entry): a new subscription is handed the snapshot already held.

So `>= forged.Version` is a bound **the stream is already sitting on**. The barrier passes whether or not the write landed, and everything downstream is anchored before the forge. In `ABrokenSource_…` the next `Match` waits for `Error && FailedBuildInputs` — for a type that cannot compile, byte-identical to the record that was already there.

Printed by the barrier itself on the real mesh, twice in one run:

```
the mirror was replaying v6, Update handed back v6 (the SAME revision — so the old '>= 6' bound
was already satisfied), owner then moved to v7.
the mirror was replaying v7, Update handed back v7 (the SAME revision — so the old '>= 7' bound
was already satisfied), owner then moved to v8.
```

And the negative assertion had **no anchor at all**. The window it *means* opens where the caller stands; the window `NotEmit` *observes* opens when its `SubscribeOn(TaskPoolScheduler)` attach lands — and `Replay(1)` collapses everything between into one snapshot. A whole `Pending → Compiling → Error` cycle fits in that gap. Its docstring claimed non-vacuity on the strength of sibling assertions that are different subscriptions and never assert a `Pending`/`Compiling` value reached anyone.

## The fix — a version watermark, plus the ledger as the primary bound

New `RedriveObservation` / `RedriveWindow` (test-side vocabulary, shared by the mesh tests and the proof):

- **Watermark.** The barrier becomes strict (`Version > watermark`) and the anchor is threaded into every observation downstream of the forge. 🚨 **Whose version:** the **owner's**, and a strict *lower bound*, not a receipt — `MeshNode.Version` is minted by the owning hub for **every** writer (`NextVersion` = `current + 1`; #1833 flaked on assuming it tracks the caller's own write). It claims exactly one thing: the owner committed at least one revision past the state this write was diffed against, so no later emission can be that state replayed. Said in those words in the code.
- **Ledger (primary).** `NodeTypeCompileParkRegistry` counts *events* — `RecordFailureRedrive` per automatic kickoff, `RecordAttempt` per real Roslyn dispatch (`RunCompile`). A counter cannot be replayed or conflated and can tell "the re-drive ran and re-failed" apart from "I was handed the pre-forge snapshot back". The window captures both counters where the *caller* stands, not where `NotEmit` happens to attach. The stream observation stays as independent corroboration.

## Non-vacuity — both halves, because "it passes" proves nothing here

`NeverCompiledFailureRedriveTest` is **10/10 green locally on `origin/main`** (class-level, 10 iterations, 75a70c20f). A false green survives its own fix, so the evidence is a **constructed replay**, not a repeat run.

`RedriveObservationReplayTest` (new; a real `ReplaySubject<MeshNode>(1)`, a real `NodeTypeCompileParkRegistry`, no mesh — 4.4 s):

```
Passed  TheOldForgeBarrier_IsSatisfiedByTheReplayedPreForgeSnapshot
  Update returned version 7; the mirror already holds version 7. The old bound is '>= 7'.
  OLD BARRIER ACCEPTED the replay: version 7,
    CompilationError='CS0103: The name 'ThisSymbolDoesNotExist' does not exist',
    FailedBuildInputs='fw=1.0|mods=abc|src=42' — no forge in it.
  NEW BARRIER REJECTED the same replay (watermark v7).
  NEW BARRIER ACCEPTED the genuine owner-minted revision v8.

Passed  TheOldNegativeAssertion_IsSatisfiedByAReplayThatHidesAWholeReDrive
  OLD NEGATIVE ASSERTION PASSED while the ledger recorded re-drive 2 and attempt 2 —
    a FALSE GREEN on the bound that keeps a permanently-broken NodeType out of an unbounded
    retry loop.
  NEW NEGATIVE ASSERTION REJECTED the same replay: Expected value to be 1 … but found 2.

Passed  TheNewNegativeAssertion_AcceptsAQuietWindow          ← the fix is not "assert false"
Passed  TheNewNegativeAssertion_CatchesADriveThatOnlyTheMirrorSaw ← the two witnesses are independent
Passed  TheWatermarkRejectsOnlyTheReplay                     ← the anchor rejects the replay, not newer state
```

## Verification

| | |
|---|---|
| `dotnet build … -c Release -p:CIRun=true -warnaserror` | 0 Warning(s), 0 Error(s) |
| `NeverCompiledFailureRedriveTest`, class-level, BEFORE (origin/main) | **10/10 pass** |
| `NeverCompiledFailureRedriveTest` + `RedriveObservationReplayTest`, class-level, AFTER | ****10/10 pass** (80 test executions)** |

No "What's New" entry: test-only change, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
