### PR TITLE
voice gateway: the spoken session — sticky thread context, spoken switching, session cookie, full MCP

### DIFF
--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -67,7 +67,7 @@ def make_router(cfg: Config) -> BrainRouter:
         # A portal entry's "agents" pins agents to the portal that HOSTS them (list of
         # names, or name → spoken-roster description) — e.g. the ExecutiveAssistant on the
         # local mesh: {"name":"mac", …, "agents": {"ExecutiveAssistant": "email"}}.
-        from .ollama import DEFAULT_AGENTS, HOME_TOOL, MESH_TOOLS
+        from .ollama import DEFAULT_AGENTS, HOME_TOOL, MESH_TOOL, MESH_TOOLS
         roster = dict(DEFAULT_AGENTS)
         agent_homes: dict[str, str] = {}
         for entry in cfg.portals:
@@ -79,14 +79,23 @@ def make_router(cfg: Config) -> BrainRouter:
                 agent_homes[name] = entry["name"]
         router = BrainRouter(brains, active, phrases=phrases, home=home,
                              agent_homes=agent_homes)
+        router.allow_destructive = cfg.allow_destructive
         # The local brain TRIAGES: quick lookups through the normal tools (search_mesh,
-        # get_node, home_assistant), real work through delegate_to_memex — a mesh thread.
+        # get_node, mesh_tool = full MCP, home_assistant), real work through
+        # delegate_to_memex — a mesh thread the context sticks to.
         for brain in brains.values():
             if isinstance(brain, OllamaBrain):
                 brain.delegator = router.delegate_task
                 brain.tool_runner = router.run_tool
-                brain.tools = list(MESH_TOOLS) + ([HOME_TOOL] if home is not None else [])
+                brain.tools = (list(MESH_TOOLS) + [MESH_TOOL]
+                               + ([HOME_TOOL] if home is not None else []))
                 brain.agents = roster
+        # The SESSION COOKIE: resume the speaker's context within the TTL, persist on
+        # every context mutation — an MCP-session-style continuity for the voice.
+        from .session import SpokenSession
+        session = SpokenSession(cfg.session_file, cfg.session_ttl_h)
+        router.restore(session.load())
+        router.on_change = lambda: session.save(**router.session_state())
         return router
     if cfg.brain == "ollama":
         return BrainRouter({"lokal": ollama({})}, "lokal", phrases=phrases, home=home)

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -32,13 +32,25 @@ PHRASES: dict[str, dict[str, str]] = {
            "connected": "Connected to {name}.",
            "unknown": "I don't know {target}. Available: {names}.",
            "delegated": "Started a {agent} thread on {portal}. You can review it there.",
-           "no_mesh": "No mesh portal is configured for threads."},
+           "no_mesh": "No mesh portal is configured for threads.",
+           "new_topic": "Okay, new topic.",
+           "switched": "Now in the thread about {topic}.",
+           "posted": "Posted to the thread about {topic}. I will announce the answer.",
+           "no_thread": "I have no open thread about {topic}.",
+           "threads_open": "Open threads: {list}.",
+           "no_threads": "No open threads."},
     "de": {"hold": "Ich schaue nach. Einen Moment bitte.",
            "error": "Entschuldigung, das hat gerade nicht geklappt.",
            "connected": "Verbunden mit {name}.",
            "unknown": "Ich kenne {target} nicht. Verfügbar: {names}.",
            "delegated": "Thread mit {agent} auf {portal} gestartet. Du kannst ihn dort anschauen.",
-           "no_mesh": "Es ist kein Portal für Threads konfiguriert."},
+           "no_mesh": "Es ist kein Portal für Threads konfiguriert.",
+           "new_topic": "Okay, neues Thema.",
+           "switched": "Wir sind jetzt im Thread über {topic}.",
+           "posted": "An den Thread über {topic} geschickt. Ich melde mich mit der Antwort.",
+           "no_thread": "Ich habe keinen offenen Thread über {topic}.",
+           "threads_open": "Offene Threads: {list}.",
+           "no_threads": "Keine offenen Threads."},
 }
 PHRASES["en"]["answer_to"] = "Answering your question: {question} —"
 PHRASES["de"]["answer_to"] = "Antwort auf deine Frage: {question} —"
@@ -91,6 +103,11 @@ class Config:
     # --- Home Assistant (optional) — a tool for the local brain, not a voice owner ---
     ha_url: str | None = None               # e.g. http://homeassistant.local:8123
     ha_token: str | None = None             # long-lived access token
+
+    # --- the spoken session (context cookie) + tool reach ---
+    session_file: str = "~/.memex-voice/session.json"   # persisted context, per speaker
+    session_ttl_h: float = 8.0              # like an MCP session id: resumes within, expires after
+    allow_destructive: bool = False         # let mesh_tool reach delete/restore (default: never)
 
     # --- endpointing (energy VAD) ---
     silence_ms: int = 800
@@ -149,6 +166,9 @@ class Config:
             system_prompt_file=_env("SYSTEM_PROMPT_FILE"),
             ha_url=(_env("HA_URL") or "").rstrip("/") or None,
             ha_token=_env("HA_TOKEN"),
+            session_file=_env("SESSION_FILE", Config.session_file) or Config.session_file,
+            session_ttl_h=float(_env("SESSION_TTL_H", "8")),
+            allow_destructive=(_env("ALLOW_DESTRUCTIVE", "false") or "false").lower() == "true",
             silence_ms=int(_env("SILENCE_MS", "800")),
             tts_engine=(_env("TTS_ENGINE", "piper") or "piper").lower(),
             stream_tts=(_env("STREAM_TTS", "false") or "false").lower() == "true",

--- a/clients/voice-gateway/memex_voice_gateway/ollama.py
+++ b/clients/voice-gateway/memex_voice_gateway/ollama.py
@@ -27,8 +27,9 @@ SYSTEM_PROMPT = (
     "wall-clock time in brackets — use it to judge gaps in the conversation.\n\n"
     "TRIAGE — decide per request: answer DIRECTLY yourself for time, dates, general "
     "knowledge, conversions, and small talk (you run on-device; speed is your virtue). "
-    "For a QUICK lookup use your read-only tools: search_mesh finds nodes in the user's "
-    "mesh, get_node reads one, home_assistant controls the smart home. DELEGATE by calling "
+    "For a QUICK lookup use your tools: search_mesh finds nodes in the user's mesh, "
+    "get_node reads one, mesh_tool calls any other portal tool by name, home_assistant "
+    "controls the smart home. DELEGATE by calling "
     "delegate_to_memex — it opens a thread in the mesh where a full agent with its own "
     "tools works the task — for anything that needs current information from the web, "
     "documents, writing or changing data, or multi-step work. Anything about EMAIL — "
@@ -118,6 +119,23 @@ MESH_TOOLS = [
             "required": ["path"]},
     }},
 ]
+
+# FULL MCP: any tool on the connected portal, by name — the same surface an MCP client
+# has. Destructive tools are filtered router-side unless explicitly enabled.
+MESH_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "mesh_tool",
+        "description": "Call ANY tool on the user's mesh portal by its MCP name — e.g. "
+                       "autocomplete, render_area, navigate_to, create, update, "
+                       "execute_script. Use search_mesh/get_node for plain lookups; use "
+                       "this for everything else the portal offers.",
+        "parameters": {"type": "object", "properties": {
+            "tool": {"type": "string", "description": "The MCP tool name, e.g. render_area."},
+            "arguments": {"type": "object", "description": "The tool's arguments object."},
+        }, "required": ["tool"]},
+    },
+}
 
 HOME_TOOL = {
     "type": "function",

--- a/clients/voice-gateway/memex_voice_gateway/pipeline.py
+++ b/clients/voice-gateway/memex_voice_gateway/pipeline.py
@@ -108,6 +108,8 @@ class VoicePipeline:
             if confirmation == "":
                 return RoundResult(transcript, None, None, interrupt=True)  # spoken "stop"
             if confirmation is not None:
+                # A spoken post-to-thread queues its announcement like any delegation.
+                self._schedule_delegations()
                 return RoundResult(transcript, confirmation,
                                    await self._try_speak(confirmation))
 
@@ -133,11 +135,7 @@ class VoicePipeline:
 
         # The local brain may have TRIAGED work to the mesh mid-round: schedule the
         # announcement of each delegated thread's answer, attributed to its task.
-        if self._drain_delegations is not None:
-            for handle, task in self._drain_delegations():
-                delegated = asyncio.create_task(self._announce_when_ready(handle, task))
-                self._background.add(delegated)
-                delegated.add_done_callback(self._background.discard)
+        self._schedule_delegations()
 
         if reply is not None:
             return RoundResult(transcript, reply, await self._try_speak(reply))
@@ -151,6 +149,14 @@ class VoicePipeline:
         hold = (self._hold_phrase_for(thread_path) if self._hold_phrase_for
                 else self._hold_phrase)
         return RoundResult(transcript, None, await self._try_speak(hold))
+
+    def _schedule_delegations(self) -> None:
+        if self._drain_delegations is None:
+            return
+        for handle, task in self._drain_delegations():
+            delegated = asyncio.create_task(self._announce_when_ready(handle, task))
+            self._background.add(delegated)
+            delegated.add_done_callback(self._background.discard)
 
     async def _announce_when_ready(self, thread_path: str, transcript: str) -> None:
         try:

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -53,6 +53,24 @@ def parse_switch_command(transcript: str) -> str | None:
     return match.group("target").strip() if match else None
 
 
+# The spoken CONTEXT commands — the side-panel model, by voice: one current thread is the
+# context; switch to another by topic, post into one by topic, or start fresh.
+_NEW_TOPIC = re.compile(
+    r"^\s*(?:neues thema|themawechsel|thema wechseln|new topic|"
+    r"(?:schliesse?|beende)\s+(?:das|den|dieses)?\s*(?:thema|thread|kontext)|"
+    r"close (?:the )?(?:topic|thread|context))[.!]?\s*$", re.IGNORECASE)
+_LIST_THREADS = re.compile(
+    r"^\s*(?:welche threads?\s+(?:sind|haben wir)\s+offen|liste\s+(?:der|die)\s+threads?|"
+    r"what threads?\s+(?:are|do we have)\s+open|list\s+(?:the\s+)?(?:open\s+)?threads?)"
+    r"\s*\??[.!]?\s*$", re.IGNORECASE)
+_SWITCH_THREAD = re.compile(
+    r"^\s*(?:wechsle|wechsel|geh|gehe|switch|go)\s+(?:zum|zu dem|to the|to)\s+thread\s*"
+    r"(?:über|ueber|about|on|zu)?\s+(?P<topic>[\wäöüéè .-]{2,50}?)[.!?]?\s*$", re.IGNORECASE)
+_POST_TO = re.compile(
+    r"^\s*(?:im|in dem|in den|an den|in the|to the|post to the|poste an den)\s+thread\s*"
+    r"(?:über|ueber|about|on|zu)?\s+(?P<topic>[^:,]{2,50}?)\s*[:,]\s+(?P<message>.{4,})$",
+    re.IGNORECASE)
+
 _DELEGATE = re.compile(
     r"^\s*(?:frag|frage|ask)\s+(?:den|die|das|the)?\s*(?P<agent>[a-zA-Zäöü]+)[:,]?\s+"
     r"(?:nach\s+|about\s+|to\s+)?(?P<task>.{4,})$",
@@ -75,6 +93,12 @@ _DEFAULT_PHRASES = {
     "delegated": "Started a {agent} thread on {portal}. You can review it there.",
     "no_mesh": "No mesh portal is configured for threads.",
     "submitted": "Submitted to {portal}. I will tell you when the answer arrives.",
+    "new_topic": "Okay, new topic.",
+    "switched": "Now in the thread about {topic}.",
+    "posted": "Posted to the thread about {topic}. I will announce the answer.",
+    "no_thread": "I have no open thread about {topic}.",
+    "threads_open": "Open threads: {list}.",
+    "no_threads": "No open threads.",
 }
 
 
@@ -95,6 +119,60 @@ class BrainRouter:
         # Agent name → the portal that HOSTS it (a portal entry's "agents" list): the
         # ExecutiveAssistant may live on the local mesh while Researcher lives in the cloud.
         self._agent_homes = agent_homes or {}
+        # The SPOKEN CONTEXT — side-panel semantics: `_context` is THE current thread
+        # (delegations post into it until switched or closed), `_threads` lists everything
+        # opened this session, `_pending` carries spoken posts awaiting their announcement,
+        # `on_change` persists the session cookie after every mutation.
+        self._context: dict | None = None
+        self._threads: list[dict] = []
+        self._pending: list = []
+        self.on_change: Callable[[], None] | None = None
+
+    # ----- the spoken context (session state) -----
+
+    def session_state(self) -> dict:
+        return {"portal": self.active, "context": self._context, "threads": self._threads}
+
+    def restore(self, state: dict) -> None:
+        """Resume a persisted session: active portal, context, open threads."""
+        if state.get("portal") in self._brains:
+            self.active = state["portal"]
+        context = state.get("context")
+        if context and context.get("portal") in self._mesh:
+            self._context = context
+        self._threads = [t for t in state.get("threads", [])
+                         if t.get("portal") in self._mesh]
+
+    def _changed(self) -> None:
+        if self.on_change is not None:
+            self.on_change()
+
+    def _remember(self, portal: str, path: str, task: str, agent: str | None) -> dict:
+        import time
+        entry = next((t for t in self._threads if t["path"] == path), None)
+        if entry is None:
+            entry = {"portal": portal, "path": path,
+                     "task": task if len(task) <= 80 else task[:77] + "…",
+                     "agent": agent or ""}
+            self._threads.append(entry)
+        entry["last"] = time.time()
+        self._context = entry
+        self._changed()
+        return entry
+
+    def _find_thread(self, topic: str) -> dict | None:
+        """Fuzzy topic → open thread: substring or word overlap on task/agent, most
+        recently used first."""
+        wanted = topic.lower().strip()
+        words = {w for w in re.split(r"\W+", wanted) if len(w) > 2}
+        best = None
+        for entry in sorted(self._threads, key=lambda t: t.get("last", 0), reverse=True):
+            haystack = f"{entry['task']} {entry['agent']}".lower()
+            if wanted in haystack or (words and words <= set(re.split(r"\W+", haystack))):
+                return entry
+            if best is None and words and words & set(re.split(r"\W+", haystack)):
+                best = entry
+        return best
 
     def _mesh_target(self) -> str | None:
         """The portal delegations go to: the active brain when it is a mesh, else the first mesh."""
@@ -103,9 +181,19 @@ class BrainRouter:
         return next(iter(self._mesh), None)
 
     async def delegate_task(self, task: str, agent: str | None = None) -> str:
-        """The local brain's triage seam: open a mesh thread, return the STAMPED handle so
-        await_reply later polls the right brain. An agent with a declared HOME portal goes
-        there; anything else goes to the active/first mesh. Raises when no mesh is configured."""
+        """The local brain's triage seam, with CONTEXT: while a context thread is open,
+        follow-ups post INTO it (the mesh agent keeps the whole conversation); a different
+        explicit agent reuses/opens that agent's own thread and the context switches to it —
+        the side-panel model. Returns the STAMPED handle so await_reply later polls the
+        right brain. Raises when no mesh is configured."""
+        context = self._context
+        if context is not None and agent and agent != (context.get("agent") or None):
+            context = next((t for t in self._threads if t["agent"] == agent), None)
+        if context is not None:
+            portal, path = context["portal"], context["path"]
+            await self._brains[portal].submit(path, task, agent or context["agent"] or None)  # type: ignore[attr-defined]
+            self._remember(portal, path, context["task"], context["agent"] or None)
+            return f"{portal}::{path}"
         target = None
         if agent and (housed := self._agent_homes.get(agent)) in self._mesh:
             target = housed
@@ -113,12 +201,19 @@ class BrainRouter:
         if target is None:
             raise RuntimeError("no mesh portal configured")
         path = await self._brains[target].delegate(task, agent)  # type: ignore[attr-defined]
+        self._remember(target, path, task, agent)
         return f"{target}::{path}"
 
+    # Irreversible mesh tools stay behind an explicit opt-in — one mis-heard word must
+    # never delete a node. Everything else on the portal's MCP surface passes through.
+    _DESTRUCTIVE = {"delete", "restore_version", "restore_from_point_in_time"}
+    allow_destructive: bool = False
+
     async def run_tool(self, name: str, args: dict) -> str:
-        """The local brain's quick tools, run in-round: mesh reads go to the same portal
+        """The local brain's quick tools, run in-round: mesh calls go to the same portal
         delegations would (the active brain when it is a mesh, else the first mesh);
-        home_assistant goes to the configured HA instance."""
+        home_assistant goes to the configured HA instance. mesh_tool is the FULL MCP
+        passthrough — any tool on the portal, by name."""
         if name == "home_assistant":
             if self._home is None:
                 return "Home Assistant is not configured."
@@ -132,11 +227,22 @@ class BrainRouter:
                                                 "limit": 8})  # type: ignore[attr-defined]
         if name == "get_node":
             return await client.call("get", {"path": str(args.get("path", "")).strip()})  # type: ignore[attr-defined]
+        if name == "mesh_tool":
+            import json as _json
+            tool = str(args.get("tool", "")).strip()
+            if tool in self._DESTRUCTIVE and not self.allow_destructive:
+                return f"The tool {tool} is destructive and disabled for voice."
+            raw = args.get("arguments") or {}
+            if isinstance(raw, str):
+                try: raw = _json.loads(raw)
+                except Exception: return "arguments must be a JSON object."
+            return await client.call(tool, raw)  # type: ignore[attr-defined]
         return f"Unknown tool: {name}"
 
     def drain_delegations(self) -> list:
-        """Pending (handle, task) pairs from ANY brain that collects them (the local one)."""
-        pending: list = []
+        """Pending (handle, task) pairs from ANY brain that collects them (the local one),
+        plus spoken posts routed by handle_command."""
+        pending, self._pending = self._pending, []
         for brain in self._brains.values():
             drain = getattr(brain, "drain_delegations", None)
             if drain:
@@ -167,6 +273,39 @@ class BrainRouter:
                 or _CHANT.match(transcript.strip())):
             return ""     # stop or courteous closure: end quietly, never reply to a reply
 
+        # The spoken CONTEXT commands come BEFORE the portal switch — "wechsle zum Thread
+        # über X" must never be eaten by "wechsle zu {portal}".
+        stripped = transcript.strip()
+        if _NEW_TOPIC.match(stripped):
+            self._context = None
+            self._changed()
+            return self._phrases["new_topic"]
+        if _LIST_THREADS.match(stripped):
+            if not self._threads:
+                return self._phrases["no_threads"]
+            names = ", ".join(t["task"] if len(t["task"]) <= 40 else t["task"][:37] + "…"
+                              for t in self._threads[-6:])
+            return self._phrases["threads_open"].format(list=names)
+        posted = _POST_TO.match(stripped)
+        if posted is not None:
+            entry = self._find_thread(posted.group("topic"))
+            if entry is None:
+                return self._phrases["no_thread"].format(topic=posted.group("topic").strip())
+            message = posted.group("message").strip()
+            await self._brains[entry["portal"]].submit(entry["path"], message,
+                                                       entry["agent"] or None)  # type: ignore[attr-defined]
+            self._remember(entry["portal"], entry["path"], entry["task"], entry["agent"] or None)
+            self._pending.append((f"{entry['portal']}::{entry['path']}", message))
+            return self._phrases["posted"].format(topic=posted.group("topic").strip())
+        switched = _SWITCH_THREAD.match(stripped)
+        if switched is not None:
+            entry = self._find_thread(switched.group("topic"))
+            if entry is None:
+                return self._phrases["no_thread"].format(topic=switched.group("topic").strip())
+            self._context = entry
+            self._changed()
+            return self._phrases["switched"].format(topic=switched.group("topic").strip())
+
         # Delegation: launch a real thread for a STANDARD agent on the mesh and leave the
         # work to be evaluated THERE — the speaker only confirms the submission.
         delegated = _DELEGATE_THREAD.match(transcript.strip())
@@ -177,12 +316,13 @@ class BrainRouter:
                 delegated = match
                 agent_name = KNOWN_AGENTS[match.group("agent").lower()]
         if delegated is not None:
-            target = self._mesh_target()
-            if target is None:
+            if self._mesh_target() is None:
                 return self._phrases["no_mesh"]
-            await self._brains[target].delegate(delegated.group("task").strip(), agent_name)  # type: ignore[attr-defined]
+            if _DELEGATE_THREAD.match(transcript.strip()):
+                self._context = None   # "start a thread" is EXPLICITLY a fresh one
+            handle = await self.delegate_task(delegated.group("task").strip(), agent_name)
             return self._phrases["delegated"].format(agent=agent_name or "Assistant",
-                                                     portal=target)
+                                                     portal=handle.partition("::")[0])
 
         spoken = parse_switch_command(transcript)
         if spoken is None:
@@ -192,6 +332,7 @@ class BrainRouter:
             return self._phrases["unknown"].format(target=spoken,
                                                    names=", ".join(self._brains))
         self.active = name
+        self._changed()   # the active portal is part of the persisted session
         return self._phrases["connected"].format(name=name)
 
     async def ask(self, text: str) -> str:

--- a/clients/voice-gateway/memex_voice_gateway/session.py
+++ b/clients/voice-gateway/memex_voice_gateway/session.py
@@ -1,0 +1,47 @@
+"""The speaker's SESSION COOKIE — spoken context, persisted with an expiry.
+
+The voice conversation has the same context model as the portal's side panel: one CURRENT
+thread is the context, everything posts into it until the user switches ("wechsle zum
+Thread über …") or starts fresh ("neues Thema"). That state — active portal, current
+context, the open threads — is persisted to disk per speaker and expires after a TTL,
+exactly like an MCP session id: a gateway restart inside the window resumes where the
+conversation was; after the window, the speaker starts clean.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+
+class SpokenSession:
+    def __init__(self, path: str, ttl_hours: float = 8.0) -> None:
+        self._path = Path(path).expanduser()
+        self._ttl_s = ttl_hours * 3600
+
+    def load(self) -> dict:
+        """The persisted session, or {} when absent/expired/corrupt."""
+        try:
+            state = json.loads(self._path.read_text())
+        except (OSError, ValueError):
+            return {}
+        if float(state.get("expires_at", 0)) < time.time():
+            return {}
+        return state
+
+    def save(self, *, portal: str, context: dict | None, threads: list[dict]) -> None:
+        """Persist and re-arm the expiry — every interaction extends the session."""
+        state = {"portal": portal, "context": context, "threads": threads,
+                 "expires_at": time.time() + self._ttl_s}
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(json.dumps(state, indent=2))
+        except OSError:
+            pass   # a failed persist degrades to an in-memory session, never breaks a round
+
+    def clear(self) -> None:
+        try:
+            self._path.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/clients/voice-gateway/memex_voice_gateway/threads.py
+++ b/clients/voice-gateway/memex_voice_gateway/threads.py
@@ -68,7 +68,9 @@ class MemexThreads:
     _session_id: str | None = field(default=None, init=False)
     _http: aiohttp.ClientSession | None = field(default=None, init=False)
     _thread_path: str | None = field(default=None, init=False)
-    _known_ids: set[str] = field(default_factory=set, init=False)
+    # Seen message ids PER THREAD — one shared set would let a reused conversation thread
+    # reset a delegated thread's watermark and re-announce an old answer.
+    _known: dict[str, set[str]] = field(default_factory=dict, init=False)
     _last_used: float = field(default=0.0, init=False)
 
     async def _post(self, payload: dict) -> tuple[dict, str]:
@@ -122,29 +124,38 @@ class MemexThreads:
     async def delegate(self, text: str, agent: str | None = None) -> str:
         """Fire-and-forget: launch a NEW thread for a standard agent (Assistant, Researcher,
         …) and return its path. Deliberately does NOT become the voice conversation thread —
-        the task runs and is evaluated in the portal, not read aloud."""
+        the task runs and is evaluated in the portal, not read aloud. CONTINUATION policy
+        (post follow-ups into the open thread) lives in the router's context, not here."""
         args: dict = {"namespacePath": self.namespace, "message": text}
         if agent or self.agent:
             args["agentName"] = agent or self.agent
         started = json.loads(await self.call("start_thread", args))
-        return started["threadPath"]
+        path = started["threadPath"]
+        self._known[path] = set()
+        return path
+
+    async def submit(self, thread_path: str, text: str, agent: str | None = None) -> str:
+        """Post a follow-up into an EXISTING thread — the context stays. The id watermark is
+        re-snapshotted first so await_reply announces only what lands AFTER this message."""
+        self._known[thread_path] = await self._snapshot_ids(thread_path)
+        args: dict = {"threadPath": thread_path, "message": text}
+        if agent or self.agent:
+            args["agentName"] = agent or self.agent
+        await self.call("submit_message", args)
+        return thread_path
 
     async def ask(self, text: str) -> str:
         """Submit an utterance; returns the thread path. Reuses a recent thread for context."""
         fresh = self._thread_path and (time.monotonic() - self._last_used) < self.thread_idle_minutes * 60
         if fresh and self._thread_path:
-            self._known_ids = await self._snapshot_ids(self._thread_path)
-            args: dict = {"threadPath": self._thread_path, "message": text}
-            if self.agent:
-                args["agentName"] = self.agent
-            await self.call("submit_message", args)
+            await self.submit(self._thread_path, text)
         else:
             args = {"namespacePath": self.namespace, "message": text}
             if self.agent:
                 args["agentName"] = self.agent
             started = json.loads(await self.call("start_thread", args))
             self._thread_path = started["threadPath"]
-            self._known_ids = set()
+            self._known[self._thread_path] = set()
         self._last_used = time.monotonic()
         return self._thread_path  # type: ignore[return-value]
 
@@ -152,13 +163,14 @@ class MemexThreads:
                           poll_interval_s: float = 1.5) -> str | None:
         """Poll until an assistant reply (or a dispatch failure) lands; None on budget miss."""
         deadline = time.monotonic() + budget_s
+        known = self._known.setdefault(thread_path, set())
         while time.monotonic() < deadline:
             thread_json = await self.call("get", {"path": f"@{thread_path}"})
-            new_ids, failure = extract_reply(thread_json, self._known_ids)
+            new_ids, failure = extract_reply(thread_json, known)
             for message_id in new_ids:
                 child = json.loads(await self.call("get", {"path": f"@{thread_path}/{message_id}"}))
                 content = child.get("content") or {}
-                self._known_ids.add(message_id)
+                known.add(message_id)
                 if content.get("role") == "assistant" and content.get("text"):
                     return content["text"]
             if failure:

--- a/clients/voice-gateway/tests/test_context.py
+++ b/clients/voice-gateway/tests/test_context.py
@@ -1,0 +1,124 @@
+"""The spoken context: sticky threads, switching, the session cookie."""
+import asyncio
+import time
+
+from memex_voice_gateway.router import BrainRouter
+from memex_voice_gateway.session import SpokenSession
+
+
+class FakeMesh:
+    def __init__(self):
+        self.started, self.submitted = [], []
+        self.counter = 0
+
+    async def ask(self, text): return "h"
+    async def await_reply(self, handle, budget_s): return None
+    async def close(self): pass
+
+    async def delegate(self, text, agent=None):
+        self.counter += 1
+        self.started.append((text, agent))
+        return f"u/_Thread/t{self.counter}"
+
+    async def submit(self, path, text, agent=None):
+        self.submitted.append((path, text, agent))
+        return path
+
+
+def test_context_sticks_until_switched_or_closed():
+    async def scenario():
+        mesh = FakeMesh()
+        router = BrainRouter({"memex": mesh}, "memex")
+        # First delegation opens the thread and SETS the context.
+        h1 = await router.delegate_task("Wetter morgen in Zürich")
+        assert h1 == "memex::u/_Thread/t1" and len(mesh.started) == 1
+        # The follow-up POSTS INTO the same thread — no new thread.
+        h2 = await router.delegate_task("Und übermorgen?")
+        assert h2 == h1 and len(mesh.started) == 1
+        assert mesh.submitted[0][0] == "u/_Thread/t1"
+        # A different explicit agent gets its own thread; context switches to it.
+        h3 = await router.delegate_task("Check my inbox", "ExecutiveAssistant")
+        assert h3 == "memex::u/_Thread/t2"
+        # …and now follow-ups continue THERE.
+        h4 = await router.delegate_task("Reply to the first one")
+        assert h4 == h3
+        # "neues Thema" clears the context: the next delegation opens thread 3.
+        assert await router.handle_command("Neues Thema") == "Okay, new topic."
+        h5 = await router.delegate_task("Plan my week")
+        assert h5 == "memex::u/_Thread/t3"
+
+    asyncio.run(scenario())
+
+
+def test_spoken_switch_and_post_by_topic():
+    async def scenario():
+        mesh = FakeMesh()
+        router = BrainRouter({"memex": mesh}, "memex")
+        weather = await router.delegate_task("Wetter morgen in Zürich")
+        await router.handle_command("Neues Thema")
+        mail = await router.delegate_task("Fasse meine Mails zusammen", "ExecutiveAssistant")
+        assert weather != mail
+        # Switch back by topic — context returns to the weather thread.
+        out = await router.handle_command("Wechsle zum Thread über Wetter")
+        assert "Wetter" in out
+        assert (await router.delegate_task("Regnet es?")) == weather
+        # Post into the OTHER thread by topic without switching a delegation there first.
+        out = await router.handle_command("Im Thread über Mails: bitte die von Anna zuerst")
+        assert "Mails" in out
+        assert mesh.submitted[-1][0] == mail.partition("::")[2]
+        # …and the answer is queued for announcement.
+        pending = router.drain_delegations()
+        assert pending and pending[0][0] == mail
+        # Listing names both threads.
+        listed = await router.handle_command("Welche Threads sind offen?")
+        assert "Wetter" in listed and "Mails" in listed
+
+    asyncio.run(scenario())
+
+
+def test_session_cookie_roundtrip_and_expiry(tmp_path):
+    store = SpokenSession(str(tmp_path / "session.json"), ttl_hours=8)
+    store.save(portal="memex", context={"portal": "memex", "path": "u/_Thread/t1",
+                                        "task": "Wetter", "agent": ""},
+               threads=[{"portal": "memex", "path": "u/_Thread/t1", "task": "Wetter",
+                         "agent": "", "last": time.time()}])
+    state = store.load()
+    assert state["portal"] == "memex" and state["context"]["path"] == "u/_Thread/t1"
+
+    async def scenario():
+        mesh = FakeMesh()
+        router = BrainRouter({"memex": mesh}, "memex")
+        router.restore(state)
+        # The restored context is live: a delegation posts into the persisted thread.
+        assert (await router.delegate_task("Und heute?")) == "memex::u/_Thread/t1"
+        assert mesh.submitted and not mesh.started
+
+    asyncio.run(scenario())
+    # An expired cookie loads as a clean session.
+    expired = SpokenSession(str(tmp_path / "expired.json"), ttl_hours=-1)
+    expired.save(portal="memex", context=None, threads=[])
+    assert expired.load() == {}
+
+
+def test_mesh_tool_passthrough_gates_destructive():
+    class ToolMesh(FakeMesh):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+        async def call(self, tool, arguments):
+            self.calls.append((tool, arguments))
+            return "ok"
+
+    async def scenario():
+        mesh = ToolMesh()
+        router = BrainRouter({"memex": mesh}, "memex")
+        assert await router.run_tool("mesh_tool", {"tool": "render_area",
+                                                   "arguments": {"path": "@X"}}) == "ok"
+        out = await router.run_tool("mesh_tool", {"tool": "delete",
+                                                  "arguments": {"path": "@X"}})
+        assert "destructive" in out and ("delete", {"path": "@X"}) not in mesh.calls
+        router.allow_destructive = True
+        assert await router.run_tool("mesh_tool", {"tool": "delete",
+                                                   "arguments": {"path": "@X"}}) == "ok"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Once a thread is started with memex, the conversation KEEPS it — the side panel's context model, spoken:

- **Sticky context**: the first delegation opens a thread and sets it as the context; follow-ups post into it until closed. A different explicit agent branches to its own thread and the context follows.
- **Spoken switching**: "wechsle zum Thread über Wetter" / "im Thread über Mails: …" (posts and announces the answer) / "welche Threads sind offen?" / "neues Thema".
- **Session cookie**: portal + context + open threads persist to disk with an MCP-session-style TTL (`SESSION_TTL_H`, default 8h) — a gateway restart resumes mid-conversation.
- **Full MCP**: `mesh_tool` passes any portal tool through by name; `delete`/`restore_*` stay behind `ALLOW_DESTRUCTIVE`.
- Per-thread message-id watermarks (the shared set could re-announce a stale answer); announcements are scheduled after command rounds too.

36 gateway tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)