### PR TITLE
The settings menu kept a live render chain per permission value (#1962)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/SettingsMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/SettingsMenuItemsExtensions.cs
@@ -45,16 +45,28 @@ public static class SettingsMenuItemsExtensions
     }
 
     /// <summary>
-    /// Evaluates all registered providers (subscribe-all-upfront via CombineLatest), filters by
-    /// permission, and returns items sorted by Order — reactive (<see cref="IObservable{T}"/>),
-    /// re-emitting whenever a provider's live check (e.g. global-admin) resolves.
+    /// The live, UNFILTERED settings-tab set: every registered provider subscribed once
+    /// (subscribe-all-upfront via <c>CombineLatest</c>), merged and sorted by <c>Order</c>,
+    /// re-emitting whenever any provider's live check (e.g. global-admin, a GitHub probe)
+    /// resolves.
+    ///
+    /// <para>🚨 <b>The permission filter is deliberately NOT applied here</b>, and that separation
+    /// is the whole point. This stream is long-lived and re-emits for reasons that have nothing to
+    /// do with the viewer; the viewer's effective permissions are a SECOND long-lived stream that
+    /// enriches on its own schedule (<c>PermissionEvaluator</c> emits a low static seed, then the
+    /// synced-assignment answer). Baking a permission SNAPSHOT into this stream produces one live
+    /// provider chain per permission value, each frozen on the value it was built with — so a late
+    /// provider emission re-renders the menu through a STALE, lower permission set and silently
+    /// removes every tab the viewer is entitled to. See
+    /// <see cref="FilterByPermission"/> and the composition in <c>SettingsLayoutArea.Settings</c>,
+    /// which combines the two streams so the LATEST permissions always win (#1962; the node menu
+    /// has always composed it that way — <c>NodeMenuItemsExtensions.GetMenuContext</c>).</para>
     /// </summary>
     internal static IObservable<IReadOnlyList<SettingsMenuItemDefinition>>
-        EvaluateSettingsMenuItems(
+        ObserveSettingsMenuItems(
             this MessageHubConfiguration config,
             LayoutAreaHost host,
-            RenderingContext ctx,
-            Permission userPermissions)
+            RenderingContext ctx)
     {
         var collection = config.Get<SettingsMenuProviderCollection>();
         if (collection == null || collection.Providers.Count == 0)
@@ -70,13 +82,37 @@ public static class SettingsMenuItemsExtensions
             {
                 var items = new List<SettingsMenuItemDefinition>();
                 foreach (var list in lists)
-                    foreach (var item in list)
-                        if (item.RequiredPermission == Permission.None
-                            || userPermissions.HasFlag(item.RequiredPermission))
-                            items.Add(item);
+                    if (list is not null)
+                        items.AddRange(list);
                 items.Sort((a, b) => a.Order.CompareTo(b.Order));
                 return (IReadOnlyList<SettingsMenuItemDefinition>)items;
             });
+    }
+
+    /// <summary>
+    /// The settings menu's permission gate — PURE, so both directions are assertable without a
+    /// hub, a circuit or a rendered area.
+    ///
+    /// <para>A tab declaring <see cref="Permission.None"/> is chrome every viewer sees; anything
+    /// else must be held by the viewer on the node whose settings page this is. That asymmetry is
+    /// the fingerprint of a lost/stale permission snapshot: when the fold hands this a
+    /// <see cref="Permission.None"/> viewer, the ONLY tabs left standing are the
+    /// <see cref="Permission.None"/> ones — which is exactly how #1962 was reported ("the
+    /// display-time-zone tab is absent; the Notifications entry beside it survives because it
+    /// requires <see cref="Permission.None"/>").</para>
+    /// </summary>
+    /// <param name="items">The unfiltered, already-sorted tab set.</param>
+    /// <param name="userPermissions">The viewer's effective permissions on the settings node.</param>
+    internal static IReadOnlyList<SettingsMenuItemDefinition> FilterByPermission(
+        IReadOnlyList<SettingsMenuItemDefinition> items,
+        Permission userPermissions)
+    {
+        var result = new List<SettingsMenuItemDefinition>(items.Count);
+        foreach (var item in items)
+            if (item.RequiredPermission == Permission.None
+                || userPermissions.HasFlag(item.RequiredPermission))
+                result.Add(item);
+        return result;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/SettingsLayoutArea.cs
+++ b/src/MeshWeaver.Graph/SettingsLayoutArea.cs
@@ -51,16 +51,53 @@ public static class SettingsLayoutArea
 
         var ownNode = host.Workspace.GetMeshNodeStream();
         var permsStream = host.Hub.GetEffectivePermissions(hubPath);
+        var itemsStream = host.Hub.Configuration.ObserveSettingsMenuItems(host, ctx);
 
-        return ownNode.CombineLatest(permsStream, (node, perms) => (Node: node, Perms: perms))
-            .SelectMany(t => host.Hub.Configuration.EvaluateSettingsMenuItems(host, ctx, t.Perms)
-                .Select(items =>
-                {
-                    var canEdit = t.Perms.HasFlag(Permission.Update);
-                    var selectedTab = string.IsNullOrEmpty(tabId) && items.Count > 0 ? items[0].Id : (tabId ?? MetadataTab);
-                    return (UiControl?)BuildSettingsPage(host, t.Node, hubAddress, hubPath, selectedTab, canEdit, items);
-                }));
+        return MenuRenderInputs(ownNode, permsStream, itemsStream)
+            .Select(t =>
+            {
+                var selectedTab = string.IsNullOrEmpty(tabId) && t.Items.Count > 0
+                    ? t.Items[0].Id
+                    : (tabId ?? MetadataTab);
+                return (UiControl?)BuildSettingsPage(
+                    host, t.Node, hubAddress, hubPath, selectedTab, t.CanEdit, t.Items);
+            });
     }
+
+    /// <summary>
+    /// The ORDERING seam of the settings page: the node, the viewer's effective permissions and
+    /// the (unfiltered) tab set folded into ONE live chain, so the newest value of every input
+    /// wins — the shape the node menu has always used
+    /// (<c>NodeMenuItemsExtensions.GetMenuContext</c>).
+    ///
+    /// <para>🚨 <b>Why this is a named seam rather than three lines inline.</b> It used to be
+    /// <c>perms.SelectMany(p =&gt; items.Select(filter through p))</c>, which builds a SEPARATE live
+    /// provider chain per permission value, each frozen on the value it captured — and never
+    /// unsubscribes the old ones. Both inputs are long-lived and enrich on their own schedules:
+    /// <c>PermissionEvaluator</c> emits a low seed (an empty assignment set reads as
+    /// <see cref="Permission.None"/>) before the synced-assignment answer arrives, and a provider
+    /// re-emits whenever its own live check settles (a global-admin probe, a GitHub call, a
+    /// cross-partition query). So the FIRST chain — the one holding <see cref="Permission.None"/> —
+    /// stays subscribed and re-renders the whole menu the next time any provider speaks, replacing
+    /// the correct menu with the one an anonymous viewer would see. Nothing errors and nothing
+    /// logs; the tabs simply disappear, and which chain wins is a race that a busy install loses
+    /// far more often than a quiet one (#1962: the display-time-zone tab absent on the cloud
+    /// portal and present locally, with the <see cref="Permission.None"/> Notifications entry
+    /// beside it surviving — the exact fingerprint of a menu rendered through
+    /// <see cref="Permission.None"/>).</para>
+    ///
+    /// <para>Pure in its inputs (three observables in, one out), so the interleaving that produced
+    /// the defect is assertable with subjects — no hub, no circuit, no rendered area.</para>
+    /// </summary>
+    internal static IObservable<(MeshNode? Node, Permission Perms, bool CanEdit,
+            IReadOnlyList<SettingsMenuItemDefinition> Items)>
+        MenuRenderInputs(
+            IObservable<MeshNode> ownNode,
+            IObservable<Permission> perms,
+            IObservable<IReadOnlyList<SettingsMenuItemDefinition>> items)
+        => Observable.CombineLatest(ownNode, perms, items,
+            (node, p, i) => ((MeshNode?)node, p, p.HasFlag(Permission.Update),
+                SettingsMenuItemsExtensions.FilterByPermission(i, p)));
 
     private static UiControl BuildSettingsPage(
         LayoutAreaHost host,

--- a/test/MeshWeaver.Graph.Test/SettingsMenuPermissionRaceTest.cs
+++ b/test/MeshWeaver.Graph.Test/SettingsMenuPermissionRaceTest.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The settings page must never render its menu through a STALE permission snapshot (#1962).
+///
+/// <para>The reported symptom was "User → Settings → the display-time-zone tab is absent" on
+/// <c>memex.meshweaver.cloud</c> while the same build showed it locally, and the reporter's own
+/// observation names the mechanism exactly: <i>"the Notifications entry beside it survives because
+/// it requires <see cref="Permission.None"/>"</i>. A menu in which only the
+/// <see cref="Permission.None"/> tabs survive is not a menu missing one tab — it is a menu rendered
+/// for a viewer whose effective permissions read as <see cref="Permission.None"/>. And the gate
+/// itself was measured to evaluate CORRECTLY on both installs, which is the puzzle: the gate is
+/// right, and a render built from an earlier, lower value of it wins the race.</para>
+///
+/// <para>Both of the page's inputs are long-lived and enrich on their own schedule:
+/// <c>PermissionEvaluator</c> emits a low seed (an empty assignment set folds to
+/// <see cref="Permission.None"/>) before the synced-assignment answer lands, and a settings-tab
+/// provider re-emits whenever its own live check settles (a global-admin probe, a GitHub call, a
+/// cross-partition query). The old composition — <c>perms.SelectMany(p =&gt; items.Select(filter
+/// through p))</c> — built one live provider chain PER permission value and unsubscribed none of
+/// them, so the chain holding <see cref="Permission.None"/> re-rendered the whole menu the next
+/// time any provider spoke.</para>
+///
+/// <para>🚨 The fix must not be "show it to everyone": <see cref="AReadOnlyViewer_NeverSeesAnUpdateGatedTab"/>
+/// and <see cref="AReadOnlyViewer_NeverSeesAnUpdateGatedTab_HoweverTheStreamsInterleave"/> pin the
+/// deny direction against exactly the interleavings the grant direction is fixed for.</para>
+/// </summary>
+public class SettingsMenuPermissionRaceTest
+{
+    private const string PreferencesTabId = "Preferences";
+    private const string NotificationsTabId = "Notifications";
+    private const string MetadataTabId = "Metadata";
+
+    /// <summary>A stand-in for the real menu: one tab per permission class the page carries.</summary>
+    private static IReadOnlyList<SettingsMenuItemDefinition> AllTabs() =>
+    [
+        Tab(MetadataTabId, Permission.Read, 0),
+        // The display-time-zone tab — UserNodeType.AddUserPreferencesSettingsTab.
+        Tab(PreferencesTabId, Permission.Update, 50),
+        // The Permission.None entry beside it; the survivor that named the bug.
+        Tab(NotificationsTabId, Permission.None, 60),
+    ];
+
+    private static SettingsMenuItemDefinition Tab(string id, Permission required, int order)
+        => new(id, id, (_, stack, _) => stack, RequiredPermission: required, Order: order);
+
+    private static IReadOnlyList<string> Ids(IReadOnlyList<SettingsMenuItemDefinition> items)
+        => items.Select(i => i.Id).ToList();
+
+    // ---------------------------------------------------------------------------------------
+    // The pure gate — both directions.
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The owner of a user node holds Update there (<c>UserScopeGrantHandler</c> writes the
+    /// self-Admin assignment), so the display-time-zone tab is theirs.
+    /// </summary>
+    [Fact]
+    public void AnOwnerWithUpdate_SeesTheDisplayTimeZoneTab()
+        => Ids(SettingsMenuItemsExtensions.FilterByPermission(
+                AllTabs(), Permission.Read | Permission.Update))
+            .Should().Contain(PreferencesTabId);
+
+    /// <summary>
+    /// 🚨 The deny direction. A viewer who may read the page but not write it must NOT be handed
+    /// the editor for someone else's time zone and language — so the fix can never be "stop
+    /// filtering".
+    /// </summary>
+    [Fact]
+    public void AReadOnlyViewer_NeverSeesAnUpdateGatedTab()
+    {
+        var visible = Ids(SettingsMenuItemsExtensions.FilterByPermission(AllTabs(), Permission.Read));
+        visible.Should().Contain(MetadataTabId, "Read is what the Metadata tab asks for");
+        visible.Should().NotContain(PreferencesTabId,
+            "the display-time-zone tab edits the node and requires Update");
+    }
+
+    /// <summary>
+    /// The fingerprint from the report, pinned: with <see cref="Permission.None"/> the ONLY
+    /// survivors are the <see cref="Permission.None"/> tabs. Anyone who sees that shape on a live
+    /// portal is looking at a viewer whose permissions read as None, not at a missing tab.
+    /// </summary>
+    [Fact]
+    public void WithNoPermissions_OnlyThePermissionNoneTabsSurvive()
+        => Ids(SettingsMenuItemsExtensions.FilterByPermission(AllTabs(), Permission.None))
+            .Should().Equal(NotificationsTabId);
+
+    /// <summary>
+    /// The tab really is Update-gated, so "make it appear" can never be quietly implemented by
+    /// lowering its requirement.
+    /// </summary>
+    [Fact]
+    public void TheShippedPreferencesTab_IsGatedOnUpdate()
+    {
+        var tab = AllTabs().Single(t => t.Id == PreferencesTabId);
+        tab.RequiredPermission.Should().Be(Permission.Update,
+            "UserNodeType.AddUserPreferencesSettingsTab declares Permission.Update — this test is "
+            + "about WHICH render wins, never about relaxing the gate");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The ordering seam — the defect itself.
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. Permissions enrich from a low seed to the real answer; THEN a provider
+    /// re-emits (its live check settled). The menu must still be the one the real permissions
+    /// produce — not the seed's.
+    ///
+    /// <para>Against the pre-fix composition the last emission is the stale chain's, so the
+    /// display-time-zone tab is gone and only the <see cref="Permission.None"/> entry is left:
+    /// the reported symptom, reproduced deterministically.</para>
+    /// </summary>
+    [Fact]
+    public void AProviderReEmission_DoesNotRevertToAStalePermissionSnapshot()
+    {
+        var node = new BehaviorSubject<MeshNode>(new MeshNode("alice") { NodeType = "User" });
+        var perms = new BehaviorSubject<Permission>(Permission.None);
+        var items = new BehaviorSubject<IReadOnlyList<SettingsMenuItemDefinition>>(AllTabs());
+
+        var seen = new List<(Permission Perms, IReadOnlyList<string> Ids)>();
+        using var _ = SettingsLayoutArea
+            .MenuRenderInputs(node, perms, items)
+            .Subscribe(t => seen.Add((t.Perms, Ids(t.Items))));
+
+        // The synced assignment query answers: the owner really does hold Update.
+        perms.OnNext(Permission.Read | Permission.Update);
+        var afterEnrichment = seen.Count - 1;
+        seen[^1].Ids.Should().Contain(PreferencesTabId, "the enriched permissions must reach the menu");
+
+        // A provider's live check settles and it re-emits the same tab set. Nothing about the
+        // viewer changed — so NO emission from here on may be built from the old value.
+        items.OnNext(AllTabs());
+
+        // 🚨 Asserting only the LAST emission would prove nothing: with one chain per permission
+        // value BOTH chains emit, and which lands last is exactly the race. The invariant is that
+        // a stale render is never produced AT ALL.
+        var later = seen.Skip(afterEnrichment).ToList();
+        later.Should().OnlyContain(e => e.Perms == (Permission.Read | Permission.Update),
+            "once the permissions have enriched, every subsequent render must be folded with the "
+            + "LATEST value; a render carrying the earlier Permission.None is a stale chain that "
+            + "was never unsubscribed (#1962)");
+        later.Should().OnlyContain(e => e.Ids.Contains(PreferencesTabId),
+            "a menu that drops the Update-gated display-time-zone tab while the viewer holds "
+            + "Update is the reported symptom — and it leaves only the Permission.None entries, "
+            + "which is exactly how the cloud portal was described");
+    }
+
+    /// <summary>
+    /// The same interleaving in the deny direction: a viewer whose permissions enrich from None to
+    /// Read only must not gain the Update-gated tab from any ordering of the inputs.
+    /// </summary>
+    [Fact]
+    public void AReadOnlyViewer_NeverSeesAnUpdateGatedTab_HoweverTheStreamsInterleave()
+    {
+        var node = new BehaviorSubject<MeshNode>(new MeshNode("alice") { NodeType = "User" });
+        var perms = new BehaviorSubject<Permission>(Permission.None);
+        var items = new BehaviorSubject<IReadOnlyList<SettingsMenuItemDefinition>>(AllTabs());
+
+        var seen = new List<IReadOnlyList<string>>();
+        using var _ = SettingsLayoutArea
+            .MenuRenderInputs(node, perms, items)
+            .Subscribe(t => seen.Add(Ids(t.Items)));
+
+        perms.OnNext(Permission.Read);
+        items.OnNext(AllTabs());
+        node.OnNext(new MeshNode("alice") { NodeType = "User", Name = "Alice" });
+        perms.OnNext(Permission.Read);
+
+        seen.Should().OnlyContain(ids => !ids.Contains(PreferencesTabId),
+            "no interleaving may hand an Update-gated tab to a viewer who only holds Read");
+    }
+
+    /// <summary>
+    /// <c>CanEdit</c> (the read-only banner above the page) rides the same fold, so it can never
+    /// disagree with the menu it is rendered beside.
+    /// </summary>
+    [Fact]
+    public void CanEdit_TracksTheLatestPermissions()
+    {
+        var node = new BehaviorSubject<MeshNode>(new MeshNode("alice") { NodeType = "User" });
+        var perms = new BehaviorSubject<Permission>(Permission.None);
+        var items = new BehaviorSubject<IReadOnlyList<SettingsMenuItemDefinition>>(AllTabs());
+
+        var seen = new List<bool>();
+        using var _ = SettingsLayoutArea
+            .MenuRenderInputs(node, perms, items)
+            .Subscribe(t => seen.Add(t.CanEdit));
+
+        seen[^1].Should().BeFalse();
+        perms.OnNext(Permission.Read | Permission.Update);
+        var afterEnrichment = seen.Count - 1;
+        items.OnNext(AllTabs());
+
+        seen.Skip(afterEnrichment).Should().OnlyContain(canEdit => canEdit,
+            "a provider re-emission must not revoke the viewer's edit rights — the read-only "
+            + "banner rides the same fold as the menu, so it can never disagree with it");
+    }
+
+    /// <summary>
+    /// The provider chain is subscribed ONCE for the life of the area, not once per permission
+    /// value. The old shape re-subscribed every provider on each permission emission — so a busy
+    /// page accumulated a full provider fan-out (global-admin probes, GitHub calls,
+    /// cross-partition queries) per enrichment, and every one of them stayed live to re-render the
+    /// menu through the snapshot it was born with.
+    /// </summary>
+    [Fact]
+    public void TheProviderChain_IsSubscribedOncePerArea_NotOncePerPermissionValue()
+    {
+        var subscriptions = 0;
+        var node = new BehaviorSubject<MeshNode>(new MeshNode("alice") { NodeType = "User" });
+        var perms = new BehaviorSubject<Permission>(Permission.None);
+        var items = Observable.Defer(() =>
+        {
+            subscriptions++;
+            return Observable.Return(AllTabs());
+        });
+
+        using var _ = SettingsLayoutArea
+            .MenuRenderInputs(node, perms, items)
+            .Subscribe(_ => { });
+
+        perms.OnNext(Permission.Read);
+        perms.OnNext(Permission.Read | Permission.Update);
+
+        subscriptions.Should().Be(1,
+            "the settings tabs are ONE live stream folded with the permissions, not a new provider "
+            + "fan-out per permission value");
+    }
+}


### PR DESCRIPTION
Mirrors #1962.

## What was wrong

Not the gate. The Preferences (display time zone) tab requires `Permission.Update`, and #1962 already establishes that gate evaluated correctly on both installs it was measured on. It is the **render that wins** that was wrong.

`SettingsLayoutArea.Settings` composed:

```csharp
ownNode.CombineLatest(permsStream, …)
    .SelectMany(t => EvaluateSettingsMenuItems(host, ctx, t.Perms).Select(items => BuildPage(…)))
```

`SelectMany` builds a **separate live provider chain per permission value**, each frozen on the value it captured, and unsubscribes none of them. Both inputs are long-lived and enrich on their own schedule:

- `PermissionEvaluator` emits a **low seed** first — its `enriched` leg is a `CombineLatest` of four synced queries, and an assignment set that has not arrived yet folds to `Permission.None` — then the real answer.
- Every settings provider re-emits when its own live check settles: `IsGlobalAdmin`, `GetEffectivePermissions(spaceRoot)` in the GitHub tabs, the coupon/composition/instance-grant admin probes.

So the chain holding `Permission.None` stays subscribed and re-renders the entire menu the next time **any** provider speaks.

## Why the symptom looked like one missing tab

A menu rendered through `Permission.None` keeps exactly one thing: its `Permission.None` entries. That is the report verbatim —

> the display-time-zone tab is absent; **the Notifications entry beside it survives because it requires `Permission.None`**

— and it is the whole reason this read as "a tab vanished" rather than "the menu was built for the wrong viewer". Nothing errors and nothing logs.

Which chain wins is a **race**, so the install that loses it is the one with the most providers and the slowest ones (Coupons, Instance grants, Composition, Partitions, GitHub sync — all present on the cloud portal). That is the cloud-vs-local split in the report, not a difference in the two installs' data: rendering the same area server-side through MCP on `memex.meshweaver.cloud` today returns the Preferences tab (`Settings/1/SettingsMenu/3`, `url: rbuergi/Settings/Preferences`), on `3.0.0-rc6.ci.4780`.

## The fix

Fold the three inputs into **one** chain so the newest value of each wins — the shape the node menu has always used (`NodeMenuItemsExtensions.GetMenuContext`, added as "the access-race fix"). Two seams fall out and are named so both can be asserted with no hub, no circuit and no rendered area:

- `SettingsLayoutArea.MenuRenderInputs` — the ordering.
- `SettingsMenuItemsExtensions.FilterByPermission` — the gate, now pure.

`ObserveSettingsMenuItems` replaces `EvaluateSettingsMenuItems`: it no longer takes a permission snapshot, so providers are subscribed **once per area** instead of once per permission value.

## Non-vacuity — verified red against the pre-fix shape

With `MenuRenderInputs` reverted to `perms.CombineLatest(ownNode).SelectMany(t => items.Select(… t.p))`, three of the eight tests fail:

```
AProviderReEmission_DoesNotRevertToAStalePermissionSnapshot [FAIL]
  Expected all items in the collection to match the predicate because once the
  permissions have enriched, every subsequent render must be folded with the
  LATEST value; a render carrying the earlier Permission.None is a stale chain
  that was never unsubscribed (#1962).
CanEdit_TracksTheLatestPermissions [FAIL]
  Expected all items in the collection to match the predicate because a provider
  re-emission must not revoke the viewer's edit rights — the read-only banner
  rides the same fold as the menu, so it can never disagree with it.
TheProviderChain_IsSubscribedOncePerArea_NotOncePerPermissionValue [FAIL]
  Expected value to be 1 because the settings tabs are ONE live stream folded
  with the permissions, not a new provider fan-out per permission value,
  but found 3.

Failed!  - Failed: 3, Passed: 5, Total: 8
```

With the fix: `Passed! - Failed: 0, Passed: 8, Total: 8`; the whole project `Passed! - Failed: 0, Passed: 1417`.

🚨 Asserting only the LAST emission proves nothing here — both chains emit and **which lands last IS the race**. The tests assert that a stale render is never produced at all.

## The fix is not "show it to everyone"

Pinned in the same file, against the same interleavings the grant direction is fixed for:

- `AReadOnlyViewer_NeverSeesAnUpdateGatedTab` — Read gets Metadata, never Preferences.
- `AReadOnlyViewer_NeverSeesAnUpdateGatedTab_HoweverTheStreamsInterleave` — **no** emission, under any ordering of the three inputs, hands an Update-gated tab to a Read-only viewer.
- `WithNoPermissions_OnlyThePermissionNoneTabsSurvive` — records the fingerprint, so the next person who sees that shape on a portal knows they are looking at a `Permission.None` viewer.
- `TheShippedPreferencesTab_IsGatedOnUpdate` — the requirement itself, so "make it appear" can never be quietly implemented by lowering it.

## Ruled out along the way

- **The email-local-part `ObjectId` guess** (#1962's cheapest-first candidate) — out, and now doubly so. It cannot be the cloud symptom for the reporter (`sglauser` matches the guess), and this defect is *independent of `ObjectId`*: it hits a viewer whose identity resolves perfectly, because the permission value that gets discarded is the correct one. Worth recording that ids **do** diverge from the guess on that install in general — `memex` carries both `rbuergi` and `roland.buergi` partitions and `rbuergi/_Access` holds a grant for each — so the failure mode is real, just not this one.
- **Truncation of the security fold's unpinned queries** (the #1960 family: `nodeType:Role`/`GroupMembership scope:subtree` with no `Complete()`). Not firing today — `memex` has 7 GroupMembership and 4 Role nodes, far under the cross-schema page. Still latent, and separate.

## Not touched

The separate UTC-rendering symptom from #1936. #1960 fixed its measured cause (the user directory read as a 50-row page); this change is about which menu render wins and does not go near it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
