### PR TITLE
fix(#1979): answer the restart-as-activation question per PROCESS, and never reassuringly

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/PendingModuleActivationHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.Distributed/PendingModuleActivationHealthCheck.cs
@@ -4,9 +4,8 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 namespace Memex.Portal.Distributed;
 
 /// <summary>
-/// Reports modules that are LANDED but not yet LOADED — the restart-as-activation signal
-/// (<see cref="ModuleActivationList.PendingRestart"/>) that #1979 found written by two sites,
-/// consumed at boot, and read by nothing else.
+/// Reports modules that are LANDED but not yet LOADED — the restart-as-activation signal that
+/// #1979 found written by two sites, consumed at boot, and read by nothing else.
 ///
 /// <para><b>Why a health check rather than a log line.</b> Loading is restart-as-activation by
 /// design, which makes the restart part of the install — and an install whose last step is
@@ -15,46 +14,54 @@ namespace Memex.Portal.Distributed;
 /// paid-and-never-delivered: a success message that is true about the half that ran. An operator
 /// surface makes a fleet with pending activations visible without opening a portal.</para>
 ///
+/// <para>🚨 <b>Per PROCESS, not per deployment.</b> It asks
+/// <see cref="PendingModuleActivations"/> — the persisted sidecar compared against the assemblies
+/// THIS pod actually loaded — rather than reading <c>PendingRestart</c>, which is one
+/// deployment-wide boolean that the next boot clears. On a multi-replica deployment the pod that
+/// clears it is not the pod that is missing the module: replica A lands one and sets the flag,
+/// replica B restarts for an unrelated reason and resets it, and A keeps serving without the
+/// module while every surface reads "nothing pending". The comparison also names only what is
+/// actually missing here, instead of every enabled entry.</para>
+///
 /// <para>🚨 <b>DEGRADED, never Unhealthy.</b> A pending activation is a to-do, not a fault: the pod
 /// is serving correctly with the modules it loaded, and failing readiness here would stall a
 /// rollout over work the rollout itself performs. Degraded is reported in the payload and by
 /// <c>/health</c>'s aggregate status without taking the instance out of service.</para>
 ///
-/// <para>🚨 Reads the PERSISTED sidecar, not an in-memory flag. The process that landed the module
-/// is not necessarily the process a viewer or an operator is talking to — the state outliving the
-/// request that created it is the entire point.</para>
+/// <para>🚨 <b>An UNREADABLE sidecar is Degraded too, never Healthy.</b> A file that cannot be
+/// parsed is the absence of an answer, and this check reported it as "no pending activation" —
+/// because <see cref="ModuleActivationSidecar.Read"/> swallows corruption into the empty list. A
+/// check that cannot reach its evidence must say so, not default to the reassuring
+/// answer.</para>
 /// </summary>
-public sealed class PendingModuleActivationHealthCheck(string moduleRoot) : IHealthCheck
+public sealed class PendingModuleActivationHealthCheck(PendingModuleActivations activations) : IHealthCheck
 {
+    /// <summary>Constructs the reader from a module root — the shape the portal's boot uses.</summary>
+    public PendingModuleActivationHealthCheck(string moduleRoot)
+        : this(new PendingModuleActivations(moduleRoot)) { }
+
     /// <inheritdoc />
     public Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        ModuleActivationList activation;
+        ModuleActivationReport report;
         try
         {
-            activation = ModuleActivationSidecar.Read(moduleRoot);
+            report = activations.Read();
         }
         catch (Exception exception)
         {
-            // An unreadable sidecar is not a pending activation, and must not read as one.
-            return Task.FromResult(HealthCheckResult.Healthy(
-                $"module activation state unreadable ({exception.GetType().Name}) — "
-                + "reporting no pending activation rather than inventing one"));
+            return Task.FromResult(HealthCheckResult.Degraded(
+                "module activation state could not be determined "
+                + $"({exception.GetType().Name}: {exception.Message}) — this pod cannot say whether "
+                + "a landed module is waiting on a restart"));
         }
 
-        if (!activation.PendingRestart)
-            return Task.FromResult(HealthCheckResult.Healthy("no module activation pending"));
+        if (report.IsUndetermined)
+            return Task.FromResult(HealthCheckResult.Degraded(report.Describe()));
 
-        var names = activation.Entries
-            .Where(e => e.Enabled)
-            .Select(e => e.Name)
-            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-
-        return Task.FromResult(HealthCheckResult.Degraded(
-            $"{names.Length} module(s) are landed but not yet loaded — a restart activates them: "
-            + string.Join(", ", names.Take(10))
-            + (names.Length > 10 ? $", …(+{names.Length - 10})" : string.Empty)));
+        return Task.FromResult(report.HasPending
+            ? HealthCheckResult.Degraded(report.Describe())
+            : HealthCheckResult.Healthy(report.Describe()));
     }
 }

--- a/src/MeshWeaver.PluginCatalog/ModuleActivationStatus.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivationStatus.cs
@@ -1,0 +1,116 @@
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// One module that has LANDED on the deployment's volume but is not LOADED in this process — the
+/// unit of the restart-as-activation signal (#1979), carrying enough to point a viewer back at the
+/// install that produced it.
+/// </summary>
+/// <param name="Name">The module's assembly simple name, as the activation entry records it.</param>
+/// <param name="PackagePath">The mesh path of the install record that landed it, when the store
+/// lane wrote one — the back-pointer a package card matches on. Null for an entry with no
+/// recorded origin.</param>
+/// <param name="Version">The package version the landed bundle was served at, when recorded.</param>
+public sealed record PendingModuleActivation(string Name, string? PackagePath, string? Version);
+
+/// <summary>
+/// Derives, per PROCESS, which activated modules are not running here yet.
+///
+/// <para>🚨 <b>Why not just read <see cref="ModuleActivationList.PendingRestart"/>.</b> That flag is
+/// a single deployment-wide boolean that the NEXT boot clears — and on a multi-replica deployment
+/// the pod that clears it is not the pod that is missing the module. Replica A lands a module and
+/// sets the flag; replica B restarts for an unrelated reason, applies the list and resets it; A is
+/// still serving WITHOUT the module while every surface reads "nothing pending". The flag answers
+/// "did something change since some boot", which is not the question a buyer or an operator is
+/// asking. Comparing the persisted list against what THIS process actually loaded answers it
+/// exactly, per pod, and needs no extra state to stay true.</para>
+///
+/// <para>Pure and total: the caller supplies both the list and the loaded set, so the rule is
+/// testable with no filesystem, no reflection and no host.</para>
+/// </summary>
+public static class ModuleActivationStatus
+{
+    /// <summary>
+    /// The enabled entries in <paramref name="activation"/> whose assembly is not among
+    /// <paramref name="loadedAssemblyNames"/>.
+    ///
+    /// <para>A DISABLED entry is never pending: it is the record of an uninstall, and its module
+    /// being absent from this process is the outcome, not a to-do. (An uninstall that has not taken
+    /// effect yet — the module still loaded — is deliberately not reported either: nothing is
+    /// missing from the user's point of view, and reporting it would put an alarming "restart
+    /// required" on a package that has just been removed.)</para>
+    /// </summary>
+    /// <param name="activation">The persisted activation list.</param>
+    /// <param name="loadedAssemblyNames">Assembly SIMPLE names loaded in this process.</param>
+    public static ImmutableList<PendingModuleActivation> NotYetLoaded(
+        ModuleActivationList activation,
+        IReadOnlySet<string> loadedAssemblyNames)
+    {
+        ArgumentNullException.ThrowIfNull(activation);
+        ArgumentNullException.ThrowIfNull(loadedAssemblyNames);
+
+        return activation.Entries
+            .Where(entry => entry.Enabled
+                && !string.IsNullOrWhiteSpace(entry.Name)
+                && !loadedAssemblyNames.Contains(entry.Name))
+            .Select(entry => new PendingModuleActivation(entry.Name, entry.PackagePath, entry.Version))
+            .ToImmutableList();
+    }
+
+    /// <summary>
+    /// Whether the install record at <paramref name="packagePath"/> landed a module that is not
+    /// loaded here — the per-package question the Store's install step asks so it can say
+    /// "restart required to finish activating this" instead of a bare "installed".
+    ///
+    /// <para>A blank path matches nothing. It is not a wildcard: a package whose card has no path
+    /// to match on must not inherit some other package's pending restart.</para>
+    /// </summary>
+    public static bool IsPendingForPackage(
+        IEnumerable<PendingModuleActivation> pending, string? packagePath) =>
+        !string.IsNullOrWhiteSpace(packagePath)
+        && pending.Any(p => string.Equals(
+            p.PackagePath?.Trim('/'), packagePath.Trim('/'), StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The simple names of every assembly loaded into <paramref name="domain"/>. The set the
+    /// derivation above is asked against on a live host.
+    /// </summary>
+    public static IReadOnlySet<string> LoadedAssemblyNames(AppDomain domain)
+    {
+        ArgumentNullException.ThrowIfNull(domain);
+        return domain.GetAssemblies()
+            .Select(a => a.GetName().Name)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Select(n => n!)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Convenience for the live process.</summary>
+    public static IReadOnlySet<string> LoadedAssemblyNames() =>
+        LoadedAssemblyNames(AppDomain.CurrentDomain);
+
+    /// <summary>
+    /// One human-readable line naming what is pending — shared by every surface so an operator and
+    /// a buyer are never told different numbers.
+    /// </summary>
+    /// <param name="pending">The pending activations.</param>
+    /// <param name="maxNamed">How many are named before the line truncates.</param>
+    public static string Describe(IReadOnlyCollection<PendingModuleActivation> pending, int maxNamed = 10)
+    {
+        ArgumentNullException.ThrowIfNull(pending);
+        if (pending.Count == 0)
+            return "no module activation pending";
+
+        var names = pending
+            .Select(p => p.Name)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return $"{names.Length} module(s) are landed but not yet loaded in this process — "
+            + "a restart activates them: "
+            + string.Join(", ", names.Take(Math.Max(1, maxNamed)))
+            + (names.Length > maxNamed ? $", …(+{names.Length - maxNamed})" : string.Empty);
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -1,0 +1,106 @@
+using System.Collections.Immutable;
+using Microsoft.Extensions.Configuration;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// What this process can say about landed-but-unloaded modules — either an ANSWER, or an explicit
+/// admission that it could not determine one.
+///
+/// <para>🚨 The two are not the same and must never render the same. "Nothing pending" is evidence;
+/// "I could not read the activation sidecar" is the absence of evidence, and a surface that shows
+/// the second as the first is exactly the gate that cannot run but looks like a gate that
+/// passed.</para>
+/// </summary>
+/// <param name="Pending">The modules landed on the volume but not loaded in this process.</param>
+/// <param name="UndeterminedReason">Why the answer is unknown, or <c>null</c> when it is known.
+/// When set, <paramref name="Pending"/> is empty and means nothing.</param>
+public sealed record ModuleActivationReport(
+    ImmutableList<PendingModuleActivation> Pending,
+    string? UndeterminedReason = null)
+{
+    /// <summary>True when this process could not establish the activation state at all.</summary>
+    public bool IsUndetermined => UndeterminedReason is not null;
+
+    /// <summary>True when the state is KNOWN and something is waiting on a restart.</summary>
+    public bool HasPending => !IsUndetermined && !Pending.IsEmpty;
+
+    /// <summary>The one line every surface renders, so nobody is told two different stories.</summary>
+    public string Describe() =>
+        UndeterminedReason is { } reason
+            ? "module activation state could not be determined — " + reason
+            : ModuleActivationStatus.Describe(Pending);
+}
+
+/// <summary>
+/// Reads the restart-as-activation state for THIS process: the persisted activation sidecar
+/// compared against the assemblies actually loaded here (#1979).
+///
+/// <para>This is the seam every surface consults — the operator health check, and (through
+/// <c>hub.ServiceProvider</c>) a package card that needs to say "restart required to finish
+/// activating this" instead of a bare "installed". One reader, so the numbers cannot
+/// disagree.</para>
+///
+/// <para>A pull-on-demand READER: it starts nothing, subscribes to nothing and writes nothing, so
+/// an instance that never asks pays nothing. The read is a single small file, which is why it is
+/// plain and synchronous — the same reason <see cref="ModuleActivationSidecar"/> is.</para>
+/// </summary>
+public sealed class PendingModuleActivations(string moduleRoot)
+{
+    /// <summary>Constructs from configuration, resolving the writable module root once.</summary>
+    public PendingModuleActivations(IConfiguration? configuration)
+        : this(ModuleRoot.Resolve(configuration)) { }
+
+    /// <summary>The deployment root whose <c>modules/</c> sidecar is read.</summary>
+    public string ModuleRootPath { get; } = moduleRoot;
+
+    /// <summary>
+    /// The current report. Recomputed per call — the state changes underneath a running process
+    /// (that is the whole point), so a cached answer would be wrong exactly when it matters.
+    /// </summary>
+    public ModuleActivationReport Read() => Read(ModuleActivationStatus.LoadedAssemblyNames());
+
+    /// <summary>Testable form: the caller supplies what counts as loaded.</summary>
+    public ModuleActivationReport Read(IReadOnlySet<string> loadedAssemblyNames)
+    {
+        string? corrupt = null;
+        ModuleActivationList activation;
+        try
+        {
+            // 🚨 The corruption callback is not optional here. ModuleActivationSidecar.Read
+            // swallows an unparseable file into the EMPTY list, so a surface that ignores the
+            // callback reports a corrupt sidecar as "nothing pending" — cheerfully, forever. That
+            // is the shape this whole cluster of defects has in common.
+            activation = ModuleActivationSidecar.Read(ModuleRootPath, reason => corrupt = reason);
+        }
+        catch (Exception exception)
+        {
+            return new ModuleActivationReport(
+                [], $"the activation sidecar under '{ModuleRootPath}' could not be opened "
+                    + $"({exception.GetType().Name}: {exception.Message})");
+        }
+
+        if (corrupt is not null)
+            return new ModuleActivationReport([], corrupt);
+
+        return new ModuleActivationReport(
+            ModuleActivationStatus.NotYetLoaded(activation, loadedAssemblyNames));
+    }
+
+    /// <summary>
+    /// Whether the install record at <paramref name="packagePath"/> landed a module that has not
+    /// loaded here.
+    ///
+    /// <para>🚨 Returns <c>false</c> when the state is UNDETERMINED, and that is deliberate: this
+    /// answers a per-package question whose only honest fallback is "I have nothing to say about
+    /// this package". The undetermined case is reported by the operator surface, which is where an
+    /// unreadable sidecar is actionable — putting "restart required" on every package card because
+    /// a file could not be parsed would be noise a buyer cannot act on.</para>
+    /// </summary>
+    public bool IsPendingForPackage(string? packagePath)
+    {
+        var report = Read();
+        return !report.IsUndetermined
+            && ModuleActivationStatus.IsPendingForPackage(report.Pending, packagePath);
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -126,6 +126,16 @@ public static class PluginCatalogConfigurationExtensions
                 // fails with a denied-path error the publisher sees as HTTP 409. See ModuleRoot.
                 .AddSingleton(sp => new ModuleLandingService(
                     sp.GetService<ILogger<ModuleLandingService>>(),
+                    ModuleRoot.Resolve(sp.GetService<IConfiguration>())))
+                // The restart-as-activation READER (#1979): which landed modules are not loaded in
+                // THIS process. Registered beside the writer and rooted at the same resolved
+                // module root — a reader looking at a different directory than the writer is how
+                // "installed, and nothing happened" becomes unexplainable. A plain singleton: it
+                // starts nothing and writes nothing, so an instance that never asks pays nothing.
+                // 🚨 It is registered rather than merely constructible so a NodeType's layout area
+                // can resolve it from hub.ServiceProvider — the Store's install step is the
+                // surface where the missing last step is actually met.
+                .AddSingleton(sp => new PendingModuleActivations(
                     ModuleRoot.Resolve(sp.GetService<IConfiguration>()))))
             .ConfigureHub(config =>
             {

--- a/test/Memex.Portal.Shared.Test/PendingModuleActivationHealthCheckTest.cs
+++ b/test/Memex.Portal.Shared.Test/PendingModuleActivationHealthCheckTest.cs
@@ -60,16 +60,80 @@ public class PendingModuleActivationHealthCheckTest : IDisposable
         Assert.Contains("MeshWeaver.Widgets", result.Description);
     }
 
+    /// <summary>
+    /// 🚨 The multi-replica hole in <c>PendingRestart</c>. It is ONE deployment-wide boolean that
+    /// the next boot clears — and on a fleet the pod that clears it is not the pod that is missing
+    /// the module. Replica A lands one; replica B restarts for its own reasons, applies the list
+    /// and resets the flag; A keeps serving WITHOUT the module while every surface reads "nothing
+    /// pending". The check must answer for THIS process, so a cleared flag with an unloaded module
+    /// is still Degraded.
+    /// </summary>
     [Fact]
-    public async Task NoPendingActivation_IsHealthy()
+    public async Task AClearedFlagWithAnUnloadedModule_IsStillDegraded()
     {
         ModuleActivationSidecar.Write(root, new ModuleActivationList
         {
-            PendingRestart = false,
+            PendingRestart = false,   // another replica's boot consumed it
             Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Acme", Enabled = true }],
         });
 
+        var result = await Check();
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("MeshWeaver.Acme", result.Description);
+    }
+
+    [Fact]
+    public async Task AModuleThisProcessHasLOADED_IsNotPending()
+    {
+        // The entry names an assembly this test process genuinely has loaded, so it is running
+        // here and is not waiting on anything — whatever the deployment-wide flag says.
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            PendingRestart = true,
+            Entries =
+            [
+                new ModuleActivationEntry
+                {
+                    Name = typeof(ModuleActivationList).Assembly.GetName().Name!,
+                    Enabled = true,
+                },
+            ],
+        });
+
         Assert.Equal(HealthStatus.Healthy, (await Check()).Status);
+    }
+
+    [Fact]
+    public async Task ADisabledEntry_IsNeverPending()
+    {
+        // A disabled entry is the record of an UNINSTALL. Its module being absent from this
+        // process is the outcome, not a to-do.
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            PendingRestart = true,
+            Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Removed", Enabled = false }],
+        });
+
+        Assert.Equal(HealthStatus.Healthy, (await Check()).Status);
+    }
+
+    /// <summary>
+    /// 🚨 FAIL CLOSED. A sidecar that cannot be parsed is the ABSENCE of an answer.
+    /// <see cref="ModuleActivationSidecar.Read"/> swallows corruption into the empty list, so a
+    /// surface that ignores its corruption callback reports "no pending activation" — cheerfully,
+    /// forever. A check that cannot reach its evidence must say so.
+    /// </summary>
+    [Fact]
+    public async Task ACorruptSidecar_IsDegraded_NeverHealthy()
+    {
+        File.WriteAllText(
+            ModuleActivationSidecar.SidecarPath(root), "{ this is not activation json");
+
+        var result = await Check();
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("could not be determined", result.Description);
     }
 
     [Fact]

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationStatusTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationStatusTest.cs
@@ -1,0 +1,223 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The restart-as-activation signal a PROCESS can honestly report (#1979).
+///
+/// <para><see cref="ModuleActivationList.PendingRestart"/> was written by both landing sites,
+/// consumed at boot, and read by nothing. Reading it directly, though, answers the wrong question:
+/// it is one deployment-wide boolean that the next boot clears, so on a fleet the pod that clears
+/// it is not the pod that is missing the module. These pin the question that IS right —
+/// which activated modules are not loaded in THIS process — and the rule that an unreadable
+/// sidecar is the absence of an answer rather than a reassuring one.</para>
+/// </summary>
+public class ModuleActivationStatusTest : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-activation-status-" + Guid.NewGuid().ToString("N"));
+
+    public ModuleActivationStatusTest() => Directory.CreateDirectory(Path.Combine(root, "modules"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+    }
+
+    private static IReadOnlySet<string> Loaded(params string[] names) =>
+        names.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    // ── the pure derivation ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnEnabledEntryThatIsNotLoaded_IsPending()
+    {
+        var pending = ModuleActivationStatus.NotYetLoaded(
+            new ModuleActivationList
+            {
+                Entries =
+                [
+                    new ModuleActivationEntry { Name = "MeshWeaver.Acme", PackagePath = "Plugins/acme", Version = "1.2.0" },
+                    new ModuleActivationEntry { Name = "MeshWeaver.Loaded" },
+                ],
+            },
+            Loaded("MeshWeaver.Loaded"));
+
+        pending.Should().ContainSingle();
+        pending[0].Name.Should().Be("MeshWeaver.Acme");
+        pending[0].PackagePath.Should().Be("Plugins/acme");
+        pending[0].Version.Should().Be("1.2.0");
+    }
+
+    /// <summary>
+    /// 🚨 The multi-replica hole. A cleared flag says only "some boot happened somewhere"; it says
+    /// nothing about whether THIS process loaded the module.
+    /// </summary>
+    [Fact]
+    public void TheDeploymentWideFlagBeingCleared_DoesNotMakeAnUnloadedModuleLoaded()
+    {
+        var pending = ModuleActivationStatus.NotYetLoaded(
+            new ModuleActivationList
+            {
+                PendingRestart = false,
+                Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Acme" }],
+            },
+            Loaded("MeshWeaver.Something.Else"));
+
+        pending.Should().ContainSingle();
+    }
+
+    /// <summary>The converse: a set flag on a pod that HAS the module is not a pending restart.</summary>
+    [Fact]
+    public void TheDeploymentWideFlagBeingSet_DoesNotMakeALoadedModuleUnloaded()
+    {
+        ModuleActivationStatus.NotYetLoaded(
+                new ModuleActivationList
+                {
+                    PendingRestart = true,
+                    Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Acme" }],
+                },
+                Loaded("MeshWeaver.Acme"))
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ADisabledEntry_IsNeverPending()
+    {
+        // A disabled entry is the record of an uninstall; the module's absence is the outcome.
+        ModuleActivationStatus.NotYetLoaded(
+                new ModuleActivationList
+                {
+                    Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Removed", Enabled = false }],
+                },
+                Loaded())
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MatchingIsCaseInsensitive_LikeAssemblyNames()
+    {
+        ModuleActivationStatus.NotYetLoaded(
+                new ModuleActivationList { Entries = [new ModuleActivationEntry { Name = "MeshWeaver.ACME" }] },
+                Loaded("meshweaver.acme"))
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TheLiveProcessSet_ContainsThisAssembly()
+    {
+        // Guards the one non-pure step: if LoadedAssemblyNames ever stopped seeing the process's
+        // own assemblies, every module would read as pending and every surface would cry wolf.
+        ModuleActivationStatus.LoadedAssemblyNames()
+            .Should().Contain(typeof(ModuleActivationStatus).Assembly.GetName().Name!);
+    }
+
+    // ── the per-package question the Store card asks ────────────────────────────────────────────
+
+    [Fact]
+    public void APackagePathMatches_ItsOwnPendingModuleOnly()
+    {
+        var pending = new[]
+        {
+            new PendingModuleActivation("MeshWeaver.Acme", "Plugins/acme", "1.0.0"),
+        };
+
+        ModuleActivationStatus.IsPendingForPackage(pending, "Plugins/acme").Should().BeTrue();
+        ModuleActivationStatus.IsPendingForPackage(pending, "/Plugins/acme/").Should().BeTrue();
+        ModuleActivationStatus.IsPendingForPackage(pending, "Plugins/other").Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A blank path is not a wildcard. A card with no path to match on must not inherit some other
+    /// package's pending restart and tell a buyer to restart for something they did not install.
+    /// </summary>
+    [Fact]
+    public void ABlankPackagePath_MatchesNothing()
+    {
+        var pending = new[] { new PendingModuleActivation("MeshWeaver.Acme", "Plugins/acme", null) };
+
+        ModuleActivationStatus.IsPendingForPackage(pending, null).Should().BeFalse();
+        ModuleActivationStatus.IsPendingForPackage(pending, "  ").Should().BeFalse();
+        ModuleActivationStatus.IsPendingForPackage(
+            [new PendingModuleActivation("X", null, null)], "Plugins/acme").Should().BeFalse();
+    }
+
+    // ── the reader, over the durable state ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheReader_ReportsWhatTheSidecarSays_AgainstThisProcess()
+    {
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Acme", PackagePath = "Plugins/acme" }],
+        });
+
+        var report = new PendingModuleActivations(root).Read(Loaded());
+
+        report.IsUndetermined.Should().BeFalse();
+        report.HasPending.Should().BeTrue();
+        report.Describe().Should().Contain("MeshWeaver.Acme");
+        new PendingModuleActivations(root).IsPendingForPackage("Plugins/acme").Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnAbsentSidecar_IsAKnownEmptyAnswer_NotAnUndeterminedOne()
+    {
+        // A fresh deployment genuinely has nothing landed. That IS evidence.
+        var report = new PendingModuleActivations(Path.Combine(root, "fresh")).Read(Loaded());
+
+        report.IsUndetermined.Should().BeFalse();
+        report.HasPending.Should().BeFalse();
+        report.Describe().Should().Be("no module activation pending");
+    }
+
+    /// <summary>
+    /// 🚨 FAIL CLOSED. <see cref="ModuleActivationSidecar.Read"/> swallows an unparseable file into
+    /// the EMPTY list, so any reader that ignores its corruption callback reports "nothing pending"
+    /// — indistinguishably from a healthy deployment, forever. The report must separate the two.
+    /// </summary>
+    [Fact]
+    public void ACorruptSidecar_IsUNDETERMINED_NotEmpty()
+    {
+        File.WriteAllText(ModuleActivationSidecar.SidecarPath(root), "{ not activation json");
+
+        var report = new PendingModuleActivations(root).Read(Loaded());
+
+        report.IsUndetermined.Should().BeTrue();
+        report.HasPending.Should().BeFalse("an undetermined report asserts nothing either way");
+        report.Describe().Should().Contain("could not be determined");
+        report.UndeterminedReason.Should().NotBeNullOrWhiteSpace();
+    }
+
+    /// <summary>
+    /// The per-package answer degrades to "nothing to say", never to a restart prompt a buyer
+    /// cannot act on. The undetermined state is an OPERATOR signal; it is reported there.
+    /// </summary>
+    [Fact]
+    public void AnUndeterminedState_DoesNotPutARestartPromptOnEveryCard()
+    {
+        File.WriteAllText(ModuleActivationSidecar.SidecarPath(root), "{ not activation json");
+
+        new PendingModuleActivations(root).IsPendingForPackage("Plugins/acme").Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheDescriptionTruncates_RatherThanPrintingTheWholeFleet()
+    {
+        var many = Enumerable.Range(0, 25)
+            .Select(i => new PendingModuleActivation($"MeshWeaver.M{i:00}", null, null))
+            .ToArray();
+
+        var line = ModuleActivationStatus.Describe(many);
+
+        line.Should().Contain("25 module(s)");
+        line.Should().Contain("…(+15)");
+    }
+}


### PR DESCRIPTION
Continues #1979 (#2003 shipped item 2, the operator surface).

## What it was — and what it still is

`PendingRestart` was written by both landing sites, consumed at boot, and read by nothing. #2003 gave it a health check. Reading *that flag* answers the wrong question, and the shipped check had three holes, all of which fail quietly:

1. **It is one deployment-wide boolean that the next boot clears.** On a multi-replica deployment the pod that clears it is not the pod that is missing the module. Replica A lands one and sets the flag; replica B restarts for unrelated reasons, applies the list, resets it; A keeps serving **without** the module while every surface reads "nothing pending".
2. **It named every `Enabled` entry, not the pending ones.** One landing on a deployment carrying fifteen modules reported *"15 module(s) are landed but not yet loaded"*.
3. **A corrupt sidecar read as Healthy.** `ModuleActivationSidecar.Read` swallows an unparseable file into the *empty list* and reports it through an `onCorrupt` callback the check did not pass. So "cannot parse the activation state" rendered as "no pending activation" — cheerfully, forever. Exactly the trap this cluster keeps falling into.

Item 1 of the issue (the Store card) was also still open, and could not be built at all: *"no API surface, so nothing external can [read it]"*.

## What changed

**`ModuleActivationStatus`** (pure, `MeshWeaver.PluginCatalog`) — the honest question: which enabled entries are **not among the assemblies this process loaded**. True per pod, needs no extra state, names only what is genuinely missing, and immune to another replica's boot. A `Disabled` entry is never pending (it is the record of an uninstall; the module's absence is the outcome).

**`PendingModuleActivations`** — the one reader every surface consults. Its `ModuleActivationReport` separates a **known** empty answer from an **undetermined** one, and `Describe()` is shared so an operator and a buyer are never told different numbers.

**The health check** now asks that reader, and reports **Degraded** for both *pending* and *undetermined* — still never `Unhealthy`: the pod serves correctly with what it loaded, and failing readiness would stall a rollout over work the rollout itself performs.

**Registered in DI** beside `ModuleLandingService`, rooted at the same resolved module root, so a NodeType's layout area can resolve it from `hub.ServiceProvider`. `IsPendingForPackage(packagePath)` answers per package off the entries' `PackagePath` back-pointer — that is what the Store install step needs to say *"restart required to finish activating this"* instead of a bare *"installed"*. A blank path matches nothing; it is not a wildcard.

Note the deliberate asymmetry: an **undetermined** state does *not* put a restart prompt on every package card. It is an operator signal, reported where it is actionable — telling a buyer to restart because a file would not parse is noise they cannot act on.

## Tests

`test/MeshWeaver.PluginCatalog.Test/ModuleActivationStatusTest.cs` (13) and the health check's suite grown to 7.

```
Passed!  - Failed: 0, Passed: 13, Skipped: 0, Total: 13  (MeshWeaver.PluginCatalog.Test)
Passed!  - Failed: 0, Passed:  7, Skipped: 0, Total:  7  (Memex.Portal.Shared.Test)
```

Fail-closed proofs: `ACorruptSidecar_IsUNDETERMINED_NotEmpty`, `ACorruptSidecar_IsDegraded_NeverHealthy`, `AnUndeterminedState_DoesNotPutARestartPromptOnEveryCard`.

**Non-vacuity** — the health check reverted to `origin/main`'s implementation, same tests:

```
Failed!  - Failed: 4, Passed: 3, Skipped: 0, Total: 7

  Failed ADisabledEntry_IsNeverPending                    Expected: Healthy
  Failed AModuleThisProcessHasLOADED_IsNotPending         Expected: Healthy
  Failed ACorruptSidecar_IsDegraded_NeverHealthy          Expected: Degraded
  Failed AClearedFlagWithAnUnloadedModule_IsStillDegraded Expected: Degraded
```

## For the maintainer

The remaining half of item 1 — rendering it on the package card — is a change in **MeshWeaver.Plugins** (`Store/Plugin/Source/PluginLayoutAreas.cs`, the install CTA), not here. This PR is the platform seam it needs; it is deliberately a separate PR because the two repos deploy on different lanes.

`PendingRestart` itself is left exactly as it is — still written, still consumed at boot. Nothing now depends on it being accurate across replicas, which is the property it never had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)