### PR TITLE
Add security response headers to the portal (CSP staged Report-Only; nosniff, Permissions-Policy, CORP enforced)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1118,6 +1118,46 @@ public static class MemexConfiguration
             return next();
         });
 
+        // Security response headers — set once, early, for every real response (health
+        // probes already short-circuited above, so they stay header-free and minimal).
+        // These harden the browser surface WITHOUT changing what the app may load: the CSP
+        // is deliberately permissive — it keeps 'unsafe-inline'/'unsafe-eval', blob:/data:
+        // and https:/wss:, so the Blazor Server circuit, the Monaco editor (eval + blob
+        // workers) and embedded https content keep working. It only adds the structural
+        // directives an OWASP ZAP scan flagged as missing (a default-src fallback so every
+        // fetch directive is defined, object-src 'none', base-uri 'self', frame-ancestors
+        // 'self'). Tightening it further (per-response nonces, dropping 'unsafe-inline') is
+        // a separate hardening pass, not this change.
+        app.Use((ctx, next) =>
+        {
+            var headers = ctx.Response.Headers;
+            ctx.Response.OnStarting(() =>
+            {
+                headers["X-Content-Type-Options"] = "nosniff";
+                headers["Cross-Origin-Resource-Policy"] = "same-site";
+                headers["Permissions-Policy"] =
+                    "accelerometer=(), camera=(), geolocation=(), gyroscope=(), " +
+                    "magnetometer=(), microphone=(), payment=(), usb=()";
+                if (!headers.ContainsKey("Content-Security-Policy"))
+                    headers["Content-Security-Policy"] =
+                        "default-src 'self'; " +
+                        "base-uri 'self'; " +
+                        "object-src 'none'; " +
+                        "frame-ancestors 'self'; " +
+                        "img-src 'self' data: blob: https:; " +
+                        "media-src 'self' data: blob: https:; " +
+                        "font-src 'self' data: https:; " +
+                        "style-src 'self' 'unsafe-inline' https:; " +
+                        "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; " +
+                        "worker-src 'self' blob:; " +
+                        "connect-src 'self' https: wss:; " +
+                        "frame-src 'self' https:; " +
+                        "form-action 'self' https:";
+                return Task.CompletedTask;
+            });
+            return next();
+        });
+
         // `@/` is a markdown-authoring / autocomplete prefix — not a URL segment.
         // Authors occasionally leak `@/` into raw HTML hrefs or users paste broken links.
         // Permanent-redirect `/@/X` → `/X` so those never 404.

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1128,6 +1128,11 @@ public static class MemexConfiguration
         // fetch directive is defined, object-src 'none', base-uri 'self', frame-ancestors
         // 'self'). Tightening it further (per-response nonces, dropping 'unsafe-inline') is
         // a separate hardening pass, not this change.
+        //
+        // The CSP ships as Content-Security-Policy-Report-Only FIRST: it cannot block a
+        // single request, so it is safe to enforce on the production registry immediately
+        // while any would-be violations surface in the browser console. A one-line follow-up
+        // renames the header to Content-Security-Policy to enforce it once it is proven quiet.
         app.Use((ctx, next) =>
         {
             var headers = ctx.Response.Headers;
@@ -1138,8 +1143,8 @@ public static class MemexConfiguration
                 headers["Permissions-Policy"] =
                     "accelerometer=(), camera=(), geolocation=(), gyroscope=(), " +
                     "magnetometer=(), microphone=(), payment=(), usb=()";
-                if (!headers.ContainsKey("Content-Security-Policy"))
-                    headers["Content-Security-Policy"] =
+                if (!headers.ContainsKey("Content-Security-Policy-Report-Only"))
+                    headers["Content-Security-Policy-Report-Only"] =
                         "default-src 'self'; " +
                         "base-uri 'self'; " +
                         "object-src 'none'; " +


### PR DESCRIPTION
## What
Adds a response-header middleware to the memex portal pipeline setting four security headers an OWASP ZAP full active scan of `memex.meshweaver.cloud` (2026-08-21) flagged. The scan found **zero exploitable vulnerabilities** (all injection/XSS/RCE/traversal/SSRF rules passed) — these are hardening headers.

| Header | Before | After | Mode |
|---|---|---|---|
| `Content-Security-Policy` | `frame-ancestors 'self'` only (no fallback) | complete policy: `default-src` fallback, `object-src 'none'`, `base-uri 'self'` | **Report-Only (staged)** |
| `X-Content-Type-Options` | absent | `nosniff` | enforced |
| `Permissions-Policy` | absent | denies camera/mic/geolocation/payment/usb/motion sensors | enforced |
| `Cross-Origin-Resource-Policy` | absent | `same-site` | enforced |

## Staged CSP rollout
The CSP ships as **`Content-Security-Policy-Report-Only`** first — it cannot block a single request, so it is safe to deploy to the production registry immediately while any would-be violations surface in the browser console. A **one-line follow-up** renames the header to `Content-Security-Policy` to enforce it once proven quiet.

The policy is a **superset of what the app already loads** — keeps `'unsafe-inline'`, `'unsafe-eval'`, `blob:`/`data:` and `https:`/`wss:` so the Blazor Server circuit, the Monaco editor (eval + blob workers), and embedded https content keep working. It only adds the *structural* directives ZAP wanted.

## Placement
Runs right after the `/healthz` short-circuit (probes stay header-free) and via `Response.OnStarting`, so headers land on static-file and error responses too.

## Not addressed (correctly reported by ZAP, not defects)
- **Proxy Disclosure** — the AKS ingress, working as intended
- **Dangerous JS Functions** — inside Monaco's own library
- **Backup File Disclosure** — false positive on SVG icon filenames (`/static/NodeTypeIcons/databasebackup.svg` etc.)

## Verification
- ✅ `dotnet build Memex.Portal.Shared` — 0 warnings, 0 errors (warnings-as-errors)
- After deploy: re-run the ZAP scan. The three enforced headers clear their findings immediately; the CSP finding clears after the Report-Only → enforced flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)