### PR TITLE
A hub RECYCLE is not an inexistent address — stop counting attempts, wait for it to answer (#1996)

### DIFF
--- a/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
@@ -252,9 +252,21 @@ public partial class NamedAreaView
                         // report, rather than spin forever (the inexistent-address storm) or
                         // silently keep a stale render that never updates. The earlier
                         // "keep previous, no retry" behaviour is now the retry's job.
-                        Logger.LogWarning(error,
-                            "Area {Area} unavailable after {Retries} reactive retries — reporting failure. Hub={Message}",
-                            AreaToBeRendered, AreaStreamRetry.DefaultMaxRetries, error.Message);
+                        // A RECYCLE that never came back is a different report from an address
+                        // that never became addressable, and the retry above already treated the
+                        // two differently (AreaStreamRetry: the recycle keeps probing under
+                        // DefaultRecycleRecoveryBudget instead of spending five attempts). Say
+                        // which one happened — "it may still be initialising … Reload to retry"
+                        // asked the user to fix the app's own transient, and named the wrong one.
+                        var recycled = AreaErrorClassifier.IsHubRecycling(error);
+                        if (recycled)
+                            Logger.LogWarning(error,
+                                "Area {Area} was served by a RECYCLING hub that did not come back within {Budget} — reporting failure. Hub={Message}",
+                                AreaToBeRendered, AreaStreamRetry.DefaultRecycleRecoveryBudget, error.Message);
+                        else
+                            Logger.LogWarning(error,
+                                "Area {Area} unavailable after {Retries} reactive retries — reporting failure. Hub={Message}",
+                                AreaToBeRendered, AreaStreamRetry.DefaultMaxRetries, error.Message);
                         try
                         {
                             InvokeAsync(() =>
@@ -262,10 +274,14 @@ public partial class NamedAreaView
                                 if (IsViewDisposed) return;
                                 try
                                 {
-                                    RootControl = new MarkdownControl(
-                                        $"**Area unavailable.** The view at `{AreaToBeRendered}` did not become "
-                                        + $"addressable after {AreaStreamRetry.DefaultMaxRetries} retries — it may still be "
-                                        + "initialising or its NodeType may be compiling. Reload to retry.");
+                                    RootControl = new MarkdownControl(recycled
+                                        ? $"**Area unavailable.** The hub serving `{AreaToBeRendered}` was being "
+                                          + $"recycled and did not come back within "
+                                          + $"{AreaStreamRetry.DefaultRecycleRecoveryBudget.TotalSeconds:0}s. "
+                                          + "Reload to retry."
+                                        : $"**Area unavailable.** The view at `{AreaToBeRendered}` did not become "
+                                          + $"addressable after {AreaStreamRetry.DefaultMaxRetries} retries — it may still be "
+                                          + "initialising or its NodeType may be compiling. Reload to retry.");
                                     RequestStateChange();
                                 }
                                 catch (ObjectDisposedException) { /* renderer gone */ }

--- a/src/MeshWeaver.Layout/AreaErrorClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaErrorClassifier.cs
@@ -43,6 +43,37 @@ public static class AreaErrorClassifier
     }
 
     /// <summary>
+    /// 🚨 True when the error says the target hub is BEING RECYCLED — <c>"Hub X is shutting down"</c>
+    /// — as opposed to not existing.
+    ///
+    /// <para><b>These are two different statements and they deserve two different policies.</b>
+    /// <c>"No node found at 'X'"</c> says the address does not exist; retrying it forever is the
+    /// 2026-06-14 message storm that wedged a partition, so a bound is right.
+    /// <c>"Hub X is shutting down"</c> says the address EXISTS and is coming back — a per-node hub
+    /// recycle is a normal lifecycle event, and it happens on every package provision right after
+    /// the content lands. Counting a recycle against the same fixed attempt budget turns a routine
+    /// event into a permanently dead page: measured in Systemorph/MeshWeaver#1996, the client spent
+    /// its 5 retries (250·2ⁿ ms = 7.75 s) between 20:35:25.586 and 20:35:33.351 and gave up
+    /// <b>2.2 s before</b> the hub was serving again at 20:35:35.552.</para>
+    ///
+    /// <para>A bound where an EVENT belongs. What ends a recycle is the hub ANSWERING, which is a
+    /// thing the retry can observe — see <see cref="AreaStreamRetry.RetryAreaWithBackoff{T}"/>,
+    /// where a recycle switches the retry from "count attempts" to "keep probing, spaced, until it
+    /// answers", with a wall-clock guard only as a last resort.</para>
+    ///
+    /// <para>Deliberately a SUBSET of <see cref="IsTransientHubFailure"/>: everything this matches
+    /// is already retry-worthy, so the recycle policy can never widen WHAT is retried — only how
+    /// long a hub that announced its own return is waited for.</para>
+    /// </summary>
+    public static bool IsHubRecycling(Exception? ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+            if ((e.Message ?? string.Empty).Contains("is shutting down", StringComparison.OrdinalIgnoreCase))
+                return true;
+        return false;
+    }
+
+    /// <summary>
     /// Returns the NodeType path of a <see cref="ErrorType.CompilationInProgress"/> NACK
     /// (so the GUI can swap to that NodeType's Progress view at once), or <c>null</c>.
     /// This is NOT retried — it has dedicated, immediate handling.

--- a/src/MeshWeaver.Layout/AreaStreamRetry.cs
+++ b/src/MeshWeaver.Layout/AreaStreamRetry.cs
@@ -23,11 +23,56 @@ namespace MeshWeaver.Layout;
 /// (<see cref="Observable.Timer(TimeSpan, IScheduler)"/> — never <c>Task.Delay</c>) for
 /// errors the caller classifies as retryable, then <b>give up and surface the last error</b>
 /// to the caller's <c>OnError</c> so the GUI can report a real failure instead of spinning.</para>
+///
+/// <para>🚨 <b>…except a RECYCLE, which is a third thing.</b> Systemorph/MeshWeaver#1996: a
+/// per-node hub recycle is a normal lifecycle event — it happens on every package provision, right
+/// after the content lands — and it announces itself
+/// (<c>"Hub X is shutting down"</c>, <see cref="AreaErrorClassifier.IsHubRecycling"/>). That is not
+/// the inexistent address the bound above exists for; it is the address telling you it is coming
+/// back. Counting it against a fixed attempt budget killed the page: measured, the client spent its
+/// five retries (250·2ⁿ ms = 7.75 s) and gave up <b>2.2 s before</b> the hub was serving again.</para>
+///
+/// <para><b>The bound was standing where an EVENT belongs.</b> What ends a recycle is the hub
+/// ANSWERING, and that is observable — so once a stream has been told the hub is recycling, this
+/// stops counting attempts and keeps probing on a CAPPED backoff until the address answers or a
+/// last-resort wall-clock guard expires. Raising 5 → N would only move the cliff, which is why that
+/// is not what this does: the exit condition changed, not the number.</para>
+///
+/// <para>The storm risk is untouched in both directions. The recycle policy is a strict SUBSET of
+/// what was already retryable (<see cref="AreaErrorClassifier.IsHubRecycling"/> ⊂
+/// <see cref="AreaErrorClassifier.IsTransientHubFailure"/>), so it can never widen WHAT is retried;
+/// <c>"No node found at 'X'"</c> is not transient, is not retried, and still fails fast. And a
+/// probe every <see cref="DefaultRecycleBackoffCap"/> at worst is nothing like the unthrottled
+/// resubscribe loop that burned a core in 2026-06-14.</para>
 /// </summary>
 public static class AreaStreamRetry
 {
     /// <summary>Default number of reactive retry attempts before giving up.</summary>
     public const int DefaultMaxRetries = 5;
+
+    /// <summary>
+    /// The longest gap between two probes of a hub that announced it is RECYCLING. The backoff
+    /// still doubles up to here (250 ms → 500 → 1 s → 2 s) and then holds, so a recovery that takes
+    /// a while is polled at a steady, cheap rate rather than at an exponentially receding one that
+    /// would answer late by construction.
+    /// </summary>
+    public static readonly TimeSpan DefaultRecycleBackoffCap = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// The LAST-RESORT wall-clock guard on waiting for a recycling hub — not the thing that decides
+    /// when to stop waiting (that is the hub answering), only the thing that stops an unbounded
+    /// wait if it never does.
+    ///
+    /// <para><b>Why 60 s, and why that is not "7.75 s plus a margin".</b> The measurement in
+    /// Systemorph/MeshWeaver#1996 is a recycle→serving gap of <b>10.06 s</b>
+    /// (20:35:25.492 → 20:35:35.552), and sizing a bound just above one observed sample is how you
+    /// get the same dead page on a slower pod. The number here is instead the framework's own
+    /// last-resort terminal for a hub that has not answered — <c>MessageHub.RequestTimeout</c>,
+    /// 60 s by default, the budget every unbudgeted request already waits. So the client waits
+    /// exactly as long for a recycling hub as the framework itself is willing to wait for any hub,
+    /// and there is no new number to keep in sync with reality.</para>
+    /// </summary>
+    public static readonly TimeSpan DefaultRecycleRecoveryBudget = TimeSpan.FromSeconds(60);
 
     /// <summary>
     /// Wraps <paramref name="source"/> so that, on an error accepted by
@@ -44,27 +89,91 @@ public static class AreaStreamRetry
     /// <param name="baseDelay">First backoff step; doubles each attempt. Default 250 ms.</param>
     /// <param name="scheduler">Scheduler for the backoff timer (inject a TestScheduler in
     /// tests). Defaults to <see cref="DefaultScheduler.Instance"/>.</param>
+    /// <param name="isRecycling">Selects the errors that say the target hub is COMING BACK
+    /// (<see cref="AreaErrorClassifier.IsHubRecycling"/> by default). Seeing one LATCHES the
+    /// recycle policy for the rest of this retry sequence: subsequent retryable errors are part of
+    /// the same recovery — a recycling hub reports "shutting down", then "target hub was not
+    /// found", then answers — so re-counting them against <paramref name="maxRetries"/> would give
+    /// up in the middle of the very recovery the first error announced.</param>
+    /// <param name="recycleBackoffCap">Ceiling on the gap between probes while recycling.</param>
+    /// <param name="recycleRecoveryBudget">Last-resort wall-clock guard on the whole recovery.</param>
     public static IObservable<T> RetryAreaWithBackoff<T>(
         this IObservable<T> source,
         Func<Exception, bool> shouldRetry,
         int maxRetries = DefaultMaxRetries,
         TimeSpan? baseDelay = null,
-        IScheduler? scheduler = null)
+        IScheduler? scheduler = null,
+        Func<Exception, bool>? isRecycling = null,
+        TimeSpan? recycleBackoffCap = null,
+        TimeSpan? recycleRecoveryBudget = null)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(shouldRetry);
         var sched = scheduler ?? DefaultScheduler.Instance;
         var stepMs = (baseDelay ?? TimeSpan.FromMilliseconds(250)).TotalMilliseconds;
+        var recycling = isRecycling ?? AreaErrorClassifier.IsHubRecycling;
+        var capMs = (recycleBackoffCap ?? DefaultRecycleBackoffCap).TotalMilliseconds;
+        var budgetMs = (recycleRecoveryBudget ?? DefaultRecycleRecoveryBudget).TotalMilliseconds;
 
         return source.RetryWhen(errors => errors
-            .Select((error, index) => (Error: error, Attempt: index))
-            .SelectMany(t =>
-                // Give up (and surface the error) when the error isn't retryable OR the
-                // attempt budget is spent. Attempt is 0-based, so `>= maxRetries` allows
-                // exactly maxRetries retries (maxRetries+1 total subscriptions).
-                !shouldRetry(t.Error) || t.Attempt >= maxRetries
-                    ? Observable.Throw<long>(t.Error)
-                    // Throttled, scheduler-driven backoff: step, 2·step, 4·step, …
-                    : Observable.Timer(TimeSpan.FromMilliseconds(stepMs * (1L << t.Attempt)), sched)));
+            // Scan, not Select((e, i) => …): the decision needs STATE — how much of the attempt
+            // budget is spent, whether a recycle has been announced, and how long we have been
+            // waiting for it — and that state must survive across errors of different kinds.
+            .Scan(
+                new RetryState(-1, -1, 0d, false, null, TimeSpan.Zero, false),
+                (state, error) => Next(state, error, shouldRetry, recycling, maxRetries, stepMs,
+                    capMs, budgetMs))
+            .SelectMany(state => state.GiveUp
+                ? Observable.Throw<long>(state.Error!)
+                : Observable.Timer(state.Delay, sched)));
+    }
+
+    // The retry decision as PURE state transition — no scheduler, no clock, no source. What makes
+    // "an announced recycle stops the attempt count and starts a capped probe" testable as an
+    // assertion rather than as a timing observation.
+    private sealed record RetryState(
+        int Attempt, int RecycleAttempt, double RecycleWaitedMs, bool Recycling,
+        Exception? Error, TimeSpan Delay, bool GiveUp);
+
+    private static RetryState Next(
+        RetryState state, Exception error, Func<Exception, bool> shouldRetry,
+        Func<Exception, bool> recycling, int maxRetries, double stepMs, double capMs, double budgetMs)
+    {
+        if (!shouldRetry(error))
+            return state with { Error = error, Delay = TimeSpan.Zero, GiveUp = true };
+
+        // Once the hub has said it is coming back, every retryable error until it answers is part
+        // of that recovery — see the isRecycling remark on why the latch, not the message, decides.
+        var latched = state.Recycling || recycling(error);
+        if (!latched)
+        {
+            var attempt = state.Attempt + 1;
+            return attempt >= maxRetries
+                ? state with { Attempt = attempt, Error = error, Delay = TimeSpan.Zero, GiveUp = true }
+                : state with
+                {
+                    Attempt = attempt,
+                    Error = error,
+                    Delay = TimeSpan.FromMilliseconds(stepMs * (1L << attempt)),
+                    GiveUp = false,
+                };
+        }
+
+        var probe = state.RecycleAttempt + 1;
+        // Shift capped at 20 so a very long recovery cannot overflow the shift; the Min against
+        // capMs is what actually bounds the gap.
+        var waitMs = Math.Min(stepMs * (1L << Math.Min(probe, 20)), capMs);
+        var waited = state.RecycleWaitedMs + waitMs;
+        return waited > budgetMs
+            ? state with { Recycling = true, Error = error, Delay = TimeSpan.Zero, GiveUp = true }
+            : state with
+            {
+                RecycleAttempt = probe,
+                RecycleWaitedMs = waited,
+                Recycling = true,
+                Error = error,
+                Delay = TimeSpan.FromMilliseconds(waitMs),
+                GiveUp = false,
+            };
     }
 }

--- a/test/MeshWeaver.Layout.Test/AreaStreamRetryTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaStreamRetryTest.cs
@@ -101,4 +101,167 @@ public class AreaStreamRetryTest
         observer.Messages[0].Value.Value.Should().Be(42);
         observer.Messages[1].Value.Kind.Should().Be(NotificationKind.OnCompleted);
     }
+
+    // ————————————————————————— a RECYCLE is not an inexistent address (#1996)
+
+    private static readonly Exception Recycling =
+        new InvalidOperationException("Hub ThinkInStreams is shutting down — cannot register new response subject.");
+
+    /// <summary>
+    /// 🚨 THE MEASURED INCIDENT, replayed on virtual time.
+    ///
+    /// <para>Systemorph/MeshWeaver#1996: a package provision recycled the node hub at 20:35:25.492;
+    /// every area stream on it failed at 20:35:25.586 with <c>"Hub … is shutting down"</c>; the hub
+    /// was serving again at 20:35:35.552 — <b>10.06 s</b> later. Under the old policy the client
+    /// spent 5 retries over 250·2ⁿ ms = 7.75 s and painted a terminal "Reload to retry" 2.2 s
+    /// BEFORE the hub came back, and the page never repaired itself.</para>
+    ///
+    /// <para>With the announced recycle switching the retry from "count attempts" to "keep probing
+    /// until it answers", the SAME timeline recovers — and the assertion is the recovery, not a
+    /// bigger number.</para>
+    /// </summary>
+    [Fact]
+    public void AnnouncedRecycle_KeepsProbingUntilTheHubAnswers_TheMeasured10Seconds()
+    {
+        var scheduler = new TestScheduler();
+        var subscribeCount = 0;
+        var hubBackAt = TimeSpan.FromMilliseconds(10_060);   // the measured recycle → serving gap
+        var source = Observable.Defer(() =>
+        {
+            subscribeCount++;
+            return scheduler.Clock < hubBackAt.Ticks
+                ? Observable.Throw<int>(Recycling, scheduler)
+                : Observable.Return(42, scheduler);
+        });
+
+        var observer = scheduler.CreateObserver<int>();
+        source
+            .RetryAreaWithBackoff(
+                shouldRetry: AreaErrorClassifier.ShouldRetryArea,
+                maxRetries: AreaStreamRetry.DefaultMaxRetries,
+                baseDelay: TimeSpan.FromMilliseconds(250),
+                scheduler: scheduler)
+            .Subscribe(observer);
+
+        scheduler.Start();
+
+        observer.Messages.Should().HaveCount(2, "the page must recover, not paint a terminal error");
+        observer.Messages[0].Value.Value.Should().Be(42);
+        observer.Messages[1].Value.Kind.Should().Be(NotificationKind.OnCompleted);
+        subscribeCount.Should().BeGreaterThan(AreaStreamRetry.DefaultMaxRetries + 1,
+            "an announced recycle must NOT be counted against the fixed attempt budget");
+    }
+
+    /// <summary>
+    /// A recycle announces itself ONCE and then reports whatever the reactivating hub reports —
+    /// "target hub was not found", a timeout — so the policy LATCHES. Without the latch the retry
+    /// falls back to counting attempts in the middle of the very recovery the first error
+    /// announced, and gives up exactly as before.
+    /// </summary>
+    [Fact]
+    public void RecycleLatches_SoTheFollowUpTransientsAreStillPartOfTheSameRecovery()
+    {
+        var scheduler = new TestScheduler();
+        var subscribeCount = 0;
+        var hubBackAt = TimeSpan.FromMilliseconds(10_060);
+        var source = Observable.Defer(() =>
+        {
+            subscribeCount++;
+            if (scheduler.Clock >= hubBackAt.Ticks)
+                return Observable.Return(42, scheduler);
+            // Only the FIRST failure says "shutting down"; the rest are the ordinary transients a
+            // reactivating hub produces.
+            return Observable.Throw<int>(
+                subscribeCount == 1
+                    ? Recycling
+                    : new InvalidOperationException("the target hub was not found"),
+                scheduler);
+        });
+
+        var observer = scheduler.CreateObserver<int>();
+        source
+            .RetryAreaWithBackoff(
+                shouldRetry: AreaErrorClassifier.ShouldRetryArea,
+                baseDelay: TimeSpan.FromMilliseconds(250),
+                scheduler: scheduler)
+            .Subscribe(observer);
+
+        scheduler.Start();
+
+        observer.Messages.Should().HaveCount(2, "the recovery is one event, whatever it reports mid-flight");
+        observer.Messages[0].Value.Value.Should().Be(42);
+    }
+
+    /// <summary>
+    /// The storm guard is untouched. A hub that never comes back is given the recovery budget and
+    /// then FAILS — bounded, never an unbounded resubscribe — and the probes are capped at
+    /// <see cref="AreaStreamRetry.DefaultRecycleBackoffCap"/>, so waiting longer never means
+    /// hammering harder.
+    /// </summary>
+    [Fact]
+    public void RecycleThatNeverReturns_StillGivesUp_WithinTheBudget_AndCappedProbes()
+    {
+        var scheduler = new TestScheduler();
+        var subscribeCount = 0;
+        var source = Observable.Defer(() =>
+        {
+            subscribeCount++;
+            return Observable.Throw<int>(Recycling, scheduler);
+        });
+
+        var observer = scheduler.CreateObserver<int>();
+        source
+            .RetryAreaWithBackoff(
+                shouldRetry: AreaErrorClassifier.ShouldRetryArea,
+                baseDelay: TimeSpan.FromMilliseconds(250),
+                scheduler: scheduler)
+            .Subscribe(observer);
+
+        scheduler.Start();
+
+        observer.Messages.Should().HaveCount(1);
+        observer.Messages[0].Value.Kind.Should().Be(NotificationKind.OnError,
+            "a hub that never comes back still fails — the guard is a guard, not a promise");
+        var budget = AreaStreamRetry.DefaultRecycleRecoveryBudget;
+        var cap = AreaStreamRetry.DefaultRecycleBackoffCap;
+        TimeSpan.FromTicks(scheduler.Clock).Should().BeLessThan(budget + cap,
+            "the whole recovery is bounded by the wall-clock guard");
+        // Every probe costs at least the cap once the backoff has grown into it, so the count can
+        // never approach the unthrottled resubscribe loop the bound exists for.
+        subscribeCount.Should().BeLessThan((int)(budget.TotalMilliseconds / cap.TotalMilliseconds) + 8,
+            "probes are capped in FREQUENCY, so waiting longer never means hammering harder");
+    }
+
+    /// <summary>
+    /// 🚨 A ROUTING NotFound IS STILL NOT RETRIED AT ALL. The 2026-06-14 storm was an inexistent
+    /// address, and the recycle policy is a strict subset of what was already retryable — it can
+    /// never widen WHAT is retried, only how long an address that announced its own return is
+    /// waited for.
+    /// </summary>
+    [Fact]
+    public void RoutingNotFound_IsNotRecycling_AndStillFailsFast()
+    {
+        var gone = new InvalidOperationException("No node found at 'me/C/Ex'. Closest ancestor is 'me'");
+        AreaErrorClassifier.IsHubRecycling(gone).Should().BeFalse("a gone address is not a recycle");
+        AreaErrorClassifier.ShouldRetryArea(gone).Should().BeFalse("…and it was never retryable");
+        AreaErrorClassifier.IsHubRecycling(Recycling).Should().BeTrue();
+        AreaErrorClassifier.IsTransientHubFailure(Recycling).Should()
+            .BeTrue("the recycle set is a SUBSET of the retryable set");
+
+        var scheduler = new TestScheduler();
+        var subscribeCount = 0;
+        var source = Observable.Defer(() =>
+        {
+            subscribeCount++;
+            return Observable.Throw<int>(gone, scheduler);
+        });
+        var observer = scheduler.CreateObserver<int>();
+        source
+            .RetryAreaWithBackoff(shouldRetry: AreaErrorClassifier.ShouldRetryArea, scheduler: scheduler)
+            .Subscribe(observer);
+        scheduler.Start();
+
+        subscribeCount.Should().Be(1, "an inexistent address is not resubscribed even once");
+        observer.Messages[0].Value.Kind.Should().Be(NotificationKind.OnError);
+    }
 }


### PR DESCRIPTION
_Recovered and opened on the author's behalf — the branch was pushed but the session was killed before it could open the PR. The commit message carries the full reasoning; this is a summary._

A per-node hub recycle is a **normal lifecycle event** — it happens on every package provision, right after the content lands. When a browser is already on a page that hub serves, every area died permanently ("Area unavailable … Reload to retry") even though the hub was healthy seconds later.

## Measured

Education run 32294269748, portal `3.0.0-rc5.ci.4547`:

```
20:35:25.492  [ROUTE] Grain ThinkInStreams returned Failed: Hub is shutting down
20:35:33.351  Area Subscribe unavailable after 5 reactive retries — reporting failure
20:35:35.552  Node created at ThinkInStreams/_Access/Public_Access   ← healthy again
```

The client's budget is 5 retries at 250·2ⁿ ms = **7.75 s**. The hub was serving again **10.06 s** after announcing shutdown — **2.2 s after the client gave up**.

## Why the fix is not a bigger number

That is **not a bound 2.2 s too short. It is a bound standing where an event belongs.** `AreaErrorClassifier.IsTransientHubFailure` folded two different statements into one policy:

| message | meaning | correct response |
|---|---|---|
| `No node found at 'X'` | the address does not exist | a bound is correct |
| `Hub X is shutting down` | the address **exists and is coming back** | wait for it |

Raising 5 → N only moves the cliff; the shutdown→ready gap has no bound to size against. So the **exit condition** changed instead of the number:

- `IsHubRecycling` classifies the recycle apart from NotFound, and is deliberately a **strict subset** of `IsTransientHubFailure` — so the new policy can never widen *what* is retried, only how long an address that announced its own return is waited for. A routing NotFound is still not retried even once: the 2026-06-14 message-storm guard is untouched.
- `AreaStreamRetry` **latches** on an announced recycle and switches from counting attempts to probing on a capped backoff (250 ms → 2 s, held) until the hub answers. The latch matters: a recycling hub says "shutting down" *once*, then reports whatever a reactivating hub reports ("target hub was not found", a timeout) — re-counting those against `maxRetries` would give up in the middle of the very recovery the first error announced.
- The wall-clock guard is a **last resort, not the decision**: 60 s, the framework's own `MessageHub.RequestTimeout`.

Closes #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)