### PR TITLE
Blazor sheds Microsoft.EntityFrameworkCore (dead reference)

### DIFF
--- a/src/MeshWeaver.Blazor/MeshWeaver.Blazor.csproj
+++ b/src/MeshWeaver.Blazor/MeshWeaver.Blazor.csproj
@@ -15,7 +15,6 @@
         <PackageReference Include="BlazorMonaco" />
         <PackageReference Include="HtmlAgilityPack" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" />
         <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" />
         <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" />
         <PackageReference Include="Microsoft.Identity.Web" />


### PR DESCRIPTION
Factor-out sweep: referenced by exactly one csproj, used by zero source files in `src/` or `memex/`. EF Core and its transitive graph rode in `/app` for nothing. Project builds clean without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)