### PR TITLE
helm: ingress names match every live environment

### DIFF
--- a/deploy/helm/templates/memex-portal/ingress.yaml
+++ b/deploy/helm/templates/memex-portal/ingress.yaml
@@ -9,7 +9,7 @@
 apiVersion: "networking.k8s.io/v1"
 kind: "Ingress"
 metadata:
-  name: "memex-portal-ingress"
+  name: "memex-portal"
   labels:
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "memex-portal"
@@ -62,7 +62,7 @@ spec:
 apiVersion: "networking.k8s.io/v1"
 kind: "Ingress"
 metadata:
-  name: "memex-portal-grpc-ingress"
+  name: "memex-portal-grpc"
   labels:
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "memex-portal"
@@ -103,7 +103,7 @@ spec:
 apiVersion: "networking.k8s.io/v1"
 kind: "Ingress"
 metadata:
-  name: "memex-portal-mcp-ingress"
+  name: "memex-portal-mcp"
   labels:
     app.kubernetes.io/name: "{{ .Chart.Name }}"
     app.kubernetes.io/component: "memex-portal"


### PR DESCRIPTION
The adopt action (Systemorph/Memex #58) surfaced this drift on memex-cloud: the chart renders `memex-portal-ingress`/`memex-portal-grpc-ingress`/`memex-portal-mcp-ingress`, while **all three live namespaces** carry `memex-portal`/`memex-portal-grpc`/`memex-portal-mcp`. A deploy would have CREATED coexisting duplicate ingresses for the same host rather than updating the live ones.

Live names are load-bearing across three environments — the chart aligns to reality. After this merges, re-running `adopt` stamps the live ingresses and `deploy` updates instead of duplicating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)