### PR TITLE
helm: extraEnvFrom — declare CSI-synced env sources instead of losing them on upgrade

### DIFF
--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -111,6 +111,16 @@ spec:
                 name: "memex-portal-config"
             - secretRef:
                 name: "memex-portal-secrets"
+            # 🚨 Extra env sources the chart does not own — typically a Key Vault CSI-synced
+            # secret (secrets-store SecretProviderClass → k8s Secret). Without this key such a
+            # source can only be wired by a live kubectl patch on the Deployment, which the next
+            # `helm upgrade` silently DROPS — memex-cloud runs exactly that shape today
+            # (memexcloud-portal-ai-secrets carrying its AI provider keys), so its first
+            # repo-driven release would detach every provider key. Entries are verbatim
+            # EnvFromSource objects: {secretRef: {name: …}} or {configMapRef: {name: …}}.
+            {{- range .Values.extraEnvFrom }}
+            - {{ toYaml . | nindent 14 | trim }}
+            {{- end }}
           env:
             # 🩺 Crash diagnostics. We hit a native SIGSEGV (exit 139) in the Npgsql → SslStream TLS
             # read path: the process dies with NO managed exception, so the logs show nothing useful.

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -177,6 +177,12 @@ spec:
               mountPath: "{{ $spec.mountPath }}"
 {{- end }}
 {{- end }}
+{{- /* Extra mounts the chart does not own — the mount half of .Values.extraVolumes (typically a
+       secrets-store CSI volume, whose mount is what makes the driver sync its k8s Secret and keep
+       rotating it). Verbatim VolumeMount objects. */}}
+{{- range .Values.extraVolumeMounts }}
+            - {{ toYaml . | nindent 14 | trim }}
+{{- end }}
             - name: "memex-dumps"
               mountPath: "/data/dumps"
           imagePullPolicy: "IfNotPresent"
@@ -292,6 +298,14 @@ spec:
           persistentVolumeClaim:
             claimName: "{{ $spec.claimName }}"
 {{- end }}
+{{- end }}
+{{- /* 🚨 Extra volumes the chart does not own — typically the secrets-store CSI volume behind a
+       SecretProviderClass: without the chart rendering it, the volume exists only as a live
+       kubectl patch, the next `helm upgrade` drops it, the CSI driver stops syncing/rotating its
+       k8s Secret, and every key it feeds goes stale (the memex-cloud AI-keys shape, paired with
+       .Values.extraEnvFrom). Verbatim Volume objects; mount them via .Values.extraVolumeMounts. */}}
+{{- range .Values.extraVolumes }}
+        - {{ toYaml . | nindent 10 | trim }}
 {{- end }}
         # 🩺 Crash-dump target (DOTNET_DbgMiniDumpName=/data/dumps/…). createdump does NOT create
         # directories — without this mount every crash failed with "Could not create output file …:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -151,6 +151,15 @@ instancesAdmin:
 # raises this without them fails the build instead of the deployment.
 replicas:
   portal: 1
+# ---- Extra env sources for the portal (verbatim EnvFromSource objects) ----
+# For env the chart does not own — typically a Key Vault CSI-synced Secret
+# (SecretProviderClass → k8s Secret). Without this key such a source can only
+# be attached by a live kubectl patch, which the next `helm upgrade` silently
+# drops (the memex-cloud AI-keys shape). Example:
+#   extraEnvFrom:
+#     - secretRef:
+#         name: memexcloud-portal-ai-secrets
+extraEnvFrom: []
 # ---- KEDA autoscaling (portal) --------------------------------------------
 # HA deployments autoscale the portal via a KEDA ScaledObject (templates/
 # memex-portal/scaledobject.yaml) instead of a fixed replica count. Off by

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -160,6 +160,24 @@ replicas:
 #     - secretRef:
 #         name: memexcloud-portal-ai-secrets
 extraEnvFrom: []
+# ---- Extra volumes/mounts for the portal (verbatim Volume/VolumeMount) ----
+# The volume-shaped twin of extraEnvFrom, for resources the chart does not
+# own — typically the secrets-store CSI volume behind a SecretProviderClass:
+# the MOUNT is what makes the CSI driver sync (and keep rotating) the k8s
+# Secret that extraEnvFrom then reads. Example:
+#   extraVolumes:
+#     - name: kv-ai-secrets
+#       csi:
+#         driver: secrets-store.csi.k8s.io
+#         readOnly: true
+#         volumeAttributes:
+#           secretProviderClass: memexcloud-portal-ai-secrets
+#   extraVolumeMounts:
+#     - name: kv-ai-secrets
+#       mountPath: /mnt/secrets-store
+#       readOnly: true
+extraVolumes: []
+extraVolumeMounts: []
 # ---- KEDA autoscaling (portal) --------------------------------------------
 # HA deployments autoscale the portal via a KEDA ScaledObject (templates/
 # memex-portal/scaledobject.yaml) instead of a fixed replica count. Off by


### PR DESCRIPTION
The portal's `envFrom` was a fixed pair (configmap + `memex-portal-secrets`), so a deployment reading env from a Key Vault CSI-synced Secret could only attach it via a live kubectl patch — which the next `helm upgrade` silently drops. memex-cloud runs exactly that shape today (`memexcloud-portal-ai-secrets` carries its AI provider keys), so its first repo-driven helm release would detach every provider key.

- New `extraEnvFrom` values key: verbatim `EnvFromSource` objects appended after the chart's own two.
- Verified with `helm template`: renders when set, no-op when unset.
- Follow-up in Systemorph/Memex: memex-cloud's public overlay declares its CSI secret via this key.

No What's New entry — chart-internal plumbing, no user-visible change of its own.

Incident context: the 2026-08-20 memex.systemorph.com outage (#1949/#1950, Systemorph/Memex#77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)