### PR TITLE
The positive control must wait on its OWN stream (main is red on it)

### DIFF
--- a/test/MeshWeaver.Layout.Test/GetDataStreamUnsetIdTest.cs
+++ b/test/MeshWeaver.Layout.Test/GetDataStreamUnsetIdTest.cs
@@ -168,8 +168,20 @@ public class GetDataStreamUnsetIdTest(ITestOutputHelper output) : HubTestBase(ou
                 () => Interlocked.Increment(ref completionsOnNeverSetId));
 
         // Positive control: the IDENTICAL idiom against an id that WAS written.
-        using var writtenGuard = host.GetDataStream<string>(WrittenId)
-            .Take(1)
+        //
+        // 🚨 Replay(1) + Connect so this can be AWAITED ON ITS OWN EMISSION below. Reading the
+        // counter after merely waiting for the CONTROL write is a race: ControlId and WrittenId are
+        // DIFFERENT streams, and one stream's delivery orders nothing about another's. The window
+        // below closing says the data plane is live — it does NOT say this subscription has been
+        // served yet. That race turned main red on 4bb6f1fca (run 32239357043): the control read 0
+        // and reported "positive control … but found 0", i.e. the guard that exists to prove the
+        // test is not vacuous was itself the flake.
+        //
+        // Replay(1) also closes the gap between Connect() and the counter's Subscribe: an emission
+        // arriving in between is buffered and still delivered, so the count cannot be lost.
+        var writtenOnce = host.GetDataStream<string>(WrittenId).Take(1).Replay(1);
+        using var writtenConnection = writtenOnce.Connect();
+        using var writtenGuard = writtenOnce
             .Subscribe(_ => Interlocked.Increment(ref guardedRunsOnWrittenId));
 
         // Close the window on an observed event, not a clock.
@@ -177,6 +189,10 @@ public class GetDataStreamUnsetIdTest(ITestOutputHelper output) : HubTestBase(ou
         using var connection = landed.Connect();
         host.UpdateData(ControlId, ControlLate);
         await landed.Should().Within(10.Seconds()).Emit();
+
+        // …and then on the positive control's OWN emission, which is the only thing that licenses
+        // reading its counter. Still clock-free — it waits for the event, not for a duration.
+        await writtenOnce.Should().Within(10.Seconds()).Emit();
 
         Volatile.Read(ref guardedRunsOnWrittenId).Should().Be(1,
             "the same .Take(1) idiom on a WRITTEN id fires exactly once — this is the positive control "


### PR DESCRIPTION
**Main is red on this** — `4bb6f1fca`, [run 32239357043](https://github.com/Systemorph/MeshWeaver/actions/runs/32239357043), shard 2:

```
MeshWeaver.Layout.Test.GetDataStreamUnsetIdTest.TakeOneOnNeverSetId_NeverFiresAndNeverCompletes_SoAOnceGuardBlocksTheFIRSTRun
  Expected value to be 1 because the same .Take(1) idiom on a WRITTEN id fires exactly once
  — this is the positive control that makes the two assertions below meaningful, but found 0.
```

## The race

The control subscribes to **`WrittenId`**, then closes its window on **`ControlId`**:

```csharp
using var writtenGuard = host.GetDataStream<string>(WrittenId).Take(1)
    .Subscribe(_ => Interlocked.Increment(ref guardedRunsOnWrittenId));

// Close the window on an observed event, not a clock.
var landed = ControlLanded(host).Replay(1);
host.UpdateData(ControlId, ControlLate);
await landed.Should().Within(10.Seconds()).Emit();

Volatile.Read(ref guardedRunsOnWrittenId).Should().Be(1, "...positive control...");
```

Two different streams. The control write landing proves the data plane is live; it proves nothing about whether *this* subscription has been served. *"Close the window on an observed event, not a clock"* is the right instinct applied to the wrong clock.

The irony is the part worth fixing carefully: the assertion that exists to prove the test isn't vacuous is the one that flaked. A reader seeing this red would reasonably suspect `GetDataStream` itself.

## The fix

Await the control's **own** emission. `Replay(1)` + `Connect` makes it awaitable and also closes the gap between `Connect()` and the counter's `Subscribe` — an emission arriving in between is buffered rather than lost. Still clock-free: it waits for the event, not a duration.

## Measurement, and why local green means nothing here

| Configuration | Result |
|---|---|
| **Original**, clean main, `DOTNET_PROCESSOR_COUNT=4` | 10/10 **pass** |
| **Fixed**, same conditions | 15/15 pass |

So this is rare, not deterministic — local green never told anyone anything, and CI load is what exposed it. That asymmetry is the argument for fixing it structurally rather than waiting to see whether it recurs.

> Method note: an earlier run of mine appeared to show the original failing 15/15. It was an artifact — that worktree had never built `MeshWeaver.Layout.Test`, so `dotnet test` exited 0 having run nothing and a `grep -q 'Passed!'` counted each silent no-op as a failure. The numbers above are from built worktrees, with a separate `no-output` bucket so a run that executes nothing can no longer be scored.

Test-only; no What's New entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)