### PR TITLE
Module bundles carry their own dependency closure, derived from deps.json

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -77,9 +77,14 @@ jobs:
           echo "packing $MODULE as $PACKAGE@$version, platform floor $floor"
 
       - name: Build the module (Release, warnings-as-errors)
+        # CopyLocalLockFileAssemblies puts the module's PACKAGE dependencies into the output
+        # folder, where the pack step's --deps-closure derivation expects to find them — a module
+        # bundle must carry its own private closure (the platform does not: those packages left
+        # /app with the module's source, and an entry-DLL-only bundle faults at first use).
         run: >
           dotnet build "${{ matrix.entry.project }}" -c Release -warnaserror
           -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver
+          -p:CopyLocalLockFileAssemblies=true
           -p:Version=${{ steps.identity.outputs.version }}
 
       - name: Run the module's tests, when it ships any
@@ -106,6 +111,7 @@ jobs:
         run: >
           dotnet run --project meshweaver/src/MeshWeaver.Plugin.Build -c Release --no-build --
           module-pack "$GITHUB_WORKSPACE/$(dirname "$PROJECT")/bin/Release/net10.0"
+          --deps-closure
           --module-name "${{ matrix.entry.module }}"
           --plugin "${{ matrix.entry.package }}"
           --package-version "${{ steps.identity.outputs.version }}"
@@ -135,6 +141,14 @@ jobs:
             || { echo "::error::manifest module.assemblies misses the entry DLL"; exit 1; }
           jq -e --arg f "$FLOOR" '.module.minMeshVersion == $f' "$manifest" > /dev/null \
             || { echo "::error::manifest floor differs from content.minMeshVersion"; exit 1; }
+          # A module bundle must NEVER carry a platform assembly beside its entry — it would
+          # shadow the platform's own binary at the consumer (the same trap-door landing refuses
+          # for the entry DLL). The deps-closure derivation excludes MeshWeaver.* by construction;
+          # this asserts that from the outside.
+          jq -e --arg m "$MODULE" \
+            '[.module.assemblies[] | select(startswith("MeshWeaver.") and (. != $m + ".dll") and (. != $m + ".pdb"))] | length == 0' \
+            "$manifest" > /dev/null \
+            || { echo "::error::bundle carries platform (MeshWeaver.*) assemblies beside the module"; exit 1; }
           echo "path=$bundle" >> "$GITHUB_OUTPUT"
           echo "bundle OK:"; jq . "$manifest"
 

--- a/src/MeshWeaver.Plugin.Build/DepsClosure.cs
+++ b/src/MeshWeaver.Plugin.Build/DepsClosure.cs
@@ -15,23 +15,23 @@ namespace MeshWeaver.Plugin.Build;
 /// Graph/Kiota to deployments that send no mail — the exact cost the module split exists to avoid.
 /// The bundle must carry the module's OWN dependencies, derived, not remembered.</para>
 ///
-/// <para><b>The rule.</b> The deps.json target graph is walked twice from the module's direct
-/// dependencies:</para>
-/// <list type="bullet">
-/// <item><b>Platform-reachable</b>: everything transitively reachable from the module's
-/// MeshWeaver.* references (project references to the framework checkout, or MeshWeaver.*
-/// packages). Those assemblies ship in the consumer's <c>/app</c> by construction — bundling them
-/// would ship the platform inside the module, and the default load context resolves the app's copy
-/// first anyway.</item>
-/// <item><b>Own</b>: everything transitively reachable from the module's NON-MeshWeaver package
-/// references, MINUS the platform-reachable set. These are exactly the assemblies present nowhere
-/// but beside the module — the private closure the bundle must carry.</item>
-/// </list>
+/// <para><b>The rule.</b> The bundle carries the transitive closure of the module's OWN package
+/// references — walked over the deps.json graph, stopping at (and never bundling) MeshWeaver.*
+/// nodes: those are the platform, they ship in the consumer's <c>/app</c> by construction, and
+/// landing one beside the module would shadow the platform's own binary.</para>
+///
+/// <para><b>A diamond RIDES — deliberately.</b> A package reachable from the module's own
+/// references AND from its MeshWeaver.* references (Azure.Identity, Microsoft.Extensions.Options)
+/// is bundled anyway: the default load context resolves <c>/app</c>'s copy first whenever the
+/// platform carries one (same behaviour as today, at the cost of bundle bytes), and the module's
+/// copy takes over the moment the platform stops carrying it. Excluding diamonds instead would
+/// couple every landed bundle to the platform's transitive dependency whims — shedding a
+/// dependency from the platform (the very point of the module split) would silently break every
+/// landed module that relied on it until re-packed. Versions agree while both carry one, because
+/// platform and modules restore from the same central package pins.</para>
 ///
 /// <para>Shared-framework assemblies (<c>FrameworkReference</c>) never appear as package nodes in
-/// deps.json, so they are excluded by construction. A diamond (a package reachable from both
-/// sides) is platform-carried and excluded — the versions agree because platform and modules
-/// restore from the same central package pins.</para>
+/// deps.json, so they are excluded by construction.</para>
 ///
 /// <para>Pure text-in/data-out so the derivation is unit-testable with no build output on disk;
 /// <see cref="ModulePackCommand"/> resolves the derived file names against the module folder and
@@ -41,8 +41,9 @@ namespace MeshWeaver.Plugin.Build;
 public static class DepsClosure
 {
     /// <summary>The derived closure: runtime file names to bundle beside the entry DLL, plus the
-    /// platform-carried names excluded (diagnostic — printed so a pack log shows the split), plus
-    /// warnings for nodes with native <c>runtimeTargets</c> the bundle does not carry.</summary>
+    /// MeshWeaver.* nodes the walk stopped at (diagnostic — printed so a pack log shows the
+    /// split), plus warnings for nodes with native <c>runtimeTargets</c> the bundle does not
+    /// carry.</summary>
     public sealed record Result(
         IReadOnlyList<string> Files,
         IReadOnlyList<string> ExcludedPlatformCarried,
@@ -119,36 +120,26 @@ public static class DepsClosure
                 $"deps.json carries no node for '{moduleName}' — wrong file, or the module was "
                 + "renamed after the build");
 
-        // The split at the module's DIRECT references. A MeshWeaver.* reference — project or
-        // package — roots the platform side; everything else roots the module's own side.
-        var platformRoots = module.Dependencies.Where(IsPlatform).ToList();
+        // The walk from the module's OWN direct references — MeshWeaver.* references root the
+        // platform side and are not walked: their transitives are /app's business, and dragging
+        // them in would ship the platform inside the module.
         var ownRoots = module.Dependencies.Where(d => !IsPlatform(d)).ToList();
-
-        var platformReachable = Reach(nodes, platformRoots);
-        var ownReachable = Reach(nodes, ownRoots);
+        var (ownReachable, platformStops) = ReachStoppingAtPlatform(nodes, ownRoots);
+        platformStops.UnionWith(module.Dependencies.Where(IsPlatform));
 
         var files = new List<string>();
-        var excluded = new List<string>();
         var warnings = new List<string>();
         foreach (var name in ownReachable.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
         {
             if (!nodes.TryGetValue(name, out var node) || node.RuntimeFiles.Count == 0)
                 continue;
-            // Safety net: a MeshWeaver.* assembly must never ride in a module bundle, whatever
-            // path reached it — landing beside the module would shadow the platform's own binary.
-            if (IsPlatform(name))
-                continue;
-            if (platformReachable.Contains(name))
-            {
-                excluded.Add(name);
-                continue;
-            }
             files.AddRange(node.RuntimeFiles);
             if (node.HasNativeAssets)
                 warnings.Add(
                     $"'{name}' declares native runtimeTargets the bundle does not carry — "
                     + "if the module needs them at runtime, they must ship another way");
         }
+        var excluded = platformStops.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
 
         return new Result(
             files.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
@@ -161,22 +152,30 @@ public static class DepsClosure
         || string.Equals(name, "MeshWeaver", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Transitive reachability over the dependency edges, from <paramref name="roots"/>
-    /// inclusive. Missing nodes (framework-supplied names deps.json lists as dependencies but
-    /// carries no entry for) are simply absent — nothing to bundle, nothing to walk.</summary>
-    private static HashSet<string> Reach(
+    /// inclusive — STOPPING at MeshWeaver.* nodes (collected separately, never walked: their
+    /// transitives are the platform's). Missing nodes (framework-supplied names deps.json lists as
+    /// dependencies but carries no entry for) are simply absent — nothing to bundle, nothing to
+    /// walk.</summary>
+    private static (HashSet<string> Reached, HashSet<string> PlatformStops) ReachStoppingAtPlatform(
         IReadOnlyDictionary<string, Node> nodes, IEnumerable<string> roots)
     {
         var reached = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var stops = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var queue = new Queue<string>(roots);
         while (queue.Count > 0)
         {
             var name = queue.Dequeue();
+            if (IsPlatform(name))
+            {
+                stops.Add(name);
+                continue;
+            }
             if (!reached.Add(name) || !nodes.TryGetValue(name, out var node))
                 continue;
             foreach (var dependency in node.Dependencies)
                 queue.Enqueue(dependency);
         }
-        return reached;
+        return (reached, stops);
     }
 
     /// <summary>"Name/version" → "Name" (deps.json keys carry the resolved version).</summary>

--- a/src/MeshWeaver.Plugin.Build/DepsClosure.cs
+++ b/src/MeshWeaver.Plugin.Build/DepsClosure.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+
+namespace MeshWeaver.Plugin.Build;
+
+/// <summary>
+/// Derives a module's PRIVATE dependency closure from its own <c>&lt;Module&gt;.deps.json</c> —
+/// the assemblies the module needs at runtime that the PLATFORM does not carry.
+///
+/// <para><b>Why this exists.</b> When a module's source left the platform repo (#1882), its
+/// package dependencies left the app closure with it — and the bundle lane packed the entry DLL
+/// alone, so every landed module faulted at first use on whichever private dependency boot touched
+/// first (<c>Microsoft.Extensions.AI.OpenAI</c> on chat, <c>Microsoft.Graph</c> at host start,
+/// 2026-08-19/20 memex outage). Hand-naming each dependency with <c>--with</c> is whack-a-mole
+/// across 12 modules; pinning the dependency into the platform instead (#1912) ships 43 MB of
+/// Graph/Kiota to deployments that send no mail — the exact cost the module split exists to avoid.
+/// The bundle must carry the module's OWN dependencies, derived, not remembered.</para>
+///
+/// <para><b>The rule.</b> The deps.json target graph is walked twice from the module's direct
+/// dependencies:</para>
+/// <list type="bullet">
+/// <item><b>Platform-reachable</b>: everything transitively reachable from the module's
+/// MeshWeaver.* references (project references to the framework checkout, or MeshWeaver.*
+/// packages). Those assemblies ship in the consumer's <c>/app</c> by construction — bundling them
+/// would ship the platform inside the module, and the default load context resolves the app's copy
+/// first anyway.</item>
+/// <item><b>Own</b>: everything transitively reachable from the module's NON-MeshWeaver package
+/// references, MINUS the platform-reachable set. These are exactly the assemblies present nowhere
+/// but beside the module — the private closure the bundle must carry.</item>
+/// </list>
+///
+/// <para>Shared-framework assemblies (<c>FrameworkReference</c>) never appear as package nodes in
+/// deps.json, so they are excluded by construction. A diamond (a package reachable from both
+/// sides) is platform-carried and excluded — the versions agree because platform and modules
+/// restore from the same central package pins.</para>
+///
+/// <para>Pure text-in/data-out so the derivation is unit-testable with no build output on disk;
+/// <see cref="ModulePackCommand"/> resolves the derived file names against the module folder and
+/// refuses a missing file (the build must run with <c>CopyLocalLockFileAssemblies=true</c> for the
+/// package assemblies to be present).</para>
+/// </summary>
+public static class DepsClosure
+{
+    /// <summary>The derived closure: runtime file names to bundle beside the entry DLL, plus the
+    /// platform-carried names excluded (diagnostic — printed so a pack log shows the split), plus
+    /// warnings for nodes with native <c>runtimeTargets</c> the bundle does not carry.</summary>
+    public sealed record Result(
+        IReadOnlyList<string> Files,
+        IReadOnlyList<string> ExcludedPlatformCarried,
+        IReadOnlyList<string> Warnings);
+
+    private sealed record Node(
+        string Name,
+        List<string> Dependencies,
+        List<string> RuntimeFiles,
+        bool HasNativeAssets,
+        string? LibraryType);
+
+    /// <summary>
+    /// Derives the private closure from the deps.json text of <paramref name="moduleName"/>.
+    /// Throws <see cref="InvalidDataException"/> on a deps.json that lacks the module's own node —
+    /// a derivation from the wrong file must be a refusal, never an empty closure that packs a
+    /// module which faults at first use.
+    /// </summary>
+    public static Result Derive(string depsJsonText, string moduleName)
+    {
+        using var document = JsonDocument.Parse(depsJsonText);
+        var root = document.RootElement;
+
+        // The target section: prefer the runtimeTarget's own name (present in every SDK-emitted
+        // deps.json), else the first target — never a RID-agnostic guess.
+        string? targetName = null;
+        if (root.TryGetProperty("runtimeTarget", out var runtimeTarget)
+            && runtimeTarget.TryGetProperty("name", out var rtName))
+            targetName = rtName.GetString();
+        if (!root.TryGetProperty("targets", out var targets))
+            throw new InvalidDataException("deps.json has no 'targets' section");
+        JsonElement target = default;
+        var found = false;
+        foreach (var candidate in targets.EnumerateObject())
+        {
+            if (targetName is null || candidate.Name == targetName)
+            {
+                target = candidate.Value;
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            throw new InvalidDataException(
+                $"deps.json target '{targetName}' not found among its targets");
+
+        // libraries: name/version -> { type: package|project|... } — the node kind.
+        var libraryTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (root.TryGetProperty("libraries", out var libraries))
+            foreach (var lib in libraries.EnumerateObject())
+                if (lib.Value.TryGetProperty("type", out var type))
+                    libraryTypes[NameOf(lib.Name)] = type.GetString() ?? "";
+
+        var nodes = new Dictionary<string, Node>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in target.EnumerateObject())
+        {
+            var name = NameOf(entry.Name);
+            var dependencies = new List<string>();
+            if (entry.Value.TryGetProperty("dependencies", out var deps))
+                dependencies.AddRange(deps.EnumerateObject().Select(d => d.Name));
+            var runtimeFiles = new List<string>();
+            if (entry.Value.TryGetProperty("runtime", out var runtime))
+                runtimeFiles.AddRange(runtime.EnumerateObject()
+                    .Select(r => Path.GetFileName(r.Name.Replace('\\', '/')))
+                    .Where(f => f.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)));
+            var hasNative = entry.Value.TryGetProperty("runtimeTargets", out var rts)
+                            && rts.EnumerateObject().Any();
+            nodes[name] = new Node(name, dependencies, runtimeFiles, hasNative,
+                libraryTypes.GetValueOrDefault(name));
+        }
+
+        if (!nodes.TryGetValue(moduleName, out var module))
+            throw new InvalidDataException(
+                $"deps.json carries no node for '{moduleName}' — wrong file, or the module was "
+                + "renamed after the build");
+
+        // The split at the module's DIRECT references. A MeshWeaver.* reference — project or
+        // package — roots the platform side; everything else roots the module's own side.
+        var platformRoots = module.Dependencies.Where(IsPlatform).ToList();
+        var ownRoots = module.Dependencies.Where(d => !IsPlatform(d)).ToList();
+
+        var platformReachable = Reach(nodes, platformRoots);
+        var ownReachable = Reach(nodes, ownRoots);
+
+        var files = new List<string>();
+        var excluded = new List<string>();
+        var warnings = new List<string>();
+        foreach (var name in ownReachable.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
+        {
+            if (!nodes.TryGetValue(name, out var node) || node.RuntimeFiles.Count == 0)
+                continue;
+            // Safety net: a MeshWeaver.* assembly must never ride in a module bundle, whatever
+            // path reached it — landing beside the module would shadow the platform's own binary.
+            if (IsPlatform(name))
+                continue;
+            if (platformReachable.Contains(name))
+            {
+                excluded.Add(name);
+                continue;
+            }
+            files.AddRange(node.RuntimeFiles);
+            if (node.HasNativeAssets)
+                warnings.Add(
+                    $"'{name}' declares native runtimeTargets the bundle does not carry — "
+                    + "if the module needs them at runtime, they must ship another way");
+        }
+
+        return new Result(
+            files.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            excluded,
+            warnings);
+    }
+
+    private static bool IsPlatform(string name) =>
+        name.StartsWith("MeshWeaver.", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(name, "MeshWeaver", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Transitive reachability over the dependency edges, from <paramref name="roots"/>
+    /// inclusive. Missing nodes (framework-supplied names deps.json lists as dependencies but
+    /// carries no entry for) are simply absent — nothing to bundle, nothing to walk.</summary>
+    private static HashSet<string> Reach(
+        IReadOnlyDictionary<string, Node> nodes, IEnumerable<string> roots)
+    {
+        var reached = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<string>(roots);
+        while (queue.Count > 0)
+        {
+            var name = queue.Dequeue();
+            if (!reached.Add(name) || !nodes.TryGetValue(name, out var node))
+                continue;
+            foreach (var dependency in node.Dependencies)
+                queue.Enqueue(dependency);
+        }
+        return reached;
+    }
+
+    /// <summary>"Name/version" → "Name" (deps.json keys carry the resolved version).</summary>
+    private static string NameOf(string key)
+    {
+        var slash = key.IndexOf('/');
+        return slash < 0 ? key : key[..slash];
+    }
+}

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -138,6 +138,14 @@ public static class ModulePackCommand
                   --with <fileName>           an additional closure file from <moduleOutputDir>
                                               (repeatable). <name>.dll is always included, and its
                                               .pdb rides along when present.
+                  --deps-closure              derive the module's PRIVATE dependency closure from
+                                              <name>.deps.json beside the entry DLL and bundle it:
+                                              assemblies reachable from the module's own package
+                                              references and NOT from its MeshWeaver.* references
+                                              (those ship in the consumer's /app). Requires the
+                                              module to be built with
+                                              CopyLocalLockFileAssemblies=true so the files are in
+                                              the output folder.
                   --out <dir>                 where to write the bundle (default: current directory)
                 """);
             return 0;
@@ -156,6 +164,7 @@ public static class ModulePackCommand
         string? minMeshVersion = null;
         string? graphDll = null;
         var extras = new List<string>();
+        var depsClosure = false;
         var outputDirectory = Environment.CurrentDirectory;
 
         string? contentDirectory = null;
@@ -182,6 +191,9 @@ public static class ModulePackCommand
                     break;
                 case "--with" when i + 1 < args.Length:
                     extras.Add(args[++i]);
+                    break;
+                case "--deps-closure":
+                    depsClosure = true;
                     break;
                 case "--out" when i + 1 < args.Length:
                     outputDirectory = Path.GetFullPath(args[++i]);
@@ -262,11 +274,59 @@ public static class ModulePackCommand
                 + "bundle records no built-against framework MVID (diagnostic metadata only; the "
                 + "landing gate is --min-mesh-version).");
 
-        // The closure: entry DLL (+ symbols when present) + exactly the files the caller named.
+        // The closure: entry DLL (+ symbols when present) + the derived private dependency
+        // closure when asked for + exactly the files the caller named.
         var closure = new List<string> { moduleName + ".dll" };
         var entryPdb = moduleName + ".pdb";
         if (File.Exists(Path.Combine(moduleDirectory, entryPdb)))
             closure.Add(entryPdb);
+
+        // 🚨 --deps-closure: the module's own package dependencies ride WITH it. Entry-DLL-only
+        // bundles landed modules that faulted at first use on their first private dependency
+        // (Microsoft.Extensions.AI.OpenAI, Microsoft.Graph — the 2026-08-19/20 memex outage);
+        // hand-naming them with --with is whack-a-mole across every module. Derived from the
+        // build's own deps.json — see DepsClosure for the platform/own split.
+        if (depsClosure)
+        {
+            var depsPath = Path.Combine(moduleDirectory, moduleName + ".deps.json");
+            if (!File.Exists(depsPath))
+            {
+                Console.Error.WriteLine(
+                    $"error: --deps-closure needs {depsPath} — build the module project (the SDK "
+                    + "emits it beside the entry DLL)");
+                return 2;
+            }
+            DepsClosure.Result derived;
+            try
+            {
+                derived = DepsClosure.Derive(File.ReadAllText(depsPath), moduleName);
+            }
+            catch (Exception e) when (e is InvalidDataException or JsonException)
+            {
+                Console.Error.WriteLine($"error: --deps-closure could not read {depsPath}: {e.Message}");
+                return 2;
+            }
+            foreach (var warning in derived.Warnings)
+                Console.Error.WriteLine($"warning: {warning}");
+            var missing = derived.Files
+                .Where(f => !File.Exists(Path.Combine(moduleDirectory, f)))
+                .ToList();
+            if (missing.Count > 0)
+            {
+                Console.Error.WriteLine(
+                    "error: --deps-closure derived files that are not in the module output — build "
+                    + "with -p:CopyLocalLockFileAssemblies=true so package assemblies are copied. "
+                    + $"Missing: {string.Join(", ", missing)}");
+                return 2;
+            }
+            foreach (var file in derived.Files)
+                if (!closure.Contains(file, StringComparer.OrdinalIgnoreCase))
+                    closure.Add(file);
+            Console.WriteLine(
+                $"deps-closure: bundling {derived.Files.Count} private dependency file(s); "
+                + $"excluded {derived.ExcludedPlatformCarried.Count} platform-carried");
+        }
+
         foreach (var extra in extras)
         {
             if (Path.GetFileName(extra) != extra)

--- a/test/MeshWeaver.Graph.Test/DepsClosureTest.cs
+++ b/test/MeshWeaver.Graph.Test/DepsClosureTest.cs
@@ -82,7 +82,19 @@ public class DepsClosureTest
     }
 
     [Fact]
-    public void PlatformSide_IsNeverBundled_IncludingTheDiamond()
+    public void TheDiamond_Rides_SoSheddingAPlatformDependencyCannotBreakLandedBundles()
+    {
+        var result = DepsClosure.Derive(Graph, "MeshWeaver.Mail.MicrosoftGraph");
+
+        // 🚨 Microsoft.Extensions.Options is reachable from BOTH sides. It rides anyway: /app's
+        // copy wins in the default load context while the platform carries one, and the module's
+        // copy takes over the moment the platform stops — excluding it would couple every landed
+        // bundle to the platform's transitive dependency whims (the #1912-revert trap).
+        Assert.Contains("Microsoft.Extensions.Options.dll", result.Files);
+    }
+
+    [Fact]
+    public void PlatformNodes_AreNeverBundled_AndNeverWalked()
     {
         var result = DepsClosure.Derive(Graph, "MeshWeaver.Mail.MicrosoftGraph");
 
@@ -90,11 +102,8 @@ public class DepsClosureTest
         Assert.DoesNotContain("MeshWeaver.AI.dll", result.Files);
         // The module's OWN entry is the packer's business, not the derivation's.
         Assert.DoesNotContain("MeshWeaver.Mail.MicrosoftGraph.dll", result.Files);
-        // 🚨 The diamond: Microsoft.Extensions.Options is reachable from BOTH sides. The platform
-        // carries it, so the bundle must not — and it is reported as excluded, not dropped
-        // silently.
-        Assert.DoesNotContain("Microsoft.Extensions.Options.dll", result.Files);
-        Assert.Contains("Microsoft.Extensions.Options", result.ExcludedPlatformCarried);
+        // The stop is reported, not silent.
+        Assert.Contains("MeshWeaver.AI", result.ExcludedPlatformCarried);
     }
 
     [Fact]

--- a/test/MeshWeaver.Graph.Test/DepsClosureTest.cs
+++ b/test/MeshWeaver.Graph.Test/DepsClosureTest.cs
@@ -1,0 +1,148 @@
+#pragma warning disable CS1591
+
+using MeshWeaver.Plugin.Build;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The deps-closure derivation (<see cref="DepsClosure"/>): a module bundle carries the module's
+/// OWN package dependencies and never the platform's. Entry-DLL-only bundles landed modules that
+/// faulted at first use (<c>Microsoft.Extensions.AI.OpenAI</c> on chat, <c>Microsoft.Graph</c> at
+/// host start — the 2026-08-19/20 memex outage), and bundling the platform side instead would
+/// shadow <c>/app</c> at the consumer. The split is the whole contract, so it is pinned here on a
+/// synthetic graph shaped like the real one.
+/// </summary>
+public class DepsClosureTest
+{
+    /// <summary>A deps.json shaped like MeshWeaver.Mail.MicrosoftGraph's: one platform project
+    /// reference, one own package with a transitive dependency, and a DIAMOND package reachable
+    /// from both sides.</summary>
+    private const string Graph = """
+        {
+          "runtimeTarget": { "name": ".NETCoreApp,Version=v10.0" },
+          "targets": {
+            ".NETCoreApp,Version=v10.0": {
+              "MeshWeaver.Mail.MicrosoftGraph/1.0.0": {
+                "dependencies": {
+                  "MeshWeaver.AI": "3.0.0",
+                  "Microsoft.Graph": "5.56.0",
+                  "Azure.Identity": "1.13.1"
+                },
+                "runtime": { "MeshWeaver.Mail.MicrosoftGraph.dll": {} }
+              },
+              "MeshWeaver.AI/3.0.0": {
+                "dependencies": { "Microsoft.Extensions.Options": "10.0.0" },
+                "runtime": { "MeshWeaver.AI.dll": {} }
+              },
+              "Microsoft.Graph/5.56.0": {
+                "dependencies": {
+                  "Microsoft.Kiota.Abstractions": "1.12.0",
+                  "Microsoft.Extensions.Options": "10.0.0"
+                },
+                "runtime": { "lib/net8.0/Microsoft.Graph.dll": {} }
+              },
+              "Microsoft.Kiota.Abstractions/1.12.0": {
+                "runtime": { "lib/net8.0/Microsoft.Kiota.Abstractions.dll": {} }
+              },
+              "Azure.Identity/1.13.1": {
+                "dependencies": { "Microsoft.Identity.Client": "4.66.1" },
+                "runtime": { "lib/net8.0/Azure.Identity.dll": {} }
+              },
+              "Microsoft.Identity.Client/4.66.1": {
+                "runtime": { "lib/net8.0/Microsoft.Identity.Client.dll": {} },
+                "runtimeTargets": { "runtimes/win/lib/net8.0/msalruntime.dll": { "rid": "win", "assetType": "native" } }
+              },
+              "Microsoft.Extensions.Options/10.0.0": {
+                "runtime": { "lib/net10.0/Microsoft.Extensions.Options.dll": {} }
+              }
+            }
+          },
+          "libraries": {
+            "MeshWeaver.Mail.MicrosoftGraph/1.0.0": { "type": "project" },
+            "MeshWeaver.AI/3.0.0": { "type": "project" },
+            "Microsoft.Graph/5.56.0": { "type": "package" },
+            "Microsoft.Kiota.Abstractions/1.12.0": { "type": "package" },
+            "Azure.Identity/1.13.1": { "type": "package" },
+            "Microsoft.Identity.Client/4.66.1": { "type": "package" },
+            "Microsoft.Extensions.Options/10.0.0": { "type": "package" }
+          }
+        }
+        """;
+
+    [Fact]
+    public void OwnPackages_AndTheirTransitives_AreBundled()
+    {
+        var result = DepsClosure.Derive(Graph, "MeshWeaver.Mail.MicrosoftGraph");
+
+        Assert.Contains("Microsoft.Graph.dll", result.Files);
+        Assert.Contains("Microsoft.Kiota.Abstractions.dll", result.Files);
+        Assert.Contains("Azure.Identity.dll", result.Files);
+        Assert.Contains("Microsoft.Identity.Client.dll", result.Files);
+    }
+
+    [Fact]
+    public void PlatformSide_IsNeverBundled_IncludingTheDiamond()
+    {
+        var result = DepsClosure.Derive(Graph, "MeshWeaver.Mail.MicrosoftGraph");
+
+        // The platform reference itself: bundling it would shadow /app at the consumer.
+        Assert.DoesNotContain("MeshWeaver.AI.dll", result.Files);
+        // The module's OWN entry is the packer's business, not the derivation's.
+        Assert.DoesNotContain("MeshWeaver.Mail.MicrosoftGraph.dll", result.Files);
+        // 🚨 The diamond: Microsoft.Extensions.Options is reachable from BOTH sides. The platform
+        // carries it, so the bundle must not — and it is reported as excluded, not dropped
+        // silently.
+        Assert.DoesNotContain("Microsoft.Extensions.Options.dll", result.Files);
+        Assert.Contains("Microsoft.Extensions.Options", result.ExcludedPlatformCarried);
+    }
+
+    [Fact]
+    public void NativeAssets_AreWarnedAbout_NotSilentlyDropped()
+    {
+        var result = DepsClosure.Derive(Graph, "MeshWeaver.Mail.MicrosoftGraph");
+
+        Assert.Contains(result.Warnings, w => w.Contains("Microsoft.Identity.Client"));
+    }
+
+    [Fact]
+    public void WrongModuleName_IsARefusal_NeverAnEmptyClosure()
+    {
+        // An empty closure from the wrong deps.json would pack an entry-only bundle — exactly the
+        // outage this derivation exists to foreclose — so it must throw, loudly, naming the module.
+        var e = Assert.Throws<InvalidDataException>(
+            () => DepsClosure.Derive(Graph, "MeshWeaver.DoesNotExist"));
+        Assert.Contains("MeshWeaver.DoesNotExist", e.Message);
+    }
+
+    [Fact]
+    public void ModuleWithNoOwnPackages_DerivesEmpty_WhichIsValid()
+    {
+        // The "DLL alone is the closure" case (Observability, Notifications.Channels): every
+        // reference is platform-side, the derivation is empty, and that is a correct answer.
+        const string platformOnly = """
+            {
+              "runtimeTarget": { "name": ".NETCoreApp,Version=v10.0" },
+              "targets": {
+                ".NETCoreApp,Version=v10.0": {
+                  "MeshWeaver.Observability/1.0.0": {
+                    "dependencies": { "MeshWeaver.Messaging.Hub": "3.0.0" },
+                    "runtime": { "MeshWeaver.Observability.dll": {} }
+                  },
+                  "MeshWeaver.Messaging.Hub/3.0.0": {
+                    "runtime": { "MeshWeaver.Messaging.Hub.dll": {} }
+                  }
+                }
+              },
+              "libraries": {
+                "MeshWeaver.Observability/1.0.0": { "type": "project" },
+                "MeshWeaver.Messaging.Hub/3.0.0": { "type": "project" }
+              }
+            }
+            """;
+
+        var result = DepsClosure.Derive(platformOnly, "MeshWeaver.Observability");
+
+        Assert.Empty(result.Files);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
@@ -97,4 +97,94 @@ public class ModulePackCommandTest : IDisposable
         Assert.Equal("Widget.dll", only.FileName);
         Assert.Equal("WIDGET", Encoding.UTF8.GetString(only.Bytes));
     }
+
+    [Fact]
+    public void DepsClosure_BundlesTheModulesOwnDependencies_AndReadsBack()
+    {
+        // The build output the flag expects: entry DLL + its private dependency (copied there by
+        // CopyLocalLockFileAssemblies=true) + the SDK's deps.json declaring the split.
+        File.WriteAllBytes(Path.Combine(root, "closure", "Gadget.Sdk.dll"), "SDK"u8.ToArray());
+        File.WriteAllText(Path.Combine(root, "closure", "Widget.deps.json"), """
+            {
+              "runtimeTarget": { "name": ".NETCoreApp,Version=v10.0" },
+              "targets": {
+                ".NETCoreApp,Version=v10.0": {
+                  "Widget/1.0.0": {
+                    "dependencies": { "MeshWeaver.AI": "3.0.0", "Gadget.Sdk": "2.0.0" },
+                    "runtime": { "Widget.dll": {} }
+                  },
+                  "MeshWeaver.AI/3.0.0": { "runtime": { "MeshWeaver.AI.dll": {} } },
+                  "Gadget.Sdk/2.0.0": { "runtime": { "lib/net10.0/Gadget.Sdk.dll": {} } }
+                }
+              },
+              "libraries": {
+                "Widget/1.0.0": { "type": "project" },
+                "MeshWeaver.AI/3.0.0": { "type": "project" },
+                "Gadget.Sdk/2.0.0": { "type": "package" }
+              }
+            }
+            """);
+
+        var outDir = Path.Combine(root, "out-deps");
+        var exit = ModulePackCommand.Run(
+        [
+            Path.Combine(root, "closure"),
+            "--deps-closure",
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.3.0",
+            "--out", outDir,
+        ]);
+
+        Assert.Equal(0, exit);
+        var (manifest, files) = BundleReader.ReadModule(File.ReadAllBytes(
+            Path.Combine(outDir, "MeshWeaver.Plugin.WidgetPkg.1.3.0.module.nupkg")));
+
+        // The private dependency rides in the bundle AND in the manifest's declared closure;
+        // the platform side does not.
+        Assert.Contains("Gadget.Sdk.dll", manifest!.Module!.Assemblies!);
+        Assert.DoesNotContain("MeshWeaver.AI.dll", manifest.Module.Assemblies!);
+        Assert.Contains(files, f => f.FileName == "Gadget.Sdk.dll"
+                                    && Encoding.UTF8.GetString(f.Bytes) == "SDK");
+    }
+
+    [Fact]
+    public void DepsClosure_WithTheFileMissingFromTheOutput_IsARefusal()
+    {
+        // deps.json names a dependency that is NOT in the folder — the build ran without
+        // CopyLocalLockFileAssemblies. Packing anyway would land a module that faults at first
+        // use, which is the outage this flag exists to close.
+        File.WriteAllText(Path.Combine(root, "closure", "Widget.deps.json"), """
+            {
+              "runtimeTarget": { "name": ".NETCoreApp,Version=v10.0" },
+              "targets": {
+                ".NETCoreApp,Version=v10.0": {
+                  "Widget/1.0.0": {
+                    "dependencies": { "Absent.Sdk": "1.0.0" },
+                    "runtime": { "Widget.dll": {} }
+                  },
+                  "Absent.Sdk/1.0.0": { "runtime": { "lib/net10.0/Absent.Sdk.dll": {} } }
+                }
+              },
+              "libraries": {
+                "Widget/1.0.0": { "type": "project" },
+                "Absent.Sdk/1.0.0": { "type": "package" }
+              }
+            }
+            """);
+
+        var exit = ModulePackCommand.Run(
+        [
+            Path.Combine(root, "closure"),
+            "--deps-closure",
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.4.0",
+            "--out", Path.Combine(root, "out-missing"),
+        ]);
+
+        Assert.Equal(2, exit);
+        Assert.False(Directory.Exists(Path.Combine(root, "out-missing")),
+            "a refused invocation must not have written anything");
+    }
 }


### PR DESCRIPTION
## The outage

When a module's source left the platform repo (#1882), its package dependencies left `/app` with it — and `module-pack` bundled the entry DLL alone (`--with` exists but nothing ever passed it). Every landed module faults at first use on its first private dependency:

- chat: `Could not load … Microsoft.Extensions.AI.OpenAI, Version=10.8.0.0`
- `3.0.0-rc5.ci.4588` crashloops at host start: `Could not load … Microsoft.Graph, Version=6.2.0.0` from `GraphMail..ctor`

Pinning each dependency into the platform (#1912) is the wrong direction — it ships 43 MB of Graph/Kiota to deployments that send no mail, the exact cost the module split exists to avoid. Fix forward: **the bundle carries the module's own closure, derived, not remembered.**

## The rule

`DepsClosure.Derive` walks the module's own `deps.json` twice from its direct references:

| reachable from | verdict |
|---|---|
| the module's **MeshWeaver.\*** references | platform-carried — in the consumer's `/app` by construction; bundling it would shadow the platform (the same trap-door `ModuleLandingService` refuses for the entry DLL) |
| ONLY the module's **own package** references | the private closure — bundled |

Diamonds (reachable from both) are platform-carried. Shared-framework assemblies never appear as package nodes, so they're excluded by construction.

## The changes

- `DepsClosure` — pure derivation, unit-tested on a synthetic graph shaped like the real one (diamond, native-assets warning, wrong-name refusal, valid-empty).
- `module-pack --deps-closure` — derived files must exist beside the entry DLL (build with `CopyLocalLockFileAssemblies=true`) or the pack **refuses**: a partial closure lands a module that faults at first use.
- `node-repo-module-pack.yml` — builds with the flag, packs with `--deps-closure`, and the inspect step asserts **no MeshWeaver.\* assembly** rides beside the entry.

## Verified against all 14 extracted modules

`Mail.MicrosoftGraph` → the ten Graph/Kiota assemblies + Std.UriTemplate (exactly what its csproj names as the module's reason to exist); `Copilot` → GitHub.Copilot.SDK; `Mcp` → ModelContextProtocol(+AspNetCore); `AzureFoundry` → 4; `ClaudeCode`/`Export` → 1; platform-only modules correctly derive empty. `Azure.Identity`/`Azure.Core` excluded wherever a MeshWeaver.* reference already reaches them.

Follow-up (separate PR): revert the #1912 platform-side pin so Microsoft.Extensions.AI.OpenAI leaves `/app` and rides in the OpenAI module's bundle instead — the derivation flips it to bundled automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)