### PR TITLE
helm: OpenRouter__ApiKey joins the secret whitelist

### DIFF
--- a/deploy/helm/templates/memex-portal/secrets.yaml
+++ b/deploy/helm/templates/memex-portal/secrets.yaml
@@ -50,6 +50,9 @@ stringData:
   {{- if .Values.secrets.memex_portal.AzureFoundry__ApiKey }}
   AzureFoundry__ApiKey: "{{ .Values.secrets.memex_portal.AzureFoundry__ApiKey }}"
   {{- end }}
+  {{- if .Values.secrets.memex_portal.OpenRouter__ApiKey }}
+  OpenRouter__ApiKey: "{{ .Values.secrets.memex_portal.OpenRouter__ApiKey }}"
+  {{- end }}
   {{- if .Values.secrets.memex_portal.OpenAICompatible__ApiKey }}
   OpenAICompatible__ApiKey: "{{ .Values.secrets.memex_portal.OpenAICompatible__ApiKey }}"
   {{- end }}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-openrouter-key-survives-upgrades.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-openrouter-key-survives-upgrades.md
@@ -1,0 +1,16 @@
+---
+Name: The OpenRouter key survives deployments
+Category: Fix
+Description: Deployments can now carry their OpenRouter API key in the release values, so OpenRouter-served models keep working after an upgrade instead of losing their key.
+Icon: Sparkle
+Order: -20260820
+---
+
+# The OpenRouter key survives deployments
+
+Deployments that serve models through OpenRouter had no place to declare the API key in their
+release configuration — the key only existed as a live, hand-applied setting, and an upgrade could
+ship without it, leaving OpenRouter-served models unable to answer.
+
+The release configuration now carries the OpenRouter key alongside the other AI provider keys, so
+it is part of every deployment and models keep working across upgrades.


### PR DESCRIPTION
The memex-portal secrets template renders a fixed whitelist of AI provider keys — OpenRouter was missing, so a deployment serving models through OpenRouter (both AKS portals do: the `z-ai/glm-5.2` ModelTier default) could only carry its key as a live kubectl patch. The 2026-08-20 memex.systemorph.com incident hit exactly this: the first repo-driven helm release shipped without the key, and OpenRouter-served tiers lost their credential.

- Adds `secrets.memex_portal.OpenRouter__ApiKey` to the whitelist, same conditional shape as its neighbours (emitted only when non-empty, so a CSI-injected value is never overwritten).
- Verified with `helm template`: renders when set, absent when unset.
- The value is already staged in the memex vault half (`Systemorph/helm-values-memex`), so the next `helm-release` deploy of ns `memex` picks it up with no further step.
- What's New entry included (Category: Fix).

Incident context: Systemorph/Memex#77, #1949, #1950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)