### PR TITLE
Build must not construct another hub (#1868, step 1)

### DIFF
--- a/src/MeshWeaver.Data/DataContext.cs
+++ b/src/MeshWeaver.Data/DataContext.cs
@@ -304,7 +304,32 @@ public sealed record DataContext : IDisposable
         logger.LogDebug("DataContext: DataSourcesByCollection has {Count} entries: {Collections}",
             DataSourcesByCollection.Count, string.Join(", ", DataSourcesByCollection.Keys));
 
-        // Initialize each data source
+        logger.LogDebug("DataContext configuration complete for {Address}, waiting for InitializeDataSources", Hub.Address);
+    }
+
+    /// <summary>
+    /// Starts each data source — the half of initialization that CREATES THINGS, split out of
+    /// <see cref="Initialize"/> so it can run OFF the hub's <c>Build</c> (#1868).
+    ///
+    /// <para>🚨 The split is the point, and it is not cosmetic. <see cref="Initialize"/> is pure
+    /// configuration — resolve the data sources, build the type sources, and REGISTER THEIR TYPES
+    /// with the hub's <c>ITypeRegistry</c> — and it must keep running inside <c>Build</c>, because a
+    /// caller that resolves the hub can read <c>TypeRegistry</c> the instant <c>Build</c> returns
+    /// (schema generation, content-discriminator validation). This method is the other half:
+    /// <c>IDataSource.Initialize</c> opens streams (<c>HubDataSource</c> eagerly calls
+    /// <c>GetStream</c> → <c>SynchronizationStream..ctor</c> → <c>GetHostedHub(sync/…)</c>), so
+    /// running it inside <c>Build</c> is what made every data-enabled hub construct a sub-hub
+    /// inside its own construction.</para>
+    ///
+    /// <para>Idempotent: a second call is a no-op, so a configurator that registers the observable
+    /// init twice cannot double-start the sources.</para>
+    /// </summary>
+    public void InitializeDataSources()
+    {
+        if (dataSourcesInitialized)
+            return;
+        dataSourcesInitialized = true;
+
         foreach (var dataSource in DataSourcesById.Values)
         {
             dataSource.Initialize();
@@ -312,8 +337,10 @@ public sealed record DataContext : IDisposable
             initialized.Add(dataSource.Reference);
         }
 
-        logger.LogDebug("DataContext initialization setup complete for {Address}, waiting for OpenInitializationGate", Hub.Address);
+        logger.LogDebug("DataContext data sources started for {Address}, waiting for OpenInitializationGate", Hub.Address);
     }
+
+    private bool dataSourcesInitialized;
 
     /// <summary>
     /// Identifies a data source in a diagnostic: its id plus the implementation type, which

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -103,43 +103,62 @@ public static class DataExtensions
 
 
     /// <summary>
-    /// Resolves the hub's <see cref="IWorkspace"/> (constructing it, and therefore its data
-    /// context's streams and their sub-hubs) and opens its initialization gate — on the hub's
-    /// INIT TURN, never inside <c>Build</c>. See the call site for why (#1868).
+    /// Constructs the hub's <see cref="IWorkspace"/> — and therefore runs
+    /// <c>DataContext.Initialize</c>, which registers every mapped type with the hub's
+    /// <c>ITypeRegistry</c>. Stays a SYNCHRONOUS buildup action: a caller that resolves the hub can
+    /// read the registry the instant <c>Build</c> returns. Creates no hub (#1868).
+    /// </summary>
+    /// <param name="hub">The hub being initialized.</param>
+    private static void RegisterWorkspaceTypes(IMessageHub hub) => hub.GetWorkspace();
+
+    /// <summary>
+    /// Starts the workspace's data sources and opens its initialization gate — on the hub's INIT
+    /// TURN, never inside <c>Build</c>, because starting a data source opens streams and therefore
+    /// constructs hubs (#1868). See the call site.
     ///
     /// <para>A static method group, so <c>WithInitialization</c>'s delegate-identity idempotency
     /// still collapses repeat registrations from composed configurators.</para>
     /// </summary>
     /// <param name="hub">The hub being initialized.</param>
-    /// <returns>An observable that completes once the workspace's gate is open.</returns>
-    private static IObservable<Unit> OpenWorkspaceInitializationGate(IMessageHub hub) =>
+    /// <returns>An observable that completes once the sources are started and the gate is open.</returns>
+    private static IObservable<Unit> StartDataSourcesAndOpenGate(IMessageHub hub) =>
         // Defer so the work happens at SUBSCRIBE time (the init turn), not when the observable is
         // constructed — HandleInitialize builds the whole Concat chain up front.
         Observable.Defer(() =>
         {
-            ((Workspace)hub.GetWorkspace()).OpenInitializationGate();
+            var workspace = (Workspace)hub.GetWorkspace();
+            workspace.DataContext.InitializeDataSources();
+            workspace.OpenInitializationGate();
             return Observable.Return(Unit.Default);
         });
 
     private static MessageHubConfiguration GetDefaultConfiguration(MessageHubConfiguration config)
     {
         return config
-            // 🚨 The OBSERVABLE overload, deliberately (#1868). These two ran as SYNCHRONOUS
-            // buildup actions, i.e. INSIDE MessageHubConfiguration.Build — and resolving the
-            // workspace constructs hubs: Workspace..ctor → DataContext.Initialize →
-            // DataSource.GetStream → SynchronizationStream..ctor, whose constructor ALWAYS calls
-            // GetHostedHub(sync/{clientId}, HostedHubCreation.Always). So every data-enabled hub
-            // built a sub-hub, and a second Autofac container, inside its own Build — 1,350 nested
-            // Builds per green MeshWeaver.FutuRe.Test run, all depth 2. A disposal that races a
-            // construction then races a TREE of constructions rather than one frame, which is the
-            // shape behind the whole shutdown-race family (#645/#715/#967/#1573).
+            // 🚨 SPLIT BY WHAT EACH HALF DOES (#1868).
             //
-            // The observable overload runs on the InitializeHubRequest turn — after Build has
-            // returned and message processing has started — and BuildupActions are Concat-ed, so
-            // this still runs FIRST and still completes before the Initialize gate opens. Messages
-            // cannot overtake it: they defer behind that gate exactly as before. Same shape #774
-            // already applied to MeshDataSource.SubscribeToOwnDeletion.
-            .WithInitialization(OpenWorkspaceInitializationGate)
+            // The SYNCHRONOUS half stays in Build, because it must: constructing the workspace runs
+            // DataContext.Initialize, which REGISTERS EVERY MAPPED TYPE with the hub's
+            // ITypeRegistry, and a caller that resolves the hub can read that registry the instant
+            // Build returns (schema generation, content-discriminator validation — moving it broke
+            // SchemaValidationTest and AgentWriteFailureTests). Resolving the workspace itself
+            // creates no hub.
+            //
+            // The OBSERVABLE half is the part that CREATES THINGS: IDataSource.Initialize opens
+            // streams (HubDataSource eagerly calls GetStream → SynchronizationStream..ctor →
+            // GetHostedHub(sync/{clientId}, HostedHubCreation.Always)). Run as a synchronous buildup
+            // action that happened INSIDE MessageHubConfiguration.Build — 1,350 nested Builds per
+            // green MeshWeaver.FutuRe.Test run, all depth 2 — so a disposal racing this hub's
+            // creation raced a TREE of constructions rather than one frame, the shape behind the
+            // whole shutdown-race family (#645/#715/#967/#1573).
+            //
+            // The observable overload runs on the InitializeHubRequest turn, after Build has
+            // returned; BuildupActions are Concat-ed, so this still runs FIRST and still completes
+            // before the Initialize gate opens. Messages cannot overtake it — they defer behind
+            // that gate exactly as before. Same shape #774 applied to
+            // MeshDataSource.SubscribeToOwnDeletion.
+            .WithInitialization(RegisterWorkspaceTypes)
+            .WithInitialization(StartDataSourcesAndOpenGate)
             .WithRoutes(routes => routes.WithHandler((delivery, _) => RouteStreamMessage(routes.Hub, delivery)))
             .WithServices(sc =>
             {

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
@@ -101,15 +102,44 @@ public static class DataExtensions
     }
 
 
+    /// <summary>
+    /// Resolves the hub's <see cref="IWorkspace"/> (constructing it, and therefore its data
+    /// context's streams and their sub-hubs) and opens its initialization gate — on the hub's
+    /// INIT TURN, never inside <c>Build</c>. See the call site for why (#1868).
+    ///
+    /// <para>A static method group, so <c>WithInitialization</c>'s delegate-identity idempotency
+    /// still collapses repeat registrations from composed configurators.</para>
+    /// </summary>
+    /// <param name="hub">The hub being initialized.</param>
+    /// <returns>An observable that completes once the workspace's gate is open.</returns>
+    private static IObservable<Unit> OpenWorkspaceInitializationGate(IMessageHub hub) =>
+        // Defer so the work happens at SUBSCRIBE time (the init turn), not when the observable is
+        // constructed — HandleInitialize builds the whole Concat chain up front.
+        Observable.Defer(() =>
+        {
+            ((Workspace)hub.GetWorkspace()).OpenInitializationGate();
+            return Observable.Return(Unit.Default);
+        });
+
     private static MessageHubConfiguration GetDefaultConfiguration(MessageHubConfiguration config)
     {
         return config
-            .WithInitialization(h => h.GetWorkspace())
-            // Initialize workspace and open gate after hub is fully constructed (handlers registered)
-            .WithInitialization(h =>
-            {
-                ((Workspace)h.GetWorkspace()).OpenInitializationGate();
-            })
+            // 🚨 The OBSERVABLE overload, deliberately (#1868). These two ran as SYNCHRONOUS
+            // buildup actions, i.e. INSIDE MessageHubConfiguration.Build — and resolving the
+            // workspace constructs hubs: Workspace..ctor → DataContext.Initialize →
+            // DataSource.GetStream → SynchronizationStream..ctor, whose constructor ALWAYS calls
+            // GetHostedHub(sync/{clientId}, HostedHubCreation.Always). So every data-enabled hub
+            // built a sub-hub, and a second Autofac container, inside its own Build — 1,350 nested
+            // Builds per green MeshWeaver.FutuRe.Test run, all depth 2. A disposal that races a
+            // construction then races a TREE of constructions rather than one frame, which is the
+            // shape behind the whole shutdown-race family (#645/#715/#967/#1573).
+            //
+            // The observable overload runs on the InitializeHubRequest turn — after Build has
+            // returned and message processing has started — and BuildupActions are Concat-ed, so
+            // this still runs FIRST and still completes before the Initialize gate opens. Messages
+            // cannot overtake it: they defer behind that gate exactly as before. Same shape #774
+            // already applied to MeshDataSource.SubscribeToOwnDeletion.
+            .WithInitialization(OpenWorkspaceInitializationGate)
             .WithRoutes(routes => routes.WithHandler((delivery, _) => RouteStreamMessage(routes.Hub, delivery)))
             .WithServices(sc =>
             {

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-hubs-not-built-inside-hubs.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-hubs-not-built-inside-hubs.md
@@ -1,0 +1,21 @@
+---
+Name: Internal parts are no longer built inside each other
+Category: Fix
+Description: Data-enabled hubs and code-cell hubs no longer construct sub-hubs from inside their own construction, so a shutdown races one thing instead of a tree.
+Icon: Sparkle
+Order: -20260822
+---
+
+# Internal parts are no longer built inside each other
+
+Everything in the mesh runs on a small internal component that is created on demand. Two of those
+components were doing part of their setup *during their own construction* — and that setup created
+further components, which created further ones again.
+
+Nothing failed visibly, but it made shutdown harder than it needed to be: stopping something while it
+was being created meant racing a whole tree of half-built parts rather than a single one, and that
+race is the shape behind a long line of shutdown bugs.
+
+The setup now runs immediately after construction instead of inside it. Nothing about the order in
+which your pages, data and code cells become ready changes — the component still finishes its setup
+before it accepts any work.

--- a/src/MeshWeaver.Kernel.Hub/KernelContainer.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelContainer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Reactive;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Data.Serialization;
@@ -121,7 +122,6 @@ public class KernelContainer(IServiceProvider serviceProvider)
             .WithInitialization(hub =>
             {
                 DisposeOnTimeout(hub);
-                StartActivityControlPlane(hub);
                 // NOTE: deliberately NO InitializeActivityLifecycle here. The
                 // kernel hub IS the executor — it activates in order to RUN the
                 // script, so its own activity is legitimately Running the instant
@@ -131,6 +131,19 @@ public class KernelContainer(IServiceProvider serviceProvider)
                 // executor (e.g. NodeType compile, where the owner re-requests
                 // from its own state). See ActivityControlPlane.md.
             })
+            // 🚨 The OBSERVABLE overload, deliberately (#1868). StartActivityControlPlane reaches
+            // hub construction — WatchControlPlane → SubscribeWithReEstablish → AcquireStream →
+            // Workspace.GetStream → SynchronizationStream..ctor, whose constructor ALWAYS calls
+            // GetHostedHub(sync/{clientId}, HostedHubCreation.Always). Run as a SYNCHRONOUS buildup
+            // action it did that from inside MessageHubConfiguration.Build, so a disposal racing
+            // this hub's creation raced a TREE of constructions rather than one frame. The
+            // observable overload runs on the InitializeHubRequest turn, after Build returns and
+            // still before the Initialize gate opens, so nothing observable to a message changes.
+            .WithInitialization(hub => Observable.Defer(() =>
+            {
+                StartActivityControlPlane(hub);
+                return Observable.Return(Unit.Default);
+            }))
             .WithHandler<SubmitCodeRequest>(ForwardSubmitCodeRequest)
             .WithHandler<CancelScriptRequest>(ForwardCancelRequest);
     }

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -272,6 +272,7 @@ public sealed class MessageHub : IMessageHub
     /// </summary>
     internal void StartMessageProcessing()
     {
+        messageProcessingStarted = true;
         messageService.Start();
         InstallStaleCallbackScanner();
         if (!Configuration.DeferredInitialization)
@@ -1387,8 +1388,73 @@ public sealed class MessageHub : IMessageHub
         HostedHubCreation create
     )
     {
+        if (create != HostedHubCreation.Never && !messageProcessingStarted)
+            ReportHubConstructionDuringBuild(address);
         var messageHub = hostedHubs.GetHub(address, config, create);
         return messageHub;
+    }
+
+    /// <summary>
+    /// Set by <see cref="StartMessageProcessing"/>, the LAST thing
+    /// <c>MessageHubConfiguration.Build</c> does. Until then this hub is still inside its own
+    /// <c>Build</c>: its <c>SyncBuildupActions</c> are running and nothing it constructs can have
+    /// been reached from a message.
+    /// </summary>
+    private bool messageProcessingStarted;
+
+    private ImmutableList<Address> hubsConstructedDuringBuild = ImmutableList<Address>.Empty;
+
+    /// <summary>
+    /// The addresses of hubs this hub constructed from inside its own <c>Build</c> — the #1868
+    /// invariant's evidence, recorded on the instance rather than only logged so a test can assert
+    /// on it without depending on log plumbing. Empty is the invariant holding.
+    /// </summary>
+    public IReadOnlyList<Address> HubsConstructedDuringBuild => hubsConstructedDuringBuild;
+
+    /// <summary>
+    /// 🚨 <b>The invariant: <c>Build</c> must not construct another hub</b> (#1868).
+    ///
+    /// <para><b>The fact.</b> <c>MessageHubConfiguration.Build</c> runs <c>SyncBuildupActions</c>
+    /// inline, before <see cref="StartMessageProcessing"/>. Two of those actions reached code that
+    /// creates hubs — <c>DataExtensions.GetDefaultConfiguration</c>'s <c>h.GetWorkspace()</c>
+    /// (→ <c>Workspace..ctor</c> → <c>DataContext.Initialize</c> → <c>DataSource.GetStream</c> →
+    /// <c>SynchronizationStream..ctor</c>) and <c>KernelContainer</c>'s
+    /// <c>StartActivityControlPlane</c> (→ <c>WatchControlPlane</c> → <c>AcquireStream</c> →
+    /// <c>Workspace.GetStream</c>) — and <c>SynchronizationStream</c>'s constructor ALWAYS calls
+    /// <c>GetHostedHub(…, HostedHubCreation.Always)</c>. So every data-enabled hub built at least
+    /// one <c>sync/{clientId}</c> sub-hub, and a second Autofac container, inside its own
+    /// <c>Build</c>. Measured with a depth counter on a GREEN run of
+    /// <c>MeshWeaver.FutuRe.Test</c>: <b>1,350 nested Builds</b>, all depth=2.</para>
+    ///
+    /// <para><b>Why it matters</b> — and explicitly NOT as a crash claim, which #1867 withdrew and
+    /// 1,350 nestings per green run refute. <i>A disposal that races a construction races a TREE of
+    /// them.</i> That is the shape behind the whole shutdown-race family (#645, #715, #967, #1573),
+    /// each of which had to widen its guard to cover work started by a construction that had itself
+    /// been started by a construction. <c>HostedHubsCollection</c>'s in-flight counter tracks the
+    /// OUTER creation; the inner one it spawns is a second entry, on the same thread, whose
+    /// refusal/finish semantics are only correct because the guards were extended by hand, one
+    /// incident at a time. It also makes <c>Build</c> reachable from arbitrary reactive emissions —
+    /// the 08-18 dump has one nested <c>Build</c> reached from <c>MessageService.DrainOne</c> and
+    /// one from a <c>MeshQuery</c> emission.</para>
+    ///
+    /// <para><b>Reported, not thrown.</b> The invariant is not yet universally true: this reports
+    /// the two adopted sites' regressions and any new one, without turning an unadopted third-party
+    /// configurator into a hard failure. Step 2 of the adoption — stopping
+    /// <c>SynchronizationStream</c>'s constructor from creating its sub-hub eagerly — is what makes
+    /// throwing here viable; it is deliberately not attempted with ~96 sites dereferencing
+    /// <c>ISynchronizationStream.Hub</c> as non-null.</para>
+    /// </summary>
+    /// <param name="inner">Address of the hub whose construction was requested.</param>
+    private void ReportHubConstructionDuringBuild(Address inner)
+    {
+        ImmutableInterlocked.Update(ref hubsConstructedDuringBuild, l => l.Add(inner));
+        TryLog(LogLevel.Error,
+            "[BUILD-NESTING] Hub {Outer} constructed hub {Inner} from inside its own Build — a "
+            + "SyncBuildupAction reached hub construction, so a disposal racing {Outer}'s creation "
+            + "races a TREE of constructions rather than one frame (#1868). Move the initialization "
+            + "to the OBSERVABLE WithInitialization overload, which runs on InitializeHubRequest "
+            + "after Build has returned.",
+            Address, inner);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Data.Test/BuildMustNotConstructHubsTest.cs
+++ b/test/MeshWeaver.Data.Test/BuildMustNotConstructHubsTest.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// 🚨 <b>#1868 — <c>Build</c> must not construct another hub.</b>
+///
+/// <para><b>The fact.</b> <c>MessageHubConfiguration.Build</c> runs <c>SyncBuildupActions</c>
+/// inline, before <c>StartMessageProcessing()</c>. Two of those actions reached code that creates
+/// hubs: <c>DataExtensions.GetDefaultConfiguration</c> registered
+/// <c>WithInitialization(h =&gt; h.GetWorkspace())</c> on the SYNCHRONOUS overload
+/// (→ <c>Workspace..ctor</c> → <c>DataContext.Initialize</c> → <c>DataSource.GetStream</c> →
+/// <c>SynchronizationStream..ctor</c>), and <c>KernelContainer</c> registered
+/// <c>StartActivityControlPlane</c> the same way (→ <c>WatchControlPlane</c> →
+/// <c>AcquireStream</c> → <c>Workspace.GetStream</c>). <c>SynchronizationStream</c>'s constructor
+/// ALWAYS calls <c>Host.GetHostedHub(sync/…, HostedHubCreation.Always)</c>, so every data-enabled
+/// hub built at least one sub-hub — and a second Autofac container — inside its own <c>Build</c>.
+/// Measured with a depth counter on a GREEN <c>MeshWeaver.FutuRe.Test</c> run: <b>1,350 nested
+/// Builds</b>, all depth=2, top outers <c>FutuRe/Analysis</c> ×156, <c>FutuRe/EuropeRe/Analysis</c>
+/// ×150, <c>FutuRe</c> ×132, <c>mesh</c> ×92.</para>
+///
+/// <para><b>What is and is not claimed.</b> NOT that this causes a SIGSEGV — that hypothesis was
+/// investigated under #613 and falsified (the faulting thread is the background GC thread with zero
+/// managed frames), and withdrawn in #1867; 1,350 nestings per green run refute it. What survives is
+/// a design defect worth judging on its own: <i>a disposal that races a construction races a TREE of
+/// constructions, not one frame.</i> That is the shape behind the whole shutdown-race family — #645
+/// (cascade the creation freeze through the subtree), #715 (finish in-flight constructions at
+/// disposal instead of racing them), #967 (unload node ALCs at the end of teardown), #1573 (the
+/// 8-issue family) — each of which had to widen its guard to cover work started by a construction
+/// that had itself been started by a construction. <c>HostedHubsCollection</c>'s in-flight counter
+/// tracks the OUTER creation; the inner one it spawns is a second entry, on the same thread, whose
+/// refusal/finish semantics are only correct because the guards were extended by hand, one incident
+/// at a time.</para>
+///
+/// <para><b>Scope.</b> This pins step 1 of the adoption: no hub is constructed from inside
+/// <c>Build</c>. Step 2 — stopping <c>SynchronizationStream</c>'s constructor from creating its
+/// sub-hub eagerly — is deliberately not attempted (~96 sites dereference
+/// <c>ISynchronizationStream.Hub</c> as non-null, and the constructor's "a stream that cannot own
+/// its sub-hub is not a stream — refuse, never fabricate" contract is worth preserving). Step 1
+/// alone does not remove the sub-hub; it moves its creation OUT of <c>Build</c>, which is the part
+/// the disposal guards care about.</para>
+/// </summary>
+public class BuildMustNotConstructHubsTest : HubTestBase
+{
+    /// <summary>Test record for the data source below — a source is required, since a DataContext
+    /// with no sources creates no stream and therefore no sub-hub either way.</summary>
+    private record Widget(string Id, string Text);
+
+    public BuildMustNotConstructHubsTest(ITestOutputHelper output) : base(output)
+    {
+        // Nothing to wire: the violations are recorded on the hub instance
+        // (MessageHub.HubsConstructedDuringBuild), not fished out of the log.
+    }
+
+    // 🚨 A HUB SOURCE, deliberately. HubDataSource.Initialize EAGERLY opens its remote stream
+    // (GetRemoteStreamAsHub → CreateExternalClient → new SynchronizationStream → GetHostedHub(sync/…,
+    // Always)), so this is the shape that actually reaches hub construction from a buildup action.
+    // A plain in-memory source's Initialize is a no-op and would make the test vacuous.
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .AddData(data => data.AddHubSource(CreateHostAddress(),
+                source => source.WithType<Widget>(type => type.WithKey(w => w.Id))));
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData(data => data.AddSource(source =>
+                source.WithType<Widget>(type => type
+                    .WithKey(w => w.Id)
+                    .WithInitialData(() => Observable.Return<IEnumerable<Widget>>([new Widget("1", "A")])))));
+
+    /// <summary>
+    /// Building a data-enabled hub must construct no hub of its own.
+    ///
+    /// <para><b>Non-vacuity.</b> On <c>origin/main</c> the workspace is resolved from a SYNCHRONOUS
+    /// buildup action, so the very first data-enabled hub logs the violation naming its
+    /// <c>sync/…</c> child, and this assertion fails with those addresses in the message.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task DataEnabledHub_BuildsNoHubOfItsOwn()
+    {
+        // Force the hubs into existence and drive them far enough that their workspaces really are
+        // built — otherwise "no nesting" could just mean "nothing was initialized".
+        var client = (MessageHub)GetClient();
+        var host = (MessageHub)GetHost();
+        client.ServiceProvider.GetRequiredService<IWorkspace>().Should().NotBeNull(
+            "the workspace must actually be constructed, or this proves nothing");
+        await client.Started.WaitAsync(30.Seconds());
+        await host.Started.WaitAsync(30.Seconds());
+
+        // The premise, asserted: the hub-backed data source really did open its remote stream, so a
+        // sync/ sub-hub really was created. Without this, "constructed nothing during Build" would
+        // also be satisfied by a hub that constructed nothing at all.
+        var hostedTree = client.GetDisposalDiagnostics() + host.GetDisposalDiagnostics();
+        hostedTree.Should().Contain("sync/",
+            "the hub-backed data source must have opened its remote stream (HubDataSource.Initialize "
+            + "→ GetRemoteStreamAsHub → new SynchronizationStream → GetHostedHub(sync/…)), or there "
+            + "is nothing that COULD have nested");
+
+        var violations = client.HubsConstructedDuringBuild.Concat(host.HubsConstructedDuringBuild)
+            .Select(a => a.ToString()).ToArray();
+        foreach (var v in violations)
+            Output.WriteLine(v);
+
+        violations.Should().BeEmpty(
+            "a SyncBuildupAction reached hub construction: Build runs those inline, before "
+            + "StartMessageProcessing, so a disposal racing this hub's creation races a TREE of "
+            + "constructions rather than one frame (#1868). The initialization belongs on the "
+            + "OBSERVABLE WithInitialization overload, which runs on InitializeHubRequest after "
+            + "Build has returned. Constructed during Build: " + string.Join(", ", violations));
+    }
+
+}


### PR DESCRIPTION
Part of #1868 — **step 1** of the adoption, plus the probe that makes the invariant testable.

## Mechanism

`MessageHubConfiguration.Build` runs `SyncBuildupActions` **inline**, before `StartMessageProcessing()`. Two of those actions reached code that creates hubs:

- `DataExtensions.GetDefaultConfiguration` registered `WithInitialization(h => h.GetWorkspace())` on the **synchronous** overload → `Workspace..ctor` → `DataContext.Initialize()` → `DataSource.GetStream` → `SynchronizationStream..ctor`;
- `KernelContainer.<Configure>` registered `StartActivityControlPlane` the same way → `WatchControlPlane` → `SubscribeWithReEstablish` → `AcquireStream` → `Workspace.GetStream` → `SynchronizationStream..ctor`;

and `SynchronizationStream`'s constructor **always** calls `Host.GetHostedHub(sync/{clientId}, HostedHubCreation.Always)`. So every data-enabled hub built at least one sub-hub — and a second Autofac container — **inside its own `Build`**: **1,350 nested `Build`s per green `MeshWeaver.FutuRe.Test` run**, all depth 2.

**Explicitly not claimed: that this causes a SIGSEGV.** That hypothesis was investigated under #613 and falsified (the faulting thread is the background GC thread with zero managed frames), and withdrawn in #1867; 1,350 nestings per *green* run refute it.

What survives is a design defect worth judging on its own: **a disposal that races a construction races a TREE of them.** That is the shape behind the whole shutdown-race family — #645 (cascade the creation freeze through the subtree), #715 (finish in-flight constructions at disposal instead of racing them), #967 (unload node ALCs at the end of teardown), #1573 (the 8-issue family) — each of which had to widen its guard to cover work started by a construction that had itself been started by a construction. `HostedHubsCollection`'s in-flight counter tracks the **outer** creation; the inner one it spawns is a second entry, on the same thread, whose refusal/finish semantics are only correct because the guards were extended by hand, one incident at a time. It also makes `Build` reachable from arbitrary reactive emissions (the 08-18 dump has one nested `Build` reached from `MessageService.DrainOne`, one from a `MeshQuery` emission).

## What changed

**Both sites move to the observable `WithInitialization` overload**, which runs on the `InitializeHubRequest` turn — after `Build` returns, and still *before* the Initialize gate opens, so nothing observable to a message changes. `BuildupActions` are `Concat`-ed, so relative ordering is preserved too. This is the same shape #774 already applied to `MeshDataSource.SubscribeToOwnDeletion`.

**…but on the data side the move had to be a SPLIT, not a relocation** — CI found this, and the finding is worth keeping. `DataContext.Initialize` was doing two unrelated things:

| half | what it does | where it must run |
|---|---|---|
| **configuration** | resolve the data sources, build the type sources, **register every mapped type with the hub's `ITypeRegistry`**, build the by-type/by-collection lookups (and raise the duplicate-registration diagnostics) | **inside `Build`** — a caller that resolves the hub reads `TypeRegistry` the instant `Build` returns |
| **starting the sources** | `IDataSource.Initialize`, where `HubDataSource` eagerly calls `GetStream` → `SynchronizationStream..ctor` → `GetHostedHub(sync/…)` | **not** inside `Build` |

Moving the whole thing moved the type registration too, and `SchemaValidationTest`, `AgentWriteFailureTests` and `ProbeHubCostTest` went red with *"TestProduct type should be registered in the hub's type registry, but found False"* (run 32557607415, shards 3 and 4). So `Initialize()` keeps the configuration half and stays a synchronous buildup action — resolving the workspace itself creates no hub — and the new, idempotent `InitializeDataSources()` runs on the init turn immediately before `OpenInitializationGate()`.

**The invariant is armed, not assumed.** `MessageHub.GetHostedHub` records any creation requested before `StartMessageProcessing()` on `MessageHub.HubsConstructedDuringBuild` and logs `[BUILD-NESTING]` naming both addresses. That flag is exact: `StartMessageProcessing()` is the last thing `Build` does, so "not started yet" *is* "inside Build".

**Recorded, not thrown** — deliberately. Step 2 (stopping `SynchronizationStream`'s constructor from creating its sub-hub eagerly) is what would make throwing viable, and it is not attempted here: ~96 sites dereference `ISynchronizationStream.Hub` as non-null, and the constructor's *"a stream that cannot own its sub-hub is not a stream — refuse, never fabricate"* contract is deliberate and worth preserving. Per the issue's own sequencing note, step 1 does not remove the sub-hub — it moves its creation **out of `Build`**, which is the part the disposal guards care about.

## Tests

`BuildMustNotConstructHubsTest` uses a **hub-backed** data source on purpose: `HubDataSource.Initialize` eagerly opens its remote stream (`GetRemoteStreamAsHub` → `CreateExternalClient` → `new SynchronizationStream` → `GetHostedHub(sync/…)`), which is the shape that actually reaches hub construction from a buildup action. A plain in-memory source's `Initialize` is a no-op and would make the test vacuous — verified: the first version of this test used one and passed against the *unfixed* code.

It **asserts its own premise** — that a `sync/` sub-hub really was created — before asserting that none was created during `Build`.

### Non-vacuity

The probe is the measuring instrument, so the control is the fix without the init moves. With only the two `WithInitialization` moves reverted (probe intact):

```
Failed  DataEnabledHub_BuildsNoHubOfItsOwn
  Expected collection to be empty because a SyncBuildupAction reached hub construction …
  Constructed during Build: sync/jwUY-bKNaE2AHttoZwUb1Q, sync/4sAvzI1OuEaMl1gUmT1awQ,
  sync/NnXPMC5RD06idyzG6qUZUw, sync/GQQ5Bhy1VUWPu2c5XPRxRw, but found 4 item(s).
```

Four nested constructions across one client and one host hub; zero after the fix.

Green on this branch: **375/375** `MeshWeaver.Data.Test`, **1181/1184** `MeshWeaver.AI.Test` (3 pre-existing skips), **263/263** `MeshWeaver.Messaging.Hub.Test`, **10/10** `MeshWeaver.Kernel.Test`, **59/59** `MeshWeaver.FutuRe.Test` (the harness the 1,350 number came from), and the three suites CI reddened. `dotnet build -c Release -warnaserror` clean.

## Deliberately left

- **Step 2** — `SynchronizationStream`'s eager sub-hub (see above). Until it lands the invariant is not universally true, which is exactly why the probe records rather than throws.
- Turning `[BUILD-NESTING]` into a hard failure. That is a one-line change once step 2 lands and the remaining sites are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
