### PR TITLE
MCP: an agent can file a GitHub issue (github_issue tool)

### DIFF
--- a/src/MeshWeaver.Mcp/McpMeshPlugin.cs
+++ b/src/MeshWeaver.Mcp/McpMeshPlugin.cs
@@ -587,6 +587,185 @@ When the sync source has two-way enabled, `update` never overwrites a node chang
     }
 
     /// <summary>
+    /// Files, comments on, and mirrors GitHub <b>issues</b> for a Space — the MCP reach of
+    /// <see cref="IssueService"/>, which the browser already exposed and MCP did not.
+    ///
+    /// <para>🚨 <b>Why this exists.</b> An agent working through MCP could read and write the mesh
+    /// but had no way to report a defect anywhere a human triages. It could only leave a mesh
+    /// thread, which nothing routes. The capability was fully built (<c>IssueService</c>: create,
+    /// comment, sync) and simply unreachable from this transport.</para>
+    ///
+    /// <para>🚨 <b>The caller's OWN GitHub token is the only authority.</b> Like every other verb on
+    /// <see cref="IssueService"/>, this runs through the caller's stored OAuth credential — so it can
+    /// reach exactly the repositories that account can reach, and nothing the mesh grants widens
+    /// that. An agent whose machine account holds Triage on one repo can file there and nowhere
+    /// else. There is deliberately no system-identity path: an issue filed by "the platform" names
+    /// nobody to ask about it.</para>
+    /// </summary>
+    [McpServerTool(Title = "File, comment on, or sync GitHub issues", Destructive = false, Idempotent = false, OpenWorld = true)]
+    [Description(@"Files an issue on the Space's configured GitHub repository, comments on one, or mirrors the repo's issues into the mesh — the same issue actions the browser's GitHub tab runs.
+
+Operations (`op`):
+  • create (default) — open a NEW issue. Needs `title`; `body` is markdown; `labels` is comma-separated.
+  • comment          — add a comment to issue `number`. Needs `number` and `body`.
+  • sync             — mirror the repo's issues into `{space}/_Issue/{number}` nodes (NodeType `GitHubIssue`), then read them with the ordinary tools: `search 'nodeType:GitHubIssue namespace:{space}/_Issue'` or `get @{space}/_Issue/{number}`. `state` filters: 'open' (default), 'closed', or 'all'.
+
+Runs as YOU, through your own connected GitHub account — it can reach exactly the repositories that account can, and no mesh permission widens that. Connect the account first in the Space's GitHub Sync settings → Connect; without it this returns a 'connect your GitHub account' error. Requires the Space's `{space}/_GitSync` config to name the repository.
+
+BEFORE FILING: run `op: 'sync'` and search the mirrored issues for the same defect. A duplicate issue costs a human the triage time this tool was meant to save.")]
+    public Task<string> GitHubIssue(
+        [Description("The Space whose configured repository the issue belongs to (e.g. 'SocialMedia'). Acts on the containing top-level Space.")] string space,
+        [Description("Operation: 'create' (default), 'comment', or 'sync'.")] string op = "create",
+        [Description("Issue title — required for 'create'.")] string? title = null,
+        [Description("Markdown body: the issue text for 'create', the comment text for 'comment'.")] string? body = null,
+        [Description("Issue number — required for 'comment'.")] int number = 0,
+        [Description("Comma-separated labels to apply on 'create' (e.g. 'bug,scheduler'). Labels must already exist on the repo.")] string? labels = null,
+        [Description("For 'sync': which issues to mirror — 'open' (default), 'closed', or 'all'.")] string? state = null)
+    {
+        space = space?.Trim().Trim('/') ?? "";
+        if (space.Length == 0)
+            return Task.FromResult("Error: 'space' is required — the Space whose GitHub repository the issue belongs to.");
+        // Issues act on the containing Space (the top path segment), mirroring GitHubSync above.
+        var spacePath = space.Split('/', 2)[0];
+
+        var operation = op?.Trim().ToLowerInvariant();
+        if (operation is not ("create" or "comment" or "sync"))
+            return Task.FromResult($"Error: 'op' must be 'create', 'comment', or 'sync'; got '{op}'.");
+
+        // The GitSync feature must be installed on this host (services registered via AddGitHubSyncServices).
+        var issues = rootHub.ServiceProvider.GetService<IssueService>();
+        if (issues is null)
+            return Task.FromResult("Error: GitHub issues are not enabled on this instance (the GitSync feature is not installed).");
+
+        // Resolve the caller the way git_hub_sync does: `Context ?? CircuitContext`. An MCP call with
+        // no resolvable identity must FAIL here rather than fall through — a write that cannot name
+        // its author would otherwise be attributed to whatever ambient identity the next hop holds.
+        var accessService = rootHub.ServiceProvider.GetService<AccessService>();
+        var user = accessService?.Context ?? accessService?.CircuitContext;
+        var userId = user?.ObjectId ?? "";
+        if (accessService is null || string.IsNullOrEmpty(userId))
+            return Task.FromResult("Error: sign-in required — could not resolve your identity for the GitHub issue operation.");
+
+        // Validate per-op BEFORE the round trip, so a missing title is a sentence rather than a 422
+        // from GitHub relayed through three layers.
+        if (operation == "create" && string.IsNullOrWhiteSpace(title))
+            return Task.FromResult("Error: 'title' is required to create an issue.");
+        if (operation == "comment")
+        {
+            if (number <= 0)
+                return Task.FromResult("Error: 'number' (the issue number) is required to comment.");
+            if (string.IsNullOrWhiteSpace(body))
+                return Task.FromResult("Error: 'body' is required to comment.");
+        }
+
+        GitHubIssueState? issueState = null;
+        if (operation == "sync" && !string.IsNullOrWhiteSpace(state))
+        {
+            var wanted = state.Trim().ToLowerInvariant();
+            if (wanted == "open") issueState = GitHubIssueState.Open;
+            else if (wanted == "closed") issueState = GitHubIssueState.Closed;
+            else if (wanted != "all")
+                return Task.FromResult($"Error: 'state' must be 'open', 'closed', or 'all'; got '{state}'.");
+        }
+        else if (operation == "sync")
+        {
+            issueState = GitHubIssueState.Open;
+        }
+
+        var labelList = labels?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        // 🚨 AccessContext is an AsyncLocal wiped across hops: re-establish the caller for the call,
+        // exactly as AsCaller/git_hub_sync do. IssueService itself reads the credential at
+        // `{userId}/_Provider/GitHub`, so the switch is what makes it read the RIGHT user's token.
+        using (accessService.SwitchAccessContext(user))
+        {
+            try
+            {
+                return operation switch
+                {
+                    "create" => issues
+                        .CreateIssue(spacePath, title!, body, labelList, userId)
+                        .FirstAsync().ToTask()
+                        .ContinueWith(t => Describe(t, "created", spacePath), TaskScheduler.Default),
+                    "comment" => issues
+                        .CommentIssue(spacePath, number, body!, userId)
+                        .FirstAsync().ToTask()
+                        .ContinueWith(t => Describe(t, "commented", spacePath), TaskScheduler.Default),
+                    _ => issues
+                        .SyncIssues(spacePath, userId, issueState)
+                        .FirstAsync().ToTask()
+                        .ContinueWith(t => t.IsFaulted
+                            ? $"Error: GitHub issue sync failed for {spacePath}: {Unwrap(t.Exception)}"
+                            : JsonSerializer.Serialize(new
+                            {
+                                status = "Synced",
+                                space = spacePath,
+                                synced = t.Result,
+                                hint = $"Read them with: search 'nodeType:{IssueService.NodeType} namespace:{IssueService.IssueNamespace(spacePath)}'",
+                            }), TaskScheduler.Default),
+                };
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "MCP github_issue {Op} failed for {Space}", operation, spacePath);
+                return Task.FromResult($"Error: GitHub issue {operation} failed for {spacePath}: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Renders the outcome of a create/comment into the tool's JSON envelope, or into an
+    /// <c>Error: …</c> sentence. The issue NUMBER and URL are the two things a caller needs next
+    /// (to comment, or to hand a human a link), so both are lifted out of the node.
+    /// </summary>
+    private string Describe(Task<MeshNode> result, string verb, string spacePath)
+    {
+        if (result.IsFaulted)
+        {
+            logger.LogWarning(result.Exception, "MCP github_issue {Verb} failed for {Space}", verb, spacePath);
+            return $"Error: GitHub issue {verb.TrimEnd('d')} failed for {spacePath}: {Unwrap(result.Exception)}";
+        }
+
+        // IssueService returns the upserted MeshNode as JSON; surface number + url when readable,
+        // but never fail the call over a shape we did not expect — the issue IS filed by this point,
+        // and reporting an error for a successful write would send the caller to file it twice.
+        var nodeJson = JsonSerializer.Serialize(result.Result, rootHub.JsonSerializerOptions);
+        int? issueNumber = null;
+        string? url = null;
+        try
+        {
+            using var doc = JsonDocument.Parse(nodeJson);
+            if (doc.RootElement.TryGetProperty("content", out var content))
+            {
+                if (content.TryGetProperty("number", out var n) && n.TryGetInt32(out var parsed))
+                    issueNumber = parsed;
+                if (content.TryGetProperty("url", out var u))
+                    url = u.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            // Shape-tolerant by design: the node is authoritative, this envelope is a convenience.
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            status = verb == "created" ? "Created" : "Commented",
+            space = spacePath,
+            path = result.Result?.Path,
+            number = issueNumber,
+            url,
+        });
+    }
+
+    /// <summary>The innermost message of a faulted task — the GitHub/Octokit reason, not "One or more errors occurred".</summary>
+    private static string Unwrap(AggregateException? ex)
+    {
+        var inner = ex?.GetBaseException();
+        return inner?.Message ?? "unknown error";
+    }
+
+    /// <summary>
     /// Copies a node and all its descendants to a target namespace, preserving
     /// source ids and rewriting paths under the target.
     /// </summary>

--- a/test/MeshWeaver.GitSync.Test/FakeGitHubRepoClient.cs
+++ b/test/MeshWeaver.GitSync.Test/FakeGitHubRepoClient.cs
@@ -81,6 +81,15 @@ public sealed class FakeGitHubRepoClient : IGitHubRepoClient
         lock (_lock) return _head.TryGetValue(Key(repositoryUrl), out var t) ? t.ToList() : new List<RepoFile>();
     }
 
+    /// <summary>The issues currently on a repo, ordered by number (for test assertions).</summary>
+    public IReadOnlyList<GitHubIssue> IssuesOn(string repositoryUrl)
+    {
+        lock (_lock)
+            return _issues.TryGetValue(Key(repositoryUrl), out var m)
+                ? m.Values.OrderBy(i => i.Number).ToList()
+                : new List<GitHubIssue>();
+    }
+
     /// <summary>True when <paramref name="branch"/> exists in the repo (for test assertions).</summary>
     public bool BranchExists(string repositoryUrl, string branch)
     {

--- a/test/MeshWeaver.GitSync.Test/McpGitHubIssueToolTest.cs
+++ b/test/MeshWeaver.GitSync.Test/McpGitHubIssueToolTest.cs
@@ -1,0 +1,219 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using MeshWeaver.Hosting.AspNetCore;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mcp;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// The MCP <c>github_issue</c> tool (<see cref="McpMeshPlugin.GitHubIssue"/>) — filing, commenting on,
+/// and mirroring a Space's GitHub issues from MCP.
+///
+/// <para>🚨 <b>Why the tool exists.</b> <see cref="IssueService"/> was fully built and reachable only
+/// from the browser, so an agent working through MCP — which is how agents work here — could read and
+/// write the whole mesh but could not report a defect anywhere a human triages. It could leave a mesh
+/// thread, which nothing routes to a backlog.</para>
+///
+/// <para>These drive the real <see cref="McpMeshPlugin"/> against the in-memory
+/// <see cref="FakeGitHubRepoClient"/>, so the whole loop runs offline.</para>
+/// </summary>
+public class McpGitHubIssueToolTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    private McpMeshPlugin CreatePlugin() =>
+        new(Mesh, Options.Create(new McpConfiguration { BaseUrl = "https://test.local" }));
+
+    // The plugin reads the caller from AccessService.Context ?? CircuitContext, exactly as every write
+    // primitive does. In production UserContextMiddleware sets it per MCP request.
+    private void SignInAsAdmin()
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        access.SetHostIdentity(new AccessContext { ObjectId = UserId, Name = TestUsers.Admin.Name });
+    }
+
+    private async Task<string> SpaceWithRepo(string prefix)
+    {
+        var space = prefix + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, $"{prefix} Space");
+        var repo = $"https://github.com/test/{space.ToLowerInvariant()}";
+        await Sync.SaveConfig(space, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+        return space;
+    }
+
+    private static string Repo(string space) => $"https://github.com/test/{space.ToLowerInvariant()}";
+
+    // ── Argument validation (pure — no Space, no config, no GitHub) ─────────────────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task GitHubIssue_BlankSpace_ReturnsError()
+    {
+        var result = await CreatePlugin().GitHubIssue(space: "  ");
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("'space' is required", result);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task GitHubIssue_UnknownOp_ReturnsError()
+    {
+        var result = await CreatePlugin().GitHubIssue(space: "ACME", op: "frobnicate");
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("must be 'create', 'comment', or 'sync'", result);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task GitHubIssue_NoIdentity_ReturnsSignInError()
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        access.SetHostIdentity(null);
+        var result = await CreatePlugin().GitHubIssue(space: "ACME", title: "x");
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("sign-in required", result);
+    }
+
+    /// <summary>A missing title is answered as a sentence, not relayed as a 422 from GitHub.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task GitHubIssue_CreateWithoutTitle_ReturnsError()
+    {
+        SignInAsAdmin();
+        var result = await CreatePlugin().GitHubIssue(space: "ACME", op: "create", body: "no title");
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("'title' is required", result);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task GitHubIssue_CommentWithoutNumberOrBody_ReturnsError()
+    {
+        SignInAsAdmin();
+        var noNumber = await CreatePlugin().GitHubIssue(space: "ACME", op: "comment", body: "hi");
+        Assert.Contains("'number'", noNumber);
+
+        var noBody = await CreatePlugin().GitHubIssue(space: "ACME", op: "comment", number: 7);
+        Assert.Contains("'body' is required", noBody);
+    }
+
+    // ── 🚨 The security boundary ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 <b>Without a connected GitHub account the tool REFUSES — it never falls back to a system or
+    /// app identity.</b> This is the whole authorization model: the caller's own OAuth token decides
+    /// which repositories are reachable, so an agent can file exactly where its own account may and
+    /// nowhere else. A system-identity fallback would turn "file an issue" into "write to every
+    /// repository the platform can see", authored by nobody you could ask about it.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task GitHubIssue_WithoutAConnectedAccount_Refuses()
+    {
+        // Deliberately NO Connect() — the caller has no stored credential.
+        var space = await SpaceWithRepo("McpIssNoCred");
+        SignInAsAdmin();
+
+        var result = await CreatePlugin().GitHubIssue(space, "create", title: "should not be filed");
+
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("Connect your GitHub account", result);
+        // Nothing reached GitHub.
+        Assert.Empty(Fake.IssuesOn(Repo(space)));
+    }
+
+    // ── Create round-trip: tool → IssueService → GitHub → mesh node ─────────────────────────────
+
+    [Fact(Timeout = 120000)]
+    public async Task GitHubIssue_Create_FilesOnGitHub_AndMirrorsTheNode()
+    {
+        await Connect();
+        var space = await SpaceWithRepo("McpIssCreate");
+        SignInAsAdmin();
+
+        var raw = await CreatePlugin().GitHubIssue(
+            space, "create", title: "Scheduler fired with stale state", body: "Timer captured at arm time.");
+
+        Assert.DoesNotContain("Error:", raw);
+        using var doc = JsonDocument.Parse(raw);
+        Assert.Equal("Created", doc.RootElement.GetProperty("status").GetString());
+        var number = doc.RootElement.GetProperty("number").GetInt32();
+        Assert.True(number > 0, "the envelope must carry the issue number — it is the handle for commenting");
+
+        // It landed on GitHub…
+        var filed = Assert.Single(Fake.IssuesOn(Repo(space)));
+        Assert.Equal("Scheduler fired with stale state", filed.Title);
+
+        // …and was mirrored to the canonical node path, so the mesh can read it back.
+        var node = await WaitForNode(IssueService.IssuePath(space, number));
+        Assert.Equal(IssueService.NodeType, node.NodeType);
+    }
+
+    /// <summary>Labels pass through, so an agent can file straight into an existing triage lane.</summary>
+    [Fact(Timeout = 120000)]
+    public async Task GitHubIssue_Create_AppliesLabels()
+    {
+        await Connect();
+        var space = await SpaceWithRepo("McpIssLabels");
+        SignInAsAdmin();
+
+        var raw = await CreatePlugin().GitHubIssue(
+            space, "create", title: "Labelled", body: "b", labels: "bug, scheduler");
+
+        Assert.DoesNotContain("Error:", raw);
+        var filed = Assert.Single(Fake.IssuesOn(Repo(space)));
+        Assert.Contains("bug", filed.Labels);
+        Assert.Contains("scheduler", filed.Labels);
+    }
+
+    // ── Comment round-trip ──────────────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 120000)]
+    public async Task GitHubIssue_Comment_PostsOnTheIssue()
+    {
+        await Connect();
+        var space = await SpaceWithRepo("McpIssComment");
+        var number = Fake.SeedIssue(Repo(space), "Existing issue", "seeded");
+        SignInAsAdmin();
+
+        var raw = await CreatePlugin().GitHubIssue(space, "comment", number: number, body: "Reproduced on main.");
+
+        Assert.DoesNotContain("Error:", raw);
+        using var doc = JsonDocument.Parse(raw);
+        Assert.Equal("Commented", doc.RootElement.GetProperty("status").GetString());
+
+        var node = await WaitForIssue(IssueService.IssuePath(space, number), i => i.CommentsCount > 0);
+        Assert.Contains(node.Comments, c => c.Body == "Reproduced on main.");
+    }
+
+    // ── Sync: mirror the repo's issues so an agent can check for duplicates ─────────────────────
+
+    [Fact(Timeout = 120000)]
+    public async Task GitHubIssue_Sync_MirrorsIssuesIntoTheSpace()
+    {
+        await Connect();
+        var space = await SpaceWithRepo("McpIssSync");
+        var first = Fake.SeedIssue(Repo(space), "First", "a");
+        var second = Fake.SeedIssue(Repo(space), "Second", "b");
+        SignInAsAdmin();
+
+        var raw = await CreatePlugin().GitHubIssue(space, "sync");
+
+        Assert.DoesNotContain("Error:", raw);
+        using var doc = JsonDocument.Parse(raw);
+        Assert.Equal("Synced", doc.RootElement.GetProperty("status").GetString());
+        Assert.Equal(2, doc.RootElement.GetProperty("synced").GetInt32());
+
+        await WaitForNode(IssueService.IssuePath(space, first));
+        await WaitForNode(IssueService.IssuePath(space, second));
+    }
+
+    /// <summary>An unknown state value is refused rather than silently treated as 'open'.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task GitHubIssue_Sync_RejectsAnUnknownState()
+    {
+        SignInAsAdmin();
+        var result = await CreatePlugin().GitHubIssue(space: "ACME", op: "sync", state: "halfopen");
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("must be 'open', 'closed', or 'all'", result);
+    }
+}


### PR DESCRIPTION
## The gap

Carson reports defects by leaving a **mesh thread**, because that is the only thing it can reach. Nothing routes a thread to a backlog, so a real finding lands somewhere nobody triages.

`IssueService` already had create / comment / sync, wired to the browser's GitHub tab. MCP exposed `git_hub_sync` and nothing else. **This is a transport gap, not a feature** — one tool over a service that already existed.

## The tool

`github_issue(space, op, title, body, number, labels, state)`

| op | what |
|---|---|
| `create` (default) | open an issue — `title`, markdown `body`, comma-separated `labels` |
| `comment` | comment on issue `number` |
| `sync` | mirror the repo's issues to `{space}/_Issue/{number}` so an agent can **search for a duplicate before filing one**, using the ordinary `search`/`get` tools |

The tool description tells the caller to `sync` and check before filing — a duplicate issue costs a human exactly the triage time this was meant to save.

## 🚨 The caller's own GitHub token is the only authority

Like every other verb on `IssueService`, this runs through the caller's stored OAuth credential (`{userId}/_Provider/GitHub`). It reaches exactly the repositories that account reaches, and no mesh grant widens it — a machine account holding Triage on one repo can file there and nowhere else.

There is deliberately **no system-identity path**. An issue filed by "the platform" names nobody you could ask about it, and such a fallback would turn *file an issue* into *write to every repository the platform can see*. `AccessContext` is re-established at the call (`SwitchAccessContext`) so `IssueService` reads the **right** user's token — the same `AsyncLocal` hazard `AsCaller` and `git_hub_sync` already handle.

## Both guards are mutation-tested, not assumed

| mutation applied | test that went red |
|---|---|
| drop the label parse | `GitHubIssue_Create_AppliesLabels` |
| fall back to `system-security` when no caller resolves | `GitHubIssue_NoIdentity_ReturnsSignInError` |

Verified by making each change and watching the named test fail, then reverting.

## Tests

11 new, driving the real `McpMeshPlugin` against the in-memory `FakeGitHubRepoClient` (whole loop offline): argument validation, the no-connected-account refusal, create → GitHub + mirrored node, labels, comment, and sync. **192/192 in `MeshWeaver.GitSync.Test`.**

Also adds `FakeGitHubRepoClient.IssuesOn(repo)` — the fake could seed and serve issues but had no accessor to assert on them, mirroring the existing `Tree(repo)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)