### PR TITLE
feat: Threads app — vertical thread rail with ✕-to-close, dock tile on the Apps tab

### DIFF
--- a/src/MeshWeaver.AI/ThreadLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ThreadLayoutAreas.cs
@@ -58,7 +58,10 @@ public static class ThreadLayoutAreas
                 // copied onto the thread at creation), same wiring as the composer node's area.
                 .WithView(ThreadComposerView.SelectorsArea, ThreadComposerView.ComposerSelectors)
                 .WithView(MeshNodeLayoutAreas.ThumbnailArea, Thumbnail)
-                .WithView(MeshNodeLayoutAreas.ThreadsArea, ThreadsCatalog));
+                .WithView(MeshNodeLayoutAreas.ThreadsArea, ThreadsCatalog)
+                // One compact row of the Threads-app vertical rail (title + ✕ close overlay);
+                // consumed as MeshSearch.ItemArea by the user hub's Threads app page.
+                .WithView(ThreadNodeType.RailItemArea, ThreadRailItem.View));
 
     /// <summary>
     /// Side panel menu items (New Chat, History, Full Screen). Static set — emitted once.

--- a/src/MeshWeaver.AI/ThreadNodeType.cs
+++ b/src/MeshWeaver.AI/ThreadNodeType.cs
@@ -98,6 +98,15 @@ public static class ThreadNodeType
     public const string ChangesArea = "Changes";
 
     /// <summary>
+    /// Layout area rendering THIS thread as one compact row of the Threads-app vertical rail
+    /// (<see cref="ThreadRailItem"/>): the title navigating to the thread, plus an ✕ overlay that
+    /// CLOSES the thread (<c>MarkThreadDone</c> — it leaves the rail but stays searchable and
+    /// reopenable; closing is never deleting). Used as a <c>MeshSearch.ItemArea</c> by the user
+    /// hub's Threads app page.
+    /// </summary>
+    public const string RailItemArea = "RailItem";
+
+    /// <summary>
     /// Generates a human-readable speaking ID from message text.
     /// Takes the first few words, lowercases, replaces non-alphanumeric with hyphens,
     /// and appends a short unique suffix.

--- a/src/MeshWeaver.AI/ThreadRailItem.cs
+++ b/src/MeshWeaver.AI/ThreadRailItem.cs
@@ -1,0 +1,72 @@
+using System.Reactive.Linq;
+using MeshWeaver.Application.Styles;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.Domain;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// One row of the Threads-app vertical rail (the GitHub-Copilot-style thread list): the thread's
+/// title as a full-width navigation button, plus an ✕ overlay that CLOSES the thread via the
+/// canonical <see cref="HubThreadExtensions.MarkThreadDone"/> — the row leaves the rail reactively
+/// (the rail's query excludes <c>content.status:Done</c>) while the thread stays searchable and
+/// reopenable; closing is never deleting. Registered on every thread hub as
+/// <see cref="ThreadNodeType.RailItemArea"/> and consumed as a <c>MeshSearch.ItemArea</c>.
+/// Mirrors the PinLayoutArea.PinnedThumbnail overlay pattern (icon-only glyph, no translated
+/// label — the i18n-preferred shape).
+/// </summary>
+public static class ThreadRailItem
+{
+    /// <summary>The rail-row renderer — runs on the thread's own hub, so the ✕ writes locally.</summary>
+    public static IObservable<UiControl?> View(LayoutAreaHost host, RenderingContext _)
+    {
+        var hubPath = host.Hub.Address.ToString();
+        return host.StreamView<MeshNode>(
+            (nodes, _) => BuildRow(nodes.FirstOrDefault(n => n.Path == hubPath), hubPath),
+            BuildSkeleton(hubPath));
+    }
+
+    /// <summary>A row-height loading skeleton so the rail doesn't jump while a thread hub warms up.</summary>
+    private static UiControl BuildSkeleton(string hubPath)
+    {
+        var shortName = hubPath.Contains('/') ? hubPath[(hubPath.LastIndexOf('/') + 1)..] : hubPath;
+        return Controls.Stack
+            .WithStyle("width: 100%; min-height: 40px; padding: 8px 12px; box-sizing: border-box; " +
+                       "display: flex; justify-content: center; opacity: 0.6;")
+            .WithView(Controls.Markdown($"_{shortName}…_"));
+    }
+
+    private static UiControl BuildRow(MeshNode? node, string hubPath)
+    {
+        var title = node?.Name ?? (hubPath.Contains('/') ? hubPath[(hubPath.LastIndexOf('/') + 1)..] : hubPath);
+
+        var row = Controls.Stack
+            .WithStyle("position: relative; width: 100%; box-sizing: border-box;")
+            .WithView(Controls.Button(title)
+                .WithAppearance(Appearance.Stealth)
+                .WithNavigateToHref($"/{hubPath}")
+                .WithStyle("width: 100%; justify-content: flex-start; text-align: left; " +
+                           "padding: 8px 36px 8px 12px; overflow: hidden; " +
+                           "text-overflow: ellipsis; white-space: nowrap;"));
+
+        // ✕ overlaid INSIDE the row, top-right — an absolutely-positioned wrapper Stack, the same
+        // shape as the pinned card's unpin toggle (a position:absolute style on the button alone
+        // stays in flex flow). MarkThreadDone is the canonical, self-subscribing close: it refuses
+        // while a round is executing and logs its own failures.
+        var close = Controls.Stack
+            .WithStyle("position: absolute; top: 6px; right: 6px; z-index: 5;")
+            .WithView(Controls.Button("")
+                .WithIconStart(FluentIcons.Dismiss())
+                .WithAppearance(Appearance.Stealth)
+                .WithStyle("min-width: 24px; width: 24px; height: 24px; padding: 0; border-radius: 50%;")
+                .WithClickAction(ctx =>
+                {
+                    ctx.Host.Hub.MarkThreadDone(hubPath, done: true);
+                    return Task.CompletedTask;
+                }));
+
+        return row.WithView(close);
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-threads-app.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-threads-app.md
@@ -1,0 +1,18 @@
+---
+Name: The Threads app
+Category: Feature
+Description: Threads is now an app — a vertical list of your open conversations beside the composer, where ✕ closes a thread.
+Icon: Chat
+Order: -20260821
+---
+
+# The Threads app
+
+Threads now has its own app, opened from the **Threads** icon on your home's Apps tab (or at
+`/{you}/Chat`). It works like the chat clients you know: a **vertical list of your open threads**
+on the left, newest first, with the composer beside it — start a new conversation and it opens
+full-screen.
+
+Every thread row carries an **✕**: clicking it **closes** the thread, so it leaves your list
+immediately. Closing never deletes anything — a closed thread stays searchable, and reopening it
+brings it right back.

--- a/src/MeshWeaver.Graph/HomeConfig.cs
+++ b/src/MeshWeaver.Graph/HomeConfig.cs
@@ -66,18 +66,20 @@ public record HomeConfig
 
     /// <summary>
     /// The platform's default apps — node paths (usually Store plugin covers, e.g. <c>Store</c>,
-    /// <c>Doc</c>) every user's Apps tab starts with. Rendered live from config (no seeding), so an
-    /// admin's edit updates every home. Users add more apps by installing from the Store, which
-    /// writes <c>{user}/_App/{appId}</c> records.
+    /// <c>Doc</c>) every user's Apps tab starts with. An entry starting with <c>~/</c> is not a
+    /// node but an AREA on the viewer's own hub (<c>~/Chat</c> → the Threads app at
+    /// <c>/{owner}/Chat</c>), rendered as a fixed system tile. Rendered live from config (no
+    /// seeding), so an admin's edit updates every home. Users add more apps by installing from the
+    /// Store, which writes <c>{user}/_App/{appId}</c> records.
     /// </summary>
-    [Description("The default apps every user's Apps tab starts with — node paths such as Store or Doc. Users add more by installing from the Store.")]
-    [Translation("de", "Die Standard-Apps, mit denen der Apps-Tab jedes Benutzers startet — Knotenpfade wie Store oder Doc. Weitere Apps kommen über den Store hinzu.")]
+    [Description("The default apps every user's Apps tab starts with — node paths such as Store or Doc, or ~/-prefixed viewer areas such as ~/Chat (the Threads app). Users add more by installing from the Store.")]
+    [Translation("de", "Die Standard-Apps, mit denen der Apps-Tab jedes Benutzers startet — Knotenpfade wie Store oder Doc, oder ~/-Einträge für eigene Bereiche wie ~/Chat (die Threads-App). Weitere Apps kommen über den Store hinzu.")]
     // Browsable(false): the generic node-content edit form has no list-capable field kind yet — a
     // Text field would write a plain string into this list-typed slot and corrupt the config. Until
     // a list field ships, admins edit DefaultApps on the node content directly (MCP patch /
     // edit_content on Admin/HomeConfig).
     [Browsable(false)]
-    public IReadOnlyList<string> DefaultApps { get; init; } = ["Store", "Doc"];
+    public IReadOnlyList<string> DefaultApps { get; init; } = ["Store", "Doc", "~/Chat"];
 
     /// <summary>Depth of the home listing: FirstLevel (top-level entries only) or Subtree (the full tree).</summary>
     [Description("How deep the home lists content. FirstLevel shows only top-level entries (the spaces, courses and plugins you can see, plus your own top-level home items). Subtree shows everything you can read.")]

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -72,6 +72,15 @@ public static class UserActivityLayoutAreas
     /// <summary>Link to the doc page that explains the configurable Body-page + <c>@@</c>-region model.</summary>
     internal const string ConfigGuideLink = "/Doc/GUI/ConfigurablePages";
 
+    /// <summary>
+    /// The per-thread rail-row item area consumed by the Threads app's vertical rail — registered
+    /// on every THREAD hub (MeshWeaver.AI, <c>ThreadNodeType.RailItemArea</c> /
+    /// <c>ThreadRailItem.View</c>: title + ✕-close overlay). Referenced here by NAME only: item
+    /// areas resolve on the result node's own hub at render time, so Graph carries no AI
+    /// dependency for it.
+    /// </summary>
+    internal const string ThreadRailItemArea = "RailItem";
+
     private const string ThinScrollbar = "scrollbar-width: thin; scrollbar-color: rgba(128,128,128,0.3) transparent;";
 
 
@@ -91,13 +100,14 @@ public static class UserActivityLayoutAreas
             .WithView(CatalogArea, CatalogAreaView)
             .WithView(ComposerArea, ComposerAreaView)
             // "/{user}/Chat" (ChatArea) is a well-known URL (thread-catalog Create-New, chat menu
-            // links). Since ChatNodeType was removed there is NO {user}/Chat node any more: the URL
-            // resolves to prefix={user} + remainder="Chat", which AreaPage renders as area "Chat"
-            // on this hub. Without this registration that's "no renderer for area Chat", and a
-            // LEGACY {user}/Chat node from an older deployment resolves as invalid-NodeType
-            // ("No node found at '{user}/Chat'… remainder='Chat'" — the prod memex report,
-            // 2026-07-02). The composer is node-less — serve it directly.
-            .WithView(ChatArea, ComposerAreaView)
+            // links, the Threads app tile). Since ChatNodeType was removed there is NO {user}/Chat
+            // node any more: the URL resolves to prefix={user} + remainder="Chat", which AreaPage
+            // renders as area "Chat" on this hub. Without this registration that's "no renderer
+            // for area Chat", and a LEGACY {user}/Chat node from an older deployment resolves as
+            // invalid-NodeType ("No node found at '{user}/Chat'… remainder='Chat'" — the prod
+            // memex report, 2026-07-02). The page is the node-less THREADS APP (vertical rail of
+            // open threads with ✕-close + the composer) — see ThreadsAppView.
+            .WithView(ChatArea, ThreadsAppView)
             // Override the generic Edit area with the SAFE per-field Body editor. Editing a
             // partition-root node generically is suppressed in the default node menu (it could
             // rewrite the whole partition); this edits THIS page only — User.Body — 1:1 with the
@@ -608,6 +618,58 @@ public static class UserActivityLayoutAreas
         => Observable.Return<UiControl?>(new ThreadChatControl().WithHideEmptyState(true));
 
     /// <summary>
+    /// The THREADS APP page (<c>/{user}/Chat</c>, the ChatArea) — the GitHub-Copilot-style shape:
+    /// a vertical RAIL of the owner's open threads on the left (each row rendered by the thread
+    /// hub's <see cref="ThreadRailItemArea"/>: title + ✕ that closes the thread via the canonical
+    /// <c>MarkThreadDone</c>, so it leaves the rail but stays searchable), and the node-less chat
+    /// composer on the right — sending starts a proper thread via <c>StartThread</c> and opens it
+    /// full-screen. Pure composition of existing pieces; see <see cref="BuildThreadsApp"/>.
+    /// </summary>
+    internal static IObservable<UiControl?> ThreadsAppView(LayoutAreaHost host, RenderingContext _)
+        => Observable.Return<UiControl?>(BuildThreadsApp(OwnerIdOf(host.Hub.Address.ToString())));
+
+    /// <summary>
+    /// The Threads-app composition — pure (no hub) so the shape is unit-testable: a horizontal
+    /// stack of (rail, composer). The rail is the SAME open-threads query as the home band
+    /// (<c>-content.status:Done</c>, newest first) rendered as a single-column list whose rows
+    /// delegate to <see cref="ThreadRailItemArea"/>; closing a thread removes it reactively (the
+    /// query excludes Done). <c>flex-wrap</c> lets the composer drop below the rail on narrow
+    /// (mobile) widths.
+    /// </summary>
+    internal static UiControl BuildThreadsApp(string nodeOwnerId)
+    {
+        var rail = Controls.Stack
+            .WithStyle("flex: 0 1 320px; min-width: 240px; box-sizing: border-box;")
+            .WithView(BuildThreadsRail(nodeOwnerId));
+
+        var composer = Controls.Stack
+            .WithStyle("flex: 1 1 480px; min-width: 320px;")
+            .WithView(new ThreadChatControl().WithHideEmptyState(true));
+
+        return Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithWidth("100%")
+            .WithStyle("gap: 16px; width: 100%; align-items: stretch; flex-wrap: wrap;")
+            .WithView(rail)
+            .WithView(composer);
+    }
+
+    /// <summary>The Threads-app rail list: the owner's open threads (never Done, newest first) as a
+    /// single-column list whose rows delegate to the thread hub's <see cref="ThreadRailItemArea"/>.</summary>
+    internal static MeshSearchControl BuildThreadsRail(string nodeOwnerId) =>
+        Controls.MeshSearch
+            .WithHiddenQuery(
+                $"namespace:{nodeOwnerId}/*_Thread nodeType:Thread -content.status:Done sort:LastModified-desc")
+            .WithShowSearchBox(false)
+            .WithShowEmptyMessage(true)
+            .WithRenderMode(MeshSearchRenderMode.List)
+            .WithCollapsibleSections(false)
+            .WithSectionCounts(false)
+            .WithItemArea(ThreadRailItemArea)
+            .WithItemLimit(50)
+            .WithReactiveMode(true);
+
+    /// <summary>
     /// The owner's OPEN threads — their own partition only (<c>{owner}/*_Thread</c>, no cross-partition
     /// fan-out), excluding finished ones (<c>-content.status:Done</c>), newest first; "New thread"
     /// creates under the user node. Mirrors what used to be the catalog's first tab, promoted to its own
@@ -703,7 +765,7 @@ public static class UserActivityLayoutAreas
         if (pinned is not null)
             tabs = tabs.WithView(pinned,
                 skin => skin.WithLabel(LocalizationCatalog.Get("home.pinned", locale)));
-        tabs = tabs.WithView(BuildApps(cfg, installedApps, locale),
+        tabs = tabs.WithView(BuildApps(nodeOwnerId, cfg, installedApps, locale),
             skin => skin.WithLabel(LocalizationCatalog.Get("home.apps", locale)));
         tabs = tabs.WithView(BuildSpaces(nodeOwnerId, cfg, locale),
             skin => skin.WithLabel(LocalizationCatalog.Get("home.spaces", locale)));
@@ -748,30 +810,69 @@ public static class UserActivityLayoutAreas
     }
 
     /// <summary>
+    /// System-app declarations: a <see cref="HomeConfig.DefaultApps"/> entry starting with
+    /// <c>~/</c> is not a node path but an AREA on the viewer's own hub (<c>~/Chat</c> →
+    /// <c>/{owner}/Chat</c>), rendered as a fixed "dock" tile ahead of the node grid. The map
+    /// gives known areas their product name + icon; an unknown <c>~/X</c> falls back to the
+    /// segment name and the generic app icon. Labels here are deliberately GLOSSARY terms
+    /// (Thread/Threads stay English in every locale), so no localization key is involved.
+    /// Immutable constant lookup, never written at runtime.
+    /// </summary>
+    private static readonly ImmutableDictionary<string, (string Label, string Icon)> SystemAppTiles =
+        new Dictionary<string, (string Label, string Icon)>
+        {
+            ["~/" + ChatArea] = ("Threads", "/static/NodeTypeIcons/chat.svg"),
+        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// The Apps tab — one icon per app, each app EXACTLY ONCE: the platform's config-declared
     /// default apps (<see cref="HomeConfig.DefaultApps"/> — e.g. <c>Store</c>, which replaces the
-    /// old hard-coded header entry, and <c>Doc</c>) unioned with the owner's installed-app records
-    /// (<c>{owner}/_App</c>, written by the Store's install flow), deduped by path. Rendered as a
-    /// reactive card grid over the app root nodes THEMSELVES, so each icon's name/image resolve
-    /// live from its node. Default order alphabetical; the last-accessed option uses the same
-    /// union-with-fallback shape as <see cref="BuildSharedWithMe"/> so a never-opened app still
-    /// shows.
+    /// old hard-coded header entry, <c>Doc</c>, and the <c>~/Chat</c> Threads app) unioned with
+    /// the owner's installed-app records (<c>{owner}/_App</c>, written by the Store's install
+    /// flow), deduped. <c>~/</c>-prefixed entries render as fixed system tiles (a phone's dock)
+    /// ahead of the reactive node-card grid, whose icons' name/image resolve live from each node.
+    /// Default order alphabetical; the last-accessed option uses the same union-with-fallback
+    /// shape as <see cref="BuildSharedWithMe"/> so a never-opened app still shows.
     /// </summary>
     internal static UiControl BuildApps(
-        HomeConfig? config, IReadOnlyList<string>? installedApps, string? locale = null)
+        string nodeOwnerId, HomeConfig? config, IReadOnlyList<string>? installedApps, string? locale = null)
     {
         var cfg = config ?? HomeConfigNodeType.Defaults;
-        var paths = (cfg.DefaultApps ?? [])
+        var entries = (cfg.DefaultApps ?? [])
             .Concat(installedApps ?? [])
             .Where(p => !string.IsNullOrWhiteSpace(p))
-            .Select(p => p.Trim('/'))
+            .Select(p => p.StartsWith("~/", StringComparison.Ordinal) ? p : p.Trim('/'))
             .Where(p => p.Length > 0)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
-        if (paths.Count == 0)
+        var systemAreas = entries.Where(p => p.StartsWith("~/", StringComparison.Ordinal)).ToList();
+        var paths = entries.Where(p => !p.StartsWith("~/", StringComparison.Ordinal)).ToList();
+        if (systemAreas.Count == 0 && paths.Count == 0)
             return Controls.Markdown(LocalizationCatalog.Get("home.noApps", locale));
 
-        var baseQuery = $"path:({string.Join(" OR ", paths)})";
+        UiControl? dock = null;
+        if (systemAreas.Count > 0)
+        {
+            var tiles = Controls.Stack
+                .WithOrientation(Orientation.Horizontal)
+                .WithWidth("100%")
+                .WithStyle("gap: 20px; width: 100%; flex-wrap: wrap;");
+            foreach (var area in systemAreas)
+            {
+                var tile = BuildSystemAppTile(nodeOwnerId, area);
+                if (tile is null)
+                    continue;
+                tiles = tiles.WithView(Controls.Stack
+                    .WithStyle("flex: 0 1 240px; min-width: 200px;")
+                    .WithView(tile));
+            }
+            dock = tiles;
+        }
+
+        if (paths.Count == 0)
+            return dock ?? Controls.Markdown(LocalizationCatalog.Get("home.noApps", locale));
+
+        var baseQuery = BuildAppsBaseQuery(paths);
         string Query(HomeCatalogSort sort, string suffix) =>
             sort == HomeCatalogSort.LastAccessed
                 ? $"{baseQuery} {suffix}\n{baseQuery} {SortSuffixAlphabetical}"
@@ -781,7 +882,7 @@ public static class UserActivityLayoutAreas
             .Select(s => new MeshSearchSortOption(
                 LocalizationCatalog.Get(s.LabelKey, locale), Query(s.Sort, s.Suffix)))
             .ToArray();
-        return Controls.MeshSearch
+        var grid = Controls.MeshSearch
             .WithHiddenQuery(sortOptions[0].Query)
             .WithSortOptions(sortOptions)
             .WithShowSearchBox(false)
@@ -795,6 +896,37 @@ public static class UserActivityLayoutAreas
             .WithItemLimit(48)
             .WithMaxRows(4)
             .WithReactiveMode(true);
+
+        if (dock is null)
+            return grid;
+        return Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("gap: 20px; width: 100%;")
+            .WithView(dock)
+            .WithView(grid);
+    }
+
+    /// <summary>Pure query core of the Apps grid, exposed for tests.</summary>
+    internal static string BuildAppsBaseQuery(IReadOnlyList<string> paths) =>
+        $"path:({string.Join(" OR ", paths)})";
+
+    /// <summary>
+    /// One system-app "dock" tile for a <c>~/</c> entry (<see cref="SystemAppTiles"/>): a static
+    /// card whose identity is an AREA on the viewer's own hub, not a node — no hub resolves it, so
+    /// the title/icon are baked here and the click navigates to <c>/{owner}/{area}</c>. Returns
+    /// null for a malformed entry (<c>~/</c> with no segment).
+    /// </summary>
+    internal static MeshNodeCardControl? BuildSystemAppTile(string nodeOwnerId, string entry)
+    {
+        if (!entry.StartsWith("~/", StringComparison.Ordinal))
+            return null;
+        var segment = entry[2..].Trim('/');
+        if (segment.Length == 0)
+            return null;
+        var (label, icon) = SystemAppTiles.TryGetValue(entry, out var known)
+            ? known
+            : (segment, "/static/NodeTypeIcons/puzzlepiece.svg");
+        return new MeshNodeCardControl($"{nodeOwnerId}/{segment}", Title: label, ImageUrl: icon);
     }
 
     /// <summary>Dedup for the Spaces tab: anything living in the Store (and therefore representable

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -655,14 +655,18 @@ public static class UserActivityLayoutAreas
     }
 
     /// <summary>The Threads-app rail list: the owner's open threads (never Done, newest first) as a
-    /// single-column list whose rows delegate to the thread hub's <see cref="ThreadRailItemArea"/>.</summary>
+    /// single-column list whose rows delegate to the thread hub's <see cref="ThreadRailItemArea"/>.
+    /// Flat render + MaxColumns(1), NOT <see cref="MeshSearchRenderMode.List"/>: the List renderer
+    /// draws its own icon·title·description rows and IGNORES <c>ItemArea</c>, so the ✕ overlay
+    /// would never render there — Flat is the ItemArea path the pinned grid already proves.</summary>
     internal static MeshSearchControl BuildThreadsRail(string nodeOwnerId) =>
         Controls.MeshSearch
             .WithHiddenQuery(
                 $"namespace:{nodeOwnerId}/*_Thread nodeType:Thread -content.status:Done sort:LastModified-desc")
             .WithShowSearchBox(false)
             .WithShowEmptyMessage(true)
-            .WithRenderMode(MeshSearchRenderMode.List)
+            .WithRenderMode(MeshSearchRenderMode.Flat)
+            .WithMaxColumns(1)
             .WithCollapsibleSections(false)
             .WithSectionCounts(false)
             .WithItemArea(ThreadRailItemArea)

--- a/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
@@ -67,20 +67,54 @@ public class HomeTabsTest
     [Fact]
     public void Apps_UnionsConfigDefaultsAndInstalled_EachAppExactlyOnce()
     {
+        // Node-path union tested through the pure query core — "store" dedupes case-insensitively
+        // against the shipped default "Store", "Chess" appears once.
+        var noDock = new HomeConfig { DefaultApps = ["Store", "Doc"] };
         var apps = UserActivityLayoutAreas.BuildApps(
-                new HomeConfig(), installedApps: ["Chess", "store", "Chess"])
+                NodePath, noDock, installedApps: ["Chess", "store", "Chess"])
             .Should().BeOfType<MeshSearchControl>().Subject;
 
-        // Shipped defaults (Store, Doc) ∪ installed (Chess) — "store" dedupes case-insensitively.
         var query = apps.HiddenQuery!.ToString()!;
         query.Should().Contain("path:(Store OR Doc OR Chess)");
         query.Should().NotContain("store OR");
     }
 
     [Fact]
+    public void Apps_ShippedDefaults_ComposeDockPlusGrid()
+    {
+        // Shipped DefaultApps include the ~/Chat Threads tile → a dock row above the node grid.
+        UserActivityLayoutAreas.BuildApps(NodePath, new HomeConfig(), installedApps: null)
+            .Should().BeOfType<StackControl>().Subject
+            .Areas.Should().HaveCount(2, "system-tile dock + the node-card grid");
+    }
+
+    [Fact]
+    public void Apps_SystemTile_ThreadsDockTile_TargetsTheViewersChatArea()
+    {
+        var tile = UserActivityLayoutAreas.BuildSystemAppTile(NodePath, "~/Chat");
+
+        tile.Should().NotBeNull();
+        tile!.NodePath.Should().Be($"{NodePath}/Chat", "the tile opens the viewer's own Threads app");
+        tile.Title.Should().Be("Threads");
+        tile.ImageUrl.Should().Be("/static/NodeTypeIcons/chat.svg");
+    }
+
+    [Fact]
+    public void Apps_SystemTile_UnknownAreaFallsBack_MalformedIsNull()
+    {
+        var unknown = UserActivityLayoutAreas.BuildSystemAppTile(NodePath, "~/Foo");
+        unknown!.Title.Should().Be("Foo");
+        unknown.ImageUrl.Should().Be("/static/NodeTypeIcons/puzzlepiece.svg");
+
+        UserActivityLayoutAreas.BuildSystemAppTile(NodePath, "~/").Should().BeNull();
+        UserActivityLayoutAreas.BuildSystemAppTile(NodePath, "Store").Should().BeNull();
+    }
+
+    [Fact]
     public void Apps_DefaultOrderIsAlphabetical_AllThreeSortsOffered()
     {
-        var apps = UserActivityLayoutAreas.BuildApps(new HomeConfig(), installedApps: null)
+        var noDock = new HomeConfig { DefaultApps = ["Store", "Doc"] };
+        var apps = UserActivityLayoutAreas.BuildApps(NodePath, noDock, installedApps: null)
             .Should().BeOfType<MeshSearchControl>().Subject;
 
         apps.SortOptions![0].Label.Should().Be("Alphabetical");
@@ -96,7 +130,8 @@ public class HomeTabsTest
         // source:accessed is an INNER join on the caller's access log — alone it would HIDE a
         // never-opened app. The last-accessed option must therefore be a two-leg path-keyed union:
         // accessed-ranked first, plain fallback second.
-        var apps = UserActivityLayoutAreas.BuildApps(new HomeConfig(), installedApps: null)
+        var noDock = new HomeConfig { DefaultApps = ["Store", "Doc"] };
+        var apps = UserActivityLayoutAreas.BuildApps(NodePath, noDock, installedApps: null)
             .Should().BeOfType<MeshSearchControl>().Subject;
 
         var lastAccessed = apps.SortOptions!.Single(o => o.Label == "Last accessed").Query;
@@ -110,8 +145,33 @@ public class HomeTabsTest
     [Fact]
     public void Apps_NoAppsAnywhere_RendersAHint()
     {
-        UserActivityLayoutAreas.BuildApps(new HomeConfig { DefaultApps = [] }, installedApps: [])
+        UserActivityLayoutAreas.BuildApps(NodePath, new HomeConfig { DefaultApps = [] }, installedApps: [])
             .Should().BeOfType<MarkdownControl>("an empty Apps tab must explain itself, not render blank");
+    }
+
+    // ── Threads app (the /{user}/Chat page) ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ThreadsApp_IsARailPlusComposer()
+    {
+        UserActivityLayoutAreas.BuildThreadsApp(NodePath)
+            .Should().BeOfType<StackControl>().Subject
+            .Areas.Should().HaveCount(2, "the vertical thread rail + the composer pane");
+    }
+
+    [Fact]
+    public void ThreadsRail_ListsOpenThreads_RowsDelegateToTheRailItemArea()
+    {
+        var rail = UserActivityLayoutAreas.BuildThreadsRail(NodePath);
+
+        var query = rail.HiddenQuery!.ToString()!;
+        query.Should().Contain($"namespace:{NodePath}/*_Thread");
+        query.Should().Contain("nodeType:Thread");
+        query.Should().Contain("-content.status:Done", "closing a thread (✕ → MarkThreadDone) must remove it from the rail");
+        query.Should().Contain("sort:LastModified-desc");
+        rail.RenderMode.Should().Be(MeshSearchRenderMode.List, "the rail is a vertical menu");
+        rail.ItemArea.Should().Be("RailItem", "each row renders via the thread hub's RailItem area (title + ✕)");
+        rail.ShowSearchBox.Should().Be(false);
     }
 
     // ── Spaces tab (dedup) ──────────────────────────────────────────────────────────────────────
@@ -161,9 +221,9 @@ public class HomeTabsTest
     // ── Config ──────────────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void HomeConfig_ShippedDefaults_TabbedWithStoreAndDoc()
+    public void HomeConfig_ShippedDefaults_TabbedWithStoreDocAndThreads()
     {
         HomeConfigNodeType.Defaults.Style.Should().Be(HomeStyle.Tabs);
-        HomeConfigNodeType.Defaults.DefaultApps.Should().Equal("Store", "Doc");
+        HomeConfigNodeType.Defaults.DefaultApps.Should().Equal("Store", "Doc", "~/Chat");
     }
 }

--- a/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
@@ -169,7 +169,10 @@ public class HomeTabsTest
         query.Should().Contain("nodeType:Thread");
         query.Should().Contain("-content.status:Done", "closing a thread (✕ → MarkThreadDone) must remove it from the rail");
         query.Should().Contain("sort:LastModified-desc");
-        rail.RenderMode.Should().Be(MeshSearchRenderMode.List, "the rail is a vertical menu");
+        // Flat + one column, NOT List: the List renderer ignores ItemArea, so the ✕ overlay would
+        // never render there — Flat is the ItemArea path the pinned grid proves.
+        rail.RenderMode.Should().Be(MeshSearchRenderMode.Flat);
+        rail.MaxColumns.Should().Be(1, "the rail is a vertical menu");
         rail.ItemArea.Should().Be("RailItem", "each row renders via the thread hub's RailItem area (title + ✕)");
         rail.ShowSearchBox.Should().Be(false);
     }

--- a/test/MeshWeaver.Portal.E2E.Test/ThreadsAppPageTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/ThreadsAppPageTest.cs
@@ -1,0 +1,38 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// The THREADS APP page (<c>/{user}/Chat</c>, the ChatArea) — the Copilot-style shape: a vertical
+/// rail of the owner's open threads (rows via the thread hub's <c>RailItem</c> area, each with an
+/// ✕ that closes the thread) beside the node-less composer. This pins that the page renders
+/// end-to-end: the rail's search container and the composer appear, and NO layout-area error
+/// boundary ("failed to render") fires anywhere on the page.
+/// </summary>
+[Collection("portal-e2e")]
+public class ThreadsAppPageTest(PortalFixture fixture)
+{
+    [Fact(Timeout = 180_000)]
+    public async Task ThreadsApp_RendersRailAndComposer_NoRenderErrors()
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+
+        await using var context = await fixture.NewAuthenticatedContextAsync();
+        var page = await context.NewPageAsync();
+        await page.SetViewportSizeAsync(1600, 1000);
+
+        await page.GotoAsync($"{fixture.BaseUrl}/{fixture.UserId}/Chat",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // The rail — a MeshSearch over the owner's open threads.
+        await page.Locator(".mesh-search-container").First
+            .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 90_000 });
+
+        await page.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/threads-app.png", FullPage = true });
+
+        // No layout-area error boundary anywhere on the page — "This view/area failed to render."
+        (await page.GetByText("failed to render", new() { Exact = false }).CountAsync())
+            .Should().Be(0, "the Threads app must render without any area error boundary firing");
+    }
+}


### PR DESCRIPTION
## What

Builds on #1970 (the tabbed home). The `/{user}/Chat` page (ChatArea) becomes the **Threads app** — the GitHub-Copilot/Grok shape: a vertical rail of the owner's open threads on the left, the node-less composer on the right (sending starts a proper thread via `StartThread` and opens it full-screen).

- **`ThreadRailItem`** (MeshWeaver.AI, registered on every thread hub as `RailItem`): one compact rail row — the title navigating to the thread, plus an **✕ overlay that CLOSES the thread** via the canonical `MarkThreadDone` (refuses mid-round; self-subscribing). The rail's query excludes `content.status:Done`, so a closed thread leaves the rail reactively; closing never deletes — the thread stays searchable and reopenable.
- The rail is a single-column MeshSearch (**Flat + MaxColumns(1) + ItemArea** — the List renderer draws its own rows and ignores item areas, so the ✕ could not render there; Flat is the path the pinned grid proves). Same overlay pattern as the pinned card's unpin toggle; the ✕ is an icon-only glyph (i18n-preferred, no translated label).
- **Apps-tab dock tiles**: a `DefaultApps` entry starting with `~/` declares an AREA on the viewer's own hub instead of a node path; `~/Chat` ships in the defaults as the **Threads** tile (chat.svg, glossary-English label). Unknown `~/x` falls back to the segment name + generic icon; malformed entries are skipped.

## Verification
- `dotnet build -c Release -warnaserror`: MeshWeaver.AI, MeshWeaver.Graph.Test, Memex.Portal.Monolith — 0 warnings, 0 errors (rebased on the merged #1970).
- `MeshWeaver.Graph.Test` home suites: 45/45 green (5 new tests: rail query/ItemArea, dock tiles, shipped defaults).
- **E2E against a locally launched Monolith** (new permanent `ThreadsAppPageTest`): `/{user}/Chat` renders rail + composer with zero layout-area error boundaries — screenshot-verified.

What's New entry included (`Category: Feature`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)