### PR TITLE
fix(rn): home sections fill in; empty embeds stop spinning; nav links navigate; signed-in remote lands home

### DIFF
--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -102,6 +102,9 @@ export default function App() {
 function AppInner() {
   const { palette } = useTheme();
   const [nav, setNav] = useState<NavTarget>(() => homeFor(currentInstance()));
+  // The CURRENT home: local → the device user's node; a signed-in remote → the viewer's OWN node
+  // (resolved from the portal via /api/mesh/whoami below); anonymous remote → the docs HOME.
+  const [home, setHome] = useState<NavTarget>(() => homeFor(currentInstance()));
   const [clientScreen, setClientScreen] = useState<ClientDestination | null>(null);
   const [instanceTick, setInstanceTick] = useState(0);
   const [source, setSource] = useState<AreaSource>(() => new StaticAreaSource(sampleArea));
@@ -133,6 +136,33 @@ function AppInner() {
       setClientScreen((c) => (c === "instances" || c === "onboarding" ? null : c));
     wasLive.current = liveConnected;
   }, [liveConnected, clientScreen]);
+  // A signed-in REMOTE lands on the viewer's own home, like Blazor's /{user} — the portal answers
+  // who the token belongs to (/api/mesh/whoami). Runs once per connection; the docs HOME stays the
+  // instant default and for anonymous viewers, and a user who already navigated is not yanked.
+  useEffect(() => {
+    const inst = currentInstance();
+    const base = homeFor(inst);
+    setHome(base);
+    if (inst.local || !inst.token) return;
+    let live = true;
+    void fetch(`${inst.url.replace(/\/+$/, "")}/api/mesh/whoami`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${inst.token}` },
+      body: "{}",
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j: { userId?: string | null } | null) => {
+        const userId = j?.userId ? String(j.userId).trim() : "";
+        if (!live || !userId) return;
+        const userHome: NavTarget = { address: userId, area: "" };
+        setHome(userHome);
+        setNav((n) => (n.address === base.address && n.area === base.area ? userHome : n));
+      })
+      .catch(() => {});
+    return () => { live = false; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [instanceTick]);
+
   const reconnect = () => {
     // On a phone the onboarding stays visible until the mesh ACKS (the transition effect
     // closes it) — closing eagerly here made a tap read as "connect just closes".
@@ -232,7 +262,7 @@ function AppInner() {
                 <Shell
                   source={source}
                   nav={effNav}
-                  home={homeFor(currentInstance())}
+                  home={home}
                   clientScreen={clientScreen}
                   onNavigate={navigate}
                   onClientScreen={setClientScreen}

--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -118,7 +118,9 @@ function AppInner() {
 
   const navigate = (t: NavTarget) => {
     setClientScreen(null);
-    setNav(t);
+    // An empty address is parseHref's "go home" sentinel (a root "/" link) — resolve it here,
+    // where the current home (device user / signed-in remote user / docs) is known.
+    setNav(t.address ? t : home);
   };
 
   // 📱 On a phone the app IS the onboarding until a mesh acks: the bundled sample

--- a/clients/react-native/src/nav.tsx
+++ b/clients/react-native/src/nav.tsx
@@ -29,6 +29,9 @@ export function parseHref(href: string, currentAddress: string): NavTarget | nul
     if (seg === "..") parts.pop();
     else if (seg && seg !== ".") parts.push(seg);
   }
-  if (parts.length === 0) return null;
+  // The ROOT link ("/" — e.g. the settings nav's Home entry) is a real target: the shell's home.
+  // An empty address is the "go home" sentinel App.navigate resolves; only a RELATIVE parse that
+  // dissolved to nothing is a miss.
+  if (parts.length === 0) return href.startsWith("/") ? { address: "", area: "" } : null;
   return { address: parts.join("/"), area: "" };
 }

--- a/clients/react-native/src/rnMeshLive.test.tsx
+++ b/clients/react-native/src/rnMeshLive.test.tsx
@@ -305,3 +305,50 @@ describe("Appearance", () => {
     expect(text).toContain(en("appearance.dark"));
   });
 });
+
+// ---- MeshSearch union queries -----------------------------------------------------------------
+
+describe("MeshSearch union queries", () => {
+  it("runs a newline-joined UNION as separate queries, appends the term, merges in order, dedupes by path", async () => {
+    // The production failure this pins: the home catalog's hidden query is a newline-joined UNION
+    // (FirstLevelUnion); sent as ONE string the server parses it to nothing and every home section
+    // said "No results". The leaf must issue each line separately.
+    const search = vi.fn(async (q: string) =>
+      q.startsWith("namespace: ")
+        ? [
+            { path: "Doc", name: "DocRoot", nodeType: "Group" },
+            { path: "Both", name: "BothFirst", nodeType: "Group" },
+          ]
+        : [
+            { path: "device-user/x", name: "OwnItem", nodeType: "Group" },
+            { path: "Both", name: "BothDup", nodeType: "Group" },
+          ]);
+    const ops = fakeOps({ search });
+    const j = await renderLive(
+      {
+        areas: {
+          main: {
+            $type: "MeshSearch",
+            hiddenQuery: "namespace: is:main\nnamespace:device-user is:main",
+            visibleQuery: "foo",
+            showSearchBox: false,
+          } as never,
+        },
+      },
+      ops,
+    );
+
+    // One call PER line — never the newline-joined union string — each with the visible term.
+    expect(search.mock.calls.map((c) => c[0])).toEqual([
+      "namespace: is:main foo",
+      "namespace:device-user is:main foo",
+    ]);
+
+    const text = allText(j).join("\n");
+    expect(text).toContain("DocRoot");
+    expect(text).toContain("OwnItem");
+    // Deduped by path in DECLARATION order: the first batch's "Both" wins, the duplicate is dropped.
+    expect(text).toContain("BothFirst");
+    expect(text).not.toContain("BothDup");
+  });
+});

--- a/clients/react-native/src/rnMeshLive.tsx
+++ b/clients/react-native/src/rnMeshLive.tsx
@@ -116,20 +116,32 @@ function toNodeResult(r: Record<string, unknown>): NodeResult {
   };
 }
 
-function useMeshQuery(ops: MeshOps | null, query: string, basePath?: string): { results: NodeResult[]; loading: boolean } {
+// A hidden query can be a newline-joined UNION of sub-queries (the server declares the home
+// catalog that way; Blazor's MeshSearchView issues them as one MeshQueryRequest union, but the
+// REST verb takes ONE query per call — a newline-joined string parses to nothing server-side).
+// Run each line, concatenate in declaration order, dedupe by path.
+function useMeshQuery(ops: MeshOps | null, queries: string[], basePath?: string): { results: NodeResult[]; loading: boolean } {
   const [state, setState] = useState<{ results: NodeResult[]; loading: boolean }>({ results: [], loading: false });
+  const key = queries.join("\n");
   useEffect(() => {
-    if (!ops?.search || !query) {
+    if (!ops?.search || queries.length === 0) {
       setState({ results: [], loading: false });
       return;
     }
     let live = true;
     setState((st) => ({ ...st, loading: true }));
-    ops
-      .search(query, basePath || undefined)
-      .then((rs) => {
+    Promise.all(queries.map((q) => ops.search!(q, basePath || undefined)))
+      .then((batches) => {
         if (!live) return;
-        setState({ results: rs.map(toNodeResult).filter((n) => n.path.length > 0), loading: false });
+        const seen = new Set<string>();
+        const merged: NodeResult[] = [];
+        for (const rs of batches)
+          for (const n of rs.map(toNodeResult))
+            if (n.path.length > 0 && !seen.has(n.path)) {
+              seen.add(n.path);
+              merged.push(n);
+            }
+        setState({ results: merged, loading: false });
       })
       .catch(() => {
         if (live) setState({ results: [], loading: false });
@@ -137,7 +149,8 @@ function useMeshQuery(ops: MeshOps | null, query: string, basePath?: string): { 
     return () => {
       live = false;
     };
-  }, [ops, query, basePath]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ops, key, basePath]);
   return state;
 }
 
@@ -300,8 +313,12 @@ const MeshSearch: ControlComponent = ({ control }) => {
   const [visible, setVisible] = useState(initialVisible);
   const [submitted, setSubmitted] = useState(initialVisible);
   const term = useDebounced(liveSearch ? visible : submitted, 250);
-  const query = [hiddenQuery, term].map((t) => t.trim()).filter(Boolean).join(" ");
-  const { results, loading } = useMeshQuery(ops, query, ns);
+  // The hidden query's newline-separated sub-queries each get the visible term appended.
+  const hiddenLines = hiddenQuery.split("\n").map((l) => l.trim()).filter(Boolean);
+  const queries = (hiddenLines.length ? hiddenLines : [""])
+    .map((l) => [l, term.trim()].filter(Boolean).join(" "))
+    .filter(Boolean);
+  const { results, loading } = useMeshQuery(ops, queries, ns);
   const items = excludeBasePath && ns ? results.filter((n) => n.path !== ns) : results;
 
   return (

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -309,8 +309,11 @@ const LayoutAreaEmbed: ControlComponent = ({ control }) => {
 function EmbeddedAreaBody({ rootArea, showProgress }: { rootArea: string; showProgress: boolean }) {
   const state = useAreaState();
   if (state.areas?.[rootArea] == null) {
+    // The source starts as {} — `areas` only EXISTS once a snapshot frame arrived, so its presence
+    // (even as an empty object: PushRenderResult clears progress to 100 with areas {} when a view
+    // returns null) plus completed progress means the render finished with nothing to show.
     const progress = (state.data as Record<string, { progress?: number }> | undefined)?.progress?.progress;
-    const settled = state.areas != null && Object.keys(state.areas).length > 0 && (progress == null || progress >= 100);
+    const settled = state.areas != null && (progress == null || progress >= 100);
     return settled || !showProgress ? null : <ActivityIndicator />;
   }
   return <RenderArea areaKey={rootArea} />;

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -32,6 +32,7 @@ import {
   type MarkdownKernelSession,
   type SkinComponent,
 } from "@meshweaver/react/core";
+import { parseHref, useNavigate } from "./nav";
 import { rnSkins } from "./rnSkins";
 import { rnContainerControls } from "./rnContainers";
 import { rnLiveControls } from "./rnMeshLive";
@@ -148,8 +149,18 @@ const Spinner: ControlComponent = ({ control }) => <ActivityIndicator />;
 const NavLink: ControlComponent = ({ control }) => {
   const emit = useEmit();
   const { area } = useScope();
+  const navigate = useNavigate();
+  const url = s(useResolve(control.url));
+  const onPress = () => {
+    // A nav link CARRIES its destination (`/Doc/Architecture/X`) — resolve it through the shell's
+    // navigation (the node's default area), exactly what the MAUI navigator bridge does. Only a
+    // url-less link falls back to the server click event.
+    const target = url ? parseHref(url, "") : null;
+    if (target) return navigate(target);
+    if (control.isClickable) emit({ kind: "click", area });
+  };
   return (
-    <Pressable onPress={() => control.isClickable && emit({ kind: "click", area })} style={{ paddingVertical: 6 }}>
+    <Pressable onPress={onPress} style={{ paddingVertical: 6 }}>
       <Text style={[styles.body, { color: "#0f6cbd" }]}>{s(useResolve(control.title))}</Text>
     </Pressable>
   );
@@ -292,10 +303,16 @@ const LayoutAreaEmbed: ControlComponent = ({ control }) => {
 };
 
 // Inside the NESTED source's scope: spin (unless progress is suppressed) until the embedded root area
-// arrives, then render its tree.
+// arrives, then render its tree. A PROCESSED snapshot withOUT the root area means the server rendered
+// NOTHING for this embed — e.g. the Pinned region emits null for a user with no pins — so render
+// nothing instead of spinning forever ("missing default if empty").
 function EmbeddedAreaBody({ rootArea, showProgress }: { rootArea: string; showProgress: boolean }) {
   const state = useAreaState();
-  if (state.areas?.[rootArea] == null) return showProgress ? <ActivityIndicator /> : null;
+  if (state.areas?.[rootArea] == null) {
+    const progress = (state.data as Record<string, { progress?: number }> | undefined)?.progress?.progress;
+    const settled = state.areas != null && Object.keys(state.areas).length > 0 && (progress == null || progress >= 100);
+    return settled || !showProgress ? null : <ActivityIndicator />;
+  }
   return <RenderArea areaKey={rootArea} />;
 }
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-mobile-home-and-doc-fixes.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-21-mobile-home-and-doc-fixes.md
@@ -1,0 +1,16 @@
+---
+Name: The phone home fills in and doc links navigate
+Category: Fix
+Description: Home sections show your content instead of "No results", empty regions stop spinning, doc links open their pages, and a signed-in portal lands on your own home.
+Icon: Sparkle
+Order: -20260821
+---
+
+# The phone home fills in and doc links navigate
+
+Four fixes from phone testing. The home catalog ran its combined query as one string the server
+could not parse, so every section said "No results" — the sub-queries now run individually and
+merge, and your content appears. A region the server deliberately renders empty (like Pinned with
+no pins) showed an endless spinner — it now shows nothing, as on the web. Documentation links
+rendered as dead text — they now navigate to their pages. And connecting to a portal you are signed
+in to lands on your own home, like the web portal, instead of the documentation.


### PR DESCRIPTION
## What

Four defects pinned from the maintainer's phone screenshots (follow-up to #2019):

1. **Home sections all said "No results"** — the catalog's hidden query is a newline-joined UNION (`FirstLevelUnion`); Blazor issues it as one `MeshQueryRequest` union, but REST `search` takes one query per call, so the joined string parsed to nothing (measured: union string → 0 rows, split lines → rows). The RN leaf now splits, runs each sub-query, merges in declaration order with path dedupe, and appends the visible term to every line.
2. **Endless spinner under "Open threads"** — it was the *Pinned* embed: the server deliberately emits null for a user with no pins (`BuildPinnedItems`), and the RN embed treated the missing root area as "still loading" forever. A processed snapshot without the root area now renders nothing — the web's `NamedAreaView` contract.
3. **Doc links were dead text** — `NavLinkControl` carries its `url`; the RN leaf only emitted click events. It now navigates through the shell (node's default area), mirroring the MAUI navigator bridge.
4. **A signed-in remote landed on Doc** — it now resolves the viewer via `POST /api/mesh/whoami` once per connection and lands on their own home (`/{userId}`, default area), like Blazor; anonymous keeps the docs HOME, and a user who already navigated is not yanked.

## Verification

- RN `npm run typecheck` clean; `npm test` 157/157
- Union-query behavior measured against the running sidecar (gRPC-web + REST probes)
- WhatsNew entry validated against a rebuilt DLL; no C# changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)