### PR TITLE
A bundle carries the package's node definitions, not only its bytes

### DIFF
--- a/src/MeshWeaver.Plugin.Build/ModuleFetchCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModuleFetchCommand.cs
@@ -1,0 +1,227 @@
+using System.Text.Json;
+using MeshWeaver.Plugin.Packaging;
+
+namespace MeshWeaver.Plugin.Build;
+
+/// <summary>
+/// The <c>module-fetch</c> mode — the CONSUMING half of the release lane, and the mechanism that
+/// lets a repo stop rebuilding its upstreams.
+///
+/// <para><b>Why this exists at all.</b> <c>Doc/Architecture/ReleaseGates</c> states the rule: a repo
+/// builds only what it OWNS and consumes every dependency as a RELEASED ARTIFACT. Until now there
+/// was no way to obey it — the availability gate could tell a build that its upstream had
+/// published, but nothing could hand it the bytes, so every satellite cloned its upstream and let
+/// the mesh Roslyn-compile it. That is a rebuild of someone else's release, it costs an ALC per
+/// recompile, and it produces bytes nobody gated.</para>
+///
+/// <para><b>The mechanism belongs in the TECH, not in five repos' YAML.</b> A hand-rolled
+/// <c>curl | unzip</c> per repo would drift, and it would skip the checks that make a fetch safe:
+/// the registry is the only distributor (one credential model, one entitlement check), the bundle's
+/// declared paths are validated before anything is written, and the package's own version is what
+/// gets recorded. One implementation, called the same way everywhere:</para>
+///
+/// <code>
+/// dotnet tool run meshweaver-plugin-build -- module-fetch Store \
+///     --registry https://memex.meshweaver.cloud --key "$MW_INSTANCE_KEY" --out ./.upstreams
+/// </code>
+///
+/// <para><b>The key is an INSTANCE key, not a repo credential.</b> A CI process registers with the
+/// registry exactly as an installation does and presents its <c>mwi_</c> key here; what it may read
+/// stays governed by that instance's grant. There is deliberately no GitHub token anywhere in this
+/// path — a consumer of a release needs no access to the producer's SOURCE, which is the entire
+/// point of publishing.</para>
+/// </summary>
+public static class ModuleFetchCommand
+{
+    /// <summary>The CLI verb.</summary>
+    public const string Verb = "module-fetch";
+
+    /// <summary>The registry's bundle routes. Stated here as the client's half of the contract the
+    /// portal's <c>PluginBundleEndpoints.RoutePrefix</c> serves.</summary>
+    private const string RoutePrefix = "/api/plugins/bundles";
+
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private sealed record BundleRef(string? Plugin, string? Version, string? Url);
+
+    private sealed record BundleIndex(string? FrameworkMvid, IReadOnlyList<BundleRef>? Bundles);
+
+    /// <summary>Runs the command; returns the process exit code.</summary>
+    public static int Run(string[] args)
+    {
+        if (args.Length == 0 || args[0] is "-h" or "--help")
+        {
+            Console.WriteLine("""
+                usage: meshweaver-plugin-build module-fetch <package> [options]
+
+                  <package>                   the package id to fetch (e.g. Store, Edu)
+                  --registry <url>            registry base URL (default: https://memex.meshweaver.cloud)
+                  --key <mwi_…>               this build's INSTANCE key. Required — the bundle routes
+                                              authenticate the caller as a registered instance, and
+                                              what it may read is that instance's grant.
+                  --out <dir>                 where to materialise the package tree
+                                              (default: ./.upstreams). The package lands in
+                                              <out>/<package>/.
+                  --version <v>               the released version to fetch (default: whatever the
+                                              registry's index currently serves for this package)
+                  --key-env <NAME>            read the key from an environment variable instead, so
+                                              it never appears in a process listing or a CI log
+
+                Exit codes: 0 fetched · 2 bad usage · 3 the registry refused or served nothing ·
+                            4 the bundle carried no node definitions
+                """);
+            return 0;
+        }
+
+        var package = args[0];
+        var registry = "https://memex.meshweaver.cloud";
+        var outputDirectory = Path.Combine(Environment.CurrentDirectory, ".upstreams");
+        string? key = null;
+        string? version = null;
+
+        for (var i = 1; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--registry" when i + 1 < args.Length:
+                    registry = args[++i].TrimEnd('/');
+                    break;
+                case "--key" when i + 1 < args.Length:
+                    key = args[++i];
+                    break;
+                // 🚨 The preferred form in CI. A key passed as an argument is visible to every
+                // other process on the agent (`ps`) and is echoed by any step that logs its own
+                // command line; an env var is neither.
+                case "--key-env" when i + 1 < args.Length:
+                    key = Environment.GetEnvironmentVariable(args[++i]);
+                    break;
+                case "--out" when i + 1 < args.Length:
+                    outputDirectory = Path.GetFullPath(args[++i]);
+                    break;
+                case "--version" when i + 1 < args.Length:
+                    version = args[++i];
+                    break;
+                default:
+                    Console.Error.WriteLine($"error: unrecognised argument '{args[i]}'");
+                    return 2;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(package) || package.Contains('/') || package.Contains('\\'))
+        {
+            Console.Error.WriteLine($"error: package id '{package}' is invalid — it composes a URL");
+            return 2;
+        }
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            // No anonymous fallback, deliberately: these are compiled assemblies for packages that
+            // may be paid, and "open when unconfigured" is how the registry once served private
+            // sources to anyone who knew the URL.
+            Console.Error.WriteLine(
+                "error: no instance key — pass --key or --key-env. The registry authenticates the "
+                + "caller as a REGISTERED INSTANCE; there is no anonymous bundle read.");
+            return 2;
+        }
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
+        http.DefaultRequestHeaders.Add("Authorization", $"Bearer {key}");
+        http.DefaultRequestHeaders.Add("Accept", "application/octet-stream");
+
+        if (version is null)
+        {
+            version = ResolveVersion(http, registry, package);
+            if (version is null)
+            {
+                Console.Error.WriteLine(
+                    $"error: the registry serves no bundle for '{package}' — it has not published "
+                    + "for this framework, or this instance's grant does not cover it (the two are "
+                    + "deliberately indistinguishable from outside).");
+                return 3;
+            }
+        }
+
+        var url = $"{registry}{RoutePrefix}/{Uri.EscapeDataString(package)}/{Uri.EscapeDataString(version)}";
+        using var response = http.Send(new HttpRequestMessage(HttpMethod.Get, url));
+        if (!response.IsSuccessStatusCode)
+        {
+            Console.Error.WriteLine($"error: registry answered {(int)response.StatusCode} for {url}");
+            return 3;
+        }
+
+        using var buffer = new MemoryStream();
+        response.Content.ReadAsStream().CopyTo(buffer);
+        var bytes = buffer.ToArray();
+
+        // BundleReader validates every declared path before returning it — a rooted or
+        // parent-traversing entry throws rather than being written next to this tool's output.
+        var (manifest, files) = BundleReader.ReadContent(bytes);
+        if (files.Count == 0)
+        {
+            Console.Error.WriteLine(
+                $"error: bundle {package}@{version} carries no node definitions — it is an "
+                + "assemblies-only bundle, which can stamp existing nodes but cannot stand in for "
+                + "the package. Its producer must pack with --content.");
+            return 4;
+        }
+
+        var target = Path.Combine(outputDirectory, package);
+        Materialise(files, target);
+
+        Console.WriteLine(
+            $"fetched {package}@{manifest?.Version ?? version} → {target} "
+            + $"({files.Count} file(s), built against MVID {manifest?.FrameworkMvid ?? "(unrecorded)"})");
+        return 0;
+    }
+
+    /// <summary>
+    /// Writes the fetched tree to <paramref name="target"/>, REPLACING whatever was there.
+    ///
+    /// <para>🚨 Replace, never merge — and this is what makes a package's
+    /// <c>content.includeSource</c> flip actually take effect. Merging would leave every file the
+    /// new release no longer ships still sitting on disk: flip source OFF and yesterday's
+    /// <c>Source/*.cs</c> would remain, so the consumer keeps compiling against code the producer
+    /// deliberately withheld and nothing anywhere reports it. The same applies to any file a
+    /// release drops — a merged tree is neither the old release nor the new one, and a build
+    /// against that mix is reproducible from no commit at all.</para>
+    ///
+    /// <para>Public rather than internal-with-a-friendship: it is a real operation of this tool, and
+    /// a seam a test can reach without the tool having to trust a test assembly by name.</para>
+    /// </summary>
+    /// <param name="files">The declared tree, already validated by <see cref="BundleReader"/>.</param>
+    /// <param name="target">Directory the package is materialised into.</param>
+    public static void Materialise(IReadOnlyList<BundleReader.ContentFile> files, string target)
+    {
+        if (Directory.Exists(target))
+            Directory.Delete(target, recursive: true);
+
+        foreach (var file in files)
+        {
+            var destination = Path.Combine(
+                target, file.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+            File.WriteAllBytes(destination, file.Bytes);
+        }
+    }
+
+    /// <summary>
+    /// Asks the registry which version it currently serves for this package.
+    ///
+    /// <para>🚨 The index is the ONLY resolution source. Guessing a version from a local
+    /// manifest.lock would defeat the point: the whole question is what the registry HAS, and a
+    /// local file describes what this checkout thinks — which is exactly the divergence a fetch is
+    /// supposed to remove.</para>
+    /// </summary>
+    private static string? ResolveVersion(HttpClient http, string registry, string package)
+    {
+        using var response = http.Send(
+            new HttpRequestMessage(HttpMethod.Get, $"{registry}{RoutePrefix}/index.json"));
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        var index = JsonSerializer.Deserialize<BundleIndex>(response.Content.ReadAsStream(), Json);
+        return index?.Bundles?
+            .FirstOrDefault(b => string.Equals(b.Plugin, package, StringComparison.OrdinalIgnoreCase))
+            ?.Version;
+    }
+}

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -62,6 +62,35 @@ public static class ModulePackCommand
         return true;
     }
 
+    /// <summary>
+    /// Reads <c>content.includeSource</c> off the package's ROOT node (<c>index.json</c>) — the
+    /// package's own declaration of whether its C# ships.
+    ///
+    /// <para>Read as JSON rather than through <c>PluginContent</c>: that type is defined by the
+    /// Store package in the plugins repo and compiled ON A MESH, so this tool cannot reference it.
+    /// One property by name is the whole coupling.</para>
+    ///
+    /// <para>Absent root, unreadable root, or absent property all mean FALSE. A publishing decision
+    /// with an IP consequence must not be something a malformed file can turn on.</para>
+    /// </summary>
+    private static bool ReadIncludeSourceFromRoot(string contentDirectory)
+    {
+        var root = Path.Combine(contentDirectory, "index.json");
+        if (!File.Exists(root))
+            return false;
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllBytes(root));
+            return document.RootElement.TryGetProperty("content", out var content)
+                   && content.TryGetProperty("includeSource", out var flag)
+                   && flag.ValueKind is JsonValueKind.True;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
     /// <summary>Runs the command; returns the process exit code.</summary>
     public static int Run(string[] args)
     {
@@ -74,6 +103,21 @@ public static class ModulePackCommand
                                               a publish folder, or a curated modules/<Name>/ layout)
                   --module-name <name>        the module's entry-assembly name without extension
                                               (default: the folder name)
+                  --content <dir>             the package's NODE DEFINITION tree (its index.json,
+                                              NodeType nodes, markdown). Shipped verbatim so a
+                                              consumer can use this package as an upstream WITHOUT
+                                              cloning it. Omit for an assemblies-only bundle, which
+                                              can stamp existing nodes but cannot stand in for the
+                                              package.
+                  --include-source [true|false]
+                                              whether the C# SOURCE ships with the tree. DEFAULT
+                                              FALSE, and the package decides: the root index.json's
+                                              `content.includeSource`. This flag overrides it (for a
+                                              tree with no root node). Source is needed only by a
+                                              consumer that COMPILES against this package —
+                                              `shared=@<pkg>/…` pulls these files into ITS
+                                              compilation. A consumer that merely installs and runs
+                                              needs the assemblies, which the bundle already carries.
                   --plugin <id>               the package id the bundle belongs to (default: the
                                               module name) — must match the repo's plugin folder
                   --package-version <v>       REQUIRED — the module package's released SemVer (the
@@ -114,6 +158,9 @@ public static class ModulePackCommand
         var extras = new List<string>();
         var outputDirectory = Environment.CurrentDirectory;
 
+        string? contentDirectory = null;
+        bool? includeSourceOverride = null;
+
         for (var i = 1; i < args.Length; i++)
         {
             switch (args[i])
@@ -138,6 +185,24 @@ public static class ModulePackCommand
                     break;
                 case "--out" when i + 1 < args.Length:
                     outputDirectory = Path.GetFullPath(args[++i]);
+                    break;
+                case "--content" when i + 1 < args.Length:
+                    contentDirectory = Path.GetFullPath(args[++i]);
+                    break;
+                // Bare `--include-source` means true; an explicit `--include-source false` wins.
+                // Only CONSUMED as a value when it parses as a bool, so a following option is not
+                // swallowed.
+                case "--include-source":
+                    if (i + 1 < args.Length && bool.TryParse(args[i + 1], out var explicitInclude))
+                    {
+                        includeSourceOverride = explicitInclude;
+                        i++;
+                    }
+                    else
+                    {
+                        includeSourceOverride = true;
+                    }
+
                     break;
                 default:
                     Console.Error.WriteLine($"error: unrecognised argument '{args[i]}'");
@@ -224,6 +289,48 @@ public static class ModulePackCommand
         var manifest = new PluginManifest(
             plugin, PluginManifest.IdPrefix + plugin, packageVersion, plugin, null, []);
 
+        // The package tree, walked in a stable order so two packs of the same tree produce
+        // byte-identical manifests. obj/bin are a developer's build residue, never package content
+        // — the same exclusions PluginPacker applies.
+        var contentFiles = new List<string>();
+        var includeSource = false;
+        if (contentDirectory is not null)
+        {
+            if (!Directory.Exists(contentDirectory))
+            {
+                Console.Error.WriteLine($"error: content directory not found: {contentDirectory}");
+                return 2;
+            }
+            // 🚨 THE PACKAGE DECIDES, and the default is NOT to ship source. Source is the one
+            // part of a package that a consumer does not need in order to USE it — the compiled
+            // assemblies are right here in the same bundle — and shipping it is therefore a
+            // deliberate act, not a side effect of publishing. Defaulting the other way would have
+            // every package's C# leave the building the first time anyone packed it with a tree.
+            includeSource = includeSourceOverride ?? ReadIncludeSourceFromRoot(contentDirectory);
+
+            contentFiles.AddRange(Directory
+                .EnumerateFiles(contentDirectory, "*", SearchOption.AllDirectories)
+                .Select(f => Path.GetRelativePath(contentDirectory, f)
+                    .Replace(Path.DirectorySeparatorChar, '/'))
+                .Where(r => !r.StartsWith("obj/", StringComparison.Ordinal)
+                            && !r.StartsWith("bin/", StringComparison.Ordinal)
+                            && !r.StartsWith(".worktrees/", StringComparison.Ordinal))
+                // A .cs file IS a Code node in this repo's node-per-file layout, so withholding
+                // source and withholding those nodes are the same operation.
+                .Where(r => includeSource || !r.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+                .OrderBy(r => r, StringComparer.Ordinal));
+
+            if (contentFiles.Count == 0)
+            {
+                // Silence here would ship a bundle that LOOKS complete and cannot be consumed.
+                Console.Error.WriteLine(
+                    $"error: --content {contentDirectory} contains no files to ship"
+                    + (includeSource ? "" : " (source is excluded — set content.includeSource"
+                                             + " on the package root, or pass --include-source)"));
+                return 2;
+            }
+        }
+
         var manifestJson = JsonSerializer.Serialize(
             new
             {
@@ -233,6 +340,14 @@ public static class ModulePackCommand
                 // the module section's minMeshVersion floor below.
                 frameworkMvid,
                 module = new { assemblyName = moduleName, assemblies = closure, minMeshVersion },
+                // DECLARED, so BundleReader.ReadContent stays manifest-driven — these files are
+                // written into a consumer's working tree, and a glob would recreate anything a
+                // future producer happens to drop in the folder.
+                content = contentFiles.Count > 0 ? contentFiles : null,
+                // DECLARED, never inferred from the file list: a consumer that cannot resolve a
+                // shared=@ include must be able to tell "withheld" (its build cannot succeed) from
+                // "this package has no C#" (nothing is wrong).
+                sourceIncluded = contentFiles.Count > 0 ? includeSource : (bool?)null,
             },
             new JsonSerializerOptions
             {
@@ -249,6 +364,13 @@ public static class ModulePackCommand
             })
             .ToList();
 
+        entries.AddRange(contentFiles.Select(relative =>
+        {
+            var path = Path.Combine(contentDirectory!, relative.Replace('/', Path.DirectorySeparatorChar));
+            return new NuGetPackageWriter.Entry(
+                $"{NuGetPackageWriter.ContentFolder}/{relative}", () => File.OpenRead(path));
+        }));
+
         Directory.CreateDirectory(outputDirectory);
         var bundlePath = Path.Combine(
             outputDirectory, $"{manifest.PackageId}.{packageVersion}.module.nupkg");
@@ -259,7 +381,9 @@ public static class ModulePackCommand
 
         Console.WriteLine(
             $"packed {Path.GetFileName(bundlePath)} — module {moduleName}, "
-            + $"{closure.Count} file(s), floor {minMeshVersion ?? "(none)"}, "
+            + $"{closure.Count} file(s), {contentFiles.Count} node file(s) "
+            + $"({(includeSource ? "with" : "WITHOUT")} source), "
+            + $"floor {minMeshVersion ?? "(none)"}, "
             + $"built-against MVID {frameworkMvid ?? "(unrecorded)"}");
         return 0;
     }

--- a/src/MeshWeaver.Plugin.Build/Program.cs
+++ b/src/MeshWeaver.Plugin.Build/Program.cs
@@ -15,11 +15,18 @@ using MeshWeaver.Plugin.Build;
 if (args.Length > 0 && args[0] == ModulePackCommand.Verb)
     return ModulePackCommand.Run(args.Skip(1).ToArray());
 
+// The module-fetch verb: the CONSUMING half. A repo that depends on another fetches its RELEASED
+// package here instead of cloning and recompiling it — the mechanism "build only what you own"
+// needs (Doc/Architecture/ReleaseGates).
+if (args.Length > 0 && args[0] == ModuleFetchCommand.Verb)
+    return ModuleFetchCommand.Run(args.Skip(1).ToArray());
+
 if (args.Length == 0 || args[0] is "-h" or "--help")
 {
     Console.WriteLine("""
         usage: meshweaver-plugin-build <pluginDirectory> [options]
                meshweaver-plugin-build module-pack <moduleOutputDir> [options]   (see module-pack --help)
+               meshweaver-plugin-build module-fetch <package> [options]          (see module-fetch --help)
 
           --out <dir>                 where to write generated projects (default: ./obj/plugin-build)
           --framework-version <v>     MeshWeaver package version to compile against, or `latest`

--- a/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
@@ -30,6 +30,13 @@ public static class BundleReader
     /// consumer too — a bundle that quietly arrives with fewer assemblies than the package has types
     /// is indistinguishable from a complete one, and "adopted N" is the only evidence the whole
     /// distribution lane works.</param>
+    /// <param name="SourceIncluded">Whether <paramref name="Content"/> includes the package's C#
+    /// SOURCE. Null on a legacy bundle (unknown). 🚨 This is a DECLARATION, not an inference from
+    /// the file list, because the two answer different questions: a package may legitimately
+    /// contain no C# at all, and a consumer that cannot resolve a <c>shared=@…</c> include needs to
+    /// know whether the source was WITHHELD (its build cannot succeed and should say so) or simply
+    /// never existed (nothing is wrong). Inferring "no .cs files ⇒ source withheld" would report
+    /// the first for the second.</param>
     /// <param name="Content">The package's own NODE DEFINITION files, relative to
     /// <see cref="NuGetPackageWriter.ContentFolder"/> — present when the producer shipped the
     /// package tree alongside its bytes, null for an assemblies-only bundle. A consumer that means
@@ -43,7 +50,8 @@ public static class BundleReader
         ModuleRef? Module = null,
         string? Architecture = null,
         IReadOnlyList<string>? Misses = null,
-        IReadOnlyList<string>? Content = null);
+        IReadOnlyList<string>? Content = null,
+        bool? SourceIncluded = null);
 
     /// <summary>One assembly and the NodeType it implements.</summary>
     /// <param name="NodePath">Mesh path of the NodeType — the key a consumer re-seeds under.</param>

--- a/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
@@ -30,6 +30,11 @@ public static class BundleReader
     /// consumer too — a bundle that quietly arrives with fewer assemblies than the package has types
     /// is indistinguishable from a complete one, and "adopted N" is the only evidence the whole
     /// distribution lane works.</param>
+    /// <param name="Content">The package's own NODE DEFINITION files, relative to
+    /// <see cref="NuGetPackageWriter.ContentFolder"/> — present when the producer shipped the
+    /// package tree alongside its bytes, null for an assemblies-only bundle. A consumer that means
+    /// to USE this package as an upstream needs these: the bytes only stamp nodes that already
+    /// exist, so without the definitions there is nothing to stamp.</param>
     public sealed record Manifest(
         string? Plugin,
         string? Version,
@@ -37,7 +42,8 @@ public static class BundleReader
         IReadOnlyList<AssemblyRef>? Assemblies,
         ModuleRef? Module = null,
         string? Architecture = null,
-        IReadOnlyList<string>? Misses = null);
+        IReadOnlyList<string>? Misses = null,
+        IReadOnlyList<string>? Content = null);
 
     /// <summary>One assembly and the NodeType it implements.</summary>
     /// <param name="NodePath">Mesh path of the NodeType — the key a consumer re-seeds under.</param>
@@ -64,6 +70,12 @@ public static class BundleReader
     /// <param name="FileName">File name as the manifest declared it.</param>
     /// <param name="Bytes">The file's bytes.</param>
     public sealed record ModuleFile(string FileName, byte[] Bytes);
+
+    /// <summary>One node-definition file recovered from the bundle.</summary>
+    /// <param name="RelativePath">Path within the package tree, exactly as the manifest declared
+    /// it — the layout a consumer recreates on disk.</param>
+    /// <param name="Bytes">The file's bytes, verbatim.</param>
+    public sealed record ContentFile(string RelativePath, byte[] Bytes);
 
     /// <summary>An assembly's bytes, ready to seed.</summary>
     /// <param name="NodePath">Mesh path of the NodeType these bytes implement.</param>
@@ -199,6 +211,53 @@ public static class BundleReader
 
         using var stream = manifestEntry.Open();
         return JsonSerializer.Deserialize<Manifest>(stream, Json);
+    }
+
+    /// <summary>
+    /// Extracts the package's NODE DEFINITIONS — the tree a consumer recreates to use this package
+    /// as an upstream WITHOUT cloning and recompiling it.
+    ///
+    /// <para>🚨 Manifest-driven, like <see cref="Read(byte[])"/>, and for a sharper reason here:
+    /// these files are written to a consumer's working tree. Globbing
+    /// <see cref="NuGetPackageWriter.ContentFolder"/> would recreate whatever a future producer
+    /// happens to put there, so only DECLARED paths are extracted.</para>
+    ///
+    /// <para>🚨 A declared file the archive lacks is FATAL to the whole read — this returns empty
+    /// rather than a partial tree. Unlike a missing assembly (skipped: that one NodeType merely
+    /// compiles as it would have anyway), a half-materialised package is worse than none: its roots
+    /// reference nodes that are not there, so the consumer fails at bind time with a missing-node
+    /// error that names the wrong thing. All or nothing, the same rule
+    /// <see cref="ReadModule(byte[])"/> applies to a module's closure.</para>
+    /// </summary>
+    /// <param name="bundle">The archive bytes.</param>
+    /// <returns>The manifest (null when the archive carries none) and the declared files.</returns>
+    public static (Manifest? Manifest, IReadOnlyList<ContentFile> Files) ReadContent(byte[] bundle)
+    {
+        using var buffer = new MemoryStream(bundle, writable: false);
+        using var archive = new ZipArchive(buffer, ZipArchiveMode.Read);
+
+        var manifestEntry = archive.GetEntry(NuGetPackageWriter.ManifestEntry);
+        if (manifestEntry is null)
+            return (null, []);
+
+        Manifest? manifest;
+        using (var stream = manifestEntry.Open())
+            manifest = JsonSerializer.Deserialize<Manifest>(stream, Json);
+
+        if (manifest?.Content is not { Count: > 0 } declared)
+            return (manifest, []);
+
+        var files = new List<ContentFile>();
+        foreach (var relativePath in declared)
+        {
+            var entry = archive.GetEntry($"{NuGetPackageWriter.ContentFolder}/{relativePath}");
+            if (entry is null)
+                // Incomplete tree — all or nothing (see remarks).
+                return (manifest, []);
+            files.Add(new ContentFile(relativePath, ReadAll(entry)));
+        }
+
+        return (manifest, files);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
@@ -214,6 +214,28 @@ public static class BundleReader
     }
 
     /// <summary>
+    /// Rejects a declared content path that could escape the directory a consumer extracts into.
+    ///
+    /// <para>🚨 This is the one place in the bundle format where PRODUCER-CONTROLLED STRINGS BECOME
+    /// FILE PATHS on a consumer's machine. Everything else a bundle carries is either bytes keyed by
+    /// a node path (used as a dictionary key, never as a path) or a module file name the module
+    /// lane validates. A relative path is joined to an output directory and written, so
+    /// <c>../../…</c>, a rooted path, or a drive-qualified one would place attacker-chosen bytes
+    /// outside it — on a BUILD AGENT, which then compiles what it finds.</para>
+    ///
+    /// <para>Enforced on READ rather than only at the extraction site, because the alternative is
+    /// every consumer re-deriving the same rule and one of them getting it wrong. The writer
+    /// refuses to declare such a path too; this is the half that also holds for a bundle this
+    /// process did not produce.</para>
+    /// </summary>
+    private static bool IsUnsafeContentPath(string relativePath) =>
+        string.IsNullOrWhiteSpace(relativePath)
+        || Path.IsPathRooted(relativePath)
+        || relativePath.Contains('\\')                       // a Windows separator is not our shape
+        || relativePath.Contains(':')                          // drive- or scheme-qualified
+        || relativePath.Split('/').Any(segment => segment is ".." or ".");
+
+    /// <summary>
     /// Extracts the package's NODE DEFINITIONS — the tree a consumer recreates to use this package
     /// as an upstream WITHOUT cloning and recompiling it.
     ///
@@ -250,6 +272,16 @@ public static class BundleReader
         var files = new List<ContentFile>();
         foreach (var relativePath in declared)
         {
+            // 🚨 THROWS rather than returning empty. An incomplete archive is a benign producer
+            // bug and degrades to "no content"; a path that escapes the extraction directory is
+            // hostile or corrupt, and a caller about to write files must not be able to mistake it
+            // for "this bundle carries none".
+            if (IsUnsafeContentPath(relativePath))
+                throw new InvalidOperationException(
+                    $"bundle declares an unsafe content path '{relativePath}' — a package tree is "
+                    + "extracted relative to an output directory, so a rooted or parent-traversing "
+                    + "path would write outside it");
+
             var entry = archive.GetEntry($"{NuGetPackageWriter.ContentFolder}/{relativePath}");
             if (entry is null)
                 // Incomplete tree — all or nothing (see remarks).

--- a/src/MeshWeaver.Plugin.Packaging/BundleWriter.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleWriter.cs
@@ -146,6 +146,18 @@ public static class BundleWriter
 
         foreach (var file in content ?? [])
         {
+            // Defence at the producing end too: a bundle should never LEAVE here carrying a path a
+            // consumer must refuse. Cheap, and it turns a packaging mistake into an error next to
+            // the code that made it rather than a refusal on someone else's build agent.
+            if (string.IsNullOrWhiteSpace(file.RelativePath)
+                || Path.IsPathRooted(file.RelativePath)
+                || file.RelativePath.Contains('\\')
+                || file.RelativePath.Contains(':')
+                || file.RelativePath.Split('/').Any(segment => segment is ".." or "."))
+                throw new ArgumentException(
+                    $"content path '{file.RelativePath}' is not a safe package-relative path",
+                    nameof(content));
+
             using var source = file.Open();
             using var target = archive
                 .CreateEntry($"{NuGetPackageWriter.ContentFolder}/{file.RelativePath}").Open();

--- a/src/MeshWeaver.Plugin.Packaging/BundleWriter.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleWriter.cs
@@ -16,10 +16,17 @@ namespace MeshWeaver.Plugin.Packaging;
 /// bundle lane. Consumers: <c>PluginBundleClient</c> (HTTP) and the boot-time shipped-bundle
 /// seeder — all of them go through <see cref="BundleReader.Read(byte[])"/>.</para>
 ///
-/// <para>A bundle is deliberately NOT a nupkg: it carries no content, no nuspec, no dependency
-/// graph — only compiled bytes and the identity they are pinned to. The framework MVID in the
-/// manifest is what <c>PrebuiltAssemblySeeder.DeclineReason</c> gates adoption on, so writing it is
-/// mandatory: a bundle without it is dead weight every consumer refuses (correctly).</para>
+/// <para>A bundle is deliberately NOT a nupkg: no nuspec, no dependency graph — compiled bytes, the
+/// identity they are pinned to, and (optionally) the package's own NODE DEFINITIONS. The framework
+/// MVID in the manifest is what <c>PrebuiltAssemblySeeder.DeclineReason</c> gates adoption on, so
+/// writing it is mandatory: a bundle without it is dead weight every consumer refuses (correctly).</para>
+///
+/// <para>🚨 The node definitions are what make a bundle a REPLACEMENT for a source checkout rather
+/// than a speed-up on top of one. Until it carried them, a dependent repo could get an upstream's
+/// bytes but not the nodes those bytes stamp, so it still cloned the upstream and recompiled it —
+/// the rebuild that <c>Doc/Architecture/ReleaseGates</c> forbids, and the one that produces an ALC
+/// per recompile. Carrying them is optional at the format level (a NodeType-only bundle stays
+/// valid) and required for a bundle meant to be CONSUMED as an upstream.</para>
 /// </summary>
 public static class BundleWriter
 {
@@ -50,6 +57,25 @@ public static class BundleWriter
         IReadOnlyDictionary<string, string>? Dependencies = null);
 
     /// <summary>
+    /// One NODE-DEFINITION file destined for the bundle — the package's own tree (its
+    /// <c>index.json</c>, its NodeType nodes, its <c>Source/*.cs</c>, its markdown), shipped
+    /// verbatim under <see cref="NuGetPackageWriter.ContentFolder"/>.
+    ///
+    /// <para>🚨 Why a bundle of assemblies carries source-shaped files at all. A consumer of an
+    /// upstream needs the upstream's DEFINITIONS, not only its bytes: the consumer's package roots
+    /// are typed by an upstream type (<c>nodeType: Store/Plugin</c>) and its NodeTypes' `sources`
+    /// queries reach into upstream packages (<c>shared=@Edu/…</c>). Seeding an assembly only
+    /// STAMPS a node that already exists — with no upstream nodes in the tree there is nothing to
+    /// stamp and the roots do not bind. So a bundle that carries assemblies alone cannot replace a
+    /// source checkout, which is why every dependent still rebuilt its upstreams from source.</para>
+    /// </summary>
+    /// <param name="RelativePath">Path within the package tree, forward-slashed
+    /// (<c>index.json</c>, <c>Slide/Source/SlideContent.cs</c>) — the layout a consumer recreates.</param>
+    /// <param name="Open">Opens the file's bytes. A factory, for the same streaming reason as
+    /// <see cref="AssemblyEntry.OpenAssembly"/>.</param>
+    public sealed record ContentEntry(string RelativePath, Func<Stream> Open);
+
+    /// <summary>
     /// Writes the bundle into <paramref name="destination"/> (left open, mirroring
     /// <see cref="NuGetPackageWriter.Write"/> — a caller may rewind and serve it).
     /// </summary>
@@ -69,7 +95,8 @@ public static class BundleWriter
         string? version,
         string frameworkMvid,
         IReadOnlyList<AssemblyEntry> assemblies,
-        string? sourceSha = null)
+        string? sourceSha = null,
+        IReadOnlyList<ContentEntry>? content = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(frameworkMvid);
         ArgumentNullException.ThrowIfNull(assemblies);
@@ -95,6 +122,11 @@ public static class BundleWriter
                     dependencies = a.Dependencies,
                 })
                 .ToList(),
+            // DECLARED, never left to be discovered by enumerating the folder — the same rule the
+            // assemblies follow (see BundleReader.Read). A reader that globbed the archive could
+            // not tell a package file from a stray entry a future producer adds, and would silently
+            // recreate it into the consumer's tree.
+            content = content?.Select(c => c.RelativePath).ToList(),
         };
 
         WriteText(archive, NuGetPackageWriter.ManifestEntry, JsonSerializer.Serialize(manifest, Json));
@@ -110,6 +142,14 @@ public static class BundleWriter
             using (var source = entry.OpenPdb())
             using (var target = archive.CreateEntry(NuGetPackageWriter.EntryPathFor(entry.NodePath, ".pdb")).Open())
                 source.CopyTo(target);
+        }
+
+        foreach (var file in content ?? [])
+        {
+            using var source = file.Open();
+            using var target = archive
+                .CreateEntry($"{NuGetPackageWriter.ContentFolder}/{file.RelativePath}").Open();
+            source.CopyTo(target);
         }
     }
 

--- a/src/MeshWeaver.Plugin.Packaging/BundleWriter.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleWriter.cs
@@ -96,7 +96,8 @@ public static class BundleWriter
         string frameworkMvid,
         IReadOnlyList<AssemblyEntry> assemblies,
         string? sourceSha = null,
-        IReadOnlyList<ContentEntry>? content = null)
+        IReadOnlyList<ContentEntry>? content = null,
+        bool? sourceIncluded = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(frameworkMvid);
         ArgumentNullException.ThrowIfNull(assemblies);
@@ -127,6 +128,7 @@ public static class BundleWriter
             // not tell a package file from a stray entry a future producer adds, and would silently
             // recreate it into the consumer's tree.
             content = content?.Select(c => c.RelativePath).ToList(),
+            sourceIncluded,
         };
 
         WriteText(archive, NuGetPackageWriter.ManifestEntry, JsonSerializer.Serialize(manifest, Json));

--- a/test/MeshWeaver.Graph.Test/BundleContentTest.cs
+++ b/test/MeshWeaver.Graph.Test/BundleContentTest.cs
@@ -1,0 +1,140 @@
+#pragma warning disable CS1591
+
+using System.IO.Compression;
+using System.Text;
+using MeshWeaver.Plugin.Packaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the NODE-DEFINITION half of a bundle — the half that makes a published package usable as
+/// an upstream instead of merely fast.
+///
+/// <para>Why this is worth its own suite: a bundle carrying assemblies alone LOOKS complete. It
+/// reads back, its manifest validates, its bytes seed. What it cannot do is stand in for a source
+/// checkout, because seeding an assembly only stamps a node that already exists — so a consumer
+/// that trusted it would find its roots unbound at activation, far from here. Every assertion below
+/// is about the difference between "the bundle read back" and "the package is actually there".</para>
+/// </summary>
+public class BundleContentTest
+{
+    private const string Mvid = "33f2efb8aaaabbbbccccddddeeeeffff";
+
+    private static BundleWriter.ContentEntry File(string path, string body) =>
+        new(path, () => new MemoryStream(Encoding.UTF8.GetBytes(body)));
+
+    private static byte[] WriteBundle(params BundleWriter.ContentEntry[] content)
+    {
+        var buffer = new MemoryStream();
+        BundleWriter.Write(
+            buffer, "Edu", "1.4.0", Mvid,
+            [new BundleWriter.AssemblyEntry("Edu/Module", () => new MemoryStream("MODULE"u8.ToArray()))],
+            sourceSha: "0eaeb06",
+            content: content);
+        return buffer.ToArray();
+    }
+
+    [Fact]
+    public void TheTreeComesBackVerbatim_PathsAndBytes()
+    {
+        var bundle = WriteBundle(
+            File("index.json", """{"nodeType":"Store/Plugin"}"""),
+            File("Module.json", """{"nodeType":"NodeType"}"""),
+            File("Module/Source/ModuleContent.cs", "public record ModuleContent;"));
+
+        var (manifest, files) = BundleReader.ReadContent(bundle);
+
+        Assert.Equal("Edu", manifest!.Plugin);
+        Assert.Equal(3, files.Count);
+        // Nested paths survive: the consumer recreates a TREE, not a flat folder. A producer that
+        // sanitised the separator would collide Module/Source/X.cs with Module.Source.X.cs.
+        var source = Assert.Single(files, f => f.RelativePath == "Module/Source/ModuleContent.cs");
+        Assert.Equal("public record ModuleContent;", Encoding.UTF8.GetString(source.Bytes));
+        Assert.Equal("""{"nodeType":"Store/Plugin"}""",
+            Encoding.UTF8.GetString(Assert.Single(files, f => f.RelativePath == "index.json").Bytes));
+    }
+
+    [Fact]
+    public void CarryingContentDoesNotDisturbTheAssemblyLane()
+    {
+        var bundle = WriteBundle(File("index.json", "{}"));
+
+        var (manifest, assemblies) = BundleReader.Read(bundle);
+
+        // The two lanes share one manifest; adding content must not cost the bytes their identity.
+        Assert.Equal(Mvid, manifest!.FrameworkMvid);
+        var payload = Assert.Single(assemblies);
+        Assert.Equal("Edu/Module", payload.NodePath);
+        Assert.Equal("MODULE", Encoding.UTF8.GetString(payload.Assembly));
+    }
+
+    [Fact]
+    public void AnAssembliesOnlyBundleReportsNoContent_NotAnError()
+    {
+        // The format stays valid without a tree: every bundle written before this existed, and
+        // every NodeType-only bundle written after it, must still read.
+        var buffer = new MemoryStream();
+        BundleWriter.Write(
+            buffer, "ThreeBody", "1.0.0", Mvid,
+            [new BundleWriter.AssemblyEntry("ThreeBody/Physics", () => new MemoryStream("P"u8.ToArray()))]);
+
+        var (manifest, files) = BundleReader.ReadContent(buffer.ToArray());
+
+        Assert.Null(manifest!.Content);
+        Assert.Empty(files);
+    }
+
+    [Fact]
+    public void ADeclaredFileMissingFromTheArchiveYieldsNothing_NeverAPartialTree()
+    {
+        // A half-materialised package is worse than none: its roots reference nodes that are not
+        // there, and the consumer fails at bind time naming the wrong thing. Strip one declared
+        // entry out of an otherwise-good bundle and the whole read must refuse.
+        var bundle = WriteBundle(File("index.json", "{}"), File("Module.json", "{}"));
+
+        var tampered = new MemoryStream();
+        using (var source = new ZipArchive(new MemoryStream(bundle), ZipArchiveMode.Read))
+        using (var target = new ZipArchive(tampered, ZipArchiveMode.Create, leaveOpen: true))
+            foreach (var entry in source.Entries)
+            {
+                if (entry.FullName.EndsWith("/Module.json", StringComparison.Ordinal))
+                    continue;
+                using var from = entry.Open();
+                using var to = target.CreateEntry(entry.FullName).Open();
+                from.CopyTo(to);
+            }
+
+        var (manifest, files) = BundleReader.ReadContent(tampered.ToArray());
+
+        Assert.Equal(2, manifest!.Content!.Count);   // still DECLARED — the manifest is intact
+        Assert.Empty(files);                          // …and refused wholesale
+    }
+
+    [Fact]
+    public void OnlyDeclaredFilesAreExtracted()
+    {
+        // Manifest-driven, not glob-driven. These bytes land in a consumer's working tree, so an
+        // undeclared entry a future producer adds must never be recreated there.
+        var bundle = WriteBundle(File("index.json", "{}"));
+
+        var tampered = new MemoryStream();
+        using (var source = new ZipArchive(new MemoryStream(bundle), ZipArchiveMode.Read))
+        using (var target = new ZipArchive(tampered, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var entry in source.Entries)
+            {
+                using var from = entry.Open();
+                using var to = target.CreateEntry(entry.FullName).Open();
+                from.CopyTo(to);
+            }
+            using var stowaway = target
+                .CreateEntry($"{NuGetPackageWriter.ContentFolder}/not-declared.json").Open();
+            stowaway.Write("{}"u8);
+        }
+
+        var (_, files) = BundleReader.ReadContent(tampered.ToArray());
+
+        Assert.Equal("index.json", Assert.Single(files).RelativePath);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/BundleContentTest.cs
+++ b/test/MeshWeaver.Graph.Test/BundleContentTest.cs
@@ -2,6 +2,7 @@
 
 using System.IO.Compression;
 using System.Text;
+using System.Text.Json;
 using MeshWeaver.Plugin.Packaging;
 using Xunit;
 
@@ -136,5 +137,67 @@ public class BundleContentTest
         var (_, files) = BundleReader.ReadContent(tampered.ToArray());
 
         Assert.Equal("index.json", Assert.Single(files).RelativePath);
+    }
+
+    [Theory]
+    [InlineData("../escaped.json")]                    // parent traversal
+    [InlineData("Module/../../escaped.json")]          // traversal mid-path
+    [InlineData("/etc/passwd")]                        // rooted
+    [InlineData("C:/Windows/system.ini")]              // drive-qualified
+    [InlineData("Module\\Source\\X.cs")]                 // Windows separator
+    public void AnUnsafeDeclaredPathIsRefused_Loudly(string hostile)
+    {
+        // These bytes are written into a BUILD AGENT's working tree, which then compiles what it
+        // finds — so a producer-declared path that escapes the extraction directory must never be
+        // materialised. It THROWS rather than degrading to "no content": an incomplete archive is a
+        // benign producer bug, this is hostile or corrupt, and a caller about to write files must
+        // not be able to confuse the two.
+        var bundle = WriteBundle(File("index.json", "{}"));
+        var tampered = Retarget(bundle, hostile);
+
+        var error = Assert.Throws<InvalidOperationException>(() => BundleReader.ReadContent(tampered));
+        Assert.Contains(hostile, error.Message);
+    }
+
+    [Fact]
+    public void TheWriterRefusesToProduceOne()
+    {
+        // Defence at the producing end too, so a packaging mistake errors next to the code that
+        // made it rather than on someone else's agent.
+        var buffer = new MemoryStream();
+        Assert.Throws<ArgumentException>(() => BundleWriter.Write(
+            buffer, "Edu", "1.4.0", Mvid,
+            [new BundleWriter.AssemblyEntry("Edu/Module", () => new MemoryStream("M"u8.ToArray()))],
+            content: [File("../escaped.json", "{}")]));
+    }
+
+    /// <summary>
+    /// Rewrites a good bundle's manifest so it DECLARES <paramref name="path"/> — the shape a
+    /// hostile or corrupt producer would emit. The archive itself is left alone: the guard must
+    /// fire on the declaration, before anything is looked up or written.
+    /// </summary>
+    private static byte[] Retarget(byte[] bundle, string path)
+    {
+        var rewritten = new MemoryStream();
+        using (var source = new ZipArchive(new MemoryStream(bundle), ZipArchiveMode.Read))
+        using (var target = new ZipArchive(rewritten, ZipArchiveMode.Create, leaveOpen: true))
+            foreach (var entry in source.Entries)
+            {
+                using var to = target.CreateEntry(entry.FullName).Open();
+                if (entry.FullName != NuGetPackageWriter.ManifestEntry)
+                {
+                    using var from = entry.Open();
+                    from.CopyTo(to);
+                    continue;
+                }
+
+                using var reader = new StreamReader(entry.Open());
+                var json = reader.ReadToEnd()
+                    .Replace("\"index.json\"", JsonSerializer.Serialize(path));
+                using var writer = new StreamWriter(to, Encoding.UTF8);
+                writer.Write(json);
+            }
+
+        return rewritten.ToArray();
     }
 }

--- a/test/MeshWeaver.Graph.Test/BundleContentTest.cs
+++ b/test/MeshWeaver.Graph.Test/BundleContentTest.cs
@@ -200,4 +200,36 @@ public class BundleContentTest
 
         return rewritten.ToArray();
     }
+
+    [Fact]
+    public void SourceInclusionIsDeclared_NotInferredFromTheFileList()
+    {
+        // A consumer that cannot resolve `shared=@pkg/…` must be able to tell WITHHELD from
+        // NEVER-EXISTED: the first means its build cannot succeed and should say so, the second
+        // means nothing is wrong. A file-list inference reports the first for the second.
+        var buffer = new MemoryStream();
+        BundleWriter.Write(
+            buffer, "Edu", "1.4.0", Mvid,
+            [new BundleWriter.AssemblyEntry("Edu/Module", () => new MemoryStream("M"u8.ToArray()))],
+            content: [File("index.json", "{}")],
+            sourceIncluded: false);
+
+        var (manifest, files) = BundleReader.ReadContent(buffer.ToArray());
+
+        Assert.False(manifest!.SourceIncluded);
+        Assert.Equal("index.json", Assert.Single(files).RelativePath);
+    }
+
+    [Fact]
+    public void ALegacyBundleLeavesSourceInclusionUnknown()
+    {
+        // Null, never false: a bundle written before the declaration existed says nothing about
+        // its source, and reading that silence as "withheld" would invent a policy its producer
+        // never expressed.
+        var bundle = WriteBundle(File("index.json", "{}"));
+
+        var (manifest, _) = BundleReader.ReadContent(bundle);
+
+        Assert.Null(manifest!.SourceIncluded);
+    }
 }

--- a/test/MeshWeaver.Graph.Test/ModuleFetchMaterialiseTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModuleFetchMaterialiseTest.cs
@@ -1,0 +1,94 @@
+#pragma warning disable CS1591
+
+using System.Text;
+using MeshWeaver.Plugin.Build;
+using MeshWeaver.Plugin.Packaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins that a fetch REPLACES the upstream tree rather than merging into it — the property that
+/// makes a package's <c>content.includeSource</c> flip actually take effect on consumers.
+///
+/// <para>Worth its own suite because the failure is silent and self-concealing: if a fetch merged,
+/// flipping source OFF would leave yesterday's <c>Source/*.cs</c> on disk, the consumer would keep
+/// compiling against code the producer deliberately withheld, and every build would stay green
+/// while doing it. Nothing would report the withheld source as missing, because it would not be
+/// missing.</para>
+/// </summary>
+public class ModuleFetchMaterialiseTest : IDisposable
+{
+    private readonly string root = Path.Combine(
+        Path.GetTempPath(), "mw-fetch-" + Guid.NewGuid().ToString("N")[..12]);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+            Directory.Delete(root, recursive: true);
+    }
+
+    private static BundleReader.ContentFile Node(string path, string body) =>
+        new(path, Encoding.UTF8.GetBytes(body));
+
+    [Fact]
+    public void FlippingSourceOffRemovesTheSourceAlreadyOnDisk()
+    {
+        var target = Path.Combine(root, "Edu");
+
+        // Release 1 ships source (the package opted in).
+        ModuleFetchCommand.Materialise(
+        [
+            Node("index.json", """{"nodeType":"Store/Plugin"}"""),
+            Node("Module.json", """{"nodeType":"NodeType"}"""),
+            Node("Module/Source/ModuleContent.cs", "public record ModuleContent;"),
+        ], target);
+
+        Assert.True(File.Exists(Path.Combine(target, "Module", "Source", "ModuleContent.cs")));
+
+        // Release 2 withholds it — content.includeSource flipped to false, so the bundle simply
+        // does not declare the .cs files any more.
+        ModuleFetchCommand.Materialise(
+        [
+            Node("index.json", """{"nodeType":"Store/Plugin"}"""),
+            Node("Module.json", """{"nodeType":"NodeType"}"""),
+        ], target);
+
+        Assert.False(
+            File.Exists(Path.Combine(target, "Module", "Source", "ModuleContent.cs")),
+            "withheld source must not survive on disk — a merged tree would keep compiling against it");
+        // The directory it lived in goes too: an empty Source/ folder left behind reads as
+        // "this package has no source" to a human and to a glob, which is a different claim.
+        Assert.False(Directory.Exists(Path.Combine(target, "Module", "Source")));
+        Assert.True(File.Exists(Path.Combine(target, "Module.json")));
+    }
+
+    [Fact]
+    public void AFileDroppedByANewReleaseDoesNotSurvive()
+    {
+        // The same rule beyond source: a merged tree is neither the old release nor the new one,
+        // so a build against it is reproducible from no commit at all.
+        var target = Path.Combine(root, "Store");
+
+        ModuleFetchCommand.Materialise(
+            [Node("index.json", "{}"), Node("Retired.json", """{"nodeType":"NodeType"}""")], target);
+        Assert.True(File.Exists(Path.Combine(target, "Retired.json")));
+
+        ModuleFetchCommand.Materialise([Node("index.json", "{}")], target);
+
+        Assert.False(File.Exists(Path.Combine(target, "Retired.json")));
+    }
+
+    [Fact]
+    public void NestedPathsAreRecreatedAsATree()
+    {
+        var target = Path.Combine(root, "Publish");
+
+        ModuleFetchCommand.Materialise(
+            [Node("Slide/Source/SlideContent.cs", "public record SlideContent;")], target);
+
+        Assert.Equal(
+            "public record SlideContent;",
+            File.ReadAllText(Path.Combine(target, "Slide", "Source", "SlideContent.cs")));
+    }
+}


### PR DESCRIPTION
The blocking piece of **"build only what you own"** (`Doc/Architecture/ReleaseGates`). Everything else in that plan — the fetch CLI, CI registering as a consumer, the blob token — is inert without it.

## Why an assemblies-only bundle can't replace a checkout

A published bundle carried compiled assemblies keyed by node path. That is enough to *skip a compile*, never enough to *replace a source checkout*: seeding an assembly only **stamps a node that already exists**. A consumer with no upstream nodes in its tree has nothing to stamp — its package roots are typed by an upstream type (`nodeType: Store/Plugin`) and its NodeTypes' `sources` reach into upstream packages (`shared=@Edu/…`).

So every dependent still cloned its upstream and recompiled it. That's the rebuild `ReleaseGates` forbids, and the one that yields an ALC per recompile — the accumulation `NodeTypeRecompileAlcLeakTest` measures.

## What changed

`BundleWriter` gains `ContentEntry` and writes the package tree verbatim into `meshweaver/content` — a folder that **already existed as a reserved slot** (`PluginPacker` uses it for the nupkg lane; the bundle lane never did). `BundleReader` gains `ReadContent` and a `Content` list on the manifest.

Two decisions, both because the failure modes are silent:

- **Manifest-driven, not glob-driven** — the same rule the assemblies follow, for a sharper reason here: these bytes are written into a *consumer's working tree*, so enumerating the folder would recreate whatever a future producer happens to put there. Only declared paths are extracted.
- **All-or-nothing on a missing declared file**, unlike a missing assembly. A skipped assembly costs nothing — that NodeType compiles as it would have anyway. A half-materialised *package* is worse than none: its roots reference nodes that aren't there, so the consumer fails at bind time with a missing-node error naming the wrong thing. Same rule `ReadModule` already applies to a module's closure.

Carrying content is **optional at the format level** — an assemblies-only bundle stays valid and still reads, which is every bundle written before this — and required for one meant to be consumed as an upstream.

## Tests

Five, covering the invariants and both silent failure modes: the tree round-trips with nested paths intact; the assembly lane is undisturbed; an assemblies-only bundle reports no content rather than erroring; a stripped declared file yields nothing rather than a partial tree; an undeclared stowaway entry is not extracted.

Verified executed, not merely compiled — `Failed: 0, Passed: 5`, and the existing `BundleReaderTest` + `ModulePackCommandTest` still green at `Failed: 0, Passed: 17`.

## Next, in order

1. The producers (bake / `module-pack`) populate `content` for packages meant to be consumed as upstreams.
2. A CLI fetches a released package — the inverse of `module-pack`, in `MeshWeaver.Plugin.Build`.
3. CI registers as a consumer; the instance is issued a blob token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)