### PR TITLE
fix(portal): the toast container was the one overlay with no declared layer (#1883)

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
@@ -77,6 +77,10 @@
         background-color: var(--neutral-layer-4);
     }
 
+    /* 🚨 This 1100 is the floor every top-of-viewport overlay has to clear. The toast container
+       sits at top:24px — INSIDE this band — so it is layered above by `.fluent-toast-provider`
+       in standard-page-layout.css (#1883). Re-tier this value and that rule must move with it;
+       PortalOverlayLayeringTest fails if the toast stops out-ranking the header. */
     ::deep.layout>header {
         grid-area: head;
         position: relative;
@@ -321,6 +325,10 @@
         background-color: var(--neutral-layer-4);
     }
 
+    /* 🚨 This 1100 is the floor every top-of-viewport overlay has to clear. The toast container
+       sits at top:24px — INSIDE this band — so it is layered above by `.fluent-toast-provider`
+       in standard-page-layout.css (#1883). Re-tier this value and that rule must move with it;
+       PortalOverlayLayeringTest fails if the toast stops out-ranking the header. */
     ::deep.layout>header {
         grid-area: head;
         position: relative;

--- a/src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css
+++ b/src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css
@@ -390,6 +390,39 @@ code {
     z-index: 10001 !important;
 }
 
+/* ————————————————————————————————————————————————————————————————— toast layer
+   The toast container must paint ABOVE the portal's top menu bar.
+
+   Fluent ships `.fluent-toast-provider { position: fixed; top: 24px; right: 24px; z-index: 999 }`,
+   while the portal header is `z-index: 1100` (PortalLayoutBase.razor.css, desktop AND mobile) and
+   occupies the top ~48px of the viewport. A top-right toast therefore opened INSIDE the header's
+   band with a LOWER z-index, and the header painted over it — issue #1883, where the
+   download-complete confirmation was hidden behind the menu bar.
+
+   🚨 This is a plain ordering collision in the ROOT stacking context, NOT a trapped-context bug:
+   no ancestor of the provider establishes one. `.body-content` is deliberately `position: relative`
+   with NO z-index for exactly this reason (see the comment on it in PortalLayoutBase.razor.css,
+   left behind by the same bug hitting the chat popups), and `.layout`'s `overflow: hidden` cannot
+   clip a `position: fixed` descendant. So a z-index above the header is sufficient and sufficient
+   alone — the value is what was missing, not a containing block.
+
+   `!important` because Fluent's own rule is SCOPED — `.fluent-toast-provider[b-wmvy1145n8]`,
+   specificity 0-2-0 — so a global class selector (0-1-0) loses to it outright and an
+   equal-specificity override would be decided by bundle order. Same reason the Monaco overflow
+   widgets above carry it.
+
+   The value joins the established "clears the header" tier already used by the chat widget, the
+   /model · /agent pickers and the Monaco popups (10000). PortalOverlayLayeringTest pins the
+   RELATIONSHIP (toast > header) rather than the literal number, so re-tiering the header fails
+   loudly here instead of silently burying the toast again.
+
+   This lives in the GLOBAL sheet, not in PortalLayoutBase's scoped CSS, so it covers every
+   FluentToastProvider the app mounts — the portal layout's, MainView's and AreaPage's — rather
+   than only the shell that happened to report the bug. */
+.fluent-toast-provider {
+    z-index: 10000 !important;
+}
+
 /* Title bar text field - borderless inline editor for page titles */
 fluent-text-field.title-bar-field::part(root) {
     border: none;

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-19-download-toast-is-no-longer-hidden-behind-the-menu-bar.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-19-download-toast-is-no-longer-hidden-behind-the-menu-bar.md
@@ -1,0 +1,20 @@
+---
+Name: Notifications are no longer hidden behind the menu bar
+Category: Fix
+Description: Toast notifications — the download-complete confirmation among them — now open in front of the top menu bar instead of behind it.
+Icon: Alert
+Order: -20260819
+---
+
+# Notifications are no longer hidden behind the menu bar
+
+Download a file from a space's **Files** tab and the portal confirms it with a small
+notification in the top-right corner. That notification was opening *underneath* the
+top menu bar, so depending on your window size you saw a sliver of it or nothing at
+all — while the download itself worked perfectly. The same applied to every other
+notification the portal raises there: upload finished, delete failed, and so on.
+
+The notification area now sits in front of the menu bar, alongside the other things
+that have to appear over it — the chat window, the model and agent pickers, the code
+editor's suggestion popups. Nothing else changes: the notifications appear in the
+same place, say the same thing, and disappear on the same timer.

--- a/test/MeshWeaver.Acme.Test/MeshWeaver.Acme.Test.csproj
+++ b/test/MeshWeaver.Acme.Test/MeshWeaver.Acme.Test.csproj
@@ -13,6 +13,20 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The two stylesheets whose z-index values must stay ordered relative to one another
+         (PortalOverlayLayeringTest). Linked in as content so the assertion reads the SHIPPED
+         rules from a clean checkout rather than a hand-copied duplicate that could drift. -->
+    <Content Include="..\..\src\MeshWeaver.Blazor\wwwroot\standard-page-layout.css">
+      <Link>PortalCss\standard-page-layout.css</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\src\MeshWeaver.Blazor.Portal\Layout\PortalLayoutBase.razor.css">
+      <Link>PortalCss\PortalLayoutBase.razor.css</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Markdown\MeshWeaver.Markdown.csproj" />

--- a/test/MeshWeaver.Acme.Test/PortalOverlayLayeringTest.cs
+++ b/test/MeshWeaver.Acme.Test/PortalOverlayLayeringTest.cs
@@ -1,0 +1,142 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Acme.Test;
+
+/// <summary>
+/// Pins the stacking ORDER of the portal's top-of-viewport chrome, as it is actually shipped in
+/// the stylesheets.
+///
+/// <para>🚨 Regression (#1883): the download-complete toast rendered BEHIND the top menu bar. Fluent
+/// ships its toast container at <c>position: fixed; top: 24px; right: 24px; z-index: 999</c>, while
+/// the portal header is <c>z-index: 1100</c> and occupies the top ~48px of the viewport — so the
+/// toast opened inside the header's band underneath it and only a sliver showed. Every other piece
+/// of portal chrome that has to clear that header (the chat widget, the /model · /agent pickers, the
+/// Monaco popups) was given an explicit z-index; the toast container was the one top-level overlay
+/// still running on a framework default.</para>
+///
+/// <para>The assertion is the RELATIONSHIP, not the literal number: re-tiering the header without
+/// moving the overlays fails here, which is the failure mode a hard-coded <c>== 10000</c> would
+/// miss. It reads the shipped CSS files (linked into this project as content), so it cannot pass
+/// against a stale copy.</para>
+///
+/// <para>⚠️ What this does NOT prove: that the toast is visible on screen. CSS ordering is necessary
+/// but not sufficient — a stacking context on an ancestor would still trap it (verified absent:
+/// <c>.body-content</c> is deliberately <c>position: relative</c> with no z-index, and nothing on
+/// the path declares transform/filter/contain/will-change). The rendered result is asserted by
+/// <c>LoginDialogAboveHeaderTest</c>'s sibling technique in the Playwright project, which is
+/// environment-gated and does not run in the normal suite — so a human or an E2E run confirms the
+/// pixels; this test confirms the contract that makes them possible.</para>
+/// </summary>
+public class PortalOverlayLayeringTest
+{
+    private static string CssDir => Path.Combine(AppContext.BaseDirectory, "PortalCss");
+
+    private static string ReadCss(string fileName)
+    {
+        var path = Path.Combine(CssDir, fileName);
+        Assert.True(File.Exists(path),
+            $"{fileName} was not copied to the test output ({path}). It is linked in via " +
+            "<Content Include> in MeshWeaver.Acme.Test.csproj — without it this test would " +
+            "silently verify nothing.");
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>
+    /// Every <c>z-index: N</c> declared by the rule whose selector block contains
+    /// <paramref name="selector"/>. Returns every match so a rule duplicated across the desktop and
+    /// mobile media queries (the header is) is checked in both places rather than only the first.
+    /// </summary>
+    private static IReadOnlyList<int> ZIndexesFor(string css, string selector)
+    {
+        var results = new List<int>();
+        var searchFrom = 0;
+        while (true)
+        {
+            var at = css.IndexOf(selector, searchFrom, StringComparison.Ordinal);
+            if (at < 0) break;
+            searchFrom = at + selector.Length;
+
+            // Only a real rule head counts — skip the selector appearing inside a comment.
+            var lastOpen = css.LastIndexOf("/*", at, StringComparison.Ordinal);
+            var lastClose = css.LastIndexOf("*/", at, StringComparison.Ordinal);
+            if (lastOpen > lastClose) continue;
+
+            var open = css.IndexOf('{', searchFrom);
+            var close = open < 0 ? -1 : css.IndexOf('}', open);
+            if (open < 0 || close < 0) continue;
+
+            var body = css[open..close];
+            var m = Regex.Match(body, @"z-index\s*:\s*(\d+)");
+            if (m.Success) results.Add(int.Parse(m.Groups[1].Value));
+        }
+        return results;
+    }
+
+    [Fact]
+    public void ToastContainer_OutranksTheTopMenuBar()
+    {
+        var headerZ = ZIndexesFor(ReadCss("PortalLayoutBase.razor.css"), "::deep.layout>header");
+        Assert.True(headerZ.Count > 0,
+            "no z-index found on '::deep.layout>header' — the portal header's layer is what every " +
+            "top-of-viewport overlay is tiered against; if it moved, this test must follow it.");
+
+        var toastZ = ZIndexesFor(ReadCss("standard-page-layout.css"), ".fluent-toast-provider");
+        Assert.True(toastZ.Count > 0,
+            "the portal declares NO z-index for '.fluent-toast-provider', so it runs on Fluent's " +
+            "default of 999 — below the header's 1100. That is exactly issue #1883: the " +
+            "download-complete toast opens at top:24px, inside the header's band, and is painted " +
+            "over by it.");
+
+        var header = headerZ.Max();
+        foreach (var toast in toastZ)
+            Assert.True(toast > header,
+                $"the toast container's z-index ({toast}) must exceed the top menu bar's ({header}); " +
+                "otherwise the header paints over a toast that opens inside its band (#1883).");
+    }
+
+    /// <summary>
+    /// The override has to actually WIN. Fluent's own rule is scoped —
+    /// <c>.fluent-toast-provider[b-…]</c>, specificity 0-2-0 — so a bare global class selector
+    /// (0-1-0) loses to it and an equal-specificity one is decided by bundle order. Dropping the
+    /// <c>!important</c> would leave a rule that reads correct and does nothing.
+    /// </summary>
+    [Fact]
+    public void ToastLayerOverride_BeatsFluentsScopedRule()
+    {
+        var css = ReadCss("standard-page-layout.css");
+        var at = css.IndexOf(".fluent-toast-provider", StringComparison.Ordinal);
+        while (at >= 0)
+        {
+            var lastOpen = css.LastIndexOf("/*", at, StringComparison.Ordinal);
+            var lastClose = css.LastIndexOf("*/", at, StringComparison.Ordinal);
+            if (lastOpen <= lastClose) break; // a rule head, not a mention inside a comment
+            at = css.IndexOf(".fluent-toast-provider", at + 1, StringComparison.Ordinal);
+        }
+        Assert.True(at >= 0, "no '.fluent-toast-provider' rule in standard-page-layout.css");
+
+        var open = css.IndexOf('{', at);
+        var close = css.IndexOf('}', open);
+        var body = css[open..close];
+
+        Assert.Matches(@"z-index\s*:\s*\d+\s*!important", body);
+    }
+
+    /// <summary>
+    /// The header carries the SAME layer in the desktop and mobile media queries. Fixing only one
+    /// would leave the bug live on the other form factor while the test above still passed.
+    /// </summary>
+    [Fact]
+    public void HeaderLayer_IsDeclaredConsistentlyAcrossBreakpoints()
+    {
+        var headerZ = ZIndexesFor(ReadCss("PortalLayoutBase.razor.css"), "::deep.layout>header");
+        Assert.Equal(2, headerZ.Count);
+        Assert.Single(headerZ.Distinct());
+    }
+}

--- a/test/MeshWeaver.Acme.Test/PortalOverlayLayeringTest.cs
+++ b/test/MeshWeaver.Acme.Test/PortalOverlayLayeringTest.cs
@@ -121,8 +121,13 @@ public class PortalOverlayLayeringTest
         }
         Assert.True(at >= 0, "no '.fluent-toast-provider' rule in standard-page-layout.css");
 
+        // Locate the rule body defensively: a malformed/reformatted stylesheet must fail with a
+        // readable assertion, not an ArgumentOutOfRangeException from the slice below.
         var open = css.IndexOf('{', at);
+        Assert.True(open > 0, "the '.fluent-toast-provider' rule has no opening brace");
         var close = css.IndexOf('}', open);
+        Assert.True(close > open, "the '.fluent-toast-provider' rule has no closing brace");
+
         var body = css[open..close];
 
         Assert.Matches(@"z-index\s*:\s*\d+\s*!important", body);


### PR DESCRIPTION
Fixes #1883.

## What users saw

Download a file from a space's Files tab and the completion toast rendered **behind** the fixed top menu bar — a sliver, or nothing. The download itself was fine.

## Cause

A plain **z-index ordering collision in the root stacking context** — not a trapped-context bug.

| | |
|---|---|
| Fluent's toast container | `position: fixed; top: 24px; right: 24px; z-index: 999` |
| Portal header | `position: relative; z-index: 1100`, top ~48px of the viewport |

`999 < 1100`, and `top: 24px` puts the toast **inside** the header's band. So the header paints over it.

Every other piece of portal chrome that has to clear that header already had an explicit layer — the chat widget, the `/model` · `/agent` pickers and the Monaco popups all sit at 10000. **The toast container was the only top-level overlay still running on a framework default.** The missing value was the whole defect.

## ⚠️ Correcting the issue's suspected cause

The issue suggests "z-index / top-offset issue between the toast container and the fixed header", which is right, and I was pointed at this repo's documented trap that the portal's `.layout` grid lives in an inline `<style>` in `MainLayout.razor`. **I checked that block and it is not involved.** `memex/Memex.Portal.Shared/Layout/MainLayout.razor`'s inline style rewrites the grid template and hides the nav column; it declares **no** `z-index`, `position`, `transform`, `filter`, `contain` or `will-change`.

I also verified no ancestor establishes a stacking context that could trap the fixed container:

- `.body-content` is deliberately `position: relative` **with no z-index** — there is a comment on it recording the last time this bug class hit, when a `z-index: 1` there trapped every chat popup so that not even `z-index: 10000` could clear the header;
- `.layout`'s `overflow: hidden` cannot clip a `position: fixed` descendant;
- the only `filter:` in the portal layout CSS is on an icon (`img.contrib-menu-icon`), not on the path.

So the toast **is** in the root stacking context. A z-index above the header is sufficient, and sufficient alone.

## Where the fix lands

In the **global** sheet (`src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css`), not in `PortalLayoutBase`'s scoped CSS — so it covers **every** `FluentToastProvider` the app mounts (the portal layout's, `MainView`'s, `AreaPage`'s) rather than only the shell that reported the bug.

`!important` is load-bearing, not cosmetic: Fluent's own rule is scoped — `.fluent-toast-provider[b-wmvy1145n8]`, specificity 0-2-0 — so a global class selector (0-1-0) loses to it outright, and an equal-specificity override would be settled by bundle order. This is the same reason the Monaco overflow widgets directly above it carry one.

The header rule (both the desktop and mobile copies) gains a cross-reference, so the two values are never re-tiered in isolation.

## Tests

`test/MeshWeaver.Acme.Test/PortalOverlayLayeringTest.cs` — 3 tests that parse the **shipped** stylesheets (linked into the test project as content, so they cannot drift from a hand-copied duplicate) and pin the **relationship**, not the literal number:

- `ToastContainer_OutranksTheTopMenuBar` — re-tiering the header without moving the overlays fails here, which a hard-coded `== 10000` would miss;
- `ToastLayerOverride_BeatsFluentsScopedRule` — dropping the `!important` leaves a rule that reads correct and does nothing;
- `HeaderLayer_IsDeclaredConsistentlyAcrossBreakpoints` — a control; fixing only the desktop copy would leave mobile broken while the first test still passed.

**Confirmed red before the fix.** With the rule removed:

```
MeshWeaver.Acme.Test.PortalOverlayLayeringTest.ToastLayerOverride_BeatsFluentsScopedRule [FAIL]
MeshWeaver.Acme.Test.PortalOverlayLayeringTest.ToastContainer_OutranksTheTopMenuBar [FAIL]
  the portal declares NO z-index for '.fluent-toast-provider', so it runs on Fluent's default
  of 999 — below the header's 1100. That is exactly issue #1883 …
Failed!  - Failed: 2, Passed: 1
```

With the fix: `Passed! - Failed: 0, Passed: 84` (whole `MeshWeaver.Acme.Test`, Release; 81 before these 3). `MeshWeaver.Documentation.Test` What's New check green. Release build with `-warnaserror`: 0 warnings, 0 errors.

**Honest limitation:** these assert the CSS contract, not the pixels. CSS ordering is necessary but not sufficient for visibility, and I verified the sufficient part (no trapping ancestor) by reading rather than by rendering. **The visual result wants a human or a Playwright run to confirm** — `LoginDialogAboveHeaderTest` is the sibling technique for exactly this bug class, but it lives in the environment-gated E2E project and does not run in the normal suite.

## Observation, not fixed here

`PortalLayoutBase.razor` mounts **two** `FluentToastProvider` instances — one at the layout root (`MaxToastCount="10"`) and one inside `.body-content` (`MaxToastCount="3" Timeout="5000"`) — both bound to the same `IToastService`. That is worth a look on its own (a single `ShowSuccess` plausibly renders in both, at the same fixed coordinates), but it is a separate question from the layering and out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)