### PR TITLE
Surface modules that landed but have not loaded (#1979)

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/PendingModuleActivationHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.Distributed/PendingModuleActivationHealthCheck.cs
@@ -1,0 +1,60 @@
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Memex.Portal.Distributed;
+
+/// <summary>
+/// Reports modules that are LANDED but not yet LOADED — the restart-as-activation signal
+/// (<see cref="ModuleActivationList.PendingRestart"/>) that #1979 found written by two sites,
+/// consumed at boot, and read by nothing else.
+///
+/// <para><b>Why a health check rather than a log line.</b> Loading is restart-as-activation by
+/// design, which makes the restart part of the install — and an install whose last step is
+/// invisible reads as a broken install: buy → Get → "installed" → the feature is not there →
+/// nothing anywhere says why. The same shape the Store already learned once with
+/// paid-and-never-delivered: a success message that is true about the half that ran. An operator
+/// surface makes a fleet with pending activations visible without opening a portal.</para>
+///
+/// <para>🚨 <b>DEGRADED, never Unhealthy.</b> A pending activation is a to-do, not a fault: the pod
+/// is serving correctly with the modules it loaded, and failing readiness here would stall a
+/// rollout over work the rollout itself performs. Degraded is reported in the payload and by
+/// <c>/health</c>'s aggregate status without taking the instance out of service.</para>
+///
+/// <para>🚨 Reads the PERSISTED sidecar, not an in-memory flag. The process that landed the module
+/// is not necessarily the process a viewer or an operator is talking to — the state outliving the
+/// request that created it is the entire point.</para>
+/// </summary>
+public sealed class PendingModuleActivationHealthCheck(string moduleRoot) : IHealthCheck
+{
+    /// <inheritdoc />
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        ModuleActivationList activation;
+        try
+        {
+            activation = ModuleActivationSidecar.Read(moduleRoot);
+        }
+        catch (Exception exception)
+        {
+            // An unreadable sidecar is not a pending activation, and must not read as one.
+            return Task.FromResult(HealthCheckResult.Healthy(
+                $"module activation state unreadable ({exception.GetType().Name}) — "
+                + "reporting no pending activation rather than inventing one"));
+        }
+
+        if (!activation.PendingRestart)
+            return Task.FromResult(HealthCheckResult.Healthy("no module activation pending"));
+
+        var names = activation.Entries
+            .Where(e => e.Enabled)
+            .Select(e => e.Name)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return Task.FromResult(HealthCheckResult.Degraded(
+            $"{names.Length} module(s) are landed but not yet loaded — a restart activates them: "
+            + string.Join(", ", names.Take(10))
+            + (names.Length > 10 ? $", …(+{names.Length - 10})" : string.Empty)));
+    }
+}

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -393,6 +393,17 @@ builder.Services.AddHostedService<Memex.Portal.Distributed.DbVersionGate>();
 builder.Services.AddHealthChecks()
     .AddCheck<Memex.Portal.Distributed.DbVersionHealthCheck>("db_version");
 
+// Modules that LANDED but have not LOADED (#1979). Loading is restart-as-activation, which makes
+// the restart part of the install — so an install whose last step is invisible reads as a broken
+// install. DEGRADED, never Unhealthy: the pod serves correctly with what it loaded, and failing
+// readiness would stall a rollout over work the rollout itself performs. Reads the PERSISTED
+// sidecar, because the process that landed the module is not the process being asked.
+builder.Services.AddHealthChecks()
+    .AddCheck(
+        "pending_module_activation",
+        new Memex.Portal.Distributed.PendingModuleActivationHealthCheck(
+            MeshWeaver.PluginCatalog.ModuleRoot.Resolve(builder.Configuration)));
+
 // The same shape, one dependency further out: DbVersionGate proves the MESH database is
 // migrated; this proves the ORLEANS database is provisioned. They are different databases,
 // provisioned by different phases, and #1798 is what happens when only the first is checked —

--- a/test/Memex.Portal.Shared.Test/PendingModuleActivationHealthCheckTest.cs
+++ b/test/Memex.Portal.Shared.Test/PendingModuleActivationHealthCheckTest.cs
@@ -1,0 +1,104 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.PluginCatalog;
+using Memex.Portal.Distributed;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The restart-as-activation signal, surfaced (#1979). PendingRestart was written by the landing
+/// sites, consumed at boot, and read by NOTHING — so a package could install, report success, and
+/// leave its module inert until someone happened to restart the pod.
+///
+/// <para>Reads the PERSISTED sidecar on purpose: the process that landed the module is not
+/// necessarily the process being asked, which is the whole reason the state is durable.</para>
+/// </summary>
+public class PendingModuleActivationHealthCheckTest : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-pending-" + Guid.NewGuid().ToString("N"));
+
+    public PendingModuleActivationHealthCheckTest() =>
+        Directory.CreateDirectory(Path.Combine(root, "modules"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+    }
+
+    private Task<HealthCheckResult> Check() =>
+        new PendingModuleActivationHealthCheck(root)
+            .CheckHealthAsync(new HealthCheckContext());
+
+    [Fact]
+    public async Task APendingActivation_IsReportedDegraded_AndNamesTheModules()
+    {
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            PendingRestart = true,
+            Entries =
+            [
+                new ModuleActivationEntry { Name = "MeshWeaver.Acme", Enabled = true },
+                new ModuleActivationEntry { Name = "MeshWeaver.Widgets", Enabled = true },
+            ],
+        });
+
+        var result = await Check();
+
+        // DEGRADED, never Unhealthy: the pod serves correctly with what it loaded, and failing
+        // readiness would stall a rollout over work the rollout itself performs.
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("MeshWeaver.Acme", result.Description);
+        Assert.Contains("MeshWeaver.Widgets", result.Description);
+    }
+
+    [Fact]
+    public async Task NoPendingActivation_IsHealthy()
+    {
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            PendingRestart = false,
+            Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Acme", Enabled = true }],
+        });
+
+        Assert.Equal(HealthStatus.Healthy, (await Check()).Status);
+    }
+
+    [Fact]
+    public async Task AnUnreadableOrAbsentSidecar_IsHealthy_NeverAnInventedPendingRestart()
+    {
+        // Absence of a "yes" is a "no": a missing sidecar must not read as a pending activation.
+        var result = await new PendingModuleActivationHealthCheck(
+                Path.Combine(root, "no-such-deployment"))
+            .CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task ALandingSetsIt_AndTheSurfaceSeesIt_WithoutAnInMemoryHandoff()
+    {
+        // End to end over the durable state: land through the service, then ask the health check,
+        // which shares nothing with it but the sidecar on disk.
+        using var landing = new ModuleLandingService(baseDirectory: root);
+        await landing.LandModule(
+                "MeshWeaver.Acme",
+                [("MeshWeaver.Acme.dll", [1])],
+                MeshWeaver.Graph.Configuration.PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                version: "1.0.0")
+            .FirstAsync().ToTask();
+
+        var result = await Check();
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("MeshWeaver.Acme", result.Description);
+    }
+}


### PR DESCRIPTION
Addresses item 2 of #1979 (the operator surface). `PendingRestart` was written by both landing sites, consumed at boot, and **read by nothing** — so a package installs, reports success, and its module stays inert until someone happens to restart the pod. Loading is restart-as-activation by design, which makes the restart part of the install.

`pending_module_activation`:
- **Degraded, never Unhealthy** — the pod serves correctly with what it loaded; failing readiness would stall a rollout over work the rollout performs.
- Reads the **persisted** sidecar, as the issue requires — the landing process is not the process being asked.
- Absent/unreadable sidecar → Healthy: absence of a "yes" is a "no", never an invented pending restart.

4/4 tests, including landing through the service then asking the check (sharing nothing but the file on disk). Item 1 (the Store card state) is the natural follow-up; item 3 (auto-roll) stays out of scope per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)