### PR TITLE
fix: write the install-records partition policy durably, so its records are visible (#1950)

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -319,8 +319,13 @@ public static class PluginBundleEndpoints
         var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}";
 
         return ServableEntries(rootHub, ct)
-            .Select(packages => (IReadOnlyList<BundleEntry>)packages
-                .Where(p => IsGranted(caller, p)).ToArray())
+            .Select(servable =>
+            {
+                var granted = (IReadOnlyList<BundleEntry>)servable
+                    .Where(p => IsGranted(caller, p)).ToArray();
+                WarnAboutAnEmptyIndex(rootHub, caller, servable, granted);
+                return granted;
+            })
             .SelectMany(packages => ServableModules(rootHub, packages)
                 .Select(modules => Results.Json(new
                 {
@@ -404,6 +409,48 @@ public static class PluginBundleEndpoints
                     return (IReadOnlyList<BundleEntry>)records.Concat(published).ToArray();
                 });
             });
+
+    /// <summary>
+    /// 🚨 Says so when an index request serves NOTHING — the one outcome that is silent on both
+    /// sides and looks exactly like a healthy day.
+    ///
+    /// <para>A consumer that receives <c>{"bundles": []}</c> concludes <c>SkipNoBundle</c> for every
+    /// module, lands nothing, and logs nothing worth reading; the registry logs nothing at all. That
+    /// is how the whole distribution lane went dark on 2026-08-20 with every consumer quietly
+    /// compiling: the <c>Plugins</c> partition was invisible to the record query, so
+    /// <see cref="InstalledPackages"/> returned an empty list and the emptiness had no author
+    /// (#1950). The two empties need different responses, so they get different lines: nothing
+    /// SERVABLE at all points at this instance's own state, while entries filtered down to zero
+    /// points at the caller's grant.</para>
+    /// </summary>
+    private static void WarnAboutAnEmptyIndex(
+        IMessageHub rootHub, AuthenticatedInstance? caller,
+        IReadOnlyList<BundleEntry> servable, IReadOnlyList<BundleEntry> granted)
+    {
+        if (granted.Count > 0)
+            return;
+
+        var logger = rootHub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(PluginBundleEndpoints));
+        if (logger is null)
+            return;
+
+        if (servable.Count == 0)
+            logger.LogWarning(
+                "Plugin bundles: serving an EMPTY index to {Instance} — this instance has nothing "
+                + "servable at all (no install records in the '{Partition}' partition and no "
+                + "published module entries). Every consumer will read SkipNoBundle for every "
+                + "package. If packages ARE installed here, the records partition is not readable "
+                + "by the query — check that its '_Policy' exists as a DURABLE node (#1950).",
+                caller?.Instance.InstanceId ?? "an unauthenticated caller",
+                PackageInstaller.InstalledPartition);
+        else
+            logger.LogWarning(
+                "Plugin bundles: serving an EMPTY index to {Instance} — {Count} servable "
+                + "package(s) exist here, but none is covered by that instance's grant, so it will "
+                + "read SkipNoBundle for every package. Grant it the sources it needs.",
+                caller?.Instance.InstanceId ?? "an unauthenticated caller", servable.Count);
+    }
 
     private static void WarnAboutUnstampedRecords(
         IMessageHub rootHub, IReadOnlyList<BundleEntry> packages)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-installed-plugins-visible-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-installed-plugins-visible-again.md
@@ -1,0 +1,15 @@
+---
+Name: Installed plugins show up in the catalog again
+Category: Fix
+Description: The list of installed packages is readable again, so the catalog stops looking empty and instances that pull modules from a registry receive them.
+Icon: Sparkle
+Order: -20260821
+---
+
+# Installed plugins show up in the catalog again
+
+Every installed package is recorded in one place, and every surface that asks "what is installed here?" reads that record — the plugin catalog, the admin pages, and the feed a connected instance pulls its modules from.
+
+That record store described who may read it only in memory. The database never learned the rule, so it filtered the whole store out of every search and listing: the catalog looked empty, and an instance asking a registry which packages it could fetch was told "none" — no error, no warning, on either side. Looking a record up by its exact address still worked, which is why it read as missing data rather than a permissions problem.
+
+The rule is now written down where the database can see it, on installation and again at startup, so an instance that was already affected repairs itself on its next restart. Nothing about who may read what has changed — the same rule now simply applies everywhere. A registry that ends up serving an empty list also says so in its log instead of going quiet.

--- a/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
@@ -29,6 +29,16 @@ namespace MeshWeaver.PluginCatalog;
 /// record carries the manifest whose declarations drive the shape — so "re-asserted on boot, a lost
 /// policy self-heals" holds for EVERY installed package, not just the baseline (#920).</para>
 ///
+/// <para><b>Why the RECORDS partition is published first.</b> Step 0 is
+/// <see cref="PackageInstaller.EnsureRecordsPartitionReadable"/> — the durable
+/// <c>Plugins/_Policy</c> that the SQL permission fold projects into
+/// <c>public.partition_access</c>. It runs BEFORE the record listing below, and unconditionally,
+/// for two reasons. First, an instance that has never installed anything still needs its records
+/// partition readable — a registry serving bundles is exactly such an instance. Second, and this is
+/// the trap: the listing is itself a partition-scoped query, so while the partition is invisible it
+/// returns ZERO records and this whole pass exits early. A heal placed after it could never fire on
+/// the instance that needed it (#1950).</para>
+///
 /// <para><b>Safe to run every boot.</b> Hooks are required to be idempotent, and the access shape is
 /// create-only — so on an already-consistent instance this reads and writes nothing. It is
 /// deliberately fire-and-forget and failure-tolerant: repair must never delay or fail startup (the
@@ -45,7 +55,15 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger<InstalledPackageRepairService>();
 
-        subscription = InstalledRecords(logger)
+        subscription = PackageInstaller.EnsureRecordsPartitionReadable(hub, logger)
+            .Catch<Unit, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "[PackageRepair] publishing the install-records partition failed — catalog "
+                    + "surfaces and the bundle index may read empty until the next boot");
+                return Observable.Return(Unit.Default);
+            })
+            .SelectMany(_ => InstalledRecords(logger))
             .SelectMany(records => records.Count == 0
                 ? Observable.Return(Unit.Default)
                 : records

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -143,7 +143,7 @@ public static class PackageInstaller
         // the permission fold correctly denies because the grants are simply not there yet.
         var ownAccess = nodes.Where(n => IsPartitionAccessSatellite(n.Path, partition)).ToArray();
         var content = nodes.Where(n => !IsPartitionAccessSatellite(n.Path, partition)).ToArray();
-        return EnsurePartitionsProvisioned(hub, partition, InstalledPartition)
+        return EnsureInstallPartitions(hub, partition, logger)
             .SelectMany(_ => ownAccess
                 .Select(n => UpsertIfChanged(hub, persistence, n, options))
                 .ToObservable().Concat().ToList())
@@ -260,6 +260,120 @@ public static class PackageInstaller
             ? Observable.Return(System.Reactive.Unit.Default)
             : Observable.Merge(leaves).ToList().Select(_ => System.Reactive.Unit.Default);
     }
+
+    /// <summary>
+    /// What every install path opens with: provision the target partition AND the install-RECORDS
+    /// partition, then make the records partition READABLE (<see cref="EnsureRecordsPartitionReadable"/>).
+    ///
+    /// <para>🚨 The two belong together. Provisioning creates the schema the records land in;
+    /// without the durable policy beside it that schema is filtered out of every query and the
+    /// records are written into the dark (#1950). Pairing them here means a future install path
+    /// cannot provision the records partition and forget its read surface — which is exactly how
+    /// the records partition ended up the one partition the installer never published.</para>
+    /// </summary>
+    private static IObservable<System.Reactive.Unit> EnsureInstallPartitions(
+        IMessageHub hub, string? targetPartition, ILogger? logger) =>
+        EnsurePartitionsProvisioned(hub, targetPartition, InstalledPartition)
+            .SelectMany(_ => EnsureRecordsPartitionReadable(hub, logger));
+
+    /// <summary>
+    /// 🚨 Makes the install-RECORDS partition (<see cref="InstalledPartition"/>) readable by
+    /// writing its <c>PartitionAccessPolicy</c> DURABLY — provisioning the partition first, so the
+    /// row has somewhere to land.
+    ///
+    /// <para><b>Why a durable node and not the static one it replaces (#1950).</b> The policy used
+    /// to be an <c>AddMeshNodes</c> registration on <c>AddPluginCatalog</c> — an in-memory node
+    /// with no row anywhere. The LIVE evaluator reads that happily, which is why every in-memory
+    /// test passed. Postgres does not: a partition-scoped query is pre-filtered by
+    /// <c>public.partition_access</c>, and those rows come from
+    /// <c>rebuild_user_effective_permissions()</c> folding <c>mesh_nodes</c> for
+    /// <c>node_type='PartitionAccessPolicy' AND id='_Policy'</c>. No row → nothing to project → no
+    /// <c>partition_access</c> row for <c>plugins</c> → the whole schema drops out of EVERY
+    /// partition query, for EVERY principal, platform admins included — while
+    /// <c>get Plugins/&lt;id&gt;</c> by exact path still works, which is what made it read as a
+    /// data bug. Measured on both production databases on 2026-08-20: the registry's
+    /// <c>/api/plugins/bundles/index.json</c> served <c>{"bundles": []}</c> to a correctly-granted
+    /// consumer, every module decided <c>SkipNoBundle</c>, and nothing logged anything. The live
+    /// heal was this exact row plus a rebuild.</para>
+    ///
+    /// <para>The comment on the fold's PublicRead projection already says <i>"PackageInstaller
+    /// writes exactly this"</i>. It did — for every partition it INSTALLS INTO, via
+    /// <see cref="EnsureDeclaredAccess"/>. Its own records partition was the one that never got the
+    /// same treatment.</para>
+    ///
+    /// <para><b>Create-only.</b> An existing policy is left completely alone — the platform must
+    /// never widen or narrow a shape someone deliberately chose. One that withholds public read is
+    /// reported, not overwritten: the records partition would then be invisible on purpose, which
+    /// is worth a line in the log rather than a silent correction.</para>
+    /// </summary>
+    /// <param name="hub">The hub to provision and write through (the write runs as System).</param>
+    /// <param name="logger">Diagnostics.</param>
+    /// <returns>Completes once the policy is present (or was already).</returns>
+    public static IObservable<Unit> EnsureRecordsPartitionReadable(IMessageHub hub, ILogger? logger)
+    {
+        var policyPath = $"{InstalledPartition}/{PartitionPolicyId}";
+        var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
+        return EnsurePartitionsProvisioned(hub, InstalledPartition)
+            .SelectMany(_ => persistence is not null
+                ? persistence.Read(policyPath, hub.JsonSerializerOptions).Take(1)
+                : Observable.Return<MeshNode?>(null))
+            .SelectMany(current =>
+            {
+                if (current is null)
+                    return Upsert(hub, InstalledPartitionPolicy())
+                        .Do(_ => logger?.LogInformation(
+                            "[PackageInstaller] published the install-records partition read-only "
+                            + "to everyone via {Path} — without a DURABLE policy node the SQL "
+                            + "permission fold has nothing to project and {Partition} is invisible "
+                            + "to every query (#1950)", policyPath, InstalledPartition))
+                        .Select(_ => Unit.Default);
+
+                if (!DeclaresPublicRead(current, hub))
+                    logger?.LogWarning(
+                        "[PackageInstaller] {Path} exists but does not declare PublicRead — the "
+                        + "install records are readable only to identities holding an explicit "
+                        + "grant on {Partition}, so catalog surfaces and the registry's bundle "
+                        + "index will come up empty. Left as authored.",
+                        policyPath, InstalledPartition);
+                return Observable.Return(Unit.Default);
+            });
+    }
+
+    /// <summary>
+    /// The read-only, world-readable policy of the install-RECORDS partition — the same shape every
+    /// built-in catalog ships. The records are written exclusively as System, so no creator grant is
+    /// ever minted, and a platform admin's <c>Admin/_Access</c> grant is scoped to the <c>Admin</c>
+    /// partition: without this policy NO real signed-in principal holds Read on
+    /// <see cref="InstalledPartition"/> and the installed-state query every catalog surface issues
+    /// is denied for all of them, platform admins included (#811).
+    ///
+    /// <para><c>PublicRead</c> is safe — a <see cref="PackageManifest"/> carries no secrets — and the
+    /// write caps keep the partition non-writable for every non-System identity (System bypasses the
+    /// evaluator, so the installer's own record writes are unaffected).</para>
+    ///
+    /// <para>🚨 <b>ONE definition, two homes.</b> <c>AddPluginCatalog</c> registers this same node
+    /// statically (for the live evaluator, and for the window before the durable write lands) and
+    /// <see cref="EnsureRecordsPartitionReadable"/> writes it durably (for the SQL fold, which can
+    /// only see rows). Sharing the definition is what keeps the two from ever disagreeing about the
+    /// partition's access — a static node and a durable node at one path that said different things
+    /// would be a worse bug than the one they exist to fix.</para>
+    /// </summary>
+    internal static MeshNode InstalledPartitionPolicy() =>
+        new(PartitionPolicyId, InstalledPartition)
+        {
+            NodeType = PartitionAccessPolicyNodeType.NodeType,
+            Name = "Access Policy",
+            State = MeshNodeState.Active,
+            Content = new PartitionAccessPolicy
+            {
+                PublicRead = true,
+                Create = false,
+                Update = false,
+                Delete = false,
+                Comment = false,
+                Thread = false,
+            },
+        };
 
     /// <summary>
     /// The install record's <c>AutoUpdate</c> on a (re-)stamp. An EXISTING record's choice is
@@ -1607,7 +1721,7 @@ public static class PackageInstaller
 
         // NodeType first (so its Source nodes attach under a present type), then the Source nodes;
         // each is skipped when unchanged.
-        return EnsurePartitionsProvisioned(hub, partition, InstalledPartition)
+        return EnsureInstallPartitions(hub, partition, logger)
             .SelectMany(_ => UpsertIfChanged(hub, persistence, nodeTypeNode, options))
             .SelectMany(typeWritten => sourceNodes
                 .Select(n => UpsertIfChanged(hub, persistence, n, options))
@@ -2171,7 +2285,7 @@ public static class PackageInstaller
                 && (!current.TryGetValue(root.Path, out var curRoot)
                     || !string.Equals(curRoot.NodeType, root.NodeType, StringComparison.Ordinal));
 
-        return EnsurePartitionsProvisioned(hub, manifest.TargetPartition ?? manifest.Id, InstalledPartition)
+        return EnsureInstallPartitions(hub, manifest.TargetPartition ?? manifest.Id, logger)
             .SelectMany(_ => ReadCurrent(persistence, nodes.Select(n => n.Path).ToArray(), options))
             .SelectMany(maybeCurrent =>
             {
@@ -2527,7 +2641,7 @@ public static class PackageInstaller
         // governs land. A delta presupposes a prior install, so the partition root already exists
         // and there is no bootstrap race to order around. Create-only, so this is free on the
         // common path.
-        return EnsurePartitionsProvisioned(hub, manifest.TargetPartition ?? manifest.Id, InstalledPartition)
+        return EnsureInstallPartitions(hub, manifest.TargetPartition ?? manifest.Id, logger)
             .SelectMany(_ => EnsureDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id,
                 logger, nodes.Select(n => n.Path)))
             .SelectMany(_ => WriteAll(head))

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -240,28 +240,24 @@ public static class PluginCatalogConfigurationExtensions
 
     // Read-only, world-readable policy for the install-records partition — the same shape every
     // other built-in catalog ships (BuiltInAgentProvider / BuiltInSkillProvider / the model
-    // catalog). The records are written exclusively under ImpersonateAsSystem (PackageInstaller),
-    // so no creator grant is ever minted, and a platform admin's Admin/_Access grant is scoped to
-    // the Admin partition — without this policy NO real signed-in principal holds Read on
-    // "Plugins", and the installed-state query every catalog surface issues
-    // (CatalogLayoutAreas.ObserveInstalled, `path:Plugins scope:children`) is denied for every
-    // real principal, platform admins included (#811).
-    // PublicRead is safe: PackageManifest carries no secrets. The write caps keep the partition
-    // non-writable for every non-System identity (System bypasses the evaluator, so the
+    // catalog). The records are written exclusively as System (PackageInstaller), so no creator
+    // grant is ever minted, and a platform admin's Admin/_Access grant is scoped to the Admin
+    // partition — without this policy NO real signed-in principal holds Read on "Plugins", and the
+    // installed-state query every catalog surface issues (CatalogLayoutAreas.ObserveInstalled,
+    // `path:Plugins scope:children`) is denied for every real principal, platform admins included
+    // (#811). PublicRead is safe: PackageManifest carries no secrets. The write caps keep the
+    // partition non-writable for every non-System identity (System bypasses the evaluator, so the
     // installer's own record writes are unaffected).
+    //
+    // 🚨 THIS STATIC NODE IS NOT ENOUGH ON ITS OWN, and that is the whole of #1950. It covers the
+    // LIVE evaluator — which reads it happily, so every in-memory test passed — but it has no row
+    // anywhere, and Postgres pre-filters partition-scoped queries by public.partition_access, whose
+    // rows come from rebuild_user_effective_permissions() folding mesh_nodes for
+    // node_type='PartitionAccessPolicy' AND id='_Policy'. So on a PG mesh the partition was
+    // invisible to every query for every principal. PackageInstaller.EnsureRecordsPartitionReadable
+    // writes the DURABLE twin (at boot and on every install); this stays because it covers the
+    // window before that write lands and the hosts with no SQL side at all. Both come from ONE
+    // definition below so the two can never drift into disagreeing about the partition's access.
     private static MeshNode CreateInstalledPartitionPolicy() =>
-        new("_Policy", PackageInstaller.InstalledPartition)
-        {
-            NodeType = "PartitionAccessPolicy",
-            Name = "Access Policy",
-            Content = new PartitionAccessPolicy
-            {
-                PublicRead = true,
-                Create = false,
-                Update = false,
-                Delete = false,
-                Comment = false,
-                Thread = false
-            }
-        };
+        PackageInstaller.InstalledPartitionPolicy();
 }

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PluginsRecordsPartitionVisibilityTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PluginsRecordsPartitionVisibilityTests.cs
@@ -1,0 +1,225 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Pins #1950: the <c>Plugins</c> install-records partition must be visible to the REAL,
+/// SQL-backed query path — the one every catalog surface and the registry's bundle index issue —
+/// for an ordinary signed-in principal.
+///
+/// <para><b>Why a Postgres test and not another monolith one.</b> <c>PluginsPartitionReadableTest</c>
+/// already pins this on the in-memory path and passes, because there the LIVE
+/// <c>PermissionEvaluator</c> reads the STATIC <c>PartitionAccessPolicy</c> that
+/// <c>AddPluginCatalog</c> registers. Postgres does not: a partition-scoped query is pre-filtered by
+/// <c>public.partition_access</c>, whose rows come from <c>rebuild_user_effective_permissions()</c>
+/// folding the DURABLE <c>mesh_nodes</c> row for <c>node_type='PartitionAccessPolicy' AND
+/// id='_Policy'</c>. A static-only policy has no such row, so the fold projects nothing, no
+/// <c>partition_access</c> row exists for <c>plugins</c>, and the whole schema drops out of every
+/// query — for EVERY principal, platform admins included, while <c>get Plugins/&lt;id&gt;</c> by exact
+/// path still works. That is exactly what took the registry's bundle feed dark on both production
+/// databases on 2026-08-20: <c>/api/plugins/bundles/index.json</c> served <c>{"bundles": []}</c> to a
+/// correctly-granted consumer, every module decided <c>SkipNoBundle</c>, and nothing logged a thing.</para>
+///
+/// <para>So the assertion here goes through <c>IMeshService.Query</c> under a plain viewer identity —
+/// never a direct <c>IStorageAdapter</c> read, which bypasses the permission fold and would pass
+/// against the defect.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class PluginsRecordsPartitionVisibilityTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private readonly PostgreSqlFixture _fixture = fixture;
+
+    /// <summary>An ordinary signed-in principal: no grants anywhere, no Admin claim. The registry's
+    /// bundle index runs under the HTTP request's identity, and the catalog surfaces run under the
+    /// viewer's — neither is System.</summary>
+    private const string Consumer = "consumer";
+
+    private const string PackageId = "visible-pack";
+
+    /// <summary>
+    /// Puts the shared container back into the state this is about — the durable <c>_Policy</c>
+    /// row gone and no <c>partition_access</c> rows for <c>plugins</c> — so a leftover from an
+    /// earlier run in the same container can never satisfy the assertions and let the test pass
+    /// against the very defect it pins. It VERIFIES its own effect, because a reset that cannot
+    /// fail is not a reset.
+    ///
+    /// <para>The schema itself is left alone deliberately: partition provisioning is
+    /// promise-cached per mesh, so dropping it out from under a built mesh only produces
+    /// <c>3F000</c>.</para>
+    ///
+    /// <para>🚨 Existence is asked of <c>pg_catalog</c>, never <c>information_schema.schemata</c> —
+    /// the latter lists only schemas the CURRENT ROLE owns, so a partition schema created by the
+    /// provisioning function reads as ABSENT there. A guard written against it skips the delete
+    /// and a count written against it returns 0, which made both the reset and its verification
+    /// silently vacuous.</para>
+    /// </summary>
+    private IObservable<System.Reactive.Unit> ResetPluginsPartition(CancellationToken ct) =>
+        _fixture.DataSource.ExecuteNonQuery(
+                """
+                DO $$ BEGIN
+                  IF to_regclass('plugins.mesh_nodes') IS NOT NULL THEN
+                    DELETE FROM plugins.mesh_nodes
+                    WHERE node_type = 'PartitionAccessPolicy' AND id = '_Policy';
+                  END IF;
+                END $$;
+                """, ct)
+            .SelectMany(_ => _fixture.DataSource.ExecuteNonQuery(
+                "DELETE FROM public.partition_access WHERE partition = 'plugins'", ct))
+            .SelectMany(_ => PolicyRowCount(ct))
+            .Do(count => count.Should().Be(0L, "the reset must leave no durable _Policy row"))
+            .SelectMany(_ => PartitionAccessRowCount(ct))
+            .Do(count => count.Should().Be(0L, "the reset must leave no partition_access row"))
+            .Select(_ => System.Reactive.Unit.Default);
+
+    /// <summary>Durable <c>_Policy</c> rows in the <c>plugins</c> schema — 0 when the schema (or
+    /// its table) does not exist yet, which is the same answer and an honest one.</summary>
+    private IObservable<long> PolicyRowCount(CancellationToken ct) =>
+        _fixture.DataSource
+            .ScalarLong("SELECT COUNT(*) FROM pg_catalog.pg_class c "
+                + "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+                + "WHERE n.nspname = 'plugins' AND c.relname = 'mesh_nodes'", ct)
+            .SelectMany(table => table == 0
+                ? Observable.Return(0L)
+                : _fixture.DataSource.ScalarLong(
+                    "SELECT COUNT(*) FROM plugins.mesh_nodes "
+                    + "WHERE node_type = 'PartitionAccessPolicy' AND id = '_Policy'", ct));
+
+    private IObservable<long> PartitionAccessRowCount(CancellationToken ct) =>
+        _fixture.DataSource.ScalarLong(
+            "SELECT COUNT(*) FROM public.partition_access WHERE partition = 'plugins'", ct);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+            {
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString);
+                return services;
+            })
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .AddSpaceType()
+            .AddPluginCatalog();
+    }
+
+    /// <summary>
+    /// End to end on the production shape: install a package (records land in <c>Plugins</c> under
+    /// System, so no creator grant is ever minted), then issue the EXACT query
+    /// <c>PluginBundleEndpoints.InstalledPackages</c> issues, under a non-System identity.
+    /// </summary>
+    [Fact(Timeout = 300000)]
+    public async Task InstalledRecords_AreVisibleToASignedInConsumer_ThroughTheRealQueryPath()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await ResetPluginsPartition(ct).Should().Within(60.Seconds()).Emit();
+
+        var manifest = new PackageManifest
+        {
+            Id = PackageId,
+            Name = "Visible Pack",
+            Kind = PackageKind.Content,
+            TargetPartition = "VisibleTarget",
+            SourceFolder = PackageId,
+            Version = "1.0.0",
+            ReleasedVersion = "1.0.0",
+        };
+        var files = new[]
+        {
+            new PackageFile($"{PackageId}/Doc.md", "# Doc\n\nInstalled for the visibility pin.")
+        };
+
+        var result = await PackageInstaller.Install(Mesh, manifest, files, "HEAD")
+            .Should().Within(180.Seconds()).Emit();
+        result.Written.Should().Be(1);
+
+        // The record really is there — read straight off the storage adapter, which BYPASSES the
+        // permission fold. This separates "the records are missing" from "the records are
+        // invisible", the distinction the outage turned on.
+        var stored = await _fixture.DataSource.ScalarLong(
+                "SELECT COUNT(*) FROM plugins.mesh_nodes WHERE id = @id",
+                new[] { ("id", (object)PackageId) }, ct)
+            .Should().Within(30.Seconds()).Emit();
+        stored.Should().Be(1L, "the install wrote the record — this test is about VISIBILITY");
+
+        // 🚨 THE PIN. The exact query the registry's bundle index issues, under the HTTP request's
+        // non-System identity. Denied/invisible nodes are filtered out of the result set, so
+        // against the defect this stays empty forever and the index serves [].
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"namespace:{PackageInstaller.InstalledPartition} "
+                + $"nodeType:{PackageInstaller.PackageNodeType}",
+                Consumer))
+            .Where(c => c.ChangeType == QueryChangeType.Initial)
+            .Should().Within(60.Seconds())
+            .Match(
+                change => change.Items.Any(n => n.Id == PackageId),
+                "a signed-in consumer must see the install records the registry's bundle index is "
+                + "built from — the records exist, so an empty result is an invisible PARTITION");
+    }
+
+    /// <summary>
+    /// The MECHANISM, asserted directly: the <c>plugins</c> schema carries the durable
+    /// <c>_Policy</c> row the SQL permission fold projects, and therefore
+    /// <c>public.partition_access</c> rows. Without those rows the schema is filtered out of every
+    /// partition-scoped query before a single node is looked at — which is why no identity, not
+    /// even a platform admin, could see the records, and why the live heal was an INSERT plus
+    /// <c>rebuild_user_effective_permissions()</c>.
+    /// </summary>
+    [Fact(Timeout = 300000)]
+    public async Task PluginsPartition_CarriesTheDurablePolicyRow_AndIsProjectedIntoPartitionAccess()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await ResetPluginsPartition(ct).Should().Within(60.Seconds()).Emit();
+
+        var manifest = new PackageManifest
+        {
+            Id = "mechanism-pack",
+            Name = "Mechanism Pack",
+            Kind = PackageKind.Content,
+            TargetPartition = "MechanismTarget",
+            SourceFolder = "mechanism-pack",
+            Version = "1.0.0",
+            ReleasedVersion = "1.0.0",
+        };
+        await PackageInstaller
+            .Install(Mesh, manifest,
+                [new PackageFile("mechanism-pack/Doc.md", "# Doc")], "HEAD")
+            .Should().Within(180.Seconds()).Emit();
+
+        var policyRows = await PolicyRowCount(ct).Should().Within(30.Seconds()).Emit();
+        policyRows.Should().Be(1L,
+            "the fold reads mesh_nodes; a policy that exists only as an in-memory static node can "
+            + "never reach the SQL side");
+
+        var access = await PartitionAccessRowCount(ct).Should().Within(30.Seconds()).Emit();
+        access.Should().BeGreaterThan(0L,
+            "no partition_access row for 'plugins' means the whole schema is pre-filtered out of "
+            + "every query, for every principal");
+    }
+}


### PR DESCRIPTION
**P0.** `/api/plugins/bundles/index.json` served `{"bundles": []}` to a correctly-registered, correctly-granted consumer. Every module decided `SkipNoBundle — the registry lists no bundle for this package`, zero modules ever landed, and **nothing logged anything on either side** — "every consumer quietly compiling" looks exactly like a healthy day. Healed live by SQL on both prod DBs on 2026-08-20; this is the code fix.

## Which of the two candidates it is — with evidence

Neither the auth mirror nor a wrong query identity. **The partition's read surface existed only in memory, so the SQL permission fold had nothing to project.**

`AddPluginCatalog` registered `Plugins/_Policy` as a STATIC `PartitionAccessPolicy` (`AddMeshNodes`) — no durable row. The live `PermissionEvaluator` reads that happily, which is why `PluginsPartitionReadableTest` has been green all along. Postgres does not: a partition-scoped query is pre-filtered by `public.partition_access`, whose rows come from `rebuild_user_effective_permissions()` folding **`mesh_nodes`** for `node_type='PartitionAccessPolicy' AND id='_Policy'` (`PostgreSqlSchemaInitializer`). No row → no `user_effective_permissions` rows → no `partition_access` row for `plugins` → the whole schema is filtered out **before a single node is looked at**.

Measured directly, against unmodified `main`, on a fresh container:

```
Failed …PluginsPartition_CarriesTheDurablePolicyRow_AndIsProjectedIntoPartitionAccess
  Expected value to be 1 because the fold reads mesh_nodes; a policy that exists only as an
  in-memory static node can never reach the SQL side, but found 0.

Failed …InstalledRecords_AreVisibleToASignedInConsumer_ThroughTheRealQueryPath
  Expected the observable to emit a value matching the predicate within 60s … but it did not.
  Last of 1 emission(s) was: QueryResultChange { ChangeType = Initial, Items = […] }   ← empty
```

In the same run the direct storage read asserted `COUNT(*) = 1` for the record. **The records exist; the partition is invisible** — which is also why `search nodeType:Package` returned 0 for a platform admin while `get Plugins/Mcp` worked, and why *no* identity would have helped: the fold produces no rows for anyone.

So this is **not** the `Space`-dropped-from-`GetAuthMirrorFunctionScript` shape (that mirror feeds the top-level catalog; these are `Package` nodes and the failing filter is `partition_access`), and **not** an identity problem — running the index as System would have masked it while every catalog surface stayed dark.

## Which side is canonical: the DURABLE node

The codebase already said so. The fold's own comment reads *"a plugin-installed catalog — PackageInstaller writes exactly this"*, and `PackageInstaller` does — via `EnsureDeclaredAccess`, for every partition it installs **into**. Its own records partition was the one partition it never published. The same conclusion is recorded one lane over: `SkillStaticRepoSource` exists precisely because *"Orleans routing does NOT consult the in-memory adapter; without this import … are invisible to `namespace:Skill` queries."*

- `PackageInstaller.EnsureRecordsPartitionReadable` provisions the records partition and writes its policy durably. **Create-only**: an existing policy is never overwritten, and one that withholds public read is REPORTED rather than corrected — the platform must not narrow or widen a shape someone chose.
- `EnsureInstallPartitions` pairs provisioning with that publish; every install path opens with it, so a future path cannot provision the records partition and forget its read surface.
- `InstalledPackageRepairService` runs it as **step 0** at boot, so an affected instance heals itself with no install. **Order matters:** the record listing under it is itself a partition-scoped query, so while the partition is invisible it returns zero records and the whole pass exits early — a heal placed after it could never fire on the instance that needed it.
- The static registration **stays** (it covers the live evaluator, the window before the durable write lands, and hosts with no SQL side) but now comes from the **same definition** as the durable node, so the two cannot drift into disagreeing about the partition's access.

No access is widened: the durable node is byte-identical to the static one the partition already declared (`PublicRead` + all write caps false). The fix is making SQL able to *see* the rule, not changing it.

## The silence

An index request that serves ZERO bundles now logs a Warning, and distinguishes the two cases that need different answers: *nothing servable here at all* (points at this instance's own state — and names the `_Policy` check) vs *entries exist but none is granted to this caller* (points at the grant). This outage was silent end-to-end; that is the half nothing covered.

## Tests

`test/MeshWeaver.Hosting.PostgreSql.Test/PluginsRecordsPartitionVisibilityTests.cs` — Postgres, because the in-memory pin structurally cannot see this.

- `InstalledRecords_AreVisibleToASignedInConsumer_ThroughTheRealQueryPath` — install a package, then issue the **exact** query `PluginBundleEndpoints.InstalledPackages` issues, under an ordinary signed-in identity with no grants. Never a direct `IStorageAdapter` read: that bypasses the fold and would pass against the defect. A storage read first asserts the record EXISTS, so a failure reads as invisibility rather than absence.
- `PluginsPartition_CarriesTheDurablePolicyRow_AndIsProjectedIntoPartitionAccess` — the mechanism: the durable row, and `partition_access` rows for `plugins`.

Each test RESETS the container to the pre-fix state first (durable `_Policy` row and `partition_access` rows deleted) **and verifies the reset landed** — a reset that cannot fail is not a reset. That verification caught a real trap worth naming: `information_schema.schemata` lists only schemas the current role OWNS, so a guard written against it skipped the delete and a count written against it returned 0 — both silently vacuous. Existence is asked of `pg_catalog`.

**Non-vacuity, measured.** With the fix neutered at both call sites (install path and boot repair), on a fresh container with the verified reset in place, both tests fail with the output quoted above. Restored:

```
Passed! - Failed: 0, Passed: 2      PluginsRecordsPartitionVisibilityTests (Postgres)
Passed! - Failed: 0, Passed: 546    MeshWeaver.PluginCatalog.Test  (incl. PluginsPartitionReadableTest)
Passed! - Failed: 0, Passed: 145    MeshWeaver.Auth.Test
Passed! - Failed: 0, Passed: 15     Memex.Portal.Shared.Test  (PluginBundle*)
Passed! - Failed: 0, Passed: 2      ImpersonationScopeSiteRatchetGuard  (no new site)
```

Neutering ONE site at a time also passes, which is the intended belt-and-braces: install and boot each publish the partition independently.

## Note for review

Boot now provisions the `Plugins` partition on every start, including on an instance that never installs anything. That is deliberate — a registry serving bundles is exactly such an instance — and it is the same sanctioned `EnsurePartitionProvisioned` the first install would have called anyway, not the router's removed lazy-create (the ghost-schema invariant is untouched).

## Relation to #1782

Distinct, and this does not close it. #1782 gap 2 is *"the index only advertises what THIS instance has installed"* — a design question about serving packages a registry has not itself installed, partly answered by #1948's publish union. This is a plain visibility defect in the records the index is built from: with #1782 fully solved and this unfixed, the index would still serve `[]`. #1782 gap 4 (adoption not universal) is untouched.

Closes #1950

🤖 Generated with [Claude Code](https://claude.com/claude-code)