### PR TITLE
Flip the remaining four view packs onto the closure lane (#1974)

### DIFF
--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -21,8 +21,14 @@
     <!-- MeshWeaver.OgCard is deliberately NOT referenced (#1644 step 2): it ships via the
          modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
          Modules:Assemblies -> OgCardModuleAttribute. -->
-    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.OpenStreetMap\MeshWeaver.Blazor.OpenStreetMap.csproj" />
-    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.AppleMaps\MeshWeaver.Blazor.AppleMaps.csproj" />
+    <!-- MeshWeaver.Blazor.OpenStreetMap and .AppleMaps are deliberately NOT referenced (#1974):
+         they ship via the modules/<Name>/ closure layout in MeshModulesPublish.targets. Both were
+         ships-the-bits references that shipped bits nothing could reach — no portal code names
+         their types AND neither DLL is listed under Modules:Assemblies, so until now they rode
+         the app closure permanently inert. On the closure lane the bits sit in modules/ and a
+         deployment turns each on by listing its DLL, which is what that switch is for. Their
+         collocated JS and OpenStreetMap's vendored wwwroot/leaflet/ are already addressed as
+         ./_content/<Pack>/... — exactly what the module static-asset provider serves (#1724). -->
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Graph\MeshWeaver.Blazor.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Portal\MeshWeaver.Blazor.Portal.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Blazor\MeshWeaver.Hosting.Blazor.csproj" />

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -10,14 +10,18 @@
   <ItemGroup>
     <!-- Core MeshWeaver -->
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor\MeshWeaver.Blazor.csproj" />
-    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Radzen\MeshWeaver.Blazor.Radzen.csproj" />
     <!-- MeshWeaver.Blazor.Analysis is deliberately NOT referenced (#1974): it ships via the
          modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
          Modules:Assemblies. Its static web assets reach the browser through the module
          static-asset provider (#1724 + the bundle-carried wwwroot), not through this
          reference's build-time static-web-assets graph. No portal code referenced its types —
          this was a ships-the-bits reference and nothing else. -->
-    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.GoogleMaps\MeshWeaver.Blazor.GoogleMaps.csproj" />
+    <!-- MeshWeaver.Blazor.Radzen and .GoogleMaps are deliberately NOT referenced (#1974): with
+         these two the whole view-pack set ships via the modules/<Name>/ closure layout. Radzen
+         matters most here — dropping this reference is what stops the HOST serving
+         _content/Radzen.Blazor/, so the copy under the module's own wwwroot/_content/ answers the
+         theme stylesheet and Radzen.Blazor.js that RadzenViewBase self-loads on first render.
+         App.razor carries no pack tags for exactly that reason. -->
     <!-- MeshWeaver.OgCard is deliberately NOT referenced (#1644 step 2): it ships via the
          modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
          Modules:Assemblies -> OgCardModuleAttribute. -->

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -33,6 +33,19 @@
          deployment turns each on by listing its DLL, which is what that switch is for. Their
          collocated JS and OpenStreetMap's vendored wwwroot/leaflet/ are already addressed as
          ./_content/<Pack>/... — exactly what the module static-asset provider serves (#1724). -->
+    <!-- 🚨 DIRECT ON PURPOSE, and it must not be "tidied away" as unused. MeshWeaver.Maps is a
+         CANONICAL CONTENT-SURFACE assembly (FrameworkBuildIdentity.ContentSurfaceAssemblies), and
+         until the view packs flipped (#1974) this host reached it only through them — every map
+         pack references it. Losing it from the COMPILE closure does not fail a build: the surface
+         manifest is written from @(ReferencePathWithRefAssemblies), so the line simply vanishes,
+         this host hashes Maps as 'absent' while mw-plugin-test still hashes a real surface id, and
+         the two hosts of ONE commit resolve DIFFERENT framework identities. Every bake then lands
+         at an address no portal reads — publication green, pods compiling everything at boot, every
+         cover serving a compilation-fallback card. That is the 2026-08-17 outage (#1814); it
+         recurred here the moment the map packs left, and
+         FrameworkBuildIdentityTest.CanonicalContentSurface_IsRecordedByEverySurfaceManifestHost
+         is what caught it. No portal code uses these types — the reference IS the point. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Maps\MeshWeaver.Maps.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Graph\MeshWeaver.Blazor.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Portal\MeshWeaver.Blazor.Portal.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Blazor\MeshWeaver.Hosting.Blazor.csproj" />

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -76,6 +76,15 @@
          because it is the simplest: six scoped .razor.css files, no collocated JS, no package
          references of its own. -->
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Analysis/MeshWeaver.Blazor.Analysis.csproj" />
+    <!-- The two map packs that were never modules at all: they rode Memex.Portal.Shared's
+         ProjectReference into the app closure while being listed under NO Modules:Assemblies, so
+         their bits shipped permanently inert. Here the bits are reachable the moment a deployment
+         lists the DLL. Both address their assets as ./_content/<Pack>/... — AppleMaps its
+         collocated AppleMapView.razor.js, OpenStreetMap that plus its vendored wwwroot/leaflet/
+         (css, js and the marker images the css resolves beside itself) — which is precisely the
+         shape the module static-asset provider serves out of modules/<Name>/wwwroot (#1724). -->
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.AppleMaps/MeshWeaver.Blazor.AppleMaps.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.OpenStreetMap/MeshWeaver.Blazor.OpenStreetMap.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
     <!-- Import + its PRIVATE closure: the SIX MeshWeaver.DataSetReader* projects (the base, Csv,
          Excel, Excel.BinaryFormat, Excel.OpenXmlFormat, Excel.Utils) and MeshWeaver.DataStructures

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -54,8 +54,6 @@
          the module static-asset provider (path-convention mapping + fingerprint/precompressed
          endpoint variants; see UiExtensibility.md "Razor assets from a runtime-loaded
          assembly"), not just this list. -->
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
     <!-- Service modules NOT flippable for compile-time coupling (reasons: PR #1681) — Speech
          (ISpeechTranscriber lives in the module; no contract split), Social (ApiCredentialNodeType
          compiles against PlatformCredential; registration deliberately host-side; RELOCATING to
@@ -85,6 +83,17 @@
          shape the module static-asset provider serves out of modules/<Name>/wwwroot (#1724). -->
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.AppleMaps/MeshWeaver.Blazor.AppleMaps.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.OpenStreetMap/MeshWeaver.Blazor.OpenStreetMap.csproj" />
+    <!-- The last two packs off the thin lane, which completes the set (#1974). Both were already
+         modules — listed under Modules:Assemblies and activated there — so this moves only where
+         their bits ship, not whether they run. GoogleMaps carries scoped CSS plus collocated JS.
+         Radzen is the one that needed the provider's dependency mount rather than its own: it
+         self-loads _content/Radzen.Blazor/... from RadzenViewBase and its two views link a theme
+         stylesheet from the same namespace — PACKAGE assets, not the pack's own. Dropping the
+         portal's reference means the host stops serving that namespace, so the copy under the
+         module's wwwroot/_content/ becomes the one that answers, which is exactly the case the
+         same-identity prune is written around. -->
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
     <!-- Import + its PRIVATE closure: the SIX MeshWeaver.DataSetReader* projects (the base, Csv,
          Excel, Excel.BinaryFormat, Excel.OpenXmlFormat, Excel.Utils) and MeshWeaver.DataStructures

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -32,15 +32,17 @@
          shells call — an unmapped one there answers the SPA fallback with a 200, not a 404 (#1474). -->
     <ProjectReference Include="..\..\memex\Memex.LocalMesh\Memex.LocalMesh.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
-    <!-- ViewPackModuleTest asserts on MeshWeaver.Blazor.Analysis's module attribute, and Analysis
-         left Memex.Portal.Shared's closure when it flipped to modules/ (#1974) — so the test
-         anchors the pack itself rather than riding a portal reference that no longer exists. Safe
-         here precisely because Analysis is NOT in MeshModulesClosureSubset above: nothing stages a
-         modules/MeshWeaver.Blazor.Analysis/ in this bin for a bin-root copy to shadow. -->
+    <!-- ViewPackModuleTest asserts on each view pack's module attribute, and all of them left
+         Memex.Portal.Shared's closure when they flipped to modules/ (#1974) — so the test anchors
+         the packs itself rather than riding portal references that no longer exist. Safe here
+         precisely because none of them is in MeshModulesClosureSubset above: nothing stages a
+         modules/MeshWeaver.Blazor.*/ in this bin for a bin-root copy to shadow. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Analysis\MeshWeaver.Blazor.Analysis.csproj" />
     <!-- Same for MapProviderModuleTest, which pins the provider-swap contract on these two. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.AppleMaps\MeshWeaver.Blazor.AppleMaps.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.OpenStreetMap\MeshWeaver.Blazor.OpenStreetMap.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Radzen\MeshWeaver.Blazor.Radzen.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.GoogleMaps\MeshWeaver.Blazor.GoogleMaps.csproj" />
     <!-- Direct on purpose (#1644 step 2): these modules left Memex.Portal.Shared's closure
          (they ship via modules/), so the module-fold tests anchor the real DLLs themselves. -->
     <!-- MigrationRegistryTest runs the migration runner's own start-up guard (VerifyComplete) in

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -38,6 +38,9 @@
          here precisely because Analysis is NOT in MeshModulesClosureSubset above: nothing stages a
          modules/MeshWeaver.Blazor.Analysis/ in this bin for a bin-root copy to shadow. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Analysis\MeshWeaver.Blazor.Analysis.csproj" />
+    <!-- Same for MapProviderModuleTest, which pins the provider-swap contract on these two. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.AppleMaps\MeshWeaver.Blazor.AppleMaps.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.OpenStreetMap\MeshWeaver.Blazor.OpenStreetMap.csproj" />
     <!-- Direct on purpose (#1644 step 2): these modules left Memex.Portal.Shared's closure
          (they ship via modules/), so the module-fold tests anchor the real DLLs themselves. -->
     <!-- MigrationRegistryTest runs the migration runner's own start-up guard (VerifyComplete) in


### PR DESCRIPTION
**This completes the view-pack set.** With #2018 (Analysis) already merged, all five now ship via `modules/<Name>/` and none is referenced by `Memex.Portal.Shared`.

> Originally opened for AppleMaps + OpenStreetMap alone; #2022 (Radzen + GoogleMaps) merged into this branch, so this single PR to `main` carries all four.

## AppleMaps and OpenStreetMap were never modules at all

They rode `Memex.Portal.Shared`'s `ProjectReference` into the app closure while appearing under **no** `Modules:Assemblies` list, and no portal code names their types. Attribute discovery is by explicit path (`MeshBuilder.InstallAssemblies`), not a scan of whatever is loaded — so nothing was ever going to pick them up. Their bits shipped in every image **permanently inert**.

**This changes only where the bits live.** No pack is added to `Modules:Assemblies` here, so each stays exactly as active (or inactive) as it is today. Turning the two map packs on is a separate call — AppleMaps needs a MapKit token; OpenStreetMap needs no key.

## Radzen is the case the earlier flips could not answer

It self-loads `_content/Radzen.Blazor/{css/material-base.css, Radzen.Blazor.js}` from `RadzenViewBase`, and its chart and pivot views link a theme stylesheet from the same namespace. Those are **package** assets, not the pack's own.

Dropping the portal's reference is precisely what stops the **host** serving that namespace, so the module's own `wwwroot/_content/Radzen.Blazor/` answers instead — the same-identity prune working from the other side. Verified: **36 files** land there, including both self-loaded files and every theme; the host's copy is gone. `App.razor` carries no pack tags, which is what makes this work.

## Verified on real publishes

For all five packs: every DLL **absent** from the app publish root, every pack **dropped** from the host's `<App>.styles.css`, and assets under `modules/<Name>/wwwroot` at the paths the code actually requests — `AppleMapView.razor.js`, `OpenStreetMapView.razor.js`, and leaflet's `css`/`js` plus the marker images its css resolves beside itself.

## Also

Anchors all four packs in `Memex.Portal.Shared.Test`, which asserts on their module attributes (`ViewPackModuleTest`, `MapProviderModuleTest`) and reached them through the portal until now. Worth recording: **a publish cannot verify a flip** — it has nothing to say about a compile-time reference the tests still need, which is how #2018 went red after a green publish.

Two observations, neither acted on here:

- **Three of five** packs (Radzen, AppleMaps, OpenStreetMap) have no `.razor.css` of their own, so their aggregate is 211 bytes of nothing but dependency imports — that is what #2020 stops linking.
- `MeshWeaver.Blazor.Radzen/wwwroot/css/radzen-grid.css` is referenced by nothing in the repo. Harmless under the module's namespace; removing it is a separate call.

## MeshWeaver.Maps stays in core

Correcting an earlier plan to move it with the map packs: it has consumers of its own (`MeshWeaver.Maui`, `PluginTester`, five test projects) and is named in `FrameworkBuildIdentity`, so node source compiles against it.