### PR TITLE
The mesh compiled identical content into a different assembly on every process

### DIFF
--- a/src/MeshWeaver.Compiler/NodeCompileShaping.cs
+++ b/src/MeshWeaver.Compiler/NodeCompileShaping.cs
@@ -210,12 +210,29 @@ public static class NodeCompileShaping
 
     /// <summary>
     /// The emit path's source-set fold: dedup by path (case-insensitive), keep only
-    /// non-executable Code nodes with non-blank code, in the order the snapshot delivered them.
+    /// non-executable Code nodes with non-blank code, ORDERED BY PATH (ordinal).
     /// Executable scripts run via the kernel (ExecuteScriptRequest), never folded into the parent
     /// NodeType's Roslyn unit — top-level statements would collide with class declarations from
     /// Source/ siblings; Test/ commonly mixes both shapes, and this filter lets them coexist.
     /// Returns the matched configurations together with the matched paths (activity-log
     /// material for the caller).
+    ///
+    /// <para>🚨 <b>The order is a function of the SOURCE SET, never of how it was delivered</b>
+    /// (#1707 slice 4). It used to be "the order the snapshot delivered them", and on the mesh path
+    /// that delivery is <c>ImmutableDictionary.Values</c> — hash-bucket order over string hashes
+    /// that .NET RANDOMISES PER PROCESS. The join order is part of the emitted bytes, so the mesh
+    /// compile emitted a different assembly for identical content on every process: not
+    /// reproducible against another producer, and not reproducible against ITSELF. That is why the
+    /// assembly store's digest-of-the-emitted-bytes could never dedupe, and it made the
+    /// generated-input CONTENT KEY move on every compile — an identity that invalidates everything
+    /// on every build, which is strictly worse than the proxy it replaces.</para>
+    ///
+    /// <para>Measured on <c>BakeEquivalenceTest</c> before the sort: the compiler-driven bake
+    /// produced <c>i3494e62e…</c> on three consecutive runs while the mesh-driven bake produced
+    /// <c>ic920384a…</c>, <c>iead1b585…</c>, <c>i70db762d…</c>. Ordinal path order is what the
+    /// tree bake already effectively had, it is stable across processes, hosts and architectures,
+    /// and C# does not care: top-level declarations in a concatenated unit are order-independent,
+    /// which is exactly what that test's type-and-member SURFACE comparison proves.</para>
     /// </summary>
     internal static (List<CodeConfiguration> Sources, List<string> MatchedPaths)
         CollectCompileSources(IEnumerable<MeshNode> matches, string nodePath, ILogger logger)
@@ -223,7 +240,7 @@ public static class NodeCompileShaping
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var acc = new List<CodeConfiguration>();
         var matchedPaths = new List<string>();
-        foreach (var n in matches)
+        foreach (var n in matches.OrderBy(n => n.Path, StringComparer.Ordinal))
         {
             if (string.IsNullOrEmpty(n.Path) || !seen.Add(n.Path))
                 continue;

--- a/test/MeshWeaver.Graph.Test/CompileSourceOrderTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompileSourceOrderTest.cs
@@ -1,0 +1,76 @@
+#pragma warning disable CS1591
+
+using MeshWeaver.Compiler;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 The compile's source ORDER is a function of the SOURCE SET, never of how it was delivered.
+///
+/// <para>The join order is part of the emitted bytes — <c>NodeCompileShaping.CombineSources</c>
+/// concatenates in this order — and it used to be whatever order the snapshot arrived in. On the
+/// mesh path that delivery is <c>ImmutableDictionary.Values</c> (see
+/// <c>MeshNodeCompilationService</c>'s source probe), i.e. hash-bucket order over string hashes
+/// that .NET RANDOMISES PER PROCESS. So the mesh compiled the same content into a different
+/// assembly on every process: not reproducible against the compiler-driven bake, and not
+/// reproducible against itself. It is why the assembly store's digest of the emitted bytes could
+/// never dedupe, and it made the generated-input content key move on every compile.</para>
+///
+/// <para>Pinned here as a unit test as well as in <c>BakeEquivalenceTest</c>, because the
+/// equivalence test is an expensive integration test in a different project and this property is
+/// cheap to state: a reversed delivery must produce an identical compile unit.</para>
+/// </summary>
+public class CompileSourceOrderTest
+{
+    private static MeshNode Code(string path, string code) =>
+        new(path[(path.LastIndexOf('/') + 1)..], path[..path.LastIndexOf('/')])
+        {
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = code, Language = "csharp" },
+        };
+
+    [Fact]
+    public void CollectCompileSources_OrdersByPath_WhateverOrderTheSnapshotDelivered()
+    {
+        MeshNode[] delivered =
+        [
+            Code("Widget/Thing/Test/ThingTests", "class T {}"),
+            Code("Lib/Shared/Source/Helper", "class H {}"),
+            Code("Widget/Thing/Source/Sub/Deep", "class D {}"),
+            Code("Widget/Thing/Source/Thing", "class Th {}"),
+        ];
+
+        var (_, matched) = NodeCompileShaping.CollectCompileSources(
+            delivered, "Widget/Thing", NullLogger.Instance);
+
+        matched.Should().Equal(
+            "Lib/Shared/Source/Helper",
+            "Widget/Thing/Source/Sub/Deep",
+            "Widget/Thing/Source/Thing",
+            "Widget/Thing/Test/ThingTests");
+    }
+
+    [Fact]
+    public void TheCombinedCompileUnit_IsIdentical_UnderAnyDeliveryOrder()
+    {
+        MeshNode[] ascending =
+        [
+            Code("Pkg/T/Source/A", "class A {}"),
+            Code("Pkg/T/Source/B", "class B {}"),
+            Code("Pkg/T/Source/C", "class C {}"),
+        ];
+        var descending = ascending.Reverse().ToArray();
+
+        var one = NodeCompileShaping.CombineSources(
+            NodeCompileShaping.CollectCompileSources(ascending, "Pkg/T", NullLogger.Instance).Sources);
+        var other = NodeCompileShaping.CombineSources(
+            NodeCompileShaping.CollectCompileSources(descending, "Pkg/T", NullLogger.Instance).Sources);
+
+        one!.Code.Should().Be(other!.Code);
+        // …and the order is the SET's, not the first caller's.
+        one.Code.Should().Be("class A {}\n\nclass B {}\n\nclass C {}");
+    }
+}


### PR DESCRIPTION
Lifted out of #1994 so it can land on its own — it is an independent bug fix with consequences well beyond the content key it was found by, and it should not wait on that PR's open decision.

## What was wrong

`CollectCompileSources` kept **"the order the snapshot delivered them"**. On the mesh path that delivery is `map.Values.ToList()` over an `ImmutableDictionary` — hash-bucket order over **per-process randomised string hashes**. The join order is in the emitted bytes.

So the mesh compiled identical content into a **different assembly on every process** — not reproducible against the compiler-driven producer, and not against itself:

| run | mesh | compiler |
|---|---|---|
| 1 | `ic920384a…` | `i3494e62e073f2a551796fa08440330ed` |
| 2 | `iead1b585…` | `i3494e62e073f2a551796fa08440330ed` |
| 3 | `i70db762d…` | `i3494e62e073f2a551796fa08440330ed` |

Now ordinal by path, inside the toolchain function that already owns the join order, so both producers agree by construction.

## What this explains

- **Cross-replica dedupe in `FileSystemAssemblyStore` was structurally impossible.** `PutWithLocation` is first-write-wins on a content-hashed file name, and its own comment reads *"The bytes are identical by construction — the hash IS the name."* With per-process source order they were not. Two silos compiling the same `(path, version)` produced different hashes, so different names — never a collision, but **never a share either**. Every replica wrote its own generation into `/data/assembly-cache`, which is retention pressure `AssemblyCacheGenerations` has been sweeping ever since. That is now genuinely dedupable and worth measuring.
- **The store's digest-of-emitted-bytes could never dedupe**, for the same reason.
- **`BakeEquivalenceTest`'s class remarks are now stale.** They document the non-determinism as a fact of life and explain why the test compares the type/member *surface* rather than bytes. That constraint is largely lifted, so byte equality between the two producers is within reach — which would prove the bake produces what the mesh would, rather than something merely surface-compatible with it. Not attempted here.

## Deploy note

It changes emitted bytes for every NodeType with **no** identity change. That is safe: existing cached DLLs stay valid for their content, and recompiles simply write new content-hashed names.

## Verification

`CompileSourceOrderTest` — 2/2, verified non-vacuous by reverting the fix. Cherry-picks onto `main` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)