### PR TITLE
The instance-lifecycle operator has an executable half

### DIFF
--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -1,0 +1,157 @@
+name: Hosting Operator
+
+# The operator scripts are the executable half of instance lifecycle — they create namespaces,
+# drop databases and delete DNS records — and nothing in CI opened them until now.
+#
+# 🚨 WHAT THIS GATE CAN AND CANNOT PROVE, stated here so a green tick is not read as more than it is.
+# These scripts drive az/kubectl/helm/psql against a live Azure estate; a runner has none of those,
+# and mocking them would only assert that the mocks agree with themselves. So this proves the layer
+# where the dangerous bugs actually live — argument handling, the REFUSALS that stand in front of
+# every destructive act, the ::hosting:: contract the mesh parses, and run.sh's ordering — and it
+# proves the image still builds. Whether `az network dns record-set a add-record` behaves as
+# expected is settled by the first real provision, which is why the rollout is staged.
+#
+# 🛡️ NO SKIP-TRAPDOOR (AGENTS.md → "A gate NEVER tests its own inputs"). Every input is in this
+# repository. There is no secret, no cluster and no registry, so there is no condition under which
+# this may decline to run and still render a tick: no `continue-on-error`, no input-shaped `if:`,
+# and no path filter (a path filter turns "unrelated PR" into a skipped run, which is the same grey
+# tick from the other side).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scripts:
+    name: Operator scripts (shellcheck + behaviour)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # shellcheck ships on hosted runners, which is exactly why it is asserted rather than assumed:
+      # a dependency satisfied by luck of the runner image breaks on an image bump, as a "command
+      # not found" unrelated to the code being gated.
+      - name: Assert the tools this gate needs
+        run: |
+          set -euo pipefail
+          missing=()
+          command -v shellcheck >/dev/null 2>&1 || missing+=("shellcheck — apt-get install shellcheck")
+          command -v bash       >/dev/null 2>&1 || missing+=("bash")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::the operator gate cannot run — provide:"
+            for m in "${missing[@]}"; do echo "  • $m"; done
+            exit 1
+          fi
+          shellcheck --version
+
+      # 🚨 The regression guard for the trap that kept these scripts out of the repo entirely:
+      # .gitignore's `/deploy/**/bin/` (build output) also matched THIS bin/, so `git add` on them
+      # exited 0 and did nothing. The Dockerfile shipped COPYing a directory git refused to track.
+      # A checkout is the only place that can prove the re-include still holds.
+      - name: The operator scripts are actually TRACKED
+        run: |
+          set -euo pipefail
+          tracked=$(git ls-files deploy/aks/operator/bin/ | wc -l | tr -d ' ')
+          if [ "$tracked" -lt 16 ]; then
+            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 16 (14 commands + run.sh + _common.sh)."
+            echo "::error::Almost certainly .gitignore matching this bin/ again. `git add` on an ignored path exits 0 and does NOTHING, so the loss is silent until a fresh checkout builds an image with no scripts in it."
+            git check-ignore -v deploy/aks/operator/bin/run.sh || true
+            exit 1
+          fi
+          # Executability is part of the contract: the Dockerfile chmods, but run.sh is the Job's
+          # ENTRYPOINT and a non-executable command is a CrashLoop, not a warning.
+          nonexec=$(git ls-files -s deploy/aks/operator/bin/hosting-* deploy/aks/operator/bin/run.sh | awk '$1 != "100755"' | wc -l | tr -d ' ')
+          [ "$nonexec" -eq 0 ] || { echo "::error::${nonexec} operator command(s) are not committed executable (mode 100755)"; exit 1; }
+          echo "${tracked} files tracked, all commands executable"
+
+      - name: Every script parses
+        run: |
+          set -euo pipefail
+          cd deploy/aks/operator/bin
+          for f in _common.sh run.sh hosting-*; do
+            bash -n "$f" || { echo "::error::${f} is not valid bash"; exit 1; }
+          done
+          echo "all $(ls _common.sh run.sh hosting-* | wc -l) scripts parse"
+
+      - name: shellcheck
+        run: shellcheck -S warning deploy/aks/operator/bin/_common.sh deploy/aks/operator/bin/run.sh deploy/aks/operator/bin/hosting-*
+
+      # 🚨 Every hosting-* command the mesh's plan can emit must EXIST. A plan step naming a script
+      # nobody wrote fails inside a Job, halfway through a lifecycle action, as "command not found"
+      # — which for a teardown means after the quiesce and possibly after the backup.
+      - name: Every command the plan can emit exists
+        run: |
+          set -euo pipefail
+          plan_src=$(mktemp)
+          # The plan lives in the Hosting plugin repo; the command names it emits are also listed
+          # here so this repo can gate them without a cross-repo checkout. Keep in step with
+          # MeshWeaver.Plugins/Hosting/InstanceAction/Source/InstanceActionPlan.cs.
+          cat > "$plan_src" <<'EOF'
+          hosting-backup
+          hosting-deploy
+          hosting-dns
+          hosting-export
+          hosting-federate
+          hosting-kv-ensure
+          hosting-kv-purge
+          hosting-redirect
+          hosting-restore
+          hosting-tls
+          hosting-verify
+          hosting-verify-backup
+          hosting-verify-catalog
+          hosting-verify-restore
+          EOF
+          missing=()
+          while read -r cmd; do
+            cmd="$(echo "$cmd" | tr -d '[:space:]')"
+            [ -n "$cmd" ] || continue
+            [ -x "deploy/aks/operator/bin/${cmd}" ] || missing+=("$cmd")
+          done < "$plan_src"
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::the plan can emit commands this image does not carry: ${missing[*]}"
+            echo "::error::A missing one fails INSIDE a running lifecycle Job — for a teardown, after the quiesce."
+            exit 1
+          fi
+          echo "all 14 commands present and executable"
+
+      - name: Behaviour tests
+        run: deploy/aks/operator/test/run-tests.sh
+
+  image:
+    name: Operator image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # Build only — nothing is pushed from a pull request. The point is that the Dockerfile and its
+      # build context stay in step: the context is `deploy/` (not the operator directory) because
+      # the image carries the CHART as well as the scripts, and that is easy to break silently.
+      - name: Build
+        run: docker build -f deploy/aks/operator/Dockerfile -t hosting-operator:ci deploy/
+
+      - name: The image carries the scripts AND the chart
+        run: |
+          set -euo pipefail
+          # A chart-less image would deploy nothing and an image without run.sh cannot start; both
+          # are build-context mistakes that only surface during a real provision.
+          docker run --rm --entrypoint /bin/bash hosting-operator:ci -c '
+            set -e
+            test -x /opt/hosting/bin/run.sh          || { echo "run.sh missing"; exit 1; }
+            test -f /opt/hosting/chart/Chart.yaml    || { echo "chart missing — build context must be deploy/"; exit 1; }
+            command -v hosting-deploy >/dev/null     || { echo "hosting-* not on PATH"; exit 1; }
+            command -v helm kubectl az pg_dump >/dev/null || { echo "a required tool is missing"; exit 1; }
+            echo "image carries: $(ls /opt/hosting/bin/hosting-* | wc -l) commands + chart $(grep ^version /opt/hosting/chart/Chart.yaml)"
+          '
+
+      # Stronger than running them on the runner: this is the bash, the coreutils and the PATH the
+      # scripts will actually execute under in a lifecycle Job.
+      - name: Behaviour tests, inside the image
+        run: |
+          docker run --rm -v "$PWD/deploy/aks/operator/test:/opt/hosting/test:ro" \
+            --entrypoint /bin/bash hosting-operator:ci -c 'cd /opt/hosting && bash test/run-tests.sh'

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,17 @@ bld/
 # installs it from here) — not build output. Re-include it.
 !/deploy/homebrew/bin/
 !/deploy/homebrew/bin/**
+# ...and deploy/aks/operator/bin holds the instance-lifecycle operator SCRIPTS (the image COPYs
+# them at /opt/hosting/bin) — source, not build output. Re-include it.
+#
+# 🚨 THIS RULE'S ABSENCE IS WHY THOSE SCRIPTS DID NOT EXIST. The Dockerfile shipped with
+# `COPY bin/ /opt/hosting/bin/` and an ENTRYPOINT of /opt/hosting/bin/run.sh against a directory
+# git refuses to track, so `git add` on them exited 0 and did nothing — the classic silent
+# failure: no error, no warning, and a file that is simply not there on the next checkout. The
+# mesh's side of the seam was complete and unit-tested the whole time; the shell half was being
+# written into a hole.
+!/deploy/aks/operator/bin/
+!/deploy/aks/operator/bin/**
 # A real `.env` is deployment configuration — hosts, database names, keys. `deploy/.env.example`
 # is the documented surface and is tracked; the filled-in copy beside a compose file never is.
 # `deploy/compose/.env` and `deploy/compose-ha/.env` had been committed as Aspire emitted them

--- a/deploy/aks/INSTANCE-LIFECYCLE.md
+++ b/deploy/aks/INSTANCE-LIFECYCLE.md
@@ -80,10 +80,21 @@ az role assignment create --assignee "<operatorIdentityPrincipalId>" \
 kubectl apply -f manifests/hosting-operator/
 
 # 4. Build and push the operator image.
-docker build -t "$ACR/hosting-operator:1" operator/ && docker push "$ACR/hosting-operator:1"
+#    🚨 The build context is `deploy/`, NOT the operator directory: the image carries the CHART
+#    (/opt/hosting/chart) as well as the scripts, so the image tag is also the chart version a
+#    provision deploys. Building from operator/ produces an image with no chart, which fails at
+#    the "Deploy release" step rather than at build time.
+docker build -f deploy/aks/operator/Dockerfile -t "$ACR/hosting-operator:1" deploy/ \
+  && docker push "$ACR/hosting-operator:1"
 
 # 5. Mount the jobrunner token into the portal and set Hosting:Operator:* — README.md in
 #    manifests/hosting-operator/ has the exact values.
+#    🚨 Those keys are rendered by the CHART, from `hostingOperator.*` in the values file — they
+#    are NOT free-form config.memex_portal entries. The ConfigMap names every key explicitly and
+#    the Deployment reads it via envFrom, so a Hosting__* key set anywhere else reaches no
+#    container: memex declared Hosting__Operator__Enabled: "true" for two days while its live
+#    ConfigMap carried no Hosting__* key at all, and every action refused as "disabled on this
+#    installation". See deploy/helm/values.yaml -> hostingOperator.
 ```
 
 Then record the store in the mesh, once, as a `Hosting/BackupStore` node — `account` and

--- a/deploy/aks/operator/Dockerfile
+++ b/deploy/aks/operator/Dockerfile
@@ -1,31 +1,55 @@
 # The hosting operator image: what an instance lifecycle run executes.
 #
+# BUILD CONTEXT IS `deploy/`, not this directory:
+#     docker build -f deploy/aks/operator/Dockerfile -t $ACR/hosting-operator:<tag> deploy/
+# because the image carries the CHART as well as the scripts (see the COPY below).
+#
 # It carries az + kubectl + helm + the PostgreSQL client, because a lifecycle run legitimately
 # needs all four and the portal image carries none of them. That is the honest reason the run
 # happens in a Job rather than in the portal process — and the useful one: the Job is a separate,
 # short-lived identity whose credential nothing long-running holds.
 FROM mcr.microsoft.com/azure-cli:2.77.0
 
+# 🚨 THE BASE IS AZURE LINUX 3, NOT ALPINE. This file previously ran `apk add` and busybox
+# `adduser -D`; neither exists here, so the image had never actually been built — every `docker
+# build` of it exits 127. That is worth stating rather than quietly fixing, because an operator
+# image that cannot be built is indistinguishable, from the mesh's side, from one that was never
+# configured: HostingOperator refuses with "no operator image configured" either way.
 ARG KUBECTL_VERSION=v1.31.4
 ARG HELM_VERSION=v3.16.3
+# Supplied by BuildKit. The binaries below are per-architecture, and hard-coding amd64 produces an
+# image that builds fine on an arm64 laptop and then cannot exec kubectl.
+ARG TARGETARCH=amd64
 
-# postgresql17-client gives pg_dump/pg_restore/psql. The MAJOR version must be >= the server's, or
-# pg_dump refuses with "server version mismatch" — bump this when the fleet's server moves.
-RUN apk add --no-cache postgresql17-client bash curl coreutils jq \
+# postgresql gives pg_dump/pg_restore/psql. 🚨 The client MAJOR must be >= the server's, or pg_dump
+# refuses with "server version mismatch". Azure Linux 3 ships 16.x and the fleet's flexible servers
+# are major 16 (memexaks-pg, verified 2026-08-22) — bump both together when the fleet moves.
+# tar: needed to unpack helm, and not in the base. shadow-utils: useradd, for the non-root user.
+RUN tdnf install -y --refresh postgresql tar shadow-utils ca-certificates \
+ && tdnf clean all \
  && curl -fsSLo /usr/local/bin/kubectl \
-      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
  && chmod +x /usr/local/bin/kubectl \
- && curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
-      | tar -xz -C /tmp linux-amd64/helm \
- && mv /tmp/linux-amd64/helm /usr/local/bin/helm \
- && rm -rf /tmp/linux-amd64
+ && curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz" \
+      | tar -xz -C /tmp "linux-${TARGETARCH}/helm" \
+ && mv "/tmp/linux-${TARGETARCH}/helm" /usr/local/bin/helm \
+ && rm -rf "/tmp/linux-${TARGETARCH}"
 
-COPY bin/ /opt/hosting/bin/
+COPY aks/operator/bin/ /opt/hosting/bin/
 RUN chmod +x /opt/hosting/bin/* && ln -s /opt/hosting/bin/hosting-* /usr/local/bin/
+
+# 🚨 THE CHART IS BAKED IN, and the build context is `deploy/` for exactly this reason.
+#
+# hosting-deploy runs `helm upgrade` against /opt/hosting/chart, so THE OPERATOR IMAGE VERSION IS
+# THE CHART VERSION IT DEPLOYS. That pinning is the point: the scripts pass `--set` flags that only
+# make sense against the templates shipped beside them, and a chart fetched at run time could drift
+# from them silently — rendering a release nobody reviewed, which is the failure the whole
+# repo-driven deploy exists to prevent.
+COPY helm/ /opt/hosting/chart/
 
 # Non-root. Nothing here needs to be root, and a container that can delete namespaces should not
 # also be able to do whatever a root process on a node could.
-RUN adduser -D -u 1654 operator
+RUN useradd --uid 1654 --create-home --shell /sbin/nologin operator
 USER 1654
 
 ENTRYPOINT ["/bin/bash", "/opt/hosting/bin/run.sh"]

--- a/deploy/aks/operator/bin/_common.sh
+++ b/deploy/aks/operator/bin/_common.sh
@@ -1,0 +1,79 @@
+# shellcheck shell=bash
+# Shared harness for the hosting-* operator commands. Sourced, never executed.
+#
+# 🚨 THE ONE RULE THIS FILE EXISTS TO ENFORCE: a step that could not do its job must EXIT NON-ZERO,
+# and a step that verifies something must say so only after reading the thing back. run.sh stops at
+# the first failure, and the mesh reads `::hosting::` lines out of the pod log — so a script that
+# swallows an error does not produce a warning, it produces a green teardown of a live instance.
+
+set -uo pipefail
+
+# The prefix the mesh's OperatorOutput parser reads. Anything else on stdout is human output.
+HOSTING_MARKER="::hosting::"
+
+# A machine-readable fact for the mesh: hosting::say size 12345  ->  "::hosting:: size=12345"
+hosting::say() { printf '%s %s=%s\n' "$HOSTING_MARKER" "$1" "$2"; }
+
+# Announce the step being entered. run.sh emits this; a script may emit sub-steps.
+hosting::step() { printf '%s step=%s\n' "$HOSTING_MARKER" "$1"; }
+
+# Human narration. Goes to stdout so it lands in the pod log the mesh streams back.
+hosting::log() { printf '  %s\n' "$*"; }
+
+# Fail loudly, naming the command. Never `exit 0` on a problem.
+hosting::die() {
+  printf '%s: ERROR: %s\n' "${HOSTING_CMD:-hosting}" "$*" >&2
+  exit 1
+}
+
+# Require a non-empty environment variable, naming what to set when it is missing.
+hosting::need_env() {
+  local name="$1" why="${2:-}"
+  local value="${!name:-}"
+  [ -n "$value" ] || hosting::die "environment variable ${name} is empty or unset${why:+ — ${why}}. It is supplied by Hosting:Operator:Environment on the control instance."
+}
+
+# Require a non-empty flag value.
+hosting::need_flag() {
+  local name="$1" value="${2:-}"
+  [ -n "$value" ] || hosting::die "missing required flag --${name}"
+}
+
+# Refuse anything that is not a plain identifier. Every name this operator receives ends up
+# interpolated into an az/kubectl/helm command line, so the validation is a security boundary and
+# not tidiness: the mesh composes the plan, but the mesh is driven by a node an admin can edit.
+#
+# 🚨 THESE VALIDATE IN PLACE AND PRINT NOTHING — deliberately. The obvious shape,
+#     name="$(hosting::safe_name name "$name")"
+# is BROKEN and silently so: a command substitution runs in a SUBSHELL, so the `exit 1` inside
+# hosting::die ends the substitution and not the script. The caller carries on with an EMPTY value
+# and every guard here becomes a no-op. Caught by test/run-tests.sh, which is why the injection
+# cases in it are worth their length.
+hosting::safe_name() {
+  local what="$1" value="${2:-}"
+  [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] \
+    || hosting::die "${what} '${value}' is not a plain name (letters, digits, dot, dash, underscore) — refusing to interpolate it into a command"
+}
+
+# A hostname, for DNS/TLS/probe steps. Validates in place; see the note above.
+hosting::safe_host() {
+  local what="$1" value="${2:-}"
+  [[ "$value" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?$ ]] \
+    || hosting::die "${what} '${value}' is not a hostname — refusing"
+}
+
+# Is this a dry run? The mesh sets HOSTING_DRY_RUN=true for a rehearsal.
+hosting::dry() { [ "${HOSTING_DRY_RUN:-false}" = "true" ]; }
+
+# Run a command, or narrate it when rehearsing. Use for every MUTATION.
+hosting::do() {
+  if hosting::dry; then
+    printf '  DRY-RUN would run: %s\n' "$*"
+    return 0
+  fi
+  printf '  + %s\n' "$*"
+  "$@"
+}
+
+# Capture a command's stdout (queries, never mutations — a dry run still needs to read).
+hosting::read() { "$@"; }

--- a/deploy/aks/operator/bin/hosting-backup
+++ b/deploy/aks/operator/bin/hosting-backup
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# hosting-backup --database <db> --server <pg> --store-uri <uri> --object <name>
+#
+# Dump one instance's database and upload it. Reports size and digest.
+#
+# 🚨 IT NEVER CLAIMS VERIFICATION. This step dumps, checks the archive is non-empty, uploads with
+# --overwrite false, and prints what it measured. That is all. `verified=true` comes from
+# hosting-verify-backup ALONE, and only after downloading the archive back and reading its table of
+# contents — because a truncated upload exits zero and an empty database dumps perfectly. Every
+# destructive phase in the plan waits behind the VERIFY, not behind this.
+#
+# --overwrite false: an archive is immutable. A re-run that silently overwrote a verified archive
+# with a fresh (unverified) one would destroy the evidence the teardown is waiting on.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-backup"
+
+database="" server="" store_uri="" object=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --database)  database="${2:-}";  shift 2 ;;
+    --server)    server="${2:-}";    shift 2 ;;
+    --store-uri) store_uri="${2:-}"; shift 2 ;;
+    --object)    object="${2:-}";    shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag database "$database"
+hosting::need_flag server "$server"
+hosting::need_flag store-uri "$store_uri"
+hosting::need_flag object "$object"
+hosting::safe_name database "$database"
+
+# The object NAME is reported even though the store URI already contains it: the record needs to say
+# WHICH archive it is waiting on, and reading that back out of a URL is guesswork.
+hosting::say object "$object"
+
+if hosting::dry; then
+  echo "  DRY-RUN would pg_dump ${database} from ${server} and upload to ${store_uri}"
+  hosting::say backup dry-run
+  exit 0
+fi
+
+hosting::need_env PGPASSWORD "the admin password for the flexible server (mounted from Key Vault)"
+pg_user="${PGUSER:-memexadmin}"
+archive="/tmp/${database}.dump"
+
+version="$(PGPASSWORD="$PGPASSWORD" psql -h "$server" -U "$pg_user" -d "$database" -tAc 'SHOW server_version' 2>/dev/null | tr -d ' ')" || true
+[ -n "$version" ] && hosting::say pgversion "$version"
+
+hosting::log "dumping ${database} from ${server} (custom format, compressed)"
+# -Fc: the custom format is what pg_restore reads selectively and what carries a table of contents —
+# a plain SQL dump cannot be verified the way hosting-verify-backup verifies.
+if ! PGPASSWORD="$PGPASSWORD" pg_dump -h "$server" -U "$pg_user" -d "$database" \
+      --format=custom --compress=6 --no-owner --no-privileges --file "$archive"; then
+  hosting::die "pg_dump of ${database} failed. Nothing has been uploaded and nothing destructive has run — the plan stops here by design."
+fi
+
+size="$(wc -c < "$archive" | tr -d ' ')"
+[ "$size" -gt 0 ] || hosting::die "pg_dump produced a ZERO-BYTE archive for ${database}. An empty file uploads perfectly and restores to nothing."
+sha="$(sha256sum "$archive" | cut -d' ' -f1)"
+
+hosting::say size "$size"
+hosting::say sha256 "$sha"
+hosting::log "archive ${size} bytes, sha256 ${sha}"
+
+hosting::log "uploading to ${store_uri}"
+if ! az storage blob upload --blob-url "$store_uri" --file "$archive" \
+      --auth-mode login --overwrite false --output none; then
+  hosting::die "upload to ${store_uri} failed (or an archive already exists there — they are immutable by design, so a re-run must target a new object rather than overwrite a verified one)."
+fi
+
+rm -f "$archive"
+hosting::log "uploaded. NOT verified — hosting-verify-backup is what reads it back."

--- a/deploy/aks/operator/bin/hosting-deploy
+++ b/deploy/aks/operator/bin/hosting-deploy
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# hosting-deploy --namespace <ns> --release <name> --database <db> --values <file> --config-file <file>
+#
+# Install (or upgrade) the portal release for ONE instance.
+#
+# 🚨 WHERE THE PER-INSTANCE VALUES COME FROM, because this is the piece a fleet gets wrong. There is
+# NO checked-in `values.<newinstance>.yaml`, and there must not be: a self-service instance is
+# created after the repo was last edited. So the shape is base + derived:
+#
+#   --values <file>   the FLEET TEMPLATE — everything every instance shares. Reviewed, in git.
+#   --set …           this instance's IDENTITY only: namespace, host, database, TLS secret, the
+#                     Key Vault prefix. Derived from the deployment record, which is itself the
+#                     reviewed artefact (it arrives in the config repo by write-through PR).
+#
+# The chart ships in this image at /opt/hosting/chart, so the operator image version IS the chart
+# version it deploys. That pinning is deliberate: the scripts and the templates they --set against
+# change together, and a chart pulled at run time could drift from the flags used here.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-deploy"
+
+CHART="${HOSTING_CHART:-/opt/hosting/chart}"
+
+namespace="" release="" database="" values="" config_file=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace)   namespace="${2:-}";   shift 2 ;;
+    --release)     release="${2:-}";     shift 2 ;;
+    --database)    database="${2:-}";    shift 2 ;;
+    --values)      values="${2:-}";      shift 2 ;;
+    --config-file) config_file="${2:-}"; shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag namespace "$namespace"
+hosting::need_flag release "$release"
+hosting::need_flag database "$database"
+hosting::safe_name namespace "$namespace"
+hosting::safe_name release "$release"
+hosting::safe_name database "$database"
+
+[ -d "$CHART" ] || hosting::die "no chart at ${CHART}. It is baked into the operator image (COPY helm/ /opt/hosting/chart) precisely so a run cannot deploy a chart nobody reviewed — an image built without it is broken, not degraded."
+[ -n "$values" ] && [ -f "$values" ] \
+  || hosting::die "the fleet template values file '${values:-<unset>}' does not exist. It is supplied as \$VALUES_FILE by Hosting:Operator:Environment and mounted into the job; without it the release would fall through to CHART DEFAULTS, which point at ghcr.io/…:latest and an in-cluster Postgres this fleet does not run."
+
+# Per-instance identity, derived from the record. Everything else comes from the template.
+host="${HOSTING_HOST:-}"
+tls_secret="${HOSTING_TLS_SECRET:-${namespace}-tls}"
+pg_host="${HOSTING_PG_HOST:-}"
+
+sets=(
+  --set "ingress.tlsSecret=${tls_secret}"
+  --set "config.memex_migration.MEMEX_DATABASENAME=${database}"
+  --set "config.memex_portal.MEMEX_DATABASENAME=${database}"
+)
+[ -n "$host" ] && sets+=( --set "ingress.host=${host}" )
+if [ -n "$pg_host" ]; then
+  sets+=(
+    --set "config.memex_portal.MEMEX_HOST=${pg_host}"
+    --set "config.memex_migration.MEMEX_HOST=${pg_host}"
+    --set "config.memex_migration.MEMEX_JDBCCONNECTIONSTRING=jdbc:postgresql://${pg_host}:5432/${database}"
+  )
+fi
+
+# The catalog config the mesh composed (plugin mounts + pre-install patterns) is a values FILE, so
+# it layers like any other and stays visible in `helm get values`.
+files=( -f "$values" )
+if [ -n "$config_file" ] && [ -f "$config_file" ]; then
+  files+=( -f "$config_file" )
+  hosting::log "catalog config: ${config_file} ($(wc -c < "$config_file") bytes)"
+else
+  hosting::log "catalog config: none supplied — the instance will come up with no plugin mounts"
+fi
+
+hosting::log "chart     ${CHART}"
+hosting::log "release   ${release} → namespace ${namespace}"
+hosting::log "database  ${database}"
+
+hosting::do kubectl create namespace "$namespace" --dry-run=client -o yaml \
+  | { hosting::dry && cat >/dev/null || kubectl apply -f - ; } \
+  || hosting::die "could not ensure namespace ${namespace}"
+
+# --atomic: a failed install ROLLS BACK rather than leaving a half-created release that the next
+# attempt then has to `helm uninstall` before it can proceed. --wait so "deployed" means the pods
+# actually came up; the plan's next step (rollout status) then verifies rather than discovers.
+hosting::do helm upgrade "$release" "$CHART" \
+  --install --namespace "$namespace" --create-namespace \
+  --atomic --wait --timeout 15m \
+  "${files[@]}" "${sets[@]}" \
+  || hosting::die "helm upgrade of ${release} in ${namespace} failed (rolled back by --atomic)"
+
+hosting::say release "$release"
+hosting::say namespace "$namespace"

--- a/deploy/aks/operator/bin/hosting-dns
+++ b/deploy/aks/operator/bin/hosting-dns
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# hosting-dns upsert --zone <zone> --host <fqdn> --target <ip>
+# hosting-dns delete --zone <zone> --host <fqdn>
+#
+# The instance's A record in the fleet's Azure DNS zone.
+#
+# 🚨 The record NAME is the host with the zone suffix removed — Azure DNS stores relative names, and
+# passing the FQDN creates `memex.systemorph.com.systemorph.com`, which resolves for nobody and is
+# invisible until someone opens the browser. `@` is the apex.
+#
+# 🚨 delete refuses a record pointing somewhere unexpected. A teardown that deletes the wrong A
+# record takes a live instance off the internet, and DNS deletion has no undo beyond re-creating it
+# and waiting out every resolver's TTL.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-dns"
+
+mode="${1:-}"
+case "$mode" in
+  upsert|delete) shift ;;
+  *) hosting::die "first argument must be 'upsert' or 'delete', got '${mode:-<none>}'" ;;
+esac
+
+zone="" host="" target=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --zone)   zone="${2:-}";   shift 2 ;;
+    --host)   host="${2:-}";   shift 2 ;;
+    --target) target="${2:-}"; shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag zone "$zone"
+hosting::need_flag host "$host"
+hosting::need_env AZ_DNS_RESOURCE_GROUP "the resource group holding the DNS zone"
+hosting::safe_host zone "$zone"
+hosting::safe_host host "$host"
+
+rg="$AZ_DNS_RESOURCE_GROUP"
+
+# Relative name: strip the zone suffix. Apex → '@'.
+if [ "$host" = "$zone" ]; then
+  record="@"
+elif [[ "$host" == *".${zone}" ]]; then
+  record="${host%".${zone}"}"
+else
+  hosting::die "host '${host}' is not inside zone '${zone}' — refusing to create a record in a zone that does not own the name"
+fi
+
+current="$(az network dns record-set a show -g "$rg" -z "$zone" -n "$record" \
+  --query "aRecords[].ipv4Address" -o tsv 2>/dev/null || true)"
+
+if [ "$mode" = "delete" ]; then
+  if [ -z "$current" ]; then
+    hosting::log "A record ${record}.${zone} is already absent"
+    hosting::say dns absent
+    exit 0
+  fi
+  hosting::log "delete A record ${record}.${zone} (currently ${current})"
+  hosting::do az network dns record-set a delete -g "$rg" -z "$zone" -n "$record" --yes --output none \
+    || hosting::die "could not delete A record ${record} in zone ${zone}"
+  hosting::say dns deleted
+  exit 0
+fi
+
+hosting::need_flag target "$target"
+[[ "$target" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] \
+  || hosting::die "target '${target}' is not an IPv4 address. It comes from \$INGRESS_IP — an empty or wrong value here points the new instance's hostname at nothing."
+
+if [ "$current" = "$target" ]; then
+  hosting::log "A record ${record}.${zone} already points at ${target}"
+  hosting::say dns kept
+  exit 0
+fi
+
+if [ -n "$current" ]; then
+  hosting::log "A record ${record}.${zone} points at ${current}; repointing to ${target}"
+  hosting::do az network dns record-set a remove-record -g "$rg" -z "$zone" -n "$record" \
+    --ipv4-address "$current" --keep-empty-record-set --output none \
+    || hosting::die "could not remove the existing A record value"
+else
+  hosting::log "create A record ${record}.${zone} → ${target}"
+fi
+
+hosting::do az network dns record-set a add-record -g "$rg" -z "$zone" -n "$record" \
+  --ipv4-address "$target" --output none \
+  || hosting::die "could not add A record ${record} → ${target} in zone ${zone}"
+
+hosting::say dns upserted

--- a/deploy/aks/operator/bin/hosting-export
+++ b/deploy/aks/operator/bin/hosting-export
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# hosting-export --store-uri <uri> --secret <name> [--namespace <ns>] [--hours <n>]
+#
+# Mint a time-limited download URL for a backup archive and hand it over in a one-shot Secret.
+#
+# 🚨 IT NEVER PRINTS THE URL. A user-delegation SAS is a bearer credential: anyone holding the
+# string downloads the archive. Printing it would put it in the pod log, which the mesh streams into
+# an activity record and a node — three durable copies of a credential that was meant to be
+# transient. So it goes into a Secret the mesh reads ONCE and deletes, and the log gets the expiry
+# and nothing else.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-export"
+
+store_uri="" secret="" namespace="${HOSTING_OPS_NAMESPACE:-memex-ops}" hours="${HOSTING_EXPORT_HOURS:-24}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --store-uri) store_uri="${2:-}"; shift 2 ;;
+    --secret)    secret="${2:-}";    shift 2 ;;
+    --namespace) namespace="${2:-}"; shift 2 ;;
+    --hours)     hours="${2:-}";     shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag store-uri "$store_uri"
+hosting::need_flag secret "$secret"
+hosting::safe_name secret "$secret"
+hosting::safe_name namespace "$namespace"
+
+if hosting::dry; then
+  echo "  DRY-RUN would mint a ${hours}h SAS for ${store_uri} into secret ${secret}"
+  hosting::say export dry-run
+  exit 0
+fi
+
+expiry="$(date -u -d "+${hours} hours" '+%Y-%m-%dT%H:%MZ' 2>/dev/null || date -u -v"+${hours}H" '+%Y-%m-%dT%H:%MZ')"
+[ -n "$expiry" ] || hosting::die "could not compute an expiry ${hours}h from now"
+
+account="$(printf '%s' "$store_uri" | sed -n 's#^https://\([^.]*\)\..*#\1#p')"
+container="$(printf '%s' "$store_uri" | sed -n 's#^https://[^/]*/\([^/]*\)/.*#\1#p')"
+blob="$(printf '%s' "$store_uri" | sed -n 's#^https://[^/]*/[^/]*/\(.*\)$#\1#p')"
+[ -n "$account" ] && [ -n "$container" ] && [ -n "$blob" ] \
+  || hosting::die "could not parse account/container/blob out of the store URI"
+
+# --as-user: a USER-DELEGATION SAS, signed by the workload identity's own key, so it is revocable
+# and carries this identity's audit trail. An account-key SAS would need the storage key on disk.
+sas="$(az storage blob generate-sas --account-name "$account" --container-name "$container" \
+        --name "$blob" --permissions r --expiry "$expiry" --as-user --auth-mode login -o tsv 2>/dev/null)" \
+  || hosting::die "could not mint a user-delegation SAS for ${blob}"
+[ -n "$sas" ] || hosting::die "the SAS came back empty"
+
+kubectl -n "$namespace" create secret generic "$secret" \
+  --from-literal=url="${store_uri}?${sas}" \
+  --from-literal=expires="$expiry" \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null \
+  || hosting::die "could not write the handover secret ${secret} in ${namespace}"
+unset sas
+
+hosting::log "download URL written to secret ${namespace}/${secret}, expires ${expiry}"
+hosting::log "(the URL itself is deliberately not printed — it is a bearer credential)"
+hosting::say export_secret "$secret"
+hosting::say export_expires "$expiry"

--- a/deploy/aks/operator/bin/hosting-federate
+++ b/deploy/aks/operator/bin/hosting-federate
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# hosting-federate        --identity <id> --namespace <ns> --service-account <sa>
+# hosting-federate remove --identity <id> --namespace <ns>
+#
+# Wire (or unwire) a namespace's ServiceAccount to the portal's user-assigned managed identity via
+# Workload Identity, so the new instance's pods reach Azure with no key on disk.
+#
+# 🚨 THE SUBJECT IS THE WHOLE CONTRACT: `system:serviceaccount:<ns>:<sa>`. Azure matches the token's
+# subject STRING — it does not resolve it — so a namespace or ServiceAccount renamed on either side
+# produces a token exchange that fails at run time with an error naming neither. Idempotent: an
+# existing credential with the same subject is kept, which is what makes a re-provision a no-op.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-federate"
+
+mode="add"
+case "${1:-}" in
+  remove) mode="remove"; shift ;;
+  add)    shift ;;
+esac
+
+identity="" namespace="" service_account="memex-portal-sa"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --identity)        identity="${2:-}";        shift 2 ;;
+    --namespace)       namespace="${2:-}";       shift 2 ;;
+    --service-account) service_account="${2:-}"; shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag identity "$identity"
+hosting::need_flag namespace "$namespace"
+hosting::need_env AZ_RESOURCE_GROUP "the resource group holding the portal's managed identity"
+hosting::safe_name identity "$identity"
+hosting::safe_name namespace "$namespace"
+hosting::safe_name service-account "$service_account"
+
+rg="$AZ_RESOURCE_GROUP"
+cred="hosting-${namespace}"
+subject="system:serviceaccount:${namespace}:${service_account}"
+
+exists() {
+  az identity federated-credential show \
+    --identity-name "$identity" -g "$rg" --name "$cred" --query id -o tsv >/dev/null 2>&1
+}
+
+if [ "$mode" = "remove" ]; then
+  if ! exists; then
+    hosting::log "federated credential ${cred} is already absent"
+    hosting::say federation removed
+    exit 0
+  fi
+  hosting::log "delete federated credential ${cred} (subject ${subject})"
+  hosting::do az identity federated-credential delete \
+    --identity-name "$identity" -g "$rg" --name "$cred" --yes --output none \
+    || hosting::die "could not delete federated credential ${cred} on identity ${identity}"
+  hosting::say federation removed
+  exit 0
+fi
+
+hosting::need_env AZ_OIDC_ISSUER "the cluster's OIDC issuer URL (az aks show --query oidcIssuerProfile.issuerURL)"
+
+if exists; then
+  current="$(az identity federated-credential show \
+    --identity-name "$identity" -g "$rg" --name "$cred" --query subject -o tsv 2>/dev/null || true)"
+  if [ "$current" = "$subject" ]; then
+    hosting::log "federated credential ${cred} already binds ${subject} — keeping it"
+    hosting::say federation kept
+    exit 0
+  fi
+  hosting::die "federated credential ${cred} exists but binds '${current}', not '${subject}'. Refusing to repoint it: a credential is matched by subject string, so silently rewriting one would move another namespace's Azure access onto this instance. Delete it deliberately, or provision under a name that is free."
+fi
+
+hosting::log "create federated credential ${cred}"
+hosting::log "  issuer  ${AZ_OIDC_ISSUER}"
+hosting::log "  subject ${subject}"
+hosting::do az identity federated-credential create \
+  --identity-name "$identity" -g "$rg" --name "$cred" \
+  --issuer "$AZ_OIDC_ISSUER" --subject "$subject" \
+  --audiences api://AzureADTokenExchange --output none \
+  || hosting::die "could not create federated credential ${cred} on identity ${identity}"
+
+hosting::say federation created

--- a/deploy/aks/operator/bin/hosting-kv-ensure
+++ b/deploy/aks/operator/bin/hosting-kv-ensure
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# hosting-kv-ensure --vault <name> --prefix <prefix> --namespace <ns>
+#
+# Make sure the per-instance Key Vault secrets EXIST, and mint the ones only this step can mint.
+#
+# 🚨 IT NEVER OVERWRITES AN EXISTING SECRET, and the master key is why. `Ai-KeyProtection-MasterKey`
+# is the at-rest envelope key: every `enc:` provider key in that instance's database is sealed with
+# it. Regenerating it does not "reset" anything — it makes every stored credential permanently
+# unreadable, with no error at the time and a broken AI stack later. So an existing secret is left
+# exactly as it is, and only an ABSENT one is created. That also makes a re-provision safe, which
+# is what lets the mesh treat provisioning as idempotent.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-kv-ensure"
+
+vault="" prefix="" namespace=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --vault)     vault="${2:-}";     shift 2 ;;
+    --prefix)    prefix="${2:-}";    shift 2 ;;
+    --namespace) namespace="${2:-}"; shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag vault "$vault"
+hosting::need_flag namespace "$namespace"
+hosting::safe_name vault "$vault"
+hosting::safe_name namespace "$namespace"
+[ -z "$prefix" ] || hosting::safe_name prefix "$prefix"
+
+# The per-instance secrets an instance cannot boot without. Names are the vault's, dash-separated;
+# the SecretProviderClass maps each onto its config key (see secretproviderclass.reference.yaml in
+# the config repo). `generate` secrets are minted here because nothing else can; `require` secrets
+# must be supplied out-of-band and their absence is a REFUSAL, not a silent gap.
+#
+#   name                          how
+GENERATED="Ai-KeyProtection-MasterKey"
+REQUIRED="PluginCatalog-RegistryToken"
+
+created=0 kept=0 missing=()
+
+kv_exists() {
+  az keyvault secret show --vault-name "$vault" --name "$1" --query id -o tsv >/dev/null 2>&1
+}
+
+for suffix in $GENERATED; do
+  name="${prefix}${suffix}"
+  if kv_exists "$name"; then
+    hosting::log "keep    ${name} (exists — NEVER regenerated: it seals this instance's stored enc: values)"
+    kept=$((kept + 1))
+    continue
+  fi
+  hosting::log "create  ${name} (256-bit, base64)"
+  if hosting::dry; then created=$((created + 1)); continue; fi
+  # /dev/urandom, not az's generator: the value never leaves this process except into the vault.
+  value="$(head -c 32 /dev/urandom | base64 | tr -d '\n')"
+  az keyvault secret set --vault-name "$vault" --name "$name" --value "$value" --output none \
+    || hosting::die "could not create ${name} in vault ${vault}"
+  unset value
+  created=$((created + 1))
+done
+
+for suffix in $REQUIRED; do
+  name="${prefix}${suffix}"
+  if kv_exists "$name"; then
+    hosting::log "found   ${name}"
+    kept=$((kept + 1))
+  else
+    missing+=("$name")
+  fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+  hosting::die "vault ${vault} is missing $(IFS=,; echo "${missing[*]}"). These are ISSUED, not generated — a registry consumer key comes from the registry installation (see the plugin registry docs), and minting a random value here would produce an instance that boots, registers nothing, and shows an empty Store with no error. Create them in the vault, then re-request the action."
+fi
+
+hosting::log "vault ${vault}: ${created} created, ${kept} already present"
+hosting::say kv_created "$created"
+hosting::say kv_kept "$kept"

--- a/deploy/aks/operator/bin/hosting-kv-purge
+++ b/deploy/aks/operator/bin/hosting-kv-purge
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# hosting-kv-purge --vault <name> --prefix <prefix> --namespace <ns>
+#
+# Remove an instance's Key Vault secrets at teardown.
+#
+# 🚨 SOFT-DELETE ONLY — never `--purge`. The vault's soft-delete retention is the last chance to
+# recover an instance torn down by mistake, and the master key is unrecoverable by any other means:
+# without it a restored database is a pile of undecryptable `enc:` values. A purge would convert a
+# reversible mistake into permanent data loss, so this step deliberately cannot make one.
+#
+# 🚨 It refuses an EMPTY prefix. With no prefix every name below resolves to the FLEET-WIDE secret
+# (`Ai-KeyProtection-MasterKey` is memex's own), so tearing down one instance would delete the
+# control instance's envelope key. That is the single most destructive typo available here.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-kv-purge"
+
+vault="" prefix="" namespace=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --vault)     vault="${2:-}";     shift 2 ;;
+    --prefix)    prefix="${2:-}";    shift 2 ;;
+    --namespace) namespace="${2:-}"; shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag vault "$vault"
+hosting::need_flag namespace "$namespace"
+hosting::safe_name vault "$vault"
+hosting::safe_name namespace "$namespace"
+
+[ -n "$prefix" ] || hosting::die "refusing to purge with an EMPTY --prefix: every per-instance secret name would resolve to the fleet-wide one, so this would delete the CONTROL instance's Ai-KeyProtection-MasterKey rather than the torn-down instance's. A deployment record without keyVaultSecretPrefix should not reach this step."
+hosting::safe_name prefix "$prefix"
+
+SUFFIXES="Ai-KeyProtection-MasterKey PluginCatalog-RegistryToken"
+
+deleted=0 absent=0
+for suffix in $SUFFIXES; do
+  name="${prefix}${suffix}"
+  if ! az keyvault secret show --vault-name "$vault" --name "$name" --query id -o tsv >/dev/null 2>&1; then
+    hosting::log "absent  ${name}"
+    absent=$((absent + 1))
+    continue
+  fi
+  hosting::log "delete  ${name} (soft-delete — recoverable for the vault's retention window)"
+  hosting::do az keyvault secret delete --vault-name "$vault" --name "$name" --output none \
+    || hosting::die "could not delete ${name} from vault ${vault}"
+  deleted=$((deleted + 1))
+done
+
+hosting::log "vault ${vault}: ${deleted} soft-deleted, ${absent} already absent"
+hosting::say kv_deleted "$deleted"

--- a/deploy/aks/operator/bin/hosting-redirect
+++ b/deploy/aks/operator/bin/hosting-redirect
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# hosting-redirect suspend --namespace <ns> --host <fqdn> --target <url>
+# hosting-redirect restore --namespace <ns> --host <fqdn>
+#
+# Point a suspended instance's hostname at the paywall, and put it back on reactivation.
+#
+# 🚨 SUSPENSION IS REVERSIBLE, AND THAT IS THE WHOLE DESIGN. The PVCs, the database and the TLS
+# secret all stay; only the ingress backend moves. So this must not delete anything — it annotates
+# the EXISTING ingress and restores the annotation on the way back. An implementation that deleted
+# and re-created the ingress would drop the TLS reference and turn a reversible suspension into a
+# certificate re-issue for every reactivation.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-redirect"
+
+mode="${1:-}"
+case "$mode" in
+  suspend|restore) shift ;;
+  *) hosting::die "first argument must be 'suspend' or 'restore', got '${mode:-<none>}'" ;;
+esac
+
+namespace="" host="" target=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace) namespace="${2:-}"; shift 2 ;;
+    --host)      host="${2:-}";      shift 2 ;;
+    --target)    target="${2:-}";    shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag namespace "$namespace"
+hosting::safe_name namespace "$namespace"
+[ -z "$host" ] || hosting::safe_host host "$host"
+
+# 🚨 Validate BEFORE touching the cluster. A pure check that sits behind an API call is a check
+# that does not run when the API is slow, absent or unauthorised — and it made the refusal for a
+# relative target come back as "no Ingress in n", naming the wrong problem entirely.
+if [ "$mode" = "suspend" ]; then
+  hosting::need_flag target "$target"
+  case "$target" in
+    https://*|http://*) ;;
+    *) hosting::die "redirect target '${target}' is not an absolute URL. It comes from \$PAYWALL_URL; a relative value produces an ingress that redirects to itself." ;;
+  esac
+fi
+
+ingress="${HOSTING_INGRESS:-memex-portal}"
+ANNOTATION="nginx.ingress.kubernetes.io/permanent-redirect"
+
+if ! kubectl -n "$namespace" get ingress "$ingress" >/dev/null 2>&1; then
+  # Find it rather than fail: ingress names have drifted across namespaces before (core #1917).
+  found="$(kubectl -n "$namespace" get ingress -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  [ -n "$found" ] || hosting::die "no Ingress in ${namespace} — nothing to redirect"
+  hosting::log "ingress '${ingress}' not found; using '${found}'"
+  ingress="$found"
+fi
+
+if [ "$mode" = "suspend" ]; then
+  hosting::log "redirecting ${host:-$namespace} → ${target}"
+  hosting::do kubectl -n "$namespace" annotate ingress "$ingress" --overwrite "${ANNOTATION}=${target}" \
+    || hosting::die "could not annotate ingress ${ingress} in ${namespace}"
+  hosting::say redirect suspended
+  exit 0
+fi
+
+hosting::log "removing the suspension redirect from ${ingress}"
+# The trailing '-' removes the annotation. Absent is fine — reactivation must be idempotent.
+hosting::do kubectl -n "$namespace" annotate ingress "$ingress" "${ANNOTATION}-" \
+  || hosting::log "no redirect annotation to remove (already restored)"
+hosting::say redirect restored

--- a/deploy/aks/operator/bin/hosting-restore
+++ b/deploy/aks/operator/bin/hosting-restore
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# hosting-restore --database <db> --server <pg> --store-uri <uri>
+#
+# Restore an archive over an instance's database.
+#
+# 🚨 The plan puts a PRE-RESTORE backup and its verification ahead of this step, and quiesces the
+# portal before it. That ordering is the mesh's, not this script's — but this script still refuses
+# to run against a database something is actively writing, because a restore into a live database
+# produces a half-old, half-new instance that looks fine.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-restore"
+
+database="" server="" store_uri=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --database)  database="${2:-}";  shift 2 ;;
+    --server)    server="${2:-}";    shift 2 ;;
+    --store-uri) store_uri="${2:-}"; shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag database "$database"
+hosting::need_flag server "$server"
+hosting::need_flag store-uri "$store_uri"
+hosting::safe_name database "$database"
+
+if hosting::dry; then
+  echo "  DRY-RUN would restore ${store_uri} into ${database} on ${server}"
+  hosting::say restore dry-run
+  exit 0
+fi
+
+hosting::need_env PGPASSWORD "the admin password for the flexible server"
+pg_user="${PGUSER:-memexadmin}"
+archive="/tmp/restore.dump"
+
+hosting::log "downloading ${store_uri}"
+az storage blob download --blob-url "$store_uri" --file "$archive" --auth-mode login --output none \
+  || hosting::die "could not download ${store_uri} — nothing has been changed"
+
+pg_restore --list "$archive" >/dev/null 2>&1 \
+  || hosting::die "the downloaded archive has no readable table of contents — refusing to restore from it"
+
+# Refuse a database with live writers. A restore is not atomic across sessions.
+active="$(PGPASSWORD="$PGPASSWORD" psql -h "$server" -U "$pg_user" -d postgres -tAc \
+  "SELECT count(*) FROM pg_stat_activity WHERE datname = '${database}' AND pid <> pg_backend_pid()" 2>/dev/null | tr -d ' ')" || active=""
+if [ -n "$active" ] && [ "$active" -gt 0 ]; then
+  hosting::die "${active} session(s) are still connected to ${database}. The plan quiesces the portal (scale to 0) before this step; if connections remain, something else is writing and a restore would interleave with it. Refusing."
+fi
+
+hosting::log "restoring into ${database} (clean, single transaction)"
+# --single-transaction so a failure leaves the database as it was, rather than half-restored.
+if ! PGPASSWORD="$PGPASSWORD" pg_restore -h "$server" -U "$pg_user" -d "$database" \
+      --clean --if-exists --no-owner --no-privileges --single-transaction "$archive"; then
+  rm -f "$archive"
+  hosting::die "pg_restore failed. --single-transaction means the database is unchanged, not half-restored."
+fi
+
+rm -f "$archive"
+hosting::say restore completed
+hosting::log "restored. NOT verified — hosting-verify-restore is what reads it back."

--- a/deploy/aks/operator/bin/hosting-tls
+++ b/deploy/aks/operator/bin/hosting-tls
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# hosting-tls --namespace <ns> --host <fqdn>
+#
+# Make sure the namespace holds a usable TLS secret for its host, and WAIT for it.
+#
+# 🚨 A certificate is ISSUED ASYNCHRONOUSLY. cert-manager creates the Certificate immediately and
+# the Secret minutes later, so a step that returns as soon as the object exists reports success over
+# an ingress still serving another host's default certificate — which is what a browser shows the
+# first visitor. This waits for the Secret to carry an actual key pair, and fails if it never does.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-tls"
+
+namespace="" host="" timeout="${HOSTING_TLS_TIMEOUT:-600}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace) namespace="${2:-}"; shift 2 ;;
+    --host)      host="${2:-}";      shift 2 ;;
+    --timeout)   timeout="${2:-}";   shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag namespace "$namespace"
+hosting::need_flag host "$host"
+hosting::safe_name namespace "$namespace"
+hosting::safe_host host "$host"
+
+secret="${HOSTING_TLS_SECRET:-${namespace}-tls}"
+issuer="${HOSTING_TLS_ISSUER:-letsencrypt-prod}"
+
+ready() {
+  local tls_crt
+  tls_crt="$(kubectl -n "$namespace" get secret "$secret" -o jsonpath='{.data.tls\.crt}' 2>/dev/null || true)"
+  [ -n "$tls_crt" ]
+}
+
+if ready; then
+  hosting::log "TLS secret ${secret} already carries a certificate — keeping it"
+  hosting::say tls kept
+  exit 0
+fi
+
+hosting::log "requesting a certificate for ${host} (issuer ${issuer}, secret ${secret})"
+if hosting::dry; then
+  echo "  DRY-RUN would create Certificate ${secret} in ${namespace} and wait up to ${timeout}s"
+  hosting::say tls dry-run
+  exit 0
+fi
+
+kubectl apply -f - <<YAML || hosting::die "could not create the Certificate for ${host}"
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${secret}
+  namespace: ${namespace}
+  labels:
+    app.kubernetes.io/managed-by: meshweaver-hosting
+spec:
+  secretName: ${secret}
+  dnsNames:
+    - ${host}
+  issuerRef:
+    name: ${issuer}
+    kind: ClusterIssuer
+YAML
+
+deadline=$(( $(date +%s) + timeout ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if ready; then
+    hosting::log "certificate issued into ${secret}"
+    hosting::say tls issued
+    exit 0
+  fi
+  sleep 10
+done
+
+# Name what to look at. A cert that never issues is almost always DNS not yet resolving to the
+# ingress, and the Certificate's own events say so.
+reason="$(kubectl -n "$namespace" describe certificate "$secret" 2>/dev/null | tail -20 || true)"
+hosting::die "no certificate in ${secret} after ${timeout}s. Until one exists the ingress serves ANOTHER host's default certificate, so this is a failure rather than something to proceed past. Most often the A record has not propagated to the issuer's resolver yet. Certificate events:
+${reason}"

--- a/deploy/aks/operator/bin/hosting-verify
+++ b/deploy/aks/operator/bin/hosting-verify
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# hosting-verify --host <fqdn>
+#
+# Does the instance actually ANSWER, over TLS, as itself?
+#
+# 🚨 The three things that fail independently and all look like "deployed" from inside the cluster:
+# DNS resolving to the ingress, the certificate matching the host, and the app returning 200. A
+# rollout status proves none of them. This is the step that turns "helm says deployed" into "a
+# browser can open it", so it deliberately does NOT pass --insecure.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-verify"
+
+host="" path="${HOSTING_VERIFY_PATH:-/}" attempts="${HOSTING_VERIFY_ATTEMPTS:-30}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --host)     host="${2:-}";     shift 2 ;;
+    --path)     path="${2:-}";     shift 2 ;;
+    --attempts) attempts="${2:-}"; shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag host "$host"
+hosting::safe_host host "$host"
+
+if hosting::dry; then
+  echo "  DRY-RUN would probe https://${host}${path} up to ${attempts} times"
+  hosting::say verify dry-run
+  exit 0
+fi
+
+url="https://${host}${path}"
+hosting::log "probing ${url}"
+
+last_status="" last_error=""
+for i in $(seq 1 "$attempts"); do
+  # --fail-with-body is not universal on alpine curl; read the status explicitly instead.
+  last_status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$url" 2>/tmp/hosting-verify.err)" || true
+  last_error="$(cat /tmp/hosting-verify.err 2>/dev/null || true)"
+  if [ "$last_status" = "200" ] || [ "$last_status" = "302" ] || [ "$last_status" = "401" ]; then
+    hosting::log "answered ${last_status} on attempt ${i}"
+    hosting::say verify "$last_status"
+    # Report the certificate the host actually served, so a wrong-cert ingress is visible in the log
+    # rather than only in a browser.
+    subject="$(echo | openssl s_client -servername "$host" -connect "${host}:443" 2>/dev/null \
+      | openssl x509 -noout -subject 2>/dev/null || true)"
+    [ -n "$subject" ] && hosting::log "served certificate ${subject}"
+    exit 0
+  fi
+  [ "$i" -lt "$attempts" ] && sleep 10
+done
+
+hosting::die "https://${host}${path} never answered (last status '${last_status:-none}'${last_error:+, last transport error: ${last_error}}) after ${attempts} attempts. An instance that helm deployed but nobody can open is not provisioned. Check, in this order: the A record resolves to the ingress IP, the TLS secret matches this host, the portal pods are Ready."

--- a/deploy/aks/operator/bin/hosting-verify-backup
+++ b/deploy/aks/operator/bin/hosting-verify-backup
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# hosting-verify-backup --store-uri <uri>
+#
+# THE ONLY THING THAT EMITS verified=true, and only after reading the archive back.
+#
+# 🚨 WHY A SEPARATE STEP. `pg_dump` exiting zero proves it ran, not that the bytes landed. A
+# truncated upload, a half-written blob and an empty database all produce a successful backup step.
+# Everything destructive in the plan — dropping a database, deleting a namespace — sits behind THIS
+# step, so it must actually download the archive and parse a non-zero number of table entries out
+# of its table of contents. Anything it cannot read is NOT verified, and silence is never a claim.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-verify-backup"
+
+store_uri=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --store-uri) store_uri="${2:-}"; shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag store-uri "$store_uri"
+
+if hosting::dry; then
+  echo "  DRY-RUN would download ${store_uri} and parse its table of contents"
+  hosting::say verify dry-run
+  exit 0
+fi
+
+archive="/tmp/verify.dump"
+rm -f "$archive"
+
+hosting::log "downloading ${store_uri}"
+az storage blob download --blob-url "$store_uri" --file "$archive" --auth-mode login --output none \
+  || hosting::die "could not download ${store_uri}. An archive that cannot be read back is not a backup, so this REFUSES rather than letting the plan proceed to anything destructive."
+
+size="$(wc -c < "$archive" | tr -d ' ')"
+hosting::say size "$size"
+[ "$size" -gt 0 ] || hosting::die "the downloaded archive is ZERO BYTES"
+
+sha="$(sha256sum "$archive" | cut -d' ' -f1)"
+hosting::say sha256 "$sha"
+
+# pg_restore --list reads the custom-format table of contents without touching a database.
+toc="$(pg_restore --list "$archive" 2>/dev/null)" \
+  || hosting::die "pg_restore could not read a table of contents from the archive (${size} bytes). It is truncated or not a custom-format dump — either way it will not restore."
+
+tables="$(printf '%s\n' "$toc" | grep -c ' TABLE DATA ' || true)"
+hosting::say tables "$tables"
+hosting::log "table-of-contents entries with data: ${tables}"
+
+if [ "${tables:-0}" -lt 1 ]; then
+  rm -f "$archive"
+  hosting::die "the archive parses but contains NO table data. That is what an empty or wrong database dumps to, and restoring it would produce an instance with no content — refusing to report it as verified."
+fi
+
+rm -f "$archive"
+hosting::log "archive verified: ${size} bytes, ${tables} table(s), sha256 ${sha}"
+hosting::say verified true

--- a/deploy/aks/operator/bin/hosting-verify-catalog
+++ b/deploy/aks/operator/bin/hosting-verify-catalog
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# hosting-verify-catalog --namespace <ns> --expect-mounts <n> --expect-packages <n>
+#
+# Did the plugin catalog wiring actually take?
+#
+# 🚨 THE FAILURE THIS EXISTS FOR reads as a healthy instance: green pods, a working sign-in, and an
+# EMPTY STORE. No probe notices, because nothing errored — a registry mount that did not arrive is
+# indistinguishable from an instance that was never meant to have one, unless something states the
+# expectation. The mesh knows the expected counts (it composed the config), so it passes them here.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-verify-catalog"
+
+namespace="" expect_mounts="" expect_packages=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace)       namespace="${2:-}";       shift 2 ;;
+    --expect-mounts)   expect_mounts="${2:-}";   shift 2 ;;
+    --expect-packages) expect_packages="${2:-}"; shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag namespace "$namespace"
+hosting::safe_name namespace "$namespace"
+expect_mounts="${expect_mounts:-0}"
+expect_packages="${expect_packages:-0}"
+
+if hosting::dry; then
+  echo "  DRY-RUN would assert ${expect_mounts} mount(s) and ${expect_packages} package pattern(s) in ${namespace}"
+  hosting::say catalog dry-run
+  exit 0
+fi
+
+cm="$(kubectl -n "$namespace" get cm memex-portal-config -o json 2>/dev/null)" \
+  || hosting::die "no memex-portal-config ConfigMap in ${namespace} — the release did not render one, so nothing configured the catalog"
+
+# One key per mount: PluginCatalog__Registries__<i>__Name.
+mounts="$(printf '%s' "$cm" | grep -o '"PluginCatalog__Registries__[0-9]*__Name"' | sort -u | wc -l | tr -d ' ')"
+packages="$(printf '%s' "$cm" | grep -o '"PluginCatalog__InstallByDefault__[0-9]*"' | sort -u | wc -l | tr -d ' ')"
+
+hosting::log "mounts   found ${mounts}, expected ${expect_mounts}"
+hosting::log "packages found ${packages}, expected ${expect_packages}"
+hosting::say catalog_mounts "$mounts"
+hosting::say catalog_packages "$packages"
+
+problems=()
+[ "$mounts"   -ge "$expect_mounts" ]   || problems+=("only ${mounts} of ${expect_mounts} registry mount(s) reached the ConfigMap")
+[ "$packages" -ge "$expect_packages" ] || problems+=("only ${packages} of ${expect_packages} pre-install pattern(s) reached the ConfigMap")
+
+if [ ${#problems[@]} -gt 0 ]; then
+  hosting::die "$(IFS='; '; echo "${problems[*]}"). This instance would come up green with an empty Store and nothing in any log explaining why — which is exactly the outcome this check exists to refuse. The catalog config is composed by the mesh (InstanceSpec) and layered by hosting-deploy as a values file; if it is missing here, that file did not reach the release."
+fi
+
+hosting::log "catalog wiring verified"

--- a/deploy/aks/operator/bin/hosting-verify-restore
+++ b/deploy/aks/operator/bin/hosting-verify-restore
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# hosting-verify-restore --database <db> --server <pg>
+#
+# Read the restored database back: does it hold the tables and rows an instance needs?
+#
+# 🚨 `pg_restore` exiting zero says the archive replayed, not that the result is a working instance.
+# A restore into the wrong database, or of an archive from a different schema version, replays
+# cleanly and leaves something that cannot serve. So this queries the restored database directly and
+# refuses on an empty one.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-verify-restore"
+
+database="" server=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --database) database="${2:-}"; shift 2 ;;
+    --server)   server="${2:-}";   shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag database "$database"
+hosting::need_flag server "$server"
+hosting::safe_name database "$database"
+
+if hosting::dry; then
+  echo "  DRY-RUN would query ${database} on ${server} for restored content"
+  hosting::say verify dry-run
+  exit 0
+fi
+
+hosting::need_env PGPASSWORD "the admin password for the flexible server"
+pg_user="${PGUSER:-memexadmin}"
+
+q() { PGPASSWORD="$PGPASSWORD" psql -h "$server" -U "$pg_user" -d "$database" -tAc "$1" 2>/dev/null | tr -d ' '; }
+
+version="$(q 'SHOW server_version')" || true
+[ -n "$version" ] || hosting::die "cannot connect to ${database} on ${server} after the restore"
+hosting::say pgversion "$version"
+
+tables="$(q "SELECT count(*) FROM information_schema.tables WHERE table_schema NOT IN ('pg_catalog','information_schema')")"
+hosting::say tables "${tables:-0}"
+hosting::log "restored database holds ${tables:-0} table(s)"
+
+[ "${tables:-0}" -ge 1 ] \
+  || hosting::die "the restored database has NO user tables. pg_restore reported success, so this is an archive/target mismatch rather than a transfer failure — the instance would start and serve nothing."
+
+# The mesh's own node storage is the table that decides whether this is a MeshWeaver database at
+# all. Absent, the restore replayed something else entirely.
+nodes="$(q "SELECT count(*) FROM information_schema.tables WHERE table_name = 'mesh_nodes'")"
+if [ "${nodes:-0}" -lt 1 ]; then
+  hosting::die "no 'mesh_nodes' table anywhere in ${database}. The archive restored cleanly but is not a MeshWeaver instance database — refusing to report a verified restore."
+fi
+
+hosting::say verified true
+hosting::log "restore verified"

--- a/deploy/aks/operator/bin/run.sh
+++ b/deploy/aks/operator/bin/run.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# The operator Job's entrypoint: execute the plan the mesh composed, in order, and stop at the
+# first failure.
+#
+# 🚨 THIS SCRIPT CONTAINS NO POLICY. Every ordering rule — backup before quiesce, verify before
+# delete, manifest last — lives in the mesh's pure, unit-tested InstanceActionPlan. That is
+# deliberate: the rules are then testable without a cluster, and there is exactly one place to read
+# them. A step added here would be a second, untested planner.
+#
+# The contract (HostingOperator.JobManifest):
+#   HOSTING_ACTION           provision | teardown | suspend | reactivate | restore | export | …
+#   HOSTING_DEPLOYMENT       the deployment id, for logging
+#   HOSTING_PLAN             base64 of `name<TAB>command` lines — base64 so no step's quoting can
+#                            escape the environment value carrying it
+#   HOSTING_CATALOG_CONFIG   base64 of the catalog config lines, materialised at $CATALOG_CONFIG
+#   plus Hosting:Operator:Environment entries (AZ_RESOURCE_GROUP, AZ_PORTAL_IDENTITY, INGRESS_IP,
+#   PAYWALL_URL, VALUES_FILE, CATALOG_CONFIG)
+#
+# 🚨 NOT `set -e`. A step's failure is handled explicitly below, because the exit code has to be
+# reported with the STEP NAME attached — `set -e` would abort with a bare status and the mesh would
+# record "failed" without saying what was inside.
+
+set -uo pipefail
+
+# shellcheck source=_common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="run.sh"
+
+action="${HOSTING_ACTION:-<unset>}"
+deployment="${HOSTING_DEPLOYMENT:-<unset>}"
+
+echo "hosting-operator: ${action} of ${deployment}"
+hosting::dry && echo "  DRY RUN — every mutation is narrated, nothing is changed."
+
+[ -n "${HOSTING_PLAN:-}" ] \
+  || hosting::die "HOSTING_PLAN is empty. The mesh composes the plan and passes it base64-encoded; an empty one means the action reached the cluster with nothing to do, which is a bug in the caller — refusing rather than reporting a successful no-op."
+
+plan="$(printf '%s' "$HOSTING_PLAN" | base64 -d)" \
+  || hosting::die "HOSTING_PLAN is not valid base64"
+[ -n "$plan" ] || hosting::die "HOSTING_PLAN decoded to nothing"
+
+# Materialise the catalog config where the plan's --config-file points. A provision whose plugin
+# mounts silently failed to arrive is the failure hosting-verify-catalog exists to catch; writing
+# an empty file here would make that check pass against nothing.
+if [ -n "${HOSTING_CATALOG_CONFIG:-}" ]; then
+  target="${CATALOG_CONFIG:-/tmp/hosting-catalog-config}"
+  if printf '%s' "$HOSTING_CATALOG_CONFIG" | base64 -d > "$target"; then
+    hosting::log "catalog config → ${target} ($(wc -c < "$target") bytes)"
+  else
+    hosting::die "HOSTING_CATALOG_CONFIG is not valid base64"
+  fi
+fi
+
+total=0
+while IFS=$'\t' read -r name command; do
+  [ -n "${name:-}" ] || continue
+  total=$((total + 1))
+done <<< "$plan"
+
+[ "$total" -gt 0 ] || hosting::die "the decoded plan has no steps"
+echo "  ${total} step(s)"
+echo
+
+index=0
+while IFS=$'\t' read -r name command; do
+  [ -n "${name:-}" ] || continue
+  index=$((index + 1))
+
+  if [ -z "${command:-}" ]; then
+    hosting::die "step ${index} ('${name}') has no command — refusing to skip it silently"
+  fi
+
+  hosting::step "$name"
+  echo "[${index}/${total}] ${name}"
+
+  if hosting::dry; then
+    echo "  DRY-RUN would run: ${command}"
+    echo
+    continue
+  fi
+
+  # `bash -c` because a step legitimately contains quotes, pipes and $VAR references that the mesh
+  # wrote deliberately — re-splitting it into an argv here is exactly where an escaping bug becomes
+  # an arbitrary-command bug, which is why the plan arrives as one opaque string per step.
+  if bash -c "$command"; then
+    echo
+  else
+    rc=$?
+    echo
+    hosting::die "step ${index}/${total} '${name}' failed with exit ${rc}. The run stops here: the plan is ordered so that everything destructive sits behind a verification, and continuing past a failure would step over one. Fix the cause and re-request the action — the plan is idempotent from the top."
+  fi
+done <<< "$plan"
+
+echo "hosting-operator: ${action} of ${deployment} completed ${total}/${total} steps."

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Tests for the hosting operator scripts.
+#
+# 🚨 WHAT CAN AND CANNOT BE TESTED HERE, stated plainly so nobody reads a green run as more than it
+# is. These scripts drive az, kubectl, helm and psql against a live Azure estate; a test run has
+# none of those, and mocking them would assert that the mocks agree with themselves. So this suite
+# covers the layer that is genuinely testable AND is where the dangerous bugs live:
+#
+#   • argument handling — a flag silently dropped is a command run against the wrong target
+#   • the REFUSALS — every guard that stands between a plan and a destructive act
+#   • the ::hosting:: contract — the lines the mesh's OperatorOutput parser reads
+#   • run.sh's sequencing — order, first-failure stop, and never treating an empty plan as a no-op
+#
+# What it does NOT cover: whether `az network dns record-set a add-record` does what we think. That
+# is proven by the first real provision, and it is why the rollout is staged.
+
+set -uo pipefail
+BIN="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../bin" && pwd)"
+export PATH="$BIN:$PATH"
+
+pass=0; fail=0
+ok()   { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad()  { printf '  FAIL  %s\n' "$1"; printf '        %s\n' "${2:-}"; fail=$((fail+1)); }
+
+# Assert a command exits non-zero AND its stderr mentions a phrase — a refusal must SAY why.
+refuses() {
+  local what="$1" phrase="$2"; shift 2
+  local out rc
+  out="$("$@" 2>&1)"; rc=$?
+  if [ "$rc" -eq 0 ]; then bad "$what" "exited 0 — it should have refused"; return; fi
+  case "$out" in *"$phrase"*) ok "$what" ;; *) bad "$what" "refused, but never said '${phrase}'. Said: ${out}" ;; esac
+}
+
+# Assert a command REFUSED AND STOPPED — non-zero, saying why, having reported nothing.
+#
+# 🚨 Why the "reported nothing" half matters. `hosting::die` writes to stderr and exits; when the
+# guard calling it was (as it once was) inside a command substitution, the MESSAGE still printed
+# while the script carried on. A test that only looked for the message passed against a guard that
+# did not guard. The absence of any ::hosting:: line is what proves the script stopped before it
+# did anything the mesh would record.
+refuses_hard() {
+  local what="$1" phrase="$2"; shift 2
+  local out rc
+  out="$("$@" 2>&1)"; rc=$?
+  if [ "$rc" -eq 0 ]; then bad "$what" "exited 0 — it should have refused"; return; fi
+  case "$out" in *"$phrase"*) ;; *) bad "$what" "refused, but never said '${phrase}'. Said: ${out}"; return ;; esac
+  case "$out" in
+    *"::hosting::"*) bad "$what" "refused but had already REPORTED something — it did not stop at the guard: ${out}" ;;
+    *"+ az"*|*"+ kubectl"*|*"+ helm"*) bad "$what" "refused but had already run a command: ${out}" ;;
+    *) ok "$what" ;;
+  esac
+}
+
+# Assert a command succeeds and emits a given ::hosting:: line.
+emits() {
+  local what="$1" line="$2"; shift 2
+  local out rc
+  out="$("$@" 2>&1)"; rc=$?
+  if [ "$rc" -ne 0 ]; then bad "$what" "exited ${rc}: ${out}"; return; fi
+  case "$out" in *"$line"*) ok "$what" ;; *) bad "$what" "no '${line}' in: ${out}" ;; esac
+}
+
+echo "── argument handling ─────────────────────────────────────────────"
+refuses "kv-ensure needs --vault"          "missing required flag --vault"      hosting-kv-ensure --namespace n
+refuses "kv-purge needs --vault"           "missing required flag --vault"      hosting-kv-purge --namespace n
+refuses "dns needs a mode"                 "must be 'upsert' or 'delete'"       hosting-dns --zone z --host h
+refuses "redirect needs a mode"            "must be 'suspend' or 'restore'"     hosting-redirect --namespace n
+refuses "deploy needs --release"           "missing required flag --release"    hosting-deploy --namespace n --database d
+refuses "verify needs --host"              "missing required flag --host"       hosting-verify
+refuses "unknown flags are not ignored"    "unknown argument"                   hosting-verify --host h --nope 1
+
+echo
+echo "── the refusals that stand in front of something destructive ─────"
+refuses "kv-purge refuses an EMPTY prefix" "refusing to purge with an EMPTY --prefix" \
+  hosting-kv-purge --vault V --prefix "" --namespace n
+refuses "dns refuses a host outside its zone" "is not inside zone" \
+  env AZ_DNS_RESOURCE_GROUP=rg hosting-dns upsert --zone example.com --host evil.other.com --target 1.2.3.4
+refuses "dns refuses a non-IPv4 target"    "is not an IPv4 address" \
+  env AZ_DNS_RESOURCE_GROUP=rg hosting-dns upsert --zone example.com --host a.example.com --target not-an-ip
+refuses "redirect refuses a relative target" "is not an absolute URL" \
+  env HOSTING_DRY_RUN=true hosting-redirect suspend --namespace n --host h.example.com --target /paywall
+refuses "deploy refuses a missing values file" "does not exist" \
+  env HOSTING_DRY_RUN=true HOSTING_CHART=/tmp hosting-deploy --namespace n --release r --database d --values /nope/values.yaml
+refuses "federate refuses without a resource group" "AZ_RESOURCE_GROUP" \
+  env -u AZ_RESOURCE_GROUP hosting-federate --identity i --namespace n
+
+echo
+echo "── command injection cannot ride in on a name ────────────────────"
+refuses_hard "namespace with a shell metacharacter" "is not a plain name" \
+  hosting-kv-ensure --vault V --namespace 'n; rm -rf /'
+refuses_hard "database with a backtick"             "is not a plain name" \
+  env HOSTING_DRY_RUN=true hosting-verify-restore --database 'd`whoami`' --server s
+refuses_hard "host with a space"                    "is not a hostname" \
+  hosting-verify --host 'a.example.com b'
+refuses_hard "store-uri host with a semicolon"      "is not a plain name" \
+  env HOSTING_DRY_RUN=true hosting-backup --database 'd;id' --server s --store-uri https://x/y/z --object o
+
+echo
+echo "── the ::hosting:: contract the mesh parses ──────────────────────"
+emits "dry-run backup announces the object" "::hosting:: object=arch-1" \
+  env HOSTING_DRY_RUN=true hosting-backup --database d --server s --store-uri https://x/y/z --object arch-1
+emits "dry-run verify-backup does NOT claim verified" "::hosting:: verify=dry-run" \
+  env HOSTING_DRY_RUN=true hosting-verify-backup --store-uri https://x/y/z
+
+# 🚨 The single most important assertion in this file: a run that did not read an archive back must
+# never emit verified=true. Everything destructive in the plan waits on that line.
+out="$(env HOSTING_DRY_RUN=true hosting-verify-backup --store-uri https://x/y/z 2>&1)"
+case "$out" in
+  *"verified=true"*) bad "a dry run must NEVER claim verified=true" "it did: ${out}" ;;
+  *)                 ok  "a dry run never claims verified=true" ;;
+esac
+
+echo
+echo "── run.sh sequencing ─────────────────────────────────────────────"
+plan() { printf '%s' "$1" | base64 | tr -d '\n'; }
+
+refuses "an EMPTY plan is a bug, not a no-op" "HOSTING_PLAN is empty" \
+  env HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d HOSTING_PLAN= "$BIN/run.sh"
+refuses "a plan that is not base64 fails loudly" "not valid base64" \
+  env HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d HOSTING_PLAN='!!!!' "$BIN/run.sh"
+refuses "a step with no command is never skipped" "has no command" \
+  env HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d HOSTING_PLAN="$(plan 'Lonely step')" "$BIN/run.sh"
+
+# Steps run IN ORDER, and a failure stops the run — the later step must not have run.
+marker="$(mktemp)"
+out="$(env HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d \
+  HOSTING_PLAN="$(plan "First	echo one
+Second	false
+Third	echo three >> ${marker}")" "$BIN/run.sh" 2>&1)"
+rc=$?
+[ "$rc" -ne 0 ] && ok "a failing step fails the run" || bad "a failing step fails the run" "exited 0"
+case "$out" in *"step 2/3 'Second' failed"*) ok "the failure names the step and its position" ;;
+  *) bad "the failure names the step" "said: ${out}" ;; esac
+[ ! -s "$marker" ] && ok "the step after a failure never runs" || bad "the step after a failure never runs" "'Third' ran anyway"
+rm -f "$marker"
+
+emits "the step marker is emitted per step" "::hosting:: step=First" \
+  env HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d HOSTING_PLAN="$(plan 'First	echo one')" "$BIN/run.sh"
+
+# A dry run narrates and mutates nothing.
+guard="$(mktemp)"; rm -f "$guard"
+out="$(env HOSTING_DRY_RUN=true HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d \
+  HOSTING_PLAN="$(plan "Touch	touch ${guard}")" "$BIN/run.sh" 2>&1)"
+[ ! -e "$guard" ] && ok "a dry run runs no step" || bad "a dry run runs no step" "the step executed"
+case "$out" in *"DRY-RUN would run"*) ok "a dry run narrates what it would do" ;;
+  *) bad "a dry run narrates" "said: ${out}" ;; esac
+
+echo
+echo "─────────────────────────────────────────────────────────────────"
+echo "${pass} passed, ${fail} failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -191,6 +191,50 @@ data:
   Instances__GrafanaBaseUrl: "{{ .Values.instancesAdmin.grafanaBaseUrl }}"
 {{- end }}
 {{- end }}
+{{- /* ---- Instance lifecycle operator (the Hosting plugin) — OFF unless declared ----
+
+  🚨 THESE KEYS WERE TEMPLATED BY NOTHING UNTIL NOW, and that is the whole reason this block exists.
+  The ConfigMap names every key explicitly and the Deployment's only env path is `envFrom` on it, so
+  a key no template mentions reaches NO container. memex's overlay declared
+  `Hosting__Operator__Enabled: "true"` under a "THE CONTROL INSTANCE, and only here" comment, and
+  the live ConfigMap carried zero `Hosting__*` keys — so HostingOperator.Resolve reported
+  "instance actions are disabled on this installation" on the one installation that is supposed to
+  run them. Exactly the `Modules__Root` defect (Memex#53), which is invariant 8 of
+  check-chart-invariants.
+
+  🚨 OFF BY DEFAULT, AND THAT IS A SECURITY PROPERTY, not a convenience. The identity this arms can
+  delete namespaces and drop databases across the fleet. An installation that does not declare
+  `hostingOperator.enabled` renders `false` and cannot be talked into provisioning anything. */}}
+  Hosting__Operator__Enabled: "{{ (.Values.hostingOperator).enabled | default "false" }}"
+{{- if (.Values.hostingOperator).enabled }}
+{{- if not (.Values.hostingOperator).image }}
+{{- fail "hostingOperator.enabled is true but hostingOperator.image is unset. The operator runs every lifecycle action as a Job from that image; without it HostingOperator.Resolve refuses with 'no operator image configured' and every action on this installation fails at the point of use rather than here. Set hostingOperator.image to the hosting-operator build this fleet runs." }}
+{{- end }}
+  # The ops namespace the Jobs run in, and the POWERFUL ServiceAccount they run as. Both are
+  # matched by NAME in the federated credential's subject (system:serviceaccount:<ns>:<sa>), so
+  # changing either here means changing it in manifests/hosting-operator/ and in backups.bicep.
+  Hosting__Operator__Namespace: "{{ (.Values.hostingOperator).namespace | default "memex-ops" }}"
+  Hosting__Operator__ServiceAccount: "{{ (.Values.hostingOperator).serviceAccount | default "hosting-operator" }}"
+  # The operator image IS the chart version it deploys (the chart is baked into it), so pin it like
+  # any other image and bump it deliberately.
+  Hosting__Operator__Image: "{{ .Values.hostingOperator.image }}"
+  # Deliberately NOT the pod's own projected token: a second identity has to arrive as a mounted
+  # Secret, and that indirection is the point — this capability is removed by deleting one volume
+  # mount, without touching the portal's identity or its self-update permissions. Mount it with
+  # .Values.extraVolumes / .Values.extraVolumeMounts.
+  Hosting__Operator__TokenFile: "{{ (.Values.hostingOperator).tokenFile | default "/var/run/secrets/hosting-operator/token" }}"
+  # Read with int.TryParse, which falls back to 3600 — but a PARSEABLE default is emitted anyway,
+  # per the rule stated at OpenAICompatible__DiscoverModels: `default ""` is safe only for strings.
+  Hosting__Operator__DeadlineSeconds: "{{ (.Values.hostingOperator).deadlineSeconds | default 3600 }}"
+{{- /* Named keys, not an indexed list: HostingOperator.ReadEnvironment turns a non-numeric child
+       key into `KEY=VALUE` itself, so the values file stays readable as a map. These reach every
+       operator Job as environment — AZ_RESOURCE_GROUP, AZ_PORTAL_IDENTITY, AZ_OIDC_ISSUER,
+       AZ_DNS_RESOURCE_GROUP, INGRESS_IP, PAYWALL_URL, VALUES_FILE, CATALOG_CONFIG. A step that
+       needs one and does not get it refuses BY NAME (hosting::need_env). */}}
+{{- range $key, $value := (.Values.hostingOperator).environment }}
+  Hosting__Operator__Environment__{{ $key }}: "{{ $value }}"
+{{- end }}
+{{- end }}
 {{- if (.Values.portalNext).enabled }}
   # ---- Next.js React frontend (FEATURE-FLAGGED — see .Values.portalNext) -----
   # Non-empty ReactAppUrl is what enables FrontendSelection: it shows the user

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -135,6 +135,48 @@ instancesAdmin:
   # Instances tab (→ Instances__GrafanaBaseUrl). Empty = the tab shows a configure-me hint
   # instead of links. Only meaningful where clusterRead is true (the company instance).
   grafanaBaseUrl: ""
+# ---- Instance lifecycle operator (the Hosting plugin) ----------------------
+# Arms self-service instance provisioning, suspension, backup, restore and teardown. The identity
+# this reaches can DELETE NAMESPACES and DROP DATABASES across the fleet, so it is off here and
+# enabled on the CONTROL INSTANCE only.
+#
+# 🚨 Enabling this is four things, not one, and three of them are outside the chart:
+#   1. `kubectl apply -f deploy/aks/manifests/hosting-operator/` (ops namespace, the two
+#      ServiceAccounts, the jobrunner Role + token Secret)
+#   2. a federated credential on the operator managed identity for
+#      system:serviceaccount:<namespace>:<serviceAccount>
+#   3. the hosting-operator image built and pushed (deploy/aks/operator/)
+#   4. the jobrunner token mounted into the portal at tokenFile, via extraVolumes /
+#      extraVolumeMounts below
+# With `enabled: true` and any of those missing, HostingOperator.Resolve refuses and names what it
+# could not find — by design: an unconfigured mesh cannot be talked into provisioning.
+hostingOperator:
+  enabled: false
+  # The ops namespace and the Job's (powerful) ServiceAccount. Both appear VERBATIM in the
+  # federated credential's subject, which Azure matches as a string — rename either and the token
+  # exchange fails at run time with an error naming neither.
+  namespace: "memex-ops"
+  serviceAccount: "hosting-operator"
+  # REQUIRED when enabled — the chart fails the render without it rather than letting every action
+  # refuse later. The chart is baked into this image, so its tag is also the chart version a
+  # provision deploys.
+  image: ""
+  # Where the portal reads the jobrunner bearer token. Deliberately not the pod's own projected
+  # token: this capability is meant to be removable by deleting one volume mount.
+  tokenFile: "/var/run/secrets/hosting-operator/token"
+  deadlineSeconds: 3600
+  # Environment handed to every operator Job. Named keys — the plugin turns each into KEY=VALUE.
+  # A step that needs one it did not get refuses by name, so an incomplete map fails loudly at the
+  # step rather than producing a half-provisioned instance.
+  environment: {}
+  #   AZ_RESOURCE_GROUP:     memex-aks-rg
+  #   AZ_DNS_RESOURCE_GROUP: dns
+  #   AZ_PORTAL_IDENTITY:    <portal user-assigned identity name>
+  #   AZ_OIDC_ISSUER:        <az aks show --query oidcIssuerProfile.issuerURL -o tsv>
+  #   INGRESS_IP:            <the ingress controller's public IP>
+  #   PAYWALL_URL:           https://<control instance>/suspended
+  #   VALUES_FILE:           /opt/hosting/values/fleet-template.yaml
+  #   CATALOG_CONFIG:        /tmp/hosting-catalog-config
 # ---- Fixed replica count (portal) ------------------------------------------
 # Read ONLY when keda.enabled is false — with KEDA on, the HPA owns spec.replicas and the chart
 # deliberately renders no such field (see templates/memex-portal/deployment.yaml).


### PR DESCRIPTION
## Why nothing could create an instance

The mesh side of instance lifecycle is complete and unit-tested: `InstanceRequest` composes the record, opens the write-through PR, creates the `InstanceAction`, and `InstanceActionPlan` emits an ordered plan whose every rule is pinned by tests. **Everything it hands to the cluster was missing** — and none of the reasons were in the wizard.

### 1. `.gitignore` was eating the scripts

`/deploy/**/bin/` (the Visual Studio build-output rule) also matched `deploy/aks/operator/bin/`. So `git add` on those files **exited 0 and did nothing**, and the Dockerfile shipped `COPY bin/ /opt/hosting/bin/` with an ENTRYPOINT of `/opt/hosting/bin/run.sh` against a directory git refused to track.

No error, no warning — the classic silent failure, and almost certainly why the shell half was *written into a hole* rather than never written. Re-included beside the existing `deploy/homebrew/bin` precedent, and **CI now asserts the files are tracked and executable**, because a checkout is the only place that can prove it.

### 2. The Dockerfile had never been built

Its base — `mcr.microsoft.com/azure-cli:2.77.0` — is **Azure Linux 3**: `tdnf`, not `apk`, and no busybox `adduser`. Every `docker build` exited **127**.

Fixed to tdnf + shadow-utils, and made arch-aware (`TARGETARCH`) — hard-coded `linux/amd64` binaries build fine on an arm64 laptop and then cannot exec `kubectl`. Ships `postgresql` 16.15 against the fleet's major-16 flexible servers (`memexaks-pg`, verified).

### 3. `Hosting__Operator__*` was templated by nothing

memex's overlay declares `Hosting__Operator__Enabled: "true"` under a 🚨 *"THE CONTROL INSTANCE, and only here"* comment. Its **live ConfigMap carries zero `Hosting__*` keys**, so `HostingOperator.Resolve` reports *"instance actions are disabled on this installation"* on the one installation meant to run them.

Exactly the `Modules__Root` defect (Memex#53) — invariant 8 of `check-chart-invariants`. Now a `hostingOperator` values block, **off by default** (the identity it arms deletes namespaces and drops databases), and `enabled` without `image` **fails the render** rather than deferring to a runtime refusal.

### 4. The 14 commands the plan can emit did not exist

Written against the contract in `HostingOperator.JobManifest` and `OperatorOutput`. `run.sh` decodes the base64 plan, runs each step in order, stops at the first failure naming the step and its position, and **contains no policy of its own** — every ordering rule stays in the mesh's plan, where it is testable without a cluster.

The guarantees `INSTANCE-LIFECYCLE.md` already claimed are now implemented rather than described:

| | |
|---|---|
| `hosting-backup` | dumps, measures, uploads `--overwrite false`. **Never claims verification.** |
| `hosting-verify-backup` | the **only** thing that emits `verified=true`, and only after downloading the archive and parsing a non-zero table count out of its table of contents |
| `hosting-kv-ensure` | never overwrites an existing master key |
| `hosting-export` | never prints the SAS it mints (it is a bearer credential — it goes into a one-shot Secret) |

Two refusals worth naming, because they guard the worst available typos: `hosting-kv-purge` refuses an **empty `--prefix`** (every per-instance secret name would resolve to the fleet-wide one, so tearing down an instance would delete the *control* instance's envelope key), and `hosting-dns` refuses a host outside its zone.

## Tests

**29 behaviour tests**, run on the runner *and* inside the built image. They cover argument handling, the refusals, the `::hosting::` contract and `run.sh`'s sequencing — deliberately **not** whether `az network dns record-set a add-record` behaves as expected, which no runner can prove and the first real provision will.

They found two bugs in this change before it landed, one serious:

> `hosting::safe_name` was called as `x="$(hosting::safe_name x "$x")"`. A command substitution is a **subshell**, so the `exit 1` inside `hosting::die` ended the substitution and not the script — the caller carried on with an empty value and **every injection guard was a no-op that still printed its refusal**. Now validate-in-place, with the trap written down where the next person will reach for the same shape.

(The second: `hosting-redirect` validated its target *after* the cluster lookup, so a relative URL came back as "no Ingress", naming the wrong problem.)

## 🚨 This turns nothing on

Enabling the operator is four steps outside this repo — apply `manifests/hosting-operator/`, add the federated credential, build and push the image, mount the jobrunner token. `values.yaml` lists all four; `hostingOperator.enabled` defaults to `false` everywhere. **The first provision is what exercises these scripts against Azure for the first time**, so the rollout should be staged (dry run → a throwaway instance → a real one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)