### PR TITLE
Bake only what a change affects: narrow-by-affected (#1707)

### DIFF
--- a/.github/scripts/bake-scope.sh
+++ b/.github/scripts/bake-scope.sh
@@ -1,0 +1,439 @@
+#!/usr/bin/env bash
+# bake-scope.sh — decide what a node repo's CI bake must actually REBUILD.
+#
+# "When updating plugins, we should check from git history which modules are affected, and we
+# should rebuild only these." Until now the answer was always "everything": every main push, and
+# every scheduled poll, ran the full tester over every module — a ~40-minute Roslyn compile of
+# ~40 packages to republish bundles that, for all but a handful of them, are byte-for-byte the
+# ones already sealed in storage.
+#
+# This script answers the narrower question, and it answers "full" whenever it cannot answer it
+# SAFELY. That bias is the whole design: narrowing a build is the shape that produces a silent
+# under-build — a module that should have been recompiled and was not becomes a stale assembly
+# every portal seeds at boot, and the evidence of the miss is the absence of evidence. So every
+# uncertainty below (no publication yet, disagreeing targets, an unreachable baseline, a diff the
+# selector refuses, a tooling change) resolves to a FULL bake, out loud, naming which one.
+#
+#     scope=full      rebuild and republish every module (today's behaviour, and every fallback)
+#     scope=narrowed  rebuild the affected closure; carry every other bundle forward unchanged
+#     scope=none      this exact content is already sealed for this identity — build nothing
+#
+# 🚨 THE BASELINE IS THE PUBLICATION, NOT `github.event.before`. The question a bake asks is
+# "what changed since the bundles that are currently published?", and only the publication knows
+# that: it carries `source-commit.txt` beside its bundles. Diffing against the push's `before`
+# instead would silently under-build after ANY run that did not publish — a cancelled run, a
+# superseded push, a red gate, a re-run of an older commit, or the concurrency group dropping a
+# run — because those commits' modules would never appear in any later diff. Reading the baseline
+# off the sealed publication makes the answer self-correcting: whatever was actually published is
+# what we diff against, however many runs it took to get there.
+#
+# 🚨 …AND THE PUBLICATION STAYS COMPLETE. A narrowed bake produces bundles only for the modules
+# it rebuilt, but `_complete` (written LAST, listing the whole set) is what portals seed from —
+# publishing just the delta would REPLACE that sentinel and shrink what every portal adopts to
+# the delta. So this script also records the currently-sealed bundle listing, and
+# `carry-forward-bundles.sh` re-hydrates every bundle the narrowed bake did not produce before
+# the publish step runs. The publication is byte-identical in shape to a full bake's; only the
+# COMPILE was narrowed.
+#
+# ENVIRONMENT (all required)
+#   BAKE_PUBLISH_TARGETS  whitespace-separated <account>/<share>[/<base-path>]
+#   IDENTITY              the framework identity this bake targets (from the image itself)
+#   SOURCE                the bake-source segment (plugins, education, …)
+#   HEAD_SHA              the content commit about to be baked
+#   REPO_DIR              the caller repo checkout (git history + scripts/affected-modules.py)
+#   EVENT_NAME            the triggering GitHub event
+#   STATE_DIR             a writable directory for the decision's artefacts
+#
+# OUTPUTS (to $GITHUB_OUTPUT when set, and always to stdout)
+#   scope, reason, baseline, mount
+# ARTEFACTS in $STATE_DIR
+#   published-bundles.txt   the sealed publication's `_complete` listing (scope=narrowed)
+#   affected.json           the selector's full answer (scope=narrowed)
+#
+# AUTH: `az login` must already have happened; data-plane reads use --auth-mode login
+# --backup-intent, as publish-bake-bundles.sh does.
+set -uo pipefail
+
+# ── self-test ────────────────────────────────────────────────────────────────────────────────
+# 🚨 THIS SCRIPT DECIDES WHAT DOES NOT GET REBUILT, so it owes its own proof that it says "full"
+# when it cannot answer safely. Every fallback below is one that, if it silently narrowed
+# instead, would ship a stale assembly to every portal with nothing red anywhere.
+#
+#     .github/scripts/bake-scope.sh --self-test
+#
+# It runs the REAL script as a subprocess against a fixture git repo and a stub `az` whose
+# "remote" is a directory tree, so the branch taken is the branch the runner would take.
+if [ "${1:-}" = "--self-test" ]; then
+  ST_TMP=$(mktemp -d)
+  trap 'rm -rf "$ST_TMP"' EXIT
+  ME="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+  # A stub `az` whose remote is a directory tree: <root>/<account>/<share>/<path>.
+  mkdir -p "$ST_TMP/bin"
+  cat > "$ST_TMP/bin/az" <<'AZ'
+#!/usr/bin/env bash
+verb=""
+for a in "$@"; do case "$a" in exists|download) verb="$a"; break;; esac; done
+account=""; share=""; path=""; dest=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --account-name) account="$2"; shift 2;;
+    --share-name)   share="$2";   shift 2;;
+    --path)         path="$2";    shift 2;;
+    --dest)         dest="$2";    shift 2;;
+    *) shift;;
+  esac
+done
+file="$MOCK_AZ_ROOT/$account/$share/$path"
+case "$verb" in
+  exists)   { [ -f "$file" ] && echo true; } || echo false;;
+  download) [ -f "$file" ] || exit 1; mkdir -p "$(dirname "$dest")"; cp "$file" "$dest";;
+  *) exit 1;;
+esac
+AZ
+  chmod +x "$ST_TMP/bin/az"
+  PATH="$ST_TMP/bin:$PATH"
+
+  # A fixture caller repo: two commits, module dirs, and a stub selector whose answer each case
+  # chooses. The selector CONTRACT this script depends on is exit code + JSON, and that is what
+  # the fixture varies — the selector's own semantics are pinned by its own --self-test, in the
+  # repo that owns it (scripts/affected-modules.py --self-test).
+  REPO="$ST_TMP/repo"
+  mkdir -p "$REPO/scripts" "$REPO/Store" "$REPO/Edu"
+  ( cd "$REPO" && git init -q . && git config user.email t@t && git config user.name t
+    echo '{"id":"Store"}' > Store/index.json
+    echo '{"id":"Edu"}'   > Edu/index.json
+    git add -A && git commit -qm base ) > /dev/null
+  BASE_SHA=$(git -C "$REPO" rev-parse HEAD)
+  ( cd "$REPO" && echo change >> Edu/index.json && git add -A && git commit -qm change ) > /dev/null
+  HEAD_SHA=$(git -C "$REPO" rev-parse HEAD)
+  # A commit on a DIVERGED branch — resolvable, but not an ancestor of HEAD.
+  ( cd "$REPO" && git checkout -q -b other "$BASE_SHA" && echo x >> Store/index.json \
+      && git add -A && git commit -qm diverged && git checkout -q - ) > /dev/null 2>&1
+  OTHER_SHA=$(git -C "$REPO" rev-parse other)
+
+  write_selector() {  # <exit-code> <stdout>
+    { echo "import sys"
+      printf 'sys.stdout.write(%s)\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$2")"
+      echo "sys.exit($1)"
+    } > "$REPO/scripts/affected-modules.py"
+  }
+  seal() {  # <account/share[/base]> <source-sha> <bundle…>
+    local target="$1" sha="$2"; shift 2
+    local account="${target%%/*}" rest="${target#*/}"
+    local share="${rest%%/*}" base=""
+    case "$rest" in */*) base="${rest#*/}";; esac
+    local dir="$ST_TMP/remote/$account/$share/${base:+$base/}prebuilt-bundles/ID1/plugins"
+    mkdir -p "$dir"
+    printf '%s\n' "$sha" > "$dir/source-commit.txt"
+    printf '%s\n' "$@" > "$dir/_complete"
+  }
+
+  run_case() {  # <event> <targets> [<head-sha>]
+    ( unset GITHUB_STEP_SUMMARY GITHUB_ENV GITHUB_OUTPUT
+      export MOCK_AZ_ROOT="$ST_TMP/remote"
+      BAKE_PUBLISH_TARGETS="$2" IDENTITY=ID1 SOURCE=plugins \
+      HEAD_SHA="${3:-$HEAD_SHA}" REPO_DIR="$REPO" EVENT_NAME="$1" \
+      STATE_DIR="$ST_TMP/state" bash "$ME" 2>&1 )
+  }
+
+  FAILED=0
+  expect() {  # <name> <expected-scope> <output>
+    local got
+    got=$(printf '%s\n' "$3" | sed -n 's/^scope=//p' | tail -1)
+    if [ "$got" = "$2" ]; then
+      printf '  OK   %s\n' "$1"
+    else
+      printf '  FAIL %s — expected scope=%s, got scope=%s\n' "$1" "$2" "${got:-<none>}"
+      printf '%s\n' "$3" | sed 's/^/       /'
+      FAILED=$((FAILED + 1))
+    fi
+  }
+  expect_line() {  # <name> <key> <expected> <output>
+    local got
+    got=$(printf '%s\n' "$4" | sed -n "s/^$2=//p" | tail -1)
+    if [ "$got" = "$3" ]; then
+      printf '  OK   %s\n' "$1"
+    else
+      printf '  FAIL %s — %s is "%s", expected "%s"\n' "$1" "$2" "$got" "$3"
+      FAILED=$((FAILED + 1))
+    fi
+  }
+
+  OK_JSON='{"runAll": false, "mount": ["Store", "Edu"], "affected": ["Edu"], "skipped": ["Chess"], "support": ["Store"]}'
+
+  echo "fallbacks to a FULL bake (the bias that makes narrowing safe):"
+  rm -rf "$ST_TMP/remote" "$ST_TMP/state"
+  write_selector 0 "$OK_JSON"
+  seal acct/share "$BASE_SHA" Store.zip Edu.zip Chess.zip
+  mv "$REPO/scripts/affected-modules.py" "$ST_TMP/selector.py"
+  expect "no scripts/affected-modules.py in the caller repo" full "$(run_case push acct/share)"
+  mv "$ST_TMP/selector.py" "$REPO/scripts/affected-modules.py"
+  expect "a framework-release dispatch (NEW identity — everything is recompiled against it)" \
+    full "$(run_case repository_dispatch acct/share)"
+  rm -rf "$ST_TMP/state"
+  expect "no sealed publication yet for this identity (the FIRST bake)" full "$(run_case push other/share)"
+  rm -rf "$ST_TMP/state"
+  expect "a malformed publish target" full "$(run_case push nonsense)"
+  rm -rf "$ST_TMP/state"; seal two/share "$OTHER_SHA" Store.zip Edu.zip Chess.zip
+  expect "publish targets that disagree on the published SOURCE" full \
+    "$(run_case push "acct/share two/share")"
+  rm -rf "$ST_TMP/state"; seal two/share "$BASE_SHA" Store.zip
+  expect "publish targets that disagree on the published BUNDLES" full \
+    "$(run_case push "acct/share two/share")"
+  rm -rf "$ST_TMP/state"; seal solo/share unknown Store.zip
+  expect "a publication whose recorded source is 'unknown'" full "$(run_case push solo/share)"
+  rm -rf "$ST_TMP/state"; seal gone/share 0000000000000000000000000000000000000000 Store.zip
+  expect "a baseline commit this checkout does not have (shallow clone)" full "$(run_case push gone/share)"
+  rm -rf "$ST_TMP/state"; seal div/share "$OTHER_SHA" Store.zip
+  expect "a baseline that is NOT an ancestor of HEAD (history rewritten)" full \
+    "$(run_case push div/share)"
+  rm -rf "$ST_TMP/state"; write_selector 1 ""
+  expect "the selector REFUSING — an empty diff or unresolvable range" full "$(run_case push acct/share)"
+  rm -rf "$ST_TMP/state"; write_selector 0 '{"runAll": true, "mount": ["Store","Edu"]}'
+  expect "the selector answering ALL modules (scripts/, .github/, a DELETED module)" full \
+    "$(run_case push acct/share)"
+  rm -rf "$ST_TMP/state"; write_selector 0 'not json at all'
+  expect "a selector answer that cannot be parsed" full "$(run_case push acct/share)"
+
+  echo "verified nothing-to-do (a POSITIVE finding, never an absent input):"
+  rm -rf "$ST_TMP/state"; write_selector 0 "$OK_JSON"
+  seal head/share "$HEAD_SHA" Store.zip Edu.zip
+  expect "this exact content is already sealed for this identity (the 30-minute release poll)" \
+    none "$(run_case schedule head/share)"
+  rm -rf "$ST_TMP/state"
+  write_selector 0 '{"runAll": false, "mount": [], "affected": [], "skipped": ["Store","Edu"], "support": []}'
+  expect "a diff that reaches no module at all (docs/, e2e/, .claude/)" none "$(run_case push acct/share)"
+
+  echo "narrowed:"
+  rm -rf "$ST_TMP/state"; write_selector 0 "$OK_JSON"
+  OUT=$(run_case push acct/share)
+  expect "a module change since the published baseline" narrowed "$OUT"
+  expect_line "the mount is the selector's order, dependencies first" mount "Store Edu" "$OUT"
+  expect_line "the baseline is the PUBLICATION's commit, not github.event.before" \
+    baseline "$BASE_SHA" "$OUT"
+  # 🚨 The carry-forward's input. Without this listing the publish would seal a SHORTER sentinel
+  # and every portal would silently stop adopting the bundles it dropped.
+  if [ "$(tr -d '[:space:]' < "$ST_TMP/state/published-bundles.txt" 2>/dev/null)" = "Store.zipEdu.zipChess.zip" ]; then
+    printf '  OK   %s\n' "the sealed bundle listing is recorded for the carry-forward"
+  else
+    printf '  FAIL published-bundles.txt is "%s"\n' "$(cat "$ST_TMP/state/published-bundles.txt" 2>&1)"
+    FAILED=$((FAILED + 1))
+  fi
+
+  if [ "$FAILED" -gt 0 ]; then
+    echo "::error title=bake-scope self-test failed::$FAILED case(s) — this script decides what is NOT rebuilt; a fallback that stops falling back is a silent under-build."
+    exit 1
+  fi
+  echo ""
+  echo "bake-scope self-test: 12 full-bake fallbacks, 2 verified nothing-to-do verdicts, 4 narrowed assertions — all green."
+  exit 0
+fi
+
+: "${BAKE_PUBLISH_TARGETS:?BAKE_PUBLISH_TARGETS is required}"
+: "${IDENTITY:?IDENTITY is required}"
+: "${SOURCE:?SOURCE is required}"
+: "${HEAD_SHA:?HEAD_SHA is required}"
+: "${REPO_DIR:?REPO_DIR is required}"
+: "${EVENT_NAME:?EVENT_NAME is required}"
+: "${STATE_DIR:?STATE_DIR is required}"
+
+SENTINEL="_complete"
+SOURCE_MARKER="source-commit.txt"
+mkdir -p "$STATE_DIR"
+
+SCOPE="full"
+REASON=""
+BASELINE=""
+MOUNT=""
+
+emit() {
+  echo "scope=$SCOPE"
+  echo "reason=$REASON"
+  echo "baseline=$BASELINE"
+  echo "mount=$MOUNT"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "scope=$SCOPE"
+      echo "reason=$REASON"
+      echo "baseline=$BASELINE"
+      echo "mount=$MOUNT"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# Every exit from this script other than "narrowed"/"none" goes through here, so a fallback can
+# never be silent: it names itself in the log AND in the job summary, where an operator looking at
+# a 40-minute bake can see why it was 40 minutes.
+full() {
+  SCOPE="full"
+  REASON="$1"
+  echo "::notice title=Full bake::$REASON"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '### 🧱 Full bake\n\n%s\n' "$REASON" >> "$GITHUB_STEP_SUMMARY"
+  fi
+  emit
+  exit 0
+}
+
+# ── 1. the selector must exist in the CALLER repo ────────────────────────────────────────────
+# It is the caller's own file (scripts/affected-modules.py) because the dependency edges are the
+# caller's content. A repo that does not ship it simply is not narrowable — never an error, and
+# never a silent narrowing to whatever a default guessed.
+SELECTOR="$REPO_DIR/scripts/affected-modules.py"
+[ -f "$SELECTOR" ] || full "the caller repo ships no scripts/affected-modules.py, so the affected closure cannot be computed — baking every module."
+
+# ── 2. the event must be one whose diff means anything ───────────────────────────────────────
+# A framework release mints a NEW identity: there is no publication to diff against and every
+# module must be recompiled against the new framework. Step 3 would reach the same verdict on its
+# own (no sealed directory), but saying it here names the real reason instead of "first bake".
+case "$EVENT_NAME" in
+  push|schedule) ;;
+  repository_dispatch) full "a repository_dispatch bake targets a framework identity this repo has not built against — every module must be recompiled against it, so the git diff is irrelevant." ;;
+  *) full "event '$EVENT_NAME' has no meaningful content diff — baking every module." ;;
+esac
+
+# ── 3. every target must already hold a SEALED publication, and they must AGREE ──────────────
+# The carry-forward re-hydrates from the publication, so a narrowed bake is only sound if the
+# publication it carries forward is the same everywhere. Targets that disagree (one lagging a
+# failed run, a newly added portal) would need per-target scopes; the honest answer is one full
+# bake that brings them all back into step.
+prev_sha=""
+prev_listing=""
+targets=0
+for target in $BAKE_PUBLISH_TARGETS; do
+  account="${target%%/*}"
+  rest="${target#*/}"
+  share="${rest%%/*}"
+  base=""
+  case "$rest" in */*) base="${rest#*/}";; esac
+  if [ -z "$account" ] || [ -z "$share" ] || [ "$account" = "$target" ]; then
+    full "malformed BAKE_PUBLISH_TARGETS entry '$target' — cannot read its publication, so the bake cannot be narrowed. (publish-bake-bundles.sh fails on this too.)"
+  fi
+  dest="${base:+$base/}prebuilt-bundles/$IDENTITY/$SOURCE"
+
+  complete=$(az storage file exists --account-name "$account" --share-name "$share" \
+    --path "$dest/$SENTINEL" --auth-mode login --backup-intent --query exists -o tsv \
+    --only-show-errors 2>/dev/null || echo false)
+  [ "$complete" = "true" ] || full "$account/$share holds no sealed publication under $dest — this is the FIRST bake of '$SOURCE' for framework identity $IDENTITY, so there is nothing to carry forward and every module must be built."
+
+  work="$STATE_DIR/probe-$targets"
+  mkdir -p "$work"
+  az storage file download --account-name "$account" --share-name "$share" \
+    --path "$dest/$SOURCE_MARKER" --dest "$work/$SOURCE_MARKER" \
+    --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1 \
+    || full "$account/$share: the sealed publication under $dest carries no $SOURCE_MARKER, so the baseline commit is unknown — baking every module."
+  az storage file download --account-name "$account" --share-name "$share" \
+    --path "$dest/$SENTINEL" --dest "$work/$SENTINEL" \
+    --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1 \
+    || full "$account/$share: could not read the $SENTINEL listing under $dest, so the bundles to carry forward are unknown — baking every module."
+
+  sha=$(tr -d '[:space:]' < "$work/$SOURCE_MARKER")
+  listing=$(grep -v '^[[:space:]]*$' "$work/$SENTINEL" | sort)
+  [ -n "$sha" ] && [ "$sha" != "unknown" ] \
+    || full "$account/$share: the publication under $dest records source '$sha' — no usable baseline commit, so the diff cannot be taken. Baking every module (which re-stamps a usable marker)."
+  [ -n "$listing" ] || full "$account/$share: the $SENTINEL under $dest lists no bundles — baking every module."
+
+  if [ "$targets" -eq 0 ]; then
+    prev_sha="$sha"
+    prev_listing="$listing"
+    cp "$work/$SENTINEL" "$STATE_DIR/published-bundles.txt"
+    CARRY_TARGET="$target"
+  else
+    [ "$sha" = "$prev_sha" ] \
+      || full "the publish targets disagree on what is published: '$prev_sha' vs '$sha' under $dest. A narrowed bake carries forward ONE publication, so it cannot serve both — one full bake brings every target back into step."
+    [ "$listing" = "$prev_listing" ] \
+      || full "the publish targets disagree on which bundles are published under $dest — one full bake brings every target back into step."
+  fi
+  targets=$((targets + 1))
+done
+[ "$targets" -gt 0 ] || full "BAKE_PUBLISH_TARGETS holds no targets — nothing to compare against."
+
+# ── 4. already published? then build NOTHING ─────────────────────────────────────────────────
+# 🚨 This is the case the every-30-minutes release poll hits almost every time it runs: the
+# schedule exists because the framework-release dispatch is dormant, and until the platform cuts a
+# new identity the poll re-bakes ~40 packages for 40 minutes so that publish-bake-bundles.sh can
+# then look at the sealed directory and skip the upload. The skip was already there; the BUILD in
+# front of it was not gated by anything.
+if [ "$prev_sha" = "$HEAD_SHA" ]; then
+  SCOPE="none"
+  REASON="content $HEAD_SHA is already sealed for framework identity $IDENTITY — nothing to rebuild and nothing to publish."
+  echo "::notice title=Nothing to bake::$REASON"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '### ✅ Already published\n\n%s\n' "$REASON" >> "$GITHUB_STEP_SUMMARY"
+  fi
+  BASELINE="$prev_sha"
+  emit
+  exit 0
+fi
+
+# ── 5. the baseline must be REACHABLE in this checkout ───────────────────────────────────────
+# A commit we cannot resolve is a commit we cannot diff. A commit that is not an ancestor of HEAD
+# means the branch was rewritten (force-push, revert-of-a-revert) and the "changes since" question
+# has no answer — both are full bakes, not guesses.
+git -C "$REPO_DIR" cat-file -e "${prev_sha}^{commit}" 2>/dev/null \
+  || full "the published baseline $prev_sha is not present in this checkout (shallow clone, or the commit was rewritten) — the diff cannot be taken, so every module is baked."
+git -C "$REPO_DIR" merge-base --is-ancestor "$prev_sha" "$HEAD_SHA" 2>/dev/null \
+  || full "the published baseline $prev_sha is not an ancestor of $HEAD_SHA — history was rewritten, so 'what changed since the publication' has no answer. Baking every module."
+
+# ── 6. ask the selector ──────────────────────────────────────────────────────────────────────
+# It refuses an empty diff (a CI diff is never empty, so an empty answer is a WRONG answer), it
+# classifies scripts/ + .github/ + repo-root files + an unknown top-level dir (a DELETED module)
+# as ALL modules, and it closes over transitive DEPENDENTS with the runtime's own edge semantics.
+# Every one of those is load-bearing here; a non-zero exit is taken as "cannot narrow", never as
+# "nothing affected".
+if ! (cd "$REPO_DIR" && python3 "$SELECTOR" --range "${prev_sha}...${HEAD_SHA}" --json) \
+      > "$STATE_DIR/affected.json" 2> "$STATE_DIR/affected.log"; then
+  sed 's/^/    /' "$STATE_DIR/affected.log" || true
+  full "scripts/affected-modules.py could not compute the closure for ${prev_sha}...${HEAD_SHA} (see above) — baking every module."
+fi
+sed 's/^/    /' "$STATE_DIR/affected.log" || true
+
+run_all=$(jq -r '.runAll' "$STATE_DIR/affected.json" 2>/dev/null || echo "parse-error")
+case "$run_all" in
+  true)  full "the diff ${prev_sha}...${HEAD_SHA} touches the gate/tooling scope (scripts/, .github/, a repo-root file, or a module directory that no longer exists) — the selector answers ALL modules." ;;
+  false) ;;
+  *)     full "could not read runAll out of the selector's JSON — baking every module." ;;
+esac
+
+MOUNT=$(jq -r '.mount | join(" ")' "$STATE_DIR/affected.json")
+if [ -z "$MOUNT" ]; then
+  SCOPE="none"
+  REASON="nothing between $prev_sha and $HEAD_SHA reaches a module (docs/, e2e/, .claude/ …) — the published bundles are still exactly right, so nothing is rebuilt and nothing is republished."
+  echo "::notice title=Nothing to bake::$REASON"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '### ✅ No module content changed\n\n%s\n' "$REASON" >> "$GITHUB_STEP_SUMMARY"
+  fi
+  BASELINE="$prev_sha"
+  emit
+  exit 0
+fi
+
+SCOPE="narrowed"
+BASELINE="$prev_sha"
+affected=$(jq -r '.affected | join(", ")' "$STATE_DIR/affected.json")
+skipped=$(jq -r '.skipped | join(", ")' "$STATE_DIR/affected.json")
+support=$(jq -r '.support | join(", ")' "$STATE_DIR/affected.json")
+REASON="rebuilding the affected closure since the published $prev_sha"
+{
+  echo "### 🎯 Narrowed bake"
+  echo ""
+  echo "| | |"
+  echo "|---|---|"
+  echo "| baseline (published) | \`$prev_sha\` |"
+  echo "| head | \`$HEAD_SHA\` |"
+  echo "| framework identity | \`$IDENTITY\` |"
+  echo "| affected (changed + dependents) | \`${affected:-none}\` |"
+  echo "| mounted as dependencies | \`${support:-none}\` |"
+  echo "| **not rebuilt** (bundles carried forward) | \`${skipped:-none}\` |"
+  echo ""
+  echo "Every module not rebuilt keeps its currently published bundle: \`carry-forward-bundles.sh\`"
+  echo "re-hydrates them before the publish step, so the \`_complete\` sentinel still lists the whole"
+  echo "set and no portal adopts less than it does today."
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+echo "::notice title=Narrowed bake::rebuilding ${affected:-none} (+ dependencies ${support:-none}); carrying forward ${skipped:-none}"
+echo "carry-forward source target: ${CARRY_TARGET}"
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "BAKE_CARRY_TARGET=${CARRY_TARGET}" >> "$GITHUB_ENV"
+fi
+emit

--- a/.github/scripts/carry-forward-bundles.sh
+++ b/.github/scripts/carry-forward-bundles.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# carry-forward-bundles.sh <bake-dir> <published-listing> <target> <identity> <source>
+#
+# Makes a NARROWED bake publish a COMPLETE publication.
+#
+# A narrowed bake (see bake-scope.sh) recompiles only the modules a change actually affects, so
+# --bake-output writes bundles only for those. Publishing that directory as-is would be a delta —
+# and the publication is atomic per identity: `_complete` is written LAST and lists the whole
+# bundle set, and a portal seeds EXACTLY what the sentinel lists
+# (ShippedPrebuiltBundles.SeedPublishedRoot). A delta publication would therefore not "add" the
+# new bundles; it would REPLACE the sentinel and shrink what every portal adopts to just the
+# delta, silently putting every other module back to compiling at boot. That is the reason the
+# bake was full until now, and this script is what removes it.
+#
+# So: for every bundle the currently-sealed publication lists that this bake did NOT produce,
+# download it into the bake directory. publish-bake-bundles.sh then runs COMPLETELY UNCHANGED —
+# it sees the whole set as local files, uploads every one of them, and seals a sentinel listing
+# all of them. The publication is indistinguishable from a full bake's; only the COMPILE was
+# narrowed.
+#
+# 🚨 A missing carried-forward bundle is FATAL, never a shrink. If the publication lists a bundle
+# that cannot be fetched, the only two options are "publish less than is published today" and
+# "stop". Shrinking is the silent failure — every portal missing that bundle recompiles it at
+# boot, nothing is red, and the tell is a slow start weeks later. So this exits non-zero and the
+# job goes red with the bundle named; the existing publication stays sealed and intact, because
+# nothing has been written yet.
+#
+# AUTH: `az login` must already have happened (data-plane reads use --auth-mode login
+# --backup-intent, exactly as publish-bake-bundles.sh's own reads do).
+set -euo pipefail
+
+# ── self-test ────────────────────────────────────────────────────────────────────────────────
+# 🚨 This script is the ONLY thing standing between a narrowed bake and a SHRUNK publication, and
+# a shrunk publication is invisible: no error, no red job — just every portal quietly recompiling
+# the bundles the sentinel stopped listing, weeks later, as a slow boot. So it owes proof that it
+# refuses rather than shrinks.
+#
+#     .github/scripts/carry-forward-bundles.sh --self-test
+if [ "${1:-}" = "--self-test" ]; then
+  # The cases below EXPECT non-zero exits from the re-invoked script, so the harness itself
+  # must not die on them; the runs under test keep `set -e` (they are separate processes).
+  set +e
+  ST=$(mktemp -d); trap 'rm -rf "$ST"' EXIT
+  ME="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+  mkdir -p "$ST/bin"
+  cat > "$ST/bin/az" <<'AZ'
+#!/usr/bin/env bash
+account=""; share=""; path=""; dest=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --account-name) account="$2"; shift 2;; --share-name) share="$2"; shift 2;;
+    --path) path="$2"; shift 2;; --dest) dest="$2"; shift 2;; *) shift;;
+  esac
+done
+file="$MOCK_AZ_ROOT/$account/$share/$path"
+[ -f "$file" ] || exit 1
+mkdir -p "$(dirname "$dest")"; cp "$file" "$dest"
+AZ
+  chmod +x "$ST/bin/az"; PATH="$ST/bin:$PATH"; export MOCK_AZ_ROOT="$ST/remote"
+  REMOTE="$ST/remote/acct/share/prebuilt-bundles/ID1/plugins"
+  FAILED=0
+  ok()   { printf '  OK   %s\n' "$1"; }
+  bad()  { printf '  FAIL %s\n' "$1"; FAILED=$((FAILED + 1)); }
+
+  setup() {  # <listing lines…> — the sealed publication holds a bundle for each
+    rm -rf "$ST/bake" "$ST/remote" "$ST/listing"
+    mkdir -p "$ST/bake" "$REMOTE"
+    for b in "$@"; do echo "published $b" > "$REMOTE/$b"; done
+    printf '%s\n' "$@" > "$ST/listing"
+  }
+  rebuilt() { echo "rebuilt $1" > "$ST/bake/$1"; }
+  run()     { ( unset GITHUB_STEP_SUMMARY; bash "$ME" "$ST/bake" "$ST/listing" acct/share ID1 plugins 2>&1 ); }
+
+  echo "carry-forward:"
+  setup Store.zip Edu.zip Chess.zip RolePlay.zip
+  rebuilt Edu.zip; rebuilt Chess.zip
+  OUT=$(run); RC=$?
+  if [ "$RC" -eq 0 ] && [ "$(ls "$ST/bake" | wc -l | tr -d ' ')" = "4" ] \
+     && [ "$(cat "$ST/bake/Edu.zip")" = "rebuilt Edu.zip" ] \
+     && [ "$(cat "$ST/bake/Store.zip")" = "published Store.zip" ]; then
+    ok "the bake dir ends up holding the WHOLE published set — rebuilt bundles win, the rest are fetched"
+  else
+    bad "happy path (rc=$RC): $(printf '%s' "$OUT" | tail -3)"
+  fi
+
+  setup Store.zip Edu.zip
+  rebuilt Edu.zip; rebuilt Brand.zip          # a NEW module the publication does not list yet
+  OUT=$(run); RC=$?
+  if [ "$RC" -eq 0 ] && [ -f "$ST/bake/Brand.zip" ] && [ -f "$ST/bake/Store.zip" ]; then
+    ok "a NEW module's bundle is additive — the set may grow, never shrink"
+  else
+    bad "new-module superset (rc=$RC)"
+  fi
+
+  echo "refusals (the publication must never shrink):"
+  setup Store.zip Edu.zip Chess.zip
+  rebuilt Edu.zip; rm "$REMOTE/Chess.zip"     # listed, not rebuilt, not fetchable
+  OUT=$(run); RC=$?
+  if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "could not carry forward: Chess.zip"; then
+    ok "a listed bundle that can neither be rebuilt nor fetched is FATAL, and it is NAMED"
+  else
+    bad "unfetchable bundle should be fatal (rc=$RC)"
+  fi
+
+  setup Store.zip; : > "$ST/listing"
+  OUT=$(run); RC=$?
+  [ "$RC" -ne 0 ] && ok "an empty published listing is refused (it cannot say what to carry forward)" \
+                  || bad "empty listing should be fatal"
+
+  setup Store.zip; printf '%s\n' "../escape.zip" > "$ST/listing"
+  OUT=$(run); RC=$?
+  [ "$RC" -ne 0 ] && ok "a listing entry that is not a plain file name is refused" \
+                  || bad "path-bearing listing entry should be fatal"
+
+  rm -rf "$ST/bake"; setup Store.zip; rm -rf "$ST/bake"
+  OUT=$(run); RC=$?
+  [ "$RC" -ne 0 ] && ok "a missing bake directory is refused" || bad "missing bake dir should be fatal"
+
+  if [ "$FAILED" -gt 0 ]; then
+    echo "::error title=carry-forward self-test failed::$FAILED case(s) — this is the only thing preventing a narrowed bake from shrinking the publication."
+    exit 1
+  fi
+  echo ""
+  echo "carry-forward self-test: 2 hydration cases, 4 refusals — all green."
+  exit 0
+fi
+
+USAGE="usage: carry-forward-bundles.sh <bake-dir> <published-listing> <target> <identity> <source>"
+BAKE_DIR="${1:?$USAGE}"
+LISTING="${2:?$USAGE}"
+TARGET="${3:?$USAGE}"
+IDENTITY="${4:?$USAGE}"
+SOURCE="${5:?$USAGE}"
+
+[ -d "$BAKE_DIR" ] || { echo "::error::bake dir '$BAKE_DIR' does not exist"; exit 1; }
+[ -s "$LISTING" ] || { echo "::error::published listing '$LISTING' is missing or empty — a narrowed bake cannot know what to carry forward, and publishing without it would shrink the publication."; exit 1; }
+
+ACCOUNT="${TARGET%%/*}"
+REST="${TARGET#*/}"
+SHARE="${REST%%/*}"
+BASE=""
+case "$REST" in */*) BASE="${REST#*/}";; esac
+SRC_DIR="${BASE:+$BASE/}prebuilt-bundles/$IDENTITY/$SOURCE"
+
+carried=0
+rebuilt=0
+missing=()
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  case "$name" in */*|..|.) echo "::error::the published listing names '$name', which is not a plain file name"; exit 1;; esac
+  if [ -f "$BAKE_DIR/$name" ]; then
+    rebuilt=$((rebuilt + 1))
+    continue
+  fi
+  if az storage file download --account-name "$ACCOUNT" --share-name "$SHARE" \
+       --path "$SRC_DIR/$name" --dest "$BAKE_DIR/$name" \
+       --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1; then
+    carried=$((carried + 1))
+    echo "carried forward: $name"
+  else
+    missing+=("$name")
+  fi
+done < "$LISTING"
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "::error title=Carry-forward failed — refusing to shrink the publication::the sealed publication under $ACCOUNT/$SHARE/$SRC_DIR lists ${#missing[@]} bundle(s) this narrowed bake neither rebuilt nor could fetch. Publishing now would replace the _complete sentinel with a SHORTER list and every portal would silently stop adopting them."
+  for m in "${missing[@]}"; do echo "::error::could not carry forward: $m"; done
+  echo "::error::Re-run this workflow to take the full-bake path (bake-scope.sh falls back to a full bake whenever the publication cannot be read), or fix access to the target."
+  exit 1
+fi
+
+# The postcondition, asserted rather than assumed: the set about to be published is a SUPERSET of
+# what is published today. A narrowed bake may legitimately ADD bundles (a new module) — it may
+# never publish fewer than the sentinel it is about to replace.
+listed=$(grep -c '[^[:space:]]' "$LISTING" || true)
+present=$(find "$BAKE_DIR" -maxdepth 1 -name '*.zip' | wc -l | tr -d ' ')
+if [ "$present" -lt "$listed" ]; then
+  echo "::error::after carry-forward the bake dir holds $present bundle(s) but the publication lists $listed — refusing to publish a shorter set."
+  exit 1
+fi
+echo "carry-forward complete: $rebuilt rebuilt, $carried carried forward, $present bundle(s) to publish (publication lists $listed)."
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  printf -- '- carried forward **%s** unchanged bundle(s); **%s** rebuilt; publishing **%s**\n' \
+    "$carried" "$rebuilt" "$present" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -343,6 +343,20 @@ jobs:
           exit 1
         fi
         echo "All required CI inputs are present."
+    # ── The CI-logic scripts that decide what CI DOES NOT DO ──────────────────────────────────
+    # Both of these narrow work, and narrowing is the shape that produces a silent under-build:
+    # bake-scope.sh decides which modules a node repo's bake rebuilds, and carry-forward-bundles.sh
+    # is the only thing stopping a narrowed bake from replacing the `_complete` sentinel with a
+    # SHORTER one — which no portal would report, it would just quietly recompile at boot again.
+    # Neither is reachable from any .NET test, and they run only on a satellite repo's main, so
+    # without this step their first execution is in production. Seconds; no secrets; no image.
+    # Both are proven non-vacuous by mutation: remove any single fallback and the step goes red.
+    - uses: actions/checkout@v7
+      with: { fetch-depth: 1 }
+    - name: "The bake-scope decision can say 'full' (self-test)"
+      run: .github/scripts/bake-scope.sh --self-test
+    - name: "The bundle carry-forward refuses to shrink a publication (self-test)"
+      run: .github/scripts/carry-forward-bundles.sh --self-test
 
   # ───────────────────────────── BUILD ─────────────────────────────
   # Compile the whole solution exactly once and package every TEST project's

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -13,11 +13,17 @@ name: Node repo publish-bake (reusable)
 # `<base>/prebuilt-bundles/<framework-identity>/<bake-source>/`. A portal whose own framework
 # identity matches seeds them at boot and compiles nothing the repo ships.
 #
-# The bake is ALWAYS the FULL repo — never a PR-style affected narrowing. The publication is
-# atomic per identity: the `_complete` sentinel (written LAST) lists the whole bundle set and the
-# portal seeds only what the sentinel lists, so a partial publish would SHRINK what portals
-# adopt. Callers gate this job to main pushes + `repository_dispatch` (framework releases) via
-# the job-level `if:`/`needs:` on the `uses:` job.
+# The PUBLICATION is always the FULL set; the COMPILE need not be. The publication is atomic per
+# identity — the `_complete` sentinel (written LAST) lists the whole bundle set and the portal
+# seeds only what the sentinel lists, so a partial publish would SHRINK what portals adopt — and
+# that is a constraint on what is UPLOADED, not on what is recompiled. With
+# `narrow-by-affected: true` the job diffs the caller's content against the commit its own sealed
+# publication records (`source-commit.txt`), rebuilds only the modules that diff AFFECTS
+# (`scripts/affected-modules.py`: changed modules + every transitive DEPENDENT + their
+# dependencies), and carries every other bundle forward from the publication before sealing — so
+# the sentinel still lists everything and no portal adopts less than it does today. Every
+# uncertainty falls back to a FULL bake, out loud. Callers gate this job to main pushes +
+# `repository_dispatch` (framework releases) via the job-level `if:`/`needs:` on the `uses:` job.
 #
 # Caller contract (see the SocialMedia/Plugins ci.yml for a worked example):
 #
@@ -44,6 +50,7 @@ name: Node repo publish-bake (reusable)
 # "Node repos run the same lane" -> "The workflow ref is PINNED".
 #     with:
 #       bake-source: socialmedia
+#       narrow-by-affected: true      # rebuild only the modules a push actually affects
 #       test-image: ${{ vars.MW_TEST_IMAGE }}
 #       image-digest: ${{ vars.MW_IMAGE_DIGEST }}     # or a workflow env / literal pin
 #       bake-publish-targets: ${{ vars.BAKE_PUBLISH_TARGETS }}
@@ -103,6 +110,24 @@ on:
           Explicitly accept an empty image-digest and bake against the tag verbatim (a repo
           that tracks :main accepts that its runs are not reproducible). Never a silent
           fallback: an empty digest WITHOUT this flag fails red.
+        required: false
+        type: boolean
+        default: false
+      narrow-by-affected:
+        description: >-
+          Rebuild only the modules the content diff AFFECTS, instead of every module on every
+          run. The baseline is the commit the repo's own sealed publication records
+          (source-commit.txt), NOT github.event.before — so a run that lost a race, was
+          cancelled, or followed a red gate still diffs against what is actually published. The
+          modules NOT rebuilt keep their published bundles, carried forward before the seal, so
+          the publication stays complete.
+
+          OPT-IN, and biased to full: no selector in the caller repo, no sealed publication yet,
+          publish targets that disagree, an unreachable baseline, a rewritten history, a diff the
+          selector refuses, or any change to scripts/ .github/ a repo-root file or a DELETED
+          module ⇒ a FULL bake, logged with the reason. Requires the caller to ship
+          scripts/affected-modules.py, and is mutually exclusive with pre-bake-script (a hook that
+          builds its own mount owns its composition).
         required: false
         type: boolean
         default: false
@@ -239,6 +264,8 @@ jobs:
           STAGE_MODULES: ${{ inputs.stage-modules }}
           DEPENDENT_REPOS: ${{ inputs.dependent-repos }}
           DEPENDENT_TOKEN: ${{ secrets.dependent-dispatch-token }}
+          NARROW: ${{ inputs.narrow-by-affected }}
+          PRE_BAKE: ${{ inputs.pre-bake-script }}
         run: |
           set -euo pipefail
           missing=()
@@ -259,14 +286,28 @@ jobs:
           if [ -n "${DEPENDENT_REPOS:-}" ] && [ -z "${DEPENDENT_TOKEN:-}" ]; then
             missing+=("dependent-dispatch-token (secret) — token with repo scope on ${DEPENDENT_REPOS}; without it this repo's publication cannot wake its dependents and they never rebuild for the release")
           fi
+          # 🚨 A DECLARED-INPUT contradiction, asserted here rather than resolved silently at run
+          # time. A pre-bake hook that writes BAKE_MOUNT_DIR OWNS the mount's composition (it can
+          # filter, snapshot or synthesise packages), so "the affected closure" is not a set this
+          # job may substitute for it. Picking one and carrying on would mean a caller reading its
+          # own workflow could not tell which mount ran.
+          if [ "${NARROW:-false}" = "true" ] && [ -n "${PRE_BAKE:-}" ]; then
+            missing+=("narrow-by-affected and pre-bake-script are mutually exclusive — a hook that builds its own bake mount owns its composition, so the affected closure cannot also decide it. Drop one.")
+          fi
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::The bake publication cannot reach any portal — required credentials are not provisioned. This job fails RED rather than skipping: a grey skip is indistinguishable from a pass and would silently leave every portal re-compiling this repo's content at boot."
             for m in "${missing[@]}"; do echo "::error::missing: ${m}"; done
             exit 1
           fi
           echo "All publish credentials are provisioned."
+      # 🚨 fetch-depth 0 when narrowing: the baseline is a commit the PUBLICATION names, which can
+      # be any distance back (as far as the last successful publish), and a shallow clone cannot
+      # resolve it. bake-scope.sh falls back to a full bake rather than guessing when it cannot —
+      # correct, but it would narrow NOTHING, ever. The string forms are deliberate: GitHub
+      # expressions treat the NUMBER 0 as falsy, so `inputs.x && 0 || 1` yields 1 in both branches.
       - uses: actions/checkout@v7
-        with: { fetch-depth: 1 }
+        with:
+          fetch-depth: ${{ inputs.narrow-by-affected && '0' || '1' }}
       - name: Resolve the bake image
         id: image
         env:
@@ -340,8 +381,8 @@ jobs:
       # bake runs at all. Same sparse checkout as the publish-side fetch further down, into its own
       # path: it carries no root index.json, so the tester never treats it as a module (identical
       # reasoning to `cross-repo-stage/`).
-      - name: Fetch the canonical gate script (platform repo)
-        if: inputs.upstream-sources != ''
+      - name: Fetch the canonical gate + bake-scope scripts (platform repo)
+        if: inputs.upstream-sources != '' || inputs.narrow-by-affected
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
@@ -351,15 +392,18 @@ jobs:
       # A SECOND login, deliberately: the gate must authenticate before a bake that can run 40
       # minutes, and the publish side re-logs in afterwards rather than relying on a token minted
       # before it. Two cheap OIDC exchanges beat one that can expire mid-job.
-      - name: Azure login for the gate (OIDC)
-        if: inputs.upstream-sources != ''
+      - name: Azure login for the gate / scope decision (OIDC)
+        if: inputs.upstream-sources != '' || inputs.narrow-by-affected
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.azure-client-id }}
           tenant-id: ${{ secrets.azure-tenant-id }}
           subscription-id: ${{ secrets.azure-subscription-id }}
+      # Needed by BOTH the upstream gate and the scope decision: a publication is keyed by
+      # framework identity, so "what is already published" is unanswerable without it — and the
+      # identity is a property of the shipped BINARIES, so only the image can report it.
       - name: "Resolve the framework identity this bake will target"
-        if: inputs.upstream-sources != ''
+        if: inputs.upstream-sources != '' || inputs.narrow-by-affected
         id: identity
         run: |
           set -euo pipefail
@@ -401,6 +445,31 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::error title=Upstreams not ready — did not build::at least one upstream of this repo has no published artifact for framework identity ${{ steps.identity.outputs.identity }}; exiting without building. The upstream's own publication re-triggers this run."
           exit 1
+      # ───────────────────── WHAT MUST ACTUALLY BE REBUILT (#1707) ─────────────────────
+      # "When updating plugins, we should check from git history which modules are affected, and
+      # we should rebuild only these."
+      #
+      # 🚨 IT RUNS BEFORE STAGING, and that ordering is load-bearing: the staged cross-repo module
+      # dirs are copied INTO the caller's checkout, and scripts/affected-modules.py discovers
+      # modules as "top-level dirs carrying an index.json". Deciding after staging would have the
+      # selector treat another repo's packages as this repo's, changing the dependency graph it
+      # derives the closure from.
+      #
+      # The decision is biased to FULL — see bake-scope.sh, where every fallback names itself in
+      # the log and the job summary. Narrowing is the shape that produces a silent under-build, so
+      # "cannot answer safely" and "nothing to do" must never be the same answer.
+      - name: Decide the bake scope (affected modules since the published baseline)
+        if: inputs.narrow-by-affected
+        id: scope
+        env:
+          BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
+          IDENTITY: ${{ steps.identity.outputs.identity }}
+          SOURCE: ${{ inputs.bake-source }}
+          HEAD_SHA: ${{ github.sha }}
+          REPO_DIR: ${{ github.workspace }}
+          EVENT_NAME: ${{ github.event_name }}
+          STATE_DIR: ${{ runner.temp }}/bake-scope
+        run: mw-platform-gate/.github/scripts/bake-scope.sh
       # Same staging the caller's gate does, for the same reason: cross-repo `requires` must
       # resolve for the package roots to bind.
       - name: Stage cross-repo modules
@@ -419,10 +488,16 @@ jobs:
       - name: Pre-bake hook
         if: inputs.pre-bake-script != ''
         run: ${{ inputs.pre-bake-script }}
-      - name: Bake the full repo (import + compile + render + tests, --bake-output)
+      - name: Bake (import + compile + render + tests, --bake-output)
+        # scope=none means the decision above VERIFIED that this exact content is already sealed
+        # for this framework identity at every target — a positive finding, logged with both
+        # shas, not an input-shaped skip. Everything downstream is skipped with it.
+        if: steps.scope.outputs.scope != 'none'
         env:
           STAGE_MODULES: ${{ inputs.stage-modules }}
           ALLOW_FILE: ${{ inputs.allow-file }}
+          BAKE_SCOPE: ${{ steps.scope.outputs.scope || 'full' }}
+          BAKE_MODULES: ${{ steps.scope.outputs.mount }}
         run: |
           set -euo pipefail
           # The mount the tester sees: the checkout, unless the pre-bake hook built its own
@@ -435,6 +510,33 @@ jobs:
             for m in ${STAGE_MODULES:-}; do
               cp -R "$GITHUB_WORKSPACE/cross-repo-stage/$m" "$GITHUB_WORKSPACE/"
             done
+          fi
+          # 🎯 THE MOUNT IS THE FILTER. mw-plugin-test gates and bakes every package it discovers
+          # under /repo and takes no module list, so a narrowed bake is a narrowed MOUNT — exactly
+          # the seam the PR gate already uses (ci.yml `test-repos`). The set is
+          # affected + transitive dependents + THEIR dependencies, dependencies-first, because the
+          # tester's mesh installs what it mounts and a package whose `requires` is absent never
+          # activates. (narrow-by-affected and pre-bake-script are mutually exclusive — asserted in
+          # preflight — so BAKE_MOUNT_DIR and a narrowed stage can never both be in play.)
+          if [ "$BAKE_SCOPE" = "narrowed" ]; then
+            NARROW="${RUNNER_TEMP:-/tmp}/bake-stage"
+            mkdir -p "$NARROW"
+            for m in $BAKE_MODULES; do cp -R "$GITHUB_WORKSPACE/$m" "$NARROW/"; done
+            for m in ${STAGE_MODULES:-}; do
+              # An `A && B` list whose test fails would abort the step under `set -e`.
+              name=$(basename "$m")
+              if [ -d "$GITHUB_WORKSPACE/$name" ]; then
+                cp -R "$GITHUB_WORKSPACE/$name" "$NARROW/"
+              fi
+            done
+            if [ -n "${ALLOW_FILE:-}" ] && [ -f "$GITHUB_WORKSPACE/$ALLOW_FILE" ]; then
+              mkdir -p "$NARROW/$(dirname "$ALLOW_FILE")"
+              cp "$GITHUB_WORKSPACE/$ALLOW_FILE" "$NARROW/$ALLOW_FILE"
+            fi
+            REPO_MOUNT="$NARROW"
+            echo "narrowed bake: $BAKE_MODULES"
+          else
+            echo "full bake: every module in the checkout"
           fi
           BAKE="${RUNNER_TEMP:-/tmp}/bake"
           mkdir -p "$BAKE"
@@ -471,6 +573,7 @@ jobs:
           echo "baked identity: $(cat "$BAKE/framework-mvid.txt")"
           echo "baked bundles:"; ls -l "$BAKE"/*.zip
       - name: Azure login (OIDC)
+        if: steps.scope.outputs.scope != 'none'
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.azure-client-id }}
@@ -480,13 +583,37 @@ jobs:
       # `_complete` sentinel must keep matching. Checked out after the bake so it never sits in
       # the tester's /repo mount. Public repo: the default token reads it from any caller.
       - name: Fetch the canonical publish script (platform repo)
+        if: steps.scope.outputs.scope != 'none'
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
           ref: ${{ inputs.platform-ref }}
           path: mw-platform
           sparse-checkout: .github/scripts
+      # ───────────── KEEP THE PUBLICATION COMPLETE (the reason the bake used to be full) ─────────────
+      # A narrowed bake wrote bundles only for what it rebuilt. The publish below uploads exactly
+      # the local bundle set and seals a `_complete` listing exactly it — and a portal seeds only
+      # what that sentinel lists. So publishing the delta would not ADD bundles, it would REPLACE
+      # the sentinel and shrink what every portal adopts, silently putting every other module back
+      # to compiling at boot.
+      #
+      # This step re-hydrates every bundle the sealed publication lists that this bake did not
+      # produce, so the publish script runs COMPLETELY UNCHANGED over a full set and the resulting
+      # publication is indistinguishable from a full bake's. A bundle that can neither be rebuilt
+      # nor fetched is FATAL here — the alternative is publishing less than is published today,
+      # which is the silent failure this whole lane exists to remove. Nothing has been written at
+      # that point, so the existing publication stays sealed and intact.
+      - name: Carry forward the bundles this bake did not rebuild
+        if: steps.scope.outputs.scope == 'narrowed'
+        run: >
+          mw-platform/.github/scripts/carry-forward-bundles.sh
+          "$BAKE_DIR"
+          "${{ runner.temp }}/bake-scope/published-bundles.txt"
+          "$BAKE_CARRY_TARGET"
+          "${{ steps.identity.outputs.identity }}"
+          "${{ inputs.bake-source }}"
       - name: Publish bundles to every portal target
+        if: steps.scope.outputs.scope != 'none'
         env:
           BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
         # Contract: layout <base>/prebuilt-bundles/<framework-identity>/<source>/<bundle>.zip,
@@ -516,8 +643,12 @@ jobs:
       # payload carries the framework identity so a receiver can gate on the exact generation, and
       # the platform version when this run was itself woken by one (the receiver needs it to resolve
       # the released image).
+      # …and only when there WAS a publication to announce. scope=none means the artefact the
+      # dependents gate on is already sealed — a dependent that exited waiting for it did so
+      # before it existed, and the run that created it fired this event then. Waking them for a
+      # no-op would put every downstream repo through a full build on every scheduled poll.
       - name: Notify dependent repos
-        if: inputs.dependent-repos != ''
+        if: inputs.dependent-repos != '' && steps.scope.outputs.scope != 'none'
         env:
           TOKEN: ${{ secrets.dependent-dispatch-token }}
           REPOS: ${{ inputs.dependent-repos }}
@@ -547,3 +678,18 @@ jobs:
           done
           echo "### 📣 Dependents woken: $REPOS" >> "$GITHUB_STEP_SUMMARY"
           exit "$failed"
+      # 🚨 An explicit, GREEN step rather than a tail of grey skips. "Already published" and "the
+      # job silently did nothing" render identically in the UI otherwise, and AGENTS.md's rule is
+      # that a gate which did not run must never look like one that passed. This one says which
+      # verdict was reached, on what evidence, and names both shas.
+      - name: Nothing to bake (this content is already sealed for this identity)
+        if: steps.scope.outputs.scope == 'none'
+        env:
+          REASON: ${{ steps.scope.outputs.reason }}
+          BASELINE: ${{ steps.scope.outputs.baseline }}
+        run: |
+          set -euo pipefail
+          echo "no bake, no publish: $REASON"
+          echo "published baseline: $BASELINE   head: $GITHUB_SHA   identity: ${{ steps.identity.outputs.identity }}"
+          echo "This is a VERIFIED outcome, not a skipped gate: the sealed publication was read from"
+          echo "every target in BAKE_PUBLISH_TARGETS and compared against this commit's content."

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -472,7 +472,7 @@ deliberately deferred.
 | `.github/workflows/node-repo-validate.yml` | JSON/manifest shape gate (`scripts/validate-repos.py`, `gen-manifests.py --check`, main-only `--check-versions`) |
 | `.github/workflows/node-repo-compile-check.yml` | the compile gate — every NodeType's resolved Source vs the assemblies of the digest-pinned platform image |
 | `.github/workflows/node-repo-gate.yml` | the tester gate — `mw-plugin-test` over the (optionally affected-narrowed) mount, cross-repo `requires` staged in |
-| `.github/workflows/node-repo-publish-bake.yml` | the main-only bake + publication — full-repo `--bake-output`, staged-module exclusion, OIDC publish via the canonical `publish-bake-bundles.sh` |
+| `.github/workflows/node-repo-publish-bake.yml` | the main-only bake + publication — `--bake-output` over the full repo or (opt-in) the affected closure, staged-module exclusion, OIDC publish via the canonical `publish-bake-bundles.sh` |
 | `.github/workflows/node-repo-tag-modules.yml` | the `<Module>/vX.Y.Z` tag publisher (`scripts/tag-modules.py`) |
 
 The design rules the extraction preserves:
@@ -509,6 +509,84 @@ The design rules the extraction preserves:
   seals independently, which is also why no cross-repo bake ORDERING is needed: a dependent
   repo's publication never contains its dependency's bundles, so there is nothing to wait for.
   The framework-release dispatch fans out to all satellites concurrently.
+
+### Rebuild only what a change AFFECTS — `narrow-by-affected`
+
+> *"When updating plugins, we should check from git history which modules are affected, and we
+> should rebuild only these."*
+
+The bake used to be the whole repo, every time — every main push and every scheduled release
+poll ran ~40 minutes of Roslyn over every package to republish bundles that, for all but a
+handful of them, were the ones already sealed in storage. The stated reason was the atomicity of
+the publication, and it was a real constraint applied to the wrong half of the job:
+
+> the `_complete` sentinel is written LAST and lists the whole bundle set, and a portal seeds
+> **only what the sentinel lists** — so publishing a delta would not ADD bundles, it would
+> REPLACE the sentinel and shrink what every portal adopts.
+
+That constrains what is **uploaded**. It says nothing about what must be **recompiled**. With
+`narrow-by-affected: true` the two are separated:
+
+| | |
+|---|---|
+| **compile** | only the modules the diff affects (+ their dependencies, because the tester's fresh mesh installs what it mounts) |
+| **publish** | still the complete set — every bundle not rebuilt is carried forward from the current publication before the seal |
+
+Three pieces, in order:
+
+1. **`bake-scope.sh`** decides. 🚨 **Its baseline is the PUBLICATION, not `github.event.before`** —
+   the sealed directory carries `source-commit.txt`, and that is the only commit that answers
+   "what changed since the bundles that are actually out there". Diffing the push instead would
+   silently under-build after any run that did not publish: a cancelled run, a superseded push, a
+   red gate, a re-run of an older commit. Reading the baseline off the publication is
+   self-correcting — whatever was published is what we diff against, however many runs it took.
+2. **The caller's `scripts/affected-modules.py`** answers. It is the caller's file because the
+   dependency edges are the caller's content, and it mirrors the runtime's own resolution 1:1
+   (`LocalNodeRepo.CollectDependencies`): changed modules → transitive **dependents** → their
+   dependencies, emitted dependencies-first. It ships its own `--self-test`.
+3. **`carry-forward-bundles.sh`** keeps the publication whole: every bundle the sealed listing
+   names that this bake did not produce is downloaded into the bake directory, so
+   `publish-bake-bundles.sh` runs **completely unchanged** over a full set and the resulting
+   publication is indistinguishable from a full bake's.
+
+**The bias is toward a full bake, always, and out loud.** Narrowing a build is the shape that
+produces a *silent* under-build — a module that should have been recompiled and was not becomes a
+stale assembly every portal seeds at boot, and the evidence of the miss is the absence of
+evidence. So each of these resolves to a FULL bake, naming itself in the log and the job summary:
+
+- the caller ships no `scripts/affected-modules.py`;
+- a `repository_dispatch` (a framework release mints a NEW identity — everything is recompiled
+  against it), or any event with no meaningful content diff;
+- no sealed publication yet for this identity, a malformed target, or an unreadable sentinel;
+- **publish targets that disagree** on the published source or bundle set (one narrowed bake
+  carries forward one publication, so it cannot serve two);
+- a baseline commit this checkout cannot resolve, or one that is not an ancestor of HEAD
+  (history rewritten);
+- the selector refusing — an **empty diff** is a broken range, never "nothing to do";
+- the selector answering ALL modules: a change under `scripts/`, `.github/`, a repo-root file, or
+  **a module directory that no longer exists**. That last one is why a DELETED module still
+  shrinks the publication correctly.
+
+And one verdict that is neither: **`scope=none`**, when the sealed publication already records
+*this* commit for *this* identity. It is a positive finding — read from every target, logged with
+both shas and an explicit green step, never a grey skip — and it is what the every-30-minutes
+release poll hits almost every time it runs. `publish-bake-bundles.sh` already skipped the upload
+in that case; nothing had ever gated the 40-minute build in front of it.
+
+A **missing** carried-forward bundle is fatal: the only alternatives are "publish less than is
+published today" and "stop", and shrinking is the one that fails silently. The job goes red with
+the bundle named, and the existing publication stays sealed and intact because nothing has been
+written yet.
+
+`narrow-by-affected` is mutually exclusive with `pre-bake-script` (a hook that builds its own
+mount owns its composition) — asserted in preflight, not resolved silently at run time. Both
+scripts carry `--self-test`, run on every platform PR from `dotnet-test.yml`'s preflight job, and
+both are proven non-vacuous by mutation: delete any single fallback and the step goes red.
+
+**Still full, deliberately:** a framework release. A new identity has no publication to carry
+forward and every module must be compiled against the new binaries — which is also what makes
+that bake the gate that catches an API removal (the 2026-08-09 `AddTracking` outage) before every
+portal parks at its next restart.
 
 ### 🔒 The workflow ref is PINNED — and bumping it is a deliberate act
 
@@ -634,6 +712,24 @@ types. The satellites escape it precisely because they bake INSIDE the image.
   `MeshWeaver/samples/Graph/Data/ACME/…` while a bundle from that tree is keyed `ACME/…`. If a
   deployment ever wants them prebuilt, the fix is to agree one canonical path per shipped tree — a
   content-layout question, not an identity one.
+- **A narrowed bake still recompiles the affected closure's DEPENDENCIES.** `mw-plugin-test`
+  takes no module list — the mount IS the filter — and it has no seed-from-directory seam: it
+  compiles every package it discovers under `/repo`. A dependency is mounted because the fresh
+  gate mesh must install it for the affected package to activate and for `shared=@…` to resolve,
+  and it is then compiled too. Almost every package requires `Store`, so `Store` is recompiled on
+  nearly every narrowed run. The win is still large (3–5 packages instead of ~40); closing the
+  rest needs the tester to ADOPT a published bundle for a mounted-but-unaffected package — the
+  same `PrebuiltAssemblySeeder` path a portal takes at boot, which is #1707 item 5 ("at install,
+  check whether a pre-built lib exists and consume it") pointed at the gate.
+- **The platform's OWN content bake (`main-cd.yml`'s `publish-bake`) is not narrowed.** It bakes
+  `src/MeshWeaver.Documentation/Data` inside the shipped image and fuses gate and bake in one
+  `mw-plugin-test` run; its content moves with the platform commit it is baking, so a
+  content-diff baseline is a different question from the node repos' one.
+- **The cross-repo rebuild cascade is a separate axis.** `narrow-by-affected` answers "which of
+  THIS repo's modules changed". "Which repos must rebuild, in what order, when an upstream
+  publishes" is the `upstream-sources` gate plus `dependent-repos`, and it is still dormant in
+  practice for this repo's dependents: `DEPENDENT_DISPATCH_TOKEN` is unprovisioned, so Plugins
+  declares no `dependent-repos` and Education/Reinsurance are woken only by their own schedule.
 - **An arm64 install adopts nothing the amd64 lane publishes** — the two architectures of one image
   resolve different identities (see the identity rule above). Local arm64 installs compile at boot
   as they always have; nothing may paper over this by publishing the same bundles twice.

--- a/test/MeshWeaver.PluginTester.Test/LocalNodeRepoDependencyTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/LocalNodeRepoDependencyTest.cs
@@ -1,0 +1,122 @@
+#pragma warning disable CS1591
+
+using System.Collections.Immutable;
+using System.Linq;
+using MeshWeaver.GitSync;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// <see cref="LocalNodeRepo.OrderByDependencies"/> — and, through it, the private
+/// <c>CollectDependencies</c> that is the SOURCE OF TRUTH for two other things: the gate's install
+/// order, and the module-selection the node repos' <c>scripts/affected-modules.py</c> mirrors 1:1
+/// (its docstring names this method, and the safety argument for narrowing a CI bake to the
+/// affected closure rests entirely on that mirror being true).
+///
+/// <para>🚨 The case that motivated this file: a <c>requires</c> entry carries an OPTIONAL VERSION
+/// RANGE — <c>"Store@^1.0.0"</c> — and the reader compared the whole entry against a bare package
+/// id, so it matched nothing and the edge silently disappeared. Nothing failed; the dependency was
+/// simply never collected. Measured across MeshWeaver.Plugins on 2026-08-21: <b>51 of its 52
+/// declared <c>requires</c> edges were dead</b>, including every one of the eleven modules
+/// <c>Essentials</c> declares. <see cref="PackageDependencyGraph.DependencyId"/> has parsed the
+/// form correctly all along — this reader was the one that drifted.</para>
+///
+/// <para>Each test below discriminates by ORDER, because that is what a dropped edge changes: the
+/// Kahn sort is alphabetical among the ready set, so a package whose only reason to come later is
+/// a dependency edge comes FIRST when the edge is missing.</para>
+/// </summary>
+public class LocalNodeRepoDependencyTest
+{
+    private static PackageManifest Package(string id, params string[] requires) =>
+        new()
+        {
+            Id = id,
+            Name = id,
+            Kind = PackageKind.NodeRepo,
+            TargetPartition = id,
+            SourceFolder = id,
+            Version = "sha",
+            Requires = requires.ToImmutableList(),
+        };
+
+    private static readonly RepoSnapshot NoFiles = new("sha", []);
+
+    private static string[] Order(params PackageManifest[] packages) =>
+        LocalNodeRepo.OrderByDependencies(packages, NoFiles).Select(p => p.Id).ToArray();
+
+    // ── the drift ────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Requires_WithAVersionRange_IsStillADependencyEdge()
+    {
+        // "Essentials" sorts BEFORE "Mcp" alphabetically, so it leads the ready set unless the
+        // edge exists. Reading the entry raw ("Mcp@^1.0.0" != "Mcp") is exactly how the edge
+        // vanished — and this assertion is what fails when it does.
+        Assert.Equal(
+            ["Mcp", "Essentials"],
+            Order(Package("Essentials", "Mcp@^1.0.0"), Package("Mcp")));
+    }
+
+    [Fact]
+    public void Requires_WithAVersionRange_CollectsEveryDeclaredDependency()
+    {
+        // The real shape of Essentials/index.json: eleven declared modules, every one versioned.
+        // Before the fix this collected NOTHING and Essentials led the order.
+        var packages = new[]
+        {
+            Package("Essentials", "Store@^1.0.0", "Export@^1.0.0", "Mcp@^1.0.0"),
+            Package("Store"), Package("Export"), Package("Mcp"),
+        };
+        Assert.Equal(["Export", "Mcp", "Store", "Essentials"], Order(packages));
+    }
+
+    [Fact]
+    public void Requires_WithoutAVersionRange_StillWorks()
+    {
+        // The un-versioned form is the one that always worked; the fix must not regress it.
+        Assert.Equal(["Mcp", "Essentials"], Order(Package("Essentials", "Mcp"), Package("Mcp")));
+    }
+
+    [Fact]
+    public void Requires_ToleratesSurroundingWhitespace()
+    {
+        Assert.Equal(["Mcp", "Essentials"], Order(Package("Essentials", " Mcp @^1.0.0"), Package("Mcp")));
+    }
+
+    // ── the guards that keep the strip from inventing edges ──────────────────────────────────
+
+    [Fact]
+    public void Requires_ForAPackageOutsideTheSet_IsIgnored()
+    {
+        // A cross-repo dependency (Store, staged from another repo) cannot be ordered against and
+        // must not fabricate an entry — the runtime's tolerance, unchanged by the strip.
+        Assert.Equal(["Essentials"], Order(Package("Essentials", "Training@^1.0.0")));
+    }
+
+    [Fact]
+    public void Requires_ThatIsBlankOrVersionOnly_IsNotAnEdge()
+    {
+        // DependencyId returns "" for these; an empty id must never be looked up, or a package
+        // named "" would become everyone's dependency.
+        Assert.Equal(["Essentials", "Mcp"], Order(Package("Essentials", "", "@^1.0.0", "   "), Package("Mcp")));
+    }
+
+    [Fact]
+    public void Requires_OnItself_IsNotAnEdge()
+    {
+        // A self-edge would be an unbreakable cycle; the id comparison must survive the strip.
+        Assert.Equal(["Essentials", "Mcp"], Order(Package("Essentials", "Essentials@^1.0.0"), Package("Mcp")));
+    }
+
+    [Fact]
+    public void Requires_ThatCycles_EmitsEveryPackageExactlyOnce()
+    {
+        // Making the edges REAL makes cycles reachable that the dead comparison could never form.
+        // The documented behaviour is "install the rest alphabetically", never drop or loop.
+        var order = Order(Package("A", "B@^1.0.0"), Package("B", "A@^1.0.0"));
+        Assert.Equal(2, order.Length);
+        Assert.Equal(["A", "B"], order.Order().ToArray());
+    }
+}

--- a/tools/MeshWeaver.PluginTester/LocalNodeRepo.cs
+++ b/tools/MeshWeaver.PluginTester/LocalNodeRepo.cs
@@ -192,8 +192,15 @@ public static class LocalNodeRepo
         PackageManifest package, RepoSnapshot snapshot, ImmutableHashSet<string> packageIds)
     {
         var deps = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
-        foreach (var required in package.Requires)
-            if (packageIds.Contains(required) && required != package.Id)
+        // 🚨 THROUGH DependencyId, never the raw entry. A `requires` entry carries an optional
+        // version range — `"Store@^1.0.0"` — and comparing the whole string against a package ID
+        // matches nothing, so the edge silently disappears. Measured 2026-08-21 across
+        // MeshWeaver.Plugins: 51 of its 52 declared `requires` edges were dead, including every
+        // one of the eleven modules `Essentials` declares, so an `Mcp` change ordered (and, once
+        // the bake reads this same graph, REBUILT) without `Essentials`. `PackageDependencyGraph`
+        // has parsed it correctly all along; this reader is the one that drifted.
+        foreach (var required in package.Requires.Select(PackageDependencyGraph.DependencyId))
+            if (required.Length > 0 && packageIds.Contains(required) && required != package.Id)
                 deps.Add(required);
 
         var prefix = (package.SourceFolder ?? package.Id) + "/";


### PR DESCRIPTION
## What now drives the bake decision

> *"When updating plugins, we should check from git history which modules are affected, and we should rebuild only these."*

The node-repo bake was **always the full repo** — every main push and every 30-minute release poll ran ~40 minutes of Roslyn over ~40 packages to republish bundles that, for all but a handful, were already sealed in storage byte for byte.

The stated reason was the publication's atomicity, and it was a real constraint **applied to the wrong half of the job**:

> `_complete` is written LAST and lists the whole bundle set, and a portal seeds **only what the sentinel lists** — so publishing a delta would not ADD bundles, it would REPLACE the sentinel and shrink what every portal adopts.

That constrains what is **uploaded**. It says nothing about what must be **recompiled**. This PR separates them.

With `narrow-by-affected: true` (opt-in, default `false` — **nothing changes for any caller that does not set it**):

| | |
|---|---|
| **compile** | only the modules the diff affects, plus their dependencies (the tester's fresh mesh installs what it mounts). The mount **is** the filter — the same seam `test-repos` already uses on PRs. |
| **publish** | still the complete set. Every bundle not rebuilt is carried forward from the current publication before the seal, so `publish-bake-bundles.sh` runs **completely unchanged** over a full local set. |

### Three pieces

1. **`.github/scripts/bake-scope.sh`** decides. 🚨 **Its baseline is the PUBLICATION, not `github.event.before`** — the sealed directory carries `source-commit.txt`, the only commit that answers *"what changed since the bundles that are actually out there"*. Diffing the push would under-build silently after any run that did not publish: a cancelled run, a superseded push, a red gate, a re-run of an older commit. Reading it off the publication is self-correcting.
2. **The caller's `scripts/affected-modules.py`** answers — the caller's file because the edges are the caller's content, mirroring `LocalNodeRepo.CollectDependencies` 1:1. Its own `--self-test` is pinned in [Systemorph/MeshWeaver.Plugins#559](https://github.com/Systemorph/MeshWeaver.Plugins/pull/559).
3. **`.github/scripts/carry-forward-bundles.sh`** keeps the publication whole. A bundle it can neither rebuild nor fetch is **fatal**: the alternatives are "publish less than is published today" and "stop", and shrinking is the one that fails silently. Nothing has been written at that point, so the existing publication stays sealed and intact.

### Fallbacks preserved (every one resolves to a FULL bake, out loud)

`affected-modules.py`'s own guarantees are load-bearing here and all kept: it **refuses an empty diff**, and it classifies `scripts/`, `.github/`, repo-root files and **an unknown top-level dir (a DELETED module)** as ALL modules. On top of those, `bake-scope.sh` falls back when:

- the caller ships no selector;
- the event is a `repository_dispatch` — a framework release mints a **new identity**, so everything is recompiled against it (that bake is also the gate that catches an API removal before every portal parks — the 2026-08-09 `AddTracking` outage);
- there is no sealed publication for this identity yet, or a malformed/unreadable target;
- **the publish targets disagree** on the published source or bundle set;
- the baseline is unresolvable in this checkout, or is not an ancestor of HEAD (history rewritten);
- the selector refuses, answers ALL modules, or returns something unparseable.

Each names itself in the log **and** in the job summary, so a 40-minute bake always says why it was 40 minutes.

### One new verdict: `scope=none`

The sealed publication already records **this** commit for **this** identity. `publish-bake-bundles.sh` already skipped the upload in that case; nothing had ever gated the 40-minute build in front of it — and it is what the every-30-minutes release poll hits almost every run. It reports as an explicit **green step naming both shas**, never a tail of grey skips (AGENTS.md: a gate that did not run must never look like one that passed).

### Tests — and proof they can fail

Both scripts carry `--self-test` and run on **every platform PR** from `dotnet-test.yml`'s preflight job. Neither is reachable from any .NET test and both run only on a satellite's `main`, so without that step their first execution would be in production.

```
fallbacks to a FULL bake (the bias that makes narrowing safe):
  OK   no scripts/affected-modules.py in the caller repo
  OK   a framework-release dispatch (NEW identity — everything is recompiled against it)
  OK   no sealed publication yet for this identity (the FIRST bake)
  OK   a malformed publish target
  OK   publish targets that disagree on the published SOURCE
  OK   publish targets that disagree on the published BUNDLES
  OK   a publication whose recorded source is 'unknown'
  OK   a baseline commit this checkout does not have (shallow clone)
  OK   a baseline that is NOT an ancestor of HEAD (history rewritten)
  OK   the selector REFUSING — an empty diff or unresolvable range
  OK   the selector answering ALL modules (scripts/, .github/, a DELETED module)
  OK   a selector answer that cannot be parsed
verified nothing-to-do (a POSITIVE finding, never an absent input):
  OK   this exact content is already sealed for this identity (the 30-minute release poll)
  OK   a diff that reaches no module at all (docs/, e2e/, .claude/)
narrowed:
  OK   a module change since the published baseline
  OK   the mount is the selector's order, dependencies first
  OK   the baseline is the PUBLICATION's commit, not github.event.before
  OK   the sealed bundle listing is recorded for the carry-forward

carry-forward:
  OK   the bake dir ends up holding the WHOLE published set — rebuilt bundles win, the rest are fetched
  OK   a NEW module's bundle is additive — the set may grow, never shrink
refusals (the publication must never shrink):
  OK   a listed bundle that can neither be rebuilt nor fetched is FATAL, and it is NAMED
  OK   an empty published listing is refused (it cannot say what to carry forward)
  OK   a listing entry that is not a plain file name is refused
  OK   a missing bake directory is refused
```

**Non-vacuous by mutation** — each of these turns the step red:

| mutation | what goes wrong |
|---|---|
| ancestor check removed | a rewritten history narrows |
| `runAll=true` no longer forces full | a `scripts/` change narrows |
| unparseable answer no longer forces full | publishes **nothing** (`scope=none`) |
| target-agreement checks removed | disagreeing targets narrow |
| already-published short-circuit off | the poll re-bakes for 40 minutes |
| an unfetchable bundle is skipped | the publication **shrinks** |
| an empty listing is accepted | the publication **shrinks** |

### Measured effect (real `MeshWeaver.Plugins` graph, 40 modules)

```
Chess/index.json                  →  mount Store → Training → Chess     (37 modules skipped)
Store/Plugin/Source/PluginGate.cs →  mount all 40                        (0 skipped — correct:
                                       every plugin root is a Store/Plugin)
```

So the win is large for leaf-module changes and correctly **zero** for a `Store` change.

### Not in this PR, deliberately

- **The cross-repo rebuild cascade.** `narrow-by-affected` is the **content** axis. "Which repos rebuild, in what order, when an upstream publishes" is `upstream-sources` + `dependent-repos`, and it still needs `DEPENDENT_DISPATCH_TOKEN` provisioned (a human-minted PAT with `repo` scope on the four satellites) before Plugins can declare `dependent-repos` at all. Its own change.
- **Slice 4 of #1707** (generated-input content hash, `FullMvidAssemblies`) — the **platform/toolchain** trigger, orthogonal to this one and being built in parallel. `FrameworkBuildIdentity.cs` is untouched here.
- **The platform's own `main-cd` content bake** — it fuses gate and bake in one `mw-plugin-test` run over content that moves with the platform commit it is baking, so a content-diff baseline is a different question.
- **Adopting published bundles for mounted-but-unaffected dependencies.** `mw-plugin-test` has no seed-from-directory seam, so a narrowed bake still recompiles the closure's dependencies — almost always including `Store`. That is #1707 item 5 pointed at the gate.

All four are written up under *"What this step does not do yet"* in `CiContentBake.md`.

### Caller opt-in is a follow-up, on purpose

`uses:` is pinned to an immutable platform commit, so a caller cannot pass a new input until this merges. Once it does, `MeshWeaver.Plugins` opts in with a two-line change: bump the pin + `narrow-by-affected: true` (tracked in Systemorph/MeshWeaver.Plugins#559). Pinning a caller at this branch's head would leave exactly the kind of trap this repo removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🚨 Drift found and fixed: `CollectDependencies` was reading `requires` raw

`affected-modules.py`'s docstring claims a **1:1 SEMANTICS CONTRACT** with `LocalNodeRepo.CollectDependencies`, and the whole safety argument for narrowing the bake rests on that claim being true. Auditing it turned up a bug in the reader itself.

A `requires` entry carries an **optional version range**, and this reader compared the whole entry against a bare package id:

```
"Store@^1.0.0"  !=  "Store"    →  no match  →  the edge silently vanishes
```

**Direction: UNDER-collecting.** Not a false edge — a real declared dependency that was simply never collected, with nothing to see.

### Scale

Measured across `MeshWeaver.Plugins` on 2026-08-21: **51 of its 52 declared `requires` edges were dead.** Every module `Essentials` declares was among them:

```
requires edges as the runtime read them (raw string vs package id):  1
requires edges once the @range is parsed off:                       51

modules whose AFFECTED closure changes:  11
  AzureFoundry, Export, Indexing, Mail, Mcp, Notifications,
  Observability, OpenAI, Teams, WebSearch   → each GAINS Essentials
  Import                                    → GAINS Northwind
```

### What a consumer observed

- **`OrderByDependencies`** ordered a package *before* its declared dependency. Benign so far only by accident: every plugin root is typed `Store/Plugin`, so the `Store` edge survived via the nodeType-by-path signal rather than via the declaration anyone reads.
- **`affected-modules.py`**, which mirrors this method — a **missed dependent**. A change to `Mcp` gated without `Essentials`; and with `narrow-by-affected` in this PR it would have **republished a stale `Essentials` bundle to every portal**. That is precisely the "stale artefact nobody notices" failure this PR's whole fallback design exists to prevent, arrived at through a declaration everyone could read and nothing honoured.

`PackageDependencyGraph.DependencyId` — *"the package id half of a requirement entry: `"Store@^1.0.0"` → `"Store"`"* — has parsed the form correctly all along. This reader is the one that drifted. Both halves are fixed together (Systemorph/MeshWeaver.Plugins#559 carries the Python mirror, so the 1:1 contract holds again).

### Pinned, and it fails against current `main`

`LocalNodeRepoDependencyTest` goes through the public `OrderByDependencies` and discriminates by **order**: the Kahn sort is alphabetical among the ready set, so a package whose only reason to come later is a dependency edge **leads** when that edge is missing.

```
=== reverted to main's reader (raw requires entry) ===
Failed!  - Failed: 3, Passed: 5, Total: 8

  Requires_WithAVersionRange_IsStillADependencyEdge
      Assert.Equal() Failure: Collections differ at index 0
      Expected: "Mcp"      Actual: "Essentials"
  Requires_WithAVersionRange_CollectsEveryDeclaredDependency
      Expected: "Export"   Actual: "Essentials"
  Requires_ToleratesSurroundingWhitespace
      Expected: "Mcp"      Actual: "Essentials"

=== with the fix ===
Passed!  - Failed: 0, Passed: 8, Total: 8
```

The other five tests are the guards on the strip — only *reachable* once the edges became real: an id outside the set is still ignored (a staged cross-repo dependency), a blank / version-only entry is **not** an edge (an empty id must never be looked up, or a package named `""` becomes everyone's dependency), a self-edge is still refused, and a genuine cycle still emits every package exactly once.


---

### One deliberate divergence from the PR-gate policy, stated plainly

The gate's rule is *"main pushes and manual dispatch never narrow"*. **The gate keeps it verbatim — `test-repos` in every caller is untouched by this PR.** The bake cannot: it only ever runs on main, so "never narrow on main" would mean never narrow at all, and that is exactly what the maintainer asked to change.

What that rule bought is recovered by three stronger mechanisms rather than dropped:

| the gate's rule bought | the bake gets it from |
|---|---|
| a full run when the diff base is untrustworthy | the baseline is the **sealed publication's** `source-commit.txt`, not the push — self-correcting across cancelled/superseded/red runs |
| never shipping less than was verified | the publication stays **complete** — un-rebuilt bundles are carried forward before the seal, and a bundle that cannot be fetched is **fatal**, never a shrink |
| a full run on a release | `repository_dispatch` is an **explicit full-bake fallback** — a new framework identity means everything is recompiled against it |

And the narrowing is off by default (`narrow-by-affected: false`), so no caller's behaviour changes until it opts in.


---

### Interaction with the two PRs in flight

| PR | Overlap | Verdict |
|---|---|---|
| **#1992** — `landed-modules-gate` | `.github/workflows/dotnet-test.yml` (the only shared file) | **Merges cleanly** — verified with `git merge-tree --write-tree`. Disjoint regions: my two self-test steps go inside the existing `preflight` job (~L354), its new job is appended after `plugin-gate` (~L1401). |
| **#1994** — slice 4, generated-input content key | none | **Orthogonal** — it is confined to `src/MeshWeaver.Compiler/*` + `MeshNodeCompilationService`; this PR touches `.github/`, `tools/MeshWeaver.PluginTester`, its test project and one doc. `FrameworkBuildIdentity.cs` is untouched here, and slice 4 keeping `FullMvidAssemblies` as the platform axis's cheap trigger changes nothing for this one. |

**Behaviourally**, `landed-modules-gate` and this PR are different lanes and neither narrows the other:

- it `dotnet build`s MeshWeaver.Plugins' **compiled `src/` modules** (16 modules + 15 test projects, one generated solution, ~16 s);
- this narrows the **node-content bake** — the mesh's Roslyn compile of `<Type>/Source/*.cs`, whose artifacts are the published bundles.

They share no discovery or ordering code: `landed-modules-gate` enumerates `.csproj` files, while `affected-modules.py` / `CollectDependencies` resolve NODE packages. At 16 s for all 31 projects, that gate is also not a narrowing candidate — its cost is the platform graph it compiles once, not the module count.

The one thing worth flagging: the `requires`-parsing fix below changes NODE-package install ORDER inside `mw-plugin-test` (`plugin-gate`), not `dotnet build` (`landed-modules-gate`). Checked against the real 40-module graph with the corrected reader — it resolves to a clean leaves-first topological order with **no cycle**, `Store` first.
