### PR TITLE
The line building is 3.0.0-rc6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,8 +64,12 @@
          never roll forward again. Keep a pre-release label on the core until 3.0.0 ships clean.
 
          It also has to RESOLVE by the time anything pins content-sync to it: data-sync pulls
-         content from the tag v$(PlatformVersion). v3.0.0-rc3 shipped 2026-08-16; v3.0.0-rc5 is
-         the line NOW BUILDING and its tag is created only when rc5 is released — never tag it
+         content from the tag v$(PlatformVersion). v3.0.0-rc3 shipped 2026-08-16; v3.0.0-rc5
+         shipped 2026-08-19 — and its tagged tree CANNOT BOOT (Modules:Assemblies still listed
+         the fourteen removed driver DLLs; fixed by #1901 after the tag). v3.0.0-rc6 is the line
+         NOW BUILDING: the first release whose tree boots, whose module bundles carry their own
+         dependency closures (#1914/#1919/#1923), and whose platform has shed the module-only
+         Azure/OpenAI dependencies. Its tag is created only when rc6 is released — never tag it
          early, the v*.*.* tag IS the trigger for the NuGet + image publish.
 
          🚨 rc4 was never tagged, and the gap is deliberate rather than a slip: the line built
@@ -75,7 +79,7 @@
          it publishes are the ones the platform still builds. Do not "fill in" rc4 later: the
          version never shipped, and minting a tag for it now would publish that superseded
          content set for real. -->
-    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc5</PlatformVersion>
+    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc6</PlatformVersion>
   </PropertyGroup>
   <!-- Multi-arch container publish race fix (main-cd / release-images / edge-images pass
        -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK's _PublishMultiArchContainers


### PR DESCRIPTION
v3.0.0-rc5 shipped 2026-08-19 and its tagged tree cannot boot (stale `Modules:Assemblies`, fixed by #1901 after the tag) — recorded beside rc4's deliberate gap so nobody fills either in. rc6 is the first release whose tree boots, whose module bundles carry their own closures (#1914/#1919/#1923), and whose platform has shed the module-only Azure/OpenAI dependencies (#1916/#1926/#1928/#1930).

Un-drafts after #1916 + #1930 merge; the `v3.0.0-rc6` tag then cuts NuGet + images from the slimmed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)