### PR TITLE
fix: boot follows the module's generation pointer, so landed modules load (#1949)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -549,11 +549,16 @@ public static class MemexConfiguration
                 // The ONE module platform gate (ModulePlatformFloor) — never a second notion of
                 // the module platform requirement.
                 ModulePlatformFloor.DeclineReason,
-                // 🚨 modules/<name>/<name>.dll SPECIFICALLY — never ResolveModulePath, whose
-                // BaseDirectory fallback would let a sidecar entry with a lost modules/ folder
-                // silently bind a same-named app-closure DLL instead of being skipped. Baseline
-                // entries below keep ResolveModulePath (both locations are legitimate for them).
-                name => ModuleActivationBoot.LandedModuleDllExists(moduleRoot, name),
+                // 🚨 The entry's OWN landed directory SPECIFICALLY — modules/<Directory ?? name>/
+                // <name>.dll — never ResolveModulePath, whose BaseDirectory fallback would let a
+                // sidecar entry with a lost modules/ folder silently bind a same-named app-closure
+                // DLL instead of being skipped. Baseline entries below keep ResolveModulePath (both
+                // locations are legitimate for them). Passing the ENTRY rather than the name is
+                // what makes this gate agree with the resolver below: landing writes generations
+                // (modules/<name>@<gen>/) and moves the entry pointer, so a name-only check found
+                // nothing for ANY generation-landed module and boot skipped every store module on
+                // the deployment while its bytes sat correctly on disk (#1949).
+                entry => ModuleActivationBoot.LandedModuleDllExists(moduleRoot, entry),
                 (module, reason) => Console.Error.WriteLine(
                     $"[ModuleActivation] SKIPPED store-installed module '{module}': {reason}"));
             // 🚨 A LISTED-BUT-ABSENT module must never crash boot. `InstallAssemblies` does
@@ -570,23 +575,15 @@ public static class MemexConfiguration
             // itself known as a missing FEATURE, which is diagnosable — a portal that will not
             // start is not.
             var resolvedModules = effectiveModules
-                // A store-landed entry with a GENERATION directory resolves THERE (the landing
-                // pointer — see ModuleActivationEntry.Directory); everything else keeps
-                // ResolveModulePath's probes (modules/<name>/ first, then the classic
-                // BaseDirectory-relative location).
-                .Select(entry =>
-                {
-                    var landed = persistedActivation.Entries.FirstOrDefault(e =>
-                        string.Equals(e.Name, Path.GetFileNameWithoutExtension(entry),
-                            StringComparison.OrdinalIgnoreCase));
-                    var path = !string.IsNullOrWhiteSpace(landed?.Directory)
-                        ? Path.Combine(
-                            ModuleLandingService.ModuleDirectoryFor(
-                                moduleRoot, landed!.Name, landed),
-                            landed.Name + ".dll")
-                        : MeshBuilder.ResolveModulePath(entry, moduleRoot);
-                    return (Entry: entry, Path: path);
-                })
+                // 🚨 ONE resolution, shared with the existence gate above
+                // (ModuleActivationBoot.ResolveLoadPath): a store-landed module resolves to the
+                // directory ITS activation entry points at — the generation the landing wrote —
+                // and a baseline entry keeps ResolveModulePath's probes. The provenance comes from
+                // the union itself rather than being re-derived here; the gate and the resolver
+                // each deciding for themselves where a module's bytes live is exactly #1949.
+                .Select(module => (
+                    module.Entry,
+                    Path: ModuleActivationBoot.ResolveLoadPath(moduleRoot, module)))
                 .Where(candidate =>
                 {
                     if (File.Exists(candidate.Path))

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-installed-modules-load-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-20-installed-modules-load-again.md
@@ -1,0 +1,15 @@
+---
+Name: Installed modules load again after a restart
+Category: Fix
+Description: Modules installed from the store are found at startup again, instead of being silently skipped so their features disappeared.
+Icon: Sparkle
+Order: -20260820
+---
+
+# Installed modules load again after a restart
+
+Installing a module writes its files into a fresh folder each time, so an update can never disturb the copy a running instance is using. Startup, however, was still looking for the older folder name — so it found nothing, skipped every installed module, and came up as if none had ever been installed.
+
+The effect was invisible until you looked for the feature: chat could not find a model to answer with, the MCP endpoint was not there, and each restart quietly re-downloaded the same modules it had just decided were missing.
+
+Startup now follows the pointer each installation records, so a module is loaded from exactly the folder it was installed into. Modules that were installed before this fix load again on the next restart, with nothing to re-install. Files a module ships for the browser — styles and scripts — are found the same way, so its pages render properly too.

--- a/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
@@ -251,9 +251,11 @@ public static class MeshModuleStaticAssetExtensions
     /// </param>
     /// <param name="logger">Receives one line per mounted or skipped dependency.</param>
     /// <param name="baseDirectory">
-    /// Where <c>modules/</c> lives; defaults to <see cref="AppContext.BaseDirectory"/>, which is
-    /// what <c>MeshBuilder.ResolveModulePath</c> probes. A parameter only so the mapping rules can
-    /// be exercised against a laid-out folder in a test.
+    /// FALLBACK root for the legacy <c>modules/&lt;Name&gt;/</c> layout, used only when a module's
+    /// loaded assembly does not say where it came from; defaults to
+    /// <see cref="AppContext.BaseDirectory"/>. The normal answer comes from the assembly itself —
+    /// see <see cref="ModuleWwwrootPath"/>. A parameter only so the mapping rules can be exercised
+    /// against a laid-out folder in a test.
     /// </param>
     internal static ModuleStaticAssetManifest Discover(
         IEnumerable<InstalledModuleAssembly> modules,
@@ -286,11 +288,11 @@ public static class MeshModuleStaticAssetExtensions
             if (string.IsNullOrEmpty(name))
                 continue;
 
-            // AppContext.BaseDirectory, matching MeshBuilder.ResolveModulePath — a module that
+            // BESIDE the assembly that was actually loaded — see ModuleWwwrootPath. A module that
             // still rides the app closure (the step-1 double-ship) has an EMPTY or absent folder
             // here, so it simply contributes nothing and the host's build-time manifest keeps
             // serving it. That is what makes this safe to switch on before any pack flips.
-            var moduleWwwroot = Path.Combine(baseDirectory, "modules", name, "wwwroot");
+            var moduleWwwroot = ModuleWwwrootPath(module.Assembly.Location, baseDirectory, name);
             if (!Directory.Exists(moduleWwwroot))
                 continue;
 
@@ -349,6 +351,46 @@ public static class MeshModuleStaticAssetExtensions
 
         return new ModuleStaticAssetManifest(mounts, stylesheets);
     }
+    /// <summary>
+    /// Where a boot-installed module's published static web assets live: <c>wwwroot</c> BESIDE the
+    /// assembly the loader actually loaded, whenever that assembly sits directly inside a
+    /// <c>modules/</c> tree.
+    ///
+    /// <para>🚨 The loaded assembly is the only thing that knows this, and asking it is what makes
+    /// the rule survive the two ways the tree moved out from under a name-based path. Landing
+    /// writes a fresh GENERATION directory per version (<c>modules/&lt;Name&gt;@&lt;id&gt;/</c>) and
+    /// moves the activation pointer — the legacy fixed <c>modules/&lt;Name&gt;/</c> folder is not
+    /// written at all any more (#1949) — and it writes into the deployment's WRITABLE, pod-shared
+    /// module root (<c>ModuleRoot</c>, <c>/data</c> on AKS), not the read-only app directory. A
+    /// path built from <see cref="AppContext.BaseDirectory"/> plus the module NAME misses on both
+    /// counts, and it misses SILENTLY: the module loads, its components render, and every asset
+    /// they request 404s.</para>
+    ///
+    /// <para>The "inside a <c>modules/</c> tree" test is what keeps a module that still rides the
+    /// APP CLOSURE contributing nothing: its assembly's directory is the app folder, whose
+    /// <c>wwwroot</c> is the HOST's — mounting that under <c>_content/&lt;Name&gt;</c> would serve
+    /// the whole host web root through a module namespace. Such a module falls back to the legacy
+    /// name-based path, which is absent for it, so it is skipped exactly as before.</para>
+    /// </summary>
+    /// <param name="assemblyLocation">The loaded module assembly's file location (empty for an
+    /// assembly with no file backing).</param>
+    /// <param name="baseDirectory">Fallback root for the legacy <c>modules/&lt;Name&gt;/</c> layout.</param>
+    /// <param name="moduleName">The module's assembly name.</param>
+    /// <returns>The absolute <c>wwwroot</c> path to inspect (it may not exist).</returns>
+    internal static string ModuleWwwrootPath(
+        string? assemblyLocation, string baseDirectory, string moduleName)
+    {
+        var assemblyDirectory = string.IsNullOrEmpty(assemblyLocation)
+            ? null
+            : Path.GetDirectoryName(assemblyLocation);
+        var parent = string.IsNullOrEmpty(assemblyDirectory)
+            ? null
+            : Path.GetFileName(Path.GetDirectoryName(assemblyDirectory));
+        return string.Equals(parent, "modules", StringComparison.OrdinalIgnoreCase)
+            ? Path.Combine(assemblyDirectory!, "wwwroot")
+            : Path.Combine(baseDirectory, "modules", moduleName, "wwwroot");
+    }
+
 }
 
 /// <summary>One mounted asset root: everything under <paramref name="PhysicalPath"/> is served at

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using MeshWeaver.Mesh;
 
 namespace MeshWeaver.PluginCatalog;
 
@@ -163,6 +164,18 @@ public static class ModuleActivationSidecar
 }
 
 /// <summary>
+/// One module the boot union activates, with the LANE it came from.
+/// </summary>
+/// <param name="Entry">The <c>Modules:Assemblies</c>-shaped entry (<c>&lt;Name&gt;.dll</c> for a
+/// sidecar entry; the operator's raw value for a baseline one).</param>
+/// <param name="Landed">The sidecar entry this came from, or <c>null</c> when it came from the
+/// appsettings baseline. 🚨 Provenance is carried rather than re-derived: a landed module's bytes
+/// live in the directory ITS entry points at, a baseline module's are resolved by probing, and a
+/// caller that guesses which lane a name belongs to is how the boot gate and the boot loader came
+/// to disagree (#1949).</param>
+public sealed record EffectiveModule(string Entry, ModuleActivationEntry? Landed);
+
+/// <summary>
 /// The boot-time union of #1664 step 9: appsettings baseline ∪ enabled persisted store installs,
 /// deduped by module name, with the two skip rules (missing DLL, unsatisfied platform floor)
 /// applied loudly — extracted PURE so the computation is unit-testable without booting a portal.
@@ -170,8 +183,15 @@ public static class ModuleActivationSidecar
 public static class ModuleActivationBoot
 {
     /// <summary>
-    /// Computes the effective <c>Modules:Assemblies</c>-shaped entry list the boot loader feeds
-    /// to <c>MeshBuilder.InstallAssemblies</c> (after per-entry <c>ResolveModulePath</c>).
+    /// Computes the effective module list the boot loader feeds to
+    /// <c>MeshBuilder.InstallAssemblies</c> (after per-module <see cref="ResolveLoadPath"/>).
+    ///
+    /// <para>Each result carries its PROVENANCE — the sidecar entry it came from, or null for an
+    /// appsettings-baseline entry — because the two lanes resolve to a file by different rules and
+    /// the caller must not re-derive which lane a name belongs to. That re-derivation is what
+    /// #1949 was: the existence gate and the load-path resolver each decided for themselves where
+    /// a module's bytes were, disagreed about generation directories, and every store module on
+    /// the deployment was skipped at boot while its bytes sat correctly on disk.</para>
     ///
     /// <para>Rules, in order:</para>
     /// <list type="bullet">
@@ -199,30 +219,33 @@ public static class ModuleActivationBoot
     /// passes <see cref="ModulePlatformFloor.DeclineReason(string?)"/> so there is never a second
     /// notion of the module platform requirement.</param>
     /// <param name="landedModuleDllExists">Whether a persisted module's LANDED entry DLL exists —
-    /// called with the module NAME, and 🚨 it must check <c>modules/&lt;name&gt;/&lt;name&gt;.dll</c>
-    /// SPECIFICALLY (production passes <see cref="LandedModuleDllExists"/>), never
-    /// <c>MeshBuilder.ResolveModulePath</c>: that resolver falls back to the app's base directory,
-    /// so a sidecar entry whose <c>modules/&lt;name&gt;/</c> folder is gone (tampered sidecar,
-    /// deleted folder) would silently BIND a same-named app-closure DLL instead of being skipped.
-    /// A store-installed module never legitimately lives in the app closure — a name collision
-    /// there is exactly what <see cref="ModuleLandingService"/> refuses at landing.</param>
+    /// called with the ENTRY, never with the bare name, because the entry is what says WHERE its
+    /// bytes are: <see cref="ModuleActivationEntry.Directory"/> names the generation directory
+    /// landing wrote them into. 🚨 It must check that ONE directory
+    /// (<c>modules/&lt;entry.Directory ?? name&gt;/&lt;name&gt;.dll</c> — production passes
+    /// <see cref="LandedModuleDllExists"/>), never <c>MeshBuilder.ResolveModulePath</c>: that
+    /// resolver falls back to the app's base directory, so a sidecar entry whose landed folder is
+    /// gone (tampered sidecar, deleted folder) would silently BIND a same-named app-closure DLL
+    /// instead of being skipped. A store-installed module never legitimately lives in the app
+    /// closure — a name collision there is exactly what <see cref="ModuleLandingService"/> refuses
+    /// at landing.</param>
     /// <param name="onSkipped">The loud channel: called once per skipped persisted entry with
     /// (module name, reason).</param>
-    public static ImmutableList<string> ComputeEffectiveModuleEntries(
+    public static ImmutableList<EffectiveModule> ComputeEffectiveModuleEntries(
         IReadOnlyList<string>? baselineEntries,
         ModuleActivationList? persisted,
         Func<string?, string?> platformGate,
-        Func<string, bool> landedModuleDllExists,
+        Func<ModuleActivationEntry, bool> landedModuleDllExists,
         Action<string, string>? onSkipped = null)
     {
-        var effective = ImmutableList.CreateBuilder<string>();
+        var effective = ImmutableList.CreateBuilder<EffectiveModule>();
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var entry in baselineEntries ?? [])
         {
             if (string.IsNullOrWhiteSpace(entry))
                 continue;
-            effective.Add(entry);
+            effective.Add(new EffectiveModule(entry, Landed: null));
             seen.Add(Path.GetFileNameWithoutExtension(entry));
         }
 
@@ -239,38 +262,75 @@ public static class ModuleActivationBoot
                 continue;
             }
 
-            if (!landedModuleDllExists(module.Name))
+            if (!landedModuleDllExists(module))
             {
                 onSkipped?.Invoke(module.Name,
-                    $"its landed DLL 'modules/{module.Name}/{module.Name}.dll' does not exist "
+                    $"its landed DLL '{RelativeLandedDll(module)}' does not exist "
                     + "(folder lost or never landed; a same-named app-closure DLL deliberately "
                     + "does NOT satisfy a store-installed entry) — re-install the module");
                 continue;
             }
 
-            effective.Add(module.Name + ".dll");
+            effective.Add(new EffectiveModule(module.Name + ".dll", module));
         }
 
         return effective.ToImmutable();
     }
 
     /// <summary>
-    /// The landed entry-DLL path of a store-installed module:
-    /// <c>{baseDirectory}/modules/{name}/{name}.dll</c> — the ONE location the landing service
-    /// writes and the boot union checks.
+    /// The landed entry-DLL path of a store-installed entry:
+    /// <c>{baseDirectory}/modules/{entry.Directory ?? entry.Name}/{entry.Name}.dll</c>.
+    ///
+    /// <para>🚨 The directory comes from the ENTRY, through the ONE resolution rule
+    /// (<see cref="ModuleLandingService.ModuleDirectoryFor"/>) the serve side and the boot loader
+    /// already share. Landing writes every version into a FRESH generation
+    /// (<c>modules/&lt;name&gt;@&lt;id&gt;/</c>) and moves this pointer; a check that looked in the
+    /// legacy fixed <c>modules/&lt;name&gt;/</c> folder would find NOTHING for any
+    /// generation-landed module — which is exactly how every store module on a
+    /// generation-landing build came up skipped at boot while its bytes sat correctly on disk
+    /// (#1949). The gate and the resolver must name ONE path or landing and activation never
+    /// converge.</para>
     /// </summary>
-    public static string LandedDllPath(string baseDirectory, string moduleName) =>
-        Path.Combine(baseDirectory, "modules", moduleName, moduleName + ".dll");
+    public static string LandedDllPath(string baseDirectory, ModuleActivationEntry entry) =>
+        Path.Combine(
+            ModuleLandingService.ModuleDirectoryFor(baseDirectory, entry.Name, entry),
+            entry.Name + ".dll");
 
     /// <summary>
     /// The PRODUCTION existence check for a persisted (store-installed) entry — the landed DLL at
     /// <see cref="LandedDllPath"/>, and nothing else. 🚨 Deliberately NOT
     /// <c>MeshBuilder.ResolveModulePath</c>: that resolver falls back to the app's base directory,
     /// which is correct for appsettings-baseline entries (both locations are legitimate for them)
-    /// but would let a sidecar entry whose <c>modules/&lt;name&gt;/</c> folder is gone silently
-    /// bind a same-named app-closure DLL instead of being skipped — a store-installed module never
-    /// legitimately lives in the app closure (the landing service refuses that collision).
+    /// but would let a sidecar entry whose landed folder is gone silently bind a same-named
+    /// app-closure DLL instead of being skipped — a store-installed module never legitimately
+    /// lives in the app closure (the landing service refuses that collision).
     /// </summary>
-    public static bool LandedModuleDllExists(string baseDirectory, string moduleName) =>
-        File.Exists(LandedDllPath(baseDirectory, moduleName));
+    public static bool LandedModuleDllExists(string baseDirectory, ModuleActivationEntry entry) =>
+        File.Exists(LandedDllPath(baseDirectory, entry));
+
+    /// <summary>
+    /// The file the boot loader loads for one <see cref="EffectiveModule"/> — the SAME resolution
+    /// the existence gate applied, which is the whole point of it living here:
+    ///
+    /// <list type="bullet">
+    ///   <item>a SIDECAR (store-landed) module resolves to <see cref="LandedDllPath"/> — its own
+    ///     landed directory and nothing else. Never <c>ResolveModulePath</c>: its app-closure
+    ///     fallback would bind a same-named platform binary for an entry the gate just decided
+    ///     was present, which is the trap-door <see cref="ModuleLandingService"/> refuses at
+    ///     landing.</item>
+    ///   <item>a BASELINE entry keeps <c>MeshBuilder.ResolveModulePath</c>'s probes (landed root's
+    ///     <c>modules/&lt;name&gt;/</c>, the image's own, then the classic BaseDirectory-relative
+    ///     location) — all of them legitimate for the image's own closure.</item>
+    /// </list>
+    /// </summary>
+    public static string ResolveLoadPath(string baseDirectory, EffectiveModule module) =>
+        module.Landed is not null
+            ? LandedDllPath(baseDirectory, module.Landed)
+            : MeshBuilder.ResolveModulePath(module.Entry, baseDirectory);
+
+    /// <summary>The entry's landed DLL as the deployment-relative path a skip report names —
+    /// the generation directory when the entry carries one, else the legacy fixed folder.</summary>
+    private static string RelativeLandedDll(ModuleActivationEntry entry) =>
+        $"modules/{(string.IsNullOrWhiteSpace(entry.Directory) ? entry.Name : entry.Directory)}"
+        + $"/{entry.Name}.dll";
 }

--- a/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
@@ -62,11 +62,11 @@ public static class ModuleBundleSource
             // Covers the missing folder, the transitional publish state (a module still riding the
             // app closure prunes its modules/ folder empty), and a lost volume alike: no entry DLL,
             // no module bundle — the package still serves its content and NodeType assemblies.
-            return ([], $"modules/{moduleName}/{moduleName}.dll does not exist on this instance");
+            return ([], $"{Path.GetFileName(folder)}/{moduleName}.dll does not exist on this instance");
 
         // Entry DLL first, the rest of the closure (dlls + symbols) in stable order. Top level
-        // only — the modules/<name>/ layout is flat by construction (ModuleLandingService writes
-        // file names, and the publish target lays closures out flat).
+        // only — a module directory is flat by construction (ModuleLandingService writes file
+        // names, and the publish target lays closures out flat).
         var files = new List<string> { entryDll };
         files.AddRange(Directory.EnumerateFiles(folder)
             .Where(f => Path.GetExtension(f).ToLowerInvariant() is ".dll" or ".pdb")

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -279,10 +279,10 @@ public sealed class ModuleLandingService : IDisposable
         });
 
         logger?.LogInformation(
-            "Module '{Name}' LANDED into modules/{Name}/ ({Count} assemblies, floor "
+            "Module '{Name}' LANDED into modules/{Generation}/ ({Count} assemblies, floor "
             + "{MinMeshVersion}, platform {Running}; built against framework MVID "
             + "{FrameworkMvid} — diagnostic) — activation recorded, RESTART REQUIRED to load it",
-            name, name, assemblies.Count, minMeshVersion ?? "(none)",
+            name, generation, assemblies.Count, minMeshVersion ?? "(none)",
             ModulePlatformFloor.RunningVersion ?? "(unknown)", frameworkMvid ?? "(unrecorded)");
     }
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
@@ -197,6 +197,55 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
         manifest.Stylesheets.Should().BeEmpty();
     }
 
+    // ---- #1949: the asset folder comes from the LOADED ASSEMBLY, not from a name-built path ----
+
+    /// <summary>
+    /// A module landed the way landing lands today — into a GENERATION directory
+    /// (<c>modules/&lt;Name&gt;@&lt;id&gt;/</c>) on the deployment's writable module ROOT, which is
+    /// not the app directory — must have its assets found there. A path built from
+    /// <c>AppContext.BaseDirectory</c> + the module NAME misses on both counts, and misses
+    /// SILENTLY: the module loads, its components render, and every asset they request 404s.
+    /// </summary>
+    [Fact]
+    public void GenerationLandedModule_TakesItsAssetsFromTheLoadedAssemblysOwnFolder()
+    {
+        // A landed module on a shared volume: /data/modules/<Name>@<gen>/<Name>.dll — a different
+        // ROOT and a different DIRECTORY SHAPE from the legacy modules/<Name>/ under the app.
+        var landed = Path.Combine("/data", "modules", $"{ModuleName}@a1b2c3d4e");
+
+        MeshModuleStaticAssetExtensions.ModuleWwwrootPath(
+                Path.Combine(landed, $"{ModuleName}.dll"),
+                AppContext.BaseDirectory,
+                ModuleName)
+            .Should().Be(Path.Combine(landed, "wwwroot"));
+
+        // The legacy fixed folder still works — same rule, it is simply the directory the
+        // assembly happens to sit in.
+        var legacy = Path.Combine("/data", "modules", ModuleName);
+        MeshModuleStaticAssetExtensions.ModuleWwwrootPath(
+                Path.Combine(legacy, $"{ModuleName}.dll"), AppContext.BaseDirectory, ModuleName)
+            .Should().Be(Path.Combine(legacy, "wwwroot"));
+    }
+
+    /// <summary>
+    /// 🚨 A module still riding the APP CLOSURE must contribute NOTHING. Its assembly sits in the
+    /// app folder, whose <c>wwwroot</c> is the HOST's — mounting that under
+    /// <c>_content/&lt;Name&gt;</c> would serve the entire host web root through a module
+    /// namespace. Only an assembly sitting directly inside a <c>modules/</c> tree supplies its own
+    /// folder; everything else falls back to the (absent) legacy name-based path.
+    /// </summary>
+    [Fact]
+    public void AppClosureModule_NeverMountsTheHostsOwnWwwroot()
+    {
+        MeshModuleStaticAssetExtensions.ModuleWwwrootPath(
+                Path.Combine("/app", $"{ModuleName}.dll"), "/app", ModuleName)
+            .Should().Be(Path.Combine("/app", "modules", ModuleName, "wwwroot"));
+
+        // No file backing at all (a dynamic assembly) degrades the same way.
+        MeshModuleStaticAssetExtensions.ModuleWwwrootPath("", "/app", ModuleName)
+            .Should().Be(Path.Combine("/app", "modules", ModuleName, "wwwroot"));
+    }
+
     /// <summary>
     /// Two modules carrying the SAME private dependency is ordinary composition, not a fault: the
     /// first mount wins and the second is skipped, rather than the loud refusal a genuine route

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationBootTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationBootTest.cs
@@ -19,7 +19,7 @@ namespace MeshWeaver.PluginCatalog.Test;
 public class ModuleActivationBootTest
 {
     private static readonly Func<string?, string?> AcceptAll = _ => null;
-    private static readonly Func<string, bool> AllDllsExist = _ => true;
+    private static readonly Func<ModuleActivationEntry, bool> AllDllsExist = _ => true;
 
     private static ModuleActivationList List(params ModuleActivationEntry[] entries) =>
         new() { Entries = [.. entries] };
@@ -36,9 +36,12 @@ public class ModuleActivationBootTest
             List(Store("Acme.Widgets"), Store("Acme.Reports")),
             AcceptAll, AllDllsExist);
 
-        effective.Should().Equal(
+        effective.Select(m => m.Entry).Should().Equal(
             "MeshWeaver.OgCard.dll", "MeshWeaver.Speech.dll",
             "Acme.Widgets.dll", "Acme.Reports.dll");
+        // The union carries each module's LANE, so the loader never re-derives it.
+        effective.Where(m => m.Landed is not null).Select(m => m.Landed!.Name)
+            .Should().Equal("Acme.Widgets", "Acme.Reports");
     }
 
     [Fact]
@@ -50,7 +53,9 @@ public class ModuleActivationBootTest
             AcceptAll, AllDllsExist);
 
         // A store install of an already-baseline module (any casing) must not double-load it.
-        effective.Should().Equal("MeshWeaver.OgCard.dll", "Acme.Widgets.dll");
+        effective.Select(m => m.Entry).Should().Equal("MeshWeaver.OgCard.dll", "Acme.Widgets.dll");
+        effective[0].Landed.Should().BeNull("the BASELINE entry won the dedupe, so it stays baseline "
+            + "— resolving it through the shadowed sidecar entry's folder would be a different file");
     }
 
     [Fact]
@@ -82,7 +87,7 @@ public class ModuleActivationBootTest
             AllDllsExist,
             (m, r) => skips.Add((m, r)));
 
-        effective.Should().Equal("MeshWeaver.OgCard.dll", "Acme.Reports.dll");
+        effective.Select(m => m.Entry).Should().Equal("MeshWeaver.OgCard.dll", "Acme.Reports.dll");
         var skip = skips.Should().ContainSingle().Subject;
         skip.Module.Should().Be("Acme.Widgets");
         skip.Reason.Should().Contain("9.0.0").And.Contain("3.2.0",
@@ -102,7 +107,7 @@ public class ModuleActivationBootTest
             floor => ModulePlatformFloor.DeclineReason(floor, "3.2.0"),
             AllDllsExist);
 
-        effective.Should().Equal("Acme.Widgets.dll");
+        effective.Select(m => m.Entry).Should().Equal("Acme.Widgets.dll");
     }
 
     [Fact]
@@ -113,10 +118,10 @@ public class ModuleActivationBootTest
             ["MeshWeaver.OgCard.dll"],
             List(Store("Acme.Widgets"), Store("Acme.Reports")),
             AcceptAll,
-            name => name != "Acme.Widgets",
+            entry => entry.Name != "Acme.Widgets",
             (m, r) => skips.Add((m, r)));
 
-        effective.Should().Equal("MeshWeaver.OgCard.dll", "Acme.Reports.dll");
+        effective.Select(m => m.Entry).Should().Equal("MeshWeaver.OgCard.dll", "Acme.Reports.dll");
         var skip = skips.Should().ContainSingle().Subject;
         skip.Module.Should().Be("Acme.Widgets");
         skip.Reason.Should().Contain("Acme.Widgets.dll");
@@ -137,15 +142,15 @@ public class ModuleActivationBootTest
         {
             Directory.CreateDirectory(Path.Combine(dir, "modules", "Acme.Widgets"));
             File.WriteAllBytes(
-                ModuleActivationBoot.LandedDllPath(dir, "Acme.Widgets"), [1]);
+                ModuleActivationBoot.LandedDllPath(dir, Store("Acme.Widgets")), [1]);
 
             var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
                 [],
                 List(Store("Acme.Widgets")),
                 AcceptAll,
-                name => ModuleActivationBoot.LandedModuleDllExists(dir, name));
+                entry => ModuleActivationBoot.LandedModuleDllExists(dir, entry));
 
-            effective.Should().Equal("Acme.Widgets.dll");
+            effective.Select(m => m.Entry).Should().Equal("Acme.Widgets.dll");
         }
         finally
         {
@@ -170,7 +175,7 @@ public class ModuleActivationBootTest
                 [],
                 List(Store("Acme.Orphan")),
                 AcceptAll,
-                name => ModuleActivationBoot.LandedModuleDllExists(dir, name),
+                entry => ModuleActivationBoot.LandedModuleDllExists(dir, entry),
                 (m, r) => skips.Add((m, r)));
 
             effective.Should().BeEmpty("a same-named app-closure DLL must never satisfy a store-installed entry");
@@ -182,6 +187,105 @@ public class ModuleActivationBootTest
         {
             Directory.Delete(dir, recursive: true);
         }
+    }
+
+    // ---- #1949: the gate must follow the entry's GENERATION pointer, not the legacy folder -----
+    //
+    // Landing writes every version into a FRESH modules/<name>@<gen>/ directory and moves
+    // ModuleActivationEntry.Directory; the legacy fixed modules/<name>/ folder is not written at
+    // all any more. A gate that looked there found NOTHING for any generation-landed module, so
+    // every store module on the deployment was SKIPPED at boot while its bytes sat correctly on
+    // disk — and the reconciler, whose lookup DID follow the pointer, re-landed them into fresh
+    // generations on every boot. Landing and activation never converged.
+
+    /// <summary>A module landed the way landing lands today — bytes only in the generation
+    /// directory, the entry pointing at it — must LOAD, and must resolve to that directory's
+    /// DLL. Fails against the legacy-folder gate: the entry is skipped and never resolved.</summary>
+    [Fact]
+    public void GenerationLandedEntry_LoadsAtBoot_AndResolvesToItsGenerationDll()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-landed-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // Exactly what ModuleLandingService leaves behind: ONE generation directory, no
+            // legacy modules/Acme.Widgets/ folder anywhere.
+            var entry = Store("Acme.Widgets") with { Directory = "Acme.Widgets@a1b2c3d4e" };
+            var generationDir = Path.Combine(dir, "modules", entry.Directory!);
+            Directory.CreateDirectory(generationDir);
+            var generationDll = Path.Combine(generationDir, "Acme.Widgets.dll");
+            File.WriteAllBytes(generationDll, [1]);
+            Directory.Exists(Path.Combine(dir, "modules", "Acme.Widgets")).Should().BeFalse(
+                "the legacy fixed folder is deliberately NOT written — that is the whole premise");
+
+            var skips = new List<(string Module, string Reason)>();
+            var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+                [],
+                List(entry),
+                AcceptAll,
+                e => ModuleActivationBoot.LandedModuleDllExists(dir, e),
+                (m, r) => skips.Add((m, r)));
+
+            skips.Should().BeEmpty("a module landed into its generation directory is PRESENT");
+            var module = effective.Should().ContainSingle().Subject;
+            module.Entry.Should().Be("Acme.Widgets.dll");
+
+            // …and the loader resolves the very file the gate just proved exists. Gate and
+            // resolver naming one path is the invariant; #1949 was them naming two.
+            ModuleActivationBoot.ResolveLoadPath(dir, module).Should().Be(generationDll);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>The POINTER is authoritative, not the folder that happens to exist: an entry whose
+    /// generation directory is gone is skipped even when a stale legacy modules/&lt;name&gt;/ copy
+    /// sits beside it (the live stopgap shape). Otherwise boot would silently load bytes the
+    /// activation record does not point at.</summary>
+    [Fact]
+    public void EntryWhoseGenerationIsGone_IsSkipped_EvenWithAStaleLegacyCopy()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-landed-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(dir, "modules", "Acme.Widgets"));
+            File.WriteAllBytes(
+                Path.Combine(dir, "modules", "Acme.Widgets", "Acme.Widgets.dll"), [1]);
+
+            var skips = new List<(string Module, string Reason)>();
+            var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+                [],
+                List(Store("Acme.Widgets") with { Directory = "Acme.Widgets@deadbeef" }),
+                AcceptAll,
+                e => ModuleActivationBoot.LandedModuleDllExists(dir, e),
+                (m, r) => skips.Add((m, r)));
+
+            effective.Should().BeEmpty();
+            var skip = skips.Should().ContainSingle().Subject;
+            skip.Reason.Should().Contain("modules/Acme.Widgets@deadbeef/Acme.Widgets.dll",
+                "the skip must name the directory the ENTRY points at, or it sends the reader "
+                + "looking in a folder nothing writes any more");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>A BASELINE entry keeps <c>ResolveModulePath</c>'s probes — including the app-closure
+    /// fallback, which is legitimate for the image's own closure and forbidden for a sidecar
+    /// entry.</summary>
+    [Fact]
+    public void BaselineModule_ResolvesThroughResolveModulePath_NotTheLandedRule()
+    {
+        var module = new EffectiveModule("MeshWeaver.OgCard.dll", Landed: null);
+        var root = Path.Combine(Path.GetTempPath(), "mw-noroot-" + Guid.NewGuid().ToString("N"));
+
+        ModuleActivationBoot.ResolveLoadPath(root, module).Should().Be(
+            Path.Combine(AppContext.BaseDirectory, "MeshWeaver.OgCard.dll"),
+            "nothing is laid out under the module root, so the baseline entry falls back to the "
+            + "app closure exactly as ResolveModulePath does");
     }
 
     [Fact]
@@ -200,9 +304,9 @@ public class ModuleActivationBootTest
                 ["MeshWeaver.OgCard.dll"],
                 new ModuleActivationList(),
                 AcceptAll,
-                name => ModuleActivationBoot.LandedModuleDllExists(dir, name));
+                entry => ModuleActivationBoot.LandedModuleDllExists(dir, entry));
 
-            effective.Should().Equal("MeshWeaver.OgCard.dll");
+            effective.Select(m => m.Entry).Should().Equal("MeshWeaver.OgCard.dll");
         }
         finally
         {


### PR DESCRIPTION
**P0.** Every consumer that lands modules via today's generation-directory landing booted with **zero** store modules — forever. Observed on `memex.systemorph.com`: all 16 default modules landed correctly into `/data/modules/<name>@<gen>/`, and every boot printed for each of them

```
[ModuleActivation] SKIPPED store-installed module 'MeshWeaver.Mcp': its landed DLL
    'modules/MeshWeaver.Mcp/MeshWeaver.Mcp.dll' does not exist … — re-install the module
```

→ `/mcp` 404, `no chat-client factory resolves model` on every thread. Each boot then RE-LANDED all 16 into fresh generations, because the reconciler's lookup *does* follow the pointer. Landing and activation never converged.

## Which side was canonical

**The writer.** `ModuleLandingService.ModuleDirectoryFor` is documented as *the* resolution rule; the serve side (`ModuleBundleSource.Collect`) and `MemexConfiguration`'s load-path resolver already used it, and `CollectGarbage`/`RemoveCore` already reason in generations. The legacy fixed `modules/<name>/` folder is not written by anything any more. Only `ModuleActivationBoot`'s existence gate still checked it.

## The fix — remove the second opinion, don't make two places agree

The defect was structural: the gate and the resolver each decided *for themselves* where a module's bytes live. So the union now carries provenance and there is one path rule.

- `ComputeEffectiveModuleEntries` returns `EffectiveModule(Entry, Landed)` — each module with the LANE it came from — and its existence gate takes the **entry**, never a bare name.
- `LandedDllPath` / `LandedModuleDllExists` resolve through `ModuleDirectoryFor`; the new `ResolveLoadPath` is the one load-path rule (sidecar → its own landed directory, never `ResolveModulePath`'s app-closure fallback; baseline → `ResolveModulePath`'s probes). `MemexConfiguration` calls it instead of re-deriving provenance itself.
- The skip report names the directory the **entry** points at.

## Everywhere else the convention was assumed

Swept the tree for readers of either form:

| site | state |
|---|---|
| `ModuleActivationBoot` boot gate | **broken → fixed** (this issue) |
| `MeshModuleStaticAssetExtensions.Discover` | **broken → fixed** — built `modules/<Name>/wwwroot` from `AppContext.BaseDirectory` + the name, so a landed module's browser assets were missed twice over: wrong directory shape **and** wrong root (landing writes the pod-shared `Modules:Root`, `/data` on AKS). Now takes the `wwwroot` **beside the assembly that was actually loaded**, when that assembly sits inside a `modules/` tree — which keeps an app-closure module contributing nothing, since mounting `/app/wwwroot` under `_content/<Name>` would serve the host's entire web root through a module namespace. |
| `ModuleBundleSource.Collect` | already correct (`ModuleDirectoryFor`); only its decline message named the legacy folder → fixed |
| `ModuleLandingService.CollectGarbage` / `RemoveCore` | already correct (reads the pointers; uninstall deletes both forms) |
| landing's success log | said `LANDED into modules/<Name>/` for a generation → fixed |
| `MeshBuilder.ResolveModulePath` | legacy probe, and correctly so — it is the **baseline** lane's resolver, which the sidecar lane no longer reaches |

## Tests

`ModuleActivationBootTest`

- `GenerationLandedEntry_LoadsAtBoot_AndResolvesToItsGenerationDll` — bytes only in `modules/<name>@<gen>/`, no legacy folder (asserted absent); the module must load AND `ResolveLoadPath` must name the file the gate just proved exists.
- `EntryWhoseGenerationIsGone_IsSkipped_EvenWithAStaleLegacyCopy` — the pointer is authoritative, not whatever folder happens to exist (this is the shape of the live stopgap `cp -r`, which must NOT be what makes a module load).
- `BaselineModule_ResolvesThroughResolveModulePath_NotTheLandedRule`.

`ModuleStaticAssetDiscoveryTest` — the asset-folder rule for the generation, legacy, app-closure and no-file-backing cases.

**Non-vacuity, measured.** Reverting `LandedDllPath` to main's legacy-folder body (gate + skip text) and rebuilding:

```
Failed …ModuleActivationBootTest.GenerationLandedEntry_LoadsAtBoot_AndResolvesToItsGenerationDll [1 ms]
Failed …ModuleActivationBootTest.EntryWhoseGenerationIsGone_IsSkipped_EvenWithAStaleLegacyCopy [1 ms]

  Expected collection to be empty because a module landed into its generation directory is
  PRESENT, but found 1 item(s).      ← the skip list; the production symptom exactly
```

Restored, the suite is green: `Passed! - Failed: 0, Passed: 549` (`MeshWeaver.PluginCatalog.Test`), `Passed: 12` (`ModuleStaticAssetDiscoveryTest`), `Memex.Portal.Shared` builds clean under `-c Release -warnaserror`.

## After this ships

The live stopgap on ns `memex` — `cp -r /data/modules/<name>@<gen> /data/modules/<name>` for all 16 — **must be removed**: GC never touches legacy dirs, so those copies are stable but go stale. `memex-cloud` was one self-update away from the same total outage.

Closes #1949

🤖 Generated with [Claude Code](https://claude.com/claude-code)