### PR TITLE
Flip the Radzen and GoogleMaps view packs onto the closure lane (#1974)

### DIFF
--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -10,14 +10,18 @@
   <ItemGroup>
     <!-- Core MeshWeaver -->
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor\MeshWeaver.Blazor.csproj" />
-    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Radzen\MeshWeaver.Blazor.Radzen.csproj" />
     <!-- MeshWeaver.Blazor.Analysis is deliberately NOT referenced (#1974): it ships via the
          modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
          Modules:Assemblies. Its static web assets reach the browser through the module
          static-asset provider (#1724 + the bundle-carried wwwroot), not through this
          reference's build-time static-web-assets graph. No portal code referenced its types —
          this was a ships-the-bits reference and nothing else. -->
-    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.GoogleMaps\MeshWeaver.Blazor.GoogleMaps.csproj" />
+    <!-- MeshWeaver.Blazor.Radzen and .GoogleMaps are deliberately NOT referenced (#1974): with
+         these two the whole view-pack set ships via the modules/<Name>/ closure layout. Radzen
+         matters most here — dropping this reference is what stops the HOST serving
+         _content/Radzen.Blazor/, so the copy under the module's own wwwroot/_content/ answers the
+         theme stylesheet and Radzen.Blazor.js that RadzenViewBase self-loads on first render.
+         App.razor carries no pack tags for exactly that reason. -->
     <!-- MeshWeaver.OgCard is deliberately NOT referenced (#1644 step 2): it ships via the
          modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
          Modules:Assemblies -> OgCardModuleAttribute. -->

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -54,8 +54,6 @@
          the module static-asset provider (path-convention mapping + fingerprint/precompressed
          endpoint variants; see UiExtensibility.md "Razor assets from a runtime-loaded
          assembly"), not just this list. -->
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
     <!-- Service modules NOT flippable for compile-time coupling (reasons: PR #1681) — Speech
          (ISpeechTranscriber lives in the module; no contract split), Social (ApiCredentialNodeType
          compiles against PlatformCredential; registration deliberately host-side; RELOCATING to
@@ -85,6 +83,17 @@
          shape the module static-asset provider serves out of modules/<Name>/wwwroot (#1724). -->
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.AppleMaps/MeshWeaver.Blazor.AppleMaps.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.OpenStreetMap/MeshWeaver.Blazor.OpenStreetMap.csproj" />
+    <!-- The last two packs off the thin lane, which completes the set (#1974). Both were already
+         modules — listed under Modules:Assemblies and activated there — so this moves only where
+         their bits ship, not whether they run. GoogleMaps carries scoped CSS plus collocated JS.
+         Radzen is the one that needed the provider's dependency mount rather than its own: it
+         self-loads _content/Radzen.Blazor/... from RadzenViewBase and its two views link a theme
+         stylesheet from the same namespace — PACKAGE assets, not the pack's own. Dropping the
+         portal's reference means the host stops serving that namespace, so the copy under the
+         module's wwwroot/_content/ becomes the one that answers, which is exactly the case the
+         same-identity prune is written around. -->
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
     <!-- Import + its PRIVATE closure: the SIX MeshWeaver.DataSetReader* projects (the base, Csv,
          Excel, Excel.BinaryFormat, Excel.OpenXmlFormat, Excel.Utils) and MeshWeaver.DataStructures

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -32,15 +32,17 @@
          shells call — an unmapped one there answers the SPA fallback with a 200, not a 404 (#1474). -->
     <ProjectReference Include="..\..\memex\Memex.LocalMesh\Memex.LocalMesh.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
-    <!-- ViewPackModuleTest asserts on MeshWeaver.Blazor.Analysis's module attribute, and Analysis
-         left Memex.Portal.Shared's closure when it flipped to modules/ (#1974) — so the test
-         anchors the pack itself rather than riding a portal reference that no longer exists. Safe
-         here precisely because Analysis is NOT in MeshModulesClosureSubset above: nothing stages a
-         modules/MeshWeaver.Blazor.Analysis/ in this bin for a bin-root copy to shadow. -->
+    <!-- ViewPackModuleTest asserts on each view pack's module attribute, and all of them left
+         Memex.Portal.Shared's closure when they flipped to modules/ (#1974) — so the test anchors
+         the packs itself rather than riding portal references that no longer exist. Safe here
+         precisely because none of them is in MeshModulesClosureSubset above: nothing stages a
+         modules/MeshWeaver.Blazor.*/ in this bin for a bin-root copy to shadow. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Analysis\MeshWeaver.Blazor.Analysis.csproj" />
     <!-- Same for MapProviderModuleTest, which pins the provider-swap contract on these two. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.AppleMaps\MeshWeaver.Blazor.AppleMaps.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.OpenStreetMap\MeshWeaver.Blazor.OpenStreetMap.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Radzen\MeshWeaver.Blazor.Radzen.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.GoogleMaps\MeshWeaver.Blazor.GoogleMaps.csproj" />
     <!-- Direct on purpose (#1644 step 2): these modules left Memex.Portal.Shared's closure
          (they ship via modules/), so the module-fold tests anchor the real DLLs themselves. -->
     <!-- MigrationRegistryTest runs the migration runner's own start-up guard (VerifyComplete) in


### PR DESCRIPTION
Stacked on #2021 (which is stacked on #2018). **This completes the view-pack set** — all five now ship via `modules/<Name>/` and none is referenced by `Memex.Portal.Shared`.

Both packs were already modules — listed under `Modules:Assemblies` and activated there — so this moves only where their bits ship, not whether they run.

## Radzen is the case the earlier flips could not answer

It self-loads `_content/Radzen.Blazor/{css/material-base.css, Radzen.Blazor.js}` from `RadzenViewBase`, and its chart and pivot views link a theme stylesheet from the same namespace. Those are **package** assets, not the pack's own — the one shape none of the other four exercise.

Dropping the portal's reference is precisely what stops the **host** serving that namespace, so the copy under the module's own `wwwroot/_content/` becomes the one that answers. That is the same-identity prune working as designed, from the other side.

Verified on a real publish:

- **36 files** under `modules/MeshWeaver.Blazor.Radzen/wwwroot/_content/Radzen.Blazor/`, including both self-loaded files (`material-base.css` 694 KB, `Radzen.Blazor.js` 141 KB) and every theme the views can name;
- the host's `wwwroot/_content/Radzen.Blazor/` is **gone**;
- `App.razor` carries no pack tags — it already documents that packs self-load on first render, which is what makes this work.

Across all five packs on that same publish: every DLL **absent** from the app publish root, and every pack **dropped** out of the host's `<App>.styles.css`.

## Also

Anchors Radzen and GoogleMaps in `Memex.Portal.Shared.Test`, which asserts on their module attributes and reached them through the portal until now.

Two observations recorded in the commit, neither acted on here:

- **Three of five** packs (Radzen, AppleMaps, OpenStreetMap) have no `.razor.css` of their own, so their aggregate is 211 bytes of nothing but dependency imports — that is what #2020 stops linking.
- `MeshWeaver.Blazor.Radzen/wwwroot/css/radzen-grid.css` is referenced by nothing in the repo, neither linked nor its class used. It ships harmlessly under the module's own namespace; removing it is a separate call.