### PR TITLE
fix(rn): standard layout resolution — empty area asks the node's declared default; breadcrumbs show names

### DIFF
--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -64,10 +64,11 @@ const CHAT: ChatOptions | null = {
 const chatNamespace = (inst: MeshInstance): string =>
   Platform.OS !== "web" && inst.local ? "device-user" : (CHAT?.namespacePath ?? "");
 
-// 📱 The native-local landing: the device user's own activities (the same landing as the MAUI
-// shell), served by the local mesh's device-user partition. Web keeps the docs HOME — a same-origin
+// 📱 The native-local landing: the device user's own node, rendered with its DECLARED default
+// area (the User layout declares the activities — the same landing as the MAUI shell) — the app
+// asks for the standard layout instead of naming an area. Web keeps the docs HOME — a same-origin
 // viewer is a real portal user whose partition this app cannot know.
-const DEVICE_HOME: NavTarget = { address: "device-user", area: "Activity" };
+const DEVICE_HOME: NavTarget = { address: "device-user", area: "" };
 const homeFor = (inst: MeshInstance): NavTarget =>
   Platform.OS !== "web" && inst.local ? DEVICE_HOME : HOME;
 

--- a/clients/react-native/src/Shell.tsx
+++ b/clients/react-native/src/Shell.tsx
@@ -15,7 +15,7 @@
 // client contexts (You: profile / voice / connect) — the same split the MAUI PortalShellPage renders.
 import { useEffect, useState, useSyncExternalStore, type ReactNode } from "react";
 import { View, Text, TextInput, Pressable, ScrollView, StyleSheet, useWindowDimensions } from "react-native";
-import { RenderArea, type AreaSource, type AreaTree } from "@meshweaver/react/core";
+import { RenderArea, useMeshOps, type AreaSource, type AreaTree } from "@meshweaver/react/core";
 import { areaErrorMessage } from "./areaError";
 import { type NavTarget } from "./nav";
 import { CLIENT_MENUS, ClientScreen, type ClientDestination } from "./screens";
@@ -25,11 +25,14 @@ import { LeftMenuView } from "./leftMenu";
 
 const useSheet = () => useStyles(makeStyles);
 
-const CONTENT_AREA = "Overview";
+// EMPTY area = the node's DECLARED default area, resolved server-side — the same standard-layout
+// resolution Blazor and portal-next use (the layout tree carries a `""` indirection to whatever
+// area the node's layout declares). The shell never hardcodes an area name for plain navigation.
+const DEFAULT_AREA = "";
 // The default home landing — the documentation home, used on the web (a same-origin viewer's own
 // partition is unknown to this app). On the native LOCAL mesh App.tsx passes the device user's
-// activities instead (device-user/Activity, the MAUI shell's landing) via the `home` prop.
-export const HOME: NavTarget = { address: "Doc/Architecture", area: CONTENT_AREA };
+// node instead via the `home` prop; its declared default area is the activities.
+export const HOME: NavTarget = { address: "Doc/Architecture", area: DEFAULT_AREA };
 
 // The mesh menu contexts streamed as $Menu:{context}, in display order, with a glyph like MAUI's.
 const MESH_CONTEXTS: { key: string; label: string; glyph: string }[] = [
@@ -152,7 +155,7 @@ function TopBar({ onNavigate, home, isMobile, onToggleMenu, onReconnect, onManag
           placeholderTextColor={palette.textMuted}
           onSubmitEditing={() => {
             const a = q.trim().replace(/^\/+/, "");
-            if (a) onNavigate({ address: a, area: CONTENT_AREA });
+            if (a) onNavigate({ address: a, area: DEFAULT_AREA });
           }}
           returnKeyType="go"
         />
@@ -239,6 +242,34 @@ function InstanceSwitcher({ isMobile, onReconnect, onManage }: { isMobile: boole
 }
 
 // ── breadcrumb toolbar ──────────────────────────────────────────────────────────
+
+// Node display names for the breadcrumb — resolved from the mesh (each node's Name, exactly what
+// the Blazor breadcrumb shows) and cached per instance+path; the raw path segment is only the
+// not-yet-resolved fallback. Without this the crumb reads like an id ("device-user"), not a name.
+const crumbNameCache = new Map<string, string>();
+function useCrumbNames(address: string): (prefix: string) => string | undefined {
+  const ops = useMeshOps();
+  const [, tick] = useState(0);
+  const instanceUrl = currentInstance().url;
+  const keyFor = (prefix: string) => `${instanceUrl}|${prefix}`;
+  useEffect(() => {
+    if (!ops?.search) return;
+    const segs = address.split("/").filter(Boolean);
+    for (let i = 0; i < segs.length; i++) {
+      const prefix = segs.slice(0, i + 1).join("/");
+      if (crumbNameCache.has(keyFor(prefix))) continue;
+      void ops.search(`path:${prefix}`, undefined, 1)
+        .then((rows) => {
+          const name = rows?.[0] && typeof (rows[0] as any).name === "string" ? String((rows[0] as any).name) : null;
+          if (name) { crumbNameCache.set(keyFor(prefix), name); tick((n) => n + 1); }
+        })
+        .catch(() => {});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [address, ops, instanceUrl]);
+  return (prefix) => crumbNameCache.get(keyFor(prefix));
+}
+
 function Breadcrumb({
   nav,
   home,
@@ -252,6 +283,7 @@ function Breadcrumb({
 }): ReactNode {
   const segs = nav.address.split("/").filter(Boolean);
   const styles = useSheet();
+  const nameOf = useCrumbNames(nav.address);
   return (
     <View style={styles.crumbs}>
       <Pressable style={({ hovered }: any) => [styles.crumbBtn, hovered && styles.crumbHover]} onPress={() => onNavigate(home)}>
@@ -264,13 +296,13 @@ function Breadcrumb({
           return (
             <View key={address} style={styles.crumbSeg}>
               <Text style={styles.crumbSep}>›</Text>
-              <Pressable style={({ hovered }: any) => [styles.crumbBtn, hovered && styles.crumbHover]} onPress={() => onNavigate({ address, area: CONTENT_AREA })}>
-                <Text style={[styles.crumbText, last && styles.crumbTextLast]}>{seg}</Text>
+              <Pressable style={({ hovered }: any) => [styles.crumbBtn, hovered && styles.crumbHover]} onPress={() => onNavigate({ address, area: DEFAULT_AREA })}>
+                <Text style={[styles.crumbText, last && styles.crumbTextLast]}>{nameOf(address) ?? seg}</Text>
               </Pressable>
             </View>
           );
         })}
-      {nav.area !== CONTENT_AREA && !clientScreen ? <Text style={[styles.crumbSep, { marginLeft: 4 }]}>· {nav.area}</Text> : null}
+      {nav.area !== DEFAULT_AREA && !clientScreen ? <Text style={[styles.crumbSep, { marginLeft: 4 }]}>· {nav.area}</Text> : null}
     </View>
   );
 }
@@ -399,7 +431,7 @@ function parseHrefLocal(href: string, currentAddress: string): NavTarget | null 
     if (seg === "..") parts.pop();
     else if (seg && seg !== ".") parts.push(seg);
   }
-  return parts.length ? { address: parts.join("/"), area: CONTENT_AREA } : null;
+  return parts.length ? { address: parts.join("/"), area: DEFAULT_AREA } : null;
 }
 function ensureId(el: HTMLElement): string {
   if (!el.id) el.id = (el.textContent ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");

--- a/clients/react-native/src/Shell.tsx
+++ b/clients/react-native/src/Shell.tsx
@@ -247,6 +247,10 @@ function InstanceSwitcher({ isMobile, onReconnect, onManage }: { isMobile: boole
 // the Blazor breadcrumb shows) and cached per instance+path; the raw path segment is only the
 // not-yet-resolved fallback. Without this the crumb reads like an id ("device-user"), not a name.
 const crumbNameCache = new Map<string, string>();
+// Prefixes already looked up (in flight, or resolved to no node/name) — each instance+path is
+// queried at most once; only a THROWN search (transient network fault) clears the mark so a later
+// navigation retries. Without this, a nameless prefix re-queried on every navigation.
+const crumbNameRequested = new Set<string>();
 function useCrumbNames(address: string): (prefix: string) => string | undefined {
   const ops = useMeshOps();
   const [, tick] = useState(0);
@@ -257,13 +261,15 @@ function useCrumbNames(address: string): (prefix: string) => string | undefined 
     const segs = address.split("/").filter(Boolean);
     for (let i = 0; i < segs.length; i++) {
       const prefix = segs.slice(0, i + 1).join("/");
-      if (crumbNameCache.has(keyFor(prefix))) continue;
+      const key = keyFor(prefix);
+      if (crumbNameCache.has(key) || crumbNameRequested.has(key)) continue;
+      crumbNameRequested.add(key);
       void ops.search(`path:${prefix}`, undefined, 1)
         .then((rows) => {
           const name = rows?.[0] && typeof (rows[0] as any).name === "string" ? String((rows[0] as any).name) : null;
-          if (name) { crumbNameCache.set(keyFor(prefix), name); tick((n) => n + 1); }
+          if (name) { crumbNameCache.set(key, name); tick((n) => n + 1); }
         })
-        .catch(() => {});
+        .catch(() => crumbNameRequested.delete(key));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [address, ops, instanceUrl]);

--- a/clients/react-native/src/nav.tsx
+++ b/clients/react-native/src/nav.tsx
@@ -16,8 +16,10 @@ export const useCurrentAddress = (): string => useContext(CurrentAddressContext)
 
 /**
  * Resolve a mesh href to a nav target. Absolute (`/Doc/Architecture/X`) and relative (`Sibling`,
- * `../Other`) links both resolve to a node whose default area is `Overview`; in-page anchors (`#x`)
- * and external `http(s)` links return null (handled elsewhere / ignored).
+ * `../Other`) links both resolve to the node with an EMPTY area — the server renders the node's
+ * DECLARED default area (the same standard-layout resolution Blazor and portal-next use; the tree
+ * carries a `""` indirection to the resolved area). In-page anchors (`#x`) and external `http(s)`
+ * links return null (handled elsewhere / ignored).
  */
 export function parseHref(href: string, currentAddress: string): NavTarget | null {
   if (!href || href.startsWith("#") || /^https?:\/\//i.test(href) || href.startsWith("mailto:")) return null;
@@ -28,5 +30,5 @@ export function parseHref(href: string, currentAddress: string): NavTarget | nul
     else if (seg && seg !== ".") parts.push(seg);
   }
   if (parts.length === 0) return null;
-  return { address: parts.join("/"), area: "Overview" };
+  return { address: parts.join("/"), area: "" };
 }

--- a/clients/react-native/src/rnMeshLive.tsx
+++ b/clients/react-native/src/rnMeshLive.tsx
@@ -323,7 +323,7 @@ const MeshSearch: ControlComponent = ({ control }) => {
       {loading ? <ActivityIndicator /> : null}
       {!loading && items.length === 0 && showEmptyMessage ? <Text style={styles.muted}>{t("common.noResults")}</Text> : null}
       {items.map((n) => (
-        <Pressable key={n.path} style={styles.resultRow} onPress={() => navigate({ address: n.path, area: "Overview" })}>
+        <Pressable key={n.path} style={styles.resultRow} onPress={() => navigate({ address: n.path, area: "" })}>
           <Text style={styles.resultName}>{n.name}</Text>
           {n.description ? <Text style={styles.muted}>{n.description}</Text> : null}
           <Text style={styles.resultPath}>{n.path}</Text>
@@ -377,7 +377,7 @@ const MeshNodeCollection: ControlComponent = ({ control }) => {
   return (
     <View style={{ gap: 8 }}>
       {items.map((n) => (
-        <Pressable key={n.path} style={styles.resultRow} onPress={() => navigate({ address: n.path, area: "Overview" })}>
+        <Pressable key={n.path} style={styles.resultRow} onPress={() => navigate({ address: n.path, area: "" })}>
           <Text style={styles.resultName}>{n.name}</Text>
           {n.description ? <Text style={styles.muted}>{n.description}</Text> : null}
         </Pressable>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-mobile-standard-layouts.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-mobile-standard-layouts.md
@@ -1,0 +1,15 @@
+---
+Name: The phone app renders every node's standard layout
+Category: Fix
+Description: Navigation asks each node for its declared default layout — your own page opens on your activities — and breadcrumbs show node names instead of raw path segments.
+Icon: Sparkle
+Order: -20260820
+---
+
+# The phone app renders every node's standard layout
+
+Navigating in the phone app used to hardcode a layout area name, so tapping your own entry in the
+breadcrumb showed your profile instead of your activities — and the breadcrumb itself displayed the
+raw path segment ("device-user") rather than your name. The app now asks the mesh for each node's
+declared default layout, exactly the way the web portal resolves it, and the breadcrumb shows every
+node's display name.


### PR DESCRIPTION
## What

From live phone testing (follow-up to #1931): after onboarding, the breadcrumb read `device-user` (the raw path segment) and tapping it rendered the profile — because the RN shell hardcoded layout-area names (`Overview` for navigation, `Activity` for the device landing) instead of asking for the node's standard layout.

Per the maintainer's direction (*"should ask for standard layouts, configured the same way as Blazor and others"*):

- **Every plain navigation subscribes with an EMPTY area** — the server resolves the node's DECLARED default area (`LayoutDefinition.WithDefaultArea`), the exact mechanism Blazor and portal-next use; the layout tree's `"" → resolved-area` indirection is already pinned in `clients/react/src/live/grpcSource.test.ts`. Applied to href parsing, breadcrumb clicks, search-result navigation, the search box, HOME, and the device landing (`device-user` now renders its declared default — the activities).
- **Breadcrumbs show node display names** resolved from the mesh (cached per instance+path; the raw segment only as the not-yet-resolved fallback) — so the crumb reads your name, not `device-user`.

## Verification

- RN `npm run typecheck` clean; `npm test` 157/157
- `WhatsNewEntryIntegrityTest` green against a rebuilt DLL
- No C# changes

What's New entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)