### PR TITLE
An undeliverable stream-routed delivery NACKs its sender instead of vanishing (#1742)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/OrleansStreamPubSubDurability.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OrleansStreamPubSubDurability.md
@@ -191,19 +191,88 @@ same retry / NACK / failure signal the forward leg already has. Sketch of what t
   address one specific process.
 - `RoutingGrain.BuildStreamRoute` replaced by that call, reusing the existing
   `DeliverToGrainWithRetry` → `PostFailureToSender` machinery verbatim.
-- and then `OrleansStreamingReadiness`, the `subscriptionReady` attach gate (#1081), the
-  `SubscribeWhenStreamingReadyAsync` retry surface and `RootMeshHubReplyStreamService` all become
-  **deletable** — the memory stream provider is only kept alive by this one use.
+- and then `OrleansStreamingReadiness` — 97 lines with exactly one consumer — becomes **deletable**.
+
+> 🚨 **The cleanup dividend is smaller than this page used to claim.** It said the memory stream
+> provider "is only kept alive by this one use". It is not: `PathCacheInvalidatorGrain`
+> (`[ImplicitStreamSubscription("mesh-created"/"mesh-deleted")]`) and
+> `OrleansMeshChangeFeed.BroadcastAsync` both publish on `StreamProviders.Memory`, so
+> `AddMemoryStreams` and its `PubSubStore` stay whatever happens to the routing leg. The
+> `subscriptionReady` attach gate (#1081) and `SubscribeWhenStreamingReadyAsync` likewise survive
+> as long as any hub subscribes a stream at all. Budget the rewrite on its own merits, not on a
+> deletion that is not there.
 
 It is a real change (new placement strategy, a directory with its own lifecycle, and a two-PROCESS
 test to prove it), which is why it is written down here rather than done alongside the durability
 fix. Tracked in [#1742](https://github.com/Systemorph/MeshWeaver/issues/1742).
 
-## 🚨 An in-process `TestCluster` cannot reproduce this
+## The subscriber check — what it buys, and the measurement that put it there
+
+Ahead of that rewrite the router now **asks whether anyone is listening** before it publishes
+(`RoutingGrain.HasLiveSubscriber`). The stream provider exposes its own subscription registry —
+`IStreamProvider.TryGetStreamSubscriptionManager(out …)`, since `PersistentStreamProvider` implements
+`IStreamSubscriptionManagerRetriever` — so this is derived from the provider the routing turn already
+captured: no DI lookup, no new grain, no new dependency. Zero subscribers ⇒ the delivery is refused
+with a `DeliveryFailure{ErrorType=NotFound}` to its sender instead of being published into a
+discard.
+
+**This page previously rejected that check on hot-path cost. That rejection did not survive
+measurement** (in-process cluster, 2026-08-21):
+
+| | measured |
+|---|---|
+| subscriber lookup, warm | **0.010 ms** |
+| the memory-stream publish it guards | **0.053 ms** |
+| a hub registered on a SILO through `RegisterStream` | 1 subscription — **visible** |
+| the same hub registered in a CLIENT process | 2 — **visible** |
+| the root `mesh/{id}` hub (`RootMeshHubReplyStreamService`) | 1 — **visible** |
+| an address nothing ever registered | 0 |
+| after its registration is disposed | back to 0 within ~250 ms |
+
+A fifth of the cost of the leg it protects is not a hot path argument, so the check is applied to
+**every** stream-routed delivery rather than confined to replies — which it had to be anyway: a
+forward request to an absent pod-process hub is dropped by exactly the same publish, and confining
+the check to replies would have left that half silent.
+
+Two properties are deliberate and must not be "tidied":
+
+- **It fails OPEN.** An unavailable, faulting or slow registry returns *"assume someone is
+  listening"* and the delivery is published exactly as before. A detector that cannot run must
+  never become a refusal — that trade turns one silent drop into a cluster-wide outage.
+- **It is check-then-act, and says so.** A subscriber can vanish between the answer and the publish,
+  and `MemoryStreamQueueGrain` — still RAM — can die with its silo holding a message the check
+  called deliverable. The check narrows the silent window; only the transport change below closes
+  it.
+
+The same question is asked before the **NACK** leg publishes (`RoutingGrain.PostFailure`). It cannot
+be answered with a NACK — you cannot NACK a NACK — so an unreachable sender is now an **error log
+naming the sender, the request and the original failure**, where before it was an env-var-gated
+trace line whose own tag admitted the gap (`FAILURE_DELIVER_OK_UNCONFIRMED`) and which production
+never emitted at all.
+
+### The gate
+
+`StreamRoutedSilenceGateTest` (test/MeshWeaver.Hosting.Orleans.Test) pins the invariant, and it does
+so **in process** — see the correction below. It posts to a `client/…` address nothing has
+registered (asserting first, through the same registry, that the stream really has no subscriber, so
+a green cannot come from a hub that happened to exist) and requires a `DeliveryFailureException`
+inside a bounded wait. Against the unfixed router it fails with the defect's own symptom: nothing
+answers, and the bound converts the hang into a `TimeoutException` at 30 s. A sibling fact posts
+between two REGISTERED pod-process hubs, so a check that refused everything cannot pass.
+
+## 🚨 An in-process `TestCluster` cannot reproduce THE REGISTRY LOSS — but it does reproduce the silence
 
 Every silo in an `Orleans.TestingHost.TestCluster` shares **one process, one heap, and therefore one
 memory grain store**. "Silo A departs" never destroys the state silo B's subscription lives in, so
-the defect is unrepresentable there. A two-silo `TestCluster` assertion for this bug was written and
+*that* defect is unrepresentable there.
+
+🚨 **Read the scope of that sentence carefully — it was over-read for months, and it cost the gate
+this page said was missing.** It is about the pub-sub REGISTRY dying with a silo. The *invariant* —
+an undeliverable delivery surfaces as a `DeliveryFailure`, never as silence — needs no silo
+departure and no second process: **a stream nobody has subscribed to is subscriber-less on any
+cluster**, including one silo in one process. Same publish, same branch of
+`RoutingGrain.RouteMessage`, same silence. `StreamRoutedSilenceGateTest` is that test, it is
+deterministic, and it was writable before the fix rather than after. A two-silo `TestCluster` assertion for this bug was written and
 **passed identically with and without the fix** — worse than no test, and it was deleted rather than
 shipped as false assurance.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-a-request-to-a-hub-that-is-gone-fails-fast.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-a-request-to-a-hub-that-is-gone-fails-fast.md
@@ -1,0 +1,13 @@
+---
+Name: A request to a hub that is gone now fails immediately
+Category: Fix
+Description: A page waiting on a part of the mesh that is no longer there gets an immediate, explicit error instead of a minute of silence.
+Icon: Sparkle
+Order: -20260821
+---
+
+# A request to a hub that is gone now fails immediately
+
+Some parts of the portal are reached over an internal broadcast channel rather than by a direct call. That channel has one awkward property: sending to it succeeds even when nobody is listening. If the intended recipient was no longer there, the message was accepted, silently discarded, and the page that was waiting for an answer waited out its full one-minute budget before giving up — with nothing anywhere saying what had happened or to whom.
+
+The sender is now asked to be sure someone is listening before the message goes out, and when nobody is, the waiting request is told so straight away. A page that would have hung for a minute now reports an error in well under a second, and the record left behind names the recipient, the request and what could not be delivered.

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -10,7 +10,10 @@ using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Concurrency;
+using Orleans.Runtime;
 using Orleans.Streams;
+using Orleans.Streams.Core;
+using Orleans.Streams.PubSub;
 
 namespace MeshWeaver.Hosting.Orleans;
 
@@ -141,6 +144,15 @@ internal class RoutingGrain(
     /// silence — the timeout surfaces through the fault branch, which NACKs the sender.
     /// </summary>
     internal static readonly TimeSpan ResolveTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Bound on the "is anyone subscribed to this stream?" lookup (issue #1742). The lookup is one
+    /// grain call to the stream's <c>PubSubRendezvousGrain</c>, which Orleans already bounds at its
+    /// 30 s <c>ResponseTimeout</c>; this exists so a registry that never answers degrades to
+    /// PUBLISHING ANYWAY rather than parking the delivery — see <see cref="HasLiveSubscriber"/>,
+    /// which fails OPEN by construction.
+    /// </summary>
+    internal static readonly TimeSpan SubscriberProbeTimeout = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// 🚨 THE TURN DOES O(1) WORK AND RETURNS — issue #1028.
@@ -330,8 +342,17 @@ internal class RoutingGrain(
             logger.LogDebug("[ROUTE] {Address} type={Type} declared stream-routed → memory stream", addressPath, address.Type);
             RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM addr={addressPath} id={delivery.Id} streamName={addressPath}");
             var s = streamProvider.GetStream<IMessageDelivery>(addressPath);
-            return PostToStream(delivery, () => s.OnNextAsync(delivery), addressPath,
-                delivery.Sender, PostFailureToSender, logger, StreamPostTimeout);
+            // 🚨 ASK WHETHER ANYONE IS LISTENING — issue #1742. A publish to a stream with NO live
+            // subscriber SUCCEEDS: nothing faults, the trace says MEMORY_STREAM_OK, and the message
+            // is discarded. That is the ONE non-delivery in the system with no failure signal of any
+            // kind, and it is what the sender experiences as a full 60 s reply budget spent on
+            // silence. See RefuseNoSubscriber for what the check does and does not buy.
+            return HasLiveSubscriber(
+                    TryGetSubscriptionManager(streamProvider), s.StreamId, addressPath, logger, SubscriberProbeTimeout)
+                .SelectMany(alive => alive
+                    ? PostToStream(delivery, () => s.OnNextAsync(delivery), addressPath,
+                        delivery.Sender, PostFailureToSender, logger, StreamPostTimeout)
+                    : RefuseNoSubscriber(delivery, addressPath, PostFailureToSender, logger));
         })
             // Composition-time faults must ALSO reach the sender — see BuildGrainRoute's trailing
             // Catch for the full rationale (the classic one: GetStream NRE'ing out of
@@ -343,6 +364,90 @@ internal class RoutingGrain(
                 PostFailureToSender($"Routing to '{addressPath}' failed: {ex.Message}", ErrorType.Failed);
                 return Observable.Return(Unit.Default);
             });
+    }
+
+    /// <summary>
+    /// The stream's subscription registry, derived from the stream PROVIDER we already hold — no DI
+    /// lookup, no silo container, no new constructor dependency. Orleans' <c>PersistentStreamProvider</c>
+    /// (which every <c>AddMemoryStreams</c> provider is) implements <c>IStreamSubscriptionManagerRetriever</c>,
+    /// so this is a cast and a property read. Null on a provider that does not expose one, which
+    /// <see cref="HasLiveSubscriber"/> treats as "cannot tell" — i.e. today's behaviour, unchanged.
+    /// </summary>
+    private static IStreamSubscriptionManager? TryGetSubscriptionManager(IStreamProvider streamProvider) =>
+        streamProvider.TryGetStreamSubscriptionManager(out var manager) ? manager : null;
+
+    /// <summary>
+    /// Answers "does this stream have a live subscriber?" — the question a memory-stream publish
+    /// never asks and whose absence is the whole of issue #1742.
+    ///
+    /// <para>🚨 <b>FAILS OPEN, always.</b> A probe that cannot run must never become a blocker: if
+    /// the registry is unavailable, faults, or does not answer inside
+    /// <see cref="SubscriberProbeTimeout"/>, this returns <c>true</c> and the delivery is published
+    /// exactly as it is today. The check is a DETECTOR, and turning a detector outage into a
+    /// mesh-wide refusal would be strictly worse than the silence it is there to remove.</para>
+    ///
+    /// <para><b>What it is measured to see</b> (in-process cluster, 2026-08-21): a hub registered
+    /// through <c>OrleansRoutingService.RegisterStream</c> on a SILO (1 subscription), the same on a
+    /// CLIENT process (2), the root <c>mesh/{id}</c> hub (1), zero for an address never registered,
+    /// and back to zero within ~250 ms of a registration being disposed. Cost is 0.010 ms warm
+    /// against 0.053 ms for the publish it guards — roughly a fifth of the leg it protects, which is
+    /// why it is applied to EVERY stream-routed delivery rather than confined to replies.</para>
+    ///
+    /// <para><b>What it does NOT buy.</b> It is a check-then-act: a subscriber can vanish between
+    /// the answer and the publish, and a <c>MemoryStreamQueueGrain</c> that dies with its silo drops
+    /// a message this probe said was deliverable. Those residuals are closed only by taking replies
+    /// off streams entirely — see <c>Doc/Architecture/OrleansStreamPubSubDurability</c>.</para>
+    /// </summary>
+    internal static IObservable<bool> HasLiveSubscriber(
+        IStreamSubscriptionManager? subscriptions,
+        StreamId streamId,
+        string addressPath,
+        ILogger logger,
+        TimeSpan timeout,
+        IScheduler? scheduler = null)
+        => subscriptions is null
+            ? Observable.Return(true)
+            : Observable.Defer(() =>
+                    subscriptions.GetSubscriptions(StreamProviders.Memory, streamId).ToObservable())
+                .Select(subs => subs.Any())
+                .Timeout(timeout, scheduler ?? Scheduler.Default)
+                .Catch<bool, Exception>(ex =>
+                {
+                    logger.LogWarning(ex,
+                        "[ROUTE] Subscriber lookup for {Address} did not answer within {Timeout} — publishing anyway. "
+                        + "The check fails OPEN on purpose: an unavailable registry must not become a refusal.",
+                        addressPath, timeout);
+                    return Observable.Return(true);
+                });
+
+    /// <summary>
+    /// The terminal answer for a stream-routed delivery whose destination has no subscriber: say
+    /// exactly what could not be delivered, and NACK the sender so its <c>Observe(...)</c> fires
+    /// <c>OnError</c> now instead of waiting out its own budget.
+    ///
+    /// <para><see cref="ErrorType.NotFound"/>, not <see cref="ErrorType.Failed"/>: nothing failed —
+    /// the address simply names no hub that any silo in this cluster is currently serving. That is
+    /// the same classification an unresolvable node path gets from
+    /// <see cref="BuildGrainRoute"/>, and it is what lets a caller distinguish "gone" from "broke".</para>
+    /// </summary>
+    private static IObservable<Unit> RefuseNoSubscriber(
+        IMessageDelivery delivery,
+        string addressPath,
+        Action<string, ErrorType> postFailureToSender,
+        ILogger logger)
+    {
+        var reason =
+            $"Stream-routed delivery to '{addressPath}' has no live subscriber: no silo in this cluster "
+            + "is currently serving that hub, so the message could not be delivered.";
+        logger.LogError(
+            "[ROUTE] {Reason} Message {MessageType} ({DeliveryId}) from {Sender} was NOT posted — a publish "
+            + "to a subscriber-less stream succeeds and discards, which is why this had to be checked "
+            + "rather than observed. Surfacing DeliveryFailure to the sender.",
+            reason, delivery.Message?.GetType().Name ?? "(null)", delivery.Id, delivery.Sender);
+        RoutingGrainTrace.Write(
+            $"RoutingGrain.RouteMessage MEMORY_STREAM_NO_SUBSCRIBER addr={addressPath} id={delivery.Id} sender={delivery.Sender}");
+        postFailureToSender(reason, ErrorType.NotFound);
+        return Observable.Return(Unit.Default);
     }
 
     /// <summary>
@@ -502,23 +607,45 @@ internal class RoutingGrain(
             return;
         }
 
-        streamProvider.GetStream<IMessageDelivery>(delivery.Sender.ToString())
-            .OnNextAsync(failureDelivery)
-            .ContinueWith(t =>
+        // 🚨 THE NACK RIDES THE CHANNEL IT IS REPORTING ON — issue #1742, residual C. For a sender
+        // this silo does not host there is no other way to reach it, so the honest thing is not to
+        // pretend: ASK whether that sender's stream still has a subscriber, and when it does not,
+        // say so LOUDLY. The old trace tag admitted the gap in its own name
+        // (FAILURE_DELIVER_OK_UNCONFIRMED) and then only wrote it to an env-var-gated file, so in
+        // production an undeliverable NACK produced no signal at all. It still cannot be delivered
+        // — you cannot NACK a NACK — but "the sender was told" and "the sender is unreachable" are
+        // now different lines instead of the same one.
+        //
+        // The publish still happens either way: the probe is check-then-act, so a subscriber that
+        // attaches in the gap would otherwise lose an answer we could have delivered.
+        var senderPath = delivery.Sender.ToString();
+        var senderStream = streamProvider.GetStream<IMessageDelivery>(senderPath);
+        HasLiveSubscriber(
+                TryGetSubscriptionManager(streamProvider), senderStream.StreamId, senderPath, logger, SubscriberProbeTimeout)
+            .Do(alive =>
             {
-                if (t.IsFaulted)
-                {
-                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_FAIL id={delivery.Id} ex={t.Exception?.InnerException?.Message ?? t.Exception?.Message}");
-                    logger.LogWarning(t.Exception, "[ROUTE] Failed to deliver {ErrorType} failure to sender {Sender}", errorType, delivery.Sender);
-                }
-                else
+                if (alive) return;
+                RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_NO_SUBSCRIBER id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
+                logger.LogError(
+                    "[ROUTE] Cannot deliver the {ErrorType} DeliveryFailure for {DeliveryId} to sender {Sender}: "
+                    + "that hub has no live subscriber on its stream, and a NACK has no NACK of its own. "
+                    + "The sender will wait out its own request budget — the original failure was: {FailureMessage}",
+                    errorType, delivery.Id, delivery.Sender, failureMessage);
+            })
+            .SelectMany(_ => senderStream.OnNextAsync(failureDelivery).ToObservable())
+            .Subscribe(
+                _ =>
                     // 🚨 "OK" here means the PUBLISH did not fault — NOT that anything received it.
                     // A memory-stream publish with no subscriber succeeds, so this line cannot
-                    // distinguish delivered from discarded. It is only reached for a sender this
-                    // silo does not host; the co-hosted case took the local route above, where
-                    // delivery IS observable.
-                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_OK_UNCONFIRMED id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
-            }, TaskScheduler.Default);
+                    // distinguish delivered from discarded; the probe above is what does. It is only
+                    // reached for a sender this silo does not host; the co-hosted case took the
+                    // local route above, where delivery IS observable.
+                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_OK_UNCONFIRMED id={delivery.Id} sender={delivery.Sender} errorType={errorType}"),
+                ex =>
+                {
+                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_FAIL id={delivery.Id} ex={ex.Message}");
+                    logger.LogWarning(ex, "[ROUTE] Failed to deliver {ErrorType} failure to sender {Sender}", errorType, delivery.Sender);
+                });
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Orleans.Test/StreamRoutedSilenceGateTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/StreamRoutedSilenceGateTest.cs
@@ -1,0 +1,128 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Streams;
+using Orleans.Streams.Core;
+using Orleans.Streams.PubSub;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 THE SILENCE GATE — issue #1742. <b>An undeliverable stream-routed delivery must surface as a
+/// <see cref="DeliveryFailure"/>, never as silence.</b>
+///
+/// <para>Delivery to a POD-PROCESS hub — <c>mesh</c>, <c>portal</c>, <c>client</c>, <c>cache</c>,
+/// plus module-registered types — cannot be a grain call, because Orleans places grains and nothing
+/// places a process. Those hubs are reached over an Orleans memory stream instead, and a stream
+/// publish is fire-and-forget: <b>a publish to a stream with no live subscriber SUCCEEDS</b>.
+/// Nothing faults, the routing trace records <c>MEMORY_STREAM_OK</c>, and the message is discarded.
+/// The requester then spends its full 60 s reply budget on an answer the router believes it sent —
+/// the <c>[STALE-CALLBACK]</c> shape measured on memex-cloud (#1729).</para>
+///
+/// <para><b>Why this is testable in-process, contrary to the note on #1770.</b> That note
+/// ("an in-process TestCluster cannot reproduce this") is true but narrow: it is about the pub-sub
+/// REGISTRY dying with a silo, which needs separate heaps. The invariant here needs no silo
+/// departure at all — an address that no hub has registered is a subscriber-less stream on any
+/// cluster, including one silo in one process. That is the same publish, the same branch of
+/// <c>RoutingGrain.RouteMessage</c>, and the same silence.</para>
+///
+/// <para><b>Non-vacuity.</b> Against <c>origin/main</c> this fails with the defect's own symptom:
+/// the post never answers and the bounded wait converts the hang into a
+/// <see cref="TimeoutException"/>. Every wait here is bounded — an unbounded one would hang exactly
+/// the way the bug does and prove nothing.</para>
+/// </summary>
+public class StreamRoutedSilenceGateTest(ITestOutputHelper output) : OrleansSharedTestBase(output)
+{
+    /// <summary>
+    /// The gate. A request addressed at a stream-routed hub that no silo serves must come back as a
+    /// <see cref="DeliveryFailureException"/> promptly — not as a 60 s wait on nothing.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task StreamRoutedDeliveryWithNoSubscriber_NacksTheSender_NeverSilence()
+    {
+        var sender = GetClient($"gate-sender-{Guid.NewGuid():N}");
+
+        // `client` is a StreamRoutedAddressType, so this takes RoutingGrain's stream branch — the
+        // one with no delivery guarantee. Nothing has ever registered this address, so the stream
+        // provably has no subscriber (asserted below, so a green cannot come from a hub that
+        // happened to exist).
+        var ghost = new Address("client", $"ghost-{Guid.NewGuid():N}");
+        await AssertNoSubscriber(ghost);
+
+        Func<Task> post = () => sender
+            .Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(ghost))
+            .FirstAsync()
+            .ToTask()
+            .WaitAsync(30.Seconds());
+
+        var thrown = await post.Should().ThrowAsync<Exception>(
+            "a delivery that cannot be delivered must produce an ANSWER — silence is the one "
+            + "outcome this transport must never have");
+
+        thrown.Which.Should().NotBeOfType<TimeoutException>(
+            "a TimeoutException from the bounded wait means the post was SILENTLY DROPPED: the "
+            + "memory-stream publish succeeded with nobody subscribed, so the sender waited on an "
+            + "answer the router believed it had sent. That is issue #1742 exactly");
+
+        thrown.Which.Should().BeOfType<DeliveryFailureException>(
+            "the router must NACK the sender when the destination stream has no live subscriber, so "
+            + "the caller's Observe fires OnError instead of parking");
+
+        Output.WriteLine($"[gate] answered with {thrown.Which.GetType().Name}: {thrown.Which.Message}");
+    }
+
+    /// <summary>
+    /// The other half of the same invariant, and the reason the check has to be a QUESTION rather
+    /// than an observation: a hub that IS registered must still be delivered to. A check that
+    /// refused everything would pass the gate above and break the mesh, so this fact is what makes
+    /// the gate's green mean something.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task RegisteredStreamRoutedHub_StillReceivesItsDelivery()
+    {
+        var sender = GetClient($"live-sender-{Guid.NewGuid():N}");
+        var receiver = GetClient($"live-receiver-{Guid.NewGuid():N}");
+
+        // A round trip THROUGH the router: the receiver is a registered pod-process hub, so the
+        // delivery takes the same stream branch the ghost took and must arrive.
+        var response = await sender
+            .Observe(new PingRequest(), o => o.WithTarget(receiver.Address))
+            .FirstAsync()
+            .ToTask()
+            .WaitAsync(30.Seconds());
+
+        response.Message.Should().NotBeNull(
+            "a registered stream-routed hub must still be reachable — the subscriber check is a "
+            + "question asked before publishing, never a refusal of live traffic");
+    }
+
+    /// <summary>
+    /// Proves the destination really has no subscriber before the gate posts to it — so a green
+    /// gate cannot be explained by "some hub was listening after all". Reads the same registry the
+    /// router consults, through the same provider-derived accessor.
+    /// </summary>
+    private async Task AssertNoSubscriber(Address address)
+    {
+        var provider = Fixture.Cluster.SiloServices()
+            .GetRequiredKeyedService<IStreamProvider>(StreamProviders.Memory);
+        provider.TryGetStreamSubscriptionManager(out var manager).Should().BeTrue(
+            "the memory stream provider must expose its subscription registry — without it the "
+            + "router cannot ask the question and this gate would be vacuous");
+        var streamId = provider.GetStream<IMessageDelivery>(address.ToString()).StreamId;
+        var subscriptions = await manager!.GetSubscriptions(StreamProviders.Memory, streamId);
+        subscriptions.Should().BeEmpty(
+            $"nothing has ever registered {address}, so its stream must have no subscriber — that "
+            + "is the precondition the gate is about");
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/StreamRoutedSilenceGateTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/StreamRoutedSilenceGateTest.cs
@@ -120,7 +120,11 @@ public class StreamRoutedSilenceGateTest(ITestOutputHelper output) : OrleansShar
             "the memory stream provider must expose its subscription registry — without it the "
             + "router cannot ask the question and this gate would be vacuous");
         var streamId = provider.GetStream<IMessageDelivery>(address.ToString()).StreamId;
-        var subscriptions = await manager!.GetSubscriptions(StreamProviders.Memory, streamId);
+        // Bounded, like every other wait here: the registry call is exactly the class of thing this
+        // PR is about, so a wedged one must fail this precondition FAST and name itself rather than
+        // ride the [Fact] timeout, where it would look like the gate's own assertion hanging.
+        var subscriptions = await manager!.GetSubscriptions(StreamProviders.Memory, streamId)
+            .WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
         subscriptions.Should().BeEmpty(
             $"nothing has ever registered {address}, so its stream must have no subscriber — that "
             + "is the precondition the gate is about");


### PR DESCRIPTION
Step 2 of 3 for #1742. Independent of #1986 (step 1); step 3 builds on this branch.

## The defect

Delivery to a **pod-process hub** — `mesh`, `portal`, `client`, `cache`, plus module-registered types — cannot be a grain call, because Orleans places grains and nothing places a process. Those hubs are reached over an Orleans memory stream, and a stream publish is fire-and-forget: **a publish to a stream with no live subscriber SUCCEEDS.** Nothing faults, the routing trace records `MEMORY_STREAM_OK`, and the message is discarded. The sender then spends its full 60 s budget on an answer the router believes it sent — the `[STALE-CALLBACK]` shape measured on memex-cloud (#1729).

## The fix

The router now **asks whether anyone is listening** before it publishes. The stream provider exposes its own subscription registry (`IStreamProvider.TryGetStreamSubscriptionManager`, since `PersistentStreamProvider` implements `IStreamSubscriptionManagerRetriever`), so the check is derived from the provider the routing turn already captured: no DI lookup, no new grain, no new dependency. Zero subscribers ⇒ `DeliveryFailure{NotFound}` to the sender instead of a publish into a discard.

## The measurement that put it there

`Doc/Architecture/OrleansStreamPubSubDurability` rejected exactly this check on hot-path cost. **That rejection did not survive measurement** (in-process cluster, 2026-08-21):

| | measured |
|---|---|
| subscriber lookup, warm | **0.010 ms** |
| the memory-stream publish it guards | **0.053 ms** |
| hub registered on a SILO through `RegisterStream` | 1 subscription — visible |
| the same hub registered in a CLIENT process | 2 — visible |
| the root `mesh/{id}` hub | 1 — visible |
| an address nothing ever registered | 0 |
| after its registration is disposed | back to 0 within ~250 ms |

A fifth of the cost of the leg it protects is not a hot-path argument, so the check applies to **every** stream-routed delivery rather than only to replies — which it had to anyway: a forward request to an absent pod-process hub is dropped by the same publish, so confining it to replies would have left that half silent.

Two properties are deliberate:

- **It fails OPEN.** An unavailable, faulting or slow registry returns "assume someone is listening" and the delivery is published exactly as before. A detector that cannot run must never become a refusal.
- **It is check-then-act and says so.** A subscriber can vanish between the answer and the publish, and `MemoryStreamQueueGrain` — still RAM — can die with its silo holding a message the check called deliverable. The check narrows the silent window; only step 3 closes it.

The same question is asked before the **NACK** leg publishes (`PostFailure`). It cannot be answered with a NACK — you cannot NACK a NACK — so an unreachable sender is now an **error log naming the sender, the request and the original failure**, where before it was an env-var-gated trace line whose own tag admitted the gap (`FAILURE_DELIVER_OK_UNCONFIRMED`) and which production never emitted at all.

## Non-vacuity

`StreamRoutedSilenceGateTest` against the unmodified router:

```
[15:32:04.053] === TEST FAILED: Did not expect value to be of type TimeoutException because a
TimeoutException from the bounded wait means the post was SILENTLY DROPPED: the memory-stream
publish succeeded with nobody subscribed, so the sender waited on an answer the router believed
it had sent. That is issue #1742 exactly, but it was.
Failed!  - Failed: 1, Passed: 1, Skipped: 0, Total: 2, Duration: 33 s
```

The gate first asserts, through the same registry, that the destination stream really has no subscriber — so a green cannot come from a hub that happened to exist. Its sibling fact posts between two **registered** pod-process hubs and passes on both revisions, so a check that refused everything could not pass. Every wait is bounded.

## Testability correction

#1770's note that "an in-process `TestCluster` cannot reproduce this" is true but **narrow** — it is about the pub-sub registry dying with a silo. A stream nobody has subscribed to is subscriber-less on any cluster, including one silo in one process, so this invariant needed neither a silo departure nor a second process. The doc now says which half is which.

Also corrects the doc's claim that the memory stream provider "is only kept alive by this one use": `PathCacheInvalidatorGrain` and `OrleansMeshChangeFeed` also use it, so `AddMemoryStreams` and `PubSubStore` stay whatever happens to the routing leg. Only `OrleansStreamingReadiness` (97 lines, one consumer) genuinely becomes deletable.

## Suites

| suite | result |
|---|---|
| `MeshWeaver.Hosting.Orleans.Test` | 179/179 |
| `MeshWeaver.Messaging.Hub.Test` | 263/263 |
| `MeshWeaver.Hosting.Monolith.Test` | 743 passed, 3 skipped, 0 failed |
| `MeshWeaver.Documentation.Test` | 39/39 |

Refs #1742, #1729, #1770.