### PR TITLE
fix(ai): read agent + model content in whatever shape it arrives (#1853)

### DIFF
--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -708,20 +708,25 @@ public static class AgentPickerProjection
     }
 
     /// <summary>
-    /// Single MeshNode → AgentDisplayInfo projection. Same Content
-    /// switch as the chat view: typed AgentConfiguration first, raw
-    /// JsonElement fallback (when the source hub didn't have
-    /// AddAITypes applied), null otherwise.
+    /// Single MeshNode → AgentDisplayInfo projection.
+    ///
+    /// <para>🚨 Reads the content through <see cref="MeshNodeContentExtensions.ContentAs{T}"/> —
+    /// NOT a <c>switch</c> over the shapes we happen to expect (#1853). This used to match a typed
+    /// <c>AgentConfiguration</c> or a <c>JsonElement</c> and return null for anything else, and a
+    /// null projection does not surface as an error: the agent simply is not in the roster. A node
+    /// written through a builder or the MCP <c>create</c> path carries the AS-WRITTEN DOM
+    /// (<c>JsonObject</c>), which is neither arm, so a freshly created agent was invisible —
+    /// <c>start_thread</c> reported it "not found among the available agents" while listing every
+    /// other agent in the same namespace. It read as a stale cache (only <c>recycle</c> healed it,
+    /// because tearing the hub down forces a re-read from storage, which returns a JsonElement) and
+    /// the cache was innocent throughout. <c>ContentAs</c> is the framework's documented answer: it
+    /// handles typed, JsonElement, JsonNode, and a same-named type from another dynamic
+    /// assembly.</para>
     /// </summary>
     public static AgentDisplayInfo? ToAgentDisplayInfo(
         MeshNode node, JsonSerializerOptions jsonOptions)
     {
-        var config = node.Content switch
-        {
-            AgentConfiguration ac => ac,
-            JsonElement je => TryDeserialise<AgentConfiguration>(je, jsonOptions),
-            _ => null,
-        };
+        var config = node.ContentAs<AgentConfiguration>(jsonOptions);
         if (config == null) return null;
         // Display metadata is sourced from the MeshNode (the single source of truth);
         // only agent-specific bits (CustomIconSvg, the config itself) come from Content.
@@ -739,19 +744,15 @@ public static class AgentPickerProjection
     }
 
     /// <summary>
-    /// Single MeshNode → ModelInfo projection. JsonElement fallback
-    /// covers the same source-hub-typed-registry-mismatch edge case
-    /// as <see cref="ToAgentDisplayInfo"/>.
+    /// Single MeshNode → ModelInfo projection. Reads content through
+    /// <see cref="MeshNodeContentExtensions.ContentAs{T}"/> for exactly the reason
+    /// <see cref="ToAgentDisplayInfo"/> does (#1853) — this carried the identical two-arm switch and
+    /// would drop a model node written as the as-written DOM the same silent way.
     /// </summary>
     public static ModelInfo? ToModelInfo(
         MeshNode node, JsonSerializerOptions jsonOptions)
     {
-        var def = node.Content switch
-        {
-            ModelDefinition md => md,
-            JsonElement je => TryDeserialise<ModelDefinition>(je, jsonOptions),
-            _ => null,
-        };
+        var def = node.ContentAs<ModelDefinition>(jsonOptions);
         // Carry the node PATH onto the ModelInfo (like ToAgentDisplayInfo does for agents) —
         // a model selection must persist the node path onto the composer's ModelName, not the
         // bare model id, so the MeshNode picker resolves it. Without this the /model selection
@@ -768,15 +769,4 @@ public static class AgentPickerProjection
             : null;
     }
 
-    private static T? TryDeserialise<T>(JsonElement je, JsonSerializerOptions jsonOptions) where T : class
-    {
-        try
-        {
-            return JsonSerializer.Deserialize<T>(je.GetRawText(), jsonOptions);
-        }
-        catch
-        {
-            return null;
-        }
-    }
 }

--- a/src/MeshWeaver.AI/AgentView.cs
+++ b/src/MeshWeaver.AI/AgentView.cs
@@ -131,21 +131,12 @@ public static class AgentView
             );
     }
 
-    /// <summary>Resolves the typed <see cref="AgentConfiguration"/> from a node's Content,
-    /// tolerating a <see cref="JsonElement"/> when the hub's registry isn't AI-typed.</summary>
+    /// <summary>Resolves the typed <see cref="AgentConfiguration"/> from a node's Content in
+    /// whatever shape it arrives — typed, JsonElement, the as-written DOM, or a same-named type
+    /// from another dynamic assembly. Was a two-arm switch that returned null for the DOM, which
+    /// renders this view as "not an agent" for an agent that is perfectly fine (#1853).</summary>
     private static AgentConfiguration? AsAgentConfiguration(MeshNode? node, JsonSerializerOptions jsonOptions)
-        => node?.Content switch
-        {
-            AgentConfiguration ac => ac,
-            JsonElement je => TryDeserialiseConfig(je, jsonOptions),
-            _ => null,
-        };
-
-    private static AgentConfiguration? TryDeserialiseConfig(JsonElement je, JsonSerializerOptions jsonOptions)
-    {
-        try { return JsonSerializer.Deserialize<AgentConfiguration>(je.GetRawText(), jsonOptions); }
-        catch { return null; }
-    }
+        => node.ContentAs<AgentConfiguration>(jsonOptions);
 
     private static UiControl BuildDetailsLayout(LayoutAreaHost host, MeshNode node, AgentConfiguration agent)
     {

--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -1006,25 +1006,15 @@ public sealed class ChatClientCredentialResolver : IDisposable
         return got ? captured : fallback;
     }
 
+    /// <summary>
+    /// Content as <typeparamref name="T"/> in whatever shape it arrives. Goes through the shared
+    /// <see cref="ObjectAsExtensions.As{T}"/> rather than a switch over the two shapes we happen to
+    /// expect (#1853): the as-written DOM (JsonObject) matched neither arm and returned null, which
+    /// here means "this provider has no credential" for a provider that is configured correctly.
+    /// This takes a bare object rather than a MeshNode, so it is As, not ContentAs.
+    /// </summary>
     private T? ExtractContent<T>(object? content) where T : class
-    {
-        return content switch
-        {
-            T typed => typed,
-            JsonElement je => TryDeserialise<T>(je),
-            _ => null,
-        };
-    }
-
-    private T? TryDeserialise<T>(JsonElement je) where T : class
-    {
-        try { return JsonSerializer.Deserialize<T>(je.GetRawText(), hub.JsonSerializerOptions); }
-        catch (Exception ex)
-        {
-            logger?.LogDebug(ex, "Failed to deserialise content as {Type}", typeof(T).Name);
-            return null;
-        }
-    }
+        => content.As<T>(hub.JsonSerializerOptions, logger);
 
     private static bool HasAnyCredential(ModelProviderConfiguration p) =>
         !string.IsNullOrEmpty(p.ApiKey) || !string.IsNullOrEmpty(p.Endpoint);

--- a/src/MeshWeaver.AI/SkillNodeType.cs
+++ b/src/MeshWeaver.AI/SkillNodeType.cs
@@ -114,12 +114,12 @@ public static class SkillNodeType
         {
             if (string.IsNullOrEmpty(node.Id)) continue;
             if (!string.Equals(node.NodeType, NodeType, StringComparison.OrdinalIgnoreCase)) continue;
-            var def = node.Content switch
-            {
-                SkillDefinition d => d,
-                JsonElement je => TryDeserialise(je, jsonOptions),
-                _ => null,
-            };
+            // 🚨 ContentAs, never a switch over the shapes we expect (#1853). A skill whose
+            // content arrives as the as-written DOM (JsonObject — what a builder or the MCP
+            // create path leaves) matched no arm and was silently skipped by the `continue`
+            // below, so a newly created Skill node was missing from the slash-command list with
+            // nothing logged. Identical defect to ToAgentDisplayInfo's, same package.
+            var def = node.ContentAs<SkillDefinition>(jsonOptions);
             if (def is null) continue;
             byId[node.Id] = new SkillInfo
             {
@@ -133,11 +133,6 @@ public static class SkillNodeType
         return byId.Values.OrderBy(s => s.Id, StringComparer.OrdinalIgnoreCase).ToList();
     }
 
-    private static SkillDefinition? TryDeserialise(JsonElement je, JsonSerializerOptions opts)
-    {
-        try { return JsonSerializer.Deserialize<SkillDefinition>(je.GetRawText(), opts); }
-        catch { return null; }
-    }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-19-a-new-agent-shows-up-right-away.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-19-a-new-agent-shows-up-right-away.md
@@ -1,0 +1,26 @@
+---
+Name: A newly created agent shows up right away
+Category: Fix
+Description: Creating an Agent node now makes it selectable immediately, instead of leaving it invisible to the agent list until the node was recycled.
+Icon: Bot
+Order: -20260819
+---
+
+# A newly created agent shows up right away
+
+Create a new agent and it is immediately available to pick and to start a thread
+with. Previously some newly created agents were simply absent from the agent list —
+starting a thread with one failed with "not found among the available agents", and
+the error helpfully listed every *other* agent sitting in the same place. Editing the
+agent did not help; only recycling the node did, which made it look like something
+was holding on to a stale list.
+
+Nothing stale was involved. The agent was being found and delivered correctly the
+whole time, then dropped at the last step: the code that turns a stored agent into a
+list entry recognised only some of the forms an agent's settings can be stored in,
+and quietly discarded the rest. Recycling the node happened to rewrite those settings
+into a form it did recognise, which is why it looked like a cache.
+
+Agents are now read in whatever form they were stored, so an agent created through
+any route — the editor, an import, the API — appears the moment it exists. The same
+correction applies to the model list, which read models the same narrow way.

--- a/test/MeshWeaver.AI.Test/AgentRosterContentShapeTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentRosterContentShapeTest.cs
@@ -101,6 +101,35 @@ public class AgentRosterContentShapeTest
     }
 
     /// <summary>
+    /// 🚨 The SKILL roster carried the identical two-arm switch in <c>SkillNodeType.ProjectSkills</c>,
+    /// where a null projection hits a bare <c>continue</c> — so a newly created Skill node written as
+    /// a DOM was silently missing from the slash-command list. This is the "skill projection cache"
+    /// staleness this bug family is known for, and it was never a cache either.
+    /// </summary>
+    [Fact]
+    public void Skill_WhoseContentIsTheAsWrittenDom_StillProjects()
+    {
+        var node = MeshNode.FromPath("rbuergi/Skill/deploy") with
+        {
+            Id = "deploy",
+            Name = "/deploy",
+            NodeType = SkillNodeType.NodeType,
+            Content = new JsonObject
+            {
+                ["id"] = "deploy",
+                ["name"] = "/deploy",
+                ["description"] = "Ship it.",
+            },
+        };
+
+        var skills = SkillNodeType.ProjectSkills([node], Options);
+
+        Assert.Single(skills);
+        Assert.Equal("deploy", skills[0].Id);
+        Assert.Equal("rbuergi/Skill/deploy", skills[0].Path);
+    }
+
+    /// <summary>
     /// The model picker's projection carries the identical two-arm switch, from the same file, and
     /// would fail the same way for a model node written as a DOM. Fixed together so the next reader
     /// does not have to rediscover it.

--- a/test/MeshWeaver.AI.Test/AgentRosterContentShapeTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentRosterContentShapeTest.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins that the agent/model roster projections read <see cref="MeshNode.Content"/> in WHATEVER
+/// shape it arrives — issue #1853.
+///
+/// <para><b>The bug.</b> <c>start_thread agentName:Voice</c> failed with "Selected agent 'Voice' was
+/// not found among the available agents" while the error's own list showed every OTHER agent in the
+/// same <c>{user}/Agent</c> namespace. It survived 20 minutes and an <c>update</c> of the node;
+/// <c>recycle</c> healed it in seconds.</para>
+///
+/// <para>That reads like a stale cache, and it is not one. The query returned the node the whole
+/// time — the PROJECTION dropped it. <c>ToAgentDisplayInfo</c> matched content against exactly two
+/// shapes, a typed <c>AgentConfiguration</c> or a <c>JsonElement</c>, with <c>_ =&gt; null</c> for
+/// everything else, and a null projection silently removes the agent from the roster. A node
+/// written through a builder or the MCP <c>create</c> path carries its content as a
+/// <c>JsonObject</c> — the as-written DOM, which is neither of those two — so it fell into the
+/// default arm. <c>recycle</c> "fixed" it only because tearing the hub down forces the node to be
+/// re-read from storage, where the content comes back as a <c>JsonElement</c>.</para>
+///
+/// <para>🚨 This is the framework's documented trap-door: <c>MeshNodeContentExtensions.ContentAs</c>
+/// says so in its own summary — "<c>node.Content is T</c> / <c>as T</c> is the trap-door and yields
+/// a silent null whenever the content arrives as untyped JSON, as the as-written DOM, or typed by a
+/// different build of the same record". The projections now go through <c>ContentAs</c>, which
+/// handles all of those.</para>
+/// </summary>
+public class AgentRosterContentShapeTest
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    private static MeshNode AgentNodeWith(object content) =>
+        MeshNode.FromPath("rbuergi/Agent/Voice") with
+        {
+            Name = "Voice",
+            NodeType = AgentNodeType.NodeType,
+            Content = content,
+        };
+
+    private static JsonObject AgentDom() => new()
+    {
+        ["id"] = "Voice",
+        ["description"] = "Speaks.",
+        ["instructions"] = "Speak.",
+    };
+
+    /// <summary>
+    /// 🚨 THE regression. A JsonObject is what a node builder / the MCP create path leaves on the
+    /// node; before the fix this projected to null and the agent vanished from the roster with
+    /// nothing logged and nothing failing.
+    /// </summary>
+    [Fact]
+    public void Agent_WhoseContentIsTheAsWrittenDom_StillProjects()
+    {
+        var info = AgentPickerProjection.ToAgentDisplayInfo(AgentNodeWith(AgentDom()), Options);
+
+        Assert.NotNull(info);
+        Assert.Equal("Voice", info!.Name);
+        Assert.Equal("rbuergi/Agent/Voice", info.Path);
+        Assert.Equal("Voice", info.AgentConfiguration.Id);
+    }
+
+    /// <summary>Control: already-typed content keeps working (the common path).</summary>
+    [Fact]
+    public void Agent_WithTypedContent_StillProjects()
+    {
+        var info = AgentPickerProjection.ToAgentDisplayInfo(
+            AgentNodeWith(new AgentConfiguration { Id = "Voice", Instructions = "Speak." }), Options);
+
+        Assert.NotNull(info);
+        Assert.Equal("Voice", info!.AgentConfiguration.Id);
+    }
+
+    /// <summary>Control: a JsonElement — the shape a node re-read from storage arrives in.</summary>
+    [Fact]
+    public void Agent_WithJsonElementContent_StillProjects()
+    {
+        using var doc = JsonDocument.Parse(AgentDom().ToJsonString());
+        var info = AgentPickerProjection.ToAgentDisplayInfo(
+            AgentNodeWith(doc.RootElement.Clone()), Options);
+
+        Assert.NotNull(info);
+        Assert.Equal("Voice", info!.AgentConfiguration.Id);
+    }
+
+    /// <summary>
+    /// Content that is genuinely not an agent must still project to null — the tolerance is about
+    /// the CARRIER shape, never about accepting the wrong payload. Without this the fix could
+    /// "pass" by making everything non-null.
+    /// </summary>
+    [Fact]
+    public void Node_WhoseContentIsNotAnAgent_StillProjectsToNull()
+    {
+        Assert.Null(AgentPickerProjection.ToAgentDisplayInfo(AgentNodeWith("just a string"), Options));
+        Assert.Null(AgentPickerProjection.ToAgentDisplayInfo(
+            MeshNode.FromPath("rbuergi/Agent/Empty") with { NodeType = AgentNodeType.NodeType }, Options));
+    }
+
+    /// <summary>
+    /// The model picker's projection carries the identical two-arm switch, from the same file, and
+    /// would fail the same way for a model node written as a DOM. Fixed together so the next reader
+    /// does not have to rediscover it.
+    /// </summary>
+    [Fact]
+    public void Model_WhoseContentIsTheAsWrittenDom_StillProjects()
+    {
+        var node = MeshNode.FromPath("Provider/OpenRouter/z-ai/glm-5.2") with
+        {
+            Name = "GLM 5.2",
+            NodeType = LanguageModelNodeType.NodeType,
+            Content = new JsonObject
+            {
+                ["id"] = "z-ai/glm-5.2",
+                ["displayName"] = "GLM 5.2",
+                ["provider"] = "OpenRouter",
+            },
+        };
+
+        var info = AgentPickerProjection.ToModelInfo(node, Options);
+
+        Assert.NotNull(info);
+        Assert.Equal("Provider/OpenRouter/z-ai/glm-5.2", info!.Path);
+        Assert.Equal("GLM 5.2", info.Label);
+    }
+}

--- a/test/MeshWeaver.AI.Test/AgentRosterLiveCreateTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentRosterLiveCreateTest.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins that an Agent node CREATED AFTER the roster is already being watched reaches that roster
+/// through the live query path — the companion to <see cref="AgentRosterContentShapeTest"/> for
+/// issue #1853.
+///
+/// <para>🚨 <b>This test PASSES against the unfixed code, deliberately.</b> It is the experiment
+/// that disproved the issue's stated diagnosis, kept as a regression pin rather than thrown away.
+/// #1853 was reported as a cache-invalidation defect — "the synced agent cache reacts to the
+/// recycle broadcast but not to node CREATE" — and that is not what was happening. A create DOES
+/// publish a change-feed event, the relevance gate DOES admit it, the query DOES re-run, and the
+/// new node IS in the snapshot. This test demonstrates all of that. The agent went missing one
+/// step later, in the projection, which <see cref="AgentRosterContentShapeTest"/> covers and which
+/// does fail against the unfixed code.</para>
+///
+/// <para>Every pre-existing agent-roster test seeds the agent BEFORE subscribing, so none of them
+/// exercises a live create at all. That gap is worth closing on its own merits: the roster stream
+/// is cached for the process lifetime (<c>MeshNodeStreamCache._queries</c>,
+/// <c>Replay(1).AutoConnect(1)</c>, evicted only on a terminal error), so if a live delta ever did
+/// stop arriving, the roster would freeze at whatever the first subscriber saw and no existing test
+/// would notice.</para>
+///
+/// <para>The agent query's distinguishing shape is a NAMESPACE ALTERNATION with no <c>path:</c>
+/// term — <c>namespace:{user}/Agent|{space}/Agent|Agent nodeType:Agent</c> — which the parser
+/// resolves to a single <c>namespace IN (…)</c> filter. Pinning the live behaviour of that
+/// particular shape is the point.</para>
+/// </summary>
+public class AgentRosterLiveCreateTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        base.ConfigureMesh(builder).AddAI();
+
+    private const string UserPath = "rbuergi";
+
+    private static MeshNode VoiceAgent() =>
+        MeshNode.FromPath($"{UserPath}/{AgentPickerProjection.AgentSubNamespace}/Voice") with
+        {
+            Name = "Voice",
+            NodeType = AgentNodeType.NodeType,
+            Content = new AgentConfiguration
+            {
+                Id = "Voice",
+                Description = "A voice agent created while the roster was already being watched.",
+                Instructions = "Speak.",
+            }
+        };
+
+    /// <summary>
+    /// Subscribe to the agent registry query, THEN create the agent, and require it to show up
+    /// without any recycle / restart. Bounded wait — a hang here is the bug, not slowness.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task AgentCreatedAfterSubscription_ReachesTheRoster_WithoutARecycle()
+    {
+        var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var query = AgentPickerProjection.BuildAgentQuery(userPath: UserPath);
+
+        // Hot + replayed so the assertion below sees every event, not just those after it attaches.
+        var roster = mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(query)).Replay();
+        using var connection = roster.Connect();
+
+        // The roster is now live and Voice is NOT in it — this is the state the portal sits in.
+        var initial = await roster.Should().Within(30.Seconds())
+            .Match(c => c.ChangeType == QueryChangeType.Initial);
+        initial.Items.Should().NotContain(n => n.Id == "Voice",
+            "the agent has not been created yet — if it is already here the test is not " +
+            "exercising a LIVE create and would pass against the broken code");
+
+        await mesh.CreateNode(VoiceAgent()).Should().Emit();
+
+        await roster.Should().Within(60.Seconds())
+            .Match(c => c.Items.Any(n => n.Path == $"{UserPath}/{AgentPickerProjection.AgentSubNamespace}/Voice"));
+    }
+
+    /// <summary>
+    /// The control: created BEFORE the subscription, the agent is in the Initial snapshot. This is
+    /// the shape every pre-existing roster test has. Kept so a future reader can see that both
+    /// orderings are covered rather than only the convenient one.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task AgentCreatedBeforeSubscription_IsInTheInitialSnapshot()
+    {
+        var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        await mesh.CreateNode(VoiceAgent()).Should().Emit();
+
+        var query = AgentPickerProjection.BuildAgentQuery(userPath: UserPath);
+        await mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(query))
+            .Should().Within(30.Seconds())
+            .Match(c => c.Items.Any(n => n.Path == $"{UserPath}/{AgentPickerProjection.AgentSubNamespace}/Voice"));
+    }
+}

--- a/test/MeshWeaver.AI.Test/AgentRosterLiveCreateTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentRosterLiveCreateTest.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using System.Reactive.Linq;
-using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,11 +33,8 @@ namespace MeshWeaver.AI.Test;
 /// resolves to a single <c>namespace IN (…)</c> filter. Pinning the live behaviour of that
 /// particular shape is the point.</para>
 /// </summary>
-public class AgentRosterLiveCreateTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+public class AgentRosterLiveCreateTest(ITestOutputHelper output) : AITestBase(output)
 {
-    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
-        base.ConfigureMesh(builder).AddAI();
-
     private const string UserPath = "rbuergi";
 
     private static MeshNode VoiceAgent() =>


### PR DESCRIPTION
Fixes #1853.

## ⚠️ Read this first — the issue's diagnosis is wrong, and it matters

The issue reports this as cache invalidation: *"the synced agent cache … reacts to the recycle broadcast but not to node CREATE"*. **It is not a cache bug, and the cache was innocent throughout.** I chased the stated diagnosis first and it does not survive contact with the code:

- **CREATE does publish a change-feed event** — `MeshExtensions.cs:838`, `WriteAndPublishCreated`.
- **The relevance gate does admit it.** The agent query is `namespace:{user}/Agent|{space}/Agent|Agent nodeType:Agent` — a namespace alternation with no `path:`. I probed all three gates on that exact shape:
  - `StorageAdapterMeshQueryProvider`: empty base path + `HasConditions` promotes the scope to `Subtree`, and `IsDescendant(x, "")` returns **true for everything**.
  - `PostgreSqlPartitionedMeshQuery.IsRelevant` (the provider that actually serves a path-less query on Postgres, via `NeedsFanOut`): admission runs through `QueryEvaluator.Matches`, which returns **`True`** for a fresh `rbuergi/Agent/Voice` node against that parsed query. Measured.
  - `PostgreSqlMeshQuery` / `SnowflakeMeshQuery` already use the namespace-aware `ShouldNotifyForQuery`.
- **The query does re-run and the node IS in the snapshot.** `AgentRosterLiveCreateTest` in this PR subscribes to the roster *first*, then creates the agent, and it goes green — **against the unfixed code**. It is committed as the record of that experiment, clearly labelled, not as the regression pin.

So a live create reaches the roster query perfectly well. The agent went missing one step later.

## The actual cause

`AgentPickerProjection.ToAgentDisplayInfo` matched content against exactly two shapes:

```csharp
var config = node.Content switch
{
    AgentConfiguration ac => ac,
    JsonElement je       => TryDeserialise<AgentConfiguration>(je, jsonOptions),
    _ => null,                       // ← everything else, silently
};
if (config == null) return null;     // ← the agent is simply not in the roster
```

A null projection is not an error. Nothing logs, nothing fails, the list just does not contain that agent — which is precisely why this survived so long and read as staleness.

A node written through a builder or the MCP `create` path carries the **as-written DOM** (`JsonObject`), which is neither arm. And `recycle` "fixed" it only because tearing the hub down forces the node to be re-read from storage, where the content comes back as a `JsonElement` — the one shape the switch did handle. That single coincidence is what made a projection bug look like a cache bug, and it explains every reported symptom: the node existed, the query returned it, every *other* agent in the same namespace listed fine, `update` (a version bump, same content shape) changed nothing, and only `recycle` healed it.

This is the framework's own documented trap-door. `MeshNodeContentExtensions.ContentAs` says so in its summary:

> **This is THE way to read a node's content as a typed instance; `node.Content is T` / `as T` is the trap-door** and yields a silent `null` whenever the content arrives as untyped JSON, as the as-written DOM, or typed by a different build of the same record.

## The fix — and the four other places carrying the same defect

Grepping for the pattern found it **five times in the same package, byte for byte**. Fixing only the agent roster would repeat the mistake that made this reachable in the first place: the namespace-relevance fix in `96ea17af2` reached one provider and left three.

| Site | What a silent null means there |
|---|---|
| `AgentPickerProjection.ToAgentDisplayInfo` | the agent is missing from the roster — **the reported bug** |
| `AgentPickerProjection.ToModelInfo` | the model is missing from the model picker |
| `SkillNodeType.ProjectSkills` | the skill is missing from the **slash-command list** |
| `AgentView.AsAgentConfiguration` | the agent details page renders as "not an agent" |
| `ChatClientCredentialResolver.ExtractContent` | "this provider has no credential", for a correctly configured provider |

🚨 **`SkillNodeType.ProjectSkills` is worth calling out.** "New Skill nodes are invisible to slash-commands until a recycle" is the prior art this bug family is known for — and on this evidence it was never a cache there either. It is the same two-arm switch, with the null landing on a bare `continue`.

All five now read through `ContentAs` (or, where the payload is a bare `object` rather than a `MeshNode`, the shared `ObjectAsExtensions.As<T>` that `ContentAs` itself delegates to). Three local `TryDeserialise` helpers are deleted — the shared path subsumes them and logs a genuinely unconvertible value loud instead of swallowing it in a bare `catch`.

Nothing here writes anything, so the re-trigger concern for a reconcile over its own subtree does not arise — this is purely a read-path shape fix.

## Tests

`test/MeshWeaver.AI.Test/AgentRosterContentShapeTest.cs` — 6 tests, **confirmed red against the unfixed code**:

```
MeshWeaver.AI.Test.AgentRosterContentShapeTest.Agent_WhoseContentIsTheAsWrittenDom_StillProjects [FAIL]
MeshWeaver.AI.Test.AgentRosterContentShapeTest.Model_WhoseContentIsTheAsWrittenDom_StillProjects [FAIL]
   Assert.NotNull() Failure: Value is null
   Assert.NotNull() Failure: Value is null
Failed!  - Failed: 2, Passed: 3
```

The skill case was verified **separately**, with only `SkillNodeType` reverted, so it pins the skill path rather than riding on the agent fix:

```
MeshWeaver.AI.Test.AgentRosterContentShapeTest.Skill_WhoseContentIsTheAsWrittenDom_StillProjects [FAIL]
Failed!  - Failed: 1, Passed: 5
```

Controls (typed content, `JsonElement` content, and **content that is genuinely not an agent still projecting to null**) pass either way — the last exists so the fix cannot "pass" by making everything non-null.

`test/MeshWeaver.AI.Test/AgentRosterLiveCreateTest.cs` — the subscribe-then-create pin described above. **It passes against main, deliberately, and says so in its doc comment.** Every pre-existing roster test seeds the agent *before* subscribing, so none exercises a live create at all; closing that gap is worth it on its own merits, since the roster stream is cached for the process lifetime (`Replay(1).AutoConnect(1)`, evicted only on a terminal error) and a genuine delta failure would freeze it unnoticed.

With the fix: **1144 passed, 0 failed, 3 skipped** (`MeshWeaver.AI.Test`, Release; the skips are pre-existing environment-gated). Release build with `-warnaserror`: 0 warnings, 0 errors.

## Separate latent bug found, deliberately NOT smuggled in here

`CosmosMeshQuery` resolves a path-less query to base `""` + `QueryScope.Children` and gates on the path-only `PathMatcher.ShouldNotify`, so `IsDirectChild("rbuergi/Agent/Voice", "")` is false — on Cosmos a namespace-only query would **never** see live creates. Same family as `96ea17af2` (which reached Postgres and Snowflake but not Cosmos), but it is **not** this bug's cause, memex does not run Cosmos, and I have no way to test a Cosmos fix here. I had it written and reverted it rather than ship an unverified change inside a bug fix. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)