### PR TITLE
voice gateway: on-device triage with the normal tools, and delegate opens a mesh thread

### DIFF
--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -59,7 +59,12 @@ def make_router(cfg: Config) -> BrainRouter:
         brains = {e["name"]: (ollama(e) if e.get("kind") == "ollama" else memex(e))
                   for e in cfg.portals}
         active = next((e["name"] for e in cfg.portals if e.get("default")), cfg.portals[0]["name"])
-        return BrainRouter(brains, active, phrases=phrases)
+        router = BrainRouter(brains, active, phrases=phrases)
+        # The local brain triages: it can hand any request to a mesh thread by itself.
+        for brain in brains.values():
+            if isinstance(brain, OllamaBrain):
+                brain.delegator = router.delegate_task
+        return router
     if cfg.brain == "ollama":
         return BrainRouter({"lokal": ollama({})}, "lokal", phrases=phrases)
     return BrainRouter({"memex": memex({"url": cfg.memex_url, "token": cfg.memex_token,
@@ -135,6 +140,7 @@ async def run() -> None:
         stream_speak=stream_speak if cfg.stream_tts else None,
         hold_phrase_for=router.describe_hold,
         answer_to_template=phrases_for(cfg.stt_language)["answer_to"],
+        drain_delegations=router.drain_delegations,
     )
     link = SatelliteLink(cfg, pipeline)
 

--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -87,7 +87,7 @@ async def run() -> None:
         """Speak a live text stream: open a chunked-WAV session (the device starts playing
         the URL immediately), synthesize sentence-by-sentence as pieces arrive, close on end.
         Both `say` (forced LEI16@22050) and the piper medium voices emit 22.05 kHz."""
-        stream, url = server.open_stream(sample_rate=22050)
+        stream, url = server.open_stream(sample_rate=16000)
 
         async def feed() -> None:
             buffer = ""
@@ -131,8 +131,8 @@ async def run() -> None:
         hold_phrase=cfg.hold_phrase,
         error_phrase=cfg.error_phrase,
         command_handler=router.handle_command,
-        stream_text=router.stream_text,
-        stream_speak=stream_speak,
+        stream_text=router.stream_text if cfg.stream_tts else None,
+        stream_speak=stream_speak if cfg.stream_tts else None,
         hold_phrase_for=router.describe_hold,
         answer_to_template=phrases_for(cfg.stt_language)["answer_to"],
     )

--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -55,20 +55,44 @@ def make_router(cfg: Config) -> BrainRouter:
                             thread_idle_minutes=cfg.thread_idle_minutes,
                             verify_tls=not entry.get("insecure", False))
 
+    home = None
+    if cfg.ha_url and cfg.ha_token:
+        from .homeassistant import HomeAssistant
+        home = HomeAssistant(cfg.ha_url, cfg.ha_token)
+
     if cfg.portals:
         brains = {e["name"]: (ollama(e) if e.get("kind") == "ollama" else memex(e))
                   for e in cfg.portals}
         active = next((e["name"] for e in cfg.portals if e.get("default")), cfg.portals[0]["name"])
-        router = BrainRouter(brains, active, phrases=phrases)
-        # The local brain triages: it can hand any request to a mesh thread by itself.
+        # A portal entry's "agents" pins agents to the portal that HOSTS them (list of
+        # names, or name → spoken-roster description) — e.g. the ExecutiveAssistant on the
+        # local mesh: {"name":"mac", …, "agents": {"ExecutiveAssistant": "email"}}.
+        from .ollama import DEFAULT_AGENTS, HOME_TOOL, MESH_TOOLS
+        roster = dict(DEFAULT_AGENTS)
+        agent_homes: dict[str, str] = {}
+        for entry in cfg.portals:
+            declared = entry.get("agents") or {}
+            if isinstance(declared, list):
+                declared = {name: roster.get(name, "specialist work") for name in declared}
+            for name, description in declared.items():
+                roster[name] = description
+                agent_homes[name] = entry["name"]
+        router = BrainRouter(brains, active, phrases=phrases, home=home,
+                             agent_homes=agent_homes)
+        # The local brain TRIAGES: quick lookups through the normal tools (search_mesh,
+        # get_node, home_assistant), real work through delegate_to_memex — a mesh thread.
         for brain in brains.values():
             if isinstance(brain, OllamaBrain):
                 brain.delegator = router.delegate_task
+                brain.tool_runner = router.run_tool
+                brain.tools = list(MESH_TOOLS) + ([HOME_TOOL] if home is not None else [])
+                brain.agents = roster
         return router
     if cfg.brain == "ollama":
-        return BrainRouter({"lokal": ollama({})}, "lokal", phrases=phrases)
+        return BrainRouter({"lokal": ollama({})}, "lokal", phrases=phrases, home=home)
     return BrainRouter({"memex": memex({"url": cfg.memex_url, "token": cfg.memex_token,
-                                        "namespace": cfg.namespace})}, "memex", phrases=phrases)
+                                        "namespace": cfg.namespace})}, "memex",
+                       phrases=phrases, home=home)
 
 
 def make_tts(cfg: Config):

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -95,6 +95,11 @@ class Config:
 
     # --- text-to-speech + the URL the satellite fetches audio from ---
     tts_engine: str = "piper"               # "piper" | "say" (macOS)
+    stream_tts: bool = False
+    record_dir: str | None = None           # save each round's raw utterance WAV here — the
+                                            # corpus for retraining the wake word on REAL voices                # chunked live TTS; OFF: ESPHome 2026's player
+                                            # aborts chunked bodies after ~200 bytes — replies
+                                            # ship as complete WAVs until device-verified
     piper_bin: str = "piper"
     piper_voice: str = "/voices/de_DE-thorsten-medium.onnx"
     say_voice: str = "Anna"                 # macOS German voice
@@ -140,11 +145,14 @@ class Config:
             system_prompt_file=_env("SYSTEM_PROMPT_FILE"),
             silence_ms=int(_env("SILENCE_MS", "800")),
             tts_engine=(_env("TTS_ENGINE", "piper") or "piper").lower(),
+            stream_tts=(_env("STREAM_TTS", "false") or "false").lower() == "true",
+            record_dir=_env("RECORD_DIR"),
             piper_bin=_env("PIPER_BIN", "piper") or "piper",
             piper_voice=_env("PIPER_VOICE", Config.piper_voice) or Config.piper_voice,
             say_voice=_env("SAY_VOICE", "Anna") or "Anna",
             gateway_host=_env("GATEWAY_HOST") or "",
             gateway_port=int(_env("GATEWAY_PORT", "8200")),
+            sample_rate=int(_env("SAMPLE_RATE", "16000")),
             portals=portals,
         )
         required = [("SATELLITE_HOST", cfg.satellite_host), ("GATEWAY_HOST", cfg.gateway_host)]

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -88,6 +88,10 @@ class Config:
     location: str | None = None             # where the speaker is (weather/'here' questions)
     system_prompt_file: str | None = None   # override the built-in voice prompt with a file
 
+    # --- Home Assistant (optional) — a tool for the local brain, not a voice owner ---
+    ha_url: str | None = None               # e.g. http://homeassistant.local:8123
+    ha_token: str | None = None             # long-lived access token
+
     # --- endpointing (energy VAD) ---
     silence_ms: int = 800
     max_utterance_s: float = 15.0
@@ -143,6 +147,8 @@ class Config:
             speak_dialect=(_env("SPEAK_DIALECT", "false") or "false").lower() == "true",
             location=_env("LOCATION"),
             system_prompt_file=_env("SYSTEM_PROMPT_FILE"),
+            ha_url=(_env("HA_URL") or "").rstrip("/") or None,
+            ha_token=_env("HA_TOKEN"),
             silence_ms=int(_env("SILENCE_MS", "800")),
             tts_engine=(_env("TTS_ENGINE", "piper") or "piper").lower(),
             stream_tts=(_env("STREAM_TTS", "false") or "false").lower() == "true",

--- a/clients/voice-gateway/memex_voice_gateway/homeassistant.py
+++ b/clients/voice-gateway/memex_voice_gateway/homeassistant.py
@@ -1,0 +1,81 @@
+"""A thin Home Assistant REST client, exposed to the local brain as ONE tool.
+
+The gateway keeps the satellite's voice subscription (the ESPHome voice pipeline has one
+owner); Home Assistant rides alongside as a tool — lights, switches, scenes, media — via
+its long-lived-access-token REST API. Configure with HA_URL + HA_TOKEN; absent, the tool
+is simply not offered.
+"""
+
+from __future__ import annotations
+
+import aiohttp
+
+_LIST_LIMIT = 40
+
+
+class HomeAssistant:
+    def __init__(self, base_url: str, token: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._headers = {"Authorization": f"Bearer {token}"}
+        self._http: aiohttp.ClientSession | None = None
+
+    async def _session(self) -> aiohttp.ClientSession:
+        if self._http is None:
+            self._http = aiohttp.ClientSession(headers=self._headers)
+        return self._http
+
+    async def run(self, args: dict) -> str:
+        action = str(args.get("action", "")).strip()
+        if action == "list_entities":
+            return await self._list_entities(str(args.get("domain", "")).strip())
+        if action == "get_state":
+            return await self._get_state(str(args.get("entity_id", "")).strip())
+        if action == "call_service":
+            return await self._call_service(str(args.get("domain", "")).strip(),
+                                            str(args.get("service", "")).strip(),
+                                            str(args.get("entity_id", "")).strip())
+        return f"Unknown action: {action!r}. Use list_entities, get_state, or call_service."
+
+    async def _list_entities(self, domain: str) -> str:
+        http = await self._session()
+        async with http.get(f"{self.base_url}/api/states") as response:
+            response.raise_for_status()
+            states = await response.json()
+        rows = [f"{s['entity_id']}: {s.get('state')}"
+                f" ({(s.get('attributes') or {}).get('friendly_name', '')})"
+                for s in states
+                if not domain or s["entity_id"].startswith(domain + ".")]
+        if not rows:
+            return f"No entities{f' in domain {domain}' if domain else ''}."
+        clipped = rows[:_LIST_LIMIT]
+        more = f" …and {len(rows) - len(clipped)} more" if len(rows) > len(clipped) else ""
+        return "\n".join(clipped) + more
+
+    async def _get_state(self, entity_id: str) -> str:
+        if not entity_id:
+            return "entity_id is required for get_state."
+        http = await self._session()
+        async with http.get(f"{self.base_url}/api/states/{entity_id}") as response:
+            if response.status == 404:
+                return f"No entity {entity_id}."
+            response.raise_for_status()
+            state = await response.json()
+        attrs = state.get("attributes") or {}
+        name = attrs.get("friendly_name", entity_id)
+        return f"{name} is {state.get('state')}."
+
+    async def _call_service(self, domain: str, service: str, entity_id: str) -> str:
+        if not (domain and service):
+            return "domain and service are required for call_service."
+        http = await self._session()
+        payload = {"entity_id": entity_id} if entity_id else {}
+        async with http.post(f"{self.base_url}/api/services/{domain}/{service}",
+                             json=payload) as response:
+            if response.status >= 400:
+                return f"Home Assistant refused {domain}.{service}: HTTP {response.status}."
+        return f"Done: {domain}.{service}" + (f" on {entity_id}." if entity_id else ".")
+
+    async def close(self) -> None:
+        if self._http is not None:
+            await self._http.close()
+            self._http = None

--- a/clients/voice-gateway/memex_voice_gateway/ollama.py
+++ b/clients/voice-gateway/memex_voice_gateway/ollama.py
@@ -27,10 +27,14 @@ SYSTEM_PROMPT = (
     "wall-clock time in brackets — use it to judge gaps in the conversation.\n\n"
     "TRIAGE — decide per request: answer DIRECTLY yourself for time, dates, general "
     "knowledge, conversions, and small talk (you run on-device; speed is your virtue). "
-    "DELEGATE by calling delegate_to_memex for anything that needs the user's own data, "
-    "current information from the web, documents, or multi-step work — the mesh runs full "
-    "agents with tools there. After delegating, tell the user in ONE sentence that Memex is "
-    "on it and will announce the answer."
+    "For a QUICK lookup use your read-only tools: search_mesh finds nodes in the user's "
+    "mesh, get_node reads one, home_assistant controls the smart home. DELEGATE by calling "
+    "delegate_to_memex — it opens a thread in the mesh where a full agent with its own "
+    "tools works the task — for anything that needs current information from the web, "
+    "documents, writing or changing data, or multi-step work. Anything about EMAIL — "
+    "reading, summarizing, or sending mail — always delegates to the ExecutiveAssistant "
+    "agent. After delegating, tell the user in ONE sentence that Memex is on it and will "
+    "announce the answer."
 )
 
 _WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
@@ -58,24 +62,79 @@ def build_messages(history: list[dict], text: str, system_prompt: str = SYSTEM_P
             {"role": "user", "content": text}]
 
 
-DELEGATE_TOOL = {
+# The standard agents offered for delegation — extended/overridden per deployment
+# (a portal entry's "agents" list adds names AND pins where each one runs).
+DEFAULT_AGENTS = {
+    "Voice": "quick data lookups",
+    "Assistant": "general work",
+    "Researcher": "deep research",
+    "ExecutiveAssistant": "EMAIL — reading, summarizing, and sending mail",
+}
+
+
+def delegate_tool(agents: dict[str, str] | None = None) -> dict:
+    """The delegate_to_memex spec, its agent enum built from the CONFIGURED roster."""
+    roster = agents or DEFAULT_AGENTS
+    return {
+        "type": "function",
+        "function": {
+            "name": "delegate_to_memex",
+            "description": "Open a THREAD in the user's mesh, where a full agent with its "
+                           "own system prompt and tools (their data, web search, documents, "
+                           "email) works the task. The answer is announced when ready.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "task": {"type": "string", "description": "The task, self-contained, in the user's language."},
+                    "agent": {"type": "string", "enum": list(roster),
+                              "description": " ".join(f"{n}: {d}." for n, d in roster.items())},
+                },
+                "required": ["task"],
+            },
+        },
+    }
+
+
+DELEGATE_TOOL = delegate_tool()
+
+# The normal read-only tools every mesh client has — run in-round by the router against the
+# active/first mesh portal, so a quick lookup never costs a whole thread.
+MESH_TOOLS = [
+    {"type": "function", "function": {
+        "name": "search_mesh",
+        "description": "Search the user's mesh (notes, documents, courses, data). Returns "
+                       "matching nodes with their paths. Free text works; so do filters "
+                       "like nodeType:Agent or name:*sales*.",
+        "parameters": {"type": "object", "properties": {
+            "query": {"type": "string", "description": "Free text or GitHub-style query."}},
+            "required": ["query"]},
+    }},
+    {"type": "function", "function": {
+        "name": "get_node",
+        "description": "Read one mesh node by path (as returned by search_mesh), e.g. "
+                       "@Doc/Architecture/Plugins.",
+        "parameters": {"type": "object", "properties": {
+            "path": {"type": "string", "description": "The node path, e.g. @Edu/Guide."}},
+            "required": ["path"]},
+    }},
+]
+
+HOME_TOOL = {
     "type": "function",
     "function": {
-        "name": "delegate_to_memex",
-        "description": "Hand a task to the user's mesh, where full agents with tools "
-                       "(their data, web search, documents) run it in a thread. The answer "
-                       "is announced to the user when ready.",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "task": {"type": "string", "description": "The task, self-contained, in the user's language."},
-                "agent": {"type": "string", "enum": ["Voice", "Assistant", "Researcher"],
-                          "description": "Voice: quick data lookups. Assistant: general work. Researcher: deep research."},
-            },
-            "required": ["task"],
-        },
+        "name": "home_assistant",
+        "description": "Control or read the smart home via Home Assistant: list entities, "
+                       "read a state, or call a service (turn_on, turn_off, toggle, ...).",
+        "parameters": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["list_entities", "get_state", "call_service"]},
+            "entity_id": {"type": "string", "description": "e.g. light.living_room"},
+            "domain": {"type": "string", "description": "service domain, e.g. light, switch, media_player"},
+            "service": {"type": "string", "description": "e.g. turn_on, turn_off, toggle"},
+        }, "required": ["action"]},
     },
 }
+
+_TOOL_RESULT_LIMIT = 1500   # a small on-device model drowns in a full search dump
 
 
 @dataclass
@@ -86,9 +145,13 @@ class OllamaBrain:
     num_predict: int = 200
     system_prompt: str = SYSTEM_PROMPT
     location: str | None = None    # anchors 'here'/weather questions to a real place
-    # The triage seam: set by the router — called as delegator(task, agent) -> stamped
-    # handle; the pipeline drains pending delegations and announces their answers.
+    # The triage seams, set by the router: delegator(task, agent) -> stamped handle OPENS A
+    # THREAD in the mesh (the pipeline drains pending delegations and announces their
+    # answers); tool_runner(name, args) -> str runs the quick read-only tools in-round.
     delegator: object = None
+    tool_runner: object = None
+    tools: list = field(default_factory=list)   # specs offered alongside delegate_to_memex
+    agents: dict | None = None                  # delegation roster: name → description
     _pending: list = field(default_factory=list, init=False)
 
     _history: list[dict] = field(default_factory=list, init=False)
@@ -132,13 +195,15 @@ class OllamaBrain:
         pieces: list[str] = []
         import json as _json
         working = list(messages)
+        offered = list(self.tools) + (
+            [delegate_tool(self.agents)] if self.delegator is not None else [])
         try:
-            for _round in range(3):   # model → (tool) → model, bounded
+            for _round in range(4):   # model → (tool) → … → model, bounded (search+get+answer)
                 payload = {"model": self.model, "messages": working, "stream": True,
                            "think": False, "keep_alive": "60m",
                            "options": {"num_predict": self.num_predict}}
-                if self.delegator is not None:
-                    payload["tools"] = [DELEGATE_TOOL]
+                if offered:
+                    payload["tools"] = offered
                 tool_calls: list = []
                 async with self._http.post(f"{self.base_url}/api/chat", json=payload,
                                            timeout=aiohttp.ClientTimeout(total=300)) as response:
@@ -158,26 +223,44 @@ class OllamaBrain:
                             break
                 if not tool_calls:
                     break
-                # TRIAGE chose the mesh: open the thread(s), tell the model, let it hand off.
                 working.append({"role": "assistant", "content": "", "tool_calls": tool_calls})
                 for call in tool_calls:
-                    fn = (call.get("function") or {})
-                    args = fn.get("arguments") or {}
-                    if isinstance(args, str):
-                        try: args = _json.loads(args)
-                        except Exception: args = {"task": args}
-                    task = str(args.get("task", "")).strip()
-                    agent = args.get("agent") or None
-                    try:
-                        stamped = await self.delegator(task, agent)
-                        self._pending.append((stamped, task))
-                        result = "Delegated to memex. The answer will be announced when ready."
-                    except Exception as e:
-                        result = f"Delegation failed: {e}"
-                    working.append({"role": "tool", "content": result})
+                    working.append({"role": "tool",
+                                    "content": await self._dispatch_tool(call)})
         finally:
             await queue.put(None)
         return "".join(pieces).strip()
+
+    async def _dispatch_tool(self, call: dict) -> str:
+        """One tool call → its result string. delegate_to_memex OPENS A THREAD (via the
+        router's delegator) and queues the stamped handle for the announce path; everything
+        else runs through tool_runner, truncated to what a small model can digest."""
+        import json as _json
+        fn = (call.get("function") or {})
+        name = fn.get("name", "")
+        args = fn.get("arguments") or {}
+        if isinstance(args, str):
+            try: args = _json.loads(args)
+            except Exception: args = {"task": args} if name == "delegate_to_memex" else {}
+        if name == "delegate_to_memex":
+            if self.delegator is None:
+                return "Delegation is not configured."
+            task = str(args.get("task", "")).strip()
+            try:
+                stamped = await self.delegator(task, args.get("agent") or None)
+                self._pending.append((stamped, task))
+                return "Delegated: a memex thread is working on it. The answer will be announced."
+            except Exception as e:
+                return f"Delegation failed: {e}"
+        if self.tool_runner is None:
+            return f"Unknown tool: {name}"
+        try:
+            result = str(await self.tool_runner(name, args))
+        except Exception as e:
+            return f"Tool {name} failed: {e}"
+        if len(result) > _TOOL_RESULT_LIMIT:
+            result = result[:_TOOL_RESULT_LIMIT] + " …(truncated)"
+        return result
 
     def drain_delegations(self) -> list:
         """(stamped_handle, task) pairs the pipeline should announce answers for."""

--- a/clients/voice-gateway/memex_voice_gateway/ollama.py
+++ b/clients/voice-gateway/memex_voice_gateway/ollama.py
@@ -19,13 +19,18 @@ from dataclasses import dataclass, field
 import aiohttp
 
 SYSTEM_PROMPT = (
-    "You are a voice assistant on a smart speaker. Everything you write is read aloud by "
-    "text-to-speech: answer in at most two short sentences — no markdown, lists, code, or "
-    "links. Reply in the language you were addressed in; Swiss German arrives transcribed "
-    "as Standard German — reply in Standard German. Give the answer directly, not the "
-    "process; ask a follow-up question only when the request is genuinely ambiguous. Each "
-    "user message starts with its wall-clock time in brackets — use it to judge the time "
-    "gaps in the conversation."
+    "You are Memex, the on-device voice of the user's personal mesh — when asked who you "
+    "are, your name is Memex. Everything you write is read aloud by text-to-speech: at most "
+    "two short sentences, no markdown, lists, code, or links. Reply in the language you were "
+    "addressed in; Swiss German arrives transcribed as Standard German — reply in Standard "
+    "German. Say numbers and dates in speakable words. Each user message starts with its "
+    "wall-clock time in brackets — use it to judge gaps in the conversation.\n\n"
+    "TRIAGE — decide per request: answer DIRECTLY yourself for time, dates, general "
+    "knowledge, conversions, and small talk (you run on-device; speed is your virtue). "
+    "DELEGATE by calling delegate_to_memex for anything that needs the user's own data, "
+    "current information from the web, documents, or multi-step work — the mesh runs full "
+    "agents with tools there. After delegating, tell the user in ONE sentence that Memex is "
+    "on it and will announce the answer."
 )
 
 _WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
@@ -53,6 +58,26 @@ def build_messages(history: list[dict], text: str, system_prompt: str = SYSTEM_P
             {"role": "user", "content": text}]
 
 
+DELEGATE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "delegate_to_memex",
+        "description": "Hand a task to the user's mesh, where full agents with tools "
+                       "(their data, web search, documents) run it in a thread. The answer "
+                       "is announced to the user when ready.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "task": {"type": "string", "description": "The task, self-contained, in the user's language."},
+                "agent": {"type": "string", "enum": ["Voice", "Assistant", "Researcher"],
+                          "description": "Voice: quick data lookups. Assistant: general work. Researcher: deep research."},
+            },
+            "required": ["task"],
+        },
+    },
+}
+
+
 @dataclass
 class OllamaBrain:
     base_url: str
@@ -61,6 +86,10 @@ class OllamaBrain:
     num_predict: int = 200
     system_prompt: str = SYSTEM_PROMPT
     location: str | None = None    # anchors 'here'/weather questions to a real place
+    # The triage seam: set by the router — called as delegator(task, agent) -> stamped
+    # handle; the pipeline drains pending delegations and announces their answers.
+    delegator: object = None
+    _pending: list = field(default_factory=list, init=False)
 
     _history: list[dict] = field(default_factory=list, init=False)
     _last_used: float = field(default=0.0, init=False)
@@ -99,29 +128,61 @@ class OllamaBrain:
     async def _chat_streaming(self, messages: list[dict], handle: str) -> str:
         if self._http is None:
             self._http = aiohttp.ClientSession()
-        payload = {"model": self.model, "messages": messages, "stream": True,
-                   "think": False, "keep_alive": "60m",
-                   "options": {"num_predict": self.num_predict}}
         queue = self._chunks[handle]
         pieces: list[str] = []
         import json as _json
+        working = list(messages)
         try:
-            async with self._http.post(f"{self.base_url}/api/chat", json=payload,
-                                       timeout=aiohttp.ClientTimeout(total=300)) as response:
-                response.raise_for_status()
-                async for line in response.content:
-                    if not line.strip():
-                        continue
-                    data = _json.loads(line)
-                    piece = (data.get("message") or {}).get("content", "")
-                    if piece:
-                        pieces.append(piece)
-                        await queue.put(piece)
-                    if data.get("done"):
-                        break
+            for _round in range(3):   # model → (tool) → model, bounded
+                payload = {"model": self.model, "messages": working, "stream": True,
+                           "think": False, "keep_alive": "60m",
+                           "options": {"num_predict": self.num_predict}}
+                if self.delegator is not None:
+                    payload["tools"] = [DELEGATE_TOOL]
+                tool_calls: list = []
+                async with self._http.post(f"{self.base_url}/api/chat", json=payload,
+                                           timeout=aiohttp.ClientTimeout(total=300)) as response:
+                    response.raise_for_status()
+                    async for line in response.content:
+                        if not line.strip():
+                            continue
+                        data = _json.loads(line)
+                        message = data.get("message") or {}
+                        piece = message.get("content", "")
+                        if piece:
+                            pieces.append(piece)
+                            await queue.put(piece)
+                        if message.get("tool_calls"):
+                            tool_calls.extend(message["tool_calls"])
+                        if data.get("done"):
+                            break
+                if not tool_calls:
+                    break
+                # TRIAGE chose the mesh: open the thread(s), tell the model, let it hand off.
+                working.append({"role": "assistant", "content": "", "tool_calls": tool_calls})
+                for call in tool_calls:
+                    fn = (call.get("function") or {})
+                    args = fn.get("arguments") or {}
+                    if isinstance(args, str):
+                        try: args = _json.loads(args)
+                        except Exception: args = {"task": args}
+                    task = str(args.get("task", "")).strip()
+                    agent = args.get("agent") or None
+                    try:
+                        stamped = await self.delegator(task, agent)
+                        self._pending.append((stamped, task))
+                        result = "Delegated to memex. The answer will be announced when ready."
+                    except Exception as e:
+                        result = f"Delegation failed: {e}"
+                    working.append({"role": "tool", "content": result})
         finally:
             await queue.put(None)
         return "".join(pieces).strip()
+
+    def drain_delegations(self) -> list:
+        """(stamped_handle, task) pairs the pipeline should announce answers for."""
+        pending, self._pending = self._pending, []
+        return pending
 
     async def ask(self, text: str) -> str:
         """Start generating; returns a handle usable with await_reply (pipeline contract)."""

--- a/clients/voice-gateway/memex_voice_gateway/pipeline.py
+++ b/clients/voice-gateway/memex_voice_gateway/pipeline.py
@@ -71,7 +71,9 @@ class VoicePipeline:
         stream_speak: Callable[[object], Awaitable[str]] | None = None,
         hold_phrase_for: Callable[[str], str] | None = None,
         answer_to_template: str | None = None,
+        drain_delegations: Callable[[], list] | None = None,
     ) -> None:
+        self._drain_delegations = drain_delegations
         self._command_handler = command_handler
         self._stream_text = stream_text
         self._stream_speak = stream_speak
@@ -128,6 +130,14 @@ class VoicePipeline:
             return RoundResult(transcript, self._error_phrase,
                                await self._try_speak(self._error_phrase))
         logger.info("round: %r → %r", transcript, (reply or "")[:120])
+
+        # The local brain may have TRIAGED work to the mesh mid-round: schedule the
+        # announcement of each delegated thread's answer, attributed to its task.
+        if self._drain_delegations is not None:
+            for handle, task in self._drain_delegations():
+                delegated = asyncio.create_task(self._announce_when_ready(handle, task))
+                self._background.add(delegated)
+                delegated.add_done_callback(self._background.discard)
 
         if reply is not None:
             return RoundResult(transcript, reply, await self._try_speak(reply))

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -32,6 +32,10 @@ _STOP = re.compile(r"^\s*(?:stop|stopp|halt|sei still|ruhe|schweig|genug)[.!]?\s
 # Courteous closure is the END of an exchange, not a prompt: answering "Vielen Dank" with
 # "Gerne geschehen!" made the device hear its own reply (or the TV's politeness) and wake
 # again — a self-thanking loop, five rounds in 90 seconds, observed live.
+# A wake-word chant ("hey memex hey memex …") is a TRAINING RECORDING, not a question —
+# record it (the satellite already has), answer nothing.
+_CHANT = re.compile(r"^\s*(?:hey,?\s*(?:memex|jarvis|nabu)[.!,;\s]*){2,}$", re.IGNORECASE)
+
 _CLOSURE = re.compile(r"^\s*(?:vielen dank|danke(?:\s*(?:dir|sch(?:ö|oe)n|vielmals))?|merci(?:\s*vielmal)?|"
                       r"thank(?:s| you)|ok(?:ay)?|gut|super|perfekt|alles klar|tsch(?:ü|ue)ss|"
                       r"bis sp(?:ä|ae)ter|gute nacht)[.!,\s]*$", re.IGNORECASE)
@@ -92,6 +96,24 @@ class BrainRouter:
             return self.active
         return next(iter(self._mesh), None)
 
+    async def delegate_task(self, task: str, agent: str | None = None) -> str:
+        """The local brain's triage seam: open a mesh thread, return the STAMPED handle so
+        await_reply later polls the right brain. Raises when no mesh portal is configured."""
+        target = self._mesh_target()
+        if target is None:
+            raise RuntimeError("no mesh portal configured")
+        path = await self._brains[target].delegate(task, agent)  # type: ignore[attr-defined]
+        return f"{target}::{path}"
+
+    def drain_delegations(self) -> list:
+        """Pending (handle, task) pairs from ANY brain that collects them (the local one)."""
+        pending: list = []
+        for brain in self._brains.values():
+            drain = getattr(brain, "drain_delegations", None)
+            if drain:
+                pending.extend(drain())
+        return pending
+
     def describe_hold(self, handle: str) -> str:
         """What to say when the answer will come later — mesh submissions are ACKNOWLEDGED
         by portal name, because their answers can arrive highly asynchronously."""
@@ -112,7 +134,8 @@ class BrainRouter:
     async def handle_command(self, transcript: str) -> str | None:
         """Returns the spoken confirmation when the transcript was a command;
         empty string = handled silently (say nothing)."""
-        if _STOP.match(transcript.strip()) or _CLOSURE.match(transcript.strip()):
+        if (_STOP.match(transcript.strip()) or _CLOSURE.match(transcript.strip())
+                or _CHANT.match(transcript.strip())):
             return ""     # stop or courteous closure: end quietly, never reply to a reply
 
         # Delegation: launch a real thread for a STANDARD agent on the mesh and leave the

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -29,6 +29,13 @@ class Brain(Protocol):
 
 _STOP = re.compile(r"^\s*(?:stop|stopp|halt|sei still|ruhe|schweig|genug)[.!]?\s*$", re.IGNORECASE)
 
+# Courteous closure is the END of an exchange, not a prompt: answering "Vielen Dank" with
+# "Gerne geschehen!" made the device hear its own reply (or the TV's politeness) and wake
+# again — a self-thanking loop, five rounds in 90 seconds, observed live.
+_CLOSURE = re.compile(r"^\s*(?:vielen dank|danke(?:\s*(?:dir|sch(?:ö|oe)n|vielmals))?|merci(?:\s*vielmal)?|"
+                      r"thank(?:s| you)|ok(?:ay)?|gut|super|perfekt|alles klar|tsch(?:ü|ue)ss|"
+                      r"bis sp(?:ä|ae)ter|gute nacht)[.!,\s]*$", re.IGNORECASE)
+
 _SWITCH = re.compile(
     r"^\s*(?:switch to|connect to|go to|wechsle zu|wechsel zu|verbinde mit|verbinde dich mit|"
     r"gang uf|verbind mit|geh zu)\s+(?P<target>[\wäöüéè .-]+?)[.!?]?\s*$",
@@ -105,8 +112,8 @@ class BrainRouter:
     async def handle_command(self, transcript: str) -> str | None:
         """Returns the spoken confirmation when the transcript was a command;
         empty string = handled silently (say nothing)."""
-        if _STOP.match(transcript.strip()):
-            return ""     # barge-in already stopped playback at wake; just end quietly
+        if _STOP.match(transcript.strip()) or _CLOSURE.match(transcript.strip()):
+            return ""     # stop or courteous closure: end quietly, never reply to a reply
 
         # Delegation: launch a real thread for a STANDARD agent on the mesh and leave the
         # work to be evaluated THERE — the speaker only confirms the submission.

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -81,7 +81,9 @@ _DEFAULT_PHRASES = {
 class BrainRouter:
     def __init__(self, brains: dict[str, Brain], active: str,
                  phrases: dict[str, str] | None = None,
-                 mesh_brains: set[str] | None = None) -> None:
+                 mesh_brains: set[str] | None = None,
+                 home: object = None,
+                 agent_homes: dict[str, str] | None = None) -> None:
         if active not in brains:
             raise ValueError(f"active brain {active!r} not among {list(brains)}")
         self._brains = brains
@@ -89,6 +91,10 @@ class BrainRouter:
         self._phrases = {**_DEFAULT_PHRASES, **(phrases or {})}
         self._mesh = mesh_brains if mesh_brains is not None else {
             n for n, b in brains.items() if hasattr(b, "delegate")}
+        self._home = home     # HomeAssistant client, when configured
+        # Agent name → the portal that HOSTS it (a portal entry's "agents" list): the
+        # ExecutiveAssistant may live on the local mesh while Researcher lives in the cloud.
+        self._agent_homes = agent_homes or {}
 
     def _mesh_target(self) -> str | None:
         """The portal delegations go to: the active brain when it is a mesh, else the first mesh."""
@@ -98,12 +104,35 @@ class BrainRouter:
 
     async def delegate_task(self, task: str, agent: str | None = None) -> str:
         """The local brain's triage seam: open a mesh thread, return the STAMPED handle so
-        await_reply later polls the right brain. Raises when no mesh portal is configured."""
-        target = self._mesh_target()
+        await_reply later polls the right brain. An agent with a declared HOME portal goes
+        there; anything else goes to the active/first mesh. Raises when no mesh is configured."""
+        target = None
+        if agent and (housed := self._agent_homes.get(agent)) in self._mesh:
+            target = housed
+        target = target or self._mesh_target()
         if target is None:
             raise RuntimeError("no mesh portal configured")
         path = await self._brains[target].delegate(task, agent)  # type: ignore[attr-defined]
         return f"{target}::{path}"
+
+    async def run_tool(self, name: str, args: dict) -> str:
+        """The local brain's quick tools, run in-round: mesh reads go to the same portal
+        delegations would (the active brain when it is a mesh, else the first mesh);
+        home_assistant goes to the configured HA instance."""
+        if name == "home_assistant":
+            if self._home is None:
+                return "Home Assistant is not configured."
+            return await self._home.run(args)
+        target = self._mesh_target()
+        if target is None:
+            return "No mesh portal is configured."
+        client = self._brains[target]
+        if name == "search_mesh":
+            return await client.call("search", {"query": str(args.get("query", "")).strip(),
+                                                "limit": 8})  # type: ignore[attr-defined]
+        if name == "get_node":
+            return await client.call("get", {"path": str(args.get("path", "")).strip()})  # type: ignore[attr-defined]
+        return f"Unknown tool: {name}"
 
     def drain_delegations(self) -> list:
         """Pending (handle, task) pairs from ANY brain that collects them (the local one)."""
@@ -183,3 +212,5 @@ class BrainRouter:
     async def close(self) -> None:
         for brain in self._brains.values():
             await brain.close()
+        if self._home is not None:
+            await self._home.close()  # type: ignore[attr-defined]

--- a/clients/voice-gateway/memex_voice_gateway/satellite.py
+++ b/clients/voice-gateway/memex_voice_gateway/satellite.py
@@ -115,11 +115,14 @@ class SatelliteLink:
             logger.warning("WAKE_WORD %r not on the device; using %r", wanted, chosen)
         # The CONFIGURED wake word must actually be active — a reflash or NVS can leave an
         # old selection in place, and "available but inactive" hears nothing.
-        if chosen not in active:
-            limit = getattr(conf, "max_active_wake_words", 1) or 1
-            desired = ([chosen] + [w for w in active if w != chosen])[:limit]
+        limit = getattr(conf, "max_active_wake_words", 1) or 1
+        # Prefer the configured word; keep a proven fallback model active beside it when the
+        # device allows more than one (a young custom model should not be the only ear).
+        fallback = [w for w in ("hey_jarvis", *active) if w in available and w != chosen]
+        desired = ([chosen] + fallback)[:limit]
+        if set(desired) != set(active):
             await self.client.set_voice_assistant_configuration(active_wake_words=desired)
-            logger.info("activated wake words %s", desired)
+            logger.info("activated wake words %s (max %s)", desired, limit)
 
     # --- voice assistant callbacks ----------------------------------------------------
 
@@ -149,8 +152,12 @@ class SatelliteLink:
             silence_ms=self.cfg.silence_ms,
             max_utterance_s=self.cfg.max_utterance_s,
             min_utterance_s=self.cfg.min_utterance_s,
-            calibrate_ms=400 if follow_up else 0,
-            onset_timeout_s=5.0 if follow_up else 0,
+            # EVERY round ignores its first moments: a wake round starts with the wake
+            # word's own tail (which must not count as the utterance — it made rounds close
+            # ~1s after wake, before the question was asked), a follow-up starts with room
+            # ambience. The lead-in calibrates the noise floor instead of listening.
+            calibrate_ms=400 if follow_up else 600,
+            onset_timeout_s=5.0 if follow_up else 8.0,
         )
         self._utterance_done.clear()
         self._round_task = asyncio.create_task(self._run_round())
@@ -180,6 +187,19 @@ class SatelliteLink:
             pass
         endpointer, self._endpointer = self._endpointer, None
         pcm = endpointer.audio if endpointer else b""
+        # Retain the raw utterance locally when configured: real-voice recordings are the
+        # retraining corpus that fixes what synthetic TTS samples cannot (the owner's accent).
+        if self.cfg.record_dir and pcm:
+            try:
+                import os as _os
+                import time as _t
+                from .stt import wav_from_pcm as _wav
+                _os.makedirs(self.cfg.record_dir, exist_ok=True)
+                name = f"round_{_t.strftime('%Y%m%d_%H%M%S')}_{'fu' if self._follow_up else 'wake'}.wav"
+                with open(_os.path.join(self.cfg.record_dir, name), "wb") as f:
+                    f.write(_wav(pcm, self.cfg.sample_rate))
+            except Exception:
+                logger.debug("recording save failed", exc_info=True)
         # A follow-up that never paused (TV, music) or never started (silence) is not
         # addressed to the assistant: end the conversation quietly instead of answering it.
         if self._follow_up and endpointer is not None and endpointer.ended_by_cap:

--- a/clients/voice-gateway/memex_voice_gateway/stt.py
+++ b/clients/voice-gateway/memex_voice_gateway/stt.py
@@ -24,6 +24,21 @@ def wav_from_pcm(pcm: bytes, sample_rate: int = 16000, channels: int = 1) -> byt
     return header + pcm
 
 
+def resample_to_16k(pcm: bytes, rate: int) -> bytes:
+    """Integer-factor downsample to 16 kHz (pairwise mean then decimate) — whisper.cpp's
+    server assumes 16 kHz and reads anything else at the wrong speed (chipmunk noise that
+    transcribes as *Klopfen*/*Musik* hallucinations; bitten live with the 32 kHz firmware)."""
+    if rate == 16000 or rate % 16000:
+        return pcm
+    factor = rate // 16000
+    import array
+    samples = array.array("h")
+    samples.frombytes(pcm[: len(pcm) - (len(pcm) % (2 * factor))])
+    out = array.array("h", (sum(samples[i:i + factor]) // factor
+                            for i in range(0, len(samples) - factor + 1, factor)))
+    return out.tobytes()
+
+
 async def transcribe(
     session: aiohttp.ClientSession,
     url: str,
@@ -34,6 +49,8 @@ async def transcribe(
     sample_rate: int = 16000,
 ) -> str:
     """Returns the transcript text; raises on transport errors, empty text on silence."""
+    pcm = resample_to_16k(pcm, sample_rate)
+    sample_rate = 16000
     form = aiohttp.FormData()
     form.add_field("file", wav_from_pcm(pcm, sample_rate), filename="utterance.wav",
                    content_type="audio/wav")

--- a/clients/voice-gateway/memex_voice_gateway/tts.py
+++ b/clients/voice-gateway/memex_voice_gateway/tts.py
@@ -46,7 +46,9 @@ class SayTts:
 
     @staticmethod
     def build_args(voice: str, out_path: str) -> list[str]:
-        return ["say", "-v", voice, "-o", out_path, "--data-format=LEI16@22050", "-f", "-"]
+        # 16 kHz: the satellite firmware micro_decoder rejects 22050 Hz ('Decode finished'
+        # after ~300ms, silent playback — the reason no reply was ever HEARD on it).
+        return ["say", "-v", voice, "-o", out_path, "--data-format=LEI16@16000", "-f", "-"]
 
     async def synthesize(self, text: str) -> bytes:
         import os
@@ -96,18 +98,34 @@ def streaming_wav_header(sample_rate: int, channels: int = 1) -> bytes:
 
 
 class StreamingWav:
-    """One in-flight streamed utterance: PCM sentences arrive on a queue while the device
-    is already playing the URL. `close()` ends the stream (and the playback)."""
+    """One in-flight streamed utterance. PCM sentences are BUFFERED as they arrive, and any
+    number of readers replay the buffer then follow the live tail — the device's player
+    sniffs the URL (a short first request) and then re-requests it for actual playback, so
+    a single-use stream plays as silence (observed: 200-byte fetches, then nothing)."""
 
     def __init__(self, sample_rate: int) -> None:
         self.sample_rate = sample_rate
-        self.queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        self.chunks: list[bytes] = []
+        self.closed = False
+        self._changed = asyncio.Condition()
 
     async def push(self, pcm: bytes) -> None:
-        await self.queue.put(pcm)
+        async with self._changed:
+            self.chunks.append(pcm)
+            self._changed.notify_all()
 
     async def close(self) -> None:
-        await self.queue.put(None)
+        async with self._changed:
+            self.closed = True
+            self._changed.notify_all()
+
+    async def read_from(self, index: int) -> bytes | None:
+        """The chunk at `index`, waiting for it if the stream is still being fed;
+        None once the stream is closed and fully consumed."""
+        async with self._changed:
+            while index >= len(self.chunks) and not self.closed:
+                await self._changed.wait()
+            return self.chunks[index] if index < len(self.chunks) else None
 
 
 class TtsFileServer:
@@ -124,9 +142,15 @@ class TtsFileServer:
         self._runner: web.AppRunner | None = None
 
     def open_stream(self, sample_rate: int) -> tuple[StreamingWav, str]:
+        # Expire finished streams by TTL (they stay addressable for the player's re-request).
+        now = time.monotonic()
+        self._stream_born = getattr(self, "_stream_born", {})
+        for sid in [sid for sid, born in self._stream_born.items() if now - born > self.ttl_s]:
+            self._streams.pop(sid, None); self._stream_born.pop(sid, None)
         stream = StreamingWav(sample_rate)
         stream_id = secrets.token_urlsafe(8)
         self._streams[stream_id] = stream
+        self._stream_born[stream_id] = now
         self._live.add(stream)
         return stream, f"http://{self.host}:{self.port}/tts-stream/{stream_id}.wav"
 
@@ -137,19 +161,22 @@ class TtsFileServer:
         self._live.clear()
 
     async def _handle_stream(self, request: web.Request) -> web.StreamResponse:
-        stream = self._streams.pop(request.match_info["id"], None)
+        stream = self._streams.get(request.match_info["id"])
         if stream is None:
             return web.Response(status=404)
         response = web.StreamResponse(headers={"Content-Type": "audio/wav"})
         response.enable_chunked_encoding()
         await response.prepare(request)
         await response.write(streaming_wav_header(stream.sample_rate))
+        index = 0
         try:
-            while (pcm := await stream.queue.get()) is not None:
+            while (pcm := await stream.read_from(index)) is not None:
+                index += 1
                 await response.write(pcm)
             await response.write_eof()
         finally:
-            self._live.discard(stream)
+            if stream.closed:
+                self._live.discard(stream)
         return response
 
     def add(self, wav: bytes) -> str:

--- a/clients/voice-gateway/memex_voice_gateway/tts.py
+++ b/clients/voice-gateway/memex_voice_gateway/tts.py
@@ -179,22 +179,35 @@ class TtsFileServer:
                 self._live.discard(stream)
         return response
 
+    @staticmethod
+    def _wav_to_flac(wav: bytes) -> bytes:
+        """The satellite's micro_decoder ships WITHOUT the WAV codec (its own config:
+        'FLAC is the least processor intensive') — Home Assistant transcodes announcements
+        to the device's announced format, and so must we."""
+        import subprocess
+        r = subprocess.run(["ffmpeg", "-loglevel", "error", "-f", "wav", "-i", "pipe:0",
+                            "-f", "flac", "-compression_level", "0", "pipe:1"],
+                           input=wav, capture_output=True)
+        if r.returncode != 0 or not r.stdout:
+            raise RuntimeError(f"flac transcode failed: {r.stderr.decode()[:200]}")
+        return r.stdout
+
     def add(self, wav: bytes) -> str:
         now = time.monotonic()
         self._files = {k: v for k, v in self._files.items() if now - v[0] < self.ttl_s}
         file_id = secrets.token_urlsafe(8)
-        self._files[file_id] = (now, wav)
-        return f"http://{self.host}:{self.port}/tts/{file_id}.wav"
+        self._files[file_id] = (now, self._wav_to_flac(wav))
+        return f"http://{self.host}:{self.port}/tts/{file_id}.flac"
 
     async def _handle(self, request: web.Request) -> web.Response:
         entry = self._files.get(request.match_info["id"])
         if entry is None:
             return web.Response(status=404)
-        return web.Response(body=entry[1], content_type="audio/wav")
+        return web.Response(body=entry[1], content_type="audio/flac")
 
     async def start(self) -> None:
         app = web.Application()
-        app.router.add_get("/tts/{id}.wav", self._handle)
+        app.router.add_get("/tts/{id}.flac", self._handle)
         app.router.add_get("/tts-stream/{id}.wav", self._handle_stream)
         self._runner = web.AppRunner(app)
         await self._runner.setup()

--- a/clients/voice-gateway/memex_voice_gateway/tts.py
+++ b/clients/voice-gateway/memex_voice_gateway/tts.py
@@ -41,8 +41,23 @@ class SayTts:
     its bytes; the temp file is removed immediately.
     """
 
-    def __init__(self, voice: str = "Anna") -> None:
+    def __init__(self, voice: str = "Anna", english_voice: str = "Samantha") -> None:
         self.voice = voice
+        self.english_voice = english_voice
+
+    @staticmethod
+    def _looks_german(text: str) -> bool:
+        """Cheap language guess: a German voice reading English sounds awful (and vice
+        versa), so the voice follows the reply's language."""
+        lowered = f" {text.lower()} "
+        german_markers = (" der ", " die ", " das ", " und ", " ist ", " nicht ", " ich ",
+                          " sie ", " mit ", " ein ", " eine ", " zu ", " haben ", " wie ",
+                          "ä", "ö", "ü", "ß")
+        english_markers = (" the ", " is ", " are ", " you ", " and ", " to ", " of ",
+                           " have ", " what ", " it ")
+        g = sum(m in lowered for m in german_markers)
+        e = sum(m in lowered for m in english_markers)
+        return g >= e
 
     @staticmethod
     def build_args(voice: str, out_path: str) -> list[str]:
@@ -56,8 +71,9 @@ class SayTts:
         fd, path = tempfile.mkstemp(suffix=".wav")
         os.close(fd)
         try:
+            voice = self.voice if self._looks_german(text) else self.english_voice
             process = await asyncio.create_subprocess_exec(
-                *self.build_args(self.voice, path),
+                *self.build_args(voice, path),
                 stdin=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
             _, err = await process.communicate(text.encode())
             if process.returncode != 0:

--- a/clients/voice-gateway/tests/test_ollama.py
+++ b/clients/voice-gateway/tests/test_ollama.py
@@ -89,3 +89,39 @@ def test_triage_delegates_and_collects_pending():
         await brain.close()
 
     asyncio.run(scenario())
+
+
+def test_dispatch_tool_routes_delegate_and_quick_tools():
+    async def scenario():
+        brain = OllamaBrain("http://unused", "test-model")
+        calls = []
+
+        async def delegator(task, agent=None):
+            calls.append(("delegate", task, agent))
+            return "memex::u/_Thread/t1"
+
+        async def tool_runner(name, args):
+            calls.append((name, args))
+            return "x" * 2000 if name == "search_mesh" else "state: on"
+
+        brain.delegator = delegator
+        brain.tool_runner = tool_runner
+
+        out = await brain._dispatch_tool({"function": {
+            "name": "delegate_to_memex",
+            "arguments": {"task": "Wetter morgen", "agent": "Voice"}}})
+        assert "announced" in out
+        assert brain.drain_delegations() == [("memex::u/_Thread/t1", "Wetter morgen")]
+
+        out = await brain._dispatch_tool({"function": {
+            "name": "search_mesh", "arguments": '{"query": "kantone"}'}})
+        assert out.endswith("…(truncated)") and len(out) < 2000
+
+        out = await brain._dispatch_tool({"function": {
+            "name": "home_assistant", "arguments": {"action": "get_state"}}})
+        assert out == "state: on"
+        assert calls[0] == ("delegate", "Wetter morgen", "Voice")
+        assert calls[1] == ("search_mesh", {"query": "kantone"})
+        await brain.close()
+
+    asyncio.run(scenario())

--- a/clients/voice-gateway/tests/test_ollama.py
+++ b/clients/voice-gateway/tests/test_ollama.py
@@ -57,3 +57,35 @@ def test_real_time_anchor_in_messages():
     assert stamp == "Current time: Tuesday, 18 August 2026, 21:30."
     messages = build_messages([], "[21:30] Frage", now=stamp)
     assert stamp in messages[0]["content"] and messages[0]["role"] == "system"
+
+
+def test_triage_delegates_and_collects_pending():
+    async def scenario():
+        brain = OllamaBrain("http://unused", "test-model")
+        delegated = []
+
+        async def delegator(task, agent=None):
+            delegated.append((task, agent))
+            return f"memex::u/_Thread/t{len(delegated)}"
+
+        brain.delegator = delegator
+
+        async def fake_streaming(messages, handle):
+            queue = brain._chunks[handle]
+            # emulate: model tool-calls, then (after the tool result) speaks the handoff
+            if not any(m.get("role") == "tool" for m in messages):
+                pass  # the real loop feeds tools within one call; simulate final directly
+            await queue.put("Memex ist dran und meldet sich.")
+            brain._pending.append(("memex::u/_Thread/t1", "Wetter morgen"))
+            await queue.put(None)
+            return "Memex ist dran und meldet sich."
+
+        brain._chat_streaming = fake_streaming
+        handle = await brain.ask("Wie wird das Wetter morgen?")
+        reply = await brain.await_reply(handle, 1.0)
+        assert reply == "Memex ist dran und meldet sich."
+        assert brain.drain_delegations() == [("memex::u/_Thread/t1", "Wetter morgen")]
+        assert brain.drain_delegations() == []
+        await brain.close()
+
+    asyncio.run(scenario())

--- a/clients/voice-gateway/tests/test_router.py
+++ b/clients/voice-gateway/tests/test_router.py
@@ -80,3 +80,59 @@ def test_delegation_to_a_standard_agent():
         assert router.describe_hold("lokal::x") == "Let me check. One moment please."
 
     asyncio.run(scenario())
+
+
+def test_run_tool_dispatches_to_mesh_and_home():
+    class FakeMesh:
+        def __init__(self):
+            self.calls = []
+        async def ask(self, text): return "h"
+        async def await_reply(self, handle, budget_s): return None
+        async def delegate(self, text, agent=None): return "u/_Thread/t1"
+        async def call(self, tool, arguments):
+            self.calls.append((tool, arguments))
+            return f"{tool}-result"
+        async def close(self): pass
+
+    class FakeHome:
+        async def run(self, args): return f"home:{args['action']}"
+        async def close(self): pass
+
+    async def scenario():
+        mesh = FakeMesh()
+        router = BrainRouter({"memex": mesh}, "memex", home=FakeHome())
+        assert await router.run_tool("search_mesh", {"query": "kantone"}) == "search-result"
+        assert await router.run_tool("get_node", {"path": "@Edu/Guide"}) == "get-result"
+        assert await router.run_tool("home_assistant", {"action": "get_state"}) == "home:get_state"
+        assert mesh.calls == [("search", {"query": "kantone", "limit": 8}),
+                              ("get", {"path": "@Edu/Guide"})]
+        bare = BrainRouter({"memex": mesh}, "memex")
+        assert "not configured" in await bare.run_tool("home_assistant", {"action": "get_state"})
+        await router.close()
+
+    asyncio.run(scenario())
+
+
+def test_delegate_routes_agent_to_its_home_portal():
+    class FakeMesh:
+        def __init__(self):
+            self.delegated = []
+        async def ask(self, text): return "h"
+        async def await_reply(self, handle, budget_s): return None
+        async def delegate(self, text, agent=None):
+            self.delegated.append((text, agent))
+            return "u/_Thread/t1"
+        async def close(self): pass
+
+    async def scenario():
+        cloud, mac = FakeMesh(), FakeMesh()
+        router = BrainRouter({"memex": cloud, "mac": mac}, "memex",
+                             agent_homes={"ExecutiveAssistant": "mac"})
+        # Email agent goes HOME to the local mesh, even while the cloud is active.
+        handle = await router.delegate_task("Check my inbox", "ExecutiveAssistant")
+        assert handle.startswith("mac::") and mac.delegated and not cloud.delegated
+        # Unpinned agents keep going to the active mesh.
+        handle = await router.delegate_task("Research quantum", "Researcher")
+        assert handle.startswith("memex::") and cloud.delegated
+
+    asyncio.run(scenario())

--- a/clients/voice-gateway/tests/test_streaming.py
+++ b/clients/voice-gateway/tests/test_streaming.py
@@ -41,10 +41,12 @@ async def test_stream_endpoint_plays_chunks_as_they_arrive():
         assert body[:4] == b"RIFF"
         assert body[44:] == b"AA" * 100 + b"BB" * 100
 
-        # a stream id is single-use
+        # a stream is REPLAYABLE: the device's player sniffs the URL and re-requests it
+        # for playback, so the second fetch must serve the full buffered audio again
         async with aiohttp.ClientSession() as http:
             async with http.get(url) as response:
-                assert response.status == 404
+                assert response.status == 200
+                assert (await response.read())[44:] == b"AA" * 100 + b"BB" * 100
     finally:
         await server.stop()
 


### PR DESCRIPTION
The satellite's local brain becomes a TRIAGE layer with the standard toolset:

- **search_mesh / get_node** — the normal read-only mesh tools, run in-round against the same portal delegations go to, so a quick lookup never costs a whole thread.
- **home_assistant** — smart-home control over HA's REST API (`HA_URL` + `HA_TOKEN`); the gateway keeps the satellite's voice subscription, HA rides alongside as a tool.
- **delegate_to_memex** — opens a real thread in the mesh, where the chosen agent's own system prompt and tools apply; the answer is announced later, attributed to its question. The agent roster is configuration: a portal entry's `agents` extends the enum and pins each agent to the portal that hosts it — email always routes to the ExecutiveAssistant on the local mesh.

Identity prompt (it IS Memex), language-aware TTS voice, and the wake-chant filter ride along. 32 gateway tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)