### PR TITLE
Close the cross-process change feed: start the PG listener, route it, and re-read on an entity-less notification

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-cross-process-change-feed.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-cross-process-change-feed.md
@@ -1,0 +1,13 @@
+---
+Name: Pages stop serving a stale page after a deploy
+Category: Fix
+Description: A write made on one server is now seen by the others straight away, instead of leaving a page stuck on old state until it was recycled by hand.
+Icon: Sparkle
+Order: -20260820
+---
+
+# Pages stop serving a stale page after a deploy
+
+When a portal runs on more than one server, a change saved by one of them was not announced to the others: their copy of the page could stay behind indefinitely, and no amount of reloading fixed it. On 17 August that is what left every course cover on the public site showing an error card for two hours — the servers disagreed about a node, and neither could learn better.
+
+The servers now tell each other about every change as it is committed, and a page that hears about one re-reads it and catches up on its own. There is nothing to do and nothing to click: pages converge within a moment of the change, instead of waiting for a restart.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -940,6 +940,22 @@ public static class MeshDataSourceExtensions
     private static readonly TimeSpan SaveSampleInterval = TimeSpan.FromMilliseconds(200);
 
     /// <summary>
+    /// Coalescing window for the own-node RE-READ the change-feed reconcile performs when a
+    /// durable notification arrives without its entity (see the pipeline in
+    /// <c>SubscribeToOwnDeletion</c>). A notification storm on one path collapses to at most one
+    /// read per quiet window, and the reads are serialised, so a bulk import cannot turn a
+    /// notification storm into a read storm.
+    ///
+    /// <para>🚨 <c>Throttle</c>, deliberately NOT <c>Sample</c>: <c>Sample</c> arms a PERIODIC
+    /// timer per subscription and there is one of these subscriptions per live node hub, so an
+    /// idle mesh would pay one timer tick per hub per window for nothing. <c>Throttle</c> arms a
+    /// one-shot timer only while a burst is in flight — an idle hub costs nothing — and it always
+    /// emits the LAST trigger of a burst, so the read that CONVERGES the mirror can never be the
+    /// one that gets dropped.</para>
+    /// </summary>
+    private static readonly TimeSpan OwnNodeReReadCoalesceWindow = TimeSpan.FromMilliseconds(50);
+
+    /// <summary>
     /// Resolves the static node SERVED at <paramref name="hubPath"/>: the first
     /// non-<see cref="MeshNode.IsDefinitionOnly"/> static node across every registered
     /// <see cref="IStaticNodeProvider"/> whose <see cref="MeshNode.Path"/> matches
@@ -1456,8 +1472,65 @@ public static class MeshDataSourceExtensions
             .Subscribe(n => lastSelfWrite.OnNext(n.Version));
         hub.RegisterForDisposal(saveEchoSub);
 
+        // 🚨 THE DURABLE FEED DOES NOT ALWAYS CARRY THE NODE — and the notification that arrives
+        // WITHOUT one is precisely the CROSS-PROCESS notification this reconcile exists for.
+        // `Entity = null` is the CONTRACT of every source whose notification can outrun row
+        // visibility: PG's LISTEN/NOTIFY (PostgreSqlChangeListener parses `{path, op}` out of the
+        // NOTIFY payload — there is no node in it), the Cosmos change feed, the Snowflake poller
+        // ("Entity = null (subscribers re-read…)"). Until this branch existed, every one of them
+        // was DISCARDED here, so a mirror in another process could be arbitrarily far behind a
+        // rival's write and would never be told (#1440, and the deterministic cross-hub write
+        // conflict in #1814).
+        //
+        // 🚨 The fix is a RE-READ, never a supplement. Populating `Entity` from the payload is the
+        // defect StorageAdapterMeshQueryProvider REMOVED (#1250): whenever the supplement changed
+        // the outcome, the re-read was the one that was right — the row it re-added was one the
+        // read had excluded by RLS, by satellite-table routing (#1193), by a path filter or past
+        // the load cap — and it raced row visibility besides. Reading keeps the PROVENANCE the
+        // adoption below depends on: what the store returns IS the durable state, by construction.
+        //
+        // 🚨 It cannot feed itself (the #223 write-storm shape). The trigger's only effects are a
+        // READ and an AdoptPersisted, and AdoptPersisted neither mints nor writes — it records the
+        // durable version so the persistence sampler and the dispose-time flush both skip it. No
+        // write on this path ⇒ no notification of our own to re-trigger it.
+        //
+        // The subject is deliberately NOT disposed: `delSub` publishes into it, and disposing the
+        // subject first would turn a write landing in the teardown window into an
+        // ObjectDisposedException thrown back into the adapter's change-feed fan-out — the exact
+        // ordering trap the synced-query pipelines document. An OnNext into a subject whose only
+        // subscription is already disposed is a harmless no-op.
+        var reReadTrigger = new System.Reactive.Subjects.Subject<Unit>();
+        var reReadSub = reReadTrigger
+            .Throttle(OwnNodeReReadCoalesceWindow)
+            .Select(_ => storage.Read(ownPath, hub.JsonSerializerOptions)
+                .Catch((Exception ex) =>
+                {
+                    // Surfaced, not swallowed: without this the Concat below would terminate on
+                    // the first transient read failure and this hub would stop reconciling for
+                    // the rest of its life. The next notification re-reads.
+                    TryLogWarning(hub, ex,
+                        "Own-node re-read after an entity-less change notification failed on "
+                        + "{Hub} — the mirror stays on its current state until the next "
+                        + "notification", hub.Address);
+                    return Observable.Empty<MeshNode?>();
+                }))
+            // One read at a time: a second burst can never interleave its adoption with the
+            // first's, and at most one read per hub is ever in flight.
+            .Concat()
+            .Subscribe(node =>
+            {
+                // null = the row is gone (a delete landed between the notification and the read).
+                // The Deleted notification carries that fact on its own branch; nothing to adopt.
+                if (node is not null)
+                    AdoptDurable(node);
+            });
+        hub.RegisterForDisposal(reReadSub);
+
         var delSub = storage.Changes.Subscribe(notification =>
         {
+            // Not this hub's node: ONE ordinal string compare, no read, no allocation. Every
+            // notification in the process reaches every live node hub, so this discard is on the
+            // hot path of the cross-process feed and has to stay this cheap.
             if (!string.Equals(notification.Path, ownPath, StringComparison.OrdinalIgnoreCase))
                 return;
 
@@ -1476,63 +1549,79 @@ public static class MeshDataSourceExtensions
 
                 case DataChangeKind.Created:
                 case DataChangeKind.Updated:
-                    if (notification.Entity is not MeshNode newNode)
-                        return;
-                    // Echo-suppression: this notification matches the version
-                    // we just wrote via saveSub → skip the Update that would
-                    // close the loop.
-                    if (newNode.Version == lastSelfWrite.Value)
-                        return;
-                    cache.IsDeleted = false;
-                    // A genuine (re)create/update clears the tombstone so a same-id recreate
-                    // persists normally (a self-write echo was already suppressed above).
-                    recentlyDeleted?.Clear(ownPath);
-                    try
+                    if (notification.Entity is MeshNode newNode)
                     {
-                        // 🚨 ADOPTION, NOT A WRITE — `notification.Entity` is the node as PERSISTED,
-                        // at the version storage already holds it under. AdoptPersisted lands it
-                        // VERBATIM: it does not mint (an `Update` here minted durable+1 — a phantom
-                        // revision that exists nowhere, which the persistence sampler then wrote back,
-                        // #1432) and it records the durable version so neither the sampler nor the
-                        // dispose-time flush echoes the observation to storage. Provenance is the
-                        // discriminator: only the durable change feed reaches this line, so nothing
-                        // here has to guess whether content is "already durable" — it is, by
-                        // construction. Every genuine change keeps going through Update and mints.
-                        //
-                        // 🚨 FORWARD-ONLY (AdoptPersisted's built-in guard) — never move the in-RAM
-                        // node BACKWARD. The durable write + its change notification are OFF-TURN, so
-                        // under a write burst this notification LAGS the in-RAM stream: by the time it
-                        // arrives, the in-RAM commit may already carry many newer writes. A blind
-                        // `_ => newNode` overwrite re-applied that STALE persisted snapshot over fresher
-                        // in-RAM state and silently dropped every field added since it was persisted —
-                        // the concurrent cross-hub-write data-loss bug (CrossHubPatchAtomicityTest: a
-                        // burst of cross-mirror dict-adds settling with entries permanently lost). The
-                        // single-write echo-suppression above only skips the EXACT latest version, not
-                        // the older lagging echoes. The IN-RAM commit is authoritative (the owner's
-                        // monotonic Version is the one clock); a persisted snapshot may only REPLACE it
-                        // when it is STRICTLY NEWER (a genuine out-of-band external write). A lagged
-                        // own-write echo (version <= live) is a no-op, so the in-RAM stream only ever
-                        // moves forward.
-                        hub.GetWorkspace().GetMeshNodeStream()
-                            .AdoptPersisted(newNode)
-                            .Subscribe(
-                                _ => { },
-                                ex => TryLogWarning(hub, ex,
-                                    "Own-node refresh from change notification failed on {Hub}",
-                                    hub.Address));
+                        // An in-process publish: the adapter committed BEFORE publishing, so the
+                        // entity IS the durable state and no read is needed.
+                        AdoptDurable(newNode);
+                        return;
                     }
-                    catch (Exception ex)
-                    {
-                        // Expected: workspace has no MeshNodeReference reducer. Logged for the same
-                        // reason as the setup guard above — this path also reaches stream
-                        // materialisation, so a silent swallow here hides a real fault.
-                        TryLogWarning(hub, ex,
-                            "Own-node change-notification reconcile failed on {Hub}", hub.Address);
-                    }
+                    // Entity-less ⇒ the durable CROSS-PROCESS feed. Trigger the coalesced re-read.
+                    reReadTrigger.OnNext(Unit.Default);
                     return;
             }
         });
         hub.RegisterForDisposal(delSub);
+        return;
+
+        // Adopts a state that is ALREADY DURABLE, whether it arrived ON the notification (an
+        // in-process publish) or was just read back for one that carried none (the cross-process
+        // feed). Both provenances are identical by construction — the store committed first —
+        // which is what makes AdoptPersisted the right call for either.
+        void AdoptDurable(MeshNode newNode)
+        {
+            // Echo-suppression: this state matches the version we just wrote via saveSub → skip
+            // the adoption that would close the loop. It works for the re-read too, because the
+            // read returns the version the write landed at.
+            if (newNode.Version == lastSelfWrite.Value)
+                return;
+            cache.IsDeleted = false;
+            // A genuine (re)create/update clears the tombstone so a same-id recreate
+            // persists normally (a self-write echo was already suppressed above).
+            recentlyDeleted?.Clear(ownPath);
+            try
+            {
+                // 🚨 ADOPTION, NOT A WRITE — `newNode` is the node as PERSISTED, at the version
+                // storage already holds it under. AdoptPersisted lands it VERBATIM: it does not
+                // mint (an `Update` here minted durable+1 — a phantom revision that exists
+                // nowhere, which the persistence sampler then wrote back, #1432) and it records
+                // the durable version so neither the sampler nor the dispose-time flush echoes the
+                // observation to storage. Provenance is the discriminator: only the durable change
+                // feed reaches this line, so nothing here has to guess whether content is "already
+                // durable" — it is, by construction. Every genuine change keeps going through
+                // Update and mints.
+                //
+                // 🚨 FORWARD-ONLY (AdoptPersisted's built-in guard) — never move the in-RAM
+                // node BACKWARD. The durable write + its change notification are OFF-TURN, so
+                // under a write burst this notification LAGS the in-RAM stream: by the time it
+                // arrives, the in-RAM commit may already carry many newer writes. A blind
+                // `_ => newNode` overwrite re-applied that STALE persisted snapshot over fresher
+                // in-RAM state and silently dropped every field added since it was persisted —
+                // the concurrent cross-hub-write data-loss bug (CrossHubPatchAtomicityTest: a
+                // burst of cross-mirror dict-adds settling with entries permanently lost). The
+                // single-write echo-suppression above only skips the EXACT latest version, not
+                // the older lagging echoes. The IN-RAM commit is authoritative (the owner's
+                // monotonic Version is the one clock); a persisted snapshot may only REPLACE it
+                // when it is STRICTLY NEWER (a genuine out-of-band external write). A lagged
+                // own-write echo (version <= live) is a no-op, so the in-RAM stream only ever
+                // moves forward.
+                hub.GetWorkspace().GetMeshNodeStream()
+                    .AdoptPersisted(newNode)
+                    .Subscribe(
+                        _ => { },
+                        ex => TryLogWarning(hub, ex,
+                            "Own-node refresh from change notification failed on {Hub}",
+                            hub.Address));
+            }
+            catch (Exception ex)
+            {
+                // Expected: workspace has no MeshNodeReference reducer. Logged for the same
+                // reason as the setup guard above — this path also reaches stream
+                // materialisation, so a silent swallow here hides a real fault.
+                TryLogWarning(hub, ex,
+                    "Own-node change-notification reconcile failed on {Hub}", hub.Address);
+            }
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting.PostgreSql/PartitionChangeRouter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PartitionChangeRouter.cs
@@ -1,0 +1,101 @@
+using System.Threading;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting.PostgreSql;
+
+/// <summary>
+/// The missing half of the cross-process change feed: routes every
+/// <c>LISTEN mesh_node_changes</c> event <see cref="PostgreSqlChangeListener"/> receives to the
+/// per-partition feed that owns its path.
+///
+/// <para><b>Why this class exists.</b> The NOTIFY channel is per DATABASE — one listener connection
+/// receives every schema's events — while the in-process change feed under
+/// <see cref="PostgreSqlPathRoutingAdapter"/> is per SCHEMA. Nothing answered "whose feed is this
+/// notification?", so the listener's DI wiring sat commented out with a TODO for exactly this
+/// routing (#1440). The consequence was measured in production: a mirror in one process could be
+/// arbitrarily far behind a rival process's write and would never be told, which is why the
+/// cross-hub write conflict behind the 2026-08-17 outage was DETERMINISTIC rather than a race — the
+/// staleness was in the snapshot, and no retry could refresh it (#1814).</para>
+///
+/// <para><b>The routing is the write's own routing.</b> A path resolves to a schema exactly as
+/// <see cref="PostgreSqlPathRoutingAdapter"/> resolves it for a write — first segment → schema,
+/// synchronously, with the same guards (satellite node types, <c>_</c>-prefix globals resolved
+/// through the registered-partition map, invalid segments refused). A notification therefore can
+/// never reach a feed the write itself would not have published to, and there is no second
+/// resolution to drift out of step with the first.</para>
+///
+/// <para><b>A notification this process has no use for is discarded cheaply</b> — one synchronous
+/// segment resolution, no DB round-trip, and (deliberately) no per-schema adapter materialised for
+/// a partition nobody here has touched. <see cref="DiscardedCount"/> counts them so "the listener
+/// is running but nothing routes" is observable rather than something to infer from silence.</para>
+///
+/// <para>🚨 Delivery is SYNCHRONOUS on the Npgsql notification callback, matching the single-schema
+/// wiring this replaces. That is safe because every subscriber's expensive work is already
+/// off-thread: the query providers hand their re-query to an <c>IIoPool</c> leaf, and the per-node
+/// hub's re-read is coalesced onto the default scheduler before it reads. Adding a queue here would
+/// buy nothing and would be an unbounded buffer in front of a storm.</para>
+/// </summary>
+internal sealed class PartitionChangeRouter : IObserver<DataChangeNotification>
+{
+    private readonly PostgreSqlPartitionStorageProvider _provider;
+    private readonly ILogger? _logger;
+    private long _routed;
+    private long _discarded;
+
+    /// <summary>Creates the router over the provider that owns the per-schema feeds.</summary>
+    public PartitionChangeRouter(
+        PostgreSqlPartitionStorageProvider provider,
+        ILogger<PartitionChangeRouter>? logger = null)
+    {
+        _provider = provider;
+        _logger = logger;
+    }
+
+    /// <summary>Test seam: notifications routed onto a partition feed since startup.</summary>
+    internal long RoutedCount => Interlocked.Read(ref _routed);
+
+    /// <summary>
+    /// Test seam: notifications discarded because their path is not a routable partition. A
+    /// discard is normal (the database can hold rows this mesh does not route) and costs one
+    /// segment resolution — but a count that equals the routed count means the routing is wrong,
+    /// not that the database is quiet.
+    /// </summary>
+    internal long DiscardedCount => Interlocked.Read(ref _discarded);
+
+    /// <inheritdoc />
+    public void OnNext(DataChangeNotification value)
+    {
+        // 🚨 Never throw back into the listener: an exception raised on the Npgsql notification
+        // callback would tear the LISTEN loop down into its reconnect branch, and a routing fault
+        // for ONE path would then cost every path its cross-process feed until the reconnect
+        // completes. Log it and keep listening — that is a surfaced fault, not a swallowed one.
+        try
+        {
+            if (_provider.PublishExternalChange(value))
+            {
+                Interlocked.Increment(ref _routed);
+                return;
+            }
+
+            Interlocked.Increment(ref _discarded);
+            _logger?.LogDebug(
+                "Cross-process change notification for '{Path}' ({Kind}) is not a routable "
+                + "partition — discarded", value.Path, value.Kind);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex,
+                "Routing the cross-process change notification for '{Path}' ({Kind}) failed",
+                value.Path, value.Kind);
+        }
+    }
+
+    /// <inheritdoc />
+    public void OnError(Exception error)
+        => _logger?.LogError(error, "The cross-process change feed faulted");
+
+    /// <inheritdoc />
+    public void OnCompleted()
+        => _logger?.LogInformation("The cross-process change feed completed");
+}

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlChangeListener.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlChangeListener.cs
@@ -12,6 +12,9 @@ namespace MeshWeaver.Hosting.PostgreSql;
 public class PostgreSqlChangeListener : IAsyncDisposable
 {
     private readonly NpgsqlDataSource _dataSource;
+    // Non-null only when this listener BUILT its data source (see OwningDataSource) and must
+    // therefore dispose it. A data source handed in from outside belongs to its owner.
+    private readonly NpgsqlDataSource? _ownedDataSource;
     private readonly IObserver<DataChangeNotification> _changeNotifier;
     private readonly ILogger<PostgreSqlChangeListener>? _logger;
     private CancellationTokenSource? _cts;
@@ -31,6 +34,39 @@ public class PostgreSqlChangeListener : IAsyncDisposable
         _dataSource = dataSource;
         _changeNotifier = changeNotifier;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Builds a listener that OWNS <paramref name="dedicatedDataSource"/> and disposes it with
+    /// itself — the shape the partitioned wiring uses, where
+    /// <c>PostgreSqlPartitionStorageProvider.CreateChangeListenerDataSource</c> builds a
+    /// single-connection source configured exactly like every other source that provider builds.
+    ///
+    /// <para>🚨 The <c>LISTEN</c> session holds one connection open for the life of the process, so
+    /// taking it from the shared pool permanently removes a connection every read and write
+    /// competes for — on a pool the portal has already exhausted once ("the connection pool has
+    /// been exhausted (currently 50)"). A dedicated source keeps that cost off the pool that serves
+    /// queries and names the session in <c>pg_stat_activity</c>, so a permanently-idle connection
+    /// is identifiable rather than suspicious.</para>
+    /// </summary>
+    /// <param name="dedicatedDataSource">The listener's own data source; disposed with the listener.</param>
+    /// <param name="changeNotifier">Observer that receives a notification per NOTIFY payload.</param>
+    /// <param name="logger">Optional logger for listener lifecycle and error diagnostics.</param>
+    internal static PostgreSqlChangeListener OwningDataSource(
+        NpgsqlDataSource dedicatedDataSource,
+        IObserver<DataChangeNotification> changeNotifier,
+        ILogger<PostgreSqlChangeListener>? logger = null)
+        => new(dedicatedDataSource, changeNotifier, logger, ownsDataSource: true);
+
+    private PostgreSqlChangeListener(
+        NpgsqlDataSource dataSource,
+        IObserver<DataChangeNotification> changeNotifier,
+        ILogger<PostgreSqlChangeListener>? logger,
+        bool ownsDataSource)
+        : this(dataSource, changeNotifier, logger)
+    {
+        if (ownsDataSource)
+            _ownedDataSource = dataSource;
     }
 
     /// <summary>
@@ -140,5 +176,7 @@ public class PostgreSqlChangeListener : IAsyncDisposable
     {
         await StopAsync().ConfigureAwait(false);
         _cts?.Dispose();
+        if (_ownedDataSource is not null)
+            await _ownedDataSource.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlExtensions.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlExtensions.cs
@@ -352,20 +352,8 @@ public static class PostgreSqlExtensions
                 sp.GetService<IoPoolRegistry>(),
                 sp.GetService<MeshConfiguration>()));
 
-        // pg_notify listener: register both the singleton and an IHostedService
-        // wrapper so the LISTEN session opens at host startup. Without the
-        // hosted-service wrapper the listener never starts and every synced
-        // query's Replay(1) cache freezes at its Initial value (writes propagate
-        // to the table but the cached observable never re-emits).
-        // TODO partitioned-pg change feed: in the partitioned setup the
-        // listener pump-notifications across many per-partition adapters.
-        // For now this PG listener wiring is disabled — each
-        // PostgreSqlStorageAdapter publishes from its own Write/Delete (no
-        // cross-process LISTEN) which is enough for the in-process test
-        // scenarios. A follow-up will route LISTEN events to the right
-        // partition adapter's ChangeObserver via the partition registry.
-        // services.AddSingleton(sp => new PostgreSqlChangeListener(baseDataSource, ..., ...));
-        // services.AddHostedService<PostgreSqlChangeListenerHostedService>();
+        services.AddPartitionedChangeListener();
+
         // Boot-time seed: CREATE SCHEMA + table init for every framework
         // partition advertised by a static node provider. No enumeration —
         // only what's explicitly registered.
@@ -469,6 +457,8 @@ public static class PostgreSqlExtensions
                 sp.GetService<IoPoolRegistry>(),
                 sp.GetService<MeshConfiguration>()));
 
+        services.AddPartitionedChangeListener();
+
         // Start the Admin/Partition/* subscription so writes can route — see
         // the longer comment on the same registration in the connection-string
         // overload above.
@@ -492,6 +482,43 @@ public static class PostgreSqlExtensions
 
         services.AddPartitionedCoreAndWrapperServices();
 
+        return services;
+    }
+
+    /// <summary>
+    /// Wires the cross-process change feed: a <see cref="PostgreSqlChangeListener"/> holding one
+    /// <c>LISTEN mesh_node_changes</c> session, an <c>IHostedService</c> that OPENS it at
+    /// host startup, and a <see cref="PartitionChangeRouter"/> that delivers each event to the
+    /// per-partition feed owning its path.
+    ///
+    /// <para>🚨 <b>Both registrations, always.</b> Registering the listener without the hosted
+    /// service is the shape this repo shipped for months (<c>AddPostgreSqlPersistenceWithChangeNotifications</c>
+    /// still does): a singleton nobody resolves, so the LISTEN session never opens and the defect
+    /// is INVISIBLE — no error, no log line, just a change feed that carries only this process's
+    /// own writes. That is #1440, and it is the middle leg of the three-way-broken notify chain
+    /// behind #1814 (the trigger, restored by V54/#1816; this listener; and the consumer that used
+    /// to discard an entity-less notification, fixed in <c>MeshDataSource</c>).</para>
+    ///
+    /// <para>The routing that was missing — and the reason the wiring was left commented out — is
+    /// <see cref="PartitionChangeRouter"/>: the NOTIFY channel is per database while the change
+    /// feed is per schema, so an event has to be resolved to a partition before it can be
+    /// published. It resolves exactly as a WRITE resolves, through the routing adapter.</para>
+    /// </summary>
+    private static IServiceCollection AddPartitionedChangeListener(this IServiceCollection services)
+    {
+        services.AddSingleton(sp =>
+        {
+            var provider = sp.GetRequiredService<PostgreSqlPartitionStorageProvider>();
+            return PostgreSqlChangeListener.OwningDataSource(
+                // Built BY THE PROVIDER, from its resolved connection string and its
+                // configureDataSource hook — never from NpgsqlDataSource.ConnectionString (Npgsql
+                // strips the password) and never from the connection string alone (on Azure the
+                // credential arrives only through that hook).
+                provider.CreateChangeListenerDataSource(),
+                new PartitionChangeRouter(provider, sp.GetService<ILogger<PartitionChangeRouter>>()),
+                sp.GetService<ILogger<PostgreSqlChangeListener>>());
+        });
+        services.AddHostedService<PostgreSqlChangeListenerHostedService>();
         return services;
     }
 }

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionStorageProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionStorageProvider.cs
@@ -101,6 +101,67 @@ public sealed class PostgreSqlPartitionStorageProvider : IPartitionStorageProvid
     /// </summary>
     internal IObservable<DataChangeNotification> MergedChanges => _adapter.Changes;
 
+    /// <summary>
+    /// Routes a change notification that came from ANOTHER process (the <c>mesh_node_changes</c>
+    /// LISTEN feed) to the per-schema feed that owns its path, or — for a partition no adapter has
+    /// been materialised for in this process — to the merged feed the cross-partition subscribers
+    /// watch. Returns <c>false</c> for a path that is not a routable partition, which is the cheap
+    /// discard: one synchronous segment resolution, no DB round-trip, no adapter created.
+    /// See <see cref="PostgreSqlPathRoutingAdapter.TryPublishExternalChange"/>.
+    /// </summary>
+    internal bool PublishExternalChange(DataChangeNotification notification)
+        => _adapter.TryPublishExternalChange(notification);
+
+    /// <summary>
+    /// Builds the change listener's OWN data source: one connection, never pruned, kept alive, and
+    /// configured through the SAME <c>configureDataSource</c> hook as every other source this
+    /// provider builds.
+    ///
+    /// <para>🚨 That hook is not optional. On Azure Postgres the portal has NO password in its
+    /// connection string — the credential is an AAD token supplied by
+    /// <c>UsePeriodicPasswordProvider</c> through this very hook (see
+    /// <c>Memex.Portal.Distributed/Program.cs</c>). A listener built from the connection string
+    /// alone would fail to authenticate and sit in its 5-second reconnect loop for ever on exactly
+    /// the deployment this feed exists for — a failure indistinguishable, from outside, from the
+    /// listener never having been wired at all.</para>
+    ///
+    /// <para><c>KeepAlive</c> is not decoration either: a LISTEN connection is idle by design, and
+    /// an idle TCP session behind a NAT/firewall (AKS → Azure Postgres) is dropped silently after
+    /// minutes. Without keepalives <c>WaitAsync</c> waits for ever on a dead socket and the process
+    /// is back to "never told" — with nothing to notice, because nothing failed.</para>
+    ///
+    /// <para>No <c>UseVector()</c>: nothing but <c>LISTEN</c> and its payloads runs here, so the
+    /// vector type mapping would be dead weight on a connection that never reads a column.</para>
+    /// </summary>
+    internal NpgsqlDataSource CreateChangeListenerDataSource()
+    {
+        var csb = new NpgsqlConnectionStringBuilder(_baseConnectionString)
+        {
+            // Exactly one connection, always the same one: the session IS the subscription, so it
+            // must not be pruned away underneath the LISTEN. MinPoolSize pins it; pruning only
+            // ever touches connections IDLE IN THE POOL, and this one is checked out for the life
+            // of the process. (ConnectionIdleLifetime = 0 is NOT the way to say this — Npgsql
+            // refuses it outright under the default pruning interval, and the throw lands in the
+            // DI factory at host startup.)
+            MinPoolSize = 1,
+            MaxPoolSize = 1,
+            KeepAlive = 30,
+            TcpKeepAlive = true,
+            ApplicationName = "meshweaver-change-listener",
+        };
+        var builder = new NpgsqlDataSourceBuilder(csb.ConnectionString);
+        _configureDataSource?.Invoke(builder);
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// Test seam: how many per-schema adapters this process has materialised. Pins that routing a
+    /// cross-process notification for a partition nobody here has touched does NOT construct (and
+    /// permanently cache) an adapter for it — on a 140-partition mesh that would leave every
+    /// process holding one per partition purely because someone, somewhere, wrote.
+    /// </summary>
+    internal int MaterialisedPartitionAdapterCount => _adapter.MaterialisedAdapterCount;
+
     /// <summary>Embedding provider for vector scoring, shared with the per-schema delegate.</summary>
     internal IEmbeddingProvider? EmbeddingProvider => _embeddingProvider;
 

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPathRoutingAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPathRoutingAdapter.cs
@@ -190,6 +190,54 @@ internal sealed class PostgreSqlPathRoutingAdapter : IStorageAdapter
     internal PostgreSqlStorageAdapter? GetSchemaAdapter(string path) => AdapterForRead(path);
 
     /// <summary>
+    /// Test seam: number of per-schema adapters materialised so far — pins that routing a
+    /// notification for an untouched partition does not construct one.
+    /// </summary>
+    internal int MaterialisedAdapterCount => _adaptersBySchema.Count;
+
+    /// <summary>
+    /// Publishes a change notification that arrived from OUTSIDE this process — a
+    /// <c>LISTEN mesh_node_changes</c> event delivered by <see cref="PostgreSqlChangeListener"/> —
+    /// onto the feed that owns its path. Returns <c>false</c> when the path is not a routable
+    /// partition, so the caller can count the discard.
+    ///
+    /// <para><b>This is the routing the partitioned change feed was missing.</b> The NOTIFY channel
+    /// is per DATABASE, so ONE listener connection receives every schema's events, while the
+    /// in-process feed is per SCHEMA — a per-schema <see cref="PostgreSqlStorageAdapter"/> each
+    /// publishing its own Write/Delete. Without a router there was no answer to "whose feed is
+    /// this?", which is why the listener wiring was left commented out and why a mirror in another
+    /// process could be arbitrarily far behind a rival's write and never be told (#1440 → #1814).
+    /// The answer is the SAME resolution a write uses — <see cref="ResolveSchema"/>, first path
+    /// segment → schema — so a notification can never land on a feed the write would not have
+    /// published to.</para>
+    ///
+    /// <para><b>It never MATERIALISES an adapter.</b> A notification for a partition this process
+    /// has never touched routes to the merged feed directly rather than constructing (and
+    /// permanently caching) a per-schema adapter for it: on a mesh with 140+ partitions, every
+    /// process would otherwise end up holding an adapter for every partition in the database
+    /// purely because someone, somewhere, wrote to it. Nothing is lost — a per-schema adapter that
+    /// does not exist has no subscribers, and the cross-partition subscribers (the unscoped
+    /// fan-out query, the pedestrian provider) all watch the merge, which still receives it.</para>
+    ///
+    /// <para>Cost of the discard branch: one <see cref="ResolveSchema"/> call — pure string work,
+    /// no DB round-trip, no allocation beyond the resolved definition.</para>
+    /// </summary>
+    internal bool TryPublishExternalChange(DataChangeNotification notification)
+    {
+        var def = ResolveSchema(notification.Path);
+        if (def is null)
+            return false;
+        var schema = !string.IsNullOrEmpty(def.Schema) ? def.Schema : def.Namespace;
+        if (schema is not null && _adaptersBySchema.TryGetValue(schema, out var adapter))
+            // The per-schema feed, exactly as its own Write would have published — and it forwards
+            // into the merged feed, so a merged subscriber sees it once, not twice.
+            adapter.ChangeObserver.OnNext(notification);
+        else
+            _changes.OnNext(notification);
+        return true;
+    }
+
+    /// <summary>
     /// Cold write pipeline. <b>NEVER creates a schema.</b> Provisioning is eager and
     /// gated to partition-owning creates (<c>OwnsPartitionProvisioningValidator</c> →
     /// <see cref="PostgreSqlPartitionStorageProvider.EnsurePartitionProvisioned"/>) — the

--- a/test/MeshWeaver.Hosting.Monolith.Test/CrossProcessChangeFeedTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CrossProcessChangeFeedTest.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reactive.Assertions;
+using MeshWeaver.ServiceProvider;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The end-to-end property of the cross-process change feed: <b>a write made in one process becomes
+/// visible to a LIVE mirror in another process — with no recycle, and without waiting out any heal
+/// timer.</b>
+///
+/// <para><b>What "another process" is here.</b> Two independent meshes, each with its own hub tree,
+/// its own workspace mirrors and its own storage adapter, over ONE shared durable store — the same
+/// shape <see cref="CrossClusterBuildClaimTest"/> uses for two Orleans clusters over one Postgres
+/// database. The one addition is the wire that was missing in production: each adapter's commits are
+/// bridged to BOTH adapters as ENTITY-LESS notifications, exactly what
+/// <c>PostgreSqlChangeListener</c> publishes from a <c>pg_notify</c> payload of <c>{path, op}</c>
+/// (and what the Cosmos change feed and the Snowflake poller publish). Including the writer's own
+/// echo is faithful too: a process's LISTEN session receives its own NOTIFY.</para>
+///
+/// <para><b>The defect this pins (#1440 → #1814).</b> The per-node hub's reconcile
+/// (<c>MeshDataSourceExtensions.SubscribeToOwnDeletion</c>) used to give up on any notification
+/// whose entity was absent — <c>if (notification.Entity is not MeshNode newNode) return;</c> — which
+/// is EVERY cross-process notification there is. So a mirror could be arbitrarily far behind a
+/// rival's write and would never be told: the staleness lived in the snapshot, not in the
+/// activation, which is why the cross-hub write conflict behind the 2026-08-17 outage was
+/// deterministic rather than a race that a retry could eventually win. Measured then: at two
+/// replicas the covers failed for two hours; at one replica (no rival mirror) the same page rendered
+/// in 2.6 s.</para>
+///
+/// <para>🚨 The fix is a RE-READ, never a supplemented entity. Populating <c>Entity</c> from the
+/// payload is the RLS bypass #1250 removed, and it races row visibility besides — so these tests
+/// deliver notifications with no entity and assert the mirror converges anyway.</para>
+/// </summary>
+public class CrossProcessChangeFeedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>ONE durable store. Two adapter instances over it = two processes over one database.</summary>
+    private readonly ConcurrentDictionary<string, MeshNode> _rows = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ConcurrentDictionary<string, List<object>> _partitionObjects =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private CrossProcessFeedAdapter AdapterA
+        => (CrossProcessFeedAdapter)Mesh.ServiceProvider.GetRequiredService<CrossProcessFeedAdapter>();
+
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(120);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        // Registered BEFORE AddInMemoryPersistence's TryAddSingleton so the write-integrity
+        // decorators (SubtreeDeletionGuard → MonotonicWriteGuard → VersionWriting) wrap THIS adapter
+        // — it then sits exactly where the durable backend sits, underneath every guard.
+        => base.ConfigureMesh(builder.ConfigureServices(UseSharedStore));
+
+    private IServiceCollection UseSharedStore(IServiceCollection services)
+    {
+        services.AddSingleton(sp => new CrossProcessFeedAdapter(new InMemoryStorageAdapter(
+            _rows, _partitionObjects, sp.GetService<ILogger<InMemoryStorageAdapter>>())));
+        services.AddSingleton<IStorageAdapter>(sp => sp.GetRequiredService<CrossProcessFeedAdapter>());
+        return services;
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task AWriteInOneProcess_ReachesTheOtherProcessesLiveMirror_WithoutARecycle()
+    {
+        var id = $"cross-proc-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+            { Name = "v1", NodeType = "Markdown", State = MeshNodeState.Active })
+            .Should().Within(30.Seconds()).Emit();
+        await WaitDurable(path, n => n.Name == "v1");
+
+        using var processB = BuildSecondProcess();
+        using var wire = Bridge(processB);
+
+        // Process B's mirror goes LIVE and stays live: Replay(1)+RefCount with a keepAlive, so the
+        // per-node hub is never torn down and re-seeded between the two assertions. Without the
+        // keepAlive the second read could pass by re-activating a cold hub, which would prove
+        // nothing about the feed.
+        var mirror = processB.Hub.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null).Replay(1).RefCount();
+        using var keepAlive = mirror.Subscribe();
+        var seeded = await mirror.Should().Within(30.Seconds()).Match(n => n.Name == "v1");
+        Output.WriteLine($"[B seeded] name={seeded.Name} version={seeded.Version}");
+        var adapterB = processB.ServiceProvider.GetRequiredService<CrossProcessFeedAdapter>();
+        // Trace EVERY emission, not just the one asserted on: against `main` this test fails with
+        // the mirror holding v3 while the store holds v2 — content that converged by accident,
+        // through a read-seeded mint of a revision that exists nowhere. Without the trace that
+        // reads as an off-by-one instead of naming the #1432 phantom it is.
+        using var trace = mirror.Subscribe(n => Output.WriteLine(
+            $"[B emit] name={n.Name} v={n.Version} writesB={adapterB.WriteCount(path)} readsB={adapterB.ReadCount(path)}"));
+
+        // The write happens in process A, through the hub that OWNS the node.
+        Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Update(n => n with { Name = "written-in-A" })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"[A write error] {ex.Message}"));
+        var durable = await WaitDurable(path, n => n.Name == "written-in-A");
+        Output.WriteLine($"[A durable] version={durable.Version}");
+
+        var converged = await mirror.Should().Within(30.Seconds())
+            .Match(n => n.Name == "written-in-A",
+                "a live mirror in another process must learn of the write from the cross-process "
+                + "feed — the entity-less notification is the ONLY thing that crosses, and before "
+                + "this change it was discarded unread");
+        Output.WriteLine($"[store] v={_rows[path].Version} name={_rows[path].Name} writesB={adapterB.WriteCount(path)} readsB={adapterB.ReadCount(path)}");
+        converged.Version.Should().Be(durable.Version,
+            "the mirror ADOPTS the durable version verbatim. Against `main` this is where the test "
+            + "fails: the mirror ends at durable+1 — a revision the store never held (#1432) — "
+            + "because the notification was dropped and the content only arrived later, through a "
+            + "read-seeded mint. Converging on content by accident, at a version that exists "
+            + "nowhere, is not a mirror learning of a write");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task AnEntitylessEchoOfTheOwnWrite_IsSuppressed_AndWritesNothingBack()
+    {
+        var id = $"self-echo-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+            { Name = "v1", NodeType = "Markdown", State = MeshNodeState.Active })
+            .Should().Within(30.Seconds()).Emit();
+        await WaitDurable(path, n => n.Name == "v1");
+
+        // Only process A exists; the wire feeds A its OWN commits back, entity-less — precisely what
+        // a LISTEN session does with the NOTIFY its own write fired.
+        using var selfWire = AdapterA.LocalChanges.Subscribe(AdapterA.PublishExternal);
+
+        var own = Mesh.GetWorkspace().GetMeshNodeStream(path).Where(n => n is not null)
+            .Replay(1).RefCount();
+        using var keepAlive = own.Subscribe();
+        await own.Should().Within(30.Seconds()).Match(n => n.Name == "v1");
+
+        Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Update(n => n with { Name = "own-write" })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"[own write error] {ex.Message}"));
+        var durable = await WaitDurable(path, n => n.Name == "own-write");
+
+        // Give the echo, the coalescing window and the re-read time to run — then assert nothing
+        // moved. A phantom mint (#1432) or a re-adoption loop (#223) would show up here as a
+        // version above the durable one, or as writes that keep arriving.
+        var writesAfterEcho = await Settle(() => AdapterA.WriteCount(path));
+        var live = await own.FirstAsync().ToTask();
+
+        live.Version.Should().Be(durable.Version,
+            "the echo of our own write must be suppressed — adopting it would mint durable+1, a "
+            + "revision that exists nowhere (#1432)");
+        _rows[path].Version.Should().Be(durable.Version,
+            "nothing on the re-read path writes, so the store must not move");
+        (await Settle(() => AdapterA.WriteCount(path))).Should().Be(writesAfterEcho,
+            "a reconcile that fed itself would keep writing — the #223 write-storm shape");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task AnEntitylessBurst_ReReadsTheOwnPathAFewTimes_AndAnUnownedPathNotAtAll()
+    {
+        var id = $"burst-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+            { Name = "v1", NodeType = "Markdown", State = MeshNodeState.Active })
+            .Should().Within(30.Seconds()).Emit();
+        await WaitDurable(path, n => n.Name == "v1");
+
+        var own = Mesh.GetWorkspace().GetMeshNodeStream(path).Where(n => n is not null)
+            .Replay(1).RefCount();
+        using var keepAlive = own.Subscribe();
+        await own.Should().Within(30.Seconds()).Match(n => n.Name == "v1");
+
+        // 🚨 A DIFFERENTIAL measurement, because the adapter's read counter is not a private line
+        // to the own-node reconcile: every live synced query in the mesh re-runs on every matching
+        // notification (deliberately, at zero debounce — "the notification is a trigger, never a
+        // result row"), and each re-run reads the nodes in scope. Counting raw reads would measure
+        // that pre-existing behaviour, not this pipeline. So run the SAME burst twice — once
+        // addressed to a sibling path no hub owns, once to the mirror's own path — and take the
+        // difference. What is left is exactly the own-node re-reads — and the control run is
+        // itself the "a path this hub does not own is discarded cheaply" measurement: the hub adds
+        // NOTHING to it, so 200 unowned notifications cost the same as the query layer alone.
+        var baselineBefore = await Settle(() => AdapterA.ReadCount(path));
+        for (var i = 0; i < 200; i++)
+            AdapterA.PublishExternal(DataChangeNotification.Updated($"{TestPartition}/sibling", null));
+        var queryCost = (await Settle(() => AdapterA.ReadCount(path))) - baselineBefore;
+
+        var burstBefore = await Settle(() => AdapterA.ReadCount(path));
+        for (var i = 0; i < 200; i++)
+            AdapterA.PublishExternal(DataChangeNotification.Updated(path, null));
+        var withOwnPath = (await Settle(() => AdapterA.ReadCount(path))) - burstBefore;
+
+        var reReads = withOwnPath - queryCost;
+        Output.WriteLine(
+            $"[burst] 200 notifications → own-path reads {withOwnPath}, query-layer baseline "
+            + $"{queryCost}, re-reads attributable to the reconcile {reReads}");
+        withOwnPath.Should().BeGreaterThan(queryCost,
+            "the LAST notification of a burst must still produce a re-read — that read is the one "
+            + "that converges the mirror, and dropping it would restore the defect");
+        reReads.Should().BeLessThan(20,
+            "a notification storm must not become a read storm: the trigger is coalesced per path "
+            + "(a 50 ms window) and the reads are serialised, so 200 notifications must cost a "
+            + "handful of reads, not 200");
+    }
+
+    /// <summary>
+    /// Polls the durable store until <paramref name="predicate"/> holds. Bounded: a store that never
+    /// gets there fails the test rather than hanging it.
+    /// </summary>
+    private async Task<MeshNode> WaitDurable(string path, Func<MeshNode, bool> predicate)
+        => await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .Select(_ => _rows.TryGetValue(path, out var n) ? n : null)
+            .Where(n => n is not null && predicate(n))
+            .Select(n => n!)
+            .Should().Within(30.Seconds()).Emit();
+
+    /// <summary>
+    /// Reads a counter until it stops moving for a full quiet window, then returns it. This is the
+    /// bounded stand-in for "everything the notifications were going to do has happened" — never a
+    /// fixed sleep, which would either flake or hide a late read.
+    /// </summary>
+    private static async Task<int> Settle(Func<int> counter)
+    {
+        var last = counter();
+        var stable = 0;
+        for (var i = 0; i < 60 && stable < 5; i++)
+        {
+            await Task.Delay(50);
+            var now = counter();
+            stable = now == last ? stable + 1 : 0;
+            last = now;
+        }
+        return last;
+    }
+
+    /// <summary>
+    /// The wire that was missing in production: every commit made by either process is delivered to
+    /// BOTH processes' feeds, entity-less. Bridging <c>LocalChanges</c> (the adapter's OWN commits)
+    /// and never <c>Changes</c> is what keeps it a wire rather than a loop — and matches Postgres,
+    /// where the NOTIFY comes off the row trigger on a write, not off receiving one.
+    /// </summary>
+    private IDisposable Bridge(SecondProcess processB)
+    {
+        var adapterB = processB.ServiceProvider.GetRequiredService<CrossProcessFeedAdapter>();
+        var wire = new System.Reactive.Disposables.CompositeDisposable
+        {
+            AdapterA.LocalChanges.Subscribe(n =>
+            {
+                AdapterA.PublishExternal(n);
+                adapterB.PublishExternal(n);
+            }),
+            adapterB.LocalChanges.Subscribe(n =>
+            {
+                AdapterA.PublishExternal(n);
+                adapterB.PublishExternal(n);
+            }),
+        };
+        return wire;
+    }
+
+    /// <summary>
+    /// A second, fully independent mesh over the SAME backing store — the stand-in for the other
+    /// pod. Its recipe mirrors <c>MonolithMeshTestBase.ConfigureMeshBase</c>; only the durable store
+    /// is shared, and the change feeds are separate instances exactly as two processes' are.
+    /// </summary>
+    private SecondProcess BuildSecondProcess()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging(l => l.ClearProviders());
+        services.AddOptions();
+
+        var builder = new MeshBuilder(c => c.Invoke(services), AddressExtensions.CreateMeshAddress())
+            .ConfigureServices(UseSharedStore)
+            .UseMonolithMesh()
+            .AddInMemoryPersistence()
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .AddSpaceType()
+            .AddMeshNodes(new MeshNode(TestPartition) { Name = "Test Data", NodeType = "Markdown" })
+            .AddMeshNodes(TestUsers.DevLoginAdminAccess())
+            .AddMeshNodes(TestUsers.PublicAdminAccess())
+            .ConfigureHub(c => c.WithRequestTimeout(TimeSpan.FromSeconds(60)));
+
+        services.AddSingleton(builder.BuildHub);
+        var serviceProvider = services.CreateMeshWeaverServiceProvider();
+        var hub = serviceProvider.GetRequiredService<IMessageHub>();
+        TestUsers.DevLogin(hub);
+        return new SecondProcess(serviceProvider, hub);
+    }
+
+    private sealed record SecondProcess(IServiceProvider ServiceProvider, IMessageHub Hub) : IDisposable
+    {
+        public void Dispose()
+        {
+            Hub.Dispose();
+            (ServiceProvider as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/CrossProcessFeedAdapter.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CrossProcessFeedAdapter.cs
@@ -1,0 +1,138 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Test-only <see cref="IStorageAdapter"/> decorator that models ONE PROCESS's view of a shared
+/// durable store: its own commits publish locally (as every adapter does), and commits made by
+/// ANOTHER process arrive through <see cref="PublishExternal"/> — stripped of their entity, which
+/// is what a cross-process feed actually delivers.
+///
+/// <para><b>Why entity-less is the faithful model, not a convenience.</b> Every source whose
+/// notification can outrun row visibility passes <c>Entity = null</c> by contract:
+/// <c>PostgreSqlChangeListener</c> parses <c>{path, op}</c> out of a <c>pg_notify</c> payload that
+/// has no room for a node, the Cosmos change feed and the Snowflake poller do the same
+/// ("Entity = null (subscribers re-read…)"). Populating it from the payload is the row-level-security
+/// bypass <c>StorageAdapterMeshQueryProvider</c> REMOVED (#1250), so a consumer that needs the node
+/// must RE-READ. This decorator therefore reproduces the exact shape of the production feed rather
+/// than a friendlier one.</para>
+///
+/// <para><see cref="LocalChanges"/> — the inner adapter's own commits — is what a bridge forwards to
+/// the other process. Forwarding <see cref="Changes"/> instead would loop for ever, and would also
+/// be wrong: a Postgres NOTIFY fires from the row trigger on a WRITE, never on receiving one.</para>
+///
+/// <para><see cref="ReadCount"/> makes the cost of a notification observable, which is what turns
+/// "the re-read is bounded" and "an unowned path is discarded cheaply" into assertions instead of
+/// claims.</para>
+/// </summary>
+internal sealed class CrossProcessFeedAdapter(IStorageAdapter inner) : IStorageAdapter
+{
+    private readonly IsolatedChangeFeed _external = new(null, "cross-process");
+    private readonly ConcurrentDictionary<string, int> _readCounts =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, int> _writeCounts =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>This process's OWN commits — what a bridge forwards to the other process.</summary>
+    public IObservable<DataChangeNotification> LocalChanges => inner.Changes;
+
+    /// <summary>
+    /// Delivers a commit made in ANOTHER process, exactly as a LISTEN/NOTIFY event arrives: the
+    /// path and the kind, and no entity.
+    /// </summary>
+    public void PublishExternal(DataChangeNotification notification)
+        => _external.OnNext(notification with { Entity = null });
+
+    /// <summary>Reads of <paramref name="path"/> that reached this adapter.</summary>
+    public int ReadCount(string path) => _readCounts.GetValueOrDefault(path);
+
+    /// <summary>Writes of <paramref name="path"/> that reached this adapter.</summary>
+    public int WriteCount(string path) => _writeCounts.GetValueOrDefault(path);
+
+    public IObservable<DataChangeNotification> Changes => inner.Changes.Merge(_external);
+
+    public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
+        => Observable.Defer(() =>
+        {
+            _readCounts.AddOrUpdate(path, 1, (_, c) => c + 1);
+            return inner.Read(path, options);
+        });
+
+    public IObservable<MeshNode> ReadMany(IReadOnlyCollection<string> paths, JsonSerializerOptions options)
+        => paths.Select(p => Read(p, options).Where(n => n is not null).Select(n => n!)).Merge();
+
+    public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
+        => Observable.Defer(() =>
+        {
+            if (!string.IsNullOrEmpty(node.Path))
+                _writeCounts.AddOrUpdate(node.Path, 1, (_, c) => c + 1);
+            return inner.Write(node, options);
+        });
+
+    public IObservable<IReadOnlyList<MeshNode>> WriteMany(
+        IReadOnlyCollection<MeshNode> nodes, JsonSerializerOptions options)
+        => Observable.Defer(() =>
+        {
+            foreach (var node in nodes)
+                if (!string.IsNullOrEmpty(node.Path))
+                    _writeCounts.AddOrUpdate(node.Path, 1, (_, c) => c + 1);
+            return inner.WriteMany(nodes, options);
+        });
+
+    // Forwarded, never defaulted: the default implementation is a read-then-write pair, which
+    // would silently drop the store's ATOMIC compare-and-set — the property the cross-cluster
+    // build claim depends on.
+    public IObservable<bool?> WriteIfVersion(MeshNode node, long expectedVersion, JsonSerializerOptions options)
+        => Observable.Defer(() =>
+        {
+            if (!string.IsNullOrEmpty(node.Path))
+                _writeCounts.AddOrUpdate(node.Path, 1, (_, c) => c + 1);
+            return inner.WriteIfVersion(node, expectedVersion, options);
+        });
+
+    public IObservable<string> Delete(string path) => inner.Delete(path);
+
+    public IObservable<bool> DeleteIfExists(string path) => inner.DeleteIfExists(path);
+
+    public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)> ListChildPaths(string? parentPath)
+        => inner.ListChildPaths(parentPath);
+
+    public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+        => inner.ListDescendantPaths(rootPath);
+
+    public IObservable<bool> Exists(string path) => inner.Exists(path);
+
+    public IObservable<(MeshNode? Node, int MatchedSegments)> FindBestPrefixMatch(
+        string fullPath, JsonSerializerOptions options)
+        => inner.FindBestPrefixMatch(fullPath, options);
+
+    public IObservable<(MeshNode? Node, int MatchedSegments)> ResolvePath(
+        string fullPath, JsonSerializerOptions options)
+        => inner.ResolvePath(fullPath, options);
+
+    public IObservable<IEnumerable<string>> ListPartitionSubPaths(string nodePath)
+        => inner.ListPartitionSubPaths(nodePath);
+
+    public IObservable<object> GetPartitionObjects(string nodePath, string? subPath, JsonSerializerOptions options)
+        => inner.GetPartitionObjects(nodePath, subPath, options);
+
+    public IObservable<Unit> SavePartitionObjects(
+        string nodePath, string? subPath,
+        IReadOnlyCollection<object> objects, JsonSerializerOptions options)
+        => inner.SavePartitionObjects(nodePath, subPath, objects, options);
+
+    public IObservable<Unit> DeletePartitionObjects(string nodePath, string? subPath = null)
+        => inner.DeletePartitionObjects(nodePath, subPath);
+
+    public IObservable<DateTimeOffset?> GetPartitionMaxTimestamp(string nodePath, string? subPath = null)
+        => inner.GetPartitionMaxTimestamp(nodePath, subPath);
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ChangeListenerWiringTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ChangeListenerWiringTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using MeshWeaver.Hosting.PostgreSql;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// The partitioned wiring must REGISTER the change listener <b>and</b> the hosted service that
+/// starts it.
+///
+/// <para>🚨 Why a shape test earns its place here: "registered but never started" is invisible from
+/// behaviour. The listener is a DI singleton nobody resolves, so no LISTEN session opens, nothing
+/// errors, nothing logs, and the change feed simply carries this process's own writes and no one
+/// else's. That is #1440 exactly — filed 2026-08-13, closed as COMPLETED with only the doc fixed,
+/// and five days later it was the middle leg of the three-way-broken notify chain that took every
+/// course cover on memex.meshweaver.cloud down for two hours (#1814). The other two legs are the
+/// per-database <c>mesh_node_notify</c> trigger (restored by V54/#1816) and the consumer that used
+/// to discard an entity-less notification (fixed in <c>MeshDataSource</c>).</para>
+///
+/// <para>No container: this asserts on the service DESCRIPTORS, so it is a fast, deterministic gate
+/// on the one property a functional test cannot cheaply cover — that a real host, which is the only
+/// thing that ever starts an <c>IHostedService</c>, will find something to start.</para>
+/// </summary>
+public class ChangeListenerWiringTests
+{
+    private const string AnyConnectionString =
+        "Host=localhost;Database=meshweaver_test;Username=postgres;Password=postgres";
+
+    [Fact]
+    public void ConnectionStringOverload_RegistersTheListenerAndStartsIt()
+        => AssertWired(new ServiceCollection()
+            .AddPartitionedPostgreSqlPersistence(AnyConnectionString));
+
+    [Fact]
+    public void AspireOverload_RegistersTheListenerAndStartsIt()
+        // The overload the portal actually uses (Memex.Portal.Distributed) — the one whose absence
+        // was measured on prod.
+        => AssertWired(new ServiceCollection().AddPartitionedPostgreSqlPersistence());
+
+    private static void AssertWired(IServiceCollection services)
+    {
+        services.Any(d => d.ServiceType == typeof(PostgreSqlChangeListener))
+            .Should().Be(true,
+                "the partitioned wiring must register the LISTEN/NOTIFY listener — without it a "
+                + "mirror in another process is never told about a rival's write (#1440)");
+
+        services.Any(d => d.ServiceType == typeof(IHostedService)
+                          && d.ImplementationType == typeof(PostgreSqlChangeListenerHostedService))
+            .Should().Be(true,
+                "…and the hosted service that OPENS the session: a registered-but-unresolved "
+                + "singleton is the exact shape that shipped for months, and it fails silently");
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossProcessNotifyPgTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossProcessNotifyPgTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.PostgreSql;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Fixture;
+using Npgsql;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// The cross-process change feed, end to end against a real Postgres: a write committed by ONE
+/// adapter reaches ANOTHER adapter's feed — through the row trigger, <c>pg_notify</c>, the
+/// <c>LISTEN</c> session and the partition router — with no polling and no recycle.
+///
+/// <para>Two <see cref="PostgreSqlStorageAdapter"/> instances over one database is the model used
+/// throughout this repo for two processes (<c>CrossClusterBuildClaimTest</c>): their in-process
+/// feeds are separate by construction, so the ONLY way a notification crosses is the wire under
+/// test. Before this wiring existed there was no wire at all — the listener registration was
+/// commented out for the partitioned setup, so on memex-cloud a pod's mirror could be arbitrarily
+/// far behind the other pod's write and would never be told (#1440 → #1814).</para>
+///
+/// <para>Uses <c>PostgreSqlIsolated</c>: the shared container's neighbouring tests write into their
+/// own schemas and would fire <c>pg_notify</c> on the same channel.</para>
+/// </summary>
+[Collection("PostgreSqlIsolated")]
+public class CrossProcessNotifyPgTests(IsolatedPostgreSqlFixture fixture) : IAsyncLifetime
+{
+    private const string Partition = "Chess";
+    private const string Schema = "chess";
+
+    private readonly JsonSerializerOptions _options = new();
+    private NpgsqlDataSource _writerDataSource = null!;
+    private PostgreSqlStorageAdapter _processA = null!;
+    private PostgreSqlPartitionStorageProvider _processB = null!;
+    // The CONTROL: a third process wired exactly like B except that nothing listens — i.e. the
+    // state `main` is in. Same database, same write, same instant, so "the notification arrived"
+    // cannot be explained by anything but the wire under test.
+    private PostgreSqlPartitionStorageProvider _processCWithoutListener = null!;
+    private PartitionChangeRouter _router = null!;
+    private PostgreSqlChangeListener _listener = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await fixture.CleanDataAsync();
+
+        // Process A: its own adapter over the partition's schema — the writer.
+        var (writerDataSource, writer) = await fixture.CreateSchemaAdapterAsync(
+            Schema, ct: TestContext.Current.CancellationToken);
+        _writerDataSource = writerDataSource;
+        _processA = writer;
+
+        // Process B: a full partitioned provider, plus the wiring this change adds — the listener
+        // over its own dedicated connection, routing through the partition router.
+        _processB = new PostgreSqlPartitionStorageProvider(
+            fixture.DataSource, fixture.ConnectionString, new PostgreSqlStorageOptions());
+        _processCWithoutListener = new PostgreSqlPartitionStorageProvider(
+            fixture.DataSource, fixture.ConnectionString, new PostgreSqlStorageOptions());
+        _router = new PartitionChangeRouter(_processB);
+        _listener = PostgreSqlChangeListener.OwningDataSource(
+            _processB.CreateChangeListenerDataSource(), _router);
+        await _listener.StartAsync(TestContext.Current.CancellationToken);
+        // The LISTEN session has to be OPEN before the write, or the NOTIFY has no subscriber —
+        // Postgres does not replay. Poll pg_stat_activity for the named session rather than sleep:
+        // a fixed delay is either flaky or slow, and this one is neither.
+        await WaitForListenSession();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _listener.DisposeAsync();
+        _processB.Dispose();
+        _processCWithoutListener.Dispose();
+        await _writerDataSource.DisposeAsync();
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task AWriteByAnotherProcess_ArrivesOnThisProcessesPartitionFeed()
+    {
+        // Materialise process B's adapter for the partition, exactly as any read of it would.
+        var mirror = _processB.GetSchemaAdapter($"{Partition}/Board");
+        mirror.Should().NotBeNull();
+
+        var received = new List<DataChangeNotification>();
+        using var sub = mirror!.Changes.Subscribe(n => { lock (received) received.Add(n); });
+
+        var control = _processCWithoutListener.GetSchemaAdapter($"{Partition}/Board")!;
+        var receivedByControl = new List<DataChangeNotification>();
+        using var controlSub = control.Changes.Subscribe(n =>
+        {
+            lock (receivedByControl) receivedByControl.Add(n);
+        });
+
+        await _processA.WriteAsync(
+            new MeshNode("Board", Partition) { Name = "written-by-A", NodeType = "Markdown" },
+            _options, TestContext.Current.CancellationToken);
+
+        var arrived = await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .Select(_ => { lock (received) return received.ToArray(); })
+            .Where(snap => snap.Any(n => n.Path == $"{Partition}/Board"))
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+
+        var notification = arrived.First(n => n.Path == $"{Partition}/Board");
+        notification.Kind.Should().Be(DataChangeKind.Created);
+        notification.Entity.Should().BeNull(
+            "a LISTEN payload is {path, op} and nothing else — populating the entity from it would "
+            + "be the RLS bypass #1250 removed, which is exactly why the consumer must RE-READ");
+        _router.RoutedCount.Should().BeGreaterThan(0L);
+
+        // 🚨 The control, evaluated at the moment B's notification landed: an identically-configured
+        // process with no listener sees NOTHING. That is the state this change ends — and it is why
+        // "the mirror is stale" was a missing edge rather than a lost race, which no retry can win.
+        lock (receivedByControl)
+            receivedByControl.Should().BeEmpty(
+                "without the listener there is no wire at all — a per-schema feed only ever carried "
+                + "its OWN process's writes, which is #1440");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task ADeleteByAnotherProcess_ArrivesToo()
+    {
+        var mirror = _processB.GetSchemaAdapter($"{Partition}/Doomed")!;
+        await _processA.WriteAsync(
+            new MeshNode("Doomed", Partition) { Name = "doomed", NodeType = "Markdown" },
+            _options, TestContext.Current.CancellationToken);
+
+        var received = new List<DataChangeNotification>();
+        using var sub = mirror.Changes.Subscribe(n => { lock (received) received.Add(n); });
+
+        await _processA.Delete($"{Partition}/Doomed").ToTask(TestContext.Current.CancellationToken);
+
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .Select(_ => { lock (received) return received.ToArray(); })
+            .Where(snap => snap.Any(n =>
+                n.Path == $"{Partition}/Doomed" && n.Kind == DataChangeKind.Deleted))
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// Waits until the listener's named session is visible in <c>pg_stat_activity</c> — the positive
+    /// "the LISTEN is open" signal. Bounded: no session inside the budget fails the test rather than
+    /// letting every assertion below time out on a missing subscription.
+    /// </summary>
+    private Task WaitForListenSession()
+        => Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+            .SelectMany(_ => fixture.DataSource.ScalarLong(
+                "SELECT count(*) FROM pg_stat_activity "
+                + "WHERE application_name = 'meshweaver-change-listener'",
+                TestContext.Current.CancellationToken))
+            .Where(count => count > 0)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .Select(_ => System.Reactive.Unit.Default)
+            .ToTask(TestContext.Current.CancellationToken);
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PartitionChangeRouterTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PartitionChangeRouterTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using MeshWeaver.Hosting.PostgreSql;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Npgsql;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// The routing that the listener wiring was blocked on: the <c>mesh_node_changes</c> channel is per
+/// DATABASE — one LISTEN session receives every schema's events — while the change feed under
+/// <see cref="PostgreSqlPathRoutingAdapter"/> is per SCHEMA. <see cref="PartitionChangeRouter"/> is
+/// the answer to "whose feed is this?", and these tests pin the three outcomes it can produce.
+///
+/// <para>No container and no connection: a data source is built, never opened. Routing is pure
+/// string work on the same resolution a WRITE uses, and that is exactly what is under test — a
+/// second, drifting resolution is the failure this design forecloses.</para>
+/// </summary>
+public class PartitionChangeRouterTests : IDisposable
+{
+    // Never connected to — the router resolves paths, it does not touch the database.
+    private const string UnusedConnectionString =
+        "Host=localhost;Database=meshweaver_test;Username=postgres;Password=postgres";
+
+    private readonly NpgsqlDataSource _dataSource =
+        new NpgsqlDataSourceBuilder(UnusedConnectionString).Build();
+
+    private PostgreSqlPartitionStorageProvider NewProvider()
+        => new(_dataSource, UnusedConnectionString, new PostgreSqlStorageOptions());
+
+    public void Dispose() => _dataSource.Dispose();
+
+    [Fact]
+    public void ANotificationLandsOnTheFeedOfThePartitionThatOwnsThePath()
+    {
+        using var provider = NewProvider();
+        // Materialise the partition's adapter the way anything reading that partition would.
+        var chess = provider.GetSchemaAdapter("Chess/Board");
+        chess.Should().NotBeNull();
+
+        var onChess = new List<DataChangeNotification>();
+        using var sub = chess!.Changes.Subscribe(onChess.Add);
+        var router = new PartitionChangeRouter(provider);
+
+        router.OnNext(DataChangeNotification.Updated("Chess/Board", null));
+
+        onChess.Should().HaveCount(1,
+            "the per-schema feed is the one a WRITE to that path would have published on, so it is "
+            + "the one a cross-process notification for it must reach");
+        onChess[0].Path.Should().Be("Chess/Board");
+        router.RoutedCount.Should().Be(1L);
+        router.DiscardedCount.Should().Be(0L);
+    }
+
+    [Fact]
+    public void APartitionThisProcessNeverTouched_ReachesTheMergedFeed_WithoutMaterialisingAnAdapter()
+    {
+        using var provider = NewProvider();
+        var onMerged = new List<DataChangeNotification>();
+        using var sub = provider.MergedChanges.Subscribe(onMerged.Add);
+        var router = new PartitionChangeRouter(provider);
+
+        router.OnNext(DataChangeNotification.Updated("Store/Plugin", null));
+
+        onMerged.Should().HaveCount(1,
+            "the cross-partition subscribers (the unscoped fan-out query, the pedestrian provider) "
+            + "watch the merge, so a notification must not be lost just because no per-schema "
+            + "adapter exists for it here");
+        provider.MaterialisedPartitionAdapterCount.Should().Be(0,
+            "routing must not CONSTRUCT a per-schema adapter: on a 140-partition mesh every process "
+            + "would end up holding one per partition purely because someone, somewhere, wrote");
+        router.RoutedCount.Should().Be(1L);
+    }
+
+    [Theory]
+    // A NodeType name as first segment — the 2026-05-21 regression guard: routing these as
+    // partitions is what once tried to CREATE SCHEMA "thread".
+    [InlineData("Thread/abc")]
+    [InlineData("AccessAssignment/x")]
+    // URL- and query-string-shaped segments — the 2026-06-05 prod DB corruption shape.
+    [InlineData("login?error=auth_failed/x")]
+    [InlineData("search?q=agent&hq=scope%3adescendants/x")]
+    // An unregistered global-satellite namespace: not routable until the boot-time seeding
+    // registers its real schema (_Access → system_access).
+    [InlineData("_Access/whoever_Access")]
+    public void AnUnroutablePath_IsDiscardedWithoutTouchingAnything(string path)
+    {
+        using var provider = NewProvider();
+        var onMerged = new List<DataChangeNotification>();
+        using var sub = provider.MergedChanges.Subscribe(onMerged.Add);
+        var router = new PartitionChangeRouter(provider);
+
+        router.OnNext(DataChangeNotification.Updated(path, null));
+
+        onMerged.Should().HaveCount(0, "an unroutable path has no feed to land on");
+        provider.MaterialisedPartitionAdapterCount.Should().Be(0);
+        router.DiscardedCount.Should().Be(1L);
+        router.RoutedCount.Should().Be(0L);
+    }
+
+    [Fact]
+    public void AGlobalSatelliteNamespace_RoutesToItsRegisteredSchema()
+    {
+        using var provider = NewProvider();
+        // What the boot-time static-partition seeding does: _Access is NOT the lowercased
+        // namespace, it is system_access.
+        provider.RegisterPartition(new PartitionDefinition
+        {
+            Namespace = "_Access",
+            DataSource = "default",
+            Schema = "system_access",
+            Table = "mesh_nodes",
+        });
+        var access = provider.GetSchemaAdapter("_Access/somebody_Access");
+        access.Should().NotBeNull();
+
+        var received = new List<DataChangeNotification>();
+        using var sub = access!.Changes.Subscribe(received.Add);
+        var router = new PartitionChangeRouter(provider);
+
+        router.OnNext(DataChangeNotification.Updated("_Access/somebody_Access", null));
+
+        received.Should().HaveCount(1,
+            "the router resolves exactly as a write resolves, so the namespace whose schema is NOT "
+            + "its lowercased name still lands on the right feed — the very case whose absence "
+            + "froze the $security-access fold");
+        router.RoutedCount.Should().Be(1L);
+    }
+
+    [Fact]
+    public void AThrowingSubscriberNeverReachesTheListener()
+    {
+        using var provider = NewProvider();
+        var chess = provider.GetSchemaAdapter("Chess/Board")!;
+        using var poison = chess.Changes.Subscribe(_ => throw new InvalidOperationException("boom"));
+        var router = new PartitionChangeRouter(provider);
+
+        // 🚨 A throw escaping here would tear the LISTEN loop into its reconnect branch, so ONE bad
+        // subscriber would cost EVERY path its cross-process feed until the reconnect completed.
+        router.OnNext(DataChangeNotification.Updated("Chess/Board", null));
+
+        router.RoutedCount.Should().Be(1L);
+    }
+}


### PR DESCRIPTION
Closes #1440.

## What this is

The cross-process change feed, end to end — the last leg of #1814's notify chain. Two halves that
only work together, which is why they land together:

**A — the LISTEN session is registered AND started, and its events are ROUTED to a partition.**
`PostgreSqlExtensions.cs:367-368` were commented out, and the comment above them named the real
blocker rather than the wiring: *"in the partitioned setup the listener [must] pump notifications
across many per-partition adapters … A follow-up will route LISTEN events to the right partition
adapter's `ChangeObserver` via the partition registry."* That router is `PartitionChangeRouter`.
The `mesh_node_changes` channel is per DATABASE — one session receives every schema's events —
while the change feed under `PostgreSqlPathRoutingAdapter` is per SCHEMA, so an event has to be
resolved to a partition before it can be published. It resolves through **exactly the resolution a
WRITE uses** (`ResolveSchema`: first path segment → schema, with the satellite-node-type guard, the
`_`-prefix globals via the registered-partition map, and the invalid-segment refusal), so a
notification can never land on a feed the write itself would not have published to, and there is no
second resolution to drift out of step with the first.

**B — the consumer re-reads instead of discarding.** `MeshDataSource.cs:1479` gave up on any
notification whose entity was absent (`if (notification.Entity is not MeshNode newNode) return;`) —
which is EVERY cross-process notification there is. Turning A on without B changes nothing: the
notifications arrive and are dropped.

## `Entity = null` is correct and stays correct

The fix is a **re-read**, never a supplemented entity. Populating `Entity` from the NOTIFY payload
would reintroduce the row-level-security bypass `StorageAdapterMeshQueryProvider` removed (#1250) —
"whenever the supplement DID change the outcome, the re-query was the one that was right: the row it
re-added was one the read had excluded by RLS, by satellite-table routing (#1193), by a path filter,
or past the load cap" — and it races row visibility besides. So the consumer reads the row back, and
the result is durable by construction, which keeps the provenance `AdoptPersisted` depends on.

## The invariants at the site, preserved

- **`AdoptPersisted`, not `Update`.** Both branches — the entity-carrying in-process publish and the
  re-read — funnel into ONE `AdoptDurable` local function that adopts. Nothing mints (#1432).
- **Echo suppression** is inside that function, so it covers the re-read too: the read returns the
  version the write landed at, and `newNode.Version == lastSelfWrite.Value` still skips.
- **Tombstone clearing** (`cache.IsDeleted = false`, `recentlyDeleted?.Clear(ownPath)`) and the
  forward-only guard are unchanged and shared by both branches.
- **Provenance** — "only the durable change feed reaches this line" — is stronger than before: a
  re-read result IS the durable row.
- **It cannot feed itself (#223).** The trigger's only effects are a READ and an `AdoptPersisted`,
  and `AdoptPersisted` neither mints nor writes (it records the durable version so the persistence
  sampler and the dispose-time flush both skip it). No write on the path ⇒ nothing of our own to
  re-trigger it. Pinned by a test that asserts the store never moves after an echo.

## The bound

`Throttle(50 ms)` per hub — and each of these subscriptions only ever sees ONE path, its own, so
that is a per-path coalesce. 200 notifications for one path cost a handful of reads, not 200
(measured below). `Concat` serialises them so at most one read per hub is ever in flight.

`Throttle`, deliberately **not** `Sample`: `Sample` arms a PERIODIC timer per subscription and there
is one subscription per live node hub, so an idle mesh would pay a timer tick per hub per window for
nothing. `Throttle` arms a one-shot timer only while a burst is in flight, and it always emits the
LAST trigger of a burst — the read that CONVERGES the mirror can never be the one that gets dropped.

**Cheap discard**: a path this hub does not own costs one ordinal string compare — no read, no
allocation. At the router, an unroutable path costs one synchronous segment resolution and does
**not** materialise a per-schema adapter (on a 140-partition mesh, routing-by-materialising would
leave every process holding an adapter for every partition purely because someone, somewhere, wrote).

## Two things the integration test caught that review would not have

- The listener's data source was built with `ConnectionIdleLifetime = 0`; Npgsql **refuses** that
  under the default pruning interval, and the throw lands in the DI factory at host startup. Fixed
  to `MinPoolSize = 1` (pruning only ever touches connections idle IN THE POOL, and this one is
  checked out for the life of the process).
- The listener's data source must be built **by the provider**, through the same
  `configureDataSource` hook as every other source it builds. On Azure Postgres the portal has no
  password in its connection string at all — the credential is an AAD token supplied by
  `UsePeriodicPasswordProvider` through that hook — so a listener built from the connection string
  alone would sit in its 5-second reconnect loop for ever on exactly the deployment this feed exists
  for, indistinguishable from never having been wired.

It also holds its own single connection (`MaxPoolSize = 1`, `KeepAlive = 30`, named
`meshweaver-change-listener` in `pg_stat_activity`) rather than taking one from the pool the portal
has already exhausted once. `KeepAlive` is not decoration: a LISTEN connection is idle by design, and
an idle TCP session behind a NAT/firewall is dropped silently — after which `WaitAsync` waits for
ever on a dead socket and the process is back to "never told", with nothing to notice.

## Tests — each fails on `origin/main`

`test/MeshWeaver.Hosting.Monolith.Test/CrossProcessChangeFeedTest.cs` — two independent meshes over
one durable store (the `CrossClusterBuildClaimTest` shape), wired with the entity-less feed:

| against `origin/main` | with this change |
|---|---|
| `AWriteInOneProcess_ReachesTheOtherProcessesLiveMirror_WithoutARecycle`: mirror ends at **v3 while the store holds v2** — a revision that exists nowhere (#1432), reached by accident through a read-seeded mint | mirror adopts **v2**, the durable version, verbatim |
| `AnEntitylessBurst_…`: `200 notifications → own-path reads 400, query-layer baseline 400, re-reads attributable to the reconcile **0**` | `own-path reads 401, query-layer baseline 400, re-reads attributable to the reconcile **1**` |
| `AnEntitylessEchoOfTheOwnWrite_IsSuppressed_AndWritesNothingBack` — passes on main too (the echo path is unchanged); it is the regression pin for #1432/#223 | passes |

`test/MeshWeaver.Hosting.PostgreSql.Test/ChangeListenerWiringTests.cs` — asserts on the service
DESCRIPTORS, because "registered but never started" is invisible from behaviour. On main both fail:
*"the partitioned wiring must register the LISTEN/NOTIFY listener … but found False."*

`test/MeshWeaver.Hosting.PostgreSql.Test/CrossProcessNotifyPgTests.cs` — a real Postgres container:
adapter A writes, adapter B's partition feed receives it through trigger → `pg_notify` → LISTEN →
router. It carries its own **control**: a third provider configured identically **but with no
listener** sees nothing, evaluated at the moment B's notification lands. That control is the state
`main` is in, and it is why the stale mirror was a missing edge rather than a lost race — no retry
can win a race that is not being run.

`test/MeshWeaver.Hosting.PostgreSql.Test/PartitionChangeRouterTests.cs` — routing decisions, no
container and no connection: owned partition → its feed; untouched partition → the merged feed with
no adapter materialised; unroutable path (a NodeType first segment, a URL-shaped segment, an
unregistered `_Access`) → discarded; `_Access` → `system_access` once registered; a throwing
subscriber never reaches the listener (a throw there would tear the LISTEN loop into its reconnect
branch, so one bad subscriber would cost every path its feed).

## What remains of #1814

Both named defects are already fixed (#1847 bake identity, #1870 the latching fault card), and the
notify chain's three legs are now all closed: the per-database trigger (V54/#1816), the listener
(this PR), the consumer (this PR).

What this PR does **not** settle, stated precisely rather than assumed:

1. **The `Conflict` retry's base still comes from `MeshNodeStreamCache`, and that cache does not
   subscribe to the change feed.** The subscribers are the own-node reconcile (fixed here), the
   synced-query providers, and `BuildNodeType`. So if the stale snapshot behind the deterministic
   conflict is a *mirror's* rather than an *owning hub's*, the notification now ARRIVES in that
   process but nothing hands it to the mirror. The cache already exposes `Invalidate(path)`; wiring
   it to the routed feed is the obvious next step — and deliberately not done here, because an
   invalidate-per-notification is a resubscribe storm shaped exactly like the 2026-06-08 outage and
   needs its own measurements.
2. **A process now receives its own writes back over NOTIFY**, so each own write costs one extra
   coalesced single-node read per live own-node hub, and one extra re-query per matching synced
   query. Correct but wasteful. The principled fix is a sender id in the NOTIFY payload (a per-process
   `application_name` the trigger emits, and the listener drops its own) — a trigger change, i.e. a
   migration PR next to #1816, not a heuristic here.

## Verification

- `dotnet build -c Release -p:CIRun=true -warnaserror` clean on every touched project.
| suite | result |
|---|---|
| `MeshWeaver.Graph.Test` | 1381 passed, 0 failed |
| `MeshWeaver.Hosting.Monolith.Test` | 731 passed, 0 failed, 3 skipped (9 m 19 s) |
| `MeshWeaver.Hosting.PostgreSql.Test` | 734 passed, 0 failed, 1 skipped (Testcontainers, ran locally) |
| `MeshWeaver.Hosting.Orleans.Test` | 170 passed, 0 failed |
| `MeshWeaver.AI.Test` | 1146 passed, 0 failed, 3 skipped |

The headline cross-process test was also run 20× in a row: 20 pass, 0 fail — it is deterministic,
not "passed once".
