### PR TITLE
Deliver to a pod-process hub by directed grain call, not a stream publish (#1742)

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/IPodHubGrain.cs
+++ b/src/MeshWeaver.Connection.Orleans/IPodHubGrain.cs
@@ -1,0 +1,85 @@
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Connection.Orleans;
+
+/// <summary>
+/// Delivery to a POD-PROCESS hub — a hub that lives in a .NET process rather than in a grain
+/// (<c>mesh/{id}</c>, <c>portal/{user}</c>, <c>client/{id}</c>, <c>cache/…</c>, and whatever a
+/// module adds through <c>AddStreamRoutedAddressType</c>) — as a directed grain call instead of an
+/// Orleans stream publish.
+///
+/// <para>🚨 <b>Why a grain can address a process at all.</b> Orleans places grains and nothing
+/// places a process, which is why this leg was a stream in the first place. The trick is that the
+/// grain's IDENTITY is the address and its ACTIVATION is created by the owning process itself
+/// (<see cref="Attach"/>, from <c>OrleansRoutingService.RegisterStream</c>, under
+/// <c>[PreferLocalPlacement]</c>) — so Orleans' single-activation guarantee turns its own grain
+/// directory into the address→silo map, with no directory of ours to write, keep durable, or
+/// lose.</para>
+///
+/// <para><b>What this buys over the stream.</b> A stream publish to nobody SUCCEEDS — silently — and
+/// that is issue #1742. A grain call has an outcome: it lands, or it fails and the router NACKs the
+/// sender. It also stops depending on Orleans streaming being ready, on the pub-sub registry
+/// surviving a silo departure, and on <c>MemoryStreamQueueGrain</c>'s RAM: the local route table it
+/// reads is written synchronously and unconditionally by <c>RegisterStream</c>.</para>
+///
+/// <para>Full mechanism and the two-release roll it must ship under:
+/// <c>Doc/Architecture/PodHubDeliveryRollPlan</c>.</para>
+/// </summary>
+public interface IPodHubGrain : IGrainWithStringKey
+{
+    /// <summary>
+    /// Claims this address for the CALLING silo: verifies that this silo's routing service really
+    /// has a local route for it, and if so pins the activation for as long as the registration
+    /// lives, so grain collection can never re-place a live hub's activation onto whichever silo
+    /// happens to call next.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when the activation is on the owning silo and is now pinned. <c>false</c> when it
+    /// landed elsewhere — the previous owner's activation has not gone yet — in which case the
+    /// activation steps aside and the caller should retry, which is how a hub MOVING between pods
+    /// (a <c>portal/{user}</c> circuit reconnecting) converges instead of wedging.
+    /// </returns>
+    Task<bool> Attach();
+
+    /// <summary>
+    /// Releases the address when its registration is disposed, so a hub that moves silos leaves no
+    /// activation stranded on the pod it left.
+    /// </summary>
+    Task Detach();
+
+    /// <summary>
+    /// Delivers to the hub this activation fronts.
+    /// </summary>
+    /// <param name="delivery">The delivery to hand to the local route.</param>
+    /// <returns>The delivery, forwarded.</returns>
+    /// <exception cref="PodHubNotHereException">
+    /// This silo has no local route for the address. Deliberately NOT a transient Orleans rejection:
+    /// retrying would re-place the activation on the caller and loop. The router treats it as
+    /// "nobody serves this address through the grain transport" and — for one release — falls back
+    /// to the stream publish.
+    /// </exception>
+    Task<IMessageDelivery> Deliver(IMessageDelivery delivery);
+}
+
+/// <summary>
+/// Thrown by <see cref="IPodHubGrain.Deliver"/> when the activation is on a silo that does not host
+/// the address's local route. It is a definitive "not through this transport, not here" — never a
+/// transient failure to retry — because <c>[PreferLocalPlacement]</c> would place the retry on the
+/// caller again and the loop would never converge.
+/// </summary>
+[global::Orleans.GenerateSerializer]
+public sealed class PodHubNotHereException : Exception
+{
+    /// <summary>Creates the exception for <paramref name="address"/>.</summary>
+    /// <param name="address">The address whose local route this silo does not have.</param>
+    public PodHubNotHereException(string address)
+        : base($"No silo in this cluster serves '{address}' through the pod-hub transport.")
+        => Address = address;
+
+    /// <summary>Parameterless ctor for the serializer.</summary>
+    public PodHubNotHereException() { }
+
+    /// <summary>The address that could not be served.</summary>
+    [global::Orleans.Id(0)]
+    public string? Address { get; set; }
+}

--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
@@ -481,6 +482,19 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         streams[address] = callback;
         OrleansRouteTrace.Write($"OrleansRoutingService.RegisterStream addr={address} streamName={address}");
 
+        // 🚨 CLAIM THE ADDRESS FOR THIS PROCESS so cross-silo deliveries can be a directed grain
+        // CALL rather than a stream publish — issue #1742. The local route written on the line above
+        // is the authority for "this process hosts that hub"; the pod-hub grain is what makes that
+        // authority visible to the rest of the cluster, using Orleans' own grain directory as the
+        // address→silo map. Everything below (the stream subscription) stays exactly as it was: the
+        // two transports run side by side for one release, and a hub the grain cannot reach still
+        // falls back to the stream. See Doc/Architecture/PodHubDeliveryRollPlan.
+        //
+        // This is a NO-OP outside a silo: an Orleans CLIENT process cannot host a grain, so Attach
+        // never lands locally, the retries give up, and that hub keeps the stream permanently. That
+        // is correct rather than degraded — and it is why the fallback is not a temporary scaffold.
+        var podHub = AttachPodHub(address);
+
         // 🚨 Attach the Orleans memory-stream subscription once Orleans streaming is READY — never
         // before. GetStream on a PersistentStreamProvider whose lifecycle Init has not yet run throws
         // an NRE from deep inside the Orleans stream runtime (issue #1129): the process-wide cache/mesh
@@ -521,6 +535,10 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         {
             streams.TryRemove(address, out _);
             subscriptionReady.TryRemove(address, out _);
+            // Release the cluster-wide claim FIRST: a hub that MOVES pods (a portal/{user} circuit
+            // reconnecting is the everyday case) must not leave a pinned activation behind on the
+            // pod it left, or the new owner's Attach lands on the old one and has to bounce off it.
+            podHub.Dispose();
             cts.Cancel();
             ioPool.Invoke(async _ =>
                 {
@@ -537,6 +555,95 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                     _ => { },
                     ex => logger.LogDebug(ex, "Failed to unsubscribe Orleans stream for {Address}", address));
             cts.Dispose();
+        });
+    }
+
+    /// <summary>
+    /// How many times an <see cref="IPodHubGrain.Attach"/> that landed on the WRONG silo is retried.
+    /// This is not a poll and not a health retry: <c>false</c> means one specific, transient thing —
+    /// the previous owner's activation has not gone yet, which happens exactly while an address
+    /// MOVES between pods. Bounded, because "the owner is not a silo at all" (an Orleans client
+    /// process, which cannot host a grain) must terminate rather than spin: that hub keeps the
+    /// stream, permanently and correctly.
+    /// </summary>
+    private const int PodHubAttachRetries = 5;
+
+    /// <summary>
+    /// Claims <paramref name="address"/> for THIS process, so the rest of the cluster can deliver to
+    /// it with a directed grain call instead of a stream publish (#1742).
+    ///
+    /// <para>Synchronous to the caller and best-effort by construction: <c>RegisterStream</c>'s local
+    /// route is already live, and a claim that never lands simply leaves this hub on the stream —
+    /// the transport it has always used. So a failure here degrades, it never blocks; the returned
+    /// disposable releases the claim.</para>
+    /// </summary>
+    private IDisposable AttachPodHub(Address address)
+    {
+        // 🚨 NO GRAIN FACTORY, NO GRAIN TRANSPORT — and that is a supported host, not a broken one.
+        // A routing service can legitimately be constructed without one (the shutdown-classification
+        // and local-route fixtures do exactly that), and the answer must be the same as for an
+        // Orleans client: this hub keeps the stream. Degrade, never throw — RegisterStream's local
+        // route is already live and the caller is holding a disposable it will dispose later, so an
+        // exception here would surface at TEARDOWN, arbitrarily far from its cause.
+        if (grainFactory is null || disposed)
+            return Disposable.Empty;
+
+        var addressPath = address.ToString();
+        var attach = new SingleAssignmentDisposable();
+        inFlight.Add(attach);
+        attach.Disposable = Observable
+            .Defer(() => grainFactory.GetGrain<IPodHubGrain>(addressPath).Attach().ToObservable())
+            // `false` is "landed on a silo that is not the owner". Turning it into an error is what
+            // lets the retry policy below express "bounce off the old activation and try again"
+            // without a hand-rolled loop.
+            .SelectMany(claimed => claimed
+                ? Observable.Return(true)
+                : Observable.Throw<bool>(new PodHubNotHereException(addressPath)))
+            .RetryWhen(errors => errors
+                .Select((ex, i) => (Exception: ex, Attempt: i))
+                .SelectMany(t => t.Attempt >= PodHubAttachRetries
+                    ? Observable.Throw<long>(t.Exception)
+                    : Observable.Timer(
+                        TimeSpan.FromMilliseconds(Math.Min(100 * Math.Pow(2, t.Attempt), 2_000)),
+                        Scheduler.Default)))
+            .Subscribe(
+                _ =>
+                {
+                    OrleansRouteTrace.Write($"OrleansRoutingService.AttachPodHub OK addr={addressPath}");
+                    logger.LogDebug("Pod-hub claim for {Address} landed on this process", addressPath);
+                },
+                ex =>
+                {
+                    // Debug, not Warning: on an Orleans CLIENT this is the expected, permanent
+                    // outcome for every hub, and a per-hub warning there would be pure noise. The
+                    // signal that matters lives on the ROUTER side — the fallback line — because
+                    // that is where "a silo-hosted hub was not reachable by call" is observable.
+                    OrleansRouteTrace.Write($"OrleansRoutingService.AttachPodHub GAVE_UP addr={addressPath} ex={ex.Message}");
+                    logger.LogDebug(ex,
+                        "Pod-hub claim for {Address} did not land in this process — it keeps the Orleans "
+                        + "stream transport. Expected on an Orleans client, which cannot host a grain.",
+                        addressPath);
+                });
+
+        return Disposable.Create(() =>
+        {
+            inFlight.Remove(attach);
+            attach.Dispose();
+            // Fire-and-forget: teardown is best-effort, and an activation that outlives its owner is
+            // recovered anyway — Deliver on a silo with no local route steps aside (see PodHubGrain).
+            // Wrapped because this runs during teardown, where the cluster client may already be
+            // gone: releasing a claim that nobody can hear is a no-op, never a throw out of Dispose.
+            try
+            {
+                grainFactory.GetGrain<IPodHubGrain>(addressPath).Detach().ToObservable()
+                    .Subscribe(
+                        _ => { },
+                        ex => logger.LogDebug(ex, "Failed to release the pod-hub claim for {Address}", addressPath));
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "Failed to release the pod-hub claim for {Address}", addressPath);
+            }
         });
     }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/OrleansStreamPubSubDurability.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OrleansStreamPubSubDurability.md
@@ -202,9 +202,12 @@ same retry / NACK / failure signal the forward leg already has. Sketch of what t
 > as long as any hub subscribes a stream at all. Budget the rewrite on its own merits, not on a
 > deletion that is not there.
 
-It is a real change (new placement strategy, a directory with its own lifecycle, and a two-PROCESS
-test to prove it), which is why it is written down here rather than done alongside the durability
-fix. Tracked in [#1742](https://github.com/Systemorph/MeshWeaver/issues/1742).
+**That change is now written down in full, with the roll it must ship under:
+[Pod-Hub Delivery — the Transport Swap and its Roll Plan](/Doc/Architecture/PodHubDeliveryRollPlan).**
+It turned out to need no custom placement director and no directory of ours at all: the address's
+grain is created BY THE OWNING PROCESS under `[PreferLocalPlacement]`, so Orleans' own grain
+directory is the address→silo map. Tracked in
+[#1742](https://github.com/Systemorph/MeshWeaver/issues/1742).
 
 ## The subscriber check — what it buys, and the measurement that put it there
 
@@ -306,6 +309,8 @@ whether it still holds after the *next* roll.
 
 ## Related
 
+- [Pod-Hub Delivery — the Transport Swap and its Roll Plan](/Doc/Architecture/PodHubDeliveryRollPlan)
+  — what replaces the stream leg, and the two-release roll it needs.
 - [Error Propagation & Wedges](/Doc/Architecture/ErrorPropagationAndWedges) — a silence is a wedge;
   every error must reach a graceful sink.
 - [Message-Based Communication](/Doc/Architecture/MessageBasedCommunication) — the routing legs this

--- a/src/MeshWeaver.Documentation/Data/Architecture/PodHubDeliveryRollPlan.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PodHubDeliveryRollPlan.md
@@ -102,9 +102,14 @@ Two lifecycle details that are the whole correctness argument:
 
 `OrderedRouteDispatcher` is unchanged and stays: the per-destination FIFO is a correctness
 requirement of the delta protocol, and a call into a `[Reentrant]` grain does not restore ordering.
-`StreamMessageSizeGuard` (#1890) does not disappear either — it **retargets**, from Orleans'
-1 MiB memory-stream block to Orleans' `MaxMessageBodySize`. #1890 was itself "the NACK died at the
-wall it was describing"; reproducing that one layer over would be the same bug at a new address.
+`StreamMessageSizeGuard` (#1890) does not disappear either — it **retargets**. It still guards the
+stream fallback, where the wall is Orleans' 1 MiB memory-stream block and crossing it is *silent*
+(the publish succeeds and the pulling agent rejects the message forever, naming a queue id and
+nothing else). On the directed call the wall is Orleans' own `MaxMessageBodySize`, and crossing it
+**throws** — so the router NACKs instead of dropping, which is the outcome the guard exists to
+produce. #1890 was itself "the NACK died at the wall it was describing"; reproducing that one layer
+over would be the same bug at a new address, so when the fallback goes the guard moves to the call's
+wall rather than being deleted with it.
 
 ## What this finally delivers
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PodHubDeliveryRollPlan.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PodHubDeliveryRollPlan.md
@@ -1,0 +1,133 @@
+---
+Name: Pod-Hub Delivery — the Transport Swap and its Roll Plan
+Category: Architecture
+Description: "Delivery to a pod-process hub moves from an Orleans stream publish to a directed grain call on the owning silo. The transport swap is a two-release roll with a deliberate fallback, because the previous change in this area left the fleet split-brain for the duration of its own deploy."
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h10a4 4 0 0 1 0 8H8a4 4 0 0 0 0 8h12"/><path d="m17 3 3 3-3 3"/></svg>
+---
+
+# Pod-Hub Delivery — the Transport Swap and its Roll Plan
+
+Read [Orleans Stream Pub-Sub Durability](/Doc/Architecture/OrleansStreamPubSubDurability) first: it
+is why this change exists. In one line — **a delivery to a hub that lives in a .NET process rather
+than in a grain rides a stream publish, and a stream publish to nobody succeeds.** Every other
+cross-process leg in the mesh is a grain call, which is retried, NACK'd, and heard about when it
+fails. This one leg is not, and that asymmetry is the defect.
+
+## 🚨 The roll plan comes first, and here is why
+
+The previous fix in this area — a durable `PubSubStore` (#1770) — shipped without one and left the
+fleet **split-brain on pub-sub for the duration of its own roll: 39 stranded addresses, unpredicted**.
+A transport swap has exactly that shape, and worse, because during a surge-first roll the two
+releases are *both live and both routing*:
+
+| | release N (old pod) | release N+1 (new pod) |
+|---|---|---|
+| **listens on** | its Orleans stream subscription | the stream **and** its pod-hub grain |
+| **sends via** | a stream publish | a directed grain call |
+
+A new pod calling the pod-hub grain for a hub owned by an **old** pod finds no activation — the old
+pod never attached one. Without a fallback that is a `NotFound` NACK for a hub that is alive and
+well, on every cross-pod exchange, for the whole overlap window. **That is the outage this section
+exists to prevent.**
+
+## The two-release plan
+
+**Release N+1 — dual: attach both, prefer the call, fall back to the stream.**
+
+1. `OrleansRoutingService.RegisterStream` keeps doing everything it does today (local route, Orleans
+   stream subscription) **and** attaches the address's pod-hub grain on the owning silo.
+2. `RoutingGrain`'s stream branch tries the directed grain call first. A `PodHubNotHereException` —
+   the grain answering *"no silo in this cluster is serving this address through me"* — is **not** a
+   failure: it means the owner is either gone or still on release N. The router then takes the old
+   path, publishing to the stream exactly as before.
+3. The stream publish keeps the subscriber check landed for #1742, so the fallback is not a return
+   to silence: an address that genuinely has no owner on *either* transport is NACK'd, not dropped.
+
+   > This is the whole reason the subscriber check is worth landing separately and first. It is what
+   > makes the fallback safe, and it stays useful for as long as the fallback exists.
+
+4. Nothing needs to be sequenced with the migration, no schema, no new storage. A pod on release N
+   is unaffected: it never calls a grain it does not know about, and its subscribers still receive
+   stream publishes from release N+1 pods.
+
+**Release N+2 — single: delete the fallback.** Only once *every* pod in *every* deployment runs
+N+1 or later. The check for that is not a date — it is that no pod logs the fallback line for a
+full roll (below).
+
+**A revert is safe at any point.** Release N+1 is a strict superset of release N's behaviour: it
+still subscribes the stream, still publishes to it when the call cannot land. Rolling back to N
+loses the directed call and keeps working.
+
+### The one-line signal that decides when N+2 may ship
+
+The fallback logs, once per address per activation, at `Information`:
+
+```
+[ROUTE] Pod-hub grain for {Address} is not attached — falling back to the stream publish.
+        This is expected only while a release-N pod still owns that hub.
+```
+
+**Ship N+2 when a full rolling deploy produces none of those lines.** A line during the overlap
+window is the plan working. A line *after* the roll has completed is a hub whose owner never
+attached — investigate that before removing the fallback, never after.
+
+## The mechanism
+
+The address→silo map is **Orleans' own grain directory**. There is no second directory to write, to
+keep durable, or to lose:
+
+- `IPodHubGrain` is keyed by the address path and placed with `[PreferLocalPlacement]`, so the
+  activation lands on the silo whose `RegisterStream` created it. Orleans' single-activation
+  guarantee then makes the grain directory the map, cluster-wide, with no custom placement director
+  and no state of our own.
+- Its `Deliver` looks up `OrleansRoutingService.TryGetLocalRoute(address)` — the table that has
+  always been the authority for "this process hosts that hub", is written **synchronously and
+  unconditionally** by `RegisterStream`, and does not depend on Orleans streaming being ready at
+  all. That is the property the stream leg never had.
+- **A silo that cannot serve the address fails LOUDLY and steps aside.** It calls
+  `DeactivateOnIdle()` so the next attach can be placed on the true owner, and throws
+  `PodHubNotHereException` — deliberately NOT a transient Orleans rejection, so
+  `DeliverToGrainWithRetry` does not retry it into a loop.
+
+Two lifecycle details that are the whole correctness argument:
+
+- **Keep-alive.** `Attach` calls `DelayDeactivation` so grain collection can never re-place a live
+  hub's activation onto whichever silo happens to call next (`PreferLocalPlacement` prefers the
+  *caller's* silo, so a collected activation would migrate to a router). The activation's lifetime
+  is deliberately tied to the owner's registration, not to traffic.
+- **Detach on disposal.** `RegisterStream`'s disposal deactivates the grain, so a hub that MOVES
+  silos — a `portal/{user}` circuit reconnecting to another pod is the everyday case — leaves no
+  activation stranded on the pod it left. `Attach` reports `false` when it lands on a silo that is
+  not the owner, and the owner retries, bounded, so the move converges instead of wedging.
+
+`OrderedRouteDispatcher` is unchanged and stays: the per-destination FIFO is a correctness
+requirement of the delta protocol, and a call into a `[Reentrant]` grain does not restore ordering.
+`StreamMessageSizeGuard` (#1890) does not disappear either — it **retargets**, from Orleans'
+1 MiB memory-stream block to Orleans' `MaxMessageBodySize`. #1890 was itself "the NACK died at the
+wall it was describing"; reproducing that one layer over would be the same bug at a new address.
+
+## What this finally delivers
+
+> An undeliverable delivery must surface as a `DeliveryFailure`, never as silence.
+
+The subscriber check narrowed the silence. The directed call **removes the class**:
+
+| residual | stream + subscriber check | directed grain call |
+|---|---|---|
+| no subscriber registered | NACK'd (checked) | NACK'd (the call has nowhere to land) |
+| subscriber vanishes between check and publish | **silent** | NACK'd — the call fails |
+| `MemoryStreamQueueGrain` dies with its silo | **silent** | not on the path at all |
+| pub-sub registry lost (non-AdoNet multi-silo) | NACK'd, but **wrongly** — the hub is alive | delivered; the registry is not consulted |
+| the reply's own requester | not reached — the NACK goes to the REPLIER | the reply is delivered, so there is nothing to report |
+
+That last row is the one that matters most and the one a producer-side check can never fix: when a
+*reply* cannot be delivered, the party that needs to know is the original requester — and it is
+precisely the party that is unreachable. Making the reply land is the only answer.
+
+## Related
+
+- [Orleans Stream Pub-Sub Durability](/Doc/Architecture/OrleansStreamPubSubDurability) — the defect,
+  the production evidence, and the subscriber check this plan builds on.
+- [Error Propagation & Wedges](/Doc/Architecture/ErrorPropagationAndWedges) — a silence is a wedge.
+- [Deployment — AKS](/Doc/Architecture/DeploymentAKS) — the surge-first rolling deploy whose overlap
+  window this plan is written against.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-replies-reach-the-page-that-asked.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-replies-reach-the-page-that-asked.md
@@ -1,0 +1,13 @@
+---
+Name: Answers now reach the page that asked for them
+Category: Fix
+Description: Replies travelling between portal servers are delivered directly instead of being broadcast and hoped for, so a page no longer waits a minute for an answer that was produced and lost.
+Icon: Sparkle
+Order: -20260821
+---
+
+# Answers now reach the page that asked for them
+
+When the portal runs on more than one server, a page's request can be answered by a different server than the one serving the page. The answer used to travel back over an internal broadcast channel — and that channel had no way to report a failure. If the bookkeeping that says who is listening had been lost, which happened on every deployment, the answer was produced, accepted for delivery, and quietly discarded. The page waited its full minute and gave up, with nothing in the logs to explain it.
+
+Answers are now sent directly to the server that asked, over the same reliable mechanism every other message between servers already used. A delivery that cannot be made is reported rather than absorbed, and the previous route is kept as a fallback so nothing is disrupted while a deployment is half-rolled.

--- a/src/MeshWeaver.Hosting.Orleans/PodHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/PodHubGrain.cs
@@ -1,0 +1,167 @@
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Reactive.Linq;
+
+namespace MeshWeaver.Hosting.Orleans;
+
+/// <summary>
+/// The silo-side implementation of <see cref="IPodHubGrain"/> — see that interface for why a grain
+/// can address a process at all, and <c>Doc/Architecture/PodHubDeliveryRollPlan</c> for the roll.
+///
+/// <para><b>The whole correctness argument is two lifecycle rules.</b></para>
+/// <list type="number">
+///   <item><b>Only the owner pins it.</b> <see cref="Attach"/> is called from
+///     <c>OrleansRoutingService.RegisterStream</c> on the silo that just created the local route,
+///     and <c>[PreferLocalPlacement]</c> places a not-yet-activated grain on the CALLER's silo — so
+///     the owner's call is what brings the activation to life in the right process. It then pins it
+///     with <c>DelayDeactivation</c>, because prefer-local prefers the *caller*: a collected
+///     activation would be re-created on whichever router called next, and every delivery to a
+///     perfectly healthy hub would then land on the wrong process.</item>
+///   <item><b>A silo that cannot serve it steps aside, loudly.</b> No throwing
+///     <c>OnActivateAsync</c> (that hides the reason inside an Orleans activation failure): the call
+///     itself answers. <see cref="Deliver"/> throws <see cref="PodHubNotHereException"/> and
+///     requests deactivation so the true owner's next <see cref="Attach"/> can be placed correctly.
+///     <see cref="Attach"/> answers <c>false</c> and does the same, which is how an address MOVING
+///     between pods converges.</item>
+/// </list>
+///
+/// <para>Not <c>[Reentrant]</c>: one activation fronts one process-local hub, the delivery it makes
+/// is a synchronous hand-off into that hub's own queue (the hub is what serialises work), and a
+/// non-reentrant grain keeps <see cref="Attach"/>/<see cref="Detach"/> strictly ordered against
+/// deliveries — which is what makes "claimed, then pinned" a single indivisible step.</para>
+/// </summary>
+/// <param name="logger">Logger for attach/detach/delivery diagnostics.</param>
+/// <param name="meshHub">Mesh hub, used only to resolve this silo's routing service.</param>
+[global::Orleans.Placement.PreferLocalPlacement]
+internal sealed class PodHubGrain(ILogger<PodHubGrain> logger, IMessageHub meshHub)
+    : Grain, IPodHubGrain
+{
+    /// <summary>
+    /// This silo's LOCAL route table — the same one <c>OrleansRoutingService.DeliverMessage</c>
+    /// short-circuits on and <c>RoutingGrain.PostFailure</c> answers through. It is written
+    /// SYNCHRONOUSLY and UNCONDITIONALLY by <c>RegisterStream</c>, before any Orleans streaming
+    /// exists, which is precisely the property the stream leg never had: a hub whose stream
+    /// subscription was never attached — or was attached and then lost — has always been reachable
+    /// here.
+    /// </summary>
+    private readonly OrleansRoutingService? localRoutes =
+        meshHub.ServiceProvider.GetService<IRoutingService>() as OrleansRoutingService;
+
+    /// <summary>
+    /// Set at the start of <see cref="OnDeactivateAsync"/> so a lifetime call arriving afterwards is
+    /// a graceful no-op rather than Orleans' invalid-activation throw — the same boundary
+    /// <c>MessageHubGrain.TryDelayDeactivation</c> documents, and the same reason (a straggler that
+    /// throws into an unobserved Task escalates to a catastrophic xUnit failure).
+    /// </summary>
+    private volatile bool deactivated;
+
+    private string AddressPath => this.GetPrimaryKeyString();
+
+    /// <inheritdoc />
+    public Task<bool> Attach()
+    {
+        Address address = AddressPath;
+        if (localRoutes?.TryGetLocalRoute(address) is null)
+        {
+            // The activation landed on a silo that does not own the address — the previous owner's
+            // activation is still alive. Step aside so the caller's retry can be placed on itself.
+            logger.LogInformation(
+                "[POD-HUB] Attach for {Address} landed on a silo that has no local route for it — "
+                + "stepping aside so the owner's retry can claim it. Expected while a hub MOVES between pods.",
+                AddressPath);
+            TryDeactivateOnIdle();
+            return Task.FromResult(false);
+        }
+
+        // 🚨 PIN IT. Prefer-local prefers the CALLER, so an activation collected for idleness would
+        // be re-created on whichever router called next — and every delivery to a live hub would
+        // then land on the wrong process, permanently. The activation's lifetime is deliberately
+        // tied to the registration, not to traffic.
+        TryDelayDeactivation(TimeSpan.MaxValue);
+        logger.LogDebug("[POD-HUB] {Address} attached and pinned on this silo", AddressPath);
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task Detach()
+    {
+        logger.LogDebug("[POD-HUB] {Address} detached", AddressPath);
+        TryDeactivateOnIdle();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<IMessageDelivery> Deliver(IMessageDelivery delivery)
+    {
+        Address address = AddressPath;
+        var route = localRoutes?.TryGetLocalRoute(address);
+        if (route is null)
+        {
+            // Not an Orleans transient rejection, on purpose: DeliverToGrainWithRetry would retry
+            // it, prefer-local would place the retry on the caller again, and the loop would never
+            // converge. This is a definitive answer about a transport, and the router reads it as
+            // "fall back" during the roll and as "NACK the sender" after it.
+            logger.LogInformation(
+                "[POD-HUB] {Address} has no local route on this silo — the owner is gone, or still on "
+                + "the previous release. Answering PodHubNotHere; the router decides what to do with it.",
+                AddressPath);
+            TryDeactivateOnIdle();
+            throw new PodHubNotHereException(AddressPath);
+        }
+
+        // 🚨 HAND OFF, DO NOT AWAIT THE HUB. Subscribing invokes the local route, which posts the
+        // delivery onto the owning hub's own queue — an O(1) enqueue. The hub's PROCESSING of it is
+        // a separate, unbounded thing, and waiting for that here would be two bugs at once: the
+        // grain turn would be held for the duration (this grain is not [Reentrant], so the
+        // destination's deliveries would serialise behind one slow handler), and a handler whose
+        // work routes back to this same address would deadlock against its own turn. The stream
+        // handler in OrleansRoutingService.SubscribeWhenStreamingReadyAsync makes exactly this
+        // choice, for exactly these reasons, and this is the same hand-off with a real outcome
+        // attached: reaching this line at all is what a stream publish could never confirm.
+        //
+        // onError is therefore mandatory here too — we answer Forwarded immediately, so nothing
+        // retries, and a faulted delivery IS a lost message that must be loud.
+        route.Invoke(delivery, CancellationToken.None)
+            .Subscribe(
+                _ => { },
+                ex => logger.LogError(ex,
+                    "[POD-HUB] Delivery callback faulted for {MessageType} ({Id}) on {Address} — message dropped",
+                    delivery.Message?.GetType().Name, delivery.Id, AddressPath));
+
+        return Task.FromResult(delivery.Forwarded(address));
+    }
+
+    /// <inheritdoc />
+    public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+    {
+        deactivated = true;
+        return base.OnDeactivateAsync(reason, cancellationToken);
+    }
+
+    private void TryDelayDeactivation(TimeSpan delay)
+    {
+        if (deactivated) return;
+        try { DelayDeactivation(delay); }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogDebug(ex,
+                "[POD-HUB] {Address}: DelayDeactivation after the activation died — keep-alive is moot",
+                AddressPath);
+        }
+    }
+
+    private void TryDeactivateOnIdle()
+    {
+        if (deactivated) return;
+        try { DeactivateOnIdle(); }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogDebug(ex,
+                "[POD-HUB] {Address}: DeactivateOnIdle after the activation died — already achieved",
+                AddressPath);
+        }
+    }
+}

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -206,7 +206,7 @@ internal class RoutingGrain(
             ReportSaturation(Interlocked.Increment(ref inFlightRoutes), addressPath);
             orderedDispatcher.Enqueue(
                 addressPath,
-                BuildStreamRoute(delivery, address, addressPath, streamProvider),
+                BuildPodHubRoute(delivery, address, addressPath, streamProvider, grainFactory),
                 () => ReportDrained(Interlocked.Decrement(ref inFlightRoutes)));
         }
         else
@@ -317,6 +317,102 @@ internal class RoutingGrain(
             "[ROUTE] Routing back-pressure [{ActivationId}#{Episode}] cleared after {ElapsedMs} ms — {InFlight} route(s) in flight",
             activationId, Volatile.Read(ref saturationEpisode), (long)lasted.TotalMilliseconds, inFlight);
     }
+
+    /// <summary>
+    /// Composes (does NOT run) the route to a POD-PROCESS hub: a directed grain call to the silo
+    /// that owns the address, falling back to the memory-stream publish when no silo claims it.
+    ///
+    /// <para>🚨 <b>This is the transport swap of issue #1742.</b> Every other cross-process leg in
+    /// the mesh is a grain call — retried, NACK'd, and heard about when it fails. This one was a
+    /// stream publish, and <b>a stream publish to nobody SUCCEEDS</b>: the reply is discarded, the
+    /// requester spends its full budget on silence, and nothing anywhere logs a thing. A directed
+    /// call has an OUTCOME, which is the entire point.</para>
+    ///
+    /// <para><b>The fallback is deliberate and is not scaffolding.</b>
+    /// <see cref="PodHubNotHereException"/> means "no silo serves this address through the grain
+    /// transport", and there are two very different reasons for that:</para>
+    /// <list type="bullet">
+    ///   <item>the owner is still on the PREVIOUS RELEASE and never claimed the address — true for
+    ///     the whole overlap window of every rolling deploy, which is precisely the window in which
+    ///     the last change in this area stranded 39 addresses by not having a fallback (#1770);</item>
+    ///   <item>the owner is an Orleans CLIENT process, which cannot host a grain at all. For those
+    ///     hubs the stream is not a legacy path, it is the only path — so this branch is
+    ///     PERMANENT.</item>
+    /// </list>
+    /// <para>Either way the fallback is safe rather than a return to silence, because the stream leg
+    /// now checks for a subscriber before it publishes and NACKs when there is none. Full plan,
+    /// including the one log line that says when the overlap window has closed:
+    /// <c>Doc/Architecture/PodHubDeliveryRollPlan</c>.</para>
+    /// </summary>
+    private IObservable<Unit> BuildPodHubRoute(
+        IMessageDelivery delivery,
+        Address address,
+        string addressPath,
+        IStreamProvider streamProvider,
+        IGrainFactory grainFactory)
+    {
+        void PostFailureToSender(string failureMessage, ErrorType errorType) =>
+            PostFailure(delivery, address, streamProvider, failureMessage, errorType);
+
+        return Observable
+            .Defer(() => grainFactory.GetGrain<IPodHubGrain>(addressPath).Deliver(delivery).ToObservable())
+            .Select(_ =>
+            {
+                RoutingGrainTrace.Write($"RoutingGrain.RouteMessage POD_HUB_OK addr={addressPath} id={delivery.Id}");
+                return Unit.Default;
+            })
+            .Catch<Unit, Exception>(ex => IsPodHubNotHere(ex)
+                ? FallBackToStream()
+                // A REAL failure of the call — the owning silo threw, went away mid-call, or the
+                // placement could not be made. This is the whole gain over a publish: it is
+                // OBSERVABLE, so it becomes a terminal answer for the sender instead of silence.
+                : TerminalCallFailure(ex))
+            // Composition-time faults must ALSO reach the sender — see BuildGrainRoute's trailing
+            // Catch for the full rationale (the classic one: GetStream NRE'ing out of
+            // PersistentStreamProvider.IsRewindable while the stream provider is still starting).
+            .Catch<Unit, Exception>(ex =>
+            {
+                RoutingGrainTrace.Write($"RoutingGrain.RouteMessage ROUTE_FAULT id={delivery.Id} addr={addressPath} ex={ex.Message}");
+                logger.LogError(ex, "[ROUTE] Routing {Address} failed before the delivery could be attempted", addressPath);
+                PostFailureToSender($"Routing to '{addressPath}' failed: {ex.Message}", ErrorType.Failed);
+                return Observable.Return(Unit.Default);
+            });
+
+        IObservable<Unit> FallBackToStream()
+        {
+            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage POD_HUB_NOT_HERE addr={addressPath} id={delivery.Id}");
+            // 🚨 THE LINE THAT DECIDES WHEN THE OVERLAP WINDOW HAS CLOSED. Information, once per
+            // delivery that takes the fallback: during a roll it is the plan working; after a roll
+            // has fully completed, for a SILO-hosted address, it is a hub that never claimed itself
+            // and wants investigating. Never read its absence as proof — read a full rolling deploy
+            // with none of these as the signal that the grain transport carries everything it can.
+            logger.LogInformation(
+                "[ROUTE] Pod-hub grain for {Address} is not attached — falling back to the stream publish. "
+                + "Expected while a previous-release pod still owns that hub, and permanently for a hub "
+                + "owned by an Orleans client process (a client cannot host a grain).",
+                addressPath);
+            return BuildStreamRoute(delivery, address, addressPath, streamProvider);
+        }
+
+        IObservable<Unit> TerminalCallFailure(Exception ex)
+        {
+            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage POD_HUB_FAULT addr={addressPath} id={delivery.Id} ex={ex.Message}");
+            logger.LogError(ex,
+                "[ROUTE] Directed delivery to pod hub {Address} failed — surfacing DeliveryFailure to sender {Sender}",
+                addressPath, delivery.Sender);
+            PostFailureToSender($"Delivery to '{addressPath}' failed: {ex.Message}", ErrorType.Failed);
+            return Observable.Return(Unit.Default);
+        }
+    }
+
+    /// <summary>
+    /// Is this the grain saying "not through this transport, not here"? Orleans wraps a thrown grain
+    /// exception on its way back to the caller, so the test walks the inner chain — matching by type
+    /// only, never by message text.
+    /// </summary>
+    internal static bool IsPodHubNotHere(Exception ex) =>
+        ex is PodHubNotHereException
+        || (ex.InnerException is not null && IsPodHubNotHere(ex.InnerException));
 
     /// <summary>
     /// Composes (does NOT run) the MEMORY-STREAM leg of a route: the "I'm a registered hosted hub,

--- a/test/MeshWeaver.Hosting.Orleans.Test/PodHubTransportTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/PodHubTransportTest.cs
@@ -1,0 +1,263 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.Streams;
+using Orleans.Streams.Core;
+using Orleans.Streams.PubSub;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// The POD-HUB TRANSPORT — issue #1742, step 3. Delivery to a hub that lives in a .NET process
+/// rather than in a grain is now a directed grain call to the silo that owns it, with the Orleans
+/// stream publish kept as a fallback for one release (and permanently for hubs owned by an Orleans
+/// CLIENT process, which cannot host a grain). See
+/// <c>Doc/Architecture/PodHubDeliveryRollPlan</c>.
+///
+/// <para>🚨 <b>The pin that matters is <see cref="SiloHostedHub_ReceivesDelivery_EvenWithItsStreamSubscriptionGone"/></b>,
+/// and it is issue #1729's production defect reproduced exactly, in process: a hub that is ALIVE —
+/// its local route present, its process healthy — whose entry in the stream's subscriber registry
+/// is gone. In production that state is manufactured by every rolling deploy, because the registry
+/// lived in the RAM of whichever silo happened to host the rendezvous grain. Here it is manufactured
+/// deterministically with <c>IStreamSubscriptionManager.RemoveSubscription</c>, which is the same
+/// end state by the same mechanism.</para>
+///
+/// <para>Against the stream transport that delivery is DROPPED — silently before #1742's subscriber
+/// check, and NACK'd (fast, but still not delivered) after it. Only a directed call to the owning
+/// silo makes it arrive, which is why this fact cannot pass on either earlier revision.</para>
+/// </summary>
+public class PodHubTransportTest : IClassFixture<TwoSiloCacheUpdateFixture>
+{
+    private readonly TwoSiloCacheUpdateFixture fixture;
+
+    public PodHubTransportTest(TwoSiloCacheUpdateFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(30);
+
+    private static IServiceProvider SiloServices(TestCluster cluster, int index)
+        => ((InProcessSiloHandle)cluster.Silos[index]).SiloHost.Services;
+
+    private static IMessageHub SiloMeshHub(TestCluster cluster, int index)
+        => SiloServices(cluster, index).GetRequiredService<IMessageHub>();
+
+    private static OrleansRoutingService Routing(TestCluster cluster, int index)
+        => (OrleansRoutingService)SiloServices(cluster, index).GetRequiredService<IRoutingService>();
+
+    // 🚨 A SILO's grain factory, never cluster.GrainFactory. This fixture deploys with
+    // withClient:false — it mirrors prod, where several silos and no separate client process is the
+    // real shape — so cluster.Client is null and cluster.GrainFactory NREs.
+    private static IGrainFactory Grains(TestCluster cluster, int index)
+        => SiloServices(cluster, index).GetRequiredService<IGrainFactory>();
+
+    /// <summary>
+    /// 🚨 THE PIN. A silo-hosted pod-process hub must receive a cross-silo delivery even when its
+    /// entry in the stream's subscriber registry has been erased — the exact state a rolling deploy
+    /// used to manufacture on memex-cloud, where it hung ~half of all content reads for their full
+    /// 60 s budget (#1729).
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task SiloHostedHub_ReceivesDelivery_EvenWithItsStreamSubscriptionGone()
+    {
+        var ct = new CancellationTokenSource(TimeSpan.FromSeconds(150)).Token;
+        var cluster = fixture.Cluster;
+        cluster.Silos.Count.Should().BeGreaterThanOrEqualTo(2, "the delivery has to CROSS silos, or "
+            + "the sender's own local route short-circuits and the router is never involved");
+
+        var address = new Address("client", $"podhub-{Guid.NewGuid():N}");
+        var received = new TaskCompletionSource<IMessageDelivery>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // The hub lives on silo A. RegisterStream writes the local route synchronously, claims the
+        // address for this silo through the pod-hub grain, and subscribes the Orleans stream.
+        using var registration = Routing(cluster, 0).RegisterStream(address, (d, _) =>
+        {
+            received.TrySetResult(d);
+            return Observable.Return(d);
+        });
+
+        // Wait until the stream subscription exists — so removing it below is a real removal and
+        // not a race with an attach that had not happened yet.
+        var (manager, streamId) = Registry(cluster, address);
+        await WaitUntil(
+            async () => (await Subscriptions(manager, streamId, ct)).Any(),
+            "the stream subscription must exist before the test erases it", ct);
+
+        // ERASE IT. The consumer's handle stays valid and reports nothing; the registry now answers
+        // "nobody is subscribed" — which is precisely what a departed rendezvous-grain host left
+        // behind in production, and what makes every subsequent publish a silent discard.
+        foreach (var subscription in await Subscriptions(manager, streamId, ct))
+            await manager.RemoveSubscription(StreamProviders.Memory, streamId, subscription.SubscriptionId)
+                .WaitAsync(Budget, ct);
+        await WaitUntil(
+            async () => !(await Subscriptions(manager, streamId, ct)).Any(),
+            "the registry must report the stream as subscriber-less — that is the defect's state", ct);
+
+        // CONTROL: prove the stream really cannot carry it any more, so a green below is the grain
+        // transport and not a stale pulling-agent cache still delivering for the removed subscriber.
+        var strayDelivery = Delivery(address, "stray");
+        await StreamOf(cluster, address).OnNextAsync(strayDelivery).WaitAsync(Budget, ct);
+        (await Settled(received.Task)).Should().BeFalse(
+            "a publish onto the subscriber-less stream must NOT reach the hub — if it does, the "
+            + "registry removal did not take effect and this test would pass without exercising the "
+            + "grain transport at all");
+
+        // THE DELIVERY. Posted on silo B's root mesh hub, so it is not in B's local route table and
+        // must go through the router — which now calls the pod-hub grain on silo A.
+        SiloMeshHub(cluster, 1).Post(new PingRequest(), o => o.WithTarget(address));
+
+        var delivered = await received.Task.WaitAsync(Budget, ct);
+        // The router packages a delivery before routing it (MeshBuilder → delivery.Package), so what
+        // arrives is RawJson carrying the original message — the same shape every routed delivery
+        // has, which is why RoutingGrain.PostFailure reads the ENVELOPE and never the CLR type.
+        delivered.Message.Should().BeOfType<RawJson>(
+            "a routed delivery arrives packaged — asserting the CLR type here would pin the "
+            + "packaging, not the transport");
+        ((RawJson)delivered.Message).Content.Should().Contain(nameof(PingRequest),
+            "a hub whose local route is live must receive its cross-silo delivery regardless of the "
+            + "state of the stream's subscriber registry — the local route is written synchronously "
+            + "by RegisterStream and never depended on Orleans streaming at all. Against the stream "
+            + "transport this delivery is discarded (silently before the #1742 subscriber check, "
+            + "NACK'd but still undelivered after it)");
+    }
+
+    /// <summary>
+    /// A hub that MOVES between pods — a <c>portal/{user}</c> circuit reconnecting elsewhere is the
+    /// everyday case — must converge on its new owner. This is what <c>Attach</c> returning
+    /// <c>false</c> plus its bounded retry are for: the new owner's claim bounces off the old
+    /// activation until that one has stepped aside.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task AddressThatMovesSilos_ConvergesOnItsNewOwner()
+    {
+        var ct = new CancellationTokenSource(TimeSpan.FromSeconds(150)).Token;
+        var cluster = fixture.Cluster;
+        var address = new Address("client", $"moving-{Guid.NewGuid():N}");
+
+        // First owner: silo A. The claim is proved the only way that matters — by a cross-silo
+        // delivery ARRIVING — rather than by asking the grain, whose `false` answer cannot tell
+        // "somebody else owns it" from "nobody does".
+        var receivedOnA = new TaskCompletionSource<IMessageDelivery>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = Routing(cluster, 0).RegisterStream(address, (d, _) =>
+        {
+            receivedOnA.TrySetResult(d);
+            return Observable.Return(d);
+        });
+        await WaitUntil(async () =>
+        {
+            SiloMeshHub(cluster, 1).Post(new PingRequest(), o => o.WithTarget(address));
+            return await Settled(receivedOnA.Task);
+        }, "the first owner must receive a cross-silo delivery before the address moves", ct);
+        first.Dispose();
+
+        // Second owner: silo B.
+        var receivedOnB = new TaskCompletionSource<IMessageDelivery>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var second = Routing(cluster, 1).RegisterStream(address, (d, _) =>
+        {
+            receivedOnB.TrySetResult(d);
+            return Observable.Return(d);
+        });
+
+        // Delivered from silo A — the pod it LEFT, which is the direction that would keep hitting a
+        // stranded activation if Detach did not release the claim.
+        await WaitUntil(async () =>
+        {
+            SiloMeshHub(cluster, 0).Post(new PingRequest(), o => o.WithTarget(address));
+            return await Settled(receivedOnB.Task);
+        }, "the moved hub must receive its delivery on its NEW owner", ct);
+
+        var moved = (await receivedOnB.Task).Message;
+        moved.Should().BeOfType<RawJson>("a routed delivery arrives packaged");
+        ((RawJson)moved).Content.Should().Contain(nameof(PingRequest),
+            "the moved hub must receive the ping on its NEW owner — a stranded claim on the pod it "
+            + "left would keep every delivery landing there instead");
+    }
+
+    /// <summary>
+    /// An address no process has claimed must be answered, not absorbed: the grain refuses with
+    /// <see cref="PodHubNotHereException"/> — a definitive "not through this transport", never a
+    /// transient rejection, because <c>[PreferLocalPlacement]</c> would place a retry on the caller
+    /// again and the loop would never converge.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task UnclaimedAddress_RefusesInsteadOfAbsorbing()
+    {
+        var cluster = fixture.Cluster;
+        var grain = Grains(cluster, 0)
+            .GetGrain<IPodHubGrain>(new Address("client", $"unclaimed-{Guid.NewGuid():N}").ToString());
+
+        (await grain.Attach().WaitAsync(Budget, TestContext.Current.CancellationToken)).Should().BeFalse(
+            "no process owns this address, so no silo may claim it");
+
+        var deliver = async () => await grain
+            .Deliver(Delivery(new Address("client", "irrelevant"), "x"))
+            .WaitAsync(Budget, TestContext.Current.CancellationToken);
+
+        var thrown = await deliver.Should().ThrowAsync<Exception>(
+            "an unclaimed address must produce an ANSWER — absorbing the message is the defect");
+        RoutingGrain.IsPodHubNotHere(thrown.Which).Should().BeTrue(
+            "the refusal must be PodHubNotHere so the router can tell 'no owner through this "
+            + "transport' from 'the owning silo failed' and route the two differently — and it must "
+            + $"still be recognisable AFTER crossing the grain boundary. Got: {thrown.Which}");
+    }
+
+    // ---- helpers -------------------------------------------------------------------------
+
+    private static (IStreamSubscriptionManager Manager, global::Orleans.Runtime.StreamId StreamId) Registry(
+        TestCluster cluster, Address address)
+    {
+        var provider = SiloServices(cluster, 0).GetRequiredKeyedService<IStreamProvider>(StreamProviders.Memory);
+        provider.TryGetStreamSubscriptionManager(out var manager).Should().BeTrue(
+            "the memory stream provider must expose its subscription registry");
+        return (manager!, provider.GetStream<IMessageDelivery>(address.ToString()).StreamId);
+    }
+
+    // Bounded, like every other wait here: the registry call is exactly the class of thing this
+    // change is about, so a wedged one must fail FAST and name itself rather than ride the [Fact]
+    // timeout, where it would read as the test's own assertion hanging.
+    private static async Task<IEnumerable<StreamSubscription>> Subscriptions(
+        IStreamSubscriptionManager manager, global::Orleans.Runtime.StreamId streamId, CancellationToken ct)
+        => await manager.GetSubscriptions(StreamProviders.Memory, streamId).WaitAsync(Budget, ct);
+
+    private static IAsyncStream<IMessageDelivery> StreamOf(TestCluster cluster, Address address)
+        => SiloServices(cluster, 0).GetRequiredKeyedService<IStreamProvider>(StreamProviders.Memory)
+            .GetStream<IMessageDelivery>(address.ToString());
+
+    private static IMessageDelivery Delivery(Address target, string payload)
+        => new MessageDelivery<string>(payload, new PostOptions(target).WithTarget(target),
+            System.Text.Json.JsonSerializerOptions.Default);
+
+    private static async Task<bool> Settled(Task task)
+    {
+        // A bounded, condition-shaped "has it happened yet" — never an unbounded await, which would
+        // hang the way the bug does.
+        var completed = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(2)));
+        return ReferenceEquals(completed, task);
+    }
+
+    private static async Task WaitUntil(Func<Task<bool>> condition, string because, CancellationToken ct)
+    {
+        var deadline = DateTime.UtcNow + Budget;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition()) return;
+            await Task.Delay(200, ct);
+        }
+        throw new TimeoutException($"Timed out after {Budget}: {because}");
+    }
+}


### PR DESCRIPTION
Step 3 of 3 for #1742. **Stacked on #1990** (step 2) — base it back to `main` once that merges. Step 1 is #1986.

## Why the transport has to change

Every cross-process leg in the mesh is an Orleans **grain call**: retried, NACK'd, and heard about when it fails. One leg was not. Delivery to a hub that lives in a .NET process rather than in a grain — `mesh/{id}`, `portal/{user}`, `client/{id}`, `cache/…`, plus module-registered types — rode a **stream publish**, because Orleans places grains and nothing places a process. And a stream publish to nobody *succeeds*.

Step 2's subscriber check narrowed that window. It cannot close it, and one row of this table is why:

| residual | stream + subscriber check | directed grain call |
|---|---|---|
| no subscriber registered | NACK'd (checked) | NACK'd (the call has nowhere to land) |
| subscriber vanishes between check and publish | **silent** | NACK'd — the call fails |
| `MemoryStreamQueueGrain` dies with its silo | **silent** | not on the path at all |
| pub-sub registry lost (non-AdoNet multi-silo) | NACK'd, but **wrongly** — the hub is alive | delivered; the registry is not consulted |
| **the reply's own requester** | **not reached** — the NACK goes to the REPLIER | the reply is delivered, so there is nothing to report |

That last row is the one no producer-side check can ever fix: when a *reply* cannot be delivered, the party that needs to know is the original requester — precisely the party that is unreachable. Making the reply **land** is the only answer.

## The mechanism — and there is no directory of ours

The address→silo map is **Orleans' own grain directory**. `IPodHubGrain` is keyed by the address and placed `[PreferLocalPlacement]`, and it is the **owning process** that activates it, from `OrleansRoutingService.RegisterStream`. Single-activation semantics then make the grain directory the map — no custom placement director, no directory grain, no state to keep durable or lose. `Deliver` looks up `TryGetLocalRoute`: the table that has always been the authority for "this process hosts that hub", written **synchronously and unconditionally** by `RegisterStream`, with no dependence on Orleans streaming being ready. That is the property the stream leg never had.

Two lifecycle rules carry the whole correctness argument:

- **`Attach` pins the activation** (`DelayDeactivation`). `PreferLocalPlacement` prefers the *caller*, so a collected activation would be re-created on whichever router called next and every delivery to a live hub would land on the wrong process. The activation's lifetime is tied to the registration, not to traffic.
- **A silo that cannot serve the address steps aside, loudly.** `Deliver` throws `PodHubNotHereException` and requests deactivation so the true owner's next `Attach` can be placed correctly; `Attach` answers `false` and does the same, which is how an address **moving** between pods converges. `PodHubNotHere` is deliberately **not** a transient Orleans rejection: `DeliverToGrainWithRetry` would retry it, prefer-local would place the retry on the caller again, and the loop would never converge.

## 🚨 The roll plan is part of the change, and was written before the code

`Doc/Architecture/PodHubDeliveryRollPlan` — because the last change in this area shipped without one and left the fleet **split-brain on pub-sub for the duration of its own deploy: 39 stranded addresses, unpredicted** (#1770).

- **Release N+1** attaches **both** transports and falls back to the stream publish on `PodHubNotHere`, so a new pod calling a hub still owned by an old pod is not a `NotFound` for a hub that is alive and well.
- The fallback is safe rather than a return to silence **because of step 2's subscriber check** — which is exactly why that check was worth landing first, and why it stays useful for as long as the fallback exists.
- The fallback is **permanent** for a hub owned by an Orleans **client** process, which cannot host a grain at all. One `Information` line per fallback delivery is the signal that says when the overlap window has closed; ship N+2 when a full rolling deploy produces none of them for a silo-hosted address.
- **A revert is safe at any point**: N+1 is a strict superset of N — it still subscribes the stream and still publishes to it when the call cannot land.

`OrderedRouteDispatcher` is unchanged; the per-destination FIFO is a correctness requirement of the delta protocol and a call into a grain does not restore ordering. `StreamMessageSizeGuard` (#1890) **retargets** rather than disappears — see the doc.

## Non-vacuity

`PodHubTransportTest.SiloHostedHub_ReceivesDelivery_EvenWithItsStreamSubscriptionGone` reproduces #1729's production defect **in process**: a hub that is ALIVE — local route present, process healthy — whose entry in the stream's subscriber registry has been erased with `IStreamSubscriptionManager.RemoveSubscription`, the same end state a departed rendezvous-grain host left behind. A **control publish runs first** and asserts the stream can no longer carry the message, so a green cannot come from a stale pulling-agent cache.

Control run with nothing claiming the address (the release-N shape — `AttachPodHub` stubbed to `Disposable.Empty`):

```
[xUnit.net 00:00:33.30]  PodHubTransportTest.SiloHostedHub_ReceivesDelivery_EvenWithItsStreamSubscriptionGone [FAIL]
  System.TimeoutException : The operation has timed out.
Failed!  - Failed: 1, Passed: 0, Skipped: 0, Total: 1, Duration: 32 s
```

With the claim in place it passes in ~2 s. Two further facts pin the lifecycle rules: an address that **moves** silos converges on its new owner, and an **unclaimed** address refuses with `PodHubNotHere` (asserted *after* the exception has crossed the grain boundary, so the router's fallback branch cannot silently stop matching).

## Suites

| suite | result |
|---|---|
| `MeshWeaver.Hosting.Orleans.Test` | 182/182 |
| `MeshWeaver.Messaging.Hub.Test` | 263/263 |
| `MeshWeaver.Documentation.Test` | 39/39 |
| `MeshWeaver.Hosting.Monolith.Test` | 742 passed, 3 skipped, 1 failed — see below |

The one Monolith failure is `UserDirectoryContentShapeTest.EveryContentShape_IsIndexedAndProjects(shape: "typed")`, a `TimeoutException` under whole-suite load on a 10-core laptop. It cannot be this diff: **`MeshWeaver.Hosting.Monolith.Test` references neither `MeshWeaver.Connection.Orleans` nor `MeshWeaver.Hosting.Orleans`** (`grep -i orleans` on its csproj returns nothing), and this diff touches only those two projects plus markdown and Orleans test files. It passes 3/3 in isolation in ~0.6 s, and the same test flaked once on #1986's branch under the same load and passed on a clean re-run.

Refs #1742, #1729, #1770, #1890.