### PR TITLE
fix: one unresolvable plugin costs the agent that plugin — never the agent

### DIFF
--- a/src/MeshWeaver.AI/ChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI/ChatClientAgentFactory.cs
@@ -202,7 +202,31 @@ public abstract class ChatClientAgentFactory : IChatClientFactory
         {
             foreach (var pluginRef in config.Plugins)
             {
-                var pluginTools = ResolvePluginTools(pluginRef, chat);
+                // 🚨 A plugin that cannot RESOLVE must cost the agent that plugin, never the agent.
+                // The concrete case: a module-contributed IAgentPlugin whose constructor dependency
+                // the host registers conditionally (ExecutiveAssistantPlugin needs IEaGraphAuth,
+                // registered only when Email:Enabled) — GetServices<IAgentPlugin>() activates EVERY
+                // registered implementation, so one unresolvable plugin threw for every agent that
+                // referenced ANY custom plugin and took the whole chat down ("Selected agent
+                // 'Agent/Assistant' was found, but creating it failed…", memex 2026-08-21). The
+                // agent still builds with its remaining tools; the skip is loud and names both
+                // sides so an operator can see exactly which capability is missing and why.
+                IReadOnlyList<AITool>? pluginTools;
+                try
+                {
+                    // Materialized HERE so a lazily-throwing tool enumeration (the method-filter
+                    // branch returns a deferred Where) still lands in THIS catch instead of
+                    // resurfacing at the later ToList and killing the agent after all.
+                    pluginTools = ResolvePluginTools(pluginRef, chat)?.ToList();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(ex,
+                        "Plugin '{PluginName}' failed to resolve for agent {AgentName} — the agent "
+                        + "runs WITHOUT this plugin's tools: {Message}",
+                        pluginRef.Name, config.Id, ex.Message);
+                    continue;
+                }
                 if (pluginTools != null)
                     tools = tools.Concat(pluginTools);
                 else

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-broken-plugin-no-longer-blocks-chat.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-broken-plugin-no-longer-blocks-chat.md
@@ -1,0 +1,16 @@
+---
+Name: A broken agent tool no longer blocks chat
+Category: Fix
+Description: When one of an agent's optional tool plugins cannot start, the agent now runs without that tool instead of failing every conversation with an error.
+Icon: Sparkle
+Order: -20260821
+---
+
+# A broken agent tool no longer blocks chat
+
+When one of an agent's optional tool integrations could not start — for example a mailbox tool on
+a deployment where email is not configured — the whole agent failed, and every conversation with
+it showed an error instead of an answer.
+
+Now the agent simply runs without that one tool: the rest of its capabilities stay available, and
+the missing integration is reported to operators in the logs.

--- a/test/MeshWeaver.AI.Test/PluginResilienceTest.cs
+++ b/test/MeshWeaver.AI.Test/PluginResilienceTest.cs
@@ -1,0 +1,128 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Plugins;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the plugin-failure blast radius (memex prod, 2026-08-21): a registered
+/// <see cref="IAgentPlugin"/> whose constructor dependency is NOT registered — the concrete case
+/// was the Mail module's ExecutiveAssistantPlugin needing IEaGraphAuth, which the host registers
+/// only when Email:Enabled — must cost the agent that plugin's tools, never the agent.
+/// <c>GetServices&lt;IAgentPlugin&gt;()</c> activates EVERY registered implementation, so before the
+/// fix ONE unresolvable plugin threw for every agent referencing ANY custom plugin, and the
+/// selected agent (Assistant) failed outright: chat down.
+/// </summary>
+[Collection("PluginResilienceTests")]
+public class PluginResilienceTest : MonolithMeshTestBase
+{
+    private static readonly string TestDataPath = Path.Combine(AppContext.BaseDirectory, "TestData");
+
+    public PluginResilienceTest(ITestOutputHelper output) : base(output) { }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        builder
+            .UseMonolithMesh()
+            .AddFileSystemPersistence(TestDataPath)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IChatClientFactory, StubChatClientFactory>();
+                // The healthy plugin the agent actually references…
+                services.AddSingleton<IAgentPlugin, WorkingPlugin>();
+                // …and the poisoned registration: its ctor dependency is deliberately NOT
+                // registered, so ANY GetServices<IAgentPlugin>() activation throws.
+                services.AddSingleton<IAgentPlugin, UnresolvablePlugin>();
+                return services;
+            })
+            .AddGraph()
+            .AddAI()
+            .ConfigureDefaultNodeHub(config => config.AddDefaultLayoutAreas());
+
+    [Fact]
+    public void UnresolvablePluginRegistration_CostsThePlugin_NeverTheAgent()
+    {
+        var factory = Mesh.ServiceProvider.GetServices<IChatClientFactory>()
+            .OfType<StubChatClientFactory>().Single();
+        var chat = new AgentChatClient(Mesh.ServiceProvider);
+
+        var config = new AgentConfiguration
+        {
+            Id = "Resilient",
+            Instructions = "Test agent",
+            Plugins = [new AgentPluginReference { Name = "Working" }],
+        };
+
+        // Before the fix this threw
+        //   "An exception was thrown while activating …IAgentPlugin[] -> …UnresolvablePlugin"
+        // out of ResolvePluginTools and the agent was never built.
+        var agent = factory.CreateAgent(
+            config, chat,
+            ImmutableDictionary<string, ChatClientAgent>.Empty,
+            [config]);
+
+        Assert.NotNull(agent);
+        Assert.Equal("Resilient", agent.Name);
+    }
+
+    internal class StubChatClientFactory(IMessageHub hub) : ChatClientAgentFactory(hub)
+    {
+        public override string Name => "StubFactory";
+        public override IReadOnlyList<string> Models => ["stub-model"];
+        public override int Order => 0;
+        protected override IChatClient CreateChatClient(AgentConfiguration agentConfig) => new StubChatClient();
+    }
+
+    private sealed class StubChatClient : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose() { }
+    }
+
+    private interface INeverRegistered
+    {
+        string Value { get; }
+    }
+
+    private sealed class UnresolvablePlugin(INeverRegistered dependency) : IAgentPlugin
+    {
+        public string Name => "Broken";
+        public IEnumerable<AITool> CreateTools() => [AIFunctionFactory.Create(() => dependency.Value, "broken_tool")];
+    }
+
+    private sealed class WorkingPlugin : IAgentPlugin
+    {
+        public string Name => "Working";
+        public IEnumerable<AITool> CreateTools() => [AIFunctionFactory.Create(() => "ok", "working_tool")];
+    }
+}


### PR DESCRIPTION
A module-contributed `IAgentPlugin` whose constructor dependency the host registers conditionally (the Mail module's `ExecutiveAssistantPlugin` needs `IEaGraphAuth`, registered only when `Email:Enabled`) made `GetServices<IAgentPlugin>()` throw for **every agent referencing any custom plugin** — the selected agent failed outright and chat was down on memex.systemorph.com (2026-08-21: "Selected agent 'Agent/Assistant' was found, but creating it failed…").

- `CreateAgentCore` isolates each plugin reference: resolution is **materialized inside a per-ref try/catch** (so a lazily-throwing tool enumeration can't resurface later and kill the agent after all), a failure logs a warning naming both plugin and agent, and the agent builds with its remaining tools.
- **Red-first pin**: `PluginResilienceTest` registers a plugin with an unregistered ctor dependency next to a healthy one — verified FAILING without the fix, passing with it.
- What's New entry included (Category: Fix).

The module-side half (make `IEaGraphAuth` optional + republish bundles) is MeshWeaver.Plugins#551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)