### PR TITLE
feat(local-first): the mesh list lives in the local mesh; the app opens into your activities

### DIFF
--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -20,7 +20,7 @@ import { buildMeshOps } from "./src/liveOps";
 import { NavContext, CurrentAddressContext, type NavTarget } from "./src/nav";
 import { Shell, HOME } from "./src/Shell";
 import { ensureWebStyles } from "./src/webStyles";
-import { currentInstance, seedDefaultInstances, setConnectStatus } from "./src/connection";
+import { attachInstanceStore, currentInstance, setConnectStatus, type MeshInstance } from "./src/connection";
 import { type ClientDestination } from "./src/screens";
 import { ThemeProvider, useTheme } from "./src/theme";
 import { ChatComposer } from "./src/chat";
@@ -59,6 +59,18 @@ const CHAT: ChatOptions | null = {
 };
 // const CHAT: ChatOptions | null = null;
 
+// Threads anchor in the viewer's OWN partition: on the native local mesh that is the device user
+// (seeded by the sidecar's DeviceSeed); against a remote portal the configured namespacePath applies.
+const chatNamespace = (inst: MeshInstance): string =>
+  Platform.OS !== "web" && inst.local ? "device-user" : (CHAT?.namespacePath ?? "");
+
+// 📱 The native-local landing: the device user's own activities (the same landing as the MAUI
+// shell), served by the local mesh's device-user partition. Web keeps the docs HOME — a same-origin
+// viewer is a real portal user whose partition this app cannot know.
+const DEVICE_HOME: NavTarget = { address: "device-user", area: "Activity" };
+const homeFor = (inst: MeshInstance): NavTarget =>
+  Platform.OS !== "web" && inst.local ? DEVICE_HOME : HOME;
+
 // react-native-render-html (the native HTML renderer) still uses React's deprecated `defaultProps`,
 // which React 18.3 logs as a dev-only warning per node — suppress that one third-party message so it
 // doesn't bury real warnings (harmless; gone in a release build).
@@ -72,7 +84,8 @@ function deviceLocale(): string | null {
 
 export default function App() {
   ensureWebStyles();
-  seedDefaultInstances(); // populate the switcher with the known environments on first run (idempotent)
+  // No seeding here: the instance list IS the local mesh's MemexInstance nodes (the sidecar seeds
+  // its defaults on first boot) — hydrated by attachInstanceStore on the Local connect below.
   return (
     <ThemeProvider>
       {/* The viewer's language. The RN app talks to the sidecar ANONYMOUSLY (no user node to read a
@@ -87,7 +100,7 @@ export default function App() {
 
 function AppInner() {
   const { palette } = useTheme();
-  const [nav, setNav] = useState<NavTarget>(HOME);
+  const [nav, setNav] = useState<NavTarget>(() => homeFor(currentInstance()));
   const [clientScreen, setClientScreen] = useState<ClientDestination | null>(null);
   const [instanceTick, setInstanceTick] = useState(0);
   const [source, setSource] = useState<AreaSource>(() => new StaticAreaSource(sampleArea));
@@ -121,7 +134,7 @@ function AppInner() {
     // On a phone the onboarding stays visible until the mesh ACKS (the transition effect
     // closes it) — closing eagerly here made a tap read as "connect just closes".
     if (Platform.OS === "web") setClientScreen(null);
-    setNav(HOME);
+    setNav(homeFor(currentInstance()));
     setLiveConnected(false);
     wasLive.current = false;
     setInstanceTick((t) => t + 1);
@@ -149,7 +162,12 @@ function AppInner() {
         setEmbedFactory(() => createGrpcEmbeddedFactory(l.connection));
         // The full MeshOps over the same connection — renderMarkdown (server Markdig) + the per-view kernel
         // anchor the interactive markdown + runnable code cells; the kernel activity lives in CHAT's partition.
-        setMeshOps(buildMeshOps(l.connection, inst.url, CHAT?.namespacePath ?? "", inst.token));
+        setMeshOps(buildMeshOps(l.connection, inst.url, chatNamespace(inst), inst.token));
+        // The LOCAL mesh is the instance STORE: hydrate the switcher's mesh list from its
+        // MemexInstance nodes. A remote connect detaches (the in-memory cache keeps serving).
+        void attachInstanceStore(
+          inst.local ? Mesh.from(l.connection, undefined, { url: inst.url, token: inst.token }) : null,
+        );
       })
       .catch((e) => {
         // Release builds swallow console — surface the failure where the user IS (the
@@ -197,6 +215,7 @@ function AppInner() {
                 <Shell
                   source={source}
                   nav={effNav}
+                  home={homeFor(currentInstance())}
                   clientScreen={clientScreen}
                   onNavigate={navigate}
                   onClientScreen={setClientScreen}
@@ -211,7 +230,7 @@ function AppInner() {
       {CHAT && (
         <ChatComposer
           submitter={submitter}
-          namespacePath={CHAT.namespacePath}
+          namespacePath={chatNamespace(currentInstance())}
           recorder={speech?.recorder}
           transcriber={speech?.transcriber}
           language={speech?.language}

--- a/clients/react-native/app.config.js
+++ b/clients/react-native/app.config.js
@@ -1,0 +1,9 @@
+// Build-time override for the mesh a native build dials (app.json → expo.extra.portalUrl).
+// A PHYSICAL device cannot reach the dev machine's sidecar at localhost — build with
+//   MEMEX_PORTAL_URL=http://<mac-hostname>.local:5250 npx expo run:ios --device …
+// (and start Memex.LocalMesh with Grpc:ListenLan=true) to point the app at it. Unset, the
+// app.json default (the simulator-reachable localhost sidecar) applies unchanged.
+module.exports = ({ config }) => ({
+  ...config,
+  extra: { ...config.extra, portalUrl: process.env.MEMEX_PORTAL_URL ?? config.extra?.portalUrl },
+});

--- a/clients/react-native/app.json
+++ b/clients/react-native/app.json
@@ -12,7 +12,8 @@
       "infoPlist": {
         "NSAppTransportSecurity": {
           "NSAllowsLocalNetworking": true
-        }
+        },
+        "NSLocalNetworkUsageDescription": "Memex connects to your local mesh on this network."
       }
     },
     "android": {

--- a/clients/react-native/docs/shell.md
+++ b/clients/react-native/docs/shell.md
@@ -73,10 +73,11 @@ The **You** menu opens in-app screens that render in the content pane instead of
 - **Voice** — dictation via the browser Speech Recognition API, with a de-CH / de-DE / en-US / fr-CH
   language choice. This is the web twin of the MAUI `Voice/` stack (on-device Whisper, incl. a Swiss-German
   fine-tune); the transcript is meant to feed the composer / a thread submission.
-- **Connect to mesh** — the instance manager: **Local** is the mesh that served this app (same origin,
-  anonymous); add a remote portal by **URL + API token** and switch to it. Persisted in `localStorage`
-  (`src/connection.ts` — the browser twin of MAUI's `InstanceStore`). Selecting an instance reconnects the
-  live source to it and returns Home.
+- **Connect to mesh** — the instance manager: **Local** is the mesh that served this app (same origin
+  on web, the Memex.LocalMesh sidecar on native — the MAIN mesh the app always dials first); add a
+  remote portal by **URL + API token** and switch to it. The list is stored IN the local mesh as
+  `MemexInstance` nodes (`src/connection.ts` — the same store the MAUI client's MeshConnector writes;
+  no device storage). Selecting an instance reconnects the live source to it and returns Home.
 - **My profile** / **Zoom & display** — identity + display prefs.
 
 ## Dark mode

--- a/clients/react-native/src/Shell.tsx
+++ b/clients/react-native/src/Shell.tsx
@@ -19,16 +19,16 @@ import { RenderArea, type AreaSource, type AreaTree } from "@meshweaver/react/co
 import { areaErrorMessage } from "./areaError";
 import { type NavTarget } from "./nav";
 import { CLIENT_MENUS, ClientScreen, type ClientDestination } from "./screens";
-import { loadInstances, currentInstance, setCurrentInstance, instanceIdentity, type InstanceIdentity } from "./connection";
+import { loadInstances, currentInstance, setCurrentInstance, instanceIdentity, onInstancesChanged, type InstanceIdentity } from "./connection";
 import { useStyles, useTheme, type Palette } from "./theme";
 import { LeftMenuView } from "./leftMenu";
 
 const useSheet = () => useStyles(makeStyles);
 
 const CONTENT_AREA = "Overview";
-// The startup / home landing. On an anonymous local mesh there is no personal user page, so we land on
-// the documentation home; connected to a portal with a signed-in identity this is where the user's own
-// node/area would go (the MAUI app lands on device-user/Activity).
+// The default home landing — the documentation home, used on the web (a same-origin viewer's own
+// partition is unknown to this app). On the native LOCAL mesh App.tsx passes the device user's
+// activities instead (device-user/Activity, the MAUI shell's landing) via the `home` prop.
 export const HOME: NavTarget = { address: "Doc/Architecture", area: CONTENT_AREA };
 
 // The mesh menu contexts streamed as $Menu:{context}, in display order, with a glyph like MAUI's.
@@ -57,6 +57,7 @@ export function Shell({
   onNavigate,
   onClientScreen,
   onReconnect,
+  home = HOME,
 }: {
   source: AreaSource;
   nav: NavTarget;
@@ -64,6 +65,7 @@ export function Shell({
   onNavigate: (t: NavTarget) => void;
   onClientScreen: (d: ClientDestination | null) => void;
   onReconnect: () => void;
+  home?: NavTarget;
 }): ReactNode {
   const tree = useTree(source);
   const styles = useSheet();
@@ -77,7 +79,7 @@ export function Shell({
   const clientNav = (d: ClientDestination | null) => { setMenuOpen(false); onClientScreen(d); };
 
   const menu = (
-    <LeftMenu tree={tree} nav={nav} clientScreen={clientScreen} onNavigate={navigate} onClientScreen={clientNav} />
+    <LeftMenu tree={tree} nav={nav} home={home} clientScreen={clientScreen} onNavigate={navigate} onClientScreen={clientNav} />
   );
   const main = clientScreen ? (
     <View style={styles.content}>
@@ -91,12 +93,13 @@ export function Shell({
     <View style={styles.root}>
       <TopBar
         onNavigate={onNavigate}
+        home={home}
         isMobile={isMobile}
         onToggleMenu={() => setMenuOpen((o) => !o)}
         onReconnect={onReconnect}
         onManageInstances={() => onClientScreen("instances")}
       />
-      <Breadcrumb nav={nav} clientScreen={clientScreen} onNavigate={onNavigate} />
+      <Breadcrumb nav={nav} home={home} clientScreen={clientScreen} onNavigate={onNavigate} />
       <View style={styles.body}>
         {isMobile ? (
           <>
@@ -121,7 +124,7 @@ export function Shell({
 }
 
 // ── top bar ───────────────────────────────────────────────────────────────────
-function TopBar({ onNavigate, isMobile, onToggleMenu, onReconnect, onManageInstances }: { onNavigate: (t: NavTarget) => void; isMobile: boolean; onToggleMenu: () => void; onReconnect: () => void; onManageInstances: () => void }): ReactNode {
+function TopBar({ onNavigate, home, isMobile, onToggleMenu, onReconnect, onManageInstances }: { onNavigate: (t: NavTarget) => void; home: NavTarget; isMobile: boolean; onToggleMenu: () => void; onReconnect: () => void; onManageInstances: () => void }): ReactNode {
   const [q, setQ] = useState("");
   const styles = useSheet();
   const { mode, toggle, palette } = useTheme();
@@ -134,7 +137,7 @@ function TopBar({ onNavigate, isMobile, onToggleMenu, onReconnect, onManageInsta
           <Text style={styles.hamburgerText}>☰</Text>
         </Pressable>
       ) : null}
-      <Pressable style={isMobile ? styles.brandMobile : styles.brand} onPress={() => onNavigate(HOME)}>
+      <Pressable style={isMobile ? styles.brandMobile : styles.brand} onPress={() => onNavigate(home)}>
         <View style={styles.logo}><Text style={styles.logoMark}>◆</Text></View>
         {isMobile ? null : <Text style={styles.brandText}>MeshWeaver</Text>}
       </Pressable>
@@ -171,6 +174,10 @@ function InstanceSwitcher({ isMobile, onReconnect, onManage }: { isMobile: boole
   const styles = useSheet();
   const [open, setOpen] = useState(false);
   const [current, setCurrent] = useState(() => currentInstance().name);
+  // The list is hydrated ASYNCHRONOUSLY from the local mesh's MemexInstance nodes — re-read it
+  // (and the current name, whose Local display name comes from the own-instance node) on change.
+  const [, listTick] = useState(0);
+  useEffect(() => onInstancesChanged(() => { listTick((n) => n + 1); setCurrent(currentInstance().name); }), []);
   const instances = loadInstances();
   const cur = instances.find((i) => i.name === current) ?? instances[0];
   const id = instanceIdentity(cur);
@@ -232,10 +239,12 @@ function InstanceSwitcher({ isMobile, onReconnect, onManage }: { isMobile: boole
 // ── breadcrumb toolbar ──────────────────────────────────────────────────────────
 function Breadcrumb({
   nav,
+  home,
   clientScreen,
   onNavigate,
 }: {
   nav: NavTarget;
+  home: NavTarget;
   clientScreen: ClientDestination | null;
   onNavigate: (t: NavTarget) => void;
 }): ReactNode {
@@ -243,7 +252,7 @@ function Breadcrumb({
   const styles = useSheet();
   return (
     <View style={styles.crumbs}>
-      <Pressable style={({ hovered }: any) => [styles.crumbBtn, hovered && styles.crumbHover]} onPress={() => onNavigate(HOME)}>
+      <Pressable style={({ hovered }: any) => [styles.crumbBtn, hovered && styles.crumbHover]} onPress={() => onNavigate(home)}>
         <Text style={styles.crumbHome}>⌂ Home</Text>
       </Pressable>
       {!clientScreen &&
@@ -270,12 +279,14 @@ function Breadcrumb({
 function LeftMenu({
   tree,
   nav,
+  home,
   clientScreen,
   onNavigate,
   onClientScreen,
 }: {
   tree: AreaTree;
   nav: NavTarget;
+  home: NavTarget;
   clientScreen: ClientDestination | null;
   onNavigate: (t: NavTarget) => void;
   onClientScreen: (d: ClientDestination | null) => void;
@@ -284,7 +295,7 @@ function LeftMenu({
     <LeftMenuView
       tree={tree}
       nav={nav}
-      home={HOME}
+      home={home}
       contexts={MESH_CONTEXTS}
       clientMenus={CLIENT_MENUS}
       clientScreen={clientScreen}

--- a/clients/react-native/src/connection.ts
+++ b/clients/react-native/src/connection.ts
@@ -156,10 +156,10 @@ async function hydrate(mesh: InstanceStoreMesh): Promise<void> {
   }
 }
 
-/** The Instance/{id} node id for a portal URL — its host (the MAUI meshId), port made path-safe. */
+/** The Instance/{id} node id for a portal URL — its HOST, port-free: the exact meshId MAUI's
+ *  MeshConnector derives (`new Uri(url).Host`), so both clients patch ONE node per portal. */
 function instanceIdFor(url: string): string {
-  const host = url.replace(/^https?:\/\//i, "").replace(/\/.*$/, "");
-  return host.replace(/:/g, "-").toLowerCase();
+  return url.replace(/^https?:\/\//i, "").replace(/\/.*$/, "").replace(/:.*$/, "").toLowerCase();
 }
 
 /** Persist one instance as its MemexInstance node — create-or-patch, fire-and-forget (the in-memory

--- a/clients/react-native/src/connection.ts
+++ b/clients/react-native/src/connection.ts
@@ -1,7 +1,10 @@
-// Mesh instances — the RN/web twin of the MAUI app's InstanceStore (memex/Memex.Client/Services/
-// InstanceStore.cs). "Local" is the mesh that served this app (same origin, anonymous). Additional
-// remote instances are portals the user connects to by URL + API token; the live gRPC-web client dials
-// whichever instance is current. Persisted in localStorage (the browser twin of MAUI Preferences).
+// Mesh instances — the RN/web twin of the MAUI app's InstanceStore, with the SAME storage backend:
+// THE LOCAL MESH. Instances are MemexInstance nodes (Instance/{id}) in the mesh this app dials by
+// default — the monolith/SQLite sidecar (Memex.LocalMesh) on native/desktop, the serving portal on
+// web. There is NO device storage: the app connects to the local mesh as its MAIN mesh, hydrates the
+// switcher's list from it (attachInstanceStore, on the Local connect), and every edit (add / token /
+// remove) writes the node back. The in-module list is only a render cache of those nodes; it resets
+// to Local-only on launch, exactly until the local mesh answers.
 
 export interface MeshInstance {
   /** Display name. */
@@ -66,21 +69,6 @@ export function instanceIdentity(inst: MeshInstance): InstanceIdentity {
 
 import Constants from "expo-constants";
 
-const INSTANCES_KEY = "mw.instances";
-const CURRENT_KEY = "mw.currentInstance";
-const SEEDED_KEY = "mw.seedVersion";
-const SEED_VERSION = 1;
-
-/**
- * The user's known environments, seeded once so the instance switcher is populated out of the box
- * (the built-in "Local" SQLite sidecar is always present via localInstance()). Tokens are empty —
- * anonymous connect; paste an API token per portal in the Connect screen to sign in.
- */
-export const KNOWN_INSTANCES: MeshInstance[] = [
-  { name: "memex.localhost (k8s)", url: "https://memex.localhost:8443", token: "", local: false, icon: "☸", color: "#d29922", kind: "Local · k8s" },
-  { name: "memex", url: "https://memex.meshweaver.cloud", token: "", local: false, icon: "☁️", color: "#4c8dff", kind: "Prod" },
-];
-
 // Live connect status — a tiny observable the Connect screen renders, because a Release
 // build swallows console and a failed connect must be VISIBLE truth on the device, not a
 // silently reopened onboarding.
@@ -95,6 +83,145 @@ export function getConnectStatus(): string { return lastConnectStatus; }
 export function onConnectStatus(listener: StatusListener): () => void {
   statusListeners.add(listener);
   return () => statusListeners.delete(listener);
+}
+
+// The instance list changed (hydrated from the mesh, or edited) — the switcher and the Connect
+// screen subscribe so an async hydration reaches an already-rendered list.
+const instanceListeners = new Set<StatusListener>();
+export function onInstancesChanged(listener: StatusListener): () => void {
+  instanceListeners.add(listener);
+  return () => instanceListeners.delete(listener);
+}
+function emitInstancesChanged(): void {
+  for (const l of instanceListeners) l();
+}
+
+// ── the store: MemexInstance nodes on the local mesh ─────────────────────────────
+
+/** The node-op surface the store needs — structurally a @meshweaver/client-web Mesh. */
+export interface InstanceStoreMesh {
+  search(query: string, basePath?: string, limit?: number): Promise<Record<string, unknown>[]>;
+  get(path: string): Promise<unknown>;
+  create(node: Record<string, unknown>): Promise<Record<string, unknown>>;
+  patch(path: string, fields: Record<string, unknown>): void;
+  delete(path: string): Promise<void>;
+}
+
+const INSTANCE_NODE_TYPE = "MemexInstance";
+const INSTANCE_SEGMENT = "Instance";
+
+let storeMesh: InstanceStoreMesh | null = null;
+let remotes: MeshInstance[] = [];
+let localDisplayName: string | null = null; // from the own-instance node (named after the device)
+let currentName = "";                       // "" = the Local default
+
+/**
+ * Attach the LOCAL mesh connection as the instance store and hydrate the list from its
+ * MemexInstance nodes. App.tsx calls this on a Local connect (pass null when dialing a remote —
+ * the cache keeps serving; edits then only live for the session).
+ */
+export function attachInstanceStore(mesh: InstanceStoreMesh | null): Promise<void> {
+  storeMesh = mesh;
+  return mesh ? hydrate(mesh) : Promise.resolve();
+}
+
+async function hydrate(mesh: InstanceStoreMesh): Promise<void> {
+  try {
+    const rows = await mesh.search(`nodeType:${INSTANCE_NODE_TYPE}`, undefined, 50);
+    const loaded: MeshInstance[] = [];
+    let ownName: string | null = null;
+    for (const r of rows) {
+      const path = String((r as any).path ?? "");
+      if (!path) continue;
+      const node: any = await mesh.get(path).catch(() => null);
+      if (!node) continue;
+      const c: any = node.content ?? {};
+      const name = String(node.name ?? c.displayName ?? path);
+      if (!c.url) { ownName = name; continue; } // the own-instance node: it names Local
+      loaded.push({
+        name,
+        url: String(c.url).replace(/\/+$/, ""),
+        token: String(c.token ?? ""),
+        local: false,
+        refreshToken: c.refreshToken ? String(c.refreshToken) : undefined,
+        clientId: c.clientId ? String(c.clientId) : undefined,
+        tokenExpiresAt: c.tokenExpiresAt ? Date.parse(String(c.tokenExpiresAt)) : undefined,
+      });
+    }
+    remotes = loaded;
+    localDisplayName = ownName;
+    emitInstancesChanged();
+  } catch {
+    // Store unreachable — the session keeps its in-memory list; next Local connect re-hydrates.
+  }
+}
+
+/** The Instance/{id} node id for a portal URL — its host (the MAUI meshId), port made path-safe. */
+function instanceIdFor(url: string): string {
+  const host = url.replace(/^https?:\/\//i, "").replace(/\/.*$/, "");
+  return host.replace(/:/g, "-").toLowerCase();
+}
+
+/** Persist one instance as its MemexInstance node — create-or-patch, fire-and-forget (the in-memory
+ *  list is already updated; a failed write surfaces on the next hydration, not as a blocked tap). */
+function persist(inst: MeshInstance): void {
+  const mesh = storeMesh;
+  if (!mesh) return;
+  const id = instanceIdFor(inst.url);
+  const path = `${INSTANCE_SEGMENT}/${id}`;
+  const content = {
+    $type: "MemexInstanceContent",
+    displayName: inst.name,
+    url: inst.url,
+    token: inst.token || null,
+    meshId: id,
+    refreshToken: inst.refreshToken ?? null,
+    clientId: inst.clientId ?? null,
+    tokenExpiresAt: inst.tokenExpiresAt ? new Date(inst.tokenExpiresAt).toISOString() : null,
+  };
+  void (async () => {
+    try {
+      const existing = await mesh.search(`path:${path}`, undefined, 1);
+      if (existing.length) mesh.patch(path, { name: inst.name, content });
+      else
+        await mesh.create({
+          id,
+          namespace: INSTANCE_SEGMENT,
+          path,
+          name: inst.name,
+          nodeType: INSTANCE_NODE_TYPE,
+          content,
+        });
+    } catch {
+      /* best-effort — see above */
+    }
+  })();
+}
+
+// The mesh a NATIVE build dials by default (it has no serving origin like the web build). Configured in
+// app.json → expo.extra.portalUrl; defaults to the LOCAL monolith mesh — Memex.LocalMesh, the in-process
+// SQLite-backed mesh sidecar (the MAUI-parity local-first host), reachable from the iOS simulator at
+// http://localhost:5250 anonymously (no token). Point it at a remote portal via Connect-to-mesh + a token.
+const DEFAULT_PORTAL_URL = String((Constants.expoConfig?.extra as any)?.portalUrl ?? "http://localhost:5250");
+
+/** The default portal URL a native build dials (app.json → expo.extra.portalUrl); prefill for the connect form. */
+export function defaultPortalUrl(): string {
+  return DEFAULT_PORTAL_URL;
+}
+
+const sameOrigin = (): string =>
+  typeof window !== "undefined" && window.location ? window.location.origin : "";
+
+/**
+ * The always-present default instance — the MAIN mesh. Web (served by the mesh) → same-origin,
+ * anonymous. Native has no serving origin, so it dials the configured default portal. Its display
+ * name comes from the mesh itself (the own-instance node, named after the device).
+ */
+export function localInstance(): MeshInstance {
+  const origin = sameOrigin();
+  return origin
+    ? { name: localDisplayName ?? "Local", url: origin, token: "", local: true }
+    : { name: localDisplayName ?? "Local mesh", url: DEFAULT_PORTAL_URL, token: "", local: true };
 }
 
 /**
@@ -130,100 +257,49 @@ export async function discoverInstances(from: MeshInstance): Promise<MeshInstanc
   }
 }
 
-/** Merge discovered instances into the saved list — an existing entry (its token, edits) always wins. */
+/** Merge discovered instances into the list — an existing entry (its token, edits) always wins.
+ *  New ones are persisted to the local mesh (the store), best-effort. */
 export function mergeDiscovered(discovered: MeshInstance[]): MeshInstance[] {
-  const existing = read<MeshInstance[]>(INSTANCES_KEY) ?? [];
-  const byName = new Map(existing.map((i) => [i.name, i]));
-  const byUrl = new Set(existing.map((i) => i.url));
-  for (const d of discovered) if (!byName.has(d.name) && !byUrl.has(d.url)) byName.set(d.name, d);
-  const merged = [...byName.values()];
-  write(INSTANCES_KEY, merged);
-  return merged;
+  const byName = new Map(remotes.map((i) => [i.name, i]));
+  const byUrl = new Set(remotes.map((i) => i.url));
+  for (const d of discovered)
+    if (!byName.has(d.name) && !byUrl.has(d.url)) {
+      byName.set(d.name, d);
+      persist(d);
+    }
+  remotes = [...byName.values()];
+  emitInstancesChanged();
+  return remotes;
 }
 
-/**
- * Idempotently add the known environments to the saved-instances list on first run (versioned, so
- * removing a seeded instance won't resurrect it). Never clobbers a user-edited instance of the same name.
- */
-export function seedDefaultInstances(): void {
-  if (typeof localStorage === "undefined") return;
-  if ((read<number>(SEEDED_KEY) ?? 0) >= SEED_VERSION) return;
-  const existing = (read<MeshInstance[]>(INSTANCES_KEY) ?? []).filter((i) => !i.local && i.url);
-  const byName = new Map(existing.map((i) => [i.name, i]));
-  for (const k of KNOWN_INSTANCES) if (!byName.has(k.name)) byName.set(k.name, k);
-  write(INSTANCES_KEY, [...byName.values()]);
-  write(SEEDED_KEY, SEED_VERSION);
-}
-
-// The mesh a NATIVE build dials by default (it has no serving origin like the web build). Configured in
-// app.json → expo.extra.portalUrl; defaults to the LOCAL monolith mesh — Memex.LocalMesh, the in-process
-// SQLite-backed mesh sidecar (the MAUI-parity local-first host), reachable from the iOS simulator at
-// http://localhost:5250 anonymously (no token). Point it at a remote portal via Connect-to-mesh + a token.
-const DEFAULT_PORTAL_URL = String((Constants.expoConfig?.extra as any)?.portalUrl ?? "http://localhost:5250");
-
-/** The default portal URL a native build dials (app.json → expo.extra.portalUrl); prefill for the connect form. */
-export function defaultPortalUrl(): string {
-  return DEFAULT_PORTAL_URL;
-}
-
-const sameOrigin = (): string =>
-  typeof window !== "undefined" && window.location ? window.location.origin : "";
-
-/**
- * The always-present default instance. Web (served by the mesh) → same-origin, anonymous. Native has no
- * serving origin, so it dials the configured default portal (the user supplies a token in-app).
- */
-export function localInstance(): MeshInstance {
-  const origin = sameOrigin();
-  return origin
-    ? { name: "Local", url: origin, token: "", local: true }
-    : { name: "Local mesh", url: DEFAULT_PORTAL_URL, token: "", local: true };
-}
-
-function read<T>(key: string): T | null {
-  if (typeof localStorage === "undefined") return null;
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : null;
-  } catch {
-    return null;
-  }
-}
-
-function write(key: string, value: unknown): void {
-  if (typeof localStorage === "undefined") return;
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch {
-    /* storage disabled — instances just won't persist */
-  }
-}
-
-/** All instances: Local first, then the saved remotes. */
+/** All instances: Local first, then the remotes hydrated from the local mesh. */
 export function loadInstances(): MeshInstance[] {
-  const saved = (read<MeshInstance[]>(INSTANCES_KEY) ?? []).filter((i) => !i.local && i.url);
-  return [localInstance(), ...saved];
+  return [localInstance(), ...remotes];
 }
 
-/** The instance the app is currently pointed at (defaults to Local). */
+/** The instance the app is currently pointed at (defaults to Local — the main mesh). */
 export function currentInstance(): MeshInstance {
-  const name = read<string>(CURRENT_KEY);
-  return loadInstances().find((i) => i.name === name) ?? localInstance();
+  return remotes.find((i) => i.name === currentName) ?? localInstance();
 }
 
 export function setCurrentInstance(name: string): void {
-  write(CURRENT_KEY, name);
+  currentName = remotes.some((i) => i.name === name) ? name : "";
 }
 
-/** Add or replace a remote instance (keyed by name) and make it current. */
+/** Add or replace a remote instance (keyed by name), persist its node, and make it current. */
 export function saveInstance(inst: MeshInstance): void {
-  const others = (read<MeshInstance[]>(INSTANCES_KEY) ?? []).filter((i) => !i.local && i.name !== inst.name);
-  write(INSTANCES_KEY, [...others, { ...inst, local: false }]);
-  setCurrentInstance(inst.name);
+  const clean: MeshInstance = { ...inst, local: false, url: inst.url.replace(/\/+$/, "") };
+  remotes = [...remotes.filter((i) => i.name !== clean.name), clean];
+  currentName = clean.name;
+  persist(clean);
+  emitInstancesChanged();
 }
 
 export function removeInstance(name: string): void {
-  const others = (read<MeshInstance[]>(INSTANCES_KEY) ?? []).filter((i) => !i.local && i.name !== name);
-  write(INSTANCES_KEY, others);
-  if (read<string>(CURRENT_KEY) === name) setCurrentInstance("Local");
+  const inst = remotes.find((i) => i.name === name);
+  remotes = remotes.filter((i) => i.name !== name);
+  if (currentName === name) currentName = "";
+  if (inst && storeMesh)
+    storeMesh.delete(`${INSTANCE_SEGMENT}/${instanceIdFor(inst.url)}`).catch(() => {});
+  emitInstancesChanged();
 }

--- a/clients/react-native/src/screens.tsx
+++ b/clients/react-native/src/screens.tsx
@@ -3,7 +3,7 @@
 // mesh): Voice (speech), Connect (remote instances), Profile, Settings.
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { View, Text, TextInput, Pressable, ScrollView, StyleSheet } from "react-native";
-import { loadInstances, saveInstance, removeInstance, setCurrentInstance, currentInstance, defaultPortalUrl, instanceIdentity, discoverInstances, mergeDiscovered, getConnectStatus, onConnectStatus, type MeshInstance } from "./connection";
+import { loadInstances, saveInstance, removeInstance, setCurrentInstance, currentInstance, defaultPortalUrl, instanceIdentity, discoverInstances, mergeDiscovered, getConnectStatus, onConnectStatus, onInstancesChanged, type MeshInstance } from "./connection";
 import { refreshOAuth, signInWithOAuth } from "./oauth";
 import { useStyles, useTheme, type Palette } from "./theme";
 
@@ -140,6 +140,9 @@ function ConnectScreen({ onConnected }: { onConnected: () => void }): ReactNode 
   // failed connect must be readable where the user is looking.
   const [connectStatus, setConnectStatus_] = useState(getConnectStatus());
   useEffect(() => onConnectStatus(() => setConnectStatus_(getConnectStatus())), []);
+  // The list lives in the LOCAL MESH (MemexInstance nodes) and hydrates asynchronously once the
+  // Local connect acks — re-read it here so the onboarding fills in without a manual refresh.
+  useEffect(() => onInstancesChanged(() => { setInstances(loadInstances()); setCurrent(currentInstance().name); }), []);
   const [showForm, setShowForm] = useState(false);
   const [tokenFor, setTokenFor] = useState<string | null>(null);
   const [rowToken, setRowToken] = useState("");

--- a/memex/Memex.LocalMesh/DeviceSeed.cs
+++ b/memex/Memex.LocalMesh/DeviceSeed.cs
@@ -47,15 +47,16 @@ public static class DeviceSeed
             .GetQuery("seed-device-user", $"nodeType:User content.email:{DeviceUserId}@local limit:1")
             .Take(1).Timeout(TimeSpan.FromSeconds(15))
             .Where(existing => !existing.Any())
-            .SelectMany(_ => Observable.Using(
-                () => accessService.ImpersonateAsSystem(),   // a brand-new partition root is owned by nobody yet
-                _ => meshService.CreateNode(new MeshNode(DeviceUserId)   // partition root → provisions schema + self-Admin
-                    {
-                        NodeType = "User",
-                        Name = name,
-                        State = MeshNodeState.Active,
-                        Content = new User { FullName = name, Email = $"{DeviceUserId}@local" },
-                    })))
+            // RunAsSystem, never Observable.Using(ImpersonateAsSystem…) — the latter latches the
+            // system identity on the subscribing thread (ImpersonationScopeSiteRatchetGuard, #1790).
+            .SelectMany(_ => accessService.RunAsSystem(   // a brand-new partition root is owned by nobody yet
+                () => meshService.CreateNode(new MeshNode(DeviceUserId)   // partition root → provisions schema + self-Admin
+                {
+                    NodeType = "User",
+                    Name = name,
+                    State = MeshNodeState.Active,
+                    Content = new User { FullName = name, Email = $"{DeviceUserId}@local" },
+                })))
             .Subscribe(
                 _ => logger?.LogInformation("Seeded device user {Name}", name),
                 ex => logger?.LogWarning(ex, "Device-user seed failed"));
@@ -68,9 +69,8 @@ public static class DeviceSeed
             .GetQuery("seed-admin-grant", $"path:Admin/_Access/{DeviceUserId}_Access limit:1")
             .Take(1).Timeout(TimeSpan.FromSeconds(15))
             .Where(existing => !existing.Any())
-            .SelectMany(_ => Observable.Using(
-                () => accessService.ImpersonateAsSystem(),
-                _ => meshService.CreateNode(new MeshNode($"{DeviceUserId}_Access", "Admin/_Access")
+            .SelectMany(_ => accessService.RunAsSystem(
+                () => meshService.CreateNode(new MeshNode($"{DeviceUserId}_Access", "Admin/_Access")
                 {
                     NodeType = "AccessAssignment",
                     Name = $"{name} — Admin",

--- a/memex/Memex.LocalMesh/DeviceSeed.cs
+++ b/memex/Memex.LocalMesh/DeviceSeed.cs
@@ -55,24 +55,36 @@ public static class DeviceSeed
                         Name = name,
                         State = MeshNodeState.Active,
                         Content = new User { FullName = name, Email = $"{DeviceUserId}@local" },
-                    })
-                    // Global admin of this instance — Admin/_Access with MainNode="Admin" (the sanctioned
-                    // shape; an empty MainNode would be a root/data-superuser grant and is refused).
-                    .SelectMany(_ => meshService.CreateNode(new MeshNode($"{DeviceUserId}_Access", "Admin/_Access")
-                    {
-                        NodeType = "AccessAssignment",
-                        Name = $"{name} — Admin",
-                        MainNode = "Admin",
-                        Content = new AccessAssignment
-                        {
-                            AccessObject = DeviceUserId,
-                            DisplayName = name,
-                            Roles = [new RoleAssignment { Role = "Admin" }],
-                        },
-                    }))))
+                    })))
             .Subscribe(
                 _ => logger?.LogInformation("Seeded device user {Name}", name),
                 ex => logger?.LogWarning(ex, "Device-user seed failed"));
+
+        // Global admin of this instance — Admin/_Access with MainNode="Admin" (the sanctioned shape;
+        // an empty MainNode would be a root/data-superuser grant and is refused). Guarded by the
+        // GRANT's own existence, not the user's: a crash between the two creates heals on the next
+        // boot, and on a single-user device mesh the owner must ALWAYS hold this grant.
+        hub.GetWorkspace()
+            .GetQuery("seed-admin-grant", $"path:Admin/_Access/{DeviceUserId}_Access limit:1")
+            .Take(1).Timeout(TimeSpan.FromSeconds(15))
+            .Where(existing => !existing.Any())
+            .SelectMany(_ => Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => meshService.CreateNode(new MeshNode($"{DeviceUserId}_Access", "Admin/_Access")
+                {
+                    NodeType = "AccessAssignment",
+                    Name = $"{name} — Admin",
+                    MainNode = "Admin",
+                    Content = new AccessAssignment
+                    {
+                        AccessObject = DeviceUserId,
+                        DisplayName = name,
+                        Roles = [new RoleAssignment { Role = "Admin" }],
+                    },
+                })))
+            .Subscribe(
+                _ => logger?.LogInformation("Seeded global-admin grant for {Name}", name),
+                ex => logger?.LogWarning(ex, "Admin-grant seed failed"));
     }
 
     /// <summary>
@@ -87,6 +99,9 @@ public static class DeviceSeed
         var deviceName = Environment.MachineName;
         if (string.IsNullOrWhiteSpace(deviceName)) deviceName = "My Memex";
 
+        // Guarded on "ANY MemexInstance exists" — deliberately, so a seeded instance the user
+        // REMOVED is not resurrected on the next boot. The two creates below are merged (not
+        // chained) so one failing cannot skip the other.
         hub.GetWorkspace()
             .GetQuery("seed-instances", $"nodeType:{MemexInstanceNodeType.NodeType}")
             .Take(1).Timeout(TimeSpan.FromSeconds(15))
@@ -99,7 +114,7 @@ public static class DeviceSeed
                 })
                 // Keyed by URL host — the id MeshConnector (MAUI) and the RN store both derive, so a
                 // later token save PATCHES this node instead of minting a duplicate.
-                .SelectMany(_ => meshService.CreateNode(new MeshNode("memex.meshweaver.cloud", MemexInstanceNodeType.Segment)
+                .Merge(meshService.CreateNode(new MeshNode("memex.meshweaver.cloud", MemexInstanceNodeType.Segment)
                 {
                     NodeType = MemexInstanceNodeType.NodeType,
                     Name = "memex",

--- a/memex/Memex.LocalMesh/DeviceSeed.cs
+++ b/memex/Memex.LocalMesh/DeviceSeed.cs
@@ -1,0 +1,117 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+
+namespace Memex.LocalMesh;
+
+/// <summary>
+/// First-boot seeding for the device mesh — the sidecar twin of the MAUI client's boot
+/// (MauiProgram + DeviceOnboarding): stamp the single device-user identity on the host, create the
+/// partition-root <c>User</c> node through the FRAMEWORK path (the framework provisions the
+/// <c>device-user</c> partition and grants self-admin; the <c>Admin/_Access</c> grant then makes the
+/// device owner the instance's global admin), and seed the <c>MemexInstance</c> nodes — this mesh IS
+/// the instance store the shells it serves read their mesh list from (no device storage).
+/// All idempotent: every seed checks existence via <c>GetQuery</c> first.
+/// </summary>
+public static class DeviceSeed
+{
+    public const string DeviceUserId = "device-user";
+
+    public static void Seed(IMessageHub hub)
+    {
+        var osName = Environment.UserName;
+        if (string.IsNullOrWhiteSpace(osName)) osName = "Device User";
+
+        // Single-user device mesh: the shells this host serves (RN, web, desktop) connect
+        // anonymously; identity lives HERE, exactly like the MAUI client's in-process mesh.
+        var deviceUser = new AccessContext { ObjectId = DeviceUserId, Name = osName };
+        hub.ServiceProvider.GetRequiredService<AccessService>().SetHostIdentity(deviceUser);
+
+        SeedDeviceUser(hub, osName);
+        SeedInstances(hub);
+    }
+
+    /// <summary>Creates the device user on first boot (absent = never onboarded), as DeviceOnboarding does.</summary>
+    private static void SeedDeviceUser(IMessageHub hub, string name)
+    {
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(nameof(DeviceSeed));
+
+        hub.GetWorkspace()
+            .GetQuery("seed-device-user", $"nodeType:User content.email:{DeviceUserId}@local limit:1")
+            .Take(1).Timeout(TimeSpan.FromSeconds(15))
+            .Where(existing => !existing.Any())
+            .SelectMany(_ => Observable.Using(
+                () => accessService.ImpersonateAsSystem(),   // a brand-new partition root is owned by nobody yet
+                _ => meshService.CreateNode(new MeshNode(DeviceUserId)   // partition root → provisions schema + self-Admin
+                    {
+                        NodeType = "User",
+                        Name = name,
+                        State = MeshNodeState.Active,
+                        Content = new User { FullName = name, Email = $"{DeviceUserId}@local" },
+                    })
+                    // Global admin of this instance — Admin/_Access with MainNode="Admin" (the sanctioned
+                    // shape; an empty MainNode would be a root/data-superuser grant and is refused).
+                    .SelectMany(_ => meshService.CreateNode(new MeshNode($"{DeviceUserId}_Access", "Admin/_Access")
+                    {
+                        NodeType = "AccessAssignment",
+                        Name = $"{name} — Admin",
+                        MainNode = "Admin",
+                        Content = new AccessAssignment
+                        {
+                            AccessObject = DeviceUserId,
+                            DisplayName = name,
+                            Roles = [new RoleAssignment { Role = "Admin" }],
+                        },
+                    }))))
+            .Subscribe(
+                _ => logger?.LogInformation("Seeded device user {Name}", name),
+                ex => logger?.LogWarning(ex, "Device-user seed failed"));
+    }
+
+    /// <summary>
+    /// Seeds the instance list on first boot: the own-instance node (this mesh, named after the
+    /// machine) plus the public memex — the same defaults the MAUI InstanceStore ships with. The
+    /// shells read these (<c>nodeType:MemexInstance</c>) as their connect list.
+    /// </summary>
+    private static void SeedInstances(IMessageHub hub)
+    {
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(nameof(DeviceSeed));
+        var deviceName = Environment.MachineName;
+        if (string.IsNullOrWhiteSpace(deviceName)) deviceName = "My Memex";
+
+        hub.GetWorkspace()
+            .GetQuery("seed-instances", $"nodeType:{MemexInstanceNodeType.NodeType}")
+            .Take(1).Timeout(TimeSpan.FromSeconds(15))
+            .Where(existing => !existing.Any())
+            .SelectMany(_ => meshService.CreateNode(new MeshNode("local", MemexInstanceNodeType.Segment)
+                {
+                    NodeType = MemexInstanceNodeType.NodeType,
+                    Name = deviceName,
+                    Content = new MemexInstanceContent { DisplayName = deviceName, MeshId = "local" },
+                })
+                // Keyed by URL host — the id MeshConnector (MAUI) and the RN store both derive, so a
+                // later token save PATCHES this node instead of minting a duplicate.
+                .SelectMany(_ => meshService.CreateNode(new MeshNode("memex.meshweaver.cloud", MemexInstanceNodeType.Segment)
+                {
+                    NodeType = MemexInstanceNodeType.NodeType,
+                    Name = "memex",
+                    Content = new MemexInstanceContent
+                    {
+                        DisplayName = "memex",
+                        Url = "https://memex.meshweaver.cloud",
+                        MeshId = "memex.meshweaver.cloud",
+                    },
+                })))
+            .Subscribe(
+                _ => logger?.LogInformation("Seeded instance nodes ({Device} + memex)", deviceName),
+                ex => logger?.LogWarning(ex, "Instance seed failed"));
+    }
+}

--- a/memex/Memex.LocalMesh/Program.cs
+++ b/memex/Memex.LocalMesh/Program.cs
@@ -24,8 +24,16 @@ var builder = WebApplication.CreateBuilder(args);
 // One cleartext port serving both gRPC transports: HTTP/2 (h2c) for the bidi Open, HTTP/1.1 for gRPC-web.
 // Local sidecar → no TLS; the client points at http://localhost:<port>.
 var port = builder.Configuration.GetValue("Grpc:Port", 5250);
+// Loopback by default. Grpc:ListenLan=true additionally exposes the mesh on the LAN so a PHYSICAL
+// phone can dial this machine (http://<host-ip>:5250) — opt-in only: this host authenticates nobody
+// (DeviceSeed stamps the device-user identity on every request), so on a LAN listen anyone on the
+// network IS the device user. The simulator/desktop path needs none of this (localhost reaches it).
+var listenLan = builder.Configuration.GetValue("Grpc:ListenLan", false);
 builder.WebHost.ConfigureKestrel(k =>
-    k.ListenLocalhost(port, l => l.Protocols = HttpProtocols.Http1AndHttp2));
+{
+    if (listenLan) k.ListenAnyIP(port, l => l.Protocols = HttpProtocols.Http1AndHttp2);
+    else k.ListenLocalhost(port, l => l.Protocols = HttpProtocols.Http1AndHttp2);
+});
 
 // SQLite file under the OS local-app-data (same shape as the MAUI client's memex-local.db).
 var dbPath = builder.Configuration["Sqlite:Path"]
@@ -38,6 +46,7 @@ builder.UseMeshWeaver(
     mesh => mesh
         .AddPartitionedSqlitePersistence($"Data Source={dbPath}")
         .AddGraph()          // node types + graph
+        .AddMemexInstanceType() // the mesh list: this mesh IS the shells' instance store (DeviceSeed)
         .AddKernel()         // C# kernel (Roslyn, MeshWeaver.Kernel.Hub) — lets doc code samples Run on the sidecar
         .AddDocumentation()  // the embedded "Doc" partition — real layout areas the client can render
         .AddGrpcHub()        // py/node stream-routed address types + the gRPC services
@@ -55,6 +64,9 @@ builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
 builder.Services.AddSpeechTranscription(builder.Configuration);
 
 var app = builder.Build();
+
+// Device identity + first-boot seeds (device user, own instance, public memex) — see DeviceSeed.
+DeviceSeed.Seed(app.Services.GetRequiredService<IMessageHub>());
 
 // Serve the packaged web client (the React-Native app exported to web, baked into wwwroot) from the SAME
 // origin as the gRPC endpoint. Same origin ⇒ the browser makes no cross-origin request ⇒ no CORS at all.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-mobile-mesh-list-in-local-mesh.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-mobile-mesh-list-in-local-mesh.md
@@ -1,0 +1,18 @@
+---
+Name: The mobile app keeps its mesh list in your local mesh
+Category: Feature
+Description: The phone app connects to your local mesh as its main mesh, reads its mesh list from it, and opens into your activities.
+Icon: Sparkle
+Order: -20260820
+---
+
+# The mobile app keeps its mesh list in your local mesh
+
+The phone app now treats your local mesh as its main mesh: it connects to it by default, and the
+list of meshes you can switch to lives IN that mesh — as ordinary Memex Instance nodes — instead of
+in device storage. Adding a portal, signing in, or removing one writes the node back, so your mesh
+list survives reinstalls with your local mesh's data and is the same list every local shell sees.
+
+On first start the local mesh sets itself up: it creates your device user and seeds the mesh list
+with itself and the public memex. Opening the app now lands on your own activities, the same landing
+the desktop client uses, instead of the documentation home.

--- a/src/MeshWeaver.Graph/Configuration/MemexInstanceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/MemexInstanceNodeType.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh;
 
@@ -18,7 +19,9 @@ public record MemexInstanceContent
     /// <summary>The portal base URL; the SignalR endpoint is <c>{Url}/signalr</c>.</summary>
     public string Url { get; init; } = "";
 
-    /// <summary>API token authenticating this client to the remote mesh. Null/empty = not yet joined.</summary>
+    /// <summary>API token authenticating this client to the remote mesh. Null/empty = not yet joined.
+    /// Credential material — hidden from the default editor forms.</summary>
+    [Browsable(false)]
     public string? Token { get; init; }
 
     /// <summary>
@@ -30,10 +33,13 @@ public record MemexInstanceContent
     /// <summary>Last time the client connected to this mesh (stamped on connect).</summary>
     public DateTime? LastConnected { get; init; }
 
-    /// <summary>OAuth refresh token from a browser sign-in; null for pasted API tokens.</summary>
+    /// <summary>OAuth refresh token from a browser sign-in; null for pasted API tokens.
+    /// Credential material — hidden from the default editor forms.</summary>
+    [Browsable(false)]
     public string? RefreshToken { get; init; }
 
     /// <summary>OAuth client id the client registered at this portal (dynamic client registration).</summary>
+    [Browsable(false)]
     public string? ClientId { get; init; }
 
     /// <summary>When the OAuth access token expires; null for pasted API tokens.</summary>

--- a/src/MeshWeaver.Graph/Configuration/MemexInstanceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/MemexInstanceNodeType.cs
@@ -30,6 +30,15 @@ public record MemexInstanceContent
     /// <summary>Last time the client connected to this mesh (stamped on connect).</summary>
     public DateTime? LastConnected { get; init; }
 
+    /// <summary>OAuth refresh token from a browser sign-in; null for pasted API tokens.</summary>
+    public string? RefreshToken { get; init; }
+
+    /// <summary>OAuth client id the client registered at this portal (dynamic client registration).</summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>When the OAuth access token expires; null for pasted API tokens.</summary>
+    public DateTime? TokenExpiresAt { get; init; }
+
     /// <summary>True when a token is present, so the client should join this mesh.</summary>
     public bool IsAuthenticated => !string.IsNullOrEmpty(Token);
 }


### PR DESCRIPTION
## What

The iPhone/RN app could not connect to the local mesh any more, and its mesh list turned out to live in `localStorage` — which does not exist on a native build: the list never seeded, saves were silent no-ops, and every choice funneled back to a doomed `localhost` connect (made visible-and-blocking by yesterday's onboarding fix).

Per the maintainer's direction: **the storage backend IS the local mesh (monolith over SQLite) — no other storage; the app connects to it as its main mesh (default) and opens into the normal user activities.**

- **Memex.LocalMesh seeds itself on first boot** (`DeviceSeed`): the device user via the framework onboarding path (partition provisioning + self-admin + the sanctioned `Admin/_Access` global-admin grant), the own-instance `MemexInstance` node (named after the machine), and the public memex — and stamps the device-user host identity, exactly like the MAUI client. `Grpc:ListenLan=true` (default off) additionally exposes the mesh on the LAN for a physical phone.
- **The RN app hydrates its switcher from the local mesh's `MemexInstance` nodes** (`attachInstanceStore` on the Local connect); add / sign-in / remove write the node back — create-or-patch keyed by URL host, the same id the MAUI `MeshConnector` derives, so both clients share one store. `localStorage` is gone from the instance store.
- **`MemexInstanceContent` gains `RefreshToken`/`ClientId`/`TokenExpiresAt`** so the OAuth browser sign-in survives an app restart through the node.
- **Native-local lands on `device-user/Activity`** (the MAUI shell's landing) and chat anchors in the device user's partition; web keeps the docs home (a same-origin viewer's partition is unknown to the app).

## Verification

- `dotnet build memex/Memex.LocalMesh -c Release -warnaserror`: 0 warnings, 0 errors
- RN `npm run typecheck` clean; `npm test` 157/157; `npm run e2e` (web export + Playwright) 5/5
- Runtime: sidecar boot seeds the 2 instance nodes + device user + both grants (verified over `/api/mesh/query-nodes`); second boot re-seeds nothing (idempotent)

What's New entry included (`2026-08-20-mobile-mesh-list-in-local-mesh.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)