### PR TITLE
Bundle index serves published modules — GitSync-native registries have no install records

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -28,6 +28,14 @@ on:
         description: Hand the packed bundles to the registry. Trunk only — a PR packs and inspects, never publishes.
         type: boolean
         default: false
+      registry-source:
+        description: >
+          The registry SOURCE these packages belong to ("Plugins", "Education", …) — it stamps the
+          landed entry's packagePath, which is the key every PluginGrant and the bundle index match
+          on. An unstamped landing is servable to nobody.
+        type: string
+        required: false
+        default: Plugins
       registry-url:
         description: The registry that will serve these bundles onward.
         type: string
@@ -175,6 +183,7 @@ jobs:
         env:
           TOKEN: ${{ secrets.publish-token }}
           REGISTRY: ${{ inputs.registry-url }}
+          REGISTRY_SOURCE: ${{ inputs.registry-source }}
           PACKAGE: ${{ matrix.entry.package }}
           MODULE: ${{ matrix.entry.module }}
           VERSION: ${{ steps.identity.outputs.version }}
@@ -186,7 +195,7 @@ jobs:
             exit 1
           fi
           code=$(curl -sS -o "$RUNNER_TEMP/publish-$MODULE.json" -w '%{http_code}' \
-            -X POST "$REGISTRY/api/plugins/bundles/$PACKAGE?version=$VERSION" \
+            -X POST "$REGISTRY/api/plugins/bundles/$PACKAGE?version=$VERSION&packagePath=$REGISTRY_SOURCE/$PACKAGE" \
             -H "Authorization: Bearer $TOKEN" \
             -H "Content-Type: application/octet-stream" \
             --data-binary "@$BUNDLE")

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -190,7 +190,8 @@ public static class PluginBundleEndpoints
                 }
 
                 var (accepted, decline) = ModulePublish.Validate(
-                    plugin, manifest, files, http.Request.Query["version"]);
+                    plugin, manifest, files, http.Request.Query["version"],
+                    http.Request.Query["packagePath"]);
                 if (accepted is null)
                 {
                     logger?.LogWarning("Module publish for {Plugin} REFUSED: {Reason}", plugin, decline);
@@ -204,6 +205,7 @@ public static class PluginBundleEndpoints
                     await landing.LandModule(
                         accepted.Module, accepted.Files,
                         frameworkMvid: accepted.FrameworkMvid,
+                        packagePath: accepted.PackagePath,
                         version: accepted.Version,
                         minMeshVersion: accepted.MinMeshVersion)
                         .FirstAsync().ToTask(ct);
@@ -316,8 +318,7 @@ public static class PluginBundleEndpoints
     {
         var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}";
 
-        return InstalledPackages(rootHub, ct)
-            .Do(packages => WarnAboutUnstampedRecords(rootHub, packages))
+        return ServableEntries(rootHub, ct)
             .Select(packages => (IReadOnlyList<BundleEntry>)packages
                 .Where(p => IsGranted(caller, p)).ToArray())
             .SelectMany(packages => ServableModules(rootHub, packages)
@@ -363,6 +364,47 @@ public static class PluginBundleEndpoints
     /// like a healthy day. Normally this logs nothing, since a record installed through any registry
     /// lane carries its source.</para>
     /// </summary>
+    /// <summary>
+    /// Everything this registry can serve: its own INSTALL RECORDS (the catalog lane) UNIONED
+    /// with the modules PUBLISHED onto it (the activation sidecar — entries whose
+    /// <c>PackagePath</c> stamps the source a <c>PluginGrant</c> matches on). The union is what
+    /// makes a GitSync-native registry serve at all: memex-cloud provisions its packages as
+    /// Spaces and never runs the catalog install, so it has NO install records — with a
+    /// record-only index its bundle feed was permanently empty and every consumer read
+    /// SkipNoBundle (found live, 2026-08-20, the first real remote consumer). Records win on a
+    /// PluginId collision — a deliberate install is more intentional than a publish.
+    /// </summary>
+    private static IObservable<IReadOnlyList<BundleEntry>> ServableEntries(
+        IMessageHub rootHub, CancellationToken ct) =>
+        InstalledPackages(rootHub, ct)
+            .Do(packages => WarnAboutUnstampedRecords(rootHub, packages))
+            .SelectMany(records =>
+            {
+                var landing = rootHub.ServiceProvider.GetService<ModuleLandingService>();
+                if (landing is null)
+                    return Observable.Return(records);
+                return landing.GetActivation().Take(1).Select(activation =>
+                {
+                    var recorded = records.Select(r => r.PluginId)
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                    var published = activation.Entries
+                        .Where(e => e.Enabled
+                            && !string.IsNullOrWhiteSpace(e.Version)
+                            && e.PackagePath?.Split('/') is { Length: 2 } segments
+                            && !recorded.Contains(segments[1]))
+                        .Select(e =>
+                        {
+                            var segments = e.PackagePath!.Split('/');
+                            return new BundleEntry(
+                                segments[1], e.Version!, segments[1],
+                                Module: e.Name,
+                                MinMeshVersion: e.MinMeshVersion,
+                                Source: segments[0]);
+                        });
+                    return (IReadOnlyList<BundleEntry>)records.Concat(published).ToArray();
+                });
+            });
+
     private static void WarnAboutUnstampedRecords(
         IMessageHub rootHub, IReadOnlyList<BundleEntry> packages)
     {
@@ -427,7 +469,7 @@ public static class PluginBundleEndpoints
     private static Task<IResult> Bundle(
         IMessageHub rootHub, string plugin, string version, string identity, string architecture,
         AuthenticatedInstance? caller, CancellationToken ct) =>
-        InstalledPackages(rootHub, ct)
+        ServableEntries(rootHub, ct)
             .SelectMany(packages =>
             {
                 // Named apart from the query-string reader Requested(HttpContext, …) above — one

--- a/src/MeshWeaver.PluginCatalog/ModulePublish.cs
+++ b/src/MeshWeaver.PluginCatalog/ModulePublish.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using MeshWeaver.Plugin.Packaging;
@@ -42,7 +43,8 @@ public static class ModulePublish
         string? Version,
         string? MinMeshVersion,
         string? FrameworkMvid,
-        IReadOnlyList<(string FileName, byte[] Bytes)> Files);
+        IReadOnlyList<(string FileName, byte[] Bytes)> Files,
+        string? PackagePath = null);
 
     /// <summary>
     /// Why <paramref name="authorizationHeader"/> may not publish, or null when it may.
@@ -84,8 +86,24 @@ public static class ModulePublish
         string plugin,
         BundleReader.Manifest? manifest,
         IReadOnlyList<BundleReader.ModuleFile> files,
-        string? version = null)
+        string? version = null,
+        string? packagePath = null)
     {
+        // The package path ("Plugins/AzureBlob") is what stamps the landed entry's SOURCE — the
+        // key every PluginGrant and serve-side filter matches on. Optional (an older publisher
+        // simply lands an unstamped entry, servable to nobody until re-published), but when
+        // given it must be a two-segment source/plugin path whose plugin half matches the URL.
+        if (!string.IsNullOrWhiteSpace(packagePath))
+        {
+            var segments = packagePath.Split('/');
+            if (segments.Length != 2
+                || segments.Any(seg => string.IsNullOrWhiteSpace(seg)
+                    || seg is "." or ".."
+                    || seg.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+                || !string.Equals(segments[1], plugin, StringComparison.OrdinalIgnoreCase))
+                return (null,
+                    $"'{packagePath}' is not a valid package path (expected <source>/{plugin})");
+        }
         if (string.IsNullOrWhiteSpace(plugin))
             return (null, "no package id was named");
         if (manifest is null)
@@ -130,6 +148,7 @@ public static class ModulePublish
             string.IsNullOrWhiteSpace(version) ? manifest.Version : version,
             manifest.Module.MinMeshVersion,
             manifest.FrameworkMvid,
-            [.. files.Select(f => (f.FileName, f.Bytes))]), null);
+            [.. files.Select(f => (f.FileName, f.Bytes))],
+            string.IsNullOrWhiteSpace(packagePath) ? null : packagePath), null);
     }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/ModulePublishTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModulePublishTest.cs
@@ -156,6 +156,32 @@ public class ModulePublishTest
     }
 
     [Fact]
+    public void APackagePathStampsTheAcceptedUpload()
+    {
+        // The path is what stamps the landed entry's SOURCE — the key grants and the bundle
+        // index match on. Its plugin half must agree with the URL, and traversal shapes are
+        // refused before anything reaches disk.
+        var manifest = Manifest(plugin: "SocialMedia", module: "MeshWeaver.Social");
+        var files = Files("MeshWeaver.Social.dll");
+
+        var (accepted, _) = ModulePublish.Validate(
+            "SocialMedia", manifest, files, packagePath: "Plugins/SocialMedia");
+        Assert.Equal("Plugins/SocialMedia", accepted!.PackagePath);
+
+        // Absent → accepted unstamped (an older publisher), never refused.
+        var (unstamped, _) = ModulePublish.Validate("SocialMedia", manifest, files);
+        Assert.NotNull(unstamped);
+        Assert.Null(unstamped!.PackagePath);
+
+        Assert.NotNull(ModulePublish.Validate(
+            "SocialMedia", manifest, files, packagePath: "Plugins/Other").DeclineReason);
+        Assert.NotNull(ModulePublish.Validate(
+            "SocialMedia", manifest, files, packagePath: "../SocialMedia").DeclineReason);
+        Assert.NotNull(ModulePublish.Validate(
+            "SocialMedia", manifest, files, packagePath: "Plugins/x/SocialMedia").DeclineReason);
+    }
+
+    [Fact]
     public void AnEmptyOrUnreadableUploadIsRefused()
     {
         Assert.NotNull(ModulePublish.Validate("SocialMedia", Manifest(), []).DeclineReason);


### PR DESCRIPTION
The bundle index/download keyed only on the registry's install records; memex-cloud (GitSync-provisioned) has none, so its bundle feed was permanently empty — every consumer read `SkipNoBundle` (found live: systemorph, the first real remote consumer, authenticated fine and adopted nothing).

- `ServableEntries` = install records **∪** sidecar entries whose `PackagePath` stamps a source (records win on collision); `IsGranted` gates both identically, so licensing semantics are unchanged.
- Publish accepts `?packagePath=<source>/<plugin>` (validated; traversal refused) → `LandModule` stamps the entry.
- `node-repo-module-pack` gains `registry-source` (default `Plugins`) and POSTs it. A re-publish stamps existing entries via fresh generations.

26/26 publish tests green (5 new for the path validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)