### PR TITLE
fix(#1635): a coordination node that is still activating is not a failed bake

### DIFF
--- a/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
+++ b/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
@@ -47,6 +48,36 @@ public static class BuildProtocolDriver
     public static readonly TimeSpan GrantWindow = TimeSpan.FromSeconds(15);
 
     /// <summary>
+    /// How many times the claim HANDSHAKE is attempted when the coordination node cannot be
+    /// reached at all (#1635).
+    ///
+    /// <para>The handshake is the first thing the sweep does, and it is a <c>SubscribeRequest</c>
+    /// to <c>Admin/Build</c>. At pod startup that grain may not have activated yet, so the request
+    /// dies on the hub's own 60 s request budget with a <see cref="TimeoutException"/> — which
+    /// propagated out of <see cref="Run"/>, faulted the whole warm-up stream and made the pod
+    /// REFUSE READINESS, stalling the rollout on a race that clears itself in seconds. Observed on
+    /// <c>memex-portal-deployment-f96d46ddf-mrgqf</c>, 2026-08-15 07:44:25Z.</para>
+    ///
+    /// <para>🚨 <b>The retry does NOT make it permissive.</b> When every attempt fails the
+    /// handshake still throws — the sweep still faults, readiness is still refused, the rollout
+    /// still stalls. What changes is that a transient race no longer counts as unreachable, and
+    /// that the terminal failure is a <see cref="BuildCoordinationUnreachableException"/> which
+    /// SAYS the coordination node was unreachable instead of leaving an operator to infer it from
+    /// a bare timeout. A check that cannot reach its evidence must fail loudly, never
+    /// permissively.</para>
+    /// </summary>
+    public const int CoordinationAttempts = 3;
+
+    /// <summary>
+    /// Backoff before re-attempting the claim handshake. Small and bounded on purpose: each failed
+    /// attempt already costs the hub's own request budget (60 s), so the wait between them only has
+    /// to outlast a grain activation, not a deployment.
+    /// </summary>
+    /// <param name="attemptsSoFar">How many attempts have already failed (1-based).</param>
+    public static TimeSpan CoordinationBackoff(int attemptsSoFar) =>
+        TimeSpan.FromSeconds(attemptsSoFar <= 1 ? 5 : 15);
+
+    /// <summary>
     /// Claim → bake → GO; or, when the claim is held elsewhere, subscribe to the GO and report the
     /// share's state when it arrives.
     /// </summary>
@@ -81,7 +112,16 @@ public static class BuildProtocolDriver
             ? BuildClaimRequest.BakePriority
             : 0;
 
-        return mesh.RequestBuildClaim(holder, fingerprint, priority: priority)
+        // 🚨 The handshake is RETRIED, the bake is not. Everything downstream of the registration
+        // is the sweep itself, whose failures are verdicts about this image and must reach the
+        // gate untouched. Only reaching the coordination node at all is retried — see
+        // CoordinationAttempts for why, and for why exhausting them is still a refusal.
+        return RetryUnreachableCoordination(
+                () => mesh.RequestBuildClaim(holder, fingerprint, priority: priority).Take(1),
+                CoordinationAttempts,
+                CoordinationBackoff,
+                Scheduler.Default,
+                logger)
             .SelectMany(_ => mesh.ObserveBuildClaim(holder)
                 .Take(1)
                 .Timeout(GrantWindow)
@@ -459,6 +499,103 @@ public static class BuildProtocolDriver
     // ── shared ──────────────────────────────────────────────────────────────────────────────────
 
     /// <summary>
+    /// Runs <paramref name="handshake"/>, re-attempting it while the failure means the coordination
+    /// node could not be REACHED (#1635) — and giving up loudly when it does not clear.
+    ///
+    /// <para>Pure Rx over an injected factory and scheduler so the policy is unit-testable without
+    /// a mesh: the property that matters is not the happy path but that exhausting the attempts
+    /// still ERRORS. A readiness gate whose evidence is unreachable must fail closed; the retry
+    /// exists only so a grain that is still activating does not count as unreachable.</para>
+    ///
+    /// <para>Only "unreachable" is retried. Any other error — a malformed state, a rejected write,
+    /// a bug — surfaces on the first attempt, unwrapped, because retrying it would just delay the
+    /// same verdict by minutes and bury the cause under three identical stack traces.</para>
+    /// </summary>
+    /// <typeparam name="T">The handshake's emission.</typeparam>
+    /// <param name="handshake">Cold factory for one attempt. Re-invoked per attempt.</param>
+    /// <param name="attempts">Total attempts, including the first. Values below 1 mean one attempt.</param>
+    /// <param name="backoff">Delay before the next attempt, given how many have failed (1-based).</param>
+    /// <param name="scheduler">Scheduler for the backoff delay.</param>
+    /// <param name="logger">Diagnostics.</param>
+    public static IObservable<T> RetryUnreachableCoordination<T>(
+        Func<IObservable<T>> handshake,
+        int attempts,
+        Func<int, TimeSpan> backoff,
+        IScheduler scheduler,
+        ILogger? logger)
+    {
+        var total = Math.Max(1, attempts);
+
+        IObservable<T> Attempt(int attemptNumber) => Observable
+            .Defer(handshake)
+            .Catch((Exception ex) =>
+            {
+                if (!IsUnreachable(ex))
+                    return Observable.Throw<T>(ex);
+
+                if (attemptNumber >= total)
+                {
+                    // Loud, and it NAMES what it could not reach. The bare TimeoutException this
+                    // replaces said "no response ... → target Admin/Build" and was read as a
+                    // compile problem for as long as anyone looked at it.
+                    var unreachable = new BuildCoordinationUnreachableException(
+                        $"BuildProtocol: could not reach the build coordination node "
+                        + $"'{BuildNodeType.RootPath}' in {total} attempt(s) — the pre-warm sweep "
+                        + "never started, so this process has verified NOTHING about its NodeTypes "
+                        + "on this image. This is a refusal, not a pass: readiness stays refused "
+                        + "and the rollout holds the previous image. A restart re-attempts.",
+                        ex);
+                    logger?.LogError(unreachable, "{Message}", unreachable.Message);
+                    return Observable.Throw<T>(unreachable);
+                }
+
+                var wait = backoff(attemptNumber);
+                logger?.LogWarning(ex,
+                    "BuildProtocol: attempt {Attempt}/{Total} could not reach the coordination "
+                    + "node '{Path}' — its hub is most likely still activating. Retrying in "
+                    + "{Wait}. If every attempt fails the sweep FAULTS and readiness is refused.",
+                    attemptNumber, total, BuildNodeType.RootPath, wait);
+
+                return wait <= TimeSpan.Zero
+                    ? Observable.Defer(() => Attempt(attemptNumber + 1))
+                    : Observable.Timer(wait, scheduler)
+                        .SelectMany(_ => Attempt(attemptNumber + 1));
+            });
+
+        return Attempt(1);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="exception"/> means the coordination node was never reached, as
+    /// opposed to having answered something we did not like. A hub request that gets no response
+    /// dies as a <see cref="TimeoutException"/>, and it can arrive wrapped (an
+    /// <see cref="AggregateException"/> from a merged inner stream), so the walk is over the whole
+    /// chain rather than the outermost type.
+    /// </summary>
+    /// <summary>
+    /// Whether a faulted warm-up stream failed because the coordination node was never reached,
+    /// rather than because the sweep produced a bad verdict. Consumed by the readiness refusal so
+    /// the two are distinguishable in the health payload — see #1635.
+    /// </summary>
+    public static bool DescribesUnreachableCoordination(Exception? exception) => exception switch
+    {
+        null => false,
+        BuildCoordinationUnreachableException => true,
+        AggregateException aggregate => aggregate.InnerExceptions.Any(DescribesUnreachableCoordination),
+        { InnerException: { } inner } => DescribesUnreachableCoordination(inner),
+        _ => false,
+    };
+
+    internal static bool IsUnreachable(Exception exception) => exception switch
+    {
+        TimeoutException => true,
+        AggregateException aggregate => aggregate.InnerExceptions.Any(IsUnreachable),
+        { InnerException: { } inner } => IsUnreachable(inner),
+        _ => false,
+    };
+
+
+    /// <summary>
     /// Derive the chunk plan: one chunk per first path segment (the partition — which is exactly a
     /// plugin's footprint for plugin content). Deterministic, order-independent, and derived rather
     /// than invented, per the design doc.
@@ -493,3 +630,16 @@ public static class BuildProtocolDriver
     private sealed record OpenedChunk(
         string Name, string Path, string ActivityPath, IReadOnlyList<string> Members);
 }
+
+/// <summary>
+/// The build coordination node (<c>Admin/Build</c>) could not be reached, so the pre-warm sweep
+/// never ran (#1635).
+///
+/// <para>Distinct from every failure the sweep itself can produce: those are verdicts about
+/// whether this image builds its NodeTypes, this one is the absence of a verdict. Both refuse
+/// readiness — a pod that verified nothing must not claim it did — but only this one is worth
+/// restarting on, which is why it has its own name in the log instead of arriving as a bare
+/// <see cref="TimeoutException"/> whose target an operator has to decode.</para>
+/// </summary>
+public sealed class BuildCoordinationUnreachableException(string message, Exception innerException)
+    : Exception(message, innerException);

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -466,7 +466,17 @@ public sealed class DynamicTypePreWarmerHostedService(
                     // Correctness is unaffected either way: lazy compilation still builds every
                     // type on first access. What changes is only whether this pod may CLAIM to have
                     // verified its NodeTypes on this image.
-                    gate?.MarkFaulted("the warm-up stream faulted before the sweep could finish");
+                    // Name the ABSENCE of a verdict apart from a bad one (#1635). Both refuse
+                    // readiness — a pod that verified nothing must never claim it did — but an
+                    // unreachable coordination node is a startup race that a restart clears,
+                    // while a faulted sweep is usually this image. An operator reading the health
+                    // payload should not have to decode a bare TimeoutException's target to tell
+                    // which of the two they have.
+                    gate?.MarkFaulted(
+                        BuildProtocolDriver.DescribesUnreachableCoordination(ex)
+                            ? "the build coordination node could not be reached, so the sweep "
+                              + "never started"
+                            : "the warm-up stream faulted before the sweep could finish");
                     if (gate is { GatesReadiness: true, Phase: BakePhase.Faulted })
                         logger.LogCritical(ex,
                             "DynamicTypePreWarmer: REFUSING READINESS — the warm-up stream FAULTED, "

--- a/test/MeshWeaver.Hosting.Test/BuildCoordinationRetryTest.cs
+++ b/test/MeshWeaver.Hosting.Test/BuildCoordinationRetryTest.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// The pre-warm sweep's claim handshake, and what happens when the coordination node
+/// (<c>Admin/Build</c>) cannot be reached (#1635).
+///
+/// <para>The defect: the handshake is a <c>SubscribeRequest</c> to a grain that may not have
+/// activated yet at pod startup. The request died on the hub's 60 s budget, the
+/// <see cref="TimeoutException"/> faulted the whole warm-up stream, and the pod REFUSED READINESS —
+/// stalling a rollout on a race that clears itself in seconds.</para>
+///
+/// <para>🚨 The property these tests exist for is NOT the retry. It is that exhausting the attempts
+/// still ERRORS. A readiness gate whose evidence is unreachable has to fail closed; the retry only
+/// buys the grain time to activate. <see cref="ExhaustingTheAttempts_StillErrors_NeverSucceedsQuietly"/>
+/// is the fail-closed proof, and it fails against an implementation that swallows.</para>
+/// </summary>
+public class BuildCoordinationRetryTest
+{
+    private static readonly Func<int, TimeSpan> NoBackoff = _ => TimeSpan.Zero;
+
+    private static Func<IObservable<string>> Handshake(int failures, Func<Exception> error, List<int> attempts)
+    {
+        var seen = 0;
+        return () => Observable.Defer(() =>
+        {
+            var n = ++seen;
+            attempts.Add(n);
+            return n <= failures
+                ? Observable.Throw<string>(error())
+                : Observable.Return("granted");
+        });
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task ATransientUnreachableNode_IsRetried_AndTheSweepProceeds()
+    {
+        var attempts = new List<int>();
+        var result = await BuildProtocolDriver.RetryUnreachableCoordination(
+                Handshake(2, () => new TimeoutException(
+                    "No response received in hub cache/x within 00:01:00 for request "
+                    + "SubscribeRequest → target Admin/Build."), attempts),
+                BuildProtocolDriver.CoordinationAttempts,
+                NoBackoff,
+                Scheduler.Immediate,
+                logger: null)
+            .FirstAsync()
+            .ToTask();
+
+        result.Should().Be("granted");
+        attempts.Should().Equal(new[] { 1, 2, 3 });
+        attempts.Should().HaveCount(3, "two startup-race timeouts must not end the sweep");
+    }
+
+    /// <summary>
+    /// 🚨 FAIL CLOSED. Every attempt fails ⇒ the handshake still errors, so the warm-up stream still
+    /// faults and readiness is still refused. A gate that cannot reach its evidence must never look
+    /// like a gate that passed.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task ExhaustingTheAttempts_StillErrors_NeverSucceedsQuietly()
+    {
+        var attempts = new List<int>();
+        var act = () => BuildProtocolDriver.RetryUnreachableCoordination(
+                Handshake(int.MaxValue, () => new TimeoutException("→ target Admin/Build"), attempts),
+                BuildProtocolDriver.CoordinationAttempts,
+                NoBackoff,
+                Scheduler.Immediate,
+                logger: null)
+            .FirstAsync()
+            .ToTask();
+
+        var thrown = await act.Should().ThrowAsync<BuildCoordinationUnreachableException>();
+        // The refusal NAMES what it could not reach, and says it is a refusal — the bare
+        // TimeoutException it replaces read as a compile problem for as long as anyone looked.
+        thrown.Which.Message.Should().Contain("Admin/Build");
+        thrown.Which.Message.Should().Contain("verified NOTHING");
+        thrown.Which.InnerException.Should().BeOfType<TimeoutException>();
+        attempts.Should().HaveCount(BuildProtocolDriver.CoordinationAttempts);
+    }
+
+    /// <summary>
+    /// A single attempt is still one attempt — a mis-configured/edge count must not turn into
+    /// "never run the handshake at all", which would be an unreachable node reported as reached.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task AZeroAttemptBudget_StillRunsOnce_AndStillErrors()
+    {
+        var attempts = new List<int>();
+        var act = () => BuildProtocolDriver.RetryUnreachableCoordination(
+                Handshake(int.MaxValue, () => new TimeoutException("→ target Admin/Build"), attempts),
+                attempts: 0,
+                NoBackoff,
+                Scheduler.Immediate,
+                logger: null)
+            .FirstAsync()
+            .ToTask();
+
+        await act.Should().ThrowAsync<BuildCoordinationUnreachableException>();
+        attempts.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// Only UNREACHABLE is retried. A real defect surfaces on the first attempt, unwrapped —
+    /// retrying it would delay the same verdict by minutes and bury the cause under three identical
+    /// stack traces.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task AnErrorThatIsNotATimeout_IsNotRetried_AndIsNotRelabelled()
+    {
+        var attempts = new List<int>();
+        var act = () => BuildProtocolDriver.RetryUnreachableCoordination(
+                Handshake(int.MaxValue, () => new InvalidOperationException("malformed BuildState"), attempts),
+                BuildProtocolDriver.CoordinationAttempts,
+                NoBackoff,
+                Scheduler.Immediate,
+                logger: null)
+            .FirstAsync()
+            .ToTask();
+
+        var thrown = await act.Should().ThrowAsync<InvalidOperationException>();
+        thrown.Which.Message.Should().Be("malformed BuildState");
+        attempts.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A hub timeout can arrive WRAPPED — merged inner streams surface as an
+    /// <see cref="AggregateException"/>, and a matcher that only tests the outermost type would
+    /// treat a startup race as a hard verdict and stall the rollout on it.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task AWrappedTimeout_CountsAsUnreachable()
+    {
+        var attempts = new List<int>();
+        var result = await BuildProtocolDriver.RetryUnreachableCoordination(
+                Handshake(1, () => new AggregateException(
+                    new InvalidOperationException("outer"),
+                    new TimeoutException("→ target Admin/Build")), attempts),
+                BuildProtocolDriver.CoordinationAttempts,
+                NoBackoff,
+                Scheduler.Immediate,
+                logger: null)
+            .FirstAsync()
+            .ToTask();
+
+        result.Should().Be("granted");
+        attempts.Should().Equal(new[] { 1, 2 });
+    }
+
+    /// <summary>
+    /// The readiness refusal must be able to tell "no verdict" from "a bad verdict". Both refuse,
+    /// but only the first is worth restarting on, and only the first is a rollout stalled on a race.
+    /// </summary>
+    [Fact]
+    public void TheRefusalDistinguishesNoVerdictFromABadOne()
+    {
+        BuildProtocolDriver.DescribesUnreachableCoordination(
+            new BuildCoordinationUnreachableException("x", new TimeoutException())).Should().BeTrue();
+        BuildProtocolDriver.DescribesUnreachableCoordination(
+            new AggregateException(new BuildCoordinationUnreachableException("x", new TimeoutException())))
+            .Should().BeTrue();
+        // A plain timeout raised INSIDE the sweep is a sweep fault, not an unreachable node: the
+        // handshake already succeeded, so a per-type activation budget expiring says something
+        // about this image and must keep its own message.
+        BuildProtocolDriver.DescribesUnreachableCoordination(new TimeoutException()).Should().BeFalse();
+        BuildProtocolDriver.DescribesUnreachableCoordination(null).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The backoff is bounded and monotone-ish — small enough that three attempts still finish
+    /// inside a startup probe budget, non-zero so a hot loop cannot re-time-out instantly.
+    /// </summary>
+    [Fact]
+    public void TheBackoffIsBoundedAndNonZero()
+    {
+        BuildProtocolDriver.CoordinationBackoff(1).Should().BeGreaterThan(TimeSpan.Zero);
+        BuildProtocolDriver.CoordinationBackoff(2).Should().BeGreaterThan(TimeSpan.Zero);
+        BuildProtocolDriver.CoordinationBackoff(2)
+            .Should().BeGreaterThanOrEqualTo(BuildProtocolDriver.CoordinationBackoff(1));
+        BuildProtocolDriver.CoordinationBackoff(9).Should().BeLessThanOrEqualTo(TimeSpan.FromSeconds(30));
+    }
+}


### PR DESCRIPTION
Fixes #1635.

## What it was

`DynamicTypePreWarmerHostedService` refused readiness when the `Admin/Build` hub was slow at startup, stalling the rollout on the previous image:

```
crit: DynamicTypePreWarmer: REFUSING READINESS — the warm-up stream FAULTED …
System.TimeoutException: No response received … within 00:01:00 for request
SubscribeRequest … → target Admin/Build.
```

The sweep's first act is the build protocol's claim handshake — a `SubscribeRequest` to `Admin/Build`. At pod startup that grain may not have activated yet, the request dies on the hub's own 60 s budget, and the `TimeoutException` propagated straight out of `BuildProtocolDriver.Run` and faulted the whole warm-up stream.

The sweep already draws exactly this distinction one level down — it keeps **two** skip sets so that *"it broke"* and *"I never found out"* cannot propagate as the same thing. The coordination handshake above it had neither.

## Still real?

Yes, in the code. Dormant on today's AKS values: `deploy/aks/values.aks.yaml` has `PreWarm__DynamicTypes: "false"`, and with the sweep off the hosted service takes the adopt-only path (`ProbeDynamicTypes`) which never reaches `BuildProtocolDriver`. It bites any deployment that enables the sweep — the bake mode, a local mesh with the escape hatch on, and the gate+sweep-on configuration `DEPLOY-RUNBOOK.md` §7 prescribes (the two keys are one setting since #1981/#2002).

## What changed

- **The handshake is retried; the bake is not.** `BuildProtocolDriver.RetryUnreachableCoordination` re-attempts the claim registration (3 attempts, 5 s then 15 s backoff) when — and only when — the failure means the node was never *reached*. Everything downstream of the registration is the sweep itself, whose failures are verdicts about this image and reach the gate untouched. A non-timeout error surfaces on the first attempt, unwrapped.
- **Exhausting the attempts still errors.** A named `BuildCoordinationUnreachableException` says which node was unreachable and that this process has verified **NOTHING**. `BuildProtocolDriver.DescribesUnreachableCoordination` lets the readiness refusal report *"the build coordination node could not be reached, so the sweep never started"* instead of *"the warm-up stream faulted"*. Both refuse readiness; only one is worth restarting on.

🚨 **Not a permissive change.** A gate whose evidence is unreachable still fails closed — the retry only buys a grain time to activate. A bare timeout raised *inside* the sweep (a per-type activation budget) is deliberately **not** matched, so it keeps gating exactly as before.

## Tests

`test/MeshWeaver.Hosting.Test/BuildCoordinationRetryTest.cs` — pure Rx over an injected handshake factory and scheduler, no mesh, 42 ms.

```
Passed!  - Failed: 0, Passed: 7, Skipped: 0, Total: 7, Duration: 42 ms
```

The load-bearing case is `ExhaustingTheAttempts_StillErrors_NeverSucceedsQuietly` — the fail-closed proof.

**Non-vacuity** — the helper reduced to the pre-fix shape (subscribe once, propagate verbatim):

```
Failed!  - Failed: 4, Passed: 3, Skipped: 0, Total: 7

  Failed ATransientUnreachableNode_IsRetried_AndTheSweepProceeds
   System.TimeoutException : No response received in hub cache/x within 00:01:00
     for request SubscribeRequest → target Admin/Build.
  Failed ExhaustingTheAttempts_StillErrors_NeverSucceedsQuietly
   Expected a BuildCoordinationUnreachableException, but found TimeoutException
  Failed AZeroAttemptBudget_StillRunsOnce_AndStillErrors
   Expected a BuildCoordinationUnreachableException, but found TimeoutException
  Failed AWrappedTimeout_CountsAsUnreachable
   System.AggregateException : One or more errors occurred. (outer) (→ target Admin/Build)
```

## For the maintainer

Worst case an unreachable coordination node now costs ~200 s before the (correct) refusal — three 60 s request budgets plus 20 s of backoff. That is inside a cold-bake startupProbe budget but it is a real change to how long a genuinely dead mesh takes to say so. `CoordinationAttempts` / `CoordinationBackoff` are the dials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)