### PR TITLE
Graph: the supplied navigation rail is a PLAN, and the current line stays in the tree

### DIFF
--- a/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
@@ -90,9 +90,12 @@ public static class MarkdownOverviewLayoutArea
     public const string NavigationArea = "Navigation";
 
     /// <summary>
-    /// The glyph that marks where the reader stands. Language-neutral by design (nothing to
-    /// translate) and carried IN ADDITION to the accent colour, so the position survives for a
-    /// reader who cannot distinguish the accent.
+    /// The glyph that used to mark where the reader stands. The rail marks position on the LINK now
+    /// (<see cref="NavLinkControl.IsActive"/> — accent bar, background and weight, none of them
+    /// colour-only), because prepending a glyph meant rendering that line as bare text, which took
+    /// it out of the tree: no icon, no indentation, and visibly detached from the group it belongs
+    /// to. Kept as a published constant — consumers pin their own marker against it — and still the
+    /// right glyph for any rail that needs a textual one.
     /// </summary>
     public const string CurrentMarker = "▸";
 
@@ -117,9 +120,8 @@ public static class MarkdownOverviewLayoutArea
     public static IObservable<UiControl?> SuppliedNavigationMenu(LayoutAreaHost host, RenderingContext _)
         => SuppliedNavigation(host)
             .Select(supplied => supplied is { Entries.Count: > 0 }
-                ? (UiControl?)Controls.NavMenu
-                    .WithSkin(s => s.WithWidth(240).WithCollapsible(true))
-                    .WithNavGroup(BuildSuppliedGroup(host, supplied))
+                ? (UiControl?)SuppliedNavigationRail.Render(
+                    SuppliedNavigationRail.Plan(supplied, host.Hub.Address.ToString()))
                 : null);
 
     /// <summary>
@@ -179,11 +181,15 @@ public static class MarkdownOverviewLayoutArea
         LayoutAreaHost host, MeshNode? node, IReadOnlyList<MeshNode> subNodes, UiControl content,
         NodeNavigation? supplied = null)
     {
-        var group = supplied is { Entries.Count: > 0 }
-            ? BuildSuppliedGroup(host, supplied)
-            : BuildChildrenGroup(host, node, subNodes);
-
-        var nav = Controls.NavMenu.WithSkin(s => s.WithWidth(240).WithCollapsible(true)).WithNavGroup(group);
+        // A module that OWNS this page supplied the whole index — rendered by the shared rail, whose
+        // shape is pinned by SuppliedNavigationRail's tests. Nothing supplied → core's default list
+        // of the node's own children, unchanged, so docs and spaces are untouched by this.
+        var nav = supplied is { Entries.Count: > 0 }
+            ? SuppliedNavigationRail.Render(
+                SuppliedNavigationRail.Plan(supplied, host.Hub.Address.ToString()))
+            : Controls.NavMenu
+                .WithSkin(s => s.WithWidth(240).WithCollapsible(true))
+                .WithNavGroup(BuildChildrenGroup(host, node, subNodes));
 
         return Controls.Stack
             .WithOrientation(Orientation.Horizontal)
@@ -209,55 +215,6 @@ public static class MarkdownOverviewLayoutArea
         }
         return group;
     }
-
-    // A module OWNS these pages and knows more about them than core does — a course knows its whole
-    // module list and which lesson the reader is standing in. The heading names what is indexed (the
-    // course), NOT the page being read, and links to it unless that root IS the page being read.
-    private static NavGroupControl BuildSuppliedGroup(LayoutAreaHost host, NodeNavigation supplied)
-    {
-        var currentPath = host.Hub.Address.ToString();
-        var titleIsCurrent = supplied.TitlePath is { } titlePath
-            && string.Equals(titlePath, currentPath, System.StringComparison.Ordinal);
-
-        var group = new NavGroupControl(Marked(supplied.Title, titleIsCurrent))
-            .WithSkin(s => s.WithExpanded(true));
-        if (supplied.TitlePath is { } path && !titleIsCurrent)
-            group = group.WithUrl($"/{path}");
-
-        foreach (var entry in supplied.Entries)
-            group = AppendEntry(host, group, entry);
-        return group;
-    }
-
-    // One supplied entry: a nested collapsible group when it has children (a course's module),
-    // a link otherwise — or, when it is where the reader stands, MARKED TEXT rather than a link.
-    private static NavGroupControl AppendEntry(
-        LayoutAreaHost host, NavGroupControl group, NodeNavigationEntry entry)
-    {
-        if (entry.Children.Count > 0)
-        {
-            var sub = new NavGroupControl(Marked(entry.Label, entry.IsCurrent))
-                .WithSkin(s => s.WithExpanded(true));
-            if (!entry.IsCurrent)
-                sub = sub.WithUrl($"/{entry.Path}");
-            if (entry.Icon is { } icon)
-                sub = sub.WithIcon(icon);
-            foreach (var child in entry.Children)
-                sub = AppendEntry(host, sub, child);
-            return group.WithGroup(sub);
-        }
-
-        return entry.IsCurrent
-            // TEXT, not a link: a link to the page you are on is a dead control that teaches the
-            // reader their position marker is broken. Glyph AND accent — see CurrentMarker.
-            ? group.WithView(Controls.Body(Marked(entry.Label, true))
-                .WithTooltip(host.Localize("nav.youAreHere"))
-                .WithStyle("display:block;padding:4px 12px;font-weight:600;color:var(--accent-fill-rest);"))
-            : group.WithView(new NavLinkControl(entry.Label, entry.Icon, $"/{entry.Path}"));
-    }
-
-    private static string Marked(string label, bool isCurrent)
-        => isCurrent ? $"{CurrentMarker} {label}" : label;
 
     private static UiControl BuildOverview(LayoutAreaHost host, MeshNode? node, bool canComment, bool canEdit, bool hideHeader)
     {

--- a/src/MeshWeaver.Graph/SuppliedNavigationRail.cs
+++ b/src/MeshWeaver.Graph/SuppliedNavigationRail.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MeshWeaver.Layout;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// Turns a module-supplied <see cref="NodeNavigation"/> into the left-hand rail — as a PURE PLAN
+/// first (<see cref="Plan"/>), then a control tree (<see cref="Render"/>).
+///
+/// <para><b>Why the plan exists.</b> A <see cref="ContainerControl{TControl}"/>'s child views are
+/// protected, so a rail built straight into controls cannot be asserted on: a test can count areas
+/// and read a skin, and nothing else. Every defect this class was written to fix was invisible to
+/// exactly that kind of test. The plan is an ordinary record, so what the rail CONTAINS — which
+/// entry is current, which group is open, what each line links to — is pinned by unit tests instead
+/// of by opening a page and looking.</para>
+///
+/// <para><b>The shape, and the three defects that chose it</b> (reported on a live course,
+/// 2026-08-19; the same rail is rendered by every page whose module supplies one):</para>
+/// <list type="number">
+///   <item><b>The title is a LINK, never the collapsible root.</b> Nesting the whole index under one
+///   <see cref="NavGroupControl"/> made its heading both a link and a toggle, so clicking the
+///   course name collapsed the entire index. Groups toggle, links navigate — never both on one
+///   control.</item>
+///   <item><b>An entry with children is a group AND its own first link.</b> The heading expands; the
+///   link beneath it opens the page and is what carries the position marker, because a group
+///   heading has no active state to carry one.</item>
+///   <item><b>The current entry stays IN the tree, as an active link.</b> It used to be swapped for
+///   a bare <c>Controls.Body</c> — no icon, no indentation — so the line the reader was standing on
+///   jumped to the far-left margin and read as belonging to nothing.
+///   <see cref="NavLinkControl.IsActive"/> gives it the accent bar, background and weight the
+///   nav menu already styles, none of which is colour-only.</item>
+/// </list>
+///
+/// <para>Only the group the reader is inside is expanded, so a long index stays a scannable list of
+/// chevrons — and every other group visibly OFFERS its expander.</para>
+/// </summary>
+public static class SuppliedNavigationRail
+{
+    /// <summary>One line of the rail.</summary>
+    /// <param name="Label">The text shown.</param>
+    /// <param name="Path">The node this line stands for.</param>
+    /// <param name="Href">Where it navigates, or null when the node is not there to link to.</param>
+    /// <param name="IsCurrent">Whether this is where the reader stands (exactly one line, at most).</param>
+    /// <param name="Icon">The node's icon, if it has one.</param>
+    public sealed record RailLink(string Label, string Path, string? Href, bool IsCurrent, string? Icon);
+
+    /// <summary>A collapsible group of the rail — one supplied entry that has children.</summary>
+    /// <param name="Label">The group heading (never a link — it toggles).</param>
+    /// <param name="Path">The node the group stands for.</param>
+    /// <param name="Expanded">Open only when the reader is at or below <paramref name="Path"/>.</param>
+    /// <param name="Links">The entry's own link first, then its children.</param>
+    public sealed record RailGroup(string Label, string Path, bool Expanded, IReadOnlyList<RailLink> Links);
+
+    /// <summary>The whole rail: the heading link, flat entries, then the groups.</summary>
+    /// <param name="Home">The index root — a link, not a collapsible heading.</param>
+    /// <param name="Pages">Supplied entries with no children of their own.</param>
+    /// <param name="Groups">Supplied entries that have children.</param>
+    public sealed record Rail(RailLink Home, IReadOnlyList<RailLink> Pages, IReadOnlyList<RailGroup> Groups);
+
+    /// <summary>
+    /// The rail a page shows, from the navigation its module supplied. Pure — see the class remarks
+    /// for the shape and why each part of it is the way it is.
+    /// </summary>
+    /// <param name="supplied">What an <see cref="INodeNavigationProvider"/> claimed the page with.</param>
+    /// <param name="currentPath">The page being read.</param>
+    public static Rail Plan(NodeNavigation supplied, string currentPath)
+    {
+        ArgumentNullException.ThrowIfNull(supplied);
+
+        var root = supplied.TitlePath;
+        var home = new RailLink(
+            supplied.Title,
+            root ?? string.Empty,
+            // A supplied index whose ROOT NODE is not there (a copy whose root was never created)
+            // must not be linked: path resolution matches the longest existing prefix and reads the
+            // trailing segment as an AREA, so the reader gets "no renderer is registered for area
+            // {Root}" — a rendering error for what is really a missing node.
+            root is null ? null : "/" + root,
+            root is not null && string.Equals(root, currentPath, StringComparison.Ordinal),
+            null);
+
+        var pages = new List<RailLink>();
+        var groups = new List<RailGroup>();
+
+        foreach (var entry in supplied.Entries)
+        {
+            if (entry.Children.Count == 0)
+            {
+                pages.Add(Link(entry));
+                continue;
+            }
+
+            var links = new List<RailLink> { Link(entry) };
+            links.AddRange(entry.Children.Select(Link));
+            groups.Add(new RailGroup(entry.Label, entry.Path, IsAtOrBelow(currentPath, entry.Path), links));
+        }
+
+        return new Rail(home, pages, groups);
+    }
+
+    /// <summary>
+    /// Renders a plan as the nav menu: the heading link, the flat entries, then one collapsible
+    /// group per entry that has children.
+    /// </summary>
+    /// <param name="rail">The plan to render.</param>
+    /// <param name="width">Menu width in pixels.</param>
+    /// <param name="collapsible">Whether the menu offers the collapse toggle.</param>
+    public static NavMenuControl Render(Rail rail, int width = 240, bool collapsible = true)
+    {
+        ArgumentNullException.ThrowIfNull(rail);
+
+        var menu = Controls.NavMenu
+            .WithSkin(s => s.WithWidth(width).WithCollapsible(collapsible))
+            .WithNavLink(RenderLink(rail.Home));
+
+        foreach (var page in rail.Pages)
+            menu = menu.WithNavLink(RenderLink(page));
+
+        foreach (var group in rail.Groups)
+        {
+            // NO url on the heading: it toggles, and a control that both navigates and toggles is
+            // how clicking the index title used to collapse the whole index. The group's own page
+            // is the first LINK inside it.
+            var rendered = new NavGroupControl(group.Label).WithSkin(s => s.WithExpanded(group.Expanded));
+            foreach (var link in group.Links)
+                rendered = rendered.WithView(RenderLink(link));
+            menu = menu.WithNavGroup(rendered);
+        }
+
+        return menu;
+    }
+
+    private static RailLink Link(NodeNavigationEntry entry)
+        => new(entry.Label, entry.Path, "/" + entry.Path, entry.IsCurrent, entry.Icon);
+
+    private static NavLinkControl RenderLink(RailLink link)
+        => new NavLinkControl(link.Label, link.Icon, link.Href).WithIsActive(link.IsCurrent);
+
+    /// <summary>Whether <paramref name="currentPath"/> IS <paramref name="path"/> or sits below it.</summary>
+    /// <param name="currentPath">The page being read.</param>
+    /// <param name="path">The candidate ancestor.</param>
+    public static bool IsAtOrBelow(string currentPath, string path)
+        => string.Equals(currentPath, path, StringComparison.Ordinal)
+           || currentPath.StartsWith(path + "/", StringComparison.Ordinal);
+}

--- a/test/MeshWeaver.Graph.Test/SuppliedNavigationRailTest.cs
+++ b/test/MeshWeaver.Graph.Test/SuppliedNavigationRailTest.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Linq;
+using MeshWeaver.Graph;
+using MeshWeaver.Layout;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The left-hand rail a module supplies through <see cref="INodeNavigationProvider"/> — what it
+/// CONTAINS, asserted on the plan rather than on a control tree whose children are protected.
+///
+/// <para>Three defects were reported together on a live course (2026-08-19) and every one of them
+/// was invisible to a control-level test: the entry the reader stood on dropped out of the tree,
+/// clicking the index title collapsed the whole index, and a long index rendered as an
+/// undifferentiated wall of links with no visible expanders. Each has a case here.</para>
+/// </summary>
+public class SuppliedNavigationRailTest
+{
+    private const string Course = "Course";
+
+    private static NodeNavigation Supplied(string? titlePath = Course) =>
+        new("The Course",
+        [
+            new NodeNavigationEntry("Lesson 1", "Course/L1", Icon: "📘")
+            {
+                Children =
+                [
+                    new NodeNavigationEntry("Lesson 1 Quiz", "Course/L1/Quiz", Icon: "❓"),
+                    new NodeNavigationEntry("Lesson 1 Solutions", "Course/L1/Solution"),
+                ],
+            },
+            new NodeNavigationEntry("Lesson 2", "Course/L2")
+            {
+                Children = [new NodeNavigationEntry("Lesson 2 Quiz", "Course/L2/Quiz")],
+            },
+            new NodeNavigationEntry("All exercises", "Course/Exercises"),
+        ])
+        { TitlePath = titlePath };
+
+    private static IEnumerable<SuppliedNavigationRail.RailLink> AllLinks(SuppliedNavigationRail.Rail rail)
+        => new[] { rail.Home }.Concat(rail.Pages).Concat(rail.Groups.SelectMany(g => g.Links));
+
+    [Fact]
+    public void TheIndexIsTheSameWhereverTheReaderStands()
+    {
+        var seen = new[] { Course, "Course/L1", "Course/L1/Quiz", "Course/L2", "Course/Exercises" }
+            .Select(p => AllLinks(SuppliedNavigationRail.Plan(Supplied(), p))
+                .Select(l => $"{l.Label}→{l.Path}")
+                .ToList())
+            .ToList();
+
+        seen.Should().OnlyContain(links => links.SequenceEqual(seen[0]),
+            "standing somewhere else moves the marker and opens a different group — it never "
+            + "re-scopes or shrinks the index");
+    }
+
+    [Fact]
+    public void TheTitleIsALinkNotTheCollapsibleRoot()
+    {
+        var rail = SuppliedNavigationRail.Plan(Supplied(), "Course/L1");
+
+        rail.Home.Href.Should().Be("/Course");
+        rail.Groups.Should().HaveCount(2, "the entries are TOP-LEVEL groups, siblings of the title");
+        rail.Groups.Should().NotContain(g => g.Label == rail.Home.Label,
+            "nothing nests the index under its own heading — that is what made clicking the title "
+            + "collapse everything");
+    }
+
+    [Fact]
+    public void TheCurrentEntryStaysInTheTreeAsAnActiveLink()
+    {
+        var rail = SuppliedNavigationRail.Plan(
+            Supplied() with
+            {
+                Entries =
+                [
+                    new NodeNavigationEntry("Lesson 1", "Course/L1", Icon: "📘")
+                    {
+                        Children =
+                        [
+                            new NodeNavigationEntry("Lesson 1 Quiz", "Course/L1/Quiz", IsCurrent: true, Icon: "❓"),
+                        ],
+                    },
+                ],
+            },
+            "Course/L1/Quiz");
+
+        var current = AllLinks(rail).Should().ContainSingle(l => l.IsCurrent).Subject;
+        current.Path.Should().Be("Course/L1/Quiz");
+        current.Href.Should().Be("/Course/L1/Quiz", "it is still a link, not inert text");
+        current.Icon.Should().Be("❓", "it keeps its icon");
+        rail.Groups.Single().Links.Should().Contain(l => l.IsCurrent,
+            "and it sits inside its own group, in the same slot as when it was not current");
+    }
+
+    [Fact]
+    public void AnEntryWithChildrenIsAGroupAndItsOwnFirstLink()
+    {
+        var rail = SuppliedNavigationRail.Plan(Supplied(), "Course/L1");
+        var lesson = rail.Groups.Single(g => g.Path == "Course/L1");
+
+        lesson.Links.Select(l => l.Path).Should().Equal(
+            "Course/L1", "Course/L1/Quiz", "Course/L1/Solution");
+        lesson.Links[0].Href.Should().Be("/Course/L1",
+            "a group HEADING has no active state to carry the position — the self-link does");
+    }
+
+    [Fact]
+    public void OnlyTheGroupTheReaderIsInsideIsExpanded()
+    {
+        foreach (var inside in new[] { "Course/L1", "Course/L1/Quiz", "Course/L1/Solution/Deep" })
+            SuppliedNavigationRail.Plan(Supplied(), inside)
+                .Groups.Where(g => g.Expanded).Select(g => g.Path)
+                .Should().Equal(["Course/L1"], "from {0}", inside);
+
+        SuppliedNavigationRail.Plan(Supplied(), Course).Groups
+            .Should().OnlyContain(g => !g.Expanded,
+                "on the index root every group is collapsed — which is what makes its expander visible");
+    }
+
+    [Fact]
+    public void AChildlessEntryIsAFlatLink()
+    {
+        var rail = SuppliedNavigationRail.Plan(Supplied(), Course);
+
+        rail.Pages.Select(p => p.Path).Should().Equal("Course/Exercises");
+        rail.Home.IsCurrent.Should().BeTrue("the reader is standing on the index root");
+        AllLinks(rail).Count(l => l.IsCurrent).Should().Be(1, "exactly one line is ever current");
+    }
+
+    [Fact]
+    public void AMissingRootNodeLeavesTheHeadingUnlinked()
+    {
+        var rail = SuppliedNavigationRail.Plan(Supplied(titlePath: null), "Course/L1");
+
+        rail.Home.Href.Should().BeNull(
+            "linking a root node that is not there renders 'no renderer is registered for area {Root}'");
+        rail.Home.Label.Should().Be("The Course", "the heading still names what is indexed");
+        rail.Groups.Should().HaveCount(2, "the index itself is unaffected — only the dead link is withheld");
+    }
+
+    [Fact]
+    public void ItRendersAsOneCollapsibleNavMenu()
+    {
+        var menu = SuppliedNavigationRail.Render(SuppliedNavigationRail.Plan(Supplied(), "Course/L1"));
+
+        menu.Skin.Width.Should().Be(240);
+        menu.Skin.Collapsible.Should().Be(true);
+        // home link + the childless entry + one area per group
+        menu.Areas.Should().HaveCount(4);
+    }
+}


### PR DESCRIPTION
The left-hand rail a module supplies through `INodeNavigationProvider` had three defects, reported together on a live course (2026-08-19). All three were invisible to any test that could be written against it, because a `ContainerControl`'s child views are `protected` — a test could count areas and read a skin, and nothing else.

So the rail is a **pure plan** first (`SuppliedNavigationRail.Plan`) and a control tree second (`Render`). What the rail *contains* is now an ordinary record that tests assert on: 8 cases, one per invariant.

## The three defects

| Reported | Cause | Shape that fixes it |
|---|---|---|
| the index looked broken | the current line was swapped for a bare `Controls.Body` with a `▸` glyph — no icon, no indentation — so the entry the reader stood on jumped to the far-left margin and read as belonging to nothing | an **active `NavLinkControl`**. The nav menu already styles `.active` with an accent bar, background and weight — none colour-only — so position survives without taking the line out of the list |
| clicking the title collapsed everything | the whole index hung under **one** `NavGroupControl` whose heading was both a link *and* a toggle | the heading is a top-level **link**; each entry is its **own group**. A group carries no url at all, so the old shape is not merely fixed but *unrepresentable* |
| no expanders visible on a long index | every group rendered `Expanded` | only the group the reader is inside is open |

An entry with children is a group **and** its own first link — a group heading has no active state, so without the self-link a reader standing on that page would have no marker anywhere.

## Unchanged

- A page nothing claims still gets core's default child list — docs and spaces are untouched.
- A supplied index whose root **node** is missing still leaves its heading unlinked (linking it renders *"no renderer is registered for area {Root}"*).
- `CurrentMarker` stays published; consumers pin their own glyph against it.

## Verification

`dotnet test --filter SuppliedNavigationRailTest` → **8/8 passed**. Non-vacuous: reverting the current-line fix (back to inert, iconless text) fails `TheCurrentEntryStaysInTheTreeAsAnActiveLink`. `src/MeshWeaver.Graph` builds Release with `-warnaserror`.

## Why now

The same rail shape shipped plugin-side in Systemorph/MeshWeaver.Plugins#530/#531 for the Edu page types, which compose their own. This brings core's renderer — the one every `Markdown` page uses — to the same shape, so a course whose pages span both types shows one index rather than two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)