### PR TITLE
Production errors render a message instead of a black screen

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1086,7 +1086,7 @@ public static class MemexConfiguration
         // Configure the HTTP request pipeline.
         if (!app.Environment.IsDevelopment())
         {
-            app.UseExceptionHandler("/Error", createScopeForErrors: true);
+            app.UseExceptionHandler(Pages.ErrorRoutes.Path, createScopeForErrors: true);
             // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
             app.UseHsts();
         }

--- a/memex/Memex.Portal.Shared/Pages/Error.razor
+++ b/memex/Memex.Portal.Shared/Pages/Error.razor
@@ -1,0 +1,67 @@
+@attribute [Route(ErrorRoutes.Path)]
+@using System.Diagnostics
+@using Memex.Portal.Shared.Pages
+@using Microsoft.AspNetCore.Diagnostics
+@using Microsoft.AspNetCore.Http
+
+@* Deliberately dependency-light and NON-interactive. This page renders while the app is already
+   failing, so it must not need a circuit, a hub, a localizer or any service that could be the very
+   thing that broke. Plain static SSR + inline styles only. *@
+
+<PageTitle>Something went wrong</PageTitle>
+
+<div style="min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px;
+            background:#0f172a;color:#e6ebf3;font-family:system-ui,-apple-system,'Segoe UI',sans-serif">
+    <div style="max-width:640px;width:100%;border:1px solid #23324a;border-radius:10px;
+                background:#111c30;padding:28px clamp(20px,4vw,36px)">
+        <div style="font-size:12px;font-weight:700;letter-spacing:.2em;text-transform:uppercase;color:#f0a8a0">Error</div>
+        <h1 style="font-size:24px;font-weight:700;margin:8px 0 0;line-height:1.2">Something went wrong</h1>
+        <p style="color:#a9b6c9;line-height:1.6;margin:14px 0 0">
+            The server hit an unexpected problem handling this request. The error has been logged.
+            If it keeps happening, quote the request id below.
+        </p>
+
+        @if (!string.IsNullOrEmpty(OriginalPath))
+        {
+            <div style="margin-top:18px">
+                <div style="font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:#7f9cf5">Request</div>
+                <code style="display:block;margin-top:6px;padding:8px 10px;border-radius:6px;background:#0b1220;
+                             color:#cdd8e8;font-size:13px;overflow-wrap:anywhere">@OriginalPath</code>
+            </div>
+        }
+
+        @if (!string.IsNullOrEmpty(RequestId))
+        {
+            <div style="margin-top:14px">
+                <div style="font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:#7f9cf5">Request id</div>
+                <code style="display:block;margin-top:6px;padding:8px 10px;border-radius:6px;background:#0b1220;
+                             color:#cdd8e8;font-size:13px;overflow-wrap:anywhere">@RequestId</code>
+            </div>
+        }
+
+        <div style="margin-top:24px;display:flex;gap:10px;flex-wrap:wrap">
+            <a href="/" style="text-decoration:none;font-weight:600;font-size:14px;color:#0f172a;background:#7f9cf5;
+                               border-radius:8px;padding:10px 16px">Back to the portal</a>
+        </div>
+    </div>
+</div>
+
+@code {
+    [CascadingParameter] private HttpContext? HttpContext { get; set; }
+
+    private string? RequestId { get; set; }
+    private string? OriginalPath { get; set; }
+
+    protected override void OnInitialized()
+    {
+        // Activity.Current is what the logs correlate on; TraceIdentifier is the fallback when no
+        // listener is attached. Either one lets an admin find the logged exception for this request.
+        RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
+
+        // The path the user actually asked for. UseExceptionHandler re-executes the pipeline onto
+        // this page, so HttpContext.Request.Path here is "/Error" — the ORIGINAL path only survives
+        // on the feature, and it is the single most useful thing to show (it is what named
+        // /auth/ea/connect when a server-side route was reached by client-side navigation).
+        OriginalPath = HttpContext?.Features.Get<IExceptionHandlerPathFeature>()?.Path;
+    }
+}

--- a/memex/Memex.Portal.Shared/Pages/ErrorRoutes.cs
+++ b/memex/Memex.Portal.Shared/Pages/ErrorRoutes.cs
@@ -1,0 +1,25 @@
+namespace Memex.Portal.Shared.Pages;
+
+/// <summary>
+/// The single definition of the production error route.
+///
+/// <para><b>Why this constant exists.</b> The portal wires
+/// <c>app.UseExceptionHandler(ErrorRoutes.Path)</c> in production only, and for a long time the
+/// path it named — <c>"/Error"</c>, written as a string literal — was served by <i>nothing</i>:
+/// no page, no controller, no endpoint anywhere in the solution. So every unhandled server-side
+/// exception in production was re-executed onto a route the Blazor router could not match, and the
+/// user got a BLACK SCREEN with no message, no status and no request id. Nothing failed to compile
+/// and nothing went red, because a route expressed as a literal in one file and as a page in
+/// another has no link between the two. It never showed up in development either — the handler is
+/// registered only when <c>!IsDevelopment()</c>, so locally you get the developer exception page.</para>
+///
+/// <para>Both sides now read this constant (<see cref="Path"/> in the pipeline,
+/// <c>@attribute [Route(ErrorRoutes.Path)]</c> on the page), so a rename breaks compilation rather
+/// than silently shipping a blank screen. <c>ErrorPageRouteTest</c> pins that a component actually
+/// claims it.</para>
+/// </summary>
+public static class ErrorRoutes
+{
+    /// <summary>The path the production exception handler re-executes onto.</summary>
+    public const string Path = "/Error";
+}

--- a/test/Memex.Portal.Shared.Test/ErrorPageRouteTest.cs
+++ b/test/Memex.Portal.Shared.Test/ErrorPageRouteTest.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using System.Reflection;
+using Memex.Portal.Shared.Pages;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the production error route to a component that actually serves it.
+///
+/// <para><b>Why this test exists.</b> The portal wires
+/// <c>app.UseExceptionHandler("/Error", createScopeForErrors: true)</c> — in production only — and
+/// for a long time <i>nothing in the solution served that path</i>. Every unhandled server-side
+/// exception was therefore re-executed onto a route the Blazor router could not match, and the user
+/// got a <b>black screen</b>: no message, no status, no request id. Nothing failed to compile and no
+/// test went red, because a route written as a string literal in the pipeline and as a page
+/// elsewhere has no link between the two — the same failure shape as the EA connect button
+/// (see <see cref="EaConnectRouteTest"/>). It was invisible locally too: the handler is registered
+/// only when <c>!IsDevelopment()</c>, so developers always saw the developer exception page.</para>
+///
+/// <para><b>What is asserted.</b> That <see cref="ErrorRoutes.Path"/> — the single constant the
+/// pipeline now passes to <c>UseExceptionHandler</c> — is claimed by a routable component in the
+/// portal assembly. Not that it compiles; that it is <i>routable</i>.</para>
+/// </summary>
+public class ErrorPageRouteTest
+{
+    /// <summary>
+    /// Every route template declared by a routable component in the portal assembly, the way the
+    /// Blazor <c>Router</c> discovers them: components carrying <see cref="RouteAttribute"/>.
+    /// </summary>
+    private static string[] ComponentRouteTemplates() =>
+        [.. typeof(ErrorRoutes).Assembly
+            .GetTypes()
+            .Where(t => typeof(IComponent).IsAssignableFrom(t))
+            .SelectMany(t => t.GetCustomAttributes<RouteAttribute>())
+            .Select(a => a.Template)];
+
+    /// <summary>
+    /// The path the production exception handler re-executes onto is served by a real page.
+    /// </summary>
+    [Fact]
+    public void The_exception_handler_path_is_served_by_a_routable_component()
+    {
+        var templates = ComponentRouteTemplates();
+
+        templates.Should().Contain(ErrorRoutes.Path,
+            "UseExceptionHandler re-executes onto this exact path — if no component claims it, "
+            + "every production exception renders a blank page instead of an error message");
+    }
+
+    /// <summary>
+    /// Non-vacuity guard. Without it, a reflection bug that returned everything (or an empty set
+    /// compared with a permissive assertion) would pass the test above while proving nothing —
+    /// exactly the failure mode that let the blank error page ship in the first place.
+    /// </summary>
+    [Fact]
+    public void A_path_no_component_serves_is_absent_from_the_route_templates()
+    {
+        var templates = ComponentRouteTemplates();
+
+        templates.Should().NotBeEmpty("component discovery must have found the portal's pages");
+        templates.Should().NotContain("/Error-no-component-serves-this",
+            "otherwise the registration assertion would pass for any string at all");
+    }
+}


### PR DESCRIPTION
## The bug

`MemexConfiguration` wires `app.UseExceptionHandler("/Error", createScopeForErrors: true)` — **in production only** — and **nothing in the solution serves `/Error`**. No page, no controller, no endpoint:

```
$ grep -rniE '@page[[:space:]]+"/error|Route\("error|HttpGet\("error' --include='*.razor' --include='*.cs' .
(nothing)
```

So every unhandled server-side exception in production is re-executed onto a route the Blazor router cannot match, and the user gets a **black screen** — no message, no status, no request id.

Two things kept it invisible:

- **It cannot reproduce locally.** The handler is registered only when `!IsDevelopment()`, so developers always get the developer exception page.
- **Nothing linked the two halves.** The path was a string literal in the pipeline with no page on the other end. Same failure shape as the EA connect button that `EaConnectRouteTest` was written for.

## How it surfaced

`/auth/ea/connect` presenting as a black screen. `EaConsentController` warns that reaching it by client-side Blazor navigation makes the router report *"does not match any registered address pattern"* — that throws, the handler re-executes onto `/Error`, and `/Error` rendered nothing. The black screen was the missing error page, not the EA flow.

## The fix

- **`Pages/Error.razor`** — dependency-light and non-interactive on purpose: it renders while the app is already failing, so it must not need a circuit, a hub or a localizer. Shows the **original request path** (recovered from `IExceptionHandlerPathFeature`; the re-executed `HttpContext.Request.Path` is `/Error`) and the **request id** (`Activity.Current?.Id ?? TraceIdentifier`) for log correlation. No exception detail or stack trace — the portal is internet-facing.
- **`Pages/ErrorRoutes.cs`** — the path defined **once**, read by both `UseExceptionHandler` and the page's `[Route]`, so a rename breaks compilation instead of silently shipping a blank screen.
- **`ErrorPageRouteTest`** — pins that a routable component claims the path, with a non-vacuity guard.

## Verification

- Full `Memex.Portal.Shared.Test` assembly: **350 passed, 0 failed**.
- **Non-vacuity proven**: with the route temporarily changed to `/ErrorTEMPORARILYBROKEN` the new test goes **red** (`Failed: 1, Passed: 1`); restored, **green** (`Passed: 2`). The guard test passes in both, as it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)