### PR TITLE
Agent tools: one bridge, every terminal settles, and the token is observed (#1956)

### DIFF
--- a/src/MeshWeaver.AI/Plugins/CollaborationPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/CollaborationPlugin.cs
@@ -18,9 +18,10 @@ namespace MeshWeaver.AI.Plugins;
 /// with <c>.SubscribeOn(TaskPoolScheduler.Default)</c> (NEVER
 /// <c>Observable.FromAsync</c>, which is forbidden outside <c>IoPool</c>) so blocking
 /// enumeration never touches the hub scheduler, and writes go through
-/// <c>hub.Observe(...).Subscribe(...)</c> with a
-/// <see cref="TaskCompletionSource{T}"/> bridging the off-hub callback thread back
-/// to the caller. See <c>Doc/Architecture/AsynchronousCalls</c> for the rationale:
+/// <c>hub.Observe(...)</c>, with <see cref="ToolTask.Bridge{T}"/> bridging the off-hub
+/// callback thread back to the caller — every terminal settles (value, error, EMPTY
+/// completion) and the round's cancellation token is observed (#1956).
+/// See <c>Doc/Architecture/AsynchronousCalls</c> for the rationale:
 /// any <c>await</c> on a hub-backed operation from inside a plugin method will
 /// deadlock the hub scheduler under load.
 /// </summary>
@@ -65,48 +66,48 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
 
         var resolvedInput = MeshOperations.ResolveContextPath(chat, documentPath);
         var resolvedPath = MeshOperations.ResolvePath(resolvedInput);
-        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         // Read the document off the hub scheduler, then fan into hub.Observe(...).
         // No `await` anywhere — the subscription runs the read on TaskPoolScheduler and
-        // the write's response arrives on the observe subscription. Both resolve the TCS.
-        ops.Get(resolvedInput)
-            .SubscribeOn(TaskPoolScheduler.Default)
-            .Subscribe(
-                docJson => AddCommentContinuation(
-                    docJson, resolvedPath, documentPath, selectedText, commentText, tcs),
-                err => tcs.TrySetResult($"Error reading '{documentPath}': {err.Message}"));
-
-        return tcs.Task;
+        // the write's response arrives on the observe subscription.
+        //
+        // 🚨 Every terminal settles and the round's token is observed (#1956): before, a bare
+        // TaskCompletionSource with a 2-arg Subscribe left the task pending forever when the read
+        // completed WITHOUT emitting, and `cancellationToken` appeared only in the doc comment — so
+        // a parked AddComment held its Ai-pool gate permit through IoPool.Drain and Stop no-opped.
+        return ToolTask.Bridge(
+            ops.Get(resolvedInput)
+                .SubscribeOn(TaskPoolScheduler.Default)
+                .Take(1)
+                .SelectMany(docJson => AddCommentContinuation(
+                    docJson, resolvedPath, documentPath, selectedText, commentText)),
+            cancellationToken,
+            answer => answer,
+            err => $"Error reading '{documentPath}': {err.Message}",
+            () => $"Document not found: {documentPath}");
     }
 
-    private void AddCommentContinuation(
+    /// <summary>
+    /// The continuation, as an observable of the tool's ANSWER. It formats its own failures rather
+    /// than erroring, so the bridge's error arm keeps naming the read that actually failed.
+    /// </summary>
+    private IObservable<string> AddCommentContinuation(
         string docJson,
         string resolvedPath,
         string documentPath,
         string selectedText,
-        string commentText,
-        TaskCompletionSource<string> tcs)
+        string commentText)
     {
         if (docJson.StartsWith("Not found") || docJson.StartsWith("Error"))
-        {
-            tcs.TrySetResult($"Document not found: {documentPath}");
-            return;
-        }
+            return Observable.Return($"Document not found: {documentPath}");
 
         var content = ExtractContent(docJson);
         if (string.IsNullOrEmpty(content))
-        {
-            tcs.TrySetResult($"Could not extract content from {documentPath}");
-            return;
-        }
+            return Observable.Return($"Could not extract content from {documentPath}");
 
         var start = content.IndexOf(selectedText, StringComparison.Ordinal);
         if (start < 0)
-        {
-            tcs.TrySetResult($"Text '{selectedText}' not found in document {documentPath}");
-            return;
-        }
+            return Observable.Return($"Text '{selectedText}' not found in document {documentPath}");
 
         var words = selectedText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         var startFragment = string.Join(" ", words.Take(Math.Min(5, words.Length)));
@@ -122,11 +123,10 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
             Author = chat.Context?.Path ?? "agent"
         };
 
-        PostAndReport<CreateCommentResponse>(
+        return PostAndReport<CreateCommentResponse>(
             request,
             new Address(resolvedPath),
             documentPath,
-            tcs,
             resp => resp.Success
                 ? $"Comment added on \"{selectedText}\" in {documentPath}"
                 : $"Error adding comment: {resp.Error ?? "unknown error"}");
@@ -165,33 +165,36 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
 
         var resolvedInput = MeshOperations.ResolveContextPath(chat, documentPath);
         var resolvedPath = MeshOperations.ResolvePath(resolvedInput);
-        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         // Probe existence first — the single most common agent mistake is passing a display name
         // instead of a path, and "Document not found" is far more actionable than whatever the write
-        // path reports for an address that routes nowhere.
-        ops.Get(resolvedInput)
-            .SubscribeOn(TaskPoolScheduler.Default)
-            .Subscribe(
-                docJson => SuggestEditContinuation(docJson, resolvedPath, documentPath, originalText, newText, tcs),
-                err => tcs.TrySetResult($"Error reading '{documentPath}': {err.Message}"));
-
-        return tcs.Task;
+        // path reports for an address that routes nowhere. Same three-terminal bridge as
+        // AddComment: value, error, and the EMPTY completion that used to park the round (#1956).
+        return ToolTask.Bridge(
+            ops.Get(resolvedInput)
+                .SubscribeOn(TaskPoolScheduler.Default)
+                .Take(1)
+                .SelectMany(docJson => SuggestEditContinuation(
+                    docJson, resolvedPath, documentPath, originalText, newText)),
+            cancellationToken,
+            answer => answer,
+            err => $"Error reading '{documentPath}': {err.Message}",
+            () => $"Document not found: {documentPath}");
     }
 
-    private void SuggestEditContinuation(
+    /// <summary>
+    /// The continuation, as an observable of the tool's ANSWER — see
+    /// <see cref="AddCommentContinuation"/> for why it formats its own failures.
+    /// </summary>
+    private IObservable<string> SuggestEditContinuation(
         string docJson,
         string resolvedPath,
         string documentPath,
         string originalText,
-        string newText,
-        TaskCompletionSource<string> tcs)
+        string newText)
     {
         if (docJson.StartsWith("Not found") || docJson.StartsWith("Error"))
-        {
-            tcs.TrySetResult($"Document not found: {documentPath}");
-            return;
-        }
+            return Observable.Return($"Document not found: {documentPath}");
 
         var options = hub.JsonSerializerOptions;
 
@@ -199,20 +202,19 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
         // the probe above only established existence; splicing the text it returned would lose any
         // edit that landed in between. DefaultIfEmpty guarantees the tool always answers: an update
         // that completes without emitting must not leave the agent's task pending forever.
-        hub.GetMeshNodeStream(resolvedPath)
+        return hub.GetMeshNodeStream(resolvedPath)
             .Update(live => MarkdownOverviewLayoutArea.WithMarkdownContent(
                 live, Splice(MarkdownOverviewLayoutArea.GetMarkdownContent(live), originalText, newText), options))
             .Take(1)
-            .DefaultIfEmpty()
-            .Subscribe(
-                written => tcs.TrySetResult(written is null
-                    ? $"The edit produced no change in {documentPath}."
-                    : Describe(documentPath, originalText, newText)),
-                err =>
-                {
-                    logger.LogWarning(err, "SuggestEdit failed for {Path}", resolvedPath);
-                    tcs.TrySetResult($"Error editing '{documentPath}': {err.Message}");
-                });
+            .Select(written => written is null
+                ? $"The edit produced no change in {documentPath}."
+                : Describe(documentPath, originalText, newText))
+            .Catch((Exception err) =>
+            {
+                logger.LogWarning(err, "SuggestEdit failed for {Path}", resolvedPath);
+                return Observable.Return($"Error editing '{documentPath}': {err.Message}");
+            })
+            .DefaultIfEmpty($"The edit produced no change in {documentPath}.");
     }
 
     /// <summary>
@@ -255,45 +257,41 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
     }
 
     /// <summary>
-    /// Posts a request via <c>hub.Observe(...)</c> and resolves <paramref name="tcs"/>
-    /// from the subscription. No <c>await</c>: the response arrives on a non-hub thread
-    /// when the response arrives. Routing failures surface as a user-actionable
-    /// error pointing the agent back at the "use `path`, not `name`" rule.
+    /// Posts a request via <c>hub.Observe(...)</c> and projects the callback into the tool's ANSWER.
+    /// No <c>await</c>: the response arrives on a non-hub thread. Routing failures surface as a
+    /// user-actionable error pointing the agent back at the "use `path`, not `name`" rule, and a
+    /// response that never comes at all still answers — <c>DefaultIfEmpty</c> is what keeps an
+    /// evicted callback stream from parking the round.
     /// </summary>
-    private void PostAndReport<TResponse>(
+    private IObservable<string> PostAndReport<TResponse>(
         IRequest<TResponse> request,
         Address target,
         string originalInput,
-        TaskCompletionSource<string> tcs,
         Func<TResponse, string> formatSuccess)
     {
         var delivery = hub.Post(request, o => o.WithTarget(target))!;
-        hub.Observe(delivery)
-            .Subscribe(
-                callback =>
-                {
-                    if (callback.Message is TResponse typed)
-                    {
-                        try { tcs.TrySetResult(formatSuccess(typed)); }
-                        catch (Exception ex) { tcs.TrySetResult($"Error formatting response: {ex.Message}"); }
-                    }
-                    else
-                    {
-                        tcs.TrySetResult($"Error: unexpected response {callback.Message?.GetType().Name ?? "null"} for {originalInput}.");
-                    }
-                },
-                ex =>
-                {
-                    logger.LogWarning(
-                        ex,
-                        "Delivery to {Target} failed for {RequestType}. Original input: {OriginalInput}",
-                        target, request.GetType().Name, originalInput);
-                    tcs.TrySetResult(
-                        $"Error: {ex.Message ?? "delivery failed"}. " +
-                        $"Check that '{originalInput}' resolves to an existing node — pass the MeshNode's " +
-                        "`path` property, not its `name`. If you only know the display name, call " +
-                        "Search('name:\"...\"') and use the `path` field of the match.");
-                });
+        return hub.Observe(delivery)
+            .Take(1)
+            .Select(callback =>
+            {
+                if (callback.Message is not TResponse typed)
+                    return $"Error: unexpected response {callback.Message?.GetType().Name ?? "null"} for {originalInput}.";
+                try { return formatSuccess(typed); }
+                catch (Exception ex) { return $"Error formatting response: {ex.Message}"; }
+            })
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(
+                    ex,
+                    "Delivery to {Target} failed for {RequestType}. Original input: {OriginalInput}",
+                    target, request.GetType().Name, originalInput);
+                return Observable.Return(
+                    $"Error: {ex.Message ?? "delivery failed"}. " +
+                    $"Check that '{originalInput}' resolves to an existing node — pass the MeshNode's " +
+                    "`path` property, not its `name`. If you only know the display name, call " +
+                    "Search('name:\"...\"') and use the `path` field of the match.");
+            })
+            .DefaultIfEmpty($"Error: no response for {originalInput} — the request was delivered but the callback stream ended without one.");
     }
 
     private static string? ExtractContent(string rawJson)

--- a/src/MeshWeaver.AI/Plugins/ContentCollectionPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/ContentCollectionPlugin.cs
@@ -42,6 +42,9 @@ public class ContentCollectionPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
     /// <param name="query">Free-text query matched semantically against indexed chunk text.</param>
     /// <param name="scope">Node path to anchor the search at (this path and each ancestor prefix); defaults to the agent's current context.</param>
     /// <param name="limit">Maximum number of chunk hits to return (1-200, default 20); not deduped by file.</param>
+    /// <param name="cancellationToken">The round's token — cancelling it unwinds the tool call and
+    /// disposes the search. Bound automatically by <c>AIFunctionFactory</c>; never part of the
+    /// tool's JSON schema.</param>
     /// <returns>A JSON string of the form <c>{count, results:[{documentPath, collectionPath, filePath, chunkIndex, rank, snippet}]}</c>.</returns>
     [Description(
         "Semantic search over INDEXED content chunks — the chunk-level companion to the node `Search`. " +
@@ -57,14 +60,22 @@ public class ContentCollectionPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
     public Task<string> SearchChunks(
         [Description("Free-text query (matched semantically against indexed chunk text — 1000-char windows, 150-char overlap). May also carry `namespace:<node>/<collection>` and `scope:subtree|exact|ancestorsandself` to target one collection.")] string query,
         [Description("Node path to anchor the search at — this path AND each ancestor prefix are searched (e.g. 'ACME/Reports'). Defaults to the agent's current context; ignored when the query carries a `namespace:` token.")] string? scope = null,
-        [Description("Maximum number of chunk hits to return (1-200, default 20). Not deduped by file — chunk-level hits are the point.")] int limit = 20)
+        [Description("Maximum number of chunk hits to return (1-200, default 20). Not deduped by file — chunk-level hits are the point.")] int limit = 20,
+        CancellationToken cancellationToken = default)
     {
         var scopePath = !string.IsNullOrWhiteSpace(scope)
             ? MeshOperations.ResolvePath(MeshOperations.ResolveContextPath(chat, scope))
             : chat.Context?.Context;
 
-        return ChunkNavigation.SearchChunks(hub.ServiceProvider, query, scopePath, limit)
-            .FirstAsync().ToTask();
+        // 🚨 Was `.FirstAsync().ToTask()` with NO token (#1956): a stalled embedder parked the round
+        // — and its Ai-pool gate permit — with nothing able to end the wait, and FirstAsync turned
+        // an empty completion into a "Sequence contains no elements" fault rather than an answer.
+        return ToolTask.Bridge(
+            ChunkNavigation.SearchChunks(hub.ServiceProvider, query, scopePath, limit),
+            cancellationToken,
+            json => json,
+            ex => $"Error searching chunks: {ex.Message}",
+            () => "{\"count\":0,\"results\":[],\"note\":\"the chunk index completed without answering — nothing was searched\"}");
     }
 
     /// <summary>
@@ -74,6 +85,8 @@ public class ContentCollectionPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
     /// <param name="collectionPath">The content collection path the chunk belongs to (from a search hit).</param>
     /// <param name="filePath">The file path within the collection (from a search hit).</param>
     /// <param name="chunkIndex">0-based chunk index within the file (or a prev/next index to step).</param>
+    /// <param name="cancellationToken">The round's token — cancelling it unwinds the tool call and
+    /// disposes the read.</param>
     /// <returns>A JSON string of the form <c>{found, collectionPath, filePath, chunkIndex, text, prevIndex, nextIndex, totalChunks}</c>.</returns>
     [Description(
         "Reads ONE indexed content chunk by its 0-based index within a file, with prev/next links so you " +
@@ -84,9 +97,14 @@ public class ContentCollectionPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
     public Task<string> GetChunk(
         [Description("The content collection path the chunk belongs to (the 'collectionPath' from a search_chunks hit).")] string collectionPath,
         [Description("The file path within the collection (the 'filePath' from a search_chunks hit).")] string filePath,
-        [Description("0-based chunk index within the file (the 'chunkIndex' from a search_chunks hit, or a prevIndex/nextIndex to step).")] int chunkIndex)
-        => ChunkNavigation.GetChunk(hub.ServiceProvider, collectionPath, filePath, chunkIndex)
-            .FirstAsync().ToTask();
+        [Description("0-based chunk index within the file (the 'chunkIndex' from a search_chunks hit, or a prevIndex/nextIndex to step).")] int chunkIndex,
+        CancellationToken cancellationToken = default)
+        => ToolTask.Bridge(
+            ChunkNavigation.GetChunk(hub.ServiceProvider, collectionPath, filePath, chunkIndex),
+            cancellationToken,
+            json => json,
+            ex => $"Error reading chunk {chunkIndex} of '{filePath}': {ex.Message}",
+            () => $"{{\"found\":false,\"collectionPath\":\"{collectionPath}\",\"filePath\":\"{filePath}\",\"chunkIndex\":{chunkIndex},\"note\":\"the chunk index completed without answering\"}}");
 
     /// <summary>
     /// Agent tool: uploads text content (SVG, markdown, JSON, CSS, etc.) into a node's content
@@ -110,21 +128,11 @@ public class ContentCollectionPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
         var resolvedPath = MeshOperations.ResolvePath(MeshOperations.ResolveContextPath(chat, nodePath));
         var address = new Address(resolvedPath);
 
-        // hub.Observe(...) + TCS — never `await` a hub response from
-        // a plugin method: that blocks the hub scheduler. The callback fires on a non-hub
-        // thread when the response arrives and resolves the TCS to unblock the caller.
-        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutCts.CancelAfter(TimeSpan.FromSeconds(30));
-        var registration = timeoutCts.Token.Register(() =>
-        {
-            if (cancellationToken.IsCancellationRequested)
-                tcs.TrySetCanceled(cancellationToken);
-            else
-                tcs.TrySetResult($"Error uploading to {resolvedPath}: the operation timed out waiting for a response.");
-        });
-        _ = tcs.Task.ContinueWith(_ => { registration.Dispose(); timeoutCts.Dispose(); }, TaskScheduler.Default);
-
+        // hub.Observe(...) bridged by ToolTask — never `await` a hub response from a plugin method:
+        // that blocks the hub scheduler. The callback fires on a non-hub thread when the response
+        // arrives. The 30 s bound is now Rx's own Timeout rather than a hand-rolled linked
+        // CancellationTokenSource + ContinueWith, so the token, the timeout, the error and the
+        // EMPTY completion are one set of terminals with one disposal path (#1956).
         var delivery = hub.Post(
             new SaveContentRequest
             {
@@ -134,27 +142,20 @@ public class ContentCollectionPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
             },
             o => o.WithTarget(address))!;
 
-        hub.Observe(delivery)
-            .Subscribe(
-                callback =>
-                {
-                    if (callback.Message is SaveContentResponse typed)
-                    {
-                        tcs.TrySetResult(typed.Success
-                            ? $"Uploaded `{filePath}` to @{resolvedPath}/{collectionName}/{filePath}"
-                            : $"Error: {typed.Error}");
-                    }
-                    else
-                    {
-                        tcs.TrySetResult($"Error: unexpected response {callback.Message?.GetType().Name ?? "null"} uploading to {resolvedPath}.");
-                    }
-                },
-                ex => tcs.TrySetResult(
-                    $"Error uploading to {resolvedPath}: {ex.Message ?? "delivery failed"}. " +
-                    $"Check that '{nodePath}' resolves to an existing node — pass the MeshNode's " +
-                    "`path` property, not its `name`."));
-
-        return tcs.Task;
+        return ToolTask.Bridge(
+            hub.Observe(delivery).Take(1).Timeout(TimeSpan.FromSeconds(30)),
+            cancellationToken,
+            callback => callback.Message is SaveContentResponse typed
+                ? typed.Success
+                    ? $"Uploaded `{filePath}` to @{resolvedPath}/{collectionName}/{filePath}"
+                    : $"Error: {typed.Error}"
+                : $"Error: unexpected response {callback.Message?.GetType().Name ?? "null"} uploading to {resolvedPath}.",
+            ex => ex is TimeoutException
+                ? $"Error uploading to {resolvedPath}: the operation timed out waiting for a response."
+                : $"Error uploading to {resolvedPath}: {ex.Message ?? "delivery failed"}. " +
+                  $"Check that '{nodePath}' resolves to an existing node — pass the MeshNode's " +
+                  "`path` property, not its `name`.",
+            () => $"Error uploading to {resolvedPath}: the callback stream ended without a response.");
     }
 }
 

--- a/src/MeshWeaver.AI/Plugins/PlanStorageTool.cs
+++ b/src/MeshWeaver.AI/Plugins/PlanStorageTool.cs
@@ -34,12 +34,17 @@ public static class PlanStorageTool
                 Content = planContent
             };
 
-            // Use IObservable CreateNode — no await, no deadlock
-            var tcs = new TaskCompletionSource<string>();
-            meshService.CreateNode(planNode).Subscribe(
-                _ => tcs.TrySetResult($"Plan stored at {execCtx.ThreadPath}/Plan"),
-                ex => tcs.TrySetResult($"Error storing plan: {ex.Message}"));
-            return tcs.Task;
+            // Use IObservable CreateNode — no await, no deadlock. Every terminal settles, and the
+            // round's token is observed: before #1956 this was a bare TaskCompletionSource with a
+            // 2-arg Subscribe, so an empty completion left the task pending and Stop no-opped on a
+            // create that was merely slow (bounded only by the hub's 30 s RequestTimeout, during
+            // which the round holds its Ai-pool gate permit).
+            return ToolTask.Bridge(
+                meshService.CreateNode(planNode),
+                cancellationToken,
+                _ => $"Plan stored at {execCtx.ThreadPath}/Plan",
+                ex => $"Error storing plan: {ex.Message}",
+                () => $"Plan was not stored at {execCtx.ThreadPath}/Plan — the create completed without confirming the node.");
         }
 
         return AIFunctionFactory.Create(

--- a/src/MeshWeaver.AI/Plugins/SkillTool.cs
+++ b/src/MeshWeaver.AI/Plugins/SkillTool.cs
@@ -27,43 +27,50 @@ public static class SkillTool
                 return Task.FromResult("Provide the skill's path — find skills with `search nodeType:Skill`.");
 
             // Authoritative single-node read (GetMeshNodeStream, not QueryAsync — the query index lags).
-            var tcs = new TaskCompletionSource<string>();
-            hub.GetMeshNodeStream(skillPath.Trim())
-                .Where(n => n is not null)
-                .Take(1)
-                .Timeout(TimeSpan.FromSeconds(10))
-                .Subscribe(
-                    node =>
-                    {
-                        var def = DefinitionOf(node!, hub.JsonSerializerOptions);
-                        var instructions = def?.Instructions;
-                        if (string.IsNullOrWhiteSpace(instructions))
-                        {
-                            tcs.TrySetResult($"Skill '{skillPath}' has no instructions to load.");
-                            return;
-                        }
+            //
+            // 🚨 The three terminals go through ToolTask.Bridge. Before #1956 this was a bare
+            // TaskCompletionSource with a 2-arg Subscribe, so the EMPTY-completion terminal was
+            // missing: a .Where(...)-filtered stream that completes without ever passing the filter
+            // (MeshNodeStreamCache completes its per-path subjects on eviction and on dispose)
+            // reached neither arm, and the task stayed pending forever. Timeout does not cover that
+            // — it passes an empty OnCompleted straight through. Nor was the token observed, so
+            // Stop could not end a load_skill parked on a hub that never activates.
+            return ToolTask.Bridge(
+                hub.GetMeshNodeStream(skillPath.Trim())
+                    .Where(n => n is not null)
+                    .Take(1)
+                    .Timeout(TimeSpan.FromSeconds(10)),
+                cancellationToken,
+                node => Answer(node!),
+                ex => $"Could not load skill '{skillPath}': {ex.Message}",
+                // An absent skill node is a CORRECT outcome, and the honest answer is that it is
+                // absent — the agent can then search for the right path instead of waiting.
+                () => $"Skill '{skillPath}' was not found — find skills with `search nodeType:Skill`.");
 
-                        // LaunchesSubThread: run the skill in its OWN sub-thread to keep the work out of
-                        // the main context, via the generic StartThread launcher (mainNode = this thread).
-                        var execCtx = chat.ExecutionContext;
-                        if (def!.LaunchesSubThread && execCtx is not null)
-                        {
-                            hub.StartThread(
-                                execCtx.ContextPath ?? execCtx.ThreadPath,
-                                instructions!,
-                                contextPath: execCtx.ContextPath,
-                                createdBy: execCtx.UserAccessContext?.ObjectId,
-                                mainNode: execCtx.ThreadPath);
-                            tcs.TrySetResult(
-                                $"Launched skill '{node!.Name ?? skillPath}' in a sub-thread to run in isolation. " +
-                                "Its result appears inline when it completes — continue with other work.");
-                            return;
-                        }
+            string Answer(MeshNode node)
+            {
+                var def = DefinitionOf(node, hub.JsonSerializerOptions);
+                var instructions = def?.Instructions;
+                if (string.IsNullOrWhiteSpace(instructions))
+                    return $"Skill '{skillPath}' has no instructions to load.";
 
-                        tcs.TrySetResult(instructions!);
-                    },
-                    ex => tcs.TrySetResult($"Could not load skill '{skillPath}': {ex.Message}"));
-            return tcs.Task;
+                // LaunchesSubThread: run the skill in its OWN sub-thread to keep the work out of
+                // the main context, via the generic StartThread launcher (mainNode = this thread).
+                var execCtx = chat.ExecutionContext;
+                if (def!.LaunchesSubThread && execCtx is not null)
+                {
+                    hub.StartThread(
+                        execCtx.ContextPath ?? execCtx.ThreadPath,
+                        instructions!,
+                        contextPath: execCtx.ContextPath,
+                        createdBy: execCtx.UserAccessContext?.ObjectId,
+                        mainNode: execCtx.ThreadPath);
+                    return $"Launched skill '{node.Name ?? skillPath}' in a sub-thread to run in isolation. " +
+                           "Its result appears inline when it completes — continue with other work.";
+                }
+
+                return instructions!;
+            }
         }
 
         return AIFunctionFactory.Create(

--- a/src/MeshWeaver.AI/Plugins/ToolTask.cs
+++ b/src/MeshWeaver.AI/Plugins/ToolTask.cs
@@ -1,0 +1,105 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+
+namespace MeshWeaver.AI.Plugins;
+
+/// <summary>
+/// The ONE bridge from a reactive source to the <c>Task&lt;string&gt;</c> an agent tool must hand
+/// back to <c>AIFunctionFactory</c>.
+///
+/// <para><b>Why a shared bridge and not a <see cref="TaskCompletionSource{TResult}"/> per tool.</b>
+/// Every hand-rolled bridge in this folder had at least one terminal that never settled the task
+/// (#1956). A tool call runs INSIDE the round's leaf on the bounded <c>IoPoolNames.Ai</c> pool and
+/// holds one gate permit for its whole duration, so a task that never settles is not a slow tool —
+/// it is a permit held through <c>IoPool.Drain()</c>, a Stop button that does nothing, and a
+/// teardown that proceeds over live code. #1863 / #1908 fixed exactly that in
+/// <see cref="DelegationTool"/> and wrote the invariant into <c>ControlledIoPooling.md</c>:
+/// <i>a tool call runs inside the leaf, so its Task must observe the token</i>.</para>
+///
+/// <para><b>The three terminals — every one of them settles.</b></para>
+/// <list type="number">
+///   <item><b>A value.</b> The first emission is the answer; the subscription is disposed at once
+///     (nothing keeps reading a node stream whose hub may be going away).</item>
+///   <item><b>An error.</b> Formatted into an answer — on an agent-facing tool the failure text IS
+///     the result the model must see.</item>
+///   <item><b>An EMPTY completion.</b> 🚨 The terminal every hand-rolled bridge missed. A
+///     2-argument <c>Subscribe(onNext, onError)</c> never fires for a source that completes
+///     without emitting, so the task stays pending forever. And an empty completion is REACHABLE:
+///     <c>MeshNodeStreamCache</c> completes its per-path subjects on eviction and on dispose, a
+///     <c>.Where(...)</c>-filtered stream completes when nothing passes the filter, and a
+///     <c>.Take(1)</c> over a permission evaluator completes empty if the evaluator does.
+///     <c>Timeout</c> does NOT cover this: it passes an empty <c>OnCompleted</c> straight through.
+///     A <c>yield break</c> is a silence; the empty answer is an ANSWER — so the caller supplies
+///     one and it is always sent.</item>
+/// </list>
+///
+/// <para><b>And cancellation is a fourth.</b> The token is registered before the source is
+/// subscribed, and firing it both cancels the task and DISPOSES the subscription, so the work the
+/// tool started actually stops rather than running on unobserved.</para>
+/// </summary>
+public static class ToolTask
+{
+    /// <summary>
+    /// Bridges <paramref name="source"/> to a task that settles on the first emission, on an error,
+    /// on an empty completion, or on <paramref name="cancellationToken"/> — whichever happens
+    /// first — and disposes the subscription in every one of those cases.
+    /// </summary>
+    /// <typeparam name="T">Element type of the source.</typeparam>
+    /// <param name="source">The reactive operation backing the tool call. Only its FIRST emission
+    /// is used; the subscription is disposed as soon as the task settles.</param>
+    /// <param name="cancellationToken">The round's token, as handed to the tool by
+    /// <c>AIFunctionFactory</c>. Cancelling it cancels the returned task and disposes the
+    /// subscription.</param>
+    /// <param name="onNext">Formats the first emission into the tool's answer.</param>
+    /// <param name="onError">Formats a fault into the tool's answer. Also covers a throw from
+    /// <paramref name="onNext"/>, which Rx routes down the error channel.</param>
+    /// <param name="onEmpty">The answer for a source that completes without emitting. Never
+    /// omit it: silence is what leaves the round parked.</param>
+    /// <returns>A task that always settles.</returns>
+    public static Task<string> Bridge<T>(
+        IObservable<T> source,
+        CancellationToken cancellationToken,
+        Func<T, string> onNext,
+        Func<Exception, string> onError,
+        Func<string> onEmpty)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(onNext);
+        ArgumentNullException.ThrowIfNull(onError);
+        ArgumentNullException.ThrowIfNull(onEmpty);
+
+        // RunContinuationsAsynchronously: without it the caller's continuation resumes INLINE on
+        // whichever thread settled us — for a hub-backed source that is the hub's response-dispatch
+        // thread, and running an agent round's continuation there is how a hub scheduler gets
+        // occupied by work that then waits on the same hub.
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Everything the wait holds: the cancellation registration and the subscription. Whichever
+        // terminal fires first releases both — a bare TrySet* would settle the caller and leave the
+        // subscription live against a hub that may already be tearing down.
+        var pending = new CompositeDisposable();
+        void Settle(Func<bool> set)
+        {
+            if (set())
+                pending.Dispose();
+        }
+
+        // Registered FIRST so an already-cancelled token settles before the source is subscribed;
+        // CompositeDisposable disposes anything added after its own disposal, so the subscription
+        // below is torn down immediately in that case.
+        pending.Add(cancellationToken.Register(() => Settle(() => tcs.TrySetCanceled(cancellationToken))));
+
+        // Take(1) → Select → DefaultIfEmpty is what turns the missing terminal into a real one: the
+        // null that reaches onNext below can ONLY come from DefaultIfEmpty, because onNext never
+        // returns null. A throw from the caller's formatter lands on the error channel.
+        pending.Add(source
+            .Take(1)
+            .Select(value => (string?)onNext(value))
+            .DefaultIfEmpty()
+            .Subscribe(
+                answer => Settle(() => tcs.TrySetResult(answer ?? onEmpty())),
+                error => Settle(() => tcs.TrySetResult(onError(error)))));
+
+        return tcs.Task;
+    }
+}

--- a/src/MeshWeaver.AI/Plugins/VersionPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/VersionPlugin.cs
@@ -23,9 +23,11 @@ namespace MeshWeaver.AI.Plugins;
 /// with <c>.SubscribeOn(TaskPoolScheduler.Default)</c> (NEVER
 /// <c>Observable.FromAsync</c>, which is forbidden outside <c>IoPool</c>) so they never
 /// occupy the hub scheduler, and restores go through <c>IMeshService.UpdateNode</c>
-/// which is already reactive (<c>IObservable&lt;MeshNode&gt;</c>). A
-/// <see cref="TaskCompletionSource{T}"/> bridges the off-hub completions back to the
-/// caller. See <c>Doc/Architecture/AsynchronousCalls</c>.
+/// which is already reactive (<c>IObservable&lt;MeshNode&gt;</c>).
+/// <see cref="ToolTask.Bridge{T}"/> bridges the off-hub completions back to the caller —
+/// every terminal settles (value, error, EMPTY completion) and the round's cancellation token
+/// is observed, so a parked read cannot hold an <c>IoPoolNames.Ai</c> gate permit through
+/// teardown (#1956). See <c>Doc/Architecture/AsynchronousCalls</c>.
 /// </summary>
 public class VersionPlugin(IMessageHub hub)
 {
@@ -107,18 +109,21 @@ public class VersionPlugin(IMessageHub hub)
     /// version number, modification date, who changed it, name and node type.
     /// </summary>
     /// <param name="path">Path to the node (e.g. <c>OrgA/my-doc</c>).</param>
+    /// <param name="cancellationToken">The round's token — cancelling it unwinds the tool call and
+    /// disposes the version read. Bound automatically by <c>AIFunctionFactory</c>; never part of
+    /// the tool's JSON schema.</param>
     /// <returns>A task resolving to JSON of the versions, or a human-readable message when none exist or version history is unavailable.</returns>
     [Description("Lists all available versions of a node, ordered newest first. Returns version number, date, who changed it, and node name.")]
     public Task<string> GetVersions(
-        [Description("Path to the node (e.g., 'OrgA/my-doc')")] string path)
+        [Description("Path to the node (e.g., 'OrgA/my-doc')")] string path,
+        CancellationToken cancellationToken = default)
     {
         if (versionQuery == null)
             return Task.FromResult("Error: Version history is not available in this environment.");
 
         logger.LogInformation("GetVersions called for path={Path}", path);
 
-        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        GateOnRead(path)
+        var pipeline = GateOnRead(path)
             .SelectMany(canRead =>
             {
                 if (!canRead)
@@ -143,17 +148,23 @@ public class VersionPlugin(IMessageHub hub)
                     })
                     .ToList();
             })
-            .SubscribeOn(TaskPoolScheduler.Default)
-            .Subscribe(
-                versions => tcs.TrySetResult(versions.Count == 0
-                    ? $"No version history found for '{path}'."
-                    : JsonSerializer.Serialize(versions, hub.JsonSerializerOptions)),
-                ex =>
-                {
-                    logger.LogWarning(ex, "Error getting versions for {Path}", path);
-                    tcs.TrySetResult($"Error: {ex.Message}");
-                });
-        return tcs.Task;
+            .SubscribeOn(TaskPoolScheduler.Default);
+
+        return ToolTask.Bridge(
+            pipeline,
+            cancellationToken,
+            versions => versions.Count == 0
+                ? $"No version history found for '{path}'."
+                : JsonSerializer.Serialize(versions, hub.JsonSerializerOptions),
+            ex =>
+            {
+                logger.LogWarning(ex, "Error getting versions for {Path}", path);
+                return $"Error: {ex.Message}";
+            },
+            // An empty completion — a permission evaluator or a version store that completes
+            // without answering — reads as absence, exactly like a deny. Silence would park the
+            // round instead.
+            () => $"No version history found for '{path}'.");
     }
 
     /// <summary>
@@ -161,19 +172,21 @@ public class VersionPlugin(IMessageHub hub)
     /// </summary>
     /// <param name="path">Path to the node.</param>
     /// <param name="version">Version number to retrieve.</param>
+    /// <param name="cancellationToken">The round's token — cancelling it unwinds the tool call and
+    /// disposes the version read.</param>
     /// <returns>A task resolving to the serialized node JSON, or a message when the version is not found.</returns>
     [Description("Retrieves the full node content at a specific version number.")]
     public Task<string> GetVersion(
         [Description("Path to the node")] string path,
-        [Description("Version number to retrieve")] long version)
+        [Description("Version number to retrieve")] long version,
+        CancellationToken cancellationToken = default)
     {
         if (versionQuery == null)
             return Task.FromResult("Error: Version history is not available in this environment.");
 
         logger.LogInformation("GetVersion called for path={Path}, version={Version}", path, version);
 
-        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        GateOnRead(path)
+        var pipeline = GateOnRead(path)
             .SelectMany(canRead =>
             {
                 if (!canRead)
@@ -186,17 +199,20 @@ public class VersionPlugin(IMessageHub hub)
                 }
                 return versionQuery.GetVersion(path, version, hub.JsonSerializerOptions);
             })
-            .SubscribeOn(TaskPoolScheduler.Default)
-            .Subscribe(
-                node => tcs.TrySetResult(node == null
-                    ? $"Version {version} not found for '{path}'."
-                    : JsonSerializer.Serialize(node, hub.JsonSerializerOptions)),
-                ex =>
-                {
-                    logger.LogWarning(ex, "Error getting version {Version} for {Path}", version, path);
-                    tcs.TrySetResult($"Error: {ex.Message}");
-                });
-        return tcs.Task;
+            .SubscribeOn(TaskPoolScheduler.Default);
+
+        return ToolTask.Bridge(
+            pipeline,
+            cancellationToken,
+            node => node == null
+                ? $"Version {version} not found for '{path}'."
+                : JsonSerializer.Serialize(node, hub.JsonSerializerOptions),
+            ex =>
+            {
+                logger.LogWarning(ex, "Error getting version {Version} for {Path}", version, path);
+                return $"Error: {ex.Message}";
+            },
+            () => $"Version {version} not found for '{path}'.");
     }
 
     /// <summary>
@@ -205,19 +221,21 @@ public class VersionPlugin(IMessageHub hub)
     /// </summary>
     /// <param name="path">Path to the node.</param>
     /// <param name="version">Version number to restore to.</param>
+    /// <param name="cancellationToken">The round's token — cancelling it unwinds the tool call and
+    /// disposes the read/restore pipeline.</param>
     /// <returns>A task resolving to a status message reporting the restored and new version numbers.</returns>
     [Description("Restores a node to a specific version number. The historical state becomes the latest version.")]
     public Task<string> RestoreVersion(
         [Description("Path to the node")] string path,
-        [Description("Version number to restore to")] long version)
+        [Description("Version number to restore to")] long version,
+        CancellationToken cancellationToken = default)
     {
         if (versionQuery == null)
             return Task.FromResult("Error: Version history is not available in this environment.");
 
         logger.LogInformation("RestoreVersion called for path={Path}, version={Version}", path, version);
 
-        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        GateOnRead(path)
+        var pipeline = GateOnRead(path)
             .SelectMany(canRead =>
             {
                 if (!canRead)
@@ -237,17 +255,20 @@ public class VersionPlugin(IMessageHub hub)
                     return Observable.Return<(MeshNode? restored, long requestedVersion)>((null, version));
                 return meshService.UpdateNode(historicalNode with { Version = 0 })
                     .Select(updated => (restored: (MeshNode?)updated, requestedVersion: version));
-            })
-            .Subscribe(
-                result => tcs.TrySetResult(result.restored == null
-                    ? $"Version {result.requestedVersion} not found for '{path}'."
-                    : $"Restored '{path}' to version {result.requestedVersion}. New version: {result.restored.Version}."),
-                ex =>
-                {
-                    logger.LogWarning(ex, "Error restoring version {Version} for {Path}", version, path);
-                    tcs.TrySetResult($"Error: {ex.Message}");
-                });
-        return tcs.Task;
+            });
+
+        return ToolTask.Bridge(
+            pipeline,
+            cancellationToken,
+            result => result.restored == null
+                ? $"Version {result.requestedVersion} not found for '{path}'."
+                : $"Restored '{path}' to version {result.requestedVersion}. New version: {result.restored.Version}.",
+            ex =>
+            {
+                logger.LogWarning(ex, "Error restoring version {Version} for {Path}", version, path);
+                return $"Error: {ex.Message}";
+            },
+            () => $"Version {version} not found for '{path}'.");
     }
 
     /// <summary>
@@ -256,11 +277,14 @@ public class VersionPlugin(IMessageHub hub)
     /// </summary>
     /// <param name="path">Path to the node.</param>
     /// <param name="timestamp">ISO 8601 timestamp to restore to (e.g. <c>2026-03-25T14:30:00Z</c>).</param>
+    /// <param name="cancellationToken">The round's token — cancelling it unwinds the tool call and
+    /// disposes the read/restore pipeline.</param>
     /// <returns>A task resolving to a status message, or an error when the timestamp is invalid or no matching version exists.</returns>
     [Description("Restores a node to its state at a specific point in time. Finds the latest version before the given timestamp.")]
     public Task<string> RestoreFromPointInTime(
         [Description("Path to the node")] string path,
-        [Description("ISO 8601 timestamp to restore to (e.g., '2026-03-25T14:30:00Z')")] string timestamp)
+        [Description("ISO 8601 timestamp to restore to (e.g., '2026-03-25T14:30:00Z')")] string timestamp,
+        CancellationToken cancellationToken = default)
     {
         if (versionQuery == null)
             return Task.FromResult("Error: Version history is not available in this environment.");
@@ -270,8 +294,7 @@ public class VersionPlugin(IMessageHub hub)
         if (!DateTimeOffset.TryParse(timestamp, out var targetTime))
             return Task.FromResult($"Error: Invalid timestamp '{timestamp}'. Use ISO 8601 format (e.g., '2026-03-25T14:30:00Z').");
 
-        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        GateOnRead(path)
+        var pipeline = GateOnRead(path)
             .SelectMany(canRead =>
             {
                 if (!canRead)
@@ -299,26 +322,27 @@ public class VersionPlugin(IMessageHub hub)
                         return meshService.UpdateNode(historicalNode with { Version = 0 })
                             .Select(updated => (restored: (MeshNode?)updated, target: (MeshNodeVersion?)targetVersion));
                     });
-            })
-            .Subscribe(
-                result =>
-                {
-                    if (result.target == null)
-                        tcs.TrySetResult($"No version found for '{path}' at or before {timestamp}.");
-                    else if (result.restored == null)
-                        tcs.TrySetResult($"Could not retrieve version {result.target.Version} for '{path}'.");
-                    else
-                        tcs.TrySetResult(
-                            $"Restored '{path}' to version {result.target.Version} " +
-                            $"(from {result.target.LastModified.UtcDateTime:yyyy-MM-ddTHH:mm:ssZ}). " +
-                            $"New version: {result.restored.Version}.");
-                },
-                ex =>
-                {
-                    logger.LogWarning(ex, "Error restoring from point in time for {Path}", path);
-                    tcs.TrySetResult($"Error: {ex.Message}");
-                });
-        return tcs.Task;
+            });
+
+        return ToolTask.Bridge(
+            pipeline,
+            cancellationToken,
+            result =>
+            {
+                if (result.target == null)
+                    return $"No version found for '{path}' at or before {timestamp}.";
+                if (result.restored == null)
+                    return $"Could not retrieve version {result.target.Version} for '{path}'.";
+                return $"Restored '{path}' to version {result.target.Version} " +
+                       $"(from {result.target.LastModified.UtcDateTime:yyyy-MM-ddTHH:mm:ssZ}). " +
+                       $"New version: {result.restored.Version}.";
+            },
+            ex =>
+            {
+                logger.LogWarning(ex, "Error restoring from point in time for {Path}", path);
+                return $"Error: {ex.Message}";
+            },
+            () => $"No version found for '{path}' at or before {timestamp}.");
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-agent-tools-answer-and-cancel.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-agent-tools-answer-and-cancel.md
@@ -1,0 +1,22 @@
+---
+Name: Agent tools always answer, and Stop now stops them
+Category: Fix
+Description: Version history, skills, plans, comments, edits and content search now answer every time and unwind when you press Stop.
+Icon: Sparkle
+Order: -20260822
+---
+
+# Agent tools always answer, and Stop now stops them
+
+Eight agent tools could leave a conversation waiting forever. When the mesh finished a read without
+returning anything — a node that had gone away, a store that answered nothing — the tool simply never
+replied, and the agent sat there with no error and nothing in the log.
+
+Pressing Stop did not help: those tools never looked at the cancellation the Stop button raises, so
+the round kept running until something else timed it out.
+
+Both are fixed. Every one of these tools now gives an answer in every case, including the "nothing
+came back" case, which now reads as a plain "not found" instead of silence. Pressing Stop unwinds the
+tool call immediately and stops the work it started. The tools affected are version history (list,
+read, restore, restore-to-a-point-in-time), loading a skill, storing a plan, adding a comment,
+suggesting an edit, uploading content, and searching or reading indexed content chunks.

--- a/test/MeshWeaver.AI.Test/AgentToolCancellationTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentToolCancellationTest.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Plugins;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// 🚨 An agent tool call MUST observe the cancellation token it is invoked with, and MUST settle on
+/// every terminal of the source it waits on.
+///
+/// <para><b>The defect (#1956, the per-site audit #1908 deferred).</b> Five tools bridged an
+/// observable to a <c>Task</c> through a hand-rolled <see cref="TaskCompletionSource{TResult}"/>
+/// with a 2-argument <c>Subscribe</c>. <c>VersionPlugin</c>'s four tools had no
+/// <see cref="CancellationToken"/> parameter at all; <c>SkillTool</c>, <c>PlanStorageTool</c> and
+/// <c>CollaborationPlugin</c> declared one and never referenced it (in <c>CollaborationPlugin</c>
+/// the only mentions were XML doc comments). So the returned task could not be cancelled, and an
+/// empty completion settled nothing.</para>
+///
+/// <para><b>Why that is a teardown defect and not a slow tool.</b> The whole round runs as a leaf on
+/// the bounded <c>IoPoolNames.Ai</c> pool, holding one gate permit for its entire duration.
+/// <c>IoPool.Drain()</c> — the join every teardown orchestrator performs before disposing the
+/// service scope and unloading collectible node ALCs — cancels the pool token and re-acquires every
+/// permit. A round parked inside an uncancellable tool call never reaches the code that would
+/// notice: <c>Drain</c> sits out its full 30&#160;s budget and teardown proceeds over live code.
+/// It also makes the Stop button a lie — a user cancelling mid tool call fires the round's
+/// <c>executionCts</c>, which reaches the tool as exactly this token.</para>
+///
+/// <para>These tests invoke the tools through their <see cref="AIFunction"/> surface — the same
+/// surface the agent loop uses, and the one that binds the invocation token — so they compile
+/// unchanged against the unfixed code and fail on BEHAVIOUR rather than on a signature.</para>
+///
+/// <para><b>What is proven where.</b> The four version tools are driven against an injected version
+/// store that accepts the read and never answers, which is the real park; all four fail on
+/// <c>origin/main</c> with a <see cref="TimeoutException"/> because nothing can end the wait. The
+/// other four sites now share ONE bridge with them (<see cref="ToolTask.Bridge{T}"/>), whose
+/// terminals — including the empty completion behind a <c>Timeout</c> — are pinned by
+/// <see cref="ToolTaskSettlementTest"/>.</para>
+/// </summary>
+public class AgentToolCancellationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Share Mesh/SP across [Fact]s — the per-test container costs more than these tests do.</summary>
+    protected override bool ShareMeshAcrossTests => true;
+
+    /// <summary>
+    /// A version store that ACCEPTS the read and then never answers — the shape of a stalled
+    /// storage leaf. It records disposal so the tests can assert the read actually stopped, not
+    /// merely that the caller stopped waiting.
+    /// </summary>
+    private sealed class ParkingVersionQuery : IVersionQuery
+    {
+        private int disposals;
+        /// <summary>How many times a subscription to this store has been disposed.</summary>
+        public int Disposals => Volatile.Read(ref disposals);
+
+        private IObservable<T> Park<T>() => Observable.Create<T>(_ =>
+            Disposable.Create(() => Interlocked.Increment(ref disposals)));
+
+        public IObservable<MeshNodeVersion> GetVersions(string path) => Park<MeshNodeVersion>();
+        public IObservable<MeshNode?> GetVersion(string path, long version, JsonSerializerOptions options) => Park<MeshNode?>();
+        public IObservable<MeshNode?> GetVersionBefore(string path, long beforeVersion, JsonSerializerOptions options) => Park<MeshNode?>();
+    }
+
+    private static readonly ParkingVersionQuery VersionStore = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IVersionQuery>(VersionStore);
+                return services;
+            })
+            // A real, routable partition. load_skill's park needs the ADDRESS to resolve while the
+            // NODE is absent — that is the case the framework's own comments describe ("for a path
+            // that does not exist yet that hub never activates"). An unregistered partition instead
+            // fails routing outright, which is an answer, not a park.
+            .AddMeshNodes(new MeshNode("Skills", "") { Name = "Skills", NodeType = "Markdown", Content = "seed" })
+            .AddGraph()
+            .AddAI();
+
+    private static AIFunctionArguments Args(params (string Name, object? Value)[] values)
+    {
+        var dict = new Dictionary<string, object?>();
+        foreach (var (name, value) in values)
+            dict[name] = value;
+        return new AIFunctionArguments(dict);
+    }
+
+    /// <summary>
+    /// Asserts that <paramref name="call"/> is genuinely parked, then that cancelling the round
+    /// unwinds it promptly. Every failure mode is distinguishable: a call that resolves before the
+    /// cancel fails the first check, and the bounded wait's own giving-up is a
+    /// <see cref="TimeoutException"/>, which is NOT an <see cref="OperationCanceledException"/>.
+    /// </summary>
+    private static async Task AssertParkedThenCancellable(Task call, CancellationTokenSource round, string because)
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var settledEarly = await Task.WhenAny(call, Task.Delay(500, ct));
+        settledEarly.Should().NotBeSameAs(call,
+            "the source never answers — the tool call must not resolve before the round is cancelled");
+
+        await round.CancelAsync();
+
+        var act = async () => await call.WaitAsync(5.Seconds(), ct);
+        await act.Should().ThrowAsync<OperationCanceledException>(because);
+    }
+
+    /// <summary>
+    /// <c>get_versions</c> against a version store that never answers.
+    ///
+    /// <para><b>Non-vacuity.</b> On <c>origin/main</c> <c>VersionPlugin</c> has no
+    /// <see cref="CancellationToken"/> parameter anywhere in the file, so nothing can end this wait
+    /// — the bounded assertion below fails with a <see cref="TimeoutException"/> instead of the
+    /// <see cref="OperationCanceledException"/> asserted here.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task GetVersions_ParkedOnAStalledStore_UnwindsWhenTheRoundIsCancelled()
+    {
+        var before = VersionStore.Disposals;
+        var plugin = new VersionPlugin(Mesh);
+        var tool = (AIFunction)plugin.CreateTools()[0];
+        using var round = new CancellationTokenSource();
+
+        var call = tool.InvokeAsync(Args(("path", "TestPartition/some-doc")), round.Token).AsTask();
+
+        await AssertParkedThenCancellable(call, round,
+            "a round parked in get_versions holds an Ai-pool gate permit that IoPool.Drain() cannot "
+            + "re-acquire, so teardown proceeds over live code");
+
+        VersionStore.Disposals.Should().BeGreaterThan(before,
+            "cancelling must dispose the version read — otherwise the storage work runs on unobserved");
+    }
+
+    /// <summary>
+    /// <c>get_version</c> — same store, same contract. Covered separately because each of the four
+    /// version tools has its own bridge, and the audit found the token missing from all four.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task GetVersion_ParkedOnAStalledStore_UnwindsWhenTheRoundIsCancelled()
+    {
+        var plugin = new VersionPlugin(Mesh);
+        var tool = (AIFunction)plugin.CreateTools()[1];
+        using var round = new CancellationTokenSource();
+
+        var call = tool.InvokeAsync(Args(("path", "TestPartition/some-doc"), ("version", 3L)), round.Token).AsTask();
+
+        await AssertParkedThenCancellable(call, round, "get_version must observe the round's token");
+    }
+
+    /// <summary>
+    /// <c>restore_version</c> — the write-side twin; a parked restore is the worst one to leave
+    /// running, since teardown may unload the assemblies it is writing through.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task RestoreVersion_ParkedOnAStalledStore_UnwindsWhenTheRoundIsCancelled()
+    {
+        var plugin = new VersionPlugin(Mesh);
+        var tool = (AIFunction)plugin.CreateTools()[2];
+        using var round = new CancellationTokenSource();
+
+        var call = tool.InvokeAsync(Args(("path", "TestPartition/some-doc"), ("version", 3L)), round.Token).AsTask();
+
+        await AssertParkedThenCancellable(call, round, "restore_version must observe the round's token");
+    }
+
+    /// <summary>
+    /// <c>restore_from_point_in_time</c> — the fourth version tool.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task RestoreFromPointInTime_ParkedOnAStalledStore_UnwindsWhenTheRoundIsCancelled()
+    {
+        var plugin = new VersionPlugin(Mesh);
+        var tool = (AIFunction)plugin.CreateTools()[3];
+        using var round = new CancellationTokenSource();
+
+        var call = tool.InvokeAsync(
+            Args(("path", "TestPartition/some-doc"), ("timestamp", "2026-03-25T14:30:00Z")), round.Token).AsTask();
+
+        await AssertParkedThenCancellable(call, round, "restore_from_point_in_time must observe the round's token");
+    }
+
+    /// <summary>
+    /// <c>load_skill</c> against a path no node owns must ANSWER — naming the path — rather than
+    /// leave the round waiting.
+    ///
+    /// <para>Scope note, stated so the coverage is not overclaimed: on this in-memory mesh an
+    /// absent node fails ROUTING (<c>DeliveryFailureException</c>), so the read errors rather than
+    /// parks and this case answers on <c>origin/main</c> too. <c>SkillTool</c>'s two genuinely
+    /// missing terminals — the round's token and the EMPTY completion that
+    /// <c>Timeout</c> passes straight through — are pinned in
+    /// <see cref="ToolTaskSettlementTest"/> against the exact pipeline shape it builds
+    /// (<c>Where → Take(1) → Timeout</c>), because a mesh cannot be driven into an empty stream
+    /// completion from a test. The four version tools below carry the tool-level proof.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task LoadSkill_AbsentSkillNode_Answers()
+    {
+        var tool = (AIFunction)SkillTool.Create(Mesh, new NoopAgentChat());
+
+        var result = await tool.InvokeAsync(Args(("skillPath", "Skills/NoSuchSkill")),
+                TestContext.Current.CancellationToken)
+            .AsTask().WaitAsync(20.Seconds(), TestContext.Current.CancellationToken);
+
+        result?.ToString().Should().Contain("Skills/NoSuchSkill");
+    }
+
+    /// <summary>
+    /// The happy paths still answer: cancellation wiring must not swallow a real result, and an
+    /// absent node must produce the ABSENCE answer rather than silence.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task LoadSkill_WithNoPath_StillAnswersImmediately()
+    {
+        var tool = (AIFunction)SkillTool.Create(Mesh, new NoopAgentChat());
+
+        var result = await tool.InvokeAsync(Args(("skillPath", "  ")), TestContext.Current.CancellationToken)
+            .AsTask().WaitAsync(10.Seconds(), TestContext.Current.CancellationToken);
+
+        result?.ToString().Should().Contain("search nodeType:Skill");
+    }
+
+    /// <summary>Minimal <see cref="IAgentChat"/> stub — the tools under test read only Context/ExecutionContext.</summary>
+    private sealed class NoopAgentChat : IAgentChat
+    {
+        public AgentContext? Context => null;
+
+        public void SetContext(AgentContext? applicationContext) => throw new NotImplementedException();
+        public void SetSelectedAgent(string? agentName) => throw new NotImplementedException();
+        public Task ResumeAsync(AI.Persistence.ChatConversation conversation) => throw new NotImplementedException();
+        public Task<IReadOnlyList<AgentDisplayInfo>> GetOrderedAgentsAsync() => throw new NotImplementedException();
+        public IAsyncEnumerable<ChatMessage> GetResponseAsync(
+            IReadOnlyCollection<ChatMessage> messages,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IReadOnlyCollection<ChatMessage> messages,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public void SetThreadId(string threadId) => throw new NotImplementedException();
+        public void DisplayLayoutArea(MeshWeaver.Layout.LayoutAreaControl layoutAreaControl) => throw new NotImplementedException();
+    }
+}

--- a/test/MeshWeaver.AI.Test/ToolTaskSettlementTest.cs
+++ b/test/MeshWeaver.AI.Test/ToolTaskSettlementTest.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Plugins;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the four terminals of <see cref="ToolTask.Bridge{T}"/> — the ONE bridge from a reactive
+/// source to the <c>Task&lt;string&gt;</c> an agent tool hands back to <c>AIFunctionFactory</c>.
+///
+/// <para><b>Why every terminal has to settle (#1956).</b> A tool call runs INSIDE the round's leaf
+/// on the bounded <c>IoPoolNames.Ai</c> pool and holds one gate permit for its whole duration. A
+/// task that never settles is therefore not a slow tool: it is a permit held through
+/// <c>IoPool.Drain()</c>, a Stop button that does nothing, and a teardown that proceeds over live
+/// code. Five tools shipped with a hand-rolled <see cref="TaskCompletionSource{TResult}"/> that had
+/// at least one terminal missing.</para>
+///
+/// <para><b>The one everybody missed is the EMPTY completion.</b> A 2-argument
+/// <c>Subscribe(onNext, onError)</c> never fires for a source that completes without emitting, and
+/// <c>Timeout</c> does not cover it — <c>Timeout</c> passes an empty <c>OnCompleted</c> straight
+/// through. A <c>yield break</c> is a silence; the empty answer is an ANSWER.</para>
+/// </summary>
+public class ToolTaskSettlementTest
+{
+    private static Task<string> Bridge<T>(IObservable<T> source, CancellationToken token) =>
+        ToolTask.Bridge(source, token, v => $"value:{v}", ex => $"error:{ex.Message}", () => "empty");
+
+    /// <summary>
+    /// The first emission is the answer, and only the first — a bridge that kept reading would keep
+    /// a node stream subscribed after the round moved on.
+    /// </summary>
+    [Fact(Timeout = 10_000)]
+    public async Task FirstEmission_IsTheAnswer()
+    {
+        var result = await Bridge(Observable.Return("hello"), TestContext.Current.CancellationToken)
+            .WaitAsync(3.Seconds(), TestContext.Current.CancellationToken);
+
+        result.Should().Be("value:hello");
+    }
+
+    /// <summary>
+    /// 🚨 THE terminal the hand-rolled bridges lacked. A source that completes without ever
+    /// emitting must produce the caller's empty ANSWER — not silence.
+    /// </summary>
+    [Fact(Timeout = 10_000)]
+    public async Task EmptyCompletion_Answers_RatherThanParkingForever()
+    {
+        var result = await Bridge(Observable.Empty<string>(), TestContext.Current.CancellationToken)
+            .WaitAsync(3.Seconds(), TestContext.Current.CancellationToken);
+
+        result.Should().Be("empty",
+            "a source that completes without emitting reaches neither onNext nor onError — the "
+            + "bridge owes the caller the empty answer, or the round parks holding an Ai-pool permit");
+    }
+
+    /// <summary>
+    /// An empty completion behind a <c>Timeout</c> still answers. This is the exact shape that made
+    /// <c>SkillTool</c> LOOK guarded: <c>Timeout</c> covers the silent source, never the empty one.
+    /// </summary>
+    [Fact(Timeout = 10_000)]
+    public async Task EmptyCompletion_BehindATimeout_StillAnswers()
+    {
+        var source = Observable.Empty<string>().Timeout(TimeSpan.FromSeconds(30));
+
+        var result = await Bridge(source, TestContext.Current.CancellationToken)
+            .WaitAsync(3.Seconds(), TestContext.Current.CancellationToken);
+
+        result.Should().Be("empty");
+    }
+
+    /// <summary>A fault is formatted into the tool's answer — on an agent-facing tool the failure text IS the result.</summary>
+    [Fact(Timeout = 10_000)]
+    public async Task Error_IsFormattedIntoTheAnswer()
+    {
+        var result = await Bridge(Observable.Throw<string>(new InvalidOperationException("boom")),
+                TestContext.Current.CancellationToken)
+            .WaitAsync(3.Seconds(), TestContext.Current.CancellationToken);
+
+        result.Should().Be("error:boom");
+    }
+
+    /// <summary>
+    /// A formatter that throws must not strand the caller: Rx routes the throw down the error
+    /// channel, which settles. (The hand-rolled bridges needed a try/catch per site for this.)
+    /// </summary>
+    [Fact(Timeout = 10_000)]
+    public async Task ThrowingFormatter_StillSettles()
+    {
+        var result = await ToolTask.Bridge<string>(
+                Observable.Return("x"),
+                TestContext.Current.CancellationToken,
+                _ => throw new InvalidOperationException("formatter blew up"),
+                ex => $"error:{ex.Message}",
+                () => "empty")
+            .WaitAsync(3.Seconds(), TestContext.Current.CancellationToken);
+
+        result.Should().Be("error:formatter blew up");
+    }
+
+    /// <summary>
+    /// Cancellation must both END the wait and STOP the work. The source here never emits and never
+    /// completes — the shape of a read against a hub that is still activating — and records its own
+    /// disposal, so this asserts the operation actually stopped rather than merely that the caller
+    /// stopped listening.
+    /// </summary>
+    [Fact(Timeout = 20_000)]
+    public async Task Cancellation_UnwindsTheTaskAndDisposesTheSource()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var round = new CancellationTokenSource();
+        var disposed = false;
+        var subscribed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var source = Observable.Create<string>(_ =>
+        {
+            subscribed.TrySetResult();
+            return Disposable.Create(() => disposed = true);
+        });
+
+        var call = Bridge(source, round.Token);
+        await subscribed.Task.WaitAsync(5.Seconds(), ct);
+
+        // It must genuinely be waiting, or "prompt" below would prove nothing.
+        var settledEarly = await Task.WhenAny(call, Task.Delay(250, ct));
+        settledEarly.Should().NotBeSameAs(call);
+        disposed.Should().BeFalse();
+
+        round.Cancel();
+
+        // WaitAsync's own failure is a TimeoutException, which is NOT an OperationCanceledException
+        // — so this cannot be satisfied by the wait giving up.
+        var act = async () => await call.WaitAsync(5.Seconds(), ct);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        disposed.Should().BeTrue(
+            "cancelling must dispose the subscription — otherwise the tool's work runs on "
+            + "unobserved against a hub that is being torn down");
+    }
+
+    /// <summary>
+    /// An already-cancelled token settles immediately and leaves nothing subscribed, so a tool
+    /// invoked during teardown does not start work it cannot finish.
+    /// </summary>
+    [Fact(Timeout = 10_000)]
+    public async Task AlreadyCancelledToken_SettlesWithoutLeavingASubscription()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var round = new CancellationTokenSource();
+        await round.CancelAsync();
+
+        var disposed = false;
+        var source = Observable.Create<string>(_ => Disposable.Create(() => disposed = true));
+
+        var act = async () => await Bridge(source, round.Token).WaitAsync(5.Seconds(), ct);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        disposed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Once settled, a later emission from a source that has not noticed yet must not throw or
+    /// re-settle — the bridge is a one-shot.
+    /// </summary>
+    [Fact(Timeout = 10_000)]
+    public async Task LateEmissionAfterSettlement_IsIgnored()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var subject = new Subject<string>();
+        using var round = new CancellationTokenSource();
+
+        var call = Bridge(subject, round.Token);
+        round.Cancel();
+
+        var act = async () => await call.WaitAsync(5.Seconds(), ct);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        // The bridge unsubscribed on cancel; pushing more must be a no-op, not an exception.
+        subject.OnNext("late");
+        subject.OnCompleted();
+    }
+}


### PR DESCRIPTION
Fixes #1956.

## Mechanism

Five agent tools bridged an observable to a `Task` through a hand-rolled `TaskCompletionSource` with a **2-argument `Subscribe`**. That shape has two holes, and both fail silently.

**1. The EMPTY completion reaches neither arm, so the task never settles.** It is reachable, not theoretical: `MeshNodeStreamCache` completes its per-path update-queue subject on eviction and its read-stream subject on dispose; a `.Where(...)`-filtered stream completes when nothing passes the filter; a `.Take(1)` over a permission evaluator completes empty if the evaluator does. `Timeout` does **not** cover it — `Timeout` passes an empty `OnCompleted` straight through, which is exactly why `SkillTool` *looked* guarded.

**2. The round's `CancellationToken` was never observed.** Per the issue's audit, re-verified here:

| Tool | Token in scope on main | Observed |
|---|---|---|
| `VersionPlugin` (×4) | ❌ no parameter anywhere in the file | — |
| `SkillTool` | ✅ declared | ❌ never referenced |
| `CollaborationPlugin` (×2) | ✅ declared | ❌ only in XML doc comments |
| `PlanStorageTool` | ✅ declared | ❌ never referenced |
| `ContentCollectionPlugin.SearchChunks` / `.GetChunk` | ❌ no parameter | `.FirstAsync().ToTask()` with no token |

A tool call runs **inside** the round's leaf on the bounded `IoPoolNames.Ai` pool and holds one gate permit for its whole duration. So an unsettled task is not a slow tool — it is a permit held through `IoPool.Drain()`, a Stop button that does nothing, and a teardown that proceeds over live code. #1863 / #1908 fixed exactly this in `DelegationTool` and deferred these sites.

## What changed

`ToolTask.Bridge` is now the **one** bridge from a reactive source to a tool's `Task<string>`. It settles on four terminals, and every one of them disposes the subscription:

- the first emission,
- an error (formatted into the answer — on an agent-facing tool the failure text *is* the result),
- an **empty completion**, using an answer the caller supplies — *a `yield break` is a silence; the empty answer is an ANSWER*,
- cancellation, which cancels the task **and** disposes the source, so the work actually stops.

Applied at all eight sites:

- **`VersionPlugin`** — `CancellationToken` added to all four tools (`AIFunctionFactory` binds it and keeps it out of the JSON schema). Empty completion masks as absence, matching the existing deny-masking so no existence oracle is introduced.
- **`SkillTool`** — the empty terminal now answers `Skill '…' was not found`, which is a *correct* outcome that previously produced silence.
- **`PlanStorageTool`**, **`CollaborationPlugin`** (both tools), **`ContentCollectionPlugin`** (all three tools).
- `CollaborationPlugin`'s continuations and `PostAndReport` became `IObservable<string>` **of the tool's answer** rather than writing into a TCS, so each call is one pipeline; each stage formats its own failures so the messages stay as specific as they were.
- `ContentCollectionPlugin.UploadContent`'s hand-rolled linked `CancellationTokenSource` + `CancelAfter` + `ContinueWith` is replaced by Rx `Timeout` inside the same bridge — one set of terminals, one disposal path.

`DelegationTool` is deliberately **not** migrated: it already has this shape (it is where the pattern came from) and settles from two independent subscriptions; rewriting it would be risk without a defect.

## Tests

`ToolTaskSettlementTest` (8 cases) pins the bridge's terminals, including:
- an **empty completion behind a `Timeout`** — the exact `SkillTool` shape;
- that **cancellation disposes the source** (the source records its own disposal, so this asserts the operation stopped, not just that the caller stopped listening);
- an already-cancelled token leaving nothing subscribed, and a late emission after settlement being a no-op.

`AgentToolCancellationTest` drives the four version tools against an injected `IVersionQuery` that accepts the read and **never answers** — the real park — then cancels the round.

### Non-vacuity

`AgentToolCancellationTest.cs` compiles **unchanged** against `origin/main` (the tools are invoked through their `AIFunction` surface, so no signature is involved). Copied onto a clean `origin/main` worktree and run:

```
Failed  GetVersions_ParkedOnAStalledStore_UnwindsWhenTheRoundIsCancelled [6 s]
  Expected a OperationCanceledException because a round parked in get_versions holds an Ai-pool
  gate permit that IoPool.Drain() cannot re-acquire, so teardown proceeds over live code,
  but found TimeoutException: The operation has timed out..
Failed  GetVersion_ParkedOnAStalledStore_UnwindsWhenTheRoundIsCancelled [5 s]
Failed  RestoreVersion_ParkedOnAStalledStore_UnwindsWhenTheRoundIsCancelled [5 s]
Failed  RestoreFromPointInTime_ParkedOnAStalledStore_UnwindsWhenTheRoundIsCancelled [5 s]
Total tests: 6   Passed: 2   Failed: 4
```

The bounded wait's own failure is a `TimeoutException`, which is **not** an `OperationCanceledException` — so the assertion cannot be satisfied by the wait giving up.

On this branch: 14/14 green (`ToolTaskSettlementTest` + `AgentToolCancellationTest`), plus `CollaborationPluginGrainFailureTest`, `AnchoredEditContentTest`, `ResolveContextPathTest`, `ContentIndexingOffToolTest` all green. `dotnet build -c Release -warnaserror` clean for `MeshWeaver.AI` and `MeshWeaver.AI.Test`.

## Deliberately left

`SkillTool` has no tool-level cancellation test: on an in-memory mesh an absent node fails **routing** (`DeliveryFailureException`), so the read errors rather than parks and that case answers on `main` too. Its two genuinely-missing terminals are pinned at the bridge against the exact pipeline shape it builds. The test file says so rather than overclaiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)