### PR TITLE
Silo teardown must not outlive the container: capture at start, not at stop

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/DbVersionGate.cs
+++ b/memex/aspire/Memex.Portal.Distributed/DbVersionGate.cs
@@ -90,6 +90,17 @@ public sealed class DbVersionGate(
             // problem. Honor the IHostedService cancellation contract and let the host
             // finish tearing down; logging this Critical + StopApplication would
             // misreport an ordinary shutdown as "DB version check failed unexpectedly".
+            //
+            // Say which of the two it was, for the same reason OrleansProvisioningGate does
+            // (#1897): a silent rethrow leaves the framework's `Hosting failed to start` as the
+            // only record, and that is indistinguishable from a gate that genuinely failed.
+            logger.LogWarning(
+                "DB version check did NOT run: host startup was cancelled before the query "
+                + "completed — shutdown raced startup (a rollout replacing this pod while it was "
+                + "still starting). This is not a migration verdict: the schema was neither "
+                + "confirmed nor faulted. Propagating the cancellation per the IHostedService "
+                + "contract, so the 'Hosting failed to start' that follows is the aborted startup "
+                + "and not a fault.");
             throw;
         }
         catch (Exception ex)

--- a/memex/aspire/Memex.Portal.Distributed/OrleansProvisioningGate.cs
+++ b/memex/aspire/Memex.Portal.Distributed/OrleansProvisioningGate.cs
@@ -155,6 +155,21 @@ public sealed class OrleansProvisioningGate(
             // verdict. Same lesson as DbVersionGate / issue #1183: honour the IHostedService
             // cancellation contract instead of misreporting an ordinary shutdown as a critical
             // failure to provision.
+            //
+            // …but SAY so on the way out (#1897). Rethrowing SILENTLY left the framework's
+            // `Hosting failed to start` — Error, with no frame above the Npgsql cancel that knows
+            // why — as the only record, and that reads exactly like a real provisioning failure:
+            // the incident was filed at "medium confidence — equally plausible a race at shutdown
+            // (expected) or a real timeout (a defect)". This gate is the only thing in the process
+            // that can tell those apart. A check that did not run must not look like one that
+            // passed; it must not look like one that FAILED either.
+            logger.LogWarning(
+                "Orleans provisioning check did NOT run: host startup was cancelled before the "
+                + "query completed — shutdown raced startup (a rollout replacing this pod while it "
+                + "was still starting). This is not a provisioning verdict: the orleans database "
+                + "was neither confirmed nor faulted. Propagating the cancellation per the "
+                + "IHostedService contract, so the 'Hosting failed to start' that follows is the "
+                + "aborted startup and not a fault.");
             throw;
         }
         catch (Exception ex)

--- a/src/MeshWeaver.Connection.Orleans/IoPoolSiloTeardown.cs
+++ b/src/MeshWeaver.Connection.Orleans/IoPoolSiloTeardown.cs
@@ -33,6 +33,31 @@ namespace MeshWeaver.Connection.Orleans;
 /// <para>Pairs with the grain no longer unloading its ALC when the reason is silo shutdown: the
 /// process is going away, so an unload buys nothing there and is precisely the window this
 /// crash lives in. Belt and braces — this join makes the unload safe wherever it still happens.</para>
+///
+/// <para>🚨 <b>Everything the stop needs is captured on <c>OnStart</c>, because the container is
+/// NOT guaranteed to outlive the stop.</b> The registry used to be resolved lazily inside
+/// <c>OnStop</c> on the reasoning that "the container is still alive during OnStop". That holds only
+/// on the ORDERLY shutdown path. When host STARTUP is aborted — a rollout replacing a pod that is
+/// still starting — <c>Host.StartAsync</c> throws, and <c>RunAsync</c>'s <c>finally</c> goes
+/// straight to <c>host.DisposeAsync()</c>: no <c>IHostedService.StopAsync</c> runs, no
+/// <c>IHostedLifecycleService.StoppedAsync</c> runs, and the root provider is disposed while the
+/// already-started silo is still stopping. This observer then resolved from a dead Autofac
+/// <c>LifetimeScope</c> and threw <see cref="ObjectDisposedException"/> from the one method whose
+/// whole job is to make the release safe — issues #1898 and #1899, both on the same pod and second
+/// as the aborted startup that caused them (#1897).</para>
+///
+/// <para>The repair is the ordering, not a <c>catch</c>: a swallowed
+/// <see cref="ObjectDisposedException"/> would make the drain silently not happen, which is the
+/// use-after-unload SIGSEGV with its only attribution removed. Capturing at
+/// <see cref="ServiceLifecycleStage.First"/> — the stage that starts FIRST, when the container is
+/// provably alive — and using the capture at the stop that runs LAST means the join needs nothing
+/// from DI at all, on either shutdown path. Same rule
+/// <c>MeshTeardownExtensions.TeardownAsync</c> already states: <i>capture mesh-scoped teardown
+/// services while the scope is still ALIVE — never resolve DI once disposal has begun.</i></para>
+///
+/// <para>Note this deliberately does NOT assume the drain faces a settled silo (#1868: a hub build
+/// constructs other hubs, so a disposal races a TREE of constructions). It cancels and joins
+/// whatever the pools hold, and reports what did not unwind.</para>
 /// </summary>
 public sealed class IoPoolSiloTeardown(
     IServiceProvider services,
@@ -43,19 +68,48 @@ public sealed class IoPoolSiloTeardown(
     /// instead. Matches <c>MeshTeardownHostedService</c>'s budget.</summary>
     private static readonly TimeSpan JoinBudget = TimeSpan.FromSeconds(30);
 
+    // Captured on OnStart while the container is provably alive, read on OnStop which may run
+    // AFTER the container is gone (see the type remarks). Volatile because start and stop are
+    // different lifecycle turns on different threads with no lock between them.
+    private volatile IoPoolRegistry? _registry;
+    private volatile bool _captured;
+
     /// <inheritdoc />
     public void Participate(ISiloLifecycle observer) =>
         // First ⇒ started first, STOPPED LAST (Orleans stops in descending stage order).
         observer.Subscribe(nameof(IoPoolSiloTeardown), ServiceLifecycleStage.First, this);
 
-    Task ILifecycleObserver.OnStart(CancellationToken cancellationToken) => Task.CompletedTask;
+    Task ILifecycleObserver.OnStart(CancellationToken cancellationToken)
+    {
+        // 🚨 The ONE DI resolution in this type, and it happens at the FIRST silo stage — the
+        // earliest moment the container is provably alive. OnStop must never resolve: see the
+        // type remarks for the aborted-startup path that disposes the container without ever
+        // running an ordered shutdown.
+        _registry = services.GetService<IoPoolRegistry>();
+        _captured = true;
+        return Task.CompletedTask;
+    }
 
     async Task ILifecycleObserver.OnStop(CancellationToken cancellationToken)
     {
-        // Resolved lazily: the container is still alive during OnStop, and resolving in the
-        // constructor would pin the registry into this participant's lifetime for no reason.
-        var registry = services.GetService<IoPoolRegistry>();
+        if (!_captured)
+        {
+            // Orleans only stops observers whose start completed, so this is not expected — but a
+            // teardown that did not run must SAY so rather than return like a clean join. Silence
+            // here would leave a later use-after-unload SIGSEGV with no attribution at all.
+            logger.LogError(
+                "IoPoolSiloTeardown: OnStop ran without OnStart, so no IoPoolRegistry was ever "
+                + "captured — pooled I/O has NOT been drained and the silo is releasing over "
+                + "whatever is still in flight. Do not resolve it here: on an aborted startup the "
+                + "container is already disposed (#1898).");
+            return;
+        }
+
+        var registry = _registry;
         if (registry is null)
+            // Nothing registered pooled I/O in this container (a silo without the mesh services),
+            // so there is genuinely nothing to drain. Distinct from the case above: this one is a
+            // real no-op, not an unrun teardown.
             return;
 
         logger.LogInformation(

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-19-shutdown-during-startup.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-19-shutdown-during-startup.md
@@ -1,0 +1,25 @@
+---
+Name: A portal replaced mid-startup shuts down cleanly
+Category: Fix
+Description: When a deployment replaces a portal that is still starting, the old pod now stops quietly and says why, instead of ending in a burst of errors that looked like a failure.
+Icon: Sparkle
+Order: -20260819
+---
+
+# A portal replaced mid-startup shuts down cleanly
+
+A rolling update can replace a portal at any moment — including while it is still starting up. When
+that happened, the old pod did not go quietly. Its startup check was cut off mid-question, and the
+last thing it wrote was a bare "hosting failed to start" with no explanation, followed by a handful
+of errors from background work that was still shutting down after the pod had already released the
+resources it needed.
+
+Nothing was actually broken — the pod was on its way out either way — but the errors were
+indistinguishable from a real failure, so every rollout that caught a pod mid-start looked like a
+problem to investigate.
+
+Now the startup check says exactly what happened: it was cancelled because the pod was being
+replaced, so nothing about the database was confirmed or faulted. And the background work that
+finishes a shutdown no longer depends on resources that may already be gone — it takes what it needs
+up front, so it always completes its work and reports the result, on both the ordinary shutdown path
+and this one.

--- a/test/Memex.Portal.Shared.Test/DbVersionGateTest.cs
+++ b/test/Memex.Portal.Shared.Test/DbVersionGateTest.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Memex.Portal.Distributed;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
 using Xunit;
@@ -64,6 +66,53 @@ public class DbVersionGateTest
         lifetime.StopRequested.Should().BeFalse(
             "an aborted startup is not a failed migration — the gate must not flag a critical "
             + "database failure and StopApplication for a host that is already tearing down");
+    }
+
+    private sealed record Entry(LogLevel Level, string Message);
+
+    /// <summary>Captures what the gate said on the way out — for an aborted startup that is the
+    /// only thing distinguishing it from a gate that genuinely failed.</summary>
+    private sealed class CapturingLogger : ILogger<DbVersionGate>
+    {
+        public List<Entry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add(new Entry(logLevel, formatter(state, exception)));
+    }
+
+    /// <summary>
+    /// 🚨 The rethrow above is correct, but it must not be SILENT (#1897). Rethrowing with no line
+    /// of its own leaves the framework's <c>Hosting failed to start</c> as the only record, and
+    /// that is indistinguishable from a gate that genuinely failed — which is exactly how one
+    /// rollout-during-startup was triaged as "medium confidence: race or defect?". The gate knows;
+    /// it has to say so.
+    /// </summary>
+    [Fact]
+    public async Task AStartupAbortedByShutdown_SaysTheCheckDidNotRun_RatherThanLookingLikeAFailure()
+    {
+        await using var dataSource = UnreachableDataSource();
+        var lifetime = new RecordingLifetime();
+        var logger = new CapturingLogger();
+        var gate = new DbVersionGate(dataSource, lifetime, logger);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => gate.StartAsync(cts.Token));
+
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Warning
+                 && e.Message.Contains("did NOT run", StringComparison.Ordinal)
+                 && e.Message.Contains("shutdown raced startup", StringComparison.Ordinal),
+            "a check that did not run must not look like one that passed — nor like one that failed");
+        logger.Entries.Should().NotContain(
+            e => e.Level == LogLevel.Critical,
+            "nothing about the schema was learned, so nothing may be reported as a migration verdict");
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/OrleansProvisioningGateTest.cs
+++ b/test/Memex.Portal.Shared.Test/OrleansProvisioningGateTest.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Memex.Portal.Distributed;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -35,6 +37,24 @@ public class OrleansProvisioningGateTest
 
     private static OrleansProvisioningGate Gate(RecordingLifetime lifetime, bool grainStorage = true)
         => new(Unreachable, grainStorage, lifetime, NullLogger<OrleansProvisioningGate>.Instance);
+
+    private sealed record Entry(LogLevel Level, string Message);
+
+    /// <summary>Captures what the gate said, which for the aborted-startup path is the ONLY
+    /// record that distinguishes it from a genuine provisioning failure.</summary>
+    private sealed class CapturingLogger : ILogger<OrleansProvisioningGate>
+    {
+        public List<Entry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add(new Entry(logLevel, formatter(state, exception)));
+    }
 
     /// <summary>
     /// The gate's reason to exist: a silo that cannot VERIFY its clustering store must not join a
@@ -73,6 +93,43 @@ public class OrleansProvisioningGateTest
         lifetime.StopRequested.Should().BeFalse(
             "an aborted startup is not a provisioning failure — the gate must not StopApplication "
             + "for a host that is already tearing down");
+    }
+
+    /// <summary>
+    /// 🚨 …and it must SAY which of the two it was (#1897). The rethrow above is correct and stays,
+    /// but it used to be SILENT — so the only record of the event was the framework's
+    /// <c>Hosting failed to start</c> (Error, with no frame above the Npgsql cancel that knows
+    /// why), which reads exactly like a gate that genuinely failed. The incident was filed at
+    /// "medium confidence — equally plausible a race at shutdown (expected) or a real timeout (a
+    /// defect)"; this gate is the only thing in the process that can tell those apart.
+    ///
+    /// <para>A check that did not run must not look like one that PASSED — and it must not look
+    /// like one that FAILED either. So: a warning naming the cancellation, and still no
+    /// LogCritical, still no <c>StopApplication</c>.</para>
+    /// </summary>
+    [Fact]
+    public async Task AStartupAbortedByShutdown_SaysTheCheckDidNotRun_RatherThanLookingLikeAFailure()
+    {
+        var lifetime = new RecordingLifetime();
+        var logger = new CapturingLogger();
+        var gate = new OrleansProvisioningGate(
+            Unreachable, requiresGrainStorage: true, lifetime, logger);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => gate.StartAsync(cts.Token));
+
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Warning
+                 && e.Message.Contains("did NOT run", StringComparison.Ordinal)
+                 && e.Message.Contains("shutdown raced startup", StringComparison.Ordinal),
+            "the gate is the only place that knows the cancellation came from shutdown, so the "
+            + "attribution has to be written here or it does not exist anywhere");
+        logger.Entries.Should().NotContain(
+            e => e.Level == LogLevel.Critical,
+            "an aborted startup is not a provisioning verdict — nothing was confirmed and nothing faulted");
+        lifetime.StopRequested.Should().BeFalse(
+            "saying what happened must not turn into refusing a startup that was already ending");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Orleans.Test/IoPoolSiloTeardownTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/IoPoolSiloTeardownTest.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 Pins the ORDERING that issues #1898 / #1899 broke, and the ninth member of the shutdown-race
+/// family (#1573, #715, #967, #1330, #1334): <see cref="IoPoolSiloTeardown"/> must capture
+/// everything its stop needs WHILE the container is alive, and resolve NOTHING once the stop runs.
+///
+/// <para>The stop is not guaranteed a live container. On the orderly path it has one — that is what
+/// the previous "resolved lazily: the container is still alive during OnStop" comment relied on.
+/// But when host STARTUP is aborted (a rollout replacing a pod that is still starting, #1897),
+/// <c>Host.StartAsync</c> throws and <c>RunAsync</c>'s <c>finally</c> goes straight to
+/// <c>host.DisposeAsync()</c>: no <c>StopAsync</c>, no <c>StoppedAsync</c>, and the root provider
+/// is disposed while the already-started silo is still stopping. The observer then resolved from a
+/// dead scope and threw <see cref="ObjectDisposedException"/> out of the one method whose whole job
+/// is to make the release safe.</para>
+///
+/// <para>These tests use a REAL MS DI <c>ServiceProvider</c> and dispose it, because a disposed
+/// DI provider throws the same <see cref="ObjectDisposedException"/> from <c>GetService</c> that
+/// Autofac's <c>LifetimeScope</c> threw in production. Every wait is bounded — the defect class
+/// here is shutdown HANGS, so an unbounded wait would fail the way the bug does.</para>
+/// </summary>
+public class IoPoolSiloTeardownTest
+{
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(10);
+
+    private sealed record Entry(LogLevel Level, string Message);
+
+    /// <summary>Captures the teardown's report lines, which are the only externally visible
+    /// evidence of what the drain actually did.</summary>
+    private sealed class CapturingLogger : ILogger<IoPoolSiloTeardown>
+    {
+        private readonly List<Entry> entries = [];
+
+        public IReadOnlyList<Entry> Entries
+        {
+            get { lock (entries) return entries.ToArray(); }
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            lock (entries) entries.Add(new Entry(logLevel, formatter(state, exception)));
+        }
+    }
+
+    /// <summary>Counts resolutions so "the stop resolves NOTHING" can be asserted as itself,
+    /// rather than only through the exception a disposed scope happens to throw.</summary>
+    private sealed class CountingProvider(IServiceProvider inner) : IServiceProvider
+    {
+        private int resolutions;
+
+        public int Resolutions => Volatile.Read(ref resolutions);
+
+        public object? GetService(Type serviceType)
+        {
+            Interlocked.Increment(ref resolutions);
+            return inner.GetService(serviceType);
+        }
+    }
+
+    private static (IoPoolRegistry Registry, Microsoft.Extensions.DependencyInjection.ServiceProvider Provider) NewContainer()
+    {
+        // The registry is created OUTSIDE the container and registered as an INSTANCE, so MS DI
+        // never owns it (it disposes only what it creates — an ImplementationInstance resolves
+        // through a ConstantCallSite, which is not captured as a disposable). Disposing the
+        // provider therefore leaves the registry alive, which is what makes these tests about the
+        // teardown's ordering rather than about container disposal. Asserted, not assumed, below.
+        var registry = new IoPoolRegistry();
+        var services = new ServiceCollection();
+        services.AddSingleton(registry);
+        return (registry, services.BuildServiceProvider());
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION PIN (#1898, #1899). The container is disposed before the stop runs — the
+    /// aborted-startup path — and the terminal drain must still happen: cancel the pooled leaf,
+    /// JOIN it, and report the outcome. Against the previous shape this throws
+    /// <see cref="ObjectDisposedException"/> at the first line of <c>OnStop</c>, so nothing is
+    /// drained and nothing is logged.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Stop_JoinsPooledIo_EvenAfterTheContainerHasBeenDisposed()
+    {
+        var (registry, provider) = NewContainer();
+        var logger = new CapturingLogger();
+        var observer = (ILifecycleObserver)new IoPoolSiloTeardown(provider, logger);
+
+        await observer.OnStart(TestContext.Current.CancellationToken);
+
+        // One pooled leaf in flight that ends ONLY when it is cancelled — the shape the drain
+        // exists for (a live change-feed leaf never completes on its own, so a wait-without-cancel
+        // would burn the budget and then release over live work).
+        using var entered = new ManualResetEventSlim(false);
+        using var unwound = new ManualResetEventSlim(false);
+        using var leaf = registry.Get(IoPoolNames.FileSystem)
+            .InvokeBlocking(ct =>
+            {
+                entered.Set();
+                ct.WaitHandle.WaitOne(Budget);
+                unwound.Set();
+                return 0;
+            })
+            .Subscribe(_ => { }, _ => { });
+
+        entered.Wait(Budget).Should().BeTrue(
+            "precondition: the pooled leaf must actually be running before the drain is asked to join it");
+
+        // 🚨 The race, reproduced: host startup was aborted, so the root provider was disposed
+        // WITHOUT any ordered shutdown, while the silo is still stopping behind it.
+        await provider.DisposeAsync();
+
+        registry.TotalInFlight.Should().Be(1,
+            "precondition: MS DI must not have disposed a registry it did not create — otherwise "
+            + "this test would be measuring container disposal instead of the teardown");
+
+        Func<Task> stop = () => observer.OnStop(TestContext.Current.CancellationToken);
+        await stop.Should().NotThrowAsync();
+
+        unwound.IsSet.Should().BeTrue(
+            "OnStop must not RETURN until the pooled leaf has actually unwound — the join is the "
+            + "whole point, and returning over live work is the use-after-unload SIGSEGV (#613)");
+        logger.Entries.Should().Contain(
+            e => e.Message.Contains("draining pooled I/O", StringComparison.Ordinal),
+            "the stop must reach the registry it captured at OnStart, with no DI resolution of its own");
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Information
+                 && e.Message.Contains("pooled I/O joined", StringComparison.Ordinal),
+            "a clean join must be REPORTED — a silent return is indistinguishable from a drain that never ran");
+    }
+
+    /// <summary>
+    /// The ordering stated as itself: the only service resolution happens at start. Reading the
+    /// count instead of the exception means this still fails if someone reintroduces a resolve in
+    /// the stop and wraps it in a <c>catch</c> — which would make the race invisible rather than
+    /// absent.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task TheOnlyServiceResolution_HappensAtStart_NeverAtStop()
+    {
+        var (_, provider) = NewContainer();
+        await using var _provider = provider;
+        var counting = new CountingProvider(provider);
+        var observer = (ILifecycleObserver)new IoPoolSiloTeardown(counting, new CapturingLogger());
+
+        await observer.OnStart(TestContext.Current.CancellationToken);
+        var afterStart = counting.Resolutions;
+        afterStart.Should().BeGreaterThan(0,
+            "the stop's dependencies are captured while the scope is provably alive");
+
+        await observer.OnStop(TestContext.Current.CancellationToken);
+
+        counting.Resolutions.Should().Be(afterStart,
+            "OnStop must resolve NOTHING: on an aborted startup the container is already disposed "
+            + "by the time it runs, and a catch around the resolve would hide the race instead of "
+            + "removing it");
+    }
+
+    /// <summary>
+    /// 🚨 A teardown that could not run must SAY so. Orleans only stops observers whose start
+    /// completed, so this is not expected — but shutdown must never swallow its own failure: this
+    /// error line is the only attribution a later use-after-unload crash would get.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Stop_WithoutStart_ReportsThatPooledIoWasNotDrained()
+    {
+        var (_, provider) = NewContainer();
+        var logger = new CapturingLogger();
+        var observer = (ILifecycleObserver)new IoPoolSiloTeardown(provider, logger);
+
+        // No OnStart, and the container is already gone — the aborted-startup shape.
+        await provider.DisposeAsync();
+
+        Func<Task> stop = () => observer.OnStop(TestContext.Current.CancellationToken);
+        await stop.Should().NotThrowAsync();
+
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Error
+                 && e.Message.Contains("without OnStart", StringComparison.Ordinal),
+            "an unrun teardown must be reported as an error, not returned like a clean join");
+        logger.Entries.Should().NotContain(
+            e => e.Message.Contains("pooled I/O joined", StringComparison.Ordinal),
+            "nothing was joined, so nothing may claim it was");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/AbortedStartupSkipsOrderedShutdownTest.cs
+++ b/test/MeshWeaver.Hosting.Test/AbortedStartupSkipsOrderedShutdownTest.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins the host behaviour every teardown in this repo is built on top of, and which the
+/// shutdown-race family (#1573, #715, #967, #1330, #1334) had only ever exercised on the ORDERLY
+/// path: <b>when host STARTUP is aborted, the ordered shutdown does not run at all.</b>
+///
+/// <para><c>Host.StartAsync</c> throws on the first hosted service that faults, and
+/// <c>HostingAbstractionsHostExtensions.RunAsync</c>'s <c>finally</c> then goes straight to
+/// <c>host.Dispose()</c> — so no <c>IHostedService.StopAsync</c> runs, no
+/// <c>IHostedLifecycleService.StoppedAsync</c> runs, and the root <see cref="IServiceProvider"/>
+/// is disposed while services that DID start are still winding down. That is why
+/// <c>MeshTeardownHostedService</c>'s window ("the scope is alive during StoppedAsync") is not
+/// available to a silo lifecycle observer, and why <c>IoPoolSiloTeardown</c> must capture what its
+/// stop needs at START rather than resolve it at stop (#1898 / #1899, triggered by exactly this
+/// path in #1897).</para>
+///
+/// <para>This is a REGRESSION pin, not framework documentation: if a future .NET starts unwinding
+/// already-started services on a failed start, this goes red and the reasoning above should be
+/// re-read before anything relies on the ordered shutdown again.</para>
+/// </summary>
+public class AbortedStartupSkipsOrderedShutdownTest
+{
+    /// <summary>Records whether the ordered shutdown ever reached it.</summary>
+    private sealed class Probe : IHostedService
+    {
+        public bool Started { get; private set; }
+        public bool Stopped { get; private set; }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            Started = true;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            Stopped = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>Stands in for a startup gate whose query is cancelled by a rollout — the #1897
+    /// shape. It honours the <see cref="IHostedService"/> cancellation contract and rethrows.</summary>
+    private sealed class CancelledGate : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+            => throw new OperationCanceledException("startup aborted by shutdown");
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task AnAbortedStartup_DisposesTheContainer_WithoutRunningAnyStopAsync()
+    {
+        var probe = new Probe();
+        var hostBuilder = new HostBuilder();
+        hostBuilder.ConfigureServices(services =>
+        {
+            // Registered FIRST, so it starts first and would stop last on the orderly path.
+            services.AddSingleton<IHostedService>(probe);
+            services.AddSingleton<IHostedService>(new CancelledGate());
+        });
+
+        var host = hostBuilder.Build();
+        var services = host.Services;
+
+        var thrown = await Record.ExceptionAsync(() => host.StartAsync(TestContext.Current.CancellationToken));
+
+        thrown.Should().NotBeNull("the gate propagates the cancellation, which aborts host startup");
+        probe.Started.Should().BeTrue(
+            "precondition: the service registered before the gate DID start — it is the one with "
+            + "live work that a shutdown would have to unwind");
+
+        // Exactly what HostingAbstractionsHostExtensions.RunAsync's finally does when StartAsync throws.
+        host.Dispose();
+
+        probe.Stopped.Should().BeFalse(
+            "🚨 an aborted startup skips the ordered shutdown entirely — so teardown work must never "
+            + "assume it runs inside one, and must not resolve anything from DI once it does run");
+
+        Action resolve = () => services.GetService(typeof(Probe));
+        resolve.Should().Throw<ObjectDisposedException>(
+            "the container is gone by the time the already-started services are winding down — "
+            + "this is the disposed scope IoPoolSiloTeardown used to resolve from (#1898)");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/MeshTeardownRunsAfterEveryOtherHostedServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Test/MeshTeardownRunsAfterEveryOtherHostedServiceTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Messaging;
@@ -49,6 +51,18 @@ public class MeshTeardownRunsAfterEveryOtherHostedServiceTest
 
         var mesh = host.Services.GetRequiredService<IMessageHub>();
         mesh.IsDisposing.Should().BeFalse("the mesh must be alive while the host runs");
+
+        // 🚨 Resolving the mesh is what CONSTRUCTS it, and its RunLevel reaches Started
+        // asynchronously afterwards — `host.StartAsync()` does not wait for that. Stopping straight
+        // away therefore raced the hub's own startup and recorded `Starting` at the probe, which is
+        // a race in this TEST, not the ordering it pins. Wait on the source of truth
+        // (RunLevelChanged replays the current level) instead of hoping the window stays wide:
+        // adding one unrelated test class to this assembly was enough to lose it.
+        await mesh.RunLevelChanged
+            .Where(level => level >= MessageHubRunLevel.Started)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
 
         await host.StopAsync();
 


### PR DESCRIPTION
Three filings, **one incident** — same pod (`memex-portal-deployment-ddbc747c4-sx266`), same second
(2026-08-19 14:24:51Z) — and **two defects**, because one of the three is the incident's *trigger*
rather than a second copy of the bug.

## What actually happened

A rollout replaced a pod that was **still starting**.

1. `OrleansProvisioningGate.StartAsync` was mid-`ExecuteReaderAsync` when the host's startup token
   was cancelled. It correctly refused to call that a provisioning verdict and rethrew (the #1183
   contract) → `Host[11] Hosting failed to start`. **(#1897)**
2. Because startup FAILED, `HostingAbstractionsHostExtensions.RunAsync`'s `finally` went straight to
   `host.Dispose()`. **No `StopAsync` ran. No `StoppedAsync` ran.** The root Autofac container was
   disposed while the already-started silo was still winding down.
3. `IoPoolSiloTeardown.OnStop` — which resolved `IoPoolRegistry` from that container as its first
   statement — threw `ObjectDisposedException` out of the one method whose whole job is to make the
   silo's release safe. **(#1898)**, and Orleans' own connection machinery hit the same dead scope
   sending `UnregisterProducer` **(#1899)**.

Step 2 is not a supposition any more — `AbortedStartupSkipsOrderedShutdownTest` pins it: after an
aborted start, an already-started hosted service's `StopAsync` is never called and `host.Services`
throws `ObjectDisposedException`.

## The ordering defect

`IoPoolSiloTeardown` subscribes at `ServiceLifecycleStage.First`, which means it **stops LAST** —
deliberately, so grains get their full chance to flush before the terminal drain. It then resolved
its dependency at that last moment, on this reasoning:

```csharp
// Resolved lazily: the container is still alive during OnStop, and resolving in the
// constructor would pin the registry into this participant's lifetime for no reason.
var registry = services.GetService<IoPoolRegistry>();
```

That premise holds only on the orderly path. Stopping last maximises the window in which it is
false, and on an aborted startup it is false from the beginning.

**The fix is the ordering, not a `catch`.** The registry is captured in `OnStart` — stage `First`
starts FIRST, the earliest moment the container is provably alive — and `OnStop` resolves nothing at
all. This is the rule `MeshTeardownExtensions.TeardownAsync` already states for the mesh
("capture mesh-scoped teardown services while the scope is still ALIVE — never resolve DI once
disposal has begun"); the silo observer was the one place that did not follow it.

A `catch (ObjectDisposedException)` would have been strictly worse: it removes the exception but not
the race, and the drain it swallows is the thing standing between a silo release and the
use-after-unload SIGSEGV of #613. So shutdown still speaks up — `OnStop` without a capture logs an
**error** naming that pooled I/O was NOT drained, rather than returning like a clean join.

## #1897 — the trigger, and the half of it that IS worth fixing

The gate's *behaviour* is already right and is pinned by a test from #1183: it distinguishes "the
host is shutting down" from "the database said something", and honours the `IHostedService`
cancellation contract. Nothing here changes that.

What was wrong is that it did so **silently**, so the only record of the event was the framework's
`Hosting failed to start` — Error, with no frame above the Npgsql cancel that knows why. That is
indistinguishable from a gate that genuinely failed, which is exactly how the incident got filed:
*"Confidence: Medium — equally plausible this was a race at shutdown (expected) or a real timeout
during startup (a defect)."* The gate is the only thing in the process that can tell those apart.

So both startup gates now say which it was on the way out — a warning naming the cancellation, still
no `LogCritical`, still no `StopApplication`, still the same rethrow. A check that did not run must
not look like one that passed, and must not look like one that failed either.

## Merged `main`: the fix now lives inside main's non-async `OnStop`

This branch was cut before #1903 (`fix/iopool-teardown-no-await`), which turned
`IoPoolSiloTeardown.OnStop` from `async Task` into a reactive composition returning ONE `.ToTask()`
at the boundary, and documented that as an invariant. My branch had inherited — not introduced —
the old `async` body, so merging naively would have **silently reverted** that invariant. (The
textual conflict was two lines, `return;` vs `return Task.CompletedTask;`; the real content of it
was the method signature above them.)

Resolved by taking main's file wholesale and re-applying the capture on top, so main's signature,
reactive chain, `Report(int)` and `AddIoPoolSiloTeardown` are byte-identical to `origin/main`. The
diff against main is now exactly: the type remarks, the two captured fields, `OnStart` doing the one
resolution, and `OnStop` READING the capture instead of resolving. There is no `async` and no
`await` anywhere in the file's code — the only occurrences are in prose.

`git diff origin/main...HEAD --stat` shows exactly the nine intended files, so nothing of anyone
else's merged work was undone in the resolution.

### Second merge: picking up #1908

The first CI run after the merge went red on shard 5 —
`DelegationSubThreadUsageTest.DelegatedSubThread_RecordsUsageUnderRealModel_AndPricesNonZero`. The
failure is worth naming precisely, because its *symptom* looks like this PR's subject matter: the
test body passed and the TEARDOWN threw `teardown DIRTY — 1 pooled I/O leaf(s) still running`.

It is not reachable from this diff. The three production files here live in
`MeshWeaver.Connection.Orleans` and `Memex.Portal.Distributed`, and **none of those assemblies is in
`MeshWeaver.Threading.Test`'s build closure** — checked against the test's actual `bin/` output, so
the changed code cannot be loaded into that host at all. It is instead the known flake #1863, whose
fix — #1908, *"a delegate_to_agent call must observe its cancellation token"* — merged to main at
19:35:06Z, **nine minutes after this branch's merge base** (`939010570`). The branch was re-sampling
a flake main had already fixed, which is exactly the case AGENTS.md says to merge trunk for rather
than investigate.

Merged `origin/main` again (clean, no conflicts) to take #1908 + #1907. The capture fix is unchanged
and the file still contains no `async`/`await` in code.

## Verification — every new test proven RED on `main`

Production code reverted to `origin/main`, tests kept, same build. **Re-run after the merge, against
the NEW non-async main** — a signature change is exactly where a non-vacuous test goes quietly
vacuous, so this was re-confirmed rather than assumed:

```
Failed MeshWeaver.Hosting.Orleans.Test.IoPoolSiloTeardownTest.Stop_JoinsPooledIo_EvenAfterTheContainerHasBeenDisposed
  Did not expect an exception, but found ObjectDisposedException: Cannot access a disposed object.
  Object name: 'IServiceProvider'.
Failed MeshWeaver.Hosting.Orleans.Test.IoPoolSiloTeardownTest.Stop_WithoutStart_ReportsThatPooledIoWasNotDrained
  Did not expect an exception, but found ObjectDisposedException: Cannot access a disposed object.
Failed MeshWeaver.Hosting.Orleans.Test.IoPoolSiloTeardownTest.TheOnlyServiceResolution_HappensAtStart_NeverAtStop
  Expected 0 to be greater than 0 because the stop's dependencies are captured while the scope is provably alive.
Failed!  - Failed: 3, Passed: 0, Total: 3

Failed Memex.Portal.Shared.Test.OrleansProvisioningGateTest.AStartupAbortedByShutdown_SaysTheCheckDidNotRun_…
Failed Memex.Portal.Shared.Test.DbVersionGateTest.AStartupAbortedByShutdown_SaysTheCheckDidNotRun_…
Failed!  - Failed: 2, Passed: 6, Total: 8
```

The failure text is the production symptom verbatim — `ObjectDisposedException` from a disposed
service provider, raised at the `OnStop` call. `TheOnlyServiceResolution_HappensAtStart_NeverAtStop`
counts resolutions instead of catching the exception, so it stays red even if someone reintroduces a
resolve in the stop and wraps it in a `try/catch`.

Every wait is bounded (10 s condition waits, `[Fact(Timeout = 30000)]`) — the defect class here is
shutdown hangs, so an unbounded wait would fail the way the bug does.

### One pre-existing race, found and fixed rather than retried past

Adding a test CLASS to `MeshWeaver.Hosting.Test` turned `#1573`'s own
`AHostedServiceThatStopsLast_StillSeesALiveMesh` red — `MeshRunLevelAtStop` was `Starting`, not
`Started`. Control run with the new file removed: 198/198 green. So it was mine to explain.

It is a race in that TEST, not in the ordering it pins: resolving `IMessageHub` is what CONSTRUCTS
the mesh, and its `RunLevel` reaches `Started` asynchronously afterwards — `host.StartAsync()` does
not wait for it. The test then stopped the host immediately, so the probe could read `Starting`. The
window is normally wide enough to win; one extra test class in the assembly was enough to lose it.

Fixed at the source — wait on `mesh.RunLevelChanged` (a replaying `BehaviorSubject`) to reach
`Started` before stopping the host. That establishes the precondition the assertion needs and
weakens nothing: the assertion about what the probe sees at STOP is unchanged. Re-verified by
reproducing the conditions that broke it (`Hosting.Test` run concurrently with the Orleans suite,
which is what the failing run had been racing).

### Suites, green with the fix in

All re-run **after both merges**, against the final tree:

- `MeshWeaver.Hosting.Orleans.Test` — **170/170**
- `MeshWeaver.Hosting.Monolith.Test` — **728 passed, 3 skipped, 0 failed** (9 m 17 s)
- `MeshWeaver.Messaging.Hub.Test` — **261/261**
- `MeshWeaver.Hosting.Test` — **199/199**, again under the concurrent load that exposed the race
  above
- `MeshWeaver.Threading.Test` — **135/135**, including the test that reddened shard 5
- `Memex.Portal.Shared.Test` (gate tests) — **8/8**
- `-c Release -warnaserror`: `MeshWeaver.Connection.Orleans`, `Memex.Portal.Distributed`, and every
  touched test project — 0 errors, 0 warnings.

## Relationship to #1868

#1868 ("Hub Build constructs other hubs — a disposal races a TREE of constructions") is why
disposals here are hard, and this fix deliberately does not assume it away: the drain still cancels
and JOINS whatever the pools hold and reports what did not unwind, however many constructions are in
flight. What changes is only that the join can no longer be prevented from happening by a container
that went first. If anything this makes #1868 easier to work on — the drain now runs on both
shutdown paths, so its residual report is trustworthy evidence rather than something an
`ObjectDisposedException` can silently pre-empt.

## The ninth member of the family

#1573 established *ordering, not suppression* — "no `catch (ObjectDisposedException)`, no widened
bound, no retry: the work simply no longer outlives the container." Same discipline here, applied to
the one path #1573 could not cover: a shutdown that never runs because startup was aborted.

Fixes #1898
Fixes #1899
Closes #1897

**Duplicates:** #1899 duplicates #1898 — same defect, same file, same line; #1899's second stack
(Orleans' own `UnregisterProducer` connection resolving from the same disposed container) has no
MeshWeaver frame and is a consequence of the host disposing on an aborted startup, not separately
fixable here. #1897 is **not** a duplicate: it is the trigger, in different code, and its
rethrow-on-cancellation is correct and stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
