### PR TITLE
fix(#1636): review follow-ups — the markdown cell save missed two content shapes and a projection

### DIFF
--- a/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
@@ -120,6 +120,9 @@ public partial class CollaborativeMarkdownView
     private Func<string, string?>? _cellCode;
     private Action<string, string>? _recordCellBuffer;
 
+    // Which document _cellBuffers belongs to — see RecordCellBuffer.
+    private string? _bufferedDocument;
+
     private Address ResolveActivityAddress()
     {
         var ownerPath = KernelOwnerPath();
@@ -603,8 +606,17 @@ public partial class CollaborativeMarkdownView
 
     private void RecordCellBuffer(string submissionId, string text)
     {
-        if (!string.IsNullOrEmpty(submissionId))
-            _cellBuffers[submissionId] = text;
+        if (string.IsNullOrEmpty(submissionId))
+            return;
+        // Scoped to the document, for the same reason the editor's key is: this view survives
+        // navigation, and a buffer keyed by the cell alone would let one page's typed text be Run
+        // on the next page that reuses the id.
+        if (!string.Equals(_bufferedDocument, BoundNodePath, StringComparison.Ordinal))
+        {
+            _cellBuffers.Clear();
+            _bufferedDocument = BoundNodePath;
+        }
+        _cellBuffers[submissionId] = text;
     }
 
     // Re-posts one executable block's submission to the per-view kernel activity — the cell
@@ -633,7 +645,8 @@ public partial class CollaborativeMarkdownView
     /// that has not been persisted yet. Unedited cells return the parsed submission unchanged.
     /// </summary>
     private SubmitCodeRequest ApplyCellBuffer(SubmitCodeRequest submission) =>
-        submission.Id is { Length: > 0 } id
+        string.Equals(_bufferedDocument, BoundNodePath, StringComparison.Ordinal)
+        && submission.Id is { Length: > 0 } id
         && _cellBuffers.TryGetValue(id, out var buffer)
         && buffer != submission.Code
             ? submission with { Code = buffer }

--- a/src/MeshWeaver.Blazor/Components/MarkdownCodeCellEditor.razor
+++ b/src/MeshWeaver.Blazor/Components/MarkdownCodeCellEditor.razor
@@ -1,5 +1,7 @@
 @using MeshWeaver.Blazor.Components.Monaco
 @using MeshWeaver.Data
+@using MeshWeaver.Graph
+@using System.Text.Json
 @using MeshWeaver.Markdown
 @using MeshWeaver.Mesh
 @using MeshWeaver.Mesh.Services
@@ -112,15 +114,26 @@
     /// <summary>
     /// Writes the debounced buffer back into THIS fence and nowhere else.
     ///
+    /// <para>🚨 The body is read and written through <c>MarkdownOverviewLayoutArea</c>'s shape-aware
+    /// pair, never <c>ContentAs&lt;MarkdownContent&gt;</c> alone. A markdown node's content arrives
+    /// as a typed record on its own hub, as a bare <c>string</c>, and as a <c>JsonElement</c> frame
+    /// (<c>$type: MarkdownDocument</c> among them) across a query seam — and a typed-only read
+    /// returns null for the rest, so the save would silently do NOTHING on exactly the pages that
+    /// still render fine. That is the repository's canonical silent-failure shape.</para>
+    ///
     /// <para>A node whose body no longer holds the fence is deliberately left UNTOUCHED — returning
     /// it unchanged makes the merge patch empty. That is the only safe answer: the alternative
-    /// ("write the whole body") turns a renamed or deleted fence into a wiped exercise.</para>
+    /// ("write the whole body") turns a renamed or deleted fence into a wiped exercise. A node that
+    /// is not markdown at all is left untouched too: the write is reached from a rendered markdown
+    /// cell, so that is unreachable rather than an error worth throwing at a keystroke.</para>
     ///
-    /// <para>The derived fields travel with the edit. <see cref="MarkdownContent.PrerenderedHtml"/>
-    /// and <see cref="MarkdownContent.CodeSubmissions"/> are projections of the body, and
-    /// CodeSubmissions is what a Run re-posts — leaving them stale would serve the OLD code back on
-    /// the next render and run it. Everything the shape does not derive (authors, tags, abstract,
-    /// thumbnail, and the [JsonExtensionData] round-trip buffer) is carried over untouched.</para>
+    /// <para>The derived artefacts travel WITH the edit, exactly as
+    /// <c>MeshOperations.WithRerenderedMarkdown</c> does for an agent's edit:
+    /// <see cref="MarkdownContent.PrerenderedHtml"/>, <see cref="MarkdownContent.CodeSubmissions"/>
+    /// — which is what a Run re-posts, so a stale one would serve AND RUN the old code — and the
+    /// node-level <c>PreRenderedHtml</c> mirror, which the Overview and prerender paths read
+    /// instead of the content. Everything the shape does not derive (authors, tags, abstract,
+    /// thumbnail, and the [JsonExtensionData] round-trip buffer) is preserved by construction.</para>
     /// </summary>
     private void SaveFence(string value)
     {
@@ -129,30 +142,51 @@
         if (_cache is null || string.IsNullOrEmpty(path) || string.IsNullOrEmpty(id))
             return;
 
-        _cache.Update(path!,
-                current =>
-                {
-                    var content = current.ContentAs<MarkdownContent>(Hub.JsonSerializerOptions);
-                    if (content is null)
-                        return current;
-                    var updated = MarkdownFenceEditing.ReplaceFenceBody(content.Content, id, value);
-                    if (updated is null || updated == content.Content)
-                        return current;
-                    var reparsed = MarkdownContent.Parse(updated, currentNodePath: path);
-                    return current with
-                    {
-                        Content = content with
-                        {
-                            Content = updated,
-                            PrerenderedHtml = reparsed.PrerenderedHtml,
-                            CodeSubmissions = reparsed.CodeSubmissions,
-                        }
-                    };
-                },
+        _cache.Update(path!, current => WithFenceBody(current, id!, value, Hub.JsonSerializerOptions),
                 Hub.JsonSerializerOptions)
             .Subscribe(_ => { },
                 ex => _logger?.LogWarning(ex,
                     "Markdown cell auto-save failed for {Submission} in {Path}", id, path));
+    }
+
+    /// <summary>
+    /// The node with one fence's body replaced and every derived artefact rebuilt, or the node
+    /// UNCHANGED when it holds no such fence. Static and dependency-free so the whole write is
+    /// pinned without a circuit — see <c>MarkdownCellEditingTest</c>.
+    /// </summary>
+    public static MeshNode WithFenceBody(
+        MeshNode current, string submissionId, string value, JsonSerializerOptions options)
+    {
+        var markdown = MarkdownOverviewLayoutArea.GetMarkdownContent(current);
+        var updated = MarkdownFenceEditing.ReplaceFenceBody(markdown, submissionId, value);
+        if (updated is null || updated == markdown)
+            return current;
+
+        MeshNode written;
+        try
+        {
+            written = MarkdownOverviewLayoutArea.WithMarkdownContent(current, updated, options);
+        }
+        catch (InvalidOperationException)
+        {
+            // Not a markdown node after all — leave it alone rather than guess at its shape.
+            return current;
+        }
+
+        var reparsed = MarkdownContent.Parse(updated, current.Namespace, current.Path);
+        return written.Content is MarkdownContent content
+            ? written with
+            {
+                Content = content with
+                {
+                    PrerenderedHtml = reparsed.PrerenderedHtml,
+                    CodeSubmissions = reparsed.CodeSubmissions,
+                },
+                PreRenderedHtml = reparsed.PrerenderedHtml,
+            }
+            // A bare-string body carries no derived fields of its own; the node-level mirror is the
+            // only projection there is, and the Overview reads it.
+            : written with { PreRenderedHtml = reparsed.PrerenderedHtml };
     }
 
     public void Dispose() => _autoSave?.Dispose();

--- a/src/MeshWeaver.Blazor/Components/MarkdownCodeCellEditor.razor
+++ b/src/MeshWeaver.Blazor/Components/MarkdownCodeCellEditor.razor
@@ -42,7 +42,12 @@
     //     keystroke and re-mount Monaco under the cursor.
     //  3. PERSIST ONLY THE FENCE. The write is pure source surgery (MarkdownFenceEditing) through
     //     the circuit-side IMeshNodeStreamCache — the same seam CodeEditorView's auto-save uses, so
-    //     it carries the viewer's own identity and every reader on the path observes it in order.
+    //     every reader on the path observes it in order through the shared upstream handle. The
+    //     write runs from the debounce callback on Scheduler.Default, which queues through the
+    //     thread pool WITH ExecutionContext capture — so the AsyncLocal AccessService.Context live
+    //     on the emitting (renderer) thread is still live there; see HubPermissionExtensions
+    //     .HopOffGate. That is a property of the shared seam, identical in CodeEditorView and
+    //     MarkdownEditorView, not something this component establishes on its own.
     //
     // 🚨 This component is rendered ONLY where the hosting view has already established that the
     // viewer holds Update on the node (MarkdownHtmlRenderer's cellEditing argument). It does not

--- a/src/MeshWeaver.Blazor/Components/MarkdownHtmlRenderer.cs
+++ b/src/MeshWeaver.Blazor/Components/MarkdownHtmlRenderer.cs
@@ -283,7 +283,12 @@ public class MarkdownHtmlRenderer
         var seed = editing.CodeOf?.Invoke(submissionId)
                    ?? MarkdownFenceEditing.StripFenceHeader(HtmlEntity.DeEntitize(node.InnerText));
         builder.OpenComponent<MarkdownCodeCellEditor>(1);
-        builder.SetKey(submissionId);
+        // 🚨 The key is (node, cell), not the cell alone. LayoutAreaView keeps a markdown subtree
+        // MOUNTED across navigation, so a bare submission id would let a component survive from one
+        // document into another that happens to reuse the id — and the editor seeds ONCE, so the
+        // viewer would be shown, and could Run, the PREVIOUS page's code. Submission ids are short
+        // authored words (`spotgap`, `blank`), which makes the collision likely rather than exotic.
+        builder.SetKey($"{editing.NodePath}\u0000{submissionId}");
         builder.AddAttribute(2, nameof(MarkdownCodeCellEditor.SubmissionId), submissionId);
         builder.AddAttribute(3, nameof(MarkdownCodeCellEditor.Language),
             node.GetAttributeValue(ExecutableCodeBlockRenderer.LanguageAttribute, "csharp"));

--- a/src/MeshWeaver.Blazor/Components/MarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MarkdownView.razor.cs
@@ -64,6 +64,9 @@ public partial class MarkdownView
     private Func<string, string?>? _cellCode;
     private Action<string, string>? _recordCellBuffer;
 
+    // Which document _cellBuffers belongs to — see RecordCellBuffer.
+    private string? _bufferedDocument;
+
     // True once THIS view actually created the per-view kernel Activity node (owner resolved +
     // CreateActivityAndSubmit called). Gates the dispose-time teardown: deleting/cancelling an
     // activity that was never created would post to a nonexistent address and NotFound-storm the
@@ -329,8 +332,17 @@ public partial class MarkdownView
 
     private void RecordCellBuffer(string submissionId, string text)
     {
-        if (!string.IsNullOrEmpty(submissionId))
-            _cellBuffers[submissionId] = text;
+        if (string.IsNullOrEmpty(submissionId))
+            return;
+        // Scoped to the document, for the same reason the editor's key is: this view survives
+        // navigation, and a buffer keyed by the cell alone would let one page's typed text be Run
+        // on the next page that reuses the id.
+        if (!string.Equals(_bufferedDocument, NodePathForEditing, StringComparison.Ordinal))
+        {
+            _cellBuffers.Clear();
+            _bufferedDocument = NodePathForEditing;
+        }
+        _cellBuffers[submissionId] = text;
     }
 
     // Re-posts one executable block's submission to the per-view kernel activity — the cell
@@ -359,7 +371,8 @@ public partial class MarkdownView
     /// that has not been persisted yet. Unedited cells return the parsed submission unchanged.
     /// </summary>
     private SubmitCodeRequest ApplyCellBuffer(SubmitCodeRequest submission) =>
-        submission.Id is { Length: > 0 } id
+        string.Equals(_bufferedDocument, NodePathForEditing, StringComparison.Ordinal)
+        && submission.Id is { Length: > 0 } id
         && _cellBuffers.TryGetValue(id, out var buffer)
         && buffer != submission.Code
             ? submission with { Code = buffer }

--- a/test/MeshWeaver.Content.Test/MarkdownCellEditingTest.cs
+++ b/test/MeshWeaver.Content.Test/MarkdownCellEditingTest.cs
@@ -1,5 +1,8 @@
+using System.Text.Json;
 using MeshWeaver.Blazor.Components;
+using MeshWeaver.Graph;
 using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -162,5 +165,78 @@ public class MarkdownCellEditingTest
         // open is seeded with the saved answer rather than the original stub.
         stored.PrerenderedHtml.Should().NotBeNull();
         stored.PrerenderedHtml!.Should().Contain("var answer = 42;").And.NotContain("// TODO");
+    }
+
+    // ── The WRITE: what actually lands on the node ────────────────────────────────────────────
+
+    private static MeshNode NodeWith(object content) =>
+        new("SpotTheGap", "Course/Lesson/Exercise") { NodeType = "Edu/Exercise", Content = content };
+
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void TheWrite_RebuildsEveryDerivedArtefact()
+    {
+        var node = NodeWith(new MarkdownContent { Content = Workbench, Authors = ["ada"], Tags = ["fp"] });
+
+        var written = MarkdownCodeCellEditor.WithFenceBody(node, "spotgap", "var answer = 42;", Options);
+
+        var content = written.Content.Should().BeOfType<MarkdownContent>().Subject;
+        content.Content.Should().Contain("var answer = 42;").And.NotContain("// TODO");
+
+        // CodeSubmissions is what a Run RE-POSTS. A stale one does not merely look wrong, it EXECUTES
+        // the old code and renders a confident result for source nobody is looking at.
+        content.CodeSubmissions.Should().NotBeNull();
+        content.CodeSubmissions!.Single(s => s.Id == "spotgap").Code.Trim().Should().Be("var answer = 42;");
+
+        // Two HTML projections, and the Overview / prerender paths read the NODE-level one rather
+        // than the content's — refreshing only the inner field serves the pre-edit page on reload.
+        content.PrerenderedHtml.Should().NotBeNull().And.Subject.As<string>()
+            .Should().Contain("var answer = 42;");
+        written.PreRenderedHtml.Should().Be(content.PrerenderedHtml);
+
+        // Metadata the shape does not derive is not collateral damage.
+        content.Authors.Should().Equal("ada");
+        content.Tags.Should().Equal("fp");
+    }
+
+    [Fact]
+    public void TheWrite_HandlesEveryShapeMarkdownContentArrivesIn()
+    {
+        // 🚨 The silent-failure shape this repository names first: content is typed on its own hub,
+        // a bare string elsewhere, and a JsonElement across a query seam. A typed-only read returns
+        // null for the last two, so the save would do NOTHING on pages that render perfectly.
+        var asString = MarkdownCodeCellEditor.WithFenceBody(
+            NodeWith(Workbench), "spotgap", "var answer = 1;", Options);
+        MarkdownOverviewLayoutArea.GetMarkdownContent(asString).Should().Contain("var answer = 1;");
+        asString.PreRenderedHtml.Should().NotBeNull("even a bare-string body has a node-level projection");
+
+        var element = JsonSerializer.SerializeToElement(
+            new { type = "MarkdownDocument", content = Workbench }, Options);
+        var asElement = MarkdownCodeCellEditor.WithFenceBody(
+            NodeWith(element), "spotgap", "var answer = 2;", Options);
+        MarkdownOverviewLayoutArea.GetMarkdownContent(asElement).Should().Contain("var answer = 2;");
+    }
+
+    [Fact]
+    public void TheWrite_LeavesTheNodeUNTOUCHEDWhenTheFenceIsGone()
+    {
+        // Returning the node unchanged makes the merge patch EMPTY. The alternative — "write the
+        // whole body" — turns a fence someone renamed into a wiped exercise.
+        var node = NodeWith(new MarkdownContent { Content = Workbench });
+
+        MarkdownCodeCellEditor.WithFenceBody(node, "nosuchcell", "x", Options)
+            .Should().BeSameAs(node);
+    }
+
+    [Fact]
+    public void TheWrite_LeavesANonMarkdownNodeAlone()
+    {
+        // Unreachable from a rendered markdown cell, so it is left alone rather than thrown at —
+        // a keystroke is not the place to surface a shape nobody can produce here.
+        var node = NodeWith(new { some = "other shape" });
+
+        MarkdownCodeCellEditor.WithFenceBody(node, "spotgap", "x", Options)
+            .Should().BeSameAs(node);
     }
 }


### PR DESCRIPTION
Follow-up to **#2009**, which was merged at its first commit while the review fixes were still in
flight. All three findings below came from the Copilot review on that PR; the replies are there.
`main` currently has the feature **without** these, so the auto-save is silently a no-op on some
markdown nodes.

### 1. The save read the body with `ContentAs<MarkdownContent>` alone

Markdown content arrives typed on its own hub, as a bare `string` elsewhere, and as a `JsonElement`
frame (`$type: MarkdownDocument` among them) across a query seam. A typed-only read returns **null**
for the last two, so auto-save did **nothing at all** on pages that render perfectly — the
repository's canonical silent-failure shape.

The write now goes through `MarkdownOverviewLayoutArea.GetMarkdownContent` /
`WithMarkdownContent`, the shape-aware pair that already sits beside each other in that file, rather
than a second, narrower implementation next to it.

### 2. Only the inner HTML projection was refreshed

`MarkdownContent.PrerenderedHtml` was rebuilt; the node-level `MeshNode.PreRenderedHtml` mirror was
left stale. The Overview and prerender paths read the **outer** one
(`OverviewLayoutArea.BuildMarkdownBody`), so a saved edit served the pre-edit page on reload. Now
both, exactly as `MeshOperations.WithRerenderedMarkdown` does for an agent's edit — and `Parse` takes
the node's namespace/path like that helper, so relative embeds resolve identically.

### 3. The editor key and Run buffers were keyed by submission id alone

`LayoutAreaView` keeps a markdown subtree mounted across navigation, and submission ids are short
authored words (`spotgap`, `blank`, `first`) — so a component could survive from one document into
another that reuses the id and, seeding once, show and **Run** the previous page's code. Both the
component key and the views' buffers are now scoped to the document.

## Tests

The whole write is now a pure static (`MarkdownCodeCellEditor.WithFenceBody`), so it is pinned
without a circuit: the derived-artefact rebuild, all three content shapes, and the two
leave-it-alone cases (fence gone → node returned unchanged so the merge patch is empty; non-markdown
node → untouched). `MeshWeaver.Content.Test` 11/11 on this branch.

Non-vacuity, by reverting each fix on top of this branch:

| reverted | red test |
|---|---|
| shape-aware read → `ContentAs<MarkdownContent>` | `TheWrite_HandlesEveryShapeMarkdownContentArrivesIn` |
| node-level `PreRenderedHtml` mirror | `TheWrite_RebuildsEveryDerivedArtefact` |

Also carries a comment correction: the auto-save identity capture is a property of the shared
`AutoSaveHandler` + `IMeshNodeStreamCache` seam (`CodeEditorView`, `MarkdownEditorView` ride the same
one), not something the component establishes — the comment now says so and names where it is
documented.

No What's New entry: #2009 shipped the user-facing one, and these are repairs to it that landed
minutes late.

🤖 Generated with [Claude Code](https://claude.com/claude-code)