### PR TITLE
IoPoolSiloTeardown composes; it does not await

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/IoPoolSiloTeardown.cs
+++ b/src/MeshWeaver.Connection.Orleans/IoPoolSiloTeardown.cs
@@ -112,8 +112,14 @@ public sealed class IoPoolSiloTeardown(
 public static class IoPoolSiloTeardownExtensions
 {
     /// <summary>
-    /// Registers <see cref="IoPoolSiloTeardown"/> as a silo lifecycle participant, so pooled I/O
-    /// is cancelled and reported before the silo releases. Idempotent.
+    /// Registers <see cref="IoPoolSiloTeardown"/> as a silo lifecycle participant, so pooled I/O is
+    /// cancelled and JOINED — bounded — before the silo releases.
+    ///
+    /// <para>"Joined" is the behaviour callers must plan for: <c>OnStop</c> returns a Task that
+    /// completes only once every pool has reported, so Orleans genuinely holds shutdown until then.
+    /// It is not fire-and-forget. The join costs no thread (the body is a reactive composition, not
+    /// an await), and it is bounded by <c>JoinBudget</c>: on timeout the residual is logged as an
+    /// error and shutdown proceeds rather than hanging. (Copilot review, #1903.)</para>
     /// </summary>
     /// <param name="services">The service collection to add the participant to.</param>
     /// <returns>The same service collection for further chaining.</returns>

--- a/src/MeshWeaver.Connection.Orleans/IoPoolSiloTeardown.cs
+++ b/src/MeshWeaver.Connection.Orleans/IoPoolSiloTeardown.cs
@@ -1,3 +1,4 @@
+using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.Mesh.Threading;
@@ -50,34 +51,44 @@ public sealed class IoPoolSiloTeardown(
 
     Task ILifecycleObserver.OnStart(CancellationToken cancellationToken) => Task.CompletedTask;
 
-    async Task ILifecycleObserver.OnStop(CancellationToken cancellationToken)
+    // 🚨 NOT `async`, and nothing here awaits. AGENTS.md: everything is IObservable<T> end-to-end —
+    // compose and Subscribe, never await. The single Task exists only because ILifecycleObserver
+    // demands one, and it is produced by ONE .ToTask() at the boundary — the sanctioned shape for a
+    // framework surface whose body stays reactive.
+    //
+    // Orleans awaits the returned Task, which is what holds the silo back until the pools report.
+    // That is the whole guarantee, and it costs no thread: nothing is parked here, the completion
+    // arrives on whichever thread the last leaf unwinds on.
+    Task ILifecycleObserver.OnStop(CancellationToken cancellationToken)
     {
         // Resolved lazily: the container is still alive during OnStop, and resolving in the
         // constructor would pin the registry into this participant's lifetime for no reason.
         var registry = services.GetService<IoPoolRegistry>();
         if (registry is null)
-            return;
+            return Task.CompletedTask;
 
         logger.LogInformation(
             "IoPoolSiloTeardown: draining pooled I/O before the silo releases (in-flight={InFlight})",
             registry.TotalInFlight);
 
-        // Dispose CANCELS every leaf (a live change-feed leaf never completes on its own, so a
-        // wait-WITHOUT-cancel would burn the budget and then release over live work) and returns
-        // immediately. The WAIT is the observable — awaited, never blocked on: parking a thread
-        // here while the leaves need threads to unwind is the starvation deadlock that made
-        // OrderedRouteDispatcherTest hang for its full budget on a 4-vCPU runner.
+        // Dispose CANCELS every leaf and RETURNS — a live change-feed leaf never completes on its
+        // own, so a wait-without-cancel would burn the budget and then release over live work.
+        // It does not join; Disposed is what completes once the last leaf has unwound.
         registry.Dispose();
 
-        var leaked = await registry.Disposed
+        return registry.Disposed
             .Timeout(JoinBudget)
-            // Timeout means a leaf never unwound. Report it as a residual rather than throwing:
+            // A timeout means a leaf never unwound. Report it as a residual rather than faulting:
             // shutdown must continue, and the log below is the only attribution a later SIGSEGV gets.
             .Catch<int, Exception>(_ => Observable.Return(-1))
+            .Do(Report)
+            .Select(_ => Unit.Default)
             .FirstAsync()
-            .ToTask()
-            .ConfigureAwait(false);
+            .ToTask();
+    }
 
+    private void Report(int leaked)
+    {
         if (leaked < 0)
             logger.LogError(
                 "IoPoolSiloTeardown: pooled I/O did not finish within {Budget} — the silo is "
@@ -102,7 +113,7 @@ public static class IoPoolSiloTeardownExtensions
 {
     /// <summary>
     /// Registers <see cref="IoPoolSiloTeardown"/> as a silo lifecycle participant, so pooled I/O
-    /// is cancelled and joined before the silo releases. Idempotent.
+    /// is cancelled and reported before the silo releases. Idempotent.
     /// </summary>
     /// <param name="services">The service collection to add the participant to.</param>
     /// <returns>The same service collection for further chaining.</returns>


### PR DESCRIPTION
Follow-up to #1887, on maintainer feedback: *"it must bring an observable when it finishes dispose and must not await."*

## The defect

`OnStop` was `async Task` with `await registry.Disposed … .ToTask()`. AGENTS.md is absolute on this — everything is `IObservable<T>` end-to-end, compose and Subscribe, never await — and a framework surface that must hand back a `Task` does so with **one** `.ToTask()` at the boundary while its body stays reactive. I wrote the body as an async method instead.

## The shape now

```csharp
registry.Dispose();                    // cancels every leaf, returns immediately — does not join

return registry.Disposed
    .Timeout(JoinBudget)
    .Catch<int, Exception>(_ => Observable.Return(-1))
    .Do(Report)
    .Select(_ => Unit.Default)
    .FirstAsync()
    .ToTask();                         // the ONE Task, at the ILifecycleObserver boundary
```

Nothing in our code awaits or parks a thread. **Orleans awaiting the returned Task is what holds the silo back** until the pools report — the guarantee from #1887 is unchanged — and the completion arrives on whichever thread the last leaf unwinds on. Reporting moved to a private `Report(int)` so the pipeline stays a pipeline.

`grep -nE '\bawait\b|async '` over the file now returns exactly one hit: the comment explaining why neither appears.

## Correcting the record

#1887's commit message and the accompanying memory described the earlier 30 s hang as a **"starvation deadlock"** — blocked thread ↔ leaves needing threads to unwind. That was a plausible story presented as a diagnosis. **What was measured is a 30 s hang exactly equal to `DrainTimeout`**, which a plain drain waiting out its full budget explains equally well. The maintainer corrected it, and this PR corrects the memory so a future reader does not inherit a fabricated mechanism.

The conclusion is unaffected either way: a blocking join has no business inside a `Dispose()` that `using` can invoke on a pool thread.

## Also

Restored `IoPoolSiloTeardownExtensions` — the DI wiring — which one of my edits had truncated away. Caught by grepping the file's class list rather than trusting the build, since the extensions class is only referenced from another project.

Verified: builds clean at `-c Release -warnaserror -p:CIRun=true`; `IoPoolTest` 20/20 across 3 runs with a `no-output` bucket (0), so a silent no-op cannot be scored as a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
