### PR TITLE
Skill + agent DISPLAY metadata is localized per viewer, and a half-localized pack cannot merge (#1626)

### DIFF
--- a/memex/Memex.Portal.Shared/Skills/AgentSkillSyncService.cs
+++ b/memex/Memex.Portal.Shared/Skills/AgentSkillSyncService.cs
@@ -149,6 +149,10 @@ public sealed class AgentSkillSyncService(
     public static string ComposeWorkspaceInstructions(
         IEnumerable<MeshNode> skillNodes, JsonSerializerOptions jsonOptions)
     {
+        // 🌍 Deliberately NO locale: this catalog is written into the CLI harness's workspace
+        // instructions — it is MODEL-facing, not a person's picker — so it stays the authored
+        // English in every deployment. Localizing it would make what an agent can discover depend
+        // on the UI language of whoever happened to trigger the sync.
         var catalog = RenderSkillCatalog(SkillNodeType.ProjectSkills(skillNodes, jsonOptions));
         return string.IsNullOrEmpty(catalog)
             ? BaseInstructions()

--- a/src/MeshWeaver.AI/AgentConfiguration.cs
+++ b/src/MeshWeaver.AI/AgentConfiguration.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using MeshWeaver.Mesh;
 
 namespace MeshWeaver.AI;
 
@@ -16,7 +17,7 @@ namespace MeshWeaver.AI;
 /// <see cref="Description"/> is kept because the agent runtime feeds it to the model as
 /// delegation metadata where only the detached configuration is in hand.)</para>
 /// </summary>
-public record AgentConfiguration
+public record AgentConfiguration : ILocalizedNodeText
 {
     /// <summary>
     /// Unique identifier for this agent. Equals the owning <see cref="MeshWeaver.Mesh.MeshNode.Id"/>
@@ -96,6 +97,22 @@ public record AgentConfiguration
     /// conversational surface (<c>AgentPickerProjection.IsUtilityAgent</c>).</para>
     /// </summary>
     public string? ModelTier { get; init; }
+
+    /// <summary>
+    /// Per-language overrides of the owning node's USER-VISIBLE display metadata (name /
+    /// description / category), keyed by BCP-47 tag — e.g. <c>de</c>. Rendered through
+    /// <see cref="NodeTextTranslations"/>, which resolves the tag exactly like the string catalog
+    /// and the <c>[Translation]</c> attributes do, so the three cannot disagree.
+    ///
+    /// <para>🚨 This localizes what the PICKER shows, and nothing else. In particular it must never
+    /// be applied to <see cref="Description"/> on this record or to <see cref="Instructions"/>:
+    /// those are the delegation catalogue and the system prompt — text a MODEL reads to decide
+    /// which agent to pick and how to behave — so translating them changes behaviour rather than
+    /// presentation. The agent's runtime identity (<see cref="Id"/>, and the paths delegations and
+    /// hand-offs name) is likewise untouched, so localizing a label can never re-point a
+    /// delegation.</para>
+    /// </summary>
+    public IReadOnlyDictionary<string, LocalizedNodeText>? Translations { get; init; }
 
     /// <summary>
     /// Optional list of additional plugins this agent should load.

--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -364,12 +364,16 @@ public static class AgentPickerProjection
         // upstream by id, so a settings change MUST mint a new id or the old subscription serves
         // stale queries forever.
         var workspace = hub.GetWorkspace();
+        // 🌍 Capture the viewer's language HERE, on the subscribing turn, exactly as the identity is
+        // captured — the projection below runs on synced-query emissions where AccessContext's
+        // AsyncLocal is already gone, so an ambient read there resolves to English at random.
+        var locale = hub.ServiceProvider.GetService<AccessService>().ViewerLocale();
         return AiSettingsNodeType.ObserveAgentQueries(workspace, hub, hub.ServiceProvider, userPath, spacePath)
             .Select(queries => ObserveSnapshot(workspace, hub,
                 $"{AgentsQueryId}|u={userPath ?? ""}|s={spacePath ?? ""}|q={Fingerprint(queries)}",
                 queries))
             .Switch()
-            .Select(snapshot => ProjectAgents(snapshot, hub.JsonSerializerOptions));
+            .Select(snapshot => ProjectAgents(snapshot, hub.JsonSerializerOptions, locale));
     }
 
     /// <summary>Deterministic short fingerprint of a resolved query set, for cache-keying the
@@ -633,8 +637,14 @@ public static class AgentPickerProjection
     /// when the receiving hub's typed registry doesn't have
     /// <see cref="AgentConfiguration"/> wired up; sorts by Order then Name.
     /// </summary>
+    /// <param name="snapshot">The mesh-node snapshot to project.</param>
+    /// <param name="jsonOptions">Serializer options used to type each node's content.</param>
+    /// <param name="locale">
+    /// 🌍 The viewer's language, resolved ONCE on the render turn and passed down — see
+    /// <see cref="ToAgentDisplayInfo"/> for why it is an argument and not an ambient read.
+    /// </param>
     public static IReadOnlyList<AgentDisplayInfo> ProjectAgents(
-        IEnumerable<MeshNode> snapshot, JsonSerializerOptions jsonOptions)
+        IEnumerable<MeshNode> snapshot, JsonSerializerOptions jsonOptions, string? locale = null)
     {
         var byPath = new Dictionary<string, AgentDisplayInfo>(StringComparer.Ordinal);
         foreach (var node in snapshot)
@@ -643,7 +653,7 @@ public static class AgentPickerProjection
             if (!string.Equals(node.NodeType, AgentNodeType.NodeType, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            var info = ToAgentDisplayInfo(node, jsonOptions);
+            var info = ToAgentDisplayInfo(node, jsonOptions, locale);
             if (info != null)
                 byPath[node.Path] = info;
         }
@@ -723,25 +733,46 @@ public static class AgentPickerProjection
     /// handles typed, JsonElement, JsonNode, and a same-named type from another dynamic
     /// assembly.</para>
     /// </summary>
+    /// <param name="node">The agent node.</param>
+    /// <param name="jsonOptions">Serializer options used to type the node's content.</param>
+    /// <param name="locale">
+    /// 🌍 The viewer's language, resolved ONCE on the render turn (<c>host.ViewerLocale()</c> /
+    /// <c>accessService.ViewerLocale()</c>) and passed down. Null = the authored (English) text.
+    /// It is an ARGUMENT rather than an ambient read for the same reason the display-time seam is:
+    /// <c>AccessContext.Locale</c> rides an AsyncLocal that does not survive a scheduler hop, and
+    /// this projection runs on a synced-query emission, off the caller's own call tree.
+    /// </param>
     public static AgentDisplayInfo? ToAgentDisplayInfo(
-        MeshNode node, JsonSerializerOptions jsonOptions)
+        MeshNode node, JsonSerializerOptions jsonOptions, string? locale = null)
     {
         var config = node.ContentAs<AgentConfiguration>(jsonOptions);
         if (config == null) return null;
         // Display metadata is sourced from the MeshNode (the single source of truth);
         // only agent-specific bits (CustomIconSvg, the config itself) come from Content.
+        //
+        // 🌍 …and the DISPLAY half of it is localized. The translation is read off the TYPED
+        // configuration, not off node.Content, because the node may carry the as-written DOM and
+        // ContentAs above already resolved it. Note what is NOT localized: config.Description is
+        // the delegation catalogue the MODEL reads, so it stays the authored text even when the
+        // node's own description is translated — a German picker label must not change which agent
+        // the model routes to.
+        var text = NodeTextTranslations.For(config, locale);
         return new AgentDisplayInfo
         {
-            Name = node.Name ?? config.Id,
+            Name = Localized(text?.Name, node.Name) ?? config.Id,
             Path = node.Path,
-            Description = node.Description ?? config.Description ?? "",
-            GroupName = node.Category,
+            Description = Localized(text?.Description, node.Description) ?? config.Description ?? "",
+            GroupName = Localized(text?.Category, node.Category),
             Order = node.Order ?? 0,
             Icon = node.Icon,
             CustomIconSvg = config.CustomIconSvg,
             AgentConfiguration = config,
         };
     }
+
+    /// <summary>Per-FIELD fallback: a translation that sets only one field keeps the authored rest.</summary>
+    private static string? Localized(string? translated, string? authored)
+        => string.IsNullOrWhiteSpace(translated) ? authored : translated;
 
     /// <summary>
     /// Single MeshNode → ModelInfo projection. Reads content through

--- a/src/MeshWeaver.AI/BuiltInAgentProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInAgentProvider.cs
@@ -258,7 +258,8 @@ public class BuiltInAgentProvider : IStaticNodeProvider
             }).ToList(),
             Plugins = frontMatter.Plugins?.Select(AgentPluginReference.Parse).ToList(),
             ContextMatchPattern = frontMatter.ContextMatchPattern,
-            ModelTier = frontMatter.ModelTier
+            ModelTier = frontMatter.ModelTier,
+            Translations = ReadTranslations(frontMatter.Translations)
         };
 
         // Node-level metadata (name, description, icon, group, order) lives on the
@@ -275,6 +276,30 @@ public class BuiltInAgentProvider : IStaticNodeProvider
             Order = frontMatter.Order,
             Content = agentConfig
         };
+    }
+
+    /// <summary>
+    /// Front matter → the typed translation map. Null for an absent or empty block, so an
+    /// untranslated agent carries no translations rather than an empty dictionary.
+    /// </summary>
+    private static IReadOnlyDictionary<string, LocalizedNodeText>? ReadTranslations(
+        Dictionary<string, LocalizedNodeTextEntry>? fm)
+    {
+        if (fm is not { Count: > 0 })
+            return null;
+        var map = new Dictionary<string, LocalizedNodeText>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (tag, text) in fm)
+        {
+            if (string.IsNullOrWhiteSpace(tag) || text is null)
+                continue;
+            map[tag.Trim()] = new LocalizedNodeText
+            {
+                Name = text.Name,
+                Description = text.Description,
+                Category = text.Category,
+            };
+        }
+        return map.Count == 0 ? null : map;
     }
 
     private static MeshNode ParseMarkdownNode(string yamlContent, string markdownBody, string relativePath)
@@ -350,6 +375,21 @@ public class BuiltInAgentProvider : IStaticNodeProvider
         public List<DelegationEntry>? Delegations { get; set; }
         public List<HandoffEntry>? Handoffs { get; set; }
         public List<string>? Plugins { get; set; }
+
+        /// <summary>
+        /// <c>translations: { de: { name: …, description: …, category: … } }</c> — per-language
+        /// overrides of the DISPLAY metadata only. The markdown body is the agent's system prompt
+        /// and stays in one language; see <see cref="AgentConfiguration.Translations"/>.
+        /// </summary>
+        public Dictionary<string, LocalizedNodeTextEntry>? Translations { get; set; }
+    }
+
+    /// <summary>One language's display overrides, as written in the front matter.</summary>
+    private class LocalizedNodeTextEntry
+    {
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public string? Category { get; set; }
     }
 
     private class DelegationEntry

--- a/src/MeshWeaver.AI/Completion/SkillAutocompleteProvider.cs
+++ b/src/MeshWeaver.AI/Completion/SkillAutocompleteProvider.cs
@@ -45,6 +45,11 @@ public class SkillAutocompleteProvider : IAutocompleteProvider
         // subscription isn't shared across identities.
         var accessService = _serviceProvider.GetService<AccessService>();
         var userHome = AgentPickerProjection.ResolveUserHome(accessService);
+        // 🌍 Resolve the viewer's language HERE, on the request turn, and carry it into the
+        // projection below. Reading it inside the .Select would read an AsyncLocal that the
+        // synced-query scheduler hop has already cleared — the same capture rule the identity above
+        // follows, and the same one the display-time seam documents.
+        var locale = accessService.ViewerLocale();
         // The user's SKILL SOURCES are configurable (AiSettings.SkillQueries — one query row per
         // source, defaulting to global/space/type/user; installing a skill package appends its row).
         // Observe the settings and Switch to the resolved query set; the cache id carries the
@@ -55,7 +60,7 @@ public class SkillAutocompleteProvider : IAutocompleteProvider
                 workspace, hub,
                 $"skill-autocomplete|{contextPath}|{userHome}|{QueryKey(queries)}", queries))
             .Switch()
-            .Select(snapshot => BuildItems(snapshot, hub));
+            .Select(snapshot => BuildItems(snapshot, hub, locale));
     }
 
     /// <summary>Stable in-process key for a resolved query set — distinct source sets must not share a
@@ -75,11 +80,20 @@ public class SkillAutocompleteProvider : IAutocompleteProvider
     internal static string[] BuildQueries(AccessService? accessService, string? contextPath)
         => SkillNodeType.SkillQueries(contextPath, AgentPickerProjection.ResolveUserHome(accessService));
 
-    private static IReadOnlyCollection<AutocompleteItem> BuildItems(IEnumerable<MeshNode> snapshot, IMessageHub? hub)
+    /// <param name="snapshot">The skill nodes to offer.</param>
+    /// <param name="hub">The hub whose serializer options type each node's content.</param>
+    /// <param name="locale">
+    /// 🌍 The viewer's language, captured on the REQUEST turn by the caller. Not read here: this
+    /// method runs on a synced-query emission where <c>AccessContext.Locale</c>'s AsyncLocal is
+    /// already gone, so an ambient read would silently serve English to a German viewer.
+    /// </param>
+    private static IReadOnlyCollection<AutocompleteItem> BuildItems(
+        IEnumerable<MeshNode> snapshot, IMessageHub? hub, string? locale)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var items = new List<AutocompleteItem>();
-        foreach (var skill in SkillNodeType.ProjectSkills(snapshot, hub?.JsonSerializerOptions ?? EmptyJsonOptions))
+        foreach (var skill in SkillNodeType.ProjectSkills(
+                     snapshot, hub?.JsonSerializerOptions ?? EmptyJsonOptions, locale))
             if (seen.Add(skill.Id))
                 items.Add(Item(skill.Id, skill.Description));
         return items;

--- a/src/MeshWeaver.AI/SkillMarkdown.cs
+++ b/src/MeshWeaver.AI/SkillMarkdown.cs
@@ -97,6 +97,7 @@ public static class SkillMarkdown
             AutoMount = fm.AutoMount,
             LaunchesSubThread = fm.LaunchesSubThread,
             Harness = fm.Harness,
+            Translations = ReadTranslations(fm.Translations),
             Action = fm.Action is null ? null : new SkillAction
             {
                 Kind = Enum.TryParse<SkillActionKind>(fm.Action.Kind, ignoreCase: true, out var kind)
@@ -149,6 +150,7 @@ public static class SkillMarkdown
             AutoMount = def.AutoMount ? null : false,               // default true → omit
             LaunchesSubThread = def.LaunchesSubThread ? true : null, // default false → omit
             Harness = def.Harness,
+            Translations = WriteTranslations(def.Translations),
             Action = def.Action is null ? null : new SkillActionFrontMatterOut
             {
                 // Pick is the default enum value → omit (Parse defaults a missing kind to Pick).
@@ -166,6 +168,48 @@ public static class SkillMarkdown
         return body.Length == 0 ? $"---\n{yaml}\n---\n" : $"---\n{yaml}\n---\n\n{body}\n";
     }
 
+    /// <summary>
+    /// Front matter → the typed translation map. Returns null for an absent or empty block so a
+    /// skill with no translations round-trips to a file with no <c>translations:</c> key — the same
+    /// omit-the-default rule every other field here follows.
+    /// </summary>
+    private static IReadOnlyDictionary<string, LocalizedNodeText>? ReadTranslations(
+        Dictionary<string, LocalizedNodeTextFrontMatter>? fm)
+    {
+        if (fm is not { Count: > 0 })
+            return null;
+        var map = new Dictionary<string, LocalizedNodeText>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (tag, text) in fm)
+        {
+            if (string.IsNullOrWhiteSpace(tag) || text is null)
+                continue;
+            map[tag.Trim()] = new LocalizedNodeText
+            {
+                Name = text.Name,
+                Description = text.Description,
+                Category = text.Category,
+            };
+        }
+        return map.Count == 0 ? null : map;
+    }
+
+    /// <summary>The exact inverse of <see cref="ReadTranslations"/>.</summary>
+    private static Dictionary<string, LocalizedNodeTextFrontMatter>? WriteTranslations(
+        IReadOnlyDictionary<string, LocalizedNodeText>? translations)
+    {
+        if (translations is not { Count: > 0 })
+            return null;
+        var map = new Dictionary<string, LocalizedNodeTextFrontMatter>(StringComparer.Ordinal);
+        foreach (var (tag, text) in translations)
+            map[tag] = new LocalizedNodeTextFrontMatter
+            {
+                Name = text.Name,
+                Description = text.Description,
+                Category = text.Category,
+            };
+        return map;
+    }
+
     // ── The frontmatter models ──────────────────────────────────────────────
 
     // Read model — matches the hand-authored files (camelCase, missing fields default).
@@ -181,6 +225,21 @@ public static class SkillMarkdown
         public bool LaunchesSubThread { get; set; }
         public string? Harness { get; set; }
         public SkillActionFrontMatter? Action { get; set; }
+
+        /// <summary>
+        /// <c>translations: { de: { name: …, description: …, category: … } }</c> — per-language
+        /// overrides of the DISPLAY metadata only. The body below the front matter is the skill's
+        /// procedure and stays in one language; see <see cref="SkillDefinition.Translations"/>.
+        /// </summary>
+        public Dictionary<string, LocalizedNodeTextFrontMatter>? Translations { get; set; }
+    }
+
+    /// <summary>One language's display overrides, as written in the front matter.</summary>
+    internal sealed class LocalizedNodeTextFrontMatter
+    {
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public string? Category { get; set; }
     }
 
     internal sealed class SkillActionFrontMatter
@@ -206,6 +265,7 @@ public static class SkillMarkdown
         public bool? LaunchesSubThread { get; set; }
         public string? Harness { get; set; }
         public SkillActionFrontMatterOut? Action { get; set; }
+        public Dictionary<string, LocalizedNodeTextFrontMatter>? Translations { get; set; }
     }
 
     private sealed class SkillActionFrontMatterOut

--- a/src/MeshWeaver.AI/SkillNodeType.cs
+++ b/src/MeshWeaver.AI/SkillNodeType.cs
@@ -106,8 +106,18 @@ public static class SkillNodeType
     /// the slash word from <see cref="MeshNode.Id"/> and help text from <see cref="MeshNode.Description"/>;
     /// the spec is the typed (or JsonElement-fallback) <see cref="SkillDefinition"/> content.
     /// </summary>
+    /// <param name="snapshot">The mesh-node snapshot to project.</param>
+    /// <param name="jsonOptions">Serializer options used to type each node's content.</param>
+    /// <param name="locale">
+    /// 🌍 The viewer's language, resolved ONCE on the render turn (<c>host.ViewerLocale()</c> /
+    /// <c>accessService.ViewerLocale()</c>) and passed down. Null = the authored (English) text.
+    /// It is an ARGUMENT rather than an ambient read for the same reason the display-time seam is:
+    /// <c>AccessContext.Locale</c> rides an AsyncLocal that does not survive a scheduler hop, so a
+    /// list filled on a later emission would silently resolve to English while the page around it
+    /// rendered German — and two call sites resolving separately can disagree on the same page.
+    /// </param>
     public static IReadOnlyList<SkillInfo> ProjectSkills(
-        IEnumerable<MeshNode> snapshot, JsonSerializerOptions jsonOptions)
+        IEnumerable<MeshNode> snapshot, JsonSerializerOptions jsonOptions, string? locale = null)
     {
         var byId = new Dictionary<string, SkillInfo>(StringComparer.OrdinalIgnoreCase);
         foreach (var node in snapshot)
@@ -121,11 +131,14 @@ public static class SkillNodeType
             // nothing logged. Identical defect to ToAgentDisplayInfo's, same package.
             var def = node.ContentAs<SkillDefinition>(jsonOptions);
             if (def is null) continue;
+            // 🌍 The translation is read off the TYPED definition, not off node.Content — the node
+            // may carry the as-written DOM, and the fold above already resolved it.
+            var text = NodeTextTranslations.For(def, locale);
             byId[node.Id] = new SkillInfo
             {
-                Id = node.Id,
-                Name = node.Name,
-                Description = node.Description,
+                Id = node.Id,   // 🚨 the slash word — an invocation token, never localized
+                Name = Localized(text?.Name, node.Name),
+                Description = Localized(text?.Description, node.Description),
                 Path = node.Path,
                 Definition = def,
             };
@@ -133,6 +146,9 @@ public static class SkillNodeType
         return byId.Values.OrderBy(s => s.Id, StringComparer.OrdinalIgnoreCase).ToList();
     }
 
+    /// <summary>Per-FIELD fallback: a translation that sets only one field keeps the authored rest.</summary>
+    private static string? Localized(string? translated, string? authored)
+        => string.IsNullOrWhiteSpace(translated) ? authored : translated;
 }
 
 /// <summary>
@@ -140,7 +156,7 @@ public static class SkillNodeType
 /// an instruction (<see cref="Instructions"/>). The skill's NAME and DESCRIPTION come from the owning
 /// <see cref="MeshWeaver.Mesh.MeshNode"/>.
 /// </summary>
-public record SkillDefinition
+public record SkillDefinition : ILocalizedNodeText
 {
     /// <summary>
     /// INSTRUCTION skill — the <c>SKILL.md</c> body (markdown). Surfaced to the CLI harnesses + the
@@ -178,6 +194,20 @@ public record SkillDefinition
     /// <c>/agent</c> + <c>/model</c>. A skill is a value + a picker + a status chip — one concept.
     /// </summary>
     public string? Harness { get; init; }
+
+    /// <summary>
+    /// Per-language overrides of this skill's USER-VISIBLE display metadata (name / description /
+    /// category), keyed by BCP-47 tag — e.g. <c>de</c>. Rendered through
+    /// <see cref="NodeTextTranslations"/>, which resolves the tag exactly like the string catalog
+    /// and the <c>[Translation]</c> attributes do, so the three cannot disagree.
+    ///
+    /// <para>🚨 Display text ONLY — never <see cref="Instructions"/>. The body is the skill's
+    /// PROCEDURE, read by a model, and translating prompt text changes behaviour rather than
+    /// presentation. The slash word is excluded for a harder reason: a skill is invoked by its node
+    /// <b>Id</b> (<c>/space</c>), so it is a wire token, not a label — which is why localizing this
+    /// record can never change what a slash command resolves to.</para>
+    /// </summary>
+    public IReadOnlyDictionary<string, LocalizedNodeText>? Translations { get; init; }
 }
 
 /// <summary>

--- a/src/MeshWeaver.AI/SkillView.cs
+++ b/src/MeshWeaver.AI/SkillView.cs
@@ -39,25 +39,35 @@ public static class SkillView
     /// <c>Take(1)</c> on the live stream.
     /// </summary>
     public static IObservable<UiControl?> Overview(LayoutAreaHost host, RenderingContext _)
-        => host.Workspace.GetMeshNodeStream()
-            .Select(node => (UiControl?)BuildOverview(host, node));
+    {
+        // 🌍 Resolve the viewer's language ONCE, on the render turn, and pass it down. Reading it
+        // inside the Select would read an AsyncLocal that the node-stream emission has already left
+        // behind, so a German viewer would get a German page frame around an English skill card.
+        var locale = host.ViewerLocale();
+        return host.Workspace.GetMeshNodeStream()
+            .Select(node => (UiControl?)BuildOverview(host, node, locale));
+    }
 
     private const string ContainerStyle = "max-width: 1080px; margin: 0 auto; padding: 24px; gap: 16px;";
 
-    private static UiControl BuildOverview(LayoutAreaHost host, MeshNode? node)
+    private static UiControl BuildOverview(LayoutAreaHost host, MeshNode? node, string? locale)
     {
         var container = Controls.Stack.WithWidth("100%").WithStyle(ContainerStyle);
 
+        var def = node.ContentAs<SkillDefinition>(host.Hub.JsonSerializerOptions);
+        // 🌍 Display text only. The INSTRUCTION body below is the skill's procedure — model-facing
+        // prompt text — and is rendered exactly as authored in every language.
+        var text = NodeTextTranslations.For(def, locale);
+
         // Title — the skill name (falls back to a humanised id).
-        var displayName = node?.Name ?? node?.Id?.Wordify() ?? "Skill";
+        var displayName = Localized(text?.Name, node?.Name) ?? node?.Id?.Wordify() ?? "Skill";
         container = container.WithView(Controls.Title(displayName, 1));
 
         // Subtitle — the slash word (`/id`) and the node's help text (description).
-        var subtitle = BuildSubtitleMarkdown(node);
+        var subtitle = BuildSubtitleMarkdown(node, Localized(text?.Description, node?.Description));
         if (!string.IsNullOrWhiteSpace(subtitle))
             container = container.WithView(Controls.Markdown(subtitle));
 
-        var def = node.ContentAs<SkillDefinition>(host.Hub.JsonSerializerOptions);
         if (def is null)
             return container;
 
@@ -75,10 +85,16 @@ public static class SkillView
         return container;
     }
 
-    private static string BuildSubtitleMarkdown(MeshNode? node)
+    /// <summary>Per-FIELD fallback: a translation that sets only one field keeps the authored rest.</summary>
+    private static string? Localized(string? translated, string? authored)
+        => string.IsNullOrWhiteSpace(translated) ? authored : translated;
+
+    private static string BuildSubtitleMarkdown(MeshNode? node, string? localizedDescription)
     {
+        // 🚨 The slash word is node.Id — the INVOCATION token — so it renders identically in every
+        // language. Localizing it would print a command the router cannot resolve.
         var slash = string.IsNullOrWhiteSpace(node?.Id) ? null : $"`/{node!.Id}`";
-        var description = string.IsNullOrWhiteSpace(node?.Description) ? null : node!.Description;
+        var description = string.IsNullOrWhiteSpace(localizedDescription) ? null : localizedDescription;
         return (slash, description) switch
         {
             ({ } s, { } d) => $"{s}\n\n{d}",

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/AgentFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/AgentFileParser.cs
@@ -122,7 +122,8 @@ public class AgentFileParser : IFileFormatParser
             }).ToList(),
             Plugins = frontMatter.Plugins?.Select(AgentPluginReference.Parse).ToList(),
             ContextMatchPattern = frontMatter.ContextMatchPattern,
-            ModelTier = frontMatter.ModelTier
+            ModelTier = frontMatter.ModelTier,
+            Translations = ReadTranslations(frontMatter.Translations)
         };
 
         var node = new MeshNode(id, ns)
@@ -187,7 +188,8 @@ public class AgentFileParser : IFileFormatParser
             Plugins = agentConfig?.Plugins?.Select(p => p.Methods is { Count: > 0 }
                 ? $"{p.Name}:{string.Join(",", p.Methods)}"
                 : p.Name).ToList(),
-            ModelTier = agentConfig?.ModelTier
+            ModelTier = agentConfig?.ModelTier,
+            Translations = WriteTranslations(agentConfig?.Translations)
         };
 
         // Always write YAML block for agent files
@@ -257,7 +259,8 @@ public class AgentFileParser : IFileFormatParser
                 ModelTier = ExtractString(element, "modelTier"),
                 Delegations = ExtractDelegations(element),
                 Handoffs = ExtractHandoffs(element),
-                Plugins = ExtractPlugins(element)
+                Plugins = ExtractPlugins(element),
+                Translations = ExtractTranslations(element)
             };
         }
         catch
@@ -280,6 +283,33 @@ public class AgentFileParser : IFileFormatParser
             return prop.ValueKind == System.Text.Json.JsonValueKind.True;
         }
         return false;
+    }
+
+    /// <summary>
+    /// Reads <c>translations</c> off an UNTYPED content element — the shape a node arrives in when
+    /// the hub did not type it. Omitting it here would make the sync-back drop every translation a
+    /// mesh-edited agent carries, silently and only on that path.
+    /// </summary>
+    private static IReadOnlyDictionary<string, LocalizedNodeText>? ExtractTranslations(
+        System.Text.Json.JsonElement element)
+    {
+        if (!element.TryGetProperty("translations", out var prop)
+            || prop.ValueKind != System.Text.Json.JsonValueKind.Object)
+            return null;
+
+        var map = new Dictionary<string, LocalizedNodeText>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in prop.EnumerateObject())
+        {
+            if (entry.Value.ValueKind != System.Text.Json.JsonValueKind.Object)
+                continue;
+            map[entry.Name] = new LocalizedNodeText
+            {
+                Name = ExtractString(entry.Value, "name"),
+                Description = ExtractString(entry.Value, "description"),
+                Category = ExtractString(entry.Value, "category"),
+            };
+        }
+        return map.Count == 0 ? null : map;
     }
 
     private static List<AgentDelegation>? ExtractDelegations(System.Text.Json.JsonElement element)
@@ -397,6 +427,47 @@ public class AgentFileParser : IFileFormatParser
         return (id, ns);
     }
 
+    /// <summary>
+    /// Front matter → the typed translation map. Null for an absent or empty block, so an
+    /// untranslated agent round-trips to a file with no <c>translations:</c> key.
+    /// </summary>
+    private static IReadOnlyDictionary<string, LocalizedNodeText>? ReadTranslations(
+        Dictionary<string, LocalizedNodeTextFrontMatter>? fm)
+    {
+        if (fm is not { Count: > 0 })
+            return null;
+        var map = new Dictionary<string, LocalizedNodeText>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (tag, text) in fm)
+        {
+            if (string.IsNullOrWhiteSpace(tag) || text is null)
+                continue;
+            map[tag.Trim()] = new LocalizedNodeText
+            {
+                Name = text.Name,
+                Description = text.Description,
+                Category = text.Category,
+            };
+        }
+        return map.Count == 0 ? null : map;
+    }
+
+    /// <summary>The exact inverse of <see cref="ReadTranslations"/>.</summary>
+    private static Dictionary<string, LocalizedNodeTextFrontMatter>? WriteTranslations(
+        IReadOnlyDictionary<string, LocalizedNodeText>? translations)
+    {
+        if (translations is not { Count: > 0 })
+            return null;
+        var map = new Dictionary<string, LocalizedNodeTextFrontMatter>(StringComparer.Ordinal);
+        foreach (var (tag, text) in translations)
+            map[tag] = new LocalizedNodeTextFrontMatter
+            {
+                Name = text.Name,
+                Description = text.Description,
+                Category = text.Category,
+            };
+        return map;
+    }
+
     private static MeshNodeState ParseState(string? state)
     {
         if (string.IsNullOrEmpty(state))
@@ -432,7 +503,23 @@ public class AgentFileParser : IFileFormatParser
         public List<DelegationFrontMatter>? Delegations { get; set; }
         public List<HandoffFrontMatter>? Handoffs { get; set; }
         public List<string>? Plugins { get; set; }
+
+        /// <summary>
+        /// <c>translations: { de: { name: …, description: …, category: … } }</c> — per-language
+        /// overrides of the DISPLAY metadata only. The markdown body is the agent's system prompt
+        /// and stays in one language; see <see cref="AgentConfiguration.Translations"/>.
+        /// </summary>
+        public Dictionary<string, LocalizedNodeTextFrontMatter>? Translations { get; set; }
     }
+
+    /// <summary>One language's display overrides, as written in the front matter.</summary>
+    private class LocalizedNodeTextFrontMatter
+    {
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public string? Category { get; set; }
+    }
+
 
     /// <summary>
     /// YAML model for delegation configuration.

--- a/src/MeshWeaver.Mesh.Contract/Localization/NodeTextTranslations.cs
+++ b/src/MeshWeaver.Mesh.Contract/Localization/NodeTextTranslations.cs
@@ -164,5 +164,60 @@ public static class NodeTextTranslations
         return result;
     }
 
+    /// <summary>
+    /// The fields a declared translation MUST carry — the two a person actually reads in a picker
+    /// row. <see cref="LocalizedNodeText.Category"/> is deliberately optional: a category is one
+    /// grouping label shared by a whole pack ("Skills"), so requiring it per node would mean
+    /// twenty-one copies of the same word, and a pack that does need it can still set it.
+    /// </summary>
+    public static ImmutableList<string> RequiredFields { get; } = ["name", "description"];
+
+    /// <summary>
+    /// 🚨 THE HALF-LOCALIZED GUARD. What <paramref name="node"/> is MISSING to be fully localized
+    /// into <paramref name="requiredLocales"/>, as <c>"{locale}:{field}"</c> entries — empty when
+    /// it is complete.
+    ///
+    /// <para>The rule is per PACK, not per node, and it is the only rule that makes a translated
+    /// pack trustworthy. A missing translation is invisible: the field falls back to English, so a
+    /// German picker with three English rows in it looks like a design choice rather than a gap.
+    /// Callers derive <paramref name="requiredLocales"/> from the pack's own union of declared
+    /// languages (<see cref="DeclaredLocales"/>), so an English-only pack requires nothing — the
+    /// gate is "do not ship HALF a language", never "you must ship every language".</para>
+    ///
+    /// <para>A required field is only required when the node HAS one: a node with no description
+    /// cannot be missing a translated description.</para>
+    /// </summary>
+    /// <param name="node">The node to check.</param>
+    /// <param name="requiredLocales">The languages this node's pack must cover.</param>
+    /// <returns>The missing <c>"{locale}:{field}"</c> entries, ordered.</returns>
+    public static ImmutableList<string> MissingTranslations(
+        MeshNode node, IEnumerable<string> requiredLocales)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        ArgumentNullException.ThrowIfNull(requiredLocales);
+        var missing = ImmutableList.CreateBuilder<string>();
+        foreach (var locale in requiredLocales.Select(Locales.Resolve).Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.Ordinal))
+        {
+            if (string.Equals(locale, Locales.Default, StringComparison.OrdinalIgnoreCase))
+                continue;   // English IS the authored text — there is nothing to declare.
+            var text = For(node.Content, locale);
+            foreach (var field in RequiredFields)
+            {
+                var authored = field switch
+                {
+                    "name" => node.Name,
+                    "description" => node.Description,
+                    "category" => node.Category,
+                    _ => null,
+                };
+                if (Blank(authored))
+                    continue;   // nothing to translate
+                if (Blank(text?.Get(field)))
+                    missing.Add($"{locale}:{field}");
+            }
+        }
+        return missing.ToImmutable();
+    }
+
     private static bool Blank(string? value) => string.IsNullOrWhiteSpace(value);
 }

--- a/src/MeshWeaver.Mesh.Contract/Localization/NodeTextTranslations.cs
+++ b/src/MeshWeaver.Mesh.Contract/Localization/NodeTextTranslations.cs
@@ -1,0 +1,168 @@
+using System.Collections.Immutable;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// One language's override of a node's USER-VISIBLE display metadata — the three
+/// <see cref="MeshNode"/> fields a picker, a catalog card or an autocomplete row actually shows.
+///
+/// <para>🚨 <b>What is deliberately NOT here.</b> Nothing MODEL-facing and nothing ADDRESSABLE.
+/// An agent's <c>AgentConfiguration.Description</c> is the delegation/hand-off catalogue the model
+/// reads to choose an agent, and a skill's <c>Instructions</c> body is its procedure — both are
+/// prompt text, and translating prompt text changes behaviour rather than presentation (the same
+/// rule that keeps <c>[Description]</c> untranslated). Identifiers are excluded for a harder
+/// reason: a skill is invoked by its node <b>Id</b> (<c>/space</c>) and an agent is resolved by
+/// path, so those are wire tokens. This record touches display text only, which is why localizing
+/// it can never change what a mention, a slash command or a delegation resolves to.</para>
+/// </summary>
+public sealed record LocalizedNodeText
+{
+    /// <summary>The node's display name in this language; null keeps the authored (English) one.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>The node's help text in this language; null keeps the authored (English) one.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>The node's grouping label in this language; null keeps the authored (English) one.</summary>
+    public string? Category { get; init; }
+
+    /// <summary>The display fields this record can carry, in author-facing order. The completeness
+    /// guard reports against these names, so it cannot drift from the record.</summary>
+    public static ImmutableList<string> Fields { get; } = ["name", "description", "category"];
+
+    /// <summary>The value of <paramref name="field"/> (one of <see cref="Fields"/>), or null.</summary>
+    /// <param name="field">The field name, case-insensitive.</param>
+    /// <returns>The value, or null when unset or unknown.</returns>
+    public string? Get(string field) => field?.ToLowerInvariant() switch
+    {
+        "name" => Name,
+        "description" => Description,
+        "category" => Category,
+        _ => null,
+    };
+
+    /// <summary>True when every field this record can carry is set to something non-blank.</summary>
+    public bool IsComplete =>
+        !string.IsNullOrWhiteSpace(Name)
+        && !string.IsNullOrWhiteSpace(Description)
+        && !string.IsNullOrWhiteSpace(Category);
+}
+
+/// <summary>
+/// Content that carries per-language overrides of its node's display metadata. Implemented by the
+/// content types whose nodes are rendered as a NAME + DESCRIPTION somewhere a person reads — today
+/// <c>SkillDefinition</c> and <c>AgentConfiguration</c>.
+/// </summary>
+public interface ILocalizedNodeText
+{
+    /// <summary>BCP-47 tag → the display overrides for that language. Null or empty = English only.</summary>
+    IReadOnlyDictionary<string, LocalizedNodeText>? Translations { get; }
+}
+
+/// <summary>
+/// The ONE rule for rendering a node's display metadata in a viewer's language — the node-data twin
+/// of <c>LocalizeExtensions</c> (string catalog) and <c>[Translation]</c> (declarations). All three
+/// resolve the language through <see cref="Locales"/>, so they cannot disagree about which language
+/// a viewer is in.
+///
+/// <para>🚨 <b>The locale is an ARGUMENT, never read ambiently here.</b> Same hazard as
+/// <c>ToDisplayTime</c>: <c>AccessContext.Locale</c> rides an <c>AsyncLocal</c> that does not
+/// survive a scheduler hop, so a picker filled on a LATER emission would silently resolve to
+/// English while the page around it rendered German — and two call sites resolving separately can
+/// disagree with each other on the same page. Resolve ONCE on the render turn
+/// (<c>host.ViewerLocale()</c> / <c>accessService.ViewerLocale()</c>) and pass the value down.</para>
+///
+/// <para><b>Per-FIELD fallback, never per-record.</b> A translation that sets only
+/// <c>description</c> keeps the authored name — the alternative (an all-or-nothing swap) would
+/// blank a name the author never intended to change. Absence therefore degrades to readable English
+/// rather than to a hole, exactly like a missing catalog key.</para>
+/// </summary>
+public static class NodeTextTranslations
+{
+    /// <summary>
+    /// The display overrides <paramref name="content"/> declares for <paramref name="locale"/>, or
+    /// null when it declares none. The tag is resolved through <see cref="Locales.Resolve"/>, so
+    /// <c>de-CH</c> and <c>de-AT</c> both find a <c>de</c> entry and an unsupported tag lands on
+    /// English (which by construction has no entry — English IS the authored text).
+    /// </summary>
+    /// <param name="content">The node's content; anything not carrying translations yields null.</param>
+    /// <param name="locale">The viewer's language tag, resolved once on the render turn.</param>
+    /// <returns>The overrides, or null.</returns>
+    public static LocalizedNodeText? For(object? content, string? locale)
+    {
+        if (content is not ILocalizedNodeText localized || localized.Translations is not { Count: > 0 } map)
+            return null;
+        var resolved = Locales.Resolve(locale);
+        if (string.Equals(resolved, Locales.Default, StringComparison.OrdinalIgnoreCase))
+            return null;   // English is the authored text; there is nothing to override it with.
+        foreach (var (tag, text) in map)
+            if (string.Equals(Locales.TryMatch(tag), resolved, StringComparison.OrdinalIgnoreCase))
+                return text;
+        return null;
+    }
+
+    /// <summary>
+    /// <paramref name="node"/> with its display metadata rendered in <paramref name="locale"/> —
+    /// the form every picker, catalog and autocomplete surface should bind to. Returns the SAME
+    /// instance when there is nothing to override, so a fully-English deployment pays nothing and
+    /// reference equality still holds for callers that cache on it.
+    /// </summary>
+    /// <param name="node">The node to render.</param>
+    /// <param name="locale">The viewer's language tag, resolved once on the render turn.</param>
+    /// <returns>The node, with Name/Description/Category localized where a translation exists.</returns>
+    public static MeshNode Localized(this MeshNode node, string? locale)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        var text = For(node.Content, locale);
+        if (text is null)
+            return node;
+        return node with
+        {
+            Name = Blank(text.Name) ? node.Name : text.Name,
+            Description = Blank(text.Description) ? node.Description : text.Description,
+            Category = Blank(text.Category) ? node.Category : text.Category,
+        };
+    }
+
+    /// <summary>The localized display NAME of <paramref name="node"/>, falling back to its authored one.</summary>
+    /// <param name="node">The node.</param>
+    /// <param name="locale">The viewer's language tag.</param>
+    /// <returns>The name, or null when the node has none in any language.</returns>
+    public static string? LocalizedName(this MeshNode node, string? locale)
+    {
+        var text = For(node?.Content, locale)?.Name;
+        return Blank(text) ? node?.Name : text;
+    }
+
+    /// <summary>The localized DESCRIPTION of <paramref name="node"/>, falling back to its authored one.</summary>
+    /// <param name="node">The node.</param>
+    /// <param name="locale">The viewer's language tag.</param>
+    /// <returns>The description, or null when the node has none in any language.</returns>
+    public static string? LocalizedDescription(this MeshNode node, string? locale)
+    {
+        var text = For(node?.Content, locale)?.Description;
+        return Blank(text) ? node?.Description : text;
+    }
+
+    /// <summary>
+    /// The languages <paramref name="content"/> declares a translation for, resolved to supported
+    /// tags and de-duplicated. Empty for content that declares none — which is a complete, valid,
+    /// English-only node, not a defect.
+    /// </summary>
+    /// <param name="content">The node's content.</param>
+    /// <returns>The declared supported languages.</returns>
+    public static ImmutableHashSet<string> DeclaredLocales(object? content)
+    {
+        if (content is not ILocalizedNodeText localized || localized.Translations is not { Count: > 0 } map)
+            return [];
+        var result = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
+        foreach (var tag in map.Keys)
+            if (Locales.TryMatch(tag) is { } matched
+                && !string.Equals(matched, Locales.Default, StringComparison.OrdinalIgnoreCase))
+                result = result.Add(matched);
+        return result;
+    }
+
+    private static bool Blank(string? value) => string.IsNullOrWhiteSpace(value);
+}

--- a/test/MeshWeaver.AI.Test/AiContentLocalizationTest.cs
+++ b/test/MeshWeaver.AI.Test/AiContentLocalizationTest.cs
@@ -1,0 +1,233 @@
+#pragma warning disable CS1591
+
+using System.Collections.Generic;
+using System.Linq;
+using MeshWeaver.AI;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// 🚨 A HALF-LOCALIZED PACK MUST NOT MERGE — issue #1626.
+///
+/// <para>Skill and Agent nodes carry user-visible <c>name</c> / <c>description</c> rendered in the
+/// skill picker, the agent combobox, autocomplete and the skill page. A missing translation is
+/// INVISIBLE: the field falls back to English (deliberately — a hole would be worse), so a German
+/// picker with three English rows in it looks like a design choice rather than a gap. Nothing is
+/// red, nothing is logged, and the only person who finds out is the German user.</para>
+///
+/// <para><b>The rule, and what it deliberately does NOT demand.</b> The unit is the PACK, and the
+/// requirement is derived from the pack itself: whatever languages the pack's nodes declare
+/// BETWEEN them, every node must cover. An English-only pack requires nothing — the gate is "do
+/// not ship half a language", never "you must ship every language", because forcing the second
+/// would make adding a skill a translation project.</para>
+///
+/// <para>This is the node-DATA member of the localization family, alongside
+/// <c>LocalizationTest</c> (the string catalog's key completeness) and the
+/// <c>[Translation]</c> attribute tests. All three resolve a viewer's language through
+/// <see cref="Locales"/>, which is what stops them disagreeing.</para>
+/// </summary>
+public class AiContentLocalizationTest
+{
+    private static IReadOnlyList<MeshNode> SkillPack => new BuiltInSkillProvider()
+        .GetStaticNodes().Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
+
+    private static IReadOnlyList<MeshNode> AgentPack => new BuiltInAgentProvider()
+        .GetStaticNodes().Where(n => n.NodeType == "Agent").ToList();
+
+    /// <summary>The languages a pack declares between all its nodes — what every node must then cover.</summary>
+    private static IReadOnlyCollection<string> PackLocales(IEnumerable<MeshNode> pack)
+        => pack.SelectMany(n => NodeTextTranslations.DeclaredLocales(n.Content))
+            .Distinct(System.StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    /// <summary>
+    /// The guard, over a whole pack: no node may be missing a language its siblings ship.
+    /// </summary>
+    private static void AssertPackIsWhole(IReadOnlyList<MeshNode> pack, string packName)
+    {
+        pack.Should().NotBeEmpty($"the {packName} pack must actually load, or this guard checks nothing");
+        var required = PackLocales(pack);
+
+        var gaps = pack
+            .Select(n => (n.Id, Missing: NodeTextTranslations.MissingTranslations(n, required)))
+            .Where(x => x.Missing.Count > 0)
+            .Select(x => $"{x.Id} → {string.Join(", ", x.Missing)}")
+            .OrderBy(x => x, System.StringComparer.Ordinal)
+            .ToArray();
+
+        gaps.Should().BeEmpty(
+            "the {0} pack declares [{1}], so EVERY node in it must carry those languages — a node "
+            + "that does not falls back to English inside an otherwise translated list, which reads "
+            + "as deliberate and is never reported. Missing: {2}",
+            packName, string.Join(", ", required.OrderBy(l => l, System.StringComparer.Ordinal)),
+            string.Join(" | ", gaps));
+    }
+
+    [Fact]
+    public void BuiltInSkillPack_IsNotHalfLocalized() => AssertPackIsWhole(SkillPack, "built-in skill");
+
+    [Fact]
+    public void BuiltInAgentPack_IsNotHalfLocalized() => AssertPackIsWhole(AgentPack, "built-in agent");
+
+    /// <summary>
+    /// 🚨 THE CONTROL. The two assertions above pass trivially while the packs are English-only, so
+    /// on their own they are not evidence the guard works. This drives the SAME rule over a
+    /// deliberately half-localized pack and requires it to fail — and names exactly what is missing,
+    /// because a guard that says only "something is wrong" gets ignored.
+    /// </summary>
+    [Fact]
+    public void TheGuard_FailsOnAHalfLocalizedPack_AndNamesTheGap()
+    {
+        var translated = Skill("alpha", "Alpha", "Does alpha things", de: ("Alpha", "Macht Alpha-Dinge"));
+        var untranslated = Skill("beta", "Beta", "Does beta things", de: null);
+        var partial = Skill("gamma", "Gamma", "Does gamma things", de: ("Gamma", null));
+
+        var pack = new[] { translated, untranslated, partial };
+        var required = PackLocales(pack);
+        // The requirement is DERIVED from the pack — one translated sibling is what makes de required.
+        required.Should().Equal(["de"]);
+
+        NodeTextTranslations.MissingTranslations(translated, required).Should().BeEmpty(
+            "a fully translated node is complete");
+        NodeTextTranslations.MissingTranslations(untranslated, required).Should().Equal(
+            ["de:name", "de:description"]);
+        // A node that translated only its NAME is exactly the half-localized case: the name renders
+        // German and the help text beside it renders English, on the same row.
+        NodeTextTranslations.MissingTranslations(partial, required).Should().Equal(["de:description"]);
+    }
+
+    /// <summary>
+    /// The other direction: an English-only pack is COMPLETE, not broken. Without this the guard
+    /// would be a demand to translate everything, which is how a localization gate gets disabled.
+    /// </summary>
+    [Fact]
+    public void AnEnglishOnlyPack_RequiresNothing()
+    {
+        var pack = new[]
+        {
+            Skill("alpha", "Alpha", "Does alpha things", de: null),
+            Skill("beta", "Beta", "Does beta things", de: null),
+        };
+        PackLocales(pack).Should().BeEmpty();
+        foreach (var node in pack)
+            NodeTextTranslations.MissingTranslations(node, PackLocales(pack)).Should().BeEmpty();
+    }
+
+    // ── Resolution ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The rendering rule: the viewer's language wins, per FIELD, and an untranslated field keeps
+    /// its authored English rather than blanking.
+    /// </summary>
+    [Fact]
+    public void Resolution_PrefersTheViewersLanguage_PerField()
+    {
+        var node = Skill("space", "/space", "Create a Space end-to-end", de: ("/space", null));
+
+        node.LocalizedDescription("de").Should().Be("Create a Space end-to-end",
+            "an untranslated field falls back to the authored text — never to a hole");
+        node.LocalizedName("de").Should().Be("/space");
+
+        var full = Skill("space", "Create a Space", "Create a Space end-to-end",
+            de: ("Space anlegen", "Legt einen Space vollständig an"));
+        full.LocalizedName("de").Should().Be("Space anlegen");
+        full.LocalizedDescription("de").Should().Be("Legt einen Space vollständig an");
+
+        full.LocalizedName("en").Should().Be("Create a Space", "English IS the authored text");
+        full.LocalizedName(null).Should().Be("Create a Space", "an unknown viewer degrades to English");
+        full.LocalizedName("fr").Should().Be("Create a Space",
+            "a language this deployment does not ship resolves to English, never to a raw key");
+    }
+
+    /// <summary>
+    /// Region variants fold onto the primary subtag exactly as everywhere else — the same
+    /// <see cref="Locales.Resolve"/> the string catalog uses, which is what stops a viewer on
+    /// <c>de-CH</c> seeing a German page frame around an English skill list.
+    /// </summary>
+    [Theory]
+    [InlineData("de")]
+    [InlineData("de-CH")]
+    [InlineData("de-AT")]
+    [InlineData("DE")]
+    public void RegionVariants_FoldOntoThePrimarySubtag(string requested)
+        => Skill("x", "X", "English", de: ("X", "Deutsch"))
+            .LocalizedDescription(requested).Should().Be("Deutsch");
+
+    /// <summary>
+    /// 🚨 NON-WIDENING, the localization edition: translating a label must never change what an
+    /// invocation resolves to. A skill is invoked by its node <b>Id</b> and an agent by path, so
+    /// those are wire tokens; the projection carries the Id through untouched in every language.
+    /// </summary>
+    [Fact]
+    public void TheInvocationToken_IsNeverLocalized()
+    {
+        var node = Skill("space", "Create a Space", "…", de: ("Space anlegen", "…"));
+        var options = new System.Text.Json.JsonSerializerOptions();
+
+        var english = SkillNodeType.ProjectSkills([node], options, "en").Single();
+        var german = SkillNodeType.ProjectSkills([node], options, "de").Single();
+
+        german.Id.Should().Be(english.Id).And.Be("space",
+            "the slash word is the node Id — a German viewer still types /space, because the router "
+            + "resolves the token, not the label");
+        german.Name.Should().Be("Space anlegen");
+        english.Name.Should().Be("Create a Space");
+    }
+
+    /// <summary>
+    /// The model-facing half stays English even when the picker label is German — an agent's
+    /// <c>AgentConfiguration.Description</c> is the delegation catalogue a MODEL reads to choose an
+    /// agent, so translating it would change routing rather than presentation.
+    /// </summary>
+    [Fact]
+    public void TheModelFacingDescription_StaysAuthored()
+    {
+        var config = new AgentConfiguration
+        {
+            Id = "Tutor",
+            Description = "Guides trainees through a course.",
+            Translations = new Dictionary<string, LocalizedNodeText>
+            {
+                ["de"] = new() { Name = "Tutor", Description = "Begleitet Lernende durch einen Kurs." },
+            },
+        };
+        var node = new MeshNode("Tutor", "Agent")
+        {
+            NodeType = "Agent",
+            Name = "Tutor",
+            Description = "Guides trainees through a course.",
+            Content = config,
+        };
+
+        var info = AgentPickerProjection.ToAgentDisplayInfo(node, new System.Text.Json.JsonSerializerOptions(), "de");
+        info.Should().NotBeNull();
+        info!.Description.Should().Be("Begleitet Lernende durch einen Kurs.",
+            "the PICKER shows the viewer's language");
+        info.AgentConfiguration!.Description.Should().Be("Guides trainees through a course.",
+            "the delegation catalogue the MODEL reads must stay the authored text — translating it "
+            + "would make agent selection depend on the viewer's UI language");
+    }
+
+    private static MeshNode Skill(
+        string id, string name, string description, (string? Name, string? Description)? de)
+        => new(id, SkillNodeType.RootNamespace)
+        {
+            NodeType = SkillNodeType.NodeType,
+            Name = name,
+            Description = description,
+            Category = "Skills",
+            Content = new SkillDefinition
+            {
+                Instructions = "body",
+                Translations = de is null
+                    ? null
+                    : new Dictionary<string, LocalizedNodeText>
+                    {
+                        ["de"] = new() { Name = de.Value.Name, Description = de.Value.Description },
+                    },
+            },
+        };
+}

--- a/test/MeshWeaver.AI.Test/SkillMarkdownRoundTripTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillMarkdownRoundTripTest.cs
@@ -53,6 +53,80 @@ public class SkillMarkdownRoundTripTest
             Assert.Equal(od.Action?.Title, rd.Action?.Title);
             Assert.Equal(od.Action?.ContentPath, rd.Action?.ContentPath);
             Assert.Equal(od.Action?.Provider, rd.Action?.Provider);
+            AssertTranslationsEqual(od, rd, id);
+        }
+    }
+
+    /// <summary>
+    /// A hand-authored <c>translations:</c> block survives Parse → Serialize → Parse. Without this
+    /// the sync-back would silently DROP every translation the moment a skill was edited in the
+    /// mesh: the file would come back English-only, the guard would go green (an English-only pack
+    /// requires nothing), and only the German viewer would notice.
+    /// </summary>
+    [Fact]
+    public void ATranslatedSkill_RoundTrips_Lossless()
+    {
+        const string Authored =
+            "---\n" +
+            "nodeType: Skill\n" +
+            "name: /space\n" +
+            "description: Create a Space end-to-end.\n" +
+            "translations:\n" +
+            "  de:\n" +
+            "    name: /space\n" +
+            "    description: Legt einen Space vollständig an.\n" +
+            "---\n\n" +
+            "The procedure stays in one language.\n";
+
+        var parsed = SkillMarkdown.Parse(Authored, "space");
+        Assert.NotNull(parsed);
+        var def = Assert.IsType<SkillDefinition>(parsed!.Content);
+        Assert.NotNull(def.Translations);
+        Assert.Equal("Legt einen Space vollständig an.", def.Translations!["de"].Description);
+
+        var serialized = SkillMarkdown.Serialize(parsed);
+        Assert.Contains("translations:", serialized);
+
+        var reparsed = SkillMarkdown.Parse(serialized, "space");
+        Assert.NotNull(reparsed);
+        var rdef = Assert.IsType<SkillDefinition>(reparsed!.Content);
+        AssertTranslationsEqual(def, rdef, "space");
+
+        // The BODY is the skill's procedure — model-facing — and the translation block never
+        // touches it.
+        Assert.Equal(def.Instructions, rdef.Instructions);
+    }
+
+    /// <summary>
+    /// The inverse: an untranslated skill must come back with NO <c>translations:</c> key, so the
+    /// round-trip of the shipped files stays byte-comparable rather than gaining an empty block.
+    /// </summary>
+    [Fact]
+    public void AnUntranslatedSkill_SerializesWithoutATranslationsKey()
+    {
+        var parsed = SkillMarkdown.Parse(
+            "---\nnodeType: Skill\ndescription: Plain.\n---\n\nBody.\n", "plain");
+        Assert.NotNull(parsed);
+        Assert.Null(((SkillDefinition)parsed!.Content!).Translations);
+        Assert.DoesNotContain("translations:", SkillMarkdown.Serialize(parsed));
+    }
+
+    private static void AssertTranslationsEqual(SkillDefinition expected, SkillDefinition actual, string id)
+    {
+        if (expected.Translations is null)
+        {
+            Assert.True(actual.Translations is null, $"{id}: translations appeared out of nowhere");
+            return;
+        }
+        Assert.NotNull(actual.Translations);
+        Assert.Equal(
+            expected.Translations.Keys.OrderBy(k => k, System.StringComparer.Ordinal),
+            actual.Translations!.Keys.OrderBy(k => k, System.StringComparer.Ordinal));
+        foreach (var (tag, text) in expected.Translations)
+        {
+            Assert.Equal(text.Name, actual.Translations[tag].Name);
+            Assert.Equal(text.Description, actual.Translations[tag].Description);
+            Assert.Equal(text.Category, actual.Translations[tag].Category);
         }
     }
 

--- a/test/MeshWeaver.Content.Test/AgentFileParserTest.cs
+++ b/test/MeshWeaver.Content.Test/AgentFileParserTest.cs
@@ -15,6 +15,57 @@ public class AgentFileParserTest
 
     #region Parse Tests
 
+    /// <summary>
+    /// 🌍 A <c>translations:</c> block reaches the configuration and survives the sync-back —
+    /// Parse → Serialize → Parse. Without the serialize half, editing an agent in the mesh would
+    /// silently write its translations away, and the file would come back English-only with
+    /// nothing red (issue #1626).
+    /// </summary>
+    [Fact(Timeout = 20000)]
+    public void Parse_TranslationsBlock_ReachesTheConfiguration_AndRoundTrips()
+    {
+        var content =
+            "---\n" +
+            "nodeType: Agent\n" +
+            "name: Tutor\n" +
+            "description: Guides trainees through a course.\n" +
+            "translations:\n" +
+            "  de:\n" +
+            "    name: Tutor\n" +
+            "    description: Begleitet Lernende durch einen Kurs.\n" +
+            "---\n\n" +
+            "You are the course tutor.\n";
+
+        var node = _parser.Parse("/Agent/Tutor.md", content, "Agent/Tutor.md");
+        node.Should().NotBeNull();
+        var config = node!.Content.Should().BeOfType<AgentConfiguration>().Subject;
+        config.Translations.Should().NotBeNull();
+        config.Translations!["de"].Description.Should().Be("Begleitet Lernende durch einen Kurs.");
+
+        // 🚨 The MODEL-facing description is the delegation catalogue and stays the authored text —
+        // translating it would make agent routing depend on the viewer's UI language.
+        config.Description.Should().Be("Guides trainees through a course.");
+        // The system prompt (the body) is likewise untouched.
+        config.Instructions.Should().Be("You are the course tutor.");
+
+        var reparsed = _parser.Parse("/Agent/Tutor.md", _parser.Serialize(node), "Agent/Tutor.md");
+        reparsed.Should().NotBeNull();
+        var round = reparsed!.Content.Should().BeOfType<AgentConfiguration>().Subject;
+        round.Translations.Should().NotBeNull();
+        round.Translations!["de"].Name.Should().Be("Tutor");
+        round.Translations["de"].Description.Should().Be("Begleitet Lernende durch einen Kurs.");
+    }
+
+    /// <summary>An untranslated agent gains no empty <c>translations:</c> key on the way back out.</summary>
+    [Fact(Timeout = 20000)]
+    public void Serialize_UntranslatedAgent_WritesNoTranslationsKey()
+    {
+        var content = "---\nnodeType: Agent\nname: Plain\ndescription: Plain agent.\n---\n\nBody.\n";
+        var node = _parser.Parse("/Agent/Plain.md", content, "Agent/Plain.md");
+        node.Should().NotBeNull();
+        _parser.Serialize(node!).Should().NotContain("translations:");
+    }
+
     [Fact(Timeout = 20000)]
     public void ParseAsync_ValidAgentMarkdown_ReturnsAgentConfiguration()
     {


### PR DESCRIPTION
Addresses requirement 1 of #1626 (localization). Requirement 2 (install paths) is answered below but
not changed — it needs a maintainer call, and the answer may be "already done".

## Requirement 1 — the mechanism

Skill and Agent nodes carry user-visible `name` / `description` / `category` rendered in the skill
picker, the agent combobox, `/`-autocomplete and the skill page. They were English-only front
matter.

This adds a `translations:` front-matter block — BCP-47 tag → `{name, description, category}` —
materialized onto the content, and **one** resolution rule (`NodeTextTranslations`) that resolves
the tag through `Locales`, exactly as the string catalog and the `[Translation]` attributes do. All
three now agree about which language a viewer is in, because all three ask the same function.

```yaml
---
nodeType: Skill
name: /space
description: Create a Space end-to-end.
translations:
  de:
    name: /space
    description: Legt einen Space vollständig an.
---
```

### Two boundaries, deliberate, documented at every seam

**Display text only.** An agent's `AgentConfiguration.Description` is the delegation/hand-off
catalogue a **model** reads to choose an agent, and a skill's `Instructions` body is its procedure.
Translating prompt text changes *behaviour*, not presentation — so the picker label can be German
while the routing text stays authored, and a test pins exactly that. The same reasoning keeps the
CLI harness's workspace skill catalog untranslated (a comment now says so at that call site).

**Identifiers are never localized.** A skill is invoked by its node **Id** (`/space`) and an agent
is resolved by path; those are wire tokens. `ProjectSkills` carries the Id through untouched in
every language, and a test asserts a German viewer still types `/space`. This is the localization
edition of "never widen": translating a label must not change what an invocation resolves to.

### The locale is an argument, resolved once per render turn

Every projection takes `string? locale` and every caller resolves it **once, on the render or
request turn**, then passes it down — `SkillAutocompleteProvider.GetItems`, `SkillView.Overview`,
`AgentPickerProjection.ObserveAgents`. This is the hazard the issue's own context names: `Locale`
rides an `AsyncLocal` on `AccessContext` that a synced-query scheduler hop clears, so an ambient
read inside a `.Select` resolves to English at random — and two call sites resolving separately can
disagree on the same page. Same capture rule `ToDisplayTime` documents, for the same reason.

### Fallback is per FIELD, never per record

A translation that sets only `description` keeps the authored name. An all-or-nothing swap would
blank a name the author never meant to change; absence degrades to readable English, exactly like a
missing catalog key.

## The guard — "a half-localized pack cannot merge"

`AiContentLocalizationTest`, in the localization family beside `LocalizationTest`.

The unit is the **pack**, and the requirement is derived from the pack: whatever languages its nodes
declare *between them*, every node must cover. An English-only pack requires nothing.

That asymmetry is the point. The gate is *"do not ship half a language"*, never *"you must ship
every language"* — the second would turn adding a skill into a translation project, and a gate with
that cost gets disabled rather than satisfied. And half-localized is precisely the state nobody
reports: the untranslated field falls back to English, so a German picker with three English rows
in it reads as a design choice. Nothing is red, nothing is logged.

## ⚠️ What is deliberately NOT in this PR

**The built-in packs are still English-only.** The issue asks for "parser support, a resolution
helper for the rendering surfaces, and a catalog test" — that is what this is. Translating 21 skills
and 14 agents is a content review, not a code review, and the guard is what makes that act safe to
do **atomically per pack** afterwards. Mixing ~2,500 words of German prose into this diff would bury
the seam it exists to establish.

The consequence is that the two real-pack assertions pass **trivially** today, which is why the test
carries its own control (below) rather than pretending otherwise.

## Requirement 2 — install paths (needs a maintainer call, and may be a no-op)

Interpretation 2 in the issue — "a plugin's skill/agent paths install and uninstall with it" — reads
as **already true**: `InstallPlan` ships fixed **Skills** (`{plugin}/Skill` → `{viewer}/Skill`) and
**Agents** directives beside the declared `installPaths`, and `Localizer` executes exactly that
plan. Nothing here changes it. The open half is the follow-on the issue raises itself — whether
install should also write a plugin's skills into the co-hosted CLI skills directory
(`Skills:Directory` / `CliSkillsDirectory.Derive`). That is a different seam and a different
decision; I have not touched it.

## Tests — executed, and non-vacuous by construction

```
Passed!  - Failed: 0, Passed: 1194, Skipped: 3, Total: 1197 — MeshWeaver.AI.Test.dll        (2 m 3 s)
Passed!  - Failed: 0, Passed:  276, Skipped: 1, Total:  277 — MeshWeaver.Content.Test.dll     (51 s)
Passed!  - Failed: 0, Passed:   56, Skipped: 0, Total:   56 — Messaging.Hub LocalizationTest
```

New coverage (11 + 2 + 2 cases):

- **`TheGuard_FailsOnAHalfLocalizedPack_AndNamesTheGap`** — the control. It drives the same rule
  over a pack of three fixtures (fully translated / untranslated / name-only) and requires the
  reported gaps to be exactly `de:name, de:description` and `de:description`. Since the shipped
  packs declare nothing, this is the assertion that proves the guard is live at all.
- **`AnEnglishOnlyPack_RequiresNothing`** — the other direction, so the guard cannot silently become
  "translate everything".
- **`TheInvocationToken_IsNeverLocalized`** — a German viewer still types `/space`.
- **`TheModelFacingDescription_StaysAuthored`** — the picker says
  *"Begleitet Lernende durch einen Kurs."* while `AgentConfiguration.Description` still says
  *"Guides trainees through a course."*
- **`Resolution_PrefersTheViewersLanguage_PerField`** + region-variant theory (`de-CH`, `de-AT`,
  `DE`) — folds onto the primary subtag exactly like the string catalog, so a `de-CH` viewer cannot
  get a German page frame around an English skill list.
- **Round-trip, both parsers** — `ATranslatedSkill_RoundTrips_Lossless`,
  `Parse_TranslationsBlock_ReachesTheConfiguration_AndRoundTrips`, plus both
  "untranslated writes no `translations:` key" inverses. Without these a sync-back would drop every
  translation the moment a node was edited in the mesh: the file returns English-only, the pack
  guard goes green (an English-only pack requires nothing), and only the German viewer finds out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
