### PR TITLE
fix(#1890): refuse an undeliverable memory-stream message at the producer

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-oversized-message-fails-fast.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-oversized-message-fails-fast.md
@@ -1,0 +1,13 @@
+---
+Name: An impossibly large message now fails instead of hanging
+Category: Fix
+Description: A request whose payload is too big for the internal transport is refused straight away with a clear reason, instead of disappearing and leaving the page waiting.
+Icon: Sparkle
+Order: -20260821
+---
+
+# An impossibly large message now fails instead of hanging
+
+Messages between parts of the portal travel over an internal queue that can carry at most one megabyte at a time. Anything bigger was accepted, then quietly dropped further down the line — and because the sender had already been told the message was on its way, the page that was waiting for an answer simply waited until it gave up. Nothing in the logs said which page, which request, or how big the payload had been, so there was no way to find out what had produced it.
+
+A message that cannot fit is now refused at the moment it is sent. The waiting page gets an immediate, explicit error rather than a long pause, and the record left behind names the request, its size and where it was going — so an oversized payload can be traced back to whatever produced it instead of vanishing.

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -330,7 +330,7 @@ internal class RoutingGrain(
             logger.LogDebug("[ROUTE] {Address} type={Type} declared stream-routed → memory stream", addressPath, address.Type);
             RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM addr={addressPath} id={delivery.Id} streamName={addressPath}");
             var s = streamProvider.GetStream<IMessageDelivery>(addressPath);
-            return PostToStream(() => s.OnNextAsync(delivery), addressPath, delivery.Id,
+            return PostToStream(delivery, () => s.OnNextAsync(delivery), addressPath,
                 delivery.Sender, PostFailureToSender, logger, StreamPostTimeout);
         })
             // Composition-time faults must ALSO reach the sender — see BuildGrainRoute's trailing
@@ -460,8 +460,15 @@ internal class RoutingGrain(
         // CLR-type test this guard used to make could not match on any routed delivery (#1485).
         if (!delivery.MayAnswer())
             return;
+        // 🚨 The NACK must not BE the thing it is reporting. DeliveryFailure embeds the ORIGINAL
+        // delivery — payload included — and this NACK travels the SAME memory stream, so a failure
+        // report about an oversized message is itself an oversized message and dies at exactly the
+        // wall it is describing, silently (#1890). Strip an undeliverable payload down to a
+        // description of itself; the sender matches a DeliveryFailure on RequestId, never on the
+        // echoed payload. A payload that fits is echoed unchanged.
+        var echoedDelivery = StreamMessageSizeGuard.WithoutOversizedPayload(delivery);
         var failureDelivery = new MessageDelivery<DeliveryFailure>(
-            new DeliveryFailure(delivery, failureMessage) { ErrorType = errorType },
+            new DeliveryFailure(echoedDelivery, failureMessage) { ErrorType = errorType },
             new PostOptions(address)
                 .WithTarget(delivery.Sender)
                 .WithProperty(PostOptions.RequestId, delivery.Id),
@@ -531,6 +538,60 @@ internal class RoutingGrain(
     /// deterministically testable without a cluster.</para>
     /// </summary>
     internal static IObservable<Unit> PostToStream(
+        IMessageDelivery delivery,
+        Func<Task> post,
+        string addressPath,
+        Address? sender,
+        Action<string, ErrorType> postFailureToSender,
+        ILogger logger,
+        TimeSpan timeout,
+        IScheduler? scheduler = null,
+        int sizeLimitBytes = StreamMessageSizeGuard.MemoryStreamBlockBytes)
+        => Observable.Defer(() =>
+        {
+            var deliveryId = delivery.Id;
+
+            // 🚨 REFUSE, LOUDLY, WHAT PROVABLY CANNOT COME OFF THIS QUEUE — issue #1890.
+            //
+            // Orleans caches memory-stream messages in fixed 1 MiB blocks and a message must fit
+            // one whole block, so a bigger payload is undeliverable by construction. Posting it
+            // anyway SUCCEEDS right here and fails on the CONSUMING side, inside
+            // PersistentStreamPullingAgent's retry loop, as an ArgumentOutOfRangeException naming
+            // a queue id and nothing else — no target, no message type, no delivery id, no sender.
+            // That retry cannot converge (the size is a property of the message, not of the
+            // attempt), so the message is lost and the caller waits out its own timeout with
+            // nothing logged that could find the producer. This is the same class of non-delivery
+            // the bound below exists for, and it gets the same answer: terminate, say exactly what
+            // was dropped and how big it was, and NACK the sender.
+            //
+            // Refusing cannot break anything that works: the bound IS Orleans' own, so everything
+            // it rejects was already being dropped. It is deliberately not an exact admission test
+            // — see StreamMessageSizeGuard.
+            if (StreamMessageSizeGuard.IsOversized(delivery, sizeLimitBytes, out var payloadBytes))
+            {
+                var refusal = StreamMessageSizeGuard.Describe(
+                    delivery, addressPath, payloadBytes, sizeLimitBytes);
+                logger.LogError(
+                    "[ROUTE] REFUSED oversized stream-routed delivery to {Address}: {Bytes} bytes "
+                    + "against the {Limit}-byte Orleans memory-stream limit ({DeliveryId}, sender "
+                    + "{Sender}) — NOT posted, because the stream's pulling agent would reject and "
+                    + "retry it forever while it was never delivered. {Refusal}",
+                    addressPath, payloadBytes, sizeLimitBytes, deliveryId, sender, refusal);
+                RoutingGrainTrace.Write(
+                    $"RoutingGrain.RouteMessage MEMORY_STREAM_REFUSED_OVERSIZED addr={addressPath} id={deliveryId} bytes={payloadBytes}");
+                postFailureToSender(refusal, ErrorType.Rejected);
+                return Observable.Return(Unit.Default);
+            }
+
+            return PostToStreamCore(
+                post, addressPath, deliveryId, sender, postFailureToSender, logger, timeout, scheduler);
+        });
+
+    /// <summary>
+    /// The post itself, once <see cref="PostToStream"/> has established the delivery CAN be
+    /// carried: issue it, bound it, and turn a fault or a non-completion into a NACK'd terminal.
+    /// </summary>
+    private static IObservable<Unit> PostToStreamCore(
         Func<Task> post,
         string addressPath,
         string deliveryId,
@@ -538,7 +599,7 @@ internal class RoutingGrain(
         Action<string, ErrorType> postFailureToSender,
         ILogger logger,
         TimeSpan timeout,
-        IScheduler? scheduler = null)
+        IScheduler? scheduler)
         => Observable.Defer(() => post().ToObservable())
             .Timeout(timeout, scheduler ?? Scheduler.Default)
             .Do(_ => RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM_OK id={deliveryId}"))

--- a/src/MeshWeaver.Hosting.Orleans/StreamMessageSizeGuard.cs
+++ b/src/MeshWeaver.Hosting.Orleans/StreamMessageSizeGuard.cs
@@ -43,9 +43,10 @@ internal static class StreamMessageSizeGuard
     /// Orleans' memory-stream block size, and therefore the hard ceiling on one memory-stream
     /// message: <c>1 &lt;&lt; 20</c> = 1,048,576 bytes. Hard-coded in
     /// <c>MemoryAdapterFactory</c> (Microsoft.Orleans.Streaming 10.2.x) with no configuration
-    /// surface — <c>MemoryStreamBlockSizeTest</c> pins this constant against the real
-    /// <c>FixedSizeBuffer</c> so an Orleans upgrade that moved it fails a test instead of silently
-    /// mis-tuning the guard.
+    /// surface — <c>OversizedStreamMessageRefusedTest
+    /// .The_orleans_block_size_is_what_the_guard_is_calibrated_against</c> pins this constant
+    /// against the real <c>FixedSizeBuffer</c>, so an Orleans upgrade that moved the block size
+    /// fails a test instead of silently mis-tuning the guard.
     /// </summary>
     internal const int MemoryStreamBlockBytes = 1 << 20;
 
@@ -99,7 +100,7 @@ internal static class StreamMessageSizeGuard
             + "memory-stream limit (one fixed 1 MiB pooled-cache block per message), so the "
             + "stream's pulling agent would reject it with 'Message size is too big' and retry "
             + "forever while the message was silently never delivered. Sender "
-            + $"'{delivery.Sender}'. Payload head: {Preview(delivery)}";
+            + $"'{delivery.Sender}'. Payload head: {Quote(Preview(delivery))}";
     }
 
     /// <summary>
@@ -125,6 +126,13 @@ internal static class StreamMessageSizeGuard
             + $"attached\",\"bytes\":{payloadBytes},\"head\":{Quote(Head(delivery))}}}"));
     }
 
+    /// <summary>
+    /// The head of the payload, for identification. 🚨 The CALLER JSON-quotes it before it reaches
+    /// a log line: this is attacker-influenced content (it is a message payload), and a raw
+    /// newline or quote in it would break the burst apart in the log pipeline — a red burst is
+    /// re-assembled from its indented continuation lines, so an embedded newline can forge a new
+    /// log record. Quoting also keeps the refusal a single parseable line.
+    /// </summary>
     private static string Preview(IMessageDelivery delivery) =>
         delivery.Message is RawJson { Content: { } content }
             ? Head(content) is var head && head.Length < content.Length ? head + "…" : head

--- a/src/MeshWeaver.Hosting.Orleans/StreamMessageSizeGuard.cs
+++ b/src/MeshWeaver.Hosting.Orleans/StreamMessageSizeGuard.cs
@@ -1,0 +1,141 @@
+using System.Text;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Hosting.Orleans;
+
+/// <summary>
+/// 🚨 The producer-side bound on an Orleans MEMORY-STREAM message — issue #1890.
+///
+/// <para><b>What happened.</b> A ~37 MB delivery (37,483,597 bytes) was posted to
+/// <c>memory-7-0xE0000007</c>. The publish SUCCEEDED. Minutes later, on the consuming side,
+/// <c>PersistentStreamPullingAgent.ReadFromQueue</c> threw
+/// <c>ArgumentOutOfRangeException: Message size is too big</c> out of
+/// <c>MemoryPooledCache.AddToCache</c> and retried — a retry that cannot succeed, because the size
+/// is a property of the message, not of the attempt. The message was never delivered and the
+/// PRODUCER was never told: it had already been handed a successful publish, so its
+/// <c>Observe(...)</c> simply waited out its timeout. The only trace was a queue id, which names
+/// nothing an operator can act on — not the target hub, not the message type, not the delivery.</para>
+///
+/// <para><b>Why the bound is not negotiable, and not ours to raise.</b> Orleans' memory stream
+/// caches messages in a pool of fixed <b>1 MiB</b> blocks
+/// (<c>MemoryAdapterFactory.CreateBufferPoolIfNotCreatedYet</c>: <c>var oneMb = 1 &lt;&lt; 20; new
+/// ObjectPool&lt;FixedSizeBuffer&gt;(() =&gt; new FixedSizeBuffer(oneMb))</c> — hard-coded, with no
+/// configuration surface), and a cached message must fit ENTIRELY in one clean block. So 1 MiB is
+/// the hard ceiling on this transport. Raising it is not an option we have; chunking would be a new
+/// wire protocol for a case that has occurred once and is far more likely to be a producer defect
+/// than a legitimate payload. What IS ours is the third option — <b>do not put a message on that
+/// queue when it provably cannot come off it</b>, and say so loudly, at the producer, where every
+/// fact needed to find the producer is still in hand.</para>
+///
+/// <para><b>This can only turn a silent loss into a loud one.</b> The bound is Orleans' own: a
+/// payload at or above the block size cannot be delivered TODAY, so nothing that works is newly
+/// refused. It deliberately does not try to be an exact admission test — the on-queue form carries
+/// an envelope this cannot see, so a payload just under the block can still be rejected inside
+/// Orleans. That residual band is unchanged by this guard; the gross case (37× over) is what it
+/// exists to attribute.</para>
+///
+/// <para>Pure and static — no hub, no Orleans types — so the decision and its wording are asserted
+/// directly, without a cluster.</para>
+/// </summary>
+internal static class StreamMessageSizeGuard
+{
+    /// <summary>
+    /// Orleans' memory-stream block size, and therefore the hard ceiling on one memory-stream
+    /// message: <c>1 &lt;&lt; 20</c> = 1,048,576 bytes. Hard-coded in
+    /// <c>MemoryAdapterFactory</c> (Microsoft.Orleans.Streaming 10.2.x) with no configuration
+    /// surface — <c>MemoryStreamBlockSizeTest</c> pins this constant against the real
+    /// <c>FixedSizeBuffer</c> so an Orleans upgrade that moved it fails a test instead of silently
+    /// mis-tuning the guard.
+    /// </summary>
+    internal const int MemoryStreamBlockBytes = 1 << 20;
+
+    /// <summary>
+    /// How much of an oversized payload the refusal quotes back. Enough to recognise the message —
+    /// its <c>$type</c> discriminator and first fields sit at the front of the JSON — without
+    /// pasting a multi-megabyte blob into a log line that is itself size-capped.
+    /// </summary>
+    internal const int PayloadPreviewChars = 200;
+
+    /// <summary>
+    /// True when <paramref name="delivery"/>'s packaged payload cannot fit an Orleans memory-stream
+    /// block, with its exact UTF-8 byte count in <paramref name="payloadBytes"/>.
+    ///
+    /// <para>Cheap on the hot path, exact on the rare one. A UTF-16 char contributes at most 3
+    /// UTF-8 bytes (a surrogate PAIR is 4 bytes for 2 chars, i.e. 2 per char), so
+    /// <c>3 × Length &lt; limit</c> is a sound O(1) proof that the payload fits and the common
+    /// case never scans. Only a delivery that could plausibly be over the line pays for the exact
+    /// count.</para>
+    ///
+    /// <para>A payload that is not <see cref="RawJson"/> is not measured and never refused: by the
+    /// time a delivery reaches the router <c>MeshBuilder</c> has already packaged it
+    /// (<c>delivery.Package(...)</c>), so RawJson is the routed shape — and guessing at the size of
+    /// anything else would mean serialising it a second time on the hot path to answer a question
+    /// that is almost always "no".</para>
+    /// </summary>
+    internal static bool IsOversized(
+        IMessageDelivery? delivery, int limitBytes, out int payloadBytes)
+    {
+        payloadBytes = 0;
+        if (delivery?.Message is not RawJson { Content: { } content })
+            return false;
+        if ((long)content.Length * 3 < limitBytes)
+            return false;
+        payloadBytes = Encoding.UTF8.GetByteCount(content);
+        return payloadBytes >= limitBytes;
+    }
+
+    /// <summary>
+    /// The refusal an operator and the sender both read: WHAT was rejected (target, delivery id,
+    /// and the head of the payload, which carries its <c>$type</c>), HOW BIG it was, and against
+    /// WHICH limit — the three facts the Orleans-side <c>ArgumentOutOfRangeException</c> could not
+    /// supply, since it knows only a queue id.
+    /// </summary>
+    internal static string Describe(
+        IMessageDelivery delivery, string addressPath, int payloadBytes, int limitBytes)
+    {
+        ArgumentNullException.ThrowIfNull(delivery);
+        return $"Refused to publish delivery '{delivery.Id}' to memory-stream '{addressPath}': its "
+            + $"payload is {payloadBytes:N0} bytes, at or over the {limitBytes:N0}-byte Orleans "
+            + "memory-stream limit (one fixed 1 MiB pooled-cache block per message), so the "
+            + "stream's pulling agent would reject it with 'Message size is too big' and retry "
+            + "forever while the message was silently never delivered. Sender "
+            + $"'{delivery.Sender}'. Payload head: {Preview(delivery)}";
+    }
+
+    /// <summary>
+    /// 🚨 A NACK about an oversized message must not BE one.
+    /// <see cref="DeliveryFailure"/> embeds the ORIGINAL delivery — payload and all — and travels
+    /// the SAME memory stream back to the sender, so a failure report about a 37 MB message is
+    /// itself a 37 MB message and dies at exactly the wall it is reporting on, silently. Replacing
+    /// the payload with a description of it keeps the report deliverable; the sender correlates a
+    /// <see cref="DeliveryFailure"/> on <c>RequestId</c>, never on the echoed payload.
+    ///
+    /// <para>Returns <paramref name="delivery"/> unchanged when its payload fits — the echo is
+    /// stripped only when carrying it is what would lose the report.</para>
+    /// </summary>
+    internal static IMessageDelivery WithoutOversizedPayload(
+        IMessageDelivery delivery, int limitBytes = MemoryStreamBlockBytes)
+    {
+        ArgumentNullException.ThrowIfNull(delivery);
+        if (!IsOversized(delivery, limitBytes, out var payloadBytes))
+            return delivery;
+        return delivery.WithMessage(new RawJson(
+            $"{{\"payloadOmitted\":\"{payloadBytes} bytes exceeded the {limitBytes}-byte "
+            + "memory-stream limit; the failure report would not have been deliverable with it "
+            + $"attached\",\"bytes\":{payloadBytes},\"head\":{Quote(Head(delivery))}}}"));
+    }
+
+    private static string Preview(IMessageDelivery delivery) =>
+        delivery.Message is RawJson { Content: { } content }
+            ? Head(content) is var head && head.Length < content.Length ? head + "…" : head
+            : delivery.Message?.GetType().Name ?? "<null>";
+
+    private static string Head(IMessageDelivery delivery) =>
+        delivery.Message is RawJson { Content: { } content } ? Head(content) : string.Empty;
+
+    private static string Head(string content) =>
+        content.Length <= PayloadPreviewChars ? content : content[..PayloadPreviewChars];
+
+    private static string Quote(string value) =>
+        System.Text.Json.JsonSerializer.Serialize(value);
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/OversizedStreamMessageRefusedTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OversizedStreamMessageRefusedTest.cs
@@ -129,6 +129,37 @@ public class OversizedStreamMessageRefusedTest
         error.Message.Should().Contain("BigAnalyticsPayload",
             "…and enough of the payload head to recognise WHAT was too big — the $type sits at the "
             + "front of the JSON, and identifying the producer is the question #1890 could not answer");
+
+        // 🚨 The payload is attacker-influenced content going into a log line, and a red burst is
+        // re-assembled from its indented continuation lines — an embedded newline in the preview
+        // would forge a second log record and split one incident into two.
+        error.Message.Split('\n').Should().HaveCount(1,
+            "the refusal must stay ONE log record: the payload head is JSON-quoted, so a newline "
+            + "inside it cannot break the burst apart");
+    }
+
+    /// <summary>
+    /// The preview is quoted, so a payload carrying newlines and quotes cannot forge log records
+    /// or break the refusal into pieces the watcher would parse as separate faults.
+    /// </summary>
+    [Fact]
+    public void A_payload_carrying_newlines_cannot_break_the_refusal_into_two_log_records()
+    {
+        var hostile = "{\"$type\":\"Evil\",\"x\":\"\nfail: Forged.Category[0]\n      forged\n"
+            + new string('y', StreamMessageSizeGuard.MemoryStreamBlockBytes) + "\"}";
+        var delivery = new MessageDelivery<RawJson>(
+            Sender, new Address("portal", "user-1"), new RawJson(hostile),
+            JsonSerializerOptions.Default) with
+        { Id = "d-hostile" };
+
+        var refusal = StreamMessageSizeGuard.Describe(
+            delivery, Target,
+            Encoding.UTF8.GetByteCount(hostile), StreamMessageSizeGuard.MemoryStreamBlockBytes);
+
+        refusal.Split('\n').Should().HaveCount(1,
+            "an unescaped newline in the payload would open what reads as a fresh `fail:` burst");
+        refusal.Should().Contain("\\n", "the newline is escaped, not dropped — the head stays legible");
+        refusal.Should().Contain("Evil", "…and the $type is still identifiable");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Orleans.Test/OversizedStreamMessageRefusedTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OversizedStreamMessageRefusedTest.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+using Orleans.Providers.Streams.Common;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 An oversized memory-stream message is REFUSED at the producer, loudly — issue #1890.
+///
+/// <para><b>The incident.</b> A 37,483,597-byte delivery went onto <c>memory-7-0xE0000007</c>. The
+/// publish succeeded. On the consuming side <c>MemoryPooledCache.AddToCache</c> threw
+/// <c>ArgumentOutOfRangeException: Message size is too big</c> inside
+/// <c>PersistentStreamPullingAgent.ReadFromQueue</c>'s retry loop — a retry that can never
+/// converge, because the size is a property of the message. The message was never delivered, and
+/// the only artefact was a queue id: no target, no message type, no delivery id, no sender. The
+/// ticket had to guess at the producer.</para>
+///
+/// <para><b>The three options, and why refusal is the answer.</b> <i>Raising the cap</i> is not
+/// available — Orleans hard-codes a 1 MiB block (<c>MemoryAdapterFactory</c>:
+/// <c>var oneMb = 1 &lt;&lt; 20; new ObjectPool&lt;FixedSizeBuffer&gt;(() =&gt; new
+/// FixedSizeBuffer(oneMb))</c>) with no configuration surface, and
+/// <see cref="The_orleans_block_size_is_what_the_guard_is_calibrated_against"/> pins that against
+/// the real type rather than against a comment. <i>Chunking</i> is a new wire protocol for a case
+/// that has happened once and is far likelier to be a producer defect. So: do not put on the queue
+/// what cannot come off it, and say exactly what was dropped — which is what turns "a queue id"
+/// into "this delivery, this size, this target, this sender".</para>
+///
+/// <para><b>This can only convert a silent loss into a loud one.</b> The bound is Orleans' own, so
+/// nothing that is delivered today is newly refused —
+/// <see cref="A_delivery_that_fits_is_posted_unchanged"/> is the control.</para>
+/// </summary>
+public class OversizedStreamMessageRefusedTest
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
+    private static readonly Address Sender = new("client", "producer-1");
+    private const string Target = "portal/user-1";
+
+    /// <summary>The incident's payload size, to the byte.</summary>
+    private const int IncidentPayloadBytes = 37_483_597;
+
+    /// <summary>Captures every record so a test can assert the refusal was REPORTED, not just made.</summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        private readonly List<(LogLevel Level, string Message)> records = [];
+
+        public IReadOnlyList<(LogLevel Level, string Message)> Records => records;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => records.Add((logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    /// <summary>
+    /// A routed delivery whose packaged payload is <paramref name="payloadBytes"/> of ASCII JSON —
+    /// the shape the router sees (MeshBuilder packages every delivery to <see cref="RawJson"/>
+    /// before <c>DeliverMessage</c>), so the guard measures the same thing production does.
+    /// </summary>
+    private static IMessageDelivery DeliveryOf(int payloadBytes, string id = "d-oversized")
+    {
+        const string head = "{\"$type\":\"BigAnalyticsPayload\",\"rows\":\"";
+        const string tail = "\"}";
+        var filler = new string('x', Math.Max(0, payloadBytes - head.Length - tail.Length));
+        var json = head + filler + tail;
+        Encoding.UTF8.GetByteCount(json).Should().Be(payloadBytes, "the fixture is exact ASCII");
+        return new MessageDelivery<RawJson>(
+            Sender, new Address("portal", "user-1"), new RawJson(json),
+            JsonSerializerOptions.Default) with
+        { Id = id };
+    }
+
+    /// <summary>
+    /// 🚨 THE regression test. The 37 MB delivery from the incident must NOT reach the stream, and
+    /// the drop must be attributable: the log names the target, the byte count, the limit, the
+    /// delivery id and the sender — every fact the Orleans-side exception could not supply.
+    ///
+    /// <para>Against <c>origin/main</c> the post is issued and the leg reports success, because
+    /// publishing an undeliverable message to a memory stream succeeds by construction. That is the
+    /// silent failure.</para>
+    /// </summary>
+    [Fact]
+    public async Task The_37mb_delivery_from_the_incident_is_never_posted()
+    {
+        var posted = 0;
+        var nacks = new List<(string Message, ErrorType Type)>();
+        var logger = new RecordingLogger();
+
+        await RoutingGrain.PostToStream(
+                delivery: DeliveryOf(IncidentPayloadBytes),
+                post: () => { posted++; return Task.CompletedTask; },
+                addressPath: Target,
+                sender: Sender,
+                postFailureToSender: (m, t) => nacks.Add((m, t)),
+                logger: logger,
+                timeout: Timeout)
+            .ToTask();
+
+        posted.Should().Be(0,
+            "a message Orleans' pooled cache provably cannot accept must never be published — "
+            + "publishing it SUCCEEDS here and fails on the consuming side, where the only "
+            + "identifying fact left is a queue id");
+
+        var error = logger.Records.Should().ContainSingle(r => r.Level == LogLevel.Error,
+            "a rejected message that vanishes is a stream delivery failure nobody can trace — the "
+            + "refusal must be reported").Which;
+        error.Message.Should().Contain(IncidentPayloadBytes.ToString("N0"),
+            "the report says HOW BIG the thing it dropped was");
+        error.Message.Should().Contain("1,048,576",
+            "…and what limit it was measured against, so the reader can tell 37x-over from 1%-over");
+        error.Message.Should().Contain(Target, "…and where it was going");
+        error.Message.Should().Contain("d-oversized", "…which delivery it was");
+        error.Message.Should().Contain("BigAnalyticsPayload",
+            "…and enough of the payload head to recognise WHAT was too big — the $type sits at the "
+            + "front of the JSON, and identifying the producer is the question #1890 could not answer");
+    }
+
+    /// <summary>
+    /// The sender must be told, and told terminally. Without a NACK the producer's
+    /// <c>Observe(...)</c> parks until its own timeout on a message that was never going anywhere —
+    /// which is precisely how this defect stayed invisible for a whole delivery cycle.
+    /// </summary>
+    [Fact]
+    public async Task The_sender_is_nacked_instead_of_waiting_for_a_message_that_can_never_arrive()
+    {
+        var nacks = new List<(string Message, ErrorType Type)>();
+
+        await RoutingGrain.PostToStream(
+                delivery: DeliveryOf(IncidentPayloadBytes),
+                post: () => Task.CompletedTask,
+                addressPath: Target,
+                sender: Sender,
+                postFailureToSender: (m, t) => nacks.Add((m, t)),
+                logger: new RecordingLogger(),
+                timeout: Timeout)
+            .ToTask();
+
+        var nack = nacks.Should().ContainSingle(
+            "the producer must fail fast rather than wait out a timeout on an undeliverable "
+            + "message").Subject;
+        nack.Type.Should().Be(ErrorType.Rejected,
+            "this is an explicit refusal by the router, not a processing fault — the sender can "
+            + "act on the difference");
+        nack.Message.Should().Contain("37,483,597");
+        nack.Message.Should().Contain(Target);
+    }
+
+    /// <summary>
+    /// 🚨 THE CONTROL that makes the fix safe: the bound is Orleans' own, so a delivery that fits
+    /// is posted exactly as before, with no NACK and no log. A guard that also refused working
+    /// traffic would trade one outage for a bigger one.
+    /// </summary>
+    [Fact]
+    public async Task A_delivery_that_fits_is_posted_unchanged()
+    {
+        var posted = 0;
+        var nacks = new List<(string Message, ErrorType Type)>();
+        var logger = new RecordingLogger();
+
+        await RoutingGrain.PostToStream(
+                delivery: DeliveryOf(StreamMessageSizeGuard.MemoryStreamBlockBytes - 1, "d-fits"),
+                post: () => { posted++; return Task.CompletedTask; },
+                addressPath: Target,
+                sender: Sender,
+                postFailureToSender: (m, t) => nacks.Add((m, t)),
+                logger: logger,
+                timeout: Timeout)
+            .ToTask();
+
+        posted.Should().Be(1, "everything under Orleans' block size is delivered exactly as before");
+        nacks.Should().BeEmpty("a delivered post must never NACK the sender");
+        logger.Records.Should().BeEmpty("nor say anything about it");
+    }
+
+    /// <summary>
+    /// 🚨 The NACK must not BE the thing it reports. <see cref="DeliveryFailure"/> embeds the
+    /// ORIGINAL delivery and travels the SAME memory stream, so a failure report about a 37 MB
+    /// message is itself a 37 MB message and dies at exactly the wall it is describing — leaving
+    /// the producer with neither the message nor the report.
+    ///
+    /// <para>This is a second-order defect of the same shape, and it is the reason a "just NACK it"
+    /// fix is not enough on its own.</para>
+    /// </summary>
+    [Fact]
+    public void The_failure_report_about_an_oversized_delivery_is_itself_deliverable()
+    {
+        var oversized = DeliveryOf(IncidentPayloadBytes);
+
+        var echoed = StreamMessageSizeGuard.WithoutOversizedPayload(oversized);
+
+        StreamMessageSizeGuard.IsOversized(
+                echoed, StreamMessageSizeGuard.MemoryStreamBlockBytes, out var echoedBytes)
+            .Should().BeFalse(
+                "the DeliveryFailure that carries this echo goes back over the same memory stream — "
+                + "if the echo is still oversized, the report about the lost message is lost the "
+                + "same way and the producer learns nothing at all");
+        echoedBytes.Should().Be(0, "the fast path proved it fits without measuring");
+
+        // Bounded before asserting: under a neutered guard this string is the 37 MB payload, and a
+        // failed assertion prints its subject.
+        var replacement = ((RawJson)echoed.Message).Content;
+        replacement.Length.Should().BeLessThan(4096,
+            "the echo the DeliveryFailure carries must be a description, not the payload");
+        replacement.Should().Contain("payloadOmitted",
+            "a stripped echo must say it was stripped, or it reads as an empty message");
+        replacement.Should().Contain("37483597", "…and how big the thing it replaced was");
+        replacement.Should().Contain("BigAnalyticsPayload",
+            "…and keep enough head to identify it");
+
+        echoed.Id.Should().Be(oversized.Id,
+            "the envelope is untouched — the sender correlates a DeliveryFailure on RequestId, and "
+            + "stripping the payload must not disturb that");
+
+        // …and a report about an ordinary failure is unchanged: stripping happens only when
+        // carrying the payload is what would lose the report.
+        var small = DeliveryOf(1024, "d-small");
+        StreamMessageSizeGuard.WithoutOversizedPayload(small).Should().BeSameAs(small);
+    }
+
+    /// <summary>
+    /// 🚨 CALIBRATION. The guard's constant is only meaningful if it IS Orleans' block size — set
+    /// it too low and working traffic is refused; too high and the guard never fires. Rather than
+    /// trust the comment in <c>MemoryAdapterFactory</c>, this asks the real
+    /// <see cref="FixedSizeBuffer"/> Orleans allocates: a block of exactly
+    /// <see cref="StreamMessageSizeGuard.MemoryStreamBlockBytes"/> holds a segment of that size and
+    /// not one byte more. An Orleans upgrade that moved the block size therefore fails HERE, rather
+    /// than silently mis-tuning the guard in production.
+    /// </summary>
+    [Fact]
+    public void The_orleans_block_size_is_what_the_guard_is_calibrated_against()
+    {
+        var block = new FixedSizeBuffer(StreamMessageSizeGuard.MemoryStreamBlockBytes);
+
+        block.TryGetSegment(StreamMessageSizeGuard.MemoryStreamBlockBytes + 1, out _)
+            .Should().BeFalse(
+                "Orleans allocates one fixed block per message and a cached message must fit it "
+                + "whole — this is the ceiling MemoryPooledCache.AddToCache reports as 'Message "
+                + "size is too big', and the guard's constant must be exactly it");
+
+        new FixedSizeBuffer(StreamMessageSizeGuard.MemoryStreamBlockBytes)
+            .TryGetSegment(StreamMessageSizeGuard.MemoryStreamBlockBytes, out _)
+            .Should().BeTrue(
+                "a full block is the most a clean buffer can hold — so refusing AT the limit (not "
+                + "just above it) is the correct side to err on: the on-queue form also carries a "
+                + "stream id and metadata in that same block");
+    }
+
+    /// <summary>
+    /// The measurement itself: exact where it matters, and free where it does not. The fast path
+    /// is a sound proof, not an approximation — a UTF-16 char never contributes more than 3 UTF-8
+    /// bytes — so a multi-byte payload is still measured correctly rather than waved through.
+    /// </summary>
+    [Fact]
+    public void The_size_check_is_exact_for_multibyte_payloads_and_free_for_small_ones()
+    {
+        // 400k characters of a 3-byte-in-UTF-8 rune: 1.2 MB on the wire, well over the block,
+        // while its UTF-16 LENGTH (400,000) is comfortably under it. A char-count check would
+        // have waved this through.
+        var multiByte = new MessageDelivery<RawJson>(
+            Sender, new Address("portal", "user-1"),
+            new RawJson(string.Concat(Enumerable.Repeat("€", 400_000))),
+            JsonSerializerOptions.Default);
+
+        StreamMessageSizeGuard.IsOversized(
+                multiByte, StreamMessageSizeGuard.MemoryStreamBlockBytes, out var bytes)
+            .Should().BeTrue("1.2 MB of UTF-8 is over the block regardless of how few chars it took");
+        bytes.Should().Be(1_200_000);
+
+        // A payload that is not RawJson is never measured — by the time a delivery reaches the
+        // router it has been packaged, so anything else would mean serialising twice on the hot
+        // path to answer a question that is almost always "no".
+        StreamMessageSizeGuard.IsOversized(
+                new MessageDelivery<string>(Sender, new Address("portal", "user-1"),
+                    new string('x', 4_000_000), JsonSerializerOptions.Default),
+                StreamMessageSizeGuard.MemoryStreamBlockBytes, out _)
+            .Should().BeFalse("an unpackaged payload is not the routed shape and is not guessed at");
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainStreamPostBoundTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainStreamPostBoundTest.cs
@@ -30,6 +30,18 @@ public class RoutingGrainStreamPostBoundTest
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
     private static readonly Address Sender = new("client", "sender-1");
 
+    /// <summary>
+    /// A routed delivery of the shape the router actually sees: the payload is already
+    /// <see cref="RawJson"/> (MeshBuilder packages it before <c>DeliverMessage</c>). Small, so the
+    /// size guard added for #1890 is a no-op on these cases and they still test what they were
+    /// written for.
+    /// </summary>
+    private static IMessageDelivery Delivery(string id) =>
+        new MessageDelivery<RawJson>(
+            Sender, new Address("portal", "user"), new RawJson("{\"$type\":\"Ping\"}"),
+            System.Text.Json.JsonSerializerOptions.Default) with
+        { Id = id };
+
     [Fact]
     public void PostThatNeverCompletes_TerminatesOnTimeout_AndNacksSender()
     {
@@ -40,9 +52,9 @@ public class RoutingGrainStreamPostBoundTest
         var terminated = false;
 
         RoutingGrain.PostToStream(
+                delivery: Delivery("d1"),
                 post: () => never.Task,
                 addressPath: "portal/user-1",
-                deliveryId: "d1",
                 sender: Sender,
                 postFailureToSender: (m, t) => nacks.Add((m, t)),
                 logger: NullLogger.Instance,
@@ -75,9 +87,9 @@ public class RoutingGrainStreamPostBoundTest
         var nacks = new List<(string Message, ErrorType Type)>();
 
         await RoutingGrain.PostToStream(
+                delivery: Delivery("d2"),
                 post: () => Task.FromException(new InvalidOperationException("stream provider down")),
                 addressPath: "portal/user-2",
-                deliveryId: "d2",
                 sender: Sender,
                 postFailureToSender: (m, t) => nacks.Add((m, t)),
                 logger: NullLogger.Instance,
@@ -95,9 +107,9 @@ public class RoutingGrainStreamPostBoundTest
         var nacks = new List<(string Message, ErrorType Type)>();
 
         var result = await RoutingGrain.PostToStream(
+                delivery: Delivery("d3"),
                 post: () => Task.CompletedTask,
                 addressPath: "portal/user-3",
-                deliveryId: "d3",
                 sender: Sender,
                 postFailureToSender: (m, t) => nacks.Add((m, t)),
                 logger: NullLogger.Instance,


### PR DESCRIPTION
Fixes #1890.

## What actually happened

A 37,483,597-byte delivery was published to `memory-7-0xE0000007`. **The publish succeeded.** On the consuming side `MemoryPooledCache.AddToCache` threw `ArgumentOutOfRangeException: Message size is too big` inside `PersistentStreamPullingAgent.ReadFromQueue`'s retry loop — a retry that can never converge, because the size is a property of the message, not of the attempt.

Three consequences, and the third is the one that matters:

1. the message was never delivered;
2. the producer was never told — it had already been handed a successful publish, so its `Observe(...)` waited out its own timeout;
3. **the only artefact was a queue id.** No target, no message type, no delivery id, no sender. The issue's own "where to look" ends with *"identify what writes to stream namespace `0xE0000007` on partition 7"* — that question is unanswerable from the evidence the current code leaves.

## Which of the three options, and why

- **Raise the cap** — not available. Orleans hard-codes the block size: `MemoryAdapterFactory.CreateBufferPoolIfNotCreatedYet` does `var oneMb = 1 << 20; new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(oneMb))`, with no configuration surface, and a cached message must fit **one whole clean block**. (Also: raising a bound to make a failure go away is the band-aid AGENTS.md forbids.)
- **Chunk the payload** — a new wire protocol for a case that has occurred once and is far likelier to be a producer defect than a legitimate payload.
- **Do not put it on that queue** — the answer. Refuse at the producer, where every fact needed to find the producer is still in hand.

## The change

The bound sits at the same seam as the existing stream-post timeout (`RoutingGrain.PostToStream`), because they are the same kind of event — *this delivery is not going to land; terminate and NACK*. On refusal:

- **nothing is posted**;
- an `Error` names the target, the byte count, the limit, the delivery id, the sender, and the head of the payload (where the `$type` sits);
- the sender gets a terminal `ErrorType.Rejected` instead of parking.

**This can only convert a silent loss into a loud one.** The bound *is* Orleans' own, so everything it refuses was already being dropped — `A_delivery_that_fits_is_posted_unchanged` is the control. It is deliberately not an exact admission test: the on-queue form carries an envelope the producer cannot see, so a payload just under the block can still be rejected inside Orleans. That residual band is unchanged; the gross case (37× over) is what this attributes.

Measurement is exact where it matters and free where it does not: `3 × Length < limit` is a sound O(1) proof that a payload fits (a UTF-16 char is at most 3 UTF-8 bytes), so the hot path never scans; only a candidate pays for `GetByteCount`.

## Second-order defect found while fixing it

`DeliveryFailure` embeds the **original delivery — payload included** — and the NACK travels the **same memory stream**. So a failure report about a 37 MB message is itself a 37 MB message and would have died at exactly the wall it was reporting on, leaving the producer with neither the message nor the report. An undeliverable echo is now replaced by a description of itself (`payloadOmitted`, the byte count, the payload head); the sender correlates a `DeliveryFailure` on `RequestId`, never on the echoed payload. `The_failure_report_about_an_oversized_delivery_is_itself_deliverable` pins it.

## Tests

6 new in `OversizedStreamMessageRefusedTest`, no cluster, deterministic:

- the incident's exact 37,483,597-byte delivery is **never posted**, and the error names size / limit / target / delivery / payload head;
- the sender is NACK'd `Rejected` rather than left waiting;
- **control**: a delivery that fits is posted unchanged, with no NACK and no log;
- the failure report about an oversized delivery is itself deliverable;
- **calibration**: the guard's constant is asserted against the real `Orleans.Providers.Streams.Common.FixedSizeBuffer` — a block of exactly `1 << 20` holds a segment of that size and not one byte more. An Orleans upgrade that moved the block size fails *here* instead of silently mis-tuning the guard.
- the size check is exact for multi-byte payloads (1.2 MB of `€` in 400k chars is caught) and skips a non-`RawJson` payload rather than guessing.

**Non-vacuity**: with `IsOversized` neutered to main's behaviour (no producer-side bound), 4 of the 6 fail —
`Expected value to be 0 …, but found 1` (the message was posted), `Expected collection to contain a single item …, but found 0` (no NACK), and the echo/measurement pins. The remaining 2 are the calibration and the fits-unchanged control, which are preservation tests by design.

`MeshWeaver.Hosting.Orleans.Test` in full: **176 passed, 0 failed** (includes the real-cluster routing tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)