### PR TITLE
Module closures were pruned by NAME, so modules lost the deps they bind to

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -300,9 +300,53 @@
     <ItemGroup>
       <_ClosureFile Include="$(_AppDir)modules/%(MeshModuleClosure.Filename)/**/*.*" />
     </ItemGroup>
+
+    <!-- 🚨 SAME IDENTITY MEANS SAME BYTES, not merely the same file NAME.
+         This condition used to be `Exists(app/<name>)` alone, which deletes the module's copy
+         whenever the app happens to ship something called the same thing — even a DIFFERENT
+         VERSION. That is not a duplicate; it is the module's dependency being removed and
+         replaced by one it does not bind to.
+
+         It broke production on 2026-08-19:
+
+             Could not load file or assembly 'Microsoft.Extensions.AI.OpenAI, Version=10.8.0.0'
+
+         The module referenced 10.8.3 directly (central package management governs DIRECT
+         references), while the app root carried 10.6.0 — which reaches the app only
+         TRANSITIVELY, so no PackageVersion lifts it. Prune (a) saw two files named
+         Microsoft.Extensions.AI.OpenAI.dll and deleted the 10.8.3 one, so every agent creation
+         through the OpenAI factory failed at bind time. Anthropic rides the same lane
+         (AzureFoundry's AzureClaude* client), so it fails identically.
+
+         Hashing is the right test rather than reading assembly versions: it is exact, it needs no
+         managed-metadata read (native and resource files go through this prune too), and two
+         copies of one NuGet package version are byte-identical by construction. A file whose
+         bytes differ is KEPT — the module then carries what it actually binds to, which is the
+         entire point of the closure lane. -->
     <ItemGroup>
-      <_ClosureAppDuplicate Include="@(_ClosureFile)" Condition="Exists('$(_AppDir)%(RecursiveDir)%(Filename)%(Extension)')" />
+      <_ClosureAppCandidate Include="@(_ClosureFile)" Condition="Exists('$(_AppDir)%(RecursiveDir)%(Filename)%(Extension)')">
+        <AppCopy>$(_AppDir)%(RecursiveDir)%(Filename)%(Extension)</AppCopy>
+      </_ClosureAppCandidate>
     </ItemGroup>
+    <GetFileHash Files="@(_ClosureAppCandidate)" Algorithm="SHA256" Condition="'@(_ClosureAppCandidate)' != ''">
+      <Output TaskParameter="Items" ItemName="_ClosureAppCandidateHashed" />
+    </GetFileHash>
+    <GetFileHash Files="@(_ClosureAppCandidate->'%(AppCopy)')" Algorithm="SHA256" Condition="'@(_ClosureAppCandidate)' != ''">
+      <Output TaskParameter="Items" ItemName="_AppRootHashed" />
+    </GetFileHash>
+    <PropertyGroup>
+      <_AppRootHashes>;@(_AppRootHashed->'%(Identity)|%(FileHash)');</_AppRootHashes>
+    </PropertyGroup>
+    <ItemGroup>
+      <_ClosureAppDuplicate Include="@(_ClosureAppCandidateHashed)"
+                            Condition="$(_AppRootHashes.Contains(';%(AppCopy)|%(FileHash);'))" />
+      <!-- Kept on purpose, and said out loud: a same-named file the app carries at a DIFFERENT
+           version is exactly the case that used to break at run time, silently, in production. -->
+      <_ClosureVersionDivergent Include="@(_ClosureAppCandidateHashed)"
+                                Condition="!$(_AppRootHashes.Contains(';%(AppCopy)|%(FileHash);'))" />
+    </ItemGroup>
+    <Message Importance="high" Condition="'@(_ClosureVersionDivergent)' != ''"
+             Text="LayoutMeshModuleClosures: KEPT %(_ClosureVersionDivergent.Filename)%(_ClosureVersionDivergent.Extension) in modules/ — the app root ships a same-named file with DIFFERENT bytes, so the module must carry the one it binds to." />
     <Delete Files="@(_ClosureAppDuplicate)" />
 
     <!-- Prune (b): shared-framework-provided assemblies. A standalone class-library publish


### PR DESCRIPTION
## Production symptom (memex.meshweaver.cloud)

```
Selected agent 'Agent/Assistant' was found, but creating it failed via factory 'OpenAI'
for model 'moonshotai/kimi-k3': Could not load file or assembly
'Microsoft.Extensions.AI.OpenAI, Version=10.8.0.0'. The system cannot find the file specified.
```

The agent was found and the pack **was loaded** — its **dependency** was gone.

## Root cause

`LayoutMeshModuleClosures`' prune (a) calls itself *"same-identity files the app publish already carries"* but tested only that a file of the same **name** exists:

```xml
Condition="Exists('$(_AppDir)%(RecursiveDir)%(Filename)%(Extension)')"
```

`MeshWeaver.AI.OpenAI` references `Microsoft.Extensions.AI.OpenAI` **10.8.3** directly — central package management governs *direct* references. The app root carries **10.6.0**, which reaches it only **transitively**, so no `PackageVersion` lifts it. The prune saw two files with one name and deleted the 10.8.3 copy, leaving the module bound to `10.8.0.0` with only 10.6.x present.

Verified inside the shipped image `rc4.ci.4513`:

```
/app/modules/MeshWeaver.AI.OpenAI/   → no Microsoft.Extensions.AI.OpenAI.dll
/app/Microsoft.Extensions.AI.OpenAI.dll  → present, 10.6.0
module deps.json → Microsoft.Extensions.AI.OpenAI/10.8.3
```

Anthropic rides the same lane (`AzureFoundry`'s `AzureClaude*` client) and fails identically.

## The fix

The prune now compares **bytes**. Hashing beats reading assembly versions: it is exact, needs no managed-metadata read (native and resource files pass through this prune too), and two copies of one NuGet package version are byte-identical by construction. A file whose bytes differ is **kept**, and the build says so.

## 🚨 This was never OpenAI-specific

A publish from current main now keeps **ten** dependencies it used to delete:

`Azure.Core`, `Azure.Identity`, `Google.Protobuf`, `Microsoft.Bcl.AsyncInterfaces`, `Microsoft.Extensions.Compliance.Abstractions`, `Microsoft.Identity.Client`, `Microsoft.Identity.Client.Extensions.Msal`, `Microsoft.IdentityModel.Abstractions`, `Newtonsoft.Json`, `OpenTelemetry.Api`

Every one was a latent `FileNotFoundException` in whichever module first touched it — which is exactly how this surfaced: not at boot, but the first time someone created an agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)