### PR TITLE
The security fold's permission-deciding queries declare completeness — and Complete() actually works now (#2011)

### DIFF
--- a/src/MeshWeaver.Hosting.Cosmos/CosmosMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.Cosmos/CosmosMeshQuery.cs
@@ -124,6 +124,13 @@ public class CosmosMeshQuery : IMeshQueryProvider
         {
             parsedQuery = parsedQuery with { Limit = request.Limit is > 0 ? request.Limit : null };
         }
+        else if (parsedQuery.Limit is <= 0)
+        {
+            // Same encoding arriving through the QUERY STRING instead — `limit:all`
+            // (MeshQueryRequest.CompleteQualifier), which the security fold uses because it can
+            // only pass strings.
+            parsedQuery = parsedQuery with { Limit = null };
+        }
 
         // Strip $type filters — all items in the nodes container are MeshNodes,
         // so $type:MeshNode is always true and other $type values always false.
@@ -173,7 +180,8 @@ public class CosmosMeshQuery : IMeshQueryProvider
                     ? ParsedQuery.ProjectToSelect(node, parsedQuery.Select)
                     : node;
                 count++;
-                if (parsedQuery.Limit.HasValue && count >= parsedQuery.Limit.Value)
+                // `is > 0`: NoLimit is non-positive, and `count >= -1` is true on the first row.
+                if (parsedQuery.Limit is > 0 && count >= parsedQuery.Limit.Value)
                     yield break;
             }
             yield break;
@@ -202,7 +210,8 @@ public class CosmosMeshQuery : IMeshQueryProvider
 
             // Apply limit
             countOrig++;
-            if (parsedQuery.Limit.HasValue && countOrig >= parsedQuery.Limit.Value)
+            // `is > 0`: see above.
+            if (parsedQuery.Limit is > 0 && countOrig >= parsedQuery.Limit.Value)
                 yield break;
         }
     }

--- a/src/MeshWeaver.Hosting.Cosmos/CosmosSqlGenerator.cs
+++ b/src/MeshWeaver.Hosting.Cosmos/CosmosSqlGenerator.cs
@@ -68,7 +68,8 @@ public class CosmosSqlGenerator
         var sql = new StringBuilder("SELECT");
 
         // Add TOP if limit specified
-        if (query.Limit.HasValue)
+        // `is > 0`: MeshQueryRequest.NoLimit is non-positive and must not become `TOP -1`.
+        if (query.Limit is > 0)
             sql.Append($" TOP {query.Limit.Value}");
 
         // When the caller projects via `select:` and didn't ask for "content",

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
@@ -302,7 +302,10 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                 if (string.IsNullOrEmpty(vectorUserId) || vectorUserId == WellKnownUsers.System)
                     vectorUserId = null;
                 var vectorNamespace = parsedQuery.Path ?? request.DefaultPath;
-                var topK = parsedQuery.Limit ?? request.Limit ?? 50;
+                // Positive(): a vector search always needs a real k, and NoLimit (non-positive)
+                // is "no cap stated" — which for an ANN ranking is the same thing as stating
+                // nothing, so it takes the same default rather than an impossible k.
+                var topK = Positive(parsedQuery.Limit) ?? Positive(request.Limit) ?? 50;
                 // Strip the text part from the filter so VectorSearchAsync's
                 // WHERE clause has the structured predicates only.
                 var structuralFilter = parsedQuery with { TextSearch = null };
@@ -363,7 +366,10 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                     ? ParsedQuery.ProjectToSelect(node, parsedQuery.Select)
                     : node);
                 count++;
-                if (parsedQuery.Limit.HasValue && count >= parsedQuery.Limit.Value)
+                // Positive(): non-positive is MeshQueryRequest.NoLimit — "every match" — NOT
+                // "stop after zero rows". `count >= -1` is true on the first row, so reading the
+                // raw value here made a Complete() read return ONE row, silently.
+                if (Positive(parsedQuery.Limit) is { } cap && count >= cap)
                     return rows;
             }
             return rows;
@@ -390,7 +396,8 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                 : node);
 
             countOrig++;
-            if (parsedQuery.Limit.HasValue && countOrig >= parsedQuery.Limit.Value)
+            // Positive(): see above — NoLimit must not read as a cap of -1.
+            if (Positive(parsedQuery.Limit) is { } capOrig && countOrig >= capOrig)
                 return rows;
         }
 

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -1674,7 +1674,11 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                   "ELSE 0 END) DESC, last_modified DESC NULLS LAST";
         }
 
-        if (query.Limit.HasValue)
+        // `is > 0`, never HasValue: MeshQueryRequest.NoLimit is non-positive ("return every
+        // match"), and emitting it verbatim produces `LIMIT -1` — Postgres 2201W, which surfaces
+        // as an AVAILABILITY failure of whatever read it was under. The sibling generators
+        // (PostgreSqlSqlGenerator) already guard this way; this branch did not.
+        if (query.Limit is > 0)
             sql += $" LIMIT {query.Limit.Value}";
 
         return (sql, parameters);

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeCrossSchemaQueryProvider.cs
@@ -405,7 +405,10 @@ public class SnowflakeCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         var effectiveQuery = query with
         {
             IsMain = true,
-            Limit = query.Limit ?? 50,
+            // Three cases, and conflating the last two is how an enumeration silently becomes a
+            // page: no limit stated → the default page; MeshQueryRequest.NoLimit (non-positive) →
+            // the caller declared this an ENUMERATION, so every match; a positive limit → honour it.
+            Limit = query.Limit switch { null => 50, <= 0 => int.MaxValue, var stated => stated },
             OrderBy = query.OrderBy ?? (string.IsNullOrEmpty(query.TextSearch)
                 ? new OrderByClause("last_modified", Descending: true)
                 : null)

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeMeshQuery.cs
@@ -240,8 +240,14 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
 
         var parsedQuery = _parser.Parse(request.Query);
 
+        // A non-positive limit — from the request OR from the query string's `limit:all`
+        // (MeshQueryRequest.CompleteQualifier) — is the framework's "return every match" encoding.
+        // It must CLEAR the cap rather than become a `LIMIT -1` (invalid SQL) or a `count >= -1`
+        // early return (which yields exactly one row, silently).
         if (request.Limit.HasValue)
-            parsedQuery = parsedQuery with { Limit = request.Limit };
+            parsedQuery = parsedQuery with { Limit = request.Limit is > 0 ? request.Limit : null };
+        else if (parsedQuery.Limit is <= 0)
+            parsedQuery = parsedQuery with { Limit = null };
 
         parsedQuery = StripTypeFilter(parsedQuery);
 
@@ -269,7 +275,9 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                 if (string.IsNullOrEmpty(vectorUserId) || vectorUserId == WellKnownUsers.System)
                     vectorUserId = null;
                 var vectorNamespace = parsedQuery.Path ?? request.DefaultPath;
-                var topK = parsedQuery.Limit ?? request.Limit ?? 50;
+                // A vector search always needs a real k; "no cap" takes the same default.
+                var topK = parsedQuery.Limit is > 0 ? parsedQuery.Limit.Value
+                    : request.Limit is > 0 ? request.Limit.Value : 50;
                 // Strip the text part from the filter so VectorSearchAsync's
                 // WHERE clause has the structured predicates only.
                 var structuralFilter = parsedQuery with { TextSearch = null };
@@ -330,7 +338,8 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                     ? ParsedQuery.ProjectToSelect(node, parsedQuery.Select)
                     : node;
                 count++;
-                if (parsedQuery.Limit.HasValue && count >= parsedQuery.Limit.Value)
+                // `is > 0`: NoLimit is non-positive, and `count >= -1` is true on the first row.
+                if (parsedQuery.Limit is > 0 && count >= parsedQuery.Limit.Value)
                     yield break;
             }
             yield break;
@@ -357,7 +366,8 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                 : node;
 
             countOrig++;
-            if (parsedQuery.Limit.HasValue && countOrig >= parsedQuery.Limit.Value)
+            // `is > 0`: see above.
+            if (parsedQuery.Limit is > 0 && countOrig >= parsedQuery.Limit.Value)
                 yield break;
         }
     }

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeSqlGenerator.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeSqlGenerator.cs
@@ -415,7 +415,8 @@ public class SnowflakeSqlGenerator
                 "ELSE 0 END) DESC, n.\"last_modified\" DESC NULLS LAST");
         }
 
-        if (query.Limit.HasValue)
+        // `is > 0`: MeshQueryRequest.NoLimit is non-positive and must not become `LIMIT -1`.
+        if (query.Limit is > 0)
             sql.Append($" LIMIT {query.Limit.Value}");
 
         return (sql.ToString(), parameters);
@@ -762,7 +763,8 @@ public class SnowflakeSqlGenerator
                 "ELSE 0 END) DESC, \"last_modified\" DESC NULLS LAST";
         }
 
-        if (query.Limit.HasValue)
+        // `is > 0`: MeshQueryRequest.NoLimit is non-positive and must not become `LIMIT -1`.
+        if (query.Limit is > 0)
             sql += $" LIMIT {query.Limit.Value}";
 
         return (sql, parameters);

--- a/src/MeshWeaver.Hosting.Sqlite/SqliteVectorMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.Sqlite/SqliteVectorMeshQuery.cs
@@ -57,7 +57,10 @@ public sealed class SqliteVectorMeshQuery : IMeshQueryProvider
         if (typeof(T) != typeof(MeshNode) || _embedder is null || string.IsNullOrWhiteSpace(parsed.TextSearch))
             return EmptyInitial<T>(parsed);
 
-        var topK = request.Limit ?? parsed.Limit ?? 50;
+        // A vector search always needs a real k, so MeshQueryRequest.NoLimit (non-positive) takes
+        // the same default as "no cap stated" rather than an impossible k.
+        var topK = request.Limit is > 0 ? request.Limit.Value
+            : parsed.Limit is > 0 ? parsed.Limit.Value : 50;
         // Embed the query (I/O leaf on the pool), then rank the stored vectors by cosine. A failed
         // embed → null → empty contribution, so lexical search still serves.
         return _ioPool.Invoke(ct => EmbedSafe(parsed.TextSearch!, ct))

--- a/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
@@ -578,7 +578,14 @@ public partial class QueryParser
 
                 if (field.Equals("limit", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (int.TryParse(value, out var limitValue))
+                    // `limit:all` is the query-string spelling of MeshQueryRequest.Complete() —
+                    // this read is an ENUMERATION, so every match must come back. It exists for the
+                    // readers that never see a MeshQueryRequest (the synced-query cache builds its
+                    // own), where the absence of a limit is silently the cross-schema fan-out's
+                    // 50-row page.
+                    if (value.Equals("all", StringComparison.OrdinalIgnoreCase))
+                        limit = Services.MeshQueryRequest.NoLimit;
+                    else if (int.TryParse(value, out var limitValue))
                         limit = limitValue;
                     continue;
                 }

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -70,14 +70,13 @@ internal static class PermissionEvaluator
     /// </summary>
     internal const string AdminScope = "Admin";
 
-    private const string RoleNodeType = "Role";
     private const string RoleQueryId = "$security-roles";
 
     // Group access is resolved GLOBALLY — a group defined in one partition can be granted in
     // another (cross-partition licensing), so we read EVERY GroupMembership node (as System, like
     // the other $security-* queries) and expand the viewer's transitive group set in-memory. This
     // mirrors the Postgres rebuild, which reads memberships from the global auth mirror.
-    private const string GroupMembershipNodeType = "GroupMembership";
+    private const string GroupMembershipNodeType = SecurityQueries.GroupMembershipNodeType;
     private const string MembershipQueryId = "$security-memberships";
 
     // Per-gated-type cached query key prefix — one shared upstream subscription per gated node
@@ -702,15 +701,15 @@ internal static class PermissionEvaluator
         // search, and path/namespace select the same flat grant set under {scope}/_Access.
         var isAdminScope = key == AdminScope
             || key.StartsWith(AdminScope + "/", StringComparison.Ordinal);
-        var selfFilter = isAdminScope
-            ? $"path:{nsQuery} scope:children nodeType:{SecurityCollections.AccessAssignmentNodeType} select:path,id,namespace,name,nodeType,content"
-            : $"namespace:{nsQuery} nodeType:{SecurityCollections.AccessAssignmentNodeType} select:path,id,namespace,name,nodeType,content";
+        var selfFilter = SecurityQueries.Scoped(isAdminScope
+            ? $"path:{nsQuery} scope:children nodeType:{SecurityCollections.AccessAssignmentNodeType} {SecurityQueries.ContentProjection}"
+            : $"namespace:{nsQuery} nodeType:{SecurityCollections.AccessAssignmentNodeType} {SecurityQueries.ContentProjection}");
 
         // Self: narrow per-scope query against the singleton cache. Each
         // scope's stream is cached PROCESS-WIDE under the key
         // "$security-access:{scope}" — every hub in the process shares one
         // upstream subscription per scope.
-        var self = cache.GetQuery($"$security-access:{key}", hub.JsonSerializerOptions, selfFilter);
+        var self = SecurityQuery(cache, $"$security-access:{key}", hub.JsonSerializerOptions, selfFilter);
 
         // Parent: recursive reference to parent-scope cached observable.
         // Root scope folds in statics instead.
@@ -735,10 +734,12 @@ internal static class PermissionEvaluator
             ? "namespace: id:_Policy"
             : $"namespace:{key} id:_Policy";
 
-        var self = cache.GetQuery(
+        var self = SecurityQuery(
+            cache,
             $"$security-policy:{key}",
             hub.JsonSerializerOptions,
-            $"{nsFilter} nodeType:{SecurityCollections.PartitionAccessPolicyNodeType} select:path,id,namespace,name,nodeType,content");
+            SecurityQueries.Scoped(
+                $"{nsFilter} nodeType:{SecurityCollections.PartitionAccessPolicyNodeType} {SecurityQueries.ContentProjection}"));
 
         IObservable<ImmutableDictionary<string, PartitionAccessPolicy>> parentOrBase;
         if (string.IsNullOrEmpty(key))
@@ -795,9 +796,8 @@ internal static class PermissionEvaluator
 
         var options = hub.JsonSerializerOptions;
         var perType = gates
-            .Select(gate => cache
-                .GetQuery($"{GatedQueryPrefix}{gate.NodeType}", options,
-                    $"nodeType:{gate.NodeType} scope:subtree select:path,id,namespace,name,nodeType")
+            .Select(gate => SecurityQuery(cache, $"{GatedQueryPrefix}{gate.NodeType}", options,
+                    SecurityQueries.GatedNodes(gate.NodeType))
                 .StartWith(Array.Empty<MeshNode>()))
             .ToArray();
 
@@ -817,10 +817,27 @@ internal static class PermissionEvaluator
             });
     }
 
+    /// <summary>
+    /// The ONE seam through which the security fold reads the mesh — every permission-deciding
+    /// query, global or anchored, is built here.
+    ///
+    /// <para>🚨 It exists to make the completeness declaration structural rather than remembered.
+    /// <c>IMeshNodeStreamCache.GetQuery</c> takes query STRINGS and builds its own
+    /// <see cref="MeshQueryRequest"/>, so nothing in this fold can call
+    /// <see cref="MeshQueryRequest.Complete"/>; a query that merely states no limit is served by the
+    /// cross-schema fan-out as a 50-row PAGE, and the caller cannot tell. Routing every read through
+    /// <see cref="SecurityQueries.Enumeration"/> means a security query cannot be truncatable no
+    /// matter what string its author wrote — which is the point, because the failure it prevents is
+    /// silent: a truncated result reads exactly like "this grants nothing" (issue #2011).</para>
+    /// </summary>
+    private static IObservable<IEnumerable<MeshNode>> SecurityQuery(
+        IMeshNodeStreamCache cache, object queryId, JsonSerializerOptions options, string query)
+        => cache.GetQuery(queryId, options, SecurityQueries.Enumeration(query));
+
     private static IObservable<MeshNode[]> ObserveAllRoleNodes(IMessageHub hub)
     {
         var cache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
-        return cache.GetQuery(RoleQueryId, hub.JsonSerializerOptions, $"nodeType:{RoleNodeType} scope:subtree select:path,id,namespace,name,nodeType,content")
+        return SecurityQuery(cache, RoleQueryId, hub.JsonSerializerOptions, SecurityQueries.Roles)
             .Select(arr => arr.ToArray());
     }
 
@@ -832,8 +849,7 @@ internal static class PermissionEvaluator
     private static IObservable<IEnumerable<MeshNode>> ObserveAllMembershipNodes(IMessageHub hub)
     {
         var cache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
-        return cache.GetQuery(MembershipQueryId, hub.JsonSerializerOptions,
-            $"nodeType:{GroupMembershipNodeType} scope:subtree select:path,id,namespace,name,nodeType,content");
+        return SecurityQuery(cache, MembershipQueryId, hub.JsonSerializerOptions, SecurityQueries.Memberships);
     }
 
     #endregion

--- a/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
@@ -1,0 +1,122 @@
+using System.Text.RegularExpressions;
+using MeshWeaver.Mesh.Services;
+
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// The ONE place the permission-deciding mesh queries are written — every read the security fold
+/// (<c>PermissionEvaluator</c>) makes to decide what a viewer may see.
+///
+/// <para>🚨 <b>In the security fold, "no result" and "not allowed" must never be the same value.</b>
+/// Several of these reads are GLOBAL by necessity — a <c>GroupMembership</c> lives under the group
+/// node, which may sit in a different partition than the grant that names the group, so the query
+/// carries no <c>path:</c> and no <c>namespace:</c>. On Postgres that is exactly the shape
+/// <c>PostgreSqlCrossSchemaQueryProvider</c> serves by UNION-ing every partition schema, ordering by
+/// <c>last_modified DESC</c> and clipping at a 50-row default page. A caller cannot tell a page from
+/// the whole set (<see cref="MeshQueryRequest.Complete"/>), and here the difference is a
+/// PERMISSION: a truncated membership list is indistinguishable from "this viewer is in no groups",
+/// so a group-derived permission simply vanishes and every surface gated on it disappears at once —
+/// with nothing logged and nothing failing (issue #2011).</para>
+///
+/// <para>It is worse than a lost grant in one direction that matters. A group-scoped <b>deny</b>
+/// (<c>AccessAssignment</c> with <c>Denied = true</c> whose subject is a group) is applied only to
+/// the viewers the membership read says are in that group — so the same truncation makes a
+/// revocation FAIL OPEN, leaving a viewer reading content the deny was written to take away.</para>
+///
+/// <para>The trigger is GROWTH, not a change: it fires the moment a mesh's <c>Role</c> or
+/// <c>GroupMembership</c> set outgrows a page, so it appears on the largest install first — the one
+/// where it is most expensive — and nobody will have touched anything.</para>
+///
+/// <para><b>Why a builder rather than a review rule.</b> Every query the fold issues goes through
+/// <see cref="Enumeration"/>, which stamps <see cref="MeshQueryRequest.CompleteQualifier"/> on it.
+/// A query string that never reaches this class is the only way back to the defect, and a query
+/// string that DOES reach it cannot come out truncatable — including one that arrives already
+/// carrying a limit, which is overwritten rather than honoured, because in this fold a page IS the
+/// bug.</para>
+/// </summary>
+public static class SecurityQueries
+{
+    /// <summary>The projection for reads whose CONTENT is folded (roles, memberships, grants, policies).</summary>
+    public const string ContentProjection = "select:path,id,namespace,name,nodeType,content";
+
+    /// <summary>The projection for reads that only need to know a node EXISTS at a path (gated nodes).</summary>
+    public const string IdentityProjection = "select:path,id,namespace,name,nodeType";
+
+    /// <summary>Node type of a custom role definition.</summary>
+    public const string RoleNodeType = "Role";
+
+    /// <summary>Node type of a group-membership record.</summary>
+    public const string GroupMembershipNodeType = "GroupMembership";
+
+    // A standalone `limit:<value>` qualifier — at the start of the query or after whitespace, so a
+    // `content.limit:3` filter or a free-text word ending in "limit:" is left alone.
+    private static readonly Regex LimitQualifier =
+        new(@"(?<=^|\s)limit:\S+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Stamps <paramref name="query"/> as an ENUMERATION — the read whose result the security fold
+    /// treats as the COMPLETE set. Idempotent, and total: a query that already states a limit has it
+    /// REPLACED, because a permission decision taken on a page is the defect this exists to prevent.
+    /// </summary>
+    /// <param name="query">The mesh query string.</param>
+    /// <returns>The same query, guaranteed to carry <see cref="MeshQueryRequest.CompleteQualifier"/>.</returns>
+    public static string Enumeration(string query)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+        var trimmed = query.Trim();
+        return LimitQualifier.IsMatch(trimmed)
+            ? LimitQualifier.Replace(trimmed, MeshQueryRequest.CompleteQualifier, 1)
+            : $"{trimmed} {MeshQueryRequest.CompleteQualifier}";
+    }
+
+    /// <summary>
+    /// A GLOBAL (path-less) security read over every instance of <paramref name="nodeType"/> in the
+    /// mesh. Path-less on purpose — the subject and the grant that names it may live in different
+    /// partitions — and therefore always an enumeration.
+    /// </summary>
+    /// <param name="nodeType">The node type to enumerate.</param>
+    /// <param name="projection">The <c>select:</c> projection; content by default.</param>
+    /// <returns>The query string.</returns>
+    public static string Global(string nodeType, string projection = ContentProjection)
+        => Enumeration($"nodeType:{nodeType} scope:subtree {projection}");
+
+    /// <summary>Every custom <c>Role</c> definition in the mesh (<c>$security-roles</c>).</summary>
+    public static string Roles => Global(RoleNodeType);
+
+    /// <summary>Every <c>GroupMembership</c> record in the mesh (<c>$security-memberships</c>).</summary>
+    public static string Memberships => Global(GroupMembershipNodeType);
+
+    /// <summary>
+    /// Every instance of a type-declared subtree GATE (<c>$security-gated:{nodeType}</c>) — the set a
+    /// target path is matched against to find its nearest gated ancestor. Truncation here loses a
+    /// gate's declared PUBLIC surface rather than opening one (the gate only ever ORs Read in), so it
+    /// fails closed — but it is still a permission decided on a page, and it is pinned with the rest.
+    /// </summary>
+    /// <param name="nodeType">The gated node type.</param>
+    /// <returns>The query string.</returns>
+    public static string GatedNodes(string nodeType) => Global(nodeType, IdentityProjection);
+
+    /// <summary>
+    /// A security read anchored to one scope — the per-scope <c>AccessAssignment</c> and
+    /// <c>_Policy</c> walks. Anchored reads are normally served by a single partition's delegate, but
+    /// the ROOT scope's anchor (<c>_Access</c> / the empty namespace) resolves to no partition and
+    /// falls through to the same cross-schema fan-out, so these are stamped too.
+    /// </summary>
+    /// <param name="query">The anchored query string.</param>
+    /// <returns>The query string, stamped as an enumeration.</returns>
+    public static string Scoped(string query) => Enumeration(query);
+
+    /// <summary>
+    /// Every query shape this class produces, for the completeness test that pins them. A member
+    /// added without an entry here is not covered — which is why the test also asserts the fold's
+    /// own builders against <see cref="Enumeration"/>.
+    /// </summary>
+    public static IReadOnlyList<string> AllShapes =>
+    [
+        Roles,
+        Memberships,
+        GatedNodes("Store/Plugin"),
+        Scoped("namespace:_Access nodeType:AccessAssignment " + ContentProjection),
+        Scoped("namespace: id:_Policy nodeType:PartitionAccessPolicy " + ContentProjection),
+    ];
+}

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshQuery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshQuery.cs
@@ -218,6 +218,20 @@ public record MeshQueryRequest
     public MeshQueryRequest Complete() => this with { Limit = NoLimit };
 
     /// <summary>
+    /// The QUERY-STRING form of <see cref="Complete"/> — <c>limit:all</c>, which the parser maps to
+    /// <see cref="NoLimit"/>.
+    ///
+    /// <para>🚨 Needed because not every read can reach a <see cref="MeshQueryRequest"/>. The
+    /// process-wide synced-query surface (<c>IMeshNodeStreamCache.GetQuery</c> →
+    /// <c>SyncedQueryMeshNodes</c>) takes query STRINGS and builds the request itself, so a caller
+    /// there has no <c>Complete()</c> to call and the absence of a limit silently becomes the
+    /// cross-schema fan-out's 50-row page. Spelling it <c>all</c> rather than <c>-1</c> is
+    /// deliberate: a bare negative number in a query string reads as a typo and invites a tidy-up
+    /// that reintroduces the truncation, which is exactly the class of defect this guards.</para>
+    /// </summary>
+    public const string CompleteQualifier = "limit:all";
+
+    /// <summary>
     /// Context for visibility filtering. When set, nodes with this context
     /// in their ExcludeFromContext are excluded from results.
     /// Parsed context: qualifier in query string is used as fallback.

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SecurityFoldEnumerationTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SecurityFoldEnumerationTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// 🚨 A GROUP-DERIVED PERMISSION MUST NOT VANISH WHEN THE MESH OUTGROWS A PAGE — issue #2011.
+///
+/// <para><b>The defect.</b> <c>PermissionEvaluator</c> resolves a viewer's groups from
+/// <c>$security-memberships</c> — <c>nodeType:GroupMembership scope:subtree</c>, path-less by design
+/// because a group and its members may live in a different partition than the grant that names the
+/// group. Path-less ⇒ the cross-schema fan-out serves it, and a fan-out that is handed no limit
+/// answers with a PAGE: the 50 most recently modified rows, ordered <c>last_modified DESC</c>. The
+/// evaluator then folds that page as if it were the complete set.</para>
+///
+/// <para><b>Why it is worse than a short list.</b> A truncated membership read is indistinguishable
+/// from "this viewer belongs to no groups", so it moves permissions in BOTH directions:</para>
+/// <list type="bullet">
+///   <item>a group GRANT silently stops reaching its member — every surface gated on it disappears
+///     at once, with nothing logged and nothing failing; and</item>
+///   <item>a group DENY silently stops reaching its member — a revocation FAILS OPEN, which is the
+///     direction that actually leaks. That is the case <c>bob</c> pins below.</item>
+/// </list>
+///
+/// <para><b>Why nobody would ever have changed anything.</b> The trigger is GROWTH. It fires the
+/// first time a mesh's <c>GroupMembership</c> (or <c>Role</c>) set outgrows a page, so it appears on
+/// the LARGEST install first — the one where it is most expensive — and it cannot reproduce on any
+/// install small enough to test on by hand.</para>
+///
+/// <para><b>Why this test is on Postgres.</b> The in-memory <c>StorageAdapterMeshQueryProvider</c>
+/// and the per-schema <c>PostgreSqlMeshQuery</c> both treat "no limit" as UNBOUNDED, so the
+/// identical fold is correct on every adapter a unit test uses (<c>GroupPermissionTests</c> passes
+/// either way). Only the cross-schema fan-out caps it — which is exactly why the defect shipped.
+/// The cheap half of the fix is asserted without a database in
+/// <c>MeshWeaver.Security.Test.SecurityQueryCompletenessTests</c>.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class SecurityFoldEnumerationTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// Memberships written AFTER the two that matter. Comfortably above the cross-schema fan-out's
+    /// 50-row default — at or below it this test reproduces nothing.
+    /// </summary>
+    private const int CrowdSize = 60;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(fixture.ConnectionString)
+        { MaxPoolSize = 16, ConnectionIdleLifetime = 10 };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services => services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString))
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .AddSpaceType();
+    }
+
+    // Per test instance, never static — the PostgreSql fixture is shared across the collection.
+    private string SpacePath { get; } = "GrpSpace" + Guid.NewGuid().ToString("N")[..8];
+    private string Cohort => $"{SpacePath}/Cohort";
+    private string Blocked => $"{SpacePath}/Blocked";
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private MeshNode Membership(string member, string groupPath)
+    {
+        var id = $"{member.Replace('/', '_')}_Membership";
+        return new MeshNode(id, groupPath)
+        {
+            NodeType = "GroupMembership",
+            Name = $"{member} membership",
+            MainNode = $"{groupPath}/{id}",
+            Content = new GroupMembership
+            {
+                Member = member,
+                DisplayName = member,
+                Groups = [new MembershipEntry { Group = groupPath }],
+            },
+        };
+    }
+
+    private MeshNode Group(string id) => new(id, SpacePath)
+    {
+        Name = id,
+        NodeType = "Group",
+        MainNode = $"{SpacePath}/{id}",
+        Content = new AccessObject { Description = id },
+    };
+
+    [Fact(Timeout = 300_000)]
+    public async Task GroupGrantsAndDenies_SurviveAMeshWithMoreMembershipsThanOnePage()
+    {
+        await MeshService.CreateNode(MeshNode.FromPath(SpacePath) with
+        { Name = SpacePath, NodeType = SpaceNodeType.NodeType, Content = new Space() })
+            .Should().Within(90.Seconds()).Emit();
+        await MeshService.CreateNode(Group("Cohort")).Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(Group("Blocked")).Should().Within(60.Seconds()).Emit();
+
+        // The grants. `Cohort` is licensed on the space; `bob` is licensed DIRECTLY (so his Read at
+        // {SpacePath}/Doc is a control that does not depend on any membership) and `Blocked` is DENIED
+        // at {SpacePath}/Gated — a revocation that only lands if bob is still resolved as its member.
+        await MeshService.CreateNode(AssignmentNodeFactory.UserRole(Cohort, "Viewer", SpacePath))
+            .Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(AssignmentNodeFactory.UserRole("bob", "Viewer", SpacePath))
+            .Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(AssignmentNodeFactory.UserRole(Blocked, "Viewer", $"{SpacePath}/Gated", denied: true))
+            .Should().Within(60.Seconds()).Emit();
+
+        // The two memberships that matter — written FIRST, so every crowd write below stamps a
+        // newer last_modified and pushes these two off the fan-out's most-recent page.
+        await MeshService.CreateNode(Membership("alice", Cohort)).Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(Membership("bob", Blocked)).Should().Within(60.Seconds()).Emit();
+
+        for (var i = 0; i < CrowdSize; i++)
+            await MeshService.CreateNode(Membership($"crowd{i:D2}", Cohort))
+                .Should().Within(60.Seconds()).Emit();
+
+        Output.WriteLine(
+            $"seeded {CrowdSize + 2} GroupMembership nodes; the fan-out's default page is "
+            + $"{PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit}");
+
+        // 1. The group GRANT still reaches its member. Before the fix alice's membership had fallen
+        //    off the page, so the fold saw her in no groups and the Cohort grant matched nobody.
+        var alice = await Mesh.GetEffectivePermissions($"{SpacePath}/Doc", "alice")
+            .Should().Within(90.Seconds()).Match(p => p.HasFlag(Permission.Read));
+        Output.WriteLine($"alice @ {SpacePath}/Doc → {alice}");
+
+        // 2. The group DENY still reaches its member — the direction that LEAKS. bob keeps his own
+        //    direct grant (the control), and the Blocked deny must still take {SpacePath}/Gated away.
+        var bobOpen = await Mesh.GetEffectivePermissions($"{SpacePath}/Doc", "bob")
+            .Should().Within(90.Seconds()).Match(p => p.HasFlag(Permission.Read));
+        Output.WriteLine($"bob @ {SpacePath}/Doc → {bobOpen} (direct grant — the control)");
+
+        var bobGated = await Mesh.GetEffectivePermissions($"{SpacePath}/Gated", "bob")
+            .Should().Within(90.Seconds()).Match(p => !p.HasFlag(Permission.Read));
+        Output.WriteLine($"bob @ {SpacePath}/Gated → {bobGated} (group deny must still apply)");
+
+        // 3. 🚨 NON-WIDENING. Completing the read must not hand anything to a viewer who was never
+        //    granted anything — a fix in this fold that opens a door is not a fix.
+        var mallory = await Mesh.GetEffectivePermissions($"{SpacePath}/Doc", "mallory")
+            .Should().Within(90.Seconds()).Match(p => p == Permission.None);
+        Output.WriteLine($"mallory @ {SpacePath}/Doc → {mallory} (member of nothing, granted nothing)");
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SecurityFoldEnumerationTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SecurityFoldEnumerationTests.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
+using MeshWeaver.Fixture;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith;
@@ -14,49 +18,121 @@ using Xunit;
 namespace MeshWeaver.Hosting.PostgreSql.Test;
 
 /// <summary>
-/// 🚨 A GROUP-DERIVED PERMISSION MUST NOT VANISH WHEN THE MESH OUTGROWS A PAGE — issue #2011.
+/// 🚨 A PERMISSION MUST NOT BE DECIDED ON A PAGE — issue #2011.
 ///
-/// <para><b>The defect.</b> <c>PermissionEvaluator</c> resolves a viewer's groups from
-/// <c>$security-memberships</c> — <c>nodeType:GroupMembership scope:subtree</c>, path-less by design
-/// because a group and its members may live in a different partition than the grant that names the
-/// group. Path-less ⇒ the cross-schema fan-out serves it, and a fan-out that is handed no limit
-/// answers with a PAGE: the 50 most recently modified rows, ordered <c>last_modified DESC</c>. The
-/// evaluator then folds that page as if it were the complete set.</para>
+/// <para><c>PermissionEvaluator</c> resolves a viewer's groups from <c>$security-memberships</c> —
+/// <c>nodeType:GroupMembership scope:subtree</c>, path-less by design because a group and its
+/// members may live in a different partition than the grant that names the group. A read of that
+/// shape which states no limit can be served as a PAGE, and the caller cannot tell a page from the
+/// whole set. In this fold that difference is a PERMISSION, and it moves in BOTH directions: a
+/// truncated membership list is indistinguishable from "this viewer belongs to no groups", so a
+/// group GRANT stops reaching its member — and so does a group DENY, which is a revocation that
+/// fails OPEN.</para>
 ///
-/// <para><b>Why it is worse than a short list.</b> A truncated membership read is indistinguishable
-/// from "this viewer belongs to no groups", so it moves permissions in BOTH directions:</para>
-/// <list type="bullet">
-///   <item>a group GRANT silently stops reaching its member — every surface gated on it disappears
-///     at once, with nothing logged and nothing failing; and</item>
-///   <item>a group DENY silently stops reaching its member — a revocation FAILS OPEN, which is the
-///     direction that actually leaks. That is the case <c>bob</c> pins below.</item>
-/// </list>
+/// <para><b>What the first test measures, and why it is at the provider seam.</b> The paging
+/// behaviour lives in <c>PostgreSqlCrossSchemaQueryProvider.QueryAcrossSchemasAsync</c>'s
+/// <c>search_across_schemas</c> form, which clips at
+/// <see cref="PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit"/> when the caller states no
+/// limit. The security fold's queries are exactly the shape that form serves, so the guarantee
+/// worth pinning is: fed the fold's OWN query strings, that fan-out returns every match — and it
+/// does so BECAUSE of the stamp, which the unstamped control in the same test proves by getting a
+/// page instead.</para>
 ///
-/// <para><b>Why nobody would ever have changed anything.</b> The trigger is GROWTH. It fires the
-/// first time a mesh's <c>GroupMembership</c> (or <c>Role</c>) set outgrows a page, so it appears on
-/// the LARGEST install first — the one where it is most expensive — and it cannot reproduce on any
-/// install small enough to test on by hand.</para>
-///
-/// <para><b>Why this test is on Postgres.</b> The in-memory <c>StorageAdapterMeshQueryProvider</c>
-/// and the per-schema <c>PostgreSqlMeshQuery</c> both treat "no limit" as UNBOUNDED, so the
-/// identical fold is correct on every adapter a unit test uses (<c>GroupPermissionTests</c> passes
-/// either way). Only the cross-schema fan-out caps it — which is exactly why the defect shipped.
-/// The cheap half of the fix is asserted without a database in
-/// <c>MeshWeaver.Security.Test.SecurityQueryCompletenessTests</c>.</para>
+/// <para>⚠️ <b>An honest scope note.</b> On this tree the runtime fan-out
+/// (<c>PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync</c>) always takes the <em>table</em>
+/// overload, which applies NO default limit — so an end-to-end mesh test that merely seeds more
+/// memberships than a page reproduces nothing today, whether or not the fold is stamped (measured:
+/// 62 seeded, 62 returned, both ways). That is a property of the current routing, not a guarantee:
+/// the paging form is still on <c>ICrossSchemaQueryProvider</c>, still implemented on both
+/// backends, and is one routing change away from serving these reads again. The stamp is what makes
+/// the fold indifferent to which form answers it, and the first test is where that is falsifiable.
+/// The second test is the end-to-end guard that the stamp did not break — or widen — the fold.</para>
 /// </summary>
 [Collection("PostgreSql")]
 public class SecurityFoldEnumerationTests(PostgreSqlFixture fixture, ITestOutputHelper output)
     : MonolithMeshTestBase(output)
 {
+    private readonly PostgreSqlFixture _fixture = fixture;
+    private readonly JsonSerializerOptions _options = new();
+
     /// <summary>
-    /// Memberships written AFTER the two that matter. Comfortably above the cross-schema fan-out's
-    /// 50-row default — at or below it this test reproduces nothing.
+    /// Membership rows per seeded partition. Two partitions ⇒ 66, comfortably above
+    /// <see cref="PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit"/> — at or below it the
+    /// paging test reproduces nothing.
     /// </summary>
-    private const int CrowdSize = 60;
+    private const int RowsPerPartition = 33;
+
+    private const int TotalRows = 2 * RowsPerPartition;
+
+    private static readonly string[] Schemas = ["secfoldalpha", "secfoldbeta"];
+
+    /// <summary>
+    /// The exact string the fold issued before this fix — kept verbatim as the CONTROL, so the
+    /// paging assertion below is a measurement rather than an assumption.
+    /// </summary>
+    private const string UnstampedMembershipQuery =
+        "nodeType:GroupMembership scope:subtree select:path,id,namespace,name,nodeType,content";
+
+    [Fact(Timeout = 120_000)]
+    public async Task TheFoldsOwnMembershipQuery_IsCompleteThroughThePagingFanOut()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        var partitionDef = new PartitionDefinition
+        {
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings()
+        };
+        await SeedMembershipsAsync(Schemas[0], "SecFoldAlpha", partitionDef, ct);
+        await SeedMembershipsAsync(Schemas[1], "SecFoldBeta", partitionDef, ct);
+
+        var cross = new PostgreSqlCrossSchemaQueryProvider(_fixture.DataSource) { SyncTtl = TimeSpan.Zero };
+        await cross.SyncSearchableSchemasAsync(ct);
+
+        var parser = new QueryParser();
+
+        // 1. THE CONTROL — the string the fold used to issue. It states no limit, so the fan-out
+        //    answers with a page, and nothing in the result says so. In the security fold those
+        //    missing rows are memberships, and a missing membership reads as "not a member".
+        var unstamped = parser.Parse(UnstampedMembershipQuery);
+        unstamped.Limit.Should().BeNull("the control must genuinely state no limit");
+        var page = await cross.QueryAcrossSchemasAsync(unstamped, _options, Schemas, ct: ct)
+            .Collect(ct).Should().Within(60.Seconds()).Emit();
+        Output.WriteLine($"unstamped: {page.Count} of {TotalRows} membership rows");
+        page.Count.Should().Be(PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit,
+            "a permission-deciding read that states no limit is served a PAGE — which is exactly "
+            + "why the fold has to declare itself an enumeration rather than trust the absence of "
+            + "a limit");
+
+        // 2. THE FIX — the fold's actual query, taken from the production builder, not retyped.
+        var stamped = parser.Parse(SecurityQueries.Memberships);
+        stamped.Limit.Should().Be(MeshQueryRequest.NoLimit);
+        var complete = await cross.QueryAcrossSchemasAsync(stamped, _options, Schemas, ct: ct)
+            .Collect(ct).Should().Within(60.Seconds()).Emit();
+        Output.WriteLine($"SecurityQueries.Memberships: {complete.Count} of {TotalRows} membership rows");
+        complete.Count.Should().Be(TotalRows,
+            "every GroupMembership must come back — a viewer's group set is not a list that may be "
+            + "shortened, it is the input to a permission decision");
+        complete.Select(n => n.Path).Distinct().Count().Should().Be(TotalRows,
+            "the complete set must be the union of both partitions, not one partition twice");
+
+        // 3. The custom-role read is the same shape and the same hazard (a custom Role that falls
+        //    off the page silently loses its permissions).
+        parser.Parse(SecurityQueries.Roles).Limit.Should().Be(MeshQueryRequest.NoLimit);
+        parser.Parse(SecurityQueries.GatedNodes("Store/Plugin")).Limit.Should().Be(MeshQueryRequest.NoLimit);
+    }
+
+    // ── End-to-end guard: the stamped fold still decides correctly, and still denies ────────────
+
+    private string SpacePath { get; } = "GrpSpace" + Guid.NewGuid().ToString("N")[..8];
+    private string Cohort => $"{SpacePath}/Cohort";
+    private string Blocked => $"{SpacePath}/Blocked";
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
     {
-        var csb = new Npgsql.NpgsqlConnectionStringBuilder(fixture.ConnectionString)
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
         { MaxPoolSize = 16, ConnectionIdleLifetime = 10 };
         return builder
             .UseMonolithMesh()
@@ -66,11 +142,59 @@ public class SecurityFoldEnumerationTests(PostgreSqlFixture fixture, ITestOutput
             .AddSpaceType();
     }
 
-    // Per test instance, never static — the PostgreSql fixture is shared across the collection.
-    private string SpacePath { get; } = "GrpSpace" + Guid.NewGuid().ToString("N")[..8];
-    private string Cohort => $"{SpacePath}/Cohort";
-    private string Blocked => $"{SpacePath}/Blocked";
-    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    /// <summary>
+    /// 🚨 The stamp changes what the fold ASKS FOR, so it has to be proved harmless end to end —
+    /// and this is not a formality. <c>limit:all</c> is <see cref="MeshQueryRequest.NoLimit"/>,
+    /// which is NEGATIVE, and the fold's per-scope <c>_Access</c> walk is partition-pinned: before
+    /// the provider fixes in this change it reached SQL as a literal <c>LIMIT -1</c>
+    /// (<c>PostgresException 2201W</c>) and, on the row-count guards, as <c>count &gt;= -1</c> —
+    /// true on the first row, so a completed read returned exactly ONE. Either one takes the whole
+    /// permission fold down: the observed failure was
+    /// <c>"the Create permission check … could NOT be established"</c> on every write.
+    ///
+    /// <para>The three assertions are grant, deny and NON-WIDENING: a member still receives a group
+    /// grant, a member is still DENIED by a group deny (the direction a lost membership leaks in),
+    /// and a viewer who was granted nothing still sees nothing.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task TheStampedFold_StillGrants_StillDenies_AndWidensNothing()
+    {
+        await MeshService.CreateNode(MeshNode.FromPath(SpacePath) with
+        { Name = SpacePath, NodeType = SpaceNodeType.NodeType, Content = new Space() })
+            .Should().Within(90.Seconds()).Emit();
+        await MeshService.CreateNode(Group("Cohort")).Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(Group("Blocked")).Should().Within(60.Seconds()).Emit();
+
+        // `Cohort` is licensed on the space; `bob` is licensed DIRECTLY (so his Read is a control
+        // that does not depend on any membership) and `Blocked` is DENIED at {Space}/Gated — a
+        // revocation that only lands if bob is still resolved as a member of it.
+        await MeshService.CreateNode(AssignmentNodeFactory.UserRole(Cohort, "Viewer", SpacePath))
+            .Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(AssignmentNodeFactory.UserRole("bob", "Viewer", SpacePath))
+            .Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(
+                AssignmentNodeFactory.UserRole(Blocked, "Viewer", $"{SpacePath}/Gated", denied: true))
+            .Should().Within(60.Seconds()).Emit();
+
+        await MeshService.CreateNode(Membership("alice", Cohort)).Should().Within(60.Seconds()).Emit();
+        await MeshService.CreateNode(Membership("bob", Blocked)).Should().Within(60.Seconds()).Emit();
+
+        var alice = await Mesh.GetEffectivePermissions($"{SpacePath}/Doc", "alice")
+            .Should().Within(90.Seconds()).Match(p => p.HasFlag(Permission.Read));
+        Output.WriteLine($"alice @ {SpacePath}/Doc → {alice} (group grant)");
+
+        var bobOpen = await Mesh.GetEffectivePermissions($"{SpacePath}/Doc", "bob")
+            .Should().Within(90.Seconds()).Match(p => p.HasFlag(Permission.Read));
+        Output.WriteLine($"bob @ {SpacePath}/Doc → {bobOpen} (direct grant — the control)");
+
+        var bobGated = await Mesh.GetEffectivePermissions($"{SpacePath}/Gated", "bob")
+            .Should().Within(90.Seconds()).Match(p => !p.HasFlag(Permission.Read));
+        Output.WriteLine($"bob @ {SpacePath}/Gated → {bobGated} (group deny still applies)");
+
+        var mallory = await Mesh.GetEffectivePermissions($"{SpacePath}/Doc", "mallory")
+            .Should().Within(90.Seconds()).Match(p => p == Permission.None);
+        Output.WriteLine($"mallory @ {SpacePath}/Doc → {mallory} (granted nothing, sees nothing)");
+    }
 
     private MeshNode Membership(string member, string groupPath)
     {
@@ -97,58 +221,20 @@ public class SecurityFoldEnumerationTests(PostgreSqlFixture fixture, ITestOutput
         Content = new AccessObject { Description = id },
     };
 
-    [Fact(Timeout = 300_000)]
-    public async Task GroupGrantsAndDenies_SurviveAMeshWithMoreMembershipsThanOnePage()
+    private async Task SeedMembershipsAsync(
+        string schema, string ns, PartitionDefinition partitionDef, CancellationToken ct)
     {
-        await MeshService.CreateNode(MeshNode.FromPath(SpacePath) with
-        { Name = SpacePath, NodeType = SpaceNodeType.NodeType, Content = new Space() })
-            .Should().Within(90.Seconds()).Emit();
-        await MeshService.CreateNode(Group("Cohort")).Should().Within(60.Seconds()).Emit();
-        await MeshService.CreateNode(Group("Blocked")).Should().Within(60.Seconds()).Emit();
+        var (_, adapter) = await _fixture.CreateSchemaAdapterAsync(
+            schema, partitionDef with { Namespace = ns, Schema = schema });
 
-        // The grants. `Cohort` is licensed on the space; `bob` is licensed DIRECTLY (so his Read at
-        // {SpacePath}/Doc is a control that does not depend on any membership) and `Blocked` is DENIED
-        // at {SpacePath}/Gated — a revocation that only lands if bob is still resolved as its member.
-        await MeshService.CreateNode(AssignmentNodeFactory.UserRole(Cohort, "Viewer", SpacePath))
-            .Should().Within(60.Seconds()).Emit();
-        await MeshService.CreateNode(AssignmentNodeFactory.UserRole("bob", "Viewer", SpacePath))
-            .Should().Within(60.Seconds()).Emit();
-        await MeshService.CreateNode(AssignmentNodeFactory.UserRole(Blocked, "Viewer", $"{SpacePath}/Gated", denied: true))
-            .Should().Within(60.Seconds()).Emit();
-
-        // The two memberships that matter — written FIRST, so every crowd write below stamps a
-        // newer last_modified and pushes these two off the fan-out's most-recent page.
-        await MeshService.CreateNode(Membership("alice", Cohort)).Should().Within(60.Seconds()).Emit();
-        await MeshService.CreateNode(Membership("bob", Blocked)).Should().Within(60.Seconds()).Emit();
-
-        for (var i = 0; i < CrowdSize; i++)
-            await MeshService.CreateNode(Membership($"crowd{i:D2}", Cohort))
-                .Should().Within(60.Seconds()).Emit();
-
-        Output.WriteLine(
-            $"seeded {CrowdSize + 2} GroupMembership nodes; the fan-out's default page is "
-            + $"{PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit}");
-
-        // 1. The group GRANT still reaches its member. Before the fix alice's membership had fallen
-        //    off the page, so the fold saw her in no groups and the Cohort grant matched nobody.
-        var alice = await Mesh.GetEffectivePermissions($"{SpacePath}/Doc", "alice")
-            .Should().Within(90.Seconds()).Match(p => p.HasFlag(Permission.Read));
-        Output.WriteLine($"alice @ {SpacePath}/Doc → {alice}");
-
-        // 2. The group DENY still reaches its member — the direction that LEAKS. bob keeps his own
-        //    direct grant (the control), and the Blocked deny must still take {SpacePath}/Gated away.
-        var bobOpen = await Mesh.GetEffectivePermissions($"{SpacePath}/Doc", "bob")
-            .Should().Within(90.Seconds()).Match(p => p.HasFlag(Permission.Read));
-        Output.WriteLine($"bob @ {SpacePath}/Doc → {bobOpen} (direct grant — the control)");
-
-        var bobGated = await Mesh.GetEffectivePermissions($"{SpacePath}/Gated", "bob")
-            .Should().Within(90.Seconds()).Match(p => !p.HasFlag(Permission.Read));
-        Output.WriteLine($"bob @ {SpacePath}/Gated → {bobGated} (group deny must still apply)");
-
-        // 3. 🚨 NON-WIDENING. Completing the read must not hand anything to a viewer who was never
-        //    granted anything — a fix in this fold that opens a door is not a fix.
-        var mallory = await Mesh.GetEffectivePermissions($"{SpacePath}/Doc", "mallory")
-            .Should().Within(90.Seconds()).Match(p => p == Permission.None);
-        Output.WriteLine($"mallory @ {SpacePath}/Doc → {mallory} (member of nothing, granted nothing)");
+        for (var i = 0; i < RowsPerPartition; i++)
+            await adapter.WriteAsync(
+                new MeshNode($"member{i:D2}_Membership", ns)
+                {
+                    Name = $"member{i:D2} membership",
+                    NodeType = "GroupMembership",
+                    State = MeshNodeState.Active
+                },
+                _options, ct);
     }
 }

--- a/test/MeshWeaver.Security.Test/SecurityQueryCompletenessTests.cs
+++ b/test/MeshWeaver.Security.Test/SecurityQueryCompletenessTests.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// 🚨 A PERMISSION MUST NEVER BE DECIDED ON A PAGE — issue #2011.
+///
+/// <para>The security fold's global reads (<c>$security-roles</c>, <c>$security-memberships</c>,
+/// the per-gated-type queries) carry no <c>path:</c> and no <c>namespace:</c>, because the subject
+/// and the grant that names it may live in different partitions. On Postgres that is the shape
+/// <c>PostgreSqlCrossSchemaQueryProvider</c> answers with a 50-row PAGE when the caller states no
+/// limit — and here the caller CANNOT state one, because
+/// <c>IMeshNodeStreamCache.GetQuery</c> takes query STRINGS and builds its own
+/// <see cref="MeshQueryRequest"/>, so <see cref="MeshQueryRequest.Complete"/> is out of reach.</para>
+///
+/// <para>These assertions are the cheap half of the fix and they name what the behavioural test
+/// (<c>SecurityFoldEnumerationTests</c>, on Postgres) protects: every security query declares itself
+/// an ENUMERATION, and it does so through a builder that cannot produce a truncatable string.</para>
+/// </summary>
+public class SecurityQueryCompletenessTests
+{
+    private static readonly QueryParser Parser = new();
+
+    /// <summary>The query-string spelling of <c>Complete()</c>, since the fold can only pass strings.</summary>
+    [Fact]
+    public void LimitAll_ParsesToNoLimit()
+    {
+        Parser.Parse($"nodeType:Role scope:subtree {MeshQueryRequest.CompleteQualifier}").Limit
+            .Should().Be(MeshQueryRequest.NoLimit,
+                "limit:all is the query-string form of MeshQueryRequest.Complete() — without the "
+                + "parser mapping it, the qualifier would be silently ignored and the query would "
+                + "still be served as a page");
+        MeshQueryRequest.CompleteQualifier.Should().Be("limit:all");
+    }
+
+    /// <summary>
+    /// The CONTROL for the behavioural test: this is the string the fold used to issue, and it is
+    /// exactly the shape that gets a page. If this ever starts parsing to a limit on its own, the
+    /// regression test below has stopped proving anything.
+    /// </summary>
+    [Fact]
+    public void TheOldUnpinnedShape_StatesNoLimitAtAll()
+        => Parser.Parse("nodeType:GroupMembership scope:subtree select:path,id,namespace,name,nodeType,content")
+            .Limit.Should().BeNull(
+                "an unpinned query that states no limit is served the cross-schema fan-out's "
+                + "default page, and a truncated membership list is indistinguishable from 'this "
+                + "viewer is in no groups'");
+
+    [Fact]
+    public void EverySecurityQueryShape_IsAnEnumeration()
+    {
+        foreach (var shape in SecurityQueries.AllShapes)
+            Parser.Parse(shape).Limit.Should().Be(MeshQueryRequest.NoLimit,
+                $"'{shape}' decides a permission — a missing row here does not shorten a list, it "
+                + "removes an access right (or, for a group-scoped deny, fails to remove one)");
+    }
+
+    [Fact]
+    public void GlobalQueries_KeepTheirShape()
+    {
+        SecurityQueries.Roles.Should().Be(
+            "nodeType:Role scope:subtree select:path,id,namespace,name,nodeType,content limit:all");
+        SecurityQueries.Memberships.Should().Be(
+            "nodeType:GroupMembership scope:subtree select:path,id,namespace,name,nodeType,content limit:all");
+        SecurityQueries.GatedNodes("Store/Plugin").Should().Be(
+            "nodeType:Store/Plugin scope:subtree select:path,id,namespace,name,nodeType limit:all");
+    }
+
+    /// <summary>
+    /// <see cref="SecurityQueries.Enumeration"/> is the seam the whole fold funnels through, so it
+    /// has to be total: idempotent, and it must OVERWRITE a stated limit rather than honour it —
+    /// in this fold a page IS the bug, whoever asked for it.
+    /// </summary>
+    [Theory]
+    [InlineData("nodeType:Role scope:subtree", "nodeType:Role scope:subtree limit:all")]
+    [InlineData("nodeType:Role scope:subtree limit:all", "nodeType:Role scope:subtree limit:all")]
+    [InlineData("nodeType:Role scope:subtree limit:10", "nodeType:Role scope:subtree limit:all")]
+    [InlineData("limit:5 nodeType:Role", "limit:all nodeType:Role")]
+    [InlineData("  nodeType:Role  ", "nodeType:Role limit:all")]
+    public void Enumeration_StampsCompleteness(string input, string expected)
+        => SecurityQueries.Enumeration(input).Should().Be(expected);
+
+    /// <summary>A filter that merely CONTAINS "limit:" is not the qualifier and must survive.</summary>
+    [Fact]
+    public void Enumeration_LeavesNonQualifierTokensAlone()
+        => SecurityQueries.Enumeration("nodeType:Role content.limit:3")
+            .Should().Be("nodeType:Role content.limit:3 limit:all");
+
+    /// <summary>
+    /// Anchored scope walks go through the same stamp. The ROOT scope's anchor (<c>_Access</c>, and
+    /// the empty namespace for <c>_Policy</c>) resolves to NO partition, so it falls through to the
+    /// very same cross-schema fan-out as the global reads — which is why "it is anchored" is not a
+    /// reason to leave one unstamped.
+    /// </summary>
+    [Fact]
+    public void ScopedQueries_AreStampedToo()
+    {
+        var rootAccess = SecurityQueries.Scoped(
+            $"namespace:_Access nodeType:AccessAssignment {SecurityQueries.ContentProjection}");
+        Parser.Parse(rootAccess).Limit.Should().Be(MeshQueryRequest.NoLimit);
+        SecurityQueries.AllShapes.Should().Contain(rootAccess);
+    }
+
+    [Fact]
+    public void Enumeration_RejectsAnEmptyQuery()
+    {
+        Assert.Throws<System.ArgumentException>(() => SecurityQueries.Enumeration("   "));
+    }
+}


### PR DESCRIPTION
Closes #2011.

## Verdict: still real — but not for the reason the issue gives, and the fix it asks for was itself broken

Two separate findings, both pinned by executed tests.

### 1. The fold declares no completeness — fixed, and made structural

`PermissionEvaluator`'s global reads (`$security-roles`, `$security-memberships`, the per-gated-type
queries) are path-less by necessity: a group and its members may live in a different partition than
the grant that names the group. A read of that shape which states no limit can be served as a PAGE,
and the caller cannot tell a page from the whole set.

In this fold the difference is a PERMISSION, and it moves in **both** directions:

- a group GRANT stops reaching its member — every surface gated on it disappears at once; and
- a group DENY stops reaching its member — **a revocation that fails OPEN**. That direction is not
  in the issue and is the one that leaks.

These reads go through `IMeshNodeStreamCache.GetQuery`, which takes query **strings** and builds its
own `MeshQueryRequest` — so `MeshQueryRequest.Complete()` is out of reach at every call site. This
adds its query-string spelling, `MeshQueryRequest.CompleteQualifier` = `limit:all`, and routes every
query the fold issues through `SecurityQueries.Enumeration`, which stamps it. A security query
therefore cannot come out truncatable whatever string its author wrote — including one that arrives
already carrying a limit, which is overwritten rather than honoured, because in this fold a page IS
the bug.

Anchored scope walks are stamped too: the ROOT scope's anchor (`_Access`, and the empty namespace
for `_Policy`) resolves to no partition and falls through to the same fan-out, so "it is anchored"
is not a reason to leave one unstamped.

### 2. 🚨 `Complete()` was broken on any partition-pinned read — so the issue's own remedy would have taken the fold down

`MeshQueryRequest.NoLimit` is documented as *"the storage providers translate it to an unbounded SQL
fetch rather than a literal `LIMIT -1`"*. That was **not true**:

- `PostgreSqlStorageAdapter`'s union branch emitted it verbatim → `PostgresException 2201W: LIMIT
  must not be negative`, which surfaces as an **availability failure of whatever read it was
  under**; and
- the row-count guards compared against it raw → `count >= -1` is true on the first row, so a
  completed read returned exactly **one** row, silently.

This is not hypothetical fallout of the stamp: any caller anywhere following `Complete()`'s advice on
a query that resolves to a single partition hit it. It is why the first run of the new end-to-end
test failed with `"the Create permission check … could NOT be established"` on every write.
Normalized across Postgres, Snowflake, Cosmos and the SQLite vector query (a vector search keeps its
documented default `k`, since "no cap" is not an expressible ANN parameter).

## ⚠️ Scope note the issue should be corrected with

The 50-row page the issue describes **cannot currently reach the security fold**. On this tree the
runtime fan-out (`PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync`) always takes the *table*
overload of `QueryAcrossSchemasAsync`, which applies **no default limit**; the paging form
(`search_across_schemas`, `DefaultFanOutLimit`) has **no `src/` caller at all** — only tests.

Measured, not assumed: seeding 62 `GroupMembership` nodes and reading them end to end returns 62,
stamped or not. The same control run against **#1960's** fix is the sharper result — removing
`.Complete()` from `UserIdentityCache.DirectoryQuery` leaves
`UserDirectoryCompletenessTests.AUserOutsideTheMostRecentlyModifiedPage_StillResolvesTheirProfile`
**passing**, so that test's behavioural half no longer demonstrates what its comment claims. Worth a
follow-up issue of its own; I have not touched it here.

That does not make the stamp pointless — it makes it the thing that keeps the fold indifferent to
which form answers it. The paging form is still on `ICrossSchemaQueryProvider`, still implemented on
both backends, and one routing change away from serving these reads again. So the guarantee is
pinned **at the seam where the page is actually produced**, where it is falsifiable, rather than by
an end-to-end test that would reproduce nothing.

## Tests — executed, and proven non-vacuous against the pre-fix code

`MeshWeaver.Security.Test/SecurityQueryCompletenessTests` (12 cases, no database) and
`MeshWeaver.Hosting.PostgreSql.Test/SecurityFoldEnumerationTests` (2 cases).

**Result with the fix:**

```
Passed!  - Failed: 0, Passed: 390, Total: 390 — MeshWeaver.Security.Test.dll
Passed!  - Failed: 0, Passed: 740, Skipped: 1, Total: 741 — MeshWeaver.Hosting.PostgreSql.Test.dll

  unstamped: 50 of 66 membership rows
  SecurityQueries.Memberships: 66 of 66 membership rows
  alice @ GrpSpace12f18c70/Doc   → Read, Execute, Api (group grant)
  bob   @ GrpSpace12f18c70/Doc   → Read, Execute, Api (direct grant — the control)
  bob   @ GrpSpace12f18c70/Gated → None (group deny still applies)
  mallory @ GrpSpace12f18c70/Doc → None (granted nothing, sees nothing)
```

The paging test carries its own control in the same run — the unstamped string the fold used to
issue gets **50 of 66**, the production builder's string gets **66 of 66**. So it is a measurement,
not an assumption.

**Control A — `SecurityQueries.Enumeration` neutered to return its input:**

```
Failed!  - Failed: 8, Passed: 4, Total: 12 — SecurityQueryCompletenessTests
  Failed …SecurityFoldEnumerationTests.TheFoldsOwnMembershipQuery_IsCompleteThroughThePagingFanOut
    AssertionException : Expected value to be -1, but found <null>.
```

**Control B — the provider `NoLimit` fixes reverted, stamp kept:**

```
  Failed …SecurityFoldEnumerationTests.TheStampedFold_StillGrants_StillDenies_AndWidensNothing
    errored: The Create permission check for node 'GrpSpace075914c0/Cohort' could not be
    established … (PostgresException: 2201W: LIMIT must not be negative)
```

## Never widens access

`mallory` — a viewer who was granted nothing and is a member of nothing — is asserted to see
`Permission.None` in the same test, and the group DENY assertion (`bob` keeps a direct grant, so his
`Read` is a control that does not depend on any membership) covers the leaking direction. Every
provider change is `HasValue` → `is > 0`, which can only return **more rows to the query engine** —
never more rows to a viewer, since row-level security is applied independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
