### PR TITLE
Give MeshWeaver.Speech.Contract a README, and gate the convention

### DIFF
--- a/src/MeshWeaver.Speech.Contract/README.md
+++ b/src/MeshWeaver.Speech.Contract/README.md
@@ -1,0 +1,24 @@
+# MeshWeaver.Speech.Contract
+
+The speech-to-text seam for MeshWeaver: the abstraction a compiled surface depends on so the
+implementation can arrive as a module — or not at all.
+
+Kept separate from `MeshWeaver.Speech` on purpose. Every surface that offers voice resolves
+`ISpeechTranscriber` **optionally** and degrades when it is absent (the mic hides, the transcribe
+endpoint answers 503), so those hosts must be able to name the interface without carrying the
+Whisper client. While the two lived in one assembly the portal had to reference the
+implementation, which kept it in the app closure: the bits shipped either way and
+`Modules:Assemblies` controlled nothing.
+
+## Features
+
+- `ISpeechTranscriber` — transcribe audio; cold `IObservable<SpeechTranscript>`, so the HTTP
+  round-trip runs on the bounded I/O pool on subscribe
+- `SpeechTranscript` — the recognised text plus the resolved language when the server reports it
+- `SpeechTranscriptionOptions` — per-call language, content type and file name; omitted values
+  fall back to the implementation's own configuration
+
+## Links
+
+- [MeshWeaver repository](https://github.com/Systemorph/MeshWeaver)
+- [Documentation](https://memex.meshweaver.cloud/Doc)

--- a/test/MeshWeaver.Graph.Test/PackableProjectReadmeTest.cs
+++ b/test/MeshWeaver.Graph.Test/PackableProjectReadmeTest.cs
@@ -1,0 +1,91 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Every project that packs must carry a <c>README.md</c> beside its csproj.
+///
+/// <para>Directory.Build.props does <c>&lt;None Include="README.md" Pack="true"&gt;</c> for ALL
+/// projects, unconditionally, and declares <c>PackageReadmeFile</c>. So a packable project without
+/// one does not merely ship a bare listing — <c>dotnet pack</c> FAILS it with
+/// <c>NU5019: File not found</c>.</para>
+///
+/// <para>🚨 The failure lands at the worst possible moment. <c>dotnet build</c> does not pack, so
+/// CI is green, review is green, and the gap first appears when a <c>v*.*.*</c> tag runs the
+/// release — after the tag is public and after the IMAGE workflow has already succeeded, leaving a
+/// release half-shipped. That is exactly how v3.0.0-rc7 went out: MeshWeaver.Speech.Contract was
+/// added without a README and the whole NuGet publish died at Pack.</para>
+/// </summary>
+public class PackableProjectReadmeTest
+{
+    [Fact]
+    public void EveryPackableProject_HasAReadmeBesideItsCsproj()
+    {
+        var root = FindRepositoryRoot();
+        Assert.SkipWhen(root is null,
+            "repository tree not reachable from the test bin — this convention check runs in-repo only");
+
+        var projects = PackableProjects(root!).ToList();
+
+        // A discovery that found nothing has verified nothing; it must not read as a pass.
+        projects.Should().HaveCountGreaterThan(20,
+            "the repository packs many projects — an empty or tiny discovery means the walk broke, "
+            + "not that the convention holds");
+
+        var missing = projects
+            .Where(csproj => !File.Exists(Path.Combine(Path.GetDirectoryName(csproj)!, "README.md")))
+            .Select(csproj => Path.GetRelativePath(root!, csproj))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "Directory.Build.props packs README.md into every package, so a packable project "
+            + "without one fails `dotnet pack` with NU5019 — and that only surfaces when a release "
+            + "tag is already public. Add a README.md beside each csproj listed here.");
+    }
+
+    /// <summary>
+    /// Projects the release packs: everything under <c>src/</c> that does not opt out with
+    /// <c>IsPackable=false</c>. Build output and worktrees are skipped; test and sample trees are
+    /// out of scope because they are not what <c>dotnet pack</c> ships from a release tag.
+    /// </summary>
+    private static IEnumerable<string> PackableProjects(string root)
+    {
+        var src = Path.Combine(root, "src");
+        if (!Directory.Exists(src))
+            yield break;
+
+        foreach (var csproj in Directory.EnumerateFiles(src, "*.csproj", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(root, csproj).Split(Path.DirectorySeparatorChar);
+            if (relative.Any(part => part is "bin" or "obj" or ".worktrees"))
+                continue;
+
+            var text = File.ReadAllText(csproj);
+            // Opting out of packing also opts out of the README rule — nothing is produced to
+            // carry it. Matched loosely because the property may sit under any condition.
+            if (text.Contains("<IsPackable>false</IsPackable>", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            yield return csproj;
+        }
+    }
+
+    private static string? FindRepositoryRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
The **v3.0.0-rc7 NuGet publish died at Pack**:

```
NU5019: File not found: src/MeshWeaver.Speech.Contract/README.md
```

`Directory.Build.props` declares `PackageReadmeFile` and does `<None Include="README.md" Pack="true"/>` for **all** projects, unconditionally — so a packable project without one does not ship a bare listing, it **fails the pack**. I added that project in #2028 without a README.

## Nothing was published

Pack precedes Push, so no package reached nuget.org and **no version resolves to anything wrong**. What rc7 *is* right now is half-shipped: container images published (that workflow succeeded), packages not.

## The gap is invisible until a release, which is why it also gets a gate

`dotnet build` does not pack. The branch was green, review was green, and the first sign was a **public tag** whose image workflow had already succeeded. That is the worst possible moment for this class of error to surface.

`PackableProjectReadmeTest` walks `src/`, skips `IsPackable=false`, and requires a `README.md` beside each csproj. It refuses to pass on a tiny discovery — a walk that breaks must not read as a convention that holds.

## Verified

- `dotnet pack` on the contract now produces `MeshWeaver.Speech.Contract.3.0.0-rc7.nupkg`
- the new test is **red** with the README removed and **green** with it (checked both ways, not just the green one)

## Completing rc7 needs a call

Once this lands, the packages still have to ship. Two options, and the tradeoff is real, so I'd rather ask than pick:

1. **Move the `v3.0.0-rc7` tag** to the fixed commit and re-run only the NuGet workflow. No package ever resolved to rc7, so nothing changes under anyone; the images stay exactly as published and are not re-rolled. Cost: the tag ends up one commit ahead of the tree the images were built from — a README, no bits.
2. **Cut `v3.0.0-rc8`.** No tag mutation at all, but it burns a version, republishes and re-rolls images, and leaves rc7 permanently as images-without-packages.

I lean to (1): the provenance delta is a documentation file, and it avoids a second image roll.