### PR TITLE
helm: postgres.enabled for external-Postgres environments

### DIFF
--- a/deploy/helm/templates/memex-migration/job.yaml
+++ b/deploy/helm/templates/memex-migration/job.yaml
@@ -38,7 +38,9 @@ spec:
           command:
             - "sh"
             - "-c"
-            - "until nc -z memex-postgres-service 5432; do echo 'waiting for postgres'; sleep 2; done"
+            {{- $pgHost := .Values.postgres.enabled | ternary "memex-postgres-service" (.Values.config.memex_migration.MEMEX_HOST | default "memex-postgres-service") }}
+            {{- $pgPort := .Values.postgres.enabled | ternary "5432" (.Values.config.memex_migration.MEMEX_PORT | default "5432") }}
+            - "until nc -z {{ $pgHost }} {{ $pgPort }}; do echo 'waiting for postgres'; sleep 2; done"
       containers:
         - image: "{{ .Values.migration.image }}"
           name: "memex-migration"

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -56,7 +56,9 @@ spec:
           command:
             - "sh"
             - "-c"
-            - "until nc -z memex-postgres-service 5432; do echo 'waiting for postgres'; sleep 2; done"
+            {{- $pgHost := .Values.postgres.enabled | ternary "memex-postgres-service" (.Values.config.memex_portal.MEMEX_HOST | default "memex-postgres-service") }}
+            {{- $pgPort := .Values.postgres.enabled | ternary "5432" (.Values.config.memex_portal.MEMEX_PORT | default "5432") }}
+            - "until nc -z {{ $pgHost }} {{ $pgPort }}; do echo 'waiting for postgres'; sleep 2; done"
       containers:
         - image: "{{ .Values.portal.image }}"
           name: "memex-portal"

--- a/deploy/helm/templates/memex-postgres/config.yaml
+++ b/deploy/helm/templates/memex-postgres/config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 ---
 apiVersion: "v1"
 kind: "ConfigMap"
@@ -11,3 +12,4 @@ data:
   POSTGRES_HOST_AUTH_METHOD: "{{ .Values.config.memex_postgres.POSTGRES_HOST_AUTH_METHOD }}"
   POSTGRES_INITDB_ARGS: "{{ .Values.config.memex_postgres.POSTGRES_INITDB_ARGS }}"
   POSTGRES_USER: "{{ .Values.config.memex_postgres.POSTGRES_USER }}"
+{{- end }}

--- a/deploy/helm/templates/memex-postgres/secrets.yaml
+++ b/deploy/helm/templates/memex-postgres/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 ---
 apiVersion: "v1"
 kind: "Secret"
@@ -10,3 +11,4 @@ metadata:
 stringData:
   POSTGRES_PASSWORD: "{{ .Values.secrets.memex_postgres.memex_postgres_password }}"
 type: "Opaque"
+{{- end }}

--- a/deploy/helm/templates/memex-postgres/service.yaml
+++ b/deploy/helm/templates/memex-postgres/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 ---
 apiVersion: "v1"
 kind: "Service"
@@ -18,3 +19,4 @@ spec:
       protocol: "TCP"
       port: 5432
       targetPort: 5432
+{{- end }}

--- a/deploy/helm/templates/memex-postgres/statefulset.yaml
+++ b/deploy/helm/templates/memex-postgres/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 ---
 apiVersion: "apps/v1"
 kind: "StatefulSet"
@@ -49,3 +50,4 @@ spec:
         resources:
           requests:
             storage: 10Gi
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -363,6 +363,16 @@ secrets:
     # HMAC secret for INBOUND GitHub webhooks (/webhooks/github). Only an install that registers
     # its own hooks on the plugin repos needs it; a registry CONSUMER does not.
     GitHub__Webhook__Secret: ""
+# ---- In-cluster Postgres ----------------------------------------------------
+# enabled: true renders the memex-postgres StatefulSet/Service/Config/Secret (the self-host
+# default). Set false on environments that run an EXTERNAL Postgres (the AKS namespaces use the
+# Azure flexible server): the in-cluster resources are not rendered, and the portal's
+# wait-for-postgres init probes the EXTERNAL host from config.memex_portal.MEMEX_HOST instead —
+# a probe against the unrendered in-cluster service would wait forever (memex, 2026-08-20:
+# every new pod stuck Init:0/1 while the old one kept serving).
+postgres:
+  enabled: true
+
 config:
   memex_postgres:
     POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"


### PR DESCRIPTION
Every AKS namespace runs the Azure flexible server, but the chart always rendered the in-cluster Postgres — its immutable StatefulSet patch failed every `helm upgrade`, and both `wait-for-postgres` inits probed the unrendered in-cluster service, hanging every new pod at `Init:0/1` (memex today; also why the declared `replicas: 2` never materialized).

`postgres.enabled: false` skips the four in-cluster resources and points both inits at `config.*.MEMEX_HOST`. Default `true` — self-host unchanged. Verified by rendering both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)