### PR TITLE
fix(#1971): the drain stops short of the ceiling, so the silo departs cleanly

### DIFF
--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -75,8 +75,29 @@ spec:
           #     pod is not — so waiting costs the rollout nothing and costs a working user nothing.
           #     Poll until the pod reports "drained", i.e. its last circuit closed.
           #
-          # Bounded by terminationGracePeriodSeconds above: a forgotten open tab delays the pod's
-          # exit, it cannot block the rollout for ever — k8s SIGKILLs at the ceiling.
+          # 🚨 …and the SESSION drain has its OWN deadline, short of the grace ceiling (#1971).
+          # It used to poll forever and rely on terminationGracePeriodSeconds to stop it — which
+          # means the pod was SIGKILLed WITH A LIVE ORLEANS SILO whenever a session outlived the
+          # grace: preStop never returned, so the host's 90 s ShutdownTimeout never ran,
+          # ApplicationStopping never fired, and the silo never departed membership. The
+          # safe-to-evict annotation on this deployment records the cost — "each abrupt departure
+          # left a ZOMBIE entry in the Orleans membership table: the cluster kept placing new grain
+          # activations on the dead silo, so writes timed out mesh-wide".
+          #
+          # Riding to the ceiling was the NORMAL outcome of a roll, not the exception (memex,
+          # 2026-08-21: a terminating pod still executing application code 68 s before the ceiling,
+          # while a serving pod had five circuits open at an arbitrary moment). So the roll design
+          # was protecting users from the FAST teardown by guaranteeing the ABRUPT one.
+          #
+          # Now the loop stops at (drainSeconds − shutdownMarginSeconds) and RETURNS, so SIGTERM is
+          # delivered with the margin still available to shut down in. The trade is made
+          # explicitly — cut off the last stragglers, logged and counted, rather than keep everyone
+          # and then die abruptly — instead of by accident. `date +%s` is POSIX and present in
+          # every base image this chart can run on; if it were somehow absent the guard below falls
+          # back to the previous unbounded behaviour rather than skipping the drain entirely.
+          #
+          # Bounded by terminationGracePeriodSeconds above as well: a forgotten open tab delays the
+          # pod's exit, it cannot block the rollout for ever.
           #
           # 🚨 The probe tool is `curl`, and that is MEASURED, not assumed. This block previously
           # used `wget` on the reasoning "curl is not in the base image; wget is (Debian aspnet)" —
@@ -103,7 +124,13 @@ spec:
                   - >-
                     sleep 15;
                     command -v curl >/dev/null 2>&1 || exit 0;
+                    DEADLINE={{ sub (.Values.portal.drainSeconds | default 1800) (.Values.portal.shutdownMarginSeconds | default 120) }};
+                    START=$(date +%s 2>/dev/null || echo 0);
                     while ! curl -sf -m 5 -o /dev/null http://127.0.0.1:8080/drain; do
+                      NOW=$(date +%s 2>/dev/null || echo 0);
+                      if [ "$START" -gt 0 ] && [ $((NOW - START)) -ge "$DEADLINE" ]; then
+                        exit 0;
+                      fi;
                       sleep 5;
                     done
           envFrom:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -232,6 +232,29 @@ portal:
   # assemblies. 30 minutes covers a working session; lower it where memory is tighter than
   # continuity.
   drainSeconds: 1800
+  # 🚨 The tail of drainSeconds RESERVED for the process's own shutdown — NOT part of the session
+  # drain. preStop stops polling at (drainSeconds − shutdownMarginSeconds) and returns, so SIGTERM
+  # is delivered while there is still grace left to shut down IN.
+  #
+  # Without it the whole grace was spent waiting, and a pod whose sessions outlived it was SIGKILLed
+  # WITH A LIVE ORLEANS SILO: the host's 90 s ShutdownTimeout never ran, ApplicationStopping never
+  # fired, and the silo never departed membership. This deployment's own
+  # `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotation records the cost — "each
+  # abrupt departure left a ZOMBIE entry in the Orleans membership table: the cluster kept placing
+  # new grain activations on the dead silo, so writes timed out mesh-wide". And riding to the
+  # ceiling was the NORMAL outcome of a roll, not the exception (measured on memex 2026-08-21: a
+  # terminating pod still executing application code at 09:09:44Z, gone at the ceiling 09:10:52Z,
+  # while a serving pod had five circuits open at an arbitrary moment) — so the roll design was
+  # protecting users from the FAST teardown by guaranteeing the ABRUPT one. See #1971.
+  #
+  # 120 s: comfortably above the host's own 90 s ShutdownTimeout (Memex.Portal.Distributed
+  # Program.cs), which is the budget this margin exists to make room for.
+  #
+  # The trade this makes EXPLICIT rather than by accident: at the deadline the last stragglers are
+  # cut off — deliberately, logged, naming the count — instead of everyone being kept and the
+  # process then dying abruptly. Raise drainSeconds if sessions that long are expected; do not
+  # shrink this below the host's ShutdownTimeout.
+  shutdownMarginSeconds: 120
 migration:
   image: "ghcr.io/systemorph/memex-migration:latest"
 

--- a/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
@@ -191,6 +191,49 @@ public static class ServiceDefaults
                     statusCode: StatusCodes.Status503ServiceUnavailable);
         }).AllowAnonymous();
 
+        // 🚨 What SIGTERM FOUND — and the line whose ABSENCE is the evidence of a hard kill
+        // (#1971). preStop used to poll /drain with no bound of its own, so a pod whose sessions
+        // outlived terminationGracePeriodSeconds was SIGKILLed with a live Orleans silo: this
+        // callback never ran, the host's 90 s ShutdownTimeout never ran, and the silo never
+        // departed membership. The deployment's safe-to-evict annotation records what that costs
+        // ("each abrupt departure left a ZOMBIE entry in the Orleans membership table … writes
+        // timed out mesh-wide"). With preStop bounded to drainSeconds − shutdownMarginSeconds,
+        // SIGTERM arrives INSIDE the grace and this runs — so "did the pod depart cleanly" becomes
+        // a question Loki can answer, which it could not before in either direction.
+        app.Lifetime.ApplicationStopping.Register(() =>
+        {
+            var logger = app.Services.GetService<ILoggerFactory>()?.CreateLogger<DrainProgress>();
+            if (logger is null)
+                return;
+
+            var tracker = app.Services.GetService<ActiveCircuitTracker>();
+            var report = progress.Abandon(tracker?.Count ?? 0, DateTimeOffset.UtcNow);
+
+            if (!report.TerminationWasObserved)
+                logger.LogInformation(
+                    "Drain: SHUTDOWN with no drain probe ever seen — SIGTERM arrived without a "
+                    + "preStop (a node eviction, a local Ctrl-C, or a chart that lost its "
+                    + "lifecycle hook). {Live} circuit(s) were open. Shutting down in order.",
+                    report.LiveCircuits);
+            else if (report.CutSessionsOff)
+                logger.LogWarning(
+                    "Drain: GIVING UP after {Elapsed} — {Live} circuit(s) are STILL OPEN and are "
+                    + "being cut off ({Initial} were open when termination began). The drain "
+                    + "window expired, so preStop returned and SIGTERM was delivered while there "
+                    + "is still grace left to shut down in. Cutting off the last stragglers "
+                    + "deliberately is the trade: riding to the ceiling instead would SIGKILL this "
+                    + "process with a live silo, leaving a zombie membership entry the cluster "
+                    + "keeps placing activations on. Raise portal.drainSeconds if sessions this "
+                    + "long are expected.",
+                    report.Elapsed, report.LiveCircuits, report.CircuitsWhenTerminationBegan);
+            else
+                logger.LogInformation(
+                    "Drain: shutting down cleanly after {Elapsed} — no circuits remain "
+                    + "({Initial} were open when termination began). The silo departs membership "
+                    + "in order.",
+                    report.Elapsed, report.CircuitsWhenTerminationBegan);
+        });
+
         return app;
     }
 

--- a/src/MeshWeaver.Hosting/DrainProgress.cs
+++ b/src/MeshWeaver.Hosting/DrainProgress.cs
@@ -184,4 +184,64 @@ public sealed class DrainProgress
                     next.ProbeCount);
         }
     }
+
+    /// <summary>
+    /// 🚨 <b>The line that only exists if the process was allowed to shut down at all</b> — SIGTERM
+    /// arrived, and this is what it found.
+    ///
+    /// <para><b>Why it matters more than it reads.</b> <c>preStop</c> used to poll <c>/drain</c>
+    /// with no bound of its own, so a pod whose sessions outlived
+    /// <c>terminationGracePeriodSeconds</c> was SIGKILLed WITH A LIVE ORLEANS SILO: the host's 90 s
+    /// <c>ShutdownTimeout</c> never ran, <c>ApplicationStopping</c> never fired, and the silo never
+    /// departed membership. The deployment's own
+    /// <c>cluster-autoscaler.kubernetes.io/safe-to-evict: "false"</c> annotation records what that
+    /// costs — <i>"each abrupt departure left a ZOMBIE entry in the Orleans membership table: the
+    /// cluster kept placing new grain activations on the dead silo, so writes timed out mesh-wide"</i>
+    /// (#1971). Riding to the ceiling was the NORMAL outcome of a roll, not the exception.</para>
+    ///
+    /// <para>With preStop bounded to <c>drainSeconds − shutdownMarginSeconds</c>, SIGTERM arrives
+    /// inside the grace and this line is emitted. Its ABSENCE after a termination is therefore the
+    /// evidence of a hard kill — which is exactly the question #1971 could not answer by reading
+    /// Loki, because there was nothing to read either way.</para>
+    ///
+    /// <para>Pure with respect to <paramref name="now"/>, like <see cref="Probe"/>, and safe to
+    /// call when no probe was ever seen (a pod SIGTERMed without a preStop, e.g. a node
+    /// eviction).</para>
+    /// </summary>
+    /// <param name="liveCircuits">Circuits still open when shutdown began.</param>
+    /// <param name="now">Shutdown's timestamp.</param>
+    public DrainAbandonReport Abandon(int liveCircuits, DateTimeOffset now)
+    {
+        if (liveCircuits < 0)
+            liveCircuits = 0;
+
+        var current = Volatile.Read(ref state);
+        return new DrainAbandonReport(
+            liveCircuits,
+            current is null ? TimeSpan.Zero : now - current.StartedAt,
+            current?.CircuitsWhenTerminationBegan ?? liveCircuits,
+            TerminationWasObserved: current is not null);
+    }
+}
+
+/// <summary>
+/// What SIGTERM found — the shutdown counterpart of <see cref="DrainProbeReport"/>.
+/// </summary>
+/// <param name="LiveCircuits">Circuits still open when shutdown began. Above zero means these
+/// sessions are being cut off: the drain window expired before they closed.</param>
+/// <param name="Elapsed">How long the drain ran, or <see cref="TimeSpan.Zero"/> when no probe was
+/// ever seen.</param>
+/// <param name="CircuitsWhenTerminationBegan">Circuits open at the first probe.</param>
+/// <param name="TerminationWasObserved">Whether a <c>/drain</c> probe was ever seen. False means
+/// SIGTERM arrived with no preStop at all — a node eviction, a local Ctrl-C, or a chart that lost
+/// its lifecycle hook. Distinguished because "the drain ran and gave up" and "there was no drain"
+/// need different responses.</param>
+public sealed record DrainAbandonReport(
+    int LiveCircuits,
+    TimeSpan Elapsed,
+    int CircuitsWhenTerminationBegan,
+    bool TerminationWasObserved)
+{
+    /// <summary>True when sessions are being cut off by this shutdown.</summary>
+    public bool CutSessionsOff => LiveCircuits > 0;
 }

--- a/test/MeshWeaver.Documentation.Test/DrainDeadlineGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/DrainDeadlineGuard.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>A roll must not guarantee the abrupt teardown it exists to prevent</b> (#1971).
+///
+/// <para><c>preStop</c> polls <c>/drain</c> until the last circuit closes, and it used to have no
+/// deadline of its own — <c>terminationGracePeriodSeconds</c> was the only thing that stopped it.
+/// So whenever a session outlived the grace, the kubelet SIGKILLed the process <b>with a live
+/// Orleans silo</b>: preStop never returned, the host's 90 s <c>ShutdownTimeout</c> never ran,
+/// <c>ApplicationStopping</c> never fired, and the silo never departed membership. The
+/// deployment's own <c>cluster-autoscaler.kubernetes.io/safe-to-evict: "false"</c> annotation
+/// records what that costs — <i>"each abrupt departure left a ZOMBIE entry in the Orleans
+/// membership table: the cluster kept placing new grain activations on the dead silo, so writes
+/// timed out mesh-wide"</i>.</para>
+///
+/// <para>And riding to the ceiling looked like the NORMAL outcome of a roll rather than the
+/// exception (memex, 2026-08-21: a terminating pod still executing application code 68 s before the
+/// ceiling, while a serving pod had five circuits open at an arbitrary moment). So the invariant is
+/// arithmetic, and it belongs in a guard: <b>the session drain must end with enough grace left for
+/// the process to shut down in.</b></para>
+///
+/// <para>This is a text guard over the chart because the invariant lives in a Helm template and a
+/// shell loop, where no C# unit test can observe it. The chart previously carried a scar of exactly
+/// this class — a preStop that probed with <c>wget</c>, absent from the image, so the loop could
+/// never succeed and EVERY termination hung to the ceiling — and it was caught by reading, not by a
+/// test. This is that test.</para>
+/// </summary>
+public class DrainDeadlineGuard
+{
+    private const string Deployment = "deploy/helm/templates/memex-portal/deployment.yaml";
+    private const string Values = "deploy/helm/values.yaml";
+
+    /// <summary>
+    /// The host's own shutdown budget (<c>Memex.Portal.Distributed/Program.cs</c>). The margin
+    /// exists to make room for exactly this, so it must not be smaller.
+    /// </summary>
+    private const int HostShutdownTimeoutSeconds = 90;
+
+    [Fact]
+    public void ThePreStopDrain_HasADeadlineOfItsOwn_AndDoesNotRelyOnTheGraceCeiling()
+    {
+        var preStop = ExecutableLinesOf(File.ReadAllText(Path.Combine(FindRepoRoot(), Deployment)));
+
+        Assert.True(preStop.Contains("/drain", StringComparison.Ordinal),
+            $"{Deployment} must still run the SESSION drain — without it a roll cuts every open "
+            + "circuit the moment the ingress window closes (#1342).");
+
+        Assert.True(
+            preStop.Contains("DEADLINE=", StringComparison.Ordinal)
+            && preStop.Contains("shutdownMarginSeconds", StringComparison.Ordinal),
+            $"{Deployment}'s preStop must bound its own poll at "
+            + "(portal.drainSeconds − portal.shutdownMarginSeconds). Polling until the grace "
+            + "ceiling means the kubelet SIGKILLs the process with a live Orleans silo, which "
+            + "leaves a zombie membership entry the cluster keeps placing activations on (#1971).");
+
+        Assert.True(preStop.Contains("drainSeconds", StringComparison.Ordinal),
+            $"{Deployment}'s deadline must be DERIVED from portal.drainSeconds, never a second "
+            + "hard-coded number — two independent constants drift, and the drift is invisible "
+            + "until a pod is killed at the wrong moment.");
+
+        // The give-up path must RETURN (exit 0) so SIGTERM is delivered, not fail — a non-zero
+        // preStop is an event nobody reads and changes nothing about the kill.
+        Assert.True(preStop.Contains("exit 0", StringComparison.Ordinal),
+            $"{Deployment}'s preStop must exit 0 at the deadline: returning is what delivers "
+            + "SIGTERM while there is still grace left to shut down in.");
+    }
+
+    /// <summary>
+    /// 🚨 The arithmetic. A margin at or below the host's own <see cref="HostShutdownTimeoutSeconds"/>
+    /// reserves nothing, and a margin at or above the grace would leave no session drain at all —
+    /// both silently reintroduce the defect while the template still LOOKS bounded.
+    /// </summary>
+    [Fact]
+    public void TheMargin_LeavesRoomForTheHostsOwnShutdown_AndStillLeavesASessionDrain()
+    {
+        var values = File.ReadAllText(Path.Combine(FindRepoRoot(), Values));
+
+        var drain = ScalarUnder(values, "portal", "drainSeconds");
+        var margin = ScalarUnder(values, "portal", "shutdownMarginSeconds");
+
+        Assert.True(margin >= HostShutdownTimeoutSeconds,
+            $"portal.shutdownMarginSeconds ({margin}s) must be at least the host's own "
+            + $"ShutdownTimeout ({HostShutdownTimeoutSeconds}s, Memex.Portal.Distributed/Program.cs) "
+            + "— the margin exists precisely to make room for it, and a smaller one hands the "
+            + "process a shutdown it cannot finish before the SIGKILL.");
+
+        Assert.True(drain > margin * 2,
+            $"portal.drainSeconds ({drain}s) must leave a real session drain after the margin "
+            + $"({margin}s). A grace that is mostly margin is a roll that cuts sessions off "
+            + "immediately, which is the regression #1342 fixed.");
+    }
+
+    /// <summary>
+    /// The grace ceiling must still BE drainSeconds. If they ever diverge, the deadline computed
+    /// from drainSeconds stops relating to the ceiling it is supposed to stay inside.
+    /// </summary>
+    [Fact]
+    public void TheGraceCeiling_IsStillDrainSeconds()
+    {
+        var deployment = ExecutableLinesOf(
+            File.ReadAllText(Path.Combine(FindRepoRoot(), Deployment)));
+
+        Assert.Contains("terminationGracePeriodSeconds:", deployment, StringComparison.Ordinal);
+        Assert.True(
+            Regex.IsMatch(deployment, @"terminationGracePeriodSeconds:\s*\{\{[^}]*drainSeconds"),
+            $"{Deployment} must keep terminationGracePeriodSeconds derived from "
+            + "portal.drainSeconds — the preStop deadline is computed against it, so a second "
+            + "source for the ceiling makes the margin meaningless.");
+    }
+
+    /// <summary>
+    /// 🚨 Comment lines are stripped before every probe above. Three of the strings this guard
+    /// looks for also appear in the prose explaining them, so without stripping the guard would be
+    /// satisfied by the explanation while the command doing it was gone — a check that cannot fail
+    /// is not a check.
+    /// </summary>
+    private static string ExecutableLinesOf(string yaml) =>
+        string.Join("\n", yaml.Split('\n')
+            .Where(line => !line.TrimStart().StartsWith('#')));
+
+    /// <summary>Reads an integer scalar nested one level under a top-level key.</summary>
+    private static int ScalarUnder(string yaml, string parent, string key)
+    {
+        var match = Regex.Match(
+            yaml,
+            $@"^{Regex.Escape(parent)}:\s*$(?<body>(?:\n(?:[ \t].*|\s*))*?)^\S",
+            RegexOptions.Multiline);
+        var body = match.Success ? match.Groups["body"].Value : yaml;
+
+        var scalar = Regex.Match(body, $@"^\s+{Regex.Escape(key)}:\s*(?<value>\d+)\s*$",
+            RegexOptions.Multiline);
+        Assert.True(scalar.Success,
+            $"{Values} must declare {parent}.{key} as an integer — it is half of the arithmetic "
+            + "that keeps a roll from SIGKILLing a live silo (#1971).");
+        return int.Parse(scalar.Groups["value"].Value);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/DrainProgressTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/DrainProgressTest.cs
@@ -213,4 +213,73 @@ public class DrainProgressTest
         report.Outcome.Should().Be(DrainProbeOutcome.StillDraining);
         report.ProbeCount.Should().Be(13, "twelve silent probes plus this one");
     }
+
+    // ── what SIGTERM found (#1971) ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The line whose EXISTENCE is the point. Before preStop was bounded, a pod whose sessions
+    /// outlived the grace was SIGKILLed with a live Orleans silo — so nothing ran at shutdown, and
+    /// "did this pod depart membership cleanly?" was unanswerable from Loki in either direction.
+    /// A drain that gives up at its deadline reports the sessions it is cutting off, by count.
+    /// </summary>
+    [Fact]
+    public void GivingUpAtTheDeadline_ReportsTheSessionsItCutsOff()
+    {
+        var progress = new DrainProgress();
+        progress.Probe(5, T0);
+        progress.Probe(3, T0.AddSeconds(600));
+
+        var report = progress.Abandon(3, T0.AddSeconds(1680));
+
+        report.CutSessionsOff.Should().BeTrue();
+        report.LiveCircuits.Should().Be(3);
+        report.CircuitsWhenTerminationBegan.Should().Be(5);
+        report.Elapsed.Should().Be(TimeSpan.FromSeconds(1680));
+        report.TerminationWasObserved.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The ordinary roll: everyone finished, then SIGTERM. It must NOT read as sessions being cut
+    /// off — a warning on every clean roll is a warning nobody reads on the roll that matters.
+    /// </summary>
+    [Fact]
+    public void ADrainThatFinished_ReportsNoSessionsCutOff()
+    {
+        var progress = new DrainProgress();
+        progress.Probe(2, T0);
+        progress.Probe(0, T0.AddSeconds(30));
+
+        var report = progress.Abandon(0, T0.AddSeconds(31));
+
+        report.CutSessionsOff.Should().BeFalse();
+        report.CircuitsWhenTerminationBegan.Should().Be(2);
+        report.TerminationWasObserved.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// SIGTERM with no preStop at all — a node eviction, a local Ctrl-C, a chart that lost its
+    /// lifecycle hook. Distinguished from "the drain ran and gave up", because the two need
+    /// different responses: one is a session-length problem, the other is a missing hook.
+    /// </summary>
+    [Fact]
+    public void ShutdownWithoutAnyProbe_SaysNoDrainWasEverObserved()
+    {
+        var report = new DrainProgress().Abandon(4, T0);
+
+        report.TerminationWasObserved.Should().BeFalse();
+        report.LiveCircuits.Should().Be(4);
+        report.CircuitsWhenTerminationBegan.Should().Be(4,
+            "with no probe to compare against, the shutdown count is the only count there is");
+        report.Elapsed.Should().Be(TimeSpan.Zero);
+    }
+
+    /// <summary>A clamped count must never turn into a phantom cut-off session.</summary>
+    [Fact]
+    public void ANegativeCountIsClampedAtShutdownToo()
+    {
+        var progress = new DrainProgress();
+        progress.Probe(1, T0);
+
+        progress.Abandon(-3, T0.AddSeconds(5)).CutSessionsOff.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
Addresses #1971 — the part that is fixable without a live roll. Read the last section for what is deliberately left open.

## What it was

`preStop` polls `/drain` until the last circuit closes, and it had **no deadline of its own** — `terminationGracePeriodSeconds` was the only thing that stopped it:

```sh
while ! curl -sf -m 5 -o /dev/null http://127.0.0.1:8080/drain; do sleep 5; done
```

So whenever a session outlived the grace, the kubelet SIGKILLed the process **with a live Orleans silo**: `preStop` never returned, the host's 90 s `ShutdownTimeout` never ran, `ApplicationStopping` never fired, and the silo never departed membership. The deployment's own annotation records what that costs:

> `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` — *"each abrupt departure left a ZOMBIE entry in the Orleans membership table: the cluster kept placing new grain activations on the dead silo, so writes timed out ('no initial state arrived within 30s') mesh-wide."*

And the issue's measurements say riding to the ceiling is the **normal** outcome of a roll, not the exception — a terminating pod still executing application code 68 s before the ceiling, while a serving pod had five circuits open at an arbitrary moment. **The roll design was protecting users from the fast teardown by guaranteeing the abrupt one.**

Framed as this cluster's rule: the whole grace was spent *waiting* and **zero** was left for shutting down. That is not a deliberate trade, it is an off-by-a-whole-budget.

## What changed

- **`preStop` bounds its own poll** at `drainSeconds − shutdownMarginSeconds` and `exit 0`, so SIGTERM is delivered with the margin still available to shut down in. The deadline is **derived** from `drainSeconds` — two independent constants drift, and the drift is invisible until a pod is killed at the wrong moment.
- **`portal.shutdownMarginSeconds: 120`** — comfortably above the host's own 90 s `ShutdownTimeout`, which is exactly what the margin exists to make room for. Session drain goes 1800 s → 1680 s.
- The trade becomes **explicit**: cut off the last stragglers, logged and counted, rather than keep everyone and then die abruptly.
- **`DrainProgress.Abandon`** + an `ApplicationStopping` line reporting what SIGTERM *found*. Its **absence** after a termination is now the evidence of a hard kill — which is precisely the question the issue could not answer from Loki, because there was nothing to read in either direction. It also separates *"the drain ran and gave up"* (a session-length problem) from *"no probe was ever seen"* (a missing lifecycle hook, or a node eviction).

## Tests

```
Passed!  - Failed: 0, Passed:  3, Skipped: 0, Total:  3   (DrainDeadlineGuard)
Passed!  - Failed: 0, Passed: 15, Skipped: 0, Total: 15   (DrainProgressTest)
```

`DrainDeadlineGuard` is a **text guard over the chart**, because the invariant lives in a Helm template and a shell loop where no C# test can observe it — and this chart already carries a scar of exactly that class: a `preStop` that probed with `wget`, absent from the image, so the loop could never succeed and **every** termination hung to the ceiling. That was caught by reading, not by a test. This is that test. It strips comment lines first, so the prose explaining the rule cannot satisfy it while the command doing it is gone.

The **shell loop itself was executed** both ways against a stub `curl`:

```
GAVE UP after 6s      (deadline reached → exit 0)
DRAINED after 3s      (drain succeeds → returns immediately, unchanged)
```

**Non-vacuity:**
- chart reverted to `origin/main` → 2 of the 3 guard cases fail (*"preStop must bound its own poll at (portal.drainSeconds − portal.shutdownMarginSeconds)"*, *"values.yaml must declare portal.shutdownMarginSeconds"*).
- `Abandon` neutered to the SIGKILL shape (nothing runs at shutdown) → 3 of the 15 `DrainProgress` cases fail.

## For the maintainer — what is deliberately NOT here

**The issue's question (1) — does the ceiling SIGKILL actually leave a zombie membership entry — is unanswered.** Answering it requires rolling a live mesh with a session held open past the grace and reading the membership table, which is a system-changing operation I did not perform. This PR makes the question **moot on the roll path** (the ceiling is no longer reached by a drain) and **observable everywhere else** (the shutdown line exists, so its absence is diagnosable).

**The policy call is yours.** The issue says the drain trade "belongs with whoever owns the user-continuity trade". I deliberately did **not** touch that trade: `drainSeconds` stays 1800, and the 120 s comes out of the tail rather than shortening the session window meaningfully. If you would rather cut the drain much earlier — say, reserve 300 s — `shutdownMarginSeconds` is the one dial, and the guard will keep the arithmetic honest.

**The e2e from #1340's acceptance list (item 2) is still missing** — roll a disposable mesh mid-session and assert the session survives. It is a genuinely different piece of work (a harness that rolls a running mesh) and it belongs in its own PR; nothing here substitutes for it.

⚠️ Deploy note: this is a **chart** change. It reaches a cluster only on `helm upgrade`, not on an image-tag roll — which is the exact reason the `wget` defect went unobserved for so long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)