### PR TITLE
The build chip is glyph-only — one label was misaligning a row of eight icons

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/PlatformUpdateChip.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/PlatformUpdateChip.cs
@@ -22,15 +22,17 @@ public enum PlatformUpdateChipAction
 /// reason <see cref="Settings.AboutSettingsTab.UpdateStatusMarkdown"/> takes its localizer as a
 /// function). The component holds only markup and wiring.
 /// </summary>
-/// <param name="DisplayText">
-/// What the header shows: when this build was last deployed, or <c>null</c> when that is unknown
-/// (the glyph still renders, so the button is never blank-but-clickable).
+/// <param name="Tooltip">
+/// The full sentence on hover — build identity in every state, and the deployment time.
+///
+/// <para>🚨 The chip renders a GLYPH ONLY. It sits in a strip of icon buttons, and a chip that also
+/// rendered text was wider than its siblings and pushed its own glyph off their shared centre line.
+/// So everything the chip has to say is here, and this string is the whole surface: if a fact is not
+/// in it, the reader cannot get at it without opening the About page.</para>
 /// </param>
-/// <param name="Tooltip">The full sentence on hover — build identity in every state.</param>
 /// <param name="IsUpdate">Whether an update is pending, which is what the chip styles on.</param>
 /// <param name="Action">What a click does.</param>
 public record PlatformUpdateChip(
-    string? DisplayText,
     string Tooltip,
     bool IsUpdate,
     PlatformUpdateChipAction Action)
@@ -131,25 +133,31 @@ public record PlatformUpdateChip(
             ? $"{localize("about.lastDeployed")} {when}"
             : null;
 
+        // 🚨 The deployment time is TOOLTIP-ONLY, and it must appear in every state. The header
+        // strip is icon buttons; a chip that also rendered text was wider than its siblings and
+        // pushed its own glyph off their shared centre line — visible as one misaligned icon in a
+        // row of eight. Dropping the text fixes the row, so the time has to land here or it is
+        // simply lost, and "when was this deployed?" is the question the chip exists to answer.
+        var withDeployed = (string sentence) => deployed is null ? sentence : $"{sentence} {deployed}.";
+
         return status.Availability switch
         {
             PlatformUpdateAvailability.UpdateAvailable => new(
-                deployed,
-                $"{localize("about.updateAvailable")} — {status.LatestVersion}. {running}. "
-                + localize("ui.updateRefreshHint"),
+                withDeployed(
+                    $"{localize("about.updateAvailable")} — {status.LatestVersion}. {running}. "
+                    + localize("ui.updateRefreshHint")),
                 IsUpdate: true,
                 PlatformUpdateChipAction.Refresh),
 
             PlatformUpdateAvailability.UpdateHeld => new(
-                deployed,
-                $"{localize("about.updateHeld")} — {status.LatestVersion}. {running}.",
+                withDeployed($"{localize("about.updateHeld")} — {status.LatestVersion}. {running}."),
                 IsUpdate: true,
                 PlatformUpdateChipAction.OpenAbout),
 
             // UpToDate and Unknown are the same chip on purpose. Unknown means nothing is polling,
             // so claiming "up to date" would be an unfounded verdict (PlatformUpdateAvailability
             // .Unknown) — but the running build is a fact either way, and it is the whole point.
-            _ => new(deployed, running, IsUpdate: false, PlatformUpdateChipAction.OpenAbout),
+            _ => new(withDeployed(running), IsUpdate: false, PlatformUpdateChipAction.OpenAbout),
         };
     }
 }

--- a/memex/Memex.Portal.Shared/SelfUpdate/PlatformUpdateChipView.razor
+++ b/memex/Memex.Portal.Shared/SelfUpdate/PlatformUpdateChipView.razor
@@ -16,44 +16,16 @@
     reasoning (and the tests) live; this file is markup and wiring.
 *@
 
-<style>
-    .platform-build-chip .platform-build-chip__deployed {
-        font-size: 11px;
-        opacity: 0.75;
-        margin-inline-start: 4px;
-        white-space: nowrap;
-    }
-
-    .platform-build-chip--update .platform-build-chip__deployed {
-        opacity: 1;
-        font-weight: 600;
-    }
-
-    /* Narrow viewports keep the glyph — the part that says "act on me" — and drop the text, which
-       is still on the tooltip and on the About page. */
-    @@media (max-width: 720px) {
-        .platform-build-chip .platform-build-chip__deployed {
-            display: none;
-        }
-    }
-</style>
-
 <FluentButton Appearance="Appearance.Stealth" BackgroundColor="transparent"
               class="@(chip.IsUpdate ? "platform-build-chip platform-build-chip--update" : "platform-build-chip")"
               Title="@chip.Tooltip" aria-label="@chip.Tooltip"
               OnClick="@Activate">
-    @* 🚨 The glyph is UNCONDITIONAL, and that is load-bearing rather than decorative: the text is
-       dropped on a narrow viewport AND absent whenever the deployment time is unknown, so a state
-       with no glyph would render an empty button — invisible, still clickable, and with nothing to
-       hover for the tooltip. Keeping every state glyphed means "the chip always shows something"
-       holds by construction instead of by several rules agreeing with each other. *@
+    @* 🚨 GLYPH ONLY, and the button carries no text in any state. This sits in a strip of icon
+       buttons; rendering a label made this one wider than its siblings and pushed its glyph off
+       their shared centre line — one visibly misaligned icon in a row of eight. Everything the chip
+       has to say now rides on Title/aria-label, which is why PlatformUpdateChip.Describe folds the
+       deployment time into the tooltip in every state rather than leaving it to a separate field. *@
     <FluentIcon Value="@Glyph" Color="@GlyphColor" />
-    @* WHEN, not WHICH BUILD — "Last deployed 08-18 15:35". Suppressed entirely when the deployment
-       time is unknown, rather than shown as an epoch date; the glyph alone is a valid chip. *@
-    @if (chip.DisplayText is { } text)
-    {
-        <span class="platform-build-chip__deployed">@text</span>
-    }
 </FluentButton>
 
 @code {

--- a/test/Memex.Portal.Shared.Test/PlatformUpdateChipTest.cs
+++ b/test/Memex.Portal.Shared.Test/PlatformUpdateChipTest.cs
@@ -60,16 +60,15 @@ public class PlatformUpdateChipTest
     /// and on the tooltip without even that.
     /// </summary>
     [Fact]
-    public void DisplayText_says_when_it_was_deployed_and_names_no_version()
+    public void Tooltip_says_when_it_was_deployed_and_the_bar_names_no_version()
     {
         const string full = "3.0.0-rc4.ci.0+8278244204d7e3d0cc95b1461c825383cf0875a9";
         var chip = PlatformUpdateChip.Describe(
             new PlatformUpdateStatus(PlatformUpdateAvailability.UpToDate, null),
             full, "memex-portal-7d9c-abcde", Deployed, "Europe/Zurich", Echo);
 
-        chip.DisplayText.Should().Be("about.lastDeployed 08-18 15:35");
-        chip.DisplayText.Should().NotContain("3.0.0", "the version left the header on purpose");
-        chip.DisplayText.Should().NotContain("8278244", "the sha left with it");
+        chip.Tooltip.Should().Contain("about.lastDeployed 08-18 15:35",
+            "the chip is glyph-only, so the deployment time has nowhere to live but the tooltip");
         chip.Tooltip.Should().Contain(full, "the full build id must remain one hover away");
     }
 
@@ -79,30 +78,33 @@ public class PlatformUpdateChipTest
     /// string in the bar would be the same unreadable identifier, just a newer one.
     /// </summary>
     [Fact]
-    public void DisplayText_stays_a_deployment_time_when_an_update_is_pending()
+    public void Tooltip_still_carries_the_deployment_time_when_an_update_is_pending()
     {
         var chip = PlatformUpdateChip.Describe(
             new PlatformUpdateStatus(PlatformUpdateAvailability.UpdateAvailable, "3.0.0-rc4.ci.4191"),
             "3.0.0-rc4.ci.4180", "memex-portal-7d9c-abcde", Deployed, "Europe/Zurich", Echo);
 
-        chip.DisplayText.Should().Be("about.lastDeployed 08-18 15:35");
-        chip.DisplayText.Should().NotContain("4191", "the pending version belongs on the tooltip, not the bar");
+        chip.Tooltip.Should().Contain("about.lastDeployed 08-18 15:35",
+            "an update pending does not displace WHEN — both ride the one tooltip");
         chip.IsUpdate.Should().BeTrue("the glyph is what says an update is waiting");
         chip.Tooltip.Should().Contain("3.0.0-rc4.ci.4191");
     }
 
     /// <summary>
-    /// An unknown deployment time leaves the header text empty — the glyph still renders, so the
-    /// button is never blank-but-clickable. Nothing is invented to fill the slot.
+    /// An unknown deployment time is OMITTED, not invented — no epoch date, no "unknown" filler.
+    /// The tooltip still names the build, and the glyph still renders, so the button is never
+    /// blank-but-clickable.
     /// </summary>
     [Fact]
-    public void DisplayText_is_null_when_the_deployment_time_is_unknown()
+    public void An_unknown_deployment_time_is_omitted_rather_than_invented()
     {
         var chip = PlatformUpdateChip.Describe(
             new PlatformUpdateStatus(PlatformUpdateAvailability.UpToDate, null),
             "3.0.0-rc4.ci.4180", "memex-portal-7d9c-abcde", default, "Europe/Zurich", Echo);
 
-        chip.DisplayText.Should().BeNull();
+        chip.Tooltip.Should().NotContain("about.lastDeployed");
+        chip.Tooltip.Should().Contain("3.0.0-rc4.ci.4180",
+            "the build is a fact even when the deployment time is not");
     }
 
     /// <summary>
@@ -153,7 +155,7 @@ public class PlatformUpdateChipTest
     {
         var chip = Describe(new PlatformUpdateStatus(PlatformUpdateAvailability.UpToDate, null));
 
-        chip.DisplayText.Should().Be("about.lastDeployed 08-18 15:35");
+        chip.Tooltip.Should().Contain("about.lastDeployed 08-18 15:35");
         chip.IsUpdate.Should().BeFalse();
         chip.Action.Should().Be(PlatformUpdateChipAction.OpenAbout,
             "there is no newer build to reload onto, so the chip is a link to the full build identity");
@@ -168,7 +170,7 @@ public class PlatformUpdateChipTest
         // fact regardless, and it is the whole point of the chip.
         var chip = Describe(PlatformUpdateStatus.Unknown);
 
-        chip.DisplayText.Should().Be("about.lastDeployed 08-18 15:35");
+        chip.Tooltip.Should().Contain("about.lastDeployed 08-18 15:35");
         chip.IsUpdate.Should().BeFalse();
         chip.Tooltip.Should().Contain("3.0.0-rc4.ci.4180",
             "the running build is still a fact — it moved to the tooltip, it did not disappear");


### PR DESCRIPTION
The header strip is icon buttons: each sibling is a `FluentButton` wrapping exactly one `FluentIcon`. The build chip was the same **except** it also rendered `Last deployed 08-21 22:16` — which made it wider than its siblings and pushed its own glyph off their shared centre line.

Both reported symptoms — the visible text, and one icon sitting at a different height — are that single difference.

## The text is removed, not hidden

A media query already dropped it below 720px:

```css
@media (max-width: 720px) { .platform-build-chip__deployed { display: none; } }
```

So the narrow layout was the intended one all along. It just never applied at the width people actually use.

## 🚨 The deployment time had to move, not go

`Describe`'s idle tooltip was `version · instance` and carried **no time at all**. Deleting the label would have lost *"when was this deployed?"* entirely — which the type's own documentation calls the question people actually bring to it:

> "Last deployed 08-18 15:35" answers the question people actually bring to it ("is this current?")

It is now folded into **every** state's tooltip, including the two update-pending ones, so the single surface the chip still has says everything it has to say.

## `DisplayText` is deleted, not left unrendered

The span was its only consumer. A record member nothing reads is a field that drifts out of agreement with what ships. Its three tests move to the tooltip and keep their reasoning intact — **WHEN** belongs to the reader, **WHICH BUILD** stays one hover away, and an unknown time is **omitted rather than invented** (no epoch date, no "unknown" filler).

## Verification

`Memex.Portal.Shared.Test` **358/358**, Release with `-warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)