### PR TITLE
The module root must be writable — and SHARED, not /app

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -531,7 +531,12 @@ public static class MemexConfiguration
             // NodeType bake lane's). Pre-DI, so diagnostics go to stderr (pod stdout/stderr ship
             // to Loki regardless).
             var moduleAssemblies = configuration.GetSection("Modules:Assemblies").Get<string[]>();
-            var persistedActivation = ModuleActivationSidecar.Read(AppContext.BaseDirectory,
+            // 🚨 The SAME root ModuleLandingService writes (ModuleRoot) — never
+            // AppContext.BaseDirectory directly. They must name one directory: a landed module
+            // read from somewhere else is simply invisible, and on a deployment whose /app is
+            // read-only the writer cannot use AppContext.BaseDirectory at all.
+            var moduleRoot = ModuleRoot.Resolve(configuration);
+            var persistedActivation = ModuleActivationSidecar.Read(moduleRoot,
                 msg => Console.Error.WriteLine($"[ModuleActivation] {msg}"));
             var effectiveModules = ModuleActivationBoot.ComputeEffectiveModuleEntries(
                 moduleAssemblies,
@@ -543,14 +548,14 @@ public static class MemexConfiguration
                 // BaseDirectory fallback would let a sidecar entry with a lost modules/ folder
                 // silently bind a same-named app-closure DLL instead of being skipped. Baseline
                 // entries below keep ResolveModulePath (both locations are legitimate for them).
-                name => ModuleActivationBoot.LandedModuleDllExists(AppContext.BaseDirectory, name),
+                name => ModuleActivationBoot.LandedModuleDllExists(moduleRoot, name),
                 (module, reason) => Console.Error.WriteLine(
                     $"[ModuleActivation] SKIPPED store-installed module '{module}': {reason}"));
             if (effectiveModules.Count > 0)
                 // ResolveModulePath probes the modules/<name>/ publish layout first (#1644),
                 // then falls back to the classic BaseDirectory-relative location.
                 builder.InstallAssemblies(effectiveModules
-                    .Select(MeshBuilder.ResolveModulePath)
+                    .Select(entry => MeshBuilder.ResolveModulePath(entry, moduleRoot))
                     .ToArray());
             // Restart-as-activation: this boot IS the restart the sidecar was waiting for —
             // consume the pending flag so the step-10 signal reads current. Best-effort: on a
@@ -558,7 +563,7 @@ public static class MemexConfiguration
             if (persistedActivation.PendingRestart)
                 try
                 {
-                    ModuleActivationSidecar.Write(AppContext.BaseDirectory,
+                    ModuleActivationSidecar.Write(moduleRoot,
                         persistedActivation with { PendingRestart = false });
                 }
                 catch (Exception ex)

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -39,13 +39,38 @@ public record MeshBuilder
     /// the classic BaseDirectory-relative location (the double-shipped transition state, and
     /// every module that still rides the app closure).
     /// </summary>
-    public static string ResolveModulePath(string entry)
+    public static string ResolveModulePath(string entry) => ResolveModulePath(entry, null);
+
+    /// <summary>
+    /// As <see cref="ResolveModulePath(string)"/>, but probing a LANDED module root first.
+    ///
+    /// <para>🚨 <b>Two <c>modules/</c> trees exist and both are legitimate</b>, which is why this
+    /// takes a root rather than moving the one it had. The image publishes baseline packs into its
+    /// own <c>modules/</c> beside the app; a module the registry LANDS at runtime is written to the
+    /// deployment's writable, pod-SHARED root instead (see <c>ModuleRoot</c>) — because
+    /// <c>AppContext.BaseDirectory</c> is read-only in the container and, even where it is not, a
+    /// per-pod copy would be invisible to every other replica.</para>
+    ///
+    /// <para>Order is landed → image → app closure, and it matters: a landed module is the one an
+    /// operator just published, so it must win over a stale baseline copy of the same name. When
+    /// <paramref name="moduleRoot"/> is null or already the app directory this is byte-for-byte
+    /// <see cref="ResolveModulePath(string)"/> — the unconfigured deployment is untouched.</para>
+    /// </summary>
+    public static string ResolveModulePath(string entry, string? moduleRoot)
     {
         if (Path.IsPathRooted(entry))
             return entry;
         var baseDirectory = AppContext.BaseDirectory;
-        var moduleFolderPath = Path.Combine(
-            baseDirectory, "modules", Path.GetFileNameWithoutExtension(entry), entry);
+        var name = Path.GetFileNameWithoutExtension(entry);
+
+        if (!string.IsNullOrWhiteSpace(moduleRoot))
+        {
+            var landed = Path.Combine(moduleRoot, "modules", name, entry);
+            if (File.Exists(landed))
+                return landed;
+        }
+
+        var moduleFolderPath = Path.Combine(baseDirectory, "modules", name, entry);
         return File.Exists(moduleFolderPath)
             ? moduleFolderPath
             : Path.Combine(baseDirectory, entry);

--- a/src/MeshWeaver.PluginCatalog/ModuleRoot.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleRoot.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Configuration;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The deployment root the writable <c>modules/</c> tree lives under — ONE resolution, shared by
+/// the writer (<see cref="ModuleLandingService"/>) and by boot-time activation, because they must
+/// name the same directory or a landed module is written where nothing ever looks for it.
+///
+/// <para>🚨 <b>Why this is configurable at all: <c>AppContext.BaseDirectory</c> is READ-ONLY in the
+/// container, and the landing path cannot tolerate that.</b> Boot already degrades gracefully there
+/// (the <c>PendingRestart</c> reset is best-effort and documented as cosmetic), which is exactly why
+/// the defect stayed invisible: everything that only READS <c>/app/modules</c> works, and the first
+/// caller that must WRITE it fails. That caller is the registry's publish route, and it failed the
+/// whole module lane with
+/// <c>Access to the path '/app/modules/.staging-…' is denied</c> — surfaced to the build as
+/// HTTP 409, four steps from the cause.</para>
+///
+/// <para>🚨 <b>And a writable path is not merely a workaround — a per-POD directory would be the
+/// wrong place even if it were writable.</b> A module landed by whichever replica served the
+/// publish must be visible to every other replica, so the root has to be the deployment's SHARED
+/// volume. On AKS that is the RWX <c>/data</c> PVC every portal pod already mounts.</para>
+///
+/// <para>The default is deliberately unchanged (<c>AppContext.BaseDirectory</c>): an unconfigured
+/// deployment, a dev run and every test behave exactly as before, so this key only ever MOVES the
+/// tree for a deployment that sets it.</para>
+/// </summary>
+public static class ModuleRoot
+{
+    /// <summary>
+    /// Configuration key holding the writable module root. Absent/blank keeps
+    /// <see cref="AppContext.BaseDirectory"/>.
+    /// </summary>
+    public const string ConfigKey = "Modules:Root";
+
+    /// <summary>
+    /// The configured root, or <see cref="AppContext.BaseDirectory"/> when none is set.
+    /// Blank is treated as absent — an empty <c>Modules:Root=</c> is a deployment that meant to
+    /// unset the key, never a request to root the tree at the process's working directory.
+    /// </summary>
+    public static string Resolve(IConfiguration? configuration) =>
+        Resolve(configuration?[ConfigKey]);
+
+    /// <summary>Pure form, for tests and for callers that already read the value.</summary>
+    public static string Resolve(string? configured) =>
+        string.IsNullOrWhiteSpace(configured) ? AppContext.BaseDirectory : configured.Trim();
+}

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -4,6 +4,8 @@ using MeshWeaver.Graph;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.PluginCatalog;
 
@@ -119,7 +121,12 @@ public static class PluginCatalogConfigurationExtensions
                 // assemblies + activation record; restart-as-activation. Inert until called:
                 // Slice C's PackageInstaller binary branch is its caller. Mesh-scoped so its
                 // bounded IO pool dies with the mesh.
-                .AddSingleton<ModuleLandingService>())
+                // 🚨 Constructed with the resolved MODULE ROOT, never the default: the default is
+                // AppContext.BaseDirectory, which is READ-ONLY in the container, so a landing there
+                // fails with a denied-path error the publisher sees as HTTP 409. See ModuleRoot.
+                .AddSingleton(sp => new ModuleLandingService(
+                    sp.GetService<ILogger<ModuleLandingService>>(),
+                    ModuleRoot.Resolve(sp.GetService<IConfiguration>()))))
             .ConfigureHub(config =>
             {
                 config.TypeRegistry.AddPluginCatalogTypes();

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleRootTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleRootTest.cs
@@ -1,0 +1,124 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// <see cref="ModuleRoot"/> and the landed-root probe on <c>MeshBuilder.ResolveModulePath</c>.
+///
+/// <para>🚨 <b>Why this is worth pinning.</b> The writer (<see cref="ModuleLandingService"/>) and
+/// boot-time activation must name ONE directory, and until #1664's publish route was first
+/// exercised end to end they both took <c>AppContext.BaseDirectory</c> — which is READ-ONLY in the
+/// container. Everything that only reads <c>/app/modules</c> worked, so the defect was invisible
+/// until the first caller that had to WRITE it: the registry's publish route refused all fourteen
+/// module bundles with <c>Access to the path '/app/modules/.staging-…' is denied</c>, surfaced to
+/// the build as HTTP 409 — four steps from the cause.</para>
+///
+/// <para>The two rules below are the ones a future edit can silently break: the unconfigured
+/// default must stay exactly what it was, and a landed module must be found under the configured
+/// root (and must WIN over a same-named baseline, which is the whole point of landing one).</para>
+/// </summary>
+public class ModuleRootTest
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Unconfigured_keeps_the_app_directory(string? configured) =>
+        // The default is load-bearing: every dev run, every test and every deployment that never
+        // sets the key must behave exactly as it did before the key existed.
+        Assert.Equal(AppContext.BaseDirectory, ModuleRoot.Resolve(configured));
+
+    [Fact]
+    public void A_configured_root_wins_and_is_trimmed() =>
+        Assert.Equal("/data", ModuleRoot.Resolve("  /data  "));
+
+    [Fact]
+    public void The_root_is_read_from_configuration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [ModuleRoot.ConfigKey] = "/data",
+            })
+            .Build();
+
+        Assert.Equal("/data", ModuleRoot.Resolve(configuration));
+    }
+
+    [Fact]
+    public void A_null_configuration_is_not_an_error() =>
+        Assert.Equal(AppContext.BaseDirectory, ModuleRoot.Resolve((IConfiguration?)null));
+
+    [Fact]
+    public void A_landed_module_is_found_under_the_configured_root_and_not_without_it()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-moduleroot-" + Guid.NewGuid().ToString("N"));
+        const string entry = "MeshWeaver.LandedOnly.Test.dll";
+        var landed = Path.Combine(root, "modules", "MeshWeaver.LandedOnly.Test", entry);
+        Directory.CreateDirectory(Path.GetDirectoryName(landed)!);
+        File.WriteAllText(landed, "not a real assembly — only its PRESENCE is resolved here");
+
+        try
+        {
+            Assert.Equal(landed, MeshBuilder.ResolveModulePath(entry, root));
+
+            // Without the root the resolver cannot see it at all — it falls back to the app
+            // closure, a path that does not exist. That gap IS the bug: landing wrote bytes
+            // somewhere boot never looked.
+            Assert.Equal(
+                Path.Combine(AppContext.BaseDirectory, entry),
+                MeshBuilder.ResolveModulePath(entry));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void A_landed_module_wins_over_a_same_named_baseline()
+    {
+        // A landed module is the one an operator just published, so a stale baseline copy of the
+        // same name must not shadow it. Unique name + cleanup: this writes into the app directory,
+        // which is shared with every other test in this assembly.
+        var name = "MeshWeaver.Shadowed" + Guid.NewGuid().ToString("N")[..8] + ".Test";
+        var entry = name + ".dll";
+
+        var baselineDirectory = Path.Combine(AppContext.BaseDirectory, "modules", name);
+        var root = Path.Combine(Path.GetTempPath(), "mw-moduleroot-" + Guid.NewGuid().ToString("N"));
+        var landedDirectory = Path.Combine(root, "modules", name);
+
+        Directory.CreateDirectory(baselineDirectory);
+        Directory.CreateDirectory(landedDirectory);
+        var baseline = Path.Combine(baselineDirectory, entry);
+        var landed = Path.Combine(landedDirectory, entry);
+        File.WriteAllText(baseline, "baseline");
+        File.WriteAllText(landed, "landed");
+
+        try
+        {
+            Assert.Equal(landed, MeshBuilder.ResolveModulePath(entry, root));
+            // …and with no root configured the baseline is still resolved, unchanged.
+            Assert.Equal(baseline, MeshBuilder.ResolveModulePath(entry));
+        }
+        finally
+        {
+            Directory.Delete(baselineDirectory, recursive: true);
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void A_rooted_entry_passes_through_untouched()
+    {
+        var rooted = Path.Combine(Path.GetTempPath(), "explicit", "Some.Module.dll");
+        Assert.Equal(rooted, MeshBuilder.ResolveModulePath(rooted, "/data"));
+    }
+}


### PR DESCRIPTION
## What failed

All fourteen module bundles failed on the Plugins `main` push — and not on anything the build did. Compile, tests, bundle shape and the publish token all passed. The registry accepted the upload and refused at **landing**:

```
{"error":"Access to the path '/app/modules/.staging-MeshWeaver.Teams-…' is denied."}
##[error]registry refused MeshWeaver.Teams@1.0.0 (HTTP 409)
```

## Why

`ModuleLandingService` and boot-time activation both took `AppContext.BaseDirectory` — `/app` in the container, which is **read-only**. The module lane could therefore never have landed anything on a deployed portal, and the cause surfaced as an HTTP 409 four steps downstream.

The read-only case was already known on the *boot* side — the `PendingRestart` reset is best-effort and documented as cosmetic. That is precisely why this stayed invisible: everything that only READS `/app/modules` works, and the first caller that must WRITE it is the publish route.

A writable path is also not merely a workaround. A module landed by whichever replica served the publish must be visible to **every other replica**, so the root has to be the deployment's shared volume — on AKS the RWX `/data` PVC every portal pod already mounts. A per-pod `/app` copy would be the wrong place even if it were writable.

## The change

- **`ModuleRoot`** — one resolution (`Modules:Root`), used by the writer and by boot, so they cannot name different directories. Defaults to `AppContext.BaseDirectory`.
- **`ResolveModulePath(entry, moduleRoot)`** — probes landed → image → app closure. A landed module is the one an operator just published, so it must win over a stale baseline of the same name.
- Unconfigured, every path is byte-for-byte what it was: dev runs, tests and any deployment that never sets the key are untouched.

## Tests

`ModuleRootTest` — 9 cases: the unconfigured default (the load-bearing one), trimming, config read, null-config, a landed module found under the root **and not without it** (that gap IS the bug), landed-beats-baseline, and rooted pass-through. Full `MeshWeaver.PluginCatalog.Test`: **531/531**.

## Not in this PR

Setting `Modules:Root` on the portals — that is the deployment half, and system-changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)