### PR TITLE
Don't link a module stylesheet that strips to nothing

### DIFF
--- a/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
@@ -330,7 +330,6 @@ public static partial class MeshModuleStaticAssetExtensions
             if (File.Exists(bundlePath))
             {
                 var requestPath = $"{ContentRoot}/{name}/{name}.styles.css";
-                stylesheets.Add(requestPath);
 
                 // 🚨 The aggregate opens with @import lines for its DEPENDENCIES' bundles at
                 // FINGERPRINTED urls, computed at MODULE-build time
@@ -342,8 +341,25 @@ public static partial class MeshModuleStaticAssetExtensions
                 // mount the dependency, so the two can never disagree about who provides what.
                 var rewritten = StripHostProvidedImports(
                     File.ReadAllText(bundlePath), hostAssets, name, logger);
-                if (rewritten is not null)
-                    rewrites["/" + requestPath] = rewritten;
+
+                // A pack with NO .razor.css of its own still emits an aggregate — one made of
+                // nothing but those imports (211 bytes for AppleMaps and OpenStreetMap). Once they
+                // are stripped there is nothing left to serve, so linking it would cost every page
+                // render a request for an empty file. Drop it from the manifest instead. Note this
+                // is decided AFTER stripping: the pre-strip file is never empty, so a check on the
+                // file itself would never fire.
+                if (rewritten is not null && string.IsNullOrWhiteSpace(rewritten))
+                {
+                    logger.LogInformation(
+                        "Module {Module}: its scoped-CSS aggregate held only host-provided imports, "
+                        + "so it is not linked — the pack has no scoped CSS of its own.", name);
+                }
+                else
+                {
+                    stylesheets.Add(requestPath);
+                    if (rewritten is not null)
+                        rewrites["/" + requestPath] = rewritten;
+                }
             }
 
             // 2. The module's DEPENDENCIES, already namespaced under its wwwroot/_content.

--- a/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
@@ -183,6 +183,31 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
             .Which.Should().Be($"_content/{ModuleName}/{ModuleName}.styles.css");
     }
 
+
+    /// <summary>
+    /// A pack with collocated JS but no <c>.razor.css</c> of its own still emits an aggregate — one
+    /// made of NOTHING but the dependency imports (211 bytes, measured for AppleMaps and
+    /// OpenStreetMap when they flipped, #1974). Once the host-provided ones are stripped there is
+    /// nothing left, so the host must not link it: every page render would fetch an empty file.
+    ///
+    /// <para>The emptiness is only knowable AFTER stripping — the file on disk is 211 bytes — which
+    /// is why the decision cannot be a test on the landed bytes.</para>
+    /// </summary>
+    [Fact]
+    public void AggregateOfNothingButHostProvidedImports_IsNotLinked()
+    {
+        // The host provides this dependency, so the module's import of it is the strippable kind.
+        File.WriteAllText(
+            Path.Combine(ModuleWwwroot, $"{ModuleName}.styles.css"),
+            "@import '_content/SharedDep/SharedDep.abc123.bundle.scp.css';\n");
+
+        var manifest = Discover(WithAssets);
+
+        manifest.Stylesheets.Should().BeEmpty();
+        // …and the module still contributes its ordinary asset mounts: the stylesheet decision
+        // must not short-circuit the dependency walk that follows it.
+        manifest.Mounts.Should().NotBeEmpty();
+    }
     /// <summary>
     /// A module with no <c>modules/&lt;Name&gt;/wwwroot</c> contributes nothing and does not throw.
     /// That is every module today — the step-1 double-ship prunes the folder empty — so this is

--- a/test/MeshWeaver.Hosting.Monolith.Test/ModuleStylesheetImportTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ModuleStylesheetImportTest.cs
@@ -85,4 +85,30 @@ public class ModuleStylesheetImportTest
             ".x[b-abc] { color: red; }", HostProviding("MeshWeaver.Blazor"),
             "MeshWeaver.Blazor.Analysis", NullLogger.Instance));
     }
+
+    /// <summary>
+    /// A pack with collocated JS but NO <c>.razor.css</c> of its own still emits an aggregate —
+    /// one made of nothing but the dependency imports. Measured at 211 bytes for both
+    /// MeshWeaver.Blazor.AppleMaps and .OpenStreetMap on the publish that flipped them (#1974).
+    /// Stripping empties it, which is why the caller must decide whether to link the stylesheet
+    /// AFTER stripping: the file on disk is never empty, so a test on its bytes never fires.
+    /// </summary>
+    [Fact]
+    public void AnAggregateOfNothingButHostProvidedImports_StripsToEmpty()
+    {
+        const string importsOnly =
+            "@import '_content/MeshWeaver.Blazor/MeshWeaver.Blazor.vbmbh1xu9q.bundle.scp.css';\n"
+            + "@import '_content/Microsoft.FluentUI.AspNetCore.Components/"
+            + "Microsoft.FluentUI.AspNetCore.Components.lcdo7z9xd2.bundle.scp.css';\n";
+
+        var rewritten = MeshModuleStaticAssetExtensions.StripHostProvidedImports(
+            importsOnly,
+            HostProviding("MeshWeaver.Blazor", "Microsoft.FluentUI.AspNetCore.Components"),
+            "MeshWeaver.Blazor.AppleMaps",
+            NullLogger.Instance);
+
+        // Not null — something WAS dropped, so the landed bytes must not be served as they are.
+        Assert.NotNull(rewritten);
+        Assert.True(string.IsNullOrWhiteSpace(rewritten));
+    }
 }


### PR DESCRIPTION
Follow-up to #2017, found while flipping the next two view packs (#1974).

A view pack with collocated JS but **no `.razor.css` of its own** still emits a scoped-CSS aggregate — one made of *nothing but* the dependency `@import` lines. That is not a corner case: it is **211 bytes for both `MeshWeaver.Blazor.AppleMaps` and `.OpenStreetMap`**, two of the five packs, measured on the publish that flips them.

#2017 strips the host-provided imports from such a file. For these two that empties it completely, so linking it would cost every page render a request that returns nothing.

So the decision to link moves to *after* the strip. The emptiness is only knowable there — on disk the file is 211 bytes — which is why a check on the landed bytes would never fire.

## Tests

Two, both against the exact bytes the publish produced:

- the strip returning whitespace for an imports-only aggregate;
- the manifest leaving it **unlinked**, while the module's ordinary asset mounts still land — the branch must not short-circuit the dependency walk that follows it.

Verified non-vacuous: with the predicate mutated to a runtime-false one, `AggregateOfNothingButHostProvidedImports_IsNotLinked` fails; restored, the 17 provider tests pass.