### PR TITLE
An install must not report success while the partition still denies

### DIFF
--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -278,6 +278,33 @@ public static class PackageInstaller
     private static readonly TimeSpan WarmTimeout = TimeSpan.FromSeconds(90);
 
     /// <summary>
+    /// How long a warmed root is given to become READABLE — i.e. for the activation-triggered
+    /// gating pass to write its cover grant — before the installer gives up waiting and says so.
+    ///
+    /// <para>🚨 This exists because <b>warmed is not gated</b>. Warming completes as soon as the
+    /// root NODE can be read; the gating pass that seeds the cover grants runs as a CONSEQUENCE of
+    /// that activation, asynchronously. So without this wait the installer reports a clean install
+    /// while the partition is still dark, and the first viewer to open <c>{package}/Subscribe</c>
+    /// is denied — measured at 12–17 s, and the whole reason MeshWeaver.Education's disposable-mesh
+    /// e2e fails non-deterministically with <c>Access denied: user 'e2e-admin' lacks Read
+    /// permission on '{course}'</c> followed by a 180 s coupon timeout.</para>
+    ///
+    /// <para>Shorter than <see cref="WarmTimeout"/> on purpose: the hub is already up by the time
+    /// this starts, so the only thing outstanding is one access-table write.</para>
+    /// </summary>
+    private static readonly TimeSpan GatingSettleTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The cover grant a gating node type writes at its partition root — the ONE observable proof
+    /// that the partition has become readable rather than merely present.
+    ///
+    /// <para>Declared here as a well-known PATH rather than by asking the type, because core cannot
+    /// introspect a plugin-side configuration lambda. A partition whose type does not gate simply
+    /// never writes it, which this treats as "nothing to wait for", never as a failure.</para>
+    /// </summary>
+    internal static string CoverGrantPath(string partition) => $"{partition}/_Access/Public_Access";
+
+    /// <summary>
     /// ACTIVATES each partition root this install just wrote, by opening its node stream once.
     ///
     /// <para>🚨 Without this a fresh install lands <b>DARK</b>. An install runs entirely as SYSTEM and
@@ -309,6 +336,37 @@ public static class PackageInstaller
     /// <para>Hooks are best-effort: the content is already committed by the time they run, so a
     /// failing hook is logged and never fails the install.</para>
     /// </summary>
+    /// <summary>
+    /// Waits for <paramref name="root"/>'s cover grant to exist, so an install that has returned
+    /// really is readable.
+    ///
+    /// <para>Bounded by <see cref="GatingSettleTimeout"/> and never fatal: a partition whose node
+    /// type does not gate never writes the grant, and that is a normal, common shape (a course
+    /// copied into a viewer's home, a plain data partition). The timeout is therefore the
+    /// "nothing to wait for" answer as well as the "gating did not settle" answer — which is why
+    /// it LOGS the distinction it can observe instead of pretending to know which it was.</para>
+    /// </summary>
+    private static IObservable<Unit> WaitForGating(
+        IWorkspace workspace, string root, ILogger? logger) =>
+        workspace.GetMeshNodeStream(CoverGrantPath(root))
+            .Where(node => node is not null)
+            .Take(1)
+            .Select(_ => Unit.Default)
+            .Do(_ => logger?.LogInformation(
+                "[PackageInstaller] root {Root} is gated and readable — its cover grant landed",
+                root))
+            .Timeout(GatingSettleTimeout)
+            .Catch<Unit, Exception>(_ =>
+            {
+                logger?.LogInformation(
+                    "[PackageInstaller] root {Root} has no cover grant after {Seconds}s. Either its "
+                    + "node type does not gate (normal — a course copy or a plain partition), or the "
+                    + "gating pass has not settled and the partition will DENY viewers until it "
+                    + "does. The install itself is complete either way.",
+                    root, GatingSettleTimeout.TotalSeconds);
+                return Observable.Return(Unit.Default);
+            });
+
     public static IObservable<Unit> RunInstallHooks(IMessageHub hub, string partition, ILogger? logger)
     {
         var hooks = hub.ServiceProvider.GetServices<IPartitionInstallHook>().ToArray();
@@ -1241,6 +1299,11 @@ public static class PackageInstaller
                                 .Where(node => node is not null)
                                 .Take(1)
                                 .Timeout(WarmTimeout)
+                                // 🚨 Warming the hub is only half of "installed". The gating pass
+                                // that makes the partition READABLE runs off this activation, so
+                                // returning here reports a clean install over a partition whose
+                                // cover still denies every viewer. Wait for the grant itself.
+                                .SelectMany(_ => WaitForGating(workspace, root, logger))
                                 .Select(_ => true)
                             : Observable.Return(false)))
                 .Where(warmed => warmed)

--- a/test/MeshWeaver.PluginCatalog.Test/InstallGatingHandshakeTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstallGatingHandshakeTest.cs
@@ -1,0 +1,48 @@
+#pragma warning disable CS1591
+
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The handshake between the installer and a gating node type.
+///
+/// <para>🚨 <b>Why this is a test and not a constant nobody checks.</b> An install used to return
+/// as soon as the root NODE could be read, but the gating pass that seeds the cover grants runs as
+/// a CONSEQUENCE of that activation, asynchronously. So the installer reported a clean install over
+/// a partition that still denied every viewer — measured at 12–17 s, and the reason
+/// MeshWeaver.Education's disposable-mesh e2e fails non-deterministically with
+/// <c>Access denied: user 'e2e-admin' lacks Read permission on '{course}'</c> followed by a 180 s
+/// coupon timeout.</para>
+///
+/// <para>The installer now WAITS for that grant. That makes the grant's PATH a contract between
+/// core (which waits on it) and the plugin (which writes it) — and a contract nothing checks is
+/// one that drifts. If <c>PluginGate</c> ever renames the cover grant, the wait would not fail
+/// loudly; it would silently degrade to the settle timeout on every install and the race would be
+/// back, wearing a "gating did not settle" log line. Hence this pin.</para>
+/// </summary>
+public class InstallGatingHandshakeTest
+{
+    // The literal PluginGate produces — see Store/Plugin/Test/PluginGateTests in
+    // MeshWeaver.Plugins: `PluginGate.ViewerAssignment("MyPlug", "Public", denied: false).Path`
+    // is asserted there to equal "MyPlug/_Access/Public_Access".
+    private const string PluginGateCoverGrant = "MyPlug/_Access/Public_Access";
+
+    [Fact]
+    public void The_installer_waits_on_the_path_the_gate_actually_writes() =>
+        Assert.Equal(PluginGateCoverGrant, PackageInstaller.CoverGrantPath("MyPlug"));
+
+    [Theory]
+    [InlineData("Edu")]
+    [InlineData("ThinkInStreams")]
+    [InlineData("Nested/Package")]
+    public void The_grant_is_a_satellite_of_the_partition_root(string partition)
+    {
+        var path = PackageInstaller.CoverGrantPath(partition);
+
+        // A satellite of THIS root — not a sibling, and not a path that would silently resolve
+        // somewhere else for a nested partition.
+        Assert.StartsWith(partition + "/", path);
+        Assert.Contains("/_Access/", path);
+    }
+}


### PR DESCRIPTION
Fixes the race behind MeshWeaver.Education's non-deterministic disposable-mesh failures.

## The race

Warming a root is only half of "installed", and `PackageInstaller` already said so:

> 🚨 Without this a fresh install lands **DARK**. An install runs entirely as SYSTEM and never touches the installed partition's root hub; a node type's gating (which seeds the cover grants that make the partition readable) **runs on HUB ACTIVATION** …

But the warm completed as soon as the root **node** could be read:

```csharp
workspace.GetMeshNodeStream(root).Where(n => n is not null).Take(1)
```

The gating pass runs as a *consequence* of that activation, asynchronously — so **warmed ≠ gated**. The installer returned a clean install over a partition whose cover still denied every viewer. Measured window: **12–17 s**.

## What it looks like when it bites

```
Access denied: user 'e2e-admin' lacks Read permission on 'ThinkInStreams'
Error: the admin was never entitled to 'AgenticPrimerDe': redeeming the bootstrap
coupon on /AgenticPrimerDe/Subscribe did not succeed within 180s
```

A 180 s timeout whose message blames the **coupon** — four steps from a cause that is neither the coupon nor a compile problem. It reads as flaky because whether the grant lands before the first page load is a race, which is exactly why education's `main` is intermittently red (failures 08-17, 08-18, 08-19 with successes between) and why five open education PRs are stuck behind it.

## The fix

The warm now waits for the **cover grant** — `{partition}/_Access/Public_Access`, the one observable proof that the partition became readable rather than merely present.

- **Bounded** (30 s — the hub is already up; the only outstanding work is one access-table write).
- **Never fatal.** A partition whose type does not gate never writes the grant, and that is a normal, common shape (a course copied into a viewer's home, a plain data partition). So the timeout answers both *"nothing to wait for"* and *"gating did not settle"* — and it logs the distinction it can actually observe instead of claiming to know which it was.

## Why the path is pinned by a test

The grant's path is now a **contract**: core waits on it, the plugin writes it. If `PluginGate` ever renames it, the wait would not fail loudly — it would silently degrade to the settle timeout on every install and the race would be back, wearing a *"gating did not settle"* log line. `InstallGatingHandshakeTest` pins core's path against the literal `PluginGateTests` asserts in MeshWeaver.Plugins.

## Verified

`MeshWeaver.PluginCatalog.Test`: **535/535**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)