### PR TITLE
fix(#1814): the compilation fault card re-evaluates instead of latching

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -296,6 +296,66 @@ keeps running however long it needs (see the stage bounds above).
 
 ---
 
+## A fault card must not outlive its cause — the overlay RE-EVALUATES
+
+The overlay is a **degraded binding with a lifetime**, never a verdict. Enrichment binds a
+per-instance hub's configuration exactly once — the re-enrichment short-circuit
+(`node.HubConfiguration != null`) is what makes activation cheap — so a card applied during a
+bad ten seconds is served for the grain's whole lifetime unless something *revokes* it. That
+revocation is `ArmOverlaySelfHeal`, and its correctness rests on one rule:
+
+> 🚨 **The heal signal must not share a failure mode with the fault.** Both original heal routes
+> — the version-advance and the grace re-read — subscribe
+> `meshHub.GetWorkspace().GetMeshNodeStream(nodeType)`: *the same stream whose silence made the
+> enrichment slow path time out*. When that stream stops emitting, the fault and its cure vanish
+> together and the card is permanent.
+
+That is not hypothetical. On **2026-08-17** (issue #1814) a deploy left the first pod compiling
+269 types; page requests inside that window latched the card onto ~12 plugin roots
+(`Training`, `Video`, `RolePlay`, `Edu`, `Chess`, `Collaboration`, …). `Store/Plugin` then
+compiled **successfully on both pods** — and **1 h 24 m later** an anonymous browser still got
+the card, while neither pod had logged a single overlay or "did not settle" event in the
+preceding 30–40 minutes. Nothing was retrying. Recycling the twelve roots by hand was the only
+remedy, and the card's own copy ("the page recovers automatically … this instance recycles
+itself") was straightforwardly false.
+
+So the watcher has a third route that owes the stream nothing:
+
+- **`AuthoritativeTypeRead`** — a one-shot `path:{nodeType}` query through `IMeshQueryCore`, as
+  System. It reads the mesh's **query providers (storage)**, not a cached stream, so a mirror
+  that can never learn it is stale cannot suppress it.
+- **A widening ladder, not a poll** — `45 s → 90 s → 3 min → 6 min`, then **10 min for ever**
+  (`ReEvaluationLadder` / `ReEvaluationCeiling`). One read per rung, each capped by
+  `ReEvaluationReadTimeout` and serialised with `Concat`, so a slow read can never overlap the
+  next rung. At the 2026-08-17 blast radius that steady state is ~72 single-node reads an hour
+  across the whole mesh. **The ladder never stops** — a re-evaluation budget that ran out would
+  re-create precisely the defect it exists to remove.
+- **A faulted or empty read is not a verdict** — it is logged and the ladder asks again. Giving
+  up quietly is how the card latched in the first place.
+- **Loud on non-convergence** — a re-read that still finds no usable build logs the type's
+  status/assembly/framework; past the last rung it does so at `Warning`, next to the existing
+  admin notification at `StuckReportDelay`.
+
+### …and the recycle it orders is SPACED, because it destroys its own watcher
+
+The heal disposes the instance hub — taking the watcher with it. The replacement hub arms a
+**fresh** watcher whose ladder starts at the first rung, so a pair whose *re-enrichment* keeps
+faulting (a type that reports a usable build the instance still cannot bind — #1814's
+deterministic cross-hub `Conflict`) would recycle every 45 s for ever. No state inside the
+watcher can bound that, because the bound has to outlive the thing being bounded.
+
+`OverlayHealBudget` (mesh-scoped singleton, registered in `AddGraph`) is that memory, keyed by
+*(instance, NodeType)*. The **first** heal is never delayed; each further heal inside a 30-minute
+window waits out a widening spacing (45 s → 90 s → 3 min → 6 min → 10 min). It **defers** a
+recycle, never cancels one, and a pair that heals once and stays healthy is forgotten.
+
+Pinned by `OverlaySelfHealWatcherTest` (silent stream → heals unaided; still-broken type → keeps
+its card on single-digit reads per hour; faulted/empty read → ladder continues; non-converging
+loop → bounded recycles, with the un-budgeted control in the same test) and
+`OverlayHealBudgetTest`.
+
+---
+
 ## Cancelling a compile
 
 Compilation is an Activity, so it cancels through the **Activity Control Plane**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-broken-page-stops-being-broken-by-itself.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-18-a-broken-page-stops-being-broken-by-itself.md
@@ -1,0 +1,41 @@
+---
+Name: A broken page stops being broken by itself
+Category: Fix
+Description: The "this page can't be displayed" card now keeps re-checking the type it is waiting for and clears itself the moment the build settles, instead of staying on screen after the cause is gone.
+Icon: ArrowSync
+Order: -20260818
+---
+
+# A broken page stops being broken by itself
+
+When a page's type is still compiling — right after a platform update, or while a
+bulk rebuild is queued — the page shows a card that says so, and promises to come
+back on its own once the build settles.
+
+It did not always keep that promise. If the page never heard that the build had
+finished, the card stayed. On 2026-08-17 every course cover on the public site kept
+serving that card for **an hour and twenty-four minutes after the type had compiled
+successfully** — nothing was retrying, and the only way out was for an operator to
+recycle twelve pages by hand.
+
+The reason was narrow and worth naming: the card was waiting to be *told* the build
+had settled, over the very channel whose silence had produced the card in the first
+place. One broken channel, and both the fault and its cure went with it.
+
+Now the page **checks for itself**. A page showing the card re-reads its type's build
+from the store — after about a minute, then less and less often — and recycles onto
+the real page as soon as there is something to bind. No notification has to arrive,
+no operator has to intervene, and nothing has to be running for it to work.
+
+Two things deliberately did **not** change:
+
+- **A genuinely broken type still shows its card.** The goal is a card that clears
+  when its cause clears, never one that hides a real problem. If the type does not
+  build, the page keeps saying so — and says it in the log too, so it is visible
+  before a user reports it.
+- **Re-checking stays cheap.** It is a widening interval, not a poll: a page that
+  cannot recover settles at one check every ten minutes, so a struggling mesh is
+  never asked to carry a retry storm on top of whatever it is already dealing with.
+
+If you would rather not wait, the **Recycle** menu still refreshes a page
+immediately — it is now a shortcut rather than the only way back.

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -295,6 +295,11 @@ public static class GraphConfigurationExtensions
                     // user-visible notification. Instance maps only — no static state. See
                     // NodeTypeCompileParkRegistry + InstallCompileWatcher's parked short-circuit.
                     services.AddSingleton<NodeTypeCompileParkRegistry>();
+                    // Mesh-scoped spacing for the compilation-overlay self-heal. A self-heal
+                    // disposes the very hub that holds its watcher, so without memory that
+                    // outlives the recycle a pair whose re-enrichment keeps faulting would
+                    // re-arm at the first rung for ever. See OverlayHealBudget + issue #1814.
+                    services.AddSingleton<OverlayHealBudget>();
                     // 🅿️ Deleting a NodeType clears its parked compile failure — the registry is
                     // keyed by PATH and outlives the node, so without this a delete+recreate at
                     // the same path started parked and never compiled (only a restart healed).

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1954,9 +1954,14 @@ internal static class NodeTypeEnrichmentHelpers
         {
             UserId = WellKnownUsers.System,
         };
-        return () => Observable.Using(
-                () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
-                _ => queryCore.Query<MeshNode>(request, options))
+        // 🚨 RunAsSystem, never `Observable.Using(() => access.ImpersonateAsSystem(), …)` (#1790):
+        // that shape opens the AsyncLocal scope on the SUBSCRIBING thread and disposes it when the
+        // query terminates — the owning hub's response thread — leaving the subscriber latched as
+        // system-security. Here the subscriber is an instance hub's watcher, so the latch would sit
+        // on a long-lived hub. RunAsSystem seals both ends inside one Subscribe; the whole cold
+        // pipeline is composed INSIDE the work factory so its emission-time behaviour is unchanged.
+        return () => accessService.RunAsSystem(() => queryCore
+            .Query<MeshNode>(request, options)
             .Where(c => c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
             .Take(1)
             // Match the path EXACTLY: this answer decides whether an instance recycles, and a
@@ -1964,7 +1969,7 @@ internal static class NodeTypeEnrichmentHelpers
             // not the one it is waiting for. No exact hit is simply "no answer" — the ladder asks
             // again rather than treating absence as news.
             .Select(c => c.Items.FirstOrDefault(
-                n => string.Equals(n.Path, nodeType, StringComparison.OrdinalIgnoreCase)));
+                n => string.Equals(n.Path, nodeType, StringComparison.OrdinalIgnoreCase))));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1433,6 +1433,18 @@ internal static class NodeTypeEnrichmentHelpers
     /// <c>MeshNodeHubFactory</c> still composes
     /// <c>DefaultNodeHubConfiguration</c> underneath, so the instance keeps
     /// serving the generic areas until it heals.</para>
+    ///
+    /// <para>🚨 <b>The watcher must not be fed ONLY by the stream the fault came from</b>
+    /// (issue #1814 defect B). Both original heal routes read
+    /// <c>meshHub.GetWorkspace().GetMeshNodeStream(nodeType)</c> — the same stream whose
+    /// silence made the slow path time out — so when that stream stops emitting, the fault card is
+    /// permanent: on memex, 2026-08-17, twelve plugin roots served it for 1 h 24 m after
+    /// <c>Store/Plugin</c> had compiled successfully on both pods, with no overlay or "did not
+    /// settle" event logged in the preceding 30–40 minutes and no operator remedy short of
+    /// recycling each root by hand. So the wrap also hands the watcher an INDEPENDENT
+    /// <see cref="AuthoritativeTypeRead"/> and the mesh's <see cref="OverlayHealBudget"/>: the card
+    /// is re-evaluated on a widening ladder against storage, and the recycle it triggers is spaced
+    /// across hub lifetimes so a non-converging pair cannot spin.</para>
     /// </summary>
     internal static MeshNode WithOverlaySelfHeal(
         MeshNode overlaid,
@@ -1454,7 +1466,11 @@ internal static class NodeTypeEnrichmentHelpers
                         instanceHub.RegisterForDisposal(ArmOverlaySelfHeal(
                             meshHub.GetWorkspace().GetMeshNodeStream(nodeType),
                             instanceHub, nodeType, typeVersionAtOverlay, logger,
-                            guards: NodeTypeCompilationHelpers.GuardsOf(meshHub)));
+                            guards: NodeTypeCompilationHelpers.GuardsOf(meshHub),
+                            // The escape hatch out of a permanently silent type stream — see
+                            // ArmOverlaySelfHeal's re-evaluation route (issue #1814 defect B).
+                            reRead: AuthoritativeTypeRead(meshHub, nodeType),
+                            budget: meshHub.ServiceProvider.GetService<OverlayHealBudget>()));
                     }
                     catch (Exception ex)
                     {
@@ -1626,10 +1642,33 @@ internal static class NodeTypeEnrichmentHelpers
     ///     pods (memex, 2026-07-27). Re-reading after a delay heals it while keeping the
     ///     anti-hot-loop property — never instant, so an instance that still cannot build
     ///     recycles at most once per grace window.</item>
+    ///   <item><b>Re-evaluation</b> (<see cref="ReEvaluationLadder"/>) — nothing arrives on
+    ///     <paramref name="typeStream"/> AT ALL, so neither of the two routes above can ever be
+    ///     evaluated against fresh state. This is the 2026-08-17 memex outage (issue #1814,
+    ///     defect B): every course cover served a fault card for 1 h 24 m AFTER
+    ///     <c>Store/Plugin</c> had compiled successfully on both pods, with no overlay and no
+    ///     "did not settle" event logged in the preceding 30–40 minutes — nothing was retrying,
+    ///     the card was simply cached on the instance hub and served. The mechanism is that both
+    ///     routes above are PUSH-driven off the same stream whose silence produced the fault, so
+    ///     the heal signal and the fault shared a single point of failure; the grace route's
+    ///     re-subscribe replays the workspace's cached snapshot rather than re-reading anything.
+    ///     <paramref name="reRead"/> breaks that: an AUTHORITATIVE one-shot read of the NodeType
+    ///     node, on a widening ladder, that owes nothing to the stream.</item>
     /// </list>
     /// Unsettled states and non-<see cref="NodeTypeDefinition"/> content are ignored. Errors are
     /// logged, never rethrown — the watcher is best-effort by design.
     /// </summary>
+    /// <param name="reRead">
+    /// An AUTHORITATIVE one-shot read of the NodeType node — see
+    /// <see cref="AuthoritativeTypeRead"/>, which resolves it from the mesh's query providers
+    /// (storage) rather than from any cached stream. Null disables re-evaluation and restores the
+    /// push-only behaviour, which is what a hub with no query core can offer.
+    /// </param>
+    /// <param name="budget">
+    /// Spacing across hub lifetimes — see <see cref="OverlayHealBudget"/>. A self-heal disposes the
+    /// hub that holds this watcher, so a pair whose re-enrichment faults again would otherwise
+    /// re-arm at the first rung forever. Null applies no spacing.
+    /// </param>
     internal static IDisposable ArmOverlaySelfHeal(
         IObservable<MeshNode> typeStream,
         IMessageHub instanceHub,
@@ -1637,13 +1676,25 @@ internal static class NodeTypeEnrichmentHelpers
         long? typeVersionAtOverlay,
         ILogger? logger,
         IScheduler? scheduler = null,
-        NodeTypeCompilationHelpers.BuildGuards? guards = null)
+        NodeTypeCompilationHelpers.BuildGuards? guards = null,
+        Func<IObservable<MeshNode?>>? reRead = null,
+        OverlayHealBudget? budget = null)
     {
+        var clock = scheduler ?? Scheduler.Default;
+        var instancePath = instanceHub.Address.ToString();
+
         // ContentAs, never `is NodeTypeDefinition` — the #1669 blindness on un-materialized JSON
-        // emissions; see ArmStaleAssemblySelfHeal's predicate note.
-        var usable = typeStream.Where(t =>
-            t?.ContentAs<NodeTypeDefinition>(instanceHub.JsonSerializerOptions, logger) is { } d
-            && NodeTypeCompilationHelpers.HasUsableBuild(t, d, guards));
+        // emissions; see ArmStaleAssemblySelfHeal's predicate note. Deserialize ONCE per node and
+        // carry the definition with the verdict: a second ContentAs would also duplicate its
+        // degraded-content warning logs.
+        (NodeTypeDefinition? Def, bool Usable) Evaluate(MeshNode? t)
+        {
+            var def = t?.ContentAs<NodeTypeDefinition>(instanceHub.JsonSerializerOptions, logger);
+            return (def, def is not null
+                && NodeTypeCompilationHelpers.HasUsableBuild(t!, def, guards));
+        }
+
+        var usable = typeStream.Where(t => Evaluate(t).Usable);
 
         // FAST path — the version advanced past the overlay: a genuinely NEW build landed, heal now.
         var advanced = usable.Where(t =>
@@ -1661,20 +1712,82 @@ internal static class NodeTypeEnrichmentHelpers
         // what keeps the original anti-hot-loop guarantee — an instance that overlays again because
         // it STILL cannot build recycles at most once per grace period instead of spinning.
         var graced = Observable
-            .Timer(SelfHealGrace, scheduler ?? Scheduler.Default)
+            .Timer(SelfHealGrace, clock)
             .SelectMany(_ => usable.Take(1));
+
+        // RE-EVALUATION path — THE fix for issue #1814 defect B. Both routes above are fed by
+        // typeStream, so a stream that goes permanently silent (a cross-process write the reader's
+        // mirror is never told about; nothing to notify a workspace snapshot that it is stale)
+        // leaves the fault card cached on the instance hub with nothing anywhere retrying. A fault
+        // card must not outlive its cause, and it must not depend for its clearing on the very
+        // signal path whose failure produced it — so this route RE-READS the NodeType from the
+        // mesh's query providers, on its own clock, owing the stream nothing.
+        //
+        // Bounded by construction, because the naive shape (re-probe per render) amplifies load
+        // exactly when the mesh is already struggling: ONE read per rung of a widening ladder
+        // (ReEvaluationLadder, then ReEvaluationCeiling for ever), each capped by
+        // ReEvaluationReadTimeout, serialised with Concat so a slow read can never overlap the
+        // next rung. A faulted read is logged and skipped, never terminal — giving up is how the
+        // card latched in the first place.
+        var reEvaluated = reRead is null
+            ? Observable.Empty<MeshNode>()
+            : Observable
+                .Generate(
+                    initialState: 0,
+                    condition: _ => true,
+                    iterate: attempt => attempt + 1,
+                    resultSelector: attempt => attempt,
+                    timeSelector: ReEvaluationDelay,
+                    scheduler: clock)
+                .Select(attempt => Observable
+                    .Defer(() => reRead().Take(1).Timeout(ReEvaluationReadTimeout, clock))
+                    .DefaultIfEmpty(null)
+                    .Catch<MeshNode?, Exception>(ex =>
+                    {
+                        // A read that could not be answered is not a verdict — the ladder simply
+                        // asks again at the next rung.
+                        logger?.LogWarning(ex,
+                            "Overlay self-heal: re-read #{Attempt} of NodeType '{NodeType}' for stuck instance '{InstancePath}' faulted ({ExceptionType}) — retrying at the next rung",
+                            attempt + 1, nodeType, instancePath, ex.GetType().Name);
+                        return Observable.Return<MeshNode?>(null);
+                    })
+                    .Select(t => (Node: t, Verdict: Evaluate(t)))
+                    .Do(x => ReportReEvaluation(attempt, x.Node, x.Verdict)))
+                .Concat()
+                .Where(x => x.Verdict.Usable)
+                .Select(x => x.Node!);
 
         var healed = 0;
         var heal = advanced
             .Merge(graced)
+            .Merge(reEvaluated)
+            .Take(1)
+            // Spacing, not suppression: the heal signal is DEFERRED to the budget's earliest
+            // instant, never dropped. A first heal is un-delayed; a pair that keeps re-overlaying
+            // after its own recycle backs off instead of spinning at the first rung.
+            .SelectMany(t =>
+            {
+                var now = clock.Now;
+                var earliest = budget?.EarliestHeal(instancePath, nodeType, now) ?? now;
+                if (earliest <= now)
+                    return Observable.Return(t);
+                // NON-CONVERGENCE, SAID OUT LOUD. Reaching here means this instance has already
+                // recycled itself off this type's overlay and is stuck on it again.
+                logger?.LogWarning(
+                    "Overlay self-heal: instance '{InstancePath}' is stuck on NodeType '{NodeType}' AGAIN after {Heals} self-heal(s) — the type reports a usable build but the instance cannot bind it. Deferring the next recycle by {Delay:0}s.",
+                    instancePath, nodeType, budget?.HealsSoFar(instancePath, nodeType, now) ?? 0,
+                    (earliest - now).TotalSeconds);
+                return Observable.Timer(earliest - now, clock).Select(_ => t);
+            })
             .Take(1)
             .Subscribe(
                 t =>
                 {
                     Interlocked.Exchange(ref healed, 1);
+                    var heals = budget?.RecordHeal(instancePath, nodeType, clock.Now) ?? 1;
                     logger?.LogInformation(
-                        "Overlay self-heal: NodeType '{NodeType}' reached a usable build (version {Version}, at-overlay {VersionAtOverlay}) — recycling stuck instance '{InstancePath}'",
-                        nodeType, t.Version, typeVersionAtOverlay, instanceHub.Address);
+                        "Overlay self-heal: NodeType '{NodeType}' reached a usable build (version {Version}, at-overlay {VersionAtOverlay}, self-heal #{Heals}) — recycling stuck instance '{InstancePath}'",
+                        nodeType, t.Version, typeVersionAtOverlay, heals, instanceHub.Address);
                     // The RecycleLayoutArea idiom: the hub disposes itself, the
                     // grain deactivates, and the next access re-enriches from
                     // scratch against the now-usable NodeType.
@@ -1684,6 +1797,29 @@ internal static class NodeTypeEnrichmentHelpers
                     "Overlay self-heal watcher for NodeType '{NodeType}' (instance '{InstancePath}') faulted — falling back to manual Recycle",
                     nodeType, instanceHub.Address));
 
+        void ReportReEvaluation(
+            int attempt, MeshNode? typeNode, (NodeTypeDefinition? Def, bool Usable) verdict)
+        {
+            if (verdict.Usable)
+                return;
+            var status = typeNode is null
+                ? "(no node at that path)"
+                : verdict.Def is { } d
+                    ? $"status {d.CompilationStatus?.ToString() ?? "(none)"}, assembly {d.LatestAssemblyPath ?? "(none)"}, framework {d.CompiledFrameworkVersion ?? "(none)"}"
+                    : "(content is not a NodeTypeDefinition)";
+            // Inside the ladder this is the expected "still building" case; once the ladder has
+            // reached its ceiling the fault is no longer transient and has to be visible at
+            // production log levels.
+            if (attempt + 1 >= ReEvaluationLadder.Length)
+                logger?.LogWarning(
+                    "Overlay self-heal: re-read #{Attempt} of NodeType '{NodeType}' STILL reports no usable build — instance '{InstancePath}' is still serving the fallback card [{Status}]",
+                    attempt + 1, nodeType, instancePath, status);
+            else
+                logger?.LogInformation(
+                    "Overlay self-heal: re-read #{Attempt} of NodeType '{NodeType}' reports no usable build yet — instance '{InstancePath}' keeps the fallback card [{Status}]",
+                    attempt + 1, nodeType, instancePath, status);
+        }
+
         // AND IF IT DOES NOT HEAL, SAY SO. The 2026-07-27 outage was invisible from the inside:
         // no log line carried the overlay text, no notification was raised, and the first signal
         // was a user reporting a dead page. A page that is still serving the fallback well past
@@ -1691,7 +1827,7 @@ internal static class NodeTypeEnrichmentHelpers
         // naming the type and the instance. Best-effort and self-contained: reporting can never
         // throw back onto the enrichment path.
         var report = Observable
-            .Timer(StuckReportDelay, scheduler ?? Scheduler.Default)
+            .Timer(StuckReportDelay, clock)
             .Subscribe(
                 _ =>
                 {
@@ -1755,6 +1891,81 @@ internal static class NodeTypeEnrichmentHelpers
     /// instance cannot spin, short enough that a deploy heals itself well inside a support call.
     /// </summary>
     private static readonly TimeSpan SelfHealGrace = TimeSpan.FromSeconds(45);
+
+    /// <summary>
+    /// The widening ladder on which a stuck instance RE-READS its NodeType from the authoritative
+    /// store — the bound on issue #1814's re-evaluation route. The first rung matches
+    /// <see cref="SelfHealGrace"/>, so a deploy window that clears heals in the same time it
+    /// always did; the rungs then widen so a fault that does not clear costs a shrinking number of
+    /// reads per hour rather than a constant poll.
+    ///
+    /// <para>🚨 It is a LADDER, not a retry budget: past the last rung the interval holds at
+    /// <see cref="ReEvaluationCeiling"/> for as long as the instance lives. Stopping would restore
+    /// exactly the defect — a card that outlives its cause because something decided to stop
+    /// looking — and one read per instance per ten minutes is not a poll worth capping. At the
+    /// 2026-08-17 blast radius (12 latched instances) the steady state is 72 single-node reads an
+    /// hour, against the 1 h 24 m of served fault cards it replaces.</para>
+    /// </summary>
+    private static readonly TimeSpan[] ReEvaluationLadder =
+    [
+        TimeSpan.FromSeconds(45),
+        TimeSpan.FromSeconds(90),
+        TimeSpan.FromMinutes(3),
+        TimeSpan.FromMinutes(6),
+    ];
+
+    /// <summary>The interval the re-evaluation ladder holds at once its rungs are exhausted.</summary>
+    private static readonly TimeSpan ReEvaluationCeiling = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Upper bound on ONE authoritative re-read. A read that does not answer is not a verdict — the
+    /// ladder asks again at the next rung — but it must never pin the ladder, which is what an
+    /// unbounded read on a wedged mesh hub would do.
+    /// </summary>
+    private static readonly TimeSpan ReEvaluationReadTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>Delay before re-evaluation attempt <paramref name="attempt"/> (0-based).</summary>
+    private static TimeSpan ReEvaluationDelay(int attempt) =>
+        attempt < ReEvaluationLadder.Length ? ReEvaluationLadder[attempt] : ReEvaluationCeiling;
+
+    /// <summary>
+    /// An AUTHORITATIVE one-shot read of the NodeType node at <paramref name="nodeType"/>, or null
+    /// when this host registers no query core (a unit-test hub) — in which case the overlay watcher
+    /// keeps its push-only behaviour rather than pretending to re-evaluate.
+    ///
+    /// <para>🚨 The point is that it does NOT go through
+    /// <c>meshHub.GetWorkspace().GetMeshNodeStream(nodeType)</c>. That stream is the one the
+    /// enrichment slow path already read, and re-subscribing to it replays the workspace's cached
+    /// snapshot — which, when the writer is another process and nothing tells this one its mirror
+    /// is stale, is exactly the value that produced the fault card. Going to the query providers
+    /// (storage) is what makes the re-evaluation independent of the failure it is recovering
+    /// from. Runs as System, like every other infrastructure read on this path (the enrichment
+    /// existence probe uses the same request shape).</para>
+    /// </summary>
+    internal static Func<IObservable<MeshNode?>>? AuthoritativeTypeRead(
+        IMessageHub meshHub, string nodeType)
+    {
+        var queryCore = meshHub.ServiceProvider.GetService<IMeshQueryCore>();
+        if (queryCore is null)
+            return null;
+        var accessService = meshHub.ServiceProvider.GetService<AccessService>();
+        var options = meshHub.JsonSerializerOptions;
+        var request = MeshQueryRequest.FromQuery($"path:{nodeType}") with
+        {
+            UserId = WellKnownUsers.System,
+        };
+        return () => Observable.Using(
+                () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
+                _ => queryCore.Query<MeshNode>(request, options))
+            .Where(c => c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+            .Take(1)
+            // Match the path EXACTLY: this answer decides whether an instance recycles, and a
+            // ranked/fuzzy hit for a neighbouring node would recycle it against a build that is
+            // not the one it is waiting for. No exact hit is simply "no answer" — the ladder asks
+            // again rather than treating absence as news.
+            .Select(c => c.Items.FirstOrDefault(
+                n => string.Equals(n.Path, nodeType, StringComparison.OrdinalIgnoreCase)));
+    }
 
     /// <summary>
     /// How long a NodeType must stop publishing before <see cref="ArmStaleAssemblySelfHeal"/> acts.
@@ -1941,11 +2152,16 @@ internal static class NodeTypeEnrichmentHelpers
     /// </summary>
     private const string NoCodeChangeNeeded =
         "**No code change is needed for this.** ";
+    // 🚨 The promise in this paragraph is a CLAIM the platform has to keep. It did not, for
+    // 1 h 24 m of every course cover on memex (2026-08-17, issue #1814 defect B): the self-heal
+    // watched a push stream that had gone permanently silent, so nothing re-checked and the card
+    // outlived its cause until twelve roots were recycled by hand. ArmOverlaySelfHeal's
+    // re-evaluation ladder is what makes the sentence true — don't weaken either without the other.
     private const string UnsettledBuildGuidance =
         "This usually happens while a mesh restart or a bulk recompile is still in progress. "
-        + "The page recovers automatically: once the type's build settles, this instance recycles "
-        + "itself and shows the real page on the next load. If it stays stuck, use the **Recycle** "
-        + "menu to refresh it manually.";
+        + "The page recovers automatically: this instance re-checks the type's build (within a "
+        + "minute at first, then less often) and recycles itself onto the real page as soon as the "
+        + "build settles. If you don't want to wait, use the **Recycle** menu to refresh it now.";
 
     // Overlay copy for a REGISTRATION LOOKUP that never answered (the probe timeout).
     // Nothing about the type's source was read, so a "correct the code" page is a
@@ -1984,8 +2200,9 @@ internal static class NodeTypeEnrichmentHelpers
         + "This is a platform fault — not a **compilation** error in the source.";
     private const string EnrichmentFaultedGuidance =
         "Preparing this type for the instance failed before its build was consulted; the summary "
-        + "above names the fault, and the full stack is in the platform log. Use the **Recycle** "
-        + "menu to retry — the page also recovers on its own once the type resolves again.";
+        + "above names the fault, and the full stack is in the platform log. The page recovers on "
+        + "its own: this instance keeps re-checking the type and recycles itself once it resolves. "
+        + "Use the **Recycle** menu to retry immediately.";
 
     private const string FrameworkStaleIntro =
         "This item's type was built by a previous MeshWeaver version, so the **compilation** output "

--- a/src/MeshWeaver.Graph/Configuration/OverlayHealBudget.cs
+++ b/src/MeshWeaver.Graph/Configuration/OverlayHealBudget.cs
@@ -1,0 +1,102 @@
+using System.Collections.Concurrent;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// How often ONE instance may recycle itself off a compilation overlay for ONE NodeType — the
+/// bound that lets <see cref="NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal"/> keep RE-EVALUATING a
+/// fault card without turning a degraded page into a recycle storm.
+///
+/// <para><b>Why the watcher cannot bound itself.</b> The self-heal's whole action is to dispose the
+/// instance hub so the next access re-enriches. That destroys the watcher too: the replacement hub
+/// arms a FRESH one, whose ladder starts again at its first rung. So every piece of "we already
+/// tried this" state a watcher could hold dies exactly when it becomes relevant. If the
+/// re-enrichment faults again — a type that reports a usable build but whose activation still
+/// cannot be prepared, which is precisely the 2026-08-17 memex shape (a deterministic cross-hub
+/// <c>Conflict</c> on the recompile flip, issue #1814) — the pair would loop at the first rung
+/// forever. This registry is the memory that survives the recycle.</para>
+///
+/// <para><b>The rule.</b> The FIRST self-heal for a pair is never delayed — the overwhelmingly
+/// common case is a deploy window that has cleared, and making it wait would be a regression. Each
+/// FURTHER self-heal inside <see cref="ForgetWindow"/> must wait out a widening spacing
+/// (<see cref="Spacing"/>), so a non-converging pair costs at most one activation per step instead
+/// of one per grace window. An entry that has not healed for <see cref="ForgetWindow"/> is
+/// forgotten, so a genuinely transient fault that healed once and stayed healthy starts fresh.</para>
+///
+/// <para><b>Mesh-scoped singleton, instance maps only — NO static state</b> (registered in
+/// <c>AddGraph</c>, exactly like <see cref="NodeTypeCompileParkRegistry"/>). Absent from the service
+/// tree — a unit-test hub, a host without <c>AddGraph</c> — the watcher simply applies no spacing,
+/// which is the pre-registry behaviour rather than a failure.</para>
+///
+/// <para>This is a SPACING budget, never a cap: it delays a recycle, it never cancels one. A cap
+/// would re-create the very defect it is bounding — a fault card that outlives its cause because
+/// something decided to stop looking.</para>
+/// </summary>
+public sealed class OverlayHealBudget
+{
+    /// <summary>
+    /// Minimum spacing before the next self-heal of a pair, indexed by how many self-heals it has
+    /// already performed inside the window. Past the last entry the final value repeats — the
+    /// steady state for a pair that never converges.
+    /// </summary>
+    private static readonly TimeSpan[] Spacing =
+    [
+        TimeSpan.FromSeconds(45),
+        TimeSpan.FromSeconds(90),
+        TimeSpan.FromMinutes(3),
+        TimeSpan.FromMinutes(6),
+        TimeSpan.FromMinutes(10),
+    ];
+
+    /// <summary>
+    /// A pair that has not self-healed for this long is forgotten, so its next fault starts from an
+    /// un-delayed heal again. Long enough to cover a full deploy + warm-up window (the interval over
+    /// which repeats are evidence of non-convergence rather than of two unrelated incidents).
+    /// </summary>
+    internal static readonly TimeSpan ForgetWindow = TimeSpan.FromMinutes(30);
+
+    private readonly ConcurrentDictionary<string, Entry> entries =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private sealed record Entry(int Heals, DateTimeOffset LastHeal);
+
+    private static string Key(string instancePath, string nodeType) => $"{instancePath} {nodeType}";
+
+    /// <summary>
+    /// The instant from which this pair may recycle itself again.
+    /// <see cref="DateTimeOffset.MinValue"/> (i.e. "no wait") for a pair with no recent self-heal.
+    /// </summary>
+    public DateTimeOffset EarliestHeal(string instancePath, string nodeType, DateTimeOffset now)
+    {
+        if (!entries.TryGetValue(Key(instancePath, nodeType), out var entry))
+            return DateTimeOffset.MinValue;
+        if (now - entry.LastHeal >= ForgetWindow)
+            return DateTimeOffset.MinValue;
+        return entry.LastHeal + SpacingAfter(entry.Heals);
+    }
+
+    /// <summary>
+    /// How many self-heals this pair has already performed inside <see cref="ForgetWindow"/> — the
+    /// number a "still not converging" diagnostic reports.
+    /// </summary>
+    public int HealsSoFar(string instancePath, string nodeType, DateTimeOffset now)
+        => entries.TryGetValue(Key(instancePath, nodeType), out var entry)
+            && now - entry.LastHeal < ForgetWindow
+            ? entry.Heals
+            : 0;
+
+    /// <summary>
+    /// Record a self-heal that is about to be posted; returns the pair's new heal count. A record
+    /// older than <see cref="ForgetWindow"/> is replaced rather than incremented.
+    /// </summary>
+    public int RecordHeal(string instancePath, string nodeType, DateTimeOffset now)
+        => entries.AddOrUpdate(
+            Key(instancePath, nodeType),
+            _ => new Entry(1, now),
+            (_, existing) => now - existing.LastHeal >= ForgetWindow
+                ? new Entry(1, now)
+                : new Entry(existing.Heals + 1, now)).Heals;
+
+    private static TimeSpan SpacingAfter(int heals)
+        => Spacing[Math.Clamp(heals - 1, 0, Spacing.Length - 1)];
+}

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshQueryCore.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshQueryCore.cs
@@ -14,6 +14,11 @@ using System.Text.Json;
 // SyncedQueryInitialGateTest decorates the REAL IMeshQueryCore with a
 // subscription-delaying wrapper to pin the pre-Initial emission gate.
 [assembly: InternalsVisibleTo("MeshWeaver.Query.Test")]
+// OverlayReEvaluationReadTest substitutes the core to pin that the compilation-overlay
+// re-evaluation reads STORAGE rather than a cached stream (issue #1814) — a wiring only a
+// test over the real seam can prove, since every shape test passes against a read that never
+// matches anything.
+[assembly: InternalsVisibleTo("MeshWeaver.Graph.Test")]
 // Castle.DynamicProxy (used by NSubstitute) generates proxies in this assembly;
 // without InternalsVisibleTo it can't implement the internal IMeshQueryCore.
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/test/MeshWeaver.Graph.Test/OverlayHealBudgetTest.cs
+++ b/test/MeshWeaver.Graph.Test/OverlayHealBudgetTest.cs
@@ -1,0 +1,101 @@
+using System;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Unit contract for <see cref="OverlayHealBudget"/> — the spacing that survives the recycle a
+/// compilation-overlay self-heal orders (issue #1814 defect B). The watcher cannot hold this state
+/// itself: its heal disposes the hub that owns it, so the replacement hub's watcher would restart
+/// at the first rung for ever if the pair never converges.
+/// </summary>
+public class OverlayHealBudgetTest
+{
+    private const string Instance = "Edu";
+    private const string NodeType = "Store/Plugin";
+
+    private static readonly DateTimeOffset T0 =
+        new(2026, 8, 17, 20, 46, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// The overwhelmingly common case — a deploy window that cleared — must not be slowed down: a
+    /// pair with no recent self-heal recycles the instant it has a usable build.
+    /// </summary>
+    [Fact]
+    public void FirstHeal_IsNeverDelayed()
+    {
+        var budget = new OverlayHealBudget();
+
+        budget.EarliestHeal(Instance, NodeType, T0).Should().Be(DateTimeOffset.MinValue);
+        budget.HealsSoFar(Instance, NodeType, T0).Should().Be(0);
+    }
+
+    /// <summary>
+    /// Repeats inside the window widen: 45s, 90s, 3m, 6m, then 10m for ever. The ladder holds at
+    /// its last rung rather than stopping — a budget that ran out would re-create the latch.
+    /// </summary>
+    [Fact]
+    public void RepeatedHeals_WidenTheSpacing_AndHoldAtTheCeiling()
+    {
+        var budget = new OverlayHealBudget();
+        var expected = new[]
+        {
+            TimeSpan.FromSeconds(45),
+            TimeSpan.FromSeconds(90),
+            TimeSpan.FromMinutes(3),
+            TimeSpan.FromMinutes(6),
+            TimeSpan.FromMinutes(10),
+            TimeSpan.FromMinutes(10),
+            TimeSpan.FromMinutes(10),
+        };
+
+        var now = T0;
+        for (var i = 0; i < expected.Length; i++)
+        {
+            budget.RecordHeal(Instance, NodeType, now).Should().Be(i + 1);
+            budget.EarliestHeal(Instance, NodeType, now).Should().Be(now + expected[i],
+                "self-heal #{0} earns the next one a {1} wait", i + 1, expected[i]);
+            // Advance to the point the spacing allows, which is where the next heal lands.
+            now += expected[i];
+        }
+    }
+
+    /// <summary>
+    /// A pair that healed once and then stayed healthy is forgotten, so a genuinely new incident
+    /// later on is not charged for the old one.
+    /// </summary>
+    [Fact]
+    public void APairThatStaysHealthy_IsForgotten()
+    {
+        var budget = new OverlayHealBudget();
+        budget.RecordHeal(Instance, NodeType, T0);
+
+        var justInside = T0 + OverlayHealBudget.ForgetWindow - TimeSpan.FromSeconds(1);
+        budget.EarliestHeal(Instance, NodeType, justInside).Should().NotBe(DateTimeOffset.MinValue);
+        budget.HealsSoFar(Instance, NodeType, justInside).Should().Be(1);
+
+        var past = T0 + OverlayHealBudget.ForgetWindow;
+        budget.EarliestHeal(Instance, NodeType, past).Should().Be(DateTimeOffset.MinValue);
+        budget.HealsSoFar(Instance, NodeType, past).Should().Be(0);
+        // …and the next heal counts from one again, not from two.
+        budget.RecordHeal(Instance, NodeType, past).Should().Be(1);
+    }
+
+    /// <summary>
+    /// The budget is keyed by the PAIR. One instance stuck on one type must not slow the recovery
+    /// of a different instance, or of the same instance on a different type — the 2026-08-17 blast
+    /// radius was twelve independent roots, and charging them to one counter would have serialised
+    /// twelve unrelated recoveries.
+    /// </summary>
+    [Fact]
+    public void SpacingIsPerInstanceAndType()
+    {
+        var budget = new OverlayHealBudget();
+        budget.RecordHeal(Instance, NodeType, T0);
+
+        budget.EarliestHeal("Chess", NodeType, T0).Should().Be(DateTimeOffset.MinValue);
+        budget.EarliestHeal(Instance, "Edu/Module", T0).Should().Be(DateTimeOffset.MinValue);
+        budget.EarliestHeal(Instance, NodeType, T0).Should().Be(T0 + TimeSpan.FromSeconds(45));
+    }
+}

--- a/test/MeshWeaver.Graph.Test/OverlayReEvaluationReadTest.cs
+++ b/test/MeshWeaver.Graph.Test/OverlayReEvaluationReadTest.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The production wiring of the compilation-overlay re-evaluation
+/// (<see cref="NodeTypeEnrichmentHelpers.AuthoritativeTypeRead"/>) — issue #1814 defect B.
+///
+/// <para>🚨 Why this test exists separately from
+/// <c>OverlaySelfHealWatcherTest</c>: that one hands the watcher a re-read lambda and proves the
+/// watcher uses it. Every one of its assertions would still pass if the REAL re-read were wired to
+/// something that can never answer — which is exactly the failure being fixed, one layer down. So
+/// this pins the seam itself: it goes to the mesh's QUERY PROVIDERS (storage), under the System
+/// identity, and it answers about the requested path and no other.</para>
+/// </summary>
+public class OverlayReEvaluationReadTest
+{
+    private const string NodeTypePath = "Store/Plugin";
+
+    private static MeshNode TypeNode(string id, string ns) =>
+        new(id, ns) { NodeType = MeshNode.NodeTypePath, Version = 3259 };
+
+    private static IMessageHub HubWith(params object[] services)
+    {
+        var provider = new ServiceCollection();
+        foreach (var service in services)
+        {
+            if (service is IMeshQueryCore core)
+                provider.AddSingleton(core);
+        }
+        var hub = Substitute.For<IMessageHub>();
+        hub.ServiceProvider.Returns(provider.BuildServiceProvider());
+        hub.JsonSerializerOptions.Returns(new JsonSerializerOptions());
+        return hub;
+    }
+
+    private static IMeshQueryCore CoreReturning(
+        params MeshNode[] items)
+    {
+        var core = Substitute.For<IMeshQueryCore>();
+        core.Query<MeshNode>(Arg.Any<MeshQueryRequest>(), Arg.Any<JsonSerializerOptions>())
+            .Returns(Observable.Return(new QueryResultChange<MeshNode>
+            {
+                ChangeType = QueryChangeType.Initial,
+                Items = items,
+            }));
+        return core;
+    }
+
+    /// <summary>
+    /// The read resolves through <c>IMeshQueryCore</c> — the mesh's query-provider fan-out over
+    /// storage — and asks for the NodeType's path as System. Not through
+    /// <c>GetWorkspace().GetMeshNodeStream(...)</c>, whose cached snapshot is the thing that went
+    /// permanently stale.
+    /// </summary>
+    [Fact]
+    public void ReadsThroughTheQueryCore_AsSystem_ForTheRequestedPath()
+    {
+        var requests = new List<MeshQueryRequest>();
+        var core = Substitute.For<IMeshQueryCore>();
+        core.Query<MeshNode>(Arg.Do<MeshQueryRequest>(requests.Add), Arg.Any<JsonSerializerOptions>())
+            .Returns(Observable.Return(new QueryResultChange<MeshNode>
+            {
+                ChangeType = QueryChangeType.Initial,
+                Items = [TypeNode("Plugin", "Store")],
+            }));
+
+        var read = NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(HubWith(core), NodeTypePath);
+        read.Should().NotBeNull();
+
+        var node = read!().Wait();
+
+        node.Should().NotBeNull();
+        node!.Path.Should().Be(NodeTypePath);
+        requests.Should().HaveCount(1);
+        requests[0].UserId.Should().Be(WellKnownUsers.System,
+            "the re-evaluation is infrastructure — it runs under the System identity like every "
+            + "other read on the enrichment path, not under whoever happened to open the page");
+    }
+
+    /// <summary>
+    /// A ranked or fuzzy hit for a NEIGHBOURING node is not an answer about this type: acting on it
+    /// would recycle an instance against a build it is not waiting for.
+    /// </summary>
+    [Fact]
+    public void ANeighbouringHit_IsNotAnAnswer()
+    {
+        var core = CoreReturning(TypeNode("PluginContent", "Store"), TypeNode("Coupon", "Store"));
+
+        var read = NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(HubWith(core), NodeTypePath);
+        read!().Wait().Should().BeNull();
+    }
+
+    /// <summary>
+    /// Nothing at the path is "no answer", not "healed" — the watcher's ladder simply asks again.
+    /// </summary>
+    [Fact]
+    public void AnEmptyResult_IsNull_NotAHealSignal()
+    {
+        var read = NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(HubWith(CoreReturning()), NodeTypePath);
+        read!().Wait().Should().BeNull();
+    }
+
+    /// <summary>
+    /// A host with no query core (a unit-test hub) gets NO re-read rather than a fake one — the
+    /// watcher then keeps its push-only behaviour instead of pretending to re-evaluate.
+    /// </summary>
+    [Fact]
+    public void NoQueryCore_MeansNoReRead()
+        => NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(HubWith(), NodeTypePath)
+            .Should().BeNull();
+}

--- a/test/MeshWeaver.Graph.Test/OverlaySelfHealWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/OverlaySelfHealWatcherTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Microsoft.Reactive.Testing;
 using MeshWeaver.Graph.Configuration;
@@ -262,5 +264,254 @@ public class OverlaySelfHealWatcherTest
         watcher.Dispose();
         typeStream.OnNext(TypeNode(version: 7, usable: true));
         AssertNoDispose(hub);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Issue #1814 defect B — the LATCHING fault card.
+    //
+    // Every test above drives the watcher by pushing onto typeStream, which quietly assumes the
+    // thing that failed on memex on 2026-08-17: that the stream emits at all. It did not. Both
+    // heal routes above read meshHub.GetWorkspace().GetMeshNodeStream(nodeType) — the same stream
+    // whose silence made the enrichment slow path time out in the first place — so the heal signal
+    // and the fault shared a single point of failure, and the grace route's re-subscribe replays
+    // the workspace's cached snapshot rather than re-reading anything. Result: twelve plugin roots
+    // served the fault card for 1 h 24 m AFTER Store/Plugin had compiled successfully on both
+    // pods, with no overlay and no "did not settle" event logged in the preceding 30–40 minutes.
+    // Nothing was retrying; the card was cached on the instance hub and served. Recycling by hand
+    // was the only remedy, twelve times.
+    //
+    // The invariant these pin: an instance serving the overlay for a type whose build subsequently
+    // settles to Ok stops serving it WITHOUT external intervention, within a bounded time — and a
+    // type that is still broken keeps its card.
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// 🚨 THE 2026-08-17 memex OUTAGE, as a unit. The type stream is PERMANENTLY SILENT after the
+    /// at-overlay emission (a cross-process write this reader's mirror is never told about), while
+    /// the authoritative record has since settled to a usable build. Neither the version-advance
+    /// route nor the grace route can ever see it — they are both fed by that stream. The instance
+    /// must still stop serving the card, on its own, inside the first ladder rung.
+    /// </summary>
+    [Fact]
+    public void SilentTypeStream_ReEvaluatesFromStorage_AndHealsWithoutIntervention()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        var reads = 0;
+        // What the store holds: Store/Plugin, compiled, Ok, assembly published, framework matching
+        // — the exact node read off prod at 22:19 while every cover was still showing the card.
+        var authoritative = TypeNode(version: 3259, usable: true);
+
+        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+            guards: null,
+            reRead: () =>
+            {
+                reads++;
+                return Observable.Return<MeshNode?>(authoritative);
+            });
+
+        // The at-overlay state, and then silence for ever — nothing else is ever pushed.
+        typeStream.OnNext(TypeNode(version: 3259, usable: false));
+
+        // Before the first rung the card stands: re-evaluation is bounded, not a per-render probe.
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(44).Ticks);
+        reads.Should().Be(0, "the ladder must not read before its first rung");
+        AssertNoDispose(hub);
+
+        // First rung: the instance recycles ITSELF off the card — no operator, no recycle by hand,
+        // no emission on the type stream. This is the assertion the 2026-08-17 code cannot satisfy.
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(2).Ticks);
+        AssertDisposedExactlyOnce(hub);
+        reads.Should().Be(1, "one read per rung — never a poll");
+
+        // Take(1) still holds: the hub is going away, so exactly one recycle is posted.
+        scheduler.AdvanceBy(TimeSpan.FromHours(1).Ticks);
+        AssertDisposedExactlyOnce(hub);
+    }
+
+    /// <summary>
+    /// The other half of the invariant: a type that is GENUINELY broken keeps its card. The ladder
+    /// must not paper over a parked type — and it must stay a ladder: over a full hour of a silent
+    /// stream and a never-usable record it costs single-digit reads, not a poll.
+    /// </summary>
+    [Fact]
+    public void StillBrokenType_KeepsItsCard_AndTheLadderStaysBounded()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        var reads = 0;
+
+        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+            guards: null,
+            reRead: () =>
+            {
+                reads++;
+                // Still no usable build — the source is broken and the type is parked.
+                return Observable.Return<MeshNode?>(TypeNode(version: 3259, usable: false));
+            });
+
+        scheduler.AdvanceBy(TimeSpan.FromHours(1).Ticks);
+
+        AssertNoDispose(hub);
+        reads.Should().BeGreaterThan(3, "the ladder keeps looking — giving up is how the card latched");
+        reads.Should().BeLessThan(12,
+            "45s/90s/3m/6m then 10m: an hour of a broken type costs single-digit reads, "
+            + "never a retry storm on a mesh that is already struggling");
+
+        // …and the moment the record does become usable, the very next rung heals it.
+        var beforeHeal = reads;
+        scheduler.AdvanceBy(TimeSpan.FromMinutes(11).Ticks);
+        reads.Should().BeGreaterThan(beforeHeal);
+        AssertNoDispose(hub);
+    }
+
+    /// <summary>
+    /// A read that cannot be answered is not a verdict. The ladder logs it and asks again at the
+    /// next rung — the opposite of the swallow-and-stop that made the card permanent.
+    /// </summary>
+    [Fact]
+    public void FaultedReRead_DoesNotEndTheLadder()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        var reads = 0;
+
+        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+            guards: null,
+            reRead: () => ++reads == 1
+                // First rung: the mesh hub is busy and the read faults.
+                ? Observable.Throw<MeshNode?>(new TimeoutException("query did not answer"))
+                // Second rung: it answers, and the answer is a usable build.
+                : Observable.Return<MeshNode?>(TypeNode(version: 3259, usable: true)));
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(46).Ticks);
+        reads.Should().Be(1);
+        // A faulted read must not be read as "still broken" — nor as "healed".
+        AssertNoDispose(hub);
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(91).Ticks);
+        reads.Should().Be(2);
+        AssertDisposedExactlyOnce(hub);
+    }
+
+    /// <summary>
+    /// An EMPTY authoritative read — no node at that path — is not a heal signal either.
+    /// </summary>
+    [Fact]
+    public void EmptyReRead_IsNotAHealSignal()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+
+        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+            guards: null,
+            reRead: Observable.Empty<MeshNode?>);
+
+        scheduler.AdvanceBy(TimeSpan.FromMinutes(30).Ticks);
+        AssertNoDispose(hub);
+    }
+
+    /// <summary>
+    /// 🚨 The recycle destroys the watcher that ordered it, so the anti-loop bound cannot live in
+    /// the watcher. <see cref="OverlayHealBudget"/> is the memory that survives: a pair that has
+    /// already recycled itself several times has its next recycle DEFERRED — never cancelled — so a
+    /// non-converging instance costs one activation per widening step instead of one per rung.
+    /// </summary>
+    [Fact]
+    public void RepeatedlyStuckInstance_HasItsNextRecycleDeferred_NeverCancelled()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        var budget = new OverlayHealBudget();
+
+        // This instance has already self-healed three times against this type inside the window —
+        // i.e. it recycled, re-enriched, and landed right back on the card. Spacing after three
+        // heals is three minutes.
+        budget.RecordHeal(InstancePath, NodeTypePath, scheduler.Now);
+        budget.RecordHeal(InstancePath, NodeTypePath, scheduler.Now);
+        budget.RecordHeal(InstancePath, NodeTypePath, scheduler.Now);
+
+        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+            guards: null,
+            reRead: () => Observable.Return<MeshNode?>(TypeNode(version: 3259, usable: true)),
+            budget: budget);
+
+        // The ladder's first rung finds a usable build at 45s — but the budget holds the recycle.
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(46).Ticks);
+        AssertNoDispose(hub);
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(133).Ticks);
+        // Still inside the 3-minute spacing that three prior heals earned.
+        AssertNoDispose(hub);
+
+        // DEFERRED, never dropped: the recycle lands the instant the spacing elapses.
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(2).Ticks);
+        AssertDisposedExactlyOnce(hub);
+        budget.HealsSoFar(InstancePath, NodeTypePath, scheduler.Now).Should().Be(4);
+    }
+
+    /// <summary>
+    /// The property that matters operationally: an instance whose re-enrichment keeps faulting
+    /// (recycle → re-overlay → recycle) must not spin. Drives the real loop — every posted
+    /// DisposeRequest tears the watcher down and a fresh one is armed, exactly as a hub recycle
+    /// does — and counts the recycles over a virtual hour.
+    /// </summary>
+    [Fact]
+    public void NonConvergingInstance_RecyclesAreSpaced_NotOncePerLadderRung()
+    {
+        WithBudget(new OverlayHealBudget()).Should().BeLessThan(12,
+            "a pair that never converges backs off to one recycle per ten minutes");
+        WithBudget(null).Should().BeGreaterThan(40,
+            "the control: with no cross-recycle memory every fresh watcher restarts at the first "
+            + "rung, which is the storm the budget exists to prevent");
+
+        static int WithBudget(OverlayHealBudget? budget)
+        {
+            var scheduler = new TestScheduler();
+            var recycles = 0;
+            IDisposable? current = null;
+            var hub = Substitute.For<IMessageHub>();
+            hub.Address.Returns(new Address(InstancePath));
+
+            IDisposable Arm() => NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+                // Silent for ever, and the record always reports a usable build the instance
+                // nevertheless cannot bind — the 2026-08-17 shape.
+                new Subject<MeshNode>(), hub, NodeTypePath,
+                typeVersionAtOverlay: null, logger: null, scheduler, guards: null,
+                reRead: () => Observable.Return<MeshNode?>(TypeNode(version: 3259, usable: true)),
+                budget: budget);
+
+            hub.Configure()
+                .Post(Arg.Any<DisposeRequest>(),
+                    Arg.Do<Func<PostOptions, PostOptions>>(_ =>
+                    {
+                        recycles++;
+                        var dying = current;
+                        // The recycle: this hub (and its watcher) goes away, the next access
+                        // re-enriches, faults again, and arms a FRESH watcher. Deferred by one
+                        // virtual tick so the watcher is not disposed from inside its own OnNext.
+                        scheduler.Schedule(TimeSpan.Zero, () =>
+                        {
+                            dying?.Dispose();
+                            current = Arm();
+                        });
+                    }))
+                .Returns((IMessageDelivery<DisposeRequest>?)null);
+
+            current = Arm();
+            scheduler.AdvanceBy(TimeSpan.FromHours(1).Ticks);
+            current?.Dispose();
+            return recycles;
+        }
     }
 }


### PR DESCRIPTION
Closes **defect B of #1814** — the latching fault card, and the reason a ten-minute deploy window became a two-hour public outage.

## The defect, precisely

Enrichment binds a per-instance hub's `HubConfiguration` **exactly once** — the `node.HubConfiguration != null` re-enrichment short-circuit is what keeps activation cheap — so a compilation overlay applied during a bad ten seconds is served for the grain's whole lifetime unless something *revokes* it. `ArmOverlaySelfHeal` is that revocation.

Both of its heal routes subscribe `meshHub.GetWorkspace().GetMeshNodeStream(nodeType)` — **the same stream whose silence made the enrichment slow path time out in the first place**:

| route | trigger |
|---|---|
| version advance | a usable emission past the at-overlay version |
| grace (45 s) | re-subscribe and take the first usable emission |

The grace route's "re-read" is a re-subscribe to the workspace's **cached** stream, so it replays the same snapshot. Neither route reads anything. **The heal signal and the fault shared a single point of failure**: one permanently silent stream and the card is permanent.

That is exactly what was measured on 2026-08-17 (#1814): `Store/Plugin` compiled **successfully on both pods**, and **1 h 24 m later** an anonymous browser still got the card, with **no overlay and no "did not settle" event logged on either pod in the preceding 30–40 minutes**. The 120 s stuck-reporter fired (`platform admins notified`) — proving the watcher was armed and had simply never seen a usable state. Twelve roots were recycled by hand.

## The fix — a third route that owes the stream nothing

**`AuthoritativeTypeRead`** — a one-shot `path:{nodeType}` query through `IMeshQueryCore`, as System: the mesh's **query providers (storage)**, not a cached stream, so a mirror that can never learn it is stale cannot suppress it. It matches the path **exactly**; a ranked/fuzzy hit for a neighbouring node is not an answer about this type.

**A widening ladder, not a poll.** `45 s → 90 s → 3 min → 6 min`, then **10 min for ever**. One read per rung, each capped at 30 s and serialised with `Concat` so a slow read can never overlap the next rung. At the 2026-08-17 blast radius (12 latched instances) the steady state is ~72 single-node reads an hour — against the 1 h 24 m of served fault cards it replaces. The naive shape (re-probe per render) is explicitly not what this is.

**The ladder never stops.** A re-evaluation budget that ran out would restore precisely the defect: a card outliving its cause because something decided to stop looking.

**A faulted or empty read is not a verdict** — it is logged and the ladder asks again. **Non-convergence is loud**: each re-read that still finds no usable build logs the status / assembly / framework it actually saw, at `Warning` once past the last rung, beside the existing admin notification.

### Bounding the recycle, which the watcher cannot do itself

The heal disposes the hub that **owns the watcher**. The replacement hub arms a fresh watcher whose ladder starts at the first rung — so a pair whose *re-enrichment* keeps faulting (a type reporting a usable build that the instance still cannot bind: #1814's deterministic cross-hub `Conflict`) would recycle every 45 s for ever. No state inside the watcher can bound that, because the bound has to outlive the thing being bounded.

`OverlayHealBudget` — mesh-scoped singleton registered in `AddGraph`, keyed by *(instance, NodeType)*, instance maps only — is that memory. The **first** heal is never delayed (the common case is a deploy window that cleared). Each further heal inside 30 minutes waits out a widening spacing (45 s → 90 s → 3 min → 6 min → 10 min). It **defers** a recycle, **never cancels** one; a pair that heals once and stays healthy is forgotten.

### What deliberately did NOT change

A **genuinely broken type still shows its card**. The goal is "clears when the cause clears", never "never shows". `StillBrokenType_KeepsItsCard_AndTheLadderStaysBounded` pins both halves.

The overlay copy's promise — *"the page recovers automatically"* — was false for 1 h 24 m and is now true; it also says **how** it recovers, so an operator knows how long to wait before reaching for **Recycle**.

## Non-vacuity — proven by neutering, with real output

The new route removed (`_ = reEvaluated;` — i.e. `origin/main`'s push-only self-heal), same machine, same test binary:

```
  Failed …SilentTypeStream_ReEvaluatesFromStorage_AndHealsWithoutIntervention
   NSubstitute.Exceptions.ReceivedCallsException : Expected to receive exactly 1 call matching:
  Failed …StillBrokenType_KeepsItsCard_AndTheLadderStaysBounded
   Expected 0 to be greater than 3 because the ladder keeps looking — giving up is how the card latched.
  Failed …FaultedReRead_DoesNotEndTheLadder
   Expected value to be 1, but found 0.
  Failed …RepeatedlyStuckInstance_HasItsNextRecycleDeferred_NeverCancelled
   NSubstitute.Exceptions.ReceivedCallsException : Expected to receive exactly 1 call matching:
  Failed …NonConvergingInstance_RecyclesAreSpaced_NotOncePerLadderRung
   Expected 0 to be greater than 40 because the control: with no cross-recycle memory every fresh
   watcher restarts at the first rung, which is the storm the budget exists to prevent.
Total tests: 12   Passed: 7   Failed: 5
```

The first line **is** the 2026-08-17 behaviour: the instance never recycled itself. The 7 pre-existing tests stay green under the neuter, so they cover the old behaviour and the 5 new ones are non-vacuous.

With the fix restored:

```
Total tests: 12   Passed: 12       (OverlaySelfHealWatcherTest)
Passed!  - Failed: 0, Passed: 1336 (MeshWeaver.Graph.Test, 33 s)
Passed!  - Failed: 0, Passed:    4 (CompileErrorOverviewTest — overlay copy)
Passed!  - Failed: 0, Passed:    1 (OverlaySelfHealInstanceRecycleTest — the e2e self-recycle)
Passed!  - Failed: 0, Passed:    1 (WhatsNewEntryIntegrityTest)
```

All time is driven by `TestScheduler` — this is a latching bug, so every wait is bounded and virtual; nothing sleeps.

## Tests

| test | pins |
|---|---|
| `SilentTypeStream_ReEvaluatesFromStorage_AndHealsWithoutIntervention` | a permanently silent stream + a settled record ⇒ the instance recycles **itself**, inside the first rung, no intervention |
| `StillBrokenType_KeepsItsCard_AndTheLadderStaysBounded` | a never-usable record ⇒ no recycle, ever; and single-digit reads over a virtual hour |
| `FaultedReRead_DoesNotEndTheLadder` / `EmptyReRead_IsNotAHealSignal` | a non-answer is neither "broken" nor "healed" |
| `RepeatedlyStuckInstance_HasItsNextRecycleDeferred_NeverCancelled` | the budget **defers**, and the recycle still lands |
| `NonConvergingInstance_RecyclesAreSpaced_NotOncePerLadderRung` | drives the real recycle→re-overlay→recycle loop for a virtual hour; bounded, with the un-budgeted control in the same test |
| `OverlayHealBudgetTest` | first heal un-delayed, widening spacing holding at the ceiling, forget window, per-pair keying |
| `OverlayReEvaluationReadTest` | **the seam itself** — query core, System identity, exact path. Every watcher-level assertion would pass against a real read wired to something that can never answer; this is the one test that can't. |

## What remains of #1814

- **Defect A — bake/portal identity mismatch: DONE** (#1847, merged).
- **Defect B — the latching card: this PR.**
- **The `Conflict` retry** (#1814's item 3) is *partly* addressed on main already: `UpdateRemote` now includes `MeshNodeErrorCode.Conflict` in the re-enqueue set, and the recursion genuinely re-runs the lambda against a re-read initial state. But it re-reads through `AcquireRemoteStreamUnchecked` — **the same workspace mirror** — so with the notify chain broken the base is stale on every attempt and the two re-enqueues cannot converge. Nothing further to change here; it is subsumed by the item below.
- **The cross-process notify chain is still open**, all three legs: `mesh_node_notify` installed per database rather than per table (**#1816**, open), `PostgreSqlChangeListener` registered but commented out for the partitioned setup (**#1440**, open — the TODO is still in `PostgreSqlExtensions.cs`), and notifications publishing `Entity = null`, which `MeshDataSource` discards.

So **#1814 should stay open** until the notify chain lands. What this PR changes is the severity: with the card re-evaluating, a stale mirror costs a page that recovers on its own within a minute (or ten, if it keeps failing) instead of an open-ended outage that only twelve manual recycles could end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
