### PR TITLE
A failed dependency install is not a failed step — the smoke print already decides

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -827,9 +827,25 @@ jobs:
           echo "retrying in ${delay}s ($(left)s of the step budget left)" >&2
           sleep "$delay"
         done
+        # 🚨 A FAILED DEPENDENCY INSTALL IS NOT A FAILED STEP. `--with-deps` is a MEANS to a
+        # capability — "this runner can launch Chromium and print a PDF" — and that capability is
+        # PROVEN directly forty lines below, by launching it and printing one. Exiting here fails
+        # on the proxy while the evidence sits further down, and on GitHub's ubuntu-24.04 image the
+        # libraries are usually already present, so the proxy is wrong in the common case.
+        #
+        # This was not a theoretical trade-off: apt contention on the hosted runners failed this
+        # step six times in one morning across `main` and three PRs, and because `Consolidate test
+        # results` is the repo's ONE required check, every one of those blocked every merge. The
+        # browser downloaded fine each time.
+        #
+        # If the libraries really are missing, the smoke print below fails and the step still
+        # fails — carrying this warning as its context. Strictly no loss of safety: the gate moves
+        # from "did apt run?" to "does the browser work?", which is the question the tests ask.
         if [ $deps_ok -eq 0 ]; then
-          echo "::error::the headless browser downloaded, but the system packages '--with-deps' installs could not be applied within ${BROWSER_STEP_BUDGET}s — this is an APT/INFRA failure, not a test failure."
-          exit 1
+          echo "::warning::the system packages '--with-deps' installs could not be applied within ${BROWSER_STEP_BUDGET}s (APT/INFRA). Continuing: the smoke print below decides, because it measures the capability directly."
+          deps_note="the '--with-deps' install did NOT complete on this runner, so a missing system library is the likely cause. "
+        else
+          deps_note=""
         fi
         # The binary is named differently per platform (see the Dockerfile); match both so this
         # keeps working if the runner architecture ever changes.
@@ -865,7 +881,7 @@ jobs:
           --no-pdf-header-footer --user-data-dir=/tmp/mw-smoke-profile \
           --print-to-pdf=/tmp/mw-smoke.pdf file:///tmp/mw-smoke.html 2>/tmp/mw-smoke.err || true
         if [ ! -s /tmp/mw-smoke.pdf ]; then
-          echo "::error::the headless browser installed but cannot print a PDF on this runner — this is an INFRA failure, not a test failure."
+          echo "::error::the headless browser cannot print a PDF on this runner — ${deps_note}this is an INFRA failure, not a test failure."
           cat /tmp/mw-smoke.err >&2 || true
           exit 1
         fi


### PR DESCRIPTION
`--with-deps` is a **means** to a capability: *this runner can launch Chromium and print a PDF*. That capability is proven **directly**, forty lines below, by launching it and printing one:

```bash
timeout 60 "$BROWSER" --headless=new … --print-to-pdf=/tmp/mw-smoke.pdf …
if [ ! -s /tmp/mw-smoke.pdf ]; then … exit 1; fi
```

Exiting on the apt failure fails on the **proxy** while the evidence sits further down — and on GitHub's `ubuntu-24.04` image the libraries are usually already present, so the proxy is wrong in the common case.

## Why now

This is not a theoretical trade-off. Apt contention failed this step **six times in one morning**, across `main` and three PRs. Because **`Consolidate test results` is this repo's one required check**, every one of those blocked *every* merge in the repository.

Phase 1 — the browser download, which touches no apt — succeeded every single time. The step had the browser on disk and failed anyway.

## The change

The deps failure becomes a warning that carries its context forward; the smoke print is the gate.

If the libraries genuinely are missing, that print fails and the step **still fails**, now saying *"the `--with-deps` install did NOT complete on this runner, so a missing system library is the likely cause"* — instead of leaving the next person to guess which of the two happened.

**No loss of safety**: the gate moves from *"did apt run?"* to *"does the browser work?"*, which is the question every PDF test actually asks.

## Relationship to the other apt work

Complementary, not competing: the orphan **reap** (#1871) and the shared **wait** (#1855) both reduce how *often* apt fights us. This stops that fight from being *fatal* when it happens anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)