### PR TITLE
Pin the full-MVID closure, so widening the rebake boundary cannot be silent (#1976)

### DIFF
--- a/test/MeshWeaver.Graph.Test/FrameworkBuildIdentityTest.cs
+++ b/test/MeshWeaver.Graph.Test/FrameworkBuildIdentityTest.cs
@@ -117,6 +117,58 @@ public class FrameworkBuildIdentityTest
             "the closure is sorted so the hash text is deterministic");
     }
 
+    /// <summary>
+    /// 🚨 THE REBAKE BOUNDARY IS PINNED, because widening it is silent and expensive.
+    ///
+    /// <para>Every member here contributes its FULL implementation MVID to the framework identity,
+    /// so a body-only commit to ANY of them mints a new identity, empties the assembly share's
+    /// key-space and rebakes every NodeType on every deployment. The set is COMPUTED (the closure
+    /// walk above), which is what keeps a new toolchain dependency from being silently OUTSIDE the
+    /// identity — and is also why one added <c>ProjectReference</c> anywhere in the closure can pull
+    /// a whole subtree INSIDE it without a line of this file changing.</para>
+    ///
+    /// <para>That already happened. #1712 moved the boundary off <c>MeshWeaver.Graph</c> (311
+    /// commits/30d, the single highest-churn assembly) and the walk pulled in <c>Mesh.Contract</c>
+    /// (190), <c>Messaging.Hub</c> (135), <c>Data</c> (59) and <c>Layout</c> (40) behind it — 383
+    /// commits/30d for the union, so the identity now moves MORE often than before, while #1707's
+    /// stated acceptance ("a body-only edit in MeshWeaver.Graph rebakes nothing") reads as passed.
+    /// See #1976.</para>
+    ///
+    /// <para><b>When this fails, do not just update the list.</b> Ask which reference widened the
+    /// closure and whether the toolchain actually needs it; a member added here is a member every
+    /// deployment now rebakes on.</para>
+    /// </summary>
+    [Fact]
+    public void FullMvidClosure_IsExactly_TheKnownSet()
+    {
+        string[] expected =
+        [
+            "MeshWeaver.Compiler",              // root — shapes generated compile input
+            "MeshWeaver.NuGet",                 // root — the #r directive parser/resolver
+            "MeshWeaver.ContentCollections",    // ↓ pulled in transitively from the roots
+            "MeshWeaver.Data",
+            "MeshWeaver.Data.Contract",
+            "MeshWeaver.Domain",
+            "MeshWeaver.Kernel",
+            "MeshWeaver.Layout",
+            "MeshWeaver.Markdown",
+            "MeshWeaver.Mesh.Contract",
+            "MeshWeaver.Messaging.Contract",
+            "MeshWeaver.Messaging.Hub",
+            "MeshWeaver.Reflection",
+            "MeshWeaver.ServiceProvider",
+            "MeshWeaver.ShortGuid",
+            "MeshWeaver.Utils",
+        ];
+
+        FrameworkBuildIdentity.FullMvidAssemblies.Should().Equal(
+            expected.OrderBy(n => n, StringComparer.Ordinal),
+            "the full-MVID closure is the set whose every commit rebakes the world — a change here "
+            + "means a ProjectReference widened (or narrowed) the toolchain's dependency graph. "
+            + "Widening: find the reference and ask whether the toolchain needs it (#1976). "
+            + "Narrowing: that is the goal — delete the line and say so in the PR.");
+    }
+
     [Fact]
     public void ToolchainClosure_WalksTransitivesAndFiltersNonMeshWeaver()
     {


### PR DESCRIPTION
Pins the measurement in #1976 so the same thing cannot happen again unnoticed.

## The gap

`FrameworkBuildIdentity.FullMvidAssemblies` is a **computed transitive closure** over the toolchain
roots' `MeshWeaver.*` AssemblyRefs (`src/MeshWeaver.Compiler/FrameworkBuildIdentity.cs:192-219`).
Computed is the right shape — it is what stops a new toolchain dependency from sitting silently
*outside* the identity, the hole `NuGetDirectiveParser` occupied before #1712. But it has an inverse
nobody was watching: **one added `ProjectReference` anywhere in the closure pulls a whole subtree
inside it**, and every member contributes its full implementation MVID, so a body-only commit to any
of them mints a new framework identity, empties the assembly share's key-space, and rebakes every
NodeType on every deployment.

That already happened. #1712 moved the boundary off `MeshWeaver.Graph` — 311 commits/30d, the single
highest-churn assembly — and the walk pulled `Mesh.Contract` (190), `Messaging.Hub` (135), `Data`
(59) and `Layout` (40) in behind it:

```
before #1712:  FullMvidAssemblies = ["MeshWeaver.Graph"]     → 311 commits/30d mint a new identity
after  #1712:  computed 16-assembly closure                  → 383 commits/30d mint a new identity
```

So #1707's stated acceptance — *"a body-only edit anywhere in `MeshWeaver.Graph` outside the
toolchain rebakes nothing"* — reads as passed, while the requirement it served ("pins a **low-churn**
assembly instead of the **highest-churn** one") regressed. Full measurement in #1976.

## Why the existing tests could not see it

`FullMvidMembership_IsTheToolchainClosureIncludingItsDirectDependencies` asserts the set **contains**
the roots plus `Mesh.Contract` and `ContentCollections`, that every member starts with `MeshWeaver.`,
and that it is sorted. Nothing bounds it. A closure of 16 and a closure of 60 both pass.

## What this adds

One test pinning the exact 16 members, with a failure message that says what a change *means* rather
than how to silence it:

> *"the full-MVID closure is the set whose every commit rebakes the world — a change here means a
> ProjectReference widened (or narrowed) the toolchain's dependency graph. Widening: find the
> reference and ask whether the toolchain needs it (#1976). Narrowing: that is the goal — delete the
> line and say so in the PR."*

A ratchet in both directions on purpose. Narrowing is the objective (#1707 slice 1's requirement 2,
or slice 4 deleting the full-MVID rule outright), and it should be a visible, deliberate edit rather
than a silently loosening assertion.

## Verification

Fails against `main` only in the sense that the test does not exist there; it passes on this branch
and the whole suite stays green:

```
MeshWeaver.Graph.Test.FrameworkBuildIdentityTest — Total tests: 23, all Passed
  Passed …FullMvidClosure_IsExactly_TheKnownSet [< 1 ms]
Release + -warnaserror: 0 Warning(s), 0 Error(s)
```

I also confirmed the pinned list is what the runtime actually computes, by resolving
`FullMvidAssemblies` against the built assemblies rather than transcribing it from the reference
graph.

Test-only; no runtime change, so no What's New entry.

Generated with [Claude Code](https://claude.com/claude-code)
