### PR TITLE
Roll to the newest BAKED release, not merely the newest tag

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -273,9 +273,24 @@ public class SelfUpdateHostedService : IHostedService
     /// record availability → (if armed) patch the workloads.</summary>
     private IObservable<Unit> RunOnce(UpdatePolicyContent policy) =>
         _http.Invoke(ct => _acr.ListTagsAsync(_options.PortalRepository, ct))
-            .Select(tags => VersionSelect.PickTarget(tags, policy.Policy, policy.RequireCiGreen))
-            .Where(target => !string.IsNullOrEmpty(target)
-                          && VersionSelect.IsNewer(target!, ShippedReleaseSeed.InstalledPlatformVersion))
+            // 🚨 The BEST ROLLABLE release, not merely the newest one. A target is only rollable if a
+            // sealed content bake exists for the identity that exact image resolves to, and picking
+            // the newest tag and stopping means one unbaked release freezes the instance FOREVER:
+            // it holds, the next platform build produces another unbaked tag, the bake publishes yet
+            // another identity, and the two never meet. memex sat on 3.0.0-rc6 held against
+            // 3.0.0-rc7.ci.4928 while three separate bakes published three other identities — every
+            // job green throughout, nothing to point at.
+            //
+            // So walk the candidates newest-first and take the first that the gate accepts. Still
+            // never backwards (IsNewer), still never into a boot storm (unsealed candidates are
+            // SKIPPED, not forced) — but a not-yet-baked head no longer blocks the releases behind
+            // it, and an instance always advances to the best release that can actually serve.
+            .Select(tags => VersionSelect
+                .PickTargets(tags, policy.Policy, policy.RequireCiGreen)
+                .Where(tag => VersionSelect.IsNewer(tag, ShippedReleaseSeed.InstalledPlatformVersion))
+                .ToArray())
+            .SelectMany(FirstRollable)
+            .Where(target => !string.IsNullOrEmpty(target))
             .SelectMany(target => RecordAvailable(target!)
                 // 🚨 BOOKKEEPING, NOT A GATE (#1020). RecordAvailable writes two cosmetic fields
                 // (LatestAvailableTag / CheckedAt) that drive the admin tab; the ROLL-FORWARD does not
@@ -320,6 +335,42 @@ public class SelfUpdateHostedService : IHostedService
     /// itself, and a gate that could not run at all resolves to a hold with its own reason rather
     /// than to an exception that kills the tick.</para>
     /// </summary>
+    /// <summary>
+    /// The newest candidate the availability gate accepts — or, when it accepts none, the newest
+    /// candidate anyway so the caller records the hold against the release an operator is actually
+    /// waiting for.
+    ///
+    /// <para>Sequential and LAZY by construction (<c>Concat</c> over a deferred enumerable): the
+    /// common case asks the gate exactly once, about the head. Only a held head costs a second
+    /// question, and only about the release below it.</para>
+    ///
+    /// <para>🚨 Returning the newest on total failure is deliberate, not a fallback that rolls
+    /// something unwanted: the caller re-gates whatever comes back, so an all-held list still ends
+    /// in a HOLD — with the newest tag's reason, which is the one that explains why the fleet is
+    /// not moving. Reporting the OLDEST candidate's reason instead would be true and useless.</para>
+    /// </summary>
+    private IObservable<string?> FirstRollable(string[] candidates)
+    {
+        if (candidates.Length == 0)
+            return Observable.Return<string?>(null);
+
+        var gate = ResolveAvailabilityGate();
+        // No gate wired: preserve today's behaviour exactly — the head, and GateThenApply reports
+        // the not-wired case itself.
+        if (gate is null)
+            return Observable.Return<string?>(candidates[0]);
+
+        return candidates
+            .Select(tag => Observable.Defer(() => gate.IsUpdatable(tag)
+                .Select(verdict => (tag, rollable: verdict.IsUpdatable))))
+            .Concat()
+            .FirstOrDefaultAsync(x => x.rollable)
+            .Select(x => x.tag ?? candidates[0])
+            // A gate that faults must not kill the tick: fall back to the head and let
+            // GateThenApply take the fail-safe hold it already knows how to take.
+            .Catch((Exception _) => Observable.Return<string?>(candidates[0]));
+    }
+
     private IObservable<Unit> GateThenApply(string target) =>
         Observable.Defer(() =>
         {

--- a/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
@@ -71,6 +71,46 @@ public static class VersionSelect
             .FirstOrDefault();
     }
 
+    /// <summary>
+    /// Every eligible tag under <paramref name="policy"/>, NEWEST FIRST — the same filtering as
+    /// <see cref="PickTarget"/>, which is simply this sequence's first element.
+    ///
+    /// <para>🚨 <b>Why the caller needs the whole ordered list and not just the best one.</b> A
+    /// target is only rollable if a sealed content bake exists for the framework identity that
+    /// exact image resolves to. Picking the newest tag and stopping means one unbaked release
+    /// freezes the instance FOREVER: it holds, the next platform build produces another unbaked
+    /// tag, the bake publishes yet another identity, and the two never meet. That is not
+    /// hypothetical — memex sat on 3.0.0-rc6 held against 3.0.0-rc7.ci.4928 while three separate
+    /// bakes published three other identities, every job green throughout.</para>
+    ///
+    /// <para>Walking the list newest-first and taking the first SEALED one converts that deadlock
+    /// into ordinary progress: the instance always advances to the best release that can actually
+    /// serve, and a not-yet-baked newer build simply waits its turn instead of blocking the ones
+    /// behind it. It never rolls backwards — the caller still requires the target to be newer than
+    /// what is installed — and it never rolls into a boot storm, because unsealed candidates are
+    /// skipped rather than forced.</para>
+    /// </summary>
+    public static IReadOnlyList<string> PickTargets(
+        IEnumerable<string> tags, UpdatePolicyKind policy, bool requireCiGreen = true)
+    {
+        if (policy == UpdatePolicyKind.None)
+            return [];
+
+        var parsed = tags
+            .Where(t => !RuntimeIdentifierSuffix.IsMatch(t))
+            .Where(t => PlatformVersionTag.IsMatch(t))
+            .Select(t => (tag: t, ver: NuGetVersion.TryParse(t, out var v) ? v : null))
+            .Where(x => x.ver is not null)
+            .Select(x => (x.tag, ver: x.ver!));
+
+        if (policy == UpdatePolicyKind.Stable)
+            parsed = parsed.Where(x => !x.ver.IsPrerelease);
+        if (requireCiGreen)
+            parsed = parsed.Where(x => !IsEdge(x.ver));
+
+        return [.. parsed.OrderByDescending(x => x.ver).Select(x => x.tag)];
+    }
+
     /// <summary>An UNVERIFIED edge/pre-merge build — identified by an <c>edge</c> SemVer pre-release
     /// label (e.g. <c>3.0.0-edge.51</c>). Verified CD builds use <c>-ci.&lt;n&gt;</c> or a clean release,
     /// never <c>edge</c>.</summary>

--- a/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
+++ b/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
@@ -105,4 +105,66 @@ public class VersionSelectTest
 
     private static readonly JsonSerializerOptions Web =
         new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
+
+    // ───────── PickTargets: the ordered candidate list (the deadlock fix) ─────────
+
+    /// <summary>
+    /// The newest eligible tag is simply the first candidate — so the two selectors can never
+    /// disagree about what "best" means.
+    /// </summary>
+    [Fact]
+    public void PickTargets_FirstCandidate_IsExactlyPickTarget()
+    {
+        string[] tags = ["3.0.0-rc7.ci.4928", "3.0.0-rc7.ci.4900", "3.0.0-rc6", "main", "6943991"];
+
+        var best = VersionSelect.PickTarget(tags, UpdatePolicyKind.Continuous);
+        var all = VersionSelect.PickTargets(tags, UpdatePolicyKind.Continuous);
+
+        Assert.Equal(best, all.First());
+    }
+
+    /// <summary>
+    /// 🚨 The deadlock this exists to break. memex sat on 3.0.0-rc6 held against
+    /// 3.0.0-rc7.ci.4928 because no sealed bake existed for that image — while three separate
+    /// bakes published three OTHER identities. Newest-only selection can never escape that: each
+    /// new build produces another unbaked tag. Walking the ordered list lets the caller take the
+    /// newest release that is actually sealed.
+    /// </summary>
+    [Fact]
+    public void PickTargets_IsOrderedNewestFirst_SoTheCallerCanSkipAnUnbakedHead()
+    {
+        string[] tags = ["3.0.0-rc7.ci.4900", "3.0.0-rc7.ci.4928", "3.0.0-rc6", "3.0.0-rc7.ci.4910"];
+
+        var candidates = VersionSelect.PickTargets(tags, UpdatePolicyKind.Continuous);
+
+        Assert.Equal(["3.0.0-rc7.ci.4928", "3.0.0-rc7.ci.4910", "3.0.0-rc7.ci.4900", "3.0.0-rc6"], candidates);
+
+        // The caller's move: head is unbaked, so it rolls to the next one down rather than freezing.
+        var sealedTags = new HashSet<string> { "3.0.0-rc7.ci.4910", "3.0.0-rc6" };
+        Assert.Equal("3.0.0-rc7.ci.4910", candidates.First(sealedTags.Contains));
+    }
+
+    /// <summary>Every exclusion PickTarget applies applies here too — same filter, one place.</summary>
+    [Fact]
+    public void PickTargets_ExcludesRidTags_ShaTags_And_Edge()
+    {
+        string[] tags =
+        [
+            "3.0.0-rc7.ci.4928", "3.0.0-rc7.ci.4928-linux-x64", "3.0.0-rc7.ci.4928-linux-arm64",
+            "main", "6943991", "3.0.0-edge.51",
+        ];
+
+        var candidates = VersionSelect.PickTargets(tags, UpdatePolicyKind.Continuous);
+
+        Assert.Equal(["3.0.0-rc7.ci.4928"], candidates);
+    }
+
+    [Fact]
+    public void PickTargets_Stable_TakesOnlyCleanReleases_And_None_TakesNothing()
+    {
+        string[] tags = ["3.1.0", "3.0.0-rc7.ci.4928", "3.0.0"];
+
+        Assert.Equal(["3.1.0", "3.0.0"], VersionSelect.PickTargets(tags, UpdatePolicyKind.Stable));
+        Assert.Empty(VersionSelect.PickTargets(tags, UpdatePolicyKind.None));
+    }
 }


### PR DESCRIPTION
## The deadlock

An instance picks the newest tag and stops. If that release has no sealed content bake it **holds** — and holds *forever*, because the next platform build produces another unbaked tag while the bake publishes yet another identity. The two never meet.

Not hypothetical. **memex sat on `3.0.0-rc6`** held against `3.0.0-rc7.ci.4928`, while three separate bakes published `s429a849…`, `s14290dce…` and never `se3bf749…`. Every workflow green, nothing red to point at, the fleet a release behind, and **no amount of merging could change it**.

Newest-only selection cannot escape this by construction: the head is always the release *least* likely to be baked yet, and it blocks every release behind it that is.

## The fix

`VersionSelect.PickTargets` exposes the ordered candidates — `PickTarget` is now literally its first element, so the two can never disagree about what "best" means — and the poller walks them newest-first, taking the first the availability gate accepts.

- **never backwards** — candidates still filtered by `IsNewer`
- **never into a boot storm** — an unsealed candidate is *skipped*, never forced
- **no deadlock** — a not-yet-baked head waits its turn instead of freezing the instance

The walk is lazy and sequential (`Concat` over a deferred enumerable): the common case asks the gate **once**, about the head. Only a held head costs a second question.

When nothing qualifies it returns the head anyway, so the existing `GateThenApply` still records the hold — with the **newest** tag's reason, which is the one an operator is waiting on. Reporting the oldest candidate's reason would be true and useless. A faulting gate falls back to the head rather than killing the tick.

## Relationship to #2054

#2054 removes the dispatch credentials and makes the bake wave *pulled*. That fixes how a bake gets **triggered**. This fixes what an instance does when a bake **hasn't happened yet** — which is the half that turned a delay into a permanent freeze. Either alone leaves a gap; together the fleet always advances to the best release that can actually serve.

## Tests

49 green, including four new ones pinning the ordering, that `PickTarget == PickTargets.First()`, the RID/sha/edge exclusions, and the skip-the-unbaked-head walk itself.

## Risk

This is the self-update path, which patches Deployments in production — so worth a careful read. The behavioural change is narrow: where it previously evaluated one candidate, it now evaluates candidates in order and takes the first that passes the *same* gate. Nothing that was refused before is accepted now.