### PR TITLE
CD must never batch a HEAD that has no image set

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -457,8 +457,25 @@ jobs:
             # Batching window (see the freshness probe above): a green merge inside the window
             # defers to the reconciler's next tick. Deliberately SILENT beyond the summary — this
             # is intentional cadence, not a fault, and the reconciler self-heals it by design.
+            elif [ "$COMPLETE" != "true" ] && [ -n "${BATCH_WINDOW:-}" ] \
+                 && [ "${FRESH_AGE_MIN:-999999}" -lt "$BATCH_WINDOW" ]; then
+              # 🚨 Batching NEVER applies to a HEAD that has no image set of its own.
+              #
+              # Coalescing several rapid merges onto one build is only safe while main is already
+              # DELIVERABLE — then the window defers an UPDATE. When HEAD has no complete set the
+              # same decision defers the ONLY image, and main sits undeliverable behind a window
+              # measured against some OTHER commit's build.
+              #
+              # Its promise ("the reconciler publishes main's tip within the hour") did not hold
+              # either, and the way it failed is worth keeping: the scheduled reconcile had already
+              # run 3 min earlier and correctly answered "waiting for CI"; the run that fired once
+              # CI went green entered via workflow_run and so took the PUSH path — and batched. No
+              # further reconcile was due for an hour. Observed 2026-08-19 on 17a7f16, whose
+              # decision log reads `Newest published set: <none>` and `🕐 Batched … 44 min old` in
+              # consecutive lines.
+              decision true "✅ Required check green and \`$SHORT\` has NO image set — publishing now rather than batching (a window may defer an update, never the only image)"
             elif [ -n "${BATCH_WINDOW:-}" ] && [ "${FRESH_AGE_MIN:-999999}" -lt "$BATCH_WINDOW" ]; then
-              decision false "🕐 Batched: newest published set is ${FRESH_AGE_MIN} min old (< ${BATCH_WINDOW} min window) — the reconciler publishes main's tip within the hour; run this workflow manually to ship now"
+              decision false "🕐 Batched: newest published set is ${FRESH_AGE_MIN} min old (< ${BATCH_WINDOW} min window) — main's tip already has a complete image set, so this defers an UPDATE; the reconciler publishes within the hour, or run this workflow manually to ship now"
             else
               decision true "✅ Required check green — publishing the full image set for \`$SHORT\`"
             fi


### PR DESCRIPTION
CD needed **three manual dispatches** today to get main delivered. Its own decision log says why, in two consecutive lines:

```
Newest published set: <none>
🕐 Batched: newest published set is 44 min old (< 60 min window)
```

It **deferred a commit that has no image**, because some *other* commit's build was 44 minutes old.

## Why batching was wrong here

Coalescing several rapid merges onto one build is only safe while main is already **deliverable** — then the window defers an *update*. With no set for HEAD, the same decision defers the **only** image, and main sits undeliverable behind a window measured against a different commit.

## The promise didn't hold either

The batch message says *"the reconciler publishes main's tip within the hour"*. What actually happened:

1. the scheduled reconcile ran 3 minutes early and correctly answered *"waiting for CI"*;
2. the run that fired once CI went green entered via `workflow_run` and therefore took the **push** path — and batched;
3. no further reconcile was due for an hour.

So the tip was delivered by neither path, and nothing was red to say so.

## The fix

Batching now applies **only when HEAD already has a complete set**; otherwise a green commit publishes immediately. The batch message states which case it is, so the log distinguishes *"deferring an update"* from what used to be indistinguishable — deferring everything.

Same family as #1895 (mutual deferral) and its `delivery-verdict` gate: CD kept finding new ways to conclude "nothing to do" while main had nothing to deliver. That gate catches the *reconcile* path; this closes the *push* path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)