### PR TITLE
A pooled leg torn down by a drain must TERMINATE, not just be disposed (#1789)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-messages-keep-flowing-during-shutdown.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-messages-keep-flowing-during-shutdown.md
@@ -1,0 +1,13 @@
+---
+Name: Messages keep flowing while a server is shutting down
+Category: Fix
+Description: A server going offline no longer strands the queue of messages waiting behind it, so pages served by the remaining servers stay responsive throughout a deployment.
+Icon: Sparkle
+Order: -20260821
+---
+
+# Messages keep flowing while a server is shutting down
+
+When a portal server begins shutting down — which happens on every deployment — it stops the background workers that carry messages between parts of the mesh. A message already being carried was torn down at that moment without ever reporting that it had finished, so the bookkeeping that lets the next message for the same destination start never ran. The queue behind that destination stopped moving and never recovered, for as long as the process was still winding down.
+
+The tear-down now reports itself, so the next message starts as it should. Deployments observed queues thirty-three messages deep sitting completely still for over ten minutes; that backlog no longer forms, and the diagnostics that say "the backlog cleared" can be emitted again instead of being impossible to reach.

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
@@ -300,9 +300,43 @@ public sealed class IoPool : IIoPool, IDisposable
                             observer.OnError(ex);
                     });
 
-            // If the pool drains AFTER the subscribe completed, tear the live subscription down too.
+            // If the pool drains AFTER the subscribe completed, tear the live subscription down too
+            // — and TERMINATE the observer, which disposing it does not do.
+            //
+            // 🚨 THE OTHER HALF OF THE SAME LEAK — issue #1789. The error arm above covers a leg the
+            // drain cancels BEFORE or DURING `source.Subscribe(observer)`: its gate wait throws
+            // OperationCanceledException and the arm turns that into OnCompleted. A leg cancelled
+            // AFTER the subscribe completed never goes near that arm — it arrives here, and this
+            // registration used to call `inner.Dispose()` and nothing else. Disposing a subscription
+            // EMITS NOTHING: no OnCompleted, no OnError. So the observable returned by
+            // SubscribeThroughPool terminated in neither direction and every `.Finally(...)` hung off
+            // it never ran — exactly the bookkeeping that decrements RoutingGrain's `inFlightRoutes`
+            // and advances OrderedRouteDispatcher's per-destination FIFO. The slot leaked and the
+            // destination's queue stranded PERMANENTLY, which is also why `cleared after` became
+            // structurally impossible to log (it needs in-flight to fall back below half the
+            // threshold). Prod, 2026-08-17: two saturation Criticals ten minutes apart at identical
+            // depth, both emitted deep inside the termination grace period — i.e. after
+            // IoPool.Drain() had cancelled `_poolCts` — with no clear line in the whole window.
+            //
+            // OnCompleted, not OnError, for the same reason the arm above chose it: a drain is
+            // expected teardown, not a fault. The latch makes the terminal exactly-once even if the
+            // drain races an unsubscribe (Rx's AutoDetachObserver would swallow a second one anyway;
+            // relying on that would leave the invariant implicit).
+            //
+            // This does NOT change IoPool.Drain()'s join reasoning: a leg past its subscribe holds
+            // no gate permit and is not counted in `_inFlight`, so terminating it moves neither the
+            // permit count Drain re-acquires nor the residual it reports.
+            var drainTerminated = 0;
             IDisposable drainReg;
-            try { drainReg = _poolCts.Token.Register(inner.Dispose); }
+            try
+            {
+                drainReg = _poolCts.Token.Register(() =>
+                {
+                    if (Interlocked.Exchange(ref drainTerminated, 1) != 0) return;
+                    inner.Dispose();
+                    observer.OnCompleted();
+                });
+            }
             catch (ObjectDisposedException) { drainReg = Disposable.Empty; }
 
             return new CompositeDisposable(setup, inner, drainReg);

--- a/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
@@ -610,6 +610,78 @@ public class IoPoolTest
             "the drain cancels before the permit is granted, so leg B's source must never be subscribed");
     }
 
+    /// <summary>
+    /// 🚨 A leg the drain cancels AFTER its subscribe completed must ALSO terminate — issue #1789,
+    /// the other half of <see cref="Drain_terminates_a_SubscribeThroughPool_leg_it_cancels"/>.
+    ///
+    /// <para>That test covers a leg cancelled BEFORE or DURING <c>source.Subscribe(observer)</c>:
+    /// its gate wait throws <see cref="OperationCanceledException"/> and the error arm turns it into
+    /// <c>OnCompleted</c>. A leg whose subscribe already RETURNED never reaches that arm. It is torn
+    /// down by the drain's cancellation registration, which disposed the inner subscription and
+    /// nothing else — and <b>disposing a subscription emits nothing</b>. No <c>OnCompleted</c>, no
+    /// <c>OnError</c>, so the observable terminated in neither direction and every
+    /// <c>.Finally(...)</c> hung off it never ran.</para>
+    ///
+    /// <para>That bookkeeping is <c>RoutingGrain.Dispatch</c>'s in-flight decrement and
+    /// <c>OrderedRouteDispatcher.DrainNext</c>'s FIFO advance. Leaking it strands a destination's
+    /// queue permanently and makes the <c>cleared after</c> line structurally impossible to emit
+    /// (it requires in-flight to fall back below half the saturation threshold) — which is exactly
+    /// what prod showed on 2026-08-17: two saturation Criticals ten minutes apart at identical
+    /// depth, both deep inside the termination grace period, with no clear line in the window.</para>
+    ///
+    /// <para>Deterministic and bounded: the source's subscribe returns immediately, and the test
+    /// waits for the pool's permit to be released before draining — so the leg is provably PAST the
+    /// window the sibling test covers. Disposal of the inner subscription is asserted first, so a
+    /// failure on termination cannot be confused with a drain that never ran.</para>
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Drain_terminates_a_SubscribeThroughPool_leg_that_already_subscribed()
+    {
+        using var pool = new IoPool(2);
+        var subscribed = new ManualResetEventSlim();
+        var innerDisposed = new ManualResetEventSlim();
+        var terminated = new ManualResetEventSlim();
+
+        // A LONG-LIVED source, the shape every real SubscribeThroughPool caller has: the subscribe
+        // returns promptly (releasing the pool permit) and the subscription then stays open,
+        // emitting on its own schedule. Nothing here emits — the leg is simply alive when the pool
+        // drains, which is what host shutdown does to every live route.
+        var source = Observable.Create<int>(obs =>
+        {
+            subscribed.Set();
+            return System.Reactive.Disposables.Disposable.Create(innerDisposed.Set);
+        });
+
+        using var sub = pool.SubscribeThroughPool(source)
+            .Finally(terminated.Set)
+            .Subscribe(_ => { }, _ => { });
+
+        Assert.True(subscribed.Wait(Timeout5),
+            "the source must have been subscribed before the drain — this test is about the window "
+            + "AFTER the subscribe completed");
+        Assert.True(SpinWait.SpinUntil(() => pool.CurrentInFlight == 0, Timeout5),
+            "the setup leaf must have released its permit, so the leg is provably past the subscribe "
+            + "window the sibling test covers (otherwise this would re-test that one)");
+
+        var drainDone = Task.Run(pool.Drain, TestContext.Current.CancellationToken);
+
+        Assert.True(innerDisposed.Wait(Timeout5),
+            "the drain must tear the live inner subscription down — asserted FIRST so a failure on "
+            + "termination below is attributable to the missing terminal, not to a drain that never ran");
+        // 🚨 THE REGRESSION GUARD. Before the fix this never fired: the drain disposed the inner
+        // subscription and emitted nothing, so `.Finally` never ran and this waited out its budget.
+        Assert.True(terminated.Wait(Timeout5),
+            "a leg the drain tears down AFTER its subscribe completed MUST terminate (OnCompleted) so "
+            + "its .Finally runs — that callback releases RoutingGrain's in-flight route slot and "
+            + "advances OrderedRouteDispatcher's per-destination FIFO; disposing the subscription "
+            + "emits nothing, so without an explicit terminal both leak permanently (#1789)");
+
+        var residual = await drainDone.WaitAsync(Timeout10, TestContext.Current.CancellationToken);
+        residual.Should().Be(0,
+            "a leg past its subscribe holds no gate permit, so terminating it must not change what "
+            + "Drain joins or reports");
+    }
+
     [Fact]
     public void Unbounded_fallback_runs_the_leaf_on_the_threadpool()
     {


### PR DESCRIPTION
Step 1 of 3 for #1742 — landed first and separately because it is smaller, live, independently valuable, and in the same file the rest of that work touches.

## The defect

`IoPool.SubscribeThroughPool` has two teardown paths and only one of them ended the observable.

- A leg the drain cancels **before or during** `source.Subscribe(observer)` throws `OperationCanceledException` out of its gate wait, and the error arm turns that into `OnCompleted`. Already fixed; pinned by `Drain_terminates_a_SubscribeThroughPool_leg_it_cancels`.
- A leg cancelled **after** the subscribe completed never reaches that arm. It is torn down by `_poolCts.Token.Register(inner.Dispose)` — and **disposing a subscription emits nothing.** No `OnCompleted`, no `OnError`.

So the observable terminated in neither direction and every `.Finally(...)` hung off it never ran. That is the bookkeeping which decrements `RoutingGrain`'s `inFlightRoutes` and advances `OrderedRouteDispatcher`'s per-destination FIFO: the slot leaked and the destination's queue stranded permanently. `ReportDrained` requires in-flight to fall back below half the saturation threshold, so the `cleared after` line became **structurally impossible to emit** — its absence was a true signal, not a lost log line.

Production, 2026-08-17: two saturation Criticals ten minutes apart at identical depth 33 on the same pod, both emitted 14 and 24 minutes into the termination grace period — i.e. after `IoPool.Drain()` had cancelled the pool token — with no clear line anywhere in the six-hour window.

## The fix

The drain registration disposes the inner subscription **and** completes the observer, latched so the terminal is exactly-once even if the drain races an unsubscribe. `OnCompleted` rather than `OnError`, for the same reason the other arm chose it: a drain is expected teardown, not a fault.

It does not move `Drain()`'s join reasoning — a leg past its subscribe holds no gate permit and is not counted in `_inFlight`, so terminating it changes neither the permits `Drain` re-acquires nor the residual it reports. The new test asserts that too.

## Non-vacuity

Against the unmodified pool:

```
[xUnit.net 00:00:05.97]     IoPoolTest.Drain_terminates_a_SubscribeThroughPool_leg_that_already_subscribed [FAIL]
  Failed IoPoolTest.Drain_terminates_a_SubscribeThroughPool_leg_that_already_subscribed [5 s]
  Error Message:
   a leg the drain tears down AFTER its subscribe completed MUST terminate (OnCompleted) so its
   .Finally runs — that callback releases RoutingGrain's in-flight route slot and advances
   OrderedRouteDispatcher's per-destination FIFO; disposing the subscription emits nothing, so
   without an explicit terminal both leak permanently (#1789)
```

The test asserts **first** that the drain genuinely ran (the inner subscription was disposed), so the failure is attributable to the absent terminal rather than to a drain that never happened. Every wait is bounded — an unbounded one would hang the way the bug does.

## Suites

| suite | result |
|---|---|
| `MeshWeaver.Hosting.Test` | 200/200 |
| `MeshWeaver.Hosting.Orleans.Test` | 177/177 |
| `MeshWeaver.Messaging.Hub.Test` | 263/263 |
| `MeshWeaver.Hosting.Monolith.Test` | 743 passed, 3 skipped, 0 failed |

Fixes #1789.