### PR TITLE
feat(local-first): operated deployments feed the switcher; one search bar on home

### DIFF
--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -20,7 +20,7 @@ import { buildMeshOps } from "./src/liveOps";
 import { NavContext, CurrentAddressContext, type NavTarget } from "./src/nav";
 import { Shell, HOME } from "./src/Shell";
 import { ensureWebStyles } from "./src/webStyles";
-import { attachInstanceStore, currentInstance, setConnectStatus, type MeshInstance } from "./src/connection";
+import { attachInstanceStore, currentInstance, discoverInstances, mergeDiscovered, setConnectStatus, type MeshInstance } from "./src/connection";
 import { type ClientDestination } from "./src/screens";
 import { ThemeProvider, useTheme } from "./src/theme";
 import { ChatComposer } from "./src/chat";
@@ -171,6 +171,10 @@ function AppInner() {
         void attachInstanceStore(
           inst.local ? Mesh.from(l.connection, undefined, { url: inst.url, token: inst.token }) : null,
         );
+        // The local mesh is ALSO where the deployments you operate are recorded
+        // (nodeType:Hosting/Deployment) — fold them into the switcher, like remote fleets.
+        if (inst.local)
+          void discoverInstances(inst).then((d) => { if (d.length) mergeDiscovered(d); }).catch(() => {});
         // 📱 First launch on the device mesh: no device user yet → the app opens INTO the
         // onboarding dialog (the RN twin of MAUI's OnboardingPage). "Get started" posts the
         // profile (POST /api/mesh/onboard) and the following reconnect ack closes the screen.

--- a/clients/react-native/src/connection.ts
+++ b/clients/react-native/src/connection.ts
@@ -232,9 +232,10 @@ export function localInstance(): MeshInstance {
  */
 export async function discoverInstances(from: MeshInstance): Promise<MeshInstance[]> {
   try {
+    const base = from.url.replace(/\/+$/, "");
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     if (from.token) headers.Authorization = `Bearer ${from.token}`;
-    const search = await fetch(`${from.url}/api/mesh/search`, {
+    const search = await fetch(`${base}/api/mesh/search`, {
       method: "POST", headers,
       body: JSON.stringify({ query: "nodeType:Hosting/Deployment scope:subtree" }),
     });
@@ -243,16 +244,19 @@ export async function discoverInstances(from: MeshInstance): Promise<MeshInstanc
     const found: MeshInstance[] = [];
     for (const r of results.slice(0, 20)) {
       if (!r.path) continue;
-      const got = await fetch(`${from.url}/api/mesh/get`, {
+      const got = await fetch(`${base}/api/mesh/get`, {
         method: "POST", headers, body: JSON.stringify({ path: `@${r.path}` }),
       });
       if (!got.ok) continue;
       const content: any = ((await got.json()) as any)?.content ?? {};
-      // An explicit content.url wins (a record can name a non-https scheme/port — e.g. the local
-      // sidecar); otherwise the host is a public portal reached over https.
-      const url: string | undefined = content.url ?? (content.host ? `https://${content.host}` : undefined);
+      // An explicit content.url wins (a record can name a non-HTTPS scheme/port — e.g. the local
+      // sidecar); otherwise the host is a public portal reached over HTTPS. Records are hand-edited
+      // data — trim before building URLs and names from them.
+      const recordUrl = typeof content.url === "string" ? content.url.trim() : "";
+      const host = typeof content.host === "string" ? content.host.trim() : "";
+      const url = recordUrl || (host ? `https://${host}` : "");
       if (!url) continue;
-      found.push({ name: r.name ?? String(content.host ?? url), url: url.replace(/\/+$/, ""), token: "", local: false, kind: "Prod" });
+      found.push({ name: (r.name ?? "").trim() || host || url, url: url.replace(/\/+$/, ""), token: "", local: false, kind: "Prod" });
     }
     return found;
   } catch {

--- a/clients/react-native/src/connection.ts
+++ b/clients/react-native/src/connection.ts
@@ -247,9 +247,12 @@ export async function discoverInstances(from: MeshInstance): Promise<MeshInstanc
         method: "POST", headers, body: JSON.stringify({ path: `@${r.path}` }),
       });
       if (!got.ok) continue;
-      const host: string | undefined = ((await got.json()) as any)?.content?.host;
-      if (!host) continue;
-      found.push({ name: r.name ?? host, url: `https://${host}`, token: "", local: false, kind: "Prod" });
+      const content: any = ((await got.json()) as any)?.content ?? {};
+      // An explicit content.url wins (a record can name a non-https scheme/port — e.g. the local
+      // sidecar); otherwise the host is a public portal reached over https.
+      const url: string | undefined = content.url ?? (content.host ? `https://${content.host}` : undefined);
+      if (!url) continue;
+      found.push({ name: r.name ?? String(content.host ?? url), url: url.replace(/\/+$/, ""), token: "", local: false, kind: "Prod" });
     }
     return found;
   } catch {
@@ -257,13 +260,15 @@ export async function discoverInstances(from: MeshInstance): Promise<MeshInstanc
   }
 }
 
-/** Merge discovered instances into the list — an existing entry (its token, edits) always wins.
+/** Merge discovered instances into the list — an existing entry (its token, edits) always wins,
+ *  and a record describing THIS app's own local mesh never duplicates the Local entry.
  *  New ones are persisted to the local mesh (the store), best-effort. */
 export function mergeDiscovered(discovered: MeshInstance[]): MeshInstance[] {
   const byName = new Map(remotes.map((i) => [i.name, i]));
   const byUrl = new Set(remotes.map((i) => i.url));
+  const localUrl = localInstance().url;
   for (const d of discovered)
-    if (!byName.has(d.name) && !byUrl.has(d.url)) {
+    if (!byName.has(d.name) && !byUrl.has(d.url) && d.url !== localUrl) {
       byName.set(d.name, d);
       persist(d);
     }

--- a/memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs
+++ b/memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs
@@ -80,6 +80,25 @@ public static class LocalMeshApiEndpoints
             QueryNodesBody body, IServiceProvider services, CancellationToken ct) =>
             RunString(services, ct, ops => ops.QueryNodes(body.Query, body.Limit ?? 50)));
 
+        // The portal's /search + /get twins (MeshApiEndpoints) — the shells' instance DISCOVERY
+        // posts these (connection.ts discoverInstances); unmapped they fell into the SPA-fallback
+        // 200 trap (#1474's shape) and discovery silently yielded nothing against this host.
+        group.MapPost("/search", (
+            SearchBody body, IServiceProvider services, CancellationToken ct) =>
+            RunString(services, ct, ops => ops.Search(body.Query, body.BasePath)));
+
+        group.MapPost("/get", (
+            GetBody body, IServiceProvider services, CancellationToken ct) =>
+            RunString(services, ct, ops => ops.Get(body.Path)));
+
+        // The portal's /create twin — IMeshService.CreateNode via MeshOperations, the ONE path
+        // that persists top-level containers too (a wire CreateNodeRequest at the root mesh hub
+        // only REGISTERS in-memory). Anonymous like every verb here: this host authenticates
+        // nobody, and every delivery acts as the device user.
+        group.MapPost("/create", (
+            CreateBody body, IServiceProvider services, CancellationToken ct) =>
+            RunString(services, ct, ops => ops.Create(body.Node)));
+
         // Content-collection directory listing — the read half of the file browser. Path is
         // "{node}/{collection}[/{dir}]".
         group.MapPost("/content/list", (
@@ -202,4 +221,13 @@ public static class LocalMeshApiEndpoints
 
     /// <summary>POST body for /api/mesh/onboard — the first-launch profile (DeviceSeed.Onboard).</summary>
     public record OnboardBody(string? FullName, string? Bio = null, string? Role = null);
+
+    /// <summary>POST body for /api/mesh/search — mirrors MeshApiEndpoints.SearchBody.</summary>
+    public record SearchBody(string Query, string? BasePath = null);
+
+    /// <summary>POST body for /api/mesh/get — mirrors MeshApiEndpoints.GetBody.</summary>
+    public record GetBody(string Path);
+
+    /// <summary>POST body for /api/mesh/create — mirrors MeshApiEndpoints.CreateBody (node JSON as a string).</summary>
+    public record CreateBody(string Node);
 }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-deployments-in-switcher.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-deployments-in-switcher.md
@@ -1,0 +1,18 @@
+---
+Name: Your deployments appear in the mesh switcher
+Category: Feature
+Description: Deployment records on your local mesh feed the app's mesh switcher, and the home page keeps a single search bar.
+Icon: Sparkle
+Order: -20260821
+---
+
+# Your deployments appear in the mesh switcher
+
+The installations you operate — recorded as Deployment nodes on your mesh — now feed the phone
+app's mesh switcher: connect to your local mesh and every recorded deployment shows up as a
+connectable instance, honoring each record's own address (a local sidecar keeps its http port, a
+public portal gets https). The local sidecar also gained the portal's search, get and create verbs,
+so discovery and record management work against it exactly as against a portal.
+
+The home page also keeps a single search bar now: the catalog section no longer embeds its own —
+the top bar's search is the one search surface, in every shell.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-deployments-in-switcher.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-deployments-in-switcher.md
@@ -10,8 +10,8 @@ Order: -20260821
 
 The installations you operate — recorded as Deployment nodes on your mesh — now feed the phone
 app's mesh switcher: connect to your local mesh and every recorded deployment shows up as a
-connectable instance, honoring each record's own address (a local sidecar keeps its http port, a
-public portal gets https). The local sidecar also gained the portal's search, get and create verbs,
+connectable instance, honoring each record's own address (a local sidecar keeps its HTTP port, a
+public portal gets HTTPS). The local sidecar also gained the portal's search, get and create verbs,
 so discovery and record management work against it exactly as against a portal.
 
 The home page also keeps a single search bar now: the catalog section no longer embeds its own —

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -1058,7 +1058,9 @@ public static class UserActivityLayoutAreas
         var everything = Controls.MeshSearch
             .WithHiddenQuery(sortOptions[0].Query)
             .WithSortOptions(sortOptions)
-            .WithShowSearchBox(true)
+            // No embedded search box: every shell already carries the top-bar search, and a second
+            // input on the home read as a duplicate (maintainer, 2026-08-21). Sort/view stay.
+            .WithShowSearchBox(false)
             .WithViewOptions(true)
             .WithShowEmptyMessage(true)
             .WithRenderMode(cfg.Render == HomeCatalogRender.Grouped

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -1059,7 +1059,7 @@ public static class UserActivityLayoutAreas
             .WithHiddenQuery(sortOptions[0].Query)
             .WithSortOptions(sortOptions)
             // No embedded search box: every shell already carries the top-bar search, and a second
-            // input on the home read as a duplicate (maintainer, 2026-08-21). Sort/view stay.
+            // input on the home reads as a duplicate (maintainer, 2026-08-21). Sort/view stay.
             .WithShowSearchBox(false)
             .WithViewOptions(true)
             .WithShowEmptyMessage(true)

--- a/test/Memex.Portal.Shared.Test/LocalMeshApiRoutesTest.cs
+++ b/test/Memex.Portal.Shared.Test/LocalMeshApiRoutesTest.cs
@@ -31,6 +31,9 @@ public class LocalMeshApiRoutesTest
         "/api/mesh/content/list",
         "/api/mesh/upload",
         "/api/mesh/onboard",
+        "/api/mesh/search",
+        "/api/mesh/get",
+        "/api/mesh/create",
     ];
 
     [Theory]

--- a/test/MeshWeaver.Graph.Test/HomeCatalogTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeCatalogTest.cs
@@ -34,7 +34,9 @@ public class HomeCatalogTest
         var search = catalog.Should().BeOfType<MeshSearchControl>().Subject;
         catalog.Should().NotBeOfType<TabsControl>();
         search.RenderMode.Should().Be(MeshSearchRenderMode.Flat);
-        search.ShowSearchBox.Should().Be(true);
+        // NO embedded search box: every shell carries the top-bar search, and a second input on
+        // the home reads as a duplicate (maintainer, 2026-08-21).
+        search.ShowSearchBox.Should().Be(false);
         // View-options on → the user controls the order.
         search.ShowViewOptions.Should().Be(true);
         // Generic create (type picker), never a type-specific target.


### PR DESCRIPTION
## What

From live phone testing (maintainer direction: *"install the deployments module and see that I can add meshweaver.cloud and my local instance"* + *"second search bar looks odd — get rid"*):

1. **Deployment records feed the mesh switcher.** `Hosting/Deployment` records on the connected **local** mesh now surface as connectable instances: `discoverInstances` honors a record's explicit `content.url` (a local sidecar keeps its http scheme/port; bare hosts remain `https://{host}`), runs against the Local mesh too (previously remotes only), and a record describing the app's own mesh never duplicates the Local entry.
2. **The sidecar gains the portal's `/api/mesh/search`, `/get`, `/create` verbs** — `MeshApiEndpoints` twins over the same `MeshOperations`. Discovery posts `/search` + `/get`; unmapped they fell into the SPA-fallback-200 trap (#1474's shape), so discovery silently yielded nothing against the sidecar. `/create` is the one path that persists top-level containers (a wire `CreateNodeRequest` at the root mesh hub only registers in-memory). Route-table test extended.
3. **One search bar on the home**: the catalog region no longer embeds its own search box (`WithShowSearchBox(false)`) — every shell already carries the top-bar search. Sort/view options stay. **Note: this also removes the embedded search box from the Blazor portal home** — deliberate, one declaration for all shells.

The full Hosting *module* (`MeshWeaver.SelfUpdate.Aks`) stays portal-only — it drags Blazor/AspNetCore/Azure and an AKS lifecycle that has no meaning on a device mesh; the records + discovery are the device-mesh slice.

## Verification

- Release `-warnaserror` clean; `LocalMeshApiRoutesTest` 10/10; RN typecheck + 157 vitest; WhatsNew validated on a rebuilt DLL
- Live against the running sidecar: created the `Hosting` group, the `Hosting/Deployment` NodeType, and the memex + local records via `/create`; `/search nodeType:Hosting/Deployment scope:subtree` finds both; `/get` returns `content.host` — the exact request sequence the app's discovery runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)