### PR TITLE
voice gateway: never read the thread's 'Generating response...' placeholder aloud

### DIFF
--- a/clients/voice-gateway/memex_voice_gateway/threads.py
+++ b/clients/voice-gateway/memex_voice_gateway/threads.py
@@ -170,9 +170,23 @@ class MemexThreads:
             for message_id in new_ids:
                 child = json.loads(await self.call("get", {"path": f"@{thread_path}/{message_id}"}))
                 content = child.get("content") or {}
-                known.add(message_id)
-                if content.get("role") == "assistant" and content.get("text"):
-                    return content["text"]
+                text = (content.get("text") or "").strip()
+                status = content.get("status")
+                # An assistant child can materialize MID-round as a placeholder
+                # ("Generating response...", status InProgress) whose text is later
+                # replaced by the real answer. Reading it aloud IS the bug (observed
+                # 2026-08-20) — and marking it seen would silence the real answer, so an
+                # in-progress child stays un-known and is re-read on the next poll.
+                if content.get("role") == "assistant":
+                    in_progress = (status not in (None, "Completed")
+                                   or text.lower().startswith("generating"))
+                    if in_progress:
+                        continue
+                    known.add(message_id)
+                    if text:
+                        return content["text"]
+                else:
+                    known.add(message_id)
             if failure:
                 return failure
             await asyncio.sleep(poll_interval_s)

--- a/clients/voice-gateway/tests/test_threads.py
+++ b/clients/voice-gateway/tests/test_threads.py
@@ -59,3 +59,35 @@ def test_pending_round_suppresses_stale_summary():
     node = thread_node(["u1"], pending=pending, summary="an old digest")
     _, failure = extract_reply(node, known_ids={"u1"})
     assert failure is None
+
+
+def test_await_reply_skips_in_progress_placeholder():
+    """The platform materializes an assistant child MID-round ('Generating response...',
+    InProgress) whose text later becomes the real answer — it must be neither read aloud
+    nor marked seen."""
+    import asyncio
+
+    from memex_voice_gateway.threads import MemexThreads
+
+    async def scenario():
+        client = MemexThreads("http://unused", "t", "ns")
+        phase = {"n": 0}
+
+        async def fake_call(tool, arguments):
+            path = arguments.get("path", "")
+            if path == "@ns/_Thread/t1":
+                return json.dumps({"content": {"messages": ["m1"]}})
+            phase["n"] += 1
+            if phase["n"] == 1:
+                return json.dumps({"content": {"role": "assistant",
+                                               "text": "Generating response...",
+                                               "status": "InProgress"}})
+            return json.dumps({"content": {"role": "assistant",
+                                           "text": "Es sind 26 Kantone.",
+                                           "status": "Completed"}})
+
+        client.call = fake_call
+        reply = await client.await_reply("ns/_Thread/t1", budget_s=5, poll_interval_s=0.01)
+        assert reply == "Es sind 26 Kantone."
+
+    asyncio.run(scenario())


### PR DESCRIPTION
The platform now materializes an assistant child MID-round whose text is a placeholder (status `InProgress`) later replaced by the real answer. `await_reply` returned the first assistant text it saw — the speaker read "Generating response..." instead of the answer, and because the id was marked seen, the real answer was never spoken (the round looked dead — observed live 2026-08-20). An in-progress assistant child is now skipped AND left un-known so the next poll re-reads it until it completes. 37 gateway tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)