### PR TITLE
fix(#1782 gap 4): a fetch MISS stays loud and countable

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/BundleAdoptionHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.Distributed/BundleAdoptionHealthCheck.cs
@@ -1,0 +1,39 @@
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Memex.Portal.Distributed;
+
+/// <summary>
+/// Reports whether this instance is actually ADOPTING the assemblies the registry is meant to serve
+/// it, or quietly compiling them itself (#1782 gap 4).
+///
+/// <para>🚨 <b>Why a surface at all.</b> Adoption's only evidence was a log line, and the miss that
+/// matters most — the registry not advertising a package for this lane — had no line at all. The
+/// measurement that justified the whole lane is a pair of log lines (prod: 80 compiles / 64.8 s →
+/// 0 compiles, 84 adopted, 32.1 s), and with instance-level pre-bake giving way to lazy
+/// compile-on-access the fetch path becomes the PRIMARY way assemblies arrive. A lazy compile
+/// absorbs a miss completely: the lane can go entirely dark while every surface looks like a
+/// healthy day. That is what 2026-08-20 was — an empty index, every consumer quietly compiling,
+/// nothing anywhere saying so.</para>
+///
+/// <para>🚨 <b>DEGRADED on a miss, never Unhealthy.</b> Compiling is correct, always-available
+/// behaviour — the instance serves fine, it just paid for something it should not have. Failing
+/// readiness would turn a distribution regression into an outage, which is strictly worse than the
+/// regression.</para>
+///
+/// <para>🚨 <b>"Nothing was attempted" is its own answer.</b> A deployment with no registry
+/// configured never attempts adoption, and reporting that as a clean sweep would make the absence
+/// of the lane look like the success of it.</para>
+/// </summary>
+public sealed class BundleAdoptionHealthCheck(BundleAdoptionLedger ledger) : IHealthCheck
+{
+    /// <inheritdoc />
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var description = ledger.Describe();
+        return Task.FromResult(ledger.Misses.IsEmpty
+            ? HealthCheckResult.Healthy(description)
+            : HealthCheckResult.Degraded(description));
+    }
+}

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -404,6 +404,14 @@ builder.Services.AddHealthChecks()
         new Memex.Portal.Distributed.PendingModuleActivationHealthCheck(
             MeshWeaver.PluginCatalog.ModuleRoot.Resolve(builder.Configuration)));
 
+// Is this instance ADOPTING the assemblies the registry is meant to serve it, or quietly compiling
+// them itself (#1782 gap 4)? With instance-level pre-bake giving way to lazy compile-on-access, a
+// fetch miss is absorbed so completely that the whole distribution lane can go dark while every
+// surface looks like a healthy day (2026-08-20). DEGRADED on a miss, never Unhealthy: compiling is
+// correct behaviour, and failing readiness would turn a distribution regression into an outage.
+builder.Services.AddHealthChecks()
+    .AddCheck<Memex.Portal.Distributed.BundleAdoptionHealthCheck>("bundle_adoption");
+
 // The same shape, one dependency further out: DbVersionGate proves the MESH database is
 // migrated; this proves the ORLEANS database is provisioned. They are different databases,
 // provisioned by different phases, and #1798 is what happens when only the first is checked —

--- a/src/MeshWeaver.PluginCatalog/BundleAdoption.cs
+++ b/src/MeshWeaver.PluginCatalog/BundleAdoption.cs
@@ -1,0 +1,152 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// How one attempt to adopt a package's prebuilt assemblies ended.
+///
+/// <para>🚨 They are separate values because <b>every one of them used to be the integer 0</b>, and
+/// a caller cannot tell an outage from a normal day given a 0. "The registry does not advertise
+/// this package for my lane" and "the registry served it and I adopted every assembly in it" were
+/// the same return value, and lazy compile absorbed the difference silently.</para>
+/// </summary>
+public enum BundleAdoptionKind
+{
+    /// <summary>Assemblies were adopted from the registry's bundle.</summary>
+    Adopted,
+
+    /// <summary>🚨 The registry's index does not list this package at all — for THIS lane. The
+    /// miss that used to be completely silent: no log line, no counter, just a compile that looked
+    /// like normal behaviour.</summary>
+    NotAdvertised,
+
+    /// <summary>The registry's whole index is baked for a different framework identity/architecture,
+    /// so nothing it holds is adoptable here. Normal during a platform roll; an outage when it
+    /// persists.</summary>
+    FrameworkDeclined,
+
+    /// <summary>The registry advertises the package but answered 404 for this lane's bytes.</summary>
+    NotServed,
+
+    /// <summary>The fetch failed — the registry is down, rate-limiting, or has revoked this
+    /// install's grant.</summary>
+    FetchFailed,
+
+    /// <summary>The bundle arrived but its own manifest declines against this framework.</summary>
+    BundleDeclined,
+
+    /// <summary>The bundle arrived and carried no assemblies.</summary>
+    NoAssemblies,
+}
+
+/// <summary>
+/// One adoption attempt's result — what was asked of which registry, and what came back.
+/// </summary>
+/// <param name="PluginId">The package.</param>
+/// <param name="Kind">How it ended.</param>
+/// <param name="Registry">The registry asked.</param>
+/// <param name="Adopted">Assemblies actually seeded.</param>
+/// <param name="Offered">Assemblies the bundle carried, when one arrived.</param>
+/// <param name="Reason">One sentence, for the kinds that have something to say.</param>
+public sealed record BundleAdoptionOutcome(
+    string PluginId,
+    BundleAdoptionKind Kind,
+    string Registry,
+    int Adopted = 0,
+    int Offered = 0,
+    string? Reason = null)
+{
+    /// <summary>
+    /// Whether this attempt left content to be COMPILED here that the distribution lane was meant
+    /// to serve. Adopting fewer assemblies than were offered counts — a partial adoption is a
+    /// partial miss, and rounding it to "adopted" is how a regression hides inside a success.
+    /// </summary>
+    public bool IsMiss => Kind != BundleAdoptionKind.Adopted || Adopted < Offered;
+
+    /// <summary>One line, for a log or a health payload.</summary>
+    public string Describe() => Kind switch
+    {
+        BundleAdoptionKind.Adopted when Adopted >= Offered =>
+            $"{PluginId}: adopted {Adopted}/{Offered}",
+        BundleAdoptionKind.Adopted =>
+            $"{PluginId}: adopted only {Adopted}/{Offered} — the rest compile here",
+        _ => $"{PluginId}: {Kind}"
+             + (string.IsNullOrWhiteSpace(Reason) ? string.Empty : $" ({Reason})"),
+    };
+}
+
+/// <summary>
+/// 🚨 <b>The count that proves the distribution lane works</b> — every adoption attempt this
+/// process made, and how it ended (#1782 gap 4).
+///
+/// <para>Adoption's only evidence today is a log line, and the measurement that justified the whole
+/// lane is a pair of them (prod: 80 compiles / 64.8 s → 0 compiles, 84 adopted, 32.1 s). With
+/// instance-level pre-bake giving way to lazy compile-on-access (#1746), the fetch path becomes the
+/// PRIMARY way assemblies arrive — and a lazy compile absorbs a miss so completely that the lane
+/// can go entirely dark while every surface looks like a healthy day. That is what happened on
+/// 2026-08-20: the registry served an empty index and every consumer quietly compiled.</para>
+///
+/// <para>So the outcomes are RECORDED, not merely logged. A miss stays countable after the log has
+/// rotated, and it is readable by an operator surface without turning anything on.</para>
+///
+/// <para>Process-scoped and cheap: one immutable list, appended under
+/// <see cref="ImmutableInterlocked"/>, bounded so a pathological reconcile loop cannot grow it
+/// without limit. It is a diagnostic, never a source of truth — nothing decides anything from
+/// it.</para>
+/// </summary>
+public sealed class BundleAdoptionLedger
+{
+    /// <summary>
+    /// How many outcomes are kept. Bounded because this is a diagnostic on a long-lived process:
+    /// the last N attempts answer "is the lane working now", which is the question, while an
+    /// unbounded list would answer it and also leak.
+    /// </summary>
+    public const int Capacity = 500;
+
+    private ImmutableList<BundleAdoptionOutcome> outcomes = ImmutableList<BundleAdoptionOutcome>.Empty;
+
+    /// <summary>Records one attempt. Thread-safe; never throws.</summary>
+    public void Record(BundleAdoptionOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        ImmutableInterlocked.Update(ref outcomes, current =>
+        {
+            var next = current.Add(outcome);
+            return next.Count > Capacity ? next.RemoveRange(0, next.Count - Capacity) : next;
+        });
+    }
+
+    /// <summary>Every recorded attempt, oldest first.</summary>
+    public ImmutableList<BundleAdoptionOutcome> Outcomes => Volatile.Read(ref outcomes);
+
+    /// <summary>The attempts that left something to compile here.</summary>
+    public ImmutableList<BundleAdoptionOutcome> Misses =>
+        Outcomes.Where(o => o.IsMiss).ToImmutableList();
+
+    /// <summary>
+    /// The one line every surface renders: how many attempts, how many assemblies adopted, and —
+    /// named — what was missed.
+    ///
+    /// <para>🚨 "Nothing was ever attempted" and "everything was adopted" are DIFFERENT sentences.
+    /// A deployment with no registry configured never attempts adoption, and reporting that as a
+    /// clean sweep would make the absence of the lane look like the success of it.</para>
+    /// </summary>
+    /// <param name="maxNamed">How many misses are named before the line truncates.</param>
+    public string Describe(int maxNamed = 10)
+    {
+        var all = Outcomes;
+        if (all.IsEmpty)
+            return "no bundle adoption has been attempted in this process";
+
+        var misses = all.Where(o => o.IsMiss).ToArray();
+        var adopted = all.Sum(o => o.Adopted);
+        if (misses.Length == 0)
+            return $"{all.Count} adoption attempt(s), {adopted} assembly/assemblies adopted, no misses";
+
+        return $"{all.Count} adoption attempt(s), {adopted} assembly/assemblies adopted, "
+            + $"{misses.Length} MISS(es) — content the registry was meant to serve is compiled "
+            + "here instead: "
+            + string.Join("; ", misses.Take(Math.Max(1, maxNamed)).Select(m => m.Describe()))
+            + (misses.Length > maxNamed ? $", …(+{misses.Length - maxNamed})" : string.Empty);
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -50,6 +50,10 @@ public sealed class PluginBundleClient
     private readonly HttpClient _http;
     private readonly ILogger<PluginBundleClient>? _logger;
 
+    // The count that proves the lane works (#1782 gap 4). Optional: a host that registers no
+    // ledger loses the counting, never the fetching.
+    private readonly BundleAdoptionLedger? _ledger;
+
     // ONE index read per client, shared by every package the install pass covers. PromiseSlot, not
     // a plain cached field: concurrent first callers share the single run, and a fault EVICTS so
     // the next caller retries rather than replaying a transient failure forever (#1369).
@@ -73,6 +77,7 @@ public sealed class PluginBundleClient
             ?.CreateClient(InstanceRegistrationClient.HttpClientName) ?? SharedHttp;
         _logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger<PluginBundleClient>();
+        _ledger = hub.ServiceProvider.GetService<BundleAdoptionLedger>();
     }
 
     /// <summary>What the registry advertises: the framework its assemblies were built against, and
@@ -159,19 +164,53 @@ public sealed class PluginBundleClient
                         _registryUrl, reason,
                         index.Architecture ?? "(an architecture it does not state)",
                         ReleaseArchitecture.Live);
-                    return Observable.Return(0);
+                    return Miss(pluginId, BundleAdoptionKind.FrameworkDeclined, reason);
                 }
 
                 var bundle = index.Bundles?.FirstOrDefault(b =>
                     string.Equals(b.Plugin, pluginId, StringComparison.OrdinalIgnoreCase));
 
-                return bundle is null
-                    ? Observable.Return(0)
-                    : Download(pluginId, bundle.Version)
-                        .SelectMany(bytes => bytes is null
-                            ? Observable.Return(0)
-                            : SeedAll(pluginId, bytes));
+                if (bundle is null)
+                {
+                    // 🚨 THE MISS THAT WAS COMPLETELY SILENT (#1782 gap 4). This branch returned 0
+                    // with no log line at all, so "the registry does not advertise this package for
+                    // my lane" was indistinguishable from a healthy adoption — and the compile that
+                    // followed looked like normal behaviour rather than the distribution lane being
+                    // dark. It is exactly the shape of the 2026-08-20 outage, seen from the
+                    // consumer: an empty index, every consumer quietly compiling, nothing in any
+                    // log worth reading.
+                    _logger?.LogWarning(
+                        "Bundle for {Plugin}: {Registry} does not advertise it on framework "
+                        + "{Identity}/{Architecture} — it will be COMPILED here. Either that "
+                        + "registry has no install record and no published module for it, or its "
+                        + "index is filtered by this instance's grant. {Advertised} package(s) are "
+                        + "advertised to this instance.",
+                        pluginId, _registryUrl, PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                        ReleaseArchitecture.Live, index.Bundles?.Count ?? 0);
+                    return Miss(pluginId, BundleAdoptionKind.NotAdvertised,
+                        $"{_registryUrl} advertises {index.Bundles?.Count ?? 0} package(s) to this "
+                        + "instance, and this is not one of them");
+                }
+
+                return Download(pluginId, bundle.Version)
+                    .SelectMany(result => result.Bytes is null
+                        ? Miss(pluginId, result.Kind, result.Reason)
+                        : SeedAll(pluginId, result.Bytes));
             });
+
+    /// <summary>
+    /// Records a miss and reports it as the zero every caller already handles.
+    ///
+    /// <para>The integer return is deliberately unchanged: adoption must never fail an install, and
+    /// widening the contract would ripple through five call sites for no gain. What changes is that
+    /// the zero is no longer the ONLY thing that happened — the reason is named in the log and
+    /// counted in the ledger, so "the lane is dark" is answerable after the fact.</para>
+    /// </summary>
+    private IObservable<int> Miss(string pluginId, BundleAdoptionKind kind, string? reason)
+    {
+        _ledger?.Record(new BundleAdoptionOutcome(pluginId, kind, _registryUrl, Reason: reason));
+        return Observable.Return(0);
+    }
 
     /// <summary>
     /// Fetches <paramref name="pluginId"/>'s bundle and LANDS the compiled module it carries into
@@ -243,9 +282,10 @@ public sealed class PluginBundleClient
                             "Module '{Module}' of {Plugin}: {Reason}",
                             moduleName, pluginId, verdict.Reason);
                         return Download(pluginId, bundle!.Version)
-                            .SelectMany(bytes => bytes is null
-                                ? Observable.Return(0)
-                                : LandFromBundle(pluginId, moduleName, packagePath, bundle.Version, bytes));
+                            .SelectMany(result => result.Bytes is null
+                                ? Miss(pluginId, result.Kind, result.Reason)
+                                : LandFromBundle(
+                                    pluginId, moduleName, packagePath, bundle.Version, result.Bytes));
                     })))
             .Catch((Exception ex) =>
             {
@@ -327,7 +367,14 @@ public sealed class PluginBundleClient
     /// <summary>
     /// Downloads the bundle, or emits null when the registry has none for this plugin/version.
     /// </summary>
-    private IObservable<byte[]?> Download(string pluginId, string version) =>
+    /// <summary>
+    /// A fetch's outcome: the bytes, or the NAMED reason there are none. A bare <c>byte[]?</c>
+    /// collapsed "404 for this lane" and "the registry is down" into the same null, and the caller
+    /// then collapsed that into the same 0 as a successful adoption.
+    /// </summary>
+    private sealed record FetchResult(byte[]? Bytes, BundleAdoptionKind Kind, string? Reason = null);
+
+    private IObservable<FetchResult> Download(string pluginId, string version) =>
         _httpPool.Invoke(async ct =>
         {
             // 🚨 The consumer asks IN ITS OWN LANE (#1751): the registry resolves each NodeType's
@@ -347,7 +394,9 @@ public sealed class PluginBundleClient
                 _logger?.LogInformation(
                     "No prebuilt bundle for {Plugin}@{Version} at {Registry} — will compile",
                     pluginId, version, _registryUrl);
-                return null;
+                return new FetchResult(null, BundleAdoptionKind.NotServed,
+                    $"the registry advertises {pluginId}@{version} but serves no bytes for "
+                    + $"{PrebuiltAssemblySeeder.LiveFrameworkMvid}/{ReleaseArchitecture.Live}");
             }
 
             if (!resp.IsSuccessStatusCode)
@@ -359,10 +408,13 @@ public sealed class PluginBundleClient
                 _logger?.LogWarning(
                     "Bundle fetch for {Plugin}@{Version} failed ({Status}) — will compile",
                     pluginId, version, (int)resp.StatusCode);
-                return null;
+                return new FetchResult(null, BundleAdoptionKind.FetchFailed,
+                    $"HTTP {(int)resp.StatusCode} from {_registryUrl}");
             }
 
-            return await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+            return new FetchResult(
+                await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false),
+                BundleAdoptionKind.Adopted);
         });
 
     /// <summary>
@@ -383,7 +435,7 @@ public sealed class PluginBundleClient
                     _logger?.LogInformation(
                         "Bundle for {Plugin} DECLINED whole: {Reason} — compiling instead",
                         pluginId, reason);
-                    return Observable.Return(0);
+                    return Miss(pluginId, BundleAdoptionKind.BundleDeclined, reason);
                 }
 
                 // 🚨 The producer's per-type MISSES (#1751), surfaced here rather than only in the
@@ -403,7 +455,8 @@ public sealed class PluginBundleClient
                 {
                     _logger?.LogInformation(
                         "Bundle for {Plugin} carried no assemblies — compiling instead", pluginId);
-                    return Observable.Return(0);
+                    return Miss(pluginId, BundleAdoptionKind.NoAssemblies,
+                        "the bundle carried no assemblies");
                 }
 
                 return assemblies
@@ -412,9 +465,19 @@ public sealed class PluginBundleClient
                         a.Dependencies))
                     .Concat()
                     .Count(adopted => adopted)
-                    .Do(count => _logger?.LogInformation(
-                        "Bundle for {Plugin}: adopted {Adopted}/{Total} prebuilt assemblies",
-                        pluginId, count, assemblies.Count));
+                    .Do(count =>
+                    {
+                        _logger?.LogInformation(
+                            "Bundle for {Plugin}: adopted {Adopted}/{Total} prebuilt assemblies",
+                            pluginId, count, assemblies.Count);
+                        // 🚨 A PARTIAL adoption is recorded as the partial thing it is. Rounding
+                        // "adopted 3 of 12" up to "adopted" is how a regression hides inside a
+                        // success — the other nine are compiled here, which is precisely the cost
+                        // this lane exists to remove.
+                        _ledger?.Record(new BundleAdoptionOutcome(
+                            pluginId, BundleAdoptionKind.Adopted, _registryUrl,
+                            Adopted: count, Offered: assemblies.Count));
+                    });
             });
 
     // Per-REQUEST auth header — never on the client: _http can be the process-wide SharedHttp, and

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -126,7 +126,15 @@ public static class PluginCatalogConfigurationExtensions
                 // fails with a denied-path error the publisher sees as HTTP 409. See ModuleRoot.
                 .AddSingleton(sp => new ModuleLandingService(
                     sp.GetService<ILogger<ModuleLandingService>>(),
-                    ModuleRoot.Resolve(sp.GetService<IConfiguration>()))))
+                    ModuleRoot.Resolve(sp.GetService<IConfiguration>())))
+                // The COUNT that proves the distribution lane works (#1782 gap 4). Adoption's only
+                // evidence used to be a log line, and the most important miss — "the registry does
+                // not advertise this package for my lane" — had no line at all. With lazy
+                // compile-on-access replacing instance pre-bake (#1746), a miss is absorbed so
+                // completely that the lane can go dark while every surface looks like a healthy
+                // day; that is exactly what 2026-08-20 was. A plain singleton, process-scoped and
+                // bounded: a diagnostic, never a source of truth.
+                .AddSingleton<BundleAdoptionLedger>())
             .ConfigureHub(config =>
             {
                 config.TypeRegistry.AddPluginCatalogTypes();

--- a/test/MeshWeaver.PluginCatalog.Test/BundleAdoptionMissTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/BundleAdoptionMissTest.cs
@@ -1,0 +1,219 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// 🚨 <b>A fetch MISS must stay loud and countable</b> (#1782 gap 4).
+///
+/// <para>Adoption's evidence was a log line, and the miss that matters most had none at all: when
+/// the registry's index does not advertise a package for this lane, <c>Adopt</c> returned the bare
+/// integer 0 — the SAME value a fully successful adoption returns — with no log and no counter.
+/// The compile that followed looked exactly like normal behaviour. That is the consumer's view of
+/// the 2026-08-20 outage: an empty index, every consumer quietly compiling, nothing anywhere
+/// saying so. With instance-level pre-bake giving way to lazy compile-on-access (#1746) the fetch
+/// path becomes the PRIMARY way assemblies arrive, so the metric that proves it works is the only
+/// reason anyone would notice it stopping.</para>
+///
+/// <para>The registry is stubbed at the <see cref="HttpMessageHandler"/> — no sockets, no ports —
+/// so the client's real index read, real decline gate and real miss accounting all run.</para>
+/// </summary>
+public class BundleAdoptionMissTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string RegistryUrl = "http://registry.test";
+
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    /// <summary>Answers the bundle routes with whatever the test staged.</summary>
+    private sealed class StubRegistry : HttpMessageHandler
+    {
+        public string? IndexJson { get; set; }
+        public HttpStatusCode DownloadStatus { get; set; } = HttpStatusCode.NotFound;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path.EndsWith("/index.json", StringComparison.Ordinal))
+                return Task.FromResult(IndexJson is null
+                    ? new HttpResponseMessage(HttpStatusCode.NotFound)
+                    : new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(IndexJson, Encoding.UTF8, "application/json"),
+                    });
+
+            return Task.FromResult(new HttpResponseMessage(DownloadStatus)
+            {
+                Content = new StringContent(string.Empty),
+            });
+        }
+    }
+
+    private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private readonly StubRegistry registry = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        base.ConfigureMesh(builder).AddGraph().AddPluginCatalog()
+            .ConfigureServices(services =>
+                services.AddSingleton<IHttpClientFactory>(new StubFactory(registry)));
+
+    private BundleAdoptionLedger Ledger =>
+        Mesh.ServiceProvider.GetRequiredService<BundleAdoptionLedger>();
+
+    private static string Index(string identity, params (string Plugin, string Version)[] bundles) =>
+        JsonSerializer.Serialize(new
+        {
+            frameworkMvid = identity,
+            architecture = ReleaseArchitecture.Live,
+            bundles = bundles.Select(b => new
+            {
+                plugin = b.Plugin,
+                version = b.Version,
+                url = $"{RegistryUrl}/api/plugins/bundles/{b.Plugin}/{b.Version}",
+            }).ToArray(),
+        }, Json);
+
+    /// <summary>
+    /// 🚨 THE defect. The registry answers with an index this instance CAN adopt from — same
+    /// framework identity, same architecture — that simply does not list the package. Before, that
+    /// was an unannotated `return 0`.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task APackageTheRegistryDoesNotAdvertise_IsRecordedAsAMiss_NotAsASilentZero()
+    {
+        registry.IndexJson = Index(PrebuiltAssemblySeeder.LiveFrameworkMvid, ("Other", "1.0.0"));
+
+        var adopted = await new PluginBundleClient(Mesh, RegistryUrl)
+            .Adopt("Store").FirstAsync().ToTask();
+
+        // The RETURN is deliberately unchanged — adoption must never fail an install.
+        adopted.Should().Be(0);
+
+        var miss = Ledger.Misses.Should().ContainSingle().Subject;
+        miss.PluginId.Should().Be("Store");
+        miss.Kind.Should().Be(BundleAdoptionKind.NotAdvertised);
+        miss.Registry.Should().Be(RegistryUrl);
+        miss.Reason.Should().Contain("1 package(s)",
+            "naming how many ARE advertised separates 'the index is empty' from 'my grant excludes me'");
+        Ledger.Describe().Should().Contain("MISS");
+        Ledger.Describe().Should().Contain("Store");
+    }
+
+    /// <summary>
+    /// The whole index baked for another framework build is a DIFFERENT miss from "not advertised",
+    /// and it must not be flattened into one. One is normal during a platform roll; the other means
+    /// the package is not being distributed at all.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AnIndexForAnotherFrameworkBuild_IsItsOwnKindOfMiss()
+    {
+        registry.IndexJson = Index(Guid.NewGuid().ToString("N"), ("Store", "1.0.0"));
+
+        (await new PluginBundleClient(Mesh, RegistryUrl).Adopt("Store").FirstAsync().ToTask())
+            .Should().Be(0);
+
+        Ledger.Misses.Should().ContainSingle()
+            .Which.Kind.Should().Be(BundleAdoptionKind.FrameworkDeclined);
+    }
+
+    /// <summary>
+    /// Advertised but not served for this lane — the third distinct miss. A bare <c>byte[]?</c>
+    /// collapsed this and a registry outage into the same null, and the caller collapsed that into
+    /// the same 0 as a success.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AdvertisedButNotServedForThisLane_IsRecordedSeparatelyFromAnOutage()
+    {
+        registry.IndexJson = Index(PrebuiltAssemblySeeder.LiveFrameworkMvid, ("Store", "1.0.0"));
+        registry.DownloadStatus = HttpStatusCode.NotFound;
+
+        (await new PluginBundleClient(Mesh, RegistryUrl).Adopt("Store").FirstAsync().ToTask())
+            .Should().Be(0);
+        Ledger.Misses.Should().ContainSingle()
+            .Which.Kind.Should().Be(BundleAdoptionKind.NotServed);
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task ARegistryThatIsDown_IsAFetchFailure_NotAMissingPackage()
+    {
+        registry.IndexJson = Index(PrebuiltAssemblySeeder.LiveFrameworkMvid, ("Store", "1.0.0"));
+        registry.DownloadStatus = HttpStatusCode.ServiceUnavailable;
+
+        (await new PluginBundleClient(Mesh, RegistryUrl).Adopt("Store").FirstAsync().ToTask())
+            .Should().Be(0);
+        Ledger.Misses.Should().ContainSingle()
+            .Which.Kind.Should().Be(BundleAdoptionKind.FetchFailed);
+    }
+
+    // ── the ledger itself: pure, and the sentence it must not say ───────────────────────────────
+
+    /// <summary>
+    /// 🚨 "Nothing was ever attempted" and "everything was adopted" are DIFFERENT sentences. A
+    /// deployment with no registry never attempts adoption, and reporting that as a clean sweep
+    /// would make the absence of the lane look like the success of it.
+    /// </summary>
+    [Fact]
+    public void AnEmptyLedgerSaysNothingWasAttempted_NeverThatEverythingWasAdopted()
+    {
+        var ledger = new BundleAdoptionLedger();
+
+        ledger.Describe().Should().Be("no bundle adoption has been attempted in this process");
+        ledger.Describe().Should().NotContain("no misses");
+        ledger.Misses.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A PARTIAL adoption is a partial miss. Rounding "adopted 3 of 12" up to "adopted" is how a
+    /// regression hides inside a success — the other nine are compiled here, which is exactly the
+    /// cost this lane exists to remove.
+    /// </summary>
+    [Fact]
+    public void APartialAdoptionCountsAsAMiss()
+    {
+        var ledger = new BundleAdoptionLedger();
+        ledger.Record(new BundleAdoptionOutcome(
+            "Store", BundleAdoptionKind.Adopted, RegistryUrl, Adopted: 3, Offered: 12));
+        ledger.Record(new BundleAdoptionOutcome(
+            "Edu", BundleAdoptionKind.Adopted, RegistryUrl, Adopted: 5, Offered: 5));
+
+        ledger.Misses.Should().ContainSingle().Which.PluginId.Should().Be("Store");
+        ledger.Describe().Should().Contain("adopted only 3/12");
+    }
+
+    /// <summary>
+    /// Bounded: a diagnostic on a long-lived process answers "is the lane working NOW" from the
+    /// last N attempts. An unbounded list would answer it and also leak.
+    /// </summary>
+    [Fact]
+    public void TheLedgerIsBounded()
+    {
+        var ledger = new BundleAdoptionLedger();
+        for (var i = 0; i < BundleAdoptionLedger.Capacity + 50; i++)
+            ledger.Record(new BundleAdoptionOutcome(
+                $"P{i}", BundleAdoptionKind.NotAdvertised, RegistryUrl));
+
+        ledger.Outcomes.Count.Should().Be(BundleAdoptionLedger.Capacity);
+        ledger.Outcomes[^1].PluginId.Should().Be($"P{BundleAdoptionLedger.Capacity + 49}",
+            "the newest attempts are the ones that answer 'is it working now'");
+    }
+}


### PR DESCRIPTION
Addresses **gap 4** of #1782. Gap 2 is deliberately not in scope — see the bottom.

## What it was

Adoption's only evidence was a log line, and **the miss that matters most had none at all**:

```csharp
var bundle = index.Bundles?.FirstOrDefault(b => …);

return bundle is null
    ? Observable.Return(0)          // ← no log, no counter, no anything
    : Download(…);
```

`0` is also what a **fully successful** adoption returns. So *"the registry does not advertise this package for my lane"* was indistinguishable from *"I adopted everything there was"*, and the compile that followed looked exactly like normal behaviour.

That is the consumer's view of the 2026-08-20 outage: an empty index, every consumer quietly compiling, nothing anywhere saying so. And it is what the issue means by:

> 🚨 a fetch MISS must stay loud and countable. If lazy compile silently absorbs it, the metric that proves adoption works disappears — and that metric is the only reason we know adoption works today (prod: 80 compiles / 64.8 s → 0 compiles, 84 adopted, 32.1 s).

With instance-level pre-bake giving way to lazy compile-on-access (#1746), the fetch path becomes the **primary** way assemblies arrive — so that metric is the only reason anyone would notice it stopping.

Two smaller collapses fell out of the same read: `Download` returned `byte[]?`, folding *"404 for this lane"* and *"the registry is down"* into one null; and a **partial** adoption ("adopted 3 of 12") reported as an unqualified success while the other nine compiled here.

## What changed

- **`BundleAdoptionKind`** names the six ways an attempt can end, because every one of them used to be the same `0`. `NotAdvertised` logs at **Warning** and names *how many packages ARE advertised to this instance* — which is what separates "the index is empty" (a registry problem) from "my grant excludes me" (an entitlement problem).
- **`Download` returns a typed result**, so the reason survives to the caller.
- **`BundleAdoptionLedger`** counts the outcomes: process-scoped, bounded (500), thread-safe, appended under `ImmutableInterlocked`. A diagnostic — nothing decides anything from it.
  - A **partial** adoption counts as a **miss**. Rounding it up is how a regression hides inside a success.
  - An empty ledger says *"no bundle adoption has been attempted in this process"*, **never** "no misses". A deployment with no registry never attempts adoption, and reporting that as a clean sweep would make the *absence* of the lane look like the *success* of it.
- **`bundle_adoption` health check** surfaces it without opening a portal. **Degraded** on a miss, never `Unhealthy`: compiling is correct, always-available behaviour, and failing readiness would turn a distribution regression into an outage — strictly worse than the regression.

The integer return of `Adopt` / `AdoptModule` is deliberately **unchanged**: adoption must never fail an install, and widening the contract would ripple through five call sites for no gain.

## Tests

`test/MeshWeaver.PluginCatalog.Test/BundleAdoptionMissTest.cs` — four against the **real client** with the registry stubbed at the `HttpMessageHandler` (no sockets, no ports, so the real index read, real decline gate and real accounting all run), three pure over the ledger.

```
Passed!  - Failed: 0, Passed: 11, Skipped: 0, Total: 11   (with ModuleFunnelTest, the neighbouring client suite)
```

**Non-vacuity** — `Miss()` reduced to a bare zero (the pre-fix shape):

```
Failed!  - Failed: 4, Passed: 3, Skipped: 0, Total: 7

  Failed APackageTheRegistryDoesNotAdvertise_IsRecordedAsAMiss_NotAsASilentZero
  Failed AnIndexForAnotherFrameworkBuild_IsItsOwnKindOfMiss
  Failed AdvertisedButNotServedForThisLane_IsRecordedSeparatelyFromAnOutage
  Failed ARegistryThatIsDown_IsAFetchFailure_NotAMissingPackage
   Expected collection to contain a single item, but found 0.
```

## For the maintainer — gap 2 is a design question, not a plumbing one

Gap 2 ("the index advertises only THIS instance's installs") has moved a long way since the issue was written and I did not close it, because what is left is a decision rather than an implementation:

- **#1948** already unions the activation sidecar's published-module entries into the index, which is what makes a GitSync-native registry serve at all.
- **#1950** fixed the record visibility that made the index serve `[]` regardless.
- What remains is the issue's own words: *"Serving uninstalled packages means finding the entitlement anchor for a package the serving instance has no install record for — that is the actual design question here, not the plumbing."* `AuthenticatedInstance.Allows` matches against the install record's `PackageManifest.Source`; with no record there is nothing to match on, and inventing an anchor would weaken what #1777 established.

Worth noting that gap 4's diagnostics make gap 2's symptom *visible* for the first time: an instance asking for a package the registry cannot advertise now says so by name, instead of silently compiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)