### PR TITLE
A model the deployment can serve must not be declared unusable (#1965)

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -2129,10 +2129,15 @@ public class AgentChatClient : IAgentChat
         if (string.IsNullOrEmpty(target)
             || string.Equals(target, currentModelName, StringComparison.OrdinalIgnoreCase))
         {
-            // Nothing usable to move TO. Not fatal on its own — a deployment can keep its keys in
-            // factory config where the resolver cannot see them — so the round still tries. The
-            // latch lets CreateAgentsSync turn "no usable model AND no agent could be built" into a
-            // speaking round failure instead of a raw provider error (#476).
+            // Nothing usable to move TO. Not fatal on its own — a factory may still bind a key this
+            // chain never saw (a provider with no registered catalog source, a driver reading its own
+            // config shape) — so the round still tries. The latch lets CreateAgentsSync turn "no
+            // usable model AND no agent could be built" into a speaking round failure instead of a
+            // raw provider error (#476).
+            //
+            // 🚨 The deployment's OWN configured keys are no longer in that blind spot: the resolver
+            // reads {Section}:ApiKey for the model's provider (MeshWeaver#1965), so a model served by
+            // Anthropic__ApiKey now takes the early return above instead of being swapped away.
             modelFallbackExhausted = true;
             if (isRouter)
                 logger.LogWarning(

--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -21,7 +21,12 @@ namespace MeshWeaver.AI;
 /// </summary>
 public record CredentialResolution(string? Endpoint, string? ApiKey, string Source)
 {
-    /// <summary>Sentinel result meaning no credential could be resolved — the caller falls back to its <c>IOptions</c> configuration binding.</summary>
+    /// <summary>
+    /// Sentinel result meaning no credential could be resolved ANYWHERE — neither on a
+    /// <c>ModelProvider</c> node nor in the deployment's configuration for the model's provider
+    /// section. Factories still apply their own <c>IOptions</c> fallback afterwards, but it now
+    /// resolves the same values this chain already looked at, so <c>Missing</c> means what it says.
+    /// </summary>
     public static readonly CredentialResolution Missing = new(null, null, "missing");
 }
 
@@ -51,9 +56,31 @@ public record CredentialResolution(string? Endpoint, string? ApiKey, string Sour
 ///         (<see cref="ModelDefinition.ApiKeySecretRef"/> /
 ///         <see cref="ModelDefinition.Endpoint"/>) — stamped per-model on
 ///         older catalog rollouts.</item>
-///   <item><see cref="CredentialResolution.Missing"/> — caller falls back
-///         to its <c>IOptions&lt;...Configuration&gt;</c> binding.</item>
+///   <item><b>The deployment's own configuration</b> — <c>{Section}:ApiKey</c> /
+///         <c>{Section}:Endpoint</c> of the <see cref="LanguageModelCatalogSource"/> whose
+///         <see cref="LanguageModelCatalogSource.ProviderName"/> the model declares. This is the
+///         SAME rung every factory already falls back to
+///         (<c>resolution.ApiKey ?? configuration.ApiKey</c>), read here so the resolver's
+///         verdict matches what actually runs — see the note below.</item>
+///   <item><see cref="CredentialResolution.Missing"/> — nothing anywhere serves this model.</item>
 /// </list>
+///
+/// <para>🚨 <b>Why configuration is a rung and not "the caller's business".</b> The catalog seeder
+/// stamps <c>{Section}:ApiKey</c> onto the <c>ModelProvider</c> node <b>create-if-absent</b>: the
+/// first boot that creates the node copies the key, and no later boot revisits it. So a key added
+/// to the deployment's configuration AFTER the node exists reaches every factory and never reaches
+/// the node — and a resolver that reads only nodes then reports a model that runs perfectly as
+/// unusable. That is not cosmetic: <c>AgentChatClient.ApplyStaleModelFallback</c> treats
+/// "unusable" as "stale selection" and SILENTLY swaps the user's explicit pick for the deployment
+/// default (measured on <c>memex.systemorph.com</c> 2026-08-21 — every <c>claude-*</c> selection
+/// was served by another provider's factory, MeshWeaver#1965). The rung is merged PER FIELD, like
+/// the factories do it: a node-supplied endpoint still wins, only the missing key is filled in.</para>
+///
+/// <para>Two deliberate limits on that rung. It is consulted ONLY when the node rungs produced no
+/// key — administered node data always wins. And it carries no
+/// <see cref="IsAllowedSharedAccess"/> gate, because a configuration value is the DEPLOYMENT's own
+/// credential, already present in every factory's <c>IOptions</c> binding: reading it here exposes
+/// nothing that was not already in the same process.</para>
 ///
 /// <para>User-partition ModelProvider visibility: callers (notably
 /// <c>AgentChatClient</c>) invoke <see cref="WatchPartition"/> to widen the
@@ -268,11 +295,46 @@ public sealed class ChatClientCredentialResolver : IDisposable
     }
 
     /// <summary>
-    /// Walks the credential precedence chain (ProviderRef → conventional Provider/{name} → legacy
-    /// model-node fields) for ONE model definition. Returns <c>null</c> when this definition yields no
-    /// credential at all (so <see cref="Resolve"/> can try the next same-id candidate).
+    /// Walks the credential precedence chain for ONE model definition: the NODE rungs (ProviderRef →
+    /// conventional Provider/{name} → legacy model-node fields) and then, only if those produced no
+    /// KEY, the deployment's own configuration for the model's provider. Returns <c>null</c> when
+    /// this definition yields no credential at all (so <see cref="Resolve"/> can try the next
+    /// same-id candidate).
+    ///
+    /// <para>The two halves merge PER FIELD, exactly as every factory merges them
+    /// (<c>endpoint = resolution.Endpoint ?? configuration.Endpoint</c>,
+    /// <c>apiKey = resolution.ApiKey ?? configuration.ApiKey</c>): an endpoint the node supplied
+    /// survives, and only the missing key is filled in from configuration. Merging whole
+    /// resolutions instead would let a config endpoint override an administered one.</para>
     /// </summary>
     private CredentialResolution? TryResolveForDefinition(IReadOnlyList<MeshNode> snapshot, ModelDefinition def)
+    {
+        var fromNodes = TryResolveFromNodes(snapshot, def);
+        // Administered node data always wins — configuration is consulted only for a MISSING key.
+        if (!string.IsNullOrEmpty(fromNodes?.ApiKey))
+            return fromNodes;
+
+        var fromConfig = TryResolveFromConfiguration(def.Provider);
+        if (fromConfig is null)
+            return fromNodes;
+
+        return fromNodes is null
+            ? fromConfig
+            : fromConfig with
+            {
+                Endpoint = fromNodes.Endpoint ?? fromConfig.Endpoint,
+                // Both rungs named, in the order they contributed: "which source answered" is the
+                // question an operator asks when a key is stale, and one tag cannot answer it.
+                Source = $"{fromNodes.Source}+{fromConfig.Source}",
+            };
+    }
+
+    /// <summary>
+    /// The NODE rungs of the precedence chain — everything that lives as mesh data. Extracted from
+    /// <see cref="TryResolveForDefinition"/> so the configuration rung composes with it rather than
+    /// being wedged inside it.
+    /// </summary>
+    private CredentialResolution? TryResolveFromNodes(IReadOnlyList<MeshNode> snapshot, ModelDefinition def)
     {
         // 1. Explicit ProviderRef — the normal path.
         if (!string.IsNullOrEmpty(def.ProviderRef)
@@ -299,6 +361,45 @@ public sealed class ChatClientCredentialResolver : IDisposable
         if (!string.IsNullOrEmpty(def.ApiKeySecretRef) || !string.IsNullOrEmpty(def.Endpoint))
         {
             return new CredentialResolution(def.Endpoint, Decrypt(def.ApiKeySecretRef), "model-node");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The DEPLOYMENT rung: <c>{Section}:ApiKey</c> / <c>{Section}:Endpoint</c> of the registered
+    /// <see cref="LanguageModelCatalogSource"/> whose <see cref="LanguageModelCatalogSource.ProviderName"/>
+    /// matches <paramref name="providerName"/> — the very values each provider factory binds into its
+    /// own <c>IOptions&lt;...Configuration&gt;</c> and falls back to.
+    ///
+    /// <para>Returns <c>null</c> unless a non-empty KEY is configured: an endpoint on its own is what
+    /// every factory rejects with <c>"ApiKey is missing for model '…'"</c>, so a keyless config
+    /// section must not make a model look usable. The value is NOT
+    /// <see cref="Decrypt(string?)"/>-ed — a configuration value is plaintext by construction, unlike
+    /// a <c>ModelProvider</c> node's encrypted-at-rest key.</para>
+    /// </summary>
+    /// <param name="providerName">The model's declared <see cref="ModelDefinition.Provider"/>.</param>
+    /// <returns>The configured credential, or <c>null</c> when this deployment configures no key for it.</returns>
+    private CredentialResolution? TryResolveFromConfiguration(string? providerName)
+    {
+        if (string.IsNullOrEmpty(providerName)) return null;
+        var catalog = hub.ServiceProvider.GetService<LanguageModelCatalogOptions>();
+        var configuration = hub.ServiceProvider.GetService<IConfiguration>();
+        if (catalog is null || configuration is null) return null;
+
+        foreach (var source in catalog.Sources)
+        {
+            if (!string.Equals(source.ProviderName, providerName, StringComparison.OrdinalIgnoreCase))
+                continue;
+            // Plain key lookups, deliberately NOT GetSection(...).Get<T>(): binding is what throws on a
+            // malformed section (which is why BuiltInLanguageModelProvider guards its Models[] read),
+            // and there is nothing to guard — and therefore nothing to swallow — around an indexer.
+            var apiKey = configuration[$"{source.SectionName}:ApiKey"];
+            if (string.IsNullOrWhiteSpace(apiKey))
+                continue;
+            var endpoint = configuration[$"{source.SectionName}:Endpoint"];
+            return new CredentialResolution(
+                endpoint ?? source.DefaultEndpoint, apiKey, $"config:{source.SectionName}");
         }
 
         return null;
@@ -471,9 +572,16 @@ public sealed class ChatClientCredentialResolver : IDisposable
     /// (<c>OpenAIChatClientAgentFactory</c> et al.) throws <c>"ApiKey is missing for model '…'"</c>
     /// without a key. Selecting such a model as a default/fallback surfaces that raw factory error to
     /// the user (the <c>z-ai/glm-5.2</c> report). Requiring a key here means default/fallback selection
-    /// only ever lands on a model that will actually run. No working model regresses: a model whose key
-    /// comes from the factory's own config/IOptions fallback (not a provider node) already resolves
-    /// <see cref="CredentialResolution.Missing"/> today and was never eligible as a catalog default.
+    /// only ever lands on a model that will actually run.
+    ///
+    /// <para>🚨 <b>"A key" includes the DEPLOYMENT's configured key.</b> This doc used to claim the
+    /// opposite — that a model keyed only from the factory's config/IOptions fallback "already
+    /// resolves Missing today and was never eligible", written as a no-regression reassurance. That
+    /// claim WAS the defect: such a model runs perfectly, so declaring it unusable made
+    /// <c>AgentChatClient.ApplyStaleModelFallback</c> silently swap an explicit user selection for
+    /// the deployment default (MeshWeaver#1965, measured on memex.systemorph.com 2026-08-21).
+    /// <see cref="Resolve"/> walks that rung too now, so this predicate answers the question it
+    /// claims to answer: can a factory actually serve this model.</para>
     /// </summary>
     public bool HasUsableCredential(string? modelId)
         => !string.IsNullOrEmpty(modelId)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-model-key-from-deployment-config.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-model-key-from-deployment-config.md
@@ -1,0 +1,20 @@
+---
+Name: The model you pick is the model that runs
+Category: Fix
+Description: Models whose API key comes from the deployment configuration are no longer treated as unusable and silently swapped for another model.
+Icon: Sparkle
+Order: -20260821
+---
+
+# The model you pick is the model that runs
+
+Picking a specific model in the chat composer could quietly get you a different one. If a
+deployment kept a provider's API key in its configuration rather than on the provider's entry
+under Settings ▸ Language Models, the platform read that provider as having no key at all — even
+though every round it served worked perfectly. Any model of that provider was then treated as a
+stale selection and replaced with the deployment's default, without a word in the chat.
+
+Credential lookup now consults the deployment's own configuration for a provider as well as its
+stored entry, so a model that can actually be served is reported as usable and your explicit
+choice is kept. A model with no key anywhere is still reported as unusable, so the platform still
+steers you away from a selection that would only produce a provider error.

--- a/test/MeshWeaver.AI.Test/DeploymentConfiguredModelUsabilityTest.cs
+++ b/test/MeshWeaver.AI.Test/DeploymentConfiguredModelUsabilityTest.cs
@@ -1,0 +1,173 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// A model the deployment can ACTUALLY serve must read as usable.
+///
+/// <para>Every provider factory resolves its driver config in two steps —
+/// <c>resolution.ApiKey ?? configuration.ApiKey</c> — so a deployment that keeps its key in
+/// configuration (<c>Anthropic__ApiKey</c>) serves that provider's models perfectly well even when
+/// the <c>ModelProvider</c> NODE carries no key. <see cref="ChatClientCredentialResolver"/> used to
+/// see only the node, so it answered <see cref="ChatClientCredentialResolver.HasUsableCredential"/>
+/// = <c>false</c> for a model that runs — and <c>AgentChatClient.ApplyStaleModelFallback</c> then
+/// SILENTLY swapped the user's explicit pick for the deployment default (measured on
+/// <c>memex.systemorph.com</c>, 2026-08-21, MeshWeaver#1965: every <c>claude-*</c> selection was
+/// served by another provider's factory).</para>
+///
+/// <para>The node is keyless in the first place because it is <b>create-if-absent</b>: the catalog
+/// seeder stamps <c>{Section}:ApiKey</c> onto the <c>ModelProvider</c> node the FIRST time it
+/// creates it and never revisits it, so a key added to the deployment's configuration afterwards
+/// reaches the factories and never reaches the node. That is why the fixtures below point their
+/// model at a provider node distinct from the one this test's own catalog source seeds: a
+/// freshly-seeded node would carry the config key and hide the case entirely.</para>
+/// </summary>
+public class DeploymentConfiguredModelUsabilityTest : AITestBase
+{
+    /// <summary>Config section + provider name of a provider whose key the DEPLOYMENT holds.</summary>
+    private const string KeyedSection = "AnthropicProbe";
+
+    /// <summary>Config section + provider name of a provider nobody holds a key for.</summary>
+    private const string KeylessSection = "GatewayProbe";
+
+    private const string DeploymentKey = "sk-ant-deployment-config-key";
+    private const string DeploymentEndpoint = "https://probe.example/anthropic/v1/messages";
+
+    /// <summary>The provider node the models point at — endpoint only, deliberately NO key.</summary>
+    private const string KeyedProviderNodeId = "AnthropicProbeExisting";
+    private const string KeylessProviderNodeId = "GatewayProbeExisting";
+    private const string NodeEndpoint = "https://node.example/anthropic/v1/messages";
+
+    public DeploymentConfiguredModelUsabilityTest(ITestOutputHelper output) : base(output) { }
+
+    protected override bool ShareMeshAcrossTests => false;
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private ChatClientCredentialResolver Resolver =>
+        Mesh.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            // The deployment's own configuration, exactly as a Helm/env deployment supplies it:
+            // Anthropic__ApiKey / Anthropic__Endpoint for ONE of the two providers below.
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IConfiguration>();
+                services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                    .SetBasePath(Directory.GetCurrentDirectory())
+                    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [$"{KeyedSection}:ApiKey"] = DeploymentKey,
+                        [$"{KeyedSection}:Endpoint"] = DeploymentEndpoint,
+                        // KeylessSection deliberately carries NOTHING.
+                    })
+                    .Build());
+                return services;
+            })
+            .AddLanguageModelCatalogSource(new LanguageModelCatalogSource(
+                SectionName: KeyedSection, ProviderName: KeyedSection, Order: 1,
+                DisplayLabel: "Anthropic (probe)", DefaultEndpoint: null,
+                DefaultModelIds: ImmutableArray<string>.Empty, RequiresApiKey: true))
+            .AddLanguageModelCatalogSource(new LanguageModelCatalogSource(
+                SectionName: KeylessSection, ProviderName: KeylessSection, Order: 2,
+                DisplayLabel: "Gateway (probe)", DefaultEndpoint: null,
+                DefaultModelIds: ImmutableArray<string>.Empty, RequiresApiKey: true));
+
+    [Fact]
+    public async Task ModelWhoseKeyLivesOnlyInDeploymentConfig_IsUsable()
+    {
+        var modelId = await SeedModel(KeyedSection, KeyedProviderNodeId, "claude-probe");
+
+        var resolution = await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .Select(_ => Resolver.Resolve(modelId))
+            .Should().Within(15.Seconds())
+            .Match(r => !string.IsNullOrEmpty(r.ApiKey),
+                "the deployment's configured key serves this provider's models");
+
+        resolution.ApiKey.Should().Be(DeploymentKey);
+        // The NODE's endpoint still wins over the configured one — same per-field precedence the
+        // factories apply (resolution.Endpoint ?? configuration.Endpoint).
+        resolution.Endpoint.Should().Be(NodeEndpoint);
+        resolution.Source.Should().Contain($"config:{KeyedSection}",
+            "the operator must be able to see WHICH source answered");
+
+        Resolver.HasUsableCredential(modelId).Should().BeTrue(
+            "a model the factories can serve must never be reported unusable — that is what "
+            + "silently swaps an explicit user selection (MeshWeaver#1965)");
+    }
+
+    [Fact]
+    public async Task ModelWithNoKeyAnywhere_StaysUnusable()
+    {
+        var modelId = await SeedModel(KeylessSection, KeylessProviderNodeId, "gateway-probe");
+
+        // Give the snapshot the same chance to warm as the positive case, then assert the negative.
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .Select(_ => Resolver.Resolve(modelId))
+            .Should().Within(15.Seconds())
+            .Match(r => r.Endpoint == NodeEndpoint, "the model's provider node is in the snapshot");
+
+        Resolver.Resolve(modelId).ApiKey.Should().BeNull(
+            "no key exists on the node and none is configured for this section");
+        Resolver.HasUsableCredential(modelId).Should().BeFalse(
+            "an endpoint-only provider still throws 'ApiKey is missing' in every factory — the "
+            + "config rung must not turn every model green");
+    }
+
+    /// <summary>
+    /// Creates the memex shape: a <c>ModelProvider</c> node carrying an endpoint but NO key, plus a
+    /// <c>LanguageModel</c> under the provider's catalog namespace that references it.
+    /// </summary>
+    /// <returns>The seeded model's wire id.</returns>
+    private async Task<string> SeedModel(string providerName, string providerNodeId, string modelPrefix)
+    {
+        var providerPath = $"{ModelProviderNodeType.RootNamespace}/{providerNodeId}";
+        await MeshService.CreateNode(new MeshNode(providerNodeId, ModelProviderNodeType.RootNamespace)
+        {
+            NodeType = ModelProviderNodeType.NodeType,
+            Name = providerNodeId,
+            State = MeshNodeState.Active,
+            Content = new ModelProviderConfiguration
+            {
+                Provider = providerName,
+                Endpoint = NodeEndpoint,
+                ApiKey = null,
+            }
+        }).Should().Within(15.Seconds()).Emit();
+
+        var modelId = $"{modelPrefix}-{Guid.NewGuid():N}"[..24];
+        var modelNamespace = $"{ModelProviderNodeType.RootNamespace}/{providerName}";
+        await MeshService.CreateNode(new MeshNode(modelId, modelNamespace)
+        {
+            NodeType = LanguageModelNodeType.NodeType,
+            Name = modelId,
+            State = MeshNodeState.Active,
+            Content = new ModelDefinition
+            {
+                Id = modelId,
+                Provider = providerName,
+                ProviderRef = providerPath,
+            }
+        }).Should().Within(15.Seconds()).Emit();
+
+        Resolver.EnsureSubscription();
+        return modelId;
+    }
+}

--- a/test/MeshWeaver.AI.Test/ProviderModulePackBootTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderModulePackBootTest.cs
@@ -1,0 +1,169 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Test;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+[assembly: ProbeProviderPack]
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// A language-model provider that ships as a Store-landed MODULE (its DLL is listed in
+/// <c>Modules:Assemblies</c> / the activation sidecar rather than compiled into the portal) must
+/// arrive in DI complete: its catalog source AND its <see cref="IChatClientFactory"/>. That is the
+/// shape <c>MeshWeaver.AI.Anthropic</c>'s <c>AnthropicProvidersAttribute</c> carries, and the shape
+/// MeshWeaver#1965 reported as broken — a mesh serving <c>claude-*</c> rounds through another
+/// provider's factory because no Anthropic factory was in DI.
+///
+/// <para>The cause there turned out to be upstream (#1949/#1954: a generation-landed module never
+/// loaded at all, so its attribute was never read). This suite pins the half the platform owns:
+/// once the DLL IS loaded, <see cref="MeshBuilder.InstallAssemblies"/> must fold the pack's
+/// registrations into the mesh's service collection. The pack below is a stand-in, deliberately
+/// modelled on the real one — the provider modules live in the MeshWeaver.Plugins repo now, so the
+/// platform can only pin the CONTRACT between them.</para>
+/// </summary>
+public class ProviderModulePackBootTest
+{
+    [Fact]
+    public void ProviderPack_CarriesAnAssemblyAttribute_RegisteringCatalogSourceAndFactory()
+    {
+        var attributes = typeof(ProbeProviderPackAttribute).Assembly
+            .GetCustomAttributes<MeshNodeProviderAttribute>()
+            .OfType<ProbeProviderPackAttribute>()
+            .ToList();
+        Assert.NotEmpty(attributes);
+
+        var services = attributes
+            .SelectMany(a => a.Nodes)
+            .SelectMany(n => n.GlobalServiceConfigurations)
+            .Aggregate((IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+
+        AssertFactoryAndCatalogSourceLanded(services);
+    }
+
+    [Fact]
+    public void InstallAssemblies_FoldsTheProviderPackIntoTheMeshServiceCollection()
+    {
+        // The SAME fold the portal's boot performs for every Modules:Assemblies entry —
+        // Assembly.LoadFrom + attribute discovery + GlobalServiceConfigurations included.
+        var configurations = new List<Func<IServiceCollection, IServiceCollection>>();
+        var builder = new MeshBuilder(configure => configurations.Add(configure),
+            AddressExtensions.CreateMeshAddress());
+
+        builder.InstallAssemblies(typeof(ProbeProviderPackAttribute).Assembly.Location);
+
+        var services = configurations.Aggregate(
+            (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+
+        AssertFactoryAndCatalogSourceLanded(services);
+    }
+
+    [Fact]
+    public void TheFactoryClaimsItsOwnModels_AndNobodyElses()
+    {
+        var factory = new ProbeClaudeChatClientFactory();
+        Assert.True(factory.Supports("claude-sonnet-4-6"));
+        Assert.True(factory.Supports("CLAUDE-opus-4-8"));
+        Assert.False(factory.Supports("moonshotai/kimi-k3"));
+        Assert.False(factory.Supports(""));
+        // Order 0 — a claude-shaped id must reach this factory before any catch-all gateway
+        // (AgentChatClient.GetFactoryForModel takes the lowest Order among factories that Support it).
+        Assert.Equal(0, factory.Order);
+    }
+
+    private static void AssertFactoryAndCatalogSourceLanded(IServiceCollection services)
+    {
+        Assert.Contains(services, d =>
+            d.ServiceType == typeof(IChatClientFactory)
+            && d.ImplementationType == typeof(ProbeClaudeChatClientFactory));
+
+        var catalog = services
+            .Where(d => d.ServiceType == typeof(LanguageModelCatalogOptions))
+            .Select(d => d.ImplementationInstance)
+            .OfType<LanguageModelCatalogOptions>()
+            .SingleOrDefault();
+        Assert.NotNull(catalog);
+        Assert.Contains(catalog!.Sources, s => s.ProviderName == ProbeProviderPackAttribute.ProviderName);
+    }
+}
+
+/// <summary>
+/// Stand-in for a provider module's boot attribute — the same three registrations
+/// <c>AnthropicProvidersAttribute</c> makes: the catalog source, the options binding, and the
+/// <see cref="IChatClientFactory"/> as an enumerable singleton.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class ProbeProviderPackAttribute : MeshNodeProviderAttribute
+{
+    public const string ProviderName = "ProbeClaude";
+
+    /// <inheritdoc />
+    public override IEnumerable<MeshNode> Nodes =>
+    [
+        new MeshNode("MeshWeaver.AI.ProbeClaude")
+        {
+            Name = "Probe Claude language-model provider",
+            NodeType = "ModuleDefinition",
+        }
+        .WithGlobalServiceRegistry(services =>
+        {
+            services.AddLanguageModelCatalogSource(new LanguageModelCatalogSource(
+                SectionName: ProviderName, ProviderName: ProviderName, Order: 1,
+                DisplayLabel: "Probe Claude", DefaultEndpoint: "https://probe.example/v1/messages",
+                DefaultModelIds: ImmutableArray<string>.Empty, RequiresApiKey: true));
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IChatClientFactory, ProbeClaudeChatClientFactory>());
+            return services;
+        }),
+    ];
+}
+
+/// <summary>
+/// Minimal <see cref="IChatClientFactory"/> with the real Anthropic factory's routing predicate.
+/// Agent creation is out of scope here — the pin is registration + routing.
+/// </summary>
+public sealed class ProbeClaudeChatClientFactory : IChatClientFactory
+{
+    /// <inheritdoc />
+    public string Name => "Probe Claude";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> Models => [];
+
+    /// <inheritdoc />
+    public int Order => 0;
+
+    /// <inheritdoc />
+    public bool Supports(string modelName) =>
+        !string.IsNullOrEmpty(modelName)
+        && modelName.StartsWith("claude", StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public Task<ChatClientAgent> CreateAgentAsync(
+        AgentConfiguration config,
+        IAgentChat chat,
+        IReadOnlyDictionary<string, ChatClientAgent> existingAgents,
+        IReadOnlyList<AgentConfiguration> hierarchyAgents,
+        string? modelName = null) =>
+        throw new NotSupportedException("Registration probe — never creates an agent.");
+
+    /// <inheritdoc />
+    public ChatClientAgent CreateAgent(
+        AgentConfiguration config,
+        IAgentChat chat,
+        IReadOnlyDictionary<string, ChatClientAgent> existingAgents,
+        IReadOnlyList<AgentConfiguration> hierarchyAgents,
+        string? modelName = null) =>
+        throw new NotSupportedException("Registration probe — never creates an agent.");
+}


### PR DESCRIPTION
Closes #1965 (its BUG half — the administration half is split out as #1982, per the maintainer's
decision to separate the two).

## First: was it a REGISTRATION failure or a LOADING failure?

**Loading — and it is already fixed.** The issue's title claim ("the landed Anthropic module
registers NO chat-client factory") does not reproduce on any current build:

- `memex.systemorph.com` right now serves a `MeshWeaver.AI.Anthropic` node of `nodeType:
  ModuleDefinition`, alongside 16 others. That node is *produced by* `AnthropicProvidersAttribute.Nodes`,
  and `MeshBuilder.InstallServices` applies each node's `GlobalServiceConfigurations` in the same
  pass that collects it — so the node existing IS the registration having run.
- The maintainer's own follow-up on #1965 (07:56Z, from a Debug-log session on ci.4730) reports
  `[AnthropicChatClientAgentFactory] Initialized with Endpoint=…/anthropic/, ApiKey=set, Models (3)`
  in the boot log, and calls the no-factory theory "an earlier boot's mis-served round".
- That earlier boot is exactly **#1949/#1954**: the activation gate looked in `modules/<name>/`
  while landing writes `modules/<name>@<gen>/`, so a generation-landed module never loaded and its
  attribute was never read. `MeshWeaver.AI.Anthropic` landed as `modules/MeshWeaver.AI.Anthropic@ffb86f44`
  — a generation directory — which is why "the DLL contains the attribute" and "no factory in DI"
  were both true at once.

The same cause explains the issue's second symptom (`Anthropic__Models__*` configured but no claude
`LanguageModel` nodes materialized): `BuiltInLanguageModelProvider` iterates the **registered
catalog sources**, and the Anthropic source ships in the same unloaded module. No source, no nodes.

`ProviderModulePackBootTest` (added here) pins the half the platform owns, so a real regression of
this shape fails a test instead of a portal: a provider module's assembly attribute must fold BOTH
its catalog source and its `IChatClientFactory` into DI through `MeshBuilder.InstallAssemblies`.
The provider modules themselves live in MeshWeaver.Plugins now, so the platform can only pin the
contract — the pack in the test is modelled line-for-line on `AnthropicProvidersAttribute`.

## What this PR actually FIXES

The defect #1965 narrowed to, and the one that cost a week of wrong model routing.

Every provider factory resolves its driver config in two steps —
`endpoint = resolution.Endpoint ?? configuration.Endpoint`,
`apiKey = resolution.ApiKey ?? configuration.ApiKey`. So a deployment that keeps a provider's key in
configuration (`Anthropic__ApiKey`) serves that provider's models perfectly well **even when the
`ModelProvider` node carries no key**. `ChatClientCredentialResolver` read only the node, so:

- `HasUsableCredential("claude-sonnet-4-6")` → **false**, for a model that runs;
- `AgentChatClient.ApplyStaleModelFallback` reads "unusable" as "stale selection" and **silently**
  swaps the user's explicit pick for the deployment default — deliberately silent for the user, and
  correctly so, which is why nobody could see it.

The resolver's own doc asserted this was impossible — *"a model whose key comes from the factory's
own config/IOptions fallback … already resolves `Missing` today and was never eligible as a catalog
default"* — written as a no-regression reassurance. **That claim was the defect**, and it is now
replaced by the opposite statement plus the incident that falsified it.

### Why the node is keyless in the first place

The catalog seeder stamps `{Section}:ApiKey` onto the `ModelProvider` node **create-if-absent** and
marks it `SyncBehavior.ExcludeThisAndChildren` — so a key added to a deployment AFTER the node
exists reaches every factory and never reaches the node. Measured, not inferred:
`Provider/Anthropic` on memex.systemorph.com was created by `system-security` on **2026-08-14** with
no key, `Anthropic__ApiKey` was configured after that, and the node stayed keyless until a human
pasted the key into it on **2026-08-21**. Everything in between resolved as unusable.

### The change

`Resolve` gains a fourth rung — the deployment's own configuration for the catalog source whose
`ProviderName` the model declares. Three deliberate constraints:

- **Last.** Consulted only when the node rungs produced no key; administered node data always wins.
- **Merged per FIELD, like the factories do it.** A node-supplied endpoint survives; only the
  missing key is filled in. Merging whole resolutions would let a config endpoint override an
  administered one.
- **Key or nothing.** A section with an endpoint and no key returns null, so an endpoint-only
  provider (the `z-ai/glm-5.2` report) stays correctly unusable — the fix must not turn every model
  green.

`Source` now names both rungs (`providerRef:Provider/Anthropic+config:Anthropic`), because "which
source answered" is the question an operator asks when a key is stale — and it is the first half of
what #1982 asks the admin surface to render.

**This is a compensator, not a cure.** It makes the platform agree with what actually runs; it does
not give anyone a place to administer model configuration. That is #1982, filed as the problem
statement (config spread across Helm values, a create-if-absent seeder and live nodes, with #1925
and #1880 as two more faces of it).

## Non-vacuity

`ModelWhoseKeyLivesOnlyInDeploymentConfig_IsUsable` was run against **unmodified `origin/main`
(ed769bf0f)** before the fix existed, and fails with the exact shape of the incident:

```
MeshWeaver.Reactive.Assertions.ObservableAssertionException :
  Expected the observable to emit a value matching the predicate within 15s because the deployment's
  configured key serves this provider's models, but it did not. Last of 300 emission(s) was:
  CredentialResolution { Endpoint = https://node.example/anthropic/v1/messages, ApiKey = ,
                         Source = providerRef:Provider/AnthropicProbeExisting }.
```

`ApiKey` empty while `AnthropicProbe:ApiKey` is configured. The negative test
(`ModelWithNoKeyAnywhere_StaysUnusable`) passed both before and after, so the fix is bounded.

## Verification

| What | Result |
|---|---|
| `MeshWeaver.AI.Test` (full, `-c Release`) | **1181 passed / 0 failed / 3 skipped**, 1 m 54 s |
| `MeshWeaver.Acme.Test` — model picker | 5 passed |
| `MeshWeaver.Hosting.Monolith.Test` — LanguageModel / AgentChatClient / AgentSyncedQuery | 5 passed |
| `MeshWeaver.Threading.Test` — `DelegationSubThreadUsageTest` | 1 passed |
| `MeshWeaver.Documentation.Test` — `WhatsNewEntryIntegrityTest` | 1 passed |
| `MeshWeaver.AI`, `MeshWeaver.Documentation`, `Memex.Portal.Shared` | `-c Release -warnaserror`, 0 warnings |

No test or portal `appsettings.json` carries a provider `ApiKey`, and the test `IConfiguration` is
built from `appsettings.json` only (no environment variables), so the new rung is inert everywhere
except where a test sets it deliberately.

What's New: `Category: Fix` — a user picking a model and getting a different one is user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
