### PR TITLE
voice gateway: the async mailbox — signal when an answer is ready, play it on 'vorlesen'

### DIFF
--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -114,6 +114,18 @@ async def run() -> None:
     cfg = Config.from_env()
     http = aiohttp.ClientSession()
     router = make_router(cfg)
+    # The STANDARD voice prompt lives in the mesh (@{user}/Voice/Prompt — deposited on
+    # first start, editable in the portal); an explicit SYSTEM_PROMPT_FILE stays the
+    # strongest override for local experiments.
+    if not cfg.system_prompt_file:
+        from .ollama import SYSTEM_PROMPT
+        try:
+            remote = await router.sync_system_prompt(SYSTEM_PROMPT)
+        except Exception:
+            remote = SYSTEM_PROMPT
+        if remote.strip():
+            router.apply_system_prompt(remote.strip()
+                                       + (DIALECT_SUFFIX if cfg.speak_dialect else ""))
     tts = make_tts(cfg)
     server = TtsFileServer(cfg.gateway_host, cfg.gateway_port)
     await server.start()

--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -174,6 +174,7 @@ async def run() -> None:
         hold_phrase_for=router.describe_hold,
         answer_to_template=phrases_for(cfg.stt_language)["answer_to"],
         drain_delegations=router.drain_delegations,
+        deliver=router.deliver_answer if cfg.announce_mode == "signal" else None,
     )
     link = SatelliteLink(cfg, pipeline)
 

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -38,7 +38,9 @@ PHRASES: dict[str, dict[str, str]] = {
            "posted": "Posted to the thread about {topic}. I will announce the answer.",
            "no_thread": "I have no open thread about {topic}.",
            "threads_open": "Open threads: {list}.",
-           "no_threads": "No open threads."},
+           "no_threads": "No open threads.",
+           "ready": "The answer about {topic} is ready. Say: read it.",
+           "nothing_new": "No new answers."},
     "de": {"hold": "Ich schaue nach. Einen Moment bitte.",
            "error": "Entschuldigung, das hat gerade nicht geklappt.",
            "connected": "Verbunden mit {name}.",
@@ -50,7 +52,9 @@ PHRASES: dict[str, dict[str, str]] = {
            "posted": "An den Thread über {topic} geschickt. Ich melde mich mit der Antwort.",
            "no_thread": "Ich habe keinen offenen Thread über {topic}.",
            "threads_open": "Offene Threads: {list}.",
-           "no_threads": "Keine offenen Threads."},
+           "no_threads": "Keine offenen Threads.",
+           "ready": "Die Antwort zu {topic} ist bereit. Sag: vorlesen.",
+           "nothing_new": "Keine neuen Antworten."},
 }
 PHRASES["en"]["answer_to"] = "Answering your question: {question} —"
 PHRASES["de"]["answer_to"] = "Antwort auf deine Frage: {question} —"
@@ -85,7 +89,10 @@ class Config:
 
     # --- conversation pacing ---
     reply_budget_s: float = 10.0            # wait this long for the answer before acking
-    announce_budget_s: float = 240.0        # keep polling this long, then announce the answer
+    announce_budget_s: float = 1800.0       # keep polling this long — memex is ASYNC, real
+                                            # work takes minutes; the poll backs off to 10s
+    announce_mode: str = "signal"           # "signal": chime + mailbox, answer on "vorlesen";
+                                            # "full": speak the whole answer unprompted
     thread_idle_minutes: float = 5.0        # reuse the conversation within this window
     hold_phrase: str = ""                   # default: PHRASES[stt_language]["hold"]
     error_phrase: str = ""                  # default: PHRASES[stt_language]["error"]
@@ -155,7 +162,8 @@ class Config:
             stt_token=stt_token,
             stt_language=_env("STT_LANGUAGE", "de") or "de",
             reply_budget_s=float(_env("REPLY_BUDGET_S", "10")),
-            announce_budget_s=float(_env("ANNOUNCE_BUDGET_S", "240")),
+            announce_budget_s=float(_env("ANNOUNCE_BUDGET_S", "1800")),
+            announce_mode=(_env("ANNOUNCE_MODE", "signal") or "signal").lower(),
             thread_idle_minutes=float(_env("THREAD_IDLE_MINUTES", "5")),
             hold_phrase=_env("HOLD_PHRASE") or phrases_for(_env("STT_LANGUAGE", "de") or "de")["hold"],
             error_phrase=_env("ERROR_PHRASE") or phrases_for(_env("STT_LANGUAGE", "de") or "de")["error"],

--- a/clients/voice-gateway/memex_voice_gateway/ollama.py
+++ b/clients/voice-gateway/memex_voice_gateway/ollama.py
@@ -34,8 +34,13 @@ SYSTEM_PROMPT = (
     "tools works the task — for anything that needs current information from the web, "
     "documents, writing or changing data, or multi-step work. Anything about EMAIL — "
     "reading, summarizing, or sending mail — always delegates to the ExecutiveAssistant "
-    "agent. After delegating, tell the user in ONE sentence that Memex is on it and will "
-    "announce the answer."
+    "agent: it acts on the user's own mailbox and calendar. NEVER claim you cannot access "
+    "email and NEVER tell the user to open a mail program — delegate instead. After "
+    "delegating, tell the user in ONE sentence that Memex is on it and will announce the "
+    "answer.\n\n"
+    "You never lack capability: whatever you cannot do on-device, the mesh can. Whenever "
+    "you think 'I cannot do that', that is EXACTLY when to call delegate_to_memex — never "
+    "refuse, never apologize for missing abilities, never send the user to another app."
 )
 
 _WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]

--- a/clients/voice-gateway/memex_voice_gateway/pipeline.py
+++ b/clients/voice-gateway/memex_voice_gateway/pipeline.py
@@ -72,7 +72,12 @@ class VoicePipeline:
         hold_phrase_for: Callable[[str], str] | None = None,
         answer_to_template: str | None = None,
         drain_delegations: Callable[[], list] | None = None,
+        deliver: Callable[[str, str, str], str] | None = None,
     ) -> None:
+        # deliver(handle, task, reply) -> the text to SPEAK when an async answer lands
+        # (signal mode: a short ready-chime; the full text waits for a spoken "vorlesen").
+        # None keeps the original behavior: announce the full answer immediately.
+        self._deliver = deliver
         self._drain_delegations = drain_delegations
         self._command_handler = command_handler
         self._stream_text = stream_text
@@ -162,10 +167,20 @@ class VoicePipeline:
         try:
             reply = await self._await_reply(thread_path, self._announce_budget_s)
             if reply is None:
+                logger.warning("no answer within %.0fs for %r (%s)",
+                               self._announce_budget_s, transcript[:60], thread_path)
                 reply = self._error_phrase
+            elif self._deliver is not None:
+                # Mailbox mode: store the answer, speak only the short READY signal.
+                signal = self._deliver(thread_path, transcript, reply)
+                logger.info("answer ready for %r (%s) — signalling", transcript[:60], thread_path)
+                url = await self._speak(signal)
+                await self._announce(url, signal)
+                return
             if self._answer_to_template:
                 question = transcript if len(transcript) <= 60 else transcript[:57] + "…"
                 reply = f"{self._answer_to_template.format(question=question)} {reply}"
+            logger.info("announcing answer for %r (%s)", transcript[:60], thread_path)
             url = await self._speak(reply)
             await self._announce(url, reply)
         except Exception:

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -108,6 +108,11 @@ _READ = re.compile(
     r"^\s*(?:vorlesen|lies\s+(?:es|sie|mir|die antwort)?\s*vor|antwort(?:en)? vorlesen|"
     r"read (?:it|the answer)|play (?:it|the answer))[.!]?\s*$", re.IGNORECASE)
 
+# EMAIL routes DETERMINISTICALLY to the ExecutiveAssistant — a small local model told
+# "delegate email" still answers "open your mail program" often enough that the rule
+# cannot live in its prompt alone (observed 2026-08-20).
+_EMAIL = re.compile(r"\b(?:e-?mails?|mails?|inbox|posteingang|mailbox)\b", re.IGNORECASE)
+
 
 class BrainRouter:
     def __init__(self, brains: dict[str, Brain], active: str,
@@ -172,6 +177,45 @@ class BrainRouter:
         if self.on_change is not None:
             self.on_change()
 
+    async def sync_system_prompt(self, default_text: str) -> str:
+        """THE STANDARD VOICE PROMPT LIVES IN THE MESH, PER USER: read
+        @{namespace}/Voice/Prompt from the delegation portal; when absent, DEPOSIT the
+        built-in standard there so the user can edit it in the portal. The mesh node wins
+        over the built-in; a local SYSTEM_PROMPT_FILE (checked by the caller) wins over
+        both. Failures degrade to the built-in — the voice must come up without a mesh."""
+        import json as _json
+        import logging
+        target = self._mesh_target()
+        if target is None:
+            return default_text
+        client = self._brains[target]
+        ns = getattr(client, "namespace", None)
+        if not ns:
+            return default_text
+        path = f"{ns}/Voice/Prompt"
+        try:
+            node = _json.loads(await client.call("get", {"path": f"@{path}"}))  # type: ignore[attr-defined]
+            body = ((node.get("content") or {}).get("body") or "").strip()
+            if body:
+                logging.getLogger(__name__).info("system prompt loaded from @%s", path)
+                return body
+        except Exception as e:
+            logging.getLogger(__name__).info("no prompt node at @%s (%r) — depositing", path, e)
+        try:
+            await client.call("create", {"node": _json.dumps({  # type: ignore[attr-defined]
+                "id": "Prompt", "namespace": f"{ns}/Voice",
+                "name": "Voice System Prompt", "nodeType": "Markdown",
+                "content": {"$type": "MarkdownContent", "body": default_text}})})
+            logging.getLogger(__name__).info("system prompt DEPOSITED at @%s — edit it there", path)
+        except Exception as e:
+            logging.getLogger(__name__).warning("could not deposit the voice prompt at @%s: %r", path, e)
+        return default_text
+
+    def apply_system_prompt(self, text: str) -> None:
+        for brain in self._brains.values():
+            if hasattr(brain, "system_prompt"):
+                brain.system_prompt = text  # type: ignore[attr-defined]
+
     def _remember(self, portal: str, path: str, task: str, agent: str | None) -> dict:
         import time
         entry = next((t for t in self._threads if t["path"] == path), None)
@@ -200,10 +244,13 @@ class BrainRouter:
         return best
 
     def _mesh_target(self) -> str | None:
-        """The portal delegations go to: the active brain when it is a mesh, else the first mesh."""
+        """The portal delegations go to: the active brain when it is a mesh, else the FIRST
+        mesh in configured order — `_mesh` is a set, and iterating it directly once sent
+        delegations to an arbitrary portal (observed: the prompt sync landing on systemorph
+        instead of the local mesh)."""
         if self.active in self._mesh:
             return self.active
-        return next(iter(self._mesh), None)
+        return next((name for name in self._brains if name in self._mesh), None)
 
     async def delegate_task(self, task: str, agent: str | None = None) -> str:
         """The local brain's triage seam, with CONTEXT: while a context thread is open,
@@ -331,6 +378,10 @@ class BrainRouter:
             self._remember(entry["portal"], entry["path"], entry["task"], entry["agent"] or None)
             self._pending.append((f"{entry['portal']}::{entry['path']}", message))
             return self._phrases["posted"].format(topic=posted.group("topic").strip())
+        if _EMAIL.search(stripped) and self._mesh_target() is not None:
+            handle = await self.delegate_task(stripped, "ExecutiveAssistant")
+            self._pending.append((handle, stripped))
+            return self._phrases["submitted"].format(portal=handle.partition("::")[0])
         switched = _SWITCH_THREAD.match(stripped)
         if switched is not None:
             entry = self._find_thread(switched.group("topic"))

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -99,7 +99,14 @@ _DEFAULT_PHRASES = {
     "no_thread": "I have no open thread about {topic}.",
     "threads_open": "Open threads: {list}.",
     "no_threads": "No open threads.",
+    "ready": "The answer about {topic} is ready. Say: read it.",
+    "nothing_new": "No new answers.",
+    "answer_to": "Answering your question: {question} —",
 }
+
+_READ = re.compile(
+    r"^\s*(?:vorlesen|lies\s+(?:es|sie|mir|die antwort)?\s*vor|antwort(?:en)? vorlesen|"
+    r"read (?:it|the answer)|play (?:it|the answer))[.!]?\s*$", re.IGNORECASE)
 
 
 class BrainRouter:
@@ -126,15 +133,19 @@ class BrainRouter:
         self._context: dict | None = None
         self._threads: list[dict] = []
         self._pending: list = []
+        # The MAILBOX: answers that arrived after their conversation ended. In signal mode
+        # the speaker plays a short ready-chime and the full text waits here for "vorlesen".
+        self._inbox: list[dict] = []
         self.on_change: Callable[[], None] | None = None
 
     # ----- the spoken context (session state) -----
 
     def session_state(self) -> dict:
-        return {"portal": self.active, "context": self._context, "threads": self._threads}
+        return {"portal": self.active, "context": self._context, "threads": self._threads,
+                "inbox": self._inbox}
 
     def restore(self, state: dict) -> None:
-        """Resume a persisted session: active portal, context, open threads."""
+        """Resume a persisted session: active portal, context, open threads, unread answers."""
         if state.get("portal") in self._brains:
             self.active = state["portal"]
         context = state.get("context")
@@ -142,6 +153,20 @@ class BrainRouter:
             self._context = context
         self._threads = [t for t in state.get("threads", [])
                          if t.get("portal") in self._mesh]
+        self._inbox = list(state.get("inbox", []))
+
+    def deliver_answer(self, handle: str, task: str, reply: str) -> str:
+        """An async answer arrived: store the full text in the mailbox and return the short
+        READY signal to speak — 'vorlesen' plays it. The answer's thread stays the pinned
+        context, so follow-ups continue exactly where the work happened."""
+        topic = task if len(task) <= 50 else task[:47] + "…"
+        self._inbox.append({"handle": handle, "task": task, "reply": reply})
+        for entry in self._threads:
+            if f"{entry['portal']}::{entry['path']}" == handle:
+                self._context = entry
+                break
+        self._changed()
+        return self._phrases["ready"].format(topic=topic)
 
     def _changed(self) -> None:
         if self.on_change is not None:
@@ -202,6 +227,8 @@ class BrainRouter:
             raise RuntimeError("no mesh portal configured")
         path = await self._brains[target].delegate(task, agent)  # type: ignore[attr-defined]
         self._remember(target, path, task, agent)
+        import logging
+        logging.getLogger(__name__).info("delegated to %s (%s): %r", target, agent or "-", task[:80])
         return f"{target}::{path}"
 
     # Irreversible mesh tools stay behind an explicit opt-in — one mis-heard word must
@@ -276,6 +303,13 @@ class BrainRouter:
         # The spoken CONTEXT commands come BEFORE the portal switch — "wechsle zum Thread
         # über X" must never be eaten by "wechsle zu {portal}".
         stripped = transcript.strip()
+        if _READ.match(stripped):
+            if not self._inbox:
+                return self._phrases["nothing_new"]
+            item = self._inbox.pop(0)
+            self._changed()
+            question = item["task"] if len(item["task"]) <= 60 else item["task"][:57] + "…"
+            return f"{self._phrases['answer_to'].format(question=question)} {item['reply']}"
         if _NEW_TOPIC.match(stripped):
             self._context = None
             self._changed()

--- a/clients/voice-gateway/memex_voice_gateway/satellite.py
+++ b/clients/voice-gateway/memex_voice_gateway/satellite.py
@@ -36,6 +36,7 @@ class SatelliteLink:
             cfg.satellite_password, noise_psk=cfg.satellite_psk,
         )
         self._endpointer: Endpointer | None = None
+        self._alt_audio = bytearray()   # channel 1 of the round, for capture diagnostics
         self._utterance_done = asyncio.Event()
         self._media_player_key: int | None = None
         self._round_task: asyncio.Task | None = None
@@ -160,13 +161,18 @@ class SatelliteLink:
             onset_timeout_s=5.0 if follow_up else 8.0,
         )
         self._utterance_done.clear()
+        self._alt_audio = bytearray()
         self._round_task = asyncio.create_task(self._run_round())
         return 0  # 0 = stream microphone audio over the API connection (no UDP)
 
     async def _handle_audio(self, data: bytes, data2: bytes | None = None) -> None:
-        # Two channels on devices with MULTI_CHANNEL_AUDIO (the XMOS sends processed + raw);
-        # channel 0 (`data`) is the echo-cancelled one — feed only that.
+        # Two channels on devices with MULTI_CHANNEL_AUDIO (the XMOS sends two feeds);
+        # we feed channel 0 to STT and RECORD channel 1 beside it — which one is actually
+        # the echo-cancelled/beamformed feed is an ASSUMPTION under test (2026-08-20:
+        # every STT model garbles room audio while the on-device wake engine hears fine).
         endpointer = self._endpointer
+        if data2 and self._endpointer is not None:
+            self._alt_audio.extend(data2)
         if endpointer is not None and endpointer.feed(data):
             self._utterance_done.set()
 
@@ -198,6 +204,10 @@ class SatelliteLink:
                 name = f"round_{_t.strftime('%Y%m%d_%H%M%S')}_{'fu' if self._follow_up else 'wake'}.wav"
                 with open(_os.path.join(self.cfg.record_dir, name), "wb") as f:
                     f.write(_wav(pcm, self.cfg.sample_rate))
+                if self._alt_audio:   # channel 1, for the which-channel-is-clean experiment
+                    with open(_os.path.join(self.cfg.record_dir,
+                                            name.replace(".wav", "_ch2.wav")), "wb") as f:
+                        f.write(_wav(bytes(self._alt_audio), self.cfg.sample_rate))
             except Exception:
                 logger.debug("recording save failed", exc_info=True)
         # A follow-up that never paused (TV, music) or never started (silence) is not

--- a/clients/voice-gateway/memex_voice_gateway/threads.py
+++ b/clients/voice-gateway/memex_voice_gateway/threads.py
@@ -164,6 +164,7 @@ class MemexThreads:
         """Poll until an assistant reply (or a dispatch failure) lands; None on budget miss."""
         deadline = time.monotonic() + budget_s
         known = self._known.setdefault(thread_path, set())
+        interval = poll_interval_s
         while time.monotonic() < deadline:
             thread_json = await self.call("get", {"path": f"@{thread_path}"})
             new_ids, failure = extract_reply(thread_json, known)
@@ -189,7 +190,11 @@ class MemexThreads:
                     known.add(message_id)
             if failure:
                 return failure
-            await asyncio.sleep(poll_interval_s)
+            # Memex is ASYNC: the announce path may wait many minutes, so the poll backs
+            # off gently (up to 10s) instead of hammering the portal every 1.5s for half
+            # an hour. The first polls stay tight so a fast answer arrives fast.
+            await asyncio.sleep(interval)
+            interval = min(interval * 1.3, 10.0)
         return None
 
     async def close(self) -> None:

--- a/clients/voice-gateway/tests/test_context.py
+++ b/clients/voice-gateway/tests/test_context.py
@@ -122,3 +122,24 @@ def test_mesh_tool_passthrough_gates_destructive():
                                                    "arguments": {"path": "@X"}}) == "ok"
 
     asyncio.run(scenario())
+
+
+def test_mailbox_signal_then_read_aloud():
+    async def scenario():
+        mesh = FakeMesh()
+        router = BrainRouter({"memex": mesh}, "memex")
+        handle = await router.delegate_task("Wetter morgen in Zürich")
+        await router.handle_command("Neues Thema")
+        # The answer lands: only a short READY signal is spoken; the text waits.
+        signal = router.deliver_answer(handle, "Wetter morgen in Zürich",
+                                       "Morgen wird es sonnig bei 24 Grad.")
+        assert "ready" in signal.lower() or "bereit" in signal.lower()
+        # …and the answered thread is pinned back as the context for follow-ups.
+        assert (await router.delegate_task("Und übermorgen?")) == handle
+        # "vorlesen" plays the stored answer, attributed to its question.
+        out = await router.handle_command("Vorlesen")
+        assert "sonnig" in out and "Wetter morgen" in out
+        # The mailbox is empty afterwards.
+        assert await router.handle_command("Lies vor") == router._phrases["nothing_new"]
+
+    asyncio.run(scenario())

--- a/clients/voice-gateway/tests/test_context.py
+++ b/clients/voice-gateway/tests/test_context.py
@@ -143,3 +143,54 @@ def test_mailbox_signal_then_read_aloud():
         assert await router.handle_command("Lies vor") == router._phrases["nothing_new"]
 
     asyncio.run(scenario())
+
+
+def test_email_routes_deterministically_to_executive_assistant():
+    async def scenario():
+        mesh = FakeMesh()
+        router = BrainRouter({"memex": mesh}, "memex",
+                             agent_homes={"ExecutiveAssistant": "memex"})
+        out = await router.handle_command("Kannst du meine Mails checken?")
+        assert out is not None and "memex" in out
+        assert mesh.started == [("Kannst du meine Mails checken?", "ExecutiveAssistant")]
+        # The answer is queued for the mailbox/announce path.
+        assert router.drain_delegations()
+        # Unrelated sentences pass through to the brain untouched.
+        assert await router.handle_command("Wie spät ist es?") is None
+
+    asyncio.run(scenario())
+
+
+def test_system_prompt_syncs_from_mesh_or_deposits():
+    import json as _json
+
+    class PromptMesh(FakeMesh):
+        def __init__(self, body=None):
+            super().__init__()
+            self.namespace = "rbuergi"
+            self.body = body
+            self.created = []
+        async def call(self, tool, arguments):
+            if tool == "get":
+                if self.body is None:
+                    raise RuntimeError("not found")
+                return _json.dumps({"content": {"$type": "MarkdownContent", "body": self.body}})
+            if tool == "create":
+                self.created.append(_json.loads(arguments["node"]))
+                return "{}"
+            raise AssertionError(tool)
+
+    async def scenario():
+        # A prompt node in the mesh WINS over the built-in.
+        mesh = PromptMesh(body="Du bist Memex, kurz und knapp.")
+        router = BrainRouter({"memex": mesh}, "memex")
+        assert await router.sync_system_prompt("BUILTIN") == "Du bist Memex, kurz und knapp."
+        # No node → the built-in is DEPOSITED for the user to edit, and used as-is.
+        mesh2 = PromptMesh(body=None)
+        router2 = BrainRouter({"memex": mesh2}, "memex")
+        assert await router2.sync_system_prompt("BUILTIN") == "BUILTIN"
+        deposited = mesh2.created[0]
+        assert deposited["namespace"] == "rbuergi/Voice" and deposited["id"] == "Prompt"
+        assert deposited["content"]["body"] == "BUILTIN"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Memex is async, and the voice UX now embraces it: a delegation acks and ends the conversation; when the answer lands the speaker plays only a short READY signal ("Die Antwort zu … ist bereit. Sag: vorlesen") and the full text waits in a mailbox — "vorlesen" / "read it" plays it attributed to its question, and the answered thread is pinned back as the context so follow-ups continue where the work happened. The mailbox persists in the session cookie.

Also: answer window 240s → 30min with poll backoff to 10s (real mesh work takes minutes), `ANNOUNCE_MODE=full` restores speak-it-all, and the delegation/announce chain now logs — its failures used to be invisible. 38 gateway tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)