### PR TITLE
fix(graph): register MemexInstanceContent mesh-wide — typed readers saw untyped JsonElement

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-memexinstance-typed-content.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-memexinstance-typed-content.md
@@ -1,0 +1,14 @@
+---
+Name: Saved mesh connections resolve reliably
+Category: Fix
+Description: A saved mesh connection's details now materialize on every hub, so clients reading them typed no longer see them as empty.
+Icon: Sparkle
+Order: -20260820
+---
+
+# Saved mesh connections resolve reliably
+
+The details of a saved mesh connection (a Memex Instance) could arrive as untyped data on hubs
+that stream or query those nodes, which made typed readers — such as a client reconnecting to your
+remembered meshes — see nothing at all. The type is now registered mesh-wide, so every reader
+resolves it.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-memexinstance-typed-content.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-memexinstance-typed-content.md
@@ -1,7 +1,7 @@
 ---
 Name: Saved mesh connections resolve reliably
 Category: Fix
-Description: A saved mesh connection's details now materialize on every hub, so clients reading them typed no longer see them as empty.
+Description: A saved mesh connection's details now resolve on every hub, so clients that read them as typed content no longer see them as empty.
 Icon: Sparkle
 Order: -20260820
 ---

--- a/src/MeshWeaver.Graph/Configuration/MemexInstanceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/MemexInstanceNodeType.cs
@@ -68,6 +68,11 @@ public static class MemexInstanceNodeType
     /// <summary>Registers the built-in "MemexInstance" MeshNode on the mesh builder.</summary>
     public static TBuilder AddMemexInstanceType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
     {
+        // The content type must resolve on EVERY hub that materializes these nodes — the per-node
+        // hub gets it via WithContentType below, but node-stream/query hubs (MeshNodeStreamCache)
+        // otherwise degrade the content to an untyped JsonElement ("stayed an untyped JsonElement"
+        // boot warning; typed ContentAs<MemexInstanceContent> consumers then read null).
+        builder.ConfigureHub(hub => hub.WithType(typeof(MemexInstanceContent), nameof(MemexInstanceContent)));
         builder.AddMeshNodes(CreateMeshNode());
         return builder;
     }

--- a/src/MeshWeaver.Graph/Configuration/MemexInstanceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/MemexInstanceNodeType.cs
@@ -71,8 +71,9 @@ public static class MemexInstanceNodeType
         // The content type must resolve on EVERY hub that materializes these nodes — the per-node
         // hub gets it via WithContentType below, but node-stream/query hubs (MeshNodeStreamCache)
         // otherwise degrade the content to an untyped JsonElement ("stayed an untyped JsonElement"
-        // boot warning; typed ContentAs<MemexInstanceContent> consumers then read null).
-        builder.ConfigureHub(hub => hub.WithType(typeof(MemexInstanceContent), nameof(MemexInstanceContent)));
+        // boot warning; typed ContentAs<MemexInstanceContent> consumers then read null). Mesh-level
+        // registry, so all hubs inherit it (the UiContributionNodeType pattern).
+        builder.WithMeshType(typeof(MemexInstanceContent), nameof(MemexInstanceContent));
         builder.AddMeshNodes(CreateMeshNode());
         return builder;
     }


### PR DESCRIPTION
## What

The sidecar's boot log warned `Content for Instance/local stayed an untyped JsonElement after deserialization (TypeRegistry lacks the $type discriminator)` — the exact renders-empty class AGENTS.md flags. `WithContentType<MemexInstanceContent>()` registers the type only on the per-node hub; hubs that stream or query the nodes (`MeshNodeStreamCache`) degraded the content, so every typed `ContentAs<MemexInstanceContent>` consumer (e.g. a client reconnecting to remembered meshes) read null.

`AddMemexInstanceType` now also registers the type on the mesh's hub configuration (`WithType(typeof(MemexInstanceContent))`).

## Verification

- Isolated sidecar boot on a scratch SQLite db: seeds run, `nodeType:MemexInstance` queries answer, and the log carries **zero** "stayed an untyped" warnings (the pre-fix build emitted it on every boot)
- `dotnet build memex/Memex.LocalMesh -c Release -warnaserror`: clean
- What's New entry included (validated against a rebuilt DLL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)