### PR TITLE
Modules__Root could not reach a container — the chart never rendered it

### DIFF
--- a/deploy/aks/scripts/check-chart-invariants.py
+++ b/deploy/aks/scripts/check-chart-invariants.py
@@ -166,6 +166,48 @@ if scaled is not None:
             "without protecting anything.",
         )
 
+# ---------------------------------------------------------------------------
+# 8. Every key the PLATFORM must let a deployment set is actually RENDERED.
+#
+# 🚨 This is the `replicas.portal: 2` defect in its other direction, and it is the one this
+# ConfigMap invites: the template names every key EXPLICITLY and the Deployment's only env path is
+# `envFrom` on it, so a key the template omits is consumed by nothing — a values file can set it in
+# three environments and no container ever sees it. helm reports success either way, because the
+# values file is syntactically perfect and the template simply never mentions it.
+#
+# That is not hypothetical. Memex#53 set `config.memex_portal.Modules__Root: /data` in all three
+# AKS values files, titled "Modules__Root belongs in the chart — that is why it kept vanishing".
+# It kept vanishing because it was never templated here.
+#
+# So: for each key below, the rendered ConfigMap must CARRY it and its value must be non-blank.
+# Blank matters as much as absent for any key whose consumer treats blank as unset — ModuleRoot
+# does exactly that and falls back to AppContext.BaseDirectory (/app), which is READ-ONLY in the
+# container, so a blank key silently restores the very defect the key exists to fix.
+REQUIRED_CONFIG = {
+    "Modules__Root":
+        "the writable root the store-installed modules/ tree and its activation.json sidecar are "
+        "written under (ModuleRoot.ConfigKey). Unset or blank resolves to AppContext.BaseDirectory "
+        "— /app, read-only in the container — so nothing can be store-activated and every "
+        "module-contributed route (/mcp among them) stays unmapped.",
+}
+
+cfg_data = (cfg or {}).get("data") or {}
+for key, why in REQUIRED_CONFIG.items():
+    checks += 1
+    if key not in cfg_data:
+        finding(
+            f"the rendered memex-portal-config carries no '{key}'",
+            f"{why} The ConfigMap names every key explicitly and the Deployment reads it via "
+            f"envFrom, so an un-templated key reaches no container — setting it in a values file "
+            f"changes nothing, silently.",
+        )
+    elif not str(cfg_data[key]).strip():
+        finding(
+            f"'{key}' renders BLANK in memex-portal-config",
+            f"{why} Give it a value in the template (defaulting to another key is fine) rather "
+            f"than emitting an empty string.",
+        )
+
 MIN_CHECKS = 5
 if checks < MIN_CHECKS:
     print(

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -31,6 +31,18 @@ data:
 {{- end }}
   Deployment__Backend: "{{ .Values.config.memex_portal.Deployment__Backend }}"
   Deployment__DataRoot: "{{ .Values.config.memex_portal.Deployment__DataRoot }}"
+  # The writable root the store-installed `modules/` tree lives under (ModuleRoot.ConfigKey).
+  # 🚨 It MUST be templated here to exist at all: this ConfigMap names every key explicitly and
+  #   the Deployment's only env path is `envFrom` — so a values file that sets a key this
+  #   template does not render produces nothing, silently. That is precisely how it "kept
+  #   vanishing" (Memex#53 set it in three AKS values files; none of them could reach a
+  #   container).
+  # 🚨 Blank is NOT the same as unset-but-harmless: ModuleRoot treats blank as absent and falls
+  #   back to AppContext.BaseDirectory (/app), which is READ-ONLY in the container — so the
+  #   module lane cannot land anything and every store-installed module's routes stay unmapped.
+  #   Default it to the deployment's data root, which is the shared writable volume by
+  #   construction, rather than emitting an empty string.
+  Modules__Root: "{{ .Values.config.memex_portal.Modules__Root | default .Values.config.memex_portal.Deployment__DataRoot }}"
   # ---- NodeType bake ------------------------------------------------------
   # 🚨 ADOPTION IS NOT CONFIGURED HERE — it is unconditional. Every boot seeds the prebuilt
   #   bundles (PreWarm__PrebuiltBundleRoot below, plus the image's own prebuilt/ directory) and

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -383,6 +383,10 @@ config:
     ASPNETCORE_HTTP_PORTS: "8080"
     Deployment__Backend: "Filesystem"
     Deployment__DataRoot: "/data"
+    # The writable root for store-installed modules (ModuleRoot.ConfigKey). Empty here means
+    # "follow Deployment__DataRoot", which the template applies — a deployment only sets this
+    # when its module tree must live somewhere other than the data root.
+    Modules__Root: ""
     # 🔗 ONE setting in two keys — they are not independent, and the gate is worthless
     # without the sweep. GateReadiness gates on state that ONLY the sweep writes, and the
     # health check reports Healthy while the sweep has not started (by design: a config

--- a/deploy/homebrew/share/values.local.defaults.yaml
+++ b/deploy/homebrew/share/values.local.defaults.yaml
@@ -18,6 +18,17 @@
 
 config:
   memex_portal:
+    # ---- Store-installed modules land on the PERSISTENT volume ---------------
+    # A module that ships in the image is not automatically ACTIVE: /mcp, the gRPC
+    # endpoint and every other module route is mapped from `Modules:Assemblies`,
+    # which is the appsettings baseline plus the store-activation sidecar. The
+    # sidecar and the landed DLLs are written under this root.
+    #
+    # 🚨 Unset means AppContext.BaseDirectory — /app — which is READ-ONLY in the
+    # container, so the landing service cannot write and NOTHING can ever be
+    # store-activated. /data is the hostPath the chart already mounts, so a module
+    # landed here also survives `memex-local update` (a new image, same volume).
+    Modules__Root: "/data"
     # ---- Startup: ADOPT prebuilt modules, do NOT compile them ----------------
     # A laptop is not a build farm. The startup bake this replaced compiled
     # EVERY dynamic NodeType in-process, and it did so again from scratch on

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-installed-modules-can-be-activated.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-installed-modules-can-be-activated.md
@@ -1,0 +1,29 @@
+---
+Name: A deployment can host modules again
+Category: Fix
+Description: The setting that tells a portal where to keep the modules it installs was being discarded before it reached the portal, so an installed module never switched on. It now arrives, and features that ship as modules — the MCP server among them — work once installed.
+Icon: Sparkle
+Order: -20260820
+---
+
+# A deployment can host modules again
+
+Features increasingly ship as **modules** rather than being built into the portal — the MCP server
+is one of them. A module travels with a deployment, and switching it on means writing a small record
+that says "this one is active". That record has to live somewhere the portal can write, which is why
+a deployment names a folder for it.
+
+The folder setting never arrived. It was written into the deployment's configuration, and it was
+read by the portal, but the step in between — the packaging that turns configuration into something
+the running portal can see — had no line for it. Nothing failed and nothing was logged: the setting
+was simply dropped on the way, every time.
+
+With no folder named, the portal fell back to a location inside its own installation, which it is
+not allowed to write to. So the record could never be written, no module could ever be switched on,
+and anything that arrives as a module was quietly absent. For the MCP server that meant its address
+answered "not found" — a portal that looked healthy in every other respect and simply did not offer
+the feature.
+
+The setting now survives the trip. A deployment that names a folder gets it; one that does not gets
+the same folder its other data already lives in, rather than the unwritable fallback. Installed
+modules switch on as intended.


### PR DESCRIPTION
## The defect

A module that ships in the image is not automatically active. `/mcp` and every other module route is mapped by `MapMeshModuleEndpoints` from **`Modules:Assemblies`**, which is the appsettings baseline ∪ the store-activation sidecar. Both the sidecar and the landed DLLs are written under **`Modules:Root`**.

Unset, that root is `AppContext.BaseDirectory` — `/app` — which is **read-only in the container**. #1891 established exactly this and made the key configurable so a deployment could point it at its shared writable volume. Memex#53 then set `config.memex_portal.Modules__Root: /data` in all three AKS values files, titled *"Modules__Root belongs in the chart — that is why it kept vanishing."*

**It kept vanishing because the chart does not render it.** `memex-portal-config` names every key explicitly, there is no catch-all range over `config.memex_portal`, and the Deployment's only env path is `envFrom` on that ConfigMap plus the Secret. A values key this template omits produces exactly nothing, with no error anywhere — the failure mode `deploy/aks` documents as *"un-templated chart keys are silently dropped"*. Three values files set the key; no container ever saw it.

## Verified on a live deployment, before the fix

```
ConfigMap                          zero Modules* keys
/app/modules                       read-only  (touch → Permission denied)
/data                              writable   (the mounted hostPath/PVC)
/data/modules/activation.json      absent
/app/modules/MeshWeaver.Mcp/…dll   present, unused
POST /mcp                          404
```

…and after, on the same portal: `Modules__Root=/data` reaches the process, the sidecar is read, the entry passes its platform floor (module built against `MeshWeaver.Graph/3.0.0-rc4.ci.0`, platform `3.0.0-rc5.ci.0`), `MeshWeaver.Mcp.dll` is mapped into the process (`/proc/1/maps`), and **`POST /mcp` → 401** with a proper `www-authenticate: Bearer resource_metadata=…` challenge. An MCP client reconnects and serves real calls.

## What changed

1. **`deploy/helm/templates/memex-portal/config.yaml`** — templates `Modules__Root`, defaulting to `Deployment__DataRoot` rather than emitting a blank. Blank is not harmless: `ModuleRoot` treats it as *absent* and falls back to the read-only `/app`, silently restoring the defect the key exists to cure. An explicit value still wins.
2. **`deploy/helm/values.yaml`** — neutral default `""` (follow the data root).
3. **`deploy/homebrew/share/values.local.defaults.yaml`** — pins `/data` for memex-local, so a laptop install gets a writable root without regenerating its user overlay, and a landed module survives `memex-local update`.
4. **`deploy/aks/scripts/check-chart-invariants.py`** — invariant 8, so the next key cannot vanish the same way.

## The gate, written test-first

`check-chart-invariants` exists because `replicas.portal: 2` sat in git for a month being consumed by nothing. This is that defect in the other direction, so the rule is pinned rather than just the instance.

**Red**, against main's own chart:

```
::error::[main, unfixed] the rendered memex-portal-config carries no 'Modules__Root'
1 contradiction(s) across 7 invariants — exit 1
```

**Green** on this branch, all three shipped combinations:

```
self-host (neutral chart defaults) — self-consistent
AKS overlay                        — self-consistent
memex-local (Colima k3s)           — self-consistent
```

**Negative control**: forcing both `Modules__Root` and `Deployment__DataRoot` blank fails on the *blank* arm, not the *missing* arm — the two halves of the assertion are independently live rather than one covering for the other.

## Risk

Low, and inert on merge. No workflow applies this chart: `main-cd.yml` builds and publishes images and never touches helm; the only helm-aware workflow is `chart-drift.yml`, a scheduled read-only drift detector. The chart takes effect when someone deliberately deploys.

On AKS the key currently resolves to read-only `/app`, so **nothing can be store-activated today**. After this it resolves to `/data`, which those pods already mount — and it stays inert until a module is actually activated. It cannot change existing behaviour, only unblock intended behaviour.

## Checks

```
deploy/aks/scripts/check-chart-invariants.sh   all 3 combinations, exit 0
helm template … | grep Modules__Root           neutral /data · AKS /data · local /data
                                               --set /mnt/modules → honoured
dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror   0 Warning(s) 0 Error(s)
dotnet test  test/MeshWeaver.Documentation.Test (repo-file guards)        15/15 passed
```

## Found while doing this — filed separately, NOT in this PR

Widening that guard from `PreWarm__*` to every `config.memex_portal` key surfaces **three more keys set in `deploy/aks/values.aks.yaml` that no template renders**: `SelfUpdate__MinRollInterval`, `WebhookInbox__Targets__0`, `AzureFoundry__Models__3`. Templating them would change live AKS behaviour, and two are recent deliberate work, so they belong to their owner rather than to this PR. Issue: #1925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
