### PR TITLE
fix(email): outbound sends are serialized and re-checked — duplicate watch emissions no longer double-deliver

### DIFF
--- a/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
@@ -17,9 +17,13 @@ namespace Memex.Portal.Shared.Email;
 /// Mesh-driven outbound sender — <b>no in-memory state</b>. The <c>Email Router</c> agent emits its
 /// reply as an outbound <see cref="MeshWeaver.Mesh.Email"/> node (<c>Direction=Outbound, Status=New</c>)
 /// in the parent email's namespace; this single hosted service watches for those via
-/// <see cref="IMeshQueryCore"/>, claims each (New → Sending, the optimistic guard against double-send),
-/// sends it through <see cref="IEmailSender"/>, and flips it to <see cref="EmailStatus.Sent"/> (or
-/// <see cref="EmailStatus.Failed"/>). Dedup + restart-safety live entirely in the node's status.
+/// <see cref="IMeshQueryCore"/> and hands each to its serialized <see cref="OutboundSendQueue"/>,
+/// which re-reads the mail's authoritative state, claims it (New → Sending), sends it through
+/// <see cref="IEmailSender"/>, and flips it to <see cref="EmailStatus.Sent"/> (or
+/// <see cref="EmailStatus.Failed"/>). Restart-safety lives in the node's status; DEDUP lives in
+/// the queue's serialize-then-re-read gate — the watch legitimately emits the same New snapshot
+/// more than once, and a plain status write is not a claim (the double-delivery this fixed is
+/// documented on the queue).
 ///
 /// <para>Reactive; the only Task boundary is the <see cref="IHostedService"/> contract. Self-skips
 /// unless <c>Email:Enabled</c>.</para>
@@ -43,8 +47,10 @@ public sealed class OutboundEmailSender(
     /// still returned the status-omitted email), so New-queued mail always matches, while
     /// explicitly stamped <c>Sending</c>/<c>Sent</c>/<c>Failed</c> mail drops out of the set as it
     /// is processed instead of accumulating forever (the Copilot review's growth concern on the
-    /// unfiltered form). Status is additionally re-checked IN CODE by <c>Send</c>, and the
-    /// New → Sending claim guards double-send. <c>content.direction:Outbound</c> is a safe
+    /// unfiltered form). Status is additionally re-checked IN CODE — serialized and against the
+    /// AUTHORITATIVE node stream — by <see cref="OutboundSendQueue"/>, which is what actually
+    /// guards double-send (duplicate emissions of the same New snapshot are a documented property
+    /// of the change feed). <c>content.direction:Outbound</c> is a safe
     /// positive match: Outbound is not the default, so it always serializes — see
     /// <c>OutboundEmailWatchQueryTest</c>.</para>
     /// </summary>
@@ -87,8 +93,26 @@ public sealed class OutboundEmailSender(
             var emailSender = sp.GetRequiredService<IEmailSender>();
             var jsonOptions = hub.JsonSerializerOptions;
 
-            // Live query: any outbound mail. Emits the current set on change; Send filters to
-            // New and claims (New → Sending) before dispatching, so already-sent nodes are no-ops.
+            // The serialized send queue: re-reads each mail's CURRENT state through the shared
+            // per-node stream handle (authoritative — never the eventually-consistent query) before
+            // claiming and sending, so duplicate emissions of the same New snapshot send ONCE.
+            var sendQueue = new OutboundSendQueue(
+                readCurrent: path => hub.GetMeshNodeStream(path)
+                    .Where(n => n is not null)
+                    .Select(n => EmailOf(n, jsonOptions)),
+                writeStatus: (node, current, status) =>
+                    SetStatus(node, current, status, meshService, accessService),
+                send: email =>
+                {
+                    var subject = email.Subject.StartsWith("Re:", StringComparison.OrdinalIgnoreCase)
+                        ? email.Subject : $"Re: {email.Subject}";
+                    return emailSender.SendEmail(email.To!, subject, email.Body);
+                },
+                logger: logger);
+            subscriptions.Add(sendQueue);
+
+            // Live query: any outbound mail. Emits the current set on change; the pre-screen keeps
+            // the queue to plausible candidates, the queue's own re-read gate decides the send.
             subscriptions.Add(query
                 .Query<MeshNode>(MeshQueryRequest.FromQuery(WatchQuery), jsonOptions)
                 .Select(change => change.Items)
@@ -96,7 +120,23 @@ public sealed class OutboundEmailSender(
                     items =>
                     {
                         foreach (var node in items)
-                            Send(node, meshService, accessService, emailSender, jsonOptions);
+                        {
+                            var email = EmailOf(node, jsonOptions);
+                            if (email is null
+                                || email.Direction != EmailDirection.Outbound
+                                || email.Status != EmailStatus.New)
+                                continue;
+                            if (string.IsNullOrEmpty(email.To))
+                            {
+                                logger?.LogWarning(
+                                    "OutboundEmailSender: outbound {Path} has no recipient — marking Failed",
+                                    node.Path);
+                                SetStatus(node, email, EmailStatus.Failed, meshService, accessService)
+                                    .Subscribe(_ => { }, _ => { });
+                                continue;
+                            }
+                            sendQueue.Enqueue(node, email);
+                        }
                     },
                     ex => logger?.LogWarning(ex, "OutboundEmailSender: query failed")));
         }
@@ -104,43 +144,6 @@ public sealed class OutboundEmailSender(
         {
             logger?.LogWarning(ex, "OutboundEmailSender: failed to start watching outbound mail");
         }
-    }
-
-    private void Send(
-        MeshNode node, IMeshService meshService, AccessService accessService,
-        IEmailSender emailSender, JsonSerializerOptions jsonOptions)
-    {
-        var email = EmailOf(node, jsonOptions);
-        if (email is null || email.Direction != EmailDirection.Outbound || email.Status != EmailStatus.New)
-            return;
-        if (string.IsNullOrEmpty(email.To))
-        {
-            logger?.LogWarning("OutboundEmailSender: outbound {Path} has no recipient — marking Failed", node.Path);
-            SetStatus(node, email, EmailStatus.Failed, meshService, accessService).Subscribe(_ => { }, _ => { });
-            return;
-        }
-
-        // Claim: New → Sending (only if still New). The CAS lives in SetStatus's lambda, so a duplicate
-        // emission that already flipped it is a no-op.
-        SetStatus(node, email, EmailStatus.Sending, meshService, accessService)
-            .SelectMany(claimed =>
-            {
-                // SetStatus returns the unchanged node when the CAS failed (already claimed) — skip.
-                if ((EmailOf(claimed, jsonOptions)?.Status) != EmailStatus.Sending)
-                    return Observable.Empty<bool>();
-                var subject = email.Subject.StartsWith("Re:", StringComparison.OrdinalIgnoreCase)
-                    ? email.Subject : $"Re: {email.Subject}";
-                return emailSender.SendEmail(email.To!, subject, email.Body)
-                    .SelectMany(ok => SetStatus(claimed, EmailOf(claimed, jsonOptions)!,
-                        ok ? EmailStatus.Sent : EmailStatus.Failed, meshService, accessService).Select(_ => ok));
-            })
-            .Subscribe(
-                ok => logger?.LogInformation("OutboundEmailSender: {Path} → {To} sent={Sent}", node.Path, email.To, ok),
-                ex =>
-                {
-                    logger?.LogWarning(ex, "OutboundEmailSender: send failed for {Path}", node.Path);
-                    SetStatus(node, email, EmailStatus.Failed, meshService, accessService).Subscribe(_ => { }, _ => { });
-                });
     }
 
     private static IObservable<MeshNode> SetStatus(

--- a/memex/Memex.Portal.Shared/Email/OutboundSendQueue.cs
+++ b/memex/Memex.Portal.Shared/Email/OutboundSendQueue.cs
@@ -1,0 +1,162 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Email;
+
+/// <summary>
+/// Serializes outbound sends and re-reads each mail's CURRENT state immediately before sending —
+/// the fix for the duplicate-delivery defect observed live on 2026-08-21 (every queued mail
+/// arrived twice).
+///
+/// <para><b>Why the old claim could not work.</b> The watch query emits the live SET on every
+/// change, and the change feed legitimately delivers the same <c>New</c> snapshot more than once
+/// (initial snapshot + change echo — the same reason tests must never assert "exactly N change
+/// events"). The old New → Sending "claim" was a plain <c>UpdateNode</c>: last-write-wins, no
+/// compare — and the node it returned always echoed <c>Sending</c>, so the "claim failed" guard
+/// was unreachable. Two emissions of the same queued mail therefore meant two full sends.</para>
+///
+/// <para><b>The shape of the fix.</b> One instance per sender; <c>Subject + Concat</c> is the
+/// serialization (the canonical queue idiom — order without a lock, no semaphore), and each item
+/// re-reads the mail's authoritative state through the seam before touching it: a duplicate
+/// emission, a stale echo, or a re-emitted snapshot finds the mail already
+/// <c>Sending</c>/<c>Sent</c>/<c>Failed</c> and is skipped. A read that does not answer within
+/// its budget SKIPS with a warning — not sending is the safe direction, the mail stays
+/// <c>New</c>, and the next emission retries.</para>
+///
+/// <para><b>What deliberately remains.</b> Two PODS overlapping during a rollout can both read
+/// <c>New</c> and both send — cross-process at-least-once is the accepted trade (same as the
+/// retry-after-partial-failure note on <c>ContactInquiry.SubmissionId</c>); this class removes
+/// the in-process duplicates, which are the ones users actually observed.</para>
+///
+/// <para>Seams are delegates so the whole state machine is testable without a hub — see
+/// <c>OutboundSendQueueTest</c>.</para>
+/// </summary>
+internal sealed class OutboundSendQueue : IDisposable
+{
+    /// <summary>How long the authoritative pre-send read may take. It answers from the node
+    /// stream's current state, so anything but a prompt answer means the read path is unhealthy —
+    /// waiting longer cannot make sending safer.</summary>
+    public static readonly TimeSpan DefaultReadBudget = TimeSpan.FromSeconds(10);
+
+    private readonly Func<string, IObservable<MeshWeaver.Mesh.Email?>> readCurrent;
+    private readonly Func<MeshNode, MeshWeaver.Mesh.Email, EmailStatus, IObservable<MeshNode>> writeStatus;
+    private readonly Func<MeshWeaver.Mesh.Email, IObservable<bool>> send;
+    private readonly TimeSpan readBudget;
+    private readonly ILogger? logger;
+
+    private readonly Subject<(MeshNode Node, MeshWeaver.Mesh.Email Snapshot)> queue = new();
+    private readonly Subject<string> processed = new();
+    private readonly IDisposable subscription;
+
+    /// <summary>Creates the queue.</summary>
+    /// <param name="readCurrent">Authoritative read of the mail node's CURRENT content by path —
+    /// emits one value (null when the node no longer exists or carries no email).</param>
+    /// <param name="writeStatus">Writes the given status onto the node (the System-identity write
+    /// lives behind this seam).</param>
+    /// <param name="send">Performs the actual send; false or an error marks the mail Failed.</param>
+    /// <param name="readBudget">Budget for <paramref name="readCurrent"/>; defaults to
+    /// <see cref="DefaultReadBudget"/>.</param>
+    /// <param name="logger">Diagnostics.</param>
+    public OutboundSendQueue(
+        Func<string, IObservable<MeshWeaver.Mesh.Email?>> readCurrent,
+        Func<MeshNode, MeshWeaver.Mesh.Email, EmailStatus, IObservable<MeshNode>> writeStatus,
+        Func<MeshWeaver.Mesh.Email, IObservable<bool>> send,
+        TimeSpan? readBudget = null,
+        ILogger? logger = null)
+    {
+        this.readCurrent = readCurrent;
+        this.writeStatus = writeStatus;
+        this.send = send;
+        this.readBudget = readBudget ?? DefaultReadBudget;
+        this.logger = logger;
+
+        // Concat subscribes the next item only after the previous completed — the serialization.
+        // Every inner observable is hardened to COMPLETE (never error), so one poisoned mail can
+        // never kill the queue for the ones behind it.
+        subscription = queue
+            .Select(item => Observable.Defer(() => ProcessOne(item.Node, item.Snapshot))
+                .Catch((Exception ex) =>
+                {
+                    logger?.LogWarning(ex,
+                        "OutboundSendQueue: processing {Path} failed unexpectedly", item.Node.Path);
+                    return Observable.Empty<Unit>();
+                })
+                .Concat(Observable.Defer(() =>
+                {
+                    processed.OnNext(item.Node.Path);
+                    return Observable.Empty<Unit>();
+                })))
+            .Concat()
+            .Subscribe(
+                _ => { },
+                ex => logger?.LogError(ex, "OutboundSendQueue: the queue itself faulted"));
+    }
+
+    /// <summary>Emits each item's node path when the queue has finished with it (sent, skipped,
+    /// or failed) — the deterministic completion signal the tests await.</summary>
+    public IObservable<string> Processed => processed;
+
+    /// <summary>Queues one emitted mail snapshot for a serialized, re-checked send.</summary>
+    public void Enqueue(MeshNode node, MeshWeaver.Mesh.Email snapshot) =>
+        queue.OnNext((node, snapshot));
+
+    private IObservable<Unit> ProcessOne(MeshNode node, MeshWeaver.Mesh.Email snapshot) =>
+        readCurrent(node.Path)
+            .Take(1)
+            .Timeout(readBudget, Observable.Throw<MeshWeaver.Mesh.Email?>(new TimeoutException(
+                $"the pre-send state read for {node.Path} did not answer within {readBudget}")))
+            .SelectMany(current =>
+            {
+                // The gate: only a mail that CURRENTLY reads New is ours to send. Anything else —
+                // a duplicate emission of an already-claimed mail, a stale echo of a finished one,
+                // a node that vanished — is skipped, not an error.
+                if (current is null
+                    || current.Direction != EmailDirection.Outbound
+                    || current.Status != EmailStatus.New)
+                {
+                    logger?.LogDebug(
+                        "OutboundSendQueue: {Path} no longer reads as queued (status {Status}) — skipped",
+                        node.Path, current?.Status.ToString() ?? "<absent>");
+                    return Observable.Empty<Unit>();
+                }
+
+                return writeStatus(node, current, EmailStatus.Sending)
+                    .SelectMany(_ => send(current)
+                        .SelectMany(ok =>
+                        {
+                            logger?.LogInformation(
+                                "OutboundSendQueue: {Path} → {To} sent={Sent}",
+                                node.Path, current.To, ok);
+                            return writeStatus(node, current,
+                                ok ? EmailStatus.Sent : EmailStatus.Failed);
+                        }))
+                    .Select(_ => Unit.Default)
+                    .Catch((Exception ex) =>
+                    {
+                        logger?.LogWarning(ex,
+                            "OutboundSendQueue: send failed for {Path} — marking Failed", node.Path);
+                        return writeStatus(node, current, EmailStatus.Failed)
+                            .Select(_ => Unit.Default)
+                            .Catch(Observable.Empty<Unit>());
+                    });
+            })
+            .Catch((TimeoutException ex) =>
+            {
+                // Fail CLOSED: without a trustworthy current state, not sending is the safe
+                // direction — the mail stays New and the next emission retries.
+                logger?.LogWarning(ex,
+                    "OutboundSendQueue: state read for {Path} timed out — send skipped, will retry "
+                    + "on the next emission", node.Path);
+                return Observable.Empty<Unit>();
+            });
+
+    public void Dispose()
+    {
+        subscription.Dispose();
+        queue.Dispose();
+        processed.Dispose();
+    }
+}

--- a/memex/Memex.Portal.Shared/Email/OutboundSendQueue.cs
+++ b/memex/Memex.Portal.Shared/Email/OutboundSendQueue.cs
@@ -52,8 +52,11 @@ internal sealed class OutboundSendQueue : IDisposable
     private readonly IDisposable subscription;
 
     /// <summary>Creates the queue.</summary>
-    /// <param name="readCurrent">Authoritative read of the mail node's CURRENT content by path —
-    /// emits one value (null when the node no longer exists or carries no email).</param>
+    /// <param name="readCurrent">Authoritative read of the mail node's CURRENT content by path.
+    /// When it answers, it emits the content (null = a node without readable e-mail content, which
+    /// is skipped). An absent or unreachable node may emit NOTHING at all — the production seam is
+    /// the per-node stream, which stays silent rather than emitting an absence — and the queue's
+    /// read budget converts that silence into a fail-closed skip.</param>
     /// <param name="writeStatus">Writes the given status onto the node (the System-identity write
     /// lives behind this seam).</param>
     /// <param name="send">Performs the actual send; false or an error marks the mail Failed.</param>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-outbound-email-double-send.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-outbound-email-double-send.md
@@ -1,0 +1,14 @@
+---
+Name: Outbound e-mails no longer arrive twice
+Category: Fix
+Description: Notification e-mails (contact-form enquiries, invitations) were sometimes delivered twice; each queued mail is now sent exactly once.
+Icon: Mail
+Order: -20260821
+---
+
+# Outbound e-mails no longer arrive twice
+
+Notification e-mails — contact-form enquiries, invitations, agent replies — could arrive in your
+inbox twice, because the sender occasionally processed the same queued mail more than once. Sends
+are now serialized and each mail's state is re-checked immediately before sending, so every queued
+e-mail is delivered exactly once.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-outbound-email-double-send.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-outbound-email-double-send.md
@@ -1,7 +1,7 @@
 ---
 Name: Outbound e-mails no longer arrive twice
 Category: Fix
-Description: Notification e-mails (contact-form enquiries, invitations) were sometimes delivered twice; each queued mail is now sent exactly once.
+Description: Notification e-mails (contact-form enquiries, invitations) were sometimes delivered twice; the sender no longer produces these duplicates.
 Icon: Mail
 Order: -20260821
 ---
@@ -10,5 +10,5 @@ Order: -20260821
 
 Notification e-mails — contact-form enquiries, invitations, agent replies — could arrive in your
 inbox twice, because the sender occasionally processed the same queued mail more than once. Sends
-are now serialized and each mail's state is re-checked immediately before sending, so every queued
-e-mail is delivered exactly once.
+are now serialized and each mail's state is re-checked immediately before sending, which eliminates
+these duplicate deliveries.

--- a/test/Memex.Portal.Shared.Test/OutboundSendQueueTest.cs
+++ b/test/Memex.Portal.Shared.Test/OutboundSendQueueTest.cs
@@ -1,0 +1,182 @@
+using System.Collections.Concurrent;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using Memex.Portal.Shared.Email;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the fix for the outbound DOUBLE-DELIVERY observed live on 2026-08-21: every queued mail
+/// arrived twice, because the watch legitimately emits the same <c>New</c> snapshot more than once
+/// (initial snapshot + change echo — the reason tests must never assert "exactly N change events")
+/// and the old New → Sending "claim" was a plain last-write-wins update whose "claim failed" guard
+/// was unreachable. <see cref="OutboundSendQueue"/> serializes sends and re-reads the mail's
+/// authoritative state before each one; these cases drive that state machine through delegate
+/// seams over a tiny in-test store — deterministic, no hub, no timing sleeps.
+/// </summary>
+public class OutboundSendQueueTest
+{
+    private static readonly TimeSpan TestBudget = TimeSpan.FromSeconds(10);
+
+    private sealed class Harness : IDisposable
+    {
+        public readonly ConcurrentDictionary<string, MeshWeaver.Mesh.Email> Store = new();
+        public readonly ConcurrentDictionary<string, int> Sends = new();
+        public Func<MeshWeaver.Mesh.Email, IObservable<bool>>? SendOverride;
+        public Func<string, IObservable<MeshWeaver.Mesh.Email?>>? ReadOverride;
+        public OutboundSendQueue Queue { get; }
+
+        public Harness(TimeSpan? readBudget = null)
+        {
+            Queue = new OutboundSendQueue(
+                // Defer: the read must observe the store AS OF the moment the queue processes the
+                // item, not as of enqueue — that freshness is the very property under test.
+                readCurrent: path => ReadOverride?.Invoke(path)
+                    ?? Observable.Defer(() => Observable.Return(
+                        Store.TryGetValue(path, out var email) ? email : null)),
+                writeStatus: (node, current, status) => Observable.Defer(() =>
+                {
+                    Store[node.Path] = current with { Status = status };
+                    return Observable.Return(node);
+                }),
+                send: email =>
+                {
+                    Sends.AddOrUpdate(email.To ?? "", 1, (_, n) => n + 1);
+                    return SendOverride?.Invoke(email) ?? Observable.Return(true);
+                },
+                readBudget: readBudget);
+        }
+
+        public MeshNode QueuedMail(string id, string to = "one@example.test")
+        {
+            var email = new MeshWeaver.Mesh.Email
+            {
+                Direction = EmailDirection.Outbound,
+                Status = EmailStatus.New,
+                To = to,
+                Subject = "s",
+                Body = "b",
+            };
+            var node = new MeshNode(id, "T") { NodeType = "Email", Name = id, Content = email };
+            Store[node.Path] = email;
+            return node;
+        }
+
+        public Task<IList<string>> AwaitProcessed(int count) =>
+            Queue.Processed.Take(count).ToList().Timeout(TestBudget).FirstAsync().ToTask();
+
+        public void Dispose() => Queue.Dispose();
+    }
+
+    [Fact]
+    public async Task DuplicateEmissions_SendExactlyOnce()
+    {
+        using var h = new Harness();
+        var node = h.QueuedMail("m1");
+        var email = (MeshWeaver.Mesh.Email)node.Content!;
+
+        // The live failure mode: the SAME New snapshot delivered twice by the watch. The awaiter
+        // is armed FIRST: the seams are synchronous, so processing completes inside Enqueue.
+        var done = h.AwaitProcessed(2);
+        h.Queue.Enqueue(node, email);
+        h.Queue.Enqueue(node, email);
+        await done;
+
+        Assert.Equal(1, h.Sends["one@example.test"]);
+        Assert.Equal(EmailStatus.Sent, h.Store[node.Path].Status);
+    }
+
+    [Fact]
+    public async Task StaleEchoAfterCompletion_DoesNotResend()
+    {
+        using var h = new Harness();
+        var node = h.QueuedMail("m1");
+        var email = (MeshWeaver.Mesh.Email)node.Content!;
+
+        var first = h.AwaitProcessed(1);
+        h.Queue.Enqueue(node, email);
+        await first;
+        // A late echo of the long-finished New snapshot — the re-read sees Sent and skips.
+        var echo = h.AwaitProcessed(1);
+        h.Queue.Enqueue(node, email);
+        await echo;
+
+        Assert.Equal(1, h.Sends["one@example.test"]);
+        Assert.Equal(EmailStatus.Sent, h.Store[node.Path].Status);
+    }
+
+    [Fact]
+    public async Task AlreadyClaimedElsewhere_IsSkipped()
+    {
+        using var h = new Harness();
+        var node = h.QueuedMail("m1");
+        var email = (MeshWeaver.Mesh.Email)node.Content!;
+        h.Store[node.Path] = email with { Status = EmailStatus.Sending };
+
+        var done = h.AwaitProcessed(1);
+        h.Queue.Enqueue(node, email);
+        await done;
+
+        Assert.Empty(h.Sends);
+        Assert.Equal(EmailStatus.Sending, h.Store[node.Path].Status);
+    }
+
+    [Fact]
+    public async Task FailedSend_MarksFailed()
+    {
+        using var h = new Harness();
+        h.SendOverride = _ => Observable.Return(false);
+        var node = h.QueuedMail("m1");
+
+        var done = h.AwaitProcessed(1);
+        h.Queue.Enqueue(node, (MeshWeaver.Mesh.Email)node.Content!);
+        await done;
+
+        Assert.Equal(1, h.Sends["one@example.test"]);
+        Assert.Equal(EmailStatus.Failed, h.Store[node.Path].Status);
+    }
+
+    [Fact]
+    public async Task SendError_MarksFailed_AndTheQueueContinues()
+    {
+        using var h = new Harness();
+        h.SendOverride = email => email.To == "boom@example.test"
+            ? Observable.Throw<bool>(new InvalidOperationException("graph down"))
+            : Observable.Return(true);
+        var poisoned = h.QueuedMail("m1", to: "boom@example.test");
+        var healthy = h.QueuedMail("m2", to: "ok@example.test");
+
+        var done = h.AwaitProcessed(2);
+        h.Queue.Enqueue(poisoned, (MeshWeaver.Mesh.Email)poisoned.Content!);
+        h.Queue.Enqueue(healthy, (MeshWeaver.Mesh.Email)healthy.Content!);
+        await done;
+
+        Assert.Equal(EmailStatus.Failed, h.Store[poisoned.Path].Status);
+        Assert.Equal(EmailStatus.Sent, h.Store[healthy.Path].Status);
+        Assert.Equal(1, h.Sends["ok@example.test"]);
+    }
+
+    [Fact]
+    public async Task UnansweredStateRead_SkipsWithoutSending_AndTheQueueContinues()
+    {
+        using var h = new Harness(readBudget: TimeSpan.FromMilliseconds(100));
+        var silent = h.QueuedMail("m1", to: "silent@example.test");
+        var healthy = h.QueuedMail("m2", to: "ok@example.test");
+        h.ReadOverride = path => path == silent.Path
+            ? Observable.Never<MeshWeaver.Mesh.Email?>()
+            : Observable.Defer(() => Observable.Return(
+                h.Store.TryGetValue(path, out var email) ? email : (MeshWeaver.Mesh.Email?)null));
+
+        var done = h.AwaitProcessed(2);
+        h.Queue.Enqueue(silent, (MeshWeaver.Mesh.Email)silent.Content!);
+        h.Queue.Enqueue(healthy, (MeshWeaver.Mesh.Email)healthy.Content!);
+        await done;
+
+        // Fail CLOSED: no send on an unanswerable read — the mail stays New for a later retry.
+        Assert.False(h.Sends.ContainsKey("silent@example.test"));
+        Assert.Equal(EmailStatus.New, h.Store[silent.Path].Status);
+        Assert.Equal(EmailStatus.Sent, h.Store[healthy.Path].Status);
+    }
+}


### PR DESCRIPTION
## Summary

Every queued outbound e-mail could be delivered **twice**: the watch query emits the live set on every change, and the change feed legitimately delivers the same `New` snapshot more than once (initial snapshot + change echo — the same property that forbids "exactly N change events" assertions in tests). The `New → Sending` "claim" that was supposed to absorb this was a plain last-write-wins `UpdateNode`: the node it returned always echoed `Sending`, so the *claim-failed* guard was unreachable and every duplicate emission ran a full Graph send. Observed live 2026-08-21 on a local portal: two identical deliveries per submitted contact-form enquiry, reproducibly.

## The fix

`OutboundSendQueue` — a serialized send queue (`Subject + Concat`, the codebase's canonical no-lock queue idiom) that **re-reads the mail's authoritative state through the per-node stream immediately before claiming**:

- a duplicate emission, stale echo, or foreign-claimed mail finds the state no longer `New` and is skipped;
- an unanswerable state read fails **closed** (no send; the mail stays `New` and the next emission retries);
- a false or throwing send marks that mail `Failed` without stalling the queue behind it.

`OutboundEmailSender` pre-screens and enqueues; the unreachable pseudo-CAS is gone, and the docs no longer describe a compare-and-swap that never existed.

**Deliberately retained:** two PODs overlapping during a rollout can still both read `New` — cross-process at-least-once is the accepted trade absent any server-side conditional write.

## Tests

Six seam-driven cases in `OutboundSendQueueTest` (no hub, no mocks of core interfaces, no sleeps): single send under duplicate emissions; no resend on a late echo; skip on foreign claim; `Failed` on a false/throwing send with the queue surviving; fail-closed on a silent read. Mutation-verified: disabling the re-read gate turns exactly the three defect-pinning cases red.

## Notes

- Pre-existing, deliberately untouched (tracked separately): the unconditional `Re:` subject prefix on fresh notifications, and the error-swallowing `.Subscribe(_ => { }, _ => { })` on the no-recipient `Failed` write.
- Related but distinct: #2023 (NoOp sender stamps mail `Sent` when `Email:Enabled=true` and the Mail module is absent) — that is about mail *not being sent at all*; this PR is about mail being sent *twice*.
- What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
