### PR TITLE
Prune 60 dead package pins

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,13 +4,11 @@
     <NoWarn>$(NoWarn);NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <!-- Used DIRECTLY by MeshWeaver.AI (skill/agent front matter) and MeshWeaver.Hosting
          (MarkdownFileParser). It used to arrive only TRANSITIVELY via EPS.Extensions.YamlMarkdown,
          so removing that unused package broke the build - an accidental dependency, now explicit. -->
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Appium.WebDriver" Version="8.3.2" />
-    <PackageVersion Include="AspectCore.Extensions.Reflection" Version="2.4.0" />
     <PackageVersion Include="AspNet.Security.OAuth.Apple" Version="10.0.0" />
     <!-- Open-source (MIT) MAUI UI libraries for the native view pack's rich controls (Phase 4+):
          charts, full data grid, and popups/expanders. All MIT-licensed — no Syncfusion/DevExpress/
@@ -26,47 +24,33 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Docker" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Kubernetes" Version="13.4.6-preview.1.26319.6" />
-    <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Orleans" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="13.4.6" />
     <PackageVersion Include="Aspire.Npgsql" Version="13.4.6" />
     <!-- Pinned: Autofac.Extensions.DI 11.0.0 breaks TryAddEnumerable with factory delegates -->
     <PackageVersion Include="Autofac" Version="9.3.2" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="11.0.2" />
-    <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
-    <PackageVersion Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
     <PackageVersion Include="Azure.Core" Version="1.60.0" />
-    <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Provisioning.Storage" Version="1.1.2" />
-    <PackageVersion Include="Azure.Search.Documents" Version="11.7.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.10.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageVersion Include="Azure.Storage.Common" Version="12.28.0" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.84.2" />
     <PackageVersion Include="System.ClientModel" Version="1.14.0" />
-    <PackageVersion Include="Azure.Storage.Files.Shares" Version="12.25.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageVersion Include="BlazorMonaco" Version="3.5.0" />
-    <PackageVersion Include="ClaudeAgentSdk" Version="0.2.1" />
     <PackageVersion Include="Radzen.Blazor" Version="10.3.2" />
-    <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="DocSharp.Markdown" Version="0.20.0" />
     <PackageVersion Include="ClosedXML" Version="0.105.1" />
     <PackageVersion Include="CSharpVitamins.ShortGuid" Version="2.0.0" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.5.1" />
-    <PackageVersion Include="EPS.Extensions.YamlMarkdown" Version="10.2.3" />
-    <PackageVersion Include="Google.Protobuf" Version="3.29.3" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />
     <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.80.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.71.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <!-- Humanizer.Core (MIT) backs the `DateTime.Humanize()` calls in MeshWeaver.Graph and
          MeshWeaver.AI. It used to arrive ONLY as an accidental transitive of JsonPointer.Net,
@@ -75,18 +59,16 @@
          Removing json-everything (#1231) exposed that, so the dependency is now declared where
          it is used. -->
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.CookiePolicy" Version="2.3.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.3" />
-    <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.1" />
-    <!-- Microsoft.AspNetCore.DataProtection pinned to override transitive 10.0.0 (CVE-2026-40372 / GHSA-9mv3-2cwr-p262) -->
+    <!-- 🚨 Microsoft.AspNetCore.DataProtection pinned to override transitive 10.0.0
+         (CVE-2026-40372 / GHSA-9mv3-2cwr-p262) — but NOTHING references it directly and
+         CentralPackageTransitivePinningEnabled is NOT set, so this pin currently overrides
+         NOTHING. Kept as the intent record; making it effective (enabling transitive pinning,
+         or adding the direct reference where the vulnerable package flows) is a change with a
+         resolution-wide blast radius and belongs in its own PR. Same for OpenTelemetry.Api. -->
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.24" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <!-- Pin the patched native SQLite engine: Microsoft.Data.Sqlite 10.0.0 pulls
          SQLitePCLRaw.lib.e_sqlite3 2.1.11 transitively, which bundles a SQLite engine with the
@@ -98,53 +80,26 @@
          3.53.3). The pin is the source of truth; this comment explains WHY it exists.
          Pinned explicitly in the Sqlite projects. -->
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
-    <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="1.6.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageVersion>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageVersion>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.2.0" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.8.3" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.8.3" />
-    <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="10.0.0-preview.1.25559.3" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.3" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.14.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Graph" Version="6.2.0" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageVersion Include="Microsoft.Identity.Web.Ui" Version="4.14.2" />
-    <PackageVersion Include="Microsoft.Orleans.BroadcastChannel" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Runtime" Version="10.2.2" />
-    <PackageVersion Include="Microsoft.Orleans.Serialization.Abstractions" Version="10.2.0" />
     <!-- 1.17.0 is where the agent-store abstractions MeshWeaver.AI.Stores implements over mesh
          nodes (AgentFileStore, AgentSkillsSource) reached their current shape. Kept in lockstep —
          these three ship together and mixing versions breaks their shared abstractions. -->
     <PackageVersion Include="Microsoft.Agents.AI" Version="1.17.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.17.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.17.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.AzureAI" Version="1.0.0-rc5" />
-    <PackageVersion Include="Microsoft.Agents.AI.AzureAI.Persistent" Version="1.4.0-preview.260505.1" />
-    <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.10" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
@@ -156,19 +111,11 @@
          multi-arch portal image requires. -->
     <PackageVersion Include="SkiaSharp" Version="3.116.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.7" />
     <PackageVersion Include="System.CommandLine" Version="2.0.10" />
-    <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta5.25306.1" />
     <PackageVersion Include="System.Composition.AttributedModel" Version="10.0.10" />
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.7" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Scripting" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
@@ -180,13 +127,11 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Orleans.Core" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Sdk" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="10.2.2" />
-    <PackageVersion Include="Microsoft.Orleans.Client" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Orleans.Server" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Streaming" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
@@ -197,11 +142,8 @@
     <PackageVersion Include="NuGet.DependencyResolver.Core" Version="7.6.0" />
     <PackageVersion Include="NuGet.Frameworks" Version="7.6.0" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Pgvector" Version="0.3.2" />
-    <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
     <PackageVersion Include="Snowflake.Data" Version="5.7.0" />
-    <PackageVersion Include="OpenAI" Version="2.12.0" />
     <!-- OpenTelemetry.Api pinned to override transitive 1.13.1 / 1.15.2 (CVE-2026-40894 / GHSA-g94r-2vxg-569j) -->
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
@@ -221,8 +163,6 @@
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.4" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.4" />
     <PackageVersion Include="Namotion.Reflection" Version="3.5.1" />
-    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.2.2" />
@@ -239,7 +179,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.runner.console" Version="3.2.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.8" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="Octokit.Reactive" Version="14.0.0" />
   </ItemGroup>


### PR DESCRIPTION
`CentralPackageTransitivePinningEnabled` is unset, so a `PackageVersion` no project references affects nothing. 60 such pins go — mostly the extraction tail (Azure.AI.\*, Microsoft.Agents.AI.\*, Microsoft.Extensions.AI.\*, OpenAI, Microsoft.Graph, ClaudeAgentSdk, GitHub.Copilot.SDK) plus EF Core, Cosmos/Aspire-Cosmos and System.\* leftovers.

**Kept on purpose:** the four MAUI placeholders, and the two CVE-override pins — with corrected comments, because they override **nothing** today (no direct reference + transitive pinning off). That's a real finding; making them effective is resolution-wide and gets its own PR.

Gate: whole 158-project solution restores clean (the first line-wise attempt corrupted multi-line `<PackageVersion>` elements and broke the Aspire AppHost restore — caught by that gate, redone element-aware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)