### PR TITLE
Portal: enforce CSP + add Cross-Origin-Opener-Policy

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1129,10 +1129,10 @@ public static class MemexConfiguration
         // 'self'). Tightening it further (per-response nonces, dropping 'unsafe-inline') is
         // a separate hardening pass, not this change.
         //
-        // The CSP ships as Content-Security-Policy-Report-Only FIRST: it cannot block a
-        // single request, so it is safe to enforce on the production registry immediately
-        // while any would-be violations surface in the browser console. A one-line follow-up
-        // renames the header to Content-Security-Policy to enforce it once it is proven quiet.
+        // The CSP is ENFORCED. It shipped Content-Security-Policy-Report-Only first (#1988);
+        // enforcing it here was validated by driving real Chrome over the live public pages
+        // against that Report-Only header and observing ZERO violations, so the enforced policy
+        // blocks nothing the app legitimately loads.
         app.Use((ctx, next) =>
         {
             var headers = ctx.Response.Headers;
@@ -1140,11 +1140,12 @@ public static class MemexConfiguration
             {
                 headers["X-Content-Type-Options"] = "nosniff";
                 headers["Cross-Origin-Resource-Policy"] = "same-site";
+                headers["Cross-Origin-Opener-Policy"] = "same-origin";
                 headers["Permissions-Policy"] =
                     "accelerometer=(), camera=(), geolocation=(), gyroscope=(), " +
                     "magnetometer=(), microphone=(), payment=(), usb=()";
-                if (!headers.ContainsKey("Content-Security-Policy-Report-Only"))
-                    headers["Content-Security-Policy-Report-Only"] =
+                if (!headers.ContainsKey("Content-Security-Policy"))
+                    headers["Content-Security-Policy"] =
                         "default-src 'self'; " +
                         "base-uri 'self'; " +
                         "object-src 'none'; " +


### PR DESCRIPTION
Follow-up to #1988 — the two remaining ZAP hardening items.

## Changes
1. **Enforce the CSP** — flip `Content-Security-Policy-Report-Only` → `Content-Security-Policy`. The policy string is unchanged (the permissive superset: `unsafe-inline`/`unsafe-eval`, `blob:`/`data:`, `https:`/`wss:`). Clears rule **10055**.
2. **Add `Cross-Origin-Opener-Policy: same-origin`** — the safe half of rule **90004** (site isolation).

## Why enforcing is safe
Validated against the **live Report-Only header** by driving real Chrome over the public pages (`/`, `/Store`, `/login`, `/Chess`, `/Doc`) and capturing `securitypolicyviolation` events with `disposition: report` — i.e. exactly what the enforced policy *would* block:

```
report-only CSP violations: 0 on every page
TOTAL: 0 — safe to enforce on the public surface
```

Authenticated editor pages need a session so weren't browser-tested, but the policy explicitly permits what Monaco needs (`script-src 'unsafe-eval'`, `worker-src blob:`).

## Deliberately NOT included
**COEP (`Cross-Origin-Embedder-Policy: require-corp`)** — the other half of 90004. It is high-breakage (blocks cross-origin embeds and worker loads unless every subresource opts in via CORP/CORS) and needs its own testing pass. Left out on purpose; 90004 will still partially flag until COEP is added.

## Verification
- ✅ `dotnet build Memex.Portal.Shared` — 0 warnings, 0 errors
- ✅ Live Report-Only browser check — 0 violations
- After deploy: rule 10055 clears; 90004 improves (COOP present, COEP still absent by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)