### PR TITLE
feat: one shared search across home scopes; apps out of Shared-with-me; All tab

### DIFF
--- a/clients/react/src/i18n/strings.de.json
+++ b/clients/react/src/i18n/strings.de.json
@@ -129,6 +129,7 @@
   "menu.createNew": "Neu erstellen…",
   "menu.fullScreen": "Vollbild",
   "menu.history": "Verlauf",
+  "home.all": "Alle",
   "home.sharedWithMe": "Mit mir geteilt",
   "home.pinned": "Angeheftet",
   "home.apps": "Apps",

--- a/clients/react/src/i18n/strings.en.json
+++ b/clients/react/src/i18n/strings.en.json
@@ -129,6 +129,7 @@
   "menu.createNew": "Create new...",
   "menu.fullScreen": "Full screen",
   "menu.history": "History",
+  "home.all": "All",
   "home.sharedWithMe": "Shared with me",
   "home.pinned": "Pinned",
   "home.apps": "Apps",

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
@@ -7,44 +7,65 @@
 @inject AccessService Access
 
 <div class="mesh-search-container@(ClassSuffix)" style="@Style">
-    @if (BoundShowSearchBox || !string.IsNullOrEmpty(BoundTitle) || ShowCreateButton)
+    @if (HasScopeTabs)
     {
-        <div class="mesh-search-box">
-            <div class="mesh-search-box-inner">
-                @if (!string.IsNullOrEmpty(BoundTitle))
-                {
-                    <div class="mesh-search-title">@BoundTitle</div>
-                }
-                @if (BoundShowSearchBox)
-                {
-                    <div class="mesh-search-box-input">
-                        <MonacoEditorView @ref="monacoEditor"
-                                          Value="@_currentValue"
-                                          ValueChanged="@OnValueChanged"
-                                          OnSubmit="HandleSearch"
-                                          Placeholder="@BoundPlaceholder"
-                                          Height="38px"
-                                          MaxHeight="38px"
-                                          ShowBorder="true"
-                                          CodeEditMode="false"
-                                          CompletionCallback="@GetCompletions" />
+        <div class="mesh-search-scopes" role="tablist">
+            @for (var i = 0; i < BoundScopeTabs.Count; i++)
+            {
+                var idx = i;
+                <button type="button" role="tab" aria-selected="@(idx == _activeScopeIndex)"
+                        class="mesh-search-scope@(idx == _activeScopeIndex ? " mesh-search-scope-active" : "")"
+                        @onclick="() => SelectScope(idx)">@BoundScopeTabs[idx].Label</button>
+            }
+        </div>
+    }
+    @* ONE header row on desktop: the search box and the view-options bar share it (wrapping on
+       narrow widths). The search input itself is DESKTOP-only — mesh-search-mobile-hide hides
+       input + Search + query-gear under the mobile breakpoint while title/create/view-options stay. *@
+    @if (BoundShowSearchBox || !string.IsNullOrEmpty(BoundTitle) || ShowCreateButton || (BoundShowViewOptions && SelectorEligible))
+    {
+        <div class="mesh-search-header">
+            @if (BoundShowSearchBox || !string.IsNullOrEmpty(BoundTitle) || ShowCreateButton)
+            {
+                <div class="mesh-search-box">
+                    <div class="mesh-search-box-inner">
+                        @if (!string.IsNullOrEmpty(BoundTitle))
+                        {
+                            <div class="mesh-search-title">@BoundTitle</div>
+                        }
+                        @if (BoundShowSearchBox)
+                        {
+                            <div class="mesh-search-box-input mesh-search-mobile-hide">
+                                <MonacoEditorView @ref="monacoEditor"
+                                                  Value="@_currentValue"
+                                                  ValueChanged="@OnValueChanged"
+                                                  OnSubmit="HandleSearch"
+                                                  Placeholder="@BoundPlaceholder"
+                                                  Height="38px"
+                                                  MaxHeight="38px"
+                                                  ShowBorder="true"
+                                                  CodeEditMode="false"
+                                                  CompletionCallback="@GetCompletions" />
+                            </div>
+                            <button type="button" class="mesh-search-button mesh-search-mobile-hide" @onclick="HandleSearch">
+                                Search
+                            </button>
+                            <button type="button" class="mesh-search-options-button mesh-search-mobile-hide" @onclick="ToggleSearchOptions"
+                                    title="@Access.Localize("search.options")">
+                                <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size16.Settings())" />
+                            </button>
+                        }
+                        @if (ShowCreateButton)
+                        {
+                            <button type="button" class="mesh-search-create-button" @onclick="HandleCreateClick"
+                                    title="@Access.Localize("search.createNew")">
+                                +
+                            </button>
+                        }
                     </div>
-                    <button type="button" class="mesh-search-button" @onclick="HandleSearch">
-                        Search
-                    </button>
-                    <button type="button" class="mesh-search-options-button" @onclick="ToggleSearchOptions"
-                            title="@Access.Localize("search.options")">
-                        <FluentIcon Value="@(new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size16.Settings())" />
-                    </button>
-                }
-                @if (ShowCreateButton)
-                {
-                    <button type="button" class="mesh-search-create-button" @onclick="HandleCreateClick"
-                            title="@Access.Localize("search.createNew")">
-                        +
-                    </button>
-                }
-            </div>
+                </div>
+            }
+            @RenderViewBar()
         </div>
     }
 
@@ -59,53 +80,6 @@
                       @bind="_editableHiddenQuery" @bind:event="oninput" />
             <div class="mesh-search-options-actions">
                 <button type="button" class="mesh-search-button" @onclick="ApplySearchOptions">@Access.Localize("common.apply")</button>
-            </div>
-        </div>
-    }
-
-    @if (BoundShowViewOptions && SelectorEligible)
-    {
-        <div class="mesh-search-viewbar">
-            <label class="mesh-search-viewbar-field">
-                <span class="mesh-search-viewbar-label">@Access.Localize("search.groupBy")</span>
-                <select class="mesh-search-groupby" @bind="GroupBySelection">
-                    @foreach (var opt in GroupByOptions)
-                    {
-                        <option value="@opt.Value">@opt.Label</option>
-                    }
-                </select>
-            </label>
-            @if (HasSortOptions)
-            {
-                <label class="mesh-search-viewbar-field">
-                    <span class="mesh-search-viewbar-label">@Access.Localize("search.sortBy")</span>
-                    <select class="mesh-search-sortby" @bind="SortBySelection">
-                        @foreach (var opt in BoundSortOptions)
-                        {
-                            <option value="@opt.Label">@opt.Label</option>
-                        }
-                    </select>
-                </label>
-            }
-            <div class="mesh-search-viewbar-spacer"></div>
-            <div class="mesh-search-viewbar-menu-wrap">
-                <button type="button" class="mesh-search-viewbar-menu-btn" title="@Access.Localize("search.displayOptions")"
-                        @onclick="ToggleViewMenu">
-                    <FluentIcon Value="@(new Icons.Regular.Size16.Options())" />
-                </button>
-                @if (_showViewMenu)
-                {
-                    <div class="mesh-search-viewbar-menu">
-                        <label class="mesh-search-viewbar-toggle">
-                            <input type="checkbox" checked="@BoundShowSearchBox" @onchange="ToggleShowSearchBox" />
-                            <span>@Access.Localize("search.searchBar")</span>
-                        </label>
-                        <label class="mesh-search-viewbar-toggle">
-                            <input type="checkbox" checked="@EffectiveShowCounts" @onchange="ToggleShowCounts" />
-                            <span>@Access.Localize("search.sectionCounts")</span>
-                        </label>
-                    </div>
-                }
             </div>
         </div>
     }
@@ -305,6 +279,61 @@
 </div>
 
 @code {
+    /// <summary>
+    /// The discreet view-options bar (Group by · Sort by · display menu) — rendered INSIDE the
+    /// shared header row so search box and ordering sit on ONE line on desktop (wrapping below
+    /// it on narrow widths). Self-guarded: emits nothing when view options are off.
+    /// </summary>
+    private RenderFragment RenderViewBar() => __builder =>
+    {
+        @if (BoundShowViewOptions && SelectorEligible)
+        {
+            <div class="mesh-search-viewbar">
+                <label class="mesh-search-viewbar-field">
+                    <span class="mesh-search-viewbar-label">@Access.Localize("search.groupBy")</span>
+                    <select class="mesh-search-groupby" @bind="GroupBySelection">
+                        @foreach (var opt in GroupByOptions)
+                        {
+                            <option value="@opt.Value">@opt.Label</option>
+                        }
+                    </select>
+                </label>
+                @if (HasSortOptions)
+                {
+                    <label class="mesh-search-viewbar-field">
+                        <span class="mesh-search-viewbar-label">@Access.Localize("search.sortBy")</span>
+                        <select class="mesh-search-sortby" @bind="SortBySelection">
+                            @foreach (var opt in BoundSortOptions)
+                            {
+                                <option value="@opt.Label">@opt.Label</option>
+                            }
+                        </select>
+                    </label>
+                }
+                <div class="mesh-search-viewbar-spacer"></div>
+                <div class="mesh-search-viewbar-menu-wrap">
+                    <button type="button" class="mesh-search-viewbar-menu-btn" title="@Access.Localize("search.displayOptions")"
+                            @onclick="ToggleViewMenu">
+                        <FluentIcon Value="@(new Icons.Regular.Size16.Options())" />
+                    </button>
+                    @if (_showViewMenu)
+                    {
+                        <div class="mesh-search-viewbar-menu">
+                            <label class="mesh-search-viewbar-toggle">
+                                <input type="checkbox" checked="@BoundShowSearchBox" @onchange="ToggleShowSearchBox" />
+                                <span>@Access.Localize("search.searchBar")</span>
+                            </label>
+                            <label class="mesh-search-viewbar-toggle">
+                                <input type="checkbox" checked="@EffectiveShowCounts" @onchange="ToggleShowCounts" />
+                                <span>@Access.Localize("search.sectionCounts")</span>
+                            </label>
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+    };
+
     private RenderFragment RenderCard(MeshNode node) => __builder =>
     {
         var cardControl = GetCardControl(node);

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
@@ -13,8 +13,8 @@
             @for (var i = 0; i < BoundScopeTabs.Count; i++)
             {
                 var idx = i;
-                <button type="button" role="tab" aria-selected="@(idx == _activeScopeIndex)"
-                        class="mesh-search-scope@(idx == _activeScopeIndex ? " mesh-search-scope-active" : "")"
+                <button type="button" role="tab" aria-selected="@(idx == ActiveScopeIndex)"
+                        class="mesh-search-scope@(idx == ActiveScopeIndex ? " mesh-search-scope-active" : "")"
                         @onclick="() => SelectScope(idx)">@BoundScopeTabs[idx].Label</button>
             }
         </div>

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -307,10 +307,14 @@ public partial class MeshSearchView
     }
 
     // ----- Scope tabs (one shared search bar across scopes) -----
-    // The active tab's index. Scope switching swaps ONLY the hidden query (and the sort set) while
-    // the typed search text and every other bit of component state stay — that is the whole point:
-    // a search term follows the user across the tabs because they are ONE component.
-    private int _activeScopeIndex;
+    // The active tab is tracked by its LABEL, not an index: the scope list is REACTIVE (a scope
+    // like Shared-with-me appears/disappears as grants, pins or the presentation screen change),
+    // so a bare index could silently re-point at a DIFFERENT scope on a list change. The label
+    // re-resolves against the current list on every read; a vanished label clamps to the first
+    // tab. Scope switching swaps ONLY the hidden query (and the sort set) while the typed search
+    // text and every other bit of component state stay — that is the whole point: a search term
+    // follows the user across the tabs because they are ONE component.
+    private string? _activeScopeLabel;
 
     /// <summary>The scope tabs supplied by the control (empty ⇒ no strip).</summary>
     private IReadOnlyList<MeshSearchScopeTab> BoundScopeTabs => ViewModel?.ScopeTabs ?? [];
@@ -318,11 +322,25 @@ public partial class MeshSearchView
     /// <summary>Render the scope strip only for two or more scopes.</summary>
     private bool HasScopeTabs => BoundScopeTabs.Count > 1;
 
+    /// <summary>The active tab's index, re-resolved from the label against the CURRENT list —
+    /// clamped to the first tab when the label is unset or its scope vanished.</summary>
+    private int ActiveScopeIndex
+    {
+        get
+        {
+            var tabs = BoundScopeTabs;
+            if (tabs.Count == 0 || _activeScopeLabel is null)
+                return 0;
+            for (var i = 0; i < tabs.Count; i++)
+                if (tabs[i].Label == _activeScopeLabel)
+                    return i;
+            return 0;
+        }
+    }
+
     /// <summary>The active scope, when scopes are declared.</summary>
     private MeshSearchScopeTab? ActiveScopeTab =>
-        BoundScopeTabs.Count > 0 && _activeScopeIndex >= 0 && _activeScopeIndex < BoundScopeTabs.Count
-            ? BoundScopeTabs[_activeScopeIndex]
-            : null;
+        BoundScopeTabs.Count > 0 ? BoundScopeTabs[ActiveScopeIndex] : null;
 
     /// <summary>
     /// Activates a scope tab: swap the base hidden query to the scope's, reset the sort choice to
@@ -331,9 +349,9 @@ public partial class MeshSearchView
     /// </summary>
     private void SelectScope(int index)
     {
-        if (index == _activeScopeIndex || index < 0 || index >= BoundScopeTabs.Count)
+        if (index == ActiveScopeIndex || index < 0 || index >= BoundScopeTabs.Count)
             return;
-        _activeScopeIndex = index;
+        _activeScopeLabel = BoundScopeTabs[index].Label;
         _viewSortLabel = null;                     // back to the scope's default (first) sort
         _overriddenHiddenQuery = null;             // the scope query IS the new base
         _lastBoundHiddenQuery = BoundHiddenQuery;  // keep OnParametersSet from re-triggering

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -141,7 +141,8 @@ public partial class MeshSearchView
 
     // Basic properties
     private string? BoundTitle => ViewModel?.Title?.ToString();
-    private string BoundHiddenQuery => _overriddenHiddenQuery ?? ViewModel?.HiddenQuery?.ToString() ?? "";
+    private string BoundHiddenQuery =>
+        _overriddenHiddenQuery ?? ActiveScopeTab?.Query ?? ViewModel?.HiddenQuery?.ToString() ?? "";
     private string BoundVisibleQuery => ViewModel?.VisibleQuery?.ToString() ?? "";
     private string BoundPlaceholder => ViewModel?.Placeholder?.ToString() ?? "Search...";
     private string BoundNamespace => ViewModel?.Namespace?.ToString() ?? "";
@@ -305,12 +306,56 @@ public partial class MeshSearchView
         }
     }
 
+    // ----- Scope tabs (one shared search bar across scopes) -----
+    // The active tab's index. Scope switching swaps ONLY the hidden query (and the sort set) while
+    // the typed search text and every other bit of component state stay — that is the whole point:
+    // a search term follows the user across the tabs because they are ONE component.
+    private int _activeScopeIndex;
+
+    /// <summary>The scope tabs supplied by the control (empty ⇒ no strip).</summary>
+    private IReadOnlyList<MeshSearchScopeTab> BoundScopeTabs => ViewModel?.ScopeTabs ?? [];
+
+    /// <summary>Render the scope strip only for two or more scopes.</summary>
+    private bool HasScopeTabs => BoundScopeTabs.Count > 1;
+
+    /// <summary>The active scope, when scopes are declared.</summary>
+    private MeshSearchScopeTab? ActiveScopeTab =>
+        BoundScopeTabs.Count > 0 && _activeScopeIndex >= 0 && _activeScopeIndex < BoundScopeTabs.Count
+            ? BoundScopeTabs[_activeScopeIndex]
+            : null;
+
+    /// <summary>
+    /// Activates a scope tab: swap the base hidden query to the scope's, reset the sort choice to
+    /// the scope's own default, and re-query — keeping the search text (<c>_currentValue</c>)
+    /// untouched, exactly like a sort switch.
+    /// </summary>
+    private void SelectScope(int index)
+    {
+        if (index == _activeScopeIndex || index < 0 || index >= BoundScopeTabs.Count)
+            return;
+        _activeScopeIndex = index;
+        _viewSortLabel = null;                     // back to the scope's default (first) sort
+        _overriddenHiddenQuery = null;             // the scope query IS the new base
+        _lastBoundHiddenQuery = BoundHiddenQuery;  // keep OnParametersSet from re-triggering
+        _collapsedGroups.Clear();
+        if (IsPrecomputedMode)
+            return;
+        if (IsNamespaceTreeMode)
+            ResetTree();
+        else if (IsGraphNavigatorMode)
+            ResetGraphNavigator();
+        else
+            LoadResults();
+    }
+
     // ----- Sort-by dropdown (view-options) -----
     // The selected option's Label. null ⇒ the default (first) option.
     private string? _viewSortLabel;
 
-    /// <summary>The user-selectable sort choices supplied by the control (empty ⇒ no Sort-by dropdown).</summary>
-    private IReadOnlyList<MeshSearchSortOption> BoundSortOptions => ViewModel?.SortOptions ?? [];
+    /// <summary>The user-selectable sort choices supplied by the control (empty ⇒ no Sort-by dropdown).
+    /// An active scope's own sort set REPLACES the control-level one.</summary>
+    private IReadOnlyList<MeshSearchSortOption> BoundSortOptions =>
+        ActiveScopeTab?.SortOptions ?? ViewModel?.SortOptions ?? [];
 
     /// <summary>Render the Sort-by dropdown only when the control declares options.</summary>
     private bool HasSortOptions => BoundSortOptions.Count > 0;

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.css
@@ -2,6 +2,70 @@
     width: 100%;
 }
 
+/* ----- Scope tabs: one shared search bar across scopes ----- */
+.mesh-search-scopes {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--neutral-stroke-rest, #d1d1d1);
+    margin-bottom: 12px;
+    overflow-x: auto;
+}
+
+.mesh-search-scope {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--neutral-foreground-rest);
+    white-space: nowrap;
+}
+
+.mesh-search-scope:hover {
+    color: var(--accent-fill-rest, #0078d4);
+}
+
+.mesh-search-scope-active {
+    border-bottom-color: var(--accent-fill-rest, #0078d4);
+    color: var(--accent-fill-rest, #0078d4);
+    font-weight: 600;
+}
+
+/* ----- Header: search box + view-options bar share ONE row on desktop, wrap when narrow ----- */
+.mesh-search-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.mesh-search-header .mesh-search-box {
+    flex: 1 1 320px;
+    min-width: 240px;
+    width: auto;
+    margin-bottom: 12px;
+}
+
+.mesh-search-header .mesh-search-viewbar {
+    flex: 0 0 auto;
+    margin-left: auto;
+    margin-bottom: 12px;
+}
+
+/* The search input is DESKTOP-only: under the mobile breakpoint the input, Search button and
+   query-gear hide (the chrome search covers mobile), while title/create/view-options stay. */
+@media (max-width: 640px) {
+    .mesh-search-mobile-hide {
+        display: none !important;
+    }
+
+    .mesh-search-header .mesh-search-box {
+        flex: 0 1 auto;
+        min-width: 0;
+    }
+}
+
 .mesh-search-box {
     margin-bottom: 16px;
     width: 100%;

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-home-shared-search.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-home-shared-search.md
@@ -1,0 +1,18 @@
+---
+Name: One search across your home tabs
+Category: Feature
+Description: The home's tabs share a single search bar — your term follows you across Shared with me, Pinned, Apps, Spaces and the new All tab.
+Icon: Search
+Order: -20260822
+---
+
+# One search across your home tabs
+
+Your home's tabs are now scopes of **one search**: type a term once and switch between **Shared
+with me**, **Pinned**, **Apps**, **Spaces** and the new **All** tab — the search follows you, and
+All searches everything you can read at any depth. The search bar and the ordering controls sit on
+one row on desktop; on phones the bar steps aside (the top search covers it).
+
+Tidier tabs, too: apps no longer flood **Shared with me** (they live on **Apps**, which now also
+lists everything you've installed from the Store), and other people's user spaces no longer appear
+as shared content.

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -525,27 +525,88 @@ public static class UserActivityLayoutAreas
     }
 
     /// <summary>
-    /// The owner's installed-app records — the <c>{owner}/_App/{appId}</c> nodes (see
-    /// <see cref="AppNodeType"/>), projected to their <see cref="App.Plugin"/> paths, ordered by
-    /// <see cref="App.Order"/>. Read via the shared, per-user-RLS, empty-on-absent <c>GetQuery</c>
-    /// cache (never a point-read that could NotFound-storm), starting empty so the home paints
+    /// The owner's installed apps, from BOTH per-user records: the <c>{owner}/_App/{appId}</c>
+    /// nodes (see <see cref="AppNodeType"/>, projected to <see cref="App.Plugin"/> paths in
+    /// <see cref="App.Order"/>) UNIONED with the Store's install manifests at
+    /// <c>{owner}/_Install/{slug}</c> — every item whose <c>installedPath</c> is live IS an
+    /// installed app, which is what puts a user's existing installs (incl. the auto-installed
+    /// standard packs) on the Apps scope before the Store's install flow writes <c>_App</c>
+    /// records. The manifest's content type is MESH-compiled (<c>Store/Install</c>), so it is read
+    /// UNTYPED here by design (the manifest's own doc says exactly that) — a JSON traversal at a
+    /// genuine type boundary, not an <c>as</c>-cast trap. Both reads go via the shared,
+    /// per-user-RLS, empty-on-absent <c>GetQuery</c> cache, starting empty so the home paints
     /// instantly and installs land reactively.
     /// </summary>
     private static IObservable<IReadOnlyList<string>> ObserveInstalledApps(
-        LayoutAreaHost host, string ownerId, JsonSerializerOptions options) =>
-        host.Workspace
+        LayoutAreaHost host, string ownerId, JsonSerializerOptions options)
+    {
+        var appRecords = host.Workspace
             .GetQuery($"home-apps:{ownerId}",
                 $"path:{ownerId}/{AppNodeType.UserNamespace} scope:children nodeType:{AppNodeType.NodeType} " +
                 "select:path,id,namespace,name,nodeType,content")
-            .Select(nodes => (IReadOnlyList<string>)nodes
+            .Select(nodes => nodes
                 .Select(n => n.ContentAs<App>(options))
                 .Where(app => !string.IsNullOrWhiteSpace(app?.Plugin))
                 .OrderBy(app => app!.Order)
                 .Select(app => app!.Plugin.Trim('/'))
                 .Where(p => p.Length > 0)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList())
-            .StartWith((IReadOnlyList<string>)[]);
+            .StartWith([]);
+        var manifests = host.Workspace
+            .GetQuery($"home-installs:{ownerId}",
+                $"path:{ownerId}/_Install scope:children nodeType:Store/Install " +
+                "select:path,id,namespace,name,nodeType,content")
+            .Select(nodes => nodes.SelectMany(n => InstalledItemsOf(n.Content, options)).ToList())
+            .StartWith([]);
+        return appRecords.CombineLatest(manifests,
+            (records, installed) => (IReadOnlyList<string>)records
+                .Concat(installed)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList());
+    }
+
+    /// <summary>
+    /// The INSTALLED item paths of one Store install-manifest content (see
+    /// <c>Store/Install/Source/InstallManifest.cs</c> in the plugins repo): <c>items[]</c> entries
+    /// whose <c>installedPath</c> is non-empty, keyed by <c>item</c> — the plugin cover path.
+    /// Tolerant JSON traversal: the type is mesh-compiled and deliberately read untyped; anything
+    /// unreadable yields nothing.
+    /// </summary>
+    internal static IEnumerable<string> InstalledItemsOf(object? content, JsonSerializerOptions options)
+    {
+        JsonElement je;
+        try
+        {
+            je = content switch
+            {
+                null => default,
+                JsonElement e => e,
+                _ => JsonSerializer.SerializeToElement(content, options),
+            };
+        }
+        catch
+        {
+            yield break;
+        }
+        if (je.ValueKind != JsonValueKind.Object
+            || !je.TryGetProperty("items", out var items)
+            || items.ValueKind != JsonValueKind.Array)
+            yield break;
+        foreach (var entry in items.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Object)
+                continue;
+            if (!entry.TryGetProperty("installedPath", out var installedPath)
+                || installedPath.ValueKind != JsonValueKind.String
+                || string.IsNullOrWhiteSpace(installedPath.GetString()))
+                continue;
+            var item = entry.TryGetProperty("item", out var itemProp) && itemProp.ValueKind == JsonValueKind.String
+                ? itemProp.GetString()
+                : null;
+            if (!string.IsNullOrWhiteSpace(item))
+                yield return item!.Trim('/');
+        }
+    }
 
     /// <summary>
     /// The cross-partition scopes the owner has been granted access to — an invited module living in
@@ -761,12 +822,17 @@ public static class UserActivityLayoutAreas
     };
 
     /// <summary>
-    /// The home surface — a TABBED page (the phone-home model): <b>Shared with me</b> first (only
-    /// when the caller has cross-partition grants; last-accessed ranking), then <b>Pinned</b> (the
-    /// owner's content shortcuts, only when any), then <b>Apps</b> (the platform default apps ∪ the
-    /// owner's installed apps — every app EXACTLY ONCE), then <b>Spaces</b> (the catalog WITHOUT
-    /// store items, so nothing is listed twice). <see cref="HomeStyle.Catalog"/> switches back to
-    /// the legacy single-list <see cref="BuildCatalog"/>. Pure (no hub) so the shape is
+    /// The home surface — ONE search control whose SCOPE TABS are the phone-home tabs:
+    /// <b>Shared with me</b> (only with cross-partition grants; store items excluded — the
+    /// auto-entitlement grants made every plugin partition read as "shared", but an app belongs on
+    /// Apps) · <b>Pinned</b> (only with pins) · <b>Apps</b> (default apps ∪ installed apps, every
+    /// app exactly once) · <b>Spaces</b> (the catalog without store items) · <b>All</b>
+    /// (everything the viewer can read, at every depth). Because the scopes live INSIDE one
+    /// <see cref="MeshSearchControl"/>, the search bar is shared: the typed term survives tab
+    /// switches and every tab is searchable — including All. The search input renders on desktop
+    /// and hides on mobile (the view's responsive rule); the <c>~/</c> system tiles (Threads)
+    /// render as a small dock row above the search. <see cref="HomeStyle.Catalog"/> switches back
+    /// to the legacy single-list <see cref="BuildCatalog"/>. Pure (no hub) so the shape is
     /// unit-testable without standing up a hub.
     /// </summary>
     internal static UiControl BuildHome(
@@ -776,67 +842,110 @@ public static class UserActivityLayoutAreas
     {
         var cfg = config ?? HomeConfigNodeType.Defaults;
         // 🚨 The viewer's presentation screen (#1803) is applied to the Shared-with-me, Pinned and
-        // Apps tabs HERE, before their queries are built — not only where the resulting cards are
+        // Apps scopes HERE, before their queries are built — not only where the resulting cards are
         // painted. Each of those three interpolates the viewer's PATHS into the control's query
         // string, which the search view exposes in its options editor and carries in the `hq=`
         // parameter of "open in search". A marked name reaching the address bar mid-presentation is
-        // the leak, whether or not a card for it is ever drawn. The Spaces tab's query is generic,
-        // so it is filtered where its results are painted and left untouched here.
+        // the leak, whether or not a card for it is ever drawn. The Spaces/All queries are generic,
+        // so they are filtered where their results are painted and left untouched here.
         var privacy = screen ?? PresentationScreen.Off;
         if (cfg.Style == HomeStyle.Catalog)
             return BuildCatalog(nodeOwnerId, cfg, sharedTargets, locale, privacy);
 
-        var visibleShared = privacy.Retain(sharedTargets);
-        var tabs = Controls.Tabs.WithSkin(skin => skin.WithWidth("100%"));
-        if (visibleShared.Count > 0)
-            tabs = tabs.WithView(BuildSharedWithMe(visibleShared, locale),
-                skin => skin.WithLabel(LocalizationCatalog.Get("home.sharedWithMe", locale)));
-        var pinned = BuildPinnedItems(user, withTitle: false, screen: privacy);
-        if (pinned is not null)
-            tabs = tabs.WithView(pinned,
-                skin => skin.WithLabel(LocalizationCatalog.Get("home.pinned", locale)));
-        tabs = tabs.WithView(BuildApps(nodeOwnerId, cfg, installedApps, locale, privacy),
-            skin => skin.WithLabel(LocalizationCatalog.Get("home.apps", locale)));
-        tabs = tabs.WithView(BuildSpaces(nodeOwnerId, cfg, locale),
-            skin => skin.WithLabel(LocalizationCatalog.Get("home.spaces", locale)));
-        return tabs;
-    }
+        var scopes = new List<MeshSearchScopeTab>();
 
-    /// <summary>
-    /// The "Shared with me" tab — modules in OTHER partitions the caller was specifically invited
-    /// into (#385), which a scope query can't reach. Default order = last accessed. Because
-    /// <c>source:accessed</c> is an INNER join on the caller's access log, that leg alone would
-    /// HIDE a share the caller never opened — the exact fresh-invitation case this tab exists for —
-    /// so the last-accessed option is a path-keyed UNION (newline-joined, deduped by the engine):
-    /// the accessed-ranked leg first, then the plain list as completeness fallback. Nothing is ever
-    /// hidden; the other sorts are single-leg.
-    /// </summary>
-    internal static UiControl BuildSharedWithMe(IReadOnlyList<string> sharedTargets, string? locale = null)
-    {
-        var pathList = string.Join("|", sharedTargets);
-        var baseQuery = $"path:{pathList} is:main";
-        string Query(HomeCatalogSort sort, string suffix) =>
-            sort == HomeCatalogSort.LastAccessed
-                ? $"{baseQuery} {suffix}\n{baseQuery} {SortSuffixLastModified}"
-                : $"{baseQuery} {suffix}";
-        var sortOptions = CatalogSorts
-            .OrderByDescending(s => s.Sort == HomeCatalogSort.LastAccessed)
-            .Select(s => new MeshSearchSortOption(
-                LocalizationCatalog.Get(s.LabelKey, locale), Query(s.Sort, s.Suffix)))
-            .ToArray();
-        return Controls.MeshSearch
-            .WithHiddenQuery(sortOptions[0].Query)
-            .WithSortOptions(sortOptions)
-            .WithShowSearchBox(false)
+        // Shared with me — #385. source:accessed is an INNER join on the caller's access log, so
+        // the last-accessed option is a path-keyed UNION with a plain completeness fallback (a
+        // fresh, never-opened invitation must not hide). Store items are EXCLUDED: the silent
+        // per-viewer entitlement grants (StandardPacks) made every plugin partition read as
+        // "shared with me", but an app is represented on the Apps scope, exactly once. USER roots
+        // are excluded too — a grant that resolves to another user's home partition must not list
+        // that person's space as "shared" content.
+        var visibleShared = privacy.Retain(sharedTargets);
+        if (visibleShared.Count > 0)
+        {
+            var sharedBase = $"path:{string.Join("|", visibleShared)} is:main -nodeType:User{SpacesDedupExclusions}";
+            scopes.Add(HomeScope("home.sharedWithMe", locale, HomeCatalogSort.LastAccessed,
+                (sort, suffix) => sort == HomeCatalogSort.LastAccessed
+                    ? $"{sharedBase} {suffix}\n{sharedBase} {SortSuffixLastModified}"
+                    : $"{sharedBase} {suffix}"));
+        }
+
+        // Pinned — the owner's content shortcuts, same union-with-fallback for last accessed.
+        var pins = privacy.Retain(user?.PinnedPaths);
+        if (pins.Count > 0)
+        {
+            var pinnedBase = $"path:({string.Join(" OR ", pins)})";
+            scopes.Add(HomeScope("home.pinned", locale, HomeCatalogSort.LastModified,
+                (sort, suffix) => sort == HomeCatalogSort.LastAccessed
+                    ? $"{pinnedBase} {suffix}\n{pinnedBase} {SortSuffixLastModified}"
+                    : $"{pinnedBase} {suffix}"));
+        }
+
+        // Apps — the config-declared defaults ∪ the owner's installed apps, budgeted to 24 TOTAL
+        // (dock tiles included) with the path query itself bounded. `~/` entries become the dock.
+        var (systemAreas, appPaths) = AppEntries(cfg, installedApps, privacy);
+        if (appPaths.Count > 0)
+        {
+            var appsBase = BuildAppsBaseQuery(appPaths);
+            scopes.Add(HomeScope("home.apps", locale, HomeCatalogSort.Alphabetical,
+                (sort, suffix) => sort == HomeCatalogSort.LastAccessed
+                    ? $"{appsBase} {suffix}\n{appsBase} {SortSuffixAlphabetical}"
+                    : $"{appsBase} {suffix}"));
+        }
+
+        // Spaces — the deduplicated catalog (an app never appears twice).
+        scopes.Add(HomeScope("home.spaces", locale, cfg.DefaultSort,
+            (_, suffix) => CatalogQuery(cfg.Scope, nodeOwnerId, suffix, SpacesDedupExclusions)));
+
+        // All — search EVERYTHING the viewer can read, at every depth (the "we can search all" tab).
+        scopes.Add(HomeScope("home.all", locale, cfg.DefaultSort,
+            (_, suffix) => CatalogQuery(HomeCatalogScope.Subtree, nodeOwnerId, suffix)));
+
+        var search = Controls.MeshSearch
+            .WithScopeTabs(scopes.ToArray())
+            // Fallbacks for clients without scope support (react renders these): the first scope.
+            .WithHiddenQuery(scopes[0].Query)
+            .WithSortOptions([.. scopes[0].SortOptions!])
+            .WithShowSearchBox(true)
             .WithViewOptions(true)
             .WithShowEmptyMessage(true)
-            .WithRenderMode(MeshSearchRenderMode.Flat)
-            .WithCollapsibleSections(false)
-            .WithSectionCounts(false)
+            .WithRenderMode(cfg.Render == HomeCatalogRender.Grouped
+                ? MeshSearchRenderMode.Grouped
+                : MeshSearchRenderMode.Flat)
             .WithMaxColumns(4)
             .WithItemLimit(50)
             .WithMaxRows(6)
-            .WithReactiveMode(true);
+            .WithReactiveMode(true)
+            .WithCreateHref("/create");
+        if (cfg.Render == HomeCatalogRender.Grouped)
+            search = search.WithSectionCounts(true).WithCollapsibleSections(true);
+
+        var dock = BuildDock(nodeOwnerId, systemAreas);
+        if (dock is null)
+            return search;
+        return Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("gap: 12px; width: 100%;")
+            .WithView(dock)
+            .WithView(search);
+    }
+
+    /// <summary>One home scope tab: localized label + the three catalog sorts (default first),
+    /// each option's full query produced by <paramref name="query"/>(sort, suffix).</summary>
+    private static MeshSearchScopeTab HomeScope(
+        string labelKey, string? locale, HomeCatalogSort defaultSort,
+        Func<HomeCatalogSort, string, string> query)
+    {
+        var sorts = CatalogSorts
+            .OrderByDescending(s => s.Sort == defaultSort)
+            .Select(s => new MeshSearchSortOption(
+                LocalizationCatalog.Get(s.LabelKey, locale), query(s.Sort, s.Suffix)))
+            .ToArray();
+        return new MeshSearchScopeTab(LocalizationCatalog.Get(labelKey, locale), sorts[0].Query)
+        {
+            SortOptions = sorts,
+        };
     }
 
     /// <summary>
@@ -855,28 +964,19 @@ public static class UserActivityLayoutAreas
         }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// The Apps tab — one icon per app, each app EXACTLY ONCE: the platform's config-declared
-    /// default apps (<see cref="HomeConfig.DefaultApps"/> — e.g. <c>Store</c>, which replaces the
-    /// old hard-coded header entry, <c>Doc</c>, and the <c>~/Chat</c> Threads app) unioned with
-    /// the owner's installed-app records (<c>{owner}/_App</c>, written by the Store's install
-    /// flow), deduped. <c>~/</c>-prefixed entries render as fixed system tiles (a phone's dock)
-    /// ahead of the reactive node-card grid, whose icons' name/image resolve live from each node.
-    /// Default order alphabetical; the last-accessed option uses the same union-with-fallback
-    /// shape as <see cref="BuildSharedWithMe"/> so a never-opened app still shows.
-    /// <para>Rendered as ONE COMPACT BAND, not a grid of full-size cards: dock tiles and the node
-    /// grid sit inline (horizontal, wrapping) with a 140px cell floor
-    /// (<see cref="MeshSearchControl.MinItemWidth"/>), so a typical app set fits a single row —
-    /// and the tab is capped at 24 items (the phone-home scale, per design).</para>
+    /// The app ENTRY LIST — the config-declared defaults (<see cref="HomeConfig.DefaultApps"/> —
+    /// e.g. <c>Store</c>, which replaces the old hard-coded header entry, <c>Doc</c>, and the
+    /// <c>~/Chat</c> Threads app) unioned with the owner's installed apps, deduped, budgeted, and
+    /// split into (<c>~/</c> system AREAS → the dock, node PATHS → the Apps scope query).
+    /// The presentation screen (#1803) drops marked paths HERE, before they reach a query string —
+    /// a <c>~/</c> entry names no node, so there is nothing for the screen to match.
+    /// The phone-home budget: at most 24 tiles TOTAL — dock AND grid together — sliced BEFORE the
+    /// split, so dock tiles count against the budget and the path query itself is bounded.
     /// </summary>
-    internal static UiControl BuildApps(
-        string nodeOwnerId, HomeConfig? config, IReadOnlyList<string>? installedApps,
-        string? locale = null, PresentationScreen? screen = null)
+    internal static (IReadOnlyList<string> SystemAreas, IReadOnlyList<string> Paths) AppEntries(
+        HomeConfig? config, IReadOnlyList<string>? installedApps, PresentationScreen? screen = null)
     {
         var cfg = config ?? HomeConfigNodeType.Defaults;
-        // An installed app's path goes straight into the `path:(…)` query below, so a marked one is
-        // dropped HERE — see the note in BuildHome for why the query string is itself a surface.
-        // A "~/" entry is a system AREA, not a mesh path: it names no node, so there is nothing for
-        // the screen to match and it is passed through untouched.
         var entries = (screen ?? PresentationScreen.Off)
             .Filter(
                 (cfg.DefaultApps ?? [])
@@ -887,82 +987,37 @@ public static class UserActivityLayoutAreas
                     .Distinct(StringComparer.OrdinalIgnoreCase),
                 p => p.StartsWith("~/", StringComparison.Ordinal) ? null : p)
             .ToList();
-        // The phone-home budget: at most 24 tiles TOTAL — dock AND grid together — sliced BEFORE
-        // the dock/grid split, so dock tiles count against the budget and the path query itself is
-        // bounded (the grid's ItemLimit below is only a belt-and-braces render cap).
         const int AppBudget = 24;
         if (entries.Count > AppBudget)
             entries = entries.Take(AppBudget).ToList();
-        var systemAreas = entries.Where(p => p.StartsWith("~/", StringComparison.Ordinal)).ToList();
-        var paths = entries.Where(p => !p.StartsWith("~/", StringComparison.Ordinal)).ToList();
-        if (systemAreas.Count == 0 && paths.Count == 0)
-            return Controls.Markdown(LocalizationCatalog.Get("home.noApps", locale));
+        return (
+            entries.Where(p => p.StartsWith("~/", StringComparison.Ordinal)).ToList(),
+            entries.Where(p => !p.StartsWith("~/", StringComparison.Ordinal)).ToList());
+    }
 
-        UiControl? dock = null;
-        if (systemAreas.Count > 0)
-        {
-            // Compact dock tiles sized to match the grid's 140px cell floor, so system and node
-            // tiles read as ONE row.
-            var tiles = Controls.Stack
-                .WithOrientation(Orientation.Horizontal)
-                .WithStyle("gap: 12px; flex-wrap: wrap; flex: 0 1 auto;");
-            foreach (var area in systemAreas)
-            {
-                var tile = BuildSystemAppTile(nodeOwnerId, area);
-                if (tile is null)
-                    continue;
-                tiles = tiles.WithView(Controls.Stack
-                    .WithStyle("flex: 0 1 170px; min-width: 140px;")
-                    .WithView(tile));
-            }
-            dock = tiles;
-        }
-
-        if (paths.Count == 0)
-            return dock ?? Controls.Markdown(LocalizationCatalog.Get("home.noApps", locale));
-
-        var baseQuery = BuildAppsBaseQuery(paths);
-        string Query(HomeCatalogSort sort, string suffix) =>
-            sort == HomeCatalogSort.LastAccessed
-                ? $"{baseQuery} {suffix}\n{baseQuery} {SortSuffixAlphabetical}"
-                : $"{baseQuery} {suffix}";
-        var sortOptions = CatalogSorts
-            .OrderByDescending(s => s.Sort == HomeCatalogSort.Alphabetical)
-            .Select(s => new MeshSearchSortOption(
-                LocalizationCatalog.Get(s.LabelKey, locale), Query(s.Sort, s.Suffix)))
-            .ToArray();
-        var grid = Controls.MeshSearch
-            .WithHiddenQuery(sortOptions[0].Query)
-            .WithSortOptions(sortOptions)
-            .WithShowSearchBox(false)
-            .WithViewOptions(true)
-            .WithShowEmptyMessage(true)
-            .WithRenderMode(MeshSearchRenderMode.Flat)
-            .WithCollapsibleSections(false)
-            .WithSectionCounts(false)
-            // A compact band: 140px cell floor (instead of the default 200) so a typical app set
-            // fits a single row, wrapping only when it must. Deliberately NO MaxColumns — the
-            // React client renders MaxColumns as an EXACT column count (24 columns would squeeze
-            // cards to ~40px there), while no-MaxColumns keeps every client's own responsive
-            // default. The real 24-item bound is the AppBudget slice above.
-            .WithMinItemWidth(140)
-            .WithGridSpacing(12)
-            .WithItemLimit(24)
-            .WithReactiveMode(true);
-
-        if (dock is null)
-            return grid;
-        // Dock tiles INLINE with the grid — one continuous band. The grid wrapper shrinks to the
-        // 140px cell floor so a phone-width tab (~375px) still fits dock tile + grid side by side
-        // instead of wrapping the whole grid below the dock.
-        return Controls.Stack
+    /// <summary>The system-app dock — one compact row of <see cref="BuildSystemAppTile"/> cards for
+    /// the <c>~/</c> entries, rendered ABOVE the home's search surface (scope-independent, like a
+    /// phone's dock). Null when there are none.</summary>
+    internal static UiControl? BuildDock(string nodeOwnerId, IReadOnlyList<string> systemAreas)
+    {
+        if (systemAreas.Count == 0)
+            return null;
+        var tiles = Controls.Stack
             .WithOrientation(Orientation.Horizontal)
             .WithWidth("100%")
-            .WithStyle("gap: 12px; width: 100%; flex-wrap: wrap; align-items: flex-start;")
-            .WithView(dock)
-            .WithView(Controls.Stack
-                .WithStyle("flex: 1 1 280px; min-width: 140px;")
-                .WithView(grid));
+            .WithStyle("gap: 12px; width: 100%; flex-wrap: wrap;");
+        var any = false;
+        foreach (var area in systemAreas)
+        {
+            var tile = BuildSystemAppTile(nodeOwnerId, area);
+            if (tile is null)
+                continue;
+            any = true;
+            tiles = tiles.WithView(Controls.Stack
+                .WithStyle("flex: 0 1 240px; min-width: 200px;")
+                .WithView(tile));
+        }
+        return any ? tiles : null;
     }
 
     /// <summary>Pure query core of the Apps grid, exposed for tests.</summary>
@@ -991,19 +1046,11 @@ public static class UserActivityLayoutAreas
         return new MeshNodeCardControl($"{nodeOwnerId}/{segment}", Title: label, ImageUrl: icon);
     }
 
-    /// <summary>Dedup for the Spaces tab: anything living in the Store (and therefore representable
-    /// as an installed app — plugin covers, the store root) is EXCLUDED, so an app appears exactly
-    /// once, on the Apps tab. Only non-redundant items survive: the user's own spaces, shared
-    /// workspaces, and their top-level home items.</summary>
+    /// <summary>Dedup for the Spaces and Shared-with-me scopes: anything living in the Store (and
+    /// therefore representable as an installed app — plugin covers, the store root) is EXCLUDED,
+    /// so an app appears exactly once, on the Apps scope. Only non-redundant items survive: the
+    /// user's own spaces, shared workspaces, and their top-level home items.</summary>
     private const string SpacesDedupExclusions = " -nodeType:Store/Plugin -nodeType:Store/Catalog";
-
-    /// <summary>The Spaces tab — the catalog list WITHOUT store items
-    /// (<see cref="SpacesDedupExclusions"/>) and WITHOUT an embedded search box: every client
-    /// already carries a global search in its chrome, and doubling it inside the tab is exactly the
-    /// two-search-bars problem on the mobile clients.</summary>
-    internal static UiControl BuildSpaces(string nodeOwnerId, HomeConfig? config = null, string? locale = null)
-        => BuildCatalogList(nodeOwnerId, config ?? HomeConfigNodeType.Defaults, SpacesDedupExclusions, locale)
-            .WithShowSearchBox(false);
 
     /// <summary>
     /// The LEGACY catalog region (<see cref="HomeStyle.Catalog"/>) — ONE tab-less list, whose shape

--- a/src/MeshWeaver.Layout/MeshSearchControl.cs
+++ b/src/MeshWeaver.Layout/MeshSearchControl.cs
@@ -65,6 +65,27 @@ public enum MeshSearchRenderMode
 public record MeshSearchSortOption(string Label, string Query);
 
 /// <summary>
+/// One SCOPE tab of a search surface — a display <paramref name="Label"/> and the scope's hidden
+/// <paramref name="Query"/>, rendered as a tab strip above the search header. Switching scopes
+/// swaps only the hidden query (and, when <see cref="SortOptions"/> is set, the sort choices)
+/// while the typed search text and the rest of the component state STAY — the scopes deliberately
+/// SHARE one search bar, which is what lets a search term follow the user across tabs. The FIRST
+/// tab is the initially active scope and should match the control's
+/// <see cref="MeshSearchControl.HiddenQuery"/>, which also serves as the fallback for clients
+/// that don't render scopes.
+/// </summary>
+/// <param name="Label">The tab's display text.</param>
+/// <param name="Query">The scope's full hidden query.</param>
+public record MeshSearchScopeTab(string Label, string Query)
+{
+    /// <summary>
+    /// Sort choices that REPLACE the control-level <see cref="MeshSearchControl.SortOptions"/>
+    /// while this scope is active (first = this scope's default). Null keeps the control-level set.
+    /// </summary>
+    public IReadOnlyList<MeshSearchSortOption>? SortOptions { get; init; }
+}
+
+/// <summary>
 /// A control that provides a configurable search with results displayed in a LayoutGrid.
 /// Supports hidden query parts (always applied), visible query (user-modifiable),
 /// and different render modes (flat, hierarchical, grouped).
@@ -139,6 +160,15 @@ public record MeshSearchControl()
     /// <see cref="HiddenQuery"/>. Null/empty ⇒ no sort dropdown (unchanged behaviour).
     /// </summary>
     public IReadOnlyList<MeshSearchSortOption>? SortOptions { get; init; }
+
+    /// <summary>
+    /// Scope tabs rendered as a strip above the search header (see
+    /// <see cref="MeshSearchScopeTab"/>): switching swaps the hidden query and (optionally) the
+    /// sort choices while the typed search text stays — the scopes SHARE one search bar. Null or
+    /// a single entry renders no strip. Clients without scope support fall back to
+    /// <see cref="HiddenQuery"/>, which should equal the first tab's query.
+    /// </summary>
+    public IReadOnlyList<MeshSearchScopeTab>? ScopeTabs { get; init; }
 
     /// <summary>
     /// Whether to exclude the base path node from results (default true).
@@ -334,6 +364,11 @@ public record MeshSearchControl()
     /// <param name="options">The user-selectable sort choices; the first is the default and should match <see cref="HiddenQuery"/>.</param>
     public MeshSearchControl WithSortOptions(params MeshSearchSortOption[] options) =>
         this with { SortOptions = options };
+
+    /// <summary>Returns a copy with the scope-tab strip set (see <see cref="ScopeTabs"/>).</summary>
+    /// <param name="tabs">The scopes; the first is initially active and should match <see cref="HiddenQuery"/>.</param>
+    public MeshSearchControl WithScopeTabs(params MeshSearchScopeTab[] tabs) =>
+        this with { ScopeTabs = tabs };
 
     // Grid fluent methods
     /// <summary>Returns a copy with responsive grid column widths set per breakpoint (MUI grid units, 1–12).</summary>

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -129,6 +129,7 @@
   "menu.createNew": "Neu erstellen…",
   "menu.fullScreen": "Vollbild",
   "menu.history": "Verlauf",
+  "home.all": "Alle",
   "home.sharedWithMe": "Mit mir geteilt",
   "home.pinned": "Angeheftet",
   "home.apps": "Apps",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -129,6 +129,7 @@
   "menu.createNew": "Create new...",
   "menu.fullScreen": "Full screen",
   "menu.history": "History",
+  "home.all": "All",
   "home.sharedWithMe": "Shared with me",
   "home.pinned": "Pinned",
   "home.apps": "Apps",

--- a/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text.Json;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Layout;
@@ -9,48 +10,71 @@ using Xunit;
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>
-/// The TABBED home surface (<see cref="UserActivityLayoutAreas.BuildHome"/>) — the phone-home model:
-/// <b>Shared with me</b> first (only with cross-partition grants, last-accessed ranking with a
-/// completeness fallback), then <b>Pinned</b> (only with pins), then <b>Apps</b> (config-declared
-/// default apps ∪ the owner's installed <c>App</c> records — every app exactly once), then
-/// <b>Spaces</b> (the catalog WITHOUT store items, so nothing is listed twice, and WITHOUT an
-/// embedded search box — the chrome search covers it). <see cref="HomeStyle.Catalog"/> switches
-/// back to the legacy single-list <see cref="UserActivityLayoutAreas.BuildCatalog"/> (covered by
-/// <see cref="HomeCatalogTest"/>).
+/// The home surface (<see cref="UserActivityLayoutAreas.BuildHome"/>) — ONE
+/// <see cref="MeshSearchControl"/> whose SCOPE TABS are the phone-home tabs: Shared with me (only
+/// with grants, store items excluded) · Pinned (only with pins) · Apps (default ∪ installed apps,
+/// 24-budgeted) · Spaces (catalog without store items) · All (everything, every depth). The scopes
+/// share one search bar by construction — the typed term survives tab switches and every tab is
+/// searchable. The search input is desktop-only (the view hides it on mobile); the <c>~/</c>
+/// system tiles render as a dock row above the search. <see cref="HomeStyle.Catalog"/> switches
+/// back to the legacy single list (covered by <see cref="HomeCatalogTest"/>).
 /// </summary>
 public class HomeTabsTest
 {
     private const string NodePath = "rbuergi";
 
-    private static string[] TabLabels(UiControl home) =>
-        home.Should().BeOfType<TabsControl>().Subject.Areas
-            .Select(a => a.Skins.OfType<TabSkin>().Single().Label!.ToString()!)
-            .ToArray();
+    /// <summary>A config whose DefaultApps carry no ~/ entry, so BuildHome returns the bare search
+    /// control (no dock stack) and its scopes are directly assertable.</summary>
+    private static HomeConfig NoDock(params string[] apps) =>
+        new() { DefaultApps = apps.Length > 0 ? apps : ["Store", "Doc"] };
+
+    private static MeshSearchControl Search(UiControl home) =>
+        home.Should().BeOfType<MeshSearchControl>().Subject;
+
+    private static string[] ScopeLabels(MeshSearchControl search) =>
+        search.ScopeTabs!.Select(t => t.Label).ToArray();
+
+    // ── Structure ───────────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Home_Default_IsTabbed_AppsThenSpaces()
+    public void Home_Default_IsDockPlusOneSearchSurface()
     {
-        // No shares, no pins → exactly the two always-present tabs, Apps before Spaces.
-        var home = UserActivityLayoutAreas.BuildHome(NodePath);
-
-        TabLabels(home).Should().Equal("Apps", "Spaces");
+        // Shipped DefaultApps include ~/Chat → a dock row above ONE search control.
+        UserActivityLayoutAreas.BuildHome(NodePath)
+            .Should().BeOfType<StackControl>().Subject
+            .Areas.Should().HaveCount(2, "system-tile dock + the single scoped search surface");
     }
 
     [Fact]
-    public void Home_WithShares_SharedWithMeComesFirst()
+    public void Home_NoShareNoPin_ScopesAreAppsSpacesAll()
     {
-        var home = UserActivityLayoutAreas.BuildHome(NodePath, sharedTargets: ["OrgA/Module"]);
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock()));
 
-        TabLabels(home).Should().Equal("Shared with me", "Apps", "Spaces");
+        ScopeLabels(search).Should().Equal("Apps", "Spaces", "All");
     }
 
     [Fact]
-    public void Home_WithPins_PinnedComesBeforeApps()
+    public void Home_WithSharesAndPins_ScopeOrder()
     {
-        var home = UserActivityLayoutAreas.BuildHome(NodePath,
-            sharedTargets: ["OrgA/Module"], user: new User { PinnedPaths = ["Doc/GUI"] });
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock(),
+            sharedTargets: ["OrgA/Module"], user: new User { PinnedPaths = ["Doc/GUI"] }));
 
-        TabLabels(home).Should().Equal("Shared with me", "Pinned", "Apps", "Spaces");
+        ScopeLabels(search).Should().Equal("Shared with me", "Pinned", "Apps", "Spaces", "All");
+    }
+
+    [Fact]
+    public void Home_OneSharedSearchBar_DesktopOn()
+    {
+        // The bar is ON (the view hides the input responsively on mobile); the control-level
+        // hidden query and sort options are the FIRST scope's — the fallback contract for clients
+        // without scope support.
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock(),
+            sharedTargets: ["OrgA/Module"]));
+
+        search.ShowSearchBox.Should().Be(true);
+        search.HiddenQuery!.ToString().Should().Be(search.ScopeTabs![0].Query);
+        search.SortOptions!.Select(o => o.Query)
+            .Should().Equal(search.ScopeTabs![0].SortOptions!.Select(o => o.Query));
     }
 
     [Fact]
@@ -59,90 +83,117 @@ public class HomeTabsTest
         var home = UserActivityLayoutAreas.BuildHome(NodePath,
             new HomeConfig { Style = HomeStyle.Catalog });
 
-        home.Should().BeOfType<MeshSearchControl>("the legacy escape hatch is the tab-less catalog");
+        home.Should().BeOfType<MeshSearchControl>().Subject
+            .ScopeTabs.Should().BeNull("the legacy escape hatch is the scope-less catalog");
     }
 
-    // ── Apps tab ────────────────────────────────────────────────────────────────────────────────
+    // ── Shared-with-me scope ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Shared_ExcludesStoreItems_AndKeepsTheCompletenessFallback()
+    {
+        // The silent per-viewer entitlement grants (StandardPacks) made every plugin partition
+        // read as "shared with me" — store items are excluded here because an app is represented
+        // on the Apps scope, exactly once. And source:accessed is an INNER join, so the default
+        // last-accessed option stays a two-leg union with a plain fallback.
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock(),
+            sharedTargets: ["OrgA/Module", "OrgB/Deck"]));
+
+        var shared = search.ScopeTabs![0];
+        shared.Label.Should().Be("Shared with me");
+        var legs = shared.Query.Split('\n');
+        legs.Should().HaveCount(2, "the accessed leg alone would hide a never-opened share");
+        legs[0].Should().Contain("source:accessed");
+        legs[1].Should().NotContain("source:accessed");
+        foreach (var leg in legs)
+        {
+            leg.Should().Contain("path:OrgA/Module|OrgB/Deck");
+            leg.Should().Contain("-nodeType:Store/Plugin");
+            leg.Should().Contain("-nodeType:Store/Catalog");
+            leg.Should().Contain("-nodeType:User",
+                "a grant resolving to another user's home partition must not list that person's space as shared");
+        }
+    }
+
+    // ── Apps scope ──────────────────────────────────────────────────────────────────────────────
 
     [Fact]
     public void Apps_UnionsConfigDefaultsAndInstalled_EachAppExactlyOnce()
     {
-        // Node-path union tested through the pure query core — "store" dedupes case-insensitively
-        // against the shipped default "Store", "Chess" appears once.
-        var noDock = new HomeConfig { DefaultApps = ["Store", "Doc"] };
-        var apps = UserActivityLayoutAreas.BuildApps(
-                NodePath, noDock, installedApps: ["Chess", "store", "Chess"])
-            .Should().BeOfType<MeshSearchControl>().Subject;
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock(),
+            installedApps: ["Chess", "store", "Chess"]));
 
-        var query = apps.HiddenQuery!.ToString()!;
-        query.Should().Contain("path:(Store OR Doc OR Chess)");
-        query.Should().NotContain("store OR");
-    }
-
-    [Fact]
-    public void Apps_ShippedDefaults_ComposeDockPlusGrid()
-    {
-        // Shipped DefaultApps include the ~/Chat Threads tile → dock tiles INLINE with the node
-        // grid, one horizontal band.
-        UserActivityLayoutAreas.BuildApps(NodePath, new HomeConfig(), installedApps: null)
-            .Should().BeOfType<StackControl>().Subject
-            .Areas.Should().HaveCount(2, "system-tile dock + the node-card grid, inline");
-    }
-
-    [Fact]
-    public void Apps_IsOneCompactBand()
-    {
-        // The Apps tab is a phone-dock band, not a grid of full-size cards: a 140px cell floor
-        // (below the control's 200px default) so a typical app set fits ONE row, wrapping only
-        // when it must. Deliberately NO MaxColumns: the React client renders MaxColumns as an
-        // EXACT column count and would squeeze cards to slivers.
-        var noDock = new HomeConfig { DefaultApps = ["Store", "Doc"] };
-        var apps = UserActivityLayoutAreas.BuildApps(NodePath, noDock, installedApps: null)
-            .Should().BeOfType<MeshSearchControl>().Subject;
-
-        apps.MinItemWidth.Should().Be(140);
-        apps.Sections!.ItemLimit.Should().Be(24);
-        apps.MaxColumns.Should().BeNull();
-        apps.Grid!.Spacing.Should().Be(12);
+        var apps = search.ScopeTabs!.Single(t => t.Label == "Apps");
+        // Defaults (Store, Doc) ∪ installed (Chess) — "store" dedupes case-insensitively.
+        apps.Query.Should().Contain("path:(Store OR Doc OR Chess)");
+        apps.Query.Should().NotContain("store OR");
+        // Default order alphabetical; all three sorts offered, scope-locally.
+        apps.SortOptions![0].Query.Should().Be(apps.Query);
+        apps.Query.Should().Contain("sort:Name-asc");
+        apps.SortOptions.Should().HaveCount(3);
     }
 
     [Fact]
     public void Apps_BudgetOf24_BoundsTheQueryItself()
     {
-        // 24 tiles TOTAL: with 30 configured paths and no dock entry, the grid's path alternation
-        // carries exactly 24 entries — the QUERY is bounded, not just the rendered list.
-        var many = new HomeConfig
-        {
-            DefaultApps = Enumerable.Range(1, 30).Select(i => $"P{i}").ToList(),
-        };
-        var apps = UserActivityLayoutAreas.BuildApps(NodePath, many, installedApps: null)
-            .Should().BeOfType<MeshSearchControl>().Subject;
+        var many = NoDock(Enumerable.Range(1, 30).Select(i => $"P{i}").ToArray());
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, many));
 
-        var firstLeg = apps.HiddenQuery!.ToString()!.Split('\n')[0];
+        var apps = search.ScopeTabs!.Single(t => t.Label == "Apps");
+        var firstLeg = apps.Query.Split('\n')[0];
         firstLeg.Split(" OR ").Should().HaveCount(24, "the AppBudget slice bounds the path alternation");
         firstLeg.Should().NotContain("P25", "entries beyond the budget are dropped in config order");
     }
 
     [Fact]
-    public void Apps_BudgetOf24_CountsDockTiles()
+    public void AppEntries_BudgetCountsDockTiles_SliceBeforeTheSplit()
     {
-        // Dock entries count against the same budget: the slice happens BEFORE the dock/grid
-        // split, so a config of ~/Chat + 30 paths still yields one band of at most 24 tiles.
-        var many = new HomeConfig
+        var cfg = new HomeConfig
         {
             DefaultApps = new[] { "~/Chat" }
                 .Concat(Enumerable.Range(1, 30).Select(i => $"P{i}"))
                 .ToList(),
         };
-        var band = UserActivityLayoutAreas.BuildApps(NodePath, many, installedApps: null)
-            .Should().BeOfType<StackControl>().Subject;
-        band.Areas.Should().HaveCount(2, "dock + grid, inline");
+
+        var (systemAreas, paths) = UserActivityLayoutAreas.AppEntries(cfg, installedApps: null);
+
+        systemAreas.Should().Equal("~/Chat");
+        paths.Should().HaveCount(23, "24 total minus the dock tile — dock counts against the budget");
     }
+
+    // ── Spaces + All scopes ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Spaces_ExcludesStoreItems_TheDedupRule()
+    {
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock()));
+
+        var spaces = search.ScopeTabs!.Single(t => t.Label == "Spaces");
+        foreach (var option in spaces.SortOptions!)
+        {
+            option.Query.Should().Contain("-nodeType:Store/Plugin");
+            option.Query.Should().Contain("-nodeType:Store/Catalog");
+        }
+    }
+
+    [Fact]
+    public void All_SearchesEverything_AtEveryDepth()
+    {
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock()));
+
+        var all = search.ScopeTabs!.Last();
+        all.Label.Should().Be("All");
+        all.Query.Should().Contain("is:main context:search");
+        all.Query.Should().NotContain("namespace:", "All is the SUBTREE query — everything, every depth");
+        all.Query.Should().NotContain("-nodeType:Store/Plugin", "the All scope hides nothing");
+    }
+
+    // ── System (dock) tiles ─────────────────────────────────────────────────────────────────────
 
     [Theory]
     [InlineData("~/Chat")]
     [InlineData("~/Chat/")]   // extra slashes normalize — the known-tile lookup keys on the TRIMMED segment
-    public void Apps_SystemTile_ThreadsDockTile_TargetsTheViewersChatArea(string entry)
+    public void SystemTile_ThreadsDockTile_TargetsTheViewersChatArea(string entry)
     {
         var tile = UserActivityLayoutAreas.BuildSystemAppTile(NodePath, entry);
 
@@ -153,7 +204,7 @@ public class HomeTabsTest
     }
 
     [Fact]
-    public void Apps_SystemTile_UnknownAreaFallsBack_MalformedIsNull()
+    public void SystemTile_UnknownAreaFallsBack_MalformedIsNull()
     {
         var unknown = UserActivityLayoutAreas.BuildSystemAppTile(NodePath, "~/Foo");
         unknown!.Title.Should().Be("Foo");
@@ -163,115 +214,38 @@ public class HomeTabsTest
         UserActivityLayoutAreas.BuildSystemAppTile(NodePath, "Store").Should().BeNull();
     }
 
-    [Fact]
-    public void Apps_DefaultOrderIsAlphabetical_AllThreeSortsOffered()
-    {
-        var noDock = new HomeConfig { DefaultApps = ["Store", "Doc"] };
-        var apps = UserActivityLayoutAreas.BuildApps(NodePath, noDock, installedApps: null)
-            .Should().BeOfType<MeshSearchControl>().Subject;
-
-        apps.SortOptions![0].Label.Should().Be("Alphabetical");
-        apps.SortOptions![0].Query.Should().Be(apps.HiddenQuery!.ToString());
-        apps.HiddenQuery!.ToString().Should().Contain("sort:Name-asc");
-        apps.SortOptions!.Select(o => o.Label).OrderBy(l => l, StringComparer.Ordinal).Should()
-            .Equal("Alphabetical", "Last accessed", "Last modified");
-    }
+    // ── Install manifests → installed apps ──────────────────────────────────────────────────────
 
     [Fact]
-    public void Apps_LastAccessedSort_IsAUnionWithACompletenessFallback()
+    public void InstalledItemsOf_YieldsOnlyItemsWithALiveInstall()
     {
-        // source:accessed is an INNER join on the caller's access log — alone it would HIDE a
-        // never-opened app. The last-accessed option must therefore be a two-leg path-keyed union:
-        // accessed-ranked first, plain fallback second.
-        var noDock = new HomeConfig { DefaultApps = ["Store", "Doc"] };
-        var apps = UserActivityLayoutAreas.BuildApps(NodePath, noDock, installedApps: null)
-            .Should().BeOfType<MeshSearchControl>().Subject;
-
-        var lastAccessed = apps.SortOptions!.Single(o => o.Label == "Last accessed").Query;
-        var legs = lastAccessed.Split('\n');
-        legs.Should().HaveCount(2);
-        legs[0].Should().Contain("source:accessed");
-        legs[1].Should().NotContain("source:accessed");
-        legs[1].Should().Contain("path:(");
-    }
-
-    [Fact]
-    public void Apps_NoAppsAnywhere_RendersAHint()
-    {
-        UserActivityLayoutAreas.BuildApps(NodePath, new HomeConfig { DefaultApps = [] }, installedApps: [])
-            .Should().BeOfType<MarkdownControl>("an empty Apps tab must explain itself, not render blank");
-    }
-
-    // ── Threads app (the /{user}/Chat page) ─────────────────────────────────────────────────────
-
-    [Fact]
-    public void ThreadsApp_IsARailPlusComposer()
-    {
-        UserActivityLayoutAreas.BuildThreadsApp(NodePath)
-            .Should().BeOfType<StackControl>().Subject
-            .Areas.Should().HaveCount(2, "the vertical thread rail + the composer pane");
-    }
-
-    [Fact]
-    public void ThreadsRail_ListsOpenThreads_RowsDelegateToTheRailItemArea()
-    {
-        var rail = UserActivityLayoutAreas.BuildThreadsRail(NodePath);
-
-        var query = rail.HiddenQuery!.ToString()!;
-        query.Should().Contain($"namespace:{NodePath}/*_Thread");
-        query.Should().Contain("nodeType:Thread");
-        query.Should().Contain("-content.status:Done", "closing a thread (✕ → MarkThreadDone) must remove it from the rail");
-        query.Should().Contain("sort:LastModified-desc");
-        // Flat + one column, NOT List: the List renderer ignores ItemArea, so the ✕ overlay would
-        // never render there — Flat is the ItemArea path the pinned grid proves.
-        rail.RenderMode.Should().Be(MeshSearchRenderMode.Flat);
-        rail.MaxColumns.Should().Be(1, "the rail is a vertical menu");
-        rail.ItemArea.Should().Be("RailItem", "each row renders via the thread hub's RailItem area (title + ✕)");
-        rail.ShowSearchBox.Should().Be(false);
-    }
-
-    // ── Spaces tab (dedup) ──────────────────────────────────────────────────────────────────────
-
-    [Fact]
-    public void Spaces_ExcludesStoreItems_TheDedupRule()
-    {
-        // An app is represented exactly once: plugin covers + the store root live on the Apps tab
-        // (or in the Store), so the Spaces tab filters them out of every sort option's query.
-        var spaces = UserActivityLayoutAreas.BuildSpaces(NodePath)
-            .Should().BeOfType<MeshSearchControl>().Subject;
-
-        foreach (var option in spaces.SortOptions!)
+        // The Store's per-user install manifest ({owner}/_Install/{slug}) is mesh-compiled and read
+        // UNTYPED by design: items[] with a non-empty installedPath ARE the installed apps.
+        var manifest = JsonSerializer.SerializeToElement(new
         {
-            option.Query.Should().Contain("-nodeType:Store/Plugin");
-            option.Query.Should().Contain("-nodeType:Store/Catalog");
-        }
+            repo = "https://github.com/Systemorph/MeshWeaver.Plugins",
+            items = new object[]
+            {
+                new { item = "Chess", installedPath = "rbuergi/Chess", installedAt = "2026-08-01" },
+                new { item = "Publish", installedPath = (string?)null },        // un-installed: keeps entitlement only
+                new { item = (string?)null, installedPath = "rbuergi/Ghost" },  // malformed: no item id
+                new { item = "Training/", installedPath = "rbuergi/Training" }, // normalizes
+            },
+        });
+
+        UserActivityLayoutAreas.InstalledItemsOf(manifest, new JsonSerializerOptions())
+            .Should().Equal("Chess", "Training");
     }
 
     [Fact]
-    public void Spaces_HasNoEmbeddedSearchBox()
+    public void InstalledItemsOf_ToleratesGarbage()
     {
-        // Every client chrome already carries a global search; an embedded box would double it
-        // (the two-search-bars problem on the mobile clients).
-        UserActivityLayoutAreas.BuildSpaces(NodePath)
-            .Should().BeOfType<MeshSearchControl>().Subject
-            .ShowSearchBox.Should().Be(false);
-    }
-
-    // ── Shared-with-me tab ──────────────────────────────────────────────────────────────────────
-
-    [Fact]
-    public void SharedWithMe_DefaultsToLastAccessed_WithACompletenessFallback()
-    {
-        var shared = UserActivityLayoutAreas.BuildSharedWithMe(["OrgA/Module", "OrgB/Deck"])
-            .Should().BeOfType<MeshSearchControl>().Subject;
-
-        shared.SortOptions![0].Label.Should().Be("Last accessed");
-        var legs = shared.HiddenQuery!.ToString()!.Split('\n');
-        legs.Should().HaveCount(2, "the accessed leg alone would hide a share the caller never opened");
-        legs[0].Should().Contain("source:accessed");
-        legs[0].Should().Contain("path:OrgA/Module|OrgB/Deck");
-        legs[1].Should().NotContain("source:accessed");
-        legs[1].Should().Contain("path:OrgA/Module|OrgB/Deck");
+        var options = new JsonSerializerOptions();
+        UserActivityLayoutAreas.InstalledItemsOf(null, options).Should().BeEmpty();
+        UserActivityLayoutAreas.InstalledItemsOf(JsonSerializer.SerializeToElement(42), options).Should().BeEmpty();
+        UserActivityLayoutAreas.InstalledItemsOf(
+                JsonSerializer.SerializeToElement(new { items = "nope" }), options)
+            .Should().BeEmpty();
     }
 
     // ── Config ──────────────────────────────────────────────────────────────────────────────────

--- a/test/MeshWeaver.Graph.Test/PresentationSurfacesTest.cs
+++ b/test/MeshWeaver.Graph.Test/PresentationSurfacesTest.cs
@@ -86,104 +86,110 @@ public class PresentationSurfacesTest
             .Should().Contain("Acme");
     }
 
-    // ── The tabbed home: Shared with me, Pinned, Apps ──────────────────────────────────────────
+    // ── The scoped home: Shared with me, Pinned, Apps ──────────────────────────────────────────
 
-    private static string[] TabLabels(UiControl home) =>
-        home.Should().BeOfType<TabsControl>().Subject.Areas
-            .Select(a => a.Skins.OfType<TabSkin>().Single().Label!.ToString()!)
-            .ToArray();
+    /// <summary>A config with no ~/ entry, so BuildHome returns the bare scoped search control.</summary>
+    private static HomeConfig NoDock(params string[] apps) =>
+        new() { DefaultApps = apps.Length > 0 ? apps : ["Store", "Doc"] };
+
+    private static MeshSearchControl HomeSearch(UiControl home) =>
+        home.Should().BeOfType<MeshSearchControl>().Subject;
+
+    private static string[] ScopeLabels(UiControl home) =>
+        HomeSearch(home).ScopeTabs!.Select(t => t.Label).ToArray();
+
+    private static string ScopeQuery(UiControl home, string label) =>
+        HomeSearch(home).ScopeTabs!.Single(t => t.Label == label).Query;
 
     [Fact]
-    public void Home_ATabWhoseWholeContentIsMarked_Disappears()
+    public void Home_AScopeWhoseWholeContentIsMarked_Disappears()
     {
         var user = new User { PinnedPaths = ["Acme/Q3-Renewal"] };
 
         // Off: both viewer-scoped tabs are there.
-        TabLabels(UserActivityLayoutAreas.BuildHome(
-                Owner, sharedTargets: ["Acme/Deals"], user: user))
-            .Should().Equal("Shared with me", "Pinned", "Apps", "Spaces");
+        ScopeLabels(UserActivityLayoutAreas.BuildHome(
+                Owner, NoDock(), sharedTargets: ["Acme/Deals"], user: user))
+            .Should().Equal("Shared with me", "Pinned", "Apps", "Spaces", "All");
 
         // On, with Acme marked: everything in both of them is inside the marked space, so both tabs
         // go — an empty tab labelled "Pinned" would itself say something.
-        TabLabels(UserActivityLayoutAreas.BuildHome(
-                Owner, sharedTargets: ["Acme/Deals"], user: user, screen: Active("Acme")))
-            .Should().Equal("Apps", "Spaces");
+        ScopeLabels(UserActivityLayoutAreas.BuildHome(
+                Owner, NoDock(), sharedTargets: ["Acme/Deals"], user: user, screen: Active("Acme")))
+            .Should().Equal("Apps", "Spaces", "All");
     }
 
     [Fact]
-    public void Home_ATabKeepsItsUnmarkedContent()
+    public void Home_AScopeKeepsItsUnmarkedContent()
     {
         var home = UserActivityLayoutAreas.BuildHome(
-            Owner,
+            Owner, NoDock(),
             sharedTargets: ["Acme/Deals", "Northwind/Sales"],
             user: new User { PinnedPaths = ["Acme", "Doc/Guide"] },
             screen: Active("Acme"));
 
-        TabLabels(home).Should().Equal("Shared with me", "Pinned", "Apps", "Spaces");
+        ScopeLabels(home).Should().Equal("Shared with me", "Pinned", "Apps", "Spaces", "All");
     }
 
     [Fact]
-    public void SharedBand_DropsAMarkedTarget()
+    public void SharedScope_DropsAMarkedTarget()
     {
         var painted = Active("Acme").Retain(["Acme/Deals", "Northwind/Sales"]);
-
         painted.Should().Equal("Northwind/Sales");
-        QueryOf(UserActivityLayoutAreas.BuildSharedWithMe(painted))
+
+        var home = UserActivityLayoutAreas.BuildHome(
+            Owner, NoDock(), sharedTargets: ["Acme/Deals", "Northwind/Sales"], screen: Active("Acme"));
+        ScopeQuery(home, "Shared with me")
             .Should().NotContain("Acme").And.Contain("Northwind/Sales");
     }
 
     [Fact]
-    public void AppsTab_DropsAMarkedApp_BeforeItReachesTheQuery()
+    public void AppsScope_DropsAMarkedApp_BeforeItReachesTheQuery()
     {
         // An installed app's path is interpolated into `path:(…)`, so a marked one must never get
         // that far.
-        var apps = UserActivityLayoutAreas.BuildApps(
-                Owner,
-                new HomeConfig { DefaultApps = ["Store"] },
-                installedApps: ["Chess", "Acme"],
-                locale: null,
-                screen: Active("Acme"))
-            .Should().BeOfType<MeshSearchControl>().Subject;
+        var home = UserActivityLayoutAreas.BuildHome(
+            Owner, NoDock("Store"), installedApps: ["Chess", "Acme"], screen: Active("Acme"));
 
-        var query = apps.HiddenQuery!.ToString()!;
+        var query = ScopeQuery(home, "Apps");
         query.Should().Contain("Store").And.Contain("Chess");
         query.Should().NotContain("Acme");
     }
 
     [Fact]
-    public void AppsTab_LeavesSystemAreasAlone()
+    public void AppEntries_LeaveSystemAreasAlone()
     {
         // A "~/" entry is a system AREA, not a mesh path — it names no node, so there is nothing for
         // the screen to match and it must pass through even while the mode is up. Asserted because
         // the code only says it in a comment, and a comment is not a test.
         // Marking the system area TOO (a viewer can type anything into their own profile) must not
         // make it disappear, and marking the only real app must not take the dock with it.
-        var apps = UserActivityLayoutAreas.BuildApps(
+        var (systemAreas, paths) = UserActivityLayoutAreas.AppEntries(
+            new HomeConfig { DefaultApps = ["~/Settings"] },
+            installedApps: ["Acme"],
+            screen: Active("Acme", "~/Settings"));
+
+        systemAreas.Should().Equal("~/Settings");
+        paths.Should().BeEmpty("every MESH path was screened away; the system-area dock survives");
+        // And the home still renders the dock (a stack above the search), never a query carrying
+        // the marked name.
+        var home = UserActivityLayoutAreas.BuildHome(
             Owner,
             new HomeConfig { DefaultApps = ["~/Settings"] },
             installedApps: ["Acme"],
-            locale: null,
             screen: Active("Acme", "~/Settings"));
-
-        // Every MESH path was screened away, so what is left is the system-area dock itself — a
-        // stack of tiles, not the "no apps" placeholder and not a query carrying the marked name.
-        apps.Should().BeOfType<StackControl>(
-            "the system area survives the screen; only the marked mesh app went");
-        apps.Should().NotBeOfType<MarkdownControl>();
+        home.Should().BeOfType<StackControl>("the dock survives the screen").Subject
+            .Areas.Should().HaveCount(2, "dock + the scoped search surface");
     }
 
     [Fact]
-    public void AppsTab_IsUnchangedWhenTheModeIsOff()
+    public void AppEntries_AreUnchangedWhenTheModeIsOff()
     {
-        var apps = UserActivityLayoutAreas.BuildApps(
-                Owner,
-                new HomeConfig { DefaultApps = ["Store"] },
-                installedApps: ["Acme"],
-                locale: null,
-                screen: PresentationScreen.For(false, ["Acme"]))
-            .Should().BeOfType<MeshSearchControl>().Subject;
+        var (_, paths) = UserActivityLayoutAreas.AppEntries(
+            new HomeConfig { DefaultApps = ["Store"] },
+            installedApps: ["Acme"],
+            screen: PresentationScreen.For(false, ["Acme"]));
 
-        apps.HiddenQuery!.ToString().Should().Contain("Acme");
+        paths.Should().Contain("Acme");
     }
 
     // ── The legacy single-list catalog ─────────────────────────────────────────────────────────
@@ -221,7 +227,12 @@ public class PresentationSurfacesTest
         QueryOf(marked).Should().Be(QueryOf(plain));
         QueryOf(marked).Should().NotContain("Acme");
 
-        QueryOf(UserActivityLayoutAreas.BuildSpaces(Owner)).Should().NotContain("Acme");
+        // Same for the home's Spaces scope: identical query with and without the screen.
+        var spacesMarked = HomeSearch(UserActivityLayoutAreas.BuildHome(Owner, NoDock(), screen: Active("Acme")))
+            .ScopeTabs!.Single(t => t.Label == "Spaces").Query;
+        var spacesPlain = HomeSearch(UserActivityLayoutAreas.BuildHome(Owner, NoDock()))
+            .ScopeTabs!.Single(t => t.Label == "Spaces").Query;
+        spacesMarked.Should().Be(spacesPlain).And.NotContain("Acme");
     }
 
     // ── The marking affordance ─────────────────────────────────────────────────────────────────

--- a/test/MeshWeaver.Portal.E2E.Test/HomePageRegionsTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/HomePageRegionsTest.cs
@@ -38,14 +38,12 @@ public class HomePageRegionsTest(PortalFixture fixture)
 
         // (b) The catalog — embedded via @@("area/Catalog") — must fill the home width.
         //
-        // The catalog region is the TABBED home (UserActivityLayoutAreas.BuildHome): a TabsControl
-        // (Shared with me · Pinned · Apps · Spaces — the first two only when present) rendering
-        // <fluent-tabs>, whose active panel holds a MeshSearch (<div class="mesh-search-container">).
-        // The default e2e user has the onboarding-seeded pins and no shares, so the active first
-        // tab is Pinned — a MeshSearch either way.
-        // Wait (don't count): CountAsync doesn't wait, so a transient 0 before the tabs render
+        // The catalog region is ONE scoped search surface (UserActivityLayoutAreas.BuildHome): a
+        // MeshSearch whose SCOPE TABS (Shared with me · Pinned · Apps · Spaces · All — the first
+        // two only when present) render as the .mesh-search-scopes strip and share one search bar.
+        // Wait (don't count): CountAsync doesn't wait, so a transient 0 before the strip renders
         // would flake this assertion.
-        await page.Locator("fluent-tabs").First
+        await page.Locator(".mesh-search-scopes").First
             .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
         var catalog = page.Locator(".mesh-search-container").First;
         await catalog.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });


### PR DESCRIPTION
Per Roland's feedback on the shipped home (the original one-row ask was the **search bar + ordering controls**, not the tiles; the search term must survive tab switches; every tab must be searchable; apps and user spaces must not appear under Shared with me):

- **`MeshSearchControl.ScopeTabs`** (new): a scope strip above the search header — switching swaps the hidden query + per-scope sort set while the typed text and component state stay, so the scopes **share one search bar by construction**. Control-level `HiddenQuery`/`SortOptions` remain the first scope (fallback for clients without scope support).
- **The home is now ONE scoped search surface**: Shared with me (grants — minus store items, since the silent `StandardPacks` entitlements made every plugin partition read as "shared", and minus `User` roots: another person's home is never shared content) · Pinned · Apps · Spaces (deduped) · **All** (subtree — search everything). The TabsControl composition is gone; `~/` system tiles render as a dock row above.
- **Search bar + Group-by/Sort-by on one row** on desktop; the input hides ≤640px (title/create/options stay) — the chrome search covers mobile.
- **Apps scope lists real installs**: it also reads the Store's per-user install manifests (`{owner}/_Install`, untyped by the manifest's own design) — every item with a live `installedPath` is an installed app, so existing installs (incl. auto-installed standard packs) appear before the Store's install flow writes `_App` records.
- **Prod data repair (memex, already applied)**: deleted 7 residual blanket-**Admin** grants for `rbuergi` on user partitions (Jul 6–27 support residue — the reason user spaces showed as "shared"); restored `anujpreet.singh`'s missing onboarding self-admin grant that the residue was masking.

Verified **in a real browser** (E2E fixture, launched Monolith): scope strip `Shared with me | Pinned | Apps | Spaces | All`, search + ordering on one row, Threads dock tile — screenshot-checked. `dotnet build -c Release -warnaserror` (Layout + Blazor + Graph.Test + Monolith) clean on the rebased tip; 62/62 home/privacy unit tests green (incl. the ported #1803 presentation-screen suite); `home.all` key (en+de) with byte-identical react mirrors.

React parity note: the JS clients ignore `ScopeTabs` and render the first scope via the fallback — graceful until they learn the strip.

What's New entry included (`Category: Feature`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)