### PR TITLE
Speech and voice become a real module (#1974)

### DIFF
--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -95,6 +95,7 @@
     <Project Path="src/MeshWeaver.ShortGuid/MeshWeaver.ShortGuid.csproj" />
     <Project Path="src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
     <Project Path="src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />
+    <Project Path="src/MeshWeaver.Speech.Contract/MeshWeaver.Speech.Contract.csproj" />
     <Project Path="src/MeshWeaver.Utils/MeshWeaver.Utils.csproj" />
   </Folder>
   <Folder Name="/test/">

--- a/memex/Memex.LocalMesh/Memex.LocalMesh.csproj
+++ b/memex/Memex.LocalMesh/Memex.LocalMesh.csproj
@@ -16,10 +16,25 @@
     <!-- Node types + content to render: Graph (sample data + node types) and the embedded Documentation. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Documentation\MeshWeaver.Documentation.csproj" />
-    <!-- Centralized speech-to-text (the Whisper client) — bakes POST /api/speech/transcribe into the
-         local sidecar so the packaged shells (macOS/Windows/web) have voice input against a local
-         whisper.cpp server, exactly like the portal exposes it. -->
-    <ProjectReference Include="..\..\src\MeshWeaver.Speech\MeshWeaver.Speech.csproj" />
+    <!-- Speech-to-text is the CONTRACT only. POST /api/speech/transcribe resolves
+         ISpeechTranscriber optionally and answers 503 when nothing provides it, exactly as the
+         portal's endpoint does — so the sidecar compiles and runs whether or not voice is
+         installed. The Whisper client itself arrives as a MODULE (below). -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Speech.Contract\MeshWeaver.Speech.Contract.csproj" />
   </ItemGroup>
+
+  <!-- ═════════ Voice ships as a module, not as a reference ═════════
+       MeshWeaver.Speech lands in modules/MeshWeaver.Speech/ and is activated by
+       Modules:Assemblies in appsettings.json — the same lane and the same DLL identity the portals
+       use. A ProjectReference would put the Whisper client back in this app's own closure, which
+       is exactly the double-ship that kept it from being a module in the sense that matters: the
+       bits shipped either way and the switch controlled nothing.
+
+       MeshModulesClosureSubset narrows the shared lane to the one module this host wants, so no
+       publish+prune is hand-rolled here. -->
+  <PropertyGroup>
+    <MeshModulesClosureSubset>MeshWeaver.Speech</MeshModulesClosureSubset>
+  </PropertyGroup>
+  <Import Project="..\MeshModulesPublish.targets" />
 
 </Project>

--- a/memex/Memex.LocalMesh/Program.cs
+++ b/memex/Memex.LocalMesh/Program.cs
@@ -5,6 +5,7 @@ using MeshWeaver.ContentCollections;
 using MeshWeaver.Documentation;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting;
+using MeshWeaver.Mesh;
 using MeshWeaver.Hosting.Grpc;
 using MeshWeaver.Hosting.Monolith;
 using MeshWeaver.Hosting.Sqlite;
@@ -50,6 +51,7 @@ builder.UseMeshWeaver(
         .AddKernel()         // C# kernel (Roslyn, MeshWeaver.Kernel.Hub) — lets doc code samples Run on the sidecar
         .AddDocumentation()  // the embedded "Doc" partition — real layout areas the client can render
         .AddGrpcHub()        // py/node stream-routed address types + the gRPC services
+        .InstallConfiguredModules(builder.Configuration)  // Modules:Assemblies — voice lands here
         .UseMonolithMesh()); // in-process single-silo runtime (NOT Orleans)
 
 // Bake speech-to-text into the sidecar: default the Whisper endpoint to a local whisper.cpp server
@@ -61,7 +63,8 @@ builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
     ["Speech:Endpoint"] = builder.Configuration["Speech:Endpoint"] ?? "http://localhost:8080",
     ["Speech:Enabled"] = builder.Configuration["Speech:Enabled"] ?? "true",
 });
-builder.Services.AddSpeechTranscription(builder.Configuration);
+// (No AddSpeechTranscription here: MeshWeaver.Speech registers the transcriber itself when the
+// module is installed. These defaults still apply — the module binds the same Speech section.)
 
 // Single-user device mesh: every token-less connection acts as the device user (the shells this
 // host serves connect anonymously), so layout areas render the OWNER view and writes are
@@ -128,9 +131,14 @@ app.MapLocalMeshApi();
 // this backend (RN, the macOS/Windows desktop apps, the web app) POSTs multipart { file, language? } and
 // gets back {"text","language"}. The transcriber forwards to the configured whisper.cpp server on the HTTP
 // IIoPool; a missing/disabled endpoint returns 503 (mic UI stays hidden), a Whisper fault surfaces as 502.
-app.MapPost("/api/speech/transcribe", async (HttpContext http, ISpeechTranscriber transcriber, CancellationToken ct) =>
+app.MapPost("/api/speech/transcribe", async (HttpContext http, CancellationToken ct) =>
 {
-    if (!transcriber.IsConfigured)
+    // OPTIONAL, like the portal's SpeechEndpoints: voice is a MODULE, so a sidecar built without it
+    // has no ISpeechTranscriber registered at all. Taking it as a required parameter would turn
+    // "voice not installed" into a DI failure on the request path — a 500 on a route that has a
+    // perfectly good 503 for exactly this. Absent and not-configured are the same answer here.
+    var transcriber = http.RequestServices.GetService(typeof(ISpeechTranscriber)) as ISpeechTranscriber;
+    if (transcriber is null || !transcriber.IsConfigured)
         return Results.Json(new { error = "Speech transcription is not configured (no Whisper endpoint, or disabled)." },
             statusCode: StatusCodes.Status503ServiceUnavailable);
     if (!http.Request.HasFormContentType)

--- a/memex/Memex.LocalMesh/appsettings.json
+++ b/memex/Memex.LocalMesh/appsettings.json
@@ -2,6 +2,15 @@
   "Grpc": {
     "Port": 5250
   },
+  "Modules": {
+    // Voice ships as a module, not as a reference: MeshWeaver.Speech lands in
+    // modules/MeshWeaver.Speech/ (MeshModulesClosureSubset in the csproj) and this list is what
+    // turns it on. Delist it and the sidecar still starts — POST /api/speech/transcribe simply
+    // answers 503, exactly as a portal without the module does.
+    "Assemblies": [
+      "MeshWeaver.Speech.dll"
+    ]
+  },
   "Speech": {
     "Enabled": true,
     "Endpoint": "http://127.0.0.1:8093",

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -54,7 +54,9 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.SignalR\MeshWeaver.Hosting.SignalR.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Grpc\MeshWeaver.Hosting.Grpc.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
-    <ProjectReference Include="..\..\src\MeshWeaver.Speech\MeshWeaver.Speech.csproj" />
+    <!-- SpeechEndpoints resolves ISpeechTranscriber OPTIONALLY (503 when absent), so the portal needs
+         the CONTRACT only — the Whisper client arrives as a module. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Speech.Contract\MeshWeaver.Speech.Contract.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
     <!-- Git-based plugin catalog / installer (the mesh's "app store"). -->
     <ProjectReference Include="..\..\src\MeshWeaver.PluginCatalog\MeshWeaver.PluginCatalog.csproj" />

--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -54,14 +54,15 @@
          the module static-asset provider (path-convention mapping + fingerprint/precompressed
          endpoint variants; see UiExtensibility.md "Razor assets from a runtime-loaded
          assembly"), not just this list. -->
-    <!-- Service modules NOT flippable for compile-time coupling (reasons: PR #1681) — Speech
-         (ISpeechTranscriber lives in the module; no contract split), Social (ApiCredentialNodeType
-         compiles against PlatformCredential; registration deliberately host-side; RELOCATING to
-         MeshWeaver.SocialMedia per the modularization program's task 63 (a program-plan task, not
-         a GitHub issue) — double-ship, this copy is the master until the flip:
-         see src/MeshWeaver.Social/README.md), Hosting.Grpc
-         (UseMeshWeaverGrpcWebWhenInstalled is middleware-order-coupled, cannot ride the endpoint hook). -->
-    <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />
+    <!-- Service modules NOT flippable for compile-time coupling (reasons: PR #1681). Only ONE is
+         left: Hosting.Grpc, whose UseMeshWeaverGrpcWebWhenInstalled is middleware-order-coupled and
+         cannot ride the endpoint hook.
+         Speech is no longer among them — the coupling WAS "ISpeechTranscriber lives in the module",
+         and splitting the interface into MeshWeaver.Speech.Contract removed it; it is on the
+         closure lane below.
+         Social is relocating to MeshWeaver.SocialMedia (the modularization program's task 63, a
+         program-plan task rather than a GitHub issue) and already ships from the closure lane here;
+         see src/MeshWeaver.Social/README.md. -->
     <MeshModule Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Hosting.Grpc/MeshWeaver.Hosting.Grpc.csproj" />
 
     <!-- Flipped off the ships-the-bits ProjectReference (#1644 step 2). -->
@@ -94,6 +95,11 @@
          same-identity prune is written around. -->
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.Radzen/MeshWeaver.Blazor.Radzen.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Blazor.GoogleMaps/MeshWeaver.Blazor.GoogleMaps.csproj" />
+    <!-- Voice. The compile-time coupling that pinned it to the thin lane is gone: ISpeechTranscriber
+         moved to MeshWeaver.Speech.Contract, so the portal's transcribe endpoint and the chat mic
+         name the interface without carrying the Whisper client, and Memex.LocalMesh installs the
+         module through Modules:Assemblies like everyone else. -->
+    <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Speech/MeshWeaver.Speech.csproj" />
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
     <!-- Import + its PRIVATE closure: the SIX MeshWeaver.DataSetReader* projects (the base, Csv,
          Excel, Excel.BinaryFormat, Excel.OpenXmlFormat, Excel.Utils) and MeshWeaver.DataStructures

--- a/src/MeshWeaver.Blazor.Portal/MeshWeaver.Blazor.Portal.csproj
+++ b/src/MeshWeaver.Blazor.Portal/MeshWeaver.Blazor.Portal.csproj
@@ -17,7 +17,9 @@
     <ProjectReference Include="..\MeshWeaver.Blazor\MeshWeaver.Blazor.csproj" />
     <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <!-- Centralized speech-to-text: the composer's mic dictates via the DI ISpeechTranscriber. -->
-    <ProjectReference Include="..\MeshWeaver.Speech\MeshWeaver.Speech.csproj" />
+    <!-- ThreadChatView resolves ISpeechTranscriber OPTIONALLY (the mic hides when absent), so this
+         needs the CONTRACT only — the Whisper client arrives as a module. -->
+    <ProjectReference Include="..\MeshWeaver.Speech.Contract\MeshWeaver.Speech.Contract.csproj" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilderModuleActivation.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilderModuleActivation.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Configuration;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// Installs the modules a host's configuration lists — the <c>Modules:Assemblies</c> lane, which is
+/// how a module gets to RUN once the publish has put its bits under <c>modules/&lt;Name&gt;/</c>.
+/// </summary>
+public static class MeshBuilderModuleActivation
+{
+    /// <summary>The configuration key every host reads its module baseline from.</summary>
+    public const string AssembliesKey = "Modules:Assemblies";
+
+    /// <summary>
+    /// Resolves each <c>Modules:Assemblies</c> entry through
+    /// <see cref="MeshBuilder.ResolveModulePath(string)"/> — one resolver, shared, probing
+    /// <c>modules/&lt;name&gt;/</c> before the app closure — and installs what is actually there.
+    ///
+    /// <para>🚨 <b>A listed-but-absent module is SKIPPED, never fatal.</b>
+    /// <see cref="MeshBuilder.InstallAssemblies"/> does <c>Assembly.LoadFrom</c>, which throws
+    /// <see cref="FileNotFoundException"/>, so one stale line would take the host down before
+    /// anything serves — as happened on 3.0.0-rc5, whose image no longer shipped fourteen extracted
+    /// modules while appsettings still listed them. A missing module must surface as a missing
+    /// FEATURE, which is diagnosable; a host that will not start is not.</para>
+    ///
+    /// <para>This is the BASELINE half only: it reads the host's own configuration and the bits its
+    /// publish laid down. A deployment that also lets an operator install modules at runtime has a
+    /// second source (the activation sidecar, generations, the platform floor) and composes them
+    /// first — see the portal's boot, which feeds the union through the same resolver.</para>
+    /// </summary>
+    /// <param name="builder">The mesh builder to install into.</param>
+    /// <param name="configuration">The host configuration carrying <c>Modules:Assemblies</c>.</param>
+    /// <param name="onSkip">
+    /// Called once per skipped entry with a human-readable reason. Defaults to stderr, which is
+    /// right for a pre-DI boot path: there is no logger yet, and stdout/stderr is what gets shipped.
+    /// </param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static MeshBuilder InstallConfiguredModules(
+        this MeshBuilder builder, IConfiguration configuration, Action<string>? onSkip = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // GetChildren().Value rather than Get<string[]>(): the binder lives in a separate package
+        // and this assembly deliberately takes Configuration.Abstractions only. For a string array
+        // the two read identically — the children of Modules:Assemblies ARE the entries.
+        var entries = configuration.GetSection(AssembliesKey).GetChildren().Select(child => child.Value);
+        var resolved = ResolveInstallable(entries, MeshBuilder.ResolveModulePath, File.Exists,
+            onSkip ?? (message => Console.Error.WriteLine($"[ModuleActivation] {message}")));
+
+        return resolved.Length == 0 ? builder : builder.InstallAssemblies(resolved);
+    }
+
+    /// <summary>
+    /// The pure half: entries in, installable paths out, one <paramref name="onSkip"/> line per
+    /// entry that is not there. Separated from the builder so the skip-don't-crash rule is testable
+    /// without a filesystem or a mesh — the rule matters most in exactly the situation where
+    /// standing one up is hardest.
+    /// </summary>
+    public static string[] ResolveInstallable(
+        IEnumerable<string?>? entries,
+        Func<string, string> resolve,
+        Func<string, bool> exists,
+        Action<string> onSkip)
+    {
+        if (entries is null)
+            return [];
+
+        var installable = new List<string>();
+        foreach (var entry in entries)
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+                continue;
+
+            var path = resolve(entry);
+            if (exists(path))
+            {
+                installable.Add(path);
+                continue;
+            }
+
+            onSkip($"SKIPPED module '{entry}': no assembly at '{path}'. It is listed under "
+                + $"{AssembliesKey} but this build does not ship it — delist it, or install it as a "
+                + "module. Starting without it; whatever it provided is absent.");
+        }
+
+        return [.. installable];
+    }
+}

--- a/src/MeshWeaver.Speech.Contract/ISpeechTranscriber.cs
+++ b/src/MeshWeaver.Speech.Contract/ISpeechTranscriber.cs
@@ -8,7 +8,8 @@ public record SpeechTranscript(string Text)
     public string? Language { get; init; }
 }
 
-/// <summary>Per-call knobs; all optional — omitted values fall back to <see cref="SpeechConfiguration"/>.</summary>
+/// <summary>Per-call knobs; all optional — omitted values fall back to the implementation's own
+/// configuration (<c>SpeechConfiguration</c>, which lives with the Whisper client, not here).</summary>
 public record SpeechTranscriptionOptions
 {
     /// <summary>Override the configured Whisper language for this call (e.g. force <c>"fr"</c>).</summary>
@@ -29,7 +30,8 @@ public record SpeechTranscriptionOptions
 /// </summary>
 public interface ISpeechTranscriber
 {
-    /// <summary>True when a Whisper endpoint is configured and speech is enabled (mirrors <see cref="SpeechConfiguration.IsConfigured"/>).</summary>
+    /// <summary>True when the implementation is configured and speech is enabled. A host that has no
+/// transcriber at all resolves null instead — both mean "no voice", and every caller handles it.</summary>
     bool IsConfigured { get; }
 
     /// <summary>

--- a/src/MeshWeaver.Speech.Contract/MeshWeaver.Speech.Contract.csproj
+++ b/src/MeshWeaver.Speech.Contract/MeshWeaver.Speech.Contract.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>The speech-to-text seam for MeshWeaver: the ISpeechTranscriber abstraction and its transcript types. Compiled surfaces (the portal's transcribe endpoint, the chat mic) depend on THIS; the Whisper implementation arrives as a module.</Description>
+  </PropertyGroup>
+
+  <!-- Deliberately tiny, and deliberately SEPARATE from MeshWeaver.Speech. Every compiled surface
+       that offers voice resolves ISpeechTranscriber OPTIONALLY and degrades when it is absent, so
+       those hosts must be able to NAME the interface without carrying the Whisper client. Keeping
+       the two in one assembly is what forced the portal to reference the implementation, which in
+       turn kept the module in the app closure — it shipped twice and could never be a module in
+       the sense that matters. Same shape as MeshWeaver.Observability.Contract.
+
+       The namespace stays MeshWeaver.Speech: this is an assembly split, not an API change, so no
+       consumer's `using` moves. -->
+  <ItemGroup>
+    <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MeshWeaver.Speech/MeshWeaver.Speech.csproj
+++ b/src/MeshWeaver.Speech/MeshWeaver.Speech.csproj
@@ -8,6 +8,9 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
   <ItemGroup>
+    <!-- The seam this implements. Compiled surfaces reference the CONTRACT and resolve
+         ISpeechTranscriber optionally, so this assembly can arrive as a module (or not at all). -->
+    <ProjectReference Include="..\MeshWeaver.Speech.Contract\MeshWeaver.Speech.Contract.csproj" />
     <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
   </ItemGroup>
 </Project>

--- a/test/MeshWeaver.Speech.Test/ConfiguredModuleActivationTest.cs
+++ b/test/MeshWeaver.Speech.Test/ConfiguredModuleActivationTest.cs
@@ -1,0 +1,82 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Speech.Test;
+
+/// <summary>
+/// The <c>Modules:Assemblies</c> baseline rule, pinned on the pure half so it needs no filesystem
+/// and no mesh — which matters because the situation it protects is exactly the one that is hardest
+/// to stand up: a host whose image no longer ships something its configuration still lists.
+///
+/// <para>Voice is the reason this exists here. <c>Memex.LocalMesh</c> stopped referencing
+/// MeshWeaver.Speech and now installs it as a module, so "the module is not there" changed from a
+/// compile error into a runtime condition — and the only acceptable behaviour is to start without
+/// voice and say so. On 3.0.0-rc5 the other answer took every portal down before anything
+/// served.</para>
+/// </summary>
+public class ConfiguredModuleActivationTest
+{
+    private static string Resolve(string entry) => $"/app/{entry}";
+
+    [Fact]
+    public void APresentModule_IsInstalled_AndNothingIsSkipped()
+    {
+        var skips = new List<string>();
+
+        var resolved = MeshBuilderModuleActivation.ResolveInstallable(
+            ["MeshWeaver.Speech.dll"], Resolve, _ => true, skips.Add);
+
+        Assert.Equal(["/app/MeshWeaver.Speech.dll"], resolved);
+        Assert.Empty(skips);
+    }
+
+    [Fact]
+    public void AListedButAbsentModule_IsSkippedLoudly_NeverThrown()
+    {
+        var skips = new List<string>();
+
+        // No throw is the assertion: InstallAssemblies would do Assembly.LoadFrom and take the host
+        // down, so the entry must be dropped BEFORE it gets there.
+        var resolved = MeshBuilderModuleActivation.ResolveInstallable(
+            ["MeshWeaver.Speech.dll"], Resolve, _ => false, skips.Add);
+
+        Assert.Empty(resolved);
+        var skip = Assert.Single(skips);
+        // The line has to name the entry AND where it looked — a skip nobody can act on is noise.
+        Assert.Contains("MeshWeaver.Speech.dll", skip);
+        Assert.Contains("/app/MeshWeaver.Speech.dll", skip);
+    }
+
+    [Fact]
+    public void OneAbsentEntry_DoesNotCostTheOthers()
+    {
+        var skips = new List<string>();
+
+        var resolved = MeshBuilderModuleActivation.ResolveInstallable(
+            ["Gone.dll", "MeshWeaver.Speech.dll"],
+            Resolve,
+            path => path.EndsWith("MeshWeaver.Speech.dll", StringComparison.Ordinal),
+            skips.Add);
+
+        Assert.Equal(["/app/MeshWeaver.Speech.dll"], resolved);
+        Assert.Contains("Gone.dll", Assert.Single(skips));
+    }
+
+    [Fact]
+    public void NoConfiguredModules_IsAQuietNoOp()
+    {
+        var skips = new List<string>();
+
+        // Null (no Modules section at all) and blank entries are ordinary, not faults: a host that
+        // installs nothing must not emit a diagnostic implying something went wrong.
+        Assert.Empty(MeshBuilderModuleActivation.ResolveInstallable(null, Resolve, _ => true, skips.Add));
+        Assert.Empty(MeshBuilderModuleActivation.ResolveInstallable(
+            ["", "   ", null], Resolve, _ => true, skips.Add));
+        Assert.Empty(skips);
+    }
+}


### PR DESCRIPTION
Speech was **listed** as a module and **shipped** like a reference. Three hosts compiled against it, so its bits rode every app closure whatever `Modules:Assemblies` said — the switch controlled nothing.

The stated blocker in `MeshModulesPublish.targets` was *"ISpeechTranscriber lives in the module; no contract split"*. That is exactly what this removes.

## The seam

`MeshWeaver.Speech.Contract` carries `ISpeechTranscriber` and its transcript types. **The namespace stays `MeshWeaver.Speech`**, so this is an assembly split and not an API change — no consumer's `using` moves. Same shape as `MeshWeaver.Observability.Contract`, for the same reason.

| Consumer | Was | Now |
|---|---|---|
| `Memex.Portal.Shared` (`SpeechEndpoints`) | referenced the module | contract — already resolved it optionally, 503 when absent |
| `MeshWeaver.Blazor.Portal` (`ThreadChatView`) | referenced the module | contract — already resolved it optionally, mic hides |
| `Memex.LocalMesh` | **called `AddSpeechTranscription`**, required DI param | installs the module via `Modules:Assemblies`, resolves optionally |

Two of the three were already loose and only ever needed the interface. **LocalMesh was the real blocker** — voice on the macOS sidecar was compiled in. Its transcribe endpoint now resolves the transcriber optionally: no module means **503**, the answer that route already had for "not configured". A required DI parameter would have turned "voice not installed" into a 500 on the request path.

## One activation path, not a second one

`MeshBuilder.InstallConfiguredModules` is the shared baseline activation, added beside the resolver it uses (`MeshBuilder.ResolveModulePath`) — so LocalMesh does **not** grow its own notion of where a module lives. It reads `Configuration.Abstractions` only, so the contract assembly gains no binder dependency.

It is deliberately the **baseline half**: a deployment that also lets an operator install modules at runtime composes the sidecar, generations and platform floor first, then feeds the union through this same resolver. The portal's boot is unchanged.

🚨 **A listed-but-absent module is skipped with a reason, never fatal.** `InstallAssemblies` does `Assembly.LoadFrom`, so one stale line takes the host down before anything serves — that is what happened on 3.0.0-rc5. Voice makes this newly reachable for LocalMesh: *"the module is not there"* used to be a compile error and is now a runtime condition. Four tests pin it on the pure half, which needs no filesystem and no mesh — the situation it protects is the hardest one to stand up.

## Verified

On **real publishes of both hosts**: `MeshWeaver.Speech.dll` absent from the app root, present under `modules/MeshWeaver.Speech/`, contract in the app root.

Also ran the framework-identity pin (23/23): Speech drags no canonical content-surface assembly out of the portal's compile closure — the trap that caught the map packs in #2021. And corrected the targets comment that still named Speech un-flippable; `Hosting.Grpc` is now the only service module left on the thin lane, for a genuine middleware-ordering reason.