### PR TITLE
Module bundles carry static web assets — the view-pack lane

### DIFF
--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -383,6 +383,21 @@ public static class ModulePackCommand
         // The package tree, walked in a stable order so two packs of the same tree produce
         // byte-identical manifests. obj/bin are a developer's build residue, never package content
         // — the same exclusions PluginPacker applies.
+        // 🚨 STATIC WEB ASSETS ride the bundle. A view pack's CSS/JS reaches the browser through
+        // the host's build-time static-web-assets graph — i.e. through the ProjectReference the
+        // module lane removes — so without this a landed view pack renders unstyled and its
+        // collocated JS 404s. A standalone RCL publish lays them under wwwroot/ (its own assets at
+        // the root, dependencies' already namespaced under wwwroot/_content/<Dep>/), which is the
+        // exact shape MeshModuleStaticAssetExtensions serves from modules/<Name>/wwwroot.
+        var assetRoot = Path.Combine(moduleDirectory, "wwwroot");
+        var staticAssets = Directory.Exists(assetRoot)
+            ? Directory.EnumerateFiles(assetRoot, "*", SearchOption.AllDirectories)
+                .Select(f => "wwwroot/" + Path.GetRelativePath(assetRoot, f)
+                    .Replace(Path.DirectorySeparatorChar, '/'))
+                .OrderBy(r => r, StringComparer.Ordinal)
+                .ToList()
+            : [];
+
         var contentFiles = new List<string>();
         var includeSource = false;
         if (contentDirectory is not null)
@@ -430,7 +445,9 @@ public static class ModulePackCommand
                 // Diagnostic: the exact platform build behind these bytes. The consumer's GATE is
                 // the module section's minMeshVersion floor below.
                 frameworkMvid,
-                module = new { assemblyName = moduleName, assemblies = closure, minMeshVersion },
+                module = new { assemblyName = moduleName, assemblies = closure, minMeshVersion,
+                    staticAssets = staticAssets.Count > 0 ? staticAssets : null,
+                },
                 // DECLARED, so BundleReader.ReadContent stays manifest-driven — these files are
                 // written into a consumer's working tree, and a glob would recreate anything a
                 // future producer happens to drop in the folder.
@@ -454,6 +471,13 @@ public static class ModulePackCommand
                     NuGetPackageWriter.ModuleEntryPathFor(fileName), () => File.OpenRead(path));
             })
             .ToList();
+
+        entries.AddRange(staticAssets.Select(relative =>
+        {
+            var path = Path.Combine(moduleDirectory, relative.Replace('/', Path.DirectorySeparatorChar));
+            return new NuGetPackageWriter.Entry(
+                NuGetPackageWriter.ModuleAssetEntryPathFor(relative), () => File.OpenRead(path));
+        }));
 
         entries.AddRange(contentFiles.Select(relative =>
         {

--- a/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
@@ -72,12 +72,24 @@ public static class BundleReader
     /// semver floor). Null = no constraint. The manifest-level <see cref="Manifest.FrameworkMvid"/>
     /// stays the NodeType lane's strict gate and, for the module, DIAGNOSTIC metadata only.</param>
     public sealed record ModuleRef(
-        string? AssemblyName, IReadOnlyList<string>? Assemblies, string? MinMeshVersion = null);
+        string? AssemblyName, IReadOnlyList<string>? Assemblies, string? MinMeshVersion = null,
+        IReadOnlyList<string>? StaticAssets = null);
 
     /// <summary>One landed-to-be module file: its name and bytes.</summary>
     /// <param name="FileName">File name as the manifest declared it.</param>
     /// <param name="Bytes">The file's bytes.</param>
     public sealed record ModuleFile(string FileName, byte[] Bytes);
+
+    /// <summary>
+    /// One static web asset travelling with a compiled module — a view pack's <c>wwwroot</c>.
+    /// Kept apart from <see cref="ModuleFile"/> because the two are placed differently: an
+    /// assembly is a FLAT file beside the entry DLL, while an asset keeps its relative path so
+    /// <c>modules/&lt;name&gt;/wwwroot/leaflet/leaflet.js</c> survives the trip.
+    /// </summary>
+    /// <param name="RelativePath">Path under the module folder, forward slashes, e.g.
+    /// <c>wwwroot/leaflet/leaflet.css</c>.</param>
+    /// <param name="Bytes">The file's bytes, verbatim.</param>
+    public sealed record ModuleAsset(string RelativePath, byte[] Bytes);
 
     /// <summary>One node-definition file recovered from the bundle.</summary>
     /// <param name="RelativePath">Path within the package tree, exactly as the manifest declared
@@ -315,6 +327,36 @@ public static class BundleReader
     /// <param name="bundle">The archive bytes.</param>
     /// <returns>The manifest (null when the archive carries none) and the module's files — empty
     /// when the bundle declares no module or the declared closure is incomplete.</returns>
+    /// <summary>
+    /// The module's STATIC WEB ASSETS, read by the same all-or-nothing rule as its assemblies: a
+    /// declared asset the archive does not carry means an incomplete bundle, and half a view pack
+    /// renders unstyled rather than failing.
+    /// </summary>
+    public static IReadOnlyList<ModuleAsset> ReadModuleAssets(byte[] bundle)
+    {
+        using var buffer = new MemoryStream(bundle, writable: false);
+        using var archive = new ZipArchive(buffer, ZipArchiveMode.Read);
+
+        var manifestEntry = archive.GetEntry(NuGetPackageWriter.ManifestEntry);
+        if (manifestEntry is null)
+            return [];
+        Manifest? manifest;
+        using (var stream = manifestEntry.Open())
+            manifest = JsonSerializer.Deserialize<Manifest>(stream, Json);
+        if (manifest?.Module?.StaticAssets is not { Count: > 0 } declared)
+            return [];
+
+        var assets = new List<ModuleAsset>();
+        foreach (var relative in declared)
+        {
+            var entry = archive.GetEntry(NuGetPackageWriter.ModuleAssetEntryPathFor(relative));
+            if (entry is null)
+                return [];
+            assets.Add(new ModuleAsset(relative, ReadAll(entry)));
+        }
+        return assets;
+    }
+
     public static (Manifest? Manifest, IReadOnlyList<ModuleFile> Files) ReadModule(byte[] bundle)
     {
         using var buffer = new MemoryStream(bundle, writable: false);

--- a/src/MeshWeaver.Plugin.Packaging/NuGetPackageWriter.cs
+++ b/src/MeshWeaver.Plugin.Packaging/NuGetPackageWriter.cs
@@ -70,6 +70,18 @@ public static class NuGetPackageWriter
     public static string ModuleEntryPathFor(string fileName) =>
         $"{ModuleFolder}/{fileName}";
 
+    /// <summary>
+    /// Where a module's STATIC WEB ASSETS ride. Separate from <see cref="ModuleFolder"/> because
+    /// module files are flat while assets keep their relative path: a view pack's
+    /// <c>wwwroot/leaflet/leaflet.js</c> has to land under the same relative path or the URLs its
+    /// own components request (<c>_content/&lt;pack&gt;/…</c>) resolve to nothing.
+    /// </summary>
+    public const string ModuleAssetFolder = "meshweaver/moduleassets";
+
+    /// <summary>The bundle entry path for one static asset, by its module-relative path.</summary>
+    public static string ModuleAssetEntryPathFor(string relativePath) =>
+        $"{ModuleAssetFolder}/{relativePath}";
+
     /// <summary>One file destined for the package.</summary>
     /// <param name="PathInPackage">Full entry path, e.g. <c>meshweaver/content/index.json</c>.</param>
     /// <param name="OpenRead">Opens the bytes. A factory rather than a byte[] so a large assembly

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -148,12 +148,32 @@ public sealed class ModuleLandingService : IDisposable
         string? frameworkMvid = null,
         string? packagePath = null,
         string? version = null,
-        string? minMeshVersion = null)
+        string? minMeshVersion = null,
+        IReadOnlyList<(string RelativePath, byte[] Bytes)>? staticAssets = null)
         => pool.InvokeBlocking(_ =>
         {
-            LandCore(name, assemblies, frameworkMvid, packagePath, version, minMeshVersion);
+            LandCore(name, assemblies, frameworkMvid, packagePath, version, minMeshVersion,
+                staticAssets);
             return Unit.Default;
         });
+
+    /// <summary>
+    /// Validates one module-relative asset path: forward slashes, no rooting, no traversal, and
+    /// every segment a legal file name. These strings become PATHS UNDER the module folder, so a
+    /// segment that escapes it is a write anywhere the process can reach — refused here, before
+    /// any byte touches disk, exactly like the flat assembly names.
+    /// </summary>
+    internal static void ValidateAssetPath(string? value, string moduleName)
+    {
+        if (string.IsNullOrWhiteSpace(value)
+            || value.Contains('\\')
+            || value.StartsWith('/')
+            || Path.IsPathRooted(value))
+            throw new ArgumentException(
+                $"Module '{moduleName}': '{value}' is not a valid module-relative asset path.");
+        foreach (var segment in value.Split('/'))
+            ValidateFileName(segment, $"asset path segment of module '{moduleName}'");
+    }
 
     /// <summary>
     /// Reads the current activation list on this service's IO pool — the runtime counterpart of the
@@ -184,8 +204,11 @@ public sealed class ModuleLandingService : IDisposable
         string? frameworkMvid,
         string? packagePath,
         string? version,
-        string? minMeshVersion)
+        string? minMeshVersion,
+        IReadOnlyList<(string RelativePath, byte[] Bytes)>? staticAssets = null)
     {
+        foreach (var (relativePath, _) in staticAssets ?? [])
+            ValidateAssetPath(relativePath, name);
         ValidateFileName(name, "module name");
         if (assemblies is not { Count: > 0 })
             throw new ArgumentException($"Module '{name}': no assemblies to land.", nameof(assemblies));
@@ -241,6 +264,16 @@ public sealed class ModuleLandingService : IDisposable
         {
             foreach (var (fileName, bytes) in assemblies)
                 File.WriteAllBytes(Path.Combine(staging, fileName), bytes);
+            // Static web assets keep their RELATIVE path — a view pack's components request
+            // _content/<pack>/leaflet/leaflet.js, and the host's module asset provider serves
+            // <module folder>/wwwroot, so the shape has to survive the trip intact.
+            foreach (var (relativePath, bytes) in staticAssets ?? [])
+            {
+                var destination = Path.Combine(
+                    staging, relativePath.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+                File.WriteAllBytes(destination, bytes);
+            }
             Directory.Move(staging, target);
         }
         catch

--- a/src/MeshWeaver.PluginCatalog/ModulePublish.cs
+++ b/src/MeshWeaver.PluginCatalog/ModulePublish.cs
@@ -44,7 +44,8 @@ public static class ModulePublish
         string? MinMeshVersion,
         string? FrameworkMvid,
         IReadOnlyList<(string FileName, byte[] Bytes)> Files,
-        string? PackagePath = null);
+        string? PackagePath = null,
+        IReadOnlyList<(string RelativePath, byte[] Bytes)>? StaticAssets = null);
 
     /// <summary>
     /// Why <paramref name="authorizationHeader"/> may not publish, or null when it may.
@@ -87,7 +88,8 @@ public static class ModulePublish
         BundleReader.Manifest? manifest,
         IReadOnlyList<BundleReader.ModuleFile> files,
         string? version = null,
-        string? packagePath = null)
+        string? packagePath = null,
+        IReadOnlyList<BundleReader.ModuleAsset>? staticAssets = null)
     {
         // The package path ("Plugins/AzureBlob") is what stamps the landed entry's SOURCE — the
         // key every PluginGrant and serve-side filter matches on. Optional (an older publisher
@@ -149,6 +151,9 @@ public static class ModulePublish
             manifest.Module.MinMeshVersion,
             manifest.FrameworkMvid,
             [.. files.Select(f => (f.FileName, f.Bytes))],
-            string.IsNullOrWhiteSpace(packagePath) ? null : packagePath), null);
+            string.IsNullOrWhiteSpace(packagePath) ? null : packagePath,
+            staticAssets is { Count: > 0 }
+                ? [.. staticAssets.Select(a => (a.RelativePath, a.Bytes))]
+                : null), null);
     }
 }

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -311,7 +311,13 @@ public sealed class PluginBundleClient
                         manifest!.FrameworkMvid,
                         packagePath,
                         version,
-                        manifest.Module?.MinMeshVersion)
+                        manifest.Module?.MinMeshVersion,
+                        // A view pack's wwwroot rides the bundle (#1724's provider serves it from
+                        // the module folder); without this the pack lands unstyled and its
+                        // collocated JS 404s.
+                        BundleReader.ReadModuleAssets(bundleBytes) is { Count: > 0 } assets
+                            ? [.. assets.Select(a => (a.RelativePath, a.Bytes))]
+                            : null)
                     .Select(_ => files.Count)
                     .Do(count => _logger?.LogInformation(
                         "Module '{Module}' of {Plugin} landed ({Count} file(s), version {Version}) "

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleStaticAssetLandingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleStaticAssetLandingTest.cs
@@ -1,0 +1,97 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Static web assets travelling with a compiled module (the view-pack lane). An assembly is a FLAT
+/// file beside the entry DLL; an asset keeps its RELATIVE path, because the pack's own components
+/// request <c>_content/&lt;pack&gt;/leaflet/leaflet.js</c> and the host serves the module folder's
+/// <c>wwwroot</c> — the shape has to survive the trip or the pack lands unstyled.
+/// </summary>
+public class ModuleStaticAssetLandingTest : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-assets-" + Guid.NewGuid().ToString("N"));
+
+    public ModuleStaticAssetLandingTest() => Directory.CreateDirectory(root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+    }
+
+    private ModuleLandingService Service => new(baseDirectory: root);
+
+    [Fact]
+    public async Task Assets_LandUnderTheGeneration_KeepingTheirRelativePath()
+    {
+        using var service = Service;
+        await service.LandModule(
+                "Acme.Views",
+                [("Acme.Views.dll", [1])],
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                version: "1.0.0",
+                staticAssets:
+                [
+                    ("wwwroot/Acme.Views.styles.css", "CSS"u8.ToArray()),
+                    ("wwwroot/leaflet/leaflet.js", "JS"u8.ToArray()),
+                ])
+            .FirstAsync().ToTask();
+
+        var entry = ModuleActivationSidecar.Read(root).Entries.Single();
+        var dir = ModuleLandingService.ModuleDirectoryFor(root, "Acme.Views", entry);
+
+        Assert.Equal("CSS", File.ReadAllText(Path.Combine(dir, "wwwroot", "Acme.Views.styles.css")));
+        Assert.Equal("JS", File.ReadAllText(Path.Combine(dir, "wwwroot", "leaflet", "leaflet.js")));
+        // The entry DLL stays FLAT beside them — the two placements are different on purpose.
+        Assert.True(File.Exists(Path.Combine(dir, "Acme.Views.dll")));
+    }
+
+    [Theory]
+    [InlineData("../escape.js")]
+    [InlineData("wwwroot/../../escape.js")]
+    [InlineData("/etc/passwd")]
+    [InlineData("wwwroot\\windows\\sep.js")]
+    [InlineData("")]
+    public void AnAssetPathThatEscapesTheModuleFolder_IsRefused(string path)
+    {
+        // These strings become paths UNDER the module folder, so a segment that escapes it is a
+        // write anywhere the process can reach. Refused before any byte touches disk.
+        Assert.Throws<ArgumentException>(
+            () => ModuleLandingService.ValidateAssetPath(path, "Acme.Views"));
+    }
+
+    [Fact]
+    public void AnOrdinaryNestedPath_IsAccepted()
+    {
+        ModuleLandingService.ValidateAssetPath("wwwroot/leaflet/images/marker.png", "Acme.Views");
+        ModuleLandingService.ValidateAssetPath("wwwroot/x.css", "Acme.Views");
+    }
+
+    [Fact]
+    public async Task ARefusedAssetPath_LandsNOTHING()
+    {
+        using var service = Service;
+        var act = () => service.LandModule(
+                "Acme.Views", [("Acme.Views.dll", [1])],
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                staticAssets: [("../escape.js", [9])])
+            .FirstAsync().ToTask();
+
+        await Assert.ThrowsAsync<ArgumentException>(act);
+        var modules = Path.Combine(root, "modules");
+        Assert.True(!Directory.Exists(modules) || Directory.GetDirectories(modules).Length == 0);
+        Assert.Empty(ModuleActivationSidecar.Read(root).Entries);
+    }
+}


### PR DESCRIPTION
**The blocker for moving the Blazor view packs.** A bundle carried assemblies only, so a view pack could be packed, published and landed and still render unstyled with its collocated JS 404ing — an RCL's `wwwroot` reaches the browser through the host's build-time static-web-assets graph, i.e. the `ProjectReference` the module lane removes.

The host half already exists (#1724 serves `modules/<Name>/wwwroot` at `_content/<Name>/`, resolving from the assembly's own folder — already generation-safe). This adds everything upstream: pack collects `wwwroot/**` and declares `module.staticAssets`; the bundle carries them under `meshweaver/moduleassets/`; landing writes them into the generation **keeping their relative path**; both the registry publish route and the consumer adopt pass them through.

🚨 Asset paths become paths *under* the module folder, so traversal is refused before any byte touches disk and a refusal lands **nothing** — pinned for `..`, rooted paths and Windows separators.

557/557 PluginCatalog tests green (8 new). Verified separately: a standalone RCL publish already emits its scoped-CSS bundle, so no `DisableScopedCssBundling` machinery is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)