### PR TITLE
voice gateway: named songs resolve through Music Assistant — their tooling, never ours

### DIFF
--- a/clients/voice-gateway/memex_voice_gateway/__main__.py
+++ b/clients/voice-gateway/memex_voice_gateway/__main__.py
@@ -129,11 +129,17 @@ async def run() -> None:
         await router.refresh_stations()
     except Exception:
         logging.getLogger(__name__).warning("station refresh failed", exc_info=True)
+    if cfg.ma_token:
+        from .musicassistant import MusicAssistant
+        router.music = MusicAssistant(cfg.ma_url, cfg.ma_token)
     capabilities = []
     if router.stations:
         names = ", ".join(name for name, _ in router.stations.values())
         capabilities.append(f"Radio is available ({names}) and handled for you "
                             "automatically — never claim you cannot play radio.")
+    if router.music is not None:
+        capabilities.append("Specific songs and playlists play through the connected "
+                            "music services — also handled for you automatically.")
     if cfg.ha_url and cfg.ha_token:
         capabilities.append("The smart home is reachable through the home_assistant tool.")
     router.apply_system_prompt(prompt_text

--- a/clients/voice-gateway/memex_voice_gateway/config.py
+++ b/clients/voice-gateway/memex_voice_gateway/config.py
@@ -24,6 +24,17 @@ def _env(name: str, default: str | None = None) -> str | None:
     return value if value not in ("", None) else default
 
 
+def _keychain(service: str) -> str | None:
+    """A secret from the macOS keychain — tokens never ride in env files or chat."""
+    import subprocess
+    try:
+        out = subprocess.run(["security", "find-generic-password", "-s", service, "-w"],
+                             capture_output=True, text=True, timeout=5)
+        return out.stdout.strip() or None
+    except Exception:
+        return None
+
+
 # What the SPEAKER says in its own voice (holding, errors, switch confirmations) — chosen by
 # the configured language; every instruction and prompt in this repo stays English.
 PHRASES: dict[str, dict[str, str]] = {
@@ -43,7 +54,8 @@ PHRASES: dict[str, dict[str, str]] = {
            "nothing_new": "No new answers.",
            "radio_on": "Here comes {station}. Say stop to end it.",
            "song_hint": "I cannot play single songs yet — but here comes {station}.",
-           "no_stations": "No radio stations are set up yet — add them under Voice, Station in the portal."},
+           "no_stations": "No radio stations are set up yet — add them under Voice, Station in the portal.",
+           "playing_song": "Here comes {title} by {artist}."},
     "de": {"hold": "Ich schaue nach. Einen Moment bitte.",
            "error": "Entschuldigung, das hat gerade nicht geklappt.",
            "connected": "Verbunden mit {name}.",
@@ -60,7 +72,8 @@ PHRASES: dict[str, dict[str, str]] = {
            "nothing_new": "Keine neuen Antworten.",
            "radio_on": "Hier kommt {station}. Sag Stopp, wenn es reicht.",
            "song_hint": "Einzelne Lieder kann ich noch nicht spielen — dafür kommt {station}.",
-           "no_stations": "Es sind noch keine Radiosender eingerichtet — füge sie im Portal unter Voice, Station hinzu."},
+           "no_stations": "Es sind noch keine Radiosender eingerichtet — füge sie im Portal unter Voice, Station hinzu.",
+           "playing_song": "Hier kommt {title} von {artist}."},
 }
 PHRASES["en"]["answer_to"] = "Answering your question: {question} —"
 PHRASES["de"]["answer_to"] = "Antwort auf deine Frage: {question} —"
@@ -116,6 +129,12 @@ class Config:
     # --- Home Assistant (optional) — a tool for the local brain, not a voice owner ---
     ha_url: str | None = None               # e.g. http://homeassistant.local:8123
     ha_token: str | None = None             # long-lived access token
+
+    # --- Music Assistant (optional) — songs/playlists via THEIR tooling (Spotify, Apple
+    # Music, Radio Browser providers); token from MA_TOKEN or the keychain entry
+    # `music-assistant-token` ---
+    ma_url: str = "http://127.0.0.1:8095"
+    ma_token: str | None = None
 
     # --- the spoken session (context cookie) + tool reach ---
     session_file: str = "~/.memex-voice/session.json"   # persisted context, per speaker
@@ -180,6 +199,8 @@ class Config:
             system_prompt_file=_env("SYSTEM_PROMPT_FILE"),
             ha_url=(_env("HA_URL") or "").rstrip("/") or None,
             ha_token=_env("HA_TOKEN"),
+            ma_url=(_env("MA_URL", Config.ma_url) or Config.ma_url).rstrip("/"),
+            ma_token=_env("MA_TOKEN") or _keychain("music-assistant-token"),
             session_file=_env("SESSION_FILE", Config.session_file) or Config.session_file,
             session_ttl_h=float(_env("SESSION_TTL_H", "8")),
             allow_destructive=(_env("ALLOW_DESTRUCTIVE", "false") or "false").lower() == "true",

--- a/clients/voice-gateway/memex_voice_gateway/musicassistant.py
+++ b/clients/voice-gateway/memex_voice_gateway/musicassistant.py
@@ -1,0 +1,77 @@
+"""Music Assistant — the household's OWN music tooling, spoken to over its WebSocket API.
+
+MA is the executor for everything beyond plain radio-station URLs: its providers (Spotify,
+Apple Music, Radio Browser, …) resolve songs, artists and stations, and its players play
+them. This client only RESOLVES and DELEGATES — it never re-implements a music service.
+Configure with MA_URL + an API token (created in MA's settings after login, stored in the
+keychain as `music-assistant-token`); absent, music stays radio-URLs-only.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import logging
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class MusicAssistant:
+    def __init__(self, base_url: str, token: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._token = token
+        self._http: aiohttp.ClientSession | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._ids = itertools.count(1)
+
+    async def _ensure(self) -> None:
+        if self._ws is not None and not self._ws.closed:
+            return
+        if self._http is None:
+            self._http = aiohttp.ClientSession()
+        self._ws = await self._http.ws_connect(f"{self.base_url}/ws", timeout=10)
+        await self._ws.receive(timeout=5)          # server-info greeting
+        reply = await self._cmd_raw("auth", token=self._token)
+        if reply.get("error_code"):
+            raise RuntimeError(f"Music Assistant auth failed: {reply.get('details')}")
+
+    async def _cmd_raw(self, command: str, **args) -> dict:
+        message_id = str(next(self._ids))
+        assert self._ws is not None
+        await self._ws.send_json({"message_id": message_id, "command": command, "args": args})
+        while True:
+            msg = json.loads((await self._ws.receive(timeout=30)).data)
+            if msg.get("message_id") == message_id:
+                return msg
+
+    async def cmd(self, command: str, **args):
+        await self._ensure()
+        reply = await self._cmd_raw(command, **args)
+        if reply.get("error_code"):
+            raise RuntimeError(f"{command}: {reply.get('details')}")
+        return reply.get("result")
+
+    async def search(self, query: str, media_types: list[str] | None = None,
+                     limit: int = 8) -> dict:
+        """MA-wide search across all configured providers. Returns MA's results object
+        (keys per media type: tracks, artists, radio, …)."""
+        return await self.cmd("music/search", search_query=query,
+                              media_types=media_types or ["track", "radio", "playlist"],
+                              limit=limit)
+
+    async def players(self) -> list[dict]:
+        return list(await self.cmd("players/all") or [])
+
+    async def play(self, uri: str, queue_id: str) -> None:
+        """Hand the resolved item to MA's own playback (its providers stream it)."""
+        await self.cmd("player_queues/play_media", queue_id=queue_id, media=uri)
+
+    async def close(self) -> None:
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+        if self._http is not None:
+            await self._http.close()
+            self._http = None

--- a/clients/voice-gateway/memex_voice_gateway/router.py
+++ b/clients/voice-gateway/memex_voice_gateway/router.py
@@ -106,6 +106,7 @@ _DEFAULT_PHRASES = {
     "radio_on": "Here comes {station}. Say stop to end it.",
     "song_hint": "I cannot play single songs yet — but here comes {station}.",
     "no_stations": "No radio stations are set up yet — add them under Voice, Station in the portal.",
+    "playing_song": "Here comes {title} by {artist}.",
 }
 
 async def load_stations(client, namespace: str) -> dict[str, tuple[str, str]]:
@@ -169,6 +170,7 @@ class BrainRouter:
             n for n, b in brains.items() if hasattr(b, "delegate")}
         self._home = home     # HomeAssistant client, when configured
         self.player: object = None   # async url -> None; the satellite's media player
+        self.music: object = None    # MusicAssistant client, when a token is configured
         # Spoken key → (display name, stream url), loaded from {user}/Voice/Station nodes.
         self.stations: dict[str, tuple[str, str]] = {}
         # Agent name → the portal that HOSTS it (a portal entry's "agents" list): the
@@ -282,6 +284,31 @@ class BrainRouter:
         self._context = entry
         self._changed()
         return entry
+
+    async def _play_named(self, request: str) -> str | None:
+        """Resolve a spoken song wish through Music Assistant and play it on the first MA
+        player. None = could not resolve/play → the caller falls back to radio + the
+        honest sentence, never to silence or an invented promise."""
+        import logging
+        try:
+            query = re.sub(r".*?\b(?:heißen|heissen|namens|called|titled)\b", "", request,
+                           flags=re.IGNORECASE).strip(" .!?,") or request
+            results = await self.music.search(query)  # type: ignore[attr-defined]
+            tracks = (results or {}).get("tracks") or []
+            if not tracks:
+                return None
+            track = tracks[0]
+            players = await self.music.players()  # type: ignore[attr-defined]
+            available = [p for p in players if p.get("available", True)]
+            if not available:
+                return None
+            await self.music.play(track["uri"], available[0]["player_id"])  # type: ignore[attr-defined]
+            artist = ((track.get("artists") or [{}])[0]).get("name", "")
+            title = track.get("name", "")
+            return self._phrases["playing_song"].format(title=title, artist=artist)
+        except Exception:
+            logging.getLogger(__name__).warning("music assistant play failed", exc_info=True)
+            return None
 
     def _match_station(self, lowered: str) -> str | None:
         """Best station for an utterance by token overlap — 'radio' itself never decides."""
@@ -463,10 +490,16 @@ class BrainRouter:
         key = self._match_station(lowered)
         if (key or "radio" in lowered or _MUSIC.search(stripped)) \
                 and self.player is not None:
-            if not self.stations:
-                return self._phrases["no_stations"]
             named_song = key is None and re.search(
                 r"\b(?:lied|song)\b", lowered) and len(stripped) > 25
+            # A NAMED song goes to Music Assistant when it is connected — THEIR tooling
+            # (Spotify / Apple Music providers) resolves and streams it.
+            if named_song and self.music is not None:
+                spoken = await self._play_named(stripped)
+                if spoken is not None:
+                    return spoken
+            if not self.stations:
+                return self._phrases["no_stations"]
             name, url = self.stations[key or next(iter(self.stations))]
             try:
                 await self.player(url)  # type: ignore[operator]
@@ -537,3 +570,5 @@ class BrainRouter:
             await brain.close()
         if self._home is not None:
             await self._home.close()  # type: ignore[attr-defined]
+        if self.music is not None:
+            await self.music.close()  # type: ignore[attr-defined]

--- a/clients/voice-gateway/tests/test_router.py
+++ b/clients/voice-gateway/tests/test_router.py
@@ -200,3 +200,44 @@ def test_station_name_alone_plays_despite_lost_first_word():
         assert out == "Hier kommt Radio SRF 3." and played[-1].endswith("srf3/mp3/128")
 
     asyncio.run(scenario())
+
+
+def test_named_song_resolves_through_music_assistant():
+    class FakeBrainOnly:
+        async def ask(self, text): return "h"
+        async def await_reply(self, handle, budget_s): return None
+        async def close(self): pass
+
+    class FakeMa:
+        def __init__(self, tracks, players):
+            self.tracks, self._players, self.played = tracks, players, []
+        async def search(self, query, **kw): return {"tracks": self.tracks}
+        async def players(self): return self._players
+        async def play(self, uri, player_id): self.played.append((uri, player_id))
+        async def close(self): pass
+
+    async def scenario():
+        router = BrainRouter({"lokal": FakeBrainOnly()}, "lokal",
+                             phrases={"playing_song": "Hier kommt {title} von {artist}.",
+                                      "song_hint": "Noch nicht — dafür {station}.",
+                                      "radio_on": "Hier kommt {station}."})
+        router.stations = {"energy zürich": ("Energy Zürich", "https://example.test/e.mp3")}
+        played_radio = []
+        async def player(url): played_radio.append(url)
+        router.player = player
+        # MA connected: the named song resolves and plays through THEIR tooling.
+        router.music = FakeMa([{"uri": "spotify://track/1", "name": "Komet",
+                                "artists": [{"name": "Udo Lindenberg"}]}],
+                              [{"player_id": "sat1", "available": True}])
+        out = await router.handle_command(
+            "Ich möchte, dass du mir ein Lied spielst und es sollte Komet heißen.")
+        assert out == "Hier kommt Komet von Udo Lindenberg."
+        assert router.music.played == [("spotify://track/1", "sat1")]
+        assert not played_radio
+        # MA finds nothing → the radio fallback with the honest sentence, never silence.
+        router.music = FakeMa([], [])
+        out = await router.handle_command(
+            "Kannst du mir bitte ein Lied spielen, es sollte Zebrastreifen heißen?")
+        assert "Noch nicht" in out and played_radio
+
+    asyncio.run(scenario())


### PR DESCRIPTION
A spoken song wish routes to Music Assistant when a token is configured (keychain `music-assistant-token` / `MA_TOKEN`): MA's own providers (Spotify, Apple Music, Radio Browser) resolve the track and MA streams it to its player — the gateway client only searches (`music/search`) and hands over (`player_queues/play_media`). No resolution or no player → radio fallback with the honest sentence, never silence. Capability line injected only when connected. 44 gateway tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)