### PR TITLE
deps-closure: module-owned MeshWeaver.* siblings ride the bundle

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -131,6 +131,7 @@ jobs:
           --plugin "${{ matrix.entry.package }}"
           --package-version "${{ steps.identity.outputs.version }}"
           --min-mesh-version "${{ steps.identity.outputs.floor }}"
+          --own-platform "$(ls "$GITHUB_WORKSPACE/src" 2>/dev/null | grep '^MeshWeaver\.' | paste -sd';' -)"
           --out "$RUNNER_TEMP/bundles"
 
       # A bundle that PACKED is not yet a bundle that LANDS: assert the closure and the manifest a
@@ -156,12 +157,20 @@ jobs:
             || { echo "::error::manifest module.assemblies misses the entry DLL"; exit 1; }
           jq -e --arg f "$FLOOR" '.module.minMeshVersion == $f' "$manifest" > /dev/null \
             || { echo "::error::manifest floor differs from content.minMeshVersion"; exit 1; }
-          # A module bundle must NEVER carry a platform assembly beside its entry — it would
+          # A module bundle must NEVER carry a PLATFORM assembly beside its entry — it would
           # shadow the platform's own binary at the consumer (the same trap-door landing refuses
-          # for the entry DLL). The deps-closure derivation excludes MeshWeaver.* by construction;
-          # this asserts that from the outside.
-          jq -e --arg m "$MODULE" \
-            '[.module.assemblies[] | select(startswith("MeshWeaver.") and (. != $m + ".dll") and (. != $m + ".pdb"))] | length == 0' \
+          # for the entry DLL). MODULE-OWNED MeshWeaver.* assemblies (their source lives in THIS
+          # repo's src/, so they exist nowhere in /app — Import's DataSetReader family) are the
+          # deliberate exception: for them, NOT riding is the fault. The jq mirrors the pack's
+          # --own-platform set exactly, so the two cannot disagree about what "platform" means.
+          own="$(ls "$GITHUB_WORKSPACE/src" 2>/dev/null | grep '^MeshWeaver\.' | paste -sd';' -)"
+          jq -e --arg m "$MODULE" --arg own "$own" \
+            '($own | split(";")) as $owned
+             | [.module.assemblies[]
+                | select(startswith("MeshWeaver.")
+                    and (. != $m + ".dll") and (. != $m + ".pdb")
+                    and ((rtrimstr(".dll") | rtrimstr(".pdb")) as $n | $owned | index($n) | not))]
+             | length == 0' \
             "$manifest" > /dev/null \
             || { echo "::error::bundle carries platform (MeshWeaver.*) assemblies beside the module"; exit 1; }
           echo "path=$bundle" >> "$GITHUB_OUTPUT"

--- a/src/MeshWeaver.Plugin.Build/DepsClosure.cs
+++ b/src/MeshWeaver.Plugin.Build/DepsClosure.cs
@@ -68,7 +68,8 @@ public static class DepsClosure
     /// a derivation from the wrong file must be a refusal, never an empty closure that packs a
     /// module which faults at first use.
     /// </summary>
-    public static Result Derive(string depsJsonText, string moduleName)
+    public static Result Derive(
+        string depsJsonText, string moduleName, ISet<string>? ownedPlatformNames = null)
     {
         using var document = JsonDocument.Parse(depsJsonText);
         var root = document.RootElement;
@@ -128,10 +129,15 @@ public static class DepsClosure
 
         // The walk from the module's OWN direct references — MeshWeaver.* references root the
         // platform side and are not walked: their transitives are /app's business, and dragging
-        // them in would ship the platform inside the module.
-        var ownRoots = module.Dependencies.Where(d => !IsPlatform(d)).ToList();
-        var (ownReachable, platformStops) = ReachStoppingAtPlatform(nodes, ownRoots);
-        platformStops.UnionWith(module.Dependencies.Where(IsPlatform));
+        // them in would ship the platform inside the module. EXCEPT the module-OWNED ones
+        // (<paramref name="ownedPlatformNames"/> — MeshWeaver.* projects that moved out of the
+        // platform and live in the module's own repo, e.g. Import's DataSetReader family): those
+        // are nowhere in /app, so stopping at them ships a module that faults on its first
+        // sibling — they ride the bundle and their subtrees are walked like any private dep.
+        bool IsStop(string d) => IsPlatform(d) && !(ownedPlatformNames?.Contains(NameOf(d)) ?? false);
+        var ownRoots = module.Dependencies.Where(d => !IsStop(d)).ToList();
+        var (ownReachable, platformStops) = ReachStoppingAtPlatform(nodes, ownRoots, IsStop);
+        platformStops.UnionWith(module.Dependencies.Where(IsStop));
 
         var files = new List<string>();
         var warnings = new List<string>();
@@ -172,7 +178,8 @@ public static class DepsClosure
     /// dependencies but carries no entry for) are simply absent — nothing to bundle, nothing to
     /// walk.</summary>
     private static (HashSet<string> Reached, HashSet<string> PlatformStops) ReachStoppingAtPlatform(
-        IReadOnlyDictionary<string, Node> nodes, IEnumerable<string> roots)
+        IReadOnlyDictionary<string, Node> nodes, IEnumerable<string> roots,
+        Func<string, bool> isStop)
     {
         var reached = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var stops = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -180,7 +187,7 @@ public static class DepsClosure
         while (queue.Count > 0)
         {
             var name = queue.Dequeue();
-            if (IsPlatform(name))
+            if (isStop(name))
             {
                 stops.Add(name);
                 continue;

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -138,6 +138,12 @@ public static class ModulePackCommand
                   --with <fileName>           an additional closure file from <moduleOutputDir>
                                               (repeatable). <name>.dll is always included, and its
                                               .pdb rides along when present.
+                  --own-platform <names>      semicolon-separated MeshWeaver.* assemblies that are
+                                              MODULE-OWNED (their source lives in the module's own
+                                              repo, not the platform) — the deps-closure walk
+                                              bundles them instead of stopping: they are nowhere
+                                              in /app, so a stop would ship a module that faults
+                                              on its first sibling (Import's DataSetReader family)
                   --deps-closure              derive the module's PRIVATE dependency closure from
                                               <name>.deps.json beside the entry DLL and bundle it:
                                               assemblies reachable from the module's own package
@@ -164,6 +170,7 @@ public static class ModulePackCommand
         string? minMeshVersion = null;
         string? graphDll = null;
         var extras = new List<string>();
+        var ownPlatform = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var depsClosure = false;
         var outputDirectory = Environment.CurrentDirectory;
 
@@ -191,6 +198,10 @@ public static class ModulePackCommand
                     break;
                 case "--with" when i + 1 < args.Length:
                     extras.Add(args[++i]);
+                    break;
+                case "--own-platform" when i + 1 < args.Length:
+                    ownPlatform.UnionWith(args[++i]
+                        .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
                     break;
                 case "--deps-closure":
                     depsClosure = true;
@@ -299,7 +310,7 @@ public static class ModulePackCommand
             DepsClosure.Result derived;
             try
             {
-                derived = DepsClosure.Derive(File.ReadAllText(depsPath), moduleName);
+                derived = DepsClosure.Derive(File.ReadAllText(depsPath), moduleName, ownPlatform);
             }
             catch (Exception e) when (e is InvalidDataException or JsonException)
             {

--- a/test/MeshWeaver.Graph.Test/DepsClosureTest.cs
+++ b/test/MeshWeaver.Graph.Test/DepsClosureTest.cs
@@ -114,6 +114,74 @@ public class DepsClosureTest
         Assert.Contains(result.Warnings, w => w.Contains("Microsoft.Identity.Client"));
     }
 
+    /// <summary>An Import-shaped graph: the module references a MODULE-OWNED MeshWeaver.*
+    /// sibling (its source lives in the module's repo, so it is nowhere in /app) which itself
+    /// references a package and a genuine platform project.</summary>
+    private const string OwnedGraph = """
+        {
+          "runtimeTarget": { "name": ".NETCoreApp,Version=v10.0" },
+          "targets": {
+            ".NETCoreApp,Version=v10.0": {
+              "MeshWeaver.Import/1.0.0": {
+                "dependencies": { "MeshWeaver.DataSetReader.Csv": "1.0.0", "MeshWeaver.Data": "3.0.0" },
+                "runtime": { "MeshWeaver.Import.dll": {} }
+              },
+              "MeshWeaver.DataSetReader.Csv/1.0.0": {
+                "dependencies": { "MeshWeaver.DataSetReader": "1.0.0", "CsvHelper": "33.0.1" },
+                "runtime": { "MeshWeaver.DataSetReader.Csv.dll": {} }
+              },
+              "MeshWeaver.DataSetReader/1.0.0": {
+                "dependencies": { "MeshWeaver.DataStructures": "1.0.0", "MeshWeaver.Domain": "3.0.0" },
+                "runtime": { "MeshWeaver.DataSetReader.dll": {} }
+              },
+              "MeshWeaver.DataStructures/1.0.0": { "runtime": { "MeshWeaver.DataStructures.dll": {} } },
+              "MeshWeaver.Domain/3.0.0": { "runtime": { "MeshWeaver.Domain.dll": {} } },
+              "MeshWeaver.Data/3.0.0": { "runtime": { "MeshWeaver.Data.dll": {} } },
+              "CsvHelper/33.0.1": { "runtime": { "lib/net8.0/CsvHelper.dll": {} } }
+            }
+          },
+          "libraries": {
+            "MeshWeaver.Import/1.0.0": { "type": "project" },
+            "MeshWeaver.DataSetReader.Csv/1.0.0": { "type": "project" },
+            "MeshWeaver.DataSetReader/1.0.0": { "type": "project" },
+            "MeshWeaver.DataStructures/1.0.0": { "type": "project" },
+            "MeshWeaver.Domain/3.0.0": { "type": "project" },
+            "MeshWeaver.Data/3.0.0": { "type": "project" },
+            "CsvHelper/33.0.1": { "type": "package" }
+          }
+        }
+        """;
+
+    [Fact]
+    public void OwnedPlatformSiblings_Ride_AndAreWalked_WhilePlatformStillStops()
+    {
+        // Without the owned set: every MeshWeaver.* stops, the family is dropped — the bundle
+        // would fault on its first sibling at the consumer.
+        var bare = DepsClosure.Derive(OwnedGraph, "MeshWeaver.Import");
+        Assert.DoesNotContain("MeshWeaver.DataSetReader.Csv.dll", bare.Files);
+        Assert.DoesNotContain("CsvHelper.dll", bare.Files.Select(Path.GetFileName));
+
+        var owned = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "MeshWeaver.DataSetReader.Csv", "MeshWeaver.DataSetReader", "MeshWeaver.DataStructures",
+        };
+        var result = DepsClosure.Derive(OwnedGraph, "MeshWeaver.Import", owned);
+
+        // The whole owned family rides, and the walk CONTINUES through it: Csv's package
+        // dependency is reached, and DataSetReader's own owned sibling too.
+        Assert.Contains("MeshWeaver.DataSetReader.Csv.dll", result.Files);
+        Assert.Contains("MeshWeaver.DataSetReader.dll", result.Files);
+        Assert.Contains("MeshWeaver.DataStructures.dll", result.Files);
+        Assert.Contains("CsvHelper.dll", result.Files.Select(Path.GetFileName));
+
+        // Genuine platform projects still stop — reached through the module AND through an owned
+        // sibling alike.
+        Assert.DoesNotContain("MeshWeaver.Data.dll", result.Files);
+        Assert.DoesNotContain("MeshWeaver.Domain.dll", result.Files);
+        Assert.Contains("MeshWeaver.Data", result.ExcludedPlatformCarried);
+        Assert.Contains("MeshWeaver.Domain", result.ExcludedPlatformCarried);
+    }
+
     [Fact]
     public void WrongModuleName_IsARefusal_NeverAnEmptyClosure()
     {


### PR DESCRIPTION
Enabler for extracting multi-project modules (Import + its DataSetReader family): the closure walk still stops at platform `MeshWeaver.*` nodes, but an OWNED set — derived by the reusable workflow from the calling repo's own `src/MeshWeaver.*` listing — rides the bundle and is walked through (their package deps ride too). Genuine platform stops survive even when reached through an owned sibling; the bundle-inspect assert mirrors the same set. 7/7 closure tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)