### PR TITLE
The time-zone preference read English to every German viewer

### DIFF
--- a/clients/react/src/i18n/strings.de.json
+++ b/clients/react/src/i18n/strings.de.json
@@ -256,6 +256,8 @@
   "settings.groupIntegration": "Integration",
   "settings.language": "Sprache",
   "settings.languageDescription": "Sprache für die Benutzeroberfläche des Portals. Inhalte werden nicht übersetzt — nur die Oberfläche. Bei der ersten Anmeldung wird die Sprache aus dem Browser übernommen; hier lässt sie sich überschreiben.",
+  "settings.timeZone": "Anzeige-Zeitzone (IANA)",
+  "settings.timeZoneDescription": "Die Anzeige-Zeitzone bestimmt, wie Zeitstempel im Portal dargestellt werden — gespeichert wird weiterhin in UTC, nur die Anzeige wird umgerechnet. Bei der ersten Anmeldung wird sie aus dem Browser übernommen; hier lässt sich eine benannte IANA-Zone auswählen, falls die Erkennung falsch liegt (die Sommerzeit wird automatisch berücksichtigt). Ohne Angabe werden Zeiten in UTC angezeigt.",
   "notifications.title": "Benachrichtigungen",
   "notifications.markAllRead": "Alle als gelesen markieren",
   "notifications.allCaughtUp": "Alles erledigt.",

--- a/clients/react/src/i18n/strings.en.json
+++ b/clients/react/src/i18n/strings.en.json
@@ -256,6 +256,8 @@
   "settings.groupIntegration": "Integration",
   "settings.language": "Language",
   "settings.languageDescription": "Choose the language for the portal interface. Your content is not translated — only the interface. Detected from your browser on first sign-in; pick a language here to override it.",
+  "settings.timeZone": "Display time zone (IANA)",
+  "settings.timeZoneDescription": "Your display time zone controls how timestamps are shown to you across the portal — stored times stay in UTC, only the display converts. It is detected from your browser on first sign-in; pick a named IANA zone here to override a wrong guess (daylight saving is applied automatically). Leave it blank to see times in UTC.",
   "notifications.title": "Notifications",
   "notifications.markAllRead": "Mark all read",
   "notifications.allCaughtUp": "You're all caught up.",

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-time-zone-preference-speaks-german.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-time-zone-preference-speaks-german.md
@@ -1,0 +1,15 @@
+---
+Name: The time-zone preference speaks German
+Category: Fix
+Description: The display time-zone setting and its explanation are now translated, instead of appearing in English for German users.
+Icon: Sparkle
+Order: -20260820
+---
+
+# The time-zone preference speaks German
+
+Settings → Preferences lets you choose the time zone your timestamps are shown in. Its label and the paragraph explaining it were only ever written in English, so a German user saw English text there — directly beside a language picker that was correctly translated.
+
+Both are now translated, and the page reads in your chosen language throughout.
+
+Nothing about your settings changed: stored times are still kept in UTC and only the display is converted, and your existing time zone is untouched.

--- a/src/MeshWeaver.Graph/Configuration/UserNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/UserNodeType.cs
@@ -160,15 +160,9 @@ public static class UserNodeType
         if (node is null)
             return stack.WithView(Controls.Html("<p><em>User not found.</em></p>"));
 
-        stack = stack.WithView(Controls.Markdown(
-            "Your **display time zone** controls how timestamps are shown to you across the portal — "
-            + "stored times stay in UTC; only the display converts. It is detected from your browser "
-            + "on first sign-in; pick a named IANA zone here to override a wrong guess (DST is applied "
-            + "automatically). Leave it blank to see times in UTC.")
-            .WithStyle("color: var(--neutral-foreground-hint); margin-bottom: 8px;"));
-
-        stack = stack.WithView(Controls.Markdown(access.Localize("settings.languageDescription"))
-            .WithStyle("color: var(--neutral-foreground-hint); margin-bottom: 8px;"));
+        foreach (var key in PreferencesDescriptionKeys)
+            stack = stack.WithView(Controls.Markdown(access.Localize(key))
+                .WithStyle("color: var(--neutral-foreground-hint); margin-bottom: 8px;"));
 
         // Data-bound editor: reads/writes User.TimeZoneId and User.Locale straight on the node
         // stream (IMeshNodeStreamCache) — no /data replica, no save loop. The tab is only shown to
@@ -176,28 +170,54 @@ public static class UserNodeType
         var editor = new MeshNodeContentEditorControl(node.Path)
         {
             CanEdit = true,
-            Fields = ImmutableList.Create(
-                new MeshNodeEditorField(
-                    nameof(User.TimeZoneId).ToCamelCase()!,
-                    "Display time zone (IANA)",
-                    MeshNodeEditorFieldKind.Enum)
-                {
-                    Options = TimeZonePreference.SystemZoneIds()
-                },
-                new MeshNodeEditorField(
-                    nameof(User.Locale).ToCamelCase()!,
-                    access.Localize("settings.language"),
-                    MeshNodeEditorFieldKind.Enum)
-                {
-                    // Stores the BCP-47 tag ("de") but shows the endonym ("Deutsch") — a German
-                    // speaker looks for "Deutsch", not "German" or a raw tag.
-                    Options = Locales.Supported,
-                    OptionLabels = Locales.DisplayNames
-                })
+            Fields = PreferenceFields(key => access.Localize(key))
         };
         stack = stack.WithView(editor);
         return stack;
     }
+
+    /// <summary>
+    /// The catalog keys for the tab's explanatory prose, in render order — one paragraph per
+    /// picker. Exposed (rather than inlined) so the localization guard can assert they ARE keys:
+    /// the time-zone paragraph shipped as an English literal while the language one beside it was
+    /// localized from the start, which is precisely the shape that survives review.
+    /// </summary>
+    internal static readonly ImmutableList<string> PreferencesDescriptionKeys =
+        ImmutableList.Create("settings.timeZoneDescription", "settings.languageDescription");
+
+    /// <summary>
+    /// The tab's two pickers, with every label resolved through <paramref name="localize"/>.
+    ///
+    /// <para>🚨 The localizer is a parameter for the same reason
+    /// <c>PlatformUpdateChip.Describe</c>'s is: it makes the WORDING assertable without a hub, a
+    /// circuit or a rendered layout area. That matters here because the defect this seam exists to
+    /// prevent is invisible to every other gate — a hard-coded label is not a MISSING catalog key,
+    /// so <c>LocalizationTest</c>'s completeness check passes, and a render test run under an
+    /// English viewer sees the correct text either way.</para>
+    ///
+    /// <para>🚨 Every label added here MUST be a key. The time-zone label read
+    /// "Display time zone (IANA)" to a German viewer for a month, sitting directly beside a
+    /// language picker that had gone through the catalog since the day it was written.</para>
+    /// </summary>
+    internal static ImmutableList<MeshNodeEditorField> PreferenceFields(Func<string, string> localize)
+        => ImmutableList.Create(
+            new MeshNodeEditorField(
+                nameof(User.TimeZoneId).ToCamelCase()!,
+                localize("settings.timeZone"),
+                MeshNodeEditorFieldKind.Enum)
+            {
+                Options = TimeZonePreference.SystemZoneIds()
+            },
+            new MeshNodeEditorField(
+                nameof(User.Locale).ToCamelCase()!,
+                localize("settings.language"),
+                MeshNodeEditorFieldKind.Enum)
+            {
+                // Stores the BCP-47 tag ("de") but shows the endonym ("Deutsch") — a German
+                // speaker looks for "Deutsch", not "German" or a raw tag.
+                Options = Locales.Supported,
+                OptionLabels = Locales.DisplayNames
+            });
 
     /// <summary>
     /// Grants read access to every SIGNED-IN user on the User node itself (path == "{userId}"),

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -256,6 +256,8 @@
   "settings.groupIntegration": "Integration",
   "settings.language": "Sprache",
   "settings.languageDescription": "Sprache für die Benutzeroberfläche des Portals. Inhalte werden nicht übersetzt — nur die Oberfläche. Bei der ersten Anmeldung wird die Sprache aus dem Browser übernommen; hier lässt sie sich überschreiben.",
+  "settings.timeZone": "Anzeige-Zeitzone (IANA)",
+  "settings.timeZoneDescription": "Die Anzeige-Zeitzone bestimmt, wie Zeitstempel im Portal dargestellt werden — gespeichert wird weiterhin in UTC, nur die Anzeige wird umgerechnet. Bei der ersten Anmeldung wird sie aus dem Browser übernommen; hier lässt sich eine benannte IANA-Zone auswählen, falls die Erkennung falsch liegt (die Sommerzeit wird automatisch berücksichtigt). Ohne Angabe werden Zeiten in UTC angezeigt.",
   "notifications.title": "Benachrichtigungen",
   "notifications.markAllRead": "Alle als gelesen markieren",
   "notifications.allCaughtUp": "Alles erledigt.",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -256,6 +256,8 @@
   "settings.groupIntegration": "Integration",
   "settings.language": "Language",
   "settings.languageDescription": "Choose the language for the portal interface. Your content is not translated — only the interface. Detected from your browser on first sign-in; pick a language here to override it.",
+  "settings.timeZone": "Display time zone (IANA)",
+  "settings.timeZoneDescription": "Your display time zone controls how timestamps are shown to you across the portal — stored times stay in UTC, only the display converts. It is detected from your browser on first sign-in; pick a named IANA zone here to override a wrong guess (daylight saving is applied automatically). Leave it blank to see times in UTC.",
   "notifications.title": "Notifications",
   "notifications.markAllRead": "Mark all read",
   "notifications.allCaughtUp": "You're all caught up.",

--- a/test/MeshWeaver.Graph.Test/UserPreferencesLocalizationTest.cs
+++ b/test/MeshWeaver.Graph.Test/UserPreferencesLocalizationTest.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Messaging;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The User → Settings → <b>Preferences</b> tab must be localized in FULL.
+///
+/// <para>🚨 It is the one tab where half-localization is easiest to ship and hardest to notice: the
+/// language picker beside it went through <c>Localize("settings.language")</c> from the day it was
+/// written, so the tab LOOKS translated to anyone glancing at the code, while the time-zone label
+/// and the paragraph explaining the whole feature were English literals. A German viewer read
+/// "Display time zone (IANA)" under a heading that was correctly "Einstellungen".</para>
+///
+/// <para>The builder takes its localizer as a <c>Func&lt;string,string&gt;</c> for exactly the reason
+/// <see cref="Memex.Portal.Shared.SelfUpdate.PlatformUpdateChip.Describe"/> does — so the WORDING is
+/// assertable without a hub, a circuit or a rendered layout area. Here that matters twice over: the
+/// bug is invisible to <c>LocalizationTest</c> (which only checks that shipped languages cover the
+/// English key list — a string that never became a key is not a missing key, it is an absent one)
+/// and invisible to any render test that happens to run under an English viewer.</para>
+/// </summary>
+public class UserPreferencesLocalizationTest
+{
+    /// <summary>
+    /// Every label the tab renders must come back from the localizer. With an echo localizer the
+    /// labels ARE the keys, so any English literal left in the builder stands out as prose among
+    /// dotted keys — and this fails whether the literal is the time zone's, the language's, or one
+    /// added later.
+    /// </summary>
+    [Fact]
+    public void EveryFieldLabel_ComesFromTheCatalog()
+    {
+        var fields = UserNodeType.PreferenceFields(key => key);
+
+        fields.Should().NotBeEmpty("the tab exists to carry the display-zone and language pickers");
+        foreach (var field in fields)
+            field.Label.Should().StartWith("settings.",
+                "an echo localizer returns the key, so a label that is not a key is a hard-coded "
+                + "literal that renders English to every viewer regardless of their language");
+    }
+
+    /// <summary>
+    /// The paragraph above the pickers is user-visible prose — the longest English string on the
+    /// tab, and the one a German reader notices first.
+    /// </summary>
+    [Fact]
+    public void TheExplanatoryText_ComesFromTheCatalog()
+        => UserNodeType.PreferencesDescriptionKeys
+            .Should().OnlyContain(k => k.StartsWith("settings."),
+                "the tab's explanatory prose must be catalog keys, not literals");
+
+    /// <summary>
+    /// End to end against the REAL catalog: a German viewer must not be shown the English label.
+    /// The echo test above proves the value went through the localizer; this proves the catalog
+    /// actually has German behind it, which is the half a key without a translation would miss.
+    /// </summary>
+    [Fact]
+    public void AGermanViewer_SeesGermanNotEnglish()
+    {
+        var german = UserNodeType.PreferenceFields(key => LocalizationCatalog.Get(key, "de"));
+
+        var zone = german.Single(f => f.Key.Equals("timeZoneId", System.StringComparison.Ordinal));
+        zone.Label.Should().NotBe("Display time zone (IANA)",
+            "this is the exact literal that shipped, and it read as English to every German viewer");
+        zone.Label.Should().NotStartWith("settings.",
+            "a raw key on screen means the German catalog has no entry for it");
+    }
+
+    /// <summary>
+    /// Both shipped languages must carry every key the tab uses. <c>LocalizationTest</c> enforces
+    /// coverage across the catalog as a whole; this names THESE keys, so deleting one is a failure
+    /// here rather than a raw token appearing on the settings page.
+    /// </summary>
+    [Fact]
+    public void EveryKeyTheTabUses_ExistsInBothShippedLanguages()
+    {
+        var keys = UserNodeType.PreferenceFields(key => key).Select(f => f.Label)
+            .Concat(UserNodeType.PreferencesDescriptionKeys)
+            .Distinct();
+
+        foreach (var key in keys)
+        foreach (var locale in Locales.Supported)
+            LocalizationCatalog.Get(key, locale).Should().NotBe(key,
+                "'{0}' is missing from strings.{1}.json — the catalog falls back to the key "
+                + "itself, so the settings page would render the raw token", key, locale);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/UserPreferencesLocalizationTest.cs
+++ b/test/MeshWeaver.Graph.Test/UserPreferencesLocalizationTest.cs
@@ -16,8 +16,10 @@ namespace MeshWeaver.Graph.Test;
 /// "Display time zone (IANA)" under a heading that was correctly "Einstellungen".</para>
 ///
 /// <para>The builder takes its localizer as a <c>Func&lt;string,string&gt;</c> for exactly the reason
-/// <see cref="Memex.Portal.Shared.SelfUpdate.PlatformUpdateChip.Describe"/> does — so the WORDING is
-/// assertable without a hub, a circuit or a rendered layout area. Here that matters twice over: the
+/// <c>PlatformUpdateChip.Describe</c> does (named, not <c>cref</c>'d — it lives in
+/// Memex.Portal.Shared, which this project does not reference, so a cref here would be a link that
+/// resolves nowhere) — so the WORDING is assertable without a hub, a circuit or a rendered layout
+/// area. Here that matters twice over: the
 /// bug is invisible to <c>LocalizationTest</c> (which only checks that shipped languages cover the
 /// English key list — a string that never became a key is not a missing key, it is an absent one)
 /// and invisible to any render test that happens to run under an English viewer.</para>


### PR DESCRIPTION
## The defect

Settings → Preferences carries two pickers. The language one has gone through `Localize("settings.language")` since the day it was written; the display **time-zone** label was the literal `"Display time zone (IANA)"`, and the paragraph explaining the whole feature was an English literal too.

So the tab rendered half-translated for a German viewer: correct heading, correct language label, English beside it. Per AGENTS.md a hard-coded user-visible string is a bug — it renders English to every viewer regardless of their language.

## Why no existing gate caught it

- **`LocalizationTest`** only asserts that each shipped language covers the English *key* list. A string that never became a key is not a *missing* key — it is an absent one, so the catalog looks complete.
- **A render test** would pass as well, under an English viewer.

That is the part worth fixing structurally rather than just editing two strings.

## The change

The pickers now come from `UserNodeType.PreferenceFields(Func<string,string> localize)` and the prose from `PreferencesDescriptionKeys`. The localizer is a **parameter** for the same reason `PlatformUpdateChip.Describe`'s is: it makes the wording assertable without a hub, a circuit or a rendered layout area.

Two keys added to **all four** catalogs — `strings.{en,de}.json` server-side, mirrored into `clients/react/src/i18n`, where the drift guard compares values per key rather than just counts.

## Tests

Written test-first. `UserPreferencesLocalizationTest` fails on the literal — **3 of its 4 assertions**, naming the exact string — and covers both halves of the bug:

1. every label goes through the localizer (echo localizer ⇒ labels *are* keys, so a literal stands out as prose among dotted keys);
2. the real German catalog has text behind those keys — which a key added without a translation would miss.

Verified locally: `-c Release -warnaserror` clean · `MeshWeaver.Graph.Test` 1372/1372 · `MeshWeaver.Messaging.Hub.Test` 56/56 · `MeshWeaver.Documentation.Test` 39/39 · `clients/react` localize 15/15.

## Notes for review

- The React catalogs are edited by **line insertion**, not re-serialized: a full re-dump churns ~200 unrelated lines in whichever direction its escaping convention differs (the file is dominantly literal UTF-8 with a handful of pre-escaped `\uXXXX` entries).
- Noted but deliberately **not** touched: `BuildPreferencesTab`'s `var locale = access.ViewerLocale()` was already unused before this change.
- Found while investigating why a portal showed UTC timestamps. Separate and **not** addressed here: an account created before the browser auto-detect (`f31b81f0a`) has no `User.TimeZoneId`, and the write-once populate only fills an *empty* field on first sign-in — it never backfills — so such a user reads every timestamp in UTC with nothing on screen saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)