### PR TITLE
Retire NuGet packages the platform no longer builds

### DIFF
--- a/.github/workflows/unlist-orphaned-packages.yml
+++ b/.github/workflows/unlist-orphaned-packages.yml
@@ -1,0 +1,93 @@
+name: Unlist orphaned NuGet packages
+
+# A module that LEAVES the platform stops being packed — but everything it already published
+# stays on nuget.org, LISTED: it keeps appearing in search and in `dotnet add package`, offered
+# to consumers as current while nothing builds or patches it any more. This is how that set is
+# retired.
+#
+# 🚨 The set is DERIVED, never hand-kept: (published under the MeshWeaver prefix) MINUS (what
+# this tree still packs). So it stays correct on its own as further modules move out — #1882
+# (the fourteen drivers) and #1752 (Cosmos/Snowflake) need no edit here.
+#
+# 🚨 REPORT BY DEFAULT. `apply` must be set explicitly AND `confirm` must read UNLIST. The
+# derivation is a subtraction, so any bug in "what this tree packs" fails toward unlisting live
+# packages — during development one such bug computed "all 90". Report-only is what caught it.
+#
+# `dotnet nuget delete` UNLISTS on nuget.org; it does not erase. Existing pins keep resolving by
+# exact version, and a listing can be restored from the nuget.org UI. That reversibility is what
+# makes this safe to automate.
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Actually unlist (unchecked = report only)"
+        type: boolean
+        default: false
+      confirm:
+        description: "Type UNLIST to confirm when apply is checked"
+        type: string
+        default: ""
+      keep:
+        description: "Space-separated package ids to spare even when orphaned"
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  unlist:
+    name: Report or unlist orphaned packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.x'
+
+      # The regression checks for the two ways the "what do we pack" half has silently lied,
+      # both of which failed toward unlisting a LIVE package. Gating the run on them means a
+      # broken detector cannot reach the apply step at all.
+      - name: Self-test the detector
+        run: python3 scripts/orphaned-nuget-packages.py --self-test
+
+      - name: Refuse an unconfirmed apply
+        if: inputs.apply && inputs.confirm != 'UNLIST'
+        run: |
+          echo "::error::apply was requested but confirm did not read UNLIST — refusing. Re-run and type UNLIST to confirm."
+          exit 1
+
+      - name: Report the orphaned set
+        run: |
+          set -euo pipefail
+          keep_args=""
+          for id in ${{ inputs.keep }}; do keep_args="$keep_args --keep $id"; done
+          python3 scripts/orphaned-nuget-packages.py --root . $keep_args | tee report.txt
+          {
+            echo "### Orphaned NuGet packages"
+            echo '```'
+            cat report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Unlist them
+        if: inputs.apply && inputs.confirm == 'UNLIST'
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NUGET_API_KEY:-}" ]; then
+            echo "::error::secrets.NUGET_PAT is not provisioned — the unlist cannot run. A step that cannot run must fail RED, never pass quietly."
+            exit 1
+          fi
+          keep_args=""
+          for id in ${{ inputs.keep }}; do keep_args="$keep_args --keep $id"; done
+          python3 scripts/orphaned-nuget-packages.py --root . --apply $keep_args \
+            | tee applied.txt
+          {
+            echo "### Unlisted"
+            echo '```'
+            cat applied.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/orphaned-nuget-packages.py
+++ b/scripts/orphaned-nuget-packages.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Which MeshWeaver packages are published on nuget.org but no longer built here.
+
+A module that LEAVES the platform stops being packed — but every version it already
+published stays on nuget.org, listed, and keeps showing up in search and in
+`dotnet add package` completion. That is a package the platform no longer ships and no
+longer patches, offered to consumers as if it were current.
+
+🚨 DERIVED, never a hand-kept list. The set is
+    (published under the MeshWeaver prefix)  MINUS  (packable projects in this tree)
+so it stays correct on its own as further modules move out (#1882, #1752 …). A checked-in
+list would be one more thing to forget, and the day it is wrong it is wrong in the
+direction of unlisting something we still ship.
+
+Exit codes: 0 = computed (orphans may be empty), 2 = could not reach nuget.org.
+"""
+import argparse, json, os, re, subprocess, sys, urllib.request, urllib.error
+from pathlib import Path
+
+SEARCH = "https://azuresearch-usnc.nuget.org/query"
+PREFIX = "MeshWeaver"
+
+
+def published(prefix: str) -> set[str]:
+    """Every package id on nuget.org matching the prefix (prerelease included)."""
+    ids, skip = set(), 0
+    while True:
+        url = f"{SEARCH}?q={prefix}&prerelease=true&take=100&skip={skip}"
+        try:
+            with urllib.request.urlopen(url, timeout=60) as response:
+                page = json.load(response)
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            print(f"error: cannot reach nuget.org ({error})", file=sys.stderr)
+            sys.exit(2)
+        data = page.get("data", [])
+        if not data:
+            break
+        # The query is a full-text search, so it also returns packages that merely MENTION
+        # MeshWeaver. Only ids in our own namespace may ever be considered for unlisting.
+        ids.update(x["id"] for x in data
+                   if x["id"] == prefix or x["id"].startswith(prefix + "."))
+        skip += 100
+        if skip >= page.get("totalHits", 0):
+            break
+    return ids
+
+
+def packable(root: Path) -> set[str]:
+    """Package ids this tree still produces.
+
+    The id is the assembly/project name unless <PackageId> overrides it. A project that
+    sets IsPackable=false produces nothing and is therefore NOT evidence that we still
+    ship it — but it is also not evidence that we don't, so it is simply excluded here
+    and the orphan check below is what decides.
+    """
+    ids = set()
+    for project in root.rglob("*.csproj"):
+        # 🚨 RELATIVE to root, never the absolute path. Testing project.parts would match a
+        # directory anywhere ABOVE the repo — a checkout under ~/.worktrees/ excluded every
+        # project, the tree looked like it packed NOTHING, and the orphan set became "every
+        # package we have ever published". The dry-run default is what caught it; this is why
+        # the default stays.
+        #
+        # Only build output is skipped — NOT tools/ or test/. Over-counting what we pack can
+        # only SPARE a package; under-counting unlists a live one. MeshWeaver.Compiler.Cli is
+        # the worked example: it ships from tools/ behind -p:PackCompilerTool=true, and a
+        # tools/ exclusion listed it as orphaned.
+        relative = project.relative_to(root).parts
+        if any(part in {"bin", "obj", ".worktrees"} for part in relative):
+            continue
+        text = project.read_text(encoding="utf-8", errors="replace")
+
+        # EVERY declared <PackageId>, regardless of the condition it sits under. Packing can
+        # be conditional — MeshWeaver.Compiler.Cli is IsPackable=false by default and packs
+        # only under -p:PackCompilerTool=true, with its id declared inside that same
+        # PropertyGroup. Reading IsPackable first and skipping made the project invisible, and
+        # a package we very much still ship was reported as orphaned. An id that appears
+        # anywhere in a csproj is evidence we own it.
+        declared = set(re.findall(r"<PackageId>\s*([^<]+?)\s*</PackageId>", text, re.I))
+        ids |= declared
+
+        if re.search(r"<IsPackable>\s*false\s*</IsPackable>", text, re.I) and not declared:
+            continue
+        if not declared:
+            ids.add(project.stem)
+    return ids
+
+
+def versions(package_id: str) -> list[str]:
+    """Every published version of one package (the flat container is the cheap index)."""
+    url = f"https://api.nuget.org/v3-flatcontainer/{package_id.lower()}/index.json"
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response:
+            return json.load(response).get("versions", [])
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return []
+        raise
+
+
+def self_test() -> int:
+    """Pin the two ways `packable` has silently lied. Both failed toward UNLISTING A LIVE
+    PACKAGE, which is why they are pinned rather than remembered."""
+    import tempfile
+    failures = []
+
+    with tempfile.TemporaryDirectory() as temporary:
+        # A checkout that itself lives under an excluded directory name. The exclusion must be
+        # judged RELATIVE to the root, or every project vanishes and everything looks orphaned.
+        root = Path(temporary) / ".worktrees" / "checkout"
+        (root / "src" / "MeshWeaver.Thing").mkdir(parents=True)
+        (root / "src" / "MeshWeaver.Thing" / "MeshWeaver.Thing.csproj").write_text(
+            "<Project><PropertyGroup></PropertyGroup></Project>", encoding="utf-8")
+
+        # Conditionally packed: IsPackable=false by default, id declared under an opt-in.
+        (root / "tools" / "Tester").mkdir(parents=True)
+        (root / "tools" / "Tester" / "Tester.csproj").write_text(
+            "<Project><PropertyGroup><IsPackable>false</IsPackable></PropertyGroup>"
+            "<PropertyGroup Condition=\"'$(PackTool)' == 'true'\"><IsPackable>true</IsPackable>"
+            "<PackageId>MeshWeaver.Tool.Cli</PackageId></PropertyGroup></Project>",
+            encoding="utf-8")
+
+        # Genuinely not packable and declaring nothing — must NOT count as shipped.
+        (root / "src" / "MeshWeaver.Private").mkdir(parents=True)
+        (root / "src" / "MeshWeaver.Private" / "MeshWeaver.Private.csproj").write_text(
+            "<Project><PropertyGroup><IsPackable>false</IsPackable></PropertyGroup></Project>",
+            encoding="utf-8")
+
+        found = packable(root)
+        if "MeshWeaver.Thing" not in found:
+            failures.append("a project under a .worktrees checkout was not seen as packable")
+        if "MeshWeaver.Tool.Cli" not in found:
+            failures.append("a conditionally-packed PackageId was not harvested")
+        if "MeshWeaver.Private" in found:
+            failures.append("an IsPackable=false project declaring no id counted as shipped")
+
+    for failure in failures:
+        print(f"FAIL: {failure}")
+    print("self-test: " + ("PASSED" if not failures else f"{len(failures)} FAILURE(S)"))
+    return 1 if failures else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--root", default=".", help="repository root to scan")
+    parser.add_argument("--prefix", default=PREFIX)
+    parser.add_argument("--apply", action="store_true",
+                        help="actually unlist (default: report only)")
+    parser.add_argument("--api-key", default=os.environ.get("NUGET_API_KEY", ""))
+    parser.add_argument("--keep", action="append", default=[],
+                        help="package id to spare even when orphaned (repeatable)")
+    parser.add_argument("--self-test", action="store_true",
+                        help="run the packable() regression checks and exit")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    root = Path(args.root).resolve()
+    on_nuget = published(args.prefix)
+    built = packable(root)
+    spared = set(args.keep)
+    orphans = sorted(on_nuget - built - spared)
+
+    print(f"published on nuget.org : {len(on_nuget)}")
+    print(f"packable in this tree  : {len(built)}")
+    if spared:
+        print(f"spared by --keep       : {', '.join(sorted(spared))}")
+    print(f"ORPHANED               : {len(orphans)}")
+    for package_id in orphans:
+        print(f"  {package_id}  ({len(versions(package_id))} version(s))")
+
+    if not orphans:
+        print("\nNothing to unlist.")
+        return 0
+
+    if not args.apply:
+        print("\nreport only — re-run with --apply (and an API key) to unlist these.")
+        return 0
+
+    if not args.api_key:
+        print("error: --apply needs an API key (NUGET_API_KEY)", file=sys.stderr)
+        return 2
+
+    # `dotnet nuget delete` UNLISTS on nuget.org — it does not erase. Existing pins keep
+    # resolving by exact version; the package simply stops appearing in search and in
+    # latest-version resolution. That is the reversible, standard deprecation path, and it
+    # is why this is safe to automate at all.
+    failed = 0
+    for package_id in orphans:
+        for version in versions(package_id):
+            result = subprocess.run(
+                ["dotnet", "nuget", "delete", package_id, version,
+                 "--source", "https://api.nuget.org/v3/index.json",
+                 "--api-key", args.api_key, "--non-interactive"],
+                capture_output=True, text=True)
+            state = "unlisted" if result.returncode == 0 else "FAILED"
+            if result.returncode != 0:
+                failed += 1
+                print(f"  {state}: {package_id} {version} — "
+                      f"{(result.stderr or result.stdout).strip().splitlines()[-1:]}")
+            else:
+                print(f"  {state}: {package_id} {version}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

A module that leaves the platform stops being packed — but everything it already published stays on nuget.org, **listed**. It keeps appearing in search and in `dotnet add package`, offered to consumers as current while nothing builds or patches it any more.

Nine are live today: `MeshWeaver.AI.AzureOpenAI`, `Approvals`, `Blazor.AI`, `BusinessRules`, `BusinessRules.Generator`, `Education`, `GoogleMaps`, `GridModel`, `Hosting.AzureStorage`. **#1882 is about to add eight more** (ClaudeCode, Copilot, Indexing.PostgreSql, Courses, Markdown.Export, Mcp, Notifications.Channels, Observability), and #1752 will add Snowflake.

## Derived, not listed

The set is `(published under the MeshWeaver prefix) MINUS (what this tree still packs)`. No hand-kept list, so #1882 and #1752 need no edit here — the day after they merge, their packages simply appear in the report.

## 🚨 Report by default

The derivation is a **subtraction**, so any bug in the "what do we pack" half fails toward unlisting live packages. Two such bugs appeared while writing it, both silent:

- the exclusion tested the **absolute** path, so a checkout under `.worktrees/` excluded every project — the tree looked like it packed nothing and the orphan set came out as **all 90 packages we have ever published**;
- `MeshWeaver.Compiler.Cli` is `IsPackable=false` by default and packs only under `-p:PackCompilerTool=true`, with its id declared in that same conditional group — reading `IsPackable` first hid the project, and a package we very much still ship was reported orphaned.

Both are pinned by `--self-test`, which the workflow runs **before** the apply step can be reached. Reverting either fix reproduces its own failure.

Applying additionally requires `apply: true` **and** `confirm: UNLIST`.

## Reversible

`dotnet nuget delete` **unlists**; it does not erase. Existing pins keep resolving by exact version, and a listing can be restored from the nuget.org UI.

## Verified

```
published on nuget.org : 90
packable in this tree  : 168
ORPHANED               : 9
```

`--self-test` passes; with either fix reverted it reports that fix's failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)