### PR TITLE
voice gateway: what disappointed the kids — real music, whole sentences, a warm model

### DIFF
--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -189,6 +189,11 @@ async def run() -> None:
         deliver=router.deliver_answer if cfg.announce_mode == "signal" else None,
     )
     link = SatelliteLink(cfg, pipeline)
+    router.player = link.play_media   # deterministic music: "spiel Musik/Radio …"
+    # Pre-warm the local model so the FIRST question after a quiet hour answers instantly.
+    for brain in getattr(router, "_brains", {}).values():
+        if isinstance(brain, OllamaBrain):
+            asyncio.ensure_future(brain.warmup())
 
     async def barge_in() -> None:
         await server.interrupt_streams()

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -40,7 +40,9 @@ PHRASES: dict[str, dict[str, str]] = {
            "threads_open": "Open threads: {list}.",
            "no_threads": "No open threads.",
            "ready": "The answer about {topic} is ready. Say: read it.",
-           "nothing_new": "No new answers."},
+           "nothing_new": "No new answers.",
+           "radio_on": "Here comes {station}. Say stop to end it.",
+           "song_hint": "I cannot play single songs yet — but here comes {station}."},
     "de": {"hold": "Ich schaue nach. Einen Moment bitte.",
            "error": "Entschuldigung, das hat gerade nicht geklappt.",
            "connected": "Verbunden mit {name}.",
@@ -54,7 +56,9 @@ PHRASES: dict[str, dict[str, str]] = {
            "threads_open": "Offene Threads: {list}.",
            "no_threads": "Keine offenen Threads.",
            "ready": "Die Antwort zu {topic} ist bereit. Sag: vorlesen.",
-           "nothing_new": "Keine neuen Antworten."},
+           "nothing_new": "Keine neuen Antworten.",
+           "radio_on": "Hier kommt {station}. Sag Stopp, wenn es reicht.",
+           "song_hint": "Einzelne Lieder kann ich noch nicht spielen — dafür kommt {station}."},
 }
 PHRASES["en"]["answer_to"] = "Answering your question: {question} —"
 PHRASES["de"]["answer_to"] = "Antwort auf deine Frage: {question} —"

--- a/clients/voice-gateway/memex_voice_gateway/ollama.py
+++ b/clients/voice-gateway/memex_voice_gateway/ollama.py
@@ -40,7 +40,10 @@ SYSTEM_PROMPT = (
     "answer.\n\n"
     "You never lack capability: whatever you cannot do on-device, the mesh can. Whenever "
     "you think 'I cannot do that', that is EXACTLY when to call delegate_to_memex — never "
-    "refuse, never apologize for missing abilities, never send the user to another app."
+    "refuse, never apologize for missing abilities, never send the user to another app.\n\n"
+    "Small talk, greetings, and questions about yourself or the speaker get a DIRECT "
+    "answer — never a tool call. Children talk to you too: stay warm, simple, and honest — "
+    "never invent an agent, a capability, or a promise you cannot keep this instant."
 )
 
 _WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
@@ -221,11 +224,14 @@ class OllamaBrain:
         offered = list(self.tools) + (
             [delegate_tool(self.agents)] if self.delegator is not None else [])
         try:
-            for _round in range(4):   # model → (tool) → … → model, bounded (search+get+answer)
+            for _round in range(3):   # tools on rounds 0-1; the LAST round must SPEAK —
+                # a child's "Wie heisse ich?" once sent the model tool-calling in circles
+                # until the cap killed the turn, and the spoken reply was the one word
+                # that dribbled out before the first call ("Du").
                 payload = {"model": self.model, "messages": working, "stream": True,
                            "think": False, "keep_alive": "60m",
                            "options": {"num_predict": self.num_predict}}
-                if offered:
+                if offered and _round < 2:
                     payload["tools"] = offered
                 tool_calls: list = []
                 async with self._http.post(f"{self.base_url}/api/chat", json=payload,
@@ -337,6 +343,21 @@ class OllamaBrain:
         self._tasks.pop(handle, None)
         self._chunks.pop(handle, None)   # nobody streamed this round — drop the piece queue
         return reply
+
+    async def warmup(self) -> None:
+        """Load the model into RAM before the first question — a cold 23GB MoE load reads
+        as the assistant ignoring you (measured: ~15-30s cold vs sub-second warm)."""
+        if self._http is None:
+            self._http = aiohttp.ClientSession()
+        try:
+            payload = {"model": self.model, "messages": [{"role": "user", "content": "hi"}],
+                       "stream": False, "think": False, "keep_alive": "60m",
+                       "options": {"num_predict": 1}}
+            async with self._http.post(f"{self.base_url}/api/chat", json=payload,
+                                       timeout=aiohttp.ClientTimeout(total=180)) as response:
+                await response.read()
+        except Exception:
+            pass   # warmup is best-effort; the first real question pays the load instead
 
     async def close(self) -> None:
         for task in self._tasks.values():

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -87,6 +87,7 @@ KNOWN_AGENTS = {"assistant": "Assistant", "researcher": "Researcher", "worker": 
                 "tutor": "Tutor", "voice": "Voice"}
 
 _DEFAULT_PHRASES = {
+    "error": "Sorry, that did not work.",
     "hold": "Let me check. One moment please.",
     "connected": "Connected to {name}.",
     "unknown": "I don't know {target}. Available: {names}.",
@@ -102,6 +103,8 @@ _DEFAULT_PHRASES = {
     "ready": "The answer about {topic} is ready. Say: read it.",
     "nothing_new": "No new answers.",
     "answer_to": "Answering your question: {question} —",
+    "radio_on": "Here comes {station}. Say stop to end it.",
+    "song_hint": "I cannot play single songs yet — but here comes {station}.",
 }
 
 _READ = re.compile(
@@ -112,6 +115,24 @@ _READ = re.compile(
 # "delegate email" still answers "open your mail program" often enough that the rule
 # cannot live in its prompt alone (observed 2026-08-20).
 _EMAIL = re.compile(r"\b(?:e-?mails?|mails?|inbox|posteingang|mailbox)\b", re.IGNORECASE)
+
+# MUSIC is deterministic too — the model answered a child's eight requests for a song
+# with invented promises about music agents that do not exist (observed 2026-08-20).
+# Radio streams play NOW; a named song gets radio plus an honest sentence until a music
+# library (Apple Music via Music Assistant) is connected.
+_MUSIC = re.compile(
+    r"^(?=.*\b(?:ab)?spiel\w*\b|.*\bplay\b)(?=.*\b(?:lied\w*|musik|songs?|radio)\b)|"
+    r"^\s*(?:musik|radio)\s*(?:an|bitte)?[.!]?\s*$", re.IGNORECASE | re.DOTALL)
+_MUSIC_OFF = re.compile(r"\b(?:musik|radio)\s+(?:aus|stopp?|off)\b|"
+                        r"\b(?:stopp?|stop)\s+(?:die\s+)?(?:musik|radio)\b", re.IGNORECASE)
+STATIONS = {
+    "energy": ("Energy Zürich", "https://energyzuerich.ice.infomaniak.ch/energyzuerich-high.mp3"),
+    "srf 3": ("Radio SRF 3", "http://stream.srg-ssr.ch/m/drs3/mp3_128"),
+    "srf drei": ("Radio SRF 3", "http://stream.srg-ssr.ch/m/drs3/mp3_128"),
+    "srf 1": ("Radio SRF 1", "http://stream.srg-ssr.ch/m/drs1/mp3_128"),
+    "virus": ("Radio SRF Virus", "http://stream.srg-ssr.ch/m/drsvirus/mp3_128"),
+}
+_DEFAULT_STATION = "energy"
 
 
 class BrainRouter:
@@ -128,6 +149,7 @@ class BrainRouter:
         self._mesh = mesh_brains if mesh_brains is not None else {
             n for n, b in brains.items() if hasattr(b, "delegate")}
         self._home = home     # HomeAssistant client, when configured
+        self.player: object = None   # async url -> None; the satellite's media player
         # Agent name → the portal that HOSTS it (a portal entry's "agents" list): the
         # ExecutiveAssistant may live on the local mesh while Researcher lives in the cloud.
         self._agent_homes = agent_homes or {}
@@ -378,6 +400,21 @@ class BrainRouter:
             self._remember(entry["portal"], entry["path"], entry["task"], entry["agent"] or None)
             self._pending.append((f"{entry['portal']}::{entry['path']}", message))
             return self._phrases["posted"].format(topic=posted.group("topic").strip())
+        if _MUSIC_OFF.search(stripped) and self.player is not None:
+            return ""    # the interrupt path stops the player quietly
+        if _MUSIC.search(stripped) and self.player is not None:
+            lowered = stripped.lower()
+            key = next((k for k in STATIONS if k in lowered), None)
+            named_song = key is None and re.search(
+                r"\b(?:lied|song)\b", lowered) and len(stripped) > 25
+            name, url = STATIONS[key or _DEFAULT_STATION]
+            try:
+                await self.player(url)  # type: ignore[operator]
+            except Exception:
+                return self._phrases["error"]
+            if named_song:
+                return self._phrases["song_hint"].format(station=name)
+            return self._phrases["radio_on"].format(station=name)
         if _EMAIL.search(stripped) and self._mesh_target() is not None:
             handle = await self.delegate_task(stripped, "ExecutiveAssistant")
             self._pending.append((handle, stripped))

--- a/clients/voice-gateway/memex_voice_gateway/satellite.py
+++ b/clients/voice-gateway/memex_voice_gateway/satellite.py
@@ -57,6 +57,12 @@ class SatelliteLink:
         except Exception:
             logger.debug("media stop failed", exc_info=True)
 
+    async def play_media(self, url: str) -> None:
+        """Start a media stream (radio, music) on the device's player."""
+        if self._media_player_key is None:
+            raise RuntimeError("no media player entity on the device")
+        self.client.media_player_command(self._media_player_key, media_url=url)
+
     # --- lifecycle -------------------------------------------------------------------
 
     async def run_forever(self) -> None:

--- a/clients/voice-gateway/tests/test_router.py
+++ b/clients/voice-gateway/tests/test_router.py
@@ -136,3 +136,34 @@ def test_delegate_routes_agent_to_its_home_portal():
         assert handle.startswith("memex::") and cloud.delegated
 
     asyncio.run(scenario())
+
+
+def test_music_commands_play_and_are_honest_about_songs():
+    class FakeBrainOnly:
+        async def ask(self, text): return "h"
+        async def await_reply(self, handle, budget_s): return None
+        async def close(self): pass
+
+    async def scenario():
+        played = []
+        router = BrainRouter({"lokal": FakeBrainOnly()}, "lokal",
+                             phrases={"radio_on": "Hier kommt {station}.",
+                                      "song_hint": "Einzelne Lieder kann ich noch nicht — dafür kommt {station}."})
+        async def player(url): played.append(url)
+        router.player = player
+        # A generic music wish plays the default station.
+        out = await router.handle_command("Kannst du für mich Musik spielen?")
+        assert out == "Hier kommt Energy Zürich." and len(played) == 1
+        # A NAMED song gets radio plus the honest sentence — never an invented promise.
+        out = await router.handle_command("Ich möchte, dass du mir ein Lied spielst und es sollte Komet heißen.")
+        assert "noch nicht" in out and len(played) == 2
+        # A named station is honored.
+        out = await router.handle_command("Spiel Radio SRF 3")
+        assert "SRF 3" in out and played[-1].endswith("drs3/mp3_128")
+        # "Musik aus" ends quietly through the interrupt path.
+        assert await router.handle_command("Musik aus") == ""
+        # Without a player wired, music requests fall through to the brain.
+        bare = BrainRouter({"lokal": FakeBrainOnly()}, "lokal")
+        assert await bare.handle_command("Spiel Musik") is None
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Followed a child's session in the round log: eight requests to play a song ('…es sollte Komet heißen') answered with invented promises about non-existent music agents, and small-talk replies truncated to single words because the tool loop ran in circles until the round cap killed the turn.

- **Music is deterministic and real**: 'spiel Musik/Radio …' plays a Swiss radio stream on the satellite's media player immediately (Energy Zürich default; SRF 1/3/Virus by name); a **named song** gets radio plus one honest sentence until a music library is connected. 'Musik aus' stops quietly. No model gets to promise music.
- **Tools only in the first two rounds** — the last round must speak, so a tool-happy turn ends in a sentence, not a fragment ('Du'). Small talk is prompted tool-free; the prompt adds: children talk to you too — warm, simple, never invented promises.
- **Model pre-warm** at gateway start — a cold 23 GB MoE load read as being ignored.

41 gateway tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)