### PR TITLE
Open the 3.0.0-rc7 line

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -66,11 +66,22 @@
          It also has to RESOLVE by the time anything pins content-sync to it: data-sync pulls
          content from the tag v$(PlatformVersion). v3.0.0-rc3 shipped 2026-08-16; v3.0.0-rc5
          shipped 2026-08-19 — and its tagged tree CANNOT BOOT (Modules:Assemblies still listed
-         the fourteen removed driver DLLs; fixed by #1901 after the tag). v3.0.0-rc6 is the line
-         NOW BUILDING: the first release whose tree boots, whose module bundles carry their own
+         the fourteen removed driver DLLs; fixed by #1901 after the tag). v3.0.0-rc6 shipped
+         2026-08-20: the first release whose tree boots, whose module bundles carry their own
          dependency closures (#1914/#1919/#1923), and whose platform has shed the module-only
-         Azure/OpenAI dependencies. Its tag is created only when rc6 is released — never tag it
-         early, the v*.*.* tag IS the trigger for the NuGet + image publish.
+         Azure/OpenAI dependencies.
+
+         v3.0.0-rc7 is the line NOW BUILDING — the release in which the optional GUI and voice
+         surfaces stop riding the app closure: all five Blazor view packs (#2018/#2021) and
+         Speech (#2028) ship under modules/<Name>/ and activate through Modules:Assemblies, with
+         their static web assets served from the module (#1724/#1987/#2017/#2020). Its tag is
+         created only when rc7 is released — never tag it early, the v*.*.* tag IS the trigger
+         for the NuGet + image publish.
+
+         🚨 BUMP THIS THE MOMENT A LINE IS TAGGED, in the same session. rc6 was released while
+         this property still read rc6, so every continuous build afterwards kept stamping a
+         version that was already published — the tag and the line it was cut from stopped being
+         distinguishable, which is precisely what the -ci.<n> suffix exists to prevent.
 
          🚨 rc4 was never tagged, and the gap is deliberate rather than a slip: the line built
          under that label all through the module extraction (#1882), so a v3.0.0-rc4 tag would
@@ -79,7 +90,7 @@
          it publishes are the ones the platform still builds. Do not "fill in" rc4 later: the
          version never shipped, and minting a tag for it now would publish that superseded
          content set for real. -->
-    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc6</PlatformVersion>
+    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc7</PlatformVersion>
   </PropertyGroup>
   <!-- Multi-arch container publish race fix (main-cd / release-images / edge-images pass
        -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK's _PublishMultiArchContainers


### PR DESCRIPTION
Prepares the next official release. **No tag here** — the `v*.*.*` tag is the publish trigger and gets pushed separately, on a green `main`, once this and #2028 have landed.

## Why now

rc6 shipped on 2026-08-20 (tag `v3.0.0-rc6`, packages on nuget.org) but `PlatformVersion` was never moved off it. So every continuous build since has stamped a version that is **already published** — the tag and the line cut from it stop being distinguishable, which is exactly what the `-ci.<n>` suffix exists to prevent.

The comment now says the bump belongs in the **same session as the tag**, since that is the step that was missed.

## What rc7 is

The line in which the optional GUI and voice surfaces stop riding the app closure:

- all five Blazor view packs — #2018, #2021 — ship under `modules/<Name>/`
- Speech — #2028 — same, with `ISpeechTranscriber` split into a contract so the hosts that offer voice no longer compile against the Whisper client
- their static web assets are served from the module: #1724, #1987, #2017, #2020

## Verified

`MeshWeaver.Mesh.Contract` stamps `3.0.0-rc7.ci.0+<sha>` — sorts above rc6, and keeps the pre-release label the self-updater's SemVer precedence depends on (a bare `3.0.0` core would sort every CI build *below* the old `3.0.0-preview1`).

Grepped for other pins on rc6: only the historical sentence in this file's own comment, which is now written as history.