### PR TITLE
fix: the portal read its user directory as a search page, so most viewers lost their time zone (#1936)

### DIFF
--- a/src/MeshWeaver.Blazor/Infrastructure/UserIdentityCache.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/UserIdentityCache.cs
@@ -3,6 +3,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Logging;
@@ -166,6 +167,21 @@ public sealed class UserIdentityCache : IDisposable
     private string? _subscriptionFailure;
 
     /// <summary>
+    /// The directory read this index is built from — exposed so its two non-negotiable properties
+    /// are assertable without a mesh (see the 🚨 note in the constructor for what each one costs).
+    ///
+    /// <list type="bullet">
+    ///   <item><b>Complete</b> — an ENUMERATION, not a search page. The query is unpinned, so on
+    ///     Postgres a request that states no limit is answered with the 50 most recently modified
+    ///     matches and the caller cannot tell.</item>
+    ///   <item><b>System</b> — a process-wide directory, resolved once, used to answer "who is the
+    ///     caller"; it must not inherit the permissions of whoever happened to construct it.</item>
+    /// </list>
+    /// </summary>
+    public static MeshQueryRequest DirectoryQuery { get; } =
+        MeshQueryRequest.FromQuery("nodeType:User").AsSystem().Complete();
+
+    /// <summary>
     /// Subscribes to the live <c>nodeType:User</c> query and builds the email-to-node index.
     /// The index is ready as soon as the first query emission arrives.
     /// </summary>
@@ -187,8 +203,39 @@ public sealed class UserIdentityCache : IDisposable
         // (see IndexChanged). Publish + Connect, not Publish().RefCount(): the cache's connection
         // is unconditional and lives for the object's lifetime, so the index keeps filling even
         // while nobody is waiting on it — a RefCount that dropped to zero would tear the query down.
+        //
+        // 🚨 Complete() + AsSystem() are BOTH load-bearing, and each on its own is the whole bug
+        // (#1936). This query is the portal's USER DIRECTORY: a row that is missing from it does
+        // not shorten a list, it changes who the portal thinks you are.
+        //
+        //   • Complete() — the query is UNPINNED (no path:/namespace:), so on Postgres it is
+        //     served by the cross-schema fan-out, which answers a request that states no limit
+        //     with a PAGE: the 50 most recently modified matches, ordered last_modified DESC
+        //     (PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit). Every user outside that
+        //     page fell out of the index. And because a User node's last_modified only moves when
+        //     the PROFILE is written, the omission is self-reinforcing: the longer you go without
+        //     editing your profile, the more certainly you are missing — the identical shape as
+        //     #1216 (baked 237 NodeTypes against 50 Code nodes) and #1326 (9 of 43 Spaces
+        //     permanently stale). This is an ENUMERATION, so it says so.
+        //   • AsSystem() — the directory is process-wide and is consumed to resolve the CALLING
+        //     user's own identity, so it must not be scoped to whichever caller happened to
+        //     resolve this singleton first. MeshService.StampViewer pins the viewer from the
+        //     ambient AccessContext at CALL time; on a portal that is whoever hit it first after a
+        //     restart, and off a circuit's own call tree it is nobody at all — an index built as
+        //     Anonymous hydrates EMPTY and answers "no such user" about everyone, forever. Reading
+        //     it as System is the framework-plumbing case AsSystem() exists for; it discloses
+        //     nothing, because every consumer looks up the AUTHENTICATED caller's OWN email
+        //     (UserContextMiddleware, ResolveHttpCaller, CircuitAccessHandler) and reads only
+        //     Id / Name / TimeZoneId / Locale off the result.
+        //
+        // What either omission COSTS, and why it was invisible: a missing row makes Lookup answer
+        // a DETERMINATE Unknown — the index is hydrated, so "not here" reads as "no such user".
+        // Both context builders then keep the claims SEED, which carries no TimeZoneId and no
+        // Locale, so every timestamp renders UTC and every string English; CircuitAccessHandler
+        // does not even start its identity repair, because that runs only on Unavailable. Nothing
+        // is logged, and ObjectId / Email / IsVirtual all still look correct.
         var applied = mesh
-            .Query<MeshNode>(MeshQueryRequest.FromQuery("nodeType:User"))
+            .Query<MeshNode>(DirectoryQuery)
             .Select(change =>
             {
                 Apply(change);
@@ -282,26 +329,25 @@ public sealed class UserIdentityCache : IDisposable
     /// </summary>
     public MeshNode? TryGetByEmail(string email) => Lookup(email).Node;
 
+    /// <summary>
+    /// The node's profile email — the index KEY.
+    ///
+    /// <para>🚨 Read through <see cref="MeshNodeContentExtensions.ContentAs{T}"/>, never a bare
+    /// <c>is JsonElement</c> probe plus reflection. Content arrives typed on the hub that owns the
+    /// type, as a <see cref="JsonElement"/> when it degraded at a query seam, and as a
+    /// <c>JsonNode</c> from the node builders — and the old shape test handled only the first two,
+    /// so any other shape silently dropped the user from the directory. A dropped user is not a
+    /// shorter list here: <see cref="Lookup"/> then answers a DETERMINATE "no such user", both
+    /// context builders keep the claims seed, and that seed has no TimeZoneId and no Locale
+    /// (#1936). Same rule, same failure mode, as the <c>_Policy</c> write storm and #189.</para>
+    /// </summary>
     private bool TryGetEmail(MeshNode node, out string email)
     {
         email = "";
         if (node.Content is null) return false;
         try
         {
-            string? value = null;
-            if (node.Content is JsonElement je)
-            {
-                if (je.ValueKind == JsonValueKind.Object
-                    && je.TryGetProperty("email", out var emailProp)
-                    && emailProp.ValueKind == JsonValueKind.String)
-                    value = emailProp.GetString();
-            }
-            else
-            {
-                var prop = node.Content.GetType().GetProperty("Email")
-                           ?? node.Content.GetType().GetProperty("email");
-                value = prop?.GetValue(node.Content) as string;
-            }
+            var value = node.ContentAs<User>(_jsonOptions, _logger)?.Email;
             if (!string.IsNullOrEmpty(value))
             {
                 email = value;

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-timestamps-in-your-own-time-zone-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-timestamps-in-your-own-time-zone-again.md
@@ -1,0 +1,34 @@
+---
+Name: Timestamps show your own time zone again
+Category: Fix
+Description: The portal stopped finding most users' profiles, so their time zone and language silently fell back to UTC and English. It reads the full user directory again.
+Icon: Clock
+Order: -20260821
+---
+
+# Timestamps show your own time zone again
+
+If your profile says `Europe/Zurich`, every timestamp in the portal is supposed to be shown in
+Zurich time. For most people it had quietly gone back to UTC — an hour or two out, and on a late
+evening a whole day out — and the portal was serving English chrome to users whose profile asks for
+German.
+
+The setting was never lost. What broke was the lookup that turns your sign-in into your profile.
+
+The portal keeps an index of every user, and asks it "who is this email?" once per sign-in; your
+time zone and your language ride along on the answer. That index was being filled with a *search*
+rather than a *listing*, so it only ever contained the fifty most recently edited profiles. Everyone
+else came back as "no such user" — a perfectly confident answer, with no error anywhere — and the
+portal fell back to what it could read off the sign-in alone: your name and your email, but no time
+zone and no language.
+
+It also got worse by itself. A profile's timestamp only moves when the profile is edited, so the
+longer you went without touching yours, the more certainly you had dropped off the list.
+
+The index now reads the whole directory, and reads it as the platform rather than as whoever
+happened to open the portal first after a restart. It also survives a couple of internal shapes a
+profile can arrive in that used to make it skip a user entirely.
+
+Nothing you stored changed: times are still kept in UTC and only converted for display, and your
+time zone and language preferences are exactly as you left them. Sign in again — or reload — and
+the clock is yours.

--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -119,13 +119,20 @@ public record LayoutAreaHost : IDisposable
         var capturedAccessContext = accessService?.Context;
         var ctorLogger = workspace.Hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.Layout.LayoutAreaHost");
+        // 🚨 TimeZoneId and Locale are logged BECAUSE they are the fields that differ between a
+        // context resolved from the mesh User profile and one left as the claims SEED — ObjectId,
+        // Email and IsVirtual are identical on both, so a line without them shows a healthy
+        // identity while every timestamp on the page renders UTC and every string English. That is
+        // exactly what made #1936 undiagnosable from logs: the capture "looked correct" for days.
         ctorLogger?.LogDebug(
-            "[LayoutAreaHost.ctor] hub={Hub} area={Area} captured AccessContext: ObjectId={ObjectId} Email={Email} IsVirtual={IsVirtual} (Context={HasContext}, CircuitContext={HasCircuit})",
+            "[LayoutAreaHost.ctor] hub={Hub} area={Area} captured AccessContext: ObjectId={ObjectId} Email={Email} IsVirtual={IsVirtual} TimeZoneId={TimeZoneId} Locale={Locale} (Context={HasContext}, CircuitContext={HasCircuit})",
             workspace.Hub.Address,
             reference.Area ?? "(default)",
             capturedAccessContext?.ObjectId ?? "(null)",
             capturedAccessContext?.Email ?? "(null)",
             capturedAccessContext?.IsVirtual ?? false,
+            capturedAccessContext?.TimeZoneId ?? "(null)",
+            capturedAccessContext?.Locale ?? "(null)",
             accessService?.Context != null,
             accessService?.CircuitContext != null);
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/UserDirectoryContentShapeTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/UserDirectoryContentShapeTest.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using MeshWeaver.Blazor.Infrastructure;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The user directory must key on the profile email in WHATEVER SHAPE the content arrives —
+/// the second half of issue #1936, and a textbook instance of the codebase's rule 1
+/// ("read <c>node.Content</c> in whatever shape it arrives; <c>is not JsonElement → give up</c>
+/// reads nothing, silently").
+///
+/// <para><see cref="UserIdentityCache"/> used to extract the email with a bare
+/// <c>node.Content is JsonElement</c> probe plus a reflection fallback for a typed instance. Content
+/// is legitimately other things in a running mesh: a <c>JsonNode</c>/<c>JsonObject</c> (what the
+/// node builders emit — <c>NodeElement.Of</c> exists for exactly this), and a same-short-named type
+/// from another dynamic assembly, which the framework re-types at the query seam. Each of those
+/// dropped the user out of the directory with no error anywhere.</para>
+///
+/// <para>A dropped user is not a shorter list: <see cref="UserIdentityCache.Lookup"/> then reports
+/// a DETERMINATE "no such user", so both the SSR request path and the Blazor circuit keep the
+/// claims seed — right <c>ObjectId</c>, right <c>Email</c>, and NO <c>TimeZoneId</c> and NO
+/// <c>Locale</c>. Timestamps render UTC, strings render English, and nothing is logged.</para>
+/// </summary>
+public class UserDirectoryContentShapeTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private static User Profile(string email) =>
+        new() { Email = email, TimeZoneId = "Europe/Zurich", Locale = "de" };
+
+    /// <summary>
+    /// Every shape a <c>User</c> node's content legitimately takes must still be indexed AND must
+    /// still project the profile onto the identity.
+    /// </summary>
+    [Theory(Timeout = 120_000)]
+    [InlineData("typed")]
+    [InlineData("JsonElement")]
+    [InlineData("JsonObject")]
+    public async Task EveryContentShape_IsIndexedAndProjects(string shape)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var id = $"shape{shape.ToLowerInvariant()}";
+        var email = $"{id}@meshweaver.io";
+        var camel = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        object content = shape switch
+        {
+            "typed" => Profile(email),
+            "JsonElement" => JsonSerializer.Deserialize<JsonElement>(
+                JsonSerializer.Serialize(Profile(email), camel), camel),
+            _ => JsonNode.Parse(JsonSerializer.Serialize(Profile(email), camel))!,
+        };
+
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        using (access.ImpersonateAsSystem())
+        {
+            await MeshService.CreateNode(MeshNode.FromPath(id) with
+            {
+                Name = id,
+                NodeType = "User",
+                State = MeshNodeState.Active,
+                Content = content
+            }).Should().Within(60.Seconds()).Emit();
+        }
+
+        using var cache = new UserIdentityCache(
+            MeshService, Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<UserIdentityCache>>());
+
+        var lookup = await cache.WhenDetermined(email).Timeout(60.Seconds()).FirstAsync().ToTask(ct);
+        Output.WriteLine(
+            $"{shape}: content={lookup.Node?.Content?.GetType().Name ?? "(none)"} "
+            + $"node={lookup.Node?.Path ?? "(null)"}");
+
+        lookup.Node.Should().NotBeNull(
+            $"a User node whose content arrives as '{shape}' must still be indexed by email — "
+            + "dropping it makes the directory answer a determinate 'no such user' and the viewer "
+            + "silently loses their time zone and language");
+
+        MeshUserProjection
+            .Apply(new AccessContext { ObjectId = id, Email = email }, lookup.Node!, Mesh.JsonSerializerOptions)
+            .TimeZoneId.Should().Be("Europe/Zurich");
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/ViewerTimeZoneRenderTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ViewerTimeZoneRenderTest.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The transport half of the display-time seam (#455 / #513, regression #1936): a SUBSCRIBER's
+/// <see cref="AccessContext.TimeZoneId"/> must reach the layout-area render that runs on the
+/// OWNING node's hub — a different hub, a different action block, and (in production) a different
+/// process from the one the viewer's identity was resolved on.
+///
+/// <para>Both entry shapes are exercised, because they carry the identity differently and the
+/// production report claimed one worked while the other did not:</para>
+/// <list type="bullet">
+///   <item><b>Request</b> — the identity is on <see cref="AccessService.Context"/> when the
+///     subscribe is issued (an HTTP request, an MCP verb, an SSR pass).</item>
+///   <item><b>Circuit</b> — the identity is on <see cref="AccessService.CircuitContext"/> and
+///     <see cref="AccessService.Context"/> is null, which is exactly what
+///     <c>CircuitAccessHandler</c> establishes per Blazor inbound activity.</item>
+/// </list>
+///
+/// <para>🚨 The area resolves the zone the way every render site must:
+/// <c>AccessService.ViewerZoneId()</c> ONCE on the render turn, then
+/// <see cref="DisplayTimeExtensions.ToDisplayTime(DateTimeOffset,string?)"/> with that captured
+/// value — never <c>.ToLocalTime()</c> / <c>.LocalDateTime</c>, which resolve to the SERVER process
+/// zone (UTC in the deployment container, so the conversion is a silent no-op).</para>
+///
+/// <para>The instants cover both DST directions and the DATE ROLLOVER, because a hard-coded offset
+/// passes one row and fails the other, and a missed conversion across midnight reads as an
+/// off-by-one day rather than as a time-zone bug.</para>
+/// </summary>
+public class ViewerTimeZoneRenderTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string NodePath = "clock/Viewer";
+
+    /// <summary>
+    /// One area per stored instant — both DST directions plus the midnight rollover. Separate
+    /// AREAS rather than one area with an id, so the assertion never depends on how an area id is
+    /// folded into the rendered area name.
+    /// </summary>
+    private static readonly (string Area, DateTimeOffset Utc)[] Clocks =
+    [
+        ("ClockSummer", new DateTimeOffset(2026, 7, 20, 14, 32, 0, TimeSpan.Zero)),   // CEST → 16:32
+        ("ClockWinter", new DateTimeOffset(2026, 1, 20, 14, 32, 0, TimeSpan.Zero)),   // CET  → 15:32
+        ("ClockRollover", new DateTimeOffset(2026, 7, 29, 23, 30, 0, TimeSpan.Zero)), // CEST → 07-30 01:30
+    ];
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMeshNodes(MeshNode.FromPath(NodePath) with
+            {
+                Name = "Viewer clock",
+                State = MeshNodeState.Active,
+                HubConfiguration = config => config.AddLayout(layout =>
+                {
+                    foreach (var (area, utc) in Clocks)
+                    {
+                        var instant = utc;
+                        layout = layout.WithView(area, (LayoutAreaHost host, RenderingContext _) =>
+                            (UiControl)Controls.Markdown(Stamp(host, instant)));
+                    }
+                    return layout;
+                })
+            });
+
+    /// <summary>
+    /// The production render shape, verbatim: resolve the viewer's zone ONCE on this turn, then
+    /// format the stored UTC instant through it.
+    /// </summary>
+    private static string Stamp(LayoutAreaHost host, DateTimeOffset storedUtc)
+    {
+        var zone = host.Hub.ServiceProvider.GetService<AccessService>().ViewerZoneId();
+        var local = DisplayTimeExtensions.ToDisplayTime(storedUtc, zone);
+        return $"zone={zone ?? "(null)"} rendered={local:yyyy-MM-dd HH:mm} (UTC{local:zzz})";
+    }
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    [Theory(Timeout = 120_000)]
+    [InlineData("ClockSummer", "2026-07-20 16:32")]
+    [InlineData("ClockWinter", "2026-01-20 15:32")]
+    // The date MOVES — a missed conversion here reads as an off-by-one day, not as a zone bug.
+    [InlineData("ClockRollover", "2026-07-30 01:30")]
+    public async Task RequestViewerZone_ReachesTheOwnerSideRender(string area, string expected)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var viewer = TestUsers.Admin with { TimeZoneId = "Europe/Zurich" };
+
+        string markdown;
+        using (access.SwitchAccessContext(viewer))
+            markdown = await Render(area);
+
+        Output.WriteLine($"request/{area}: {markdown}");
+        markdown.Should().Contain("Europe/Zurich");
+        markdown.Should().Contain(expected);
+    }
+
+    /// <summary>
+    /// The Blazor-circuit shape: the viewer's identity lives ONLY on
+    /// <see cref="AccessService.CircuitContext"/> — <c>CircuitAccessHandler</c> sets that per
+    /// inbound activity and never <see cref="AccessService.Context"/>. This is the path #1936 was
+    /// reported against.
+    /// </summary>
+    [Theory(Timeout = 120_000)]
+    [InlineData("ClockSummer", "2026-07-20 16:32")]
+    [InlineData("ClockWinter", "2026-01-20 15:32")]
+    [InlineData("ClockRollover", "2026-07-30 01:30")]
+    public async Task CircuitViewerZone_ReachesTheOwnerSideRender(string area, string expected)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var viewer = TestUsers.Admin with { TimeZoneId = "Europe/Zurich" };
+
+        access.SetCircuitContext(viewer);
+        string markdown;
+        try
+        {
+            access.Context?.TimeZoneId.Should().BeNull(
+                "the circuit shape is: identity on CircuitContext, nothing on Context — a test that "
+                + "leaked the zone onto Context would prove nothing about the circuit");
+            markdown = await Render(area);
+        }
+        finally
+        {
+            access.SetCircuitContext(null);
+        }
+
+        Output.WriteLine($"circuit/{area}: {markdown}");
+        markdown.Should().Contain("Europe/Zurich");
+        markdown.Should().Contain(expected);
+    }
+
+    /// <summary>
+    /// An unset zone degrades to UTC — never to the SERVER's zone, which looks right in CI and is
+    /// wrong in Zurich.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task NoViewerZone_RendersUtc_NotTheServerZone()
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        string markdown;
+        using (access.SwitchAccessContext(TestUsers.Admin with { TimeZoneId = null }))
+            markdown = await Render("ClockSummer");
+
+        Output.WriteLine($"nozone: {markdown}");
+        markdown.Should().Contain("zone=(null)");
+        markdown.Should().Contain("2026-07-20 14:32");
+        markdown.Should().Contain("(UTC+00:00)");
+    }
+
+    private async Task<string> Render(string area)
+    {
+        var client = GetClient();
+        var reference = new LayoutAreaReference(area);
+        var stream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(NodePath), reference);
+        try
+        {
+            var control = await stream.GetControlStream(reference.Area!)
+                .Should().Within(60.Seconds()).Match(c => c is not null,
+                    $"the '{area}' render must produce a frame");
+            return (control as MarkdownControl)?.Markdown?.ToString() ?? string.Empty;
+        }
+        finally
+        {
+            stream.Dispose();
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/UserDirectoryCompletenessTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/UserDirectoryCompletenessTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Blazor.Infrastructure;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// 🚨 THE PORTAL'S USER DIRECTORY IS AN ENUMERATION — issue #1936.
+///
+/// <para><b>The defect.</b> <see cref="UserIdentityCache"/> is the ONE index that turns an
+/// authenticated caller's email into their mesh <c>User</c> node, and that node is the only source
+/// of <see cref="AccessContext.TimeZoneId"/> and <see cref="AccessContext.Locale"/>
+/// (<see cref="MeshUserProjection"/>). It used to issue a bare <c>nodeType:User</c> query with no
+/// limit. That query carries no <c>path:</c> and no <c>namespace:</c>, so on Postgres it is the
+/// UNPINNED shape served by <c>PostgreSqlCrossSchemaQueryProvider</c>, which answers a request that
+/// states no limit with a PAGE: the 50 most recently modified matches, ordered
+/// <c>last_modified DESC</c>. Every other user was silently absent from the directory.</para>
+///
+/// <para><b>Why it is invisible, and why it gets worse on its own.</b> A missing row makes
+/// <see cref="UserIdentityCache.Lookup"/> answer a DETERMINATE <c>Unknown</c> — the index IS
+/// hydrated, so "not in here" reads as "no such user". Both context builders then keep the claims
+/// SEED: <c>ObjectId</c>, <c>Email</c> and <c>IsVirtual</c> are all still correct, so nothing looks
+/// wrong, no warning is logged (the degradation warning fires only on <c>Unavailable</c>), and
+/// <c>CircuitAccessHandler</c> does not even start its identity repair. What the seed does NOT
+/// carry is the time zone and the language — so every timestamp renders UTC and every string
+/// English. And a <c>User</c> node's <c>last_modified</c> only moves when the PROFILE is written,
+/// so the longer a user goes without editing their profile the more certainly they fall off the
+/// page: self-reinforcing and invisible, the same shape as #1216 and #1326.</para>
+///
+/// <para><b>Why this test is on Postgres.</b> The in-memory <c>StorageAdapterMeshQueryProvider</c>
+/// and the per-schema <c>PostgreSqlMeshQuery</c> both treat "no limit" as UNBOUNDED, so the
+/// identical code is correct on every adapter a unit test uses. Only the cross-schema fan-out caps
+/// it — which is exactly why the defect shipped.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class UserDirectoryCompletenessTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private readonly PostgreSqlFixture _fixture = fixture;
+
+    /// <summary>
+    /// Users seeded ahead of the one under test. Comfortably above the cross-schema fan-out's
+    /// 50-row default — at or below it this test reproduces nothing.
+    /// </summary>
+    private const int CrowdSize = 60;
+
+    /// <summary>The viewer whose profile must still resolve. Seeded FIRST, then buried under
+    /// <see cref="CrowdSize"/> more recently modified users, so it is off the default page.</summary>
+    private const string ForgottenUser = "forgotten";
+
+    private const string ForgottenEmail = "forgotten@meshweaver.io";
+    private const string ForgottenZone = "Europe/Zurich";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString))
+            .AddGraph();
+    }
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private IObservable<Unit> ProvisionPartition(string ns) =>
+        Mesh.ServiceProvider.GetServices<IPartitionStorageProvider>()
+            .Select(p => p.EnsurePartitionProvisioned(ns))
+            .Concat()
+            .DefaultIfEmpty(Unit.Default)
+            .LastOrDefaultAsync();
+
+    /// <summary>
+    /// The directory read's two properties, asserted without a mesh. Cheap, and it names WHAT the
+    /// behavioural test below is protecting — a future edit that drops either one fails here first.
+    /// </summary>
+    [Fact]
+    public void DirectoryQuery_IsAnEnumerationReadAsSystem()
+    {
+        UserIdentityCache.DirectoryQuery.Limit.Should().Be(MeshQueryRequest.NoLimit,
+            "the user directory is an ENUMERATION — a user missing from it does not shorten a list, "
+            + "it changes who the portal thinks the caller is");
+        UserIdentityCache.DirectoryQuery.UserId.Should().Be(WellKnownUsers.System,
+            "a process-wide directory resolved once must not inherit the permissions of whichever "
+            + "caller happened to construct the singleton — off a circuit's own call tree that is "
+            + "nobody at all, and the index then hydrates EMPTY and answers 'no such user' forever");
+    }
+
+    /// <summary>
+    /// The regression itself, end to end: a user buried under more recently modified ones is still
+    /// found by the directory, and their stored zone still reaches the <see cref="AccessContext"/>.
+    /// Before the fix the lookup answered a determinate <c>Unknown</c> and the projection never ran.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task AUserOutsideTheMostRecentlyModifiedPage_StillResolvesTheirProfile()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        // Post-v10 every user OWNS a partition, so this is also the production shape of the read:
+        // an unpinned query UNIONing one schema per user.
+        using (access.ImpersonateAsSystem())
+        {
+            await SeedUser(ForgottenUser, ForgottenEmail, ForgottenZone, "de");
+
+            // Bury it. Each write stamps a NEWER last_modified, so after this the forgotten user is
+            // the OLDEST User node in the mesh and sits well outside the 50-row default page.
+            for (var i = 0; i < CrowdSize; i++)
+                await SeedUser($"crowd{i:D2}", $"crowd{i:D2}@meshweaver.io", "UTC", "en");
+        }
+
+        using var cache = new UserIdentityCache(
+            MeshService, Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<UserIdentityCache>>());
+
+        var lookup = await cache.WhenDetermined(ForgottenEmail)
+            .Timeout(60.Seconds())
+            .FirstAsync()
+            .ToTask(ct);
+
+        Output.WriteLine(
+            $"lookup: node={lookup.Node?.Path ?? "(null)"} unavailable={lookup.UnavailableReason ?? "(no)"}");
+
+        lookup.Node.Should().NotBeNull(
+            $"the directory must contain every user, not the {CrowdSize} most recently modified — a "
+            + "determinate 'no such user' here is what makes both context builders keep the claims "
+            + "seed, which carries no time zone and no language");
+
+        // The whole point of finding the node: the profile reaches the identity.
+        var projected = MeshUserProjection.Apply(
+            new AccessContext { ObjectId = ForgottenUser, Email = ForgottenEmail },
+            lookup.Node!,
+            Mesh.JsonSerializerOptions);
+
+        Output.WriteLine($"projected: tz={projected.TimeZoneId ?? "(null)"} locale={projected.Locale ?? "(null)"}");
+        projected.TimeZoneId.Should().Be(ForgottenZone,
+            "AccessContext.TimeZoneId is what every render path converts stored UTC through — "
+            + "without it the viewer sees the container's clock, which is UTC for everyone");
+        projected.Locale.Should().Be("de");
+
+        // And the zone actually converts: 14:32Z is 16:32 in Zurich in July (CEST).
+        DisplayTimeExtensions
+            .ToDisplayTime(new DateTimeOffset(2026, 7, 20, 14, 32, 0, TimeSpan.Zero), projected.TimeZoneId)
+            .ToString("HH:mm")
+            .Should().Be("16:32");
+    }
+
+    private async Task SeedUser(string id, string email, string zone, string locale)
+    {
+        await ProvisionPartition(id).Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(MeshNode.FromPath(id) with
+        {
+            Name = id,
+            NodeType = "User",
+            State = MeshNodeState.Active,
+            Content = new User { Email = email, TimeZoneId = zone, Locale = locale }
+        }).Should().Within(60.Seconds()).Emit();
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/DisplayTimeTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisplayTimeTest.cs
@@ -36,6 +36,31 @@ public class DisplayTimeTest
         display.Date.Should().Be(utc.UtcDateTime.Date); // no day rollover for these cases
     }
 
+    /// <summary>
+    /// 🚨 The DATE moves. A conversion that never happened reads as an off-by-one DAY rather than
+    /// as a time-zone bug, which is why it survives review — and why an "as of" list, an activity
+    /// feed or a "last deployed" line can be a whole day wrong while every hour on the page looks
+    /// plausible. Both directions: forward across midnight for a zone ahead of UTC, backward for
+    /// one behind it.
+    /// </summary>
+    [Theory]
+    // 23:30Z on 29 July is 01:30 on the THIRTIETH in Zurich (CEST, +2).
+    [InlineData("Europe/Zurich", 2026, 7, 29, 23, 30, 2026, 7, 30, 1, 30)]
+    // 00:30Z on 30 July is 20:30 on the TWENTY-NINTH in New York (EDT, -4).
+    [InlineData("America/New_York", 2026, 7, 30, 0, 30, 2026, 7, 29, 20, 30)]
+    public void ConvertsAcrossMidnight_TheDateMoves(
+        string zoneId,
+        int utcYear, int utcMonth, int utcDay, int utcHour, int utcMinute,
+        int expectedYear, int expectedMonth, int expectedDay, int expectedHour, int expectedMinute)
+    {
+        var utc = new DateTimeOffset(utcYear, utcMonth, utcDay, utcHour, utcMinute, 0, TimeSpan.Zero);
+
+        var display = DisplayTimeExtensions.ToDisplayTime(utc, zoneId);
+
+        display.ToString("yyyy-MM-dd HH:mm")
+            .Should().Be($"{expectedYear:D4}-{expectedMonth:D2}-{expectedDay:D2} {expectedHour:D2}:{expectedMinute:D2}");
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]


### PR DESCRIPTION
Closes #1936.

## What was actually wrong

Not the circuit, and not `AsyncLocal`. **The portal was reading its user directory as a search page.**

`UserIdentityCache` is the one index that turns an authenticated caller's email into their mesh `User` node — and that node is the **only** source of `AccessContext.TimeZoneId` and `AccessContext.Locale` (`MeshUserProjection`). It issued a bare `nodeType:User` query with **no limit**. That query carries no `path:` and no `namespace:`, so on Postgres it is the UNPINNED shape served by `PostgreSqlCrossSchemaQueryProvider`, which answers a request that states no limit with a **PAGE: the 50 most recently modified matches**, ordered `last_modified DESC`. Every other user was silently absent from the directory.

This is the failure family `MeshQueryRequest.Complete()` is documented against, and its third occurrence: #1216 baked 237 NodeTypes against 50 Code nodes; #1326 left 9 of 43 Spaces permanently stale.

### Why the symptom looked like a circuit bug, and why nothing logged

A missing row makes `Lookup` answer a **determinate `Unknown`** — the index *is* hydrated, so "not in here" reads as "no such user". Both context builders then keep the claims SEED, whose `ObjectId`, `Email` and `IsVirtual` are all still correct. Only `TimeZoneId` and `Locale` are missing. And nothing is logged: `CircuitAccessHandler`'s degraded-identity warning **and** its identity repair both fire only on `Unavailable`, never on a determinate miss.

That is the entire reported symptom set — right identity, no warning, UTC clock — on **both** the circuit and the request path.

It also decays on its own: a `User` node's `last_modified` moves only when the profile is *written*, so the longer a viewer goes without editing theirs, the more certainly they have dropped off the page. That is "it worked on this install earlier, and then stopped".

### Measured on the live portal

Two hours of the investigation went into an assumption from the report — that the server-side path still worked. It does not, any more:

- `get @_Setting/area/SettingsAbout` on `memex.meshweaver.cloud` as `rbuergi` (profile `Europe/Zurich`) renders **`Last deployed: 2026-08-20 15:57 (UTC+00:00)`**, and still does on a forced-fresh render (`…/SettingsAbout/probe1`, a different stream key).
- An agent round submitted through MCP shows the decisive fact directly. `HubThreadExtensions.CaptureSubmitter` copies the live `AccessContext` onto the pending `ThreadMessage`, and the node reads:

  ```json
  "submitterObjectId": "rbuergi",
  "submitterName": "Roland Buergi",
  ```

  — no `submitterTimeZoneId`, no `submitterLocale`. The live context has the identity and neither preference. My profile was last modified 2026-08-04; memex has far more than 50 users.

## The fix

Three changes, because each on its own reproduces the whole symptom.

1. **`Complete()`** — the directory is an ENUMERATION, not a search page.
2. **`AsSystem()`** — it is a process-wide directory, resolved once, consumed to answer *"who is the caller"*. It must not inherit the permissions of whichever caller happened to construct the singleton: `MeshService.StampViewer` pins the viewer from the ambient `AccessContext` at **call** time, which on a portal is whoever hit it first after a restart, and off a circuit's own call tree is nobody at all — an index built as Anonymous hydrates EMPTY and answers "no such user" about everyone, forever. It discloses nothing: all three consumers (`UserContextMiddleware`, `ResolveHttpCaller`, `CircuitAccessHandler`) look up the **authenticated caller's own** email and read only `Id` / `Name` / `TimeZoneId` / `Locale` off the result.
3. **`TryGetEmail` reads the content in whatever shape it arrives** (`ContentAs<User>`) instead of an `is JsonElement` probe plus reflection — the codebase's rule 1. A `JsonObject` content (what the node builders emit) silently dropped the user from the directory with no error anywhere.

Plus one diagnosability change the issue explicitly asked for: `LayoutAreaHost`'s capture line now logs `TimeZoneId` and `Locale`. Those are precisely the fields that differ between a resolved context and a claims seed — without them the line showed a healthy identity for days while every timestamp on the page rendered UTC.

## Non-vacuity — each test verified red against the pre-fix code

**`UserDirectoryCompletenessTests`** (Postgres, because the in-memory and per-schema providers both treat "no limit" as unbounded — only the fan-out caps): 61 users, each owning a partition, the oldest one still resolves and its zone still projects. With the fix reverted:

```
lookup: node=(null) unavailable=(no)
Failed  AUserOutsideTheMostRecentlyModifiedPage_StillResolvesTheirProfile
  Expected value not to be <null> because the directory must contain every user,
  not the 60 most recently modified …
Failed  DirectoryQuery_IsAnEnumerationReadAsSystem
  Expected value to be -1 … but found <null>
```

`unavailable=(no)` is the whole bug in one line: a **confident** "no such user".

**`UserDirectoryContentShapeTest`**: typed / `JsonElement` / `JsonObject` all index and project. With `TryGetEmail` reverted, `JsonObject` fails and the other two pass.

**`ViewerTimeZoneRenderTest`**: a subscriber's zone reaches the layout-area render on the OWNING node's hub, for both entry shapes — identity on `Context` (request / MCP / SSR) and identity on `CircuitContext` with `Context` null (the Blazor circuit) — across both DST directions, the midnight rollover, and the unset-zone fallback to UTC (never the server zone). This one **passes on main**, and that is the finding: it is what proved the framework transport was innocent and sent the search upstream. It stays as the regression pin for the seam.

**`DisplayTimeTest`** gains the date-rollover row in both directions (`2026-07-29 23:30Z` → `2026-07-30 01:30` Zurich; `2026-07-30 00:30Z` → `2026-07-29 20:30` New York) — the row that reads as an off-by-one *day* rather than as a time-zone bug.

## Eliminated hypotheses (all three correction comments hold)

- **The pooled render hop drops the `AsyncLocal`** — stays retracted, and now positively disproven: `ViewerTimeZoneRenderTest` renders through `IoPool.SubscribeThroughPool` and gets the right zone.
- **The hub action block loses the context** — no. `MessageHub.HandleMessageAsync` stamps `delivery.AccessContext` onto `AccessService.Context` for the duration of handling, and `LayoutAreaHost` captures it there. Both render tests exercise exactly that.
- **A degraded circuit** — correct, there was none: a determinate miss is not the degraded leg, which is why no warning appeared.

## Did #1819 contribute?

**No.** It added `ThreadMessage.SubmitterTimeZoneId` and a `ResolveViewerZoneId()` rider on the agent path; it touched no identity resolution and no query. It was, however, the most useful instrument in this investigation — the submitter rider is what read the live `AccessContext` out of production and showed the zone was already missing before any render.

## The missing Preferences tab — separate issue

Not the same defect, and it should get its own issue. The tab is gated on `Permission.Update` on the viewer's own node, which is a permission evaluation over `ObjectId` — and `ObjectId` is correct on both installs here (the claims seed derives it from the email local part, which matches the node id for the reporter). Consistent with the report itself: local shows the tab and still renders UTC.

Worth recording for whoever picks it up: this fix does narrow one plausible coupling. An un-indexed user falls back to the **email-local-part guess** for `ObjectId`, so any user whose node id differs from that guess loses every self-permission at once — which is exactly a "the Preferences tab vanished" shape. That is not the reporter's case, so it cannot be the cloud symptom, but it is worth ruling in or out first on the new issue.

## Deploy note

This is a framework fix; nothing on any mesh changes until a portal runs the new image. No data migration — the stored `User.TimeZoneId` / `User.Locale` values were correct throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
