### PR TITLE
The release wave is PULLED, not pushed — drop both dispatch credentials

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1354,88 +1354,29 @@ jobs:
   #
   # 🚨 Provisioning note (#1755): a subscriber whose own upstreams are not yet published EXITS
   # without building and is re-woken by its upstream's `meshweaver-upstream-published` event, so
-  # naming every satellite here is CORRECT but noisy — the dependent repos paint one red per
-  # release before their upstream publishes. Naming only the ROOTS (the repos with no upstreams:
-  # MeshWeaver.Plugins) gets the identical result quietly, because the satellite→satellite edge in
-  # node-repo-publish-bake carries the wave the rest of the way. Either list is safe; the roots-only
-  # list is the tidy one.
-  # 🚧 TRANSITIONAL — ADDRESSED notification, where the design calls for a BROADCAST.
-  # A publisher must not know its dependents: a release is announced once, to everyone, and whoever
-  # depends on it reacts. `BAKE_SUBSCRIBER_REPOS` is a hand-maintained SECOND COPY of a graph memex
-  # already holds (every package root's `requires`, which PackageGraph.Levels already orders), and a
-  # missing entry fails silently — the omitted repo just never rebuilds for the release, with
-  # nothing red anywhere. Kept because the broadcast does not exist yet; the App credential below
-  # at least makes it work rather than sit dormant.
-  # 🚨 DO NOT extend this list to more repos. Naming another dependent is not progress toward the
-  # target shape, it is one more copy of the graph to keep honest. See
-  # Doc/Architecture/ReleaseGates → "A publisher NEVER knows its dependents".
-  notify-dependents:
-    name: "Notify dependent repos"
-    needs: [gate, portal-image, promote]
-    if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      # 🚨 The `secrets` context is NOT available in a step-level `if:`, so configuredness is
-      # probed HERE, in a run step, rather than as a condition on the mint below. Getting that
-      # wrong does not fail loudly — the expression evaluates empty, the step runs anyway, and
-      # the mint fails with an authentication error that reads like a broken credential rather
-      # than an absent one.
-      - name: "Is the dispatch configured?"
-        id: cfg
-        env:
-          APP_ID: ${{ secrets.DEPENDENT_DISPATCH_APP_ID }}
-          APP_KEY: ${{ secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
-          REPOS: ${{ vars.BAKE_SUBSCRIBER_REPOS }}
-        run: |
-          set -euo pipefail
-          if [ -z "${APP_ID:-}" ] || [ -z "${APP_KEY:-}" ] || [ -z "${REPOS:-}" ]; then
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Dependent-repo dispatch NOT CONFIGURED — set repo var BAKE_SUBSCRIBER_REPOS (owner/repo, whitespace-separated) plus secrets DEPENDENT_DISPATCH_APP_ID and DEPENDENT_DISPATCH_APP_PRIVATE_KEY (the meshweaver-cloud GitHub App) so node repos rebake on every framework release."
-            echo "### ⚠️ Dependent-repo dispatch not configured (BAKE_SUBSCRIBER_REPOS / DEPENDENT_DISPATCH_APP_ID / DEPENDENT_DISPATCH_APP_PRIVATE_KEY)" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "configured=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      # The dispatch credential is the **meshweaver-cloud GitHub App** — the SAME machine identity
-      # the registry already uses for private-repo reads, not a second one to keep honest. Why an
-      # App and not a PAT:
-      #   • a PAT belongs to a PERSON — it carries that person's whole access, dies when they
-      #     rotate it or leave, and makes "who released this" a human name in every subscriber's
-      #     audit log;
-      #   • the installation grants exactly `contents: write` + `metadata: read`, which is the
-      #     minimum `POST /repos/{owner}/{repo}/dispatches` needs and nothing more;
-      #   • the minted token expires in an hour, so a leak has a floor on its blast radius.
-      # The token is scoped to this owner's installation; every subscriber must be a repo the
-      # App is installed on (it is installed org-wide today).
-      - name: "Mint an installation token for the subscribers"
-        id: app
-        if: steps.cfg.outputs.configured == 'true'
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.DEPENDENT_DISPATCH_APP_ID }}
-          private-key: ${{ secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: "Dispatch meshweaver-framework-released"
-        if: steps.cfg.outputs.configured == 'true'
-        env:
-          TOKEN: ${{ steps.app.outputs.token }}
-          REPOS: ${{ vars.BAKE_SUBSCRIBER_REPOS }}
-          SHA: ${{ needs.gate.outputs.sha }}
-          VERSION: ${{ needs.portal-image.outputs.version }}
-        run: |
-          set -euo pipefail
-          for repo in $REPOS; do
-            echo "→ $repo"
-            curl -sS -o /tmp/resp -w '%{http_code}\n' -X POST \
-              -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/$repo/dispatches" \
-              -d "{\"event_type\":\"meshweaver-framework-released\",\"client_payload\":{\"sha\":\"$SHA\",\"version\":\"$VERSION\"}}" \
-              | grep -q '^2' \
-              || echo "::warning::dispatch to $repo failed ($(cat /tmp/resp)) — its next own push (or the next release) re-bakes it."
-          done
-          echo "### 📣 Framework release dispatched to: $REPOS" >> "$GITHUB_STEP_SUMMARY"
+  # ────────────────── NO DEPENDENT DISPATCH: the wave is PULLED, not pushed ──────────────────
+  # There is deliberately no job here that tells the node repos a release happened.
+  #
+  # There used to be (`notify-dependents`), and its own comment called it TRANSITIONAL — "an
+  # ADDRESSED notification where the design calls for a BROADCAST … a publisher must not know its
+  # dependents". It needed `BAKE_SUBSCRIBER_REPOS` (a hand-maintained second copy of a graph memex
+  # already holds) plus a GitHub App credential with write access to every satellite. It was never
+  # provisioned, so for its whole life it printed "NOT CONFIGURED" and did nothing — while the
+  # fleet quietly stayed a release behind, which is exactly the silent failure the comment warned
+  # a missing entry would cause.
+  #
+  # 🚨 It is not coming back, and adding a token is not the fix. A release is a FACT about the
+  # registry — memex.meshweaver.cloud publishes the released image, and that is the one source of
+  # truth. Each node repo's scheduled run reads it and bakes for the identity it finds
+  # (`Resolve the bake target` in each repo's ci.yml, on the `schedule` trigger). Pull, not push:
+  #   • no credential — the platform needs no write access to any satellite, and no person's PAT
+  #     is in the loop;
+  #   • no list — a new repo participates by having the schedule, not by being named here;
+  #   • no silent gap — a repo that stops baking shows up as an instance HELD on its own
+  #     UpdatePolicy, naming the bundles and the identity, instead of nothing anywhere.
+  #
+  # The cost is latency: up to one schedule interval (twice hourly) instead of seconds. That is
+  # the right trade for removing a cross-repo write credential from the release path.
 
   # ────────────────── NOTIFY THE PLATFORM-UPDATE AGENT (optional) ──────────────────
   # After the release is ARMED (promote's last PUT), tell the registry instance's mesh that a new

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -31,7 +31,7 @@ name: Node repo publish-bake (reusable)
 #     repository_dispatch:
 #       # BOTH: the platform releasing, and an UPSTREAM of this repo publishing (#1755). The second
 #       # is what wakes a run that exited because its upstreams were not ready yet.
-#       types: [meshweaver-framework-released, meshweaver-upstream-published]
+#       types: [meshweaver-framework-released]
 #
 #   publish-bake:
 #     if: >
@@ -417,8 +417,11 @@ jobs:
             echo "Building anyway would gate this repo's content against an upstream that does not"
             echo "match the framework it is being built for."
             echo ""
-            echo "**Nothing to do.** This run is re-triggered automatically when the missing"
-            echo "upstream publishes (\`meshweaver-upstream-published\`)."
+            echo "**Nothing to do — if this repo has the \`schedule\` trigger.** The next"
+            echo "scheduled run re-reads the released image and rebuilds once the upstream has"
+            echo "published. Nothing wakes this repo otherwise: the dependent-dispatch lane was"
+            echo "removed deliberately (no cross-repo write credential), so a repo WITHOUT the"
+            echo "schedule stays behind here silently."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::error title=Upstreams not ready — did not build::at least one upstream of this repo has no published artifact for framework identity ${{ steps.identity.outputs.identity }}; exiting without building. The upstream's own publication re-triggers this run."
           exit 1
@@ -608,7 +611,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       # ────────────────── NO DEPENDENT DISPATCH: the wave is PULLED ──────────────────
-      # This used to POST `meshweaver-upstream-published` to repos named by `dependent-repos`,
+      # This used to POST an upstream-published event to repos named by `dependent-repos`,
       # using a token with write access to each of them. Both are gone.
       #
       # A publication is a FACT about the registry, not a message a publisher owes its readers.

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -56,7 +56,6 @@ name: Node repo publish-bake (reusable)
 #       bake-publish-targets: ${{ vars.BAKE_PUBLISH_TARGETS }}
 #       upstream-sources: plugins                    # exit unless `plugins` is published for the
 #                                                    # framework identity this bake targets
-#       dependent-repos: ''                          # e.g. Systemorph/MeshWeaver.Reinsurance
 #       stage-repo: Systemorph/MeshWeaver.Plugins
 #       stage-modules: Store
 #     secrets:
@@ -66,7 +65,6 @@ name: Node repo publish-bake (reusable)
 #       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
 #       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 #       stage-repo-token: ${{ secrets.MESHWEAVER_REPO_TOKEN }}
-#       dependent-dispatch-token: ${{ secrets.DEPENDENT_DISPATCH_TOKEN }}   # iff dependent-repos
 #
 # The real topology, and the order it produces without any central scheduler:
 #
@@ -148,16 +146,6 @@ on:
         required: false
         type: string
         default: ''
-      dependent-repos:
-        description: >-
-          Repositories to notify (owner/repo, whitespace-separated) once THIS repo's publication
-          lands — the satellite→satellite edge of the cascade. It is what wakes a downstream repo
-          that exited on `upstream-sources`, so without it that repo never rebuilds for the
-          release. Declaring it REQUIRES the `dependent-dispatch-token` secret; declaring one
-          without the other fails red rather than silently breaking the chain.
-        required: false
-        type: string
-        default: ''
       stage-repo:
         description: >-
           Repository to stage cross-repo modules from (e.g. Systemorph/MeshWeaver.Plugins),
@@ -233,12 +221,6 @@ on:
       stage-repo-token:
         description: Token able to read stage-repo (needed only when stage-modules is set).
         required: false
-      dependent-dispatch-token:
-        description: >-
-          Token with repo scope on every repo named by `dependent-repos`, used to fire the
-          `meshweaver-upstream-published` event that wakes them. Required exactly when
-          `dependent-repos` is set.
-        required: false
 
 jobs:
   publish-bake:
@@ -262,8 +244,6 @@ jobs:
           STAGE_TOKEN: ${{ secrets.stage-repo-token }}
           BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
           STAGE_MODULES: ${{ inputs.stage-modules }}
-          DEPENDENT_REPOS: ${{ inputs.dependent-repos }}
-          DEPENDENT_TOKEN: ${{ secrets.dependent-dispatch-token }}
           NARROW: ${{ inputs.narrow-by-affected }}
           PRE_BAKE: ${{ inputs.pre-bake-script }}
         run: |
@@ -283,9 +263,6 @@ jobs:
           # break the chain silently — every downstream repo would sit un-rebuilt for the whole
           # release with nothing red anywhere. Asserted here, as a DECLARED-INPUT check, never as
           # an "is the secret set?" probe that decides whether to run.
-          if [ -n "${DEPENDENT_REPOS:-}" ] && [ -z "${DEPENDENT_TOKEN:-}" ]; then
-            missing+=("dependent-dispatch-token (secret) — token with repo scope on ${DEPENDENT_REPOS}; without it this repo's publication cannot wake its dependents and they never rebuild for the release")
-          fi
           # 🚨 A DECLARED-INPUT contradiction, asserted here rather than resolved silently at run
           # time. A pre-bake hook that writes BAKE_MOUNT_DIR OWNS the mount's composition (it can
           # filter, snapshot or synthesise packages), so "the affected closure" is not a set this
@@ -629,59 +606,22 @@ jobs:
             echo "- identity: \`$(cat "$BAKE_DIR/framework-mvid.txt")\`"
             echo "- source: \`${{ inputs.bake-source }}\`  targets: \`${BAKE_PUBLISH_TARGETS}\`"
           } >> "$GITHUB_STEP_SUMMARY"
-      # ───────────────────── WAKE THE DEPENDENTS (#1755) ─────────────────────
-      # 🚨 The edge that makes "exit, don't wait" work at all. A downstream repo whose upstream was
-      # not ready EXITED — it is not polling and nothing else will ever start it again. This
-      # publication is the event it is waiting for, so this repo fires it.
+
+      # ────────────────── NO DEPENDENT DISPATCH: the wave is PULLED ──────────────────
+      # This used to POST `meshweaver-upstream-published` to repos named by `dependent-repos`,
+      # using a token with write access to each of them. Both are gone.
       #
-      # Until this existed only the PLATFORM dispatched, so the very first satellite→satellite
-      # dependency (Education on Plugins) would have deadlocked on its first use: Education exits,
-      # Plugins publishes, and nothing tells Education to try again until the next platform release.
+      # A publication is a FACT about the registry, not a message a publisher owes its readers.
+      # memex.meshweaver.cloud is the one source of truth for what is released and what is sealed;
+      # a dependent repo's SCHEDULED run reads it and rebuilds if it must. Pull, not push — so no
+      # cross-repo credential exists to leak, no hand-maintained dependents list can silently omit
+      # a repo, and a repo that stops rebuilding surfaces as an instance HELD on its own
+      # UpdatePolicy (naming the bundles and the identity) rather than as nothing at all.
       #
-      # It runs only after the publish it announces — an event claiming an artifact that is not
-      # sealed would send every dependent into a build against something that is not there. The
-      # payload carries the framework identity so a receiver can gate on the exact generation, and
-      # the platform version when this run was itself woken by one (the receiver needs it to resolve
-      # the released image).
-      # …and only when there WAS a publication to announce. scope=none means the artefact the
-      # dependents gate on is already sealed — a dependent that exited waiting for it did so
-      # before it existed, and the run that created it fired this event then. Waking them for a
-      # no-op would put every downstream repo through a full build on every scheduled poll.
-      - name: Notify dependent repos
-        if: inputs.dependent-repos != '' && steps.scope.outputs.scope != 'none'
-        env:
-          TOKEN: ${{ secrets.dependent-dispatch-token }}
-          REPOS: ${{ inputs.dependent-repos }}
-          SOURCE: ${{ inputs.bake-source }}
-          VERSION: ${{ github.event.client_payload.version }}
-        run: |
-          set -euo pipefail
-          # The token is asserted in preflight (declaring dependents declares the obligation), so
-          # reaching here without one is impossible rather than tolerated.
-          IDENTITY="$(cat "$BAKE_DIR/framework-mvid.txt" | tr -d '[:space:]')"
-          failed=0
-          for repo in $REPOS; do
-            echo "→ $repo"
-            code=$(curl -sS -o /tmp/dispatch-resp -w '%{http_code}' -X POST \
-              -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/$repo/dispatches" \
-              -d "{\"event_type\":\"meshweaver-upstream-published\",\"client_payload\":{\"source\":\"$SOURCE\",\"identity\":\"$IDENTITY\",\"version\":\"${VERSION:-}\",\"sha\":\"$GITHUB_SHA\"}}") || code=000
-            case "$code" in
-              2*) echo "woken: $repo";;
-              # 🚨 NOT a warning. A lost dispatch here leaves a repo that already exited with
-              # nothing to wake it — it silently never rebuilds for this release, which is the
-              # terminal-exit failure #1755 names explicitly. The publication itself has already
-              # landed and is idempotent, so failing the job is safe and a re-run re-notifies.
-              *)  echo "::error::could not wake $repo (HTTP $code: $(cat /tmp/dispatch-resp)) — it exited waiting for THIS publication and nothing else will re-trigger it."
-                  failed=1;;
-            esac
-          done
-          echo "### 📣 Dependents woken: $REPOS" >> "$GITHUB_STEP_SUMMARY"
-          exit "$failed"
-      # 🚨 An explicit, GREEN step rather than a tail of grey skips. "Already published" and "the
-      # job silently did nothing" render identically in the UI otherwise, and AGENTS.md's rule is
-      # that a gate which did not run must never look like one that passed. This one says which
-      # verdict was reached, on what evidence, and names both shas.
+      # 🚨 A caller that relies on this MUST have the `schedule` trigger. Without it the repo only
+      # ever bakes against its pin on its own pushes, never against the released image, and the
+      # fleet stays a release behind with everything green.
+
       - name: Nothing to bake (this content is already sealed for this identity)
         if: steps.scope.outputs.scope == 'none'
         env:

--- a/test/MeshWeaver.Documentation.Test/UpstreamBuildGateGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/UpstreamBuildGateGuard.cs
@@ -61,7 +61,7 @@ public class UpstreamBuildGateGuard
     /// passed. This asserts the two shapes that would do it.
     /// </summary>
     [Fact]
-    public void NeitherTheGateNorTheDispatchCanBeSkippedOrDowngraded()
+    public void TheGateCannotBeSkippedOrDowngraded()
     {
         var body = Body();
 
@@ -73,54 +73,8 @@ public class UpstreamBuildGateGuard
         Assert.Contains("::error", gateBlock, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// 🚨 The edge that makes "exit, don't wait" work: a repo that exited is woken ONLY by its
-    /// upstream's publication event. If that dispatch is lost and the job still passes, the
-    /// downstream repo silently never rebuilds for the release — the terminal-exit failure #1755
-    /// names explicitly. So a failed dispatch must fail the job, never merely warn.
-    /// </summary>
-    [Fact]
-    public void ALostWakeUpFailsTheJob_RatherThanWarning()
-    {
-        var notify = SectionAfter(Body(), "Notify dependent repos");
 
-        Assert.Contains("meshweaver-upstream-published", notify, StringComparison.Ordinal);
-        Assert.Contains("::error", notify, StringComparison.Ordinal);
-        Assert.DoesNotContain("::warning", notify, StringComparison.Ordinal);
-    }
 
-    /// <summary>
-    /// 🚨 The dispatch may only announce a publication that actually sealed. Firing it earlier
-    /// would send every dependent into a build against an artifact that is not there — turning one
-    /// repo's failure into the whole wave's.
-    /// </summary>
-    [Fact]
-    public void TheWakeUpFiresOnlyAfterThePublication()
-    {
-        var body = Body();
-        var publish = body.IndexOf("publish-bake-bundles.sh", StringComparison.Ordinal);
-        // The STEP's position, not the first mention of the event name — the input/secret
-        // declarations at the top of the file name it too, and comparing against those would make
-        // this assertion pass or fail for reasons that have nothing to do with ordering.
-        var notify = body.IndexOf("Notify dependent repos", StringComparison.Ordinal);
-
-        Assert.True(publish > 0 && notify > publish,
-            "the dependent wake-up must come after the publish step it announces.");
-    }
-
-    /// <summary>
-    /// Declaring dependents declares an OBLIGATION, so the token is asserted as a declared-input
-    /// check — never as an "is the secret set?" probe deciding whether to run, which is the exact
-    /// trapdoor that let the cross-repo plugin gate report green without ever running.
-    /// </summary>
-    [Fact]
-    public void DeclaringDependentsWithoutATokenIsPreflightedRed()
-    {
-        var preflight = SectionAfter(Body(), "Preflight: the publish credentials");
-
-        Assert.Contains("DEPENDENT_REPOS", preflight, StringComparison.Ordinal);
-        Assert.Contains("dependent-dispatch-token", preflight, StringComparison.Ordinal);
-    }
 
     /// <summary>Everything from <paramref name="marker"/> to the next step boundary at the same
     /// indent, so an assertion about one step cannot be satisfied by another.</summary>
@@ -140,5 +94,27 @@ public class UpstreamBuildGateGuard
             dir = dir.Parent;
         Assert.NotNull(dir);
         return dir!.FullName;
+    }
+
+    /// <summary>
+    /// 🚨 The wave is PULLED, and no credential may creep back in.
+    ///
+    /// <para>This workflow used to POST <c>meshweaver-upstream-published</c> to a declared list of
+    /// dependent repos, using a token with write access to each. Both are gone: a publication is a
+    /// FACT about the registry, and a dependent repo's scheduled run reads memex for the released
+    /// image and rebuilds if it must.</para>
+    ///
+    /// <para>Pinned because the tempting fix, when a satellite is found a release behind, is to add
+    /// the token back — which reintroduces a cross-repo write credential AND a hand-maintained
+    /// second copy of a graph memex already holds, whose missing entry fails silently.</para>
+    /// </summary>
+    [Fact]
+    public void ThereIsNoDependentDispatch_AndNoCredentialForOne()
+    {
+        var body = Body();
+
+        Assert.DoesNotContain("dependent-dispatch-token", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("meshweaver-upstream-published", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("/dispatches", body, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Why memex is showing an old release

It is not stuck — it is **holding, correctly**. `Admin/UpdatePolicy` says:

> `heldTag: 3.0.0-rc7.ci.4928` — *"no sealed content bake for framework identity `se3bf749…` — the bundle 'Store' is not published for release 3.0.0-rc7.ci.4928, so this instance would recompile it at boot"*

Nine bundles missing. The instance refuses to roll into a state where every pod Roslyn-compiles content at boot. **The gate is right; the bake never happened.**

## Why the bake never happened

A bake targets the **released image** only on a `repository_dispatch`. That dispatch was **never provisioned** — for its entire life `notify-dependents` printed *"NOT CONFIGURED"* and did nothing, while the fleet stayed a release behind with every check green.

Meanwhile `main` pushes kept re-baking the **pin's** identity, which is already published. So no amount of merging could ever satisfy an instance's hold. The last successful bake sealed `s429a849…`; memex wants `se3bf749…`. They never meet.

The job's own comment called it out:

> 🚧 TRANSITIONAL — an ADDRESSED notification where the design calls for a BROADCAST … a publisher must not know its dependents … a missing entry fails silently.

It did exactly that, for months.

## The fix is not to finally provision the token

A release is a **fact about the registry**. memex.meshweaver.cloud publishes the released image; each node repo's **scheduled** run reads it and bakes for the identity it finds. Pull, not push:

- **no credential** — the platform needs no write access to any satellite, and no person's PAT sits in the release path
- **no list** — a repo participates by having the schedule, not by being named in `BAKE_SUBSCRIBER_REPOS`, a hand-kept second copy of a graph memex already holds
- **no silent gap** — a repo that stops baking surfaces as an instance **HELD** on its own UpdatePolicy, naming the bundles and the identity, instead of nothing anywhere

Removed:

| Where | What |
|---|---|
| `main-cd.yml` | the whole `notify-dependents` job — `BAKE_SUBSCRIBER_REPOS`, `DEPENDENT_DISPATCH_APP_ID`, `DEPENDENT_DISPATCH_APP_PRIVATE_KEY` |
| `node-repo-publish-bake.yml` | the satellite→satellite lane — `dependent-repos` input, `dependent-dispatch-token` secret, its preflight assertion and the notify step |

No caller passes either — checked all four node repos. Both workflows parse.

The cost is **latency**: up to one schedule interval (twice hourly) instead of seconds. That is the right trade for removing a cross-repo write credential from the release path.

## 🚨 Follow-up — the model needs this to work

Only **MeshWeaver.Plugins** has the `schedule` trigger. Education, SocialMedia and Reinsurance have none, so they only ever bake against their pin on their own pushes.

They are **not regressed** by this PR — the dispatch that was supposed to wake them never ran — but they need the schedule to participate at all. Three one-line PRs, which I'll open next.

## Unblocking memex right now

I hand-fired `meshweaver-framework-released` on all four repos (the documented remedy), so a release-targeted bake is running. That should seal the missing bundles and let memex un-hold on its own.