### PR TITLE
Content key over the fully generated compile input (#1707 slice 4) — and why the full-MVID rule cannot go with it

### DIFF
--- a/src/MeshWeaver.Compiler/CompiledDependencies.cs
+++ b/src/MeshWeaver.Compiler/CompiledDependencies.cs
@@ -54,6 +54,31 @@ public static class CompiledDependencies
     public const string ToolchainKey = "!toolchain";
 
     /// <summary>
+    /// The reserved record key carrying the build's CONTENT KEY (#1707 slice 4) — the hash of the
+    /// FULLY GENERATED compilation input folded with the pruned reference surfaces
+    /// (<see cref="GeneratedInputIdentity"/>). Same '!' prefix convention as
+    /// <see cref="ToolchainKey"/>.
+    ///
+    /// <para><b>What it is FOR, and what it is not.</b> <see cref="ToolchainKey"/> is a PROXY —
+    /// "the toolchain moved, so the bytes MIGHT be stale". This is the direct observation: "the
+    /// input that produced these bytes hashed to X". A consumer that has REGENERATED the input can
+    /// therefore answer exactly, and a toolchain change that did not move a type's generated input
+    /// is provably not a reason to rebuild it.</para>
+    ///
+    /// <para>🚨 It is consequently validated ONLY against a live value the caller computed by
+    /// regenerating (<see cref="FindMismatch"/>'s <c>liveContentKey</c>). There is no cheap live
+    /// counterpart: the key is a function of the toolchain AND the source text, and no metadata-only
+    /// check can evaluate it. That is precisely why the toolchain entry cannot simply be deleted in
+    /// favour of this one — see the note on <see cref="ComputeToolchainId"/>.</para>
+    ///
+    /// <para>OPTIONAL: a record produced where the generated input was not available (an adopted
+    /// prebuilt, the disk-cache hit path, the hydration shortcut) carries no entry, and
+    /// <see cref="FindMismatch"/> then simply has nothing to compare — the toolchain entry still
+    /// governs, exactly as before this key existed.</para>
+    /// </summary>
+    public const string ContentKey = "!input";
+
+    /// <summary>
     /// The toolchain id for <see cref="ToolchainKey"/>: SHA-256 over the
     /// <see cref="FrameworkBuildIdentity.FullMvidAssemblies"/> closure members' implementation
     /// MVIDs (name=mvid lines, in the closure's sorted order), 32 hex chars. Moves exactly when
@@ -82,10 +107,17 @@ public static class CompiledDependencies
     /// null = out of scope (System/TPA), excluded from the record.</param>
     /// <param name="toolchainId">The producing process's toolchain id
     /// (<see cref="ComputeToolchainId"/>).</param>
+    /// <param name="generatedInputDigest">The stage-1 generated-input digest
+    /// (<see cref="GeneratedInputIdentity.OfGeneratedInput"/>) of the compile that produced these
+    /// bytes, or null when the caller did not compile (an adopted prebuilt, a cache hit, the
+    /// hydration shortcut). Non-null folds the pruned reference surfaces in and writes the
+    /// <see cref="ContentKey"/> entry — the record's own assembly entries ARE that set, so the two
+    /// cannot drift apart.</param>
     public static ImmutableSortedDictionary<string, string> Compute(
         IEnumerable<string?> referencedSimpleNames,
         Func<string, string?> idOf,
-        string toolchainId)
+        string toolchainId,
+        string? generatedInputDigest = null)
     {
         var builder = ImmutableSortedDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
         builder[ToolchainKey] = toolchainId;
@@ -96,6 +128,13 @@ public static class CompiledDependencies
             if (idOf(name) is { } id)
                 builder[name] = id;
         }
+        if (!string.IsNullOrEmpty(generatedInputDigest))
+            // The reference surfaces are the record's ASSEMBLY entries — the reserved '!' entries
+            // are deliberately excluded. Folding the toolchain MVID into the content key would
+            // make the key move on every toolchain commit, which is the exact proxy this key
+            // exists to replace.
+            builder[ContentKey] = GeneratedInputIdentity.Combine(
+                generatedInputDigest, builder.Where(pair => !IsReservedKey(pair.Key)));
         return builder.ToImmutable();
     }
 
@@ -106,10 +145,17 @@ public static class CompiledDependencies
     /// mismatch — a build that binds something this environment cannot even classify is not
     /// provably compatible.
     /// </summary>
+    /// <param name="record">The stamped record.</param>
+    /// <param name="liveIdOf">The live surface-id resolver (<see cref="CreateIdResolver"/>).</param>
+    /// <param name="liveToolchainId">The live toolchain id (<see cref="ComputeToolchainId"/>).</param>
+    /// <param name="liveContentKey">The content key the caller computed by REGENERATING this
+    /// type's compile input (<see cref="GeneratedInputIdentity"/>), or null when it did not — see
+    /// <see cref="ContentKey"/>.</param>
     public static string? FindMismatch(
         IReadOnlyDictionary<string, string> record,
         Func<string, string?> liveIdOf,
-        string liveToolchainId)
+        string liveToolchainId,
+        string? liveContentKey = null)
     {
         // 🚨 A record WITHOUT the reserved toolchain entry is never trusted: FindMismatch only
         // compares entries that are PRESENT, so such a record would validate forever across
@@ -122,14 +168,32 @@ public static class CompiledDependencies
 
         foreach (var (name, stamped) in record)
         {
-            var live = string.Equals(name, ToolchainKey, StringComparison.Ordinal)
-                ? liveToolchainId
-                : liveIdOf(name) ?? AbsentId;
+            string live;
+            if (string.Equals(name, ToolchainKey, StringComparison.Ordinal))
+                live = liveToolchainId;
+            else if (string.Equals(name, ContentKey, StringComparison.Ordinal))
+            {
+                // The content key has NO cheap live counterpart — evaluating it means regenerating
+                // the compile input. A caller that did so passes it and gets an EXACT verdict; a
+                // caller that did not skips the entry rather than inventing a live value, and the
+                // toolchain entry above still governs. Skipping is not fail-open here for exactly
+                // that reason: the record is refused outright if it carries no toolchain entry.
+                if (string.IsNullOrEmpty(liveContentKey))
+                    continue;
+                live = liveContentKey;
+            }
+            else
+                live = liveIdOf(name) ?? AbsentId;
             if (!string.Equals(stamped, live, StringComparison.Ordinal))
                 return $"'{name}' built against {stamped}, live is {live}";
         }
         return null;
     }
+
+    /// <summary>True for the reserved '!'-prefixed record keys, which name compile FACTS rather
+    /// than referenced assemblies.</summary>
+    public static bool IsReservedKey(string key) =>
+        key.StartsWith('!');
 
     /// <summary>
     /// The surface-id resolver over one environment: installed modules FIRST (exact-build MVID —

--- a/src/MeshWeaver.Compiler/EmitPipeline.cs
+++ b/src/MeshWeaver.Compiler/EmitPipeline.cs
@@ -27,6 +27,21 @@ public static class EmitPipeline
             .WithPlatform(Platform.AnyCpu);
 
     /// <summary>
+    /// The canonical option set rendered for the CONTENT KEY (#1707 slice 4) — see
+    /// <see cref="GeneratedInputIdentity.OptionsFingerprint"/>. It lives here, beside the three
+    /// factories it renders, so an option added to one of them cannot be forgotten by the key:
+    /// the rendering is REFLECTED, so a new option joins automatically.
+    ///
+    /// <para>Process-constant (a <see cref="Lazy{T}"/> of an immutable string): the options are
+    /// literals, so this is a constant lookup rather than cached state.</para>
+    /// </summary>
+    internal static string OptionsFingerprint => _optionsFingerprint.Value;
+
+    private static readonly Lazy<string> _optionsFingerprint = new(() =>
+        GeneratedInputIdentity.OptionsFingerprint(
+            CreateParseOptions(), CreateCompilationOptions(), DebugInformationFormat.PortablePdb));
+
+    /// <summary>
     /// Builds the single-tree emit compilation for the generated source: parse with the source
     /// path and UTF-8 encoding embedded (critical for PDB source linking) + the canonical
     /// options.

--- a/src/MeshWeaver.Compiler/GeneratedInputIdentity.cs
+++ b/src/MeshWeaver.Compiler/GeneratedInputIdentity.cs
@@ -226,25 +226,47 @@ public static class GeneratedInputIdentity
     }
 
     /// <summary>
-    /// Assembly file name → implementation MVID ("N" format), read METADATA-ONLY so nothing is
-    /// loaded into the process. Keyed by FILE NAME rather than by full path: a path is a property
-    /// of the host's layout, and a key that carried one could never match between a bake container
-    /// and a portal pod. A missing or unreadable file resolves <see cref="AbsentId"/> — absence is
-    /// part of the key.
+    /// Assembly file name → its implementation MVID(s) ("N" format), read METADATA-ONLY so nothing
+    /// is loaded into the process. Keyed by FILE NAME rather than by full path: a path is a
+    /// property of the host's layout, and a key that carried one could never match between a bake
+    /// container and a portal pod. A missing or unreadable file resolves <see cref="AbsentId"/> —
+    /// absence is part of the key.
+    ///
+    /// <para>🚨 <b>A file name can be AMBIGUOUS, so the value is a SET, not the last writer.</b>
+    /// NuGet resolution can hand back two different assemblies with the same file name (two
+    /// packages, or two target-framework folders), and <c>RunSourceGenerators</c> loads BOTH paths.
+    /// Overwriting on collision would drop one of them from the key: the key would then claim
+    /// "same input" for a genuinely different effective generator set — the UNDER-invalidating
+    /// direction, i.e. stale bytes — and which one survived would depend on enumeration order,
+    /// reintroducing exactly the order-dependence this type exists to remove. So colliding entries
+    /// are de-duplicated and joined as ordinal-sorted MVIDs (<see cref="IdentitySeparator"/>).
+    /// The same assembly resolved twice by different paths still collapses to one id, which is
+    /// correct: it IS one input.</para>
     /// </summary>
     public static ImmutableSortedDictionary<string, string> AssemblyFileIdentities(
         IEnumerable<string> assemblyPaths)
     {
         ArgumentNullException.ThrowIfNull(assemblyPaths);
-        var builder = ImmutableSortedDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+        var byName = new SortedDictionary<string, SortedSet<string>>(StringComparer.Ordinal);
         foreach (var path in assemblyPaths)
         {
             if (string.IsNullOrEmpty(path))
                 continue;
-            builder[Path.GetFileName(path)] = ReadMvid(path) ?? AbsentId;
+            var name = Path.GetFileName(path);
+            if (!byName.TryGetValue(name, out var ids))
+                byName[name] = ids = new SortedSet<string>(StringComparer.Ordinal);
+            ids.Add(ReadMvid(path) ?? AbsentId);
         }
+        var builder = ImmutableSortedDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+        foreach (var (name, ids) in byName)
+            builder[name] = string.Join(IdentitySeparator, ids);
         return builder.ToImmutable();
     }
+
+    /// <summary>Joins the several MVIDs a single file NAME resolved to — see
+    /// <see cref="AssemblyFileIdentities"/>. Not a hex digit, so it can never be mistaken for part
+    /// of one MVID.</summary>
+    public const string IdentitySeparator = "+";
 
     private static string? ReadMvid(string path)
     {

--- a/src/MeshWeaver.Compiler/GeneratedInputIdentity.cs
+++ b/src/MeshWeaver.Compiler/GeneratedInputIdentity.cs
@@ -1,0 +1,356 @@
+using System.Collections;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+
+namespace MeshWeaver.Compiler;
+
+/// <summary>
+/// 🚨 THE CONTENT KEY of a compiled NodeType (#1707 slice 4): a hash of the <b>fully generated
+/// compilation input</b> — the exact text handed to Roslyn after skeleton generation, source
+/// aggregation, <c>@@</c>-include expansion and the <c>#r</c> strip — together with everything
+/// else that decides the emitted bytes given that text: the assembly name, the parse/compilation
+/// option set, the Roslyn version, the source generators that run, and the reference SURFACE set.
+///
+/// <para><b>Why it exists.</b> Every invalidation signal that preceded it was a PROXY.
+/// <see cref="FrameworkBuildIdentity.FullMvidAssemblies"/> folds the toolchain's full
+/// implementation MVID into the framework identity precisely because a generator body change
+/// reshapes what Roslyn is fed with no API change — so surface hashing cannot see it. That proxy
+/// is correct and unbelievably coarse: a body-only commit to any member of the toolchain closure
+/// (16 assemblies, 383 commits/30d — issue #1976) mints a new global identity, empties the
+/// assembly share's key-space, and rebakes every NodeType on every deployment, including the ones
+/// whose generated input is byte-for-byte what it was. This is the DIRECT observation the proxy
+/// stands in for: two compiles whose generated input hashes equal produce interchangeable bytes,
+/// whoever built them and whenever.</para>
+///
+/// <para><b>Two stages, because the two halves are known at different moments.</b>
+/// <see cref="OfGeneratedInput"/> runs BEFORE Roslyn, where the generated text exists;
+/// <see cref="Combine"/> folds in the PRUNED reference surfaces read off the emitted assembly
+/// afterwards (Roslyn emits an AssemblyRef row only for what the produced code actually uses —
+/// see <see cref="CompiledDependencies"/>). Hashing the pruned set rather than the candidate set
+/// is what keeps the key per-type: a platform surface change invalidates the types that bind it,
+/// not the world.</para>
+///
+/// <para><b>Determinism is the whole product.</b> An unstable key invalidates everything on every
+/// build, which is the current complaint amplified. Everything enumerable is ordinal-sorted,
+/// every value is rendered invariant-culture, and the source text is normalised by
+/// <see cref="NormalizeGeneratedSource"/>. Exactly three normalisations are applied, and each is
+/// a deliberate trade:
+/// <list type="number">
+/// <item><description><b>A leading UTF-8 BOM is dropped.</b> Whether the text carries one is a
+/// property of how it was read, not of what it means.</description></item>
+/// <item><description><b>Line endings are folded to <c>\n</c>.</b> The skeleton is built with
+/// <c>StringBuilder.AppendLine</c>, i.e. <see cref="Environment.NewLine"/>, so the SAME node
+/// generates CRLF text on a Windows dev box and LF in a Linux pod. Without this fold the key would
+/// differ per host for identical content and nothing would ever share a build. The cost is
+/// explicit and small: two inputs that differ ONLY in the line endings inside a verbatim/raw
+/// string literal hash equal. Their emitted bytes do differ, so this is the one place the key is
+/// deliberately coarser than the bytes — and it is coarser in the direction of a Windows-built
+/// artifact matching its Linux twin, which is the shape a mixed-host mesh needs.</description></item>
+/// <item><description><b>The skeleton's <c>// Generated at: &lt;UtcNow&gt;</c> header line is
+/// replaced by a fixed marker</b> (<see cref="NormalizedGeneratedAtLine"/>).
+/// <c>DynamicMeshNodeAttributeGenerator.GenerateAttributeSource</c> stamps a WALL CLOCK into the
+/// generated text, so the input is never twice the same and no content key over it could ever
+/// hit. It is a comment: it contributes no IL. (It does move the PDB's document hash, which is
+/// why the assembly-store's digest-of-the-emitted-bytes can never dedupe two compiles of
+/// identical content either — the observation that motivates this type.)</description></item>
+/// </list>
+/// Nothing else is touched: no trimming, no whitespace collapsing, no comment stripping. Every
+/// other byte of the generated text is part of the key.</para>
+/// </summary>
+public static class GeneratedInputIdentity
+{
+    /// <summary>Prefix of a stage-1 GENERATED-INPUT digest (<see cref="OfGeneratedInput"/>) — the
+    /// text-and-toolchain half, before the reference surfaces are known.</summary>
+    public const string GeneratedInputPrefix = "g";
+
+    /// <summary>Prefix of the complete CONTENT KEY (<see cref="Combine"/>).</summary>
+    public const string ContentKeyPrefix = "i";
+
+    /// <summary>Recorded for an input whose identity cannot be resolved (a generator assembly that
+    /// is not on disk, a reference with no id). Absence is part of the key, never silently
+    /// skipped — two environments with different presence sets must not hash equal.</summary>
+    public const string AbsentId = "absent";
+
+    /// <summary>The fixed text every <c>// Generated at: …</c> line normalises to.</summary>
+    internal const string NormalizedGeneratedAtLine = "// Generated at: (normalized)";
+
+    /// <summary>
+    /// Matches the skeleton's wall-clock header line. Anchored to a whole line (Multiline) and
+    /// deliberately narrow — it must not touch a line of USER code that happens to mention the
+    /// phrase inside a string literal, which is why it requires the line to START with the comment
+    /// marker rather than merely contain it.
+    /// </summary>
+    private static readonly Regex GeneratedAtLinePattern = new(
+        @"^//[ \t]*Generated at:.*$", RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// The identity of the Roslyn that will do the compiling. A compiler upgrade can change the
+    /// emitted bytes for identical input, and it is NOT covered by anything else here: the
+    /// framework identity walks <c>MeshWeaver.*</c> references only
+    /// (<c>FrameworkBuildIdentity.ComputeToolchainClosure</c>), so <c>Microsoft.CodeAnalysis.*</c>
+    /// has never been in it directly — it rode in on <c>MeshWeaver.Compiler</c>'s MVID, which a
+    /// package bump moves. A content key that replaces that MVID must carry the compiler
+    /// explicitly or it under-invalidates on exactly the change that rewrites every assembly.
+    /// </summary>
+    public static string CompilerIdentity { get; } = ResolveCompilerIdentity();
+
+    private static string ResolveCompilerIdentity()
+    {
+        var assembly = typeof(CSharpCompilation).Assembly;
+        var name = assembly.GetName();
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return string.Create(CultureInfo.InvariantCulture,
+            $"{name.Name}/{name.Version}/{informational ?? AbsentId}");
+    }
+
+    /// <summary>
+    /// Normalises the fully generated compilation input for hashing — see the three normalisations
+    /// documented on the type. Pure; a null/empty input normalises to the empty string.
+    /// </summary>
+    public static string NormalizeGeneratedSource(string? source)
+    {
+        if (string.IsNullOrEmpty(source))
+            return string.Empty;
+        var text = source[0] == '\uFEFF' ? source[1..] : source;
+        text = text.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+        return GeneratedAtLinePattern.Replace(text, NormalizedGeneratedAtLine);
+    }
+
+    /// <summary>
+    /// STAGE 1 — the digest of everything that is known BEFORE Roslyn runs: the generated text,
+    /// the emitted assembly's name, the option set, the compiler, and the source generators that
+    /// will run over the compilation.
+    ///
+    /// <para>The generators are in here rather than in the text because they ADD source Roslyn
+    /// never shows the caller: a generator body change alters the emitted bytes while the text
+    /// handed in is unchanged. Their identities are MVIDs
+    /// (<see cref="AssemblyFileIdentities"/>) — a generator is a build tool, and the only honest
+    /// question about one is "is it the same build".</para>
+    /// </summary>
+    /// <param name="assemblyName">The emitted assembly's name — it is written into the metadata,
+    /// so it is part of the bytes.</param>
+    /// <param name="generatedSource">The full C# text handed to Roslyn (post skeleton, aggregation,
+    /// <c>@@</c>-include expansion and <c>#r</c> strip). Normalised here.</param>
+    /// <param name="optionsFingerprint">The canonical rendering of the parse/compilation/emit
+    /// options — see <see cref="OptionsFingerprint"/>.</param>
+    /// <param name="compilerIdentity">The Roslyn identity — <see cref="CompilerIdentity"/> in
+    /// production, injectable so the rule is testable without rebuilding the compiler.</param>
+    /// <param name="generatorIdentities">Source-generator assembly file name → identity.</param>
+    public static string OfGeneratedInput(
+        string assemblyName,
+        string? generatedSource,
+        string optionsFingerprint,
+        string compilerIdentity,
+        IEnumerable<KeyValuePair<string, string>> generatorIdentities)
+    {
+        ArgumentNullException.ThrowIfNull(assemblyName);
+        ArgumentNullException.ThrowIfNull(optionsFingerprint);
+        ArgumentNullException.ThrowIfNull(compilerIdentity);
+        ArgumentNullException.ThrowIfNull(generatorIdentities);
+
+        var document = new StringBuilder();
+        document.Append("generated-input/v1\n");
+        document.Append("assembly=").Append(assemblyName).Append('\n');
+        document.Append("compiler=").Append(compilerIdentity).Append('\n');
+        document.Append("options=").Append(Sha256Hex(optionsFingerprint)).Append('\n');
+        AppendPairs(document, "generator", generatorIdentities);
+        document.Append("source=")
+            .Append(Sha256Hex(NormalizeGeneratedSource(generatedSource))).Append('\n');
+        return GeneratedInputPrefix + Sha256Hex(document.ToString())[..32];
+    }
+
+    /// <summary>
+    /// STAGE 2 — the complete CONTENT KEY: the stage-1 digest folded with the PRUNED reference
+    /// surfaces the emitted assembly actually binds (<see cref="CompiledDependencies"/>'s
+    /// assembly entries — platform assemblies by reference-assembly hash, modules and NuGet
+    /// packages by MVID).
+    ///
+    /// <para>Reference SURFACES, not reference builds: two hosts whose platform assemblies present
+    /// the same API surface resolve the same ids (#1696's construction), so the key is equal
+    /// across them — which is the entire point of a content key that a bake and a portal can both
+    /// compute.</para>
+    /// </summary>
+    /// <param name="generatedInputDigest">The stage-1 value from <see cref="OfGeneratedInput"/>.</param>
+    /// <param name="referenceSurfaces">Referenced assembly simple name → surface id.</param>
+    public static string Combine(
+        string generatedInputDigest,
+        IEnumerable<KeyValuePair<string, string>> referenceSurfaces)
+    {
+        ArgumentNullException.ThrowIfNull(generatedInputDigest);
+        ArgumentNullException.ThrowIfNull(referenceSurfaces);
+
+        var document = new StringBuilder();
+        document.Append("content-key/v1\n");
+        document.Append("input=").Append(generatedInputDigest).Append('\n');
+        AppendPairs(document, "reference", referenceSurfaces);
+        return ContentKeyPrefix + Sha256Hex(document.ToString())[..32];
+    }
+
+    /// <summary>
+    /// Assembly file name → implementation MVID ("N" format), read METADATA-ONLY so nothing is
+    /// loaded into the process. Keyed by FILE NAME rather than by full path: a path is a property
+    /// of the host's layout, and a key that carried one could never match between a bake container
+    /// and a portal pod. A missing or unreadable file resolves <see cref="AbsentId"/> — absence is
+    /// part of the key.
+    /// </summary>
+    public static ImmutableSortedDictionary<string, string> AssemblyFileIdentities(
+        IEnumerable<string> assemblyPaths)
+    {
+        ArgumentNullException.ThrowIfNull(assemblyPaths);
+        var builder = ImmutableSortedDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+        foreach (var path in assemblyPaths)
+        {
+            if (string.IsNullOrEmpty(path))
+                continue;
+            builder[Path.GetFileName(path)] = ReadMvid(path) ?? AbsentId;
+        }
+        return builder.ToImmutable();
+    }
+
+    private static string? ReadMvid(string path)
+    {
+        if (!File.Exists(path))
+            return null;
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var pe = new PEReader(stream);
+            var metadata = pe.GetMetadataReader();
+            return metadata.GetGuid(metadata.GetModuleDefinition().Mvid).ToString("N");
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException
+                                       or UnauthorizedAccessException)
+        {
+            // Unreadable is recorded as ABSENT, not swallowed: the caller's key then differs from
+            // one computed where the file was readable, which is the conservative direction
+            // (a rebuild), and the identity resolution must never fault a compile.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The canonical rendering of everything the toolchain tells Roslyn ABOUT the compilation,
+    /// as opposed to the text of it. A body-only change to
+    /// <c>EmitPipeline.CreateCompilationOptions</c> — flipping the optimization level, say —
+    /// rewrites every emitted assembly while leaving the generated text identical, so the option
+    /// set has to be in the key or the key under-invalidates on it.
+    ///
+    /// <para>🚨 REFLECTED, never hand-listed. A hand-list is how <c>NuGetDirectiveParser</c> sat
+    /// outside the identity boundary while shaping compile input (#1707), and the same trap is
+    /// waiting here: an option the toolchain starts setting would be silently outside the key, and
+    /// the failure mode of that is stale bytes with no diagnostic. Reflecting over the option
+    /// objects' public properties also makes the key sensitive to a Roslyn upgrade that ADDS an
+    /// option, which is correct — the new default may change what is emitted.</para>
+    ///
+    /// <para>The PDB file path is deliberately NOT here: the emit sets it to a host-local
+    /// directory, and a key carrying it could never match across hosts. It lands in the DLL's
+    /// debug directory, so the emitted BYTES do differ by host — which is one more reason a digest
+    /// of the emitted bytes cannot be a content key, and no reason to poison this one.</para>
+    /// </summary>
+    public static string OptionsFingerprint(
+        CSharpParseOptions parseOptions,
+        CSharpCompilationOptions compilationOptions,
+        DebugInformationFormat debugInformationFormat)
+    {
+        ArgumentNullException.ThrowIfNull(parseOptions);
+        ArgumentNullException.ThrowIfNull(compilationOptions);
+        var text = new StringBuilder();
+        text.Append("options/v1\n");
+        text.Append(RenderOptions(parseOptions));
+        text.Append(RenderOptions(compilationOptions));
+        text.Append("emit.DebugInformationFormat=")
+            .Append(debugInformationFormat.ToString()).Append('\n');
+        return text.ToString();
+    }
+
+    /// <summary>
+    /// One option object rendered as sorted <c>Type.Property=value</c> lines. Values are rendered
+    /// invariant-culture; a collection is rendered as its ordinal-sorted elements so declaration
+    /// order can never move the key; anything that is not a scalar, a string, an enum or a
+    /// collection is rendered as its runtime TYPE NAME — never <c>ToString()</c> of an arbitrary
+    /// object (which may embed a hash code) and never a reference identity.
+    /// </summary>
+    internal static string RenderOptions(object options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var type = options.GetType();
+        var text = new StringBuilder();
+        var properties = type
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
+            .OrderBy(p => p.Name, StringComparer.Ordinal);
+        foreach (var property in properties)
+            text.Append(type.Name).Append('.').Append(property.Name).Append('=')
+                .Append(ReadAndRender(property, options)).Append('\n');
+        return text.ToString();
+    }
+
+    private static string ReadAndRender(PropertyInfo property, object instance)
+    {
+        try
+        {
+            return RenderValue(property.GetValue(instance));
+        }
+        catch (Exception ex)
+        {
+            // A getter that throws is rendered as a STABLE marker naming the fault type, so the
+            // fingerprint stays deterministic instead of faulting the compile that needs it.
+            // It is not a swallow: the marker differs from every real value, so a property that
+            // starts throwing invalidates — the safe direction.
+            return "<threw:" + ex.GetType().Name + ">";
+        }
+    }
+
+    private static string RenderValue(object? value)
+    {
+        switch (value)
+        {
+            case null:
+                return "null";
+            case string s:
+                return s;
+            case bool b:
+                return b ? "true" : "false";
+            case Enum e:
+                return e.ToString();
+            case IFormattable formattable when value.GetType().IsPrimitive
+                                               || value is decimal or Guid:
+                return formattable.ToString(null, CultureInfo.InvariantCulture);
+            case IDictionary dictionary:
+                return Join(dictionary.Cast<DictionaryEntry>()
+                    .Select(entry => RenderValue(entry.Key) + "=" + RenderValue(entry.Value)));
+            case IEnumerable enumerable:
+                return Join(enumerable.Cast<object?>().Select(RenderValue));
+        }
+
+        var type = value.GetType();
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+            return RenderValue(type.GetProperty("Key")?.GetValue(value))
+                   + "=" + RenderValue(type.GetProperty("Value")?.GetValue(value));
+        return "<" + (type.FullName ?? type.Name) + ">";
+    }
+
+    private static string Join(IEnumerable<string> rendered) =>
+        "[" + string.Join(",", rendered.OrderBy(s => s, StringComparer.Ordinal)) + "]";
+
+    private static void AppendPairs(
+        StringBuilder document, string label, IEnumerable<KeyValuePair<string, string>> pairs)
+    {
+        foreach (var pair in pairs.OrderBy(p => p.Key, StringComparer.Ordinal))
+            document.Append(label).Append('=').Append(pair.Key).Append('=')
+                .Append(pair.Value ?? AbsentId).Append('\n');
+    }
+
+    private static string Sha256Hex(string text) =>
+        Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(text)));
+}

--- a/src/MeshWeaver.Compiler/GeneratedInputIdentity.cs
+++ b/src/MeshWeaver.Compiler/GeneratedInputIdentity.cs
@@ -61,6 +61,20 @@ namespace MeshWeaver.Compiler;
 /// hit. It is a comment: it contributes no IL. (It does move the PDB's document hash, which is
 /// why the assembly-store's digest-of-the-emitted-bytes can never dedupe two compiles of
 /// identical content either — the observation that motivates this type.)</description></item>
+/// <item><description><b>The skeleton's <c>LastModified = DateTimeOffset.Parse("…")</c> line is
+/// replaced by a fixed marker</b> (<see cref="NormalizedLastModifiedLine"/>) — the SECOND wall
+/// clock, and the one that is not obvious. The generator emits the NodeType node's own
+/// <c>LastModified</c> into the provider's node, and <c>PackageInstaller.BulkSave</c> stamps that
+/// field with <c>DateTimeOffset.UtcNow</c> on EVERY import. So the same repo content imported
+/// twice generates different text: a key that discriminated on it would be unique per import,
+/// never hit, and — decisively — a CI bake and a portal import the same commit at different
+/// moments BY CONSTRUCTION, so a bundle could never match the input a portal would regenerate.
+/// <para>🚨 This one is a real trade, unlike the other three: the value IS a string literal in the
+/// emitted IL, so two assemblies differing only in it hash equal. What differs is one provenance
+/// timestamp on the provider's node — not a type, a member, a signature or a reference — and the
+/// alternative is a key that cannot work at all. The match is anchored to the generator's exact
+/// emitted shape, so a same-shaped line in USER code is the only false positive available, and its
+/// only consequence is that one timestamp literal stops discriminating.</para></description></item>
 /// </list>
 /// Nothing else is touched: no trimming, no whitespace collapsing, no comment stripping. Every
 /// other byte of the generated text is part of the key.</para>
@@ -82,6 +96,10 @@ public static class GeneratedInputIdentity
     /// <summary>The fixed text every <c>// Generated at: …</c> line normalises to.</summary>
     internal const string NormalizedGeneratedAtLine = "// Generated at: (normalized)";
 
+    /// <summary>The fixed text the skeleton's node-timestamp line normalises to.</summary>
+    internal const string NormalizedLastModifiedLine =
+        "                LastModified = DateTimeOffset.Parse(\"(normalized)\"),";
+
     /// <summary>
     /// Matches the skeleton's wall-clock header line. Anchored to a whole line (Multiline) and
     /// deliberately narrow — it must not touch a line of USER code that happens to mention the
@@ -90,6 +108,16 @@ public static class GeneratedInputIdentity
     /// </summary>
     private static readonly Regex GeneratedAtLinePattern = new(
         @"^//[ \t]*Generated at:.*$", RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Matches the skeleton's node-timestamp line. Anchored to a whole line and to the generator's
+    /// exact emitted shape — the assignment, the <c>DateTimeOffset.Parse</c> call, a simple string
+    /// literal, the trailing comma — so it cannot swallow an arbitrary line of user code that
+    /// merely mentions <c>LastModified</c>.
+    /// </summary>
+    private static readonly Regex LastModifiedLinePattern = new(
+        @"^[ \t]*LastModified = DateTimeOffset\.Parse\(""[^""\\]*""\),[ \t]*$",
+        RegexOptions.Multiline | RegexOptions.Compiled);
 
     /// <summary>
     /// The identity of the Roslyn that will do the compiling. A compiler upgrade can change the
@@ -123,7 +151,8 @@ public static class GeneratedInputIdentity
         var text = source[0] == '\uFEFF' ? source[1..] : source;
         text = text.Replace("\r\n", "\n", StringComparison.Ordinal)
             .Replace('\r', '\n');
-        return GeneratedAtLinePattern.Replace(text, NormalizedGeneratedAtLine);
+        text = GeneratedAtLinePattern.Replace(text, NormalizedGeneratedAtLine);
+        return LastModifiedLinePattern.Replace(text, NormalizedLastModifiedLine);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Compiler/GeneratorPipeline.cs
+++ b/src/MeshWeaver.Compiler/GeneratorPipeline.cs
@@ -62,6 +62,22 @@ public static class GeneratorPipeline
     }
 
     /// <summary>
+    /// The generator-candidate assemblies a compile actually loads: the built-in generator (when a
+    /// copy is present beside the app) plus everything the node's <c>#r</c> directives resolved to,
+    /// minus a duplicate of the built-in. Extracted so the CONTENT KEY
+    /// (<see cref="GeneratedInputIdentity.OfGeneratedInput"/>) hashes the SAME set
+    /// <see cref="RunSourceGenerators"/> runs — a key computed over a different set would be a key
+    /// about a compile that never happened.
+    /// </summary>
+    internal static IReadOnlyList<string> EffectiveGeneratorPaths(
+        IReadOnlyList<string> generatorAssemblyPaths)
+        => BuiltInGeneratorPaths.Count == 0
+            ? generatorAssemblyPaths
+            : [.. BuiltInGeneratorPaths,
+               .. generatorAssemblyPaths.Where(p => !string.Equals(
+                   Path.GetFileName(p), BuiltInScopeGeneratorId + ".dll", StringComparison.OrdinalIgnoreCase))];
+
+    /// <summary>
     /// Runs the built-in scope generator plus any OTHER generator a node <c>#r</c>'d over
     /// <paramref name="compilation"/>. A node's own
     /// <c>#r "nuget:MeshWeaver.BusinessRules.Generator"</c> is filtered OUT — otherwise the same
@@ -73,11 +89,7 @@ public static class GeneratorPipeline
     internal static CSharpCompilation RunSourceGenerators(
         CSharpCompilation compilation, IReadOnlyList<string> generatorAssemblyPaths, ILogger logger, CancellationToken ct)
     {
-        IReadOnlyList<string> allPaths = BuiltInGeneratorPaths.Count == 0
-            ? generatorAssemblyPaths
-            : [.. BuiltInGeneratorPaths,
-               .. generatorAssemblyPaths.Where(p => !string.Equals(
-                   Path.GetFileName(p), BuiltInScopeGeneratorId + ".dll", StringComparison.OrdinalIgnoreCase))];
+        var allPaths = EffectiveGeneratorPaths(generatorAssemblyPaths);
         if (allPaths.Count == 0)
             return compilation;
         var generators = SourceGeneratorLoader.Discover(allPaths, logger);

--- a/src/MeshWeaver.Compiler/NodeCompileShaping.cs
+++ b/src/MeshWeaver.Compiler/NodeCompileShaping.cs
@@ -210,12 +210,29 @@ public static class NodeCompileShaping
 
     /// <summary>
     /// The emit path's source-set fold: dedup by path (case-insensitive), keep only
-    /// non-executable Code nodes with non-blank code, in the order the snapshot delivered them.
+    /// non-executable Code nodes with non-blank code, ORDERED BY PATH (ordinal).
     /// Executable scripts run via the kernel (ExecuteScriptRequest), never folded into the parent
     /// NodeType's Roslyn unit — top-level statements would collide with class declarations from
     /// Source/ siblings; Test/ commonly mixes both shapes, and this filter lets them coexist.
     /// Returns the matched configurations together with the matched paths (activity-log
     /// material for the caller).
+    ///
+    /// <para>🚨 <b>The order is a function of the SOURCE SET, never of how it was delivered</b>
+    /// (#1707 slice 4). It used to be "the order the snapshot delivered them", and on the mesh path
+    /// that delivery is <c>ImmutableDictionary.Values</c> — hash-bucket order over string hashes
+    /// that .NET RANDOMISES PER PROCESS. The join order is part of the emitted bytes, so the mesh
+    /// compile emitted a different assembly for identical content on every process: not
+    /// reproducible against another producer, and not reproducible against ITSELF. That is why the
+    /// assembly store's digest-of-the-emitted-bytes could never dedupe, and it made the
+    /// generated-input CONTENT KEY move on every compile — an identity that invalidates everything
+    /// on every build, which is strictly worse than the proxy it replaces.</para>
+    ///
+    /// <para>Measured on <c>BakeEquivalenceTest</c> before the sort: the compiler-driven bake
+    /// produced <c>i3494e62e…</c> on three consecutive runs while the mesh-driven bake produced
+    /// <c>ic920384a…</c>, <c>iead1b585…</c>, <c>i70db762d…</c>. Ordinal path order is what the
+    /// tree bake already effectively had, it is stable across processes, hosts and architectures,
+    /// and C# does not care: top-level declarations in a concatenated unit are order-independent,
+    /// which is exactly what that test's type-and-member SURFACE comparison proves.</para>
     /// </summary>
     internal static (List<CodeConfiguration> Sources, List<string> MatchedPaths)
         CollectCompileSources(IEnumerable<MeshNode> matches, string nodePath, ILogger logger)
@@ -223,7 +240,7 @@ public static class NodeCompileShaping
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var acc = new List<CodeConfiguration>();
         var matchedPaths = new List<string>();
-        foreach (var n in matches)
+        foreach (var n in matches.OrderBy(n => n.Path, StringComparer.Ordinal))
         {
             if (string.IsNullOrEmpty(n.Path) || !seen.Add(n.Path))
                 continue;

--- a/src/MeshWeaver.Compiler/NodeSetCompiler.cs
+++ b/src/MeshWeaver.Compiler/NodeSetCompiler.cs
@@ -247,8 +247,30 @@ public static class NodeSetCompiler
             File.Exists(pdbPath) ? pdbPath : null,
             inputs,
             CompiledDependencies.Compute(
-                ReferencedAssemblyNames(artifact.DllPath), dependencyIdOf, toolchainId));
+                ReferencedAssemblyNames(artifact.DllPath), dependencyIdOf, toolchainId,
+                GeneratedInputDigestOf(inputs, generatorPaths)));
     }
+
+    /// <summary>
+    /// The stage-1 CONTENT KEY digest of a resolved compile (#1707 slice 4): the generated text
+    /// plus everything else that decides the bytes given that text. Shared by this bake and the
+    /// runtime's <c>MeshNodeCompilationService</c> — the two paths differ only in where the nodes
+    /// came from, so their keys must agree for identical content, which is what makes a CI bake's
+    /// bytes adoptable by a portal.
+    ///
+    /// <para>The NuGet-resolved assemblies are folded in as generator CANDIDATES: they are what
+    /// <see cref="GeneratorPipeline.RunSourceGenerators"/> discovers over, and a change in what a
+    /// <c>#r "nuget:"</c> directive resolves to changes the emitted bytes.</para>
+    /// </summary>
+    internal static string GeneratedInputDigestOf(
+        CompileInputs inputs, IReadOnlyList<string> nugetAssemblyPaths) =>
+        GeneratedInputIdentity.OfGeneratedInput(
+            inputs.AssemblyName,
+            inputs.GeneratedSource,
+            EmitPipeline.OptionsFingerprint,
+            GeneratedInputIdentity.CompilerIdentity,
+            GeneratedInputIdentity.AssemblyFileIdentities(
+                GeneratorPipeline.EffectiveGeneratorPaths(nugetAssemblyPaths)));
 
     /// <summary>
     /// The include reader the tree bake hands <see cref="NodeCompileShaping.ResolveCodeIncludes"/>:

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -167,7 +167,7 @@ internal class MeshNodeCompilationService(
     // path even though caller 1 had just finished). Entries clear once the
     // task settles so a future re-compile (e.g. after source edit) starts
     // fresh.
-    private readonly ConcurrentDictionary<string, Lazy<Task<string?>>> _inflightCompiles =
+    private readonly ConcurrentDictionary<string, Lazy<Task<CompileEmit>>> _inflightCompiles =
         new(StringComparer.Ordinal);
 
     // Query expansion lives in CodeQueryResolver (MeshWeaver.Compiler) so the NodeType
@@ -274,15 +274,23 @@ internal class MeshNodeCompilationService(
         => GetAssemblyLocationWithLog(node).Select(t => t.Path);
 
     /// <summary>
-    /// One compile attempt's outcome: the assembly path (null on failure), the
-    /// <see cref="ActivityLog"/>, and — the point of carrying it — the ONE source snapshot
-    /// the attempt was taken against. Every downstream stage
-    /// (<see cref="DiscoverSourceVersionSnapshot"/>, <see cref="BuildFailureDiagnostics"/>)
-    /// reuses <see cref="Sources"/> instead of re-discovering; see
+    /// What one Roslyn emit produced: where the bytes landed, and the stage-1 CONTENT KEY digest
+    /// of the fully generated input that produced them (#1707 slice 4 — see
+    /// <see cref="GeneratedInputIdentity"/>).
+    /// </summary>
+    private readonly record struct CompileEmit(string? Path, string? InputDigest);
+
+    /// <summary>
+    /// One compile attempt's outcome: the assembly path (null on failure), the CONTENT KEY digest
+    /// of the input that produced it (null when no compile ran — a disk-cache hit; the dependency
+    /// record then simply carries no content key), the <see cref="ActivityLog"/>, and — the point
+    /// of carrying it — the ONE source snapshot the attempt was taken against. Every downstream
+    /// stage (<see cref="DiscoverSourceVersionSnapshot"/>, <see cref="BuildFailureDiagnostics"/>)
+    /// reuses <c>Sources</c> instead of re-discovering; see
     /// <see cref="GetAssemblyLocationWithLog"/>.
     /// </summary>
     private readonly record struct CompileAttempt(
-        string? Path, ActivityLog Log, IReadOnlyList<MeshNode> Sources);
+        string? Path, string? InputDigest, ActivityLog Log, IReadOnlyList<MeshNode> Sources);
 
     /// <summary>
     /// Companion to <see cref="GetAssemblyLocation"/> that also surfaces the
@@ -325,7 +333,7 @@ internal class MeshNodeCompilationService(
         if (string.IsNullOrEmpty(node.NodeType))
         {
             logger.LogDebug("Node {NodePath} has no NodeType, skipping assembly compilation", node.Path);
-            return Observable.Return(new CompileAttempt(null,
+            return Observable.Return(new CompileAttempt(null, null,
                 AppendInfo(log, $"Skipped — node '{node.Path}' has no NodeType.")
                     .Finish((int)hub.Version, ActivityStatus.Succeeded),
                 Array.Empty<MeshNode>()));
@@ -405,6 +413,8 @@ internal class MeshNodeCompilationService(
                                 node.Path, cachedDllPath, effectiveLastModified);
                             return Observable.Return(new CompileAttempt(
                                 cachedDllPath,
+                                // No compile ran, so there is no generated input to key on.
+                                null,
                                 AppendInfo(log,
                                     $"Cache hit — returning {cachedDllPath} (effective LastModified={effectiveLastModified:O}).")
                                     .Finish((int)hub.Version, ActivityStatus.Succeeded),
@@ -415,7 +425,7 @@ internal class MeshNodeCompilationService(
                     // Hand the snapshot down as the override — CompileCore then short-circuits
                     // its own SnapshotSources to this authoritative point-in-time set.
                     return CompileCore(node, ntDef, selfPath, log, sources)
-                        .Select(t => new CompileAttempt(t.Path, t.Log, sources));
+                        .Select(t => new CompileAttempt(t.Path, t.InputDigest, t.Log, sources));
                 });
         });
     }
@@ -802,7 +812,7 @@ internal class MeshNodeCompilationService(
     /// no <c>await</c> on hub round-trips — both are the canonical deadlock
     /// patterns documented in <c>Doc/Architecture/AsynchronousCalls.md</c>.
     /// </summary>
-    private IObservable<(string? Path, ActivityLog Log)> CompileCore(
+    private IObservable<(string? Path, string? InputDigest, ActivityLog Log)> CompileCore(
         MeshNode node, NodeTypeDefinition? ntDef, string selfPath, ActivityLog log,
         IReadOnlyList<MeshNode>? sourcesOverride = null)
     {
@@ -928,8 +938,9 @@ internal class MeshNodeCompilationService(
                         ct => OnThreadPool(() =>
                             CompileAsync(codeFile, configuration, contentCollections, node, ct)),
                         _cacheOptions.RoslynCompileTimeout, "roslyn-compile", node.Path)
-                    .Select(actualPath =>
+                    .Select(emit =>
                     {
+                        var actualPath = emit.Path;
                         ActivityLog finalLog;
                         string? finalPath;
                         if (cacheService.IsDiskCacheEnabled)
@@ -959,7 +970,8 @@ internal class MeshNodeCompilationService(
                             finalLog = AppendInfo(discoveryLog,
                                 $"Compiled assembly loaded in-memory ({actualPath}).");
                         }
-                        return (finalPath, finalLog.Finish((int)hub.Version, ActivityStatus.Succeeded));
+                        return (finalPath, emit.InputDigest,
+                            finalLog.Finish((int)hub.Version, ActivityStatus.Succeeded));
                     })
                     // 🚨 THE SINGLE REPORTER of a compile failure. Every CompilationException —
                     // Roslyn diagnostics from the disk emit (EmitCompilationToDirectory) or the
@@ -970,7 +982,7 @@ internal class MeshNodeCompilationService(
                     // same diagnostics too, which double-counted every failure in prod and put a
                     // context-free record first — do not re-add a log next to a `throw new
                     // CompilationException`.
-                    .Catch<(string?, ActivityLog), CompilationException>(ex =>
+                    .Catch<(string?, string?, ActivityLog), CompilationException>(ex =>
                     {
                         var diag = CompileDiagnostics.BuildSourceDiscoveryReport(executedQueries, matchedCodePaths);
                         // 🚨 ORDER BY ACTIONABILITY — issue #1840. This report leads with the
@@ -997,7 +1009,8 @@ internal class MeshNodeCompilationService(
                         var failedLog = AppendError(discoveryLog,
                                 $"Compilation failed: {ex.Message}\n--- Source discovery ---\n{diag}")
                             .Finish((int)hub.Version, ActivityStatus.Failed);
-                        return Observable.Return<(string?, ActivityLog)>((null, failedLog));
+                        return Observable.Return<(string?, string?, ActivityLog)>(
+                            (null, null, failedLog));
                     });
             });
     }
@@ -1107,7 +1120,7 @@ internal class MeshNodeCompilationService(
         IReadOnlyList<MeshNode>? sourcesOverride = null)
         => GetAssemblyLocationWithLog(node, sourcesOverride).SelectMany(attempt =>
         {
-            var (assemblyLocation, log, sources) = attempt;
+            var (assemblyLocation, _, log, sources) = attempt;
             if (string.IsNullOrEmpty(assemblyLocation))
                 // Failed compile: capture the per-source-file Roslyn diagnostics (one
                 // LSP-style per-file-tree compilation of all this NodeType's src+test) so
@@ -1144,7 +1157,8 @@ internal class MeshNodeCompilationService(
                 // the abandoned load thread is the honest cost.
                 .SelectMany(snapshot => BoundLeg(
                     _ => OnThreadPool(() =>
-                        CompileResultFromAssembly(node, assemblyLocation, log, snapshot)),
+                        CompileResultFromAssembly(
+                            node, assemblyLocation, log, snapshot, attempt.InputDigest)),
                     _cacheOptions.AssemblyLoadTimeout, "assembly-load", node.Path))
                 // Re-Finish the log after CompileResultFromAssembly. CompileCore already
                 // Finished it Succeeded, but CompileResultFromAssembly's downstream steps
@@ -1435,9 +1449,14 @@ internal class MeshNodeCompilationService(
         });
     }
 
+    /// <param name="generatedInputDigest">The stage-1 CONTENT KEY digest of the compile that
+    /// produced these bytes (#1707 slice 4), or null when no compile ran in this process — a
+    /// disk-cache hit or the assembly-hydration shortcut. Null simply leaves the record without a
+    /// content key; the toolchain entry still governs.</param>
     private NodeCompilationResult? CompileResultFromAssembly(
         MeshNode node, string assemblyLocation, ActivityLog log,
-        ImmutableDictionary<string, long> compiledSources)
+        ImmutableDictionary<string, long> compiledSources,
+        string? generatedInputDigest = null)
     {
 
             var nodeName = cacheService.SanitizeNodeName(node.Path);
@@ -1538,7 +1557,11 @@ internal class MeshNodeCompilationService(
                 var dependencies = Compiler.CompiledDependencies.Compute(
                     assembly.GetReferencedAssemblies().Select(n => n.Name),
                     NodeTypeCompilationHelpers.DependencyIdResolverOf(hub),
-                    NodeTypeCompilationHelpers.ProcessToolchainId);
+                    NodeTypeCompilationHelpers.ProcessToolchainId,
+                    // The CONTENT KEY (#1707 slice 4) is completed here: stage 1 came from the
+                    // emit, and the PRUNED reference surfaces are the record's own entries — the
+                    // set Roslyn proved the bytes actually bind.
+                    generatedInputDigest);
 
                 return new NodeCompilationResult(
                     assemblyLocation, configurations, log, compiledSources,
@@ -1568,7 +1591,7 @@ internal class MeshNodeCompilationService(
     /// Compiles CodeConfiguration into an assembly using Roslyn.
     /// Supports both disk-based and in-memory compilation.
     /// </summary>
-    private Task<string?> CompileAsync(
+    private Task<CompileEmit> CompileAsync(
         CodeConfiguration? codeFile,
         string? hubConfiguration,
         IReadOnlyList<ContentCollectionConfig>? contentCollections,
@@ -1582,12 +1605,12 @@ internal class MeshNodeCompilationService(
         // once the task settles so a future invalidation triggers a fresh
         // compile instead of returning the stale completed task.
         var lazy = _inflightCompiles.GetOrAdd(nodeName, n =>
-            new Lazy<Task<string?>>(() => RunCompileAndEvict(
+            new Lazy<Task<CompileEmit>>(() => RunCompileAndEvict(
                 codeFile, hubConfiguration, contentCollections, node, n, ct)));
         return lazy.Value;
     }
 
-    private async Task<string?> RunCompileAndEvict(
+    private async Task<CompileEmit> RunCompileAndEvict(
         CodeConfiguration? codeFile,
         string? hubConfiguration,
         IReadOnlyList<ContentCollectionConfig>? contentCollections,
@@ -1605,7 +1628,7 @@ internal class MeshNodeCompilationService(
         }
     }
 
-    private async Task<string?> CompileAsyncCore(
+    private async Task<CompileEmit> CompileAsyncCore(
         CodeConfiguration? codeFile,
         string? hubConfiguration,
         IReadOnlyList<ContentCollectionConfig>? contentCollections,
@@ -1661,6 +1684,20 @@ internal class MeshNodeCompilationService(
         // Parse + compile via the toolchain (EmitPipeline, #1707) — source path and encoding
         // embedded (critical for PDB source linking); canonical options; generators applied.
         var assemblyName = $"DynamicNode_{nodeName}";
+
+        // 🚨 THE CONTENT KEY's first stage (#1707 slice 4), taken HERE — the last point at which
+        // the fully generated input exists as text, and before a single Roslyn call. It keys the
+        // exact thing the toolchain's full-MVID proxy stands in for: what Roslyn is actually fed.
+        // The NuGet-resolved assemblies ride in as generator candidates, so a change in what a
+        // `#r "nuget:"` resolves to moves the key (GeneratorPipeline.EffectiveGeneratorPaths is
+        // the same set RunSourceGenerators loads — one resolution, no drift).
+        var generatedInputDigest = GeneratedInputIdentity.OfGeneratedInput(
+            assemblyName,
+            source,
+            EmitPipeline.OptionsFingerprint,
+            GeneratedInputIdentity.CompilerIdentity,
+            GeneratedInputIdentity.AssemblyFileIdentities(
+                GeneratorPipeline.EffectiveGeneratorPaths(nugetAssemblyPaths)));
         var compilation = GeneratorPipeline.RunSourceGenerators(
             EmitPipeline.CreateEmitCompilation(
                 source,
@@ -1685,6 +1722,6 @@ internal class MeshNodeCompilationService(
         }
 
         logger.LogInformation("Successfully compiled assembly for {NodePath} to {ActualPath}", node.Path, actualPath);
-        return actualPath;
+        return new CompileEmit(actualPath, generatedInputDigest);
     }
 }

--- a/test/MeshWeaver.Graph.Test/CompileSourceOrderTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompileSourceOrderTest.cs
@@ -1,0 +1,76 @@
+#pragma warning disable CS1591
+
+using MeshWeaver.Compiler;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 The compile's source ORDER is a function of the SOURCE SET, never of how it was delivered.
+///
+/// <para>The join order is part of the emitted bytes — <c>NodeCompileShaping.CombineSources</c>
+/// concatenates in this order — and it used to be whatever order the snapshot arrived in. On the
+/// mesh path that delivery is <c>ImmutableDictionary.Values</c> (see
+/// <c>MeshNodeCompilationService</c>'s source probe), i.e. hash-bucket order over string hashes
+/// that .NET RANDOMISES PER PROCESS. So the mesh compiled the same content into a different
+/// assembly on every process: not reproducible against the compiler-driven bake, and not
+/// reproducible against itself. It is why the assembly store's digest of the emitted bytes could
+/// never dedupe, and it made the generated-input content key move on every compile.</para>
+///
+/// <para>Pinned here as a unit test as well as in <c>BakeEquivalenceTest</c>, because the
+/// equivalence test is an expensive integration test in a different project and this property is
+/// cheap to state: a reversed delivery must produce an identical compile unit.</para>
+/// </summary>
+public class CompileSourceOrderTest
+{
+    private static MeshNode Code(string path, string code) =>
+        new(path[(path.LastIndexOf('/') + 1)..], path[..path.LastIndexOf('/')])
+        {
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = code, Language = "csharp" },
+        };
+
+    [Fact]
+    public void CollectCompileSources_OrdersByPath_WhateverOrderTheSnapshotDelivered()
+    {
+        MeshNode[] delivered =
+        [
+            Code("Widget/Thing/Test/ThingTests", "class T {}"),
+            Code("Lib/Shared/Source/Helper", "class H {}"),
+            Code("Widget/Thing/Source/Sub/Deep", "class D {}"),
+            Code("Widget/Thing/Source/Thing", "class Th {}"),
+        ];
+
+        var (_, matched) = NodeCompileShaping.CollectCompileSources(
+            delivered, "Widget/Thing", NullLogger.Instance);
+
+        matched.Should().Equal(
+            "Lib/Shared/Source/Helper",
+            "Widget/Thing/Source/Sub/Deep",
+            "Widget/Thing/Source/Thing",
+            "Widget/Thing/Test/ThingTests");
+    }
+
+    [Fact]
+    public void TheCombinedCompileUnit_IsIdentical_UnderAnyDeliveryOrder()
+    {
+        MeshNode[] ascending =
+        [
+            Code("Pkg/T/Source/A", "class A {}"),
+            Code("Pkg/T/Source/B", "class B {}"),
+            Code("Pkg/T/Source/C", "class C {}"),
+        ];
+        var descending = ascending.Reverse().ToArray();
+
+        var one = NodeCompileShaping.CombineSources(
+            NodeCompileShaping.CollectCompileSources(ascending, "Pkg/T", NullLogger.Instance).Sources);
+        var other = NodeCompileShaping.CombineSources(
+            NodeCompileShaping.CollectCompileSources(descending, "Pkg/T", NullLogger.Instance).Sources);
+
+        one!.Code.Should().Be(other!.Code);
+        // …and the order is the SET's, not the first caller's.
+        one.Code.Should().Be("class A {}\n\nclass B {}\n\nclass C {}");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/GeneratedInputIdentityTest.cs
+++ b/test/MeshWeaver.Graph.Test/GeneratedInputIdentityTest.cs
@@ -394,6 +394,54 @@ public class GeneratedInputIdentityTest
             .Should().Contain(CompiledDependencies.ContentKey);
     }
 
+    /// <summary>
+    /// 🚨 A file NAME can be ambiguous — NuGet can resolve two different assemblies to the same
+    /// file name (two packages, or two TFM folders), and <c>RunSourceGenerators</c> loads BOTH.
+    /// Overwriting on collision would drop one from the key, so the key would claim "same input"
+    /// for a genuinely different effective generator set — the UNDER-invalidating direction — and
+    /// which one survived would depend on enumeration order, reintroducing the order-dependence
+    /// this type exists to remove.
+    /// </summary>
+    [Fact]
+    public void ACollidingGeneratorFileName_AggregatesEveryIdentity_OrderIndependently()
+    {
+        var dir = Directory.CreateTempSubdirectory("mw-gen-collide-");
+        try
+        {
+            // Two DIFFERENT unreadable-but-present files would both resolve `absent`, which cannot
+            // show aggregation — so use the real toolchain assemblies, which have distinct MVIDs,
+            // copied under ONE shared file name in two directories.
+            var real = typeof(GeneratedInputIdentity).Assembly.Location;
+            var other = typeof(Xunit.FactAttribute).Assembly.Location;
+            var a = Path.Combine(dir.FullName, "a"); Directory.CreateDirectory(a);
+            var b = Path.Combine(dir.FullName, "b"); Directory.CreateDirectory(b);
+            var first = Path.Combine(a, "Gen.dll");
+            var second = Path.Combine(b, "Gen.dll");
+            File.Copy(real, first);
+            File.Copy(other, second);
+
+            var ascending = GeneratedInputIdentity.AssemblyFileIdentities([first, second]);
+            var descending = GeneratedInputIdentity.AssemblyFileIdentities([second, first]);
+
+            ascending.Keys.Should().Equal("Gen.dll");
+            // BOTH identities are represented, and the order they arrived in does not matter.
+            ascending["Gen.dll"].Should().Contain(GeneratedInputIdentity.IdentitySeparator);
+            descending["Gen.dll"].Should().Be(ascending["Gen.dll"]);
+
+            // …and dropping one of the two MUST move the key — that is the whole point.
+            GeneratedInputIdentity.AssemblyFileIdentities([first])["Gen.dll"]
+                .Should().NotBe(ascending["Gen.dll"]);
+
+            // The SAME assembly reached by two paths is ONE input, so it collapses to one id.
+            var duplicated = GeneratedInputIdentity.AssemblyFileIdentities([first, first]);
+            duplicated["Gen.dll"].Should().NotContain(GeneratedInputIdentity.IdentitySeparator);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
     [Fact]
     public void AssemblyFileIdentities_AreKeyedByFileName_NotByHostPath()
     {

--- a/test/MeshWeaver.Graph.Test/GeneratedInputIdentityTest.cs
+++ b/test/MeshWeaver.Graph.Test/GeneratedInputIdentityTest.cs
@@ -1,0 +1,372 @@
+#pragma warning disable CS1591
+
+using System.Collections.Immutable;
+using MeshWeaver.Compiler;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the CONTENT KEY (#1707 slice 4) — the hash of the FULLY GENERATED compilation input.
+///
+/// <para>The key exists to replace a PROXY. <c>FrameworkBuildIdentity.FullMvidAssemblies</c> folds
+/// the toolchain's whole implementation MVID into the framework identity because a generator body
+/// change reshapes what Roslyn is fed with no API change — correct, and so coarse that a body-only
+/// commit anywhere in a 16-assembly closure rebakes every NodeType on every deployment (#1976). So
+/// the key has to DISCRIMINATE, and these are the four claims that make it usable:</para>
+///
+/// <list type="number">
+/// <item><description>identical generated input ⇒ identical key, in one process and across
+/// processes/hosts/architectures (the golden vector);</description></item>
+/// <item><description>a GENERATOR BODY change that alters the generated input ⇒ the key MOVES
+/// (this is the case the full-MVID rule exists for — the load-bearing one);</description></item>
+/// <item><description>a body-only change that does NOT alter the generated input ⇒ the key does
+/// NOT move (this is the win);</description></item>
+/// <item><description>a REFERENCE-SURFACE change ⇒ the key MOVES.</description></item>
+/// </list>
+///
+/// <para>An unstable key is worse than the proxy it replaces: it would invalidate everything on
+/// every build and nobody would know why. Hence the golden vectors — a literal a DIFFERENT process
+/// on a DIFFERENT architecture has to reproduce, which is exactly what CI does on every run.</para>
+/// </summary>
+public class GeneratedInputIdentityTest
+{
+    // Fixed, injected environment: the algorithm is pinned, not this machine's Roslyn build.
+    private const string Compiler = "Microsoft.CodeAnalysis.CSharp/4.14.0.0/4.14.0-test";
+    private const string Options = "options/v1\nCSharpParseOptions.LanguageVersion=Preview\n";
+
+    private const string GeneratedSource =
+        "// Auto-generated from MeshNode: Demo/Thing\n"
+        + "// Generated at: 2026-08-21T09:14:02.1234567+00:00\n"
+        + "using System;\n"
+        + "[assembly: MeshWeaver.Graph.Generated.DemoThingMeshNodeProvider]\n"
+        + "public record ThingContent(string Name);\n";
+
+    private static ImmutableSortedDictionary<string, string> Pairs(
+        params (string Key, string Value)[] pairs)
+    {
+        var builder = ImmutableSortedDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in pairs)
+            builder[key] = value;
+        return builder.ToImmutable();
+    }
+
+    private static string Digest(
+        string source, string options = Options, params (string Key, string Value)[] generators) =>
+        GeneratedInputIdentity.OfGeneratedInput(
+            "DynamicNode_Demo_Thing", source, options, Compiler, Pairs(generators));
+
+    // ── 1. identical generated input ⇒ identical key ─────────────────────────────────────────
+
+    [Fact]
+    public void IdenticalGeneratedInput_HashesIdentically_WithinOneProcess()
+    {
+        Digest(GeneratedSource).Should().Be(Digest(GeneratedSource));
+        GeneratedInputIdentity.Combine(Digest(GeneratedSource), Pairs(("MeshWeaver.Layout", "ref:a")))
+            .Should().Be(GeneratedInputIdentity.Combine(
+                Digest(GeneratedSource), Pairs(("MeshWeaver.Layout", "ref:a"))));
+    }
+
+    /// <summary>
+    /// 🚨 THE CROSS-PROCESS / CROSS-HOST / CROSS-ARCHITECTURE claim, expressed the only way a test
+    /// can make it: a LITERAL. Every CI run on every runner recomputes these from the same inputs
+    /// in a different process — an implementation that picked up ANY ambient state (culture, line
+    /// endings, enumeration order, a clock, a hash seed) fails here rather than silently
+    /// invalidating every build in production.
+    ///
+    /// <para>A change to these literals is a change to the KEY SPACE: every stamped record stops
+    /// matching and every NodeType rebuilds once. That is legitimate when the algorithm genuinely
+    /// changes — bump the <c>generated-input/v1</c> / <c>content-key/v1</c> document versions with
+    /// it and say so in the PR. It is never legitimate as a way to make a failing test pass.</para>
+    /// </summary>
+    [Fact]
+    public void TheKey_IsAPinnedFunctionOfItsInputs_AcrossProcessesAndHosts()
+    {
+        var digest = Digest(GeneratedSource);
+        digest.Should().Be("gb7fb3927697f90ef616dc94be3d91869");
+
+        GeneratedInputIdentity.Combine(digest, Pairs(
+                ("MeshWeaver.Layout", "ref:aaa"), ("MeshWeaver.Mesh.Contract", "ref:bbb")))
+            .Should().Be("i01e1f2f47df6303c72c00a1f6857eae7");
+    }
+
+    [Fact]
+    public void LineEndings_AreNormalized_SoAWindowsBuildAndALinuxBuildAgree()
+    {
+        // The skeleton is built with StringBuilder.AppendLine — Environment.NewLine — so the SAME
+        // node generates CRLF on a Windows dev box and LF in a pod. Without the fold nothing would
+        // ever share a build across hosts.
+        Digest(GeneratedSource.Replace("\n", "\r\n", StringComparison.Ordinal))
+            .Should().Be(Digest(GeneratedSource));
+        Digest("\uFEFF" + GeneratedSource).Should().Be(Digest(GeneratedSource));
+    }
+
+    [Fact]
+    public void TheGeneratorsWallClockHeader_IsNormalizedOut()
+    {
+        // DynamicMeshNodeAttributeGenerator stamps DateTimeOffset.UtcNow into the generated text.
+        // Left in, the input is never twice the same and NO content key over it could ever hit.
+        var later = GeneratedSource.Replace(
+            "2026-08-21T09:14:02.1234567+00:00", "2027-01-02T23:59:59.9999999+00:00",
+            StringComparison.Ordinal);
+        later.Should().NotBe(GeneratedSource);
+        Digest(later).Should().Be(Digest(GeneratedSource));
+
+        // …and ONLY that line: the same timestamp text inside user code is content, and moves it.
+        var inUserCode = GeneratedSource.Replace(
+            "public record ThingContent(string Name);",
+            "public const string Stamp = \"// Generated at: 2026-08-21T09:14:02.1234567+00:00\";",
+            StringComparison.Ordinal);
+        Digest(inUserCode).Should().NotBe(Digest(GeneratedSource));
+    }
+
+    // ── 2. a generator body change that alters the generated input ⇒ the key MOVES ───────────
+
+    /// <summary>
+    /// The load-bearing case. A body-only edit to the skeleton generator — the #1802 shape, where
+    /// <c>GenerateGlobalUsingsSource</c>/<c>GenerateAttributeSource</c> started emitting a
+    /// different import scope — changes the emitted bytes with NO API change anywhere. This is
+    /// exactly what surface hashing cannot see and what <c>FullMvidAssemblies</c> exists for.
+    /// </summary>
+    [Fact]
+    public void AGeneratorBodyChange_ThatAltersTheGeneratedText_MovesTheKey()
+    {
+        var afterGeneratorChange = GeneratedSource.Replace(
+            "using System;\n", "using System;\nusing System.Linq;\n", StringComparison.Ordinal);
+
+        Digest(afterGeneratorChange).Should().NotBe(Digest(GeneratedSource));
+    }
+
+    /// <summary>
+    /// The other half of the same case: a SOURCE GENERATOR whose body changed emits different
+    /// source into the compilation while the text handed to Roslyn is byte-identical. Nothing in
+    /// the generated text can see that, so the generators' own identities are part of the key.
+    /// </summary>
+    [Fact]
+    public void AGeneratorAssemblyBodyChange_MovesTheKey_EvenWhenTheTextIsIdentical()
+    {
+        var before = Digest(GeneratedSource, Options, ("Scope.Generator.dll", "mvid:1111"));
+        var after = Digest(GeneratedSource, Options, ("Scope.Generator.dll", "mvid:2222"));
+
+        after.Should().NotBe(before);
+        // …and adding a generator is a change too — an empty set must not hash like a populated one.
+        Digest(GeneratedSource).Should().NotBe(before);
+    }
+
+    /// <summary>
+    /// A body-only change to <c>EmitPipeline.CreateCompilationOptions</c> (flipping the
+    /// optimization level, say) rewrites every emitted assembly while the generated text is
+    /// unchanged — so the option set is in the key, and it is REFLECTED rather than hand-listed so
+    /// a newly-set option cannot sit silently outside it.
+    /// </summary>
+    [Fact]
+    public void AnOptionChange_MovesTheKey()
+    {
+        Digest(GeneratedSource, Options + "CSharpCompilationOptions.OptimizationLevel=Release\n")
+            .Should().NotBe(Digest(GeneratedSource));
+    }
+
+    [Fact]
+    public void RenderOptions_IsSortedOrdinalAndInvariant_AndNamesEveryPublicProperty()
+    {
+        var rendered = GeneratedInputIdentity.RenderOptions(
+            Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.Default);
+        var lines = rendered.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        lines.Should().NotBeEmpty();
+        lines.Should().Equal(lines.OrderBy(l => l, StringComparer.Ordinal));
+        lines.Should().Contain(l => l.StartsWith("CSharpParseOptions.LanguageVersion=", StringComparison.Ordinal));
+        // Reflected, so a Roslyn upgrade that ADDS an option joins the key automatically.
+        lines.Should().HaveCountGreaterThan(5);
+    }
+
+    // ── 3. a body-only change that does NOT alter the generated input ⇒ the key does NOT move ──
+
+    /// <summary>
+    /// 🚨 THE WIN, and the claim the whole slice is for. Two compiles of the SAME content by two
+    /// toolchains whose implementation MVIDs differ — the situation after any body-only commit to
+    /// the 16-assembly toolchain closure — produce the SAME content key. The <c>!toolchain</c>
+    /// proxy moves and the record records that it moved; the CONTENT key does not, because the
+    /// generated input did not.
+    /// </summary>
+    [Fact]
+    public void AToolchainBodyChange_ThatDoesNotAlterTheGeneratedInput_LeavesTheKeyPut()
+    {
+        Func<string, string?> ids = name => name == "MeshWeaver.Layout" ? "ref:aaa" : null;
+        var digest = Digest(GeneratedSource);
+
+        var before = CompiledDependencies.Compute(
+            ["MeshWeaver.Layout"], ids, "mvid:toolchain-BEFORE", digest);
+        var after = CompiledDependencies.Compute(
+            ["MeshWeaver.Layout"], ids, "mvid:toolchain-AFTER", digest);
+
+        before[CompiledDependencies.ToolchainKey]
+            .Should().NotBe(after[CompiledDependencies.ToolchainKey]);
+        after[CompiledDependencies.ContentKey]
+            .Should().Be(before[CompiledDependencies.ContentKey]);
+    }
+
+    /// <summary>
+    /// The record's content key is folded over the ASSEMBLY entries only — never over the reserved
+    /// <c>!</c> entries. Folding the toolchain id in would make the key move on every toolchain
+    /// commit, i.e. reproduce the proxy it replaces.
+    /// </summary>
+    [Fact]
+    public void TheRecordsContentKey_IsFoldedOverTheAssemblyEntriesOnly()
+    {
+        Func<string, string?> ids = name => name == "MeshWeaver.Layout" ? "ref:aaa" : null;
+        var digest = Digest(GeneratedSource);
+        var record = CompiledDependencies.Compute(
+            ["MeshWeaver.Layout"], ids, "mvid:toolchain-1", digest);
+
+        record[CompiledDependencies.ContentKey].Should().Be(
+            GeneratedInputIdentity.Combine(digest, Pairs(("MeshWeaver.Layout", "ref:aaa"))));
+    }
+
+    [Fact]
+    public void NoDigest_MeansNoContentKey_AndValidationIsUnchanged()
+    {
+        Func<string, string?> ids = _ => "ref:aaa";
+        var record = CompiledDependencies.Compute(["MeshWeaver.Layout"], ids, "mvid:t");
+
+        record.Should().NotContainKey(CompiledDependencies.ContentKey);
+        CompiledDependencies.FindMismatch(record, ids, "mvid:t").Should().BeNull();
+    }
+
+    [Fact]
+    public void AStampedContentKey_IsSkippedWithoutALiveOne_AndDecisiveWithOne()
+    {
+        Func<string, string?> ids = _ => "ref:aaa";
+        var record = CompiledDependencies.Compute(
+            ["MeshWeaver.Layout"], ids, "mvid:t", Digest(GeneratedSource));
+        var stamped = record[CompiledDependencies.ContentKey];
+
+        // No live key (every metadata-only caller): skipped — the toolchain entry still governs.
+        CompiledDependencies.FindMismatch(record, ids, "mvid:t").Should().BeNull();
+        // A caller that REGENERATED the input gets an exact verdict, both ways.
+        CompiledDependencies.FindMismatch(record, ids, "mvid:t", stamped).Should().BeNull();
+        CompiledDependencies.FindMismatch(record, ids, "mvid:t", "i-something-else")
+            .Should().Contain(CompiledDependencies.ContentKey);
+    }
+
+    // ── 4. a reference-surface change ⇒ the key MOVES ────────────────────────────────────────
+
+    [Fact]
+    public void AReferenceSurfaceChange_MovesTheKey()
+    {
+        var digest = Digest(GeneratedSource);
+
+        var before = GeneratedInputIdentity.Combine(digest, Pairs(
+            ("MeshWeaver.Layout", "ref:aaa"), ("MeshWeaver.Mesh.Contract", "ref:bbb")));
+        var afterSurfaceChange = GeneratedInputIdentity.Combine(digest, Pairs(
+            ("MeshWeaver.Layout", "ref:aaa"), ("MeshWeaver.Mesh.Contract", "ref:CHANGED")));
+        var afterNewReference = GeneratedInputIdentity.Combine(digest, Pairs(
+            ("MeshWeaver.Layout", "ref:aaa"), ("MeshWeaver.Mesh.Contract", "ref:bbb"),
+            ("Some.Module", "mvid:ccc")));
+
+        afterSurfaceChange.Should().NotBe(before);
+        afterNewReference.Should().NotBe(before);
+    }
+
+    [Fact]
+    public void ReferenceOrder_DoesNotMoveTheKey()
+    {
+        var digest = Digest(GeneratedSource);
+        var ascending = new[] { ("A.Ref", "ref:1"), ("B.Ref", "ref:2") };
+        var descending = new[] { ("B.Ref", "ref:2"), ("A.Ref", "ref:1") };
+
+        GeneratedInputIdentity.Combine(digest, Pairs(descending))
+            .Should().Be(GeneratedInputIdentity.Combine(digest, Pairs(ascending)));
+    }
+
+    // ── the stage-1/stage-2 split ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheTwoStages_AreDistinguishableByPrefix()
+    {
+        var digest = Digest(GeneratedSource);
+        digest.Should().StartWith(GeneratedInputIdentity.GeneratedInputPrefix);
+        GeneratedInputIdentity.Combine(digest, Pairs())
+            .Should().StartWith(GeneratedInputIdentity.ContentKeyPrefix);
+    }
+
+    [Fact]
+    public void AnUnreadableGeneratorAssembly_IsRecordedAsAbsent_NotSkipped()
+    {
+        var identities = GeneratedInputIdentity.AssemblyFileIdentities(
+            [Path.Combine(Path.GetTempPath(), "definitely-not-here-4d1f.dll")]);
+
+        identities.Should().ContainKey("definitely-not-here-4d1f.dll")
+            .WhoseValue.Should().Be(GeneratedInputIdentity.AbsentId);
+    }
+
+    // ── why the full-MVID rule could NOT be deleted with this slice ─────────────────────────
+
+    /// <summary>
+    /// 🚨 THE BLOCKER, pinned so it is checkable rather than an assertion in a PR body.
+    ///
+    /// <para>#1707 slice 4 says the content key lets the full-MVID rule "be deleted entirely". It
+    /// does not — not on its own — and this test is why. The content key answers "were these bytes
+    /// produced from THIS input" exactly; what it cannot do is answer it CHEAPLY, because
+    /// evaluating it means regenerating the compile input (source discovery, includes, skeleton).
+    /// Every consumer that decides "rebuild or not" today is metadata-only, so it has no live value
+    /// to compare against and <see cref="CompiledDependencies.FindMismatch"/> correctly skips the
+    /// entry.</para>
+    ///
+    /// <para>So with <c>FullMvidAssemblies</c> emptied, a body-only toolchain commit that DOES
+    /// change generated input — the #1802 global-usings fix, the <c>AnchorIncludePath</c> fix,
+    /// both real — moves NOTHING that any check looks at: the surface identity is unchanged
+    /// (no API moved), the toolchain entry is a constant, and the content key is skipped. The type
+    /// keeps bytes compiled from input that no longer exists, and the failure mode is a
+    /// <c>TypeLoadException</c> inside an ALC at activation with no diagnostic.</para>
+    ///
+    /// <para><b>What unblocks it</b> is a re-evaluation lane, not a better key: something that
+    /// REGENERATES the input on a toolchain change and compares. The toolchain MVID then stops
+    /// being the invalidation unit and becomes the trigger for that comparison — which is the
+    /// demotion #1976 actually wants, and which this key is the precondition for.</para>
+    /// </summary>
+    [Fact]
+    public void DeletingTheFullMvidRule_WouldLeaveNothingWatchingTheToolchain()
+    {
+        // Identical API surfaces; only the toolchain's IMPLEMENTATION moved — a body-only commit.
+        var surfaces = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["MeshWeaver.Compiler"] = "surface-unchanged",
+        };
+
+        // WITH the rule, the global identity moves and every stale-build check fires.
+        FrameworkBuildIdentity.ComputeSurfaceIdentity(surfaces, _ => "mvidBEFORE", ["MeshWeaver.Compiler"])
+            .Should().NotBe(FrameworkBuildIdentity.ComputeSurfaceIdentity(
+                surfaces, _ => "mvidAFTER", ["MeshWeaver.Compiler"]));
+
+        // WITHOUT it, the identity is the same value — nothing re-drives anything.
+        FrameworkBuildIdentity.ComputeSurfaceIdentity(surfaces, _ => "mvidBEFORE", [])
+            .Should().Be(FrameworkBuildIdentity.ComputeSurfaceIdentity(surfaces, _ => "mvidAFTER", []));
+
+        // …and the per-type record cannot cover for it: the toolchain entry has degenerated to a
+        // constant, and the content key is skipped because no metadata-only caller can compute a
+        // live one. A stamped record therefore validates forever across a toolchain change.
+        Func<string, string?> ids = _ => "ref:unchanged";
+        const string ToolchainAfterDeletion = "mvid:constant";
+        var record = CompiledDependencies.Compute(
+            ["MeshWeaver.Layout"], ids, ToolchainAfterDeletion, Digest(GeneratedSource));
+
+        CompiledDependencies.FindMismatch(record, ids, ToolchainAfterDeletion).Should().BeNull();
+        // The SAME record, judged by a caller that regenerated, is decisive — which is the lane
+        // that has to exist before the rule can go.
+        var afterAToolchainChangeThatDidAlterTheInput = GeneratedInputIdentity.Combine(
+            Digest(GeneratedSource + "using System.Text;\n"),
+            Pairs(("MeshWeaver.Layout", "ref:unchanged")));
+        CompiledDependencies.FindMismatch(
+                record, ids, ToolchainAfterDeletion, afterAToolchainChangeThatDidAlterTheInput)
+            .Should().Contain(CompiledDependencies.ContentKey);
+    }
+
+    [Fact]
+    public void AssemblyFileIdentities_AreKeyedByFileName_NotByHostPath()
+    {
+        // A key carrying a host path could never match between a bake container and a portal pod.
+        GeneratedInputIdentity.AssemblyFileIdentities(["/a/b/Gen.dll"])
+            .Keys.Should().Equal("Gen.dll");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/GeneratedInputIdentityTest.cs
+++ b/test/MeshWeaver.Graph.Test/GeneratedInputIdentityTest.cs
@@ -120,6 +120,38 @@ public class GeneratedInputIdentityTest
         Digest(inUserCode).Should().NotBe(Digest(GeneratedSource));
     }
 
+    /// <summary>
+    /// 🚨 THE SECOND WALL CLOCK, and the one that is not obvious. The skeleton emits the NodeType
+    /// node's own <c>LastModified</c> into the provider's node, and <c>PackageInstaller.BulkSave</c>
+    /// stamps that field with <c>DateTimeOffset.UtcNow</c> on EVERY import — so the same repo
+    /// content imported twice generates different text. A CI bake and a portal import the same
+    /// commit at different moments by construction, so a key that discriminated on it could never
+    /// match a bundle against the input a portal regenerates.
+    ///
+    /// <para>Caught by <c>BakeEquivalenceTest</c>: with only the source order fixed, the mesh
+    /// producer still emitted a different key on every run (<c>iaa2ed0ef…</c>, <c>ib704fb17…</c>)
+    /// while the compiler producer sat on <c>i770851b4…</c>.</para>
+    /// </summary>
+    [Fact]
+    public void TheNodeTimestampStamp_IsNormalizedOut_ButOnlyInItsGeneratedShape()
+    {
+        const string WithStamp = "        [\n            new MeshNode(\"Demo/Thing\")\n"
+            + "            {\n"
+            + "                LastModified = DateTimeOffset.Parse(\"2026-08-21T09:14:02.1234567+00:00\"),\n"
+            + "                HubConfiguration = ConfigureHub\n            }\n        ];\n";
+        var reimported = WithStamp.Replace(
+            "2026-08-21T09:14:02.1234567+00:00", "2027-03-04T11:22:33.4455667+00:00",
+            StringComparison.Ordinal);
+        reimported.Should().NotBe(WithStamp);
+
+        Digest(GeneratedSource + reimported).Should().Be(Digest(GeneratedSource + WithStamp));
+
+        // …and it is anchored to the generator's emitted SHAPE: a user-code line that merely
+        // mentions the member, or a different call shape, is content and still moves the key.
+        Digest(GeneratedSource + "public string LastModified = \"2026-01-01\";\n")
+            .Should().NotBe(Digest(GeneratedSource + "public string LastModified = \"2027-01-01\";\n"));
+    }
+
     // ── 2. a generator body change that alters the generated input ⇒ the key MOVES ───────────
 
     /// <summary>


### PR DESCRIPTION
Ships the generated-input content hash of #1707 slice 4. **It does not delete the full-MVID rule**, and the reason is the point of this PR — see "Why the deletion is blocked".

## What the generated-input pipeline actually is

Established by reading `MeshWeaver.Compiler`, not from the issue's list. Both compile paths run the same eight stages (`MeshNodeCompilationService.CompileCore` → `CompileAsyncCore`; `NodeSetCompiler.ResolveInputs` → `Compile`):

1. **source discovery** — `CodeQueryResolver.ExpandAll` over `Sources` ∪ `Tests`, raced/established as a `SourceSnapshot`
2. **`@@`-include expansion** — `NodeCompileShaping.ResolveCodeIncludes` + `AnchorIncludePath`
3. **dedup / executable filter / order** — `CollectCompileSources`
4. **aggregation** — `CombineSources` (joined `"\n\n"`, snapshot order)
5. **skeleton generation** — `DynamicMeshNodeAttributeGenerator.GenerateAttributeSource` (standard usings, hoisted user usings, assembly attribute, user code, the provider class carrying the `configuration` lambda and content collections)
6. **`#r` strip** — `NuGetDirectiveParser.Extract` + `GeneratorPipeline.StripBuiltInScopeGeneratorRef`, then NuGet resolution
7. **parse/compile** — `EmitPipeline.CreateEmitCompilation` with the canonical parse + compilation options
8. **source generators** — `GeneratorPipeline.RunSourceGenerators` over the compilation, then emit

Two stages the issue does not name belong in the key and are in it: **the option set** (7) — a body-only edit to `CreateCompilationOptions` rewrites every assembly while the text is identical — and **the source generators** (8), which add source the caller never sees. So does **Roslyn's own build**: `ComputeToolchainClosure` walks `MeshWeaver.*` refs only, so `Microsoft.CodeAnalysis.CSharp` has never been in the identity directly — it rode in on `MeshWeaver.Compiler`'s MVID, which a package bump moves. A key replacing that MVID must carry the compiler explicitly or it under-invalidates on the change that rewrites *everything*.

## What is hashed, and what is normalised

Two stages, because the halves are known at different moments. `OfGeneratedInput` (prefix `g`) runs before Roslyn: assembly name, generated text, reflected option fingerprint, Roslyn identity, generator-assembly MVIDs. `Combine` (prefix `i`) folds in the **pruned** reference surfaces read off the emitted assembly — pruned, not candidate, is what keeps the key per-type. The result lands in the per-type dependency record as `!input`, folded over the record's **assembly entries only**; folding the toolchain id in would reproduce the proxy it replaces.

**The option set is reflected, never hand-listed.** A hand-list is how `NuGetDirectiveParser` sat outside the identity boundary while shaping compile input; an option the toolchain starts setting must not be able to sit silently outside the key.

Exactly three normalisations, each a deliberate trade:

| normalised | why | cost |
|---|---|---|
| a leading BOM | a property of how the text was read, not of what it means | none |
| line endings → `\n` | the skeleton is built with `AppendLine`, i.e. `Environment.NewLine`, so the SAME node generates CRLF on a Windows dev box and LF in a pod — unfolded, nothing could ever share a build across hosts | two inputs differing ONLY in line endings inside a verbatim/raw string literal hash equal; deliberately coarser than the bytes, in the direction a mixed-host mesh needs |
| `// Generated at: <UtcNow>` → a fixed marker | 🚨 `GenerateAttributeSource` stamps a **wall clock** into the generated text, so the input is never twice the same and no key over it could ever hit | none — it is a comment, contributing no IL |

Nothing else is touched: no trimming, no whitespace collapsing, no comment stripping. Everything enumerable is ordinal-sorted; every value renders invariant-culture.

> **Side finding worth recording:** that wall clock also moves the PDB document hash, so the assembly store's "content hash" — a digest of the emitted bytes (`FileSystemAssemblyStore:204-217`) — **can never dedupe two compiles of identical content**. Neither can it match across hosts: the emit writes a host-local `pdbFilePath` into the debug directory. That is the observation motivating the whole slice, now stated in code.

## The four discriminations, and their non-vacuity

Each property was verified by **breaking the implementation and watching the test go red**, then restoring.

| # | claim | test | control applied | result |
|---|---|---|---|---|
| 1 | identical input ⇒ identical key, one process **and** two | `TheKey_IsAPinnedFunctionOfItsInputs_AcrossProcessesAndHosts`, `IdenticalGeneratedInput_HashesIdentically_WithinOneProcess`, `LineEndings_AreNormalized_…`, `TheGeneratorsWallClockHeader_IsNormalizedOut` | wall-clock normalisation removed | **2 FAIL** |
| 1b | " | " | line-ending fold removed | **1 FAIL** |
| 2 | a generator body change that alters generated input ⇒ key MOVES | `AGeneratorBodyChange_ThatAltersTheGeneratedText_MovesTheKey`, `AGeneratorAssemblyBodyChange_MovesTheKey_EvenWhenTheTextIsIdentical`, `AnOptionChange_MovesTheKey` | generated text dropped from the key | **3 FAIL** |
| 2b | " | " | generator identities dropped | **1 FAIL** |
| 3 | a body-only change that does NOT alter generated input ⇒ key does NOT move | `AToolchainBodyChange_ThatDoesNotAlterTheGeneratedInput_LeavesTheKeyPut`, `TheRecordsContentKey_IsFoldedOverTheAssemblyEntriesOnly` | toolchain MVID folded into the content key | **2 FAIL** |
| 4 | a reference-surface change ⇒ key MOVES | `AReferenceSurfaceChange_MovesTheKey` | reference surfaces dropped from `Combine` | **2 FAIL** |

**Two processes, and a hostile one.** The cross-process claim is expressed as golden vectors — literals a different process on a different architecture must reproduce, which every CI run re-verifies. Locally, a second process under Turkish culture (the classic ambient-culture trap):

```
=== process A (default locale) ===
Passed!  - Failed: 0, Passed:  1, Total:  1
=== process B (LANG=tr_TR.UTF-8, DOTNET_CLI_UI_LANGUAGE=tr) ===
Başarılı!  - Başarısız: 0, Başarılı: 17, Toplam: 17
```

Final state: `GeneratedInputIdentityTest` 18/18; the compile/identity suite 138/138; `MeshWeaver.Hosting.Monolith.Test` compile tests 13/13; Release + `-warnaserror` clean on `MeshWeaver.Compiler`, `.Graph`, `.Hosting`, `.Plugin.Build`, `PluginTester` and the five affected test projects — 0 Warning(s), 0 Error(s).

## 🚨 Why the deletion is blocked — and what unblocks it

The instruction was explicit: *if the hash turns out not to capture something the MVID did, stop and report rather than deleting.* It does not capture one thing, and it is structural rather than fixable by a better key.

`FullMvidAssemblies` is read in exactly two places: `ComputeSurfaceIdentity` (→ the global `FrameworkVersion`) and `ComputeToolchainId` (→ the record's `!toolchain`). Empty the set and both degenerate. Then trace a **body-only toolchain commit that DOES change generated input** — the #1802 global-usings fix and the `AnchorIncludePath` fix are both exactly this shape — through `HasStaleFrameworkBuild`, the only automatic re-drive:

- `CompiledFrameworkVersion == FrameworkVersion` — unchanged, no API moved;
- every per-assembly entry — unchanged ref-asm hashes;
- `!toolchain` — a constant;
- `!input` — **skipped**, because `FindMismatch` has no live value to compare it against.

⇒ `HasStaleFrameworkBuild` = false. Nothing recompiles, the stale bytes are served, and the failure surfaces as a `TypeLoadException` inside an ALC at activation with no diagnostic.

The gap is not in the key. **The key has no cheap live counterpart by construction**: it is a function of the toolchain *and* the source text, so evaluating it means regenerating the input (discovery, includes, skeleton), and every consumer that decides "rebuild or not" today is deliberately metadata-only (`HasUsableBuild`: *"no `IAssemblyStore` probe, no `File.Exists`"*). The toolchain MVID is therefore the only cheap **witness that the toolchain moved at all**.

This is pinned as a test rather than left as prose — `DeletingTheFullMvidRule_WouldLeaveNothingWatchingTheToolchain` demonstrates the identity collapsing to one value with the rule emptied, and the record validating forever across the change.

**What unblocks it is a re-evaluation lane, not a better key.** On a toolchain change, regenerate the input and compare the key: equal ⇒ keep the bytes and restamp; different ⇒ compile. The MVID then stops being the *invalidation unit* and becomes the *trigger* for that comparison — which is the demotion #1976 actually wants, at a cost of a generation pass instead of a Roslyn compile per type. This PR is its precondition: the key exists, discriminates, and is stamped by both producers.

## #1976 / #1977

**Neither can be closed by this PR.** #1976's complaint — the closure moves more often than the single root it replaced, and any member's commit empties the share's key-space — is untouched while the rule stands. #1977's pin stays **necessary**, and more so: it is now the guard on a boundary we have documented as un-deletable-for-now, so a silent widening would be a regression against a known-load-bearing set. Recommend merging #1977 and keeping #1976 open, retargeted at the re-evaluation lane.

## Risk

The record gains one optional entry; no consumer reads it yet (`FindMismatch`'s new parameter defaults to null, so `HasUsableBuild`, `HasStaleFrameworkBuild`, `NodeTypeBakeStatus.Classify` and `PrebuiltAssemblySeeder` behave exactly as before). Existing records without the entry validate unchanged. No identity, filename tag or store key changes, so **no rebake**.

Internal only — no user-visible effect, so no What's New entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
