### PR TITLE
Two blockers that would have failed tomorrow's 08:00 post

### DIFF
--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -389,12 +389,49 @@ public sealed class EventSubscriptionRunner(
         var delay = subscription.FireAt!.Value - DateTimeOffset.UtcNow;
         if (delay < TimeSpan.Zero)
             delay = TimeSpan.Zero;
-        slot.Disposable = Observable.Timer(delay).Subscribe(_tick =>
-        {
-            if (timerSubs.TryRemove(subscription.Id, out var d))
-                d.Dispose();
-            Execute(subscription, subscription.SubjectId ?? "");
-        });
+        slot.Disposable = Observable.Timer(delay)
+            // 🚨 RE-READ AT FIRE TIME. The subscription captured when this timer was ARMED is a
+            // snapshot, and a timer's whole nature is that time passes between arming and firing —
+            // during which the subscription can be edited, or cancelled outright.
+            //
+            // Both failures were observed in production on 2026-08-20, on one post:
+            //   • it was CANCELLED at 05:58:53 (its post stopped being schedulable) and fired anyway
+            //     at 06:00:00.005, because cancelling writes the NODE and never touched this
+            //     already-scheduled in-memory timer; and
+            //   • it fired reporting "names no CreatedBy" while the stored node plainly had one —
+            //     an operator had set it hours after the timer armed, and the closure still held the
+            //     value from arming time.
+            // A scheduled job that ignores every edit made after it was scheduled is not a schedule,
+            // it is a recording.
+            .SelectMany(_ => AsSystem(() => hub.GetWorkspace()
+                    .GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id)))
+                .Take(1)
+                .Select(node => node?.ContentAs<EventSubscription>(hub.JsonSerializerOptions))
+                .Catch<EventSubscription?, Exception>(ex =>
+                {
+                    // Unreadable at fire time: fall back to the snapshot rather than silently skip.
+                    // A missed publish is worse than one made on slightly stale data, and the
+                    // continuation re-checks its own target anyway.
+                    logger?.LogWarning(ex,
+                        "Could not re-read subscription {Id} at fire time; using the armed snapshot",
+                        subscription.Id);
+                    return Observable.Return<EventSubscription?>(subscription);
+                }))
+            .Subscribe(current =>
+            {
+                if (timerSubs.TryRemove(subscription.Id, out var d))
+                    d.Dispose();
+
+                var live = current ?? subscription;
+                if (live.Status != EventSubscriptionStatus.Pending)
+                {
+                    logger?.LogInformation(
+                        "Timer {Id} reached its slot but the subscription is {Status} — not firing.",
+                        subscription.Id, live.Status);
+                    return;
+                }
+                Execute(live, live.SubjectId ?? "");
+            });
     }
 
     /// <summary>

--- a/src/MeshWeaver.Social/LinkedInPostsApi.cs
+++ b/src/MeshWeaver.Social/LinkedInPostsApi.cs
@@ -34,13 +34,14 @@ public static class LinkedInPostsApi
     /// LinkedIn versioned-API month header value (<c>LinkedIn-Version: YYYYMM</c>). LinkedIn pins
     /// each versioned endpoint to a month; bump this to a currently-supported version as LinkedIn
     /// rolls the window forward. Callers may override per-call.
-    /// </summary>
+    ///
     /// <para>🚨 A version LinkedIn has sunset fails every call with HTTP 426
     /// <c>NONEXISTENT_VERSION</c> — publish included. Measured against the live API on 2026-08-19:
     /// <c>202506</c> and <c>202508</c> both returned 426 "not active", while 202511 and everything
     /// from 202601 on were still served. The pin had gone stale, so every publish from the mesh was
     /// failing before it reached LinkedIn's business logic. Re-check this when a call starts
     /// returning 426; the window rolls forward roughly a year behind the current month.</para>
+    /// </summary>
     public const string DefaultApiVersion = "202606";
 
     private static readonly Uri PostsEndpoint = new("https://api.linkedin.com/rest/posts");

--- a/src/MeshWeaver.Social/LinkedInPostsApi.cs
+++ b/src/MeshWeaver.Social/LinkedInPostsApi.cs
@@ -35,7 +35,13 @@ public static class LinkedInPostsApi
     /// each versioned endpoint to a month; bump this to a currently-supported version as LinkedIn
     /// rolls the window forward. Callers may override per-call.
     /// </summary>
-    public const string DefaultApiVersion = "202506";
+    /// <para>🚨 A version LinkedIn has sunset fails every call with HTTP 426
+    /// <c>NONEXISTENT_VERSION</c> — publish included. Measured against the live API on 2026-08-19:
+    /// <c>202506</c> and <c>202508</c> both returned 426 "not active", while 202511 and everything
+    /// from 202601 on were still served. The pin had gone stale, so every publish from the mesh was
+    /// failing before it reached LinkedIn's business logic. Re-check this when a call starts
+    /// returning 426; the window rolls forward roughly a year behind the current month.</para>
+    public const string DefaultApiVersion = "202606";
 
     private static readonly Uri PostsEndpoint = new("https://api.linkedin.com/rest/posts");
     private const string SocialActionsBase = "https://api.linkedin.com/rest/socialActions/";

--- a/src/MeshWeaver.Social/ScheduledPostWatcher.cs
+++ b/src/MeshWeaver.Social/ScheduledPostWatcher.cs
@@ -64,7 +64,14 @@ public sealed class ScheduledPostWatcher(
     /// <para>Deliberately NOT capped with <c>limit:</c>: a truncated candidate set drops posts that
     /// were legitimately scheduled, and it drops them invisibly.</para>
     /// </summary>
-    private const string Query = "nodeType:*Post select:path,id,namespace,name,nodeType,content";
+    /// 🚨 <c>lastModifiedBy</c> is in the projection because the watcher READS it — it becomes the
+    /// subscription's <c>CreatedBy</c>, i.e. the identity the publish runs as. A projection that
+    /// omits it does not fail: the field is simply null, every timer is armed with no identity, and
+    /// the handler then refuses every single publish with "names no CreatedBy" — hours later, at the
+    /// slot, on a post that looked perfectly scheduled. Adding a field to this select without adding
+    /// it here is the same bug waiting to happen.
+    private const string Query =
+        "nodeType:*Post select:path,id,namespace,name,nodeType,content,lastModifiedBy";
 
     /// <summary>The timers already armed. Read as a QUERY rather than one node-stream read per post:
     /// a stream opened on a path that does not exist yet ERRORS (<c>No node found</c>), so the
@@ -74,7 +81,7 @@ public sealed class ScheduledPostWatcher(
 
     private static readonly string SubscriptionQuery =
         $"path:{EventSubscriptionNodeType.Namespace} scope:children "
-        + $"nodeType:{EventSubscriptionNodeType.NodeType} select:path,id,namespace,name,nodeType,content";
+        + $"nodeType:{EventSubscriptionNodeType.NodeType} select:path,id,namespace,name,nodeType,content,lastModifiedBy";
 
     private IDisposable? querySub;
 

--- a/src/MeshWeaver.Social/ScheduledPostWatcher.cs
+++ b/src/MeshWeaver.Social/ScheduledPostWatcher.cs
@@ -109,7 +109,23 @@ public sealed class ScheduledPostWatcher(
     private void Reconcile(IEnumerable<MeshNode> nodes, IEnumerable<MeshNode> timerNodes)
     {
         var all = nodes.ToList();
-        var posts = all.Where(IsSchedulablePost).ToList();
+        var asking = all.Where(IsSchedulablePost).ToList();
+
+        // 🚨 A post that names no author profile CANNOT publish — LinkedInPublishService refuses it
+        // with `profile-path-missing`, because the credential is chosen by the post's own authorPath.
+        // Arming a timer for one buys nothing and costs the worst failure mode there is: the calendar
+        // shows the post as scheduled, the slot passes, and NOTHING happens or is said. So they are
+        // separated out here and reported LOUDLY at every reconcile, naming the posts, because the
+        // fix (pick the profile) is a human action nobody will take if nobody is told.
+        var authorless = asking.Where(p => string.IsNullOrWhiteSpace(AuthorPathOf(p))).ToList();
+        if (authorless.Count > 0)
+            logger?.LogWarning(
+                "{Count} post(s) are marked Scheduled but name NO author profile, so they can never "
+                + "publish (the credential is chosen by authorPath). No timer is armed for them. "
+                + "Set authorPath, or reset them to Draft: {Paths}",
+                authorless.Count, string.Join(", ", authorless.Select(p => p.Path)));
+
+        var posts = asking.Where(p => !string.IsNullOrWhiteSpace(AuthorPathOf(p))).ToList();
         var timers = timerNodes
             .Select(n => n.ContentAs<EventSubscription>(hub.JsonSerializerOptions))
             .Where(s => s is { ContinuationType: EventContinuationType.PublishSocialPost })
@@ -243,6 +259,15 @@ public sealed class ScheduledPostWatcher(
         return string.IsNullOrEmpty(platform)
             || string.Equals(platform, "LinkedIn", StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// The profile this post goes out AS, or null when it names none. Reads both spellings for the
+    /// same reason <see cref="LinkedInPublishService"/> does: <c>profilePath</c> is the imported
+    /// shape and <c>authorPath</c> the node-native one, and a post naming its profile in the other
+    /// spelling must not be mistaken for one naming none.
+    /// </summary>
+    public static string? AuthorPathOf(MeshNode node) =>
+        Prop(node, "profilePath") ?? Prop(node, "authorPath");
 
     /// <summary>The post's slot as an instant, or null when it names none. A bare (unzoned) timestamp is
     /// read as UTC — every stored <c>scheduledAt</c> in the mesh is UTC, and guessing a local zone here

--- a/test/MeshWeaver.Graph.Test/EventContinuationHandlerTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventContinuationHandlerTest.cs
@@ -33,6 +33,7 @@ public class EventContinuationHandlerTest(ITestOutputHelper output) : MonolithMe
     {
         public EventContinuationType ContinuationType => EventContinuationType.PublishSocialPost;
         public string? SeenTargetPath { get; private set; }
+        public string? SeenCreatedBy { get; private set; }
         public int Calls { get; private set; }
         public string? FailWith { get; set; }
 
@@ -42,6 +43,7 @@ public class EventContinuationHandlerTest(ITestOutputHelper output) : MonolithMe
         {
             Calls++;
             SeenTargetPath = subscription.TargetPath;
+            SeenCreatedBy = subscription.CreatedBy;
             return FailWith is { } reason
                 ? Observable.Throw<MeshNode>(new InvalidOperationException(reason))
                 : Observable.Return(new MeshNode(subscription.TargetPath!));
@@ -136,6 +138,93 @@ public class EventContinuationHandlerTest(ITestOutputHelper output) : MonolithMe
         Assert.Equal(EventSubscriptionStatus.Pending, current.Status);
         Assert.True(current.FireAt > DateTimeOffset.UtcNow,
             "a repeater records its NEXT slot, or a restart replays the old one");
+    }
+
+    /// <summary>
+    /// A subscription CANCELLED between arming and its slot must not fire. Observed failing in
+    /// production on 2026-08-20: a post's timer was cancelled at 05:58:53 when the post stopped
+    /// being schedulable, and fired regardless at 06:00:00.005.
+    ///
+    /// <para>🚨 <b>This test does NOT reproduce that, and passes with or without the fix</b> —
+    /// measured, not assumed. Here the pending-set query re-emits within milliseconds of the cancel
+    /// and the runner's existing reconcile disposes the timer, so cancellation is caught by a path
+    /// that in production did not run inside the 67 seconds available. What actually protects the
+    /// deployed system is the fire-time status re-read, and the guard for THAT is
+    /// <see cref="ATimerFiresWithTheSubscriptionAsItStandsAtItsSlot"/>, which does fail without it.
+    /// This one is kept because it would catch cancellation breaking outright — not because it
+    /// covers the bug it describes.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task ATimerCancelledBeforeItsSlot_DoesNotFire()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.Timer,
+            FireAt = DateTimeOffset.UtcNow.AddSeconds(6),
+            ContinuationType = EventContinuationType.PublishSocialPost,
+            TargetPath = PostPath,
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+
+        var runner = new EventSubscriptionRunner(Mesh, changeFeed, meshService, accessService,
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        runners.Add(runner);
+        await runner.StartAsync(default);
+
+        // Cancel it while the timer is armed and still counting down.
+        await EventSubscriptionOps.SetStatus(Mesh, EventSubscriptionNodeType.Path(subscription.Id),
+            EventSubscriptionStatus.Cancelled, "no longer wanted").Should().Emit();
+
+        // Well past the slot: the handler must never have been reached.
+        await Task.Delay(12.Seconds());
+        Assert.Equal(0, handler.Calls);
+    }
+
+    /// <summary>
+    /// 🚨 A timer fires with the subscription as it stands AT ITS SLOT, not as it was when armed.
+    /// Time passing is the entire nature of a timer, and edits land in that gap: in production an
+    /// operator set CreatedBy hours after arming, and the fire still reported "names no CreatedBy"
+    /// because the closure held the value from arming time. A schedule that ignores every edit made
+    /// after it was scheduled is a recording, not a schedule.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task ATimerFiresWithTheSubscriptionAsItStandsAtItsSlot()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.Timer,
+            FireAt = DateTimeOffset.UtcNow.AddSeconds(6),
+            ContinuationType = EventContinuationType.PublishSocialPost,
+            TargetPath = PostPath,
+            CreatedBy = null,          // armed WITHOUT an identity …
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+
+        var runner = new EventSubscriptionRunner(Mesh, changeFeed, meshService, accessService,
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        runners.Add(runner);
+        await runner.StartAsync(default);
+
+        // … and given one while the timer counts down, exactly as the operator did.
+        await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Update(node => node.Content is EventSubscription s
+                ? node with { Content = s with { CreatedBy = "rbuergi" } }
+                : node)
+            .Should().Emit();
+
+        var seen = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(_ => handler.SeenCreatedBy)
+            .Where(v => v is not null)
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.Equal("rbuergi", seen);
     }
 
     private async Task<EventSubscription> ArmDueTimer()

--- a/test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs
@@ -169,8 +169,33 @@ public class ScheduledPostWatcherTest(ITestOutputHelper output) : MonolithMeshTe
         using var watcher = StartWatcher();
         var armed = await AwaitSubscription(postPath);
 
-        Assert.False(string.IsNullOrWhiteSpace(armed.CreatedBy),
-            "a timer with no CreatedBy is refused at fire time — it would have to publish as system");
+        // The identity the publish will run as. Asserted exactly, not merely "not blank".
+        //
+        // 🚨 This assertion CANNOT catch the projection bug it looks like it covers, and saying so
+        // is the point. In production the watcher's query projected no lastModifiedBy, so CreatedBy
+        // came back null and every publish was refused with "names no CreatedBy" — hours later, at
+        // the slot, on a post that looked perfectly scheduled (2026-08-19). This test passed
+        // throughout: the IN-MEMORY query provider ignores `select:` and hands back the whole node,
+        // so the projection is only real on the Postgres/Orleans path. ProjectionCarriesTheIdentity
+        // below guards the string itself, which is the only part a test here can actually hold.
+        Assert.Equal(SeededBy, armed.CreatedBy);
+    }
+
+    /// <summary>
+    /// The candidate query must PROJECT the field the watcher reads. A guard on the string, not on
+    /// behaviour — and deliberately so: the in-memory query provider ignores <c>select:</c>, so no
+    /// test in this suite can observe a missing projection. What this does catch is the change that
+    /// actually caused the outage — someone editing the select and dropping a field the code below
+    /// still reads. In production that is silent: the field is null, the timer arms with no
+    /// identity, and every publish is refused at its slot.
+    /// </summary>
+    [Fact]
+    public void ProjectionCarriesTheIdentity()
+    {
+        var query = typeof(ScheduledPostWatcher)
+            .GetField("Query", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .GetRawConstantValue() as string;
+        Assert.Contains("lastModifiedBy", query!, StringComparison.Ordinal);
     }
 
     // ---- helpers ----
@@ -185,6 +210,10 @@ public class ScheduledPostWatcherTest(ITestOutputHelper output) : MonolithMeshTe
         watcher.StartAsync(default).GetAwaiter().GetResult();
         return watcher;
     }
+
+    /// <summary>The identity the seeded posts are written by — what the watcher must carry onto the
+    /// timer as the identity the publish will run as.</summary>
+    private const string SeededBy = "Roland";
 
     private Task SeedPostAsync(
         string postPath, string status, string scheduledAt, string? publishedUrn = null)

--- a/test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs
@@ -192,9 +192,14 @@ public class ScheduledPostWatcherTest(ITestOutputHelper output) : MonolithMeshTe
     [Fact]
     public void ProjectionCarriesTheIdentity()
     {
-        var query = typeof(ScheduledPostWatcher)
-            .GetField("Query", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
-            .GetRawConstantValue() as string;
+        var field = typeof(ScheduledPostWatcher)
+            .GetField("Query", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.True(field is not null,
+            "ScheduledPostWatcher.Query (private const string) is gone or was renamed — this test reads it by "
+            + "reflection, so update the name here rather than deleting the guard: the projection dropping "
+            + "lastModifiedBy is what armed every timer with no identity.");
+        var query = field!.GetRawConstantValue() as string;
+        Assert.True(query is not null, "ScheduledPostWatcher.Query is no longer a compile-time string const.");
         Assert.Contains("lastModifiedBy", query!, StringComparison.Ordinal);
     }
 
@@ -212,8 +217,10 @@ public class ScheduledPostWatcherTest(ITestOutputHelper output) : MonolithMeshTe
     }
 
     /// <summary>The identity the seeded posts are written by — what the watcher must carry onto the
-    /// timer as the identity the publish will run as.</summary>
-    private const string SeededBy = "Roland";
+    /// timer as the identity the publish will run as. Derived from the DevLogin harness identity
+    /// rather than repeated as a literal, so it follows the login context instead of drifting from
+    /// it.</summary>
+    private static readonly string SeededBy = TestUsers.Admin.Name!;
 
     private Task SeedPostAsync(
         string postPath, string status, string scheduledAt, string? publishedUrn = null)

--- a/test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs
@@ -203,6 +203,38 @@ public class ScheduledPostWatcherTest(ITestOutputHelper output) : MonolithMeshTe
         Assert.Contains("lastModifiedBy", query!, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// 🚨 A post marked Scheduled but naming NO author profile gets no timer.
+    ///
+    /// <para>It cannot publish — the credential is chosen by the post's own <c>authorPath</c>, so
+    /// <c>LinkedInPublishService</c> refuses it with <c>profile-path-missing</c>. Arming a timer
+    /// anyway buys nothing and costs the worst failure mode available: the calendar shows the post
+    /// as scheduled, the slot passes, and nothing happens or is said. Posts/RobertHaircuts sat in
+    /// exactly that shape (Approved, no author, slot already past) — written straight onto the
+    /// content field, which is the only way to reach it, since the workflow button refuses to
+    /// approve a post with no profile.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task APostWithNoAuthorProfile_IsNotArmed()
+    {
+        var postPath = $"TestData/sched_{Guid.NewGuid():N}/post1";
+        await SeedPostAsync(postPath, status: "Scheduled",
+            scheduledAt: DateTimeOffset.UtcNow.AddHours(6).ToString("o"),
+            authorPath: null);
+
+        // A well-formed post beside it gives the watcher something it MUST arm, so this proves the
+        // authorless one was SKIPPED rather than that the watcher simply never ran.
+        var controlPath = $"TestData/sched_{Guid.NewGuid():N}/post1";
+        await SeedPostAsync(controlPath, status: "Scheduled",
+            scheduledAt: DateTimeOffset.UtcNow.AddHours(6).ToString("o"));
+
+        using var watcher = StartWatcher();
+
+        await AwaitSubscription(controlPath);   // the watcher has demonstrably done a pass
+
+        Assert.Null(await ReadSubscription(postPath));
+    }
+
     // ---- helpers ----
 
     private ScheduledPostWatcher StartWatcher()
@@ -223,16 +255,19 @@ public class ScheduledPostWatcherTest(ITestOutputHelper output) : MonolithMeshTe
     private static readonly string SeededBy = TestUsers.Admin.Name!;
 
     private Task SeedPostAsync(
-        string postPath, string status, string scheduledAt, string? publishedUrn = null)
+        string postPath, string status, string scheduledAt, string? publishedUrn = null,
+        string? authorPath = "TestData/profile")
     {
         var (id, ns) = LinkedInPublishServiceTest.SplitPath(postPath);
         var content = new Dictionary<string, object?>
         {
             ["body"] = "Scheduled body",
-            ["authorPath"] = "TestData/profile",
             ["status"] = status,
             ["scheduledAt"] = scheduledAt,
         };
+        // Omitted entirely, not set to null — an absent key is the shape a real authorless post has.
+        if (authorPath is not null)
+            content["authorPath"] = authorPath;
         if (publishedUrn is not null)
             content["publishedUrn"] = publishedUrn;
         return NodeFactory.CreateNode(new MeshNode(id, ns)


### PR DESCRIPTION
Both found by checking a **real** scheduled post rather than trusting the tests. `Posts/JobIsManageAgents` was scheduled at 19:23 for `2026-08-20T06:00Z`, its timer armed 0.19 s later — and it would have refused to publish, twice over.

## 1 · The timer had no identity

The watcher's candidate query projected `select:path,id,namespace,name,nodeType,content` — **no `lastModifiedBy`**. That is the field it reads to set `CreatedBy`, i.e. *who the publish runs as*. Missing from the projection it is simply null, so every timer armed with no identity and #1849's handler refused every publish with `"names no CreatedBy"` — hours later, at the slot, on a post that looked perfectly scheduled.

The live subscription proves it: no `createdBy` on the node.

## 2 · The LinkedIn API version is sunset

`DefaultApiVersion = "202506"`. Measured against the live API today:

| version | result |
|---|---|
| `202506` | **426** `NONEXISTENT_VERSION` — "Requested version 20250601 is not active" |
| `202508` | **426** |
| `202511`, `202601`, `202603`, `202606`, `202607`, `202608` | served (403 on the partner-only finder, i.e. the version itself is valid) |

That constant is also what the **publish** path sends, so every publish from the mesh was failing before it reached LinkedIn's business logic. Pinned to `202606` — live, with months of margin.

## 🚨 The test for (1) cannot catch (1)

`ArmedTimer_RecordsTheIdentityThatScheduledThePost` **passed throughout**. The in-memory query provider ignores `select:` and hands back the whole node, so the projection only exists on the Postgres/Orleans path — the same in-memory/real divergence that made `status:Scheduled` match everything locally and nothing in production.

Pretending it were covered would be worse than the bug, so the comment says so, and the new guard asserts the **query string** carries the field — the only part a test here can hold. It is a real guard, not a tautology: **verified to fail when the field is dropped.** It catches the change that actually caused this — someone editing the select while the code below still reads the field.

9 watcher/identity tests green; full solution builds clean under CI flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFx1SsoKDhRKHdaJbQPEWQ