### PR TITLE
The unlister must VERIFY, not trust an exit code

### DIFF
--- a/scripts/orphaned-nuget-packages.py
+++ b/scripts/orphaned-nuget-packages.py
@@ -14,7 +14,7 @@ direction of unlisting something we still ship.
 
 Exit codes: 0 = computed (orphans may be empty), 2 = could not reach nuget.org.
 """
-import argparse, json, os, re, subprocess, sys, urllib.request, urllib.error
+import argparse, gzip, json, os, re, subprocess, sys, time, urllib.request, urllib.error
 from pathlib import Path
 
 SEARCH = "https://azuresearch-usnc.nuget.org/query"
@@ -140,6 +140,28 @@ def self_test() -> int:
     return 1 if failures else 0
 
 
+def is_listed(package_id: str, version: str) -> bool | None:
+    """Whether nuget.org still LISTS this version. None when it cannot be read.
+
+    🚨 This is the ONLY evidence that an unlist happened. `dotnet nuget delete` returning 0 is
+    not: it reports that the call was made, not the resulting state, and its output is easy to
+    swallow. The first version of this script trusted the exit code, printed "unlisted: …"
+    fifty-five times, and the registration still read listed=true ten minutes later — an outcome
+    indistinguishable from success.
+    """
+    url = ("https://api.nuget.org/v3/registration5-gz-semver2/"
+           f"{package_id.lower()}/{version.lower()}.json")
+    request = urllib.request.Request(url, headers={"Accept-Encoding": "gzip"})
+    try:
+        with urllib.request.urlopen(request, timeout=45) as response:
+            raw = response.read()
+            if response.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+            return bool(json.loads(raw).get("listed"))
+    except Exception:
+        return None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -150,6 +172,10 @@ def main() -> int:
     parser.add_argument("--api-key", default=os.environ.get("NUGET_API_KEY", ""))
     parser.add_argument("--keep", action="append", default=[],
                         help="package id to spare even when orphaned (repeatable)")
+    parser.add_argument("--verify-attempts", type=int, default=6,
+                        help="how many times to re-read nuget.org before giving a verdict")
+    parser.add_argument("--verify-wait", type=int, default=60,
+                        help="seconds between verification attempts")
     parser.add_argument("--self-test", action="store_true",
                         help="run the packable() regression checks and exit")
     args = parser.parse_args()
@@ -187,6 +213,7 @@ def main() -> int:
     # resolving by exact version; the package simply stops appearing in search and in
     # latest-version resolution. That is the reversible, standard deprecation path, and it
     # is why this is safe to automate at all.
+    called: list[tuple[str, str]] = []
     failed = 0
     for package_id in orphans:
         for version in versions(package_id):
@@ -195,14 +222,44 @@ def main() -> int:
                  "--source", "https://api.nuget.org/v3/index.json",
                  "--api-key", args.api_key, "--non-interactive"],
                 capture_output=True, text=True)
-            state = "unlisted" if result.returncode == 0 else "FAILED"
+            # ALWAYS echo what the tool said. A silent success is how a no-op passes for a write.
+            said = " | ".join(
+                line.strip()
+                for line in ((result.stdout or "") + (result.stderr or "")).splitlines()
+                if line.strip())
             if result.returncode != 0:
                 failed += 1
-                print(f"  {state}: {package_id} {version} — "
-                      f"{(result.stderr or result.stdout).strip().splitlines()[-1:]}")
+                print(f"  CALL FAILED: {package_id} {version} (exit {result.returncode}) — {said}")
             else:
-                print(f"  {state}: {package_id} {version}")
-    return 1 if failed else 0
+                called.append((package_id, version))
+                print(f"  called delete: {package_id} {version} — {said or '(no output)'}")
+
+    if not called:
+        return 1 if failed else 0
+
+    # 🚨 VERIFY, then report. nuget.org rebuilds its registration blobs asynchronously, so a
+    # still-listed reading immediately after the call is inconclusive rather than a failure —
+    # poll, and state only what is observable. Never record an unlist that was not seen.
+    print(f"\nverifying {len(called)} version(s) against nuget.org …")
+    pending = list(called)
+    for attempt in range(1, args.verify_attempts + 1):
+        still = [(p, v) for p, v in pending if is_listed(p, v) is True]
+        if not still:
+            print(f"  VERIFIED on attempt {attempt}: every version now reads as unlisted")
+            return 1 if failed else 0
+        pending = still
+        if attempt < args.verify_attempts:
+            print(f"  attempt {attempt}: {len(pending)} still listed — waiting "
+                  f"{args.verify_wait}s for the registration to rebuild")
+            time.sleep(args.verify_wait)
+
+    print(f"\n::error::{len(pending)} version(s) STILL read as listed after "
+          f"{args.verify_attempts} checks. The delete call reported success, so this is either a "
+          f"slower registration rebuild than expected or an API key without unlist rights. Do NOT "
+          f"record these as retired until a later check reads false.")
+    for package_id, version in pending[:20]:
+        print(f"  still listed: {package_id} {version}")
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #1892, from running it for real.

## What happened

The apply run reported `unlisted: …` **fifty-five times** and proved nothing. It took `dotnet nuget delete` returning `0` as evidence and discarded the tool's output on success. Ten minutes later nuget.org's registration still read `listed=true` for every one of them.

The unlist *had* in fact worked — the search index went **90 → 81** — but **nothing in the script could tell those two cases apart**, which is the defect. That is the same silent-write trap this codebase keeps warning about: a call that reports success is not a state that changed.

## The fix

The apply path now:

- **always echoes what `dotnet` said**, success included — a silent success is how a no-op passes for a write;
- **verifies against nuget.org afterwards**, re-reading each version's registration until it reads unlisted, with a bounded poll (`--verify-attempts` / `--verify-wait`) because the registration blobs rebuild asynchronously, so a still-listed reading immediately after the call is *inconclusive*, not a failure;
- **fails loudly** when versions still read listed after the polls run out, naming the two causes worth telling apart — a slower-than-expected rebuild vs an API key without unlist rights — and saying explicitly not to record those versions as retired.

`is_listed` reads the **registration**, not the search index: search is a derived, later-updating view that can report "gone" before the fact is durable, which would let the check pass early.

## Verified

`--self-test` passes. Against current main the detector now reports `published: 81 / packable: 168 / ORPHANED: 0` — i.e. #1892's nine really are retired, which is also the evidence that the search-index reading and the registration reading disagree and that only one of them belongs in a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)