### PR TITLE
fix: #1993 review follow-ups — normalized dock-tile lookup, accessible ✕ label

### DIFF
--- a/clients/react/src/i18n/strings.de.json
+++ b/clients/react/src/i18n/strings.de.json
@@ -137,6 +137,7 @@
   "home.sortLastModified": "Zuletzt geändert",
   "home.sortAlphabetical": "Alphabetisch",
   "home.noApps": "Noch keine Apps — Apps lassen sich im Store installieren.",
+  "thread.close": "Thread schließen",
   "theme.switchToLight": "Zum hellen Design wechseln",
   "theme.switchToDark": "Zum dunklen Design wechseln",
   "chat.new": "Neuer Chat",

--- a/clients/react/src/i18n/strings.en.json
+++ b/clients/react/src/i18n/strings.en.json
@@ -137,6 +137,7 @@
   "home.sortLastModified": "Last modified",
   "home.sortAlphabetical": "Alphabetical",
   "home.noApps": "No apps yet — install apps from the Store.",
+  "thread.close": "Close thread",
   "theme.switchToLight": "Switch to light theme",
   "theme.switchToDark": "Switch to dark theme",
   "chat.new": "New chat",

--- a/src/MeshWeaver.AI/ThreadRailItem.cs
+++ b/src/MeshWeaver.AI/ThreadRailItem.cs
@@ -4,6 +4,7 @@ using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Layout.Domain;
 using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
 
 namespace MeshWeaver.AI;
 
@@ -23,8 +24,9 @@ public static class ThreadRailItem
     public static IObservable<UiControl?> View(LayoutAreaHost host, RenderingContext _)
     {
         var hubPath = host.Hub.Address.ToString();
+        var locale = host.ViewerLocale();
         return host.StreamView<MeshNode>(
-            (nodes, _) => BuildRow(nodes.FirstOrDefault(n => n.Path == hubPath), hubPath),
+            (nodes, _) => BuildRow(nodes.FirstOrDefault(n => n.Path == hubPath), hubPath, locale),
             BuildSkeleton(hubPath));
     }
 
@@ -38,7 +40,7 @@ public static class ThreadRailItem
             .WithView(Controls.Markdown($"_{shortName}…_"));
     }
 
-    private static UiControl BuildRow(MeshNode? node, string hubPath)
+    private static UiControl BuildRow(MeshNode? node, string hubPath, string? locale)
     {
         var title = node?.Name ?? (hubPath.Contains('/') ? hubPath[(hubPath.LastIndexOf('/') + 1)..] : hubPath);
 
@@ -59,6 +61,9 @@ public static class ThreadRailItem
             .WithStyle("position: absolute; top: 6px; right: 6px; z-index: 5;")
             .WithView(Controls.Button("")
                 .WithIconStart(FluentIcons.Dismiss())
+                // Label = the button's aria-label/tooltip (ButtonView): the icon-only ✕ still
+                // needs an accessible, localized name for screen readers (Copilot review).
+                .WithLabel(LocalizationCatalog.Get("thread.close", locale))
                 .WithAppearance(Appearance.Stealth)
                 .WithStyle("min-width: 24px; width: 24px; height: 24px; padding: 0; border-radius: 50%;")
                 .WithClickAction(ctx =>

--- a/src/MeshWeaver.Documentation/Data/Architecture/AppsHome.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AppsHome.md
@@ -1,0 +1,100 @@
+# The Apps Home
+
+The user home's catalog region is a **tabbed surface** — the phone-home model: what you see first
+is what you *use*, not everything the mesh can show you. The tabs, in order:
+
+| Tab | Present when | Contents | Default order |
+|---|---|---|---|
+| **Shared with me** | the caller has cross-partition grants | modules in OTHER partitions the caller was invited into (#385) | last accessed |
+| **Pinned** | the caller has pins | the owner's content shortcuts (`User.PinnedPaths`) | last modified |
+| **Apps** | always | the platform's default apps ∪ the owner's installed apps — every app **exactly once** | alphabetical |
+| **Spaces** | always | the catalog **without** store items | last accessed |
+
+Every listing tab offers the three sort options (last accessed · last modified · alphabetical).
+The whole surface is built by `UserActivityLayoutAreas.BuildHome` (`src/MeshWeaver.Graph`), pure and
+unit-tested (`HomeTabsTest`); the reactive shell is `CatalogAreaView`, which combines the config,
+the caller's grants, the installed-app records, and the owner node.
+
+## Installed apps — `{user}/_App/{appId}`, a REGULAR node
+
+One node per icon, nodeType **`InstalledApp`**, stored at `{user}/_App/{appId}` as an ordinary
+`mesh_nodes` row: deliberately **not a satellite** (no `IsSatelliteType`, no `SatelliteTableMapping`
+entry — an unmapped `_` segment routes to the partition table, and the `_` prefix already keeps it
+out of the search context). This is the same shape as `{user}/_Memex/AiSettings`.
+
+The content record (`App`, `MeshWeaver.Mesh.Contract`) carries **presence and placement only** —
+the `Plugin` path (the app's identity, usually a Store cover), `Order`, an optional `OpenPath`
+override, and `Source`. Name, icon, and translations resolve **live** from the plugin node; tile
+state is derived at render time. Nothing is copied, so nothing can drift.
+
+> 🚨 **Why the nodeType is `InstalledApp`, not `App`.** A built-in NodeType's definition node claims
+> the TOP-LEVEL PATH of its name (`AddMeshNodes`), and `App`/`app` is a name real content uses. A
+> static claim at `App` refused node creation at `app`, broke path resolution for `app/…` with
+> routing loops, and refused installing any package named App (the static/durable claim collision,
+> #1209). Pick collision-improbable names for built-in NodeTypes.
+
+**Writers:** the Store's install flow creates the record when a viewer Gets/Adds an app; removing
+the icon deletes the node — never the entitlement. The platform's default apps are **not** written
+as nodes at all: they come from config at render time.
+
+## The config — `Admin/HomeConfig`
+
+The admin-editable platform node (`HomeConfigNodeType`, public-read, live-reloading) drives the
+whole surface without an image roll:
+
+- **`Style`** — `Tabs` (the default) or `Catalog`, the escape hatch back to the legacy single flat
+  list (`BuildCatalog`).
+- **`DefaultApps`** — the paths every user's Apps tab starts with (shipped: `Store`, `Doc`,
+  `~/Chat`). A **render-time union** with the owner's `_App` records, deduped — no seeding, and an
+  admin's edit updates every open home live. An entry starting with **`~/`** declares an AREA on
+  the *viewer's own hub* instead of a node path (`~/Chat` → the Threads app at `/{owner}/Chat`),
+  rendered as a fixed "dock" tile ahead of the node grid (`BuildSystemAppTile`).
+  Until a list-capable edit-form field ships, `DefaultApps` is `[Browsable(false)]` on the generic
+  content editor — admins edit it on the node content directly (MCP `patch` on `Admin/HomeConfig`).
+- `Scope`, `Render`, `DefaultSort` — unchanged, applying to the Spaces tab (and the legacy list).
+
+**The dedup rule:** an app is represented exactly once. The Spaces tab excludes
+`-nodeType:Store/Plugin -nodeType:Store/Catalog` — anything living in the Store is reachable in
+the Store and (when installed) on the Apps tab, never listed twice. And no tab embeds its own
+search box: every client's chrome already carries the global search, and doubling it is the
+two-search-bars problem on the mobile clients.
+
+**The Store itself is an app.** Signed-in users reach it as the 🏪 tile (a config default), not a
+header anchor; only the anonymous header keeps a Store link — visitors have no home grid, and the
+storefront is the public sales surface.
+
+## Sort semantics — why last-accessed is a two-leg union
+
+`source:accessed` is an **INNER join** on the caller's access log: a pure accessed-sorted query
+HIDES anything never opened — a fresh invitation, a never-launched app, the exact items those tabs
+exist to surface. The last-accessed sort option is therefore a newline-joined, path-keyed UNION:
+the accessed-ranked leg first, a plain leg as completeness fallback (the engine dedupes by path).
+Nothing is ever hidden by a sort.
+
+## The Threads app
+
+`/{user}/Chat` (the ChatArea) is the **Threads app** — a vertical rail of the owner's open threads
+beside the node-less composer (`BuildThreadsApp`). Each rail row renders on the *thread's own hub*
+via the `RailItem` area (`ThreadRailItem`, `MeshWeaver.AI`): the title navigates to the thread, and
+an **✕ closes it** through the canonical `MarkThreadDone` — the rail's query excludes
+`content.status:Done`, so a closed thread leaves the list reactively while staying searchable and
+reopenable. Closing never deletes.
+
+Two render details that matter: the rail is `Flat + MaxColumns(1) + ItemArea` — the `List` render
+mode draws its own rows and **ignores** item areas, so the ✕ could never render there; and the
+icon-only ✕ carries `ButtonControl.Label` (the aria-label) with the localized `thread.close`.
+
+## What comes next
+
+Store integration lives in the MeshWeaver.Plugins repo (mesh-compiled — invisible to CI): the
+install flow writes the `InstalledApp` record after `WriteManifest`, an **Add** action covers
+open-only domain plugins, uninstall removes the tile, and `Tile`/`Setup` declarations on
+`PluginContent` decide which of the store's items surface as apps at all — the ~20 auto-installed
+platform capabilities never mint icons.
+
+## See also
+
+- [Configurable Home & Space Pages](/Doc/GUI/ConfigurablePages) — the `Body` + `@@`-region model the home is built on
+- [Mesh Search & Catalogs](/Doc/GUI/MeshSearch) — the search control behind every tab
+- [Thread Operations](../ThreadOperations) — the canonical thread mutation surface (`MarkThreadDone` et al.)
+- [Localization](../Localization) — why every tab label and sort option resolves off `AccessContext.Locale`

--- a/src/MeshWeaver.Documentation/Data/GUI/ConfigurablePages.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/ConfigurablePages.md
@@ -61,10 +61,11 @@ Some areas exist on **every** node; others are specific to the home page.
 | Embed | Where | What it shows |
 |---|---|---|
 | `@@("area/Search")` | every node | The node's [search catalog](/Doc/GUI/MeshSearch) — group, filter, and drill down via query params |
-| `@@("area/Pinned")` | home page | The items you've pinned |
+| `@@("area/Pinned")` | home page | The items you've pinned (also the Pinned tab of the catalog — embed it separately only if you want it twice) |
 | `@@("area/Threads")` | home page | Your open (not-done) threads, newest first |
-| `@@("area/Catalog")` | home page | A tabbed catalog — Spaces, your items, recently read, recently edited |
+| `@@("area/Catalog")` | home page | The [tabbed home surface](/Doc/Architecture/AppsHome) — Shared with me, Pinned, **Apps** (your installed apps + the platform defaults, incl. the Store), and Spaces |
 | `@@("area/Composer")` | home page | The chat composer (start a new thread right from your home) |
+| `@@("area/Chat")` | home page | The [Threads app](/Doc/Architecture/AppsHome) — your open threads as a vertical rail (✕ closes) beside the composer; also a full page at `/{you}/Chat` |
 
 > Generic areas like `Search` are not special to the home — they come from the standard node layout,
 > so the same `@@("area/Search")` works on a Space, a folder, or any other node.

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -927,7 +927,10 @@ public static class UserActivityLayoutAreas
         var segment = entry[2..].Trim('/');
         if (segment.Length == 0)
             return null;
-        var (label, icon) = SystemAppTiles.TryGetValue(entry, out var known)
+        // Look up by the NORMALIZED key, not the raw entry: a config value like "~/Chat/" must
+        // still resolve the known Threads tile instead of silently falling back to the generic
+        // icon/label (Copilot review, PR #1993).
+        var (label, icon) = SystemAppTiles.TryGetValue("~/" + segment, out var known)
             ? known
             : (segment, "/static/NodeTypeIcons/puzzlepiece.svg");
         return new MeshNodeCardControl($"{nodeOwnerId}/{segment}", Title: label, ImageUrl: icon);

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -137,6 +137,7 @@
   "home.sortLastModified": "Zuletzt geändert",
   "home.sortAlphabetical": "Alphabetisch",
   "home.noApps": "Noch keine Apps — Apps lassen sich im Store installieren.",
+  "thread.close": "Thread schließen",
   "theme.switchToLight": "Zum hellen Design wechseln",
   "theme.switchToDark": "Zum dunklen Design wechseln",
   "chat.new": "Neuer Chat",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -137,6 +137,7 @@
   "home.sortLastModified": "Last modified",
   "home.sortAlphabetical": "Alphabetical",
   "home.noApps": "No apps yet — install apps from the Store.",
+  "thread.close": "Close thread",
   "theme.switchToLight": "Switch to light theme",
   "theme.switchToDark": "Switch to dark theme",
   "chat.new": "New chat",

--- a/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
@@ -88,10 +88,12 @@ public class HomeTabsTest
             .Areas.Should().HaveCount(2, "system-tile dock + the node-card grid");
     }
 
-    [Fact]
-    public void Apps_SystemTile_ThreadsDockTile_TargetsTheViewersChatArea()
+    [Theory]
+    [InlineData("~/Chat")]
+    [InlineData("~/Chat/")]   // extra slashes normalize — the known-tile lookup keys on the TRIMMED segment
+    public void Apps_SystemTile_ThreadsDockTile_TargetsTheViewersChatArea(string entry)
     {
-        var tile = UserActivityLayoutAreas.BuildSystemAppTile(NodePath, "~/Chat");
+        var tile = UserActivityLayoutAreas.BuildSystemAppTile(NodePath, entry);
 
         tile.Should().NotBeNull();
         tile!.NodePath.Should().Be($"{NodePath}/Chat", "the tile opens the viewer's own Threads app");


### PR DESCRIPTION
#1993 merged before its two Copilot review findings were addressed; both are real and land here, together with the docs update for the whole apps-home change set.

- **`BuildSystemAppTile` lookup normalization** — the known-tile map was keyed by the RAW config entry while the rendered segment was trimmed, so `~/Chat/` (extra slashes) silently fell back to the generic icon/label. The lookup now keys on the normalized `~/` + segment; the trailing-slash case is pinned by a theory row.
- **Accessible name for the rail's ✕** — the icon-only close button had no aria-label. `ButtonControl.Label` doubles as the aria-label in ButtonView, so the button now carries the localized **Close thread** (new `thread.close` key, en + de, react i18n mirrors byte-identical).
- **Docs**: new `Doc/Architecture/AppsHome` (the tabbed home, `InstalledApp` records + why the discriminator is not `App`, `Admin/HomeConfig` incl. the `~/` area-tile convention, the dedup rule, the two-leg last-accessed union, the Threads app); `Doc/GUI/ConfigurablePages` regions table brought current (it still described the pre-refactor catalog).

No What's New entry: accessibility/config-robustness repair + docs riding the already-announced Threads app.

Verification: `dotnet build -c Release -warnaserror` (MeshWeaver.AI + Graph.Test + Documentation.Test) clean; HomeTabsTest 18/18 incl. the new trailing-slash case; `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` green; mirrors verified with `cmp`.

I'll resolve the two threads on #1993 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)