### PR TITLE
Module landings are generations — nothing on the landing path deletes

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -535,13 +535,12 @@ public static class MemexConfiguration
             // read from somewhere else is simply invisible, and on a deployment whose /app is
             // read-only the writer cannot use AppContext.BaseDirectory at all.
             var moduleRoot = ModuleRoot.Resolve(configuration);
-            // Deferred re-lands FIRST — before anything is loaded, while no module file is open.
-            // A re-land onto a RUNNING instance cannot swap the loaded copy on an SMB volume
-            // (open files refuse deletion), so it parks at modules/.pending-<name>; this is the
-            // boot half that swaps it in. See ModuleLandingService.ApplyPendingLandings.
-            var appliedPending = ModuleLandingService.ApplyPendingLandings(moduleRoot);
-            if (appliedPending > 0)
-                Console.WriteLine($"[ModuleActivation] applied {appliedPending} deferred landing(s) before load");
+            // Generations GC — delete only what NO activation entry references and nothing holds
+            // open (skip-on-locked). Landing never deletes anything on a shared volume; this is
+            // the one reclaim point. See ModuleLandingService.CollectGarbage.
+            var collected = ModuleLandingService.CollectGarbage(moduleRoot);
+            if (collected > 0)
+                Console.WriteLine($"[ModuleActivation] modules GC removed {collected} unreferenced generation(s)");
             var persistedActivation = ModuleActivationSidecar.Read(moduleRoot,
                 msg => Console.Error.WriteLine($"[ModuleActivation] {msg}"));
             var effectiveModules = ModuleActivationBoot.ComputeEffectiveModuleEntries(
@@ -571,9 +570,23 @@ public static class MemexConfiguration
             // itself known as a missing FEATURE, which is diagnosable — a portal that will not
             // start is not.
             var resolvedModules = effectiveModules
-                // ResolveModulePath probes the modules/<name>/ publish layout first (#1644),
-                // then falls back to the classic BaseDirectory-relative location.
-                .Select(entry => (Entry: entry, Path: MeshBuilder.ResolveModulePath(entry, moduleRoot)))
+                // A store-landed entry with a GENERATION directory resolves THERE (the landing
+                // pointer — see ModuleActivationEntry.Directory); everything else keeps
+                // ResolveModulePath's probes (modules/<name>/ first, then the classic
+                // BaseDirectory-relative location).
+                .Select(entry =>
+                {
+                    var landed = persistedActivation.Entries.FirstOrDefault(e =>
+                        string.Equals(e.Name, Path.GetFileNameWithoutExtension(entry),
+                            StringComparison.OrdinalIgnoreCase));
+                    var path = !string.IsNullOrWhiteSpace(landed?.Directory)
+                        ? Path.Combine(
+                            ModuleLandingService.ModuleDirectoryFor(
+                                moduleRoot, landed!.Name, landed),
+                            landed.Name + ".dll")
+                        : MeshBuilder.ResolveModulePath(entry, moduleRoot);
+                    return (Entry: entry, Path: path);
+                })
                 .Where(candidate =>
                 {
                     if (File.Exists(candidate.Path))

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -37,6 +37,17 @@ public sealed record ModuleActivationEntry
     /// the store lane wrote it — the back-pointer Slice C's funnel uses.</summary>
     public string? PackagePath { get; init; }
 
+    /// <summary>
+    /// The GENERATION directory under <c>modules/</c> this entry's bytes live in
+    /// (<c>&lt;name&gt;@&lt;id&gt;</c>). Landing writes every version into a FRESH generation and
+    /// moves this pointer — nothing on the landing path ever deletes or overwrites a directory a
+    /// running pod may hold open, which is what made delete-based swaps unsafe on a shared volume
+    /// (2026-08-20: a rolling restart's boot-time applies half-deleted 13 of 15 module closures).
+    /// Absent → the legacy fixed folder <c>modules/&lt;name&gt;/</c>. Unreferenced generations are
+    /// garbage-collected at boot, skip-on-locked.
+    /// </summary>
+    public string? Directory { get; init; }
+
     /// <summary>The framework MVID (MeshWeaver.Graph's ModuleVersionId) the landed assemblies
     /// were built against, as the producer recorded it — DIAGNOSTIC metadata only: it names the
     /// exact build behind the bytes when something needs debugging, but it is never a gate.

--- a/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
@@ -52,14 +52,11 @@ public static class ModuleBundleSource
             // registry must never fan out a module it could not load itself.
             return ([], $"module '{moduleName}' is not loadable on this instance: {unsatisfied}");
 
-        var folder = Path.Combine(baseDirectory, "modules", moduleName);
-        // A DEFERRED re-land (the running instance had the module loaded, so the swap parked at
-        // .pending-<name> until the next boot) is the NEWEST landed content — serve it: consumers
-        // must fetch what was published, not what this process happens to still be running.
-        var pending = ModuleLandingService.PendingPathFor(baseDirectory, moduleName);
-        if (Directory.Exists(pending)
-            && File.Exists(Path.Combine(pending, moduleName + ".dll")))
-            folder = pending;
+        // The entry's GENERATION directory is the newest landed content — the one resolution
+        // rule (ModuleDirectoryFor), shared with boot. Serving follows the pointer immediately,
+        // so consumers fetch what was PUBLISHED even while this process still runs an older
+        // generation it loaded at ITS boot.
+        var folder = ModuleLandingService.ModuleDirectoryFor(baseDirectory, moduleName, entry);
         var entryDll = Path.Combine(folder, moduleName + ".dll");
         if (!File.Exists(entryDll))
             // Covers the missing folder, the transitional publish state (a module still riding the

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -299,19 +299,38 @@ public sealed class ModuleLandingService : IDisposable
                 $"Module '{name}' was not landed by the store lane (no activation entry) — "
                 + "publish-laid-out module folders are managed by the deployment, not uninstall.");
 
+        // The generation pointer is CLEARED on uninstall — a disabled entry must not keep its
+        // directory 'referenced', or boot GC could never reclaim it.
         ModuleActivationSidecar.Write(baseDirectory, list with
         {
-            Entries = list.Entries.Replace(existing, existing with { Enabled = false }),
+            Entries = list.Entries.Replace(existing,
+                existing with { Enabled = false, Directory = null }),
             PendingRestart = true,
         });
 
-        var target = Path.Combine(baseDirectory, "modules", name);
-        if (Directory.Exists(target))
-            Directory.Delete(target, recursive: true);
+        // Best-effort immediate delete: on a shared volume the files of a LOADED module refuse
+        // deletion (SMB keeps them open) — that is fine, the cleared pointer above makes the
+        // next boot's CollectGarbage reclaim the generation once no pod holds it.
+        var targets = new List<string> { Path.Combine(baseDirectory, "modules", name) };
+        if (!string.IsNullOrWhiteSpace(existing.Directory))
+            targets.Add(Path.Combine(baseDirectory, "modules", existing.Directory!));
+        foreach (var target in targets.Where(Directory.Exists))
+        {
+            try
+            {
+                Directory.Delete(target, recursive: true);
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+            {
+                logger?.LogDebug(
+                    "Uninstall of '{Name}': {Dir} is in use, boot GC reclaims it ({Reason})",
+                    name, Path.GetFileName(target), e.Message);
+            }
+        }
 
         logger?.LogInformation(
-            "Module '{Name}' UNINSTALLED: activation disabled, modules/{Name}/ deleted — "
-            + "takes effect at the next restart", name, name);
+            "Module '{Name}' UNINSTALLED: activation disabled — takes effect at the next restart",
+            name);
     }
 
     private static void ValidateFileName(string? value, string what)

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -39,48 +39,59 @@ namespace MeshWeaver.PluginCatalog;
 /// </summary>
 public sealed class ModuleLandingService : IDisposable
 {
-    /// <summary>The deferred-swap folder for a module (see the re-land fallback in
-    /// <see cref="LandModule"/>). Pure.</summary>
-    public static string PendingPathFor(string baseDirectory, string moduleName) =>
-        Path.Combine(baseDirectory, "modules", ".pending-" + moduleName);
+    /// <summary>
+    /// The directory a landed module's bytes live in: the entry's GENERATION when it names one,
+    /// else the legacy fixed folder <c>modules/&lt;name&gt;/</c>. Pure — the one resolution rule,
+    /// shared by boot and the serving side.
+    /// </summary>
+    public static string ModuleDirectoryFor(
+        string baseDirectory, string moduleName, ModuleActivationEntry? entry) =>
+        Path.Combine(baseDirectory, "modules",
+            string.IsNullOrWhiteSpace(entry?.Directory) ? moduleName : entry!.Directory!);
 
     /// <summary>
-    /// Applies every deferred landing under <c>modules/.pending-*</c> — the boot half of the
-    /// re-land fallback. MUST run before any module assembly is loaded: at that moment no file
-    /// is open, so the delete the running instance could not perform succeeds. A failed apply
-    /// logs, leaves the pending folder for the next boot, and the OLD module folder keeps
-    /// loading — stale but working, never a boot failure.
+    /// Boot-time garbage collection over <c>modules/</c>: deletes generation directories
+    /// (<c>&lt;name&gt;@&lt;id&gt;</c>) no activation entry references, leftover
+    /// <c>.staging-*</c>, and the retired <c>.pending-*</c> folders of the abandoned deferred-swap
+    /// scheme. Skip-on-locked: a directory some still-running pod holds open simply survives to
+    /// the next boot. Never touches legacy <c>&lt;name&gt;/</c> folders — entries without a
+    /// generation still resolve there.
     /// </summary>
-    /// <returns>How many pending landings were applied.</returns>
-    public static int ApplyPendingLandings(string baseDirectory, ILogger? logger = null)
+    /// <returns>How many directories were removed.</returns>
+    public static int CollectGarbage(string baseDirectory, ILogger? logger = null)
     {
         var modulesRoot = Path.Combine(baseDirectory, "modules");
         if (!Directory.Exists(modulesRoot))
             return 0;
-        var applied = 0;
-        foreach (var pending in Directory.EnumerateDirectories(modulesRoot, ".pending-*"))
+        var activation = ModuleActivationSidecar.Read(baseDirectory,
+            msg => logger?.LogError("{Message}", msg));
+        var referenced = activation.Entries
+            .Where(e => !string.IsNullOrWhiteSpace(e.Directory))
+            .Select(e => e.Directory!)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var removed = 0;
+        foreach (var dir in Directory.EnumerateDirectories(modulesRoot))
         {
-            var name = Path.GetFileName(pending)[".pending-".Length..];
-            if (string.IsNullOrWhiteSpace(name))
+            var leaf = Path.GetFileName(dir);
+            var collectable =
+                leaf.StartsWith(".staging-", StringComparison.OrdinalIgnoreCase)
+                || leaf.StartsWith(".pending-", StringComparison.OrdinalIgnoreCase)
+                || (leaf.Contains('@') && !referenced.Contains(leaf));
+            if (!collectable)
                 continue;
-            var target = Path.Combine(modulesRoot, name);
             try
             {
-                if (Directory.Exists(target))
-                    Directory.Delete(target, recursive: true);
-                Directory.Move(pending, target);
-                applied++;
-                logger?.LogInformation(
-                    "Module '{Name}': deferred landing applied at boot ({Target})", name, target);
+                Directory.Delete(dir, recursive: true);
+                removed++;
+                logger?.LogInformation("Modules GC: removed {Dir}", leaf);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
             {
-                logger?.LogError(e,
-                    "Module '{Name}': deferred landing could NOT be applied — the previous copy "
-                    + "keeps loading; the pending folder stays for the next boot", name);
+                // Held open by a still-running pod — the next boot collects it.
+                logger?.LogDebug("Modules GC: {Dir} is in use, skipped ({Reason})", leaf, e.Message);
             }
         }
-        return applied;
+        return removed;
     }
 
     // Cap 1 deliberately: LandModule/RemoveModule each read-modify-write the shared
@@ -213,41 +224,24 @@ public sealed class ModuleLandingService : IDisposable
                 + $"modules/{name}/ would SHADOW it at the next boot "
                 + "(ResolveModulePath probes the modules folder first).");
 
+        // 🚨 GENERATIONS, NEVER SWAPS. Every landing writes a FRESH directory and moves the
+        // activation pointer; nothing on this path ever deletes or overwrites a directory a
+        // running pod may hold open. The delete-based swap could not be made safe on a shared
+        // volume: an open file refuses deletion on SMB (the 409s), and the boot-time deferred
+        // apply raced the OTHER pods of a rolling restart — deletes half-succeeded and 13 of 15
+        // module closures were reduced to their entry DLL (2026-08-20). Old generations are
+        // garbage-collected at boot (CollectGarbage), skip-on-locked, once no entry references
+        // them.
         var modulesRoot = Path.Combine(baseDirectory, "modules");
-        var target = Path.Combine(modulesRoot, name);
+        var generation = $"{name}@{Guid.NewGuid():N}"[..(name.Length + 9)];
+        var target = Path.Combine(modulesRoot, generation);
         var staging = Path.Combine(modulesRoot, $".staging-{name}-{Guid.NewGuid():N}");
         Directory.CreateDirectory(staging);
         try
         {
             foreach (var (fileName, bytes) in assemblies)
                 File.WriteAllBytes(Path.Combine(staging, fileName), bytes);
-            try
-            {
-                if (Directory.Exists(target))
-                    Directory.Delete(target, recursive: true);
-                Directory.Move(staging, target);
-            }
-            catch (Exception swap) when (swap is IOException or UnauthorizedAccessException)
-            {
-                // 🚨 The target's files are OPEN — this instance has the module LOADED, and on an
-                // SMB-backed volume (Azure Files) an open file cannot be deleted, so the in-place
-                // swap fails with "Directory not empty". That is the RE-LAND-ONTO-A-RUNNING-
-                // REGISTRY case (first hit 2026-08-20: every re-published module 409'd the moment
-                // the portal actually loaded its modules). The bytes are not lost and the publish
-                // must not fail: they park as modules/.pending-<name>/, the activation entry still
-                // flips PendingRestart, and ApplyPendingLandings swaps them in at the next boot —
-                // BEFORE anything is loaded, when the delete cannot be refused. The serving side
-                // prefers the pending folder, so consumers fetch the NEW bytes immediately even
-                // while this process still runs the old ones.
-                var pending = PendingPathFor(baseDirectory, name);
-                if (Directory.Exists(pending))
-                    Directory.Delete(pending, recursive: true);
-                Directory.Move(staging, pending);
-                logger?.LogWarning(
-                    "Module '{Name}': the loaded copy's files are open, so the swap is DEFERRED — "
-                    + "staged at {Pending}; applies at the next restart ({Reason})",
-                    name, pending, swap.Message);
-            }
+            Directory.Move(staging, target);
         }
         catch
         {
@@ -274,6 +268,7 @@ public sealed class ModuleLandingService : IDisposable
             Version = version,
             MinMeshVersion = minMeshVersion,
             Enabled = true,
+            Directory = generation,
         };
         ModuleActivationSidecar.Write(baseDirectory, list with
         {

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleFunnelTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleFunnelTest.cs
@@ -120,12 +120,12 @@ public class ModuleFunnelTest(ITestOutputHelper output) : MonolithMeshTestBase(o
             .FirstAsync().ToTask();
 
         landed.Should().Be(1);
-        File.ReadAllBytes(Path.Combine(
-                landingRoot, "modules", "MeshWeaver.Social", "MeshWeaver.Social.dll"))
-            .Should().Equal("SOCIAL"u8.ToArray());
-
         var list = ModuleActivationSidecar.Read(landingRoot);
         var entry = list.Entries.Should().ContainSingle().Subject;
+        File.ReadAllBytes(Path.Combine(
+                ModuleLandingService.ModuleDirectoryFor(landingRoot, "MeshWeaver.Social", entry),
+                "MeshWeaver.Social.dll"))
+            .Should().Equal("SOCIAL"u8.ToArray());
         entry.Name.Should().Be("MeshWeaver.Social");
         entry.Version.Should().Be("1.2.0",
             "the recorded version is what lets the reconcile answer 'already landed' without a download");

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
@@ -53,19 +53,22 @@ public class ModuleLandingServiceTest : IDisposable
                 minMeshVersion: "0.0.1")
             .FirstAsync().ToTask();
 
-        // The files, in the exact layout ResolveModulePath probes.
-        File.ReadAllBytes(Path.Combine(baseDirectory, "modules", "Acme.Widgets", "Acme.Widgets.dll"))
-            .Should().Equal([1, 2, 3]);
-        File.Exists(Path.Combine(baseDirectory, "modules", "Acme.Widgets", "Acme.Widgets.Support.dll"))
-            .Should().BeTrue();
+        // The activation entry + the minimal step-10 restart-required signal.
+        var list = ModuleActivationSidecar.Read(baseDirectory);
+        var entry = list.Entries.Should().ContainSingle().Subject;
+
+        // The files land in a fresh GENERATION directory the entry points at — resolved by the
+        // one rule boot and the serving side share.
+        entry.Directory.Should().StartWith("Acme.Widgets@",
+            "a landing writes modules/<name>@<id>/ and moves the pointer — it never overwrites");
+        var dir = ModuleLandingService.ModuleDirectoryFor(baseDirectory, "Acme.Widgets", entry);
+        File.ReadAllBytes(Path.Combine(dir, "Acme.Widgets.dll")).Should().Equal([1, 2, 3]);
+        File.Exists(Path.Combine(dir, "Acme.Widgets.Support.dll")).Should().BeTrue();
         // No staging leftovers.
         Directory.GetDirectories(Path.Combine(baseDirectory, "modules"))
             .Select(Path.GetFileName)
             .Should().NotContain(n => n!.StartsWith(".staging-"));
 
-        // The activation entry + the minimal step-10 restart-required signal.
-        var list = ModuleActivationSidecar.Read(baseDirectory);
-        var entry = list.Entries.Should().ContainSingle().Subject;
         entry.Name.Should().Be("Acme.Widgets");
         entry.Source.Should().Be(ModuleActivationSources.Store);
         entry.PackagePath.Should().Be("Plugins/acme-widgets");
@@ -85,10 +88,16 @@ public class ModuleLandingServiceTest : IDisposable
         await service.LandModule("Acme.Widgets", [("Acme.Widgets.dll", [9, 9])], LiveFrameworkMvid)
             .FirstAsync().ToTask();
 
-        File.ReadAllBytes(Path.Combine(baseDirectory, "modules", "Acme.Widgets", "Acme.Widgets.dll"))
-            .Should().Equal([9, 9], "a re-landing replaces the folder atomically");
-        ModuleActivationSidecar.Read(baseDirectory).Entries
-            .Should().ContainSingle("re-landing upserts the entry, never appends a duplicate");
+        var entry = ModuleActivationSidecar.Read(baseDirectory).Entries
+            .Should().ContainSingle("re-landing upserts the entry, never appends a duplicate")
+            .Subject;
+        var dir = ModuleLandingService.ModuleDirectoryFor(baseDirectory, "Acme.Widgets", entry);
+        File.ReadAllBytes(Path.Combine(dir, "Acme.Widgets.dll"))
+            .Should().Equal([9, 9], "the pointer moves to the fresh generation");
+        Directory.GetDirectories(Path.Combine(baseDirectory, "modules"))
+            .Should().HaveCount(2,
+                "the superseded generation SURVIVES the landing path — a running pod may hold "
+                + "it open; boot GC reclaims it once nothing references it");
     }
 
     [Fact]
@@ -109,8 +118,9 @@ public class ModuleLandingServiceTest : IDisposable
                 ModulePlatformFloor.RunningVersion!,
                 "the refusal must name BOTH versions so the operator can see which side is behind");
 
-        Directory.Exists(Path.Combine(baseDirectory, "modules", "Acme.Widgets"))
-            .Should().BeFalse("declined bytes never reach disk");
+        var modulesRoot = Path.Combine(baseDirectory, "modules");
+        (Directory.Exists(modulesRoot) ? Directory.GetDirectories(modulesRoot) : [])
+            .Should().BeEmpty("declined bytes never reach disk — no generation, no staging");
         ModuleActivationSidecar.Read(baseDirectory).Entries.Should().BeEmpty();
     }
 
@@ -129,11 +139,14 @@ public class ModuleLandingServiceTest : IDisposable
                 "Acme.Widgets", [("Acme.Widgets.dll", [1])], foreignBuild, version: "1.0.0")
             .FirstAsync().ToTask();
 
-        File.Exists(Path.Combine(baseDirectory, "modules", "Acme.Widgets", "Acme.Widgets.dll"))
+        var entry = ModuleActivationSidecar.Read(baseDirectory).Entries.Should().ContainSingle()
+            .Subject;
+        File.Exists(Path.Combine(
+                ModuleLandingService.ModuleDirectoryFor(baseDirectory, "Acme.Widgets", entry),
+                "Acme.Widgets.dll"))
             .Should().BeTrue();
-        ModuleActivationSidecar.Read(baseDirectory).Entries.Should().ContainSingle()
-            .Which.FrameworkMvid.Should().Be(foreignBuild,
-                "the built-against MVID is kept as diagnostics naming the exact producing build");
+        entry.FrameworkMvid.Should().Be(foreignBuild,
+            "the built-against MVID is kept as diagnostics naming the exact producing build");
     }
 
     [Fact]
@@ -178,11 +191,15 @@ public class ModuleLandingServiceTest : IDisposable
 
         await service.RemoveModule("Acme.Widgets").FirstAsync().ToTask();
 
-        Directory.Exists(Path.Combine(baseDirectory, "modules", "Acme.Widgets"))
-            .Should().BeFalse("uninstall deletes the landed folder");
+        Directory.GetDirectories(Path.Combine(baseDirectory, "modules"))
+            .Should().BeEmpty("uninstall deletes the landed generation (best-effort here; on a "
+                + "shared volume a loaded copy survives to boot GC)");
         var list = ModuleActivationSidecar.Read(baseDirectory);
         var entry = list.Entries.Should().ContainSingle().Subject;
         entry.Enabled.Should().BeFalse("the entry is kept, disabled — history + idempotence");
+        entry.Directory.Should().BeNull(
+            "the pointer is cleared so boot GC can reclaim the generation — a disabled entry "
+            + "must not keep its directory referenced");
         list.PendingRestart.Should().BeTrue("the removal takes effect at the next restart");
     }
 

--- a/test/MeshWeaver.PluginCatalog.Test/PendingLandingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PendingLandingTest.cs
@@ -4,15 +4,17 @@ using Xunit;
 namespace MeshWeaver.PluginCatalog.Test;
 
 /// <summary>
-/// The deferred-swap half of module landing (2026-08-20): a re-land onto a RUNNING instance
-/// cannot delete the loaded copy's files on an SMB volume, so the bytes park at
-/// <c>modules/.pending-&lt;name&gt;</c> and boot swaps them in before anything is loaded — and
-/// the serving side prefers the pending folder, so consumers always fetch what was published.
+/// The GENERATIONAL landing contract (2026-08-20): a landing writes a fresh
+/// <c>modules/&lt;name&gt;@&lt;id&gt;/</c> and moves the activation pointer — nothing on the
+/// landing path ever deletes or overwrites a directory a running pod may hold open. The
+/// delete-based swap could not be made safe on a shared volume: open files refuse deletion on
+/// SMB, and the boot-time deferred apply raced the other pods of a rolling restart — 13 of 15
+/// module closures were reduced to their entry DLL. Boot GC reclaims what nothing references.
 /// </summary>
 public class PendingLandingTest : IDisposable
 {
     private readonly string root =
-        Path.Combine(Path.GetTempPath(), "mw-pending-" + Guid.NewGuid().ToString("N"));
+        Path.Combine(Path.GetTempPath(), "mw-gen-" + Guid.NewGuid().ToString("N"));
 
     public PendingLandingTest() => Directory.CreateDirectory(Path.Combine(root, "modules"));
 
@@ -30,79 +32,91 @@ public class PendingLandingTest : IDisposable
         File.WriteAllText(Path.Combine(Modules, folder, file), content);
     }
 
+    private ModuleActivationEntry Entry(string name, string? directory) =>
+        new() { Name = name, Directory = directory };
+
     [Fact]
-    public void ApplyPendingLandings_SwapsThePendingCopyIn()
+    public void ModuleDirectoryFor_FollowsThePointer_AndFallsBackToLegacy()
     {
-        Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "OLD");
-        Write(".pending-MeshWeaver.Widget", "MeshWeaver.Widget.dll", "NEW");
-        Write(".pending-MeshWeaver.Widget", "Widget.Dep.dll", "DEP");
-
-        var applied = ModuleLandingService.ApplyPendingLandings(root);
-
-        Assert.Equal(1, applied);
-        Assert.Equal("NEW", File.ReadAllText(Path.Combine(Modules, "MeshWeaver.Widget", "MeshWeaver.Widget.dll")));
-        Assert.True(File.Exists(Path.Combine(Modules, "MeshWeaver.Widget", "Widget.Dep.dll")),
-            "the whole pending closure moves, not just the entry");
-        Assert.False(Directory.Exists(Path.Combine(Modules, ".pending-MeshWeaver.Widget")),
-            "an applied pending folder is gone");
+        Assert.Equal(
+            Path.Combine(Modules, "MeshWeaver.Widget@abc12345"),
+            ModuleLandingService.ModuleDirectoryFor(root, "MeshWeaver.Widget",
+                Entry("MeshWeaver.Widget", "MeshWeaver.Widget@abc12345")));
+        // Legacy entry (no generation) and no entry at all both resolve the fixed folder.
+        Assert.Equal(
+            Path.Combine(Modules, "MeshWeaver.Widget"),
+            ModuleLandingService.ModuleDirectoryFor(root, "MeshWeaver.Widget",
+                Entry("MeshWeaver.Widget", null)));
+        Assert.Equal(
+            Path.Combine(Modules, "MeshWeaver.Widget"),
+            ModuleLandingService.ModuleDirectoryFor(root, "MeshWeaver.Widget", null));
     }
 
     [Fact]
-    public void ApplyPendingLandings_WithNoTarget_StillLands()
+    public void CollectGarbage_RemovesOnlyTheUnreferenced()
     {
-        // A pending for a module whose folder vanished (fresh volume) simply becomes the folder.
-        Write(".pending-MeshWeaver.Fresh", "MeshWeaver.Fresh.dll", "NEW");
+        // Two generations of Widget; the sidecar references the second. Plus legacy folder,
+        // leftover staging, and a retired pending — the legacy folder must SURVIVE (entries
+        // without a generation still resolve there), everything else goes.
+        Write("MeshWeaver.Widget@old00001", "MeshWeaver.Widget.dll", "OLD");
+        Write("MeshWeaver.Widget@new00002", "MeshWeaver.Widget.dll", "NEW");
+        Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "LEGACY");
+        Write(".staging-MeshWeaver.Widget-x", "half.dll", "H");
+        Write(".pending-MeshWeaver.Widget", "MeshWeaver.Widget.dll", "P");
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry
+            {
+                Name = "MeshWeaver.Widget",
+                Directory = "MeshWeaver.Widget@new00002",
+            }],
+        });
 
-        var applied = ModuleLandingService.ApplyPendingLandings(root);
+        var removed = ModuleLandingService.CollectGarbage(root);
 
-        Assert.Equal(1, applied);
-        Assert.Equal("NEW", File.ReadAllText(Path.Combine(Modules, "MeshWeaver.Fresh", "MeshWeaver.Fresh.dll")));
+        Assert.Equal(3, removed);
+        Assert.False(Directory.Exists(Path.Combine(Modules, "MeshWeaver.Widget@old00001")));
+        Assert.False(Directory.Exists(Path.Combine(Modules, ".staging-MeshWeaver.Widget-x")));
+        Assert.False(Directory.Exists(Path.Combine(Modules, ".pending-MeshWeaver.Widget")));
+        Assert.True(Directory.Exists(Path.Combine(Modules, "MeshWeaver.Widget@new00002")),
+            "the referenced generation survives");
+        Assert.True(Directory.Exists(Path.Combine(Modules, "MeshWeaver.Widget")),
+            "the legacy fixed folder survives — un-generationed entries resolve there");
     }
 
     [Fact]
-    public void ApplyPendingLandings_WithNothingPending_IsAQuietZero()
+    public void Collect_ServesTheEntrysGeneration()
     {
-        Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "OLD");
-        Assert.Equal(0, ModuleLandingService.ApplyPendingLandings(root));
-        Assert.Equal(0, ModuleLandingService.ApplyPendingLandings(
-            Path.Combine(root, "no-such-deployment")));
-    }
-
-    [Fact]
-    public void Collect_PrefersThePendingCopy_SoConsumersFetchWhatWasPublished()
-    {
-        Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "OLD");
-        Write(".pending-MeshWeaver.Widget", "MeshWeaver.Widget.dll", "NEW");
-        Write(".pending-MeshWeaver.Widget", "Widget.Dep.dll", "DEP");
+        Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "LEGACY");
+        Write("MeshWeaver.Widget@gen00001", "MeshWeaver.Widget.dll", "NEW");
+        Write("MeshWeaver.Widget@gen00001", "Widget.Dep.dll", "DEP");
+        var activation = new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry
+            {
+                Name = "MeshWeaver.Widget",
+                Directory = "MeshWeaver.Widget@gen00001",
+            }],
+        };
 
         var (files, decline) = ModuleBundleSource.Collect(
-            root, "MeshWeaver.Widget",
-            new ModuleActivationList(), _ => null);
+            root, "MeshWeaver.Widget", activation, _ => null);
 
         Assert.Null(decline);
-        Assert.All(files, f => Assert.Contains(".pending-MeshWeaver.Widget", f));
+        Assert.All(files, f => Assert.Contains("MeshWeaver.Widget@gen00001", f));
         Assert.Equal("NEW", File.ReadAllText(files[0]));
         Assert.Equal(2, files.Count);
     }
 
     [Fact]
-    public void Collect_WithoutAPending_ServesTheModuleFolder()
+    public void Collect_WithoutAGeneration_ServesTheLegacyFolder()
     {
         Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "CURRENT");
 
         var (files, decline) = ModuleBundleSource.Collect(
-            root, "MeshWeaver.Widget",
-            new ModuleActivationList(), _ => null);
+            root, "MeshWeaver.Widget", new ModuleActivationList(), _ => null);
 
         Assert.Null(decline);
         Assert.Equal("CURRENT", File.ReadAllText(files[0]));
-    }
-
-    [Fact]
-    public void PendingPathFor_IsThePendingConvention()
-    {
-        Assert.Equal(
-            Path.Combine(root, "modules", ".pending-X"),
-            ModuleLandingService.PendingPathFor(root, "X"));
     }
 }


### PR DESCRIPTION
The delete-based swap failed twice: SMB refuses deleting open files (the 409s, #1933), and #1933's boot-time deferred apply **raced the sibling pods of a rolling restart** on the shared volume — half-successful deletes reduced 13 of 15 module closures on the production registry to their entry DLL (caught before the next boot crashlooped).

**Generations**: a landing writes a fresh `modules/<name>@<id>/` and moves the activation entry's new `Directory` pointer. Boot + serving follow the pointer (`ModuleDirectoryFor`, one rule); un-generationed entries keep the legacy folder. Boot GC reclaims unreferenced generations/staging/retired-pendings, **skip-on-locked** — a directory a running pod holds open survives to the next boot. No delete ever happens on the landing path.

4 tests pin the pointer rule, GC selectivity (legacy folders survive), and serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)