### PR TITLE
fix(#1754): an UNWIRED release-availability gate is a hold, not a pass

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/ReleaseAvailabilityService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/ReleaseAvailabilityService.cs
@@ -64,6 +64,30 @@ public class ReleaseAvailabilityService(
     public string? PublishedRoot => configuration[ShippedPrebuiltBundles.PublishedRootConfigKey];
 
     /// <summary>
+    /// 🚨 <b>Does this gate APPLY to this deployment at all?</b> Returns the reason it does not, or
+    /// <c>null</c> when it does.
+    ///
+    /// <para>Decided from CONFIGURATION alone, which is what makes it answerable by a caller that
+    /// has no instance of this service — and that is the whole point. "Cannot verify" and "verified
+    /// as nothing to verify" are different states, and only the first may hold. A deployment that
+    /// consumes no CI bakes already compiles its content at every boot, so a registered gate would
+    /// answer <see cref="UpdatabilityVerdict.NotEnforced"/> for it; the gate being ABSENT on such a
+    /// deployment tells you nothing new, and holding on it would freeze an environment the gate was
+    /// never going to protect.</para>
+    ///
+    /// <para>Static and shared on purpose: the poller's unwired path (#1754) and
+    /// <see cref="IsUpdatable"/> must reach the same applicability answer, and a rule that only one
+    /// caller honours is not a rule.</para>
+    /// </summary>
+    /// <param name="configuration">The host's configuration; null reads as "nothing configured".</param>
+    public static string? NotApplicableReason(IConfiguration? configuration) =>
+        string.IsNullOrWhiteSpace(configuration?[ShippedPrebuiltBundles.PublishedRootConfigKey])
+            ? $"this deployment consumes no CI bakes ({ShippedPrebuiltBundles.PublishedRootConfigKey} "
+              + "is not configured), so it already compiles its content at every boot — the "
+              + "release-availability gate has nothing to enforce here"
+            : null;
+
+    /// <summary>
     /// Is <paramref name="targetVersion"/> a release this environment may be rolled to? Cold —
     /// the file-system leaves run on the <see cref="IoPoolNames.FileSystem"/> pool, never on a hub
     /// action block — and total: every failure resolves to a HOLD carrying its reason, so a
@@ -72,12 +96,11 @@ public class ReleaseAvailabilityService(
     public virtual IObservable<UpdatabilityVerdict> IsUpdatable(string? targetVersion) =>
         Observable.Defer(() =>
         {
-            var publishedRoot = PublishedRoot;
-            if (string.IsNullOrWhiteSpace(publishedRoot))
-                return Observable.Return(UpdatabilityVerdict.NotEnforced(
-                    $"this deployment consumes no CI bakes ({ShippedPrebuiltBundles.PublishedRootConfigKey} "
-                    + "is not configured), so it already compiles its content at every boot — the "
-                    + "release-availability gate has nothing to enforce here"));
+            // ONE applicability rule, shared with the poller's unwired path — see NotApplicableReason.
+            if (NotApplicableReason(configuration) is { } notApplicable)
+                return Observable.Return(UpdatabilityVerdict.NotEnforced(notApplicable));
+
+            var publishedRoot = PublishedRoot!;
 
             return RequiredPackages(publishedRoot)
                 .SelectMany(required => PublishedBundleCatalogue

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -324,15 +324,7 @@ public class SelfUpdateHostedService : IHostedService
         {
             var gate = ResolveAvailabilityGate();
             if (gate is null)
-                // No gate registered at all (a host that wires the poller without it). Say so once
-                // per tick rather than silently rolling as if it had passed.
-                return Observable.Defer(() =>
-                {
-                    _logger?.LogInformation(
-                        "[SelfUpdate] no release-availability gate is registered — rolling {Tag} "
-                        + "without checking whether its packages are available.", target);
-                    return Apply(target);
-                });
+                return GateNotWired(target);
 
             return gate.IsUpdatable(target)
                 .SelectMany(verdict =>
@@ -354,6 +346,54 @@ public class SelfUpdateHostedService : IHostedService
                         target, ShippedReleaseSeed.InstalledPlatformVersion, verdict.HoldReason);
                     return RecordHold(target, verdict).Catch(HoldWriteFailed(target));
                 });
+        });
+
+    /// <summary>
+    /// 🚨 <b>No gate is registered on this host — so the roll HOLDS.</b>
+    ///
+    /// <para>This branch used to log at Information and roll anyway. That is the trap this whole
+    /// area keeps falling into: a gate that cannot run must never look like a gate that passed. The
+    /// gate answers "does every package this environment deploys have a usable artifact for the
+    /// target release"; a host with no gate registered has not answered it — it has failed to ask.
+    /// An unwired check is the absence of a verdict, not a passing one, and #1754's own rule says
+    /// "cannot determine" is not "clear to proceed".</para>
+    ///
+    /// <para>It is a hold with all the properties that make a hold safe rather than a freeze: it is
+    /// recorded on the policy node so the Updates tab NAMES it, it is logged at Error (a wiring
+    /// defect nobody sees is how an environment sits un-updated for weeks), and it is re-evaluated
+    /// from scratch on every tick — registering the gate clears it with no manual un-sticking.</para>
+    ///
+    /// <para>The deliberate escape hatch is <see cref="SelfUpdateOptions.AllowUnverifiedRoll"/>:
+    /// set it in configuration, where it is visible, and the roll proceeds while saying so at
+    /// Warning on every tick. It can never waive a gate that DID run.</para>
+    /// </summary>
+    private IObservable<Unit> GateNotWired(string target) =>
+        Observable.Defer(() =>
+        {
+            if (_options.AllowUnverifiedRoll)
+            {
+                _logger?.LogWarning(
+                    "[SelfUpdate] rolling {Tag} UNVERIFIED — no release-availability gate is "
+                    + "registered on this host and '{Key}:{Property}' is set, so nothing checked "
+                    + "whether the packages this environment deploys have artifacts for it. Unset "
+                    + "that key to make the missing gate a hold again.",
+                    target, SelfUpdateOptions.SectionName, nameof(SelfUpdateOptions.AllowUnverifiedRoll));
+                return Apply(target);
+            }
+
+            var verdict = UpdatabilityVerdict.Unavailable(
+                "no release-availability gate is registered on this host, so nothing could check "
+                + "whether the packages this environment deploys have usable artifacts for this "
+                + $"release — that is a hold, not clearance to proceed. Register "
+                + $"{nameof(ReleaseAvailabilityService)} (it is wired by AddSelfUpdate), or set "
+                + $"'{SelfUpdateOptions.SectionName}:{nameof(SelfUpdateOptions.AllowUnverifiedRoll)}'"
+                + " to roll unverified on purpose.");
+
+            _logger?.LogError(
+                "[SelfUpdate] HOLDING update to {Tag} (staying on {Current}) — {Reason}",
+                target, ShippedReleaseSeed.InstalledPlatformVersion, verdict.HoldReason);
+
+            return RecordHold(target, verdict).Catch(HoldWriteFailed(target));
         });
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using System.Reactive.Disposables;
 using System.Collections.Immutable;
 using System.Reactive;
@@ -358,6 +359,15 @@ public class SelfUpdateHostedService : IHostedService
     /// An unwired check is the absence of a verdict, not a passing one, and #1754's own rule says
     /// "cannot determine" is not "clear to proceed".</para>
     ///
+    /// <para>🚨 <b>But only where there is something to verify.</b> The hold is scoped by
+    /// <see cref="ReleaseAvailabilityService.NotApplicableReason"/>: on a deployment that consumes
+    /// no CI bakes a registered gate would itself answer
+    /// <see cref="UpdatabilityVerdict.NotEnforced"/>, so its ABSENCE is not an unanswered question
+    /// — it is the same answer arrived at from configuration. Failing closed on that state would
+    /// freeze an environment the gate was never going to protect, and would brick a first-ever
+    /// roll (the manual button honours the same verdict), which is the classic cost of a
+    /// fail-closed rule drawn one state too wide.</para>
+    ///
     /// <para>It is a hold with all the properties that make a hold safe rather than a freeze: it is
     /// recorded on the policy node so the Updates tab NAMES it, it is logged at Error (a wiring
     /// defect nobody sees is how an environment sits un-updated for weeks), and it is re-evaluated
@@ -370,6 +380,30 @@ public class SelfUpdateHostedService : IHostedService
     private IObservable<Unit> GateNotWired(string target) =>
         Observable.Defer(() =>
         {
+            // 🚨 "CANNOT VERIFY" AND "VERIFIED AS NOTHING TO VERIFY" ARE DIFFERENT STATES, and only
+            // the first may hold. This branch originally held on both, which swept in a case that
+            // is legitimately clear: a deployment that consumes no CI bakes already compiles its
+            // content at every boot, so a REGISTERED gate would have answered NotEnforced for it.
+            // The gate being absent on such a deployment tells you nothing new — holding on it
+            // would freeze an environment the gate was never going to protect, and (since the
+            // manual roll honours the same verdict) an install with no roll history could never
+            // take its first update at all.
+            //
+            // The applicability rule is read from CONFIGURATION through the gate's own static, so
+            // the answer here and the answer a registered gate would give cannot drift apart.
+            if (ReleaseAvailabilityService.NotApplicableReason(ResolveConfiguration())
+                is { } notApplicable)
+            {
+                _logger?.LogInformation(
+                    "[SelfUpdate] release-availability gate not enforced for {Tag}: {Reason} "
+                    + "(no gate is registered on this host either, which changes nothing here — "
+                    + "there is nothing for it to check against).",
+                    target, notApplicable);
+                // Clearing is unconditional, exactly as on the verdict path: a previous hold that
+                // no longer applies must disappear from the admin tab the moment it is resolved.
+                return RecordHold(target, null).Catch(HoldWriteFailed(target)).Concat(Apply(target));
+            }
+
             if (_options.AllowUnverifiedRoll)
             {
                 _logger?.LogWarning(
@@ -403,6 +437,16 @@ public class SelfUpdateHostedService : IHostedService
     /// </summary>
     protected virtual ReleaseAvailabilityService? ResolveAvailabilityGate() =>
         _hub.ServiceProvider.GetService<ReleaseAvailabilityService>();
+
+    /// <summary>
+    /// The host's configuration, resolved from the mesh's services. Virtual for the same reason
+    /// <see cref="ResolveAvailabilityGate"/> is: whether the release-availability gate APPLIES to
+    /// this deployment is read from configuration, so a test must be able to present a
+    /// bake-consuming deployment and a bake-free one without standing up two meshes for a one-key
+    /// difference.
+    /// </summary>
+    protected virtual IConfiguration? ResolveConfiguration() =>
+        _hub.ServiceProvider.GetService<IConfiguration>();
 
     private Func<Exception, IObservable<Unit>> HoldWriteFailed(string target) =>
         ex =>

--- a/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
@@ -92,13 +92,20 @@ public static class UpdatePolicySettingsTab
                     // 🚨 The manual roll honours the SAME release-availability gate as the poller
                     // (#1754). A gate only the unattended path respects is not a gate — and this
                     // button is exactly the moment an operator, seeing an update that never
-                    // applied, would force the roll the poller refused for good reason. Absent the
-                    // service the button behaves as before (nothing to check against), which is
-                    // said out loud rather than read as a pass.
+                    // applied, would force the roll the poller refused for good reason.
+                    //
+                    // 🚨 An UNWIRED gate is a HOLD here too. It used to resolve to NotEnforced,
+                    // which is `IsUpdatable: true` — so the one host where nothing checks anything
+                    // was also the one host where this button never refused. NotEnforced is the
+                    // single stated applicability exemption (a deployment that consumes no CI
+                    // bakes); a missing registration is not an exemption, it is the absence of a
+                    // verdict, and it must not render as a pass.
                     var gate = h.Hub.ServiceProvider.GetService<ReleaseAvailabilityService>();
                     var decision = gate is null
-                        ? Observable.Return(UpdatabilityVerdict.NotEnforced(
-                            "no release-availability gate is registered on this install"))
+                        ? Observable.Return(UpdatabilityVerdict.Unavailable(
+                            "no release-availability gate is registered on this install, so nothing "
+                            + "could check whether the packages it deploys have usable artifacts for "
+                            + "this release — that is a hold, not clearance to proceed"))
                         : gate.IsUpdatable(tag);
                     decision.Subscribe(verdict =>
                     {

--- a/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using System.Reactive.Linq;
 using MeshWeaver.Application.Styles;
 using MeshWeaver.Data;
@@ -100,13 +101,24 @@ public static class UpdatePolicySettingsTab
                     // single stated applicability exemption (a deployment that consumes no CI
                     // bakes); a missing registration is not an exemption, it is the absence of a
                     // verdict, and it must not render as a pass.
+                    //
+                    // 🚨 …and the hold is SCOPED to what is actually unverifiable. On a deployment
+                    // that consumes no CI bakes a registered gate answers NotEnforced anyway, so
+                    // its absence is the same answer reached from configuration — not an
+                    // unanswered question. Holding there would freeze an install the gate was
+                    // never going to protect.
                     var gate = h.Hub.ServiceProvider.GetService<ReleaseAvailabilityService>();
-                    var decision = gate is null
-                        ? Observable.Return(UpdatabilityVerdict.Unavailable(
-                            "no release-availability gate is registered on this install, so nothing "
-                            + "could check whether the packages it deploys have usable artifacts for "
-                            + "this release — that is a hold, not clearance to proceed"))
-                        : gate.IsUpdatable(tag);
+                    var decision = gate is not null
+                        ? gate.IsUpdatable(tag)
+                        : Observable.Return(
+                            ReleaseAvailabilityService.NotApplicableReason(
+                                h.Hub.ServiceProvider.GetService<IConfiguration>()) is { } notApplicable
+                                ? UpdatabilityVerdict.NotEnforced(notApplicable)
+                                : UpdatabilityVerdict.Unavailable(
+                                    "no release-availability gate is registered on this install, so "
+                                    + "nothing could check whether the packages it deploys have "
+                                    + "usable artifacts for this release — that is a hold, not "
+                                    + "clearance to proceed"));
                     decision.Subscribe(verdict =>
                     {
                         if (!verdict.IsUpdatable)

--- a/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
@@ -74,6 +74,22 @@ public record SelfUpdateOptions
     /// </summary>
     public TimeSpan EventCoalesceWindow { get; init; } = TimeSpan.FromMinutes(1);
 
+    /// <summary>
+    /// 🚨 Roll even though the release-availability gate is NOT WIRED into this host.
+    ///
+    /// <para>Default <c>false</c>: an unwired gate is a HOLD. The gate answers "does every package
+    /// this environment deploys have a usable artifact for the target release" (#1754), and a host
+    /// that has no gate registered has not answered it — it has failed to ask. That is the absence
+    /// of a verdict, not a passing one, and this repo has paid for treating the two the same more
+    /// than once.</para>
+    ///
+    /// <para>Set it <c>true</c> to roll unverified — deliberately, in configuration, where it is
+    /// visible — exactly as <c>PreWarm:AllowUnprovenBake</c> lets a pod serve on an unproven bake.
+    /// The roll then proceeds AND says so, at Warning, on every tick. It can never waive a gate
+    /// that DID run: a real hold is unaffected by this key.</para>
+    /// </summary>
+    public bool AllowUnverifiedRoll { get; init; }
+
     /// <summary>The policy seeded onto <c>Admin/UpdatePolicy</c> when it doesn't exist yet, and the
     /// fallback used before the policy node's first live emission.</summary>
     public UpdatePolicyKind DefaultPolicy { get; init; } = UpdatePolicyKind.Continuous;

--- a/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
+++ b/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
@@ -250,6 +250,26 @@ public sealed record UpdatabilityVerdict(
     public static UpdatabilityVerdict NotEnforced(string reason) =>
         new(true, [], null, reason);
 
+    /// <summary>
+    /// 🚨 The gate could not RUN — it is not wired into this host at all.
+    ///
+    /// <para>This is a HOLD, and it is deliberately not <see cref="NotEnforced"/>. That answer
+    /// exists for the one stated applicability exemption (a deployment consuming no CI bakes);
+    /// reusing it for a wiring failure is the trap this repo has been bitten by repeatedly — an
+    /// <c>if: vars.X != ''</c> that skips green, a health check reporting Healthy while the bake
+    /// is <c>NotStarted</c>. A gate that cannot run must never look like a gate that passed, and
+    /// "the service is not registered" is the purest possible case of cannot-run: there is no
+    /// verdict at all, only the absence of one.</para>
+    ///
+    /// <para>It reports as <see cref="IsIndeterminate"/> — an availability failure to FIX, never
+    /// a compatibility verdict about the release — so the surfaces that already distinguish the
+    /// two do so here without changing.</para>
+    /// </summary>
+    public static UpdatabilityVerdict Unavailable(string reason) =>
+        new(false,
+            [new PackageAvailability("(gate)", PackageAvailabilityKind.Indeterminate, reason)],
+            reason);
+
     /// <summary>The packages that block the roll.</summary>
     public IEnumerable<PackageAvailability> Blockers => Packages.Where(p => !p.IsAvailable);
 

--- a/test/Memex.Portal.Shared.Test/ReleaseGateApplicabilityTest.cs
+++ b/test/Memex.Portal.Shared.Test/ReleaseGateApplicabilityTest.cs
@@ -1,0 +1,82 @@
+#pragma warning disable CS1591
+
+using System.Collections.Generic;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Hosting;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>"Cannot verify" and "verified as nothing to verify" are different states, and only the
+/// first may hold.</b>
+///
+/// <para>The release-availability gate (#1754) fails closed, and the first cut of its
+/// unwired-gate hold drew that rule one state too wide: it held on ANY host with no gate
+/// registered, including deployments the gate was never going to protect. Caught by
+/// <c>SelfUpdateRollFloorTest</c>, whose three roll-expecting cases went red — and the serious one
+/// was <c>NeverRolled_IsNotHeld</c>, because holding there means a first roll can never
+/// happen.</para>
+///
+/// <para><see cref="ReleaseAvailabilityService.NotApplicableReason"/> is the line between them,
+/// and it is decided from CONFIGURATION alone — which is what lets a caller with no instance of
+/// the service reach the same answer a registered one would. These pin that rule; the behavioural
+/// halves live in <c>SelfUpdateAvailabilityGateTest</c>.</para>
+/// </summary>
+public class ReleaseGateApplicabilityTest
+{
+    private static IConfiguration With(string? bundleRoot) =>
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [ShippedPrebuiltBundles.PublishedRootConfigKey] = bundleRoot,
+        }).Build();
+
+    /// <summary>
+    /// A deployment that consumes CI bakes has something an unwired gate has failed to verify —
+    /// so it is unverifiable, and the hold stands.
+    /// </summary>
+    [Fact]
+    public void ADeploymentThatConsumesBakes_IsInScopeOfTheGate()
+    {
+        Assert.Null(ReleaseAvailabilityService.NotApplicableReason(With("/data/prebuilt-bundles")));
+    }
+
+    /// <summary>
+    /// A deployment with no bundle root already compiles its content at every boot, so a REGISTERED
+    /// gate answers NotEnforced for it. Its absence is therefore the same answer reached from
+    /// configuration, not an unanswered question — and holding on it would freeze an environment
+    /// the gate could never have protected.
+    /// </summary>
+    [Fact]
+    public void ADeploymentThatConsumesNoBakes_HasNothingToEnforce_AndSaysWhy()
+    {
+        var reason = ReleaseAvailabilityService.NotApplicableReason(With(null));
+
+        Assert.NotNull(reason);
+        // The reason must NAME the key, or an operator cannot tell "not applicable" from "broken".
+        Assert.Contains(ShippedPrebuiltBundles.PublishedRootConfigKey, reason);
+    }
+
+    /// <summary>
+    /// Blank is absent. An empty <c>PreWarm__PrebuiltBundleRoot=</c> is a deployment that meant to
+    /// unset the key, never a request to gate against the process's working directory.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ABlankBundleRoot_ReadsAsAbsent(string blank)
+    {
+        Assert.NotNull(ReleaseAvailabilityService.NotApplicableReason(With(blank)));
+    }
+
+    /// <summary>
+    /// No configuration at all reads as "nothing configured" rather than throwing — the caller is a
+    /// poller tick, and an exception there would kill the tick that was supposed to decide.
+    /// </summary>
+    [Fact]
+    public void NoConfigurationAtAll_IsNotApplicable_NeverAThrow()
+    {
+        Assert.NotNull(ReleaseAvailabilityService.NotApplicableReason(null));
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
@@ -222,6 +222,83 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
     }
 
     /// <summary>
+    /// 🚨 <b>An UNWIRED gate is a hold, not a pass.</b> The poller used to log at Information and
+    /// roll — so the one host where nothing checked anything was also the one host that never
+    /// refused. A gate that cannot run must never look like a gate that passed, and #1754's own
+    /// rule is that "cannot determine" is not "clear to proceed".
+    ///
+    /// <para>As with every other hold, "no patch happened" is not the assertion — that would pass
+    /// against a poller that had simply died. The positive signal is the hold WRITTEN where the
+    /// Updates tab reads it, flagged INDETERMINATE: this is a wiring defect to fix, never a verdict
+    /// about the release.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AnUnwiredGate_HoldsTheRoll_AndSaysItCouldNotLook()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var updater = new RecordingUpdater();
+        await SeedPolicyNode();
+        var service = new GatedSelfUpdateService(
+            Mesh, new FakeAcrTagLister(), updater, FastPoll(),
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>(), gate: null);
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            var held = await Mesh.GetWorkspace()
+                .GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                .Select(node => UpdatePolicyNodeType.Parse(node, Mesh.JsonSerializerOptions))
+                .Where(content => content.IsHeld(CandidateTag))
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(ct);
+
+            held.HeldIndeterminate.Should().BeTrue(
+                "an unwired gate is the ABSENCE of a verdict — an availability failure to fix, "
+                + "never an incompatibility to re-bake");
+            held.HeldReason.Should().Contain("no release-availability gate is registered");
+            held.HeldReason.Should().Contain("not clearance to proceed");
+
+            updater.Tags.Should().BeEmpty("an unverified release must not be rolled");
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// The escape hatch is DELIBERATE and CONFIGURED, in the shape this repo already uses for
+    /// <c>PreWarm:AllowUnprovenBake</c>: an operator can still roll unverified, but only by setting
+    /// the key — never by omission, and never silently.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AnUnwiredGate_RollsOnlyWhenTheOperatorOptedInDeliberately()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var updater = new RecordingUpdater();
+        await SeedPolicyNode();
+        var service = new GatedSelfUpdateService(
+            Mesh, new FakeAcrTagLister(), updater,
+            FastPoll() with { AllowUnverifiedRoll = true },
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>(), gate: null);
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            var applied = await updater.Patched
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(ct);
+            applied.Should().Be(CandidateTag);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
     /// The poller with the gate supplied directly. The production poller resolves it from the mesh's
     /// service provider; injecting it here keeps the test from rebuilding the whole mesh just to
     /// register one singleton, without changing which code path decides.
@@ -232,7 +309,7 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
         IDeploymentUpdater updater,
         SelfUpdateOptions options,
         ILogger<SelfUpdateHostedService>? logger,
-        ReleaseAvailabilityService gate)
+        ReleaseAvailabilityService? gate)
         : SelfUpdateHostedService(hub, acr, updater, options, logger)
     {
         protected override ReleaseAvailabilityService? ResolveAvailabilityGate() => gate;

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -7,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Memex.Portal.Shared.SelfUpdate;
 using MeshWeaver.Data;
+using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
@@ -41,11 +43,28 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
 {
     private const string CandidateTag = "9999.0.0-ci.1";
 
+    /// <summary>
+    /// 🚨 This host CONSUMES CI BAKES — it configures a published bundle root, exactly as a
+    /// production portal does. That is load-bearing for every unwired-gate case below.
+    ///
+    /// <para>The gate's applicability is decided from configuration
+    /// (<see cref="ReleaseAvailabilityService.NotApplicableReason"/>): a deployment with no bundle
+    /// root already compiles its content at every boot, so a registered gate answers
+    /// <c>NotEnforced</c> for it and its ABSENCE is therefore not an unanswered question. Only a
+    /// deployment that actually consumes bakes has something an unwired gate has failed to
+    /// verify — so a test host that configured nothing could only ever assert the trivial
+    /// case.</para>
+    /// </summary>
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         // AddGitHubSyncTypes registers the BuildCompletion satellite — the record the workflow_run
         // webhook writes and the self-update watch reacts to. Types only, no credentials: the same
         // production registration rather than a duplicate declaration that could drift from it.
-        => base.ConfigureMesh(builder).AddUpdatePolicyType().AddGitHubSyncTypes();
+        => base.ConfigureMesh(builder).AddUpdatePolicyType().AddGitHubSyncTypes()
+            .ConfigureServices(services => services.AddSingleton<IConfiguration>(
+                new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [ShippedPrebuiltBundles.PublishedRootConfigKey] = "/data/prebuilt-bundles",
+                }).Build()));
 
     /// <summary>Fake registry (the documented IO seam): one build newer than anything installed.</summary>
     private sealed class FakeAcrTagLister : IAcrTagLister
@@ -268,6 +287,97 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
     }
 
     /// <summary>
+    /// 🚨 <b>"Cannot verify" and "verified as nothing to verify" are DIFFERENT states, and only the
+    /// first may hold.</b> This is the case the first cut of the unwired-gate hold swept in, caught
+    /// by <c>SelfUpdateRollFloorTest</c>: a deployment that consumes no CI bakes already compiles
+    /// its content at every boot, so a REGISTERED gate answers <c>NotEnforced</c> for it — its
+    /// absence is the same answer reached from configuration, not an unanswered question.
+    ///
+    /// <para>Holding here would have frozen an environment the gate was never going to protect,
+    /// and — because the manual roll honours the same verdict — an install with no roll history
+    /// could never have taken its first update at all. A fail-closed rule drawn one state too wide
+    /// is its own outage.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AnUnwiredGate_OnADeploymentThatConsumesNoBakes_IsNotEnforced_AndRolls()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var updater = new RecordingUpdater();
+        await SeedPolicyNode();
+        // This service reads a configuration with NO published bundle root — the one difference
+        // from AnUnwiredGate_HoldsTheRoll_AndSaysItCouldNotLook, and the whole distinction.
+        var service = new GatedSelfUpdateService(
+            Mesh, new FakeAcrTagLister(), updater, FastPoll(),
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>(),
+            gate: null, configuration: new ConfigurationBuilder().Build());
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            var applied = await updater.Patched
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(ct);
+            applied.Should().Be(CandidateTag);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// The interaction the two gates have with each other: a NEVER-ROLLED install, on a deployment
+    /// that does consume bakes, with no gate registered.
+    ///
+    /// <para>It HOLDS — and the two gates are independent, which is the point. The pacing floor
+    /// (#1778) asks "has this install rolled too recently?" and a never-rolled install passes it
+    /// trivially; the availability gate asks "can the packages this environment deploys survive the
+    /// target?" and an unwired gate has not answered that. Passing the first does not make the
+    /// second verifiable. Pinned because the tempting reading — "no history, so nothing can be
+    /// wrong, so let it through" — would reopen exactly the hole #1754 closed, on the instance
+    /// least likely to be watched.</para>
+    ///
+    /// <para>It is not a brick: the hold is re-evaluated every tick and clears the moment the gate
+    /// is registered, it is named on <c>Admin/UpdatePolicy</c> and logged at Error, and
+    /// <see cref="SelfUpdateOptions.AllowUnverifiedRoll"/> is the deliberate one-line opt-out. No
+    /// host in this repo can reach the state at all — <c>AddSelfUpdate</c> registers the gate
+    /// unconditionally.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task NeverRolled_WithTheGateUnavailable_StillHolds()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var updater = new RecordingUpdater();   // LastRolledAtAsync → null: never rolled.
+        await SeedPolicyNode();
+        var service = new GatedSelfUpdateService(
+            Mesh, new FakeAcrTagLister(), updater,
+            FastPoll() with { MinRollInterval = TimeSpan.FromHours(1) },
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>(), gate: null);
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            var held = await Mesh.GetWorkspace()
+                .GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                .Select(node => UpdatePolicyNodeType.Parse(node, Mesh.JsonSerializerOptions))
+                .Where(content => content.IsHeld(CandidateTag))
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(ct);
+
+            held.HeldIndeterminate.Should().BeTrue(
+                "clearing the PACING floor says nothing about whether the release is AVAILABLE — "
+                + "the two gates answer different questions");
+            updater.Tags.Should().BeEmpty();
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
     /// The escape hatch is DELIBERATE and CONFIGURED, in the shape this repo already uses for
     /// <c>PreWarm:AllowUnprovenBake</c>: an operator can still roll unverified, but only by setting
     /// the key — never by omission, and never silently.
@@ -309,9 +419,15 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
         IDeploymentUpdater updater,
         SelfUpdateOptions options,
         ILogger<SelfUpdateHostedService>? logger,
-        ReleaseAvailabilityService? gate)
+        ReleaseAvailabilityService? gate,
+        IConfiguration? configuration = null)
         : SelfUpdateHostedService(hub, acr, updater, options, logger)
     {
         protected override ReleaseAvailabilityService? ResolveAvailabilityGate() => gate;
+
+        /// <summary>Present a deployment that consumes no CI bakes when the test asks for one —
+        /// the one key the unwired-gate distinction turns on.</summary>
+        protected override IConfiguration? ResolveConfiguration() =>
+            configuration ?? base.ResolveConfiguration();
     }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/ReleaseAvailabilityTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ReleaseAvailabilityTest.cs
@@ -198,4 +198,25 @@ public class ReleaseAvailabilityTest
         Assert.False(string.IsNullOrEmpty(verdict.NotEnforcedReason));
         Assert.False(verdict.IsIndeterminate);
     }
+
+    /// <summary>
+    /// 🚨 The gate could not RUN — it is not wired in at all — is a HOLD, and is deliberately not
+    /// <see cref="UpdatabilityVerdict.NotEnforced"/>. That answer is the ONE stated applicability
+    /// exemption (a deployment consuming no CI bakes); reusing it for a wiring failure is how a
+    /// gate that cannot run comes to look like a gate that passed.
+    /// </summary>
+    [Fact]
+    public void Unavailable_IsAHold_AndReadsAsAnAvailabilityFailure_NotAnIncompatibility()
+    {
+        var verdict = UpdatabilityVerdict.Unavailable("no gate is registered on this host");
+
+        Assert.False(verdict.IsUpdatable);
+        Assert.False(string.IsNullOrEmpty(verdict.HoldReason));
+        // Indeterminate, so every surface that already separates "I could not look" from "I looked
+        // and it is incompatible" keeps doing so here without changing.
+        Assert.True(verdict.IsIndeterminate);
+        // NOT an applicability exemption: NotEnforcedReason is what makes a verdict updatable.
+        Assert.Null(verdict.NotEnforcedReason);
+        Assert.Single(verdict.Blockers);
+    }
 }


### PR DESCRIPTION
Continues #1754.

## Still real? Mostly shipped — one hole left, and it is the one this cluster is about

The gate landed on `main` (`8c8cc2005` and follow-ups) and is genuinely good: `ReleaseAvailability.IsUpdatable` is pure and fails safe, `ReleaseAvailabilityService` times out into `Indeterminate` rather than hanging, and all three roll paths read one verdict — the poller, the Updates tab's manual button, `/api/plugins/is-updatable`, plus CD's post-promote `check-release-availability.sh` (unconditional, no `if:`, fails red).

What was left: **both roll paths treated "the gate is not registered on this host" as clearance to proceed.**

```csharp
// SelfUpdateHostedService.GateThenApply — before
if (gate is null)
    _logger?.LogInformation("… rolling {Tag} without checking …");
    return Apply(target);

// UpdatePolicySettingsTab — before
var decision = gate is null
    ? Observable.Return(UpdatabilityVerdict.NotEnforced("no release-availability gate is registered"))
    : gate.IsUpdatable(tag);           // NotEnforced is IsUpdatable: true
```

So the one host where nothing checked anything was also the one host that never refused, and the only trace was an Information line nobody reads. That is the trap: *a gate that cannot run must never look like a gate that passed.*

`NotEnforced` is the **single stated applicability exemption** — a deployment that consumes no CI bakes, and therefore already compiles at every boot, which holding could only freeze forever. Reusing it for a **wiring failure** is precisely how the two become indistinguishable, and it is the same shape as `if: vars.X != ''` skipping green.

Reachable today? Only by a host that registers `SelfUpdateHostedService` without `AddSelfUpdate` — which registers both. So this is a latent hazard rather than a live incident, and it is exactly the kind that surfaces later as "why has this environment not updated / why did this environment roll".

## What changed

- **`UpdatabilityVerdict.Unavailable(reason)`** — a HOLD, reported `IsIndeterminate`, so every surface that already separates *"I could not look"* from *"I looked and it is incompatible"* keeps doing so unchanged. `NotEnforcedReason` stays null; that field is what makes a verdict updatable.
- **The poller holds**, records the hold on `Admin/UpdatePolicy` where the Updates tab reads it, and logs at **Error** rather than Information. Re-evaluated every tick like every other hold, so registering the gate clears it with nothing to un-stick by hand — that is what makes refusing safe rather than a freeze.
- **The manual roll button holds too** — it is exactly the moment an operator, seeing an update that never applied, would force the roll.
- **`SelfUpdate:AllowUnverifiedRoll`** is the deliberate escape hatch, in the shape this repo already uses for `PreWarm:AllowUnprovenBake`: roll unverified *on purpose*, in configuration where it is visible, saying so at Warning on every tick. It can never waive a gate that **did** run.

## Tests

```
Passed!  - Failed: 0, Passed: 13, Skipped: 0, Total: 13  (ReleaseAvailabilityTest)
Passed!  - Failed: 0, Passed:  4, Skipped: 0, Total:  4  (SelfUpdateAvailabilityGateTest, real monolith mesh)
```

New:
- `Unavailable_IsAHold_AndReadsAsAnAvailabilityFailure_NotAnIncompatibility`
- `AnUnwiredGate_HoldsTheRoll_AndSaysItCouldNotLook` — the fail-closed proof. The assertion is the hold **written** where the Updates tab reads it, flagged indeterminate, never "no patch happened" (which would pass against a poller that had simply died).
- `AnUnwiredGate_RollsOnlyWhenTheOperatorOptedInDeliberately`

**Non-vacuity** — `GateThenApply` reverted to the pre-fix branch:

```
Failed!  - Failed: 1, Passed: 3, Skipped: 0, Total: 4

  Failed AnUnwiredGate_HoldsTheRoll_AndSaysItCouldNotLook [30 s]
   System.TimeoutException : The operation has timed out.
```

(The hold never lands, because the poller rolled.)

## For the maintainer

One judgement call worth confirming: **the default is now HOLD.** A host that wires the poller by hand without `AddSelfUpdate` stops auto-updating until it either registers `ReleaseAvailabilityService` or sets `SelfUpdate:AllowUnverifiedRoll`. Every in-tree host goes through `AddSelfUpdate`, which registers the gate unconditionally, so nothing in this repo changes behaviour — but a downstream host might, and it will find out via an Error log plus a named hold on the Updates tab rather than silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)