### PR TITLE
feat(#1951): Auto routes the round to the most appropriate model

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -18,6 +18,7 @@ using MeshWeaver.Messaging;
 using MeshWeaver.ShortGuid;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using TextContent = Microsoft.Extensions.AI.TextContent;
@@ -814,6 +815,13 @@ public class AgentChatClient : IAgentChat
         // Detect agent @references in message text (for selection override)
         var lastMessageText = messages.LastOrDefault() is { } last ? ExtractTextFromMessage(last) : null;
         DetectMessageAgentReferences(lastMessageText);
+
+        // 🧭 Auto refinement (#1951). When THIS round asked for the Auto router, the sync dispatch
+        // in CreateAgentsSync has already parked it on the agent-tier/default model — the floor a
+        // round can always run on. Here, on the AI pool thread where a model call is legal, one
+        // cheap bounded call refines that floor using the round's actual content. Any failure
+        // keeps the floor; runs BEFORE SelectAgent so a changed model rebuilds agents first.
+        await ApplyAutoRouterSelectionAsync(lastMessageText, cancellationToken).ConfigureAwait(false);
 
         // Pure in-memory lookup against the synced agent cache.
         // 🚨 Callers MUST await `WhenInitialized` before calling here on a
@@ -2060,10 +2068,14 @@ public class AgentChatClient : IAgentChat
     /// <list type="number">
     /// <item><b>Auto (the router) was selected</b> — the DEFAULT for a new thread. Auto has no wire
     /// API of its own, so it is DISPATCHED to a real model here, before any factory sees it. The
-    /// dispatch rule is deliberately the simplest one that is explainable: <b>run the tier the
+    /// dispatch rule here is deliberately the simplest one that is explainable: <b>run the tier the
     /// selected agent declares</b> (<see cref="AgentConfiguration.ModelTier"/>), and the deployment
-    /// default when it declares none. No classification call, no guessing — a router nobody can
-    /// predict is worse than a fixed default.</item>
+    /// default when it declares none. No model call in THIS stage — it is synchronous and must
+    /// always produce a runnable floor. The content-aware refinement is a SECOND stage
+    /// (<see cref="ApplyAutoRouterSelectionAsync"/>, #1951): one bounded selection call on the AI
+    /// pool thread that may move the round off this floor, and keeps it on ANY failure — so the
+    /// old "a router nobody can predict is worse than a fixed default" stance survives as the
+    /// guaranteed fallback rather than the whole story.</item>
     /// <item><b>The selection is stale</b> — deleted / refactored out of the catalog, or its provider
     /// carries no key — so it is swapped for a working model on the same chain.</item>
     /// </list>
@@ -2164,6 +2176,105 @@ public class AgentChatClient : IAgentChat
             "[AgentChatClient] Selected model '{Stale}' is not usable (no resolvable key); "
             + "silently falling back to model '{Default}' (via {Source}).",
             string.IsNullOrEmpty(previous) ? "(none selected)" : previous, target, resolution.Source);
+    }
+
+    /// <summary>How long the Auto refinement call may take before the round proceeds on the floor —
+    /// the routing must stay a small fraction of the round it routes.</summary>
+    private static readonly TimeSpan AutoRouterTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Stage two of Auto (#1951): the CONTENT-AWARE selection. Runs only when this round's
+    /// REQUESTED model was the Auto router (<see cref="requestedModelName"/> — an explicit human
+    /// model pick, and every automation round that names its model, never reaches here), after
+    /// <see cref="ApplyStaleModelFallback"/> has already parked the round on the tier/default
+    /// floor. One bounded call on the floor model asks it to pick the best candidate for the
+    /// round's text; a valid answer moves <see cref="currentModelName"/> and rebuilds the agents,
+    /// anything else — timeout, refusal, an id outside the candidates, a factory with no bare
+    /// chat client — keeps the floor. So this can improve a round, and can never break one.
+    ///
+    /// <para>Deliberately NOT run for: rounds with fewer than two usable candidates (nothing to
+    /// choose), empty round text, or when the deployment opts out
+    /// (<c>Ai:Router:Selection = Tier</c>). The choice is logged with the engine's own stated
+    /// reason, so an operator can always answer "why did this round run on that model".</para>
+    /// </summary>
+    private async Task ApplyAutoRouterSelectionAsync(string? roundText, CancellationToken cancellationToken)
+    {
+        var resolver = hub.ServiceProvider.GetService<ChatClientCredentialResolver>();
+        if (resolver is null || string.IsNullOrWhiteSpace(roundText))
+            return;
+        if (!resolver.IsRouterSelection(requestedModelName))
+            return;
+        if (string.Equals(
+                hub.ServiceProvider.GetService<IConfiguration>()?["Ai:Router:Selection"],
+                "Tier", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var candidates = AutoModelRouter.UsableCandidates(loadedModels, resolver.HasUsableCredential);
+        if (candidates.Count < 2)
+            return;
+
+        // The engine is the FLOOR model the sync dispatch already selected — always usable when we
+        // get here, and the one model this deployment considers a sane default anyway.
+        var engine = currentModelName;
+        if (string.IsNullOrEmpty(engine))
+            return;
+        var factory = GetFactoryForModel(engine);
+        if (factory is null)
+            return;
+
+        try
+        {
+            using var client = factory.CreateChatClient(engine);
+            using var bounded = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            bounded.CancelAfter(AutoRouterTimeout);
+
+            var response = await client.GetResponseAsync(
+                    AutoModelRouter.BuildMessages(candidates, roundText),
+                    new ChatOptions { MaxOutputTokens = 120, Temperature = 0 },
+                    bounded.Token)
+                .ConfigureAwait(false);
+
+            var candidateIds = candidates.Select(c => c.Id).ToArray();
+            if (!AutoModelRouter.TryParseChoice(response.Text, candidateIds, out var chosen, out var reason))
+            {
+                logger.LogDebug(
+                    "[AutoRouter] engine '{Engine}' gave no usable choice — keeping the floor model.",
+                    engine);
+                return;
+            }
+
+            if (string.Equals(chosen, currentModelName, StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogDebug(
+                    "[AutoRouter] engine '{Engine}' confirmed the floor model '{Model}' ({Reason}).",
+                    engine, chosen, reason);
+                return;
+            }
+
+            currentModelName = chosen;
+            // Rebuild for the routed model. ApplyStaleModelFallback re-runs inside and early-returns
+            // (a usable non-router selection); substitutedFromModel keeps carrying the router id, so
+            // the requested→effective record stays truthful (#476).
+            agentsInitialized = false;
+            CreateAgentsSync();
+            logger.LogInformation(
+                "[AutoRouter] routed the round to '{Model}' ({Reason}); floor was '{Floor}'.",
+                chosen, string.IsNullOrEmpty(reason) ? "no reason stated" : reason, engine);
+        }
+        catch (NotSupportedException)
+        {
+            // The floor model's factory has no bare chat client (persistent/server-side threads) —
+            // routing has no engine here; the floor is the answer.
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            logger.LogDebug("[AutoRouter] selection timed out after {Timeout}s — keeping the floor model.",
+                AutoRouterTimeout.TotalSeconds);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "[AutoRouter] selection failed — keeping the floor model.");
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -2266,7 +2266,13 @@ public class AgentChatClient : IAgentChat
             // The floor model's factory has no bare chat client (persistent/server-side threads) —
             // routing has no engine here; the floor is the answer.
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The ROUND was cancelled — routing must not swallow that into "keep the floor and
+            // continue"; the caller's cancellation propagates.
+            throw;
+        }
+        catch (OperationCanceledException)
         {
             logger.LogDebug("[AutoRouter] selection timed out after {Timeout}s — keeping the floor model.",
                 AutoRouterTimeout.TotalSeconds);

--- a/src/MeshWeaver.AI/AutoModelRouter.cs
+++ b/src/MeshWeaver.AI/AutoModelRouter.cs
@@ -1,0 +1,148 @@
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// The Auto router's SELECTION step (#1951) — the pure half: builds the routing prompt and parses
+/// the engine's answer. The orchestration (when to run, which engine serves the call, how a choice
+/// takes effect) lives in <c>AgentChatClient.ApplyAutoRouterSelectionAsync</c>; everything HERE is
+/// deterministic and unit-testable without a portal or a model.
+///
+/// <para><b>Two-stage Auto, by design.</b> The synchronous dispatch in
+/// <c>AgentChatClient.ApplyStaleModelFallback</c> stays the FLOOR: it parks an Auto round on the
+/// selected agent's declared tier (or the deployment default) with no model call, so a round can
+/// always run — the original "a router nobody can predict is worse than a fixed default" stance.
+/// This step then REFINES that floor with one cheap, bounded model call over the round's actual
+/// content (maintainer direction, 2026-08-20: Auto "should trigger an agent to determine the most
+/// appropriate model for the thread"). Predictability is preserved by construction: any failure —
+/// timeout, unparseable answer, an id outside the candidate list, an engine with no bare chat
+/// client — keeps the floor, and the choice is logged with the model's own stated reason.</para>
+/// </summary>
+public static class AutoModelRouter
+{
+    /// <summary>One candidate the router may pick: the model's wire id plus the display facts the
+    /// prompt names it by.</summary>
+    /// <param name="Id">The model's registered id — what the round runs on when picked.</param>
+    /// <param name="Provider">The serving provider/factory label.</param>
+    /// <param name="Label">Human label from the model node, when one exists.</param>
+    public readonly record struct RouterCandidate(string Id, string Provider, string? Label);
+
+    /// <summary>The router's answer wire shape — what the engine is instructed to reply.</summary>
+    private sealed record RouterChoice(string? Model, string? Reason);
+
+    /// <summary>Cap on the task text embedded in the prompt — routing needs the shape of the ask,
+    /// never the whole document; an unbounded paste would make the routing call cost more than the
+    /// round it routes.</summary>
+    public const int MaxTaskChars = 2000;
+
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Builds the routing conversation: a system message defining the contract (pick ONE candidate
+    /// id, answer strict JSON) and a user message carrying the candidates and the task.
+    /// </summary>
+    public static IReadOnlyList<ChatMessage> BuildMessages(
+        IReadOnlyList<RouterCandidate> candidates, string taskText)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Candidate models:");
+        foreach (var c in candidates)
+        {
+            sb.Append("- ").Append(c.Id).Append(" (provider: ").Append(c.Provider);
+            if (!string.IsNullOrWhiteSpace(c.Label) && !string.Equals(c.Label, c.Id, StringComparison.OrdinalIgnoreCase))
+                sb.Append(", label: ").Append(c.Label);
+            sb.AppendLine(")");
+        }
+        sb.AppendLine();
+        sb.AppendLine("Task:");
+        var task = taskText.Length <= MaxTaskChars ? taskText : taskText[..MaxTaskChars];
+        sb.AppendLine(task);
+
+        return
+        [
+            new ChatMessage(ChatRole.System,
+                "You route a user task to the most appropriate language model. "
+                + "Prefer a stronger model for complex reasoning, coding, or long multi-step work, "
+                + "and a faster or cheaper model for short, simple, or conversational tasks. "
+                + "Pick exactly one id from the candidate list. "
+                + "Reply with ONLY a JSON object of the shape "
+                + "{\"model\": \"<candidate id>\", \"reason\": \"<one short sentence>\"} — "
+                + "no prose, no code fences."),
+            new ChatMessage(ChatRole.User, sb.ToString()),
+        ];
+    }
+
+    /// <summary>
+    /// Parses the engine's answer into a validated choice. Tolerates code fences and prose around
+    /// the JSON object (models add both, whatever the instructions say), but the picked id must
+    /// match a candidate EXACTLY (case-insensitive) — an invented or partial id is a refusal, never
+    /// a fuzzy match, because the caller falls back to a model that certainly works.
+    /// </summary>
+    public static bool TryParseChoice(
+        string? responseText,
+        IReadOnlyCollection<string> candidateIds,
+        out string chosenId,
+        out string reason)
+    {
+        chosenId = "";
+        reason = "";
+        if (string.IsNullOrWhiteSpace(responseText))
+            return false;
+
+        // The first balanced-looking JSON object in the text: from the first '{' to the last '}'.
+        // Good enough for a reply that is "a JSON object, possibly fenced/prefixed" — anything more
+        // broken than that reads as a refusal and keeps the floor.
+        var start = responseText.IndexOf('{');
+        var end = responseText.LastIndexOf('}');
+        if (start < 0 || end <= start)
+            return false;
+
+        RouterChoice? choice;
+        try
+        {
+            choice = JsonSerializer.Deserialize<RouterChoice>(
+                responseText[start..(end + 1)], Json);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        if (choice?.Model is not { Length: > 0 } picked)
+            return false;
+
+        var match = candidateIds.FirstOrDefault(id =>
+            string.Equals(id, picked.Trim(), StringComparison.OrdinalIgnoreCase));
+        if (match is null)
+            return false;
+
+        chosenId = match;
+        reason = choice.Reason?.Trim() ?? "";
+        return true;
+    }
+
+    /// <summary>
+    /// The candidate set for one round: every loaded non-router model whose credentials actually
+    /// resolve, de-duplicated by id, in catalog order. Pure — both inputs are snapshots.
+    /// </summary>
+    public static ImmutableList<RouterCandidate> UsableCandidates(
+        IReadOnlyList<ModelInfo> loadedModels, Func<string, bool> hasUsableCredential)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = ImmutableList.CreateBuilder<RouterCandidate>();
+        foreach (var model in loadedModels.OrderBy(m => m.Order))
+        {
+            if (model.IsRouter || string.IsNullOrWhiteSpace(model.Name))
+                continue;
+            if (!seen.Add(model.Name))
+                continue;
+            if (!hasUsableCredential(model.Name))
+                continue;
+            result.Add(new RouterCandidate(model.Name, model.Provider, model.Label));
+        }
+        return result.ToImmutable();
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-auto-picks-the-right-model.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-auto-picks-the-right-model.md
@@ -1,0 +1,18 @@
+---
+Name: Auto picks the right model for the job
+Category: Feature
+Description: The Auto model selection now looks at what you asked and routes the round to the most suitable model, instead of always using one fixed default.
+Icon: Sparkle
+Order: -20260821
+---
+
+# Auto picks the right model for the job
+
+Until now, choosing **Auto** as the model always ran your thread on one fixed default. Now Auto
+reads your request first: a quick routing step picks the most suitable of the available models —
+a stronger model for complex reasoning or coding work, a faster one for short and simple asks —
+and the round runs on that choice.
+
+The routing is careful by design: if it cannot decide quickly, your round simply runs on the
+familiar default, so Auto is never slower or less reliable than before. The chosen model is
+recorded on the response, so you can always see which model served a round.

--- a/test/MeshWeaver.AI.Test/AutoModelRouterTest.cs
+++ b/test/MeshWeaver.AI.Test/AutoModelRouterTest.cs
@@ -1,0 +1,113 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the pure half of the Auto router's selection stage (#1951): the candidate filter, the
+/// prompt contract, and — most load-bearing — the answer parser. The parser is the gate between
+/// "whatever the engine replied" and "which model serves the round", so every tolerance
+/// (code fences, prose, casing) and every refusal (invented id, garbage, empty) is pinned here.
+/// A refusal is SAFE — the round keeps the tier/default floor — so when in doubt the parser
+/// must refuse, never fuzzy-match.
+/// </summary>
+public class AutoModelRouterTest
+{
+    private static readonly string[] Candidates = ["DeepSeek-V4-Pro", "DeepSeek-V4-Flash", "z-ai/glm-5.2"];
+
+    [Fact]
+    public void ParsesAPlainJsonChoice()
+    {
+        var ok = AutoModelRouter.TryParseChoice(
+            """{"model": "DeepSeek-V4-Pro", "reason": "multi-step coding task"}""",
+            Candidates, out var chosen, out var reason);
+
+        Assert.True(ok);
+        Assert.Equal("DeepSeek-V4-Pro", chosen);
+        Assert.Equal("multi-step coding task", reason);
+    }
+
+    [Fact]
+    public void ToleratesCodeFencesAndProseAroundTheJson()
+    {
+        var ok = AutoModelRouter.TryParseChoice(
+            "Sure! Here is my pick:\n```json\n{\"model\": \"z-ai/glm-5.2\", \"reason\": \"short chat\"}\n```\nHope that helps.",
+            Candidates, out var chosen, out _);
+
+        Assert.True(ok);
+        Assert.Equal("z-ai/glm-5.2", chosen);
+    }
+
+    [Fact]
+    public void MatchesCandidatesCaseInsensitively_ButReturnsTheCanonicalId()
+    {
+        var ok = AutoModelRouter.TryParseChoice(
+            """{"model": "deepseek-v4-flash", "reason": "simple"}""",
+            Candidates, out var chosen, out _);
+
+        Assert.True(ok);
+        Assert.Equal("DeepSeek-V4-Flash", chosen);
+    }
+
+    [Theory]
+    [InlineData("""{"model": "gpt-9-ultra", "reason": "made up"}""")] // invented id
+    [InlineData("""{"model": "DeepSeek", "reason": "partial id must not fuzzy-match"}""")]
+    [InlineData("""{"reason": "no model field"}""")]
+    [InlineData("""{"model": "", "reason": "empty"}""")]
+    [InlineData("DeepSeek-V4-Pro")] // bare id without the JSON contract
+    [InlineData("not json at all")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void RefusesAnythingOutsideTheContract(string? response)
+    {
+        var ok = AutoModelRouter.TryParseChoice(response, Candidates, out _, out _);
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void BuildMessages_NamesEveryCandidate_AndTruncatesTheTask()
+    {
+        var candidates = new[]
+        {
+            new AutoModelRouter.RouterCandidate("DeepSeek-V4-Pro", "Azure Foundry", "DeepSeek V4 Pro"),
+            new AutoModelRouter.RouterCandidate("z-ai/glm-5.2", "OpenRouter", null),
+        };
+        var longTask = new string('x', AutoModelRouter.MaxTaskChars + 500);
+
+        var messages = AutoModelRouter.BuildMessages(candidates, longTask);
+
+        Assert.Equal(2, messages.Count);
+        Assert.Equal(ChatRole.System, messages[0].Role);
+        var user = messages[1].Text;
+        Assert.Contains("DeepSeek-V4-Pro", user);
+        Assert.Contains("z-ai/glm-5.2", user);
+        Assert.Contains("Azure Foundry", user);
+        // The task is capped: the full 500-over payload must not survive into the prompt.
+        Assert.DoesNotContain(longTask, user);
+        Assert.Contains(new string('x', 100), user);
+    }
+
+    [Fact]
+    public void UsableCandidates_DropsRouters_Duplicates_AndKeylessModels_InCatalogOrder()
+    {
+        var loaded = new List<ModelInfo>
+        {
+            new() { Name = "auto", Provider = "Auto", IsRouter = true, Order = -10 },
+            new() { Name = "DeepSeek-V4-Pro", Provider = "Azure Foundry", Order = 2 },
+            new() { Name = "DeepSeek-V4-Pro", Provider = "Azure Foundry", Order = 3 }, // duplicate id
+            new() { Name = "z-ai/glm-5.2", Provider = "OpenRouter", Order = 6 },
+            new() { Name = "keyless-model", Provider = "OpenRouter", Order = 7 },
+        };
+
+        var candidates = AutoModelRouter.UsableCandidates(
+            loaded, id => id != "keyless-model");
+
+        Assert.Equal(
+            new[] { "DeepSeek-V4-Pro", "z-ai/glm-5.2" },
+            candidates.Select(c => c.Id).ToArray());
+    }
+}


### PR DESCRIPTION
Closes #1951 (maintainer direction 2026-08-20: Auto "should trigger an agent to determine the most appropriate model for the thread").

## Two-stage Auto

- **Stage one (unchanged)**: the synchronous dispatch in `ApplyStaleModelFallback` parks an Auto round on the selected agent's declared tier / deployment default — the floor a round can always run on.
- **Stage two (new)**: when the round *requested* the Auto router, `ApplyAutoRouterSelectionAsync` (AI pool thread, inside `GetResponseAsync`) makes one bounded call on the floor model via the factory's bare `CreateChatClient` — the round's text + the usable candidates in, strict JSON `{model, reason}` out. A valid candidate id moves the round and rebuilds the agents; **anything else keeps the floor** (timeout 10s, refusal, invented/partial id, persistent factory with no bare client). Routing can improve a round and can never break one.

## Guardrails

- Only a router *request* routes — explicit human picks and automation rounds naming their model never reach it; fewer than two usable candidates or empty round text skips; `Ai:Router:Selection=Tier` opts a deployment out.
- The choice is logged with the engine's stated reason; `substitutedFromModel` keeps carrying the router id so the requested→effective record (#476) stays truthful.
- Existing test fakes don't implement `CreateChatClient` → the router no-ops for them by construction.

## Verification

- `AutoModelRouter` (pure prompt/parse/candidates): 13 new tests.
- Full `MeshWeaver.AI.Test` suite: 1175 passed / 0 failed, Release `-warnaserror` clean.
- What's New entry included (Category: Feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)