### PR TITLE
Named-registry consumers: legacy-token fallback + per-registry secret channel

### DIFF
--- a/deploy/helm/templates/memex-portal/secrets.yaml
+++ b/deploy/helm/templates/memex-portal/secrets.yaml
@@ -92,6 +92,11 @@ stringData:
   {{- range $i, $t := .Values.secrets.memex_portal.PluginCatalog__RegistryTokens }}
   PluginCatalog__RegistryTokens__{{ $i }}: "{{ $t }}"
   {{- end }}
+  {{- /* Per-registry CONSUMER tokens, index-aligned with pluginCatalog.registries — the vault
+         half carries secrets.memex_portal.PluginCatalogConsumerRegistryTokens as a list. */}}
+  {{- range $i, $t := .Values.secrets.memex_portal.PluginCatalogConsumerRegistryTokens }}
+  PluginCatalog__Registries__{{ $i }}__Token: "{{ $t }}"
+  {{- end }}
   {{- if .Values.secrets.memex_portal.PluginCatalog__BootstrapKey }}
   # Registration bootstrap key (mwr_) — first-startup auto-registration: the install registers
   # itself at the registry and persists the issued instance key; no per-instance token copying.

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace MeshWeaver.PluginCatalog;
 
@@ -81,6 +82,15 @@ public sealed class RegistryTokenResolver(IMessageHub hub, ILogger<RegistryToken
         if (!string.IsNullOrWhiteSpace(registry.Token))
             return Observable.Return(registry.Token.Trim());
 
+        if (hub.ServiceProvider.GetService<IOptions<PluginCatalogOptions>>()?.Value is { } options
+            && LegacyTokenFallback(options, registry) is { } legacy)
+        {
+            logger.LogInformation(
+                "Registry {Url}: using the legacy PluginCatalog:RegistryToken (no per-registry token configured)",
+                registry.Url);
+            return Observable.Return(legacy);
+        }
+
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
         return Observable.Using(
                 () => accessService.ImpersonateAsSystem(),
@@ -104,6 +114,28 @@ public sealed class RegistryTokenResolver(IMessageHub hub, ILogger<RegistryToken
                 logger.LogWarning(ex, "Reading the stored registry credential for {Url} failed", registry.Url);
                 return Observable.Return("");
             });
+    }
+
+    /// <summary>
+    /// The legacy-token fallback decision, PURE: a named registry with no token of its own may
+    /// use the legacy single-registry <see cref="PluginCatalogOptions.RegistryToken"/> ONLY when
+    /// the attribution is unambiguous — the registry IS the legacy URL, or it is the sole one
+    /// configured. Without the fallback, upgrading a consumer from RegistryUrl+RegistryToken to
+    /// the named Registries shape silently drops auth and every catalog read 401s (systemorph,
+    /// 2026-08-20); without the ambiguity guard, a token could be sent to a host it was not
+    /// issued for. Null → no fallback, resolve the stored credential.
+    /// </summary>
+    public static string? LegacyTokenFallback(
+        PluginCatalogOptions options, PluginRegistryReference registry)
+    {
+        if (string.IsNullOrWhiteSpace(options.RegistryToken)
+            || !string.IsNullOrWhiteSpace(registry.Token))
+            return null;
+        var matchesLegacyUrl = !string.IsNullOrWhiteSpace(options.RegistryUrl)
+            && string.Equals(registry.Url.TrimEnd('/'), options.RegistryUrl.TrimEnd('/'),
+                StringComparison.OrdinalIgnoreCase);
+        var sole = options.Registries.Count(r => !string.IsNullOrWhiteSpace(r.Url)) == 1;
+        return matchesLegacyUrl || sole ? options.RegistryToken.Trim() : null;
     }
 
     private PluginRegistryCredential? ContentAs(MeshNode? node)

--- a/test/MeshWeaver.PluginCatalog.Test/RegistryTokenFallbackTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RegistryTokenFallbackTest.cs
@@ -1,0 +1,70 @@
+#pragma warning disable CS1591
+
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The legacy-token fallback decision (<see cref="RegistryTokenResolver.LegacyTokenFallback"/>):
+/// a named registry with no token of its own inherits the legacy
+/// <c>PluginCatalog:RegistryToken</c> ONLY when attribution is unambiguous — it is the legacy URL
+/// or the sole configured registry. Without the fallback, upgrading a consumer to the named
+/// Registries shape silently drops auth (every catalog read 401s — systemorph, 2026-08-20);
+/// without the guard, a token could be sent to a host it was not issued for.
+/// </summary>
+public class RegistryTokenFallbackTest
+{
+    private static PluginCatalogOptions Options(
+        string legacyUrl = "", string legacyToken = "mwi_legacy",
+        params PluginRegistryReference[] registries) => new()
+    {
+        RegistryUrl = legacyUrl,
+        RegistryToken = legacyToken,
+        Registries = [.. registries],
+    };
+
+    [Fact]
+    public void SoleNamedRegistry_WithoutOwnToken_InheritsTheLegacyToken()
+    {
+        var reg = new PluginRegistryReference { Name = "Plugins", Url = "https://reg.example" };
+        Assert.Equal("mwi_legacy",
+            RegistryTokenResolver.LegacyTokenFallback(Options(registries: reg), reg));
+    }
+
+    [Fact]
+    public void MatchingLegacyUrl_InheritsTheLegacyToken_EvenAmongSeveral()
+    {
+        var plugins = new PluginRegistryReference { Name = "Plugins", Url = "https://reg.example" };
+        var edu = new PluginRegistryReference { Name = "Edu", Url = "https://other.example" };
+        var options = Options(legacyUrl: "https://reg.example/", registries: [plugins, edu]);
+        Assert.Equal("mwi_legacy", RegistryTokenResolver.LegacyTokenFallback(options, plugins));
+    }
+
+    [Fact]
+    public void AmbiguousRegistry_DoesNotInheritTheLegacyToken()
+    {
+        var plugins = new PluginRegistryReference { Name = "Plugins", Url = "https://reg.example" };
+        var edu = new PluginRegistryReference { Name = "Edu", Url = "https://other.example" };
+        var options = Options(registries: [plugins, edu]);
+        Assert.Null(RegistryTokenResolver.LegacyTokenFallback(options, edu));
+        Assert.Null(RegistryTokenResolver.LegacyTokenFallback(options, plugins));
+    }
+
+    [Fact]
+    public void OwnToken_SuppressesTheFallback()
+    {
+        var reg = new PluginRegistryReference
+        {
+            Name = "Plugins", Url = "https://reg.example", Token = "mwi_own",
+        };
+        Assert.Null(RegistryTokenResolver.LegacyTokenFallback(Options(registries: reg), reg));
+    }
+
+    [Fact]
+    public void NoLegacyToken_NoFallback()
+    {
+        var reg = new PluginRegistryReference { Name = "Plugins", Url = "https://reg.example" };
+        Assert.Null(RegistryTokenResolver.LegacyTokenFallback(
+            Options(legacyToken: "", registries: reg), reg));
+    }
+}


### PR DESCRIPTION
Upgrading a consumer from `RegistryUrl`+`RegistryToken` to the named `Registries` shape (needed so grants/`InstallByDefault` patterns match the source NAME) silently dropped auth — the resolver never fell back to the legacy token, every catalog read 401'd, zero modules landed (systemorph, live today).

- `RegistryTokenResolver.LegacyTokenFallback` — PURE decision, 5 tests: inherit the legacy token only when the registry IS the legacy URL or is the sole one configured (never send a token to a host it wasn't issued for).
- Chart: `secrets.memex_portal.PluginCatalogConsumerRegistryTokens` (list, index-aligned with `pluginCatalog.registries`) → `PluginCatalog__Registries__{i}__Token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)