### PR TITLE
fix(rn): interactive onboarding on first launch; never connect anonymously; themed chat

### DIFF
--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -125,9 +125,11 @@ function AppInner() {
   useEffect(() => {
     if (Platform.OS === "web") return;
     if (!liveConnected && clientScreen == null) setClientScreen("instances");
-    // Close the onboarding exactly ONCE, on the not-connected → connected transition —
-    // a connected user opening the switcher on purpose must not have it snap shut.
-    if (liveConnected && !wasLive.current) setClientScreen((c) => (c === "instances" ? null : c));
+    // Close the gate screens exactly ONCE, on the not-connected → connected transition —
+    // a connected user opening the switcher on purpose must not have it snap shut. The
+    // profile onboarding closes the same way: completing it reconnects, and the ack lands here.
+    if (liveConnected && !wasLive.current)
+      setClientScreen((c) => (c === "instances" || c === "onboarding" ? null : c));
     wasLive.current = liveConnected;
   }, [liveConnected, clientScreen]);
   const reconnect = () => {
@@ -168,6 +170,16 @@ function AppInner() {
         void attachInstanceStore(
           inst.local ? Mesh.from(l.connection, undefined, { url: inst.url, token: inst.token }) : null,
         );
+        // 📱 First launch on the device mesh: no device user yet → the app opens INTO the
+        // onboarding dialog (the RN twin of MAUI's OnboardingPage). "Get started" posts the
+        // profile (POST /api/mesh/onboard) and the following reconnect ack closes the screen.
+        if (Platform.OS !== "web" && inst.local)
+          void fetch(`${inst.url.replace(/\/+$/, "")}/api/mesh/onboard`)
+            .then((r) => (r.ok ? r.json() : null))
+            .then((j: { onboarded?: boolean } | null) => {
+              if (j && j.onboarded === false) setClientScreen("onboarding");
+            })
+            .catch(() => {});
       })
       .catch((e) => {
         // Release builds swallow console — surface the failure where the user IS (the

--- a/clients/react-native/src/Shell.tsx
+++ b/clients/react-native/src/Shell.tsx
@@ -19,7 +19,7 @@ import { RenderArea, type AreaSource, type AreaTree } from "@meshweaver/react/co
 import { areaErrorMessage } from "./areaError";
 import { type NavTarget } from "./nav";
 import { CLIENT_MENUS, ClientScreen, type ClientDestination } from "./screens";
-import { loadInstances, currentInstance, setCurrentInstance, instanceIdentity, onInstancesChanged, type InstanceIdentity } from "./connection";
+import { loadInstances, currentInstance, instanceIdentity, onInstancesChanged, selectAndSignIn, setConnectStatus, type InstanceIdentity } from "./connection";
 import { useStyles, useTheme, type Palette } from "./theme";
 import { LeftMenuView } from "./leftMenu";
 
@@ -182,10 +182,12 @@ function InstanceSwitcher({ isMobile, onReconnect, onManage }: { isMobile: boole
   const cur = instances.find((i) => i.name === current) ?? instances[0];
   const id = instanceIdentity(cur);
   const pick = (n: string) => {
-    setCurrentInstance(n);
-    setCurrent(n);
     setOpen(false);
-    onReconnect();
+    // Never dial a portal anonymously: a remote without a usable token runs the browser
+    // sign-in first; a failed sign-in opens the manage screen, where the status renders.
+    selectAndSignIn(n,
+      () => { setCurrent(n); onReconnect(); },
+      (message) => { setConnectStatus(message); onManage(); });
   };
   const nameStyle = (t: InstanceIdentity, color: string) => [
     styles.switchName,

--- a/clients/react-native/src/chat.tsx
+++ b/clients/react-native/src/chat.tsx
@@ -14,6 +14,7 @@ import { useMemo, useRef, useState } from "react";
 import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import type { Recorder } from "./speech/recorder";
 import { PushToTalkController, type SpeechFlowState, type ThreadSubmitter, type Transcriber } from "./speech/pushToTalk";
+import { useStyles, useTheme, type Palette } from "./theme";
 
 export interface ChatComposerProps {
   /** The mesh thread surface (Mesh.from(connection)); undefined = dictation-only (send disabled). */
@@ -28,6 +29,10 @@ export interface ChatComposerProps {
 }
 
 export function ChatComposer({ submitter, namespacePath, recorder, transcriber, language }: ChatComposerProps) {
+  // Themed like every other screen — a static light stylesheet here left the composer glaring
+  // white (and its typed text near-invisible) in dark mode.
+  const styles = useStyles(makeStyles);
+  const { palette } = useTheme();
   const [draft, setDraft] = useState("");
   const [speechState, setSpeechState] = useState<SpeechFlowState>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -118,7 +123,7 @@ export function ChatComposer({ submitter, namespacePath, recorder, transcriber, 
       )}
       {transcribing && (
         <View style={styles.stateRow}>
-          <ActivityIndicator size="small" color="#0f6cbd" />
+          <ActivityIndicator size="small" color={palette.accent} />
           <Text style={styles.transcribingText}>Transcribing…</Text>
         </View>
       )}
@@ -130,6 +135,7 @@ export function ChatComposer({ submitter, namespacePath, recorder, transcriber, 
           value={draft}
           onChangeText={setDraft}
           placeholder={submitter ? "Message the mesh…" : "Dictate a note… (offline — no mesh connection)"}
+          placeholderTextColor={palette.textMuted}
           multiline
         />
         {controller && (
@@ -157,30 +163,32 @@ export function ChatComposer({ submitter, namespacePath, recorder, transcriber, 
   );
 }
 
-const styles = StyleSheet.create({
-  bar: { borderTopWidth: 1, borderTopColor: "#e1dfdd", padding: 8, gap: 6, backgroundColor: "#faf9f8" },
+// Palette-driven (light + dark); only the semantic recording/error red stays fixed in both themes.
+const makeStyles = (p: Palette) => StyleSheet.create({
+  bar: { borderTopWidth: 1, borderTopColor: p.border, padding: 8, gap: 6, backgroundColor: p.topbarBg },
   stateRow: { flexDirection: "row", alignItems: "center", gap: 8 },
   recordingDot: { width: 10, height: 10, borderRadius: 5, backgroundColor: "#d13438" },
   recordingText: { color: "#d13438", fontWeight: "600" },
-  transcribingText: { color: "#0f6cbd" },
+  transcribingText: { color: p.accent },
   errorText: { color: "#d13438" },
-  threadText: { color: "#605e5c", fontSize: 12 },
+  threadText: { color: p.textMuted, fontSize: 12 },
   inputRow: { flexDirection: "row", alignItems: "flex-end", gap: 8 },
   input: {
     flex: 1,
     minHeight: 40,
     maxHeight: 120,
     borderWidth: 1,
-    borderColor: "#c8c6c4",
+    borderColor: p.border,
     borderRadius: 8,
     paddingHorizontal: 10,
     paddingVertical: 8,
-    backgroundColor: "white",
+    backgroundColor: p.inputBg,
+    color: p.text,
   },
   roundBtn: { width: 40, height: 40, borderRadius: 20, alignItems: "center", justifyContent: "center" },
-  mic: { backgroundColor: "#edebe9" },
+  mic: { backgroundColor: p.navHover },
   micRecording: { backgroundColor: "#d13438" },
-  send: { backgroundColor: "#0f6cbd" },
+  send: { backgroundColor: p.accent },
   disabled: { opacity: 0.4 },
-  btnText: { color: "white", fontSize: 16 },
+  btnText: { color: p.onAccent, fontSize: 16 },
 });

--- a/clients/react-native/src/connection.ts
+++ b/clients/react-native/src/connection.ts
@@ -286,6 +286,34 @@ export function setCurrentInstance(name: string): void {
   currentName = remotes.some((i) => i.name === name) ? name : "";
 }
 
+import { refreshOAuth, signInWithOAuth } from "./oauth";
+
+/**
+ * Make `name` the current instance, ensuring a REMOTE portal is signed in FIRST — the app never
+ * dials a portal anonymously (an anonymous viewer gets 401s and renders nothing, which reads as a
+ * broken app). Local is the device's own mesh and connects as-is. An expired OAuth token refreshes
+ * silently; a missing or dead token opens the portal's own browser sign-in. onReady() fires when
+ * the selection is ready to dial; onError(message) when sign-in failed — the selection is NOT
+ * switched then, so the app stays on the mesh it could actually talk to.
+ */
+export function selectAndSignIn(name: string, onReady: () => void, onError: (message: string) => void): void {
+  const inst = loadInstances().find((i) => i.name === name);
+  if (!inst) return onError(`Unknown mesh: ${name}`);
+  if (inst.local) { setCurrentInstance(name); return onReady(); }
+  const expired = !!inst.tokenExpiresAt && inst.tokenExpiresAt < Date.now();
+  if (inst.token && !expired) { setCurrentInstance(name); return onReady(); }
+  const finish = (r: { accessToken: string; refreshToken?: string; clientId: string; expiresAt?: number }) => {
+    saveInstance({ ...inst, token: r.accessToken, refreshToken: r.refreshToken, clientId: r.clientId, tokenExpiresAt: r.expiresAt });
+    onReady();
+  };
+  const browser = () => signInWithOAuth(inst.url)
+    .then(finish)
+    .catch((e) => onError(`${inst.name}: ${e?.message ?? "sign-in failed"}`));
+  if (expired && inst.refreshToken && inst.clientId)
+    refreshOAuth(inst.url, inst.clientId, inst.refreshToken).then((r) => (r ? finish(r) : browser()), browser);
+  else void browser();
+}
+
 /** Add or replace a remote instance (keyed by name), persist its node, and make it current. */
 export function saveInstance(inst: MeshInstance): void {
   const clean: MeshInstance = { ...inst, local: false, url: inst.url.replace(/\/+$/, "") };

--- a/clients/react-native/src/screens.tsx
+++ b/clients/react-native/src/screens.tsx
@@ -3,13 +3,13 @@
 // mesh): Voice (speech), Connect (remote instances), Profile, Settings.
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { View, Text, TextInput, Pressable, ScrollView, StyleSheet } from "react-native";
-import { loadInstances, saveInstance, removeInstance, setCurrentInstance, currentInstance, defaultPortalUrl, instanceIdentity, discoverInstances, mergeDiscovered, getConnectStatus, onConnectStatus, onInstancesChanged, type MeshInstance } from "./connection";
-import { refreshOAuth, signInWithOAuth } from "./oauth";
+import { loadInstances, saveInstance, removeInstance, currentInstance, defaultPortalUrl, instanceIdentity, discoverInstances, mergeDiscovered, getConnectStatus, onConnectStatus, onInstancesChanged, selectAndSignIn, type MeshInstance } from "./connection";
+import { signInWithOAuth } from "./oauth";
 import { useStyles, useTheme, type Palette } from "./theme";
 
 const useSheet = () => useStyles(makeStyles);
 
-export type ClientDestination = "profile" | "voice" | "instances" | "settings";
+export type ClientDestination = "profile" | "voice" | "instances" | "settings" | "onboarding";
 
 export interface ClientMenuItem {
   label: string;
@@ -46,7 +46,57 @@ export function ClientScreen({
       return <ProfileScreen />;
     case "settings":
       return <SettingsScreen />;
+    case "onboarding":
+      return <OnboardingScreen onDone={onConnected} />;
   }
+}
+
+// ── First-launch onboarding (device mesh) ───────────────────────────────────────
+// The RN twin of MAUI's OnboardingPage: on the first launch against the local mesh there is no
+// device user yet, so the app opens INTO this dialog — the person enters their profile and
+// "Get started" posts it to the sidecar (POST /api/mesh/onboard → DeviceSeed.Onboard creates the
+// partition-root User + global-admin grant through the framework path). App.tsx shows this screen
+// when the local connect acks but GET /api/mesh/onboard reports onboarded=false.
+function OnboardingScreen({ onDone }: { onDone: () => void }): ReactNode {
+  const s = useSheet();
+  const [fullName, setFullName] = useState("");
+  const [bio, setBio] = useState("");
+  const [role, setRole] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const start = () => {
+    if (!fullName.trim()) {
+      setError("Enter your name — it is how your work is attributed.");
+      return;
+    }
+    setBusy(true); setError("");
+    const url = currentInstance().url.replace(/\/+$/, "");
+    fetch(`${url}/api/mesh/onboard`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fullName: fullName.trim(), bio: bio.trim() || null, role: role.trim() || null }),
+    })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`onboarding failed (HTTP ${r.status})`);
+        await r.json();
+        onDone();
+      })
+      .catch((e) => setError(e?.message ?? "onboarding failed"))
+      .finally(() => setBusy(false));
+  };
+  return (
+    <ScreenScroll
+      title="Welcome — set up your profile"
+      subtitle="This mesh is yours alone: your profile lives on it, and everything you create is attributed to it.">
+      <Field label="Your name" value={fullName} onChange={setFullName} placeholder="e.g. Ada Lovelace" />
+      <Field label="About you (optional)" value={bio} onChange={setBio} placeholder="A sentence or two about what you do" multiline />
+      <Field label="Role (optional)" value={role} onChange={setRole} placeholder="e.g. Actuary" />
+      {error ? <Text style={{ color: "#d13438", marginBottom: 8 }}>{error}</Text> : null}
+      <Pressable onPress={start} style={s.primaryBtn} disabled={busy}>
+        <Text style={s.primaryBtnText}>{busy ? "Setting up…" : "Get started"}</Text>
+      </Pressable>
+    </ScreenScroll>
+  );
 }
 
 // ── Voice (speech) ────────────────────────────────────────────────────────────
@@ -181,24 +231,18 @@ function ConnectScreen({ onConnected }: { onConnected: () => void }): ReactNode 
     discoverInstances(inst).then((d) => { if (d.length) { mergeDiscovered(d); refresh(); } }).catch(() => {});
   };
   const select = (n: string) => {
-    setCurrentInstance(n); setCurrent(n);
-    const inst = loadInstances().find((i) => i.name === n);
-    if (inst && !inst.local) {
-      // An expired OAuth token refreshes silently; a dead refresh token falls back to the
-      // visible "Sign in" affordance rather than failing areas one by one.
-      if (inst.refreshToken && inst.clientId && inst.tokenExpiresAt && inst.tokenExpiresAt < Date.now()) {
-        refreshOAuth(inst.url, inst.clientId, inst.refreshToken).then((r) => {
-          if (r) {
-            saveInstance({ ...inst, token: r.accessToken, refreshToken: r.refreshToken, tokenExpiresAt: r.expiresAt });
-            refresh(); onConnected();
-          } else {
-            setRowError(`${inst.name}: session expired — sign in again.`);
-          }
-        }).catch(() => {});
-      }
-      discover(inst);
-    }
-    onConnected();
+    // Never dial a portal anonymously: selecting a remote without a usable token runs the
+    // browser sign-in first (selectAndSignIn refreshes an expired token silently).
+    setBusyFor(n); setRowError(null);
+    selectAndSignIn(n,
+      () => {
+        setBusyFor(null);
+        refresh();
+        const inst = loadInstances().find((i) => i.name === n);
+        if (inst && !inst.local) discover(inst);
+        onConnected();
+      },
+      (message) => { setBusyFor(null); setRowError(message); });
   };
   const add = () => {
     const nm = name.trim() || url.trim().replace(/^https?:\/\//, "");
@@ -318,13 +362,17 @@ function ScreenScroll({ title, subtitle, children }: { title: string; subtitle?:
   );
 }
 
-function Field({ label, value, onChange, placeholder }: { label: string; value: string; onChange: (v: string) => void; placeholder?: string }): ReactNode {
+function Field({ label, value, onChange, placeholder, multiline }: { label: string; value: string; onChange: (v: string) => void; placeholder?: string; multiline?: boolean }): ReactNode {
   const s = useSheet();
   const { palette } = useTheme();
   return (
     <View style={{ marginBottom: 12 }}>
       <Text style={s.fieldLabel}>{label}</Text>
-      <TextInput style={s.input} value={value} onChangeText={onChange} placeholder={placeholder} placeholderTextColor={palette.textMuted} autoCapitalize="none" autoCorrect={false} />
+      <TextInput
+        style={[s.input, multiline && { minHeight: 84, textAlignVertical: "top" as const }]}
+        value={value} onChangeText={onChange} placeholder={placeholder}
+        placeholderTextColor={palette.textMuted} autoCapitalize="none" autoCorrect={false}
+        multiline={multiline} numberOfLines={multiline ? 4 : 1} />
     </View>
   );
 }

--- a/memex/Memex.LocalMesh/DeviceSeed.cs
+++ b/memex/Memex.LocalMesh/DeviceSeed.cs
@@ -106,14 +106,19 @@ public static class DeviceSeed
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(nameof(DeviceSeed));
 
-        IsOnboarded(hub)
-            .Where(onboarded => onboarded)
-            .SelectMany(_ => hub.GetWorkspace()
+        hub.GetWorkspace()
+            .GetQuery("repair-grant-user", $"nodeType:User content.email:{DeviceUserId}@local limit:1")
+            .Take(1).Timeout(TimeSpan.FromSeconds(15))
+            .Where(users => users.Any())
+            // The grant carries the ONBOARDED profile name (the user node's), not the OS account —
+            // they differ whenever the person entered their real name in the onboarding dialog.
+            .SelectMany(users => hub.GetWorkspace()
                 .GetQuery("seed-admin-grant", $"path:Admin/_Access/{DeviceUserId}_Access limit:1")
-                .Take(1).Timeout(TimeSpan.FromSeconds(15)))
-            .Where(existing => !existing.Any())
-            .SelectMany(_ => accessService.RunAsSystem(
-                () => meshService.CreateNode(AdminGrant(OsUserName()))))
+                .Take(1).Timeout(TimeSpan.FromSeconds(15))
+                .Where(existing => !existing.Any())
+                .Select(_ => users.First().Name ?? OsUserName()))
+            .SelectMany(name => accessService.RunAsSystem(
+                () => meshService.CreateNode(AdminGrant(name))))
             .Subscribe(
                 _ => logger?.LogInformation("Repaired the missing global-admin grant"),
                 ex => logger?.LogWarning(ex, "Admin-grant repair failed"));

--- a/memex/Memex.LocalMesh/DeviceSeed.cs
+++ b/memex/Memex.LocalMesh/DeviceSeed.cs
@@ -10,13 +10,13 @@ using MeshWeaver.Messaging;
 namespace Memex.LocalMesh;
 
 /// <summary>
-/// First-boot seeding for the device mesh — the sidecar twin of the MAUI client's boot
-/// (MauiProgram + DeviceOnboarding): stamp the single device-user identity on the host, create the
-/// partition-root <c>User</c> node through the FRAMEWORK path (the framework provisions the
-/// <c>device-user</c> partition and grants self-admin; the <c>Admin/_Access</c> grant then makes the
-/// device owner the instance's global admin), and seed the <c>MemexInstance</c> nodes — this mesh IS
-/// the instance store the shells it serves read their mesh list from (no device storage).
-/// All idempotent: every seed checks existence via <c>GetQuery</c> first.
+/// Device identity + first-boot seeding for the device mesh — the sidecar twin of the MAUI client's
+/// boot (MauiProgram + DeviceOnboarding). Onboarding is INTERACTIVE, exactly like MAUI's
+/// OnboardingPage: the device user is created by <see cref="Onboard"/> with the profile the person
+/// entered (the shell shows the onboarding dialog on first launch, via <c>POST /api/mesh/onboard</c>)
+/// — never auto-seeded, which would land them on an empty profile they never set up. The boot pass
+/// only stamps the identity, seeds the <c>MemexInstance</c> nodes (this mesh IS the instance store
+/// the shells read their mesh list from), and repairs a missing global-admin grant. All idempotent.
 /// </summary>
 public static class DeviceSeed
 {
@@ -24,73 +24,108 @@ public static class DeviceSeed
 
     public static void Seed(IMessageHub hub)
     {
-        var osName = Environment.UserName;
-        if (string.IsNullOrWhiteSpace(osName)) osName = "Device User";
-
         // Single-user device mesh: the shells this host serves (RN, web, desktop) connect
         // anonymously; identity lives HERE, exactly like the MAUI client's in-process mesh.
-        var deviceUser = new AccessContext { ObjectId = DeviceUserId, Name = osName };
-        hub.ServiceProvider.GetRequiredService<AccessService>().SetHostIdentity(deviceUser);
+        hub.ServiceProvider.GetRequiredService<AccessService>().SetHostIdentity(
+            new AccessContext { ObjectId = DeviceUserId, Name = OsUserName() });
 
-        SeedDeviceUser(hub, osName);
         SeedInstances(hub);
+        RepairAdminGrant(hub);
     }
 
-    /// <summary>Creates the device user on first boot (absent = never onboarded), as DeviceOnboarding does.</summary>
-    private static void SeedDeviceUser(IMessageHub hub, string name)
+    private static string OsUserName()
+    {
+        var osName = Environment.UserName;
+        return string.IsNullOrWhiteSpace(osName) ? "Device User" : osName;
+    }
+
+    /// <summary>True once the device user's User node exists (first-launch detection).</summary>
+    public static IObservable<bool> IsOnboarded(IMessageHub hub) =>
+        hub.GetWorkspace()
+            .GetQuery("onboard-check", $"nodeType:User content.email:{DeviceUserId}@local limit:1")
+            .Take(1).Timeout(TimeSpan.FromSeconds(15))
+            .Select(existing => existing.Any());
+
+    /// <summary>
+    /// Interactive onboarding — the FRAMEWORK path DeviceOnboarding (MAUI) takes: creating the
+    /// partition-root <c>User</c> node provisions the <c>device-user</c> partition and grants
+    /// self-admin; the <c>Admin/_Access</c> grant then makes the device owner the instance's global
+    /// admin. Emits true when it created the user, false when already onboarded.
+    /// </summary>
+    public static IObservable<bool> Onboard(IMessageHub hub, string? fullName, string? bio, string? role)
+    {
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        var name = string.IsNullOrWhiteSpace(fullName) ? OsUserName() : fullName.Trim();
+
+        return IsOnboarded(hub).SelectMany(onboarded => onboarded
+            ? Observable.Return(false)
+            // RunAsSystem, never Observable.Using(ImpersonateAsSystem…) — the latter latches the
+            // system identity on the subscribing thread (ImpersonationScopeSiteRatchetGuard, #1790).
+            : accessService.RunAsSystem(   // a brand-new partition root is owned by nobody yet
+                    () => meshService.CreateNode(new MeshNode(DeviceUserId)   // → provisions schema + self-Admin
+                    {
+                        NodeType = "User",
+                        Name = name,
+                        State = MeshNodeState.Active,
+                        Content = new User
+                        {
+                            FullName = name,
+                            Email = $"{DeviceUserId}@local",
+                            Bio = string.IsNullOrWhiteSpace(bio) ? null : bio.Trim(),
+                            Role = string.IsNullOrWhiteSpace(role) ? null : role.Trim(),
+                        },
+                    }))
+                .SelectMany(_ => accessService.RunAsSystem(
+                    () => meshService.CreateNode(AdminGrant(name))))
+                .Select(_ => true));
+    }
+
+    /// <summary>Global admin of this instance — Admin/_Access with MainNode="Admin" (the sanctioned
+    /// shape; an empty MainNode would be a root/data-superuser grant and is refused).</summary>
+    private static MeshNode AdminGrant(string name) => new($"{DeviceUserId}_Access", "Admin/_Access")
+    {
+        NodeType = "AccessAssignment",
+        Name = $"{name} — Admin",
+        MainNode = "Admin",
+        Content = new AccessAssignment
+        {
+            AccessObject = DeviceUserId,
+            DisplayName = name,
+            Roles = [new RoleAssignment { Role = "Admin" }],
+        },
+    };
+
+    /// <summary>
+    /// Heals a crash between Onboard's two creates: the device user exists but the global-admin
+    /// grant is missing — on a single-user device mesh the owner must ALWAYS hold it.
+    /// </summary>
+    private static void RepairAdminGrant(IMessageHub hub)
     {
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(nameof(DeviceSeed));
 
-        hub.GetWorkspace()
-            .GetQuery("seed-device-user", $"nodeType:User content.email:{DeviceUserId}@local limit:1")
-            .Take(1).Timeout(TimeSpan.FromSeconds(15))
-            .Where(existing => !existing.Any())
-            // RunAsSystem, never Observable.Using(ImpersonateAsSystem…) — the latter latches the
-            // system identity on the subscribing thread (ImpersonationScopeSiteRatchetGuard, #1790).
-            .SelectMany(_ => accessService.RunAsSystem(   // a brand-new partition root is owned by nobody yet
-                () => meshService.CreateNode(new MeshNode(DeviceUserId)   // partition root → provisions schema + self-Admin
-                {
-                    NodeType = "User",
-                    Name = name,
-                    State = MeshNodeState.Active,
-                    Content = new User { FullName = name, Email = $"{DeviceUserId}@local" },
-                })))
-            .Subscribe(
-                _ => logger?.LogInformation("Seeded device user {Name}", name),
-                ex => logger?.LogWarning(ex, "Device-user seed failed"));
-
-        // Global admin of this instance — Admin/_Access with MainNode="Admin" (the sanctioned shape;
-        // an empty MainNode would be a root/data-superuser grant and is refused). Guarded by the
-        // GRANT's own existence, not the user's: a crash between the two creates heals on the next
-        // boot, and on a single-user device mesh the owner must ALWAYS hold this grant.
-        hub.GetWorkspace()
-            .GetQuery("seed-admin-grant", $"path:Admin/_Access/{DeviceUserId}_Access limit:1")
-            .Take(1).Timeout(TimeSpan.FromSeconds(15))
+        IsOnboarded(hub)
+            .Where(onboarded => onboarded)
+            .SelectMany(_ => hub.GetWorkspace()
+                .GetQuery("seed-admin-grant", $"path:Admin/_Access/{DeviceUserId}_Access limit:1")
+                .Take(1).Timeout(TimeSpan.FromSeconds(15)))
             .Where(existing => !existing.Any())
             .SelectMany(_ => accessService.RunAsSystem(
-                () => meshService.CreateNode(new MeshNode($"{DeviceUserId}_Access", "Admin/_Access")
-                {
-                    NodeType = "AccessAssignment",
-                    Name = $"{name} — Admin",
-                    MainNode = "Admin",
-                    Content = new AccessAssignment
-                    {
-                        AccessObject = DeviceUserId,
-                        DisplayName = name,
-                        Roles = [new RoleAssignment { Role = "Admin" }],
-                    },
-                })))
+                () => meshService.CreateNode(AdminGrant(OsUserName()))))
             .Subscribe(
-                _ => logger?.LogInformation("Seeded global-admin grant for {Name}", name),
-                ex => logger?.LogWarning(ex, "Admin-grant seed failed"));
+                _ => logger?.LogInformation("Repaired the missing global-admin grant"),
+                ex => logger?.LogWarning(ex, "Admin-grant repair failed"));
     }
 
     /// <summary>
     /// Seeds the instance list on first boot: the own-instance node (this mesh, named after the
     /// machine) plus the public memex — the same defaults the MAUI InstanceStore ships with. The
-    /// shells read these (<c>nodeType:MemexInstance</c>) as their connect list.
+    /// shells read these (<c>nodeType:MemexInstance</c>) as their connect list. Guarded on "ANY
+    /// MemexInstance exists" — deliberately, so a seeded instance the user REMOVED is not
+    /// resurrected on the next boot. The two creates are merged (not chained) so one failing cannot
+    /// skip the other.
     /// </summary>
     private static void SeedInstances(IMessageHub hub)
     {
@@ -99,9 +134,6 @@ public static class DeviceSeed
         var deviceName = Environment.MachineName;
         if (string.IsNullOrWhiteSpace(deviceName)) deviceName = "My Memex";
 
-        // Guarded on "ANY MemexInstance exists" — deliberately, so a seeded instance the user
-        // REMOVED is not resurrected on the next boot. The two creates below are merged (not
-        // chained) so one failing cannot skip the other.
         hub.GetWorkspace()
             .GetQuery("seed-instances", $"nodeType:{MemexInstanceNodeType.NodeType}")
             .Take(1).Timeout(TimeSpan.FromSeconds(15))

--- a/memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs
+++ b/memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs
@@ -90,6 +90,24 @@ public static class LocalMeshApiEndpoints
         // host has no antiforgery pipeline and no session to forge against.
         group.MapPost("/upload", HandleUpload).DisableAntiforgery();
 
+        // Interactive device onboarding — SIDECAR-ONLY (a portal onboards through its own signed-in
+        // flow, so this verb deliberately has no portal twin). The shell's first-launch dialog posts
+        // the profile; DeviceSeed.Onboard creates the partition-root User + the global-admin grant
+        // through the framework path. Idempotent: an already-onboarded mesh answers created=false.
+        group.MapPost("/onboard", async (OnboardBody body, IServiceProvider services, CancellationToken ct) =>
+        {
+            var created = await DeviceSeed.Onboard(RootHub(services), body.FullName, body.Bio, body.Role)
+                .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask(ct);
+            return Results.Json(new { ok = true, created });
+        });
+
+        // First-launch detection for the shells: {"onboarded": bool}.
+        group.MapGet("/onboard", async (IServiceProvider services, CancellationToken ct) =>
+        {
+            var onboarded = await DeviceSeed.IsOnboarded(RootHub(services)).FirstAsync().ToTask(ct);
+            return Results.Json(new { onboarded });
+        });
+
         return endpoints;
     }
 
@@ -181,4 +199,7 @@ public static class LocalMeshApiEndpoints
 
     /// <summary>POST body for /api/mesh/content/list — mirrors MeshApiEndpoints.PathBody.</summary>
     public record PathBody(string Path);
+
+    /// <summary>POST body for /api/mesh/onboard — the first-launch profile (DeviceSeed.Onboard).</summary>
+    public record OnboardBody(string? FullName, string? Bio = null, string? Role = null);
 }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-mobile-onboarding-and-signin.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-mobile-onboarding-and-signin.md
@@ -1,0 +1,16 @@
+---
+Name: The phone app onboards you properly and signs in to portals
+Category: Fix
+Description: First launch shows the profile onboarding dialog, remote portals always open their sign-in instead of connecting anonymously, and the chat composer follows dark mode.
+Icon: Sparkle
+Order: -20260820
+---
+
+# The phone app onboards you properly and signs in to portals
+
+Three fixes from first-day use of the phone app. On first launch against your local mesh the app now
+opens into an onboarding dialog — enter your name and a line about yourself, and it creates your
+device user with that profile, instead of silently creating an empty one that greeted you with
+"set up your profile". Picking a remote portal now always opens that portal's own sign-in when you
+have no valid session — the app never connects anonymously any more, which used to render as a
+blank portal. And the chat composer now follows dark mode instead of staying light.

--- a/test/Memex.Portal.Shared.Test/LocalMeshApiRoutesTest.cs
+++ b/test/Memex.Portal.Shared.Test/LocalMeshApiRoutesTest.cs
@@ -30,6 +30,7 @@ public class LocalMeshApiRoutesTest
         "/api/mesh/query-nodes",
         "/api/mesh/content/list",
         "/api/mesh/upload",
+        "/api/mesh/onboard",
     ];
 
     [Theory]


### PR DESCRIPTION
## What

Three fixes from first-day use of the phone app (follow-up to #1920):

1. **Interactive onboarding (MAUI parity).** The sidecar no longer auto-creates a hollow device user — that landed the person on the framework's *"set up your profile"* getting-started card with a profile they never entered. `DeviceSeed.Onboard` now creates the partition-root User (entered name/bio/role) + the `Admin/_Access` grant via `RunAsSystem`; boot only stamps identity, seeds `MemexInstance` nodes, and repairs a missing grant. New sidecar verbs `GET/POST /api/mesh/onboard` (route-table test extended — sidecar-only by design; a portal onboards through its own signed-in flow). The RN app opens INTO the onboarding dialog when the local connect acks un-onboarded; completing it reconnects and the ack closes the screen.
2. **Never connect anonymously.** `selectAndSignIn` — picking a remote portal without a usable token opens the portal's own browser sign-in (expired OAuth refreshes silently; dead refresh falls back to the browser). Anonymous prod rendered as a blank portal (`/api/mesh/query-nodes` is 401 anonymously). Wired at both selection points: the connect screen and the top-bar switcher.
3. **Chat composer follows dark mode** — it was a static light stylesheet (and had no input text color at all).

## Verification

- `dotnet build memex/Memex.LocalMesh -c Release -warnaserror`: clean
- `LocalMeshApiRoutesTest` 7/7, `WhatsNewEntryIntegrityTest` green (rebuilt DLL, mtime-checked)
- RN `npm run typecheck` clean; `npm test` 157/157
- Runtime, against a reset SQLite mesh: `GET onboard` → false → `POST` with profile → `created:true` + user carries the entered name + grant exists → `GET` → true; second `POST` → `created:false`

What's New entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)