### PR TITLE
fix(#1910): a Conflict retry must rebase on state the owner has not refused

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-activity-survives-a-write-collision.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-activity-survives-a-write-collision.md
@@ -1,0 +1,13 @@
+---
+Name: Your activity is recorded even when two pages update it at once
+Category: Fix
+Description: A visit that collided with another update to the same record used to be dropped; the record is now re-read and the visit applied.
+Icon: Sparkle
+Order: -20260821
+---
+
+# Your activity is recorded even when two pages update it at once
+
+Every page you open updates one small record of what you have looked at and when. When two of those updates arrived at the same moment, one of them was refused — correctly, because it had been written against a version that had already moved on — and then thrown away. The visit was simply not recorded. Nothing failed visibly, which is the awkward part: the history looked complete while occasionally missing an entry.
+
+A refused update now waits for the newer version of the record to arrive, re-reads it, and applies the visit on top. The count and the "last opened" time come out right whether one page updated the record or several did at once.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
@@ -111,6 +112,91 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     // (recycle churn). NEVER retried: silence (a busy owner still applies the original
     // patch) and every other NACK code (validation/RLS/NotFound are terminal verdicts).
     private const int MaxOwnerDisposingReenqueues = 2;
+
+    // 🚨 How long a CONFLICT re-attempt waits for this hub's mirror to carry state the owner has
+    // not already refused. Not a retry interval and not a backoff — it is the bound on ONE wait
+    // for a fact that is already on its way: the owner committed the winning write BEFORE it
+    // NACK'd us, so the newer state is in flight to the mirror we are about to read. The wait is
+    // for the arrival, not for a repeat. Generous against a sub-second propagation, and short
+    // enough to sit well inside the caller's own budget.
+    private static readonly TimeSpan ConflictRebaseBound = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// 🚨 The emission a (re)attempt rebuilds its patch from — and the whole of the #1910 fix.
+    ///
+    /// <para><b>The defect.</b> A cross-hub <c>stream.Update</c> reads this hub's MIRROR, runs the
+    /// lambda against it, and ships a merge patch carrying the base values it diffed against. The
+    /// owner three-way-merges: any key whose live value has moved since that base is REFUSED, and
+    /// when nothing lands it answers <c>Conflict</c> — "re-read and re-apply". <c>UpdateRemote</c>
+    /// does re-enqueue on that verdict, and it does re-run the lambda rather than re-post the
+    /// patch. But it re-ran the lambda against <c>mirror.Take(1)</c>, i.e. against whatever the
+    /// mirror holds AT THAT INSTANT — which, immediately after a NACK, is very often still the
+    /// version the owner just refused. The lambda then recomputes the same values from the same
+    /// base, <c>ExtractBaseValues</c> produces the same base, and the owner refuses identically.
+    /// Three attempts, three identical patches, then a terminal <c>MeshNodeStreamException</c> and
+    /// the caller's write is gone. A retry whose input cannot change is not a retry.</para>
+    ///
+    /// <para><b>The rule.</b> A Conflict means the owner is provably AHEAD of
+    /// <paramref name="refusedBaseVersion"/> — it minted a version for the write that beat us
+    /// before it answered us — so the state that makes the re-attempt converge already exists and
+    /// is on its way here. Wait for it, then rebase on it.</para>
+    ///
+    /// <para><b>Conflict only.</b> <c>OwnerDisposing</c> / <c>OwnerNotReady</c> re-enqueues pass
+    /// <c>0</c> and are unaffected: those say the patch never reached a merge at all, so no newer
+    /// version exists and waiting for one would burn the bound for nothing.</para>
+    ///
+    /// <para><b>Never parks.</b> If the mirror does not advance within
+    /// <see cref="ConflictRebaseBound"/> the re-attempt proceeds against what it has — exactly the
+    /// previous behaviour — and <paramref name="onStaleMirror"/> says so, so "the write was
+    /// refused AND the mirror never caught up" is a reported fact rather than a silent
+    /// re-refusal. This is why the change can only improve on the old behaviour: it converges
+    /// where the old shape could not, and degrades to the old shape where it cannot.</para>
+    ///
+    /// <para>Static, with the mirror and the scheduler as seams, so the re-read rule is asserted
+    /// deterministically — no hub, no cluster, no wall clock.</para>
+    /// </summary>
+    /// <param name="mirror">This hub's view of the node — replays its current state to a new
+    /// subscriber and emits again as the owner's commits arrive.</param>
+    /// <param name="refusedBaseVersion">The version the owner refused, or <c>0</c> for a first
+    /// attempt (and for the non-staleness re-enqueue codes), which reads the mirror as before.</param>
+    /// <param name="onStaleMirror">Called with <paramref name="refusedBaseVersion"/> when the
+    /// bound elapsed and the re-attempt fell back to un-advanced state.</param>
+    /// <param name="scheduler">Timer seam for tests.</param>
+    internal static IObservable<MeshNode> RebaseSource(
+        IObservable<MeshNode> mirror,
+        long refusedBaseVersion,
+        Action<long> onStaleMirror,
+        IScheduler? scheduler = null)
+        => refusedBaseVersion <= 0
+            // A first attempt reads the mirror exactly as it always did — the ordinary write path
+            // gains no filter, no timer and no second subscription.
+            ? mirror.Take(1)
+            : mirror
+                .Where(node => node.Version > refusedBaseVersion)
+                .Take(1)
+                .Timeout(
+                    ConflictRebaseBound,
+                    Observable.Defer(() =>
+                    {
+                        onStaleMirror(refusedBaseVersion);
+                        return mirror.Take(1);
+                    }),
+                    scheduler ?? Scheduler.Default)
+                // 🚨 An EMPTY completion must not reach the caller. Filtering introduces a
+                // completion the un-filtered shape could not produce: a mirror that ends (its hub
+                // torn down) while holding only the refused version completes this source with no
+                // value, the write's observer is never called, and the caller waits on a pipeline
+                // that has already finished. A source that cannot answer must SAY so — the same
+                // rule the compile pipeline's DefaultIfEmpty totality guard applies.
+                .Select(node => (MeshNode?)node)
+                .DefaultIfEmpty(null)
+                .SelectMany(node => node is null
+                    ? Observable.Throw<MeshNode>(new InvalidOperationException(
+                        $"Update aborted: the owner refused this write as stale at version "
+                        + $"{refusedBaseVersion} and the mirror ended before carrying anything "
+                        + "newer, so there is no state to re-apply against. The write did NOT "
+                        + "land; re-issue it."))
+                    : Observable.Return(node));
 
     internal MeshNodeStreamHandle(IWorkspace workspace, string? path = null,
         IMeshNodeStreamCache? cache = null, bool bypassCache = false)
@@ -1086,7 +1172,12 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// <param name="attempt">Re-enqueue depth: 0 for a caller write, incremented by the
     /// late OwnerDisposing-NACK re-enqueue, capped at <see cref="MaxOwnerDisposingReenqueues"/>.
     /// Carried as a parameter — never static state.</param>
-    private IObservable<MeshNode> UpdateRemote(Func<MeshNode, MeshNode> update, int attempt = 0)
+    /// <param name="refusedBaseVersion">On a CONFLICT re-enqueue, the node version the owner
+    /// refused this write against, so the re-attempt rebases on something newer
+    /// (<see cref="RebaseSource"/>). 0 for a caller write and for the re-enqueue codes that never
+    /// reached a merge.</param>
+    private IObservable<MeshNode> UpdateRemote(
+        Func<MeshNode, MeshNode> update, int attempt = 0, long refusedBaseVersion = 0)
         => Observable.Create<MeshNode>(observer =>
         {
             var diagLogger = _workspace.Hub.ServiceProvider
@@ -1130,14 +1221,26 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             // running the user lambda — the lambda needs a non-null current
             // to diff against. A 30 s outer timeout bounds the wait so a
             // missing per-node hub surfaces with a precise TimeoutException.
-            var initialSub = remoteStream
-                .Timeout(TimeSpan.FromSeconds(30))
-                .Where(change => change.Value is not null)
-                .Take(1)
+            //
+            // 🚨 …and on a CONFLICT re-attempt, wait for state the owner has not already
+            // refused. See RebaseSource: re-running the lambda against the SAME mirror emission
+            // recomputes the same values from the same base and is refused identically, so the
+            // re-enqueue cannot converge (#1910).
+            var initialSub = RebaseSource(
+                    remoteStream
+                        .Timeout(TimeSpan.FromSeconds(30))
+                        .Where(change => change.Value is not null)
+                        .Select(change => change.Value!),
+                    refusedBaseVersion,
+                    staleVersion => diagLogger?.LogWarning(
+                        "[UpdateRemote] STALE_MIRROR hub={Hub} target={Path} attempt={Attempt} — the "
+                        + "owner refused this write as stale at version {Version}, but this hub's "
+                        + "mirror did not advance past it within {Bound}; rebuilding the patch "
+                        + "against the state it has. The re-attempt may be refused again",
+                        _workspace.Hub.Address, _path, attempt, staleVersion, ConflictRebaseBound))
                 .Subscribe(
-                    change =>
+                    current =>
                     {
-                        var current = change.Value!;
                         try
                         {
                             var updated = update(current);
@@ -1353,9 +1456,16 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                         or MeshNodeErrorCode.Conflict
                                     && attempt < MaxOwnerDisposingReenqueues)
                                 {
+                                    // 🚨 Conflict alone carries a stale BASE — see RebaseSource.
+                                    // OwnerDisposing / OwnerNotReady mean the patch never reached
+                                    // a merge, so there is no newer version to wait for and
+                                    // waiting would only burn the bound.
+                                    var lateRebaseFrom = lateErr.Code == MeshNodeErrorCode.Conflict
+                                        ? current.Version
+                                        : 0;
                                     diagLogger?.LogWarning(
-                                        "[UpdateRemote] LATE_NACK_REENQUEUE hub={Hub} target={Path} attempt={Attempt} — owner disposed before the merge turn; re-enqueueing the original update against the fresh activation",
-                                        _workspace.Hub.Address, _path, attempt + 1);
+                                        "[UpdateRemote] LATE_NACK_REENQUEUE hub={Hub} target={Path} attempt={Attempt} code={Code} — the patch was never applied; re-enqueueing the original update, rebased on state newer than {RebaseFrom}",
+                                        _workspace.Hub.Address, _path, attempt + 1, lateErr.Code, lateRebaseFrom);
                                     // Restore the writer's identity: this callback runs on the
                                     // cache hub's action block where the AsyncLocal context is
                                     // the hub's own, and the re-posted patch must carry the
@@ -1365,7 +1475,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                         ? accessServiceAtEntry.SwitchAccessContext(capturedContextAtEntry)
                                         : null)
                                     {
-                                        UpdateRemote(update, attempt + 1).Subscribe(
+                                        UpdateRemote(update, attempt + 1, lateRebaseFrom).Subscribe(
                                             _ => { },
                                             ex2 => diagLogger?.LogWarning(ex2,
                                                 "[UpdateRemote] LATE_NACK_REENQUEUE failed hub={Hub} target={Path} attempt={Attempt}",
@@ -1450,14 +1560,28 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                                     or MeshNodeErrorCode.Conflict
                                                 && attempt < MaxOwnerDisposingReenqueues)
                                             {
+                                                // 🚨 A Conflict says the owner is provably PAST
+                                                // the base we diffed against — it committed the
+                                                // winning write before answering us. Re-running
+                                                // the lambda against the mirror as it stands
+                                                // recomputes the same patch from the same base
+                                                // and is refused identically, which is why the
+                                                // re-enqueue could not converge (#1910). Carry
+                                                // the refused version so the re-attempt rebases
+                                                // on state newer than it. OwnerDisposing /
+                                                // OwnerNotReady never reached a merge, so there
+                                                // is nothing newer to wait for — they pass 0.
+                                                var rebaseFrom = err.Code == MeshNodeErrorCode.Conflict
+                                                    ? current.Version
+                                                    : 0;
                                                 diagLogger?.LogWarning(
-                                                    "[UpdateRemote] OWNER_NACK_REENQUEUE hub={Hub} target={Path} code={Code} attempt={Attempt} — the patch was never applied; re-enqueueing against the fresh activation",
-                                                    _workspace.Hub.Address, _path, err.Code, attempt + 1);
+                                                    "[UpdateRemote] OWNER_NACK_REENQUEUE hub={Hub} target={Path} code={Code} attempt={Attempt} — the patch was never applied; re-enqueueing rebased on state newer than {RebaseFrom}",
+                                                    _workspace.Hub.Address, _path, err.Code, attempt + 1, rebaseFrom);
                                                 using (accessServiceAtEntry is not null && capturedContextAtEntry is not null
                                                     ? accessServiceAtEntry.SwitchAccessContext(capturedContextAtEntry)
                                                     : null)
                                                 {
-                                                    composite.Add(UpdateRemote(update, attempt + 1)
+                                                    composite.Add(UpdateRemote(update, attempt + 1, rebaseFrom)
                                                         .Subscribe(observer.OnNext, observer.OnError, observer.OnCompleted));
                                                 }
                                                 return;

--- a/test/MeshWeaver.Query.Test/ActivityWriteSurvivesConflictTest.cs
+++ b/test/MeshWeaver.Query.Test/ActivityWriteSurvivesConflictTest.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Mesh;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Query.Test;
+
+/// <summary>
+/// 🚨 A cross-hub write refused as STALE must converge on the retry — issue #1910.
+///
+/// <para><b>The incident.</b> <c>ActivityTracking</c> failed to record a navigation:
+/// <c>MeshNode Conflict at 'rbuergi/_UserActivity/rbuergi': cross-hub write refused: 3 field(s)
+/// changed on the owner since the writer's base and nothing was applied — re-read and
+/// re-apply</c>. The activity entry for that moment simply does not exist. The issue proposed
+/// "adding a retry-with-refresh loop, or switching to an append-only pattern".</para>
+///
+/// <para><b>What was actually there, and why it could not work.</b> A retry-with-refresh loop
+/// already existed. <c>UpdateRemote</c> re-enqueues on <c>Conflict</c> (and re-runs the update
+/// lambda rather than re-posting the patch — the #1814 defect, already fixed). What it did NOT do
+/// is guarantee that the re-run sees anything DIFFERENT. It rebuilt from <c>mirror.Take(1)</c> —
+/// whatever this hub's mirror holds at that instant — and immediately after a NACK that is very
+/// often still the version the owner just refused. The lambda then recomputes the same values
+/// from the same base, <c>ExtractBaseValues</c> emits the same base, and the owner refuses
+/// identically. Three attempts, three identical patches, then a terminal
+/// <c>MeshNodeStreamException</c> and the write is gone. <b>A retry whose input cannot change is
+/// not a retry</b> — the same shape as #1814 one level down: there the patch was re-posted, here
+/// the base is re-read from a source that had not moved.</para>
+///
+/// <para><b>Why waiting is sound rather than hopeful.</b> A <c>Conflict</c> is the owner stating
+/// that it is AHEAD of the writer's base — it minted a version for the write that beat us BEFORE
+/// it answered us. So the state that makes the re-attempt converge already exists and is on its
+/// way to this mirror. The re-attempt waits for that specific fact (a version strictly greater
+/// than the one refused), bounded, and falls back to the old behaviour if it never arrives —
+/// which is why the change can only improve on what was there.</para>
+///
+/// <para>Deterministic: the mirror and the clock are both seams. No hub, no cluster, no
+/// wall-clock sleep — the interleaving that makes this defect rare in a test and common in
+/// production is CONSTRUCTED here rather than raced for.</para>
+/// </summary>
+public class ActivityWriteSurvivesConflictTest
+{
+    /// <summary>The activity node from the incident.</summary>
+    private const string Path = "rbuergi/_UserActivity/rbuergi";
+
+    /// <summary>
+    /// A stand-in for this hub's mirror: replays its current state to a new subscriber and emits
+    /// again as the owner's commits arrive — the shape <c>UpdateRemote</c> reads.
+    /// </summary>
+    private static ReplaySubject<MeshNode> Mirror(long version)
+    {
+        var mirror = new ReplaySubject<MeshNode>(1);
+        mirror.OnNext(NodeAt(version));
+        return mirror;
+    }
+
+    private static MeshNode NodeAt(long version) =>
+        MeshNode.FromPath(Path) with { NodeType = "UserActivity", Version = version };
+
+    /// <summary>
+    /// 🚨 THE regression pin. The owner refused version 10 as stale; the re-attempt must not
+    /// rebuild from version 10.
+    ///
+    /// <para>Against <c>origin/main</c> this fails immediately with <c>10</c> — see
+    /// <see cref="NegativeControl_TheOldShapeRebuildsFromTheVeryVersionTheOwnerRefused"/>, which
+    /// is that shape written out.</para>
+    /// </summary>
+    [Fact]
+    public void A_conflict_retry_rebases_on_state_newer_than_the_version_that_was_refused()
+    {
+        var scheduler = new TestScheduler();
+        var mirror = Mirror(version: 10);
+        var stale = new List<long>();
+        var seen = new List<long>();
+
+        MeshNodeStreamHandle
+            .RebaseSource(mirror, refusedBaseVersion: 10, stale.Add, scheduler)
+            .Subscribe(node => seen.Add(node.Version));
+
+        // The mirror still holds exactly what the owner refused. Rebuilding from it would produce
+        // the same patch with the same base — refused again, and again, until the budget is spent
+        // and the caller's write is dropped.
+        seen.Should().BeEmpty(
+            "re-running the lambda against the very version the owner refused recomputes the same "
+            + "patch from the same base — the retry cannot converge, which is how a tracked "
+            + "activity ends up silently absent");
+
+        // The winning writer's commit arrives at the mirror — it was already in flight, because
+        // the owner committed it before it NACK'd us.
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+        mirror.OnNext(NodeAt(11));
+
+        seen.Should().Equal([11L],
+            "the re-attempt rebases on the state the owner actually has, which IS the 're-read and "
+            + "re-apply' the refusal asked for");
+        stale.Should().BeEmpty("the mirror advanced, so nothing degraded");
+    }
+
+    /// <summary>
+    /// NEGATIVE CONTROL — the shape <c>UpdateRemote</c> had, written out. It is one operator, and
+    /// it is the whole defect: a re-attempt is handed the refused version and rebuilds from it.
+    /// Keeping it here means the regression above cannot quietly become vacuous.
+    /// </summary>
+    [Fact]
+    public void NegativeControl_TheOldShapeRebuildsFromTheVeryVersionTheOwnerRefused()
+    {
+        var mirror = Mirror(version: 10);
+        var seen = new List<long>();
+
+        // origin/main: `remoteStream.Where(c => c.Value is not null).Take(1)`.
+        mirror.Take(1).Subscribe(node => seen.Add(node.Version));
+
+        seen.Should().Equal([10L],
+            "this is the defect: the retry reads the mirror as it stands, which right after a "
+            + "Conflict NACK is still the version the owner refused — so the recomputed patch is "
+            + "byte-identical to the one that was just rejected");
+    }
+
+    /// <summary>
+    /// The bound, and the reason it is a bound and not a wait: a mirror that never advances must
+    /// not park the caller. The re-attempt proceeds against what it has — exactly the previous
+    /// behaviour — and REPORTS that it did, so "refused as stale AND the mirror never caught up"
+    /// is a fact in the log rather than a second silent refusal.
+    /// </summary>
+    [Fact]
+    public void A_mirror_that_never_advances_is_not_parked_on_and_the_degradation_is_reported()
+    {
+        var scheduler = new TestScheduler();
+        var mirror = Mirror(version: 10);
+        var stale = new List<long>();
+        var seen = new List<long>();
+
+        MeshNodeStreamHandle
+            .RebaseSource(mirror, refusedBaseVersion: 10, stale.Add, scheduler)
+            .Subscribe(node => seen.Add(node.Version));
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(4).Ticks);
+        seen.Should().BeEmpty("still inside the bound");
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(2).Ticks);
+
+        seen.Should().Equal([10L],
+            "a fresher base never arrived, so the re-attempt does the best it can rather than "
+            + "hanging — never worse than the behaviour it replaces");
+        stale.Should().Equal([10L],
+            "…and says so, because a re-attempt that is about to be refused for the same reason "
+            + "is exactly the thing that was invisible");
+    }
+
+    /// <summary>
+    /// A FIRST attempt has no refused base and must not wait for anything — the fix costs the
+    /// normal write path nothing. This is the case every cross-hub write in the mesh takes.
+    /// </summary>
+    [Fact]
+    public void A_first_attempt_reads_the_mirror_immediately()
+    {
+        var scheduler = new TestScheduler();
+        var seen = new List<long>();
+
+        MeshNodeStreamHandle
+            .RebaseSource(Mirror(version: 10), refusedBaseVersion: 0, _ => { }, scheduler)
+            .Subscribe(node => seen.Add(node.Version));
+
+        seen.Should().Equal([10L],
+            "no timer, no gate — the ordinary write path is untouched, which is what makes this "
+            + "safe to put on every cross-hub Update");
+    }
+
+    /// <summary>
+    /// 🚨 The hazard the FILTER introduces, closed in the same change. Waiting for a newer version
+    /// creates a completion the un-filtered shape could not produce: a mirror that ENDS (its hub
+    /// torn down) while holding only the refused version would complete this source with no value
+    /// at all — the write's observer never fires and the caller waits on a pipeline that has
+    /// already finished. A source that cannot answer must say so; an empty completion is the one
+    /// outcome a caller cannot distinguish from "still working".
+    /// </summary>
+    [Fact]
+    public void A_mirror_that_ends_without_newer_state_errors_rather_than_completing_empty()
+    {
+        var scheduler = new TestScheduler();
+        var mirror = Mirror(version: 10);
+        var seen = new List<long>();
+        Exception? error = null;
+        var completed = false;
+
+        MeshNodeStreamHandle
+            .RebaseSource(mirror, refusedBaseVersion: 10, _ => { }, scheduler)
+            .Subscribe(node => seen.Add(node.Version), ex => error = ex, () => completed = true);
+
+        // The owning hub goes away before anything newer arrives.
+        mirror.OnCompleted();
+
+        seen.Should().BeEmpty();
+        completed.Should().BeFalse(
+            "an empty completion is indistinguishable from 'still working' to the caller — it is "
+            + "how a write turns into a hang instead of a failure");
+        error.Should().NotBeNull(
+            "the re-attempt has nothing to rebase on and must terminate the caller, not strand it");
+        error!.Message.Should().Contain("did NOT land",
+            "…and say plainly that the write is gone, so the caller can re-issue it");
+    }
+
+    /// <summary>
+    /// 🚨 The distinction that keeps the bound from being burned for nothing: only
+    /// <c>Conflict</c> means "the owner moved past you". <c>OwnerDisposing</c> /
+    /// <c>OwnerNotReady</c> mean the patch never reached a merge at all — no newer version was
+    /// minted, so there is nothing to wait for. Those re-enqueues pass <c>0</c> and behave exactly
+    /// as they did.
+    /// </summary>
+    [Fact]
+    public void A_non_staleness_reenqueue_does_not_wait_for_a_version_that_will_never_come()
+    {
+        var scheduler = new TestScheduler();
+        var seen = new List<long>();
+
+        // What an OwnerDisposing / OwnerNotReady re-enqueue passes.
+        MeshNodeStreamHandle
+            .RebaseSource(Mirror(version: 10), refusedBaseVersion: 0, _ => { }, scheduler)
+            .Subscribe(node => seen.Add(node.Version));
+
+        seen.Should().Equal([10L],
+            "a patch that never reached a merge left the owner's version untouched — waiting for "
+            + "it to advance would spend the whole bound before every one of these retries");
+    }
+}

--- a/test/MeshWeaver.Query.Test/MeshWeaver.Query.Test.csproj
+++ b/test/MeshWeaver.Query.Test/MeshWeaver.Query.Test.csproj
@@ -12,6 +12,9 @@
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Namotion.Reflection" />
     <PackageReference Include="NSubstitute" />
+    <!-- TestScheduler: ActivityWriteSurvivesConflictTest drives the conflict-rebase bound
+         deterministically (issue #1910) rather than sleeping on it. -->
+    <PackageReference Include="Microsoft.Reactive.Testing" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #1910.

## The issue's remedy was already implemented — that is the finding

#1910 suggests "adding a retry-with-refresh loop for concurrency conflicts, or switching to an append-only/event-sourced pattern". The loop exists. `UpdateRemote` re-enqueues on `Conflict` (bounded at 2), and it re-runs the **update lambda** rather than re-posting the precomputed patch — the #1814 defect, already fixed.

What it did not do is guarantee the re-run sees anything **different**.

```
attempt 0: read mirror.Take(1) → v10 → lambda → patch{accessCount:6, lastAccessedAt:T1, lastModified:T1}
                                        base{accessCount:5, lastAccessedAt:T0, lastModified:T0}
owner:     live is v11 (someone else's increment landed) → all 3 keys refused → nothing applied
           → NACK Conflict "3 field(s) changed … re-read and re-apply"
attempt 1: read mirror.Take(1) → still v10   ← the mirror has not received v11 yet
           → identical patch, identical base → refused identically
attempt 2: same
           → terminal MeshNodeStreamException → the activity write is dropped and logged as an error
```

The mirror is read *at the instant the NACK arrives*, which is exactly when it is most likely to still hold the version that was just refused. **A retry whose input cannot change is not a retry** — it is #1814 one level down: there the patch was re-sent, here the base is re-read from a source that had not moved.

(The "3 field(s)" in the incident is the shape's fingerprint: the diff of a `UserActivity` fold is `content.accessCount`, `content.lastAccessedAt`, and the `lastModified` stamp `UpdateRemote` adds — three leaves, all refused.)

## The fix

A `Conflict` is the owner *stating* it is ahead of the writer's base: it minted a version for the write that beat us **before** it answered us. So the state that makes the re-attempt converge already exists and is in flight to this mirror. The re-attempt now waits for exactly that fact — a version strictly greater than the one refused — and rebases on it. That IS the "re-read and re-apply" the refusal asks for.

`MeshNodeStreamHandle.RebaseSource` — static, with the mirror and the scheduler as seams:

- **Conflict only.** `OwnerDisposing` / `OwnerNotReady` mean the patch never reached a merge, so no newer version was minted; they pass `0` and are untouched, as is every first attempt (no filter, no timer, no second subscription on the ordinary write path).
- **Never parks.** If the mirror does not advance within 5s, the re-attempt proceeds against what it has — exactly the previous behaviour — and logs `STALE_MIRROR`. It converges where the old shape could not and degrades to the old shape where it cannot, so it cannot be worse.
- **Not a backoff.** It is the bound on *one wait for an arrival*, not an interval between repeats. The retry budget is unchanged — deliberately, since raising it would be the band-aid.

It also relieves the *other* way that budget gets spent: a loser no longer re-issues at the same instant as every other loser, it issues after the state that beat it, so a burst of concurrent writers serialises into a chain instead of re-stampeding.

**Closed in the same change**: filtering introduces a completion the unfiltered shape could not produce. A mirror that *ends* (its hub torn down) while holding only the refused version would complete the source **empty** — the write's observer never fires and the caller waits on a pipeline that has already finished. That now errors, naming the write as not landed.

## Tests

6 deterministic tests in `ActivityWriteSurvivesConflictTest` — `TestScheduler` + a `ReplaySubject` mirror, no hub, no cluster, no sleep:

- a Conflict retry waits for a version newer than the refused one, and rebases on it;
- **negative control**: the old `mirror.Take(1)` shape, written out — it yields the very version the owner refused, so the regression above cannot go vacuous;
- a mirror that never advances is not parked on, and the degradation is reported;
- a first attempt reads immediately (the ordinary path costs nothing);
- a non-staleness re-enqueue does not wait for a version that will never come;
- a mirror that ends without newer state errors instead of completing empty.

**Non-vacuity**: with `RebaseSource` reverted to `mirror.Take(1)`, 2 fail —
`Expected collection to be empty because re-running the lambda against the very version the owner refused …, but found 1 item(s)` and `Expected collection to be empty because still inside the bound, but found 1 item(s)`.

## What I could not reproduce, and why that matters

**40 concurrent `TrackActivityRequest`s for one path land all 40 increments in a monolith test, both with and without this change** (3 runs each). In-process the cache's per-path serial queue plus sub-millisecond mirror propagation means the retry's re-read is fresh anyway. The end-to-end loss needs the production interleaving — the write queue advancing on `UpdateRemote`'s optimistic 2s emit while a patch is still in flight, and a mirror that has not caught up — which is why the incident reads "1 occurrence on 1 pod for 1 user" rather than as a reproducible failure.

So the regression is pinned at the seam, with the old shape kept beside it as a control, rather than with a concurrency test that would be green on `main` by luck and flaky forever after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
