### PR TITLE
/app version floor: direct-pin the module-shared Azure family

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,6 +46,9 @@
     <PackageVersion Include="Azure.Search.Documents" Version="11.7.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.10.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageVersion Include="Azure.Storage.Common" Version="12.28.0" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.84.2" />
+    <PackageVersion Include="System.ClientModel" Version="1.14.0" />
     <PackageVersion Include="Azure.Storage.Files.Shares" Version="12.25.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.62.0" />

--- a/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+++ b/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
@@ -136,6 +136,21 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.Npgsql" />
     <PackageReference Include="Aspire.Azure.Storage.Blobs" />
+    <!-- 🚨 THE /app VERSION FLOOR for module-shared assemblies. Any assembly shipped BOTH in
+         /app and inside a module bundle binds to /app's copy in the default load context
+         ("diamonds ride") — which is only safe while /app's version is ≥ every module's
+         reference. Post-shed, these four resolved from TRANSITIVE graphs (Aspire, KeyVault)
+         BELOW the central pins the modules compile against, and the mismatch is boot-fatal:
+         memex-cloud crashlooped on Azure.Storage.Blobs 12.28 (app) vs 12.29.1 (module), then on
+         Azure.Core 1.55 vs 1.60 (2026-08-20). A DIRECT reference makes the central pin apply.
+         The full conflict sweep: Azure.Core, Azure.Storage.Blobs (+Common), the Msal extension,
+         System.ClientModel. When a module bumps an Azure-family package, bump the central pin
+         here FIRST — the platform floor moves before the module's reference does. -->
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Azure.Storage.Common" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
+    <PackageReference Include="System.ClientModel" />
     <PackageReference Include="Aspire.Azure.Data.Tables" />
     <PackageReference Include="Aspire.Npgsql" />
     <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" />


### PR DESCRIPTION
Boot-fatal diamond found on memex-cloud: an assembly shipped both in /app and in a module bundle binds to /app's copy ("diamonds ride"), which is only safe while /app's version ≥ the module's reference. Post-shed, /app's Azure family resolved from Aspire/KeyVault transitives BELOW the central pins modules compile against → `FileLoadException` at host build (Azure.Storage.Blobs 12.28 vs 12.29.1, then Azure.Core 1.55 vs 1.60).

Direct references on the Distributed host make the central pins apply. A sweep of all 37 assemblies shared between /app and any module bundle found exactly four conflicts, all covered: Azure.Core 1.60.0, Azure.Storage.Blobs 12.29.1 (+Common 12.28.0), Microsoft.Identity.Client.Extensions.Msal 4.84.2, System.ClientModel 1.14.0 — verified in the produced deps.json.

Rule going forward (comment in the csproj): when a module bumps an Azure-family package, bump the platform pin FIRST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)