### PR TITLE
The platform must carry the AI.OpenAI version it PINS, not a stale transitive one

### DIFF
--- a/src/MeshWeaver.AI/MeshWeaver.AI.csproj
+++ b/src/MeshWeaver.AI/MeshWeaver.AI.csproj
@@ -39,6 +39,15 @@
         <PackageReference Include="Microsoft.Extensions.Http" />
         <PackageReference Include="Microsoft.Extensions.AI" />
         <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+        <!-- 🚨 Referenced DIRECTLY so the app closure carries the version this repo PINS (10.8.3),
+             not the older one it would otherwise inherit transitively. Central package management
+             governs DIRECT references only, so with no reference here the app shipped 10.6.0 while
+             MeshWeaver.AI.OpenAI — which does reference it directly — resolved 10.8.3. The provider
+             pack then bound Microsoft.Extensions.AI.OpenAI 10.8.0.0 against an app that had only
+             10.6.x, and EVERY agent creation through the OpenAI factory failed at run time with
+             "Could not load file or assembly". The platform carrying its own declared version is
+             what keeps a provider pack and its host on one graph. -->
+        <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
         <PackageReference Include="Microsoft.Agents.AI" />
         <PackageReference Include="Microsoft.Agents.AI.OpenAI" />
         <PackageReference Include="Microsoft.Agents.AI.Workflows" />


### PR DESCRIPTION
## Production symptom

```
Selected agent 'Agent/Assistant' was found, but creating it failed via factory 'OpenAI'
for model 'moonshotai/kimi-k3': Could not load file or assembly
'Microsoft.Extensions.AI.OpenAI, Version=10.8.0.0'. The system cannot find the file specified.
```

## Root cause

`Directory.Packages.props` pins `Microsoft.Extensions.AI.OpenAI` at **10.8.3** — but **nothing in the platform referenced it directly**, and central package management governs *direct* references only.

So the app closure inherited **10.6.0** transitively, while `MeshWeaver.AI.OpenAI` (which does reference it directly) resolved **10.8.3**. Verified inside the shipped image:

```
/app/Microsoft.Extensions.AI.OpenAI.dll        → 10.6.0
module deps.json → Microsoft.Extensions.AI.OpenAI/10.8.3
```

The provider pack bound `10.8.0.0` against a host carrying only 10.6.x, so every agent creation through the OpenAI factory failed at run time. Anthropic rides the same lane (`AzureFoundry`'s `AzureClaude*` client).

## The fix

Reference it directly from `MeshWeaver.AI`, so the app closure carries the version this repo already declares. The pack and its host then sit on **one graph** — and that holds whether the pack ships inside the image or lands as a module, because both bind against the same assembly.

## Relationship to #1909

Different bug, same symptom. #1909 stopped the module-closure prune from deleting a module's private copy by **name** — that prevents the whole class. This removes the version **divergence** that made this instance of it possible. Both are needed: without #1909 a module can still lose a genuinely private dependency; without this, the platform ships a version its own pin contradicts.

## Note on the module lane

`module-pack` deliberately bundles the entry DLL only ("the closure is an explicit statement, never a scrape"), so landing the module does **not** work around this — the landed folder contains just `MeshWeaver.AI.OpenAI.dll` + `.pdb`, and since `ResolveModulePath` prefers landed over image, it shadowed the image copy with an equally dependency-less one. Aligning the platform is what fixes both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)