### PR TITLE
deps-closure: skip framework-trimmed files instead of refusing

### DIFF
--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -308,23 +308,36 @@ public static class ModulePackCommand
             }
             foreach (var warning in derived.Warnings)
                 Console.Error.WriteLine($"warning: {warning}");
-            var missing = derived.Files
-                .Where(f => !File.Exists(Path.Combine(moduleDirectory, f)))
+            var present = derived.Files
+                .Where(f => File.Exists(Path.Combine(moduleDirectory, f)))
                 .ToList();
-            if (missing.Count > 0)
+            var missing = derived.Files.Except(present, StringComparer.OrdinalIgnoreCase).ToList();
+
+            // A derived file ABSENT from a CopyLocalLockFileAssemblies build was FRAMEWORK-TRIMMED:
+            // the SDK resolved that package to the shared framework (Microsoft.Extensions.* riding
+            // in Microsoft.AspNetCore.App), so the consumer's runtime provides it and the bundle
+            // need not. Skipped with a line each, never silently. The one case that must STAY an
+            // error is a build that ran without the flag at all — then NOTHING was copied, and
+            // skipping would pack the entry-only bundle this flag exists to abolish. The two are
+            // distinguishable: package assemblies in the output prove the flag was on (project
+            // references copy only MeshWeaver.*, which the derivation never includes).
+            if (missing.Count > 0 && present.Count == 0)
             {
                 Console.Error.WriteLine(
-                    "error: --deps-closure derived files that are not in the module output — build "
+                    "error: --deps-closure derived files and NONE are in the module output — build "
                     + "with -p:CopyLocalLockFileAssemblies=true so package assemblies are copied. "
                     + $"Missing: {string.Join(", ", missing)}");
                 return 2;
             }
-            foreach (var file in derived.Files)
+            foreach (var file in missing)
+                Console.WriteLine($"deps-closure: excluded (framework-resolved): {file}");
+            foreach (var file in present)
                 if (!closure.Contains(file, StringComparer.OrdinalIgnoreCase))
                     closure.Add(file);
             Console.WriteLine(
-                $"deps-closure: bundling {derived.Files.Count} private dependency file(s); "
-                + $"excluded {derived.ExcludedPlatformCarried.Count} platform-carried");
+                $"deps-closure: bundling {present.Count} private dependency file(s); "
+                + $"excluded {derived.ExcludedPlatformCarried.Count} platform-carried, "
+                + $"{missing.Count} framework-resolved");
         }
 
         foreach (var extra in extras)

--- a/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
@@ -149,11 +149,61 @@ public class ModulePackCommandTest : IDisposable
     }
 
     [Fact]
+    public void DepsClosure_SkipsFrameworkTrimmedFiles_WhenOthersArePresent()
+    {
+        // Gadget.Sdk was copied to the output; Microsoft.Extensions.Options was FRAMEWORK-TRIMMED
+        // by the SDK (resolved to the shared framework, so CopyLocalLockFileAssemblies does not
+        // copy it). The bundle carries what is present and skips what the consumer's runtime
+        // provides — loudly, never as an error, because failing here blocked six of fourteen
+        // modules on CI while the same pack passed on a dev machine whose SDK had copied the file.
+        File.WriteAllBytes(Path.Combine(root, "closure", "Gadget.Sdk.dll"), "SDK"u8.ToArray());
+        File.WriteAllText(Path.Combine(root, "closure", "Widget.deps.json"), """
+            {
+              "runtimeTarget": { "name": ".NETCoreApp,Version=v10.0" },
+              "targets": {
+                ".NETCoreApp,Version=v10.0": {
+                  "Widget/1.0.0": {
+                    "dependencies": { "Gadget.Sdk": "2.0.0", "Microsoft.Extensions.Options": "10.0.0" },
+                    "runtime": { "Widget.dll": {} }
+                  },
+                  "Gadget.Sdk/2.0.0": { "runtime": { "lib/net10.0/Gadget.Sdk.dll": {} } },
+                  "Microsoft.Extensions.Options/10.0.0": { "runtime": { "lib/net10.0/Microsoft.Extensions.Options.dll": {} } }
+                }
+              },
+              "libraries": {
+                "Widget/1.0.0": { "type": "project" },
+                "Gadget.Sdk/2.0.0": { "type": "package" },
+                "Microsoft.Extensions.Options/10.0.0": { "type": "package" }
+              }
+            }
+            """);
+
+        var outDir = Path.Combine(root, "out-trimmed");
+        var exit = ModulePackCommand.Run(
+        [
+            Path.Combine(root, "closure"),
+            "--deps-closure",
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.5.0",
+            "--out", outDir,
+        ]);
+
+        Assert.Equal(0, exit);
+        var (manifest, files) = BundleReader.ReadModule(File.ReadAllBytes(
+            Path.Combine(outDir, "MeshWeaver.Plugin.WidgetPkg.1.5.0.module.nupkg")));
+        Assert.Contains("Gadget.Sdk.dll", manifest!.Module!.Assemblies!);
+        Assert.DoesNotContain("Microsoft.Extensions.Options.dll", manifest.Module.Assemblies!);
+        Assert.Contains(files, f => f.FileName == "Gadget.Sdk.dll");
+    }
+
+    [Fact]
     public void DepsClosure_WithTheFileMissingFromTheOutput_IsARefusal()
     {
         // deps.json names a dependency that is NOT in the folder — the build ran without
-        // CopyLocalLockFileAssemblies. Packing anyway would land a module that faults at first
-        // use, which is the outage this flag exists to close.
+        // CopyLocalLockFileAssemblies, so NOTHING was copied. Packing anyway would land a module
+        // that faults at first use, which is the outage this flag exists to close. (A PARTIAL
+        // absence is the framework-trim case above — skipped, not refused.)
         File.WriteAllText(Path.Combine(root, "closure", "Widget.deps.json"), """
             {
               "runtimeTarget": { "name": ".NETCoreApp,Version=v10.0" },


### PR DESCRIPTION
Six of fourteen module packs failed on the first #1914 main run: `Microsoft.Extensions.*` assemblies were derived from deps.json but absent from the build output — the SDK **framework-trimmed** them (resolved to the shared framework, so `CopyLocalLockFileAssemblies` doesn't copy them). They're in every consumer's runtime by construction, so the bundle need not carry them.

- some derived files present → absent ones are skipped as `framework-resolved`, one log line each
- **none** present → still a refusal (the build ran without the flag; skipping would re-create the entry-only bundle)

The distinction is sound: project references copy only MeshWeaver.\* — which the derivation never includes — so any package assembly in the output proves the flag was on.

Pinned by a new round-trip test (14/14 green). After merge: re-run the failed six jobs on the Plugins main run — the packer is rebuilt from the fresh platform checkout, so no workflow change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)