### PR TITLE
A runtime-loaded module can ship NATIVE assets (#1728)

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -244,8 +244,11 @@
          trees (the prune below deletes them), and a flipped module is OUTSIDE the host's restore
          graph, so a RID flowing in from CD's per-arch container publish fails NETSDK1047 (no
          linux-x64/arm64 target in the module's portable assets file) — the 2026-08-16 CD outage.
-         A module with genuinely RID-specific native deps (Speech) ships them via runtimes/*
-         inside its folder, which a PORTABLE publish lays out correctly.
+         A module with genuinely RID-specific NATIVE deps ships them via runtimes/<rid>/native/
+         inside its folder, which a PORTABLE publish lays out for every RID and prune (0) below now
+         KEEPS; the host picks its own RID at load time (ModuleNativeAssets, #1728). No module ships
+         one today — MeshWeaver.Speech, long cited here as the exception, is an HTTP client to a
+         Whisper container and carries no native package at all.
 
          Restore explicitly: post-flip the module is OUTSIDE the host's project graph, so the
          host's implicit restore never touches it and a clean machine has no assets file. A
@@ -282,14 +285,55 @@
              Properties="Configuration=$(Configuration);NoBuild=true;SatelliteResourceLanguages=en;PublishDir=$(_AppDir)modules/%(Filename)/"
              RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
 
-    <!-- Prune (0): RID trees. A module loads via Assembly.LoadFrom, which never consults the
-         module's deps.json — the fallback probe is the module's FLAT folder only — so a
-         runtimes/<rid>/ tree under a module folder is unreachable dead weight by construction
-         (today: a net8.0-flavoured Pkcs copy and the Windows EventLog message table). A module
-         that truly needs native/RID assets (Speech is the known exception, per the #1644 design)
-         needs explicit flat placement or NativeLibrary resolution in ITS flip, not a RID tree. -->
-    <RemoveDir Directories="$(_AppDir)modules/%(MeshModuleClosure.Filename)/runtimes"
-               Condition="Exists('$(_AppDir)modules/%(MeshModuleClosure.Filename)/runtimes')" />
+    <!-- Prune (0): the UNREACHABLE half of the RID tree — everything except runtimes/<rid>/native.
+
+         A module loads via Assembly.LoadFrom, which never consults the module's deps.json, so the
+         MANAGED RID assets (runtimes/<rid>/lib/<tfm>/*.dll — today a net8.0-flavoured Pkcs copy and
+         the Windows EventLog message table) are dead weight by construction: nothing can ever bind
+         them. They still go.
+
+         🚨 NATIVE assets are a different case since #1728, and this used to delete them too. The
+         runtime's own fallback probe is the module's FLAT folder only, which is why a
+         runtimes/<rid>/native/ tree WAS unreachable — but ModuleNativeAssets (MeshWeaver.Mesh.Contract)
+         now resolves it: the host subscribes AssemblyLoadContext.Default.ResolvingUnmanagedDll,
+         derives the module folder from the REQUESTING assembly's own location (so a dependency such
+         as SkiaSharp.dll, which declares the P/Invokes, resolves too) and probes
+         runtimes/<current-rid>/native/ then the flat folder. Deleting the payload here would make
+         that resolver structurally unable to find anything.
+
+         Why the tree and not flat placement: every module invocation strips RID globals by design
+         (#1675/#1676 — the 2026-08-16 CD outage), so a module publish is ALWAYS portable and the RID
+         is unknown when the bits are laid out. Only the host knows its own RID, and it resolves at
+         load time.
+
+         🚨 This is NOT hypothetical for the modules already on this lane. Snowflake ships
+         libsf_mini_core.* and libMono.Unix.*, and Cosmos ships Microsoft.Azure.Cosmos.ServiceInterop
+         + the MSVC CRT — 23 loadable natives, 11 MB, ALL of which the RemoveDir this replaces was
+         deleting. `Graph:Storage:Type = Snowflake` on a shipped image would therefore have failed at
+         its first native call, in a backend whose emulator suites green-SKIP when unreachable. The
+         one lane that ships them is this one.
+
+         Empty RID directories are left behind (Delete removes files, as prunes (a) and (b) below
+         also do): removing a parent recursively could take a sibling native/ with it, and an empty
+         directory costs nothing in the image. Narrowing the kept RIDs to the publishing host's own
+         (which would cut the 11 MB to ~4) needs the outer publish's RuntimeIdentifier and is
+         deliberately NOT done here — mis-reading it is precisely the #1675/#1676 failure. -->
+    <ItemGroup>
+      <_ClosureRidFile Include="$(_AppDir)modules/%(MeshModuleClosure.Filename)/runtimes/**/*.*" />
+    </ItemGroup>
+    <ItemGroup>
+      <!-- LOADABLE natives only. A .a static archive and a .lib import library are LINK-time
+           artifacts — dlopen/LoadLibrary can never open either — so they are dead weight exactly
+           the way the managed RID tree is (Snowflake alone ships 5.4 MB of libMono.Unix.a). -->
+      <_ClosureRidNative Include="$(_AppDir)modules/%(MeshModuleClosure.Filename)/runtimes/*/native/**/*.*"
+                         Exclude="$(_AppDir)modules/%(MeshModuleClosure.Filename)/runtimes/*/native/**/*.a;$(_AppDir)modules/%(MeshModuleClosure.Filename)/runtimes/*/native/**/*.lib" />
+    </ItemGroup>
+    <ItemGroup>
+      <_ClosureRidUnreachable Include="@(_ClosureRidFile)" Exclude="@(_ClosureRidNative)" />
+    </ItemGroup>
+    <Delete Files="@(_ClosureRidUnreachable)" />
+    <Message Importance="high" Condition="'@(_ClosureRidNative)' != ''"
+             Text="LayoutMeshModuleClosures: KEPT @(_ClosureRidNative->Count()) native RID asset(s) under modules/*/runtimes — resolved at load time by ModuleNativeAssets (#1728): @(_ClosureRidNative->'%(Filename)%(Extension)')" />
 
     <!-- Prune (a): same-identity files the app publish already carries, compared by RELATIVE
          path (%(RecursiveDir)) so a nested duplicate matches the app's nested copy, not just

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -237,6 +237,31 @@ none; the engine's package closure still rides the app via other references). Be
 DLL exists nowhere else, the closure lane also lays it into a plain build's output
 (`bin/…/modules/`), keeping `dotnet run` on a host working without a publish step.
 
+### Native assets — `runtimes/<rid>/native/` (#1728)
+
+A module is loaded with `Assembly.LoadFrom`, which never consults the module's own `deps.json`, so
+the runtime's fallback probe is the module's FLAT folder and nothing else. That is why the closure
+lane's first prune used to delete `runtimes/` outright — and why a module could not ship a native
+library at all.
+
+It can now. The publish keeps `runtimes/<rid>/native/**` (dropping the managed `runtimes/<rid>/lib`
+trees, which genuinely need the deps.json, and `.a`/`.lib` link-time artifacts, which nothing can
+open), and the host resolves them at load time: `ModuleNativeAssets` subscribes
+`AssemblyLoadContext.Default.ResolvingUnmanagedDll`, derives the module folder from the REQUESTING
+assembly's own location — so a dependency such as `SkiaSharp.dll`, which declares the P/Invokes
+rather than the module assembly, resolves too — and probes
+`modules/<Name>/runtimes/<current-rid>/native/`, then the flat folder.
+
+Resolution rather than placement, because every module MSBuild invocation strips RID globals by
+design (#1675/#1676): a module publish is always portable, so the RID is unknown when the bits are
+laid out and only the host knows its own. The RID probe is the running RID plus its portable form
+(`osx.14-arm64` → `osx-arm64`); it deliberately does NOT walk a wider graph, because
+`linux-musl-x64` and `linux-x64` are different C libraries and loading one for the other crashes
+instead of failing cleanly.
+
+Two modules already needed this: Snowflake P/Invokes `libsf_mini_core.*` (and Mono.Unix), and
+Cosmos' query-plan `ServiceInterop` is native. Both were shipping with those files pruned away.
+
 ## The bundle lane — modules as Store packages (#1664)
 
 A compiled module reaches a deployment one of two ways: shipped in the image (the baseline above),

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-modules-can-ship-native-libraries.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-modules-can-ship-native-libraries.md
@@ -1,0 +1,23 @@
+---
+Name: Storage backends load their native drivers
+Category: Fix
+Description: Snowflake and Cosmos ship native libraries that the module publish was deleting, so selecting either backend would have failed at its first call — modules can now carry and resolve native assets.
+Icon: Sparkle
+Order: -20260821
+---
+
+# Storage backends load their native drivers
+
+Alternative storage backends ship as modules beside the portal rather than inside it. Their
+native libraries — the pieces that are not .NET code — were being removed when the image was
+assembled, because nothing could load them from a module folder anyway. That left Snowflake and
+Cosmos looking installable while a deployment that actually selected one would have failed the
+moment it called into the driver.
+
+Modules can now carry native libraries, and the portal finds them at the moment they are needed,
+picking the build that matches the machine it is running on. Nothing changes for a deployment on
+PostgreSQL, which is every memex portal today; what changes is that the other backends are now
+genuinely shippable.
+
+This also removes the last blocker on moving image-only features — such as social share-card
+rendering, which needs a graphics library — out of the base image and into optional modules.

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -83,6 +83,10 @@ public record MeshBuilder
     /// <returns>The builder for method chaining.</returns>
     public MeshBuilder InstallAssemblies(params string[] assemblyLocations)
     {
+        // A module's NATIVE payload is unreachable without this (#1728): Assembly.LoadFrom never
+        // consults the module's deps.json, so nothing probes modules/<Name>/runtimes/<rid>/native/.
+        // Subscribed here — before anything from a module folder is loaded — and idempotent.
+        ModuleNativeAssets.EnsureRegistered();
         var assemblies = assemblyLocations
             .Select(Assembly.LoadFrom)
             .ToArray();

--- a/src/MeshWeaver.Mesh.Contract/ModuleNativeAssets.cs
+++ b/src/MeshWeaver.Mesh.Contract/ModuleNativeAssets.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// Native-asset resolution for RUNTIME-LOADED MODULES (issue #1728).
+///
+/// <para><b>The gap this closes.</b> A module ships as <c>modules/&lt;Name&gt;/</c> beside the app and
+/// is loaded with <see cref="Assembly.LoadFrom(string)"/>, which never consults the module's own
+/// <c>deps.json</c> — the runtime's fallback probe is the module's FLAT folder only. So a
+/// <c>runtimes/&lt;rid&gt;/native/</c> tree under a module folder was unreachable BY CONSTRUCTION, which
+/// is why <c>MeshModulesPublish.targets</c> deleted it outright. That made "a module cannot ship
+/// non-IL assets" a hard capability gap: it is what keeps the SkiaSharp share-card renderer
+/// (<c>OgCardRenderer</c>, 5–15 MB of <c>libSkiaSharp.*</c> per RID) inside the portal image closure
+/// rather than in <c>MeshWeaver.OgCard</c>.</para>
+///
+/// <para><b>Why resolution at LOAD time, not placement at PUBLISH time.</b> Every module MSBuild
+/// invocation strips RID globals by design (#1675/#1676 — a flipped module is outside the host's
+/// restore graph, so a RID flowing in from CD's per-arch publish fails <c>NETSDK1047</c>; the
+/// 2026-08-16 CD outage). A module publish is therefore ALWAYS portable, so the RID is not known
+/// when the bits are laid out and natives always land under <c>runtimes/</c>. Only the host knows
+/// its own RID, and it knows it here.</para>
+///
+/// <para><b>No state, by construction.</b> The hook derives everything from its arguments: the
+/// requesting assembly's own location IS the module folder, so there is no registry of module
+/// directories to keep, invalidate, or leak across meshes (AGENTS.md — no static collections).
+/// <see cref="AssemblyLoadContext.ResolvingUnmanagedDll"/> fires ONLY after the runtime's own
+/// probing has already failed, so this can never shadow a resolution that works today.</para>
+/// </summary>
+public static class ModuleNativeAssets
+{
+    /// <summary>The folder name the modules lane publishes into, beside the app.</summary>
+    public const string ModulesFolderName = "modules";
+
+    /// <summary>
+    /// Subscribes the process-wide resolver exactly once. A <c>static readonly</c> initialised by
+    /// the type initialiser: run-once, never written afterwards, and holding no collection — the
+    /// shape AGENTS.md permits. The subscription's scope genuinely IS the process, because
+    /// <see cref="AssemblyLoadContext.Default"/> is; a mesh-scoped singleton could not unsubscribe
+    /// a native library that is already loaded anyway.
+    /// </summary>
+    private static readonly bool Registered = Register();
+
+    private static bool Register()
+    {
+        AssemblyLoadContext.Default.ResolvingUnmanagedDll += ResolveForModule;
+        return true;
+    }
+
+    /// <summary>
+    /// Ensures the resolver is subscribed. Idempotent — the work happens in the type initialiser,
+    /// so calling this from every <c>InstallAssemblies</c> stacks nothing.
+    /// </summary>
+    public static void EnsureRegistered() => _ = Registered;
+
+    private static IntPtr ResolveForModule(Assembly requesting, string libraryName)
+    {
+        var moduleDirectory = ModuleDirectoryOf(requesting);
+        if (moduleDirectory is null)
+            return IntPtr.Zero;
+
+        foreach (var candidate in CandidatePaths(moduleDirectory, libraryName, RuntimeInformation.RuntimeIdentifier))
+            if (File.Exists(candidate) && NativeLibrary.TryLoad(candidate, out var handle))
+                return handle;
+
+        return IntPtr.Zero;
+    }
+
+    /// <summary>
+    /// The module folder an assembly was loaded from, or null when it did not come from one.
+    ///
+    /// <para>The test is structural and deliberately narrow: the assembly sits DIRECTLY in
+    /// <c>…/modules/&lt;Name&gt;/</c>. That is exactly what both layout lanes produce — the module's own
+    /// DLL and its pruned private closure land flat in that folder — and it is what makes a
+    /// dependency such as <c>SkiaSharp.dll</c> (which declares the P/Invokes, not the module
+    /// assembly) resolve its natives too. Anything deeper, or an assembly with no location
+    /// (dynamic, single-file, collectible), is not a module and is left to the runtime.</para>
+    /// </summary>
+    /// <param name="assembly">The assembly whose native dependency failed to resolve.</param>
+    /// <returns>The absolute module folder, or <c>null</c>.</returns>
+    public static string? ModuleDirectoryOf(Assembly assembly)
+    {
+        var location = assembly.Location;
+        if (string.IsNullOrEmpty(location))
+            return null;
+        var directory = Path.GetDirectoryName(location);
+        return IsModuleDirectory(directory) ? directory : null;
+    }
+
+    /// <summary>
+    /// Whether a directory is a module folder — i.e. its parent is named <c>modules</c>.
+    /// </summary>
+    /// <param name="directory">The candidate directory.</param>
+    /// <returns><c>true</c> when the directory is <c>…/modules/&lt;Name&gt;</c>.</returns>
+    public static bool IsModuleDirectory(string? directory)
+    {
+        if (string.IsNullOrEmpty(directory))
+            return false;
+        var parent = Path.GetFileName(Path.GetDirectoryName(directory.TrimEnd(
+            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)));
+        return string.Equals(parent, ModulesFolderName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Every path this resolver will try for <paramref name="libraryName"/>, in order — the pure
+    /// half, so the ordering and the RID policy are unit-testable without loading anything.
+    ///
+    /// <para>RID candidates are the running RID and, when it carries an OS VERSION
+    /// (<c>osx.14-arm64</c> — the shape older runtimes reported), the portable form
+    /// (<c>osx-arm64</c>) that native packages actually publish. 🚨 There is deliberately NO wider
+    /// fallback: <c>linux-musl-x64</c> and <c>linux-x64</c> are different C libraries, so a graph
+    /// walk between them would load a binary that cannot run — a crash at first P/Invoke rather
+    /// than a clean "not found" that leaves the runtime's own error message intact.</para>
+    ///
+    /// <para>Flat placement (the library directly in the module folder) is tried last, so the
+    /// landing step's option of laying a single RID's payload flat keeps working without the tree.</para>
+    /// </summary>
+    /// <param name="moduleDirectory">The module folder (<c>…/modules/&lt;Name&gt;</c>).</param>
+    /// <param name="libraryName">The library name as the P/Invoke declared it.</param>
+    /// <param name="runtimeIdentifier">The running RID.</param>
+    /// <returns>Candidate absolute paths, most specific first.</returns>
+    public static IReadOnlyList<string> CandidatePaths(
+        string moduleDirectory, string libraryName, string runtimeIdentifier)
+    {
+        var names = FileNameCandidates(libraryName);
+        var paths = new List<string>();
+        foreach (var rid in RuntimeIdentifierCandidates(runtimeIdentifier))
+        foreach (var name in names)
+            paths.Add(Path.Combine(moduleDirectory, "runtimes", rid, "native", name));
+        foreach (var name in names)
+            paths.Add(Path.Combine(moduleDirectory, name));
+        return paths;
+    }
+
+    /// <summary>
+    /// The RIDs to probe, most specific first: the running one, plus its OS-version-stripped
+    /// portable form when they differ.
+    /// </summary>
+    /// <param name="runtimeIdentifier">The running RID.</param>
+    /// <returns>The RID probe order.</returns>
+    public static IReadOnlyList<string> RuntimeIdentifierCandidates(string runtimeIdentifier)
+    {
+        if (string.IsNullOrWhiteSpace(runtimeIdentifier))
+            return [];
+        var portable = PortableForm(runtimeIdentifier);
+        return string.Equals(portable, runtimeIdentifier, StringComparison.OrdinalIgnoreCase)
+            ? [runtimeIdentifier]
+            : [runtimeIdentifier, portable];
+    }
+
+    private static string PortableForm(string runtimeIdentifier)
+    {
+        // `osx.14-arm64` → `osx-arm64`; `linux-musl-x64` (no dot) is returned unchanged.
+        var dash = runtimeIdentifier.IndexOf('-');
+        var head = dash < 0 ? runtimeIdentifier : runtimeIdentifier[..dash];
+        var dot = head.IndexOf('.');
+        if (dot < 0)
+            return runtimeIdentifier;
+        return dash < 0 ? head[..dot] : string.Concat(head.AsSpan(0, dot), runtimeIdentifier.AsSpan(dash));
+    }
+
+    /// <summary>
+    /// The file names a P/Invoke name can take on this platform, most specific first: the name as
+    /// written (a declaration may already carry its extension), then the platform-decorated forms
+    /// the runtime itself tries — <c>&lt;name&gt;.so</c>/<c>lib&lt;name&gt;.so</c> and their macOS and
+    /// Windows equivalents. <c>SkiaSharp</c> declares <c>libSkiaSharp</c> and ships
+    /// <c>libSkiaSharp.so</c>, so both halves matter.
+    /// </summary>
+    /// <param name="libraryName">The library name as the P/Invoke declared it.</param>
+    /// <returns>Candidate file names, most specific first.</returns>
+    public static IReadOnlyList<string> FileNameCandidates(string libraryName)
+    {
+        if (string.IsNullOrWhiteSpace(libraryName))
+            return [];
+        var (prefix, extension) = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? (string.Empty, ".dll")
+            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                ? ("lib", ".dylib")
+                : ("lib", ".so");
+
+        var names = new List<string> { libraryName };
+        void Add(string candidate)
+        {
+            if (!names.Contains(candidate, StringComparer.Ordinal))
+                names.Add(candidate);
+        }
+
+        var hasExtension = libraryName.EndsWith(extension, StringComparison.OrdinalIgnoreCase);
+        if (!hasExtension)
+            Add(libraryName + extension);
+        if (prefix.Length > 0 && !libraryName.StartsWith(prefix, StringComparison.Ordinal))
+            Add(prefix + libraryName + (hasExtension ? string.Empty : extension));
+        return names;
+    }
+}

--- a/test/Memex.Portal.Shared.Test/StorageModuleLayoutTest.cs
+++ b/test/Memex.Portal.Shared.Test/StorageModuleLayoutTest.cs
@@ -86,6 +86,70 @@ public class StorageModuleLayoutTest
     }
 
     /// <summary>
+    /// module name · the RID · the LOADABLE native the backend calls into. Issue #1728: the closure
+    /// lane's prune used to delete <c>runtimes/</c> outright, on the reasoning that
+    /// <c>Assembly.LoadFrom</c> never consults a module's deps.json — true, and the reason nothing
+    /// could ever find the payload. Both backends on this lane genuinely ship natives, so that prune
+    /// shipped two storage backends that fault at their first native call, in exactly the two
+    /// suites that green-SKIP when their emulator is unreachable.
+    /// </summary>
+    public static TheoryData<string, string, string> Natives() => new()
+    {
+        // Snowflake.Data P/Invokes its own mini-core; Mono.Unix rides with it.
+        { "MeshWeaver.Hosting.Snowflake", "linux-x64", "libsf_mini_core.so" },
+        { "MeshWeaver.Hosting.Snowflake", "linux-arm64", "libMono.Unix.so" },
+        // Cosmos' ServiceInterop is a native win-x64 DLL (query plan evaluation).
+        { "MeshWeaver.Hosting.Cosmos", "win-x64", "Microsoft.Azure.Cosmos.ServiceInterop.dll" },
+    };
+
+    /// <summary>
+    /// The native payload rides the closure, under the RID tree the host resolves at load time
+    /// (<c>ModuleNativeAssets</c>). Asserted per (module, RID, file) rather than by counting the
+    /// tree: a count would pass on any surviving RID, and the RID a deployment needs is the one
+    /// that must be there.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Natives))]
+    public void ClosureLane_KeepsTheBackendsLoadableNatives(
+        string moduleName, string runtimeIdentifier, string nativeFile)
+    {
+        var expected = Path.Combine(
+            AppContext.BaseDirectory, "modules", moduleName,
+            "runtimes", runtimeIdentifier, "native", nativeFile);
+        Assert.True(
+            File.Exists(expected),
+            $"{moduleName}: '{nativeFile}' is missing from runtimes/{runtimeIdentifier}/native. A module's "
+            + "native payload exists nowhere else, and ModuleNativeAssets resolves it from exactly this "
+            + "path — so a deployment selecting this backend would fault at its first P/Invoke. Check "
+            + "prune (0) in memex/MeshModulesPublish.targets (#1728).");
+    }
+
+    /// <summary>
+    /// The directory the host probes is the directory the lane wrote. Pins the two halves of #1728
+    /// to each other: a prune that keeps a tree the resolver never looks in, or a resolver that
+    /// looks where the prune does not keep, would each pass its own test alone.
+    ///
+    /// <para>Compared as a DIRECTORY, not a file name: the decorated file forms are per-platform
+    /// (<c>libX.so</c> / <c>libX.dylib</c> / <c>X.dll</c>, covered by <c>ModuleNativeAssetTest</c>),
+    /// and a win-x64 payload is correctly unresolvable on Linux. The layout claim is not.</para>
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Natives))]
+    public void TheResolverProbesExactlyWhereTheLaneWrote(
+        string moduleName, string runtimeIdentifier, string nativeFile)
+    {
+        var moduleDirectory = Path.Combine(AppContext.BaseDirectory, "modules", moduleName);
+        var laidOut = Path.GetDirectoryName(Path.Combine(
+            moduleDirectory, "runtimes", runtimeIdentifier, "native", nativeFile));
+
+        var probed = ModuleNativeAssets
+            .CandidatePaths(moduleDirectory, "probe", runtimeIdentifier)
+            .Select(Path.GetDirectoryName)
+            .ToList();
+        Assert.Contains(laidOut, probed);
+    }
+
+    /// <summary>
     /// The seam binds: loading the module the way <c>Modules:Assemblies</c> does registers the keyed
     /// factory <c>Graph:Storage:Type</c> resolves, and the registration comes from the module folder
     /// DLL. Then <c>Create</c> runs far enough to JIT against the platform's contract types and its

--- a/test/MeshWeaver.Graph.Test/ModuleNativeAssetTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModuleNativeAssetTest.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Issue #1728 — a runtime-loaded module could not ship NATIVE assets.
+///
+/// <para>A module is loaded with <c>Assembly.LoadFrom</c>, which never consults the module's own
+/// <c>deps.json</c>, so nothing probed <c>modules/&lt;Name&gt;/runtimes/&lt;rid&gt;/native/</c> and the publish
+/// lane deleted the tree as unreachable dead weight. That is what keeps SkiaSharp (and therefore
+/// <c>OgCardRenderer</c>) inside the portal image closure.</para>
+///
+/// <para>These pin the resolver that closes it. The last test is the one that matters: a REAL
+/// assembly, loaded from a REAL <c>modules/&lt;Name&gt;/</c> folder, resolving a REAL native library that
+/// exists ONLY under that folder's RID tree — through the runtime's own P/Invoke resolution path
+/// (<see cref="NativeLibrary.Load(string, Assembly, DllImportSearchPath?)"/>), not through a helper
+/// the test calls directly. Against <c>main</c> that throws <see cref="DllNotFoundException"/>.</para>
+/// </summary>
+public class ModuleNativeAssetTest
+{
+    [Fact]
+    public void ModuleDirectory_IsRecognisedOnlyDirectlyUnderModules()
+    {
+        var app = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+        Assert.True(ModuleNativeAssets.IsModuleDirectory(Path.Combine(app, "modules", "MeshWeaver.OgCard")));
+        // A trailing separator must not change the verdict — Path.GetDirectoryName would otherwise
+        // return the folder itself and the parent test would read "modules" as the module name.
+        Assert.True(ModuleNativeAssets.IsModuleDirectory(
+            Path.Combine(app, "modules", "MeshWeaver.OgCard") + Path.DirectorySeparatorChar));
+
+        // The app root itself, a look-alike folder, and the modules root are all NOT modules.
+        Assert.False(ModuleNativeAssets.IsModuleDirectory(app));
+        Assert.False(ModuleNativeAssets.IsModuleDirectory(Path.Combine(app, "notmodules", "X")));
+        Assert.False(ModuleNativeAssets.IsModuleDirectory(Path.Combine(app, "modules")));
+        Assert.False(ModuleNativeAssets.IsModuleDirectory(null));
+        Assert.False(ModuleNativeAssets.IsModuleDirectory(string.Empty));
+
+        // An assembly that did NOT come from a module folder yields no module directory, so the
+        // hook returns immediately for every platform assembly on every failed native load.
+        Assert.Null(ModuleNativeAssets.ModuleDirectoryOf(typeof(ModuleNativeAssetTest).Assembly));
+    }
+
+    [Fact]
+    public void RuntimeIdentifierCandidates_AddThePortableForm_AndNeverCrossTheLibcBoundary()
+    {
+        Assert.Equal(["linux-x64"], ModuleNativeAssets.RuntimeIdentifierCandidates("linux-x64"));
+
+        // A versioned RID (what older runtimes reported) falls back to the portable form native
+        // packages actually publish.
+        Assert.Equal(["osx.14-arm64", "osx-arm64"],
+            ModuleNativeAssets.RuntimeIdentifierCandidates("osx.14-arm64"));
+
+        // 🚨 musl must NEVER fall back to glibc: the binaries are not interchangeable, so a graph
+        // walk between them would load something that cannot run — a crash at the first P/Invoke
+        // instead of a clean "not found" that leaves the runtime's own message intact.
+        Assert.Equal(["linux-musl-x64"], ModuleNativeAssets.RuntimeIdentifierCandidates("linux-musl-x64"));
+
+        Assert.Empty(ModuleNativeAssets.RuntimeIdentifierCandidates(""));
+    }
+
+    [Fact]
+    public void FileNameCandidates_CoverTheDecoratedFormsWithoutDoublingAnExtension()
+    {
+        var extension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll"
+            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ".dylib" : ".so";
+
+        // SkiaSharp declares `libSkiaSharp` and ships `libSkiaSharp.so` — both halves are needed.
+        var candidates = ModuleNativeAssets.FileNameCandidates("libSkiaSharp");
+        Assert.Equal("libSkiaSharp", candidates[0]);
+        Assert.Contains("libSkiaSharp" + extension, candidates);
+
+        // A name that already carries the extension is never decorated with a second one.
+        Assert.DoesNotContain(
+            ModuleNativeAssets.FileNameCandidates("libSkiaSharp" + extension),
+            n => n.EndsWith(extension + extension, StringComparison.Ordinal));
+
+        Assert.Empty(ModuleNativeAssets.FileNameCandidates(" "));
+    }
+
+    [Fact]
+    public void CandidatePaths_ProbeTheRidTreeBeforeTheFlatFolder()
+    {
+        var module = Path.Combine(AppContext.BaseDirectory, "modules", "Probe");
+        var paths = ModuleNativeAssets.CandidatePaths(module, "libSkiaSharp", "linux-x64");
+
+        var ridTree = Path.Combine(module, "runtimes", "linux-x64", "native");
+        var firstFlat = paths.ToList().FindIndex(p => Path.GetDirectoryName(p) == module);
+        var lastRid = paths.ToList().FindLastIndex(p => Path.GetDirectoryName(p) == ridTree);
+
+        Assert.True(lastRid >= 0, "the RID tree must be probed");
+        Assert.True(firstFlat >= 0, "flat placement must remain supported");
+        // The portable publish lays the tree out; flat placement is the landing step's option, so
+        // it must not shadow a RID-correct payload.
+        Assert.True(lastRid < firstFlat, "the RID tree must be probed BEFORE the flat folder");
+    }
+
+    /// <summary>
+    /// The end-to-end claim: an assembly in <c>modules/&lt;Name&gt;/</c> resolves a native library that
+    /// exists ONLY under that module's <c>runtimes/&lt;rid&gt;/native/</c>, through the runtime's own
+    /// P/Invoke resolution. The library is a genuine one copied out of the shared framework under a
+    /// new name, so nothing on the machine can resolve it by any other route — if it loads, it
+    /// loaded from the module folder.
+    /// </summary>
+    [Fact]
+    public void AnAssemblyInAModuleFolder_ResolvesANativeLibraryFromItsOwnRidTree()
+    {
+        ModuleNativeAssets.EnsureRegistered();
+
+        var source = FindShippedNativeLibrary();
+        var extension = Path.GetExtension(source);
+        var probeName = $"meshweaver_probe_{Guid.NewGuid():N}";
+        var moduleName = $"NativeProbe{Guid.NewGuid():N}";
+        var moduleDirectory = Path.Combine(AppContext.BaseDirectory, "modules", moduleName);
+        var nativeDirectory = Path.Combine(
+            moduleDirectory, "runtimes", RuntimeInformation.RuntimeIdentifier, "native");
+        Directory.CreateDirectory(nativeDirectory);
+
+        try
+        {
+            var prefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? string.Empty : "lib";
+            File.Copy(source, Path.Combine(nativeDirectory, prefix + probeName + extension));
+
+            var assemblyPath = Path.Combine(moduleDirectory, moduleName + ".dll");
+            EmitProbeAssembly(moduleName, assemblyPath);
+            var moduleAssembly = Assembly.LoadFrom(assemblyPath);
+
+            // Sanity: the assembly really is the one in the module folder (LoadFrom returns an
+            // already-loaded assembly on an identity match, which would make this prove nothing).
+            Assert.Equal(moduleDirectory.TrimEnd(Path.DirectorySeparatorChar),
+                ModuleNativeAssets.ModuleDirectoryOf(moduleAssembly)?.TrimEnd(Path.DirectorySeparatorChar));
+
+            // Nothing outside the module folder can resolve this name: an assembly loaded from the
+            // app root must still fail, or the test would pass on the machine's own search path.
+            Assert.Throws<DllNotFoundException>(
+                () => NativeLibrary.Load(probeName, typeof(ModuleNativeAssetTest).Assembly, null));
+
+            // THE claim — this is what throws DllNotFoundException against main.
+            var handle = NativeLibrary.Load(probeName, moduleAssembly, null);
+            Assert.NotEqual(IntPtr.Zero, handle);
+            NativeLibrary.Free(handle);
+        }
+        finally
+        {
+            // The emitted assembly stays loaded (non-collectible), so the DLL may be locked on
+            // Windows; the directory tree is per-test and disposable either way.
+            try { Directory.Delete(moduleDirectory, recursive: true); } catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    /// <summary>
+    /// A real, loadable native library from the shared framework — the payload the module folder
+    /// will carry under a new name. Asserted rather than skipped: a test that quietly does nothing
+    /// when it cannot find its fixture is not a test (AGENTS.md).
+    /// </summary>
+    private static string FindShippedNativeLibrary()
+    {
+        var runtimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var extension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll"
+            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ".dylib" : ".so";
+        var candidates = Directory
+            .EnumerateFiles(runtimeDirectory, "*Native*" + extension)
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+        foreach (var candidate in candidates)
+            if (NativeLibrary.TryLoad(candidate, out var handle))
+            {
+                NativeLibrary.Free(handle);
+                return candidate;
+            }
+        Assert.Fail(
+            $"no loadable native library found in '{runtimeDirectory}' "
+            + $"(looked for *Native*{extension}; {candidates.Count} candidate(s))");
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// The smallest real assembly that can be loaded from a path: emitted to disk so its
+    /// <see cref="Assembly.Location"/> is the module folder, which is what the resolver reads.
+    /// </summary>
+    private static void EmitProbeAssembly(string name, string path)
+    {
+        var builder = new PersistedAssemblyBuilder(new AssemblyName(name), typeof(object).Assembly);
+        builder.DefineDynamicModule(name)
+            .DefineType("Probe", TypeAttributes.Public | TypeAttributes.Class)
+            .CreateType();
+        builder.Save(path);
+    }
+}


### PR DESCRIPTION
Closes #1728.

## The finding that changed the scope

#1728 was filed as a *capability* gap blocking future work (OgCard/SkiaSharp, Speech). Measuring it
first turned up a live defect instead: **the two storage backends already on the closure lane ship
natives, and the publish was deleting all of them.**

```
LayoutMeshModuleClosures: KEPT 23 native RID asset(s) under modules/*/runtimes (#1728):
  Cosmos.CRTCompat.dll; Microsoft.Azure.Cosmos.ServiceInterop.dll; msvcp140.dll; vcruntime140*.dll;
  libMono.Unix.so x6; libsf_mini_core.so x4; libMono.Unix.dylib x2; libsf_mini_core.dylib x2; ...
```

11 MB, previously pruned to nothing. So `Graph:Storage:Type = Snowflake` on a shipped image would
have failed at its first native call - and nothing could have caught it: both emulator suites
green-SKIP when their backend is unreachable, which is exactly why `StorageModuleLayoutTest` exists
(#1752) and exactly the assertion it was missing.

The issue's own citations needed correcting too: `MeshWeaver.Speech`, named in the targets file for
months as *the* module with RID-specific natives, is an HTTP client to a Whisper container and
carries no native package at all.

## The fix - two halves, pinned to each other

**Publish keeps the loadable payload.** Prune (0) drops the managed `runtimes/<rid>/lib` trees
(which genuinely need the deps.json `Assembly.LoadFrom` never reads) and `.a`/`.lib` link-time
artifacts (5.4 MB of `libMono.Unix.a` alone, which nothing can `dlopen`), and keeps
`runtimes/<rid>/native/**`.

**The host resolves them at load time.** `ModuleNativeAssets` subscribes
`AssemblyLoadContext.Default.ResolvingUnmanagedDll`, derives the module folder from the
**requesting assembly's own location**, and probes `runtimes/<current-rid>/native/` then the flat
folder.

Three properties worth stating, because each was a design choice:

- **The event, not `SetDllImportResolver`.** The P/Invokes are declared in the *dependency*
  (`SkiaSharp.dll`, `Snowflake.Data`'s `Mono.Unix`), not in the module assembly, so a per-module
  resolver would have missed them. `ResolvingUnmanagedDll` also fires only *after* the runtime's own
  probing failed, so it can never shadow a resolution that works today.
- **No state.** Deriving the folder from the requesting assembly means there is no registry of
  module directories to keep, invalidate, or leak across meshes (AGENTS.md - no static collections).
  The only static is a `static readonly bool` latch for the one-time subscription.
- **Resolution, not placement.** Every module MSBuild invocation strips RID globals by design
  (#1675/#1676 - the 2026-08-16 CD outage), so a module publish is always portable: the RID is
  unknown when the bits are laid out and only the host knows its own. The probe is the running RID
  plus its portable form (`osx.14-arm64` -> `osx-arm64`) and walks no wider graph - `linux-musl-x64`
  and `linux-x64` are different C libraries, and loading one for the other crashes instead of
  failing cleanly.

## Tests - both halves fail against `main`

Verified by neutering each half in turn on this branch.

**Without the resolver** (`ResolvingUnmanagedDll` subscription removed), the end-to-end test throws,
and the dlopen trace is the mechanism itself - the flat module folder is probed, the RID tree never
is:

```
System.DllNotFoundException : Unable to load shared library 'meshweaver_probe_6b2b538a...'
dlopen(.../modules/NativeProbe7d8f6d42.../meshweaver_probe_....dylib) - no such file
dlopen(.../modules/NativeProbe7d8f6d42.../libmeshweaver_probe_....dylib) - no such file
   at MeshWeaver.Graph.Test.ModuleNativeAssetTest.AnAssemblyInAModuleFolder_ResolvesANativeLibraryFromItsOwnRidTree()
```

**With `main`'s prune** restored, the layout assertions fail for all three shipped natives:

```
Failed StorageModuleLayoutTest.ClosureLane_KeepsTheBackendsLoadableNatives(
    moduleName: "MeshWeaver.Hosting.Snowflake", runtimeIdentifier: "linux-x64", nativeFile: "libsf_mini_core.so")
  MeshWeaver.Hosting.Snowflake: 'libsf_mini_core.so' is missing from runtimes/linux-x64/native. ...
```

Green on this branch:

```
MeshWeaver.Graph.Test         - 8/8 (5 new)
Memex.Portal.Shared.Test      - StorageModuleLayoutTest 10/10 (6 new)
MeshWeaver.Documentation.Test - DocumentationLinkIntegrityTest 1/1
Release + -warnaserror: 0 Warning(s), 0 Error(s)
```

`ModuleNativeAssetTest.AnAssemblyInAModuleFolder_...` is the load-bearing one: it emits a real
assembly into a real `modules/<Name>/` folder, copies a genuine native library out of the shared
framework under a name nothing on the machine can otherwise resolve, and loads it through the
runtime's own P/Invoke resolution (`NativeLibrary.Load(name, assembly, null)`) - not through a
helper the test calls directly. It also asserts the *negative*: the same name loaded against an
app-root assembly must still throw, or the test would pass on the machine's search path.

## Deliberately not here

Narrowing the kept RIDs to the publishing host's own would cut the 11 MB to ~4, but it needs the
outer publish's `RuntimeIdentifier` - and mis-reading that is precisely the #1675/#1676 failure this
lane already paid for once. Correctness first; the size follow-up wants a CD publish to test
against.

Empty RID directories are left behind after the file-level prune (removing a parent recursively
could take a sibling `native/` with it); an empty directory costs nothing in an image layer.

Generated with [Claude Code](https://claude.com/claude-code)
