### PR TITLE
Template the three AKS keys that reached no container (#1925)

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -228,6 +228,15 @@ data:
   AzureFoundry__Models__0: "{{ .Values.config.memex_portal.AzureFoundry__Models__0 }}"
   AzureFoundry__Models__1: "{{ .Values.config.memex_portal.AzureFoundry__Models__1 }}"
   AzureFoundry__Models__2: "{{ .Values.config.memex_portal.AzureFoundry__Models__2 }}"
+  AzureFoundry__Models__3: "{{ .Values.config.memex_portal.AzureFoundry__Models__3 }}"
+  # 🚨 A values key this template omits reaches NO container, with no error anywhere: the
+  # ConfigMap names every key explicitly, there is no catch-all range over config.memex_portal,
+  # and the Deployment's only env path is envFrom on this ConfigMap. Both keys below were set in
+  # values.aks.yaml and rendered by nothing (#1925) — SelfUpdate__MinRollInterval is the restart
+  # BUDGET from #1780, which AGENTS.md documents as the fix for restart churn and which sat inert;
+  # its predecessor SelfUpdate__PollInterval had the identical defect until #1778.
+  SelfUpdate__MinRollInterval: "{{ .Values.config.memex_portal.SelfUpdate__MinRollInterval }}"
+  WebhookInbox__Targets__0: "{{ .Values.config.memex_portal.WebhookInbox__Targets__0 }}"
   # ---- OpenAI-compatible provider (self-hosted / local: Ollama, vLLM, LM Studio, …) ----
   # Generic OpenAI-wire endpoint. Set Endpoint + Models (+ ApiKey in secrets) to seed a
   # provider + LanguageModel nodes pointing at any OpenAI-compatible gateway. Empty = inert.


### PR DESCRIPTION
Closes #1925. The ConfigMap names every key explicitly with no catch-all range, so a values key the template omits reaches **no container, with no error anywhere**.

- `AzureFoundry__Models__3` — its three siblings are templated; the fourth model was never offered.
- `SelfUpdate__MinRollInterval` — the restart **budget** from #1780 that AGENTS.md documents as the fix for restart churn, sitting inert. Its predecessor `SelfUpdate__PollInterval` had the identical defect until #1778, so the comment now names the mechanism.
- `WebhookInbox__Targets__0` — the platform-build webhook allowlist.

Verified by rendering the chart against `values.aks.yaml`: all three appear with their intended values. **They change live behaviour on the next deploy** — which is the point of the issue, and why the deploy itself stays your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)