### PR TITLE
module-pack packs from publish output; package-universe lane witness

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -77,14 +77,9 @@ jobs:
           echo "packing $MODULE as $PACKAGE@$version, platform floor $floor"
 
       - name: Build the module (Release, warnings-as-errors)
-        # CopyLocalLockFileAssemblies puts the module's PACKAGE dependencies into the output
-        # folder, where the pack step's --deps-closure derivation expects to find them — a module
-        # bundle must carry its own private closure (the platform does not: those packages left
-        # /app with the module's source, and an entry-DLL-only bundle faults at first use).
         run: >
           dotnet build "${{ matrix.entry.project }}" -c Release -warnaserror
           -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver
-          -p:CopyLocalLockFileAssemblies=true
           -p:Version=${{ steps.identity.outputs.version }}
 
       - name: Run the module's tests, when it ships any
@@ -102,6 +97,18 @@ jobs:
             echo "no test project at $tests — nothing to run"
           fi
 
+      # Publish materializes the module's PACKAGE dependencies beside the entry DLL — the SDK's
+      # own answer to the runtime closure (framework-trimmed packages excluded, everything else
+      # included), which the pack step's --deps-closure derivation selects from. A
+      # -p:CopyLocalLockFileAssemblies=true build was tried first and copied NOTHING on the CI
+      # SDK while copying everything on a dev machine (2026-08-20, 12/14 jobs) — publish does not
+      # depend on that flag at all.
+      - name: Publish the module (the closure the pack selects from)
+        run: >
+          dotnet publish "${{ matrix.entry.project }}" -c Release --no-build
+          -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver
+          -p:Version=${{ steps.identity.outputs.version }}
+
       - name: Build the module-pack tool
         run: dotnet build meshweaver/src/MeshWeaver.Plugin.Build/MeshWeaver.Plugin.Build.csproj -c Release
 
@@ -110,7 +117,7 @@ jobs:
           PROJECT: ${{ matrix.entry.project }}
         run: >
           dotnet run --project meshweaver/src/MeshWeaver.Plugin.Build -c Release --no-build --
-          module-pack "$GITHUB_WORKSPACE/$(dirname "$PROJECT")/bin/Release/net10.0"
+          module-pack "$GITHUB_WORKSPACE/$(dirname "$PROJECT")/bin/Release/net10.0/publish"
           --deps-closure
           --module-name "${{ matrix.entry.module }}"
           --plugin "${{ matrix.entry.package }}"

--- a/src/MeshWeaver.Plugin.Build/DepsClosure.cs
+++ b/src/MeshWeaver.Plugin.Build/DepsClosure.cs
@@ -43,11 +43,17 @@ public static class DepsClosure
     /// <summary>The derived closure: runtime file names to bundle beside the entry DLL, plus the
     /// MeshWeaver.* nodes the walk stopped at (diagnostic — printed so a pack log shows the
     /// split), plus warnings for nodes with native <c>runtimeTargets</c> the bundle does not
-    /// carry.</summary>
+    /// carry, plus the PACKAGE UNIVERSE — every runtime file of every non-MeshWeaver package node
+    /// in the whole graph. The universe is the packer's lane witness: a folder that materializes
+    /// package assets at all (a publish folder, a CopyLocalLockFileAssemblies build) contains SOME
+    /// of it, however framework-trimmed the module's own dependencies are — so "none of the
+    /// universe present" cleanly means "this folder never had package assets", never "everything
+    /// was framework-resolved".</summary>
     public sealed record Result(
         IReadOnlyList<string> Files,
         IReadOnlyList<string> ExcludedPlatformCarried,
-        IReadOnlyList<string> Warnings);
+        IReadOnlyList<string> Warnings,
+        IReadOnlyList<string> PackageUniverse);
 
     private sealed record Node(
         string Name,
@@ -141,10 +147,19 @@ public static class DepsClosure
         }
         var excluded = platformStops.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
 
+        var universe = nodes.Values
+            .Where(n => !IsPlatform(n.Name)
+                        && string.Equals(n.LibraryType, "package", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(n => n.RuntimeFiles)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
         return new Result(
             files.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
             excluded,
-            warnings);
+            warnings,
+            universe);
     }
 
     private static bool IsPlatform(string name) =>

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -313,19 +313,26 @@ public static class ModulePackCommand
                 .ToList();
             var missing = derived.Files.Except(present, StringComparer.OrdinalIgnoreCase).ToList();
 
-            // A derived file ABSENT from a CopyLocalLockFileAssemblies build was FRAMEWORK-TRIMMED:
-            // the SDK resolved that package to the shared framework (Microsoft.Extensions.* riding
-            // in Microsoft.AspNetCore.App), so the consumer's runtime provides it and the bundle
-            // need not. Skipped with a line each, never silently. The one case that must STAY an
-            // error is a build that ran without the flag at all — then NOTHING was copied, and
-            // skipping would pack the entry-only bundle this flag exists to abolish. The two are
-            // distinguishable: package assemblies in the output prove the flag was on (project
-            // references copy only MeshWeaver.*, which the derivation never includes).
-            if (missing.Count > 0 && present.Count == 0)
+            // A derived file ABSENT from a folder that materializes package assets was
+            // FRAMEWORK-TRIMMED: the SDK resolved that package to the shared framework
+            // (Microsoft.Extensions.* riding in Microsoft.AspNetCore.App), so the consumer's
+            // runtime provides it and the bundle need not. Skipped with a line each, never
+            // silently. The one case that must STAY an error is a folder that never had package
+            // assets at all — a plain classlib build output — where skipping would pack the
+            // entry-only bundle this flag exists to abolish. The witness is the PACKAGE UNIVERSE
+            // (every non-MeshWeaver package runtime file in the whole graph, platform-reachable
+            // ones included): a publish folder contains some of it even when the module's OWN
+            // dependencies are entirely framework-trimmed, because the MeshWeaver references drag
+            // their package deps in — so an empty intersection cleanly means "wrong folder",
+            // never "everything was framework-resolved". (Checking only the module's own derived
+            // set got this wrong both ways on CI, 2026-08-20.)
+            if (missing.Count > 0
+                && !derived.PackageUniverse.Any(f => File.Exists(Path.Combine(moduleDirectory, f))))
             {
                 Console.Error.WriteLine(
-                    "error: --deps-closure derived files and NONE are in the module output — build "
-                    + "with -p:CopyLocalLockFileAssemblies=true so package assemblies are copied. "
+                    "error: --deps-closure derived files and the folder holds NO package assets at "
+                    + "all — pack from `dotnet publish` output (or a CopyLocalLockFileAssemblies "
+                    + "build), not a plain build folder. "
                     + $"Missing: {string.Join(", ", missing)}");
                 return 2;
             }

--- a/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
@@ -198,6 +198,60 @@ public class ModulePackCommandTest : IDisposable
     }
 
     [Fact]
+    public void DepsClosure_AllOwnDepsFrameworkTrimmed_PacksEntryOnly_WhenTheFolderHasPackageAssets()
+    {
+        // The Notifications shape in a publish folder: the module's OWN dependencies are all
+        // framework-trimmed (absent), but the folder plainly materializes package assets — a
+        // platform-reachable package file is right there. That is a valid entry-only bundle,
+        // not a broken lane; refusing it blocked 2 of 14 modules on CI (2026-08-20).
+        File.WriteAllBytes(Path.Combine(root, "closure", "Autofac.dll"), "AF"u8.ToArray());
+        File.WriteAllText(Path.Combine(root, "closure", "Widget.deps.json"), """
+            {
+              "runtimeTarget": { "name": ".NETCoreApp,Version=v10.0" },
+              "targets": {
+                ".NETCoreApp,Version=v10.0": {
+                  "Widget/1.0.0": {
+                    "dependencies": { "MeshWeaver.AI": "3.0.0", "Microsoft.Extensions.Options": "10.0.0" },
+                    "runtime": { "Widget.dll": {} }
+                  },
+                  "MeshWeaver.AI/3.0.0": {
+                    "dependencies": { "Autofac": "8.0.0" },
+                    "runtime": { "MeshWeaver.AI.dll": {} }
+                  },
+                  "Autofac/8.0.0": { "runtime": { "lib/net8.0/Autofac.dll": {} } },
+                  "Microsoft.Extensions.Options/10.0.0": { "runtime": { "lib/net10.0/Microsoft.Extensions.Options.dll": {} } }
+                }
+              },
+              "libraries": {
+                "Widget/1.0.0": { "type": "project" },
+                "MeshWeaver.AI/3.0.0": { "type": "project" },
+                "Autofac/8.0.0": { "type": "package" },
+                "Microsoft.Extensions.Options/10.0.0": { "type": "package" }
+              }
+            }
+            """);
+
+        var outDir = Path.Combine(root, "out-fw-only");
+        var exit = ModulePackCommand.Run(
+        [
+            Path.Combine(root, "closure"),
+            "--deps-closure",
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.6.0",
+            "--out", outDir,
+        ]);
+
+        Assert.Equal(0, exit);
+        var (manifest, _) = BundleReader.ReadModule(File.ReadAllBytes(
+            Path.Combine(outDir, "MeshWeaver.Plugin.WidgetPkg.1.6.0.module.nupkg")));
+        // Entry only: the trimmed dependency stays out, and the platform-reachable Autofac —
+        // present in the folder — must NOT ride either.
+        Assert.DoesNotContain("Microsoft.Extensions.Options.dll", manifest!.Module!.Assemblies!);
+        Assert.DoesNotContain("Autofac.dll", manifest.Module.Assemblies!);
+    }
+
+    [Fact]
     public void DepsClosure_WithTheFileMissingFromTheOutput_IsARefusal()
     {
         // deps.json names a dependency that is NOT in the folder — the build ran without


### PR DESCRIPTION
Third slice of the bundle-closure lane (#1914, #1919). The re-run failed differently: `-p:CopyLocalLockFileAssemblies=true` copies everything on a dev machine and **nothing on the CI SDK** — same command line, flag visibly in the log. Instead of chasing that, the lane stops depending on the flag:

- **Pack from `dotnet publish --no-build` output** — the SDK's own runtime closure (framework-trimmed excluded, packages included), no flag involved.
- **The all-missing refusal's witness is now the package universe** (every non-MeshWeaver package runtime file in the whole graph). Checking only the module's own derived set couldn't distinguish 'all framework-trimmed' (valid entry-only — Notifications, Observability) from 'lane broken': a publish folder always holds some universe file (MeshWeaver refs drag their package deps in), so empty intersection = wrong folder → refuse; anything present → trimmed files skip with a note.

15/15 pack tests; verified against the real `Mail.MicrosoftGraph` publish output (28 files bundled).

After merge: re-run the 12 failed `Module bundle` jobs on Plugins main run 32348846606 — the packer rebuilds from the fresh platform checkout. **Note the workflow file change means a plain re-run keeps the OLD workflow snapshot** — if the re-run still packs from `bin/…/net10.0`, dispatch a fresh main run instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)