### PR TITLE
For an enum, EMPTY IS NOT ABSENT — three chart keys that strip every agent's tools

### DIFF
--- a/deploy/aks/scripts/check-chart-invariants.py
+++ b/deploy/aks/scripts/check-chart-invariants.py
@@ -208,6 +208,56 @@ for key, why in REQUIRED_CONFIG.items():
             f"than emitting an empty string.",
         )
 
+# ---------------------------------------------------------------------------
+# 9. A key whose consumer does NOT read it as a string must never render BLANK.
+#
+# 🚨 The mirror of 8, and the more dangerous half: 8 catches a key that reaches no container, this
+# catches one that reaches every container carrying a value that cannot be parsed. For a string,
+# blank and absent mean the same thing — that is why `default ""` is the file's usual idiom. For an
+# enum, an int or a bool they are opposites: ABSENT leaves the binder at the type's default, BLANK
+# throws, and the throw happens during DI activation rather than at config load, so it surfaces
+# somewhere else entirely.
+#
+# WebSearch__Provider did this to memex.systemorph.com on 2026-08-20. It binds to the enum
+# WebSearchProviderType (default None = auto-detect); the template emitted it with `default ""`;
+# "" is not a member, so WebSearchPlugin's constructor threw FormatException. Because
+# ChatClientAgentFactory resolves plugins with GetServices<IAgentPlugin>(), which activates the
+# whole array, that one plugin removed EVERY custom tool from EVERY agent — and the log blamed the
+# agent it was resolving at the time, not the plugin that threw. Two days, ~100 failures/24h, and
+# the two namespaces that still worked were simply the ones the chart had never rendered.
+#
+# The chart already knew the rule — OpenAICompatible__DiscoverModels carries a note saying
+# `default "false"`, never `default ""`, because Boolean.Parse fails on empty (issue #352) — and
+# the WebSearch block violated it forty lines further down. A rule stated in a comment is not a
+# gate; this is the gate.
+#
+# Absent is ACCEPTED here (that is the fix's whole point). Only a rendered-but-blank value fails.
+NEVER_BLANK_CONFIG = {
+    "WebSearch__Provider":
+        "binds to the enum WebSearchProviderType (WebSearchConfiguration.Provider). Its default, "
+        "None, means auto-detect, so LEAVING THE KEY OUT is correct for an instance with no web "
+        "search configured. An empty string is not a member of the enum and throws FormatException "
+        "while WebSearchPlugin is being constructed — which, via GetServices<IAgentPlugin>(), "
+        "removes every custom tool from every agent.",
+    "OpenAICompatible__DiscoverModels":
+        "read with GetValue<bool> — Boolean.Parse throws on an empty string and takes host startup "
+        "with it (issue #352). Emit \"false\", never \"\".",
+    "Anthropic__Order":
+        "read as an Int32 — empty fails the binder. Emit \"0\", never \"\".",
+    "AzureAIS__Order":
+        "read as an Int32 — empty fails the binder. Emit \"0\", never \"\".",
+}
+
+for key, why in NEVER_BLANK_CONFIG.items():
+    checks += 1
+    if key in cfg_data and not str(cfg_data[key]).strip():
+        finding(
+            f"'{key}' renders BLANK in memex-portal-config",
+            f"{why} Guard the line so the key is emitted only when a value is set "
+            f"({{{{- if .Values.config.memex_portal.{key} }}}}), or give it a PARSEABLE default — "
+            f"never `default \"\"`. Absent is fine here; blank is not.",
+        )
+
 MIN_CHECKS = 5
 if checks < MIN_CHECKS:
     print(

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -283,15 +283,35 @@ data:
   AzureAIS__Endpoint: "{{ .Values.config.memex_portal.AzureAIS__Endpoint | default "" }}"
   AzureAIS__Order: "{{ .Values.config.memex_portal.AzureAIS__Order | default "0" }}"
   # ---- Agent web search (WebSearchPlugin) — optional --------------------------
-  # SearchWeb is advertised to agents ONLY when a provider is configured; with these empty the
+  # SearchWeb is advertised to agents ONLY when a provider is configured; with these unset the
   # tool is not offered at all (agents fall back to FetchWebPage on explicit URLs). The
   # deployment supplies the Google Programmable Search credentials (API key + Search-Engine id /
   # cx) — get them from the Google Cloud console + programmablesearchengine.google.com. Provider
-  # defaults to auto-detect ("" → Google when key+cx are set); set "Google" to force. Bing
+  # auto-detects when ABSENT (Google when key+cx are set); set "Google" to force. Bing
   # (WebSearch:Provider=Bing) is retired (API shut down 2025-08-11) and kept only for back-compat.
-  WebSearch__Provider: "{{ .Values.config.memex_portal.WebSearch__Provider | default "" }}"
-  WebSearch__Google__ApiKey: "{{ .Values.config.memex_portal.WebSearch__Google__ApiKey | default "" }}"
-  WebSearch__Google__Cx: "{{ .Values.config.memex_portal.WebSearch__Google__Cx | default "" }}"
+  #
+  # 🚨 EMITTED ONLY WHEN SET — for an enum, EMPTY IS NOT ABSENT, and the difference is an outage.
+  # WebSearch:Provider binds to WebSearchProviderType, whose default None means "auto-detect"; ""
+  # is not a member of it, so binding throws FormatException in WebSearchPlugin's constructor.
+  # ChatClientAgentFactory resolves plugins through GetServices<IAgentPlugin>(), which activates
+  # the WHOLE array — so ONE unconstructable plugin strips EVERY custom tool from EVERY agent, and
+  # the log names the wrong victim ("Plugin 'ExecutiveAssistant' failed to resolve … ->
+  # WebSearchPlugin"). memex.systemorph.com lost every agent tool exactly this way after its first
+  # chart-driven deploy (2026-08-20 → 2026-08-22, ~100 failures/24h); memex-cloud and atioz were
+  # unaffected only because no chart had ever rendered their ConfigMap. This is the same rule the
+  # OpenAICompatible__DiscoverModels note above states: `default ""` is safe ONLY for keys whose
+  # consumer reads them as strings. Guarded rather than `default "None"` so an instance that
+  # configures no web search renders no WebSearch keys at all — the shape the two healthy
+  # namespaces already run, and one that cannot be re-broken by a future rename of the enum member.
+  {{- if .Values.config.memex_portal.WebSearch__Provider }}
+  WebSearch__Provider: "{{ .Values.config.memex_portal.WebSearch__Provider }}"
+  {{- end }}
+  {{- if .Values.config.memex_portal.WebSearch__Google__ApiKey }}
+  WebSearch__Google__ApiKey: "{{ .Values.config.memex_portal.WebSearch__Google__ApiKey }}"
+  {{- end }}
+  {{- if .Values.config.memex_portal.WebSearch__Google__Cx }}
+  WebSearch__Google__Cx: "{{ .Values.config.memex_portal.WebSearch__Google__Cx }}"
+  {{- end }}
   # ---- Observability (OTLP collector) — optional ----------------------------
   OTEL_EXPORTER_OTLP_ENDPOINT: "{{ .Values.config.memex_portal.OTEL_EXPORTER_OTLP_ENDPOINT | default "" }}"
   OTEL_EXPORTER_OTLP_PROTOCOL: "{{ .Values.config.memex_portal.OTEL_EXPORTER_OTLP_PROTOCOL | default "" }}"


### PR DESCRIPTION
## What broke

`memex.systemorph.com` had **no custom tools on any agent** for two days (2026-08-20 → 08-22). The cause is three lines of the chart — not anything in either half of the values:

```yaml
WebSearch__Provider: "{{ .Values.config.memex_portal.WebSearch__Provider | default "" }}"
WebSearch__Google__ApiKey: …
WebSearch__Google__Cx: …
```

The ConfigMap names every key explicitly, so these render **unconditionally**. A namespace that has never heard of web search still gets `WebSearch__Provider=""`.

`WebSearch:Provider` binds to the enum `WebSearchProviderType`, whose default `None` *already* means auto-detect. `""` is not a member, so binding throws `FormatException` in `WebSearchPlugin`'s constructor. `ChatClientAgentFactory` resolves plugins via `GetServices<IAgentPlugin>()`, which activates the **whole array** — so one unconstructable plugin removes **every** custom plugin from **every** agent, and the log blames whoever it was resolving at the time:

```
Plugin 'ExecutiveAssistant' failed to resolve … -> WebSearchPlugin
```

## Why it hid

It needs a chart-rendered ConfigMap to appear at all. `memex-cloud` and `atioz` were `kubectl`-applied for years and are clean **today**; `memex` got its first chart-driven deploy on 2026-08-20.

Verified live:

| ns | first chart deploy | `WebSearch__*` in ConfigMap |
|---|---|---|
| memex-cloud | never | none ✅ |
| atioz | never | none ✅ |
| memex | 2026-08-20 | all three — deleted by hand 08-22 (~100 failures/24h → 0) |

That hand-fix lives **only in the cluster**. The next `helm upgrade` puts all three keys straight back — and `memex-cloud`'s first chart-driven deploy was already being prepared, which would have broken it the same way. With this change, the upgrade that would have re-broken memex **repairs** it instead, since helm replaces the ConfigMap wholesale.

## The rule the chart already knew

Forty lines above, `OpenAICompatible__DiscoverModels` carries:

> this key is read as a Boolean (`GetValue<bool>`), so its default must be a PARSEABLE value — `default "false"`, never `default ""` … an empty string fails `Boolean.Parse` and crashes host startup (issue #352).

`default ""` is safe **only** for keys whose consumer reads them as strings. A rule stated in a comment is not a gate.

## The change

1. **Emit the three keys only when set.** Guarded rather than `default "None"`, so an instance with no web search renders no `WebSearch` keys at all — the shape the two healthy namespaces already run, and one a future rename of the enum member cannot re-break.
2. **`check-chart-invariants` gains #9**, the mirror of #8: a key whose consumer does not read it as a string must never render **blank** (absent is explicitly fine — that is the fix). Seeded with `WebSearch__Provider` plus the three keys that already carry parseable defaults.

## Non-vacuous

With the template reverted to `main`, the gate fails **all three** values combinations naming `WebSearch__Provider`; with the fix all three pass. Render checked both ways — unset → no keys; `--set WebSearch__Provider=Google` → key present.

## Follow-up, deliberately not here

`Authentication__Provider` is emitted the same unconditional `default ""` way, and `MemexConfiguration` reads it as `authSection["Provider"] ?? <auto-detect>`. An empty string is not null, so the `??` never fires and a freshly chart-deployed instance resolves its auth mode to `""` instead of auto-detecting. It is a *string*, so nothing throws — which is why it needs its own change with its own reasoning about existing namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)