### PR TITLE
Restore the 14 pins the satellite repos consume

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -183,4 +183,28 @@
     <PackageVersion Include="Octokit.Reactive" Version="14.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- 🚨 PINS THE SATELLITE REPOS CONSUME. This file is the ONE source of package versions for
+         the plugin repos too — MeshWeaver.Plugins et al. declare NO PackageVersion of their own and
+         resolve every version from here through $(MeshWeaverRoot). So "no project in THIS repo
+         references it" does not mean a pin is dead: these fourteen belong to modules that LEFT the
+         platform (the AI providers, Mail/Graph, the agent SDKs) and are referenced from the plugin
+         repos alone. Pruning them as orphans (2026-08-21) turned nine module-bundle jobs red on the
+         plugins trunk with a build failure that named only the package. Audit across the satellites
+         before removing anything here. -->
+    <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.10" />
+    <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
+    <PackageVersion Include="ClaudeAgentSdk" Version="0.2.1" />
+    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.8" />
+    <PackageVersion Include="Microsoft.Agents.AI.AzureAI" Version="1.0.0-rc5" />
+    <PackageVersion Include="Microsoft.Agents.AI.AzureAI.Persistent" Version="1.4.0-preview.260505.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.17.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="10.0.0-preview.1.25559.3" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Graph" Version="6.2.0" />
+    <PackageVersion Include="OpenAI" Version="2.12.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
**Regression from #1978.** The orphan audit scanned this repo only, but `Directory.Packages.props` is the single source of versions for the plugin repos too — they declare none and resolve through `$(MeshWeaverRoot)`. Fourteen pruned pins belong to modules that *left* the platform (AI providers, Mail/Graph, agent SDKs) and are referenced from the satellites alone; removing them turned **nine module-bundle jobs red** on the plugins trunk, with a build failure naming only the package.

Restored, with the cross-repo audit rule written beside them. Verified `MeshWeaver.AI.WebSearch` builds green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)