### PR TITLE
Hosting.Orleans sheds Azure.Data.Tables (dead reference)

### DIFF
--- a/src/MeshWeaver.Hosting.Orleans/MeshWeaver.Hosting.Orleans.csproj
+++ b/src/MeshWeaver.Hosting.Orleans/MeshWeaver.Hosting.Orleans.csproj
@@ -8,7 +8,6 @@
   </ItemGroup>
 
     <ItemGroup>
-    <PackageReference Include="Azure.Data.Tables" />
     <PackageReference Include="Microsoft.Orleans.Core" />
     <PackageReference Include="Microsoft.Orleans.Runtime" />
     <PackageReference Include="Microsoft.Orleans.Sdk" />


### PR DESCRIPTION
Part of the Azure-out-of-the-platform sweep. No source in `src/` uses `Azure.Data.Tables`; the one real user is the Distributed app's aspire wiring, whose own csproj already carries its own reference. Project builds clean without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)