### PR TITLE
The platform-build webhook target is allowlisted, and its secret is mounted

### DIFF
--- a/deploy/aks/envs/example/secretproviderclass.yaml
+++ b/deploy/aks/envs/example/secretproviderclass.yaml
@@ -86,6 +86,13 @@ spec:
         - |
           objectName: Plugins-Registry-PublishToken
           objectType: secret
+        # The platform-build webhook's shared HMAC secret (pairs with
+        # config WebhookInbox__Targets__N = Hosting/PlatformBuilds). The inbox verifies
+        # NOTHING — signature verification is the consuming plugin's job — so without this
+        # the Hosting watcher drops every delivery as unverifiable and the roll never starts.
+        - |
+          objectName: Hosting-PlatformWebhookSecret
+          objectType: secret
   secretObjects:
     - secretName: exampledb-portal-ai-secrets
       type: Opaque
@@ -114,3 +121,7 @@ spec:
         # publish route compares in constant time.
         - objectName: Plugins-Registry-PublishToken
           key: Plugins__Registry__PublishToken
+        # Hosting__PlatformWebhookSecret → Hosting:PlatformWebhookSecret — what
+        # PlatformBuildInboxWatcher compares the X-Hub-Signature-256 against.
+        - objectName: Hosting-PlatformWebhookSecret
+          key: Hosting__PlatformWebhookSecret

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -73,6 +73,19 @@ config:
     MEMEX_JDBCCONNECTIONSTRING: "jdbc:postgresql://memex-postgres-service:5432/memex"
     MEMEX_DATABASENAME: "memex"
     ASPNETCORE_HTTP_PORTS: "8080"
+    # ---- Webhook inbox targets ---------------------------------------------
+    # 🚨 The generic inbox (POST /api/hooks/{target}) is FAIL-CLOSED: a target that is not
+    # listed here answers 404 — byte-identical to a target that does not exist. So an
+    # unlisted target does not look misconfigured, it looks like a wrong URL, which is how
+    # the platform-build notification went unnoticed: CD posted, memex 404'd, and the whole
+    # self-update chain simply never received a release event.
+    #
+    # Hosting/PlatformBuilds is the platform-build fact CD's notify-platform-update posts
+    # after every promoted build; the Hosting package's PlatformBuildInboxWatcher verifies
+    # its HMAC (Hosting:PlatformWebhookSecret) and drives the roll. The package must be
+    # provisioned for anything to read the inbox — an allowlisted target with no watcher
+    # stores deliveries nobody consumes.
+    WebhookInbox__Targets__0: "Hosting/PlatformBuilds"
     # ---- Instance branding (per-env) ----------------------------------------
     # Large Safari bookmark / Start-Page / Add-to-Dock tile (apple-touch-icon, 180×180 PNG).
     # This ships the PROJECT's own mark (Systemorph builds MeshWeaver — the chart's


### PR DESCRIPTION
Found by tracing why `memex.meshweaver.cloud` sat **50 commits (~14 h) behind main** while CD was green and publishing.

## Where it breaks

```
CD promotes an image
  → notify-platform-update posts a signed build fact
  → generic inbox stores it at Hosting/PlatformBuilds/_Inbox     ← 404 HERE
  → Hosting's PlatformBuildInboxWatcher verifies the HMAC and rolls
```

Step three answers **404**, because the generic inbox is fail-closed on `WebhookInbox:Targets` and that target was never listed. Verified directly: `POST /api/hooks/Hosting/PlatformBuilds` returns 404 **byte-identical** to `POST /api/hooks/Definitely/Not/A/Target`.

🚨 That identity is deliberate (the endpoint must not be an inventory oracle) — and it is exactly why this went unnoticed. An unlisted target doesn't look misconfigured, it looks like somebody typed the wrong URL.

Self-update is **event-driven** — one startup pass, then a check per build event — so a missing event isn't a slow update, it's *no* update, ever. The visible symptom is a frozen `Admin/UpdatePolicy` (`latestAvailableTag` stuck at `3.0.0-rc4.ci.4332`, `checkedAt` at 2026-08-18T18:49) because the bookkeeping write only happens once a *newer* tag has been found, and no event ever arrives to go look.

## What this changes

Two halves, both required, each useless alone:

| | |
|---|---|
| **target** (`values.aks.yaml`) | without it the POST 404s |
| **secret** (SPC → `Hosting__PlatformWebhookSecret`) | the inbox verifies *nothing* by design — signature checking is the consuming plugin's job — so without it the watcher drops every delivery as unverifiable |

A third piece isn't config: the **Hosting package must be provisioned**, or the inbox stores deliveries nobody reads. Done on `memex.meshweaver.cloud` via `Store/Provision` — 7/7 phases including compile types.

Also now set outside this PR: `PLATFORM_WEBHOOK_URL` / `PLATFORM_WEBHOOK_SECRET` on this repo, and `Hosting-PlatformWebhookSecret` in the `Systemorph` Key Vault (same value).

## ⚠️ Scope

These files are the **chart default** and the **example env**. The authoritative values for a live instance live in the private env repo, so this makes the pattern correct and shipped-by-default — **the deployed instance still needs the same two keys applied there**, which is the one step this PR cannot perform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)