### PR TITLE
3.0.0-rc5's portal does not boot: a listed module the image no longer ships

### DIFF
--- a/memex/Memex.Portal.Monolith/appsettings.json
+++ b/memex/Memex.Portal.Monolith/appsettings.json
@@ -24,26 +24,12 @@
       // 🚨 FIRST: the in-mesh compile reference set is composed from the installed modules in
       // list order, so a module whose content compiles against MeshWeaver.Import must follow it.
       "MeshWeaver.Import.dll",
-      "MeshWeaver.AI.OpenAI.dll",
-      "MeshWeaver.AI.AzureFoundry.dll",
-      "MeshWeaver.AI.ClaudeCode.dll",
-      "MeshWeaver.AI.Copilot.dll",
-      "MeshWeaver.Teams.dll",
-      "MeshWeaver.SelfUpdate.Aks.dll",
-      "MeshWeaver.AI.WebSearch.dll",
-      "MeshWeaver.Courses.dll",
-      "MeshWeaver.Mail.MicrosoftGraph.dll",
-      "MeshWeaver.Mcp.dll",
       "MeshWeaver.Blazor.Radzen.dll",
       "MeshWeaver.Blazor.Analysis.dll",
       "MeshWeaver.Blazor.GoogleMaps.dll",
-      "MeshWeaver.ContentCollections.Indexing.PostgreSql.dll",
       "MeshWeaver.Speech.dll",
-      "MeshWeaver.Markdown.Export.dll",
-      "MeshWeaver.Observability.dll",
       "MeshWeaver.OgCard.dll",
       "MeshWeaver.Social.dll",
-      "MeshWeaver.Notifications.Channels.dll",
       "MeshWeaver.Hosting.Grpc.dll"
     ]
   }

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -551,12 +551,39 @@ public static class MemexConfiguration
                 name => ModuleActivationBoot.LandedModuleDllExists(moduleRoot, name),
                 (module, reason) => Console.Error.WriteLine(
                     $"[ModuleActivation] SKIPPED store-installed module '{module}': {reason}"));
-            if (effectiveModules.Count > 0)
+            // 🚨 A LISTED-BUT-ABSENT module must never crash boot. `InstallAssemblies` does
+            // `Assembly.LoadFrom`, which throws FileNotFoundException, so one stale line in
+            // `Modules:Assemblies` takes the whole portal down before anything is serving —
+            // observed on 3.0.0-rc5, whose image no longer ships the fourteen extracted modules
+            // while appsettings still listed them: every boot died on
+            // `Could not load file or assembly '/app/MeshWeaver.AI.OpenAI.dll'`.
+            //
+            // The sidecar half already skips a missing DLL loudly (LandedModuleDllExists above);
+            // the appsettings BASELINE did not, and a baseline entry is exactly the one a platform
+            // change can invalidate without touching the deployment. So the same rule applies to
+            // both: skip, say so on stderr, and boot. A module that is genuinely required makes
+            // itself known as a missing FEATURE, which is diagnosable — a portal that will not
+            // start is not.
+            var resolvedModules = effectiveModules
                 // ResolveModulePath probes the modules/<name>/ publish layout first (#1644),
                 // then falls back to the classic BaseDirectory-relative location.
-                builder.InstallAssemblies(effectiveModules
-                    .Select(entry => MeshBuilder.ResolveModulePath(entry, moduleRoot))
-                    .ToArray());
+                .Select(entry => (Entry: entry, Path: MeshBuilder.ResolveModulePath(entry, moduleRoot)))
+                .Where(candidate =>
+                {
+                    if (File.Exists(candidate.Path))
+                        return true;
+                    Console.Error.WriteLine(
+                        $"[ModuleActivation] SKIPPED module '{candidate.Entry}': no assembly at "
+                        + $"'{candidate.Path}'. It is listed in Modules:Assemblies but this image "
+                        + "does not ship it — delist it, or install it as a module. Booting without "
+                        + "it; whatever it provided is absent.");
+                    return false;
+                })
+                .Select(candidate => candidate.Path)
+                .ToArray();
+
+            if (resolvedModules.Length > 0)
+                builder.InstallAssemblies(resolvedModules);
             // Restart-as-activation: this boot IS the restart the sidecar was waiting for —
             // consume the pending flag so the step-10 signal reads current. Best-effort: on a
             // read-only app filesystem the flag simply stays set (cosmetic), and boot proceeds.

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -9,26 +9,12 @@
       // 🚨 FIRST: the in-mesh compile reference set is composed from the installed modules in
       // list order, so a module whose content compiles against MeshWeaver.Import must follow it.
       "MeshWeaver.Import.dll",
-      "MeshWeaver.AI.OpenAI.dll",
-      "MeshWeaver.AI.AzureFoundry.dll",
-      "MeshWeaver.AI.ClaudeCode.dll",
-      "MeshWeaver.AI.Copilot.dll",
-      "MeshWeaver.Teams.dll",
-      "MeshWeaver.SelfUpdate.Aks.dll",
-      "MeshWeaver.AI.WebSearch.dll",
-      "MeshWeaver.Courses.dll",
-      "MeshWeaver.Mail.MicrosoftGraph.dll",
-      "MeshWeaver.Mcp.dll",
       "MeshWeaver.Blazor.Radzen.dll",
       "MeshWeaver.Blazor.Analysis.dll",
       "MeshWeaver.Blazor.GoogleMaps.dll",
-      "MeshWeaver.ContentCollections.Indexing.PostgreSql.dll",
       "MeshWeaver.Speech.dll",
-      "MeshWeaver.Markdown.Export.dll",
-      "MeshWeaver.Observability.dll",
       "MeshWeaver.OgCard.dll",
       "MeshWeaver.Social.dll",
-      "MeshWeaver.Notifications.Channels.dll",
       "MeshWeaver.Hosting.Grpc.dll"
     ]
   },


### PR DESCRIPTION
## 🚨 rc5 is published and its portal cannot start

```
Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly
File name: '/app/MeshWeaver.AI.OpenAI.dll'
   at MeshWeaver.Mesh.MeshBuilder.InstallAssemblies(String[])
   at Memex.Portal.Shared.MemexConfiguration.ConfigureMemexMesh
   at Program.<Main>$
```

#1882 removed the fourteen extracted modules from the image but left all fourteen **listed** in `Modules:Assemblies`. `InstallAssemblies` does `Assembly.LoadFrom`, so the first stale line kills the process before anything serves. The container exits **139**.

This is not "chat degrades" — **the portal never starts.** It reproduced on every shard of MeshWeaver.Education's disposable-mesh gate the moment its pin moved to rc5 (Education#188), which is how it was caught.

**Do not roll rc5 anywhere until this ships.** The last image that both boots and carries the drivers is `3.0.0-rc4.ci.4513`.

## Two fixes, because the config was wrong *and* the code was brittle

**1. Delist what the image does not ship.** The fourteen stale entries are removed from both portal appsettings (Distributed and Monolith).

**2. A listed-but-absent module must never crash boot.** It is now skipped with a loud stderr line. The sidecar half already did exactly this (`LandedModuleDllExists`); the appsettings **baseline** did not — and a baseline entry is precisely the one a *platform* change can invalidate without anyone touching the deployment.

A missing module then surfaces as a missing **feature**, which is diagnosable. A portal that will not start is not.

## Why this class matters

It is the same shape as the other silent-failure fixes today, inverted: those were failures that looked like success; this is a failure whose *cause* (a config list) is nowhere near its *symptom* (a segfaulting container). Both are fixed by making the component say what it saw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)