### PR TITLE
fix(#1636): make markdown fence workbenches editable

### DIFF
--- a/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
@@ -105,6 +105,21 @@ public partial class CollaborativeMarkdownView
     // code routinely changes under a result pane still showing the previous run.
     private readonly CodeCellRunTracker _runTracker = new();
 
+    // What each editable cell currently HOLDS, keyed by submission id — written on every keystroke
+    // by MarkdownCodeCellEditor, read by ResubmitBlock. Auto-save is debounced by design, so the
+    // stored document lags the buffer by up to half a second: without this, Run pressed immediately
+    // after typing executes the code the learner just replaced. Same reason
+    // CodeLayoutAreas.RunFromBuffer exists for the Code-node cell. Per-view, renderer-thread only,
+    // so a plain dictionary — like _runTracker beside it.
+    private readonly Dictionary<string, string> _cellBuffers = new(StringComparer.OrdinalIgnoreCase);
+
+    // Cached once: a method group allocates a NEW delegate on every evaluation, and these travel to
+    // the editor component as PARAMETERS. A parameter that changes identity every render marks the
+    // child dirty on every render — for a live Monaco that is exactly the churn the
+    // "the control must be identical across re-renders" rule exists to avoid.
+    private Func<string, string?>? _cellCode;
+    private Action<string, string>? _recordCellBuffer;
+
     private Address ResolveActivityAddress()
     {
         var ownerPath = KernelOwnerPath();
@@ -564,11 +579,32 @@ public partial class CollaborativeMarkdownView
         // Cell toolbars' Run buttons are enabled only once the kernel activity is routable —
         // the same gate as the live result-area embed above. The run state is computed against the
         // CURRENT parse, so a cell the author just edited renders as stale until it is re-run.
+        // 🚨 The cells are editable exactly when the viewer may WRITE this node — BoundCanEdit,
+        // which the layout area folded out of hub.GetEffectivePermissions server-side (and which a
+        // pinned historical comparison already forces false: there is no live text to edit there).
+        // Passing null is the read-only rendering. No client-side permission re-derivation.
+        var editing = BoundCanEdit
+            ? new MarkdownCellEditing(BoundNodePath, _cellCode ??= CellCode, _recordCellBuffer ??= RecordCellBuffer)
+            : null;
+
         var renderer = new MarkdownHtmlRenderer(Mode, Stream,
             _kernelReady ? ResubmitBlock : null,
-            id => _runTracker.StateOf(id, _codeSubmissions));
+            id => _runTracker.StateOf(id, _codeSubmissions),
+            editing);
         renderer.ShowReferencesSection = true;
         renderer.RenderHtml(builder, html);
+    }
+
+    // The code the CURRENT parse holds for a cell — the editor's seed, so it starts from the same
+    // text the kernel would run rather than from re-decoded HTML.
+    private string? CellCode(string submissionId) =>
+        _codeSubmissions?.FirstOrDefault(
+            s => string.Equals(s.Id, submissionId, StringComparison.OrdinalIgnoreCase))?.Code;
+
+    private void RecordCellBuffer(string submissionId, string text)
+    {
+        if (!string.IsNullOrEmpty(submissionId))
+            _cellBuffers[submissionId] = text;
     }
 
     // Re-posts one executable block's submission to the per-view kernel activity — the cell
@@ -580,6 +616,10 @@ public partial class CollaborativeMarkdownView
             .FirstOrDefault(s => string.Equals(s.Id, submissionId, StringComparison.OrdinalIgnoreCase));
         if (submission is null || !_kernelReady)
             return;
+        // Run the BUFFER, not the file. The document is re-parsed only after the debounced auto-save
+        // lands, so posting `submission` verbatim would execute code the learner has already
+        // replaced — and hand back a confidently-rendered result for source nobody is looking at.
+        submission = ApplyCellBuffer(submission);
         _runTracker.Record(submission);
         Hub.Post(submission, o => o.WithTarget(KernelAddress));
         // The toolbar's OnRun is a plain Action, not an EventCallback, so nothing re-renders THIS
@@ -587,6 +627,17 @@ public partial class CollaborativeMarkdownView
         // so without this the "stale cell" chip survives the very re-run that cleared it.
         StateHasChanged();
     }
+
+    /// <summary>
+    /// The submission as the viewer's editor currently reads, when an editable cell has typed text
+    /// that has not been persisted yet. Unedited cells return the parsed submission unchanged.
+    /// </summary>
+    private SubmitCodeRequest ApplyCellBuffer(SubmitCodeRequest submission) =>
+        submission.Id is { Length: > 0 } id
+        && _cellBuffers.TryGetValue(id, out var buffer)
+        && buffer != submission.Code
+            ? submission with { Code = buffer }
+            : submission;
 
     private string RenderMarkdown(string content)
     {

--- a/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.css
@@ -1266,3 +1266,17 @@
     background: var(--neutral-layer-2);
     border-color: var(--accent-fill-rest);
 }
+
+/* The EDITABLE code segment (#1636). MarkdownCodeCellEditor REPLACES the server's `code-content`
+   marker div for a viewer holding Update, exactly as MarkdownCodeCellToolbar replaces the toolbar
+   marker — so the hydrated DOM carries `md-cell-editor`, NOT `code-content`, and anything selecting
+   the cell's code in a live Blazor page (e2e, styling) must look for this class. The `md-code-cell`
+   frame around it is untouched server HTML and still identifies a workbench. */
+::deep .md-cell-editor {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+::deep .md-code-cell .md-cell-editor {
+    border-bottom: 1px solid var(--neutral-stroke-rest);
+}

--- a/src/MeshWeaver.Blazor/Components/MarkdownCellEditing.cs
+++ b/src/MeshWeaver.Blazor/Components/MarkdownCellEditing.cs
@@ -1,0 +1,30 @@
+namespace MeshWeaver.Blazor.Components;
+
+/// <summary>
+/// What a markdown view hands <see cref="MarkdownHtmlRenderer"/> to make its executable cells
+/// EDITABLE (#1636) — the fence workbench's counterpart of the Code node's inline cell editor.
+///
+/// <para>🚨 <b>Its presence IS the permission decision.</b> A view supplies this object only when the
+/// viewer holds <c>Permission.Update</c> on the node, resolved server-side by the layout area that
+/// produced the control (<c>MarkdownOverviewLayoutArea</c> folds
+/// <c>hub.GetEffectivePermissions</c> into <c>CollaborativeMarkdownControl.CanEdit</c>) — the same
+/// check, from the same evaluator, that decides whether a Code node renders an editor or a
+/// <c>&lt;pre&gt;</c>. Null means read-only, which is the default everywhere. There is no second
+/// permission model here and there must not be one: a client-side re-derivation could only ever
+/// disagree with the server, and the direction it would disagree in is the one that shows an editor
+/// to someone who cannot save.</para>
+/// </summary>
+/// <param name="NodePath">Path of the markdown MeshNode whose body holds the fences — the auto-save
+/// target. Null/empty when there is no node behind the markdown (a generated
+/// <c>Controls.Markdown</c>): the cell is still editable and runnable, but nothing is persisted.</param>
+/// <param name="CodeOf">Resolves a submission id to the code the document currently holds for it,
+/// so the editor seeds from the hosting view's own parse rather than from re-decoded HTML. Null
+/// falls back to the rendered <c>&lt;pre&gt;</c>'s text.</param>
+/// <param name="OnBufferChanged">Receives (submissionId, text) on every keystroke so the view's Run
+/// submits what the viewer is LOOKING at. The auto-save is debounced by design, so without this a
+/// Run pressed straight after typing executes the previous code — the exact trap
+/// <c>CodeLayoutAreas.RunFromBuffer</c> exists to close for the Code-node cell.</param>
+public sealed record MarkdownCellEditing(
+    string? NodePath,
+    Func<string, string?>? CodeOf,
+    Action<string, string>? OnBufferChanged);

--- a/src/MeshWeaver.Blazor/Components/MarkdownCodeCellEditor.razor
+++ b/src/MeshWeaver.Blazor/Components/MarkdownCodeCellEditor.razor
@@ -1,0 +1,159 @@
+@using MeshWeaver.Blazor.Components.Monaco
+@using MeshWeaver.Data
+@using MeshWeaver.Markdown
+@using MeshWeaver.Mesh
+@using MeshWeaver.Mesh.Services
+@using MeshWeaver.Messaging
+@using Microsoft.Extensions.DependencyInjection
+@using Microsoft.Extensions.Logging
+@namespace MeshWeaver.Blazor.Components
+@implements IDisposable
+@inject IMessageHub Hub
+@inject ILoggerFactory LoggerFactory
+
+<div class="md-cell-editor">
+    <MonacoEditorView Value="@_seed"
+                      Language="@(Language ?? "csharp")"
+                      Height="@_height"
+                      MaxHeight="none"
+                      ShowLineNumbers="true"
+                      ShowBorder="false"
+                      CodeEditMode="true"
+                      ValueChanged="@OnValueChanged" />
+</div>
+
+@code {
+    // The MARKDOWN-FENCE workbench editor (#1636).
+    //
+    // A learner's workbench is very often a ```csharp --render X --show-code fence inside a markdown
+    // BODY, not a Code child node. The Code-node cell has been editable since CodeLayoutAreas grew
+    // its inline Monaco; the fence stayed a static <pre>, so the ONE place a learner is asked to
+    // write was the one place they could not type.
+    //
+    // This is the fence's counterpart of CodeLayoutAreas.BuildCellEditor, and it follows the same
+    // three rules, each of which is load-bearing:
+    //
+    //  1. SEED ONCE. From then on the EDITOR is the writer. Re-seeding on a later parameter set
+    //     would clobber whatever the viewer has typed since — every auto-save echoes a node
+    //     emission, which re-renders the parent, which re-supplies InitialCode.
+    //  2. HEIGHT FROM THE SEED. A height that followed the text would change the editor on every
+    //     keystroke and re-mount Monaco under the cursor.
+    //  3. PERSIST ONLY THE FENCE. The write is pure source surgery (MarkdownFenceEditing) through
+    //     the circuit-side IMeshNodeStreamCache — the same seam CodeEditorView's auto-save uses, so
+    //     it carries the viewer's own identity and every reader on the path observes it in order.
+    //
+    // 🚨 This component is rendered ONLY where the hosting view has already established that the
+    // viewer holds Update on the node (MarkdownHtmlRenderer's cellEditing argument). It does not
+    // make a permission decision of its own — there is one permission model, and it is the server's.
+
+    /// <summary>The fence's submission id — its <c>--render</c> value, and the name of the kernel
+    /// result area its output streams into. Addresses the fence for the save.</summary>
+    [Parameter] public string? SubmissionId { get; set; }
+
+    /// <summary>The fence language, for Monaco's syntax highlighting.</summary>
+    [Parameter] public string? Language { get; set; }
+
+    /// <summary>Path of the markdown MeshNode whose body holds this fence — the auto-save target.
+    /// Empty/null disables persistence (the cell is still editable and still runnable, but the edit
+    /// lives only for this view's lifetime — a generated <c>Controls.Markdown</c> has no node).</summary>
+    [Parameter] public string? NodePath { get; set; }
+
+    /// <summary>The code the fence currently holds. Read ONCE, as the editor's seed.</summary>
+    [Parameter] public string? InitialCode { get; set; }
+
+    /// <summary>Invoked with (submissionId, text) on every keystroke, so the hosting view's Run
+    /// submits the BUFFER rather than the last-parsed document. Without it a learner who types and
+    /// immediately presses Run executes the code they just replaced.</summary>
+    [Parameter] public Action<string, string>? OnBufferChanged { get; set; }
+
+    private static readonly TimeSpan AutoSaveThrottleInterval = TimeSpan.FromMilliseconds(500);
+
+    private string _seed = "";
+    private string _height = MarkdownFenceEditing.CellEditorHeight(null);
+    private bool _seeded;
+    private AutoSaveHandler? _autoSave;
+    private IMeshNodeStreamCache? _cache;
+    private ILogger? _logger;
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        if (_seeded)
+            return;
+        _seeded = true;
+        _seed = InitialCode ?? "";
+        _height = MarkdownFenceEditing.CellEditorHeight(_seed);
+        _logger = LoggerFactory.CreateLogger("MeshWeaver.MarkdownCodeCellEditor");
+
+        if (string.IsNullOrEmpty(NodePath))
+            return;
+        try
+        {
+            _cache = Hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+        }
+        catch (Exception ex)
+        {
+            // LOUD, like CodeEditorView's: a silently-absent cache reads as "editing just doesn't
+            // save", with nothing to diagnose by.
+            _logger?.LogWarning(ex,
+                "Failed to resolve IMeshNodeStreamCache for markdown cell auto-save at {Path}", NodePath);
+            return;
+        }
+        _autoSave = new AutoSaveHandler(AutoSaveThrottleInterval, SaveFence);
+    }
+
+    private Task OnValueChanged(string value)
+    {
+        OnBufferChanged?.Invoke(SubmissionId ?? "", value);
+        _autoSave?.OnValueChanged(value);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Writes the debounced buffer back into THIS fence and nowhere else.
+    ///
+    /// <para>A node whose body no longer holds the fence is deliberately left UNTOUCHED — returning
+    /// it unchanged makes the merge patch empty. That is the only safe answer: the alternative
+    /// ("write the whole body") turns a renamed or deleted fence into a wiped exercise.</para>
+    ///
+    /// <para>The derived fields travel with the edit. <see cref="MarkdownContent.PrerenderedHtml"/>
+    /// and <see cref="MarkdownContent.CodeSubmissions"/> are projections of the body, and
+    /// CodeSubmissions is what a Run re-posts — leaving them stale would serve the OLD code back on
+    /// the next render and run it. Everything the shape does not derive (authors, tags, abstract,
+    /// thumbnail, and the [JsonExtensionData] round-trip buffer) is carried over untouched.</para>
+    /// </summary>
+    private void SaveFence(string value)
+    {
+        var path = NodePath;
+        var id = SubmissionId;
+        if (_cache is null || string.IsNullOrEmpty(path) || string.IsNullOrEmpty(id))
+            return;
+
+        _cache.Update(path!,
+                current =>
+                {
+                    var content = current.ContentAs<MarkdownContent>(Hub.JsonSerializerOptions);
+                    if (content is null)
+                        return current;
+                    var updated = MarkdownFenceEditing.ReplaceFenceBody(content.Content, id, value);
+                    if (updated is null || updated == content.Content)
+                        return current;
+                    var reparsed = MarkdownContent.Parse(updated, currentNodePath: path);
+                    return current with
+                    {
+                        Content = content with
+                        {
+                            Content = updated,
+                            PrerenderedHtml = reparsed.PrerenderedHtml,
+                            CodeSubmissions = reparsed.CodeSubmissions,
+                        }
+                    };
+                },
+                Hub.JsonSerializerOptions)
+            .Subscribe(_ => { },
+                ex => _logger?.LogWarning(ex,
+                    "Markdown cell auto-save failed for {Submission} in {Path}", id, path));
+    }
+
+    public void Dispose() => _autoSave?.Dispose();
+}

--- a/src/MeshWeaver.Blazor/Components/MarkdownHtmlRenderer.cs
+++ b/src/MeshWeaver.Blazor/Components/MarkdownHtmlRenderer.cs
@@ -43,6 +43,7 @@ public class MarkdownHtmlRenderer
     private readonly ISynchronizationStream? _stream;
     private readonly Action<string>? _runSubmission;
     private readonly Func<string, CodeCellRunState>? _runState;
+    private readonly MarkdownCellEditing? _cellEditing;
 
     /// <summary>
     /// Initialises the renderer with the current UI theme and an optional synchronization stream
@@ -56,16 +57,23 @@ public class MarkdownHtmlRenderer
     /// <param name="runState">Answers, per submission id, whether the cell's displayed output still belongs to
     /// the code shown (the hosting view's <c>CodeCellRunTracker</c>). Null → every cell renders as
     /// <see cref="CodeCellRunState.NeverRun"/>, i.e. no staleness claim at all.</param>
+    /// <param name="cellEditing">Supplied by the hosting view ONLY when the viewer may write the node —
+    /// the cells' code segments then hydrate into inline editors instead of static <c>&lt;pre&gt;</c>
+    /// blocks (#1636). Null (the default) is the read-only rendering, unchanged. 🚨 This renderer makes
+    /// NO permission decision of its own: passing this argument IS the decision, taken server-side by
+    /// the layout area that produced the control, exactly as the Code-node cell decides it.</param>
     public MarkdownHtmlRenderer(
         DesignThemeModes mode,
         ISynchronizationStream? stream,
         Action<string>? runSubmission = null,
-        Func<string, CodeCellRunState>? runState = null)
+        Func<string, CodeCellRunState>? runState = null,
+        MarkdownCellEditing? cellEditing = null)
     {
         _mode = mode;
         _stream = stream;
         _runSubmission = runSubmission;
         _runState = runState;
+        _cellEditing = cellEditing;
     }
 
     /// <summary>
@@ -128,6 +136,19 @@ public class MarkdownHtmlRenderer
                     break;
                 case { Name: "a" } when node.GetAttributeValue("class", "").Contains(LayoutAreaMarkdownRenderer.UcrLink):
                     RenderUcrLink(builder, node);
+                    break;
+                // The cell's CODE segment, when the hosting view says this viewer may write the node:
+                // hydrate the static <pre> into an inline editor, exactly as the toolbar marker below
+                // is hydrated into the Run bar. A read-only viewer — and every client that does not
+                // implement this — falls through to the default case and keeps the <pre>.
+                //
+                // 🚨 Ordered BEFORE the toolbar case only for readability; the two classes are
+                // disjoint. It must stay ahead of the `default:` arm, which is what renders the div
+                // and its children today.
+                case { Name: "div" } when _cellEditing is not null
+                                          && node.GetAttributeValue("class", "").Contains(ExecutableCodeBlockRenderer.CellCodeClass)
+                                          && node.GetAttributeValue(ExecutableCodeBlockRenderer.SubmissionIdAttribute, "") is { Length: > 0 } cellId:
+                    RenderCellEditor(builder, node, cellId);
                     break;
                 case { Name: "div" } when node.GetAttributeValue("class", "").Contains(ExecutableCodeBlockRenderer.CellToolbarClass):
                     var submissionId = node.GetAttributeValue(ExecutableCodeBlockRenderer.SubmissionIdAttribute, "");
@@ -245,6 +266,31 @@ public class MarkdownHtmlRenderer
                 || c is '=' or '"' or '\'' or '>' or '/' or '<')
                 return false;
         return true;
+    }
+
+    /// <summary>
+    /// Emits the inline editor for one executable cell. The seed is the code the fence holds NOW —
+    /// taken from the hosting view's current parse when it can answer, else read back out of the
+    /// rendered <c>&lt;pre&gt;</c>. <c>DeEntitize</c> is not optional on that fallback: the fence body
+    /// is HTML-escaped on the way in, so <c>&amp;lt;</c> would otherwise reach Monaco literally and a
+    /// generic type argument would arrive as mojibake.
+    /// <para>Keyed on the submission id so a re-render diffs the SAME editor rather than tearing one
+    /// down and mounting another under the viewer's cursor.</para>
+    /// </summary>
+    private void RenderCellEditor(RenderTreeBuilder builder, HtmlNode node, string submissionId)
+    {
+        var editing = _cellEditing!;
+        var seed = editing.CodeOf?.Invoke(submissionId)
+                   ?? MarkdownFenceEditing.StripFenceHeader(HtmlEntity.DeEntitize(node.InnerText));
+        builder.OpenComponent<MarkdownCodeCellEditor>(1);
+        builder.SetKey(submissionId);
+        builder.AddAttribute(2, nameof(MarkdownCodeCellEditor.SubmissionId), submissionId);
+        builder.AddAttribute(3, nameof(MarkdownCodeCellEditor.Language),
+            node.GetAttributeValue(ExecutableCodeBlockRenderer.LanguageAttribute, "csharp"));
+        builder.AddAttribute(4, nameof(MarkdownCodeCellEditor.NodePath), editing.NodePath);
+        builder.AddAttribute(5, nameof(MarkdownCodeCellEditor.InitialCode), seed);
+        builder.AddAttribute(6, nameof(MarkdownCodeCellEditor.OnBufferChanged), editing.OnBufferChanged);
+        builder.CloseComponent();
     }
 
     private void RenderUcrLink(RenderTreeBuilder builder, HtmlNode node)

--- a/src/MeshWeaver.Blazor/Components/MarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MarkdownView.razor.cs
@@ -53,6 +53,17 @@ public partial class MarkdownView
     // to the code on screen. Recorded at every submit site below; read while rendering.
     private readonly CodeCellRunTracker _runTracker = new();
 
+    // What each editable cell currently HOLDS, keyed by submission id — see
+    // CollaborativeMarkdownView's twin. Run must submit the buffer, not the last parse.
+    private readonly Dictionary<string, string> _cellBuffers = new(StringComparer.OrdinalIgnoreCase);
+
+    // Cached once: a method group allocates a NEW delegate on every evaluation, and these travel to
+    // the editor component as PARAMETERS. A parameter that changes identity every render marks the
+    // child dirty on every render — for a live Monaco that is exactly the churn the
+    // "the control must be identical across re-renders" rule exists to avoid.
+    private Func<string, string?>? _cellCode;
+    private Action<string, string>? _recordCellBuffer;
+
     // True once THIS view actually created the per-view kernel Activity node (owner resolved +
     // CreateActivityAndSubmit called). Gates the dispose-time teardown: deleting/cancelling an
     // activity that was never created would post to a nonexistent address and NotFound-storm the
@@ -291,11 +302,35 @@ public partial class MarkdownView
         // The cell toolbars' Run buttons are enabled only once the kernel activity is routable —
         // the same gate as the live result-area embed above. The run state is computed against the
         // CURRENT parse, so a cell whose code changed since its last run renders as stale.
+        // Editable cells only when the producing layout area SAID so (MarkdownControl.CanEdit,
+        // folded from hub.GetEffectivePermissions server-side) and there is a node to save into.
+        // Both halves are required: CanEdit defaults to false, so every existing producer — chat
+        // bubbles, generated Controls.Markdown, docs — keeps today's read-only rendering.
+        var editing = ViewModel.CanEdit && !string.IsNullOrEmpty(NodePathForEditing)
+            ? new MarkdownCellEditing(NodePathForEditing, _cellCode ??= CellCode, _recordCellBuffer ??= RecordCellBuffer)
+            : null;
+
         var renderer = new MarkdownHtmlRenderer(Mode, Stream,
             _kernelReady ? ResubmitBlock : null,
-            id => _runTracker.StateOf(id, CodeSubmissions));
+            id => _runTracker.StateOf(id, CodeSubmissions),
+            editing);
         renderer.ShowReferencesSection = ShowReferencesSection;
         renderer.RenderHtml(builder, html);
+    }
+
+    // The node an edit persists into: the control's explicit NodePath, else the bound stream's
+    // owner — the same precedence BindData uses to resolve relative @@ embeds.
+    private string? NodePathForEditing =>
+        MarkdownViewLogic.CoerceString(NodePathRaw) ?? Stream?.Owner?.ToString();
+
+    private string? CellCode(string submissionId) =>
+        CodeSubmissions?.FirstOrDefault(
+            s => string.Equals(s.Id, submissionId, StringComparison.OrdinalIgnoreCase))?.Code;
+
+    private void RecordCellBuffer(string submissionId, string text)
+    {
+        if (!string.IsNullOrEmpty(submissionId))
+            _cellBuffers[submissionId] = text;
     }
 
     // Re-posts one executable block's submission to the per-view kernel activity — the cell
@@ -308,6 +343,9 @@ public partial class MarkdownView
             .FirstOrDefault(s => string.Equals(s.Id, submissionId, StringComparison.OrdinalIgnoreCase));
         if (submission is null || !_kernelReady)
             return;
+        // Run the BUFFER, not the file — the debounced auto-save means the parse lags what the
+        // viewer is looking at. See CollaborativeMarkdownView.ApplyCellBuffer.
+        submission = ApplyCellBuffer(submission);
         _runTracker.Record(submission);
         Hub.Post(submission, o => o.WithTarget(KernelAddress));
         // The toolbar's OnRun is a plain Action, not an EventCallback, so nothing re-renders THIS
@@ -315,4 +353,15 @@ public partial class MarkdownView
         // so without this the "stale cell" chip survives the very re-run that cleared it.
         StateHasChanged();
     }
+
+    /// <summary>
+    /// The submission as the viewer's editor currently reads, when an editable cell has typed text
+    /// that has not been persisted yet. Unedited cells return the parsed submission unchanged.
+    /// </summary>
+    private SubmitCodeRequest ApplyCellBuffer(SubmitCodeRequest submission) =>
+        submission.Id is { Length: > 0 } id
+        && _cellBuffers.TryGetValue(id, out var buffer)
+        && buffer != submission.Code
+            ? submission with { Code = buffer }
+            : submission;
 }

--- a/src/MeshWeaver.Blazor/Components/MarkdownView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/MarkdownView.razor.css
@@ -423,3 +423,17 @@
     border-radius: 4px;
     color: var(--annotation-delete-color);
 }
+
+/* The EDITABLE code segment (#1636). MarkdownCodeCellEditor REPLACES the server's `code-content`
+   marker div for a viewer holding Update, exactly as MarkdownCodeCellToolbar replaces the toolbar
+   marker — so the hydrated DOM carries `md-cell-editor`, NOT `code-content`, and anything selecting
+   the cell's code in a live Blazor page (e2e, styling) must look for this class. The `md-code-cell`
+   frame around it is untouched server HTML and still identifies a workbench. */
+.markdown-body ::deep .md-cell-editor {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.markdown-body ::deep .md-code-cell .md-cell-editor {
+    border-bottom: 1px solid var(--neutral-stroke-rest);
+}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-editable-markdown-workbenches.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-editable-markdown-workbenches.md
@@ -1,0 +1,20 @@
+---
+Name: Markdown workbenches are editable
+Category: Fix
+Description: A runnable code cell written as a fence in a markdown page is now an editor, not a static block, for anyone who may edit the page.
+Icon: Sparkle
+Order: -20260821
+---
+
+# Markdown workbenches are editable
+
+An exercise, lesson or documentation page can carry a runnable code cell in two ways: as an embedded
+code node, or as a fenced block written straight into the page's own text. The first kind has been
+editable for a while. The second kind was not — it rendered as a static block, so on the pages where
+you were asked to write the answer, you could not type.
+
+Both kinds now behave the same. If you may edit the page, its runnable cells are real editors: type
+in them, press Run, and your work is saved back into the page as you go. If you may not edit the
+page — someone else's course, a published document — nothing changes: you still see the code and can
+still run it, exactly as before. Code blocks that are not runnable stay read-only for everyone,
+because they are material to read rather than a place to work.

--- a/src/MeshWeaver.Layout/MarkdownControl.cs
+++ b/src/MeshWeaver.Layout/MarkdownControl.cs
@@ -37,4 +37,23 @@ public record MarkdownControl(object Markdown)
     /// Defaults to true.
     /// </summary>
     public object ShowReferences { get; init; } = true;
+
+    /// <summary>
+    /// Whether this viewer may WRITE the node named by <see cref="NodePath"/>. When true, the
+    /// markdown's executable cells (<c>```csharp --render X --show-code</c>) render as inline
+    /// editors that persist back into their own fence, instead of static <c>&lt;pre&gt;</c> blocks
+    /// (#1636). <c>false</c> — the default — is the read-only rendering.
+    ///
+    /// <para>🚨 Set it from the SERVER's permission fold and nowhere else:
+    /// <c>host.Hub.GetEffectivePermissions(path).HasFlag(Permission.Update)</c>, the same evaluator
+    /// the Code-node cell and <see cref="CollaborativeMarkdownControl.CanEdit"/> use. Defaulting to
+    /// false is what keeps this from widening access as a side effect: a producer that does not know
+    /// the answer does not get to guess it.</para>
+    /// </summary>
+    public bool CanEdit { get; init; }
+
+    /// <summary>Returns a copy whose executable cells are editable per <paramref name="canEdit"/>.</summary>
+    /// <param name="canEdit">True when the viewer holds <c>Permission.Update</c> on <see cref="NodePath"/>.</param>
+    /// <returns>A new instance with the updated CanEdit.</returns>
+    public MarkdownControl WithCanEdit(bool canEdit) => this with { CanEdit = canEdit };
 }

--- a/src/MeshWeaver.Markdown/ExecutableCodeBlockExtension.cs
+++ b/src/MeshWeaver.Markdown/ExecutableCodeBlockExtension.cs
@@ -147,15 +147,37 @@ public class ExecutableCodeBlock(BlockParser parser) : FencedCodeBlock(parser)
         var language = string.IsNullOrWhiteSpace(Info) ? "csharp" : Info;
         // --execute: silent execution (explicit opt-in).
         if (Args.TryGetValue(Execute, out var executionId))
-            return new(string.Join('\n', Lines.Lines)) { Id = executionId ?? Guid.NewGuid().AsString(), Language = language };
+            return new(Body()) { Id = executionId ?? Guid.NewGuid().AsString(), Language = language };
         if (SubmitCode is not null)
             return SubmitCode;
         // --render <AreaId>: execute + stream output to a named layout area.
         if (Args.TryGetValue(Render, out var renderId))
-            return new(string.Join('\n', Lines.Lines)) { Id = renderId ?? Guid.NewGuid().AsString(), Language = language };
+            return new(Body()) { Id = renderId ?? Guid.NewGuid().AsString(), Language = language };
         // Bare ```csharp blocks are documentation-only by default.
         // Use --execute for silent execution or --render <AreaId> to stream output.
         return null;
+    }
+
+    /// <summary>
+    /// The fence's body as a single string.
+    ///
+    /// <para>🚨 Bounded by <c>Lines.Count</c> and null-safe, which the raw
+    /// <c>string.Join('\n', Lines.Lines)</c> was neither. <c>StringLineGroup.Lines</c> is a
+    /// capacity-sized array that is <b>null until the first line is added</b>, so an EMPTY
+    /// executable fence — <c>```csharp --render X --show-code</c> with nothing between the fences,
+    /// the natural shape of a "write your answer here" workbench — threw out of
+    /// <see cref="Initialize"/> and took the whole document's parse down with it. It also joined the
+    /// unused tail of an over-allocated array, appending phantom blank lines to the submitted code.
+    /// Found while making markdown cells editable (#1636): clearing a cell is a legal edit, and it
+    /// must not brick the page it lives on.</para>
+    /// </summary>
+    private string Body()
+    {
+        var lines = Lines.Lines;
+        var count = Lines.Count;
+        if (lines is null || count <= 0)
+            return string.Empty;
+        return string.Join('\n', lines.Take(count));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Markdown/ExecutableCodeBlockRenderer.cs
+++ b/src/MeshWeaver.Markdown/ExecutableCodeBlockRenderer.cs
@@ -36,6 +36,16 @@ public class ExecutableCodeBlockRenderer : CodeBlockRenderer
     /// <summary>CSS class of the output segment holding the kernel result area inside the cell frame.</summary>
     public const string CellOutputClass = "md-code-cell-output";
 
+    /// <summary>
+    /// CSS class of the cell's CODE segment. Inside a cell frame it doubles as a marker: it carries
+    /// the same <see cref="SubmissionIdAttribute"/> / <see cref="LanguageAttribute"/> the toolbar
+    /// marker carries, so a client renderer can swap the static <c>&lt;pre&gt;</c> for a live editor
+    /// exactly the way it already swaps the toolbar marker for the Run bar (#1636). A client that
+    /// does not (React, React Native, any static HTML consumer) sees an ordinary div and keeps
+    /// rendering the fence read-only — the attributes are additive.
+    /// </summary>
+    public const string CellCodeClass = "code-content";
+
     /// <summary>Attribute on the toolbar marker carrying the block's submission id (= its result-area name).</summary>
     public const string SubmissionIdAttribute = "data-submission-id";
 
@@ -83,7 +93,7 @@ public class ExecutableCodeBlockRenderer : CodeBlockRenderer
 
         if (showsHeader)
         {
-            renderer.Write("<div class=\"code-content\">");
+            renderer.Write(OpenCodeSegment(fenced, isCell));
             renderer.Write($"<pre><code class='language-{fenced.Info}'>");
             renderer.WriteLine("```" + fenced.Info + $" {fenced.Arguments}");
 
@@ -95,7 +105,7 @@ public class ExecutableCodeBlockRenderer : CodeBlockRenderer
         }
         else if (showsCode)
         {
-            renderer.Write("<div class=\"code-content\">");
+            renderer.Write(OpenCodeSegment(fenced, isCell));
             base.Write(renderer, obj);
             renderer.Write("</div>");
         }
@@ -167,4 +177,16 @@ public class ExecutableCodeBlockRenderer : CodeBlockRenderer
     }
 
 
+    /// <summary>
+    /// The opening tag of the cell's code segment. Inside a cell frame it carries the submission id
+    /// and language — the marker a client needs to hydrate the segment into an editor; outside one
+    /// (a bare <c>--show-code</c> block with nothing to run) it stays a plain styling div, because
+    /// there is no submission to address and nothing to persist an edit into.
+    /// </summary>
+    private static string OpenCodeSegment(ExecutableCodeBlock fenced, bool isCell) =>
+        isCell
+            ? $"<div class=\"{CellCodeClass}\" " +
+              $"{SubmissionIdAttribute}=\"{HttpUtility.HtmlAttributeEncode(fenced.SubmitCode!.Id)}\" " +
+              $"{LanguageAttribute}=\"{HttpUtility.HtmlAttributeEncode(fenced.SubmitCode.Language)}\">"
+            : $"<div class=\"{CellCodeClass}\">";
 }

--- a/src/MeshWeaver.Markdown/MarkdownFenceEditing.cs
+++ b/src/MeshWeaver.Markdown/MarkdownFenceEditing.cs
@@ -1,0 +1,213 @@
+using Markdig.Syntax;
+
+namespace MeshWeaver.Markdown;
+
+/// <summary>
+/// PURE source surgery on the executable fences inside a markdown body: read the code a
+/// <c>--render</c>/<c>--execute</c> cell currently holds, and write a new body back into exactly
+/// that fence, leaving every other byte of the document alone.
+///
+/// <para>This is what makes a markdown workbench editable (#1636). The learner's cell is a fence in
+/// the node's <see cref="MarkdownContent.Content"/>, not a Code child node, so persisting an edit
+/// means replacing the fence's BODY — and only its body. Addressed by the fence's submission id
+/// (its <c>--render &lt;id&gt;</c> argument), which is the same id the toolbar, the kernel result
+/// area and <see cref="CodeCellRunTracker"/> already use.</para>
+///
+/// <para>🚨 The id is matched case-INSENSITIVELY on purpose: <c>ExecutableCodeBlock.ParseArguments</c>
+/// lower-cases argument values, so a fence written <c>--render SpotGap</c> produces the submission id
+/// <c>spotgap</c>. Matching ordinally would find nothing for every fence whose author used
+/// PascalCase — which is all of them.</para>
+///
+/// <para>Everything here is a pure function over strings: no hub, no stream, no I/O. That is
+/// deliberate — the persistence path is the part that must be pinned by tests before an editable
+/// cell ships (#1606: a Code node's edit that did not survive a reload).</para>
+/// </summary>
+public static class MarkdownFenceEditing
+{
+    /// <summary>
+    /// The code currently inside the fence whose submission id is <paramref name="submissionId"/>,
+    /// or <c>null</c> when the document holds no such executable fence.
+    /// </summary>
+    /// <param name="markdown">The raw markdown body to read.</param>
+    /// <param name="submissionId">The fence's submission id (its <c>--render</c>/<c>--execute</c> value).</param>
+    public static string? FenceBody(string? markdown, string? submissionId) =>
+        Locate(markdown, submissionId) is { } found ? found.Body : null;
+
+    /// <summary>
+    /// Returns <paramref name="markdown"/> with the body of the fence identified by
+    /// <paramref name="submissionId"/> replaced by <paramref name="newCode"/>, or <c>null</c> when
+    /// the document holds no such executable fence (the caller must then write NOTHING — a
+    /// not-found must never be turned into an append or a whole-document overwrite).
+    ///
+    /// <para>Only the body bytes move. The info string, the fence arguments, the fence characters,
+    /// the surrounding prose and every OTHER fence are preserved verbatim, so a save cannot rewrite
+    /// a document the viewer never touched. An indented fence (inside a list item) keeps its
+    /// indentation: every line of the new body is re-indented to the fence's own column.</para>
+    /// </summary>
+    /// <param name="markdown">The raw markdown body to edit.</param>
+    /// <param name="submissionId">The fence's submission id (its <c>--render</c>/<c>--execute</c> value).</param>
+    /// <param name="newCode">The replacement code, without a trailing newline.</param>
+    public static string? ReplaceFenceBody(string? markdown, string? submissionId, string? newCode)
+    {
+        if (Locate(markdown, submissionId) is not { } found)
+            return null;
+
+        var code = NormalizeNewlines(newCode ?? string.Empty);
+        // An EMPTY fence has no body bytes to overwrite, so the span is a zero-width insertion
+        // point at the start of the CLOSING fence line. Text written there must bring its own
+        // indentation and its own newline, or the first line of code fuses with the ``` that ends
+        // the block — the fence stops closing and the rest of the document is swallowed into it.
+        var replacement = found.IsInsertionPoint && code.Length > 0
+            ? Indent(code, found.Indent, indentFirstLine: true) + "\n"
+            : Indent(code, found.Indent, indentFirstLine: false);
+        return markdown!.Substring(0, found.Start) + replacement + markdown.Substring(found.End);
+    }
+
+    /// <summary>
+    /// The inline editor's height for a markdown cell seeded with <paramref name="code"/>: Monaco's
+    /// 19px per line plus the frame chrome, clamped to [96, 480] px. Computed once from the SEED —
+    /// a height that followed the text would change the editor control on every keystroke and
+    /// re-mount Monaco under the viewer's cursor. Mirrors <c>CodeLayoutAreas.CellEditorHeight</c>
+    /// so the two cell shapes read identically; pure.
+    /// </summary>
+    /// <param name="code">The code the editor is seeded with.</param>
+    public static string CellEditorHeight(string? code)
+    {
+        var lines = string.IsNullOrEmpty(code) ? 1 : code!.Split('\n').Length;
+        var px = Math.Clamp(lines * 19 + 20, 96, 480);
+        return $"{px}px";
+    }
+
+    /// <summary>
+    /// Drops the fence delimiter lines from <paramref name="text"/> — the leading
+    /// <c>```lang --args</c> and the trailing <c>```</c>.
+    ///
+    /// <para>Needed only on the LAST-RESORT seed path. A <c>--show-header</c> cell deliberately
+    /// renders its own fence header inside the code segment, so text scraped back out of that
+    /// <c>&lt;pre&gt;</c> carries delimiters the fence body never contained. Seeding an editor with
+    /// them would put them into the code on the first save. Pure; a no-op on text that has none.</para>
+    /// </summary>
+    /// <param name="text">Text read back out of a rendered code segment.</param>
+    public static string StripFenceHeader(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return string.Empty;
+        var lines = NormalizeNewlines(text!).Split('\n').ToList();
+        if (lines.Count > 0 && lines[0].TrimStart().StartsWith("```", StringComparison.Ordinal))
+            lines.RemoveAt(0);
+        while (lines.Count > 0 && lines[^1].Trim().Length == 0)
+            lines.RemoveAt(lines.Count - 1);
+        if (lines.Count > 0 && lines[^1].Trim() == "```")
+            lines.RemoveAt(lines.Count - 1);
+        return string.Join('\n', lines);
+    }
+
+    private readonly record struct Located(
+        int Start, int End, string Body, int Indent, bool IsInsertionPoint);
+
+    /// <summary>
+    /// Finds the executable fence carrying <paramref name="submissionId"/> and returns the
+    /// half-open source span of its BODY. Uses the same Markdig pipeline that produced the
+    /// submission id in the first place — never a regex over fence syntax, which cannot tell a
+    /// fence from a fence quoted inside another fence.
+    /// </summary>
+    private static Located? Locate(string? markdown, string? submissionId)
+    {
+        if (string.IsNullOrEmpty(markdown) || string.IsNullOrEmpty(submissionId))
+            return null;
+
+        var pipeline = MarkdownExtensions.CreateMarkdownPipeline(null, null);
+        var document = Markdig.Markdown.Parse(markdown, pipeline);
+
+        foreach (var block in document.Descendants<ExecutableCodeBlock>())
+        {
+            block.Initialize();
+            var submission = block.GetSubmitCodeRequest();
+            if (submission is null
+                || !string.Equals(submission.Id, submissionId, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            return BodySpan(block, markdown!);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The half-open <c>[start,end)</c> source span of a fenced block's body, derived from the
+    /// per-line slices Markdig kept into the ORIGINAL document string.
+    ///
+    /// <para>An EMPTY fence has no lines at all, so there is no slice to anchor on: the span
+    /// collapses to the position just after the opening fence line's newline, which is exactly
+    /// where a first line of code belongs.</para>
+    /// </summary>
+    private static Located? BodySpan(ExecutableCodeBlock block, string markdown)
+    {
+        var indent = FenceColumn(block, markdown);
+        var lines = block.Lines.Lines;
+        var count = block.Lines.Count;
+
+        if (count <= 0)
+        {
+            var openEnd = markdown.IndexOf('\n', block.Span.Start);
+            if (openEnd < 0)
+                return null;
+            return new Located(openEnd + 1, openEnd + 1, string.Empty, indent, IsInsertionPoint: true);
+        }
+
+        var start = lines[0].Slice.Start;
+        // Slice.End is INCLUSIVE of the last character, and an empty trailing line has End < Start.
+        // Clamping to `start` keeps the span half-open and non-negative in both cases.
+        var last = lines[count - 1].Slice;
+        var end = Math.Max(start, last.End + 1);
+        if (start < 0 || end > markdown.Length || start > end)
+            return null;
+
+        return new Located(
+            start, end, markdown.Substring(start, end - start), indent, IsInsertionPoint: false);
+    }
+
+    /// <summary>
+    /// The COLUMN the opening fence sits in, read off the source.
+    ///
+    /// <para>🚨 Not <c>block.IndentCount</c>, which is the fence's indent RELATIVE to its container
+    /// and is therefore <c>0</c> for the case that actually needs re-indenting — a fence nested in a
+    /// list item, where the container already supplies two spaces. Measuring from the start of the
+    /// line gives the absolute column, which is what the closing fence is aligned to; get this wrong
+    /// and a multi-line save silently pushes the closing fence out of the list, so the rest of the
+    /// document becomes part of the code block.</para>
+    /// </summary>
+    private static int FenceColumn(Block block, string markdown)
+    {
+        var fenceStart = block.Span.Start;
+        if (fenceStart <= 0 || fenceStart > markdown.Length)
+            return 0;
+        var lineStart = markdown.LastIndexOf('\n', fenceStart - 1) + 1;
+        for (var i = lineStart; i < fenceStart; i++)
+            if (markdown[i] is not (' ' or '\t'))
+                return 0;
+        return fenceStart - lineStart;
+    }
+
+    private static string NormalizeNewlines(string code) =>
+        code.Replace("\r\n", "\n").Replace('\r', '\n');
+
+    /// <summary>
+    /// Re-indents <paramref name="code"/> to <paramref name="indent"/> spaces.
+    ///
+    /// <para>The first line is skipped unless <paramref name="indentFirstLine"/> — when the fence
+    /// already HAS a body, that line's indentation sits in the document before the replaced span,
+    /// so indenting it again would double it. At an insertion point there is nothing before it,
+    /// so it needs the pad like every other line.</para>
+    /// </summary>
+    private static string Indent(string code, int indent, bool indentFirstLine)
+    {
+        if (indent <= 0)
+            return code;
+        var pad = new string(' ', indent);
+        var lines = code.Split('\n');
+        for (var i = indentFirstLine ? 0 : 1; i < lines.Length; i++)
+            lines[i] = lines[i].Length == 0 ? lines[i] : pad + lines[i];
+        return string.Join('\n', lines);
+    }
+}

--- a/test/MeshWeaver.Content.Test/MarkdownCellEditingTest.cs
+++ b/test/MeshWeaver.Content.Test/MarkdownCellEditingTest.cs
@@ -1,0 +1,166 @@
+using MeshWeaver.Blazor.Components;
+using MeshWeaver.Markdown;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Xunit;
+
+namespace MeshWeaver.Content.Test;
+
+/// <summary>
+/// #1636 — <b>ALL code cells must be editable</b>, including the fenced
+/// <c>```csharp --render X --show-code</c> workbench inside a markdown BODY, which is what a large
+/// share of exercise and lesson workbenches are (every ReinsurancePractice exercise, for one).
+/// Editing already worked for Code NODES; the fence stayed a static <c>&lt;pre&gt;</c>, so the one
+/// place a learner is asked to write was the one place they could not type.
+///
+/// <para>These pin the CLIENT half: which cells hydrate into an editor, for whom, and that a
+/// read-only viewer's page is byte-for-byte the page they saw before. The persistence half —
+/// where the edit lands and that a re-parse finds it — is pinned purely in
+/// <c>MarkdownFenceEditingTest</c>, and deliberately comes first (#1606 shipped a Code-node edit
+/// that did not survive a reload).</para>
+/// </summary>
+public class MarkdownCellEditingTest
+{
+    private const string Workbench =
+        "Some prose.\n\n```csharp --render SpotGap --show-code\nvar answer = 0; // TODO\n```\n\nMore prose.\n";
+
+    private const string GivenMaterial =
+        "Read this code and say what is wrong with it.\n\n```csharp\nvar broken = 1;\n```\n";
+
+    private static string Html(string markdown) =>
+        Markdig.Markdown.ToHtml(markdown, MarkdownExtensions.CreateMarkdownPipeline(null, null));
+
+    /// <summary>
+    /// The names of every component the renderer emitted, in document order. Read off the frames
+    /// because there is no public API that reports what a RenderTreeBuilder was told to build.
+    /// </summary>
+    private static List<string> ComponentsOf(string markdown, MarkdownCellEditing? editing)
+    {
+        var renderer = new MarkdownHtmlRenderer(
+            DesignThemeModes.Light, stream: null, runSubmission: null, runState: null, cellEditing: editing);
+        var builder = new RenderTreeBuilder();
+        renderer.RenderHtml(builder, Html(markdown));
+
+        // BL0006: inspecting render-tree frames is exactly how the sibling tag-safety test pins its
+        // invariant — there is no public API for it. Intentional, test-only.
+#pragma warning disable BL0006
+        var frames = builder.GetFrames();
+        var names = new List<string>();
+        for (var i = 0; i < frames.Count; i++)
+        {
+            var frame = frames.Array[i];
+            if (frame.FrameType == RenderTreeFrameType.Component)
+                names.Add(frame.ComponentType.Name);
+        }
+        return names;
+#pragma warning restore BL0006
+    }
+
+    private static MarkdownCellEditing MayWrite(Action<string, string>? onBuffer = null) =>
+        new("Course/Lesson/Exercise/SpotTheGap", _ => null, onBuffer);
+
+    [Fact]
+    public void ViewerWithUpdate_GetsAnEditorInsteadOfTheStaticPre()
+    {
+        var components = ComponentsOf(Workbench, MayWrite());
+
+        components.Should().Contain(nameof(MarkdownCodeCellEditor),
+            "a viewer who may write the node edits the workbench IN PLACE — the same rule the "
+            + "Code-node cell follows, and the whole point of #1636");
+        components.Should().NotContain("CodeBlock",
+            "the static code block is REPLACED, not rendered beside the editor");
+        components.Should().Contain(nameof(MarkdownCodeCellToolbar),
+            "the cell keeps its Run bar — an editable cell that cannot be run is half a workbench");
+    }
+
+    [Fact]
+    public void ViewerWithoutUpdate_KeepsTheReadOnlyRendering()
+    {
+        // 🚨 The permission decision is the hosting view's, taken server-side from the same
+        // evaluator the Code-node cell uses; the renderer is handed the ANSWER. Null is "read-only",
+        // and it is the default on every constructor that does not opt in — which is what stops this
+        // from widening access as a side effect anywhere it was not deliberately wired.
+        var components = ComponentsOf(Workbench, editing: null);
+
+        components.Should().NotContain(nameof(MarkdownCodeCellEditor));
+        components.Should().Contain("CodeBlock", "a read-only viewer still SEES the code");
+        components.Should().Contain(nameof(MarkdownCodeCellToolbar),
+            "and can still run it — running was never gated on Update");
+    }
+
+    [Fact]
+    public void GivenMaterial_StaysReadOnlyEvenForAViewerWhoMayWrite()
+    {
+        // A plain fence is given material: legacy code to diagnose, an incident, code under review.
+        // It deliberately pre-exists, carries no submission id, and nothing addresses it — so
+        // "all code cells editable" must not become "all code editable".
+        var components = ComponentsOf(GivenMaterial, MayWrite());
+
+        components.Should().NotContain(nameof(MarkdownCodeCellEditor));
+        components.Should().Contain("CodeBlock");
+    }
+
+    [Fact]
+    public void EveryWorkbenchInADocumentBecomesItsOwnEditor()
+    {
+        const string two = "```csharp --render First --show-code\nvar a = 1;\n```\n\n"
+                           + "```csharp --render Second --show-code\nvar b = 2;\n```\n";
+
+        var components = ComponentsOf(two, MayWrite());
+
+        components.Count(n => n == nameof(MarkdownCodeCellEditor)).Should().Be(2,
+            "ALL code cells editable — a page's second workbench is not a lesser one");
+    }
+
+    [Fact]
+    public void HiddenCodeCellIsNotAnEditor()
+    {
+        // `--render X` WITHOUT --show-code is a live demo: it streams a result and deliberately shows
+        // no source. There is nothing on screen to edit, and materialising an editor for it would put
+        // code in front of the reader that the author chose to hide.
+        var components = ComponentsOf("```csharp --render Hidden\nControls.Html(\"<b>hi</b>\")\n```", MayWrite());
+
+        components.Should().NotContain(nameof(MarkdownCodeCellEditor));
+    }
+
+    [Fact]
+    public void TheEditorIsSeededFromTheHostingViewsParse_NotFromReDecodedHtml()
+    {
+        // The seed has to survive HTML escaping: a generic argument or a comparison in the fence body
+        // is written as &lt; on the way in. The hosting view answers from its own parse when it can —
+        // this pins that the resolver is consulted and its answer wins.
+        var seen = new List<string>();
+        var editing = new MarkdownCellEditing(
+            "Course/Page",
+            id => { seen.Add(id); return "List<int> xs = [];"; },
+            null);
+
+        ComponentsOf(Workbench, editing).Should().Contain(nameof(MarkdownCodeCellEditor));
+        // The id the renderer asks with is the SUBMISSION id — lower-cased by ParseArguments,
+        // which is why every lookup on it is case-insensitive. Asking with the author's `SpotGap`
+        // would miss in every consumer that keys on the submission.
+        seen.Should().Equal("spotgap");
+    }
+
+    [Fact]
+    public void EditsRoundTripToWhereTheRunnerReadsThem()
+    {
+        // The end-to-end claim, stated where it can be proven without a circuit: what the editor
+        // saves is what a fresh parse of the stored body hands the kernel under the same id. The
+        // component's save is exactly ReplaceFenceBody + MarkdownContent.Parse, so this IS that path.
+        const string answer = "var answer = 42;";
+
+        var saved = MarkdownFenceEditing.ReplaceFenceBody(Workbench, "spotgap", answer);
+        saved.Should().NotBeNull();
+
+        var stored = MarkdownContent.Parse(saved!);
+        stored.CodeSubmissions.Should().NotBeNull();
+        stored.CodeSubmissions!.Single(s => s.Id == "spotgap").Code.Trim().Should().Be(answer);
+
+        // …and the page the NEXT reader gets is rendered from that same body, so the editor they
+        // open is seeded with the saved answer rather than the original stub.
+        stored.PrerenderedHtml.Should().NotBeNull();
+        stored.PrerenderedHtml!.Should().Contain("var answer = 42;").And.NotContain("// TODO");
+    }
+}

--- a/test/MeshWeaver.Markdown.Test/ExecutableCodeCellRenderingTest.cs
+++ b/test/MeshWeaver.Markdown.Test/ExecutableCodeCellRenderingTest.cs
@@ -85,7 +85,12 @@ public class ExecutableCodeCellRenderingTest
     {
         var html = Render("```python --render PyDemo --show-code\nprint(1)\n```");
 
-        html.Should().Contain($"{ExecutableCodeBlockRenderer.LanguageAttribute}=\"python\"");
+        // On the CODE segment specifically — the toolbar marker carries the language too, so an
+        // unanchored substring check would pass against an unmarked code segment.
+        html.Should().Contain(
+            $"<div class=\"{ExecutableCodeBlockRenderer.CellCodeClass}\" " +
+            $"{ExecutableCodeBlockRenderer.SubmissionIdAttribute}=\"pydemo\" " +
+            $"{ExecutableCodeBlockRenderer.LanguageAttribute}=\"python\">");
     }
 
     [Fact]
@@ -121,5 +126,79 @@ public class ExecutableCodeCellRenderingTest
         pending.Should().Contain("markdown-kernel-pending");
         pending.Should().Contain(ExecutableCodeBlockRenderer.CellOutputClass,
             "the notice renders inside the cell's output segment");
+    }
+
+    // ── #1636: the code segment carries the marker a client needs to hydrate it ──────────────
+    //
+    // Editing worked for Code NODES and not for the fences inside a markdown body, which is what
+    // most exercise/lesson workbenches actually are. The toolbar marker already showed the shape of
+    // the fix: a client swaps a marked div for a live component. The code segment simply had no
+    // marker, so it stayed a <pre> — the one place a learner is asked to write was the one place
+    // they could not type.
+
+    [Fact]
+    public void CellCodeSegment_CarriesTheSubmissionIdAndLanguage()
+    {
+        var html = Render("```csharp --render MyDemo --show-code\nControls.Markdown(\"hi\")\n```");
+
+        html.Should().Contain(
+            $"<div class=\"{ExecutableCodeBlockRenderer.CellCodeClass}\" " +
+            $"{ExecutableCodeBlockRenderer.SubmissionIdAttribute}=\"mydemo\" " +
+            $"{ExecutableCodeBlockRenderer.LanguageAttribute}=\"csharp\">",
+            "a client can only hydrate the code segment into an editor if the segment says WHICH "
+            + "cell it is — the same two attributes the toolbar marker already carries");
+    }
+
+    [Fact]
+    public void ShowHeaderVariant_CarriesTheMarkerToo()
+    {
+        // --show-header renders through a DIFFERENT branch of the renderer. Marking only one branch
+        // is exactly the silent inconsistency the toolbar-placement fix had to clean up once already.
+        var html = Render("```csharp --render HeaderDemo --show-header\n1 + 1\n```");
+
+        html.Should().Contain(
+            $"{ExecutableCodeBlockRenderer.SubmissionIdAttribute}=\"headerdemo\"")
+            .And.Contain($"<div class=\"{ExecutableCodeBlockRenderer.CellCodeClass}\" ");
+    }
+
+    [Fact]
+    public void PythonCell_CarriesItsOwnLanguage()
+    {
+        var html = Render("```python --render PyDemo --show-code\nprint(1)\n```");
+
+        // On the CODE segment specifically — the toolbar marker carries the language too, so an
+        // unanchored substring check would pass against an unmarked code segment.
+        html.Should().Contain(
+            $"<div class=\"{ExecutableCodeBlockRenderer.CellCodeClass}\" " +
+            $"{ExecutableCodeBlockRenderer.SubmissionIdAttribute}=\"pydemo\" " +
+            $"{ExecutableCodeBlockRenderer.LanguageAttribute}=\"python\">");
+    }
+
+    [Fact]
+    public void GivenMaterial_IsNotMarkedAndSoCanNeverBecomeAnEditor()
+    {
+        // A plain fence is GIVEN material — legacy code to diagnose, an incident, code under review.
+        // It has no submission, nothing addresses it, and it must stay a static <pre>. This is the
+        // assertion that keeps "all code cells editable" from becoming "all code editable".
+        var html = Render("```csharp\nvar broken = 1;\n```");
+
+        html.Should().NotContain(ExecutableCodeBlockRenderer.SubmissionIdAttribute);
+        html.Should().NotContain(ExecutableCodeBlockRenderer.CellClass);
+    }
+
+    [Fact]
+    public void EmptyCell_ParsesInsteadOfThrowing()
+    {
+        // 🚨 A "write your answer here" workbench is an EMPTY fence, and an editable cell makes
+        // clearing one a legal edit. StringLineGroup.Lines is null until the first line is added, so
+        // the raw string.Join over it threw out of Initialize() and took the whole document's parse
+        // with it — a saved-empty cell would have bricked the page it lives on.
+        var html = Render("```csharp --render Blank --show-code\n```");
+
+        html.Should().Contain($"{ExecutableCodeBlockRenderer.SubmissionIdAttribute}=\"blank\"");
+
+        var parsed = MarkdownContent.Parse("```csharp --render Blank --show-code\n```");
+        parsed.CodeSubmissions.Should().NotBeNull();
+        parsed.CodeSubmissions!.Single().Code.Should().BeEmpty();
     }
 }

--- a/test/MeshWeaver.Markdown.Test/MarkdownFenceEditingTest.cs
+++ b/test/MeshWeaver.Markdown.Test/MarkdownFenceEditingTest.cs
@@ -1,0 +1,179 @@
+using Xunit;
+
+namespace MeshWeaver.Markdown.Test;
+
+/// <summary>
+/// Pins the persistence half of #1636 — "ALL code cells must be editable". A markdown workbench is a
+/// fence in the node's body, so an edit has to land back in THAT fence and nowhere else. The
+/// surgery is a pure function precisely so the round-trip is provable without a hub, a circuit or a
+/// mesh: #1606 shipped a Code-node edit that did not survive a reload, and the lesson taken from it
+/// is that the persistence test comes FIRST.
+/// </summary>
+public class MarkdownFenceEditingTest
+{
+    private const string Doc = """
+# Exercise
+
+Some prose that must not move.
+
+```csharp --render SpotGap --show-code
+static double Premium(double x)
+    => 0.0;   // TODO
+```
+
+More prose.
+
+```csharp
+// GIVEN MATERIAL — a plain fence. Not a workbench, not addressable.
+var broken = 1;
+```
+
+```csharp --render Other --show-code
+var other = 2;
+```
+""";
+
+    [Fact]
+    public void FenceBody_ReadsTheCellAddressedByItsSubmissionId()
+    {
+        // The author wrote `--render SpotGap`; ParseArguments lower-cases argument values, so the
+        // submission id every other surface uses is `spotgap`. Both must address the same fence, or
+        // the editor seeds from one cell and saves into another.
+        MarkdownFenceEditing.FenceBody(Doc, "spotgap").Should()
+            .Contain("static double Premium").And.Contain("// TODO");
+        MarkdownFenceEditing.FenceBody(Doc, "SpotGap").Should()
+            .Be(MarkdownFenceEditing.FenceBody(Doc, "spotgap"),
+                "the id is matched case-insensitively — a PascalCase --render value is the norm");
+    }
+
+    [Fact]
+    public void ReplaceFenceBody_RoundTripsToWhereTheRunnerReadsIt()
+    {
+        const string answer = "static double Premium(double x)\n    => x * 2;";
+
+        var updated = MarkdownFenceEditing.ReplaceFenceBody(Doc, "spotgap", answer);
+
+        updated.Should().NotBeNull();
+        // THE round-trip that matters: the runner does not read the editor, it re-parses the
+        // document and posts the submission it finds. So the edit is only persisted if a fresh
+        // parse of the saved markdown yields the new code under the SAME id.
+        var reparsed = MarkdownContent.Parse(updated!);
+        reparsed.CodeSubmissions.Should().NotBeNull();
+        var submission = reparsed.CodeSubmissions!.Single(s => s.Id == "spotgap");
+        submission.Code.Trim().Should().Be(answer);
+    }
+
+    [Fact]
+    public void ReplaceFenceBody_TouchesNothingButTheAddressedFence()
+    {
+        var updated = MarkdownFenceEditing.ReplaceFenceBody(Doc, "spotgap", "var replaced = 1;");
+
+        updated.Should().NotBeNull();
+        updated!.Should().Contain("# Exercise")
+            .And.Contain("Some prose that must not move.")
+            .And.Contain("More prose.")
+            .And.Contain("// GIVEN MATERIAL")
+            .And.Contain("var other = 2;", "a sibling workbench is not part of this edit")
+            .And.Contain("```csharp --render SpotGap --show-code",
+                "the fence header — info string AND arguments — is preserved verbatim")
+            .And.NotContain("// TODO", "the old body is gone");
+    }
+
+    [Fact]
+    public void ReplaceFenceBody_GivenMaterialIsNotAddressable()
+    {
+        // A fence with no --render/--execute is documentation, not a workbench: it produces no
+        // submission id, so nothing can address it and no edit can ever be written into it.
+        MarkdownFenceEditing.FenceBody(Doc, "broken").Should().BeNull();
+        MarkdownFenceEditing.ReplaceFenceBody(Doc, "broken", "hacked").Should().BeNull();
+    }
+
+    [Fact]
+    public void ReplaceFenceBody_UnknownIdReturnsNullRatherThanRewritingTheDocument()
+    {
+        // 🚨 A not-found must never degrade into "write the whole body" — that is how an auto-save
+        // turns a missing fence into a wiped exercise.
+        MarkdownFenceEditing.ReplaceFenceBody(Doc, "nosuchcell", "x").Should().BeNull();
+        MarkdownFenceEditing.ReplaceFenceBody(null, "spotgap", "x").Should().BeNull();
+        MarkdownFenceEditing.ReplaceFenceBody(Doc, null, "x").Should().BeNull();
+    }
+
+    [Fact]
+    public void ReplaceFenceBody_HandlesAnEmptyCellAndAnEmptyEdit()
+    {
+        const string empty = "before\n\n```csharp --render Blank --show-code\n```\n\nafter\n";
+
+        var filled = MarkdownFenceEditing.ReplaceFenceBody(empty, "blank", "var x = 1;");
+        filled.Should().NotBeNull();
+        MarkdownContent.Parse(filled!).CodeSubmissions!
+            .Single(s => s.Id == "blank").Code.Trim().Should().Be("var x = 1;");
+
+        // …and back to empty: clearing the cell must not eat the closing fence.
+        var cleared = MarkdownFenceEditing.ReplaceFenceBody(filled!, "blank", "");
+        cleared.Should().NotBeNull();
+        cleared!.Should().Contain("before").And.Contain("after");
+        MarkdownFenceEditing.FenceBody(cleared, "blank").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceFenceBody_ReIndentsIntoAnIndentedFence()
+    {
+        const string inList = "- step one\n\n  ```csharp --render Nested --show-code\n  var a = 1;\n  ```\n\n- step two\n";
+
+        var updated = MarkdownFenceEditing.ReplaceFenceBody(inList, "nested", "var a = 1;\nvar b = 2;");
+
+        updated.Should().NotBeNull();
+        updated!.Should().Contain("  var b = 2;",
+            "a fence inside a list item keeps its column, or the closing fence stops closing it");
+        MarkdownContent.Parse(updated!).CodeSubmissions!
+            .Single(s => s.Id == "nested").Code.Should().Contain("var b = 2;");
+        updated.Should().Contain("- step two", "the list must survive the edit");
+    }
+
+    [Fact]
+    public void ReplaceFenceBody_NormalisesWindowsNewlinesFromTheBrowser()
+    {
+        // Monaco hands back \r\n on Windows clients; leaving them in makes the stored body differ
+        // from what any other editor writes and shows as ^M in every diff.
+        var updated = MarkdownFenceEditing.ReplaceFenceBody(Doc, "spotgap", "var a = 1;\r\nvar b = 2;");
+
+        updated.Should().NotBeNull();
+        updated!.Should().NotContain("\r");
+    }
+
+    [Theory]
+    [InlineData(null, "96px")]
+    [InlineData("one line", "96px")]
+    public void CellEditorHeight_ClampsToTheSameFloorAsTheCodeNodeCell(string? code, string expected) =>
+        MarkdownFenceEditing.CellEditorHeight(code).Should().Be(expected);
+
+    [Fact]
+    public void CellEditorHeight_GrowsWithTheSeedAndStopsAtTheCeiling()
+    {
+        MarkdownFenceEditing.CellEditorHeight(string.Join('\n', Enumerable.Repeat("x", 10)))
+            .Should().Be("210px");
+        MarkdownFenceEditing.CellEditorHeight(string.Join('\n', Enumerable.Repeat("x", 400)))
+            .Should().Be("480px");
+    }
+
+    [Theory]
+    // A --show-header cell renders its own fence delimiters INSIDE the code segment, so text
+    // scraped back out of that <pre> (the editor's last-resort seed) carries lines the fence body
+    // never held. Seeding with them would write them into the code on the first save.
+    [InlineData("```csharp --render X --show-header\nvar a = 1;\n```", "var a = 1;")]
+    [InlineData("```csharp\nvar a = 1;\nvar b = 2;\n```", "var a = 1;\nvar b = 2;")]
+    [InlineData("var a = 1;", "var a = 1;")]          // no delimiters — a no-op
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void StripFenceHeader_RemovesOnlyTheDelimiters(string? text, string expected) =>
+        MarkdownFenceEditing.StripFenceHeader(text).Should().Be(expected);
+
+    [Fact]
+    public void StripFenceHeader_LeavesAFenceThatIsPartOfTheCodeAlone()
+    {
+        // A trailing ``` is a delimiter; a ``` in the MIDDLE is someone's string literal or a
+        // markdown-generating cell, and eating it would corrupt their code.
+        const string code = "var md = \"```csharp\";\nvar tail = 2;";
+        MarkdownFenceEditing.StripFenceHeader(code).Should().Be(code);
+    }
+}


### PR DESCRIPTION
Fixes #1636 — **all code cells editable**, including the fenced ` ```csharp --render X --show-code `
workbench inside a markdown **body**.

## Why this was still needed (I checked before building)

The issue predates Education #170, which migrated several courses to `@@Source/{Id}` embeds of
`nodeType:Code` children. So I measured the split on every plugin repo's `origin/main` before writing
code:

| repo | fence workbenches on `origin/main` |
|---|---|
| **MeshWeaver.Reinsurance** | **36** — every `ReinsurancePractice/**/Exercise/*.md` (`--render <Id> --show-code`), unmigrated. Their `Solution/` pages use `@@Source`; the **exercises deliberately do not**. |
| MeshWeaver.Education | 0 workbenches. DataModeling / AdvancedBusinessRules / ThinkInStreams are migrated; AgenticEngineering's 8 remaining fences are all `--render Chat` / `--render Prompt` UI furniture. |
| MeshWeaver.Plugins | the fence form is the **documented authoring shape** — `Skill/markdown` teaches ` ```csharp --render MyDemo --show-code ` as the way to write a runnable cell. |

So the two shapes coexist by design, the fence one is taught, and 36 live learner workbenches are
affected. Build it.

*(A stale local checkout suggests ~305 affected files; that count is 25 commits behind `origin/main`
plus untracked `e2e/mesh` fixtures. The real number is the table above.)*

## What changed

The seam was already there — `MarkdownHtmlRenderer.RenderNodes` swaps **marker divs** for live
components, and does exactly that for the cell toolbar. The code segment simply had no marker.

- **`ExecutableCodeBlockRenderer`** — the cell's `code-content` div now carries the same
  `data-submission-id` / `data-language` the toolbar marker carries. Purely additive: React, React
  Native and any static-HTML consumer see an ordinary div and keep rendering a `<pre>`.
- **`MarkdownFenceEditing`** (new, pure) — read a fence's body by submission id, write a new one back
  into **that fence and nowhere else**, preserving the info string, arguments, indentation and every
  other byte. A not-found returns `null` rather than degrading into a whole-body overwrite.
- **`MarkdownCodeCellEditor`** (new) — the fence's counterpart of the Code-node cell editor: seeds
  ONCE, height from the seed (so Monaco never re-mounts under the cursor), and persists through the
  circuit-side `IMeshNodeStreamCache.Update` seam `CodeEditorView`'s auto-save uses. It carries the
  derived `MarkdownContent` fields (`PrerenderedHtml`, `CodeSubmissions`) with the edit — the issue's
  first "watch out": `CodeSubmissions` is what Run re-posts, so leaving it stale would serve and run
  the old code.
- **Both markdown views** wire it, and **Run submits the BUFFER, not the file**. Auto-save is
  debounced, so posting the parse would execute code the learner had already replaced — the trap
  `CodeLayoutAreas.RunFromBuffer` closes for the Code-node cell.

## Permission — unchanged, and still one model

The editor appears exactly when the viewer holds `Permission.Update`, decided **server-side** by the
layout area that produced the control: `MarkdownOverviewLayoutArea` already folds
`hub.GetEffectivePermissions(...).HasFlag(Update)` into `CollaborativeMarkdownControl.CanEdit`, which
is the same evaluator the Code-node cell uses. The renderer is handed the *answer* and makes no
decision of its own; `MarkdownCellEditing == null` is the read-only rendering, and
`MarkdownControl.CanEdit` defaults to **false**, so every existing producer (chat bubbles, generated
`Controls.Markdown`, docs) keeps today's behaviour. Nothing widens as a side effect — in particular a
GitSynced space has no interactive account holding Update, so its pages stay read-only.

## Also fixed: an empty `--render` fence crashed the parse

Found while testing "clear the cell", which an editable cell makes a legal edit — and which is also
the natural authored shape of a *write your answer here* workbench. `StringLineGroup.Lines` is
**null until the first line is added**, so the raw `string.Join('\n', Lines.Lines)` threw
`ArgumentNullException` out of `ExecutableCodeBlock.Initialize()` and took the whole document's parse
with it. The same join also appended phantom blank lines from an over-allocated array's unused tail.

## Tests — 28 new, all executed, each proven non-vacuous

`MeshWeaver.Markdown.Test` **159 passed**, `MeshWeaver.Content.Test` (Markdown filter) **121
passed**, `MeshWeaver.Layout.Test` **468 passed**. Covered: a `--render` fence becomes editable for a
viewer with Update; the same fence stays a static `CodeBlock` without it; a plain fence (given
material) never becomes an editor even for a viewer who may write; and the edit round-trips to where
the runner reads it (a fresh parse of the saved body yields the new code under the same id).

Non-vacuity was proven by reverting each production change and watching the matching tests go red:

| reverted | result |
|---|---|
| the code-segment marker | `Expected collection {"CodeBlock", "LayoutAreaView", "MarkdownCodeCellToolbar"} to contain "MarkdownCodeCellEditor"` — i.e. today's `origin/main` behaviour exactly |
| the renderer's hydration case | same 3 failures |
| `ReplaceFenceBody`'s not-found guard + case-insensitive id | `Expected value to be <null>, but found "hacked"` (given material became writable) |
| the empty-fence fix | `System.ArgumentNullException : Value cannot be null. (Parameter 'values')` |

## Deliberately not fixed

- **No LSP in the fence editor.** `CodeLayoutAreas.BuildCellEditor` wires Roslyn diagnostics via
  `(nodeTypePath, sourcePath)` — a fence has neither: its code is not a source node. Wiring a
  synthetic path would need `IMeshLanguageService` to model script cells that live inside a markdown
  body. The fence cell gets highlighting, editing, Run and persistence; completions are a follow-up.
- **`MarkdownControl.CanEdit` has no producer yet.** `MarkdownView` honours it and it is tested, but
  every node-backed markdown page routes through `CollaborativeMarkdownControl`, which is wired.
  It is there so a plugin layout area can opt a generated markdown body in.
- **`MarkdownEditorView` still writes `new MarkdownContent { Content = content }`**, dropping
  `Authors`/`Tags`/`Abstract`/derived fields on every whole-body auto-save. Pre-existing, out of
  scope, and the new cell editor deliberately does **not** copy that pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)