### PR TITLE
A stream's disposal releases its registrants synchronously (#1613)

### DIFF
--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Reflection;
@@ -215,6 +216,35 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
 
     private bool isDisposed;
     private readonly object disposeLock = new();
+
+    /// <summary>
+    /// Everything <see cref="RegisterForDisposal(IDisposable)"/> coupled to THIS STREAM's lifetime,
+    /// disposed SYNCHRONOUSLY inside <see cref="Dispose"/>.
+    ///
+    /// <para>🚨 It used to be the hub's composite instead, and that is a leak, not a detail (#1613).
+    /// <c>MessageHub.Dispose()</c> disposes nothing synchronously: it closes hosted-hub creation,
+    /// cancels in-flight handlers, posts <c>ShutdownRequest(Quiescing)</c> and RETURNS. The hub's
+    /// <c>disposables</c> composite is walked in the ShutDown phase — several posted messages and
+    /// action-block turns later, bounded by nothing, on a host that is itself tearing down. So a
+    /// registrant whose whole job is to release something the moment the stream dies (the
+    /// <c>hub.Observe</c> subscription for the initial <c>SubscribeRequest</c>, whose disposal is
+    /// what removes the pending callback from <c>responseSubjects</c>) was released minutes of
+    /// scheduling later, or never.</para>
+    ///
+    /// <para>Locally that never showed, because the callback was not closed by disposal at all — the
+    /// owner's reply closed it. It only surfaces when the owner is still <c>Starting</c> and the
+    /// delivery sits <c>DEFERRED gates=[DataContextInit,Initialize]</c>: no reply, and the only
+    /// remaining closer too slow. That is why it read as a flaky test while being present in every
+    /// run.</para>
+    ///
+    /// <para>The hub registration is KEPT as a backstop — this composite is hooked onto the hub once,
+    /// so a hub that tears down WITHOUT the stream being disposed still releases everything.
+    /// <see cref="CompositeDisposable"/> is idempotent, so the two paths cannot double-dispose.</para>
+    /// </summary>
+    private readonly CompositeDisposable streamDisposables = new();
+
+    /// <summary>0 until the composite above has been hooked onto the hub's own disposal (once).</summary>
+    private int hubDisposalHooked;
     private readonly ILogger<SynchronizationStream<TStream>> logger;
 
     /// <summary>
@@ -895,7 +925,16 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
             try { disposable.Dispose(); } catch { /* best-effort */ }
             return;
         }
-        Hub.RegisterForDisposal(_ => disposable.Dispose());
+
+        // Hook the stream's composite onto the hub ONCE — the backstop for a hub that tears down
+        // without Dispose() ever being called on the stream. Everything else rides the composite,
+        // which Dispose() walks SYNCHRONOUSLY (see the field note).
+        if (Interlocked.Exchange(ref hubDisposalHooked, 1) == 0)
+            Hub.RegisterForDisposal(streamDisposables);
+
+        // CompositeDisposable.Add disposes the registrant immediately if the composite is already
+        // disposed, so a registration racing Dispose() cannot leak.
+        streamDisposables.Add(disposable);
     }
 
     /// <summary>
@@ -1602,9 +1641,32 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
         // remaining lifetime.
         Store.OnCompleted();
         // The shared children were registered for disposal on THIS stream (CreateReducedStream),
-        // so the hub teardown below is what disposes them; dropping the index here just stops this
+        // so the composite below is what disposes them; dropping the index here just stops this
         // corpse from referencing them.
         sharedReduceCache.Clear();
+
+        // 🚨 SYNCHRONOUSLY, and BEFORE Hub.Dispose() — this is the whole point of the stream owning
+        // its own composite (#1613). The registrant that matters most is the hub.Observe
+        // subscription for the initial SubscribeRequest: disposing it is what removes the pending
+        // callback from responseSubjects. Routed through the hub's ShutDown phase instead, that
+        // removal happened several action-block turns after the caller had already gone away — so a
+        // subscribe the owner never answered (because the owner was still Starting and the delivery
+        // sat DEFERRED behind its init gates) stayed pending until the ~30 s RequestTimeout.
+        //
+        // Guarded: Dispose() is called from consumers' `.Finally(stream.Dispose)`, and a throw out
+        // of an Rx Finally REPLACES the terminal notification. A faulting registrant must be
+        // reported, never allowed to swap a completion for an error — and Hub.Dispose() below still
+        // has to run.
+        try
+        {
+            streamDisposables.Dispose();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "[SYNC_STREAM] Registrant faulted while disposing stream {StreamId}", StreamId);
+        }
+
         if (Hub is not null && Hub.RunLevel <= MessageHubRunLevel.Started)
             Hub.Dispose();
     }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-stream-dispose-releases-subscribe.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-stream-dispose-releases-subscribe.md
@@ -1,0 +1,18 @@
+---
+Name: Closing a view releases its subscription immediately
+Category: Fix
+Description: A layout area or page that is closed while still loading no longer leaves a request hanging against the server for 30 seconds.
+Icon: Sparkle
+Order: -20260822
+---
+
+# Closing a view releases its subscription immediately
+
+When a page or layout area opens, it subscribes to the data it needs. If you navigate away — or the
+render is cancelled — before the answer arrives, that subscription should be dropped straight away.
+
+It was not. The release was queued behind the full shutdown of the subscription's internal machinery,
+which takes an unbounded number of steps and runs while the host is already tearing down. In practice
+the request kept waiting on the server for up to thirty seconds after nobody was listening any more.
+
+It is now released the moment the view lets go. Nothing else changes for anyone who stays on the page.

--- a/test/MeshWeaver.Data.Test/RemoteStreamDisposeCancelsSubscribeTest.cs
+++ b/test/MeshWeaver.Data.Test/RemoteStreamDisposeCancelsSubscribeTest.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// 🚨 Disposing a remote synchronization stream must cancel its in-flight
+/// <see cref="SubscribeRequest"/> <b>synchronously</b> — not several hub action-block turns later
+/// via the inner sync hub's ShutDown phase.
+///
+/// <para><b>The defect (#1613).</b> <c>SynchronizationStream.RegisterForDisposal</c> forwarded every
+/// registrant to <c>Hub.RegisterForDisposal</c>, i.e. to the INNER <c>sync/</c> hub's composite,
+/// which is walked in the ShutDown phase. But <c>MessageHub.Dispose()</c> disposes nothing
+/// synchronously: it closes hosted-hub creation, cancels in-flight handlers, posts
+/// <c>ShutdownRequest(Quiescing)</c> and returns. So the registrant that RELEASES the pending
+/// callback — the <c>hub.Observe(SubscribeRequest)</c> subscription, whose disposal is what removes
+/// the entry from <c>responseSubjects</c> (<c>MessageHub.WrapWithCancelOnDispose</c>) — was reached
+/// only after the inner hub walked <c>Quiescing → DisposeHostedHubs → HostedHubsDisposed →
+/// ShutDown</c>. Several posted messages, bounded by nothing, on a host that is itself tearing
+/// down.</para>
+///
+/// <para><b>Why it read as a flake.</b> Normally the callback is not closed by disposal at all — the
+/// owner answers in milliseconds and <c>.Take(1)</c> closes it the ordinary way. The leak is only
+/// VISIBLE when the owner never answers, which in CI is the loaded case where the target hub is
+/// still <c>Starting</c> and the delivery sits <c>DEFERRED gates=[DataContextInit,Initialize]</c>.
+/// The leak was present in every run; only its visibility was load-dependent. It surfaced as
+/// <c>RenderAreaOperationTest</c> failing in TEARDOWN — *"left Observe subscriptions pending past the
+/// Quiescing budget … 1 pending callback(s) after 0.50s: SubscribeRequest@…"* — on branches whose
+/// diff had no path to RenderArea at all, and it turned <b>main</b> red at least twice.</para>
+///
+/// <para>Any consumer that disposes a remote stream while its subscribe is in flight hits the same
+/// window: a Blazor circuit dropping a layout area, a cancelled SSR render, an agent's
+/// <c>RenderArea</c> giving up on its budget.</para>
+/// </summary>
+public class RemoteStreamDisposeCancelsSubscribeTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// Signals each <see cref="SubscribeRequest"/> the owner swallows — instance state, never
+    /// static, so nothing bleeds across tests.
+    /// </summary>
+    private readonly ReplaySubject<string> subscribeReceived = new();
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            // The owner ACCEPTS the SubscribeRequest and never answers it: no ack, no
+            // DataChangedEvent, no failure. That is the shape of a target hub still working
+            // through its init gates — the delivery is received and deferred, and no reply is
+            // ever sent. The client's pending callback therefore has exactly one possible
+            // closer left: the stream's disposal.
+            .WithHandler<SubscribeRequest>((_, delivery) =>
+            {
+                subscribeReceived.OnNext(delivery.Message.StreamId);
+                return delivery.Processed();
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddData();
+
+    [HubFact]
+    public async Task DisposingTheStream_ReleasesThePendingSubscribeCallback_Synchronously()
+    {
+        GetHost(); // activate the swallowing owner
+        var client = GetClient();
+        var workspace = client.ServiceProvider.GetRequiredService<IWorkspace>();
+
+        var stream = workspace.GetRemoteStream<EntityStore, CollectionsReference>(
+            CreateHostAddress(), new CollectionsReference("ghost"));
+
+        // Wait on the ACTUAL condition — the owner holds the SubscribeRequest, so the client's
+        // pending callback exists. No sleeps.
+        await subscribeReceived
+            .Where(id => id == stream.StreamId)
+            .FirstAsync()
+            .Timeout(10.Seconds())
+            .ToTask();
+
+        // Precondition that makes the seam live. Without it a "released" assertion after Dispose
+        // would pass against a hub that never had the callback in the first place.
+        client.GetPendingRequestDiagnostics().Should().Contain(nameof(SubscribeRequest),
+            "the owner accepted the subscribe and never answered, so the client must be holding a "
+            + "pending callback for it — otherwise this test proves nothing");
+
+        // THE CONTRACT: one synchronous call, then the callback is gone. No polling, no budget —
+        // a bounded wait here would pass against the unfixed code the moment the budget exceeded
+        // the inner hub's shutdown walk, which is precisely the load-dependence that made this
+        // read as a flake.
+        stream.Dispose();
+
+        var afterDispose = client.GetPendingRequestDiagnostics();
+        afterDispose.Should().NotContain(nameof(SubscribeRequest),
+            "disposing a remote stream must cancel its in-flight SubscribeRequest THERE AND THEN. "
+            + "Routed through the inner sync hub's ShutDown phase instead, the release takes several "
+            + "posted messages and action-block turns — long enough for the teardown leak check to "
+            + "fire, and for the callback to sit in responseSubjects until the ~30 s RequestTimeout. "
+            + "Diagnostics: " + afterDispose);
+    }
+
+    /// <summary>
+    /// The same contract, stated on the general seam rather than on one registrant: anything
+    /// coupled to the stream with <c>RegisterForDisposal</c> is released by
+    /// <c>stream.Dispose()</c> itself, not by the hub's later ShutDown phase.
+    /// </summary>
+    [HubFact]
+    public async Task RegisterForDisposal_IsReleasedByTheStreamsOwnDispose()
+    {
+        GetHost();
+        var client = GetClient();
+        var workspace = client.ServiceProvider.GetRequiredService<IWorkspace>();
+
+        var stream = workspace.GetRemoteStream<EntityStore, CollectionsReference>(
+            CreateHostAddress(), new CollectionsReference("ghost2"));
+
+        await subscribeReceived
+            .Where(id => id == stream.StreamId)
+            .FirstAsync()
+            .Timeout(10.Seconds())
+            .ToTask();
+
+        var released = false;
+        stream.RegisterForDisposal(System.Reactive.Disposables.Disposable.Create(() => released = true));
+        released.Should().BeFalse("registration must not dispose eagerly");
+
+        stream.Dispose();
+
+        released.Should().BeTrue(
+            "RegisterForDisposal documents 'disposed when the stream is disposed' — before #1613 it "
+            + "meant 'disposed when the stream's inner hub reaches its ShutDown phase', which is an "
+            + "unbounded number of action-block turns later");
+    }
+}


### PR DESCRIPTION
Addresses #1613 — the subscribe/dispose half. Deliberately NOT auto-closing: the RCA's second half (a delivery parked behind init gates that are never opened is owed a terminal response) is a separate receiver-side change and stays open.

## Mechanism

`SynchronizationStream.RegisterForDisposal` forwarded **every** registrant to `Hub.RegisterForDisposal` — the **inner `sync/` hub's** composite, which is walked in the **ShutDown** phase.

But `MessageHub.Dispose()` disposes nothing synchronously. It closes hosted-hub creation, cancels in-flight handlers, posts `ShutdownRequest(Quiescing)` and **returns**. So a registrant whose entire job is to release something the instant the stream dies was reached only after the inner hub walked `Quiescing → DisposeHostedHubs → HostedHubsDisposed → ShutDown` — several posted messages and action-block turns, bounded by nothing, on a host that is itself tearing down.

The registrant that matters is the `hub.Observe` subscription for the initial `SubscribeRequest`. Disposing it is what removes the entry from `responseSubjects` (`MessageHub.WrapWithCancelOnDispose`). Left to the ShutDown phase, a subscribe the owner never answered stayed pending until the ~30 s `RequestTimeout`.

**Why it read as a flake.** Normally the callback is not closed by disposal at all — the owner replies in milliseconds and `.Take(1)` closes it the ordinary way. The leak is only *visible* when the owner never answers, i.e. when the target hub is still `Starting` and the delivery sits `DEFERRED gates=[DataContextInit,Initialize]`. So the leak was present in **every** run and only its *visibility* was load-dependent — which is why it surfaced as `RenderAreaOperationTest` failing in **teardown** on branches with no path to RenderArea, and turned `main` red at least twice.

Any consumer that disposes a remote stream while its subscribe is in flight hits the same window: a Blazor circuit dropping a layout area, a cancelled SSR render, an agent's `RenderArea` giving up on its budget.

## What changed

`SynchronizationStream` now owns a `CompositeDisposable`, disposed **synchronously** inside `Dispose()` — after the store completes and `sharedReduceCache` is cleared (preserving the existing order), before `Hub.Dispose()`.

- **The hub registration is kept as a backstop**, hooked once, for a hub that tears down *without* `stream.Dispose()` ever being called. `CompositeDisposable` is idempotent, so the two paths cannot double-dispose.
- **The composite disposal is guarded and logged at Warning.** `Dispose()` is called from consumers' `.Finally(stream.Dispose)`, and a throw out of an Rx `Finally` *replaces* the terminal notification — a faulting registrant must be reported, never allowed to swap a completion for an error, and `Hub.Dispose()` still has to run. (A throwing registrant already aborted the rest of the loop under the hub's own plain `CompositeDisposable`, so failure isolation is unchanged.)

Scope note: this is the half #1745 deliberately left. #1745 fixed the *sender* (`RenderArea` re-checks its deadline before `GetRemoteStream`, so an elapsed budget faults without opening the stream); this fixes the general subscribe/dispose contract behind it.

## Tests

`RemoteStreamDisposeCancelsSubscribeTest`, built on the swallowing-owner harness `TeardownPendingSubscribeGracefulTest` already established (the owner accepts every `SubscribeRequest` and never answers — the shape of a target hub still working through its init gates).

1. **`DisposingTheStream_ReleasesThePendingSubscribeCallback_Synchronously`** — asserts the precondition first (the client *is* holding a pending `SubscribeRequest`, so a later "released" assertion cannot pass vacuously), then **one synchronous `stream.Dispose()`**, then the callback is gone. **No polling and no budget**: a bounded wait would pass against the unfixed code the moment the budget exceeded the shutdown walk, which is precisely the load-dependence that made this read as a flake.
2. **`RegisterForDisposal_IsReleasedByTheStreamsOwnDispose`** — the same contract stated on the general seam rather than on one registrant.

### Non-vacuity

Both fail on a clean `origin/main` worktree (the file compiles there unchanged):

```
Failed  DisposingTheStream_ReleasesThePendingSubscribeCallback_Synchronously [59 ms]
  Did not expect "Hub client/8f81aa169e7e RunLevel=Started Queue(buffer=0,deferred=0,exec=0)
  PendingCallbacks=1[vDkn6lICIE-x76V-sfbCCg=SubscribeRequest@host/1(3ms)]"
  to contain "SubscribeRequest" …
Failed  RegisterForDisposal_IsReleasedByTheStreamsOwnDispose
  Expected value to be true …, but found False.
Total tests: 2   Failed: 2
```

On this branch: **376/376 green** in `MeshWeaver.Data.Test` (full project), and `RenderAreaOperationTest` — the suite this issue was filed on — 9/9 green including `RenderArea_Timeout_FaultsWithTimeoutException`. `dotnet build -c Release -warnaserror` clean.

## Deliberately left

The issue's second half — *"a delivery parked behind init gates that are never opened is owed a terminal response when the gate is abandoned"* (the #1486 / #1549 / #1616 rule) — is a separate change on the receiver side and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
