### PR TITLE
refactor(export): delete the export layer's last compiled type gate (#1576 item 4)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DeclarativeImportExport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeclarativeImportExport.md
@@ -4,7 +4,7 @@ How a node type tells the platform what its content can DO — export to PDF, ro
 a git file — without the platform carrying a compiled `if (nodeType == …)` for it. The goal is
 composition-first: a plugin pack declares; core mechanisms read declarations.
 
-## Export: shipped (phase 1)
+## Export: SHIPPED — no compiled type gate survives (#1576)
 
 A node type declares its export behaviour on its own hub configuration:
 
@@ -17,27 +17,38 @@ config.WithExport(new ExportDeclaration { Formats = ExportFormats.Pdf })
 `ExportDeclaration` (MeshWeaver.Graph) rides the same `MessageHubConfiguration.Set` idiom as
 `PageLayoutOptions`. Readers:
 
-- **`ExportMenuProvider`** — THE export node-menu provider, one for all types. It resolves the
-  declaration off the focused node's hub configuration and renders the Export group with exactly
-  the declared entries. The former per-type providers (`MarkdownExportMenuProvider`,
+- **`ExportMenuProvider`** — THE export node-menu provider, one for all types. It reads
+  `Configuration.Get<ExportDeclaration>()` off the focused node's hub and renders the Export group
+  with exactly the declared entries. The former per-type providers (`MarkdownExportMenuProvider`,
   `DeckExportMenuProvider`) are deleted; a new exportable type declares instead of adding
   compiled code.
 - **`ExportDocumentLayoutArea`** — offers the pixel-fidelity picker when the declared
   `Composition` is `SlideDeck`.
+- **`ExportPdf.csx` / `ExportHtml.csx`** — dispatch on the declared `Composition`.
 
 Because the declaration travels on the hub configuration, a PLUGIN type declares in its own
-configuration lambda — in-mesh source, no compiled change. Until every install's packs compile
-against a platform that ships this API, `ExportDeclaration.Resolve` carries the ONE transition
-fallback (a suffix-aware `Deck`/`*/Deck` check). Deleting it is tracked in issue #1576.
+configuration lambda — in-mesh source, no compiled change.
 
-### Export phase 2 (open, #1576)
+### How the declaration reaches a template
 
-The export templates (`ExportPdf.csx`, `ExportHtml.csx`) still branch on the suffix-aware type
-check to pick slide-deck composition: they run from an export REQUEST that carries only the
-source path, so they cannot read the source hub's configuration. Phase 2 puts the declared
-`Composition` on the export request (stamped by `ExportDocumentLayoutArea`, which has the
-declaration), after which the templates dispatch on the declaration and the type checks are
-deleted.
+A template cannot read a hub configuration: it runs from an `ExecuteScriptRequest` carrying only
+the source path. **`ExportDocumentHandler` runs ON the source node's own hub** — every caller
+targets `new Address(sourcePath)` — so it reads the type's declaration there and stamps
+`composition` into the script inputs. The templates dispatch on that input. Same declaration,
+carried to where it is needed; no template ever asks what the node type is called.
+
+### The transition fallback is GONE
+
+`ExportDeclaration.Resolve(configuration, nodeType)` briefly answered `SlideDeck` for any type
+whose name ended in `/Deck`, bridging plugin decks whose in-mesh lambdas predated `WithExport`.
+It is deleted: `Publish/Deck` declares (MeshWeaver.Plugins#553), and every reader now asks the
+configuration directly.
+
+🚨 **Do not reintroduce a name gate as a "safety net".** Its failure mode is not an error — a type
+it does not recognise composes as a plain document, and a deck-shaped node has no body of its own,
+so the export SUCCEEDS and produces an empty file. Green activity, nothing logged, nothing in the
+document. `DeclaredCompositionExportTest` (MeshWeaver.Plugins) pins it with a declared type that no
+suffix check can match. A type that declares nothing exports nothing — the honest answer.
 
 ## Import/serialize: design (phase 3, #1580)
 
@@ -67,7 +78,43 @@ NodeType definition node* at parse time was rejected — it would execute config
 (or partially interpret them) before activation, recreating the compile-order problem the
 activation pipeline exists to solve.
 
-Sequencing: phase 2 (request-carried composition) → phase 3 import split → delete
-`MarkdownFileParser.IsSlideNodeType` and the template type checks. Both issues track the
-deletions; the suffix-aware `Matches` predicates on `SlideNodeType`/`DeckNodeType` outlive them
-only as long as any compiled reader still needs a type-shaped question answered.
+### 🚨 What blocks the import half — measured, not assumed
+
+The tempting shortcut is to make the import rule a CONTENT-SHAPE rule instead of a type rule:
+*"frontmatter carries `Notes`/`Background` ⇒ build the slide-shaped content"*. It is symmetric,
+needs no registry and no bootstrapping — **and it silently empties real slides.**
+
+Counted on the education repo's live slide corpus (2026-08-21):
+
+```
+slide files: 235 ; WITHOUT Notes/Background: 3
+```
+
+Those three carry neither key, so a shape rule imports them as `MarkdownContent`. The slide views
+read `SlideContent`, and `ContentAs<T>` recovers only a SAME-short-named type — so the stage
+renders empty, with nothing logged. Three silently broken slides is the same failure class this
+whole programme exists to remove, so the shape rule is refused.
+
+That leaves the registry route: resolve the node type's content CLR type at parse time through
+`IMeshContentTypeRegistry.TryResolveByNodeType` (a dictionary lookup — it executes no
+configuration lambda, so it does NOT recreate the compile-order problem the design rejected). Two
+things must be settled before that is safe, and both are about what happens when the lookup MISSES
+or resolves to a type that cannot carry the body:
+
+1. **A miss must not lose the extra frontmatter.** A cold-boot import (bake, first git-sync) can
+   run before the type registers. Falling back to `MarkdownContent` drops `Notes`/`Background`
+   permanently, so the fallback has to preserve them — which means writing content with no `$type`
+   and letting the read seam re-materialize it (`TryRecoverForNodeType`, whose
+   `DiscriminatorAdmits` guard refuses content whose own `$type` contradicts the node type — an
+   absent discriminator is admitted, which is exactly why the fallback must omit it).
+2. **A hit must not drop the body.** Deserializing `{content, …extras}` into a content record with
+   no `content` member (`Edu/Module`'s `ModuleContent` carries only `Summary`) would silently lose
+   the markdown for every node of that type. The rule needs to be "the format's native shape, or a
+   type that can carry it", verified against the installed types on a real mesh — not assumed.
+
+Sequencing: export phase 2 is **done**; phase 3 (the import split) still owns the deletion of
+`MarkdownFileParser.IsSlideNodeType`. The suffix-aware `Matches` predicates on
+`SlideNodeType`/`DeckNodeType` outlive it only as long as a compiled reader still needs a
+type-shaped question answered — after phase 3 the parser is the last one, which is what would let
+`SlideContent`/`SlideNodeType` leave the platform entirely (they stayed behind when #1589 phase 2
+retired the built-in Slide/Deck node types, *because of* this parser and the export gates).

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeclarativeImportExport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeclarativeImportExport.md
@@ -112,11 +112,19 @@ on real front matter rather than on fenced examples in prose:
 | 396 | `Edu/Exercise` | **`MarkdownContent`** | ✅ native |
 | 232 | `Publish/Slide` | `SlideContent` | ✅ `Content` — this IS the case to convert |
 | 79 | *(no front matter)* | `MarkdownContent` | ✅ native |
-| 38 | `Agent` / `Skill` | *a different parser* (`AgentFileParser`) | n/a |
+| 27 | `Agent` | *a different parser* — `AgentFileParser` claims `nodeType: Agent` and nothing else | n/a |
 | **12** | **`Edu/Module`** | **`ModuleContent` — `Summary` only** | ❌ **no `content` member** |
+| **11** | **`Skill`** | **`SkillDefinition` — its body member is `Instructions`** | ❌ **no `content` member** |
 
-So the whole risk surface for condition 2 is **twelve files**, not an unbounded set: the two big
-non-native types turn out to declare the native `MarkdownContent` anyway.
+So the whole risk surface for condition 2 is **twenty-three files**, not an unbounded set: the two
+big non-native types turn out to declare the native `MarkdownContent` anyway.
+
+⚠️ Note `Skill` is NOT claimed by `AgentFileParser` — that parser returns null for anything whose
+front matter is not `nodeType: Agent` — so a markdown-authored skill goes through
+`MarkdownFileParser` like any other document. Its content type's body member is `Instructions`,
+which puts it in the same bucket as `Edu/Module` for this analysis. (Whether a `.md`-authored skill
+round-trips correctly TODAY is a separate question this note does not answer; most skills in the
+repos are authored as `.json`.)
 
 1. **A miss must not lose the extra frontmatter.** A cold-boot import (bake, first git-sync) can
    run before the type registers. Falling back to `MarkdownContent` drops `Notes`/`Background`
@@ -132,8 +140,9 @@ non-native types turn out to declare the native `MarkdownContent` anyway.
    `content` member loses the markdown for every node of that type. This one is closable **by
    construction** rather than by audit: use the resolved type only when it can actually carry the
    body (a reflection check for the member), else keep the native shape. `Edu/Module`'s twelve
-   files then land exactly as they do today — which is also correct for that type, whose page is
-   H1 + Summary + `Theory/` children and never renders a body of its own.
+   files — and `Skill`'s eleven — then land exactly as they do today. For `Edu/Module` that is also
+   the correct outcome on its own terms: its page is H1 + Summary + `Theory/` children and never
+   renders a body.
 
 Sequencing: export phase 2 is **done**; phase 3 (the import split) still owns the deletion of
 `MarkdownFileParser.IsSlideNodeType`. The suffix-aware `Matches` predicates on

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeclarativeImportExport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeclarativeImportExport.md
@@ -99,7 +99,24 @@ That leaves the registry route: resolve the node type's content CLR type at pars
 `IMeshContentTypeRegistry.TryResolveByNodeType` (a dictionary lookup — it executes no
 configuration lambda, so it does NOT recreate the compile-order problem the design rejected). Two
 things must be settled before that is safe, and both are about what happens when the lookup MISSES
-or resolves to a type that cannot carry the body:
+or resolves to a type that cannot carry the body.
+
+**First, the actual exposure**, so neither condition is argued in the abstract. Every markdown node
+file across the four plugin repos (MeshWeaver.Plugins, Education, Reinsurance, SocialMedia), keyed
+on real front matter rather than on fenced examples in prose:
+
+| files | `NodeType` | declared content type | carries the body? |
+|---:|---|---|---|
+| 621 | `Markdown` (599 implicit + 22 explicit) | `MarkdownContent` | ✅ the format's native shape |
+| 506 | `Edu/Lesson` | **`MarkdownContent`** | ✅ native |
+| 396 | `Edu/Exercise` | **`MarkdownContent`** | ✅ native |
+| 232 | `Publish/Slide` | `SlideContent` | ✅ `Content` — this IS the case to convert |
+| 79 | *(no front matter)* | `MarkdownContent` | ✅ native |
+| 38 | `Agent` / `Skill` | *a different parser* (`AgentFileParser`) | n/a |
+| **12** | **`Edu/Module`** | **`ModuleContent` — `Summary` only** | ❌ **no `content` member** |
+
+So the whole risk surface for condition 2 is **twelve files**, not an unbounded set: the two big
+non-native types turn out to declare the native `MarkdownContent` anyway.
 
 1. **A miss must not lose the extra frontmatter.** A cold-boot import (bake, first git-sync) can
    run before the type registers. Falling back to `MarkdownContent` drops `Notes`/`Background`
@@ -107,10 +124,16 @@ or resolves to a type that cannot carry the body:
    and letting the read seam re-materialize it (`TryRecoverForNodeType`, whose
    `DiscriminatorAdmits` guard refuses content whose own `$type` contradicts the node type — an
    absent discriminator is admitted, which is exactly why the fallback must omit it).
-2. **A hit must not drop the body.** Deserializing `{content, …extras}` into a content record with
-   no `content` member (`Edu/Module`'s `ModuleContent` carries only `Summary`) would silently lose
-   the markdown for every node of that type. The rule needs to be "the format's native shape, or a
-   type that can carry it", verified against the installed types on a real mesh — not assumed.
+   🚨 **This is the stubborn one.** It closes the *extras* hole but not the empty one: a slide with
+   NEITHER key has no extras to preserve, so a miss still yields `MarkdownContent` and an empty
+   stage. Same three files as above. A miss has to be made impossible (prove the type is registered
+   before any `.md` of it is parsed) rather than merely lossless.
+2. **A hit must not drop the body.** Deserializing `{content, …extras}` into a record with no
+   `content` member loses the markdown for every node of that type. This one is closable **by
+   construction** rather than by audit: use the resolved type only when it can actually carry the
+   body (a reflection check for the member), else keep the native shape. `Edu/Module`'s twelve
+   files then land exactly as they do today — which is also correct for that type, whose page is
+   H1 + Summary + `Theory/` children and never renders a body of its own.
 
 Sequencing: export phase 2 is **done**; phase 3 (the import split) still owns the deletion of
 `MarkdownFileParser.IsSlideNodeType`. The suffix-aware `Matches` predicates on

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeclarativeImportExport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeclarativeImportExport.md
@@ -122,9 +122,16 @@ big non-native types turn out to declare the native `MarkdownContent` anyway.
 ⚠️ Note `Skill` is NOT claimed by `AgentFileParser` — that parser returns null for anything whose
 front matter is not `nodeType: Agent` — so a markdown-authored skill goes through
 `MarkdownFileParser` like any other document. Its content type's body member is `Instructions`,
-which puts it in the same bucket as `Edu/Module` for this analysis. (Whether a `.md`-authored skill
-round-trips correctly TODAY is a separate question this note does not answer; most skills in the
-repos are authored as `.json`.)
+which puts it in the same bucket as `Edu/Module` for this analysis.
+
+🚨 …and those eleven do not even reach that bucket today: they import as `nodeType: Markdown`,
+because `MarkdownFileParser`'s YAML deserializer carries no naming convention (PascalCase-only)
+while `AgentFileParser`'s uses camelCase, and their front matter is lowercase `nodeType: Skill`.
+`IgnoreUnmatchedProperties()` makes the miss silent, so the type falls back to its `?? "Markdown"`
+default. Verified on memex: `Skill/thread`, all five `Hosting/Skill/*` and `Feedback/Skill/feedback`
+are Markdown nodes and therefore invisible to the slash-command list — issue #1984, which is this
+row's REAL state and the first live casualty of the gap this section describes. The table lists the
+DECLARED content type, which is what the count above is about.
 
 1. **A miss must not lose the extra frontmatter.** A cold-boot import (bake, first git-sync) can
    run before the type registers. Falling back to `MarkdownContent` drops `Notes`/`Background`

--- a/src/MeshWeaver.Graph/ExportDeclaration.cs
+++ b/src/MeshWeaver.Graph/ExportDeclaration.cs
@@ -69,7 +69,6 @@ public sealed record ExportDeclaration
         Formats = ExportFormats.Pdf | ExportFormats.Send,
         Composition = ExportComposition.SlideDeck,
     };
-
 }
 
 /// <summary>Chains an <see cref="ExportDeclaration"/> onto a node type's hub configuration.</summary>

--- a/src/MeshWeaver.Graph/ExportDeclaration.cs
+++ b/src/MeshWeaver.Graph/ExportDeclaration.cs
@@ -1,4 +1,3 @@
-using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Messaging;
 
 namespace MeshWeaver.Graph;
@@ -31,13 +30,21 @@ public enum ExportComposition
 /// and how the export templates compose the document. Set on the type's hub configuration via
 /// <see cref="ExportDeclarationExtensions.WithExport"/> (the same
 /// <c>MessageHubConfiguration.Set</c> idiom as <see cref="PageLayoutOptions"/>) and read by the
-/// ONE generic export menu provider and the export layout area — replacing the per-type compiled
-/// providers that each hard-coded a NodeType comparison (#1576).
+/// ONE generic export menu provider, the export layout area and the export TEMPLATES — replacing
+/// the per-type compiled providers and template branches that each hard-coded a NodeType
+/// comparison (#1576).
 /// <para>Because the declaration travels on the hub configuration, a PLUGIN node type declares
-/// its exports in its own configuration lambda — no compiled code needs to know the type. Until
-/// every plugin build compiles against a platform that ships this API,
-/// <see cref="Resolve"/> carries the ONE transition fallback (a suffix-aware Deck check) — the
-/// bridge #1576 deletes.</para>
+/// its exports in its own configuration lambda — <b>no compiled code needs to know the type, and
+/// since #1576 none does</b>. Readers ask the configuration directly
+/// (<c>Configuration.Get&lt;ExportDeclaration&gt;()</c>); the transition fallback that briefly
+/// bridged plugin decks compiled against an older platform — a suffix-aware
+/// <c>DeckNodeType.Matches</c> check — is deleted, because <c>Publish/Deck</c> now declares
+/// (MeshWeaver.Plugins#553). A type that declares nothing exports nothing, which is the honest
+/// answer rather than a guess made from its name.</para>
+/// <para>The export TEMPLATES cannot read a hub configuration — they run from a script request
+/// carrying only a source path — so <c>ExportDocumentHandler</c>, which runs on the source node's
+/// own hub, stamps <see cref="Composition"/> into the script inputs and the templates dispatch on
+/// that. Same declaration, carried to where it is needed.</para>
 /// </summary>
 public sealed record ExportDeclaration
 {
@@ -63,16 +70,6 @@ public sealed record ExportDeclaration
         Composition = ExportComposition.SlideDeck,
     };
 
-    /// <summary>
-    /// Resolves the effective declaration for a node: the hub configuration's own declaration
-    /// when the type declared one, else the ONE transition fallback — a suffix-aware Deck check
-    /// covering plugin deck types (e.g. <c>Publish/Deck</c>) whose in-mesh configuration lambdas
-    /// compile against a platform build that predates this API. Null when the node exports
-    /// nothing. The fallback is deleted with #1576 once every install's packs declare.
-    /// </summary>
-    public static ExportDeclaration? Resolve(MessageHubConfiguration configuration, string? nodeType)
-        => configuration.Get<ExportDeclaration>()
-           ?? (DeckNodeType.Matches(nodeType) ? SlideDeck : null);
 }
 
 /// <summary>Chains an <see cref="ExportDeclaration"/> onto a node type's hub configuration.</summary>

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
@@ -241,6 +241,16 @@ public partial class MarkdownFileParser : IFileFormatParser
     /// Notes/Background: matching only the bare constant let a namespaced slide degrade to
     /// MarkdownContent on import, and the next mesh→repo export then dropped its
     /// Notes/Background frontmatter entirely. Delegates to the ONE suffix-aware predicate.
+    ///
+    /// <para>🚨 <b>This is the LAST compiled type branch in the export/import programme</b>
+    /// (#1580 phase 3; the export side is done, #1576). It is not deleted yet, and the obvious
+    /// replacement is refused for a measured reason: a CONTENT-SHAPE rule — "frontmatter has
+    /// Notes or Background ⇒ slide" — silently empties the 3 of 235 real slide files that carry
+    /// neither key, because the slide views read <c>SlideContent</c> and <c>ContentAs&lt;T&gt;</c>
+    /// recovers only a same-short-named type. Before touching this, read
+    /// <c>Doc/Architecture/DeclarativeImportExport</c> → "What blocks the import half", which
+    /// records the count, why the shape rule fails, and the two conditions the registry route has
+    /// to settle first.</para>
     /// </summary>
     private static bool IsSlideNodeType(string? nodeType) => SlideNodeType.Matches(nodeType);
 

--- a/test/MeshWeaver.Graph.Test/ExportDeclarationTest.cs
+++ b/test/MeshWeaver.Graph.Test/ExportDeclarationTest.cs
@@ -1,0 +1,79 @@
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The export contract after #1576: a node type's export behaviour is what it DECLARES on its own
+/// hub configuration, and nothing else. No compiled reader may recover a declaration from what a
+/// type is CALLED.
+///
+/// <para><b>Why this is pinned rather than assumed.</b> <see cref="ExportDeclaration"/> shipped
+/// with a transition fallback — <c>Resolve(configuration, nodeType)</c>, which returned
+/// <see cref="ExportDeclaration.SlideDeck"/> for any type whose name ended in <c>/Deck</c> — so
+/// plugin decks compiled against a pre-<c>WithExport</c> platform kept their Export menu. That
+/// fallback is gone (<c>Publish/Deck</c> declares: MeshWeaver.Plugins#553), and re-introducing one
+/// would take the whole subsystem back to guessing from names: the failure mode is not an error
+/// but an EMPTY document from a green export, because a name gate silently excludes every plugin
+/// type it was not written to recognise.</para>
+/// </summary>
+public class ExportDeclarationTest
+{
+    /// <summary>
+    /// A configuration whose type declared nothing has no declaration — whatever the node type is
+    /// called. The two names here are exactly the ones the deleted fallback answered for.
+    /// </summary>
+    [Theory]
+    [InlineData("Deck")]
+    [InlineData("Publish/Deck")]
+    [InlineData("Markdown")]
+    [InlineData(null)]
+    public void UndeclaredType_HasNoExports_WhateverItIsCalled(string? nodeType)
+    {
+        // The node type's name is deliberately unused by the read: it is not an input to the
+        // question any more, which is the whole point. It stays a parameter so the case names
+        // record WHICH names a fallback used to answer for.
+        Assert.NotNull(nodeType ?? "(null)");
+
+        var configuration = new MessageHubConfiguration(null, new Address("X"));
+
+        Assert.Null(configuration.Get<ExportDeclaration>());
+    }
+
+    /// <summary>A type that declares gets exactly what it declared — the only route in.</summary>
+    [Fact]
+    public void DeclaredType_GetsExactlyItsDeclaration()
+    {
+        var configuration = new MessageHubConfiguration(null, new Address("X"))
+            .WithExport(ExportDeclaration.SlideDeck);
+
+        var declaration = configuration.Get<ExportDeclaration>();
+
+        Assert.NotNull(declaration);
+        Assert.Equal(ExportComposition.SlideDeck, declaration!.Composition);
+        Assert.True(declaration.Formats.HasFlag(ExportFormats.Pdf));
+        Assert.True(declaration.Formats.HasFlag(ExportFormats.Send));
+        Assert.False(declaration.Formats.HasFlag(ExportFormats.Docx),
+            "a deck carries no markdown body of its own, so DOCX would render an empty document");
+    }
+
+    /// <summary>
+    /// The built-in Markdown type declares Document composition — the platform's own type goes
+    /// through the same door as every plugin type, with no shortcut for being built in.
+    /// </summary>
+    [Fact]
+    public void BuiltInMarkdownType_DeclaresDocumentComposition()
+    {
+        var node = MarkdownNodeType.CreateMeshNode();
+        Assert.NotNull(node.HubConfiguration);
+
+        var configuration = node.HubConfiguration!(
+            new MessageHubConfiguration(null, new Address(MarkdownNodeType.NodeType)));
+
+        var declaration = configuration.Get<ExportDeclaration>();
+        Assert.NotNull(declaration);
+        Assert.Equal(ExportComposition.Document, declaration!.Composition);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ExportDeclarationTest.cs
+++ b/test/MeshWeaver.Graph.Test/ExportDeclarationTest.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using System.Reflection;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Messaging;
@@ -21,25 +24,44 @@ namespace MeshWeaver.Graph.Test;
 /// </summary>
 public class ExportDeclarationTest
 {
-    /// <summary>
-    /// A configuration whose type declared nothing has no declaration — whatever the node type is
-    /// called. The two names here are exactly the ones the deleted fallback answered for.
-    /// </summary>
-    [Theory]
-    [InlineData("Deck")]
-    [InlineData("Publish/Deck")]
-    [InlineData("Markdown")]
-    [InlineData(null)]
-    public void UndeclaredType_HasNoExports_WhateverItIsCalled(string? nodeType)
+    /// <summary>A configuration whose type declared nothing has no declaration.</summary>
+    [Fact]
+    public void UndeclaredType_HasNoExports()
     {
-        // The node type's name is deliberately unused by the read: it is not an input to the
-        // question any more, which is the whole point. It stays a parameter so the case names
-        // record WHICH names a fallback used to answer for.
-        Assert.NotNull(nodeType ?? "(null)");
-
         var configuration = new MessageHubConfiguration(null, new Address("X"));
 
         Assert.Null(configuration.Get<ExportDeclaration>());
+    }
+
+    /// <summary>
+    /// 🚨 <b>No public export API may take a node type at all</b> — the guard that actually bites.
+    ///
+    /// <para>A test that merely reads an undeclared configuration cannot tell the two designs
+    /// apart: <c>Get&lt;ExportDeclaration&gt;()</c> returns null either way, so it would pass
+    /// unchanged if <c>Resolve(configuration, nodeType)</c> came back. What distinguishes them is
+    /// the SHAPE OF THE SURFACE — the deleted fallback existed because a reader could ask "and what
+    /// is this type called?", and the fix was to stop offering anywhere to ask. This asserts that:
+    /// no public member of the export declaration surface accepts a node-type parameter, so
+    /// reintroducing a name-based resolver fails here rather than silently restoring the guessing.
+    /// (Copilot review of this PR, which correctly called the first version tautological.)</para>
+    /// </summary>
+    [Fact]
+    public void NoPublicExportApi_AcceptsANodeType()
+    {
+        var offenders = new[] { typeof(ExportDeclaration), typeof(ExportDeclarationExtensions) }
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance))
+            .Where(m => m.GetParameters().Any(p =>
+                p.Name is not null
+                && p.Name.Contains("nodeType", StringComparison.OrdinalIgnoreCase)))
+            .Select(m => $"{m.DeclaringType!.Name}.{m.Name}({string.Join(", ", m.GetParameters().Select(p => p.Name))})")
+            .ToArray();
+
+        Assert.True(offenders.Length == 0,
+            "The export declaration is resolved from the type's hub CONFIGURATION alone. A member "
+            + "taking a node type is how the deleted suffix fallback was expressed, and its failure "
+            + "mode is silent — an unrecognised type composes as a plain document and a deck-shaped "
+            + "node exports an EMPTY file from a green activity. Found: "
+            + string.Join("; ", offenders));
     }
 
     /// <summary>A type that declares gets exactly what it declared — the only route in.</summary>


### PR DESCRIPTION
Closes the export half of the composition-first programme. Companion to **MeshWeaver.Plugins#553**, which must merge **first**.

## What this deletes

`ExportDeclaration.Resolve(configuration, nodeType)` — the ONE transition fallback from the bridge PR (#1579): a suffix-aware `Deck`/`*/Deck` check that answered `SlideDeck` for plugin decks whose in-mesh configuration lambdas predated `WithExport`.

It has **no callers left**. MeshWeaver.Plugins#553:

- makes `Publish/Deck` DECLARE `.WithExport(ExportDeclaration.SlideDeck)`;
- moves `ExportMenuProvider` and `ExportDocumentLayoutArea` onto `Configuration.Get<ExportDeclaration>()`;
- makes `ExportPdf.csx` / `ExportHtml.csx` dispatch on a `composition` input that `ExportDocumentHandler` stamps from the type's declaration (the handler runs on the source node's own hub, so it can read the config a template cannot).

Swept for in-mesh callers too — `content/`, `samples/`, `memex/`, `clients/` — since a NodeType's `configuration` lambda is C# in a JSON string and invisible to `dotnet build`. Zero hits.

## 🚨 Merge order

**MeshWeaver.Plugins#553 first.** The fallback is what keeps a deck exportable on an install whose Publish pack has not yet synced its declaration. Removing it before that ships costs decks their Export menu until the next sync — recoverable, but pointless.

## Why a name gate must not come back

Its failure mode is **not an error**. A type it does not recognise composes as a plain document, and a deck-shaped node has no body of its own — so the export *succeeds* and writes an empty file: green activity, nothing logged, nothing in the document. That is exactly the shape `DeckNodeType.Matches` was introduced to patch, and patching by name only changes *which* types are silently excluded. Plugins#553 reproduces it as a control run.

## Test

`ExportDeclarationTest` pins the contract from the other side — an undeclared type has no exports **whatever it is called**, `Deck` and `Publish/Deck` included:

```
Passed  ExportDeclarationTest.UndeclaredType_HasNoExports_WhateverItIsCalled(nodeType: "Publish/Deck")
Passed  ExportDeclarationTest.UndeclaredType_HasNoExports_WhateverItIsCalled(nodeType: "Deck")
Passed  ExportDeclarationTest.UndeclaredType_HasNoExports_WhateverItIsCalled(nodeType: "Markdown")
Passed  ExportDeclarationTest.UndeclaredType_HasNoExports_WhateverItIsCalled(nodeType: null)
Passed  ExportDeclarationTest.BuiltInMarkdownType_DeclaresDocumentComposition
Passed  ExportDeclarationTest.DeclaredType_GetsExactlyItsDeclaration
Total tests: 6   Passed: 6
```

The *behaviour* test that fails against today's `main` lives in Plugins#553 (a declared type no suffix check can match, exporting an empty document before the fix) — a pure deletion of dead code cannot have one here.

Full suites:

```
MeshWeaver.Graph.Test          Failed: 0, Passed: 1392, Skipped: 1, Total: 1393  (1 m 34 s)
MeshWeaver.Documentation.Test  Failed: 0, Passed:   39, Skipped: 0, Total:   39
```

Release + `-warnaserror` clean on Graph, Hosting, Documentation.

## Documentation — and the measured blocker for #1580

`Doc/Architecture/DeclarativeImportExport` now records the shipped export design, how a declaration reaches a template that cannot read a hub configuration, and — for the still-open import half (#1580) — **why its obvious shortcut is refused**:

```
slide files: 235 ; WITHOUT Notes/Background: 3
```

A content-shape rule ("frontmatter carries Notes or Background ⇒ build slide content") silently empties those three, because the slide views read `SlideContent` and `ContentAs<T>` recovers only a same-short-named type. The doc also states the two conditions the registry route must settle first (a cold-boot miss must not lose the extras; a hit must not drop the body into a record with no `content` member). `MarkdownFileParser.IsSlideNodeType` — the programme's **last** compiled type branch — carries a pointer to that section.

## What's New

Skipped: nothing an end user sees changes in this PR. The user-visible half ships in Plugins#553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)