### PR TITLE
A delegate_to_agent call must observe its cancellation token

### DIFF
--- a/src/MeshWeaver.AI/Plugins/DelegationTool.cs
+++ b/src/MeshWeaver.AI/Plugins/DelegationTool.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text;
 using System.Text.Json;
@@ -202,9 +203,58 @@ public static class DelegationTool
             var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             var sb = new StringBuilder();
 
+            // Everything this call HOLDS while it waits: the delegation-event subscription, the
+            // sub-thread result subscription, the sub-thread launch, and the cancellation
+            // registration below. Released by whichever terminal fires first, so a delegation that
+            // is cancelled leaves nothing subscribed to a node stream whose hub is going away.
+            var pending = new CompositeDisposable();
+
+            // Settle ONCE and release what the wait was holding. Every resolution path goes through
+            // here — a bare tcs.TrySet* would resolve the caller and leave the subscriptions live.
+            void Settle(Func<bool> set)
+            {
+                if (set()) pending.Dispose();
+            }
+
+            // 🚨 THE ROUND'S CANCELLATION MUST REACH THIS TASK. Nothing else can end the wait
+            // promptly: the reactive path gates on a Dispatched event and then on the sub-thread
+            // reaching a terminal state (backstopped only by WaitForDelegationResult's 10-MINUTE
+            // timeout), and the legacy chunk-aggregate path has no backstop at all. So a round
+            // parked in delegate_to_agent used to be UNCANCELLABLE — the Stop button did nothing,
+            // and teardown was worse:
+            //
+            // The whole round runs as a leaf on the bounded IoPoolNames.Ai pool and holds one gate
+            // permit for its entire duration. IoPool.Drain() — the join every teardown orchestrator
+            // performs before disposing the service scope and unloading collectible node ALCs —
+            // cancels the pool token and then re-acquires every permit. #1879 made the ROUND observe
+            // that token, but a round parked inside this Task never reaches the code that would
+            // notice: the parked continuation holds the permit, Drain sits out its full 30 s
+            // DrainTimeout, and teardown then proceeds over live code — the use-after-unload SIGSEGV
+            // precondition Drain exists to rule out.
+            //
+            // Observed as DelegationSubThreadUsageTest failing in TEARDOWN with "teardown DIRTY —
+            // 1 pooled I/O leaf(s) still running" after a ~32 s dispose, every assertion in the test
+            // body having passed (#1863; CI run 32271833370). That test waits on the SUB-thread's
+            // usage satellite, which RecordUsage writes as an independent side effect deliberately
+            // NOT chained before the round's terminal write — so it can legitimately finish while
+            // the PARENT round is still parked here.
+            //
+            // Cancelling (rather than resolving an "Error: …" string) is the honest terminal: it is
+            // what ThreadExecution's `catch (OperationCanceledException) when (executionCts ||
+            // poolCt)` classifies as a graceful shutdown/stop, so the round unwinds, releases its
+            // permit, and writes Status=Cancelled instead of a false #147 streaming timeout.
+            // Pinned by DelegationCancellationTest.
+            pending.Add(cancellationToken.Register(() =>
+            {
+                logger?.LogInformation(
+                    "Delegation to {AgentName} cancelled before the sub-thread finished — unwinding the tool call",
+                    agentName);
+                Settle(() => tcs.TrySetCanceled(cancellationToken));
+            }));
+
             if (delegationEvents is not null && workspace is not null)
             {
-                delegationEvents
+                pending.Add(delegationEvents
                     .Where(e => e.Phase == MeshWeaver.AI.Delegation.DelegationLifecycle.Dispatched
                              || e.Phase == MeshWeaver.AI.Delegation.DelegationLifecycle.Failed)
                     .Take(1)
@@ -218,8 +268,8 @@ public static class DelegationTool
                         {
                             logger?.LogWarning(
                                 "Delegation FAILED to start: callId={CallId} — {Error}", evt.CallId, evt.Error);
-                            tcs.TrySetResult(
-                                $"Error: delegation to {agentName} failed to start — {evt.Error}.");
+                            Settle(() => tcs.TrySetResult(
+                                $"Error: delegation to {agentName} failed to start — {evt.Error}."));
                             return;
                         }
                         var subThreadPath = evt.SubThreadPath;
@@ -246,7 +296,7 @@ public static class DelegationTool
                         // 2026-06-26 prod wedge: a stuck sub-thread init resolved as
                         // empty success while the wedged sub-hub stormed path-resolution
                         // until the portal GC-thrashed and liveness wedged).
-                        WaitForDelegationResult(
+                        pending.Add(WaitForDelegationResult(
                                 workspace.GetMeshNodeStream(subThreadPath)
                                     // ContentAs (not `Content as`): a degraded JsonElement
                                     // (unresolved $type) LOGS loud here instead of silently
@@ -264,7 +314,7 @@ public static class DelegationTool
                                     logger?.LogInformation(
                                         "Sub-thread {SubPath} resolved: result len={Len}",
                                         subThreadPath, result.Length);
-                                    tcs.TrySetResult(result);
+                                    Settle(() => tcs.TrySetResult(result));
                                 },
                                 ex =>
                                 {
@@ -274,10 +324,10 @@ public static class DelegationTool
                                     logger?.LogWarning(ex,
                                         "Sub-thread {SubPath} result stream faulted unexpectedly",
                                         subThreadPath);
-                                    tcs.TrySetResult(
-                                        $"Error: delegation to {agentName} failed — {ex.Message}.");
-                                });
-                    });
+                                    Settle(() => tcs.TrySetResult(
+                                        $"Error: delegation to {agentName} failed — {ex.Message}."));
+                                }));
+                    }));
             }
 
             // Pure Subscribe — executeAsync now returns IObservable<string> directly
@@ -294,15 +344,15 @@ public static class DelegationTool
             // for every MoveNextAsync — if that's the grain scheduler, every sub-thread
             // continuation posts back through it and wedges the grain. Hop the Subscribe
             // to ThreadPool so the entire drain runs free of the caller's context.
-            executeAsync(agentName, task, context, cancellationToken)
+            pending.Add(executeAsync(agentName, task, context, cancellationToken)
             .SubscribeOn(TaskPoolScheduler.Default)
             .Subscribe(
                 chunk => sb.Append(chunk),
                 ex =>
                 {
                     logger?.LogError(ex, "Delegation to {AgentName} failed", agentName);
-                    if (ex is OperationCanceledException) tcs.TrySetCanceled(cancellationToken);
-                    else tcs.TrySetException(ex);
+                    if (ex is OperationCanceledException) Settle(() => tcs.TrySetCanceled(cancellationToken));
+                    else Settle(() => tcs.TrySetException(ex));
                 },
                 () =>
                 {
@@ -319,13 +369,16 @@ public static class DelegationTool
                     // delegationEvents/workspace) resolves from chunks here.
                     if (delegationEvents is not null && workspace is not null)
                         return;
-                    if (tcs.TrySetResult(sb.ToString()))
+                    var aggregated = sb.ToString();
+                    Settle(() =>
                     {
+                        if (!tcs.TrySetResult(aggregated)) return false;
                         logger?.LogInformation(
                             "Delegation to {AgentName} completed via chunk-aggregate fallback (len={Len})",
-                            agentName, sb.Length);
-                    }
-                });
+                            agentName, aggregated.Length);
+                        return true;
+                    });
+                }));
 
             return tcs.Task;
         }

--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
@@ -296,6 +296,48 @@ Why this is deadlock-free, point by point: the enumerator runs on a **pool** Thr
 
 ---
 
+## 🚨 A tool call runs INSIDE the leaf — so its `Task` must observe the token
+
+The round in the previous section holds **one gate permit for its whole duration**, and a tool call
+happens *inside* that `await foreach`. So the tool's `Task<string>` is not a detail of the agent
+loop — it is the thing standing between `Drain()` and a real join.
+
+Agent tools are `Task`-returning by contract (`AIFunctionFactory` needs a Task-returning delegate),
+and the usual shape bridges an observable to it with a `TaskCompletionSource`. That bridge is the
+one sanctioned Task boundary here — but **the token that is bound into the tool's
+`CancellationToken` parameter must be able to settle it.** It is the round's token: linked to the
+user's Stop (`executionCts`) *and* to the pool token that `IoPool.Drain()` cancels.
+
+```csharp
+var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+// Everything the wait holds — subscriptions AND the cancellation registration — in one bag,
+// released by whichever terminal fires first.
+var pending = new CompositeDisposable();
+void Settle(Func<bool> set) { if (set()) pending.Dispose(); }
+
+pending.Add(cancellationToken.Register(() => Settle(() => tcs.TrySetCanceled(cancellationToken))));
+pending.Add(source.Subscribe(r => Settle(() => tcs.TrySetResult(r)), …));
+return tcs.Task;
+```
+
+**Why a timeout is not a substitute.** `delegate_to_agent` had a 10-minute backstop on one of its
+two completion paths and none on the other. Ten minutes is 20× the 30 s `DrainTimeout`, so from
+teardown's point of view a backstop that generous is indistinguishable from no exit at all: the
+parked continuation keeps its permit, `Drain()` sits out its budget, reports a leaked leaf, and the
+scope is disposed (and collectible node ALCs unloaded) over live code. The user-visible half of the
+same defect is that **Stop does nothing** — the round is parked in a Task the Stop cannot reach.
+
+Cancel rather than resolve an error string: `ThreadExecution`'s
+`catch (OperationCanceledException) when (executionCts.IsCancellationRequested || poolCt.IsCancellationRequested)`
+classifies that as the graceful shutdown/stop it is, so the round settles `Cancelled` instead of
+writing a false "#147 streaming exceeded the maximum round duration" into the user's response cell.
+
+Pinned by `DelegationCancellationTest` (unit) and `DelegationDrainJoinsParkedToolCallTest`
+(integration — a delegation that never resolves, asserting `DrainAll() == 0`), the sibling of
+`AiPoolDrainJoinsRoundTest` for a round parked on the model call.
+
+---
+
 ## Scope — storage and Postgres are pooled too
 
 Earlier guidance carved storage and Postgres out of the pool and left them on plain `Observable.FromAsync`. **That carve-out is rescinded — there is no exemption.** `FromAsync` is never tolerated (see the absolute rule above), so storage / file-system / Postgres leaves go through `IIoPool` like everything else.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-19-stopping-a-delegating-thread-works.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-19-stopping-a-delegating-thread-works.md
@@ -1,0 +1,24 @@
+---
+Name: Stopping a thread that is waiting on a delegated agent now works
+Category: Fix
+Description: Stop — and a portal restart — now end a round that had handed work to another agent, instead of leaving it waiting on a sub-agent that will never answer.
+Icon: Timer
+Order: -20260819
+---
+
+# Stopping a thread that is waiting on a delegated agent now works
+
+When an agent hands part of your request to another agent, it waits for that
+sub-agent's answer before carrying on. Until now that wait listened to nothing:
+pressing **Stop** while the delegation was in flight changed the thread's state
+but did not end the round, and neither did a portal restart. The round sat there
+holding one of the slots reserved for AI work, and let go only when the sub-agent
+happened to finish — or, if it never did, after a ten-minute backstop.
+
+Stop now ends the wait immediately. The thread settles as **Cancelled**, its AI
+slot is released, and a restart that lands mid-delegation shuts the round down
+with everything else rather than leaving it running in the background.
+
+This completes the shutdown fix shipped earlier the same day: rounds already
+stopped promptly when they were waiting on the model itself, but not when they
+were waiting on a delegated agent.

--- a/test/MeshWeaver.AI.Test/DelegationCancellationTest.cs
+++ b/test/MeshWeaver.AI.Test/DelegationCancellationTest.cs
@@ -1,0 +1,116 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Plugins;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// 🚨 A <c>delegate_to_agent</c> call MUST observe the cancellation token it is invoked with.
+///
+/// <para><b>The defect this pins (#1863).</b> The tool bridged sub-thread completion back to the
+/// parent agent loop through a <see cref="TaskCompletionSource{TResult}"/> that <b>nothing ever
+/// cancelled</b>. Its <c>cancellationToken</c> parameter was forwarded to the sub-thread launch and
+/// consulted in one error branch, but no path completed the returned <c>Task</c> when the token
+/// fired. So the only ways out were a sub-thread reaching a terminal state, a
+/// <c>Dispatched</c>/<c>Failed</c> delegation event, or
+/// <see cref="DelegationTool.WaitForDelegationResult"/>'s <b>10-minute</b> backstop — and the
+/// legacy (no delegation-events) path had no backstop at all.</para>
+///
+/// <para><b>Why that is a teardown defect, not a slow tool call.</b> The whole agent round runs as
+/// a leaf on the bounded <c>IoPoolNames.Ai</c> pool, holding one gate permit for its entire
+/// duration. <c>IoPool.Drain()</c> — the join every teardown orchestrator performs before it
+/// disposes the service scope and unloads collectible node ALCs — cancels the pool token and then
+/// re-acquires every permit. #1879 made the round itself observe that token, but a round parked
+/// inside an uncancellable tool call never reaches the code that would notice: the parked
+/// continuation holds the permit, <c>Drain</c> sits out its full 30&#160;s <c>DrainTimeout</c>, and
+/// teardown proceeds over live code — the use-after-unload SIGSEGV precondition.</para>
+///
+/// <para>Observed as <c>DelegationSubThreadUsageTest</c> failing in teardown with
+/// <c>teardown DIRTY — 1 pooled I/O leaf(s) still running</c> after a ~32&#160;006&#160;ms dispose,
+/// with every assertion in the test body having passed (CI run 32271833370, shard 5). The test
+/// waits on the SUB-thread's usage satellite, which <c>RecordUsage</c> writes as an independent
+/// side effect that is deliberately NOT chained before the round's terminal write — so the test can
+/// legitimately finish while the PARENT round is still parked in its delegation await.</para>
+///
+/// <para>The same defect makes the Stop button a lie: a user cancelling a thread that is mid
+/// delegation fires the round's <c>executionCts</c>, which reaches the tool as this same token.</para>
+/// </summary>
+public class DelegationCancellationTest
+{
+    private static readonly AgentConfiguration AgentA = new() { Id = "AgentA" };
+    private static readonly AgentConfiguration AgentB = new() { Id = "AgentB", Description = "target" };
+
+    private static AIFunction CreateTool(
+        Func<string, string, string?, CancellationToken, IObservable<string>> execute) =>
+        (AIFunction)DelegationTool.CreateUnifiedDelegationTool(
+            AgentA, [AgentA, AgentB], execute);
+
+    private static AIFunctionArguments Args() => new(new Dictionary<string, object?>
+    {
+        ["agentName"] = "AgentB",
+        ["task"] = "do work"
+    });
+
+    /// <summary>
+    /// The sub-thread never produces anything and never terminates — the shape of a delegation that
+    /// is still in flight when the round is cancelled (Stop button, hub disposal, or
+    /// <c>IoPool.Drain</c> during teardown). Cancelling the invocation token must complete the tool
+    /// call promptly.
+    ///
+    /// <para>Non-vacuity: against the unfixed <c>DelegationTool</c> this never completes, so the
+    /// bounded wait below fails with a <see cref="TimeoutException"/> instead of the
+    /// <see cref="OperationCanceledException"/> asserted here.</para>
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task ParkedDelegation_UnwindsWhenTheRoundsTokenIsCancelled()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var round = new CancellationTokenSource();
+
+        // Never emits, never completes: the sub-thread is running and has said nothing yet.
+        var tool = CreateTool((_, _, _, _) => Observable.Never<string>());
+
+        var call = tool.InvokeAsync(Args(), round.Token).AsTask();
+
+        // It must genuinely be waiting — otherwise a "prompt" completion below would prove nothing.
+        var settledEarly = await Task.WhenAny(call, Task.Delay(250, ct));
+        settledEarly.Should().NotBeSameAs(call,
+            "the delegation is still in flight — the tool call must not resolve before either the "
+            + "sub-thread finishes or the round is cancelled");
+
+        round.Cancel();
+
+        var act = async () => await call.WaitAsync(TimeSpan.FromSeconds(10), ct);
+        // WaitAsync's own failure is a TimeoutException, which is NOT an
+        // OperationCanceledException — so this assertion cannot be satisfied by the wait giving up.
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "a cancelled round must unwind its parked tool call — the round holds an Ai-pool gate "
+            + "permit for its whole duration, and IoPool.Drain() cannot join a leaf that is parked "
+            + "inside a Task nothing cancels");
+    }
+
+    /// <summary>
+    /// The happy path is untouched: a delegation that completes normally still resolves with the
+    /// aggregated sub-thread text, and the cancellation wiring does not swallow it.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task CompletedDelegation_StillReturnsItsResult()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var round = new CancellationTokenSource();
+
+        var tool = CreateTool((_, _, _, _) => Observable.Return("Hello, ").Concat(Observable.Return("world!")));
+
+        var result = await tool.InvokeAsync(Args(), round.Token).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), ct);
+
+        result?.ToString().Should().Contain("Hello, ").And.Contain("world!");
+    }
+}

--- a/test/MeshWeaver.Threading.Test/DelegationDrainJoinsParkedToolCallTest.cs
+++ b/test/MeshWeaver.Threading.Test/DelegationDrainJoinsParkedToolCallTest.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI;
+using MeshWeaver.AI.Plugins;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshThread = MeshWeaver.AI.Thread;
+
+namespace MeshWeaver.Threading.Test;
+
+/// <summary>
+/// 🚨 The sibling of <see cref="AiPoolDrainJoinsRoundTest"/> for the OTHER place a round parks:
+/// inside a <c>delegate_to_agent</c> TOOL CALL, waiting for a sub-agent.
+///
+/// <para><b>What #1879 fixed, and what it did not.</b> #1879 linked the pool's cancellation token
+/// into the round, so a round parked on the MODEL call unwinds when <c>IoPool.Drain()</c> cancels
+/// the pool. A round parked in a delegation never reaches that code: it is sitting on the
+/// <c>Task&lt;string&gt;</c> the delegation tool returned, and nothing completed that Task when the
+/// token fired. Its only exits were the sub-thread reaching a terminal state, a delegation
+/// lifecycle event, or <c>WaitForDelegationResult</c>'s <b>10-minute</b> backstop — 20× the drain
+/// budget, and the legacy path had no backstop at all.</para>
+///
+/// <para><b>Why that is a teardown defect.</b> The round holds one <c>IoPoolNames.Ai</c> gate
+/// permit for its whole duration. <c>Drain()</c> — the join every teardown orchestrator performs
+/// before disposing the service scope and unloading collectible node ALCs — cancels the pool token
+/// and then re-acquires every permit, so a parked round makes it sit out its full 30&#160;s
+/// <c>DrainTimeout</c> and then report the permit as a leaked leaf, after which teardown proceeds
+/// over live code (the use-after-unload SIGSEGV precondition). Observed as
+/// <see cref="DelegationSubThreadUsageTest"/> failing in TEARDOWN with
+/// <c>teardown DIRTY — 1 pooled I/O leaf(s) still running</c> after a ~32&#160;006&#160;ms dispose,
+/// every assertion in its body having passed (#1863; CI run 32271833370, shard 5). That test waits
+/// on the SUB-thread's usage satellite, which <c>RecordUsage</c> writes as an independent side
+/// effect deliberately NOT chained before the round's terminal write — so it can finish while the
+/// PARENT round is still parked in its delegation.</para>
+///
+/// <para><b>Deterministic by construction.</b> The delegation here NEVER resolves — the factory
+/// hands <c>DelegationTool</c> an <c>executeAsync</c> that returns <see cref="Observable.Never{T}"/>
+/// — so the only way the drain can return 0 is the round's cancellation genuinely reaching the tool
+/// call. Against the unfixed <c>DelegationTool</c> the drain blocks for its whole 30&#160;s budget
+/// and returns 1.</para>
+/// </summary>
+public class DelegationDrainJoinsParkedToolCallTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static readonly string ContextPath = "User/Roland";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IChatClientFactory, ParkedDelegationFactory>();
+                return services;
+            })
+            .AddAI()
+            .AddSampleUsers();
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddAITypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task DrainingTheAiPool_UnwindsARoundParkedInADelegation()
+    {
+        var client = GetClient();
+        var workspace = client.GetWorkspace();
+
+        var threadNode = ThreadNodeType.BuildThreadNode(ContextPath, "delegation drain", "Roland");
+        var createResp = await client.Observe(new CreateNodeRequest(threadNode),
+            o => o.WithTarget(Mesh.Address)).Should().Within(30.Seconds()).Emit();
+        createResp.Message.Success.Should().BeTrue(createResp.Message.Error ?? "");
+        var threadPath = createResp.Message.Node!.Path!;
+
+        // Warm the remote stream before submitting so the IsExecuting transition is not raced
+        // (same reason AiPoolDrainJoinsRoundTest and CancelThreadExecutionTest do it).
+        await workspace.GetMeshNodeStream(threadPath)
+            .Select(n => n.Content as MeshThread)
+            .Should().Within(10.Seconds()).Match(t => t != null);
+
+        client.SubmitMessage(threadPath, "delegate please", contextPath: ContextPath);
+
+        await workspace.GetMeshNodeStream(threadPath)
+            .Select(n => n.Content as MeshThread)
+            .Should().Within(30.Seconds())
+            .Match(t => t is { IsExecuting: true, ActiveMessageId: { Length: > 0 } });
+
+        // The tool call has genuinely been ENTERED — the round is parked inside the delegation,
+        // not merely dispatched. Without this the drain could join a leaf that never took a permit,
+        // which would pass vacuously.
+        ParkedDelegationFactory.DelegationEntered
+            .Wait(TimeSpan.FromSeconds(60), TestContext.Current.CancellationToken)
+            .Should().BeTrue("the delegation tool must be executing before the drain proves anything");
+        Output.WriteLine("Round is parked inside delegate_to_agent — draining the Ai pool.");
+
+        var registry = Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>();
+
+        // Drain on another thread: it is synchronous and, pre-fix, blocks for its full 30 s budget.
+        // Bounding the wait here turns that into a fast, legible failure instead of a 30 s stall.
+        var drain = Task.Run(registry.DrainAll, TestContext.Current.CancellationToken);
+        var finished = await Task.WhenAny(drain, Task.Delay(TimeSpan.FromSeconds(20),
+            TestContext.Current.CancellationToken));
+        finished.Should().BeSameAs(drain,
+            "Drain must join the round promptly once it cancels the pool token — if it is still "
+            + "blocked after 20 s the round is parked inside a delegation Task that nothing "
+            + "cancels, and Drain is sitting out its 30 s DrainTimeout before reporting the permit "
+            + "as leaked");
+
+        var residual = await drain;
+        residual.Should().Be(0,
+            "a delegation that observes the round's cancellation token releases the round, which "
+            + "releases its gate permit — so the join is real and teardown may unload node ALCs");
+
+        // …and it must unwind as a graceful CANCEL, never as a #147 wall-clock streaming timeout —
+        // the same classification AiPoolDrainJoinsRoundTest pins for the model-call park. A pool
+        // drain fires the round's linked timeout CTS WITHOUT executionCts, which is byte for byte
+        // the shape that used to be converted into "AI streaming exceeded the maximum round
+        // duration" and written to the user's response cell.
+        var settled = await workspace.GetMeshNodeStream(threadPath)
+            .Select(n => n.Content as MeshThread)
+            .Should().Within(30.Seconds()).Match(t => t is { IsExecuting: false });
+        settled!.Status.Should().Be(ThreadExecutionStatus.Cancelled,
+            "a round stopped by pool drain is a graceful shutdown cancel — including when it was "
+            + "waiting on a delegated agent rather than on the model");
+    }
+
+    #region A delegation that never resolves — and nothing else
+
+    /// <summary>
+    /// The real <see cref="ChatClientAgentFactory"/>, with two seams replaced: the chat client
+    /// always emits one <c>delegate_to_agent</c> call, and the delegation tool's launch observable
+    /// NEVER emits or completes. Everything between them — ThreadExecution's Ai-pool leaf,
+    /// FunctionInvokingChatClient, DelegationTool's Task bridge — is the production path.
+    /// </summary>
+    private sealed class ParkedDelegationFactory(IMessageHub hub) : ChatClientAgentFactory(hub)
+    {
+        /// <summary>Set once the delegation launch has genuinely been subscribed.</summary>
+        internal static readonly ManualResetEventSlim DelegationEntered = new(false);
+
+        public override string Name => "ParkedDelegationFactory";
+        public override IReadOnlyList<string> Models => ["parked-delegation-model"];
+        public override int Order => 0;
+
+        protected override IChatClient CreateChatClient(AgentConfiguration agentConfig)
+            => new DelegatingParentClient();
+
+        protected override IEnumerable<AITool> GetAgentTools(
+            AgentConfiguration agentConfig,
+            IAgentChat chat,
+            IReadOnlyDictionary<string, ChatClientAgent> allAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents)
+        {
+            yield return DelegationTool.CreateUnifiedDelegationTool(
+                agentConfig,
+                hierarchyAgents,
+                executeAsync: (_, _, _, _) => Observable.Create<string>(_ =>
+                {
+                    DelegationEntered.Set();
+                    // Never emits, never completes: the sub-agent is "still working" forever. The
+                    // ONLY way out is the tool observing its cancellation token.
+                    return Disposable.Empty;
+                }));
+        }
+    }
+
+    /// <summary>Turn 1 delegates; a later turn would stream a wrap-up that this test never reaches.</summary>
+    private sealed class DelegatingParentClient : IChatClient
+    {
+        private int _streamingCallCount;
+
+        public ChatClientMetadata Metadata => new("ParkedDelegationParent");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "Done")));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var callIndex = Interlocked.Increment(ref _streamingCallCount);
+            if (callIndex == 1)
+            {
+                yield return new ChatResponseUpdate(ChatRole.Assistant,
+                    [new FunctionCallContent("call1", "delegate_to_agent",
+                        new Dictionary<string, object?>
+                        {
+                            ["agentName"] = "Worker",
+                            ["task"] = "produce a quick reply"
+                        })]);
+                await Task.Yield();
+                yield break;
+            }
+
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "unreachable");
+            await Task.CompletedTask;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+        public void Dispose() { }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Fixes #1863.

`DelegationSubThreadUsageTest` was still failing on `main` today with the teardown signature #1879
was supposed to have removed — most recently CI run [32271833370](https://github.com/Systemorph/MeshWeaver/actions/runs/32271833370) (shard 5):

```
System.InvalidOperationException : DelegationSubThreadUsageTest teardown left work RUNNING:
  teardown DIRTY — 1 pooled I/O leaf(s) still running, async dispose queue drained
[16:07:02.700] === TEST END ===                     ← every assertion passed
[16:07:34.706] Mesh.Disposal completed in 32006ms   ← 30 s DrainTimeout + overhead
```

This is the second path, and it is why #1879's fix reduced the rate ~5× without eliminating it.

## It is a real defect, not a flaky assertion

`DelegationTool`'s `delegate_to_agent` bridges sub-thread completion back to the parent agent loop
through a `TaskCompletionSource` that **nothing ever cancelled**. Its `cancellationToken` parameter —
which `AIFunctionFactory` binds to the round's token, itself linked to `executionCts` **and** the Ai
pool token — was forwarded to the sub-thread launch and read in one error branch, but **no path
completed the returned `Task` when it fired**. The only exits were the sub-thread reaching a terminal
state, a `Dispatched`/`Failed` lifecycle event, or `WaitForDelegationResult`'s **10-minute** backstop;
the legacy (no delegation-events) path had no backstop at all.

So a round parked in a delegation was **uncancellable**, with two consequences:

- **Stop did nothing.** A user stopping a thread mid-delegation fires `executionCts`, which reaches
  the tool as this same token.
- **Teardown ran over live code.** The whole round is a leaf on the bounded `IoPoolNames.Ai` pool and
  holds one gate permit for its entire duration. `IoPool.Drain()` — the join every teardown
  orchestrator performs before disposing the service scope and unloading collectible node ALCs —
  cancels the pool token and then re-acquires every permit. A round parked in the tool call never
  reaches the code #1879 added, so the parked continuation keeps its permit, `Drain` sits out its
  full 30 s budget and reports a leaked leaf, and teardown proceeds anyway: the use-after-unload
  SIGSEGV precondition `Drain` exists to rule out.

Why only *that* test ever caught it: `RecordUsage` writes the sub-thread's usage satellite as an
independent side effect, deliberately not chained before the round's terminal write — so the test can
legitimately finish while the **parent** round is still parked in its delegation await.

## The fix

Register the token so it settles the TCS as a **cancellation**, and hold every subscription the wait
owns — the delegation-event subscription, the sub-thread result subscription and the launch — in one
`CompositeDisposable` released by whichever terminal fires first (so a cancelled delegation also
leaves nothing subscribed to a node stream whose hub is going away).

Cancelling rather than resolving an `"Error: …"` string is the honest terminal: it is what
`ThreadExecution`'s `catch (OperationCanceledException) when (executionCts || poolCt)` classifies as a
graceful shutdown/stop, so the round unwinds, releases its permit, and writes `Status=Cancelled`
instead of a false #147 "streaming exceeded the maximum round duration" in the user's response cell.

No budget was widened and nothing was retried.

## Measured — same machine, interleaved control/fixed, under load

`DelegationSubThreadUsageTest`, 16 busy-loop CPU hogs, `DOTNET_PROCESSOR_COUNT=2`, control and fix
**alternating within one script** so both arms see identical machine conditions:

| arm | iterations | failures |
|---|---|---|
| **control** (`origin/main`, unmodified) | 100 | **7 (7 %)** |
| **fixed** (this branch) | 100 | **0** |

Every control failure reproduces the CI signature exactly — e.g. `Mesh.Disposal completed in
32043ms — teardown DIRTY — 1 pooled I/O leaf(s) still running`.

## Non-vacuity — both pins fail against the unfixed code

- **`DelegationCancellationTest.ParkedDelegation_UnwindsWhenTheRoundsTokenIsCancelled`** (unit, no
  hub). Against unfixed `DelegationTool` the call never completes, so the bounded wait raises
  `TimeoutException` instead of the asserted `OperationCanceledException`:
  ```
  Expected a OperationCanceledException because a cancelled round must unwind its parked tool
  call …, but found TimeoutException: The operation has timed out.
  ```
- **`DelegationDrainJoinsParkedToolCallTest.DrainingTheAiPool_UnwindsARoundParkedInADelegation`**
  (integration — the real `IoPool` → `ThreadExecution` → `FunctionInvokingChatClient` →
  `DelegationTool` path, with a delegation that never resolves). Against unfixed code `DrainAll()` is
  still blocked after 20 s and the class teardown then prints the production signature verbatim:
  ```
  === TEST FAILED: Expected value to refer to the same instance because Drain must join the round
  promptly once it cancels the pool token …
  Mesh.Disposal completed in 39990ms — teardown DIRTY — 1 pooled I/O leaf(s) still running
  ```
  It is the sibling of `AiPoolDrainJoinsRoundTest`, which pins the same contract for a round parked
  on the **model** call.

Both are deterministic — no load, no sleep, no retry.

## Suites run locally

| suite | result |
|---|---|
| `MeshWeaver.AI.Test` | 1138 passed, 0 failed, 3 skipped |
| `MeshWeaver.Threading.Test` (incl. the new pin) | 135 passed, 0 failed |
| `MeshWeaver.Documentation.Test` (What's New integrity) | passed |

`dotnet build -c Release -p:CIRun=true -warnaserror` clean for `MeshWeaver.AI`,
`MeshWeaver.AI.Test`, `MeshWeaver.Threading.Test`, `MeshWeaver.Documentation`.

## Noted, not fixed here

`delegate_to_agent` is not the only agent tool that bridges an observable to a `Task<string>` through
a TCS with no cancellation link — `CollaborationPlugin`, `VersionPlugin`, `ContentCollectionPlugin`,
`PlanStorageTool` and `SkillTool` have the same shape. None of them is implicated in an observed
failure, so they are left alone rather than changed speculatively; the invariant they all need is now
written down in `ControlledIoPooling.md` ("A tool call runs INSIDE the leaf").

## What's New

`Category: Fix` — "Stopping a thread that is waiting on a delegated agent now works". User-visible:
Stop previously did not end a round parked in a delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
