### PR TITLE
A test that moved repos lost its internals grant, and CS1729 does not say so

### DIFF
--- a/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
+++ b/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
@@ -26,6 +26,19 @@
          or it does not register as a node provider at all. Reproducing that generation in the
          tool would be a second implementation free to drift from the one that matters. -->
     <InternalsVisibleTo Include="MeshWeaver.Plugin.Build" />
+    <!-- 🚨 THIS ONE LIVES IN ANOTHER REPO. MeshWeaver.OgCard and its tests moved to
+         MeshWeaver.Plugins/src when the module left the platform; OpenGraphPreviewService did
+         NOT, because GraphConfigurationExtensions registers it and Memex.Portal.Shared's
+         OgCardRenderer consumes it. So the test still needs the internal seam constructor — the
+         one that takes `allowLoopback: true`, without which it cannot point the service at its
+         own local listener, because the production SSRF guard refuses loopback by design.
+         Dropping this grant does not fail here: it fails in the OTHER repo, as CS1729 "does not
+         contain a constructor that takes 3 arguments", which reads as a signature change rather
+         than as lost visibility. That is exactly how it reddened MeshWeaver.Plugins' main on
+         2026-08-21 — the test moved out and the grant did not follow it. The
+         `landed-modules-gate` job now compiles that repo's projects against this one, so the
+         coupling is checked here rather than discovered there. -->
+    <InternalsVisibleTo Include="MeshWeaver.OgCard.Test" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**MeshWeaver.Plugins' `main` is red right now**, and this is the fix.

`MeshWeaver.OgCard` and its tests moved to `MeshWeaver.Plugins/src` when the module left the platform. `OpenGraphPreviewService` did **not** — `GraphConfigurationExtensions` registers it and `Memex.Portal.Shared`'s `OgCardRenderer` consumes it — so the test still needs the **internal seam constructor**, the one taking `allowLoopback: true`. Without it the test cannot point the service at its own local listener at all, because the production SSRF guard refuses loopback by design.

The `InternalsVisibleTo` grant did not follow the test.

## Why this was hard to see

Losing the grant does not fail in this repo. It fails in the *other* one, as:

```
error CS1729: 'OpenGraphPreviewService' does not contain a constructor that takes 3 arguments
```

which reads as a **signature change** — so the investigation starts by diffing a constructor that never moved. Nothing anywhere says "visibility".

## Verification

Built all 31 of MeshWeaver.Plugins' projects against this tree:

| tree | result |
|---|---|
| `origin/main` | `error CS1729` — `OgCardLayoutAreaTest.cs(39,21)` |
| this branch | `Build succeeded.` |

## Follow-on

The comment on the new entry says it lives in another repo and why, because nothing in this repo's build can tell you that. #1992's `landed-modules-gate` compiles those projects against this one — including the test projects, specifically because of this failure — so from now on the coupling is checked here rather than discovered there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)