### PR TITLE
An agent round must observe the I/O pool's cancellation token

### DIFF
--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -2538,7 +2538,15 @@ internal static class ThreadExecution
                     // OperationCanceledException (the linked streamingTimeoutCts fired WITHOUT
                     // executionCts) but must NOT masquerade as a user cancel — it falls through to
                     // the generic catch below and terminates as a round ERROR (#147).
-                    catch (OperationCanceledException) when (executionCts.IsCancellationRequested)
+                    // poolCt is the SHUTDOWN cancel: IoPool.Drain() cancelling the pool is teardown,
+                    // semantically the same graceful stop as hub disposal — NOT a streaming hang. It
+                    // must be classified here, because it fires streamingTimeoutCts WITHOUT
+                    // executionCts, which is exactly the shape the generic catch below converts into
+                    // "AI streaming exceeded the maximum round duration of 00:30:00" and terminates
+                    // as Status=Error. Without this clause every round alive at shutdown would write
+                    // that alarming, false timeout to the user's response cell. (Copilot review, #1879.)
+                    catch (OperationCanceledException)
+                        when (executionCts.IsCancellationRequested || poolCt.IsCancellationRequested)
                     {
                         logger.LogInformation("[ThreadExec] CANCELLED: {Time:HH:mm:ss.fff} threadPath={ThreadPath}", DateTime.UtcNow, threadPath);
                         // ToString must be under logLock — UpdateDelegationStatus
@@ -2634,9 +2642,14 @@ internal static class ThreadExecution
                         // below (response cell → Status=Error, thread → Idle, parent notified)
                         // tells the user WHY the round was aborted instead of a bare "The
                         // operation was canceled." — never a silent swallow, never a fake cancel.
+                        // 🚨 !poolCt: a pool-driven (teardown) cancel also fires streamingTimeoutCts
+                        // without executionCts, so without this guard shutdown would be reported as
+                        // a #147 streaming timeout. The catch above already claims that case; this
+                        // keeps the predicate honest if the clauses are ever reordered.
                         var ex = exRaw is OperationCanceledException
                                  && streamingTimeoutCts.IsCancellationRequested
                                  && !executionCts.IsCancellationRequested
+                                 && !poolCt.IsCancellationRequested
                             ? new TimeoutException(
                                 $"AI streaming exceeded the maximum round duration of " +
                                 $"{maxStreamingDuration} and was aborted (#147). The model endpoint " +

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -2033,9 +2033,30 @@ internal static class ThreadExecution
                 var roundCompletion = new System.Reactive.Subjects.AsyncSubject<System.Reactive.Unit>();
                 var aiPool = parentHub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Ai)
                     ?? IoPool.Unbounded;
-                // poolCt (the pool's cancellation) is intentionally unused — the round's
-                // own executionCts.Token (below) is authoritative and is cancelled on hub
-                // disposal, so cancellation flows through it regardless of the pool token.
+                // 🚨 poolCt MUST be observed — it is linked into the round's token below.
+                //
+                // This used to say the pool token was "intentionally unused" because
+                // executionCts "is cancelled on hub disposal, so cancellation flows through it
+                // regardless of the pool token". That premise is false: IoPool.Drain() is NOT hub
+                // disposal. Drain is the join every teardown orchestrator (MonolithMeshTestBase,
+                // MeshTeardownExtensions, HubTestBase) performs BEFORE disposing the service scope
+                // and unloading collectible node ALCs, and it works by cancelling the pool token
+                // and then re-acquiring every gate permit. A round that never reads poolCt holds
+                // its permit, so the join cannot complete: Drain sits out its full 30 s
+                // DrainTimeout and then reports the permit as a leaked leaf, and teardown proceeds
+                // over a thread still executing that ALC's code — the use-after-unload SIGSEGV
+                // precondition Drain exists to rule out. Without the link the round unwound only
+                // on hub disposal or the 30-MINUTE MaxStreamingDuration ceiling.
+                //
+                // Observed in CI as DelegationSubThreadUsageTest failing in TEARDOWN with
+                // "1 pooled I/O leaf(s) still running" after a 32 009 ms dispose — 30 s of
+                // DrainTimeout plus overhead — with no assertion in the test body having failed.
+                // Pinned by AiPoolDrainJoinsRoundTest, which parks a round inside the model call
+                // and asserts DrainAll() returns 0.
+                //
+                // During normal operation this changes nothing: _poolCts is cancelled only by
+                // Drain()/Dispose(), both terminal teardown operations after which the pool is not
+                // reused. So the link is inert until teardown, and at teardown it is the point.
                 return aiPool.Invoke(async poolCt =>
                 {
                     // Re-seed user AccessContext at the task-launch boundary. Inside this lambda we
@@ -2062,7 +2083,7 @@ internal static class ThreadExecution
                         parentHub.ServiceProvider.GetService<AiStreamingLimits>()?.MaxStreamingDuration
                         ?? MaxStreamingDuration;
                     var streamingTimeoutCts =
-                        CancellationTokenSource.CreateLinkedTokenSource(executionCts.Token);
+                        CancellationTokenSource.CreateLinkedTokenSource(executionCts.Token, poolCt);
                     streamingTimeoutCts.CancelAfter(maxStreamingDuration);
                     var ct = streamingTimeoutCts.Token;
                     // responseText / capturedResponseText / segment.ResponseText were

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-19-agent-rounds-stop-cleanly-on-shutdown.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-19-agent-rounds-stop-cleanly-on-shutdown.md
@@ -1,0 +1,16 @@
+---
+Name: Agent rounds stop cleanly when the portal shuts down
+Category: Fix
+Description: A chat round that was mid-answer during a restart no longer keeps a worker busy in the background.
+Icon: Sparkle
+Order: -20260819
+---
+
+# Agent rounds stop cleanly when the portal shuts down
+
+When the portal restarted while an agent was still writing an answer, that round
+could keep running in the background instead of stopping with everything else. It
+held on to one of the slots reserved for AI work, and only gave up much later.
+
+Rounds now stop as soon as shutdown begins, so a restart releases its AI capacity
+immediately and the next start-up begins with a clean slate.

--- a/test/MeshWeaver.Threading.Test/AiPoolDrainJoinsRoundTest.cs
+++ b/test/MeshWeaver.Threading.Test/AiPoolDrainJoinsRoundTest.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshThread = MeshWeaver.AI.Thread;
+
+namespace MeshWeaver.Threading.Test;
+
+/// <summary>
+/// 🚨 An agent round runs as a leaf on the bounded <c>IoPoolNames.Ai</c> pool, and that leaf MUST
+/// unwind when the pool's cancellation token fires. <c>IoPool.Drain()</c> — the join every teardown
+/// orchestrator trusts before it disposes the service scope and unloads collectible node ALCs —
+/// cancels the pool token and then re-acquires every gate permit. A leaf that never observes the
+/// token holds its permit, so the join cannot complete: <c>Drain</c> sits out its full 30&#160;s
+/// <c>DrainTimeout</c> and then reports the permit as a leaked leaf, and teardown proceeds over
+/// live code. That is the use-after-unload SIGSEGV precondition, not a slow shutdown.
+///
+/// <para><b>The defect this pins.</b> <c>ThreadExecution</c> took the pool token as <c>poolCt</c>
+/// and never read it — the round's linked CTS chained <c>executionCts</c> alone, on the stated
+/// assumption that "executionCts is cancelled on hub disposal, so cancellation flows through it
+/// regardless of the pool token". Drain is NOT hub disposal: it can run without the hub-disposal
+/// cancel having fired, and that path left the round parked on its model call until the 30-minute
+/// <c>MaxStreamingDuration</c> ceiling. Observed in CI as <c>DelegationSubThreadUsageTest</c>
+/// failing in teardown with "1 pooled I/O leaf(s) still running" after a 32&#160;009&#160;ms
+/// dispose — 30&#160;s of DrainTimeout plus overhead.</para>
+///
+/// <para>The assertion is <c>Drain() == 0</c> while a round is mid-stream. Pre-fix this returns 1
+/// after burning the full DrainTimeout; post-fix the round's token is cancelled by the pool and the
+/// leaf unwinds promptly. The stub below parks until ITS token fires and nothing else, so a pass
+/// can only mean the cancellation genuinely reached the model call.</para>
+/// </summary>
+public class AiPoolDrainJoinsRoundTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static readonly string ContextPath = "User/Roland";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IChatClientFactory>(new ParkingChatClientFactory());
+                return services;
+            })
+            .AddAI()
+            .AddSampleUsers();
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddAITypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task DrainingTheAiPool_UnwindsAnInFlightRound()
+    {
+        var client = GetClient();
+        var workspace = client.GetWorkspace();
+
+        var threadNode = ThreadNodeType.BuildThreadNode(ContextPath, "Ai pool drain", "Roland");
+        var createResp = await client.Observe(new CreateNodeRequest(threadNode),
+            o => o.WithTarget(Mesh.Address)).Should().Within(30.Seconds()).Emit();
+        createResp.Message.Success.Should().BeTrue(createResp.Message.Error ?? "");
+        var threadPath = createResp.Message.Node!.Path!;
+
+        // Warm the remote stream before submitting, so the IsExecuting transition is not raced
+        // (same reason CancelThreadExecutionTest does it).
+        await workspace.GetMeshNodeStream(threadPath)
+            .Select(n => n.Content as MeshThread)
+            .Should().Within(10.Seconds()).Match(t => t != null);
+
+        client.SubmitMessage(threadPath, "park please", contextPath: ContextPath);
+
+        var executing = await workspace.GetMeshNodeStream(threadPath)
+            .Select(n => n.Content as MeshThread)
+            .Should().Within(30.Seconds())
+            .Match(t => t is { IsExecuting: true, ActiveMessageId: { Length: > 0 } });
+        var responseMsgId = executing!.ActiveMessageId!;
+
+        // "Generating response..." is written AFTER the CTS is stored and immediately before the
+        // streaming task starts — the deterministic "the pooled leaf is armed" signal. Draining
+        // before it means joining a leaf that does not exist yet, which would pass vacuously.
+        await Observable.Defer(() => workspace.GetMeshNodeStream($"{threadPath}/{responseMsgId}"))
+            .Select(n => (n.Content as ThreadMessage)?.Text ?? "")
+            .Where(t => t.StartsWith("Generating response", StringComparison.Ordinal))
+            .Take(1)
+            .RetryWhen(errors => errors
+                .Select((ex, i) => i)
+                .TakeWhile(i => i < 50)
+                .SelectMany(_ => Observable.Timer(TimeSpan.FromMilliseconds(100))))
+            .Should().Within(30.Seconds()).Emit();
+
+        // The stub has actually been entered — the leaf is inside the model call, not merely
+        // dispatched. Without this the round could still be in setup, holding no permit.
+        ParkingChatClient.Entered.Wait(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken)
+            .Should().BeTrue("the streaming stub must be executing before the drain proves anything");
+        Output.WriteLine("Round is parked inside the model call — draining the Ai pool.");
+
+        // DrainAll() is exactly what the teardown orchestrator calls between DisposalCompleted and
+        // scope disposal — so this drives the real path rather than a hand-picked pool.
+        var registry = Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>();
+
+        // Drain on another thread: it is synchronous and, pre-fix, blocks for its full 30 s budget.
+        // Bounding the wait here turns that into a fast, legible failure instead of a 30 s stall.
+        var drain = Task.Run(registry.DrainAll, TestContext.Current.CancellationToken);
+        var finished = await Task.WhenAny(drain, Task.Delay(TimeSpan.FromSeconds(20),
+            TestContext.Current.CancellationToken));
+        finished.Should().BeSameAs(drain,
+            "Drain must join the round promptly once it cancels the pool token — if it is still "
+            + "blocked after 20 s the round is ignoring poolCt and Drain is sitting out its "
+            + "30 s DrainTimeout before reporting the permit as leaked");
+
+        var residual = await drain;
+        residual.Should().Be(0,
+            "a round that observes the pool's cancellation token unwinds and releases its gate "
+            + "permit, so the join is real and teardown may unload node ALCs safely");
+    }
+
+    #region A model call that parks until ITS token is cancelled — and nothing else
+
+    private sealed class ParkingChatClientFactory : IChatClientFactory
+    {
+        public string Name => "ParkingFactory";
+        public IReadOnlyList<string> Models => ["parking-model"];
+        public int Order => 0;
+
+        public ChatClientAgent CreateAgent(
+            AgentConfiguration config, IAgentChat chat,
+            IReadOnlyDictionary<string, ChatClientAgent> existingAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents,
+            string? modelName = null)
+            => new(chatClient: new ParkingChatClient(),
+                instructions: config.Instructions ?? "You are a parking test assistant.",
+                name: config.Id, description: config.Description ?? config.Id,
+                tools: [], loggerFactory: null, services: null);
+
+        public Task<ChatClientAgent> CreateAgentAsync(
+            AgentConfiguration config, IAgentChat chat,
+            IReadOnlyDictionary<string, ChatClientAgent> existingAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents,
+            string? modelName = null)
+            => Task.FromResult(CreateAgent(config, chat, existingAgents, hierarchyAgents, modelName));
+    }
+
+    private sealed class ParkingChatClient : IChatClient
+    {
+        /// <summary>Set once the stub is genuinely inside the streaming call.</summary>
+        internal static readonly ManualResetEventSlim Entered = new(false);
+
+        public ChatClientMetadata Metadata => new("Parking");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "Done")));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            // One update first, so the round is unambiguously streaming rather than stuck in setup.
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "thinking ");
+            Entered.Set();
+            // Park. The ONLY way out is this token — which is what makes a passing drain meaningful:
+            // it proves the pool's cancellation actually reached the model call.
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "unreachable");
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    #endregion
+}

--- a/test/MeshWeaver.Threading.Test/AiPoolDrainJoinsRoundTest.cs
+++ b/test/MeshWeaver.Threading.Test/AiPoolDrainJoinsRoundTest.cs
@@ -126,6 +126,27 @@ public class AiPoolDrainJoinsRoundTest(ITestOutputHelper output) : MonolithMeshT
         residual.Should().Be(0,
             "a round that observes the pool's cancellation token unwinds and releases its gate "
             + "permit, so the join is real and teardown may unload node ALCs safely");
+
+        // 🚨 …and it must unwind as a CANCEL, not as a #147 wall-clock timeout. Linking poolCt made
+        // teardown fire streamingTimeoutCts WITHOUT executionCts — byte for byte the shape the
+        // generic catch converts into "AI streaming exceeded the maximum round duration of
+        // 00:30:00" and terminates as Status=Error. Draining the pool is an ordinary shutdown, so
+        // reporting that to the user would be a false alarm written to their response cell. Without
+        // this assertion the join above passes while the classification is wrong. (Copilot, #1879.)
+        var settled = await workspace.GetMeshNodeStream(threadPath)
+            .Select(n => n.Content as MeshThread)
+            .Should().Within(30.Seconds()).Match(t => t is { IsExecuting: false });
+        settled!.Status.Should().Be(ThreadExecutionStatus.Cancelled,
+            "a round stopped by pool drain is a graceful shutdown cancel. Verified to FAIL without "
+            + "the poolCt classification guards, reporting Idle — the terminal thread state of the "
+            + "ERROR path, which is where a misclassified teardown cancel lands after being "
+            + "converted into a #147 streaming-timeout TimeoutException");
+
+        var responseText = (await workspace.GetMeshNodeStream($"{threadPath}/{responseMsgId}")
+            .Select(n => (n.Content as ThreadMessage)?.Text ?? "")
+            .Should().Within(10.Seconds()).Match(_ => true)) ?? "";
+        responseText.Should().NotContain("exceeded the maximum round duration",
+            "the #147 timeout message must never be shown for a shutdown-cancelled round");
     }
 
     #region A model call that parks until ITS token is cancelled — and nothing else


### PR DESCRIPTION
`ThreadExecution` runs every agent round as a leaf on the bounded `Ai` I/O pool, takes the pool's cancellation token as `poolCt` — and never reads it. `poolCt` appeared exactly twice in the file:

```csharp
// poolCt (the pool's cancellation) is intentionally unused — the round's
// own executionCts.Token (below) is authoritative and is cancelled on hub
// disposal, so cancellation flows through it regardless of the pool token.
return aiPool.Invoke(async poolCt =>
```

**That premise is false: `IoPool.Drain()` is not hub disposal.** Drain is the join every teardown orchestrator (`MonolithMeshTestBase`, `MeshTeardownExtensions`, `HubTestBase`) performs *before* disposing the service scope and unloading collectible node ALCs, and it works by cancelling the pool token and then re-acquiring every gate permit. A round that never reads `poolCt` holds its permit, so the join cannot complete — `Drain` sits out its full 30 s `DrainTimeout`, reports the permit as a leaked leaf, and teardown proceeds over a thread still executing that ALC's code. That is the use-after-unload SIGSEGV precondition `Drain`'s non-zero return exists to report, not a slow shutdown. Without the link, the round unwound only on hub disposal or the **30-minute** `MaxStreamingDuration` ceiling.

## How it surfaced

CI run [32227663864](https://github.com/Systemorph/MeshWeaver/actions/runs/32227663864), shard 5 — `DelegationSubThreadUsageTest` failed in **teardown**, with no assertion in the test body having failed:

```
System.InvalidOperationException : DelegationSubThreadUsageTest teardown left work RUNNING:
teardown DIRTY — 1 pooled I/O leaf(s) still running, async dispose queue drained.
  at MonolithMeshTestBase.DisposeAsync()

[DISPOSE] Mesh.Disposal completed in 32009ms
```

32 009 ms = the 30 s `DrainTimeout` plus overhead, and exactly 1 permit unreleased. **That test is not the defect and is not touched here.**

## The fix

One line — link the token the pool hands us:

```diff
-    CancellationTokenSource.CreateLinkedTokenSource(executionCts.Token);
+    CancellationTokenSource.CreateLinkedTokenSource(executionCts.Token, poolCt);
```

**Inert in normal operation.** `_poolCts` is cancelled only by `Drain()`/`Dispose()`, both terminal teardown operations after which the pool is not reused — so the link does nothing until teardown, which is the point. The stale comment is replaced with why the token must be observed.

**No budget was widened.** The 15 s quiesce the delegation tests carry stays exactly as it is; widening it further would have hidden this rather than fixed it.

## Verification — the repro fails first

`AiPoolDrainJoinsRoundTest` parks a stub model call that exits **only** on its own token, waits for the round to be genuinely inside the streaming call, then calls `DrainAll()` — the same call the teardown orchestrator makes — and asserts it returns 0. A pass can only mean the pool's cancellation actually reached the model call.

| | result |
|---|---|
| **Unfixed code** | ❌ `Failed [20 s]` — "Drain must join the round promptly once it cancels the pool token … but it did not" |
| **With the fix** | ✅ `Passed [830 ms]` |
| **Full project, fixed** | ✅ `134/134` at `DOTNET_PROCESSOR_COUNT=4` (the documented way to reproduce CI-load races locally) |
| **Build** | `0 Warning(s) 0 Error(s)` at `-c Release -warnaserror -p:CIRun=true` |

Kept deliberately separate from #1876 (the repo cleanup that surfaced it) so a hang here can only have one cause — the same reasoning `IoPool.Dispose`'s own comment records for why its fix was deferred to its own PR.

## Not fixed here

`IoPool.Dispose()` still calls `Drain()` *after* setting `_disposed`, whose idempotence guard returns early on exactly that flag — so `Dispose` joins nothing, as its own comment admits. That is a second, independent defect on the disposal path with a documented history of turning `OrderedRouteDispatcherTest` red; it wants its own PR and its own evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)