### PR TITLE
fix(#1794): a terminating pod says so, and says how its drain is going

### DIFF
--- a/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
@@ -157,16 +157,34 @@ public static class ServiceDefaults
     /// <c>terminationGracePeriodSeconds</c>, so a pod with a forgotten open tab cannot block a
     /// rollout forever. No session, no state, no auth — infrastructure, exactly like
     /// <c>/health</c> and <c>/alive</c> beside it.</para>
+    ///
+    /// <para><b>…and it LOGS what it reports.</b> preStop probes with
+    /// <c>curl -sf -m 5 -o /dev/null</c>, which throws the count away and cannot tell a 503 from a
+    /// refused connection — so without a log line a pod sitting in <c>Terminating</c> is opaque
+    /// from outside, and "one forgotten tab" is indistinguishable from "the HTTP layer is wedged"
+    /// (#1794). Since a probe of this endpoint is the only notice the process gets that it is
+    /// terminating at all — preStop runs BEFORE SIGTERM — the probe is also the right moment to say
+    /// so. <see cref="DrainProgress"/> holds the rate limiting and the decision; see its remarks
+    /// for how the three cases read in the log.</para>
     /// </summary>
     public static WebApplication MapDrainEndpoint(this WebApplication app)
     {
-        app.MapGet("/drain", (IServiceProvider services) =>
+        // Process-wide, captured here rather than resolved: the endpoint is mapped once per app, so
+        // the closure IS the process scope, and this stays independent of whether the host happens
+        // to register Blazor's tracker. See DrainProgress for why the endpoint — not a timer — is
+        // the right place to notice that this pod is terminating.
+        var progress = new DrainProgress();
+
+        app.MapGet("/drain", (IServiceProvider services, ILogger<DrainProgress> logger) =>
         {
             // GetService, not GetRequired: a host without Blazor (a worker, a test host) has no
             // tracker and is trivially drained — never a 500 that a preStop would read as "keep
             // waiting" and then hard-kill at the grace ceiling anyway.
             var tracker = services.GetService<ActiveCircuitTracker>();
             var live = tracker?.Count ?? 0;
+
+            Report(logger, progress.Probe(live, DateTimeOffset.UtcNow));
+
             return live == 0
                 ? Results.Text("drained", "text/plain")
                 : Results.Text($"{live} circuit(s) still open", "text/plain",
@@ -174,6 +192,58 @@ public static class ServiceDefaults
         }).AllowAnonymous();
 
         return app;
+    }
+
+    /// <summary>
+    /// Writes the one line a probe is worth. Information: a pod termination is a rare lifecycle
+    /// event, and <see cref="DrainProgress.ReportInterval"/> already caps a full 1800 s drain at
+    /// roughly thirty lines. Each line is self-sufficient — it states the counts and the elapsed
+    /// time rather than requiring the reader to diff it against an earlier one.
+    /// </summary>
+    private static void Report(ILogger logger, DrainProbeReport report)
+    {
+        switch (report.Outcome)
+        {
+            case DrainProbeOutcome.TerminationBegun:
+                logger.LogInformation(
+                    "Drain: TERMINATION BEGUN — preStop is polling /drain, so Kubernetes has already " +
+                    "deleted this pod and removed it from the Service; the process has NOT been " +
+                    "SIGTERMed yet and keeps serving its {Live} open circuit(s) until they close or " +
+                    "the grace ceiling SIGKILLs it. Treat every log line after this one as coming " +
+                    "from a terminating replica, not a serving one.",
+                    report.LiveCircuits);
+                break;
+
+            case DrainProbeOutcome.StillDraining:
+                logger.LogInformation(
+                    "Drain: still draining after {Elapsed} — {Live} circuit(s) open (was " +
+                    "{Previous} at the last report, {Initial} when termination began) over " +
+                    "{Probes} probe(s). {Verdict}",
+                    report.Elapsed,
+                    report.LiveCircuits,
+                    report.CircuitsAtLastReport,
+                    report.CircuitsWhenTerminationBegan,
+                    report.ProbeCount,
+                    report.Progressing
+                        ? "Progressing — sessions are closing."
+                        : "NO progress since the last report; if the count stays flat this pod " +
+                          "will ride the grace period to SIGKILL.");
+                break;
+
+            case DrainProbeOutcome.Drained:
+                logger.LogInformation(
+                    "Drain: DRAINED after {Elapsed} over {Probes} probe(s) — the last circuit " +
+                    "closed ({Initial} were open when termination began). preStop returns now and " +
+                    "the process shuts down normally.",
+                    report.Elapsed,
+                    report.ProbeCount,
+                    report.CircuitsWhenTerminationBegan);
+                break;
+
+            case DrainProbeOutcome.Silent:
+            default:
+                break;
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/DrainProgress.cs
+++ b/src/MeshWeaver.Hosting/DrainProgress.cs
@@ -1,0 +1,187 @@
+namespace MeshWeaver.Hosting;
+
+/// <summary>What a single <c>/drain</c> probe is worth saying out loud.</summary>
+public enum DrainProbeOutcome
+{
+    /// <summary>Nothing to report — this probe fell inside the reporting interval.</summary>
+    Silent,
+
+    /// <summary>The first probe, with sessions still open: this pod has entered termination.</summary>
+    TerminationBegun,
+
+    /// <summary>A periodic progress line while circuits remain.</summary>
+    StillDraining,
+
+    /// <summary>The last circuit closed — reported exactly once.</summary>
+    Drained
+}
+
+/// <summary>
+/// One <c>/drain</c> probe, decided. Everything a log line needs is on the record, so the caller
+/// formats and does not re-derive.
+/// </summary>
+/// <param name="Outcome">Whether — and what — to report.</param>
+/// <param name="LiveCircuits">Circuits open at this probe.</param>
+/// <param name="CircuitsWhenTerminationBegan">Circuits open at the FIRST probe.</param>
+/// <param name="CircuitsAtLastReport">Circuits open when a line was last emitted.</param>
+/// <param name="Elapsed">Time since the first probe.</param>
+/// <param name="ProbeCount">Probes seen so far, this one included.</param>
+public sealed record DrainProbeReport(
+    DrainProbeOutcome Outcome,
+    int LiveCircuits,
+    int CircuitsWhenTerminationBegan,
+    int CircuitsAtLastReport,
+    TimeSpan Elapsed,
+    long ProbeCount)
+{
+    /// <summary>
+    /// True when the count FELL since the last reported line. This is the whole diagnostic: a
+    /// drain that is progressing ends on its own, a flat one rides the grace ceiling to SIGKILL.
+    /// </summary>
+    public bool Progressing => LiveCircuits < CircuitsAtLastReport;
+}
+
+/// <summary>
+/// Turns the <c>/drain</c> poll into a BOUNDED, readable shutdown narrative — the missing half of
+/// the session drain (#1342), and what #1794 asks for.
+///
+/// <para><b>The gap this closes.</b> <see cref="ActiveCircuitTracker"/> already knows exactly how
+/// many sessions are holding the pod open, and <c>/drain</c> already returns that number in its 503
+/// body. Nobody reads it: the container's preStop probe is
+/// <c>curl -sf -m 5 -o /dev/null …</c> — the count goes to <c>/dev/null</c> and nothing is logged.
+/// So a pod sitting in <c>Terminating</c> for twenty-nine minutes is, from outside, completely
+/// opaque: one forgotten browser tab and a wedged HTTP layer look identical, and the only way to
+/// tell was to exec into a pod that is about to be SIGKILLed.</para>
+///
+/// <para><b>Why the endpoint is the right place, and why there is no timer.</b> <c>preStop</c> runs
+/// BEFORE SIGTERM, so during the whole drain the process has not been told anything: nothing has
+/// fired <c>ApplicationStopping</c>, and the pod cannot know it is terminating by any other means.
+/// A probe of <c>/drain</c> IS that knowledge — the endpoint is polled by preStop and by nothing
+/// else. So the signal is already arriving on its own schedule and needs no watchdog, no poller and
+/// no timer of ours: this type only decides what each arriving probe is worth saying.</para>
+///
+/// <para><b>Reading it from outside.</b> Three cases, now distinguishable in the log alone:</para>
+/// <list type="bullet">
+/// <item><description><b>Draining normally</b> — the count falls line over line and a
+/// <see cref="DrainProbeOutcome.Drained"/> line ends it.</description></item>
+/// <item><description><b>A forgotten tab</b> — <see cref="DrainProbeReport.Progressing"/> stays
+/// false at a steady count until the kubelet SIGKILLs at the grace ceiling. Working as designed,
+/// and now visibly so.</description></item>
+/// <item><description><b>A wedged HTTP layer</b> — <see cref="DrainProbeOutcome.TerminationBegun"/>
+/// appears and then NOTHING follows, because the endpoint that would report is itself not
+/// answering. preStop cannot see this difference (<c>curl -sf</c> fails identically on a 503 and on
+/// a refused connection); the absence of the follow-up line is the tell.</description></item>
+/// </list>
+///
+/// <para><b>The other thing the first line buys.</b> It is a durable, greppable marker that this
+/// process is past its <c>deletionTimestamp</c>. Every line after it — including a
+/// <c>LogCritical</c> from <c>RoutingGrain</c> — comes from a replica Kubernetes has already
+/// removed from the Service. Two such Criticals were read as live production alarms during the
+/// 2026-08-17 incident precisely because nothing in the log distinguished them.</para>
+///
+/// <para><b>Bounded on purpose.</b> preStop probes every 5 s; at the 1800 s ceiling that is 360
+/// probes. Reporting each one would put 360 Information lines per pod termination into Loki, which
+/// is a real cost for no extra information. One line per <see cref="ReportInterval"/> caps a full
+/// drain at ~30 lines while still resolving movement.</para>
+///
+/// <para>Lock-free like the tracker beside it: probes are HTTP requests and may arrive on any
+/// thread, and the state transition must be exactly-once (two threads must not both announce the
+/// start of termination).</para>
+/// </summary>
+public sealed class DrainProgress
+{
+    /// <summary>
+    /// Minimum spacing between progress lines. Not a poll interval — nothing here ticks; it is the
+    /// rate limit applied to probes that arrive anyway.
+    /// </summary>
+    public static readonly TimeSpan ReportInterval = TimeSpan.FromSeconds(60);
+
+    private sealed record State(
+        DateTimeOffset StartedAt,
+        DateTimeOffset LastReportedAt,
+        int CircuitsWhenTerminationBegan,
+        int CircuitsAtLastReport,
+        long ProbeCount,
+        bool DrainedReported);
+
+    private State? state;
+
+    /// <summary>True once a probe has been seen — i.e. preStop is polling and this pod is going away.</summary>
+    public bool TerminationBegun => Volatile.Read(ref state) is not null;
+
+    /// <summary>
+    /// Records one probe and decides what it is worth reporting. Pure with respect to
+    /// <paramref name="now"/> — the caller supplies the clock, so the whole narrative is unit
+    /// testable with no host, no HTTP and no waiting.
+    /// </summary>
+    /// <param name="liveCircuits">
+    /// <see cref="ActiveCircuitTracker.Count"/> at this probe. Negative values are treated as zero:
+    /// the tracker clamps, but this type must never turn a bad count into a missing Drained line.
+    /// </param>
+    /// <param name="now">The probe's timestamp.</param>
+    public DrainProbeReport Probe(int liveCircuits, DateTimeOffset now)
+    {
+        if (liveCircuits < 0)
+            liveCircuits = 0;
+
+        while (true)
+        {
+            var current = Volatile.Read(ref state);
+            var previousReported = current?.CircuitsAtLastReport ?? liveCircuits;
+
+            DrainProbeOutcome outcome;
+            State next;
+
+            if (current is null)
+            {
+                // First probe. If nobody is connected the pod is free to go immediately, and that
+                // is worth exactly one line — it is the healthy rollout, and its absence is what
+                // makes a slow one hard to spot.
+                outcome = liveCircuits == 0 ? DrainProbeOutcome.Drained : DrainProbeOutcome.TerminationBegun;
+                next = new State(now, now, liveCircuits, liveCircuits, 1, outcome == DrainProbeOutcome.Drained);
+            }
+            else if (current.DrainedReported)
+            {
+                // preStop exits on the first success, so a probe after "drained" means something
+                // else is polling. Count it, say nothing — the narrative already has its ending.
+                outcome = DrainProbeOutcome.Silent;
+                next = current with { ProbeCount = current.ProbeCount + 1 };
+            }
+            else if (liveCircuits == 0)
+            {
+                outcome = DrainProbeOutcome.Drained;
+                next = current with
+                {
+                    LastReportedAt = now,
+                    CircuitsAtLastReport = 0,
+                    ProbeCount = current.ProbeCount + 1,
+                    DrainedReported = true
+                };
+            }
+            else if (now - current.LastReportedAt >= ReportInterval)
+            {
+                outcome = DrainProbeOutcome.StillDraining;
+                next = current with
+                {
+                    LastReportedAt = now,
+                    CircuitsAtLastReport = liveCircuits,
+                    ProbeCount = current.ProbeCount + 1
+                };
+            }
+            else
+            {
+                outcome = DrainProbeOutcome.Silent;
+                next = current with { ProbeCount = current.ProbeCount + 1 };
+            }
+
+            if (ReferenceEquals(Interlocked.CompareExchange(ref state, next, current), current))
+                return new DrainProbeReport(
+                    outcome,
+                    liveCircuits,
+                    next.CircuitsWhenTerminationBegan,
+                    previousReported,
+                    now - next.StartedAt,
+                    next.ProbeCount);
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/DrainProgressTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/DrainProgressTest.cs
@@ -1,0 +1,216 @@
+using MeshWeaver.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// The shutdown narrative a terminating pod writes into its own log.
+///
+/// <para>The thing under test is a DIAGNOSTIC, so the failure directions are not symmetric. Too
+/// few lines and the pod is opaque again — which is the state #1794 was filed about, where a pod
+/// held a node for twenty-nine minutes and nobody could tell from outside whether that was a
+/// forgotten browser tab or a wedge. Too many and a full 1800 s drain puts 360 Information lines
+/// per pod termination into Loki for no extra information. Both are pinned below.</para>
+///
+/// <para>Everything runs on a supplied clock: the drain being modelled is half an hour long, and a
+/// test that actually waited for it would be useless.</para>
+/// </summary>
+public class DrainProgressTest
+{
+    private static readonly DateTimeOffset T0 = new(2026, 8, 21, 8, 40, 52, TimeSpan.Zero);
+
+    /// <summary>
+    /// The line that makes every later line readable: after it, any Critical in this process came
+    /// from a replica Kubernetes had already deleted. Nothing else in the log says so, because
+    /// preStop runs before SIGTERM and no lifetime event has fired.
+    /// </summary>
+    [Fact]
+    public void FirstProbeWithSessionsOpen_AnnouncesTermination()
+    {
+        var progress = new DrainProgress();
+
+        progress.TerminationBegun.Should().BeFalse("nothing has probed /drain yet");
+
+        var report = progress.Probe(5, T0);
+
+        report.Outcome.Should().Be(DrainProbeOutcome.TerminationBegun);
+        report.LiveCircuits.Should().Be(5);
+        report.CircuitsWhenTerminationBegan.Should().Be(5);
+        report.Elapsed.Should().Be(TimeSpan.Zero);
+        report.ProbeCount.Should().Be(1);
+        progress.TerminationBegun.Should().BeTrue("a /drain probe is the only notice this pod gets");
+    }
+
+    /// <summary>The healthy rollout — and worth exactly one line, so that a SLOW one stands out.</summary>
+    [Fact]
+    public void FirstProbeWithNobodyConnected_ReportsDrainedImmediately()
+    {
+        var progress = new DrainProgress();
+
+        var report = progress.Probe(0, T0);
+
+        report.Outcome.Should().Be(DrainProbeOutcome.Drained);
+        report.Elapsed.Should().Be(TimeSpan.Zero);
+    }
+
+    /// <summary>
+    /// preStop probes every 5 s. At the 1800 s ceiling that is 360 probes, and reporting each one
+    /// would make the fix more expensive than the opacity it removes.
+    /// </summary>
+    [Fact]
+    public void ProbesInsideTheInterval_AreSilent()
+    {
+        var progress = new DrainProgress();
+        progress.Probe(5, T0).Outcome.Should().Be(DrainProbeOutcome.TerminationBegun);
+
+        for (var seconds = 5; seconds < 60; seconds += 5)
+            progress.Probe(5, T0.AddSeconds(seconds)).Outcome.Should()
+                .Be(DrainProbeOutcome.Silent, $"the probe at +{seconds}s is inside the report interval");
+    }
+
+    /// <summary>
+    /// A full 1800 s drain that never progresses must stay bounded. 360 probes in, the log holds
+    /// the opening line plus one per minute — about thirty lines, not three hundred and sixty.
+    /// </summary>
+    [Fact]
+    public void AFullGracePeriodOfProbes_StaysBounded()
+    {
+        var progress = new DrainProgress();
+        var reported = 0;
+
+        for (var seconds = 0; seconds < 1800; seconds += 5)
+            if (progress.Probe(5, T0.AddSeconds(seconds)).Outcome != DrainProbeOutcome.Silent)
+                reported++;
+
+        reported.Should().Be(30, "the opening line plus one per minute of a 30-minute drain");
+    }
+
+    /// <summary>
+    /// The distinguishing signal. A drain that is progressing ends by itself; a flat one rides the
+    /// ceiling to SIGKILL, and the log has to SAY which of the two is happening — that is the whole
+    /// question #1794 could not answer from outside.
+    /// </summary>
+    [Fact]
+    public void FallingCount_ReportsProgress_FlatCountDoesNot()
+    {
+        var progress = new DrainProgress();
+        progress.Probe(5, T0);
+
+        var falling = progress.Probe(3, T0.AddSeconds(60));
+        falling.Outcome.Should().Be(DrainProbeOutcome.StillDraining);
+        falling.CircuitsAtLastReport.Should().Be(5, "the previous line said 5");
+        falling.Progressing.Should().BeTrue("5 → 3 is a drain that will end on its own");
+
+        var flat = progress.Probe(3, T0.AddSeconds(120));
+        flat.Outcome.Should().Be(DrainProbeOutcome.StillDraining);
+        flat.CircuitsAtLastReport.Should().Be(3);
+        flat.Progressing.Should().BeFalse("3 → 3 is the forgotten tab that will be SIGKILLed");
+        flat.CircuitsWhenTerminationBegan.Should().Be(5, "every line carries where the drain started");
+        flat.Elapsed.Should().Be(TimeSpan.FromSeconds(120));
+    }
+
+    /// <summary>
+    /// A count that goes UP is not progress. Someone can still open a session against a terminating
+    /// pod through an affinity cookie, and calling that "progressing" would read as an ending in
+    /// sight when the opposite is true.
+    /// </summary>
+    [Fact]
+    public void RisingCount_IsNotProgress()
+    {
+        var progress = new DrainProgress();
+        progress.Probe(2, T0);
+
+        var rising = progress.Probe(4, T0.AddSeconds(60));
+
+        rising.Outcome.Should().Be(DrainProbeOutcome.StillDraining);
+        rising.Progressing.Should().BeFalse("2 → 4 is further from done, not closer");
+    }
+
+    /// <summary>
+    /// The ending, and only one of them. preStop exits on the first success, so a second "drained"
+    /// line means something else is polling the endpoint — count it, say nothing.
+    /// </summary>
+    [Fact]
+    public void ReachingZero_ReportsDrainedExactlyOnce()
+    {
+        var progress = new DrainProgress();
+        progress.Probe(5, T0);
+
+        var drained = progress.Probe(0, T0.AddSeconds(30));
+
+        drained.Outcome.Should().Be(DrainProbeOutcome.Drained,
+            "the ending is reported the moment it happens, not at the next interval");
+        drained.Elapsed.Should().Be(TimeSpan.FromSeconds(30));
+        drained.CircuitsWhenTerminationBegan.Should().Be(5);
+
+        progress.Probe(0, T0.AddSeconds(35)).Outcome.Should().Be(DrainProbeOutcome.Silent);
+        progress.Probe(0, T0.AddMinutes(10)).Outcome.Should().Be(DrainProbeOutcome.Silent,
+            "not even a later interval boundary reopens a finished narrative");
+    }
+
+    /// <summary>
+    /// <see cref="ActiveCircuitTracker"/> clamps at zero, but this type must not depend on that:
+    /// a negative count read as "still busy" would swallow the Drained line, and the log would end
+    /// mid-sentence on exactly the rollout that went fine.
+    /// </summary>
+    [Fact]
+    public void NegativeCount_ReadsAsDrained()
+    {
+        var progress = new DrainProgress();
+        progress.Probe(1, T0);
+
+        var report = progress.Probe(-3, T0.AddSeconds(10));
+
+        report.Outcome.Should().Be(DrainProbeOutcome.Drained);
+        report.LiveCircuits.Should().Be(0, "a negative count is reported as none, never as -3");
+    }
+
+    /// <summary>
+    /// A clock that steps backwards (NTP correction mid-drain) must not throw and must not spray
+    /// lines — it simply does not reach the next interval yet.
+    /// </summary>
+    [Fact]
+    public void ClockGoingBackwards_StaysSilent()
+    {
+        var progress = new DrainProgress();
+        progress.Probe(5, T0.AddMinutes(5));
+
+        var report = progress.Probe(5, T0);
+
+        report.Outcome.Should().Be(DrainProbeOutcome.Silent);
+    }
+
+    /// <summary>
+    /// <c>/drain</c> is an anonymous HTTP endpoint, so probes can arrive on any thread and in
+    /// parallel. Exactly one of them may announce the start of termination — two opening lines
+    /// would put two different "began" timestamps in the log and make the elapsed times in every
+    /// later line unreadable.
+    /// </summary>
+    [Fact]
+    public void ConcurrentProbes_AnnounceTerminationExactlyOnce()
+    {
+        var progress = new DrainProgress();
+        var outcomes = new System.Collections.Concurrent.ConcurrentBag<DrainProbeOutcome>();
+
+        Parallel.For(0, 64, i => outcomes.Add(progress.Probe(5, T0.AddMilliseconds(i)).Outcome));
+
+        outcomes.Count(o => o == DrainProbeOutcome.TerminationBegun).Should().Be(1);
+        outcomes.Count(o => o == DrainProbeOutcome.Silent).Should().Be(63,
+            "every other probe fell inside the report interval");
+    }
+
+    /// <summary>Every probe is counted even when it is not reported — the line says how many.</summary>
+    [Fact]
+    public void EveryProbeIsCounted_EvenTheSilentOnes()
+    {
+        var progress = new DrainProgress();
+
+        for (var seconds = 0; seconds < 60; seconds += 5)
+            progress.Probe(5, T0.AddSeconds(seconds));
+
+        var report = progress.Probe(5, T0.AddSeconds(60));
+
+        report.Outcome.Should().Be(DrainProbeOutcome.StillDraining);
+        report.ProbeCount.Should().Be(13, "twelve silent probes plus this one");
+    }
+}


### PR DESCRIPTION
Closes the part of #1794 that survived its own retraction.

## What #1794 turned out to be

The issue was filed as *"a wedged portal pod rides the full 1800 s grace"*, and the author
retracted that framing in the only comment on it: `preStop` runs **before** SIGTERM, so during
those 29 minutes the host had not received SIGTERM at all and the long termination was the
**intended** behaviour of #1342's session drain. What it left open was one untested question and
one observation worth keeping:

> `preStop` polls `/drain` every 5 s and only exits when it returns success. This pod polled for
> **29 minutes without success**. Either (a) circuits genuinely stayed open that long — plausible,
> and by design — or (b) `/drain` could not report success on *this* pod. I have not tested this
> and the pod has since been SIGKILLed, so it is a question for the next roll.

> **Worth keeping regardless:** a `crit` from a pod that Kubernetes has already deleted is
> indistinguishable in Loki from one raised by a serving replica.

## The next roll, measured

`memex` rolled while I was auditing this, and I tested it on the live pod:

```
deletionTimestamp = 2026-08-21T09:10:52Z   grace = 1800   (SIGTERM scheduled 08:40:52Z)
09:09:44Z  pod still 3/3 Running, phase=Running, Terminating
09:09:33Z  still executing application code (AgentChatClient)
09:10:52Z  gone — SIGKILLed at the ceiling, the full 1800 s
```

And, from inside a **live** portal pod:

```
$ curl -s -w "http=%{http_code}" http://127.0.0.1:8080/drain
http=503
5 circuit(s) still open
$ curl -sf -m 5 -o /dev/null http://127.0.0.1:8080/drain ; echo rc=$?
rc=22
```

So the answer is **(a)**: `/drain` is healthy and reporting, and the pod was draining as designed.
Two things follow, and they are what this PR is about:

1. **It is not exceptional.** It repeated on the very next roll, with five circuits open on a
   *serving* pod at an arbitrary moment. Riding most of the grace and ending in SIGKILL is the
   normal shape of a roll now, not an edge case.
2. **Nothing in the log said any of it.** The count exists, the endpoint returns it in the 503
   body, and `preStop`'s `-o /dev/null` throws it away. Determining (a) vs (b) required `kubectl
   exec` into a pod that was about to be killed — which is precisely why the original question
   went unanswered the first time.

## The change

`/drain` now logs what it already computes. The endpoint is the right place and **there is no
timer**: `preStop` runs before SIGTERM, so no lifetime event has fired and a probe of `/drain` is
the only notice the process gets that it is terminating. The poll already arrives on its own
schedule — `DrainProgress` only decides what each arriving probe is worth saying.

| | |
|---|---|
| **first probe** | one line: Kubernetes has already deleted this pod; N circuits open. Also the marker that makes every later line readable — a `crit` after it came from a terminating replica. |
| **then, per minute** | count now, count at the previous line, count when termination began, and whether it is **falling**. |
| **last circuit closes** | reported once, and only once. |
| **wedged HTTP layer** | opening line, then **nothing** — the absence of the follow-up is the tell, visible without exec'ing in. |

Three cases that were identical in Loki are now distinguishable from the log alone.

## Bounded on purpose

360 probes fit in an 1800 s grace. Reporting each would put 360 Information lines into Loki per pod
termination for no extra information; one line per minute caps a full drain at ~30.
`AFullGracePeriodOfProbes_StaysBounded` pins that number, and reports **360 instead of 30** when the
rate limit is removed — I ran it that way to check the suite is not vacuous.

## Not in scope

The other half of #1794 — *should one replica be able to hold a node for 30 minutes?* — is
`portal.drainSeconds`, a deliberate trade between user continuity and rollout tail, and the issue
itself restates it as a policy question rather than a defect. Untouched here. The status codes and
body of `/drain` are also untouched, so `preStop` reads exactly what it read before.

## Verification

```
dotnet build src/MeshWeaver.Hosting -c Release -warnaserror                     0 Warning(s) 0 Error(s)
dotnet build memex/aspire/Memex.Portal.ServiceDefaults -c Release -warnaserror  0 Warning(s) 0 Error(s)
dotnet build test/MeshWeaver.Hosting.Blazor.Test -c Release -warnaserror        0 Warning(s) 0 Error(s)
dotnet test  --filter DrainProgressTest      Passed: 11, Failed: 0
dotnet test  --filter ActiveCircuitTracker   Passed:  4, Failed: 0   (unchanged neighbour)
```

No **What's New** entry: this is operator-visible logging with no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Closes #1794
