### PR TITLE
Re-landing onto a running instance defers its swap to boot

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -536,6 +536,13 @@ public static class MemexConfiguration
             // read from somewhere else is simply invisible, and on a deployment whose /app is
             // read-only the writer cannot use AppContext.BaseDirectory at all.
             var moduleRoot = ModuleRoot.Resolve(configuration);
+            // Deferred re-lands FIRST — before anything is loaded, while no module file is open.
+            // A re-land onto a RUNNING instance cannot swap the loaded copy on an SMB volume
+            // (open files refuse deletion), so it parks at modules/.pending-<name>; this is the
+            // boot half that swaps it in. See ModuleLandingService.ApplyPendingLandings.
+            var appliedPending = ModuleLandingService.ApplyPendingLandings(moduleRoot);
+            if (appliedPending > 0)
+                Console.WriteLine($"[ModuleActivation] applied {appliedPending} deferred landing(s) before load");
             var persistedActivation = ModuleActivationSidecar.Read(moduleRoot,
                 msg => Console.Error.WriteLine($"[ModuleActivation] {msg}"));
             var effectiveModules = ModuleActivationBoot.ComputeEffectiveModuleEntries(

--- a/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
@@ -53,6 +53,13 @@ public static class ModuleBundleSource
             return ([], $"module '{moduleName}' is not loadable on this instance: {unsatisfied}");
 
         var folder = Path.Combine(baseDirectory, "modules", moduleName);
+        // A DEFERRED re-land (the running instance had the module loaded, so the swap parked at
+        // .pending-<name> until the next boot) is the NEWEST landed content — serve it: consumers
+        // must fetch what was published, not what this process happens to still be running.
+        var pending = ModuleLandingService.PendingPathFor(baseDirectory, moduleName);
+        if (Directory.Exists(pending)
+            && File.Exists(Path.Combine(pending, moduleName + ".dll")))
+            folder = pending;
         var entryDll = Path.Combine(folder, moduleName + ".dll");
         if (!File.Exists(entryDll))
             // Covers the missing folder, the transitional publish state (a module still riding the

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -39,6 +39,50 @@ namespace MeshWeaver.PluginCatalog;
 /// </summary>
 public sealed class ModuleLandingService : IDisposable
 {
+    /// <summary>The deferred-swap folder for a module (see the re-land fallback in
+    /// <see cref="LandModule"/>). Pure.</summary>
+    public static string PendingPathFor(string baseDirectory, string moduleName) =>
+        Path.Combine(baseDirectory, "modules", ".pending-" + moduleName);
+
+    /// <summary>
+    /// Applies every deferred landing under <c>modules/.pending-*</c> — the boot half of the
+    /// re-land fallback. MUST run before any module assembly is loaded: at that moment no file
+    /// is open, so the delete the running instance could not perform succeeds. A failed apply
+    /// logs, leaves the pending folder for the next boot, and the OLD module folder keeps
+    /// loading — stale but working, never a boot failure.
+    /// </summary>
+    /// <returns>How many pending landings were applied.</returns>
+    public static int ApplyPendingLandings(string baseDirectory, ILogger? logger = null)
+    {
+        var modulesRoot = Path.Combine(baseDirectory, "modules");
+        if (!Directory.Exists(modulesRoot))
+            return 0;
+        var applied = 0;
+        foreach (var pending in Directory.EnumerateDirectories(modulesRoot, ".pending-*"))
+        {
+            var name = Path.GetFileName(pending)[".pending-".Length..];
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+            var target = Path.Combine(modulesRoot, name);
+            try
+            {
+                if (Directory.Exists(target))
+                    Directory.Delete(target, recursive: true);
+                Directory.Move(pending, target);
+                applied++;
+                logger?.LogInformation(
+                    "Module '{Name}': deferred landing applied at boot ({Target})", name, target);
+            }
+            catch (Exception e)
+            {
+                logger?.LogError(e,
+                    "Module '{Name}': deferred landing could NOT be applied — the previous copy "
+                    + "keeps loading; the pending folder stays for the next boot", name);
+            }
+        }
+        return applied;
+    }
+
     // Cap 1 deliberately: LandModule/RemoveModule each read-modify-write the shared
     // activation.json sidecar, and the cap IS the serialization — no lock, no semaphore
     // outside the sealed IoPool primitive. Landing is rare and short; 1 costs nothing.
@@ -177,9 +221,33 @@ public sealed class ModuleLandingService : IDisposable
         {
             foreach (var (fileName, bytes) in assemblies)
                 File.WriteAllBytes(Path.Combine(staging, fileName), bytes);
-            if (Directory.Exists(target))
-                Directory.Delete(target, recursive: true);
-            Directory.Move(staging, target);
+            try
+            {
+                if (Directory.Exists(target))
+                    Directory.Delete(target, recursive: true);
+                Directory.Move(staging, target);
+            }
+            catch (Exception swap) when (swap is IOException or UnauthorizedAccessException)
+            {
+                // 🚨 The target's files are OPEN — this instance has the module LOADED, and on an
+                // SMB-backed volume (Azure Files) an open file cannot be deleted, so the in-place
+                // swap fails with "Directory not empty". That is the RE-LAND-ONTO-A-RUNNING-
+                // REGISTRY case (first hit 2026-08-20: every re-published module 409'd the moment
+                // the portal actually loaded its modules). The bytes are not lost and the publish
+                // must not fail: they park as modules/.pending-<name>/, the activation entry still
+                // flips PendingRestart, and ApplyPendingLandings swaps them in at the next boot —
+                // BEFORE anything is loaded, when the delete cannot be refused. The serving side
+                // prefers the pending folder, so consumers fetch the NEW bytes immediately even
+                // while this process still runs the old ones.
+                var pending = PendingPathFor(baseDirectory, name);
+                if (Directory.Exists(pending))
+                    Directory.Delete(pending, recursive: true);
+                Directory.Move(staging, pending);
+                logger?.LogWarning(
+                    "Module '{Name}': the loaded copy's files are open, so the swap is DEFERRED — "
+                    + "staged at {Pending}; applies at the next restart ({Reason})",
+                    name, pending, swap.Message);
+            }
         }
         catch
         {

--- a/test/MeshWeaver.PluginCatalog.Test/PendingLandingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PendingLandingTest.cs
@@ -1,0 +1,108 @@
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The deferred-swap half of module landing (2026-08-20): a re-land onto a RUNNING instance
+/// cannot delete the loaded copy's files on an SMB volume, so the bytes park at
+/// <c>modules/.pending-&lt;name&gt;</c> and boot swaps them in before anything is loaded — and
+/// the serving side prefers the pending folder, so consumers always fetch what was published.
+/// </summary>
+public class PendingLandingTest : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-pending-" + Guid.NewGuid().ToString("N"));
+
+    public PendingLandingTest() => Directory.CreateDirectory(Path.Combine(root, "modules"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+    }
+
+    private string Modules => Path.Combine(root, "modules");
+
+    private void Write(string folder, string file, string content)
+    {
+        Directory.CreateDirectory(Path.Combine(Modules, folder));
+        File.WriteAllText(Path.Combine(Modules, folder, file), content);
+    }
+
+    [Fact]
+    public void ApplyPendingLandings_SwapsThePendingCopyIn()
+    {
+        Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "OLD");
+        Write(".pending-MeshWeaver.Widget", "MeshWeaver.Widget.dll", "NEW");
+        Write(".pending-MeshWeaver.Widget", "Widget.Dep.dll", "DEP");
+
+        var applied = ModuleLandingService.ApplyPendingLandings(root);
+
+        Assert.Equal(1, applied);
+        Assert.Equal("NEW", File.ReadAllText(Path.Combine(Modules, "MeshWeaver.Widget", "MeshWeaver.Widget.dll")));
+        Assert.True(File.Exists(Path.Combine(Modules, "MeshWeaver.Widget", "Widget.Dep.dll")),
+            "the whole pending closure moves, not just the entry");
+        Assert.False(Directory.Exists(Path.Combine(Modules, ".pending-MeshWeaver.Widget")),
+            "an applied pending folder is gone");
+    }
+
+    [Fact]
+    public void ApplyPendingLandings_WithNoTarget_StillLands()
+    {
+        // A pending for a module whose folder vanished (fresh volume) simply becomes the folder.
+        Write(".pending-MeshWeaver.Fresh", "MeshWeaver.Fresh.dll", "NEW");
+
+        var applied = ModuleLandingService.ApplyPendingLandings(root);
+
+        Assert.Equal(1, applied);
+        Assert.Equal("NEW", File.ReadAllText(Path.Combine(Modules, "MeshWeaver.Fresh", "MeshWeaver.Fresh.dll")));
+    }
+
+    [Fact]
+    public void ApplyPendingLandings_WithNothingPending_IsAQuietZero()
+    {
+        Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "OLD");
+        Assert.Equal(0, ModuleLandingService.ApplyPendingLandings(root));
+        Assert.Equal(0, ModuleLandingService.ApplyPendingLandings(
+            Path.Combine(root, "no-such-deployment")));
+    }
+
+    [Fact]
+    public void Collect_PrefersThePendingCopy_SoConsumersFetchWhatWasPublished()
+    {
+        Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "OLD");
+        Write(".pending-MeshWeaver.Widget", "MeshWeaver.Widget.dll", "NEW");
+        Write(".pending-MeshWeaver.Widget", "Widget.Dep.dll", "DEP");
+
+        var (files, decline) = ModuleBundleSource.Collect(
+            root, "MeshWeaver.Widget",
+            new ModuleActivationList(), _ => null);
+
+        Assert.Null(decline);
+        Assert.All(files, f => Assert.Contains(".pending-MeshWeaver.Widget", f));
+        Assert.Equal("NEW", File.ReadAllText(files[0]));
+        Assert.Equal(2, files.Count);
+    }
+
+    [Fact]
+    public void Collect_WithoutAPending_ServesTheModuleFolder()
+    {
+        Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "CURRENT");
+
+        var (files, decline) = ModuleBundleSource.Collect(
+            root, "MeshWeaver.Widget",
+            new ModuleActivationList(), _ => null);
+
+        Assert.Null(decline);
+        Assert.Equal("CURRENT", File.ReadAllText(files[0]));
+    }
+
+    [Fact]
+    public void PendingPathFor_IsThePendingConvention()
+    {
+        Assert.Equal(
+            Path.Combine(root, "modules", ".pending-X"),
+            ModuleLandingService.PendingPathFor(root, "X"));
+    }
+}


### PR DESCRIPTION
The registry's bundle POST lands modules locally via `Directory.Delete` + `Move` — and Azure Files refuses to delete files the running portal has LOADED, so the moment prod actually loaded its modules, every re-publish 409'd (`Directory not empty`, 14/15 jobs on the #542 publish run).

- The swap falls back to `modules/.pending-<name>/` (activation still flips `PendingRestart`).
- `ApplyPendingLandings` runs at boot **before any load** — the delete cannot be refused then. A failed apply leaves the old copy loading: stale but working, never a boot failure.
- `ModuleBundleSource.Collect` prefers the pending folder — consumers always fetch what was **published**, not what this process still runs.

6 tests. Unblocks the republish for MeshWeaver.Plugins #542's bundles (AzureFoundry/Export 1.2), which gates #1916/#1930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)