### PR TITLE
The disposal watchdog measures a STALL, not a duration (#1701)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-teardown-waits-for-progress.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-teardown-waits-for-progress.md
@@ -1,0 +1,22 @@
+---
+Name: Shutdown no longer cuts itself short
+Category: Fix
+Description: A package or space that takes a while to shut down is now allowed to finish, instead of being force-torn-down after eight seconds.
+Icon: Sparkle
+Order: -20260822
+---
+
+# Shutdown no longer cuts itself short
+
+Restarting or recycling something in the mesh — a package root, a space, a node type being rebuilt —
+tears down a whole tree of internal parts, one level at a time. A safety net was watching that
+teardown and stepping in if it had not finished after eight seconds.
+
+The net measured the wrong thing. It counted total elapsed time, so a teardown that was going
+perfectly well but simply had several levels to work through was cut off and forced apart halfway.
+Anything reading that package during the window then saw it as unavailable, and a rebuild started in
+that window could fail outright.
+
+The net now watches for a teardown that has actually *stopped moving*: as long as the shutdown keeps
+making progress it is left alone, however long it takes, and it is still stepped in on the moment it
+genuinely stalls.

--- a/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
@@ -40,6 +40,37 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     public IObservable<IMessageHub> HubAdded => _hubAdded.AsObservable();
 
     /// <summary>
+    /// Every disposal-PROGRESS signal from anywhere in this collection's hosted subtree — each
+    /// hub's <c>RunLevel</c> transitions, recursively, plus hubs that appear while the merge is
+    /// live (<see cref="HubAdded"/>).
+    ///
+    /// <para>🚨 This is what stops an owner OUT-RUNNING the mechanism that answers it (#1701).
+    /// The owner's disposal watchdog is armed at the owner's own <c>Dispose()</c>; a child's is
+    /// armed strictly later, in the owner's <c>DisposeHostedHubs</c> phase — so with a fixed
+    /// DURATION watchdog the owner ALWAYS expires first, reports
+    /// <c>DISPOSAL DEADLOCK DETECTED … RunLevel=DisposeHostedHubs</c>, and force-tears-down a
+    /// subtree that was merely still working. That is the same inversion #1317 removed one level
+    /// down (<see cref="DisposeHubsReactive"/>'s flat 5 s cap), left in place one level up. Feeding
+    /// subtree progress back to the owner turns its watchdog into a STALL detector: a healthy
+    /// nested teardown keeps re-arming it, and a genuinely wedged one still trips — the difference
+    /// being that the message is then TRUE.</para>
+    ///
+    /// <para>Depth-capped like the diagnostics walk, and every child's stream is Catch-guarded:
+    /// a progress signal must never fault the teardown it is reporting on.</para>
+    /// </summary>
+    /// <param name="depth">Current recursion depth; the walk stops at the same cap as the
+    /// diagnostics snapshot.</param>
+    /// <returns>A hot stream of progress descriptions; never faults.</returns>
+    internal IObservable<string> SubtreeDisposalProgress(int depth) =>
+        // Defer so the snapshot is taken at SUBSCRIBE time (the owner subscribes inside its own
+        // Dispose, by which point the children it must wait for are present).
+        Observable.Defer(() => Hubs.ToArray().ToObservable().Merge(HubAdded))
+            .SelectMany(h => h is MessageHub concrete
+                ? concrete.DisposalProgressAtDepth(depth)
+                : Observable.Empty<string>())
+            .Catch<string, Exception>(_ => Observable.Empty<string>());
+
+    /// <summary>
     /// Looks up the hosted hub for <paramref name="address"/>, optionally creating
     /// it. Existing-hub lookups and <see cref="HostedHubCreation.Never"/> probes
     /// are lock-free pure reads; creation is single-flighted per address and runs

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1463,6 +1463,34 @@ public sealed class MessageHub : IMessageHub
     public IObservable<Unit> DisposalCompleted => disposalCompleted.AsObservable();
 
     /// <summary>
+    /// Every disposal-PROGRESS signal from this hub and its hosted SUBTREE: each hub's
+    /// <c>RunLevel</c> transition, recursively. Not a heartbeat — nothing here is emitted on a
+    /// timer, so a stream that goes quiet means the teardown genuinely stopped moving.
+    ///
+    /// <para>Consumed by the disposal watchdog, which re-arms on every signal (see
+    /// <see cref="Dispose"/>). Exposed so a test can assert the difference between "slow but
+    /// progressing" and "wedged" without waiting on wall-clock.</para>
+    /// </summary>
+    public IObservable<string> DisposalProgress => DisposalProgressAtDepth(0);
+
+    /// <summary>
+    /// <see cref="DisposalProgress"/> with the recursion depth threaded through, so the subtree
+    /// walk is capped exactly like the diagnostics snapshot.
+    /// </summary>
+    /// <param name="depth">Current recursion depth.</param>
+    /// <returns>A hot stream of progress descriptions; never faults.</returns>
+    internal IObservable<string> DisposalProgressAtDepth(int depth)
+    {
+        // RunLevelChanged is a BehaviorSubject, so subscribing reports the CURRENT level at once —
+        // that first emission is the "we are observing from here" mark, and it costs nothing
+        // because the watchdog re-arms on it exactly as it would on a transition.
+        var own = runLevelChanged.Select(level => $"{Address} → {level}");
+        return depth >= MaxHostedHubRecursionDepth
+            ? own
+            : own.Merge(hostedHubs.SubtreeDisposalProgress(depth + 1));
+    }
+
+    /// <summary>
     /// Set when the Quiescing-phase drain budget (<see cref="QuiesceTimeout"/>)
     /// expires with callbacks still pending. Tests inspect this on the root mesh
     /// (and recursively on hosted hubs via <see cref="GetDisposalDiagnostics"/>)
@@ -1580,19 +1608,46 @@ public sealed class MessageHub : IMessageHub
         // immediately. (The original uncancelled `Task.Delay(25s)` rooted the ENTIRE hub graph
         // — cache, data sources, action block, subscriptions — for 25 s after EVERY dispose,
         // even a fast one: TimerQueue → TimerQueueTimer → DelayPromise → state machine → hub.)
-        watchdogSubscription = Observable
-            .Timer(DisposalWatchdogTimeout)
+        //
+        // 🚨 It measures a STALL, not a DURATION (#1701). A fixed-duration watchdog on an owner
+        // OUT-RUNS the very mechanism that answers it: the owner arms at its own Dispose(), a
+        // child arms strictly later — in the owner's DisposeHostedHubs phase — for the same 8 s.
+        // So whenever a child needs its own watchdog to produce an answer, the OWNER's expires
+        // first and reports "DISPOSAL DEADLOCK DETECTED … RunLevel=DisposeHostedHubs" about a
+        // subtree that was working correctly, then force-tears it down mid-flight. That is the
+        // #1317 inversion ("a join must not out-run the answers it is joining") left in place one
+        // level up, and it is why #1701's captures show TWO force-teardown pairs of which only the
+        // inner one carries information.
+        //
+        // Switch() over the progress stream re-arms the timer on every sign of life anywhere in
+        // the subtree, so a healthy nested teardown never trips however deep it is, and a hub that
+        // genuinely stops moving still trips 8 s later — with the message finally TRUE: no
+        // progress, rather than "not finished yet".
+        watchdogSubscription = DisposalProgress
+            .StartWith($"{Address} Dispose() called")
+            .Select(reason => Observable.Timer(DisposalWatchdogTimeout).Select(_ => reason))
+            .Switch()
             .TakeUntil(disposalCompleted)
+            .Take(1)
+            // 🚨 OFF the progress path. Switch serialises its downstream delivery under its own
+            // gate, and a progress signal originates INSIDE the emitting hub's `locker` (the
+            // RunLevel setter runs under it in HandleShutdownCore). Running the force-teardown
+            // inline would therefore hold Switch's gate while taking a child's `locker`, while
+            // that child holds its `locker` and wants Switch's gate — a lock-order inversion that
+            // wedges the child's action block on its own ShutdownRequest (measured: the child
+            // sitting at Executing(ShutdownRequest, 8000ms) with deliveryActionCompleted=False).
+            // The pre-Switch watchdog ran on the bare timer thread; this restores that isolation.
+            .ObserveOn(System.Reactive.Concurrency.DefaultScheduler.Instance)
             .Subscribe(
-                _ =>
+                lastProgress =>
                 {
                     if (DisposalSignalled)
                         return;
                     logger.LogError(
-                        "DISPOSAL DEADLOCK DETECTED: Hub {Address} did not complete shutdown within {Timeout}. " +
-                        "RunLevel={RunLevel}. Forcing out-of-band teardown so children/subscriptions cannot leak.\n" +
-                        "{Diagnostics}",
-                        Address, DisposalWatchdogTimeout, RunLevel, DescribeWedge());
+                        "DISPOSAL DEADLOCK DETECTED: Hub {Address} made no teardown progress for {Timeout} " +
+                        "(last progress: {LastProgress}). RunLevel={RunLevel}. Forcing out-of-band teardown " +
+                        "so children/subscriptions cannot leak.\n{Diagnostics}",
+                        Address, DisposalWatchdogTimeout, lastProgress, RunLevel, DescribeWedge());
                     ForceTeardownAfterWatchdog();
                 },
                 // disposalCompleted faulting (SignalDisposalFaulted) propagates through TakeUntil;

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposalStallWatchdogTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposalStallWatchdogTest.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 #1701 — <b>an owner must not out-run the mechanism that answers it.</b>
+///
+/// <para><b>The inversion.</b> The disposal watchdog is armed per hub, at that hub's OWN
+/// <c>Dispose()</c>, for a flat 8 s at every depth. A child's <c>Dispose()</c> is NOT called at the
+/// parent's t=0 — it is called in the parent's <c>DisposeHostedHubs</c> phase, i.e. strictly AFTER
+/// the parent's quiesce budget. So a child's watchdog is armed strictly later than its parent's, for
+/// the same duration: whenever a child needs its own watchdog to produce an answer, the PARENT's
+/// always expires first. The parent then logs
+/// <c>DISPOSAL DEADLOCK DETECTED … RunLevel=DisposeHostedHubs</c> and force-tears-down a subtree that
+/// was working correctly.</para>
+///
+/// <para>That is exactly the defect #1317 fixed one level down — <c>DisposeHubsReactive</c>'s flat
+/// 5 s cap, removed with the note that <i>"a child's answer is guaranteed terminal, just not inside
+/// 5 s"</i> — left in place one level up, between an owner's watchdog and its children's. It is why
+/// #1701's captures show TWO <c>[FORCE-TEARDOWN]</c> pairs of which only the inner one carries
+/// information, and it is a real production cost: the 8 s force-teardown is inside the recycle window
+/// that clients must ride out (#1996 measured recovery at 10.06 s against a 7.75 s retry budget).</para>
+///
+/// <para><b>The fix is a shape, not a bound.</b> The watchdog measures a STALL instead of a
+/// DURATION: it re-arms on every disposal-progress signal from anywhere in the subtree (each hub's
+/// <c>RunLevel</c> transitions, recursively — never a heartbeat, so quiet means genuinely stopped).
+/// A healthy nested teardown keeps it re-armed however deep it is; a hub that stops moving still
+/// trips 8 s later, with the message finally TRUE.</para>
+/// </summary>
+public class DisposalStallWatchdogTest : HubTestBase
+{
+    private readonly DeadlockLogCapture capture = new();
+
+    public DisposalStallWatchdogTest(ITestOutputHelper output) : base(output)
+    {
+        Services.AddLogging(l => l.Services.AddSingleton<ILoggerProvider>(capture));
+    }
+
+    /// <summary>Posted to a hub that handles it WITHOUT responding, so the observing callback
+    /// stays pending and that hub's Quiescing phase burns its whole budget.</summary>
+    private record NeverAnswered;
+
+    /// <summary>Slow turns, queued deep enough to starve the phased shutdown — a genuine wedge.</summary>
+    private record WedgeEvent;
+
+    /// <summary>Per level: long enough that the whole chain outlasts the 8 s watchdog, short
+    /// enough that no single gap between progress signals reaches it.</summary>
+    private static readonly TimeSpan PerLevelQuiesce = TimeSpan.FromSeconds(3);
+    private const int ChainDepth = 4;   // 4 × 3 s ≈ 12 s > 8 s, in 3 s steps
+
+    /// <summary>
+    /// A nested teardown that legitimately takes LONGER than the watchdog window, while every
+    /// individual step stays well inside it. Four hosted hubs, each holding one unanswered callback
+    /// so its Quiescing phase runs its full 3 s budget: the chain needs ~12 s end to end, in 3 s
+    /// steps, and nothing is wedged at any point.
+    ///
+    /// <para><b>Non-vacuity.</b> On <c>origin/main</c> the root's fixed 8 s timer expires at t=8 —
+    /// four seconds before the subtree it is waiting on could possibly have finished — and logs
+    /// <c>DISPOSAL DEADLOCK DETECTED</c>, force-tearing down a healthy teardown mid-flight.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task NestedTeardownSlowerThanTheWindow_DoesNotTripTheWatchdog()
+    {
+        var chain = BuildQuiesceChain();
+        var root = chain[0];
+
+        var started = DateTime.UtcNow;
+        root.Dispose();
+        await root.DisposalCompleted.FirstOrDefaultAsync().ToTask().WaitAsync(120.Seconds());
+        var elapsed = DateTime.UtcNow - started;
+
+        // The premise of the test, asserted rather than assumed: the teardown really did outlast
+        // the watchdog window. If it did not, "no deadlock was logged" would prove nothing.
+        elapsed.Should().BeGreaterThan(TimeSpan.FromSeconds(9),
+            "the chain must genuinely take longer than the 8 s watchdog window, or this test is vacuous "
+            + $"(actual {elapsed.TotalSeconds:F1}s over {ChainDepth} levels of {PerLevelQuiesce.TotalSeconds}s)");
+
+        foreach (var entry in capture.Entries)
+            Output.WriteLine(entry);
+
+        capture.Entries.Should().BeEmpty(
+            "nothing was wedged — every level advanced through its phases within 3 s of the last. "
+            + "A watchdog that fires here is measuring DURATION, and it out-runs the very mechanism "
+            + "that answers it: a child's watchdog is armed one quiesce budget later than its "
+            + $"parent's, for the same 8 s. Elapsed {elapsed.TotalSeconds:F1}s.");
+    }
+
+    /// <summary>
+    /// The safety half: a hub that genuinely stops moving must STILL trip. Re-arming on progress
+    /// must not be a way of switching the backstop off — a stall watchdog that never fires is just
+    /// a deleted watchdog.
+    ///
+    /// <para>Same wedge recipe as <c>DisposalDeadlockDiagnosticsTest</c>: a FIFO backlog of slow
+    /// turns that the phased <c>ShutdownRequest</c> cannot jump. The hub emits no phase transition
+    /// while starved, so there is no progress to re-arm on — and the report still names the message
+    /// holding the action block.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task GenuinelyWedgedHub_StillTripsTheWatchdog()
+    {
+        var wedgeTurns = 0;
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "stall-watchdog"), c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithHandler<WedgeEvent>((_, d) =>
+            {
+                Interlocked.Increment(ref wedgeTurns);
+                Thread.Sleep(15);
+                return d.Processed();
+            }), HostedHubCreation.Always)!;
+
+        for (var i = 0; i < 800; i++)
+            victim.Post(new WedgeEvent(), o => o.WithTarget(victim.Address));
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        victim.Dispose();
+        await victim.DisposalCompleted.FirstOrDefaultAsync().ToTask().WaitAsync(60.Seconds());
+
+        var deadlock = capture.Entries.FirstOrDefault();
+        deadlock.Should().NotBeNull(
+            "a hub whose pump is starved emits no phase transition, so there is no progress to re-arm "
+            + "on and the watchdog must still fire "
+            + $"(wedge turns processed: {Volatile.Read(ref wedgeTurns)})");
+        Output.WriteLine(deadlock!);
+
+        deadlock!.Should().Contain("made no teardown progress",
+            "the message must now say what is actually true — no progress — rather than conflating "
+            + "'slow but progressing' with 'wedged'");
+        deadlock.Should().Contain(nameof(WedgeEvent),
+            "the report must still NAME the message occupying the action block (#1701's diagnostic half)");
+    }
+
+    /// <summary>
+    /// Builds <see cref="ChainDepth"/> nested hosted hubs, each with a long Quiescing budget it
+    /// will actually burn: one unanswered self-request per hub keeps its <c>responseSubjects</c>
+    /// non-empty, so the Quiescing drain runs to its deadline instead of completing early.
+    /// </summary>
+    private MessageHub[] BuildQuiesceChain()
+    {
+        var chain = new MessageHub[ChainDepth];
+        IMessageHub parent = Mesh;
+        for (var level = 0; level < ChainDepth; level++)
+        {
+            var hub = (MessageHub)parent.GetHostedHub(
+                new Address("chain", $"level{level}"),
+                c => c.WithPostingIdentity(PostingIdentity.System)
+                      .WithQuiesceTimeout(PerLevelQuiesce)
+                      // Handled, never answered: the observing callback below stays pending.
+                      .WithHandler<NeverAnswered>((_, d) => d.Processed()),
+                HostedHubCreation.Always)!;
+
+            // One pending callback is enough — Quiescing polls for responseSubjects to EMPTY.
+            hub.Observe(new NeverAnswered(), o => o.WithTarget(hub.Address)).Subscribe(_ => { }, _ => { });
+
+            chain[level] = hub;
+            parent = hub;
+        }
+        return chain;
+    }
+
+    /// <summary>Keeps only the disposal-deadlock lines (the provider sees every category).</summary>
+    private sealed class DeadlockLogCapture : ILoggerProvider
+    {
+        public ConcurrentQueue<string> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new Capturing(Entries);
+        public void Dispose() { }
+
+        private sealed class Capturing(ConcurrentQueue<string> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel < LogLevel.Error)
+                    return;
+                var message = formatter(state, exception);
+                if (message.Contains("DISPOSAL DEADLOCK DETECTED", StringComparison.Ordinal))
+                    sink.Enqueue(message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #1701 — the **watchdog inversion** (item 2 of the three the issue leaves open).

## Mechanism

**An owner must not out-run the mechanism that answers it.**

The disposal watchdog is armed **per hub, at that hub's own `Dispose()`**, for a flat 8 s at every depth. A child's `Dispose()` is *not* called at the parent's t=0 — it is called in the parent's `DisposeHostedHubs` phase, i.e. strictly **after** the parent's quiesce budget. So a child's watchdog is armed strictly later than its parent's, for the same duration: whenever a child needs its own watchdog to produce an answer, **the parent's always expires first**, logs `DISPOSAL DEADLOCK DETECTED … RunLevel=DisposeHostedHubs`, and force-tears-down a subtree that was working correctly.

That is exactly the defect #1317 fixed one level down — `DisposeHubsReactive`'s flat 5 s cap, removed with the note *"a child's answer is guaranteed terminal, just not inside 5 s"* — left in place one level up, between an owner's watchdog and its children's. It is why #1701's captures show **two** `[FORCE-TEARDOWN]` pairs of which only the inner one carries information.

Measured on `origin/main` by the new test — a four-level chain, each level burning a 3 s quiesce budget, needing ~12 s in 3 s steps:

```
[08:15:07.011] DISPOSAL DEADLOCK DETECTED: Hub chain/level0 did not complete shutdown within 00:00:08.
               RunLevel=DisposeHostedHubs. Forcing out-of-band teardown …
Hub chain/level0 RunLevel=DisposeHostedHubs Disposal=Pending
  Hub chain/level1 RunLevel=DisposeHostedHubs Disposal=Pending
    Hub chain/level2 RunLevel=Quiescing      Disposal=Pending
      Hub chain/level3 RunLevel=Started      Disposal=<not started>
```

The owner declared a deadlock on a subtree whose **deepest member had not begun disposing**, and truncated the teardown to exactly 8.001 s.

**This is the server side of the recycle window** #1996/#2032 fixed from the client: that issue measured actual recovery at **10.06 s** against a 7.75 s retry budget, and an 8 s force-teardown sits squarely inside it. The 8 s is not a coincidental cost — it is where the recycle's duration comes from.

## What changed

The watchdog measures a **stall** instead of a **duration** — a shape change, not a widened bound.

- `MessageHub.DisposalProgress` merges this hub's `RunLevel` transitions with those of its **whole hosted subtree**, recursively (`HostedHubsCollection.SubtreeDisposalProgress`), depth-capped exactly like the diagnostics walk and Catch-guarded so a progress signal can never fault the teardown it reports on. Hubs created while the merge is live are picked up through `HubAdded`.
- The watchdog `Switch()`es a fresh 8 s timer on every signal. **Nothing is emitted on a timer** — the only sources are real phase transitions — so a quiet stream means the teardown genuinely stopped. A healthy nested teardown never trips however deep it is; a wedged one still trips 8 s after the last sign of life; and the message becomes true: `made no teardown progress for 00:00:08 (last progress: X)`.
- 🚨 **The trip runs through `ObserveOn(DefaultScheduler)`, not inline on the progress path.** `Switch` serialises downstream delivery under its own gate, and a progress signal originates *inside* the emitting hub's `locker` (the `RunLevel` setter runs under it in `HandleShutdownCore`). An inline force-teardown therefore holds `Switch`'s gate while taking a child's `locker`, while that child holds its `locker` and wants `Switch`'s gate. That is not hypothetical — it is what the first iteration did, and `MessageHubTest.Dispose_WhenActionBlockWedged_…` timed out with the child sitting at `Executing(ShutdownRequest, 8000ms)`, `deliveryActionCompleted=False`. The pre-`Switch` watchdog ran on the bare timer thread; the `ObserveOn` restores that isolation.

`IMessageHub` is untouched — `HostedHubsCollection` walks the concrete `MessageHub` (the sole, sealed implementation).

## Tests

`DisposalStallWatchdogTest`:

1. **`NestedTeardownSlowerThanTheWindow_DoesNotTripTheWatchdog`** — four nested hosted hubs, each holding one unanswered callback so its Quiescing phase burns its full 3 s budget: ~12 s end to end, in 3 s steps, nothing wedged. It **asserts the premise** (elapsed > 9 s) before asserting no deadlock was logged, so "no deadlock" cannot pass vacuously.
2. **`GenuinelyWedgedHub_StillTripsTheWatchdog`** — the safety half. Re-arming on progress must not be a way of switching the backstop off. Same FIFO-backlog wedge recipe as `DisposalDeadlockDiagnosticsTest`: a starved hub emits no phase transition, so there is nothing to re-arm on, it still trips, and the report still **names** the message holding the action block.

### Non-vacuity

Both fail on a clean `origin/main` worktree (the file compiles there unchanged):

```
Failed  NestedTeardownSlowerThanTheWindow_DoesNotTripTheWatchdog
  Expected 00:00:08.0010210 to be greater than 00:00:09 because the chain must genuinely take
  longer than the 8 s watchdog window, or this test is vacuous (actual 8.0s over 4 levels of 3s).
  …with the DISPOSAL DEADLOCK snapshot quoted above.
Failed  GenuinelyWedgedHub_StillTripsTheWatchdog     (main's message still reads "did not complete
                                                      shutdown within", i.e. not the true statement)
Total tests: 2   Failed: 2
```

On this branch: **265/265** `MeshWeaver.Messaging.Hub.Test` and **374/374** `MeshWeaver.Data.Test` green, including `DisposalDeadlockDiagnosticsTest` and `MessageHubTest.Dispose_WhenActionBlockWedged_WatchdogTearsDownChildrenAndDisposables`. `dotnet build -c Release -warnaserror` clean.

## Deliberately left

- **The wedge itself** (#1701 item 1) — *why* a particular `sync/*` hub's pump never reached its `ShutdownRequest`. That needs one occurrence with #1740's diagnostics; guessing between "FIFO starvation" and "one non-terminating turn" and fixing the guess is how a bound gets widened. What this PR does change is that a *healthy* nested teardown no longer manufactures the outer half of that signature, so the next capture's outer `[FORCE-TEARDOWN]` will mean something.
- **`ArmOverlaySelfHeal`'s watcher dying at birth on an absent type node** (#1701 item 4) — untouched.
- `CompileWatcher` treating "recycling" as transient was already fixed in #1726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)