### PR TITLE
Schema init is not a request: give it a real command timeout

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -9,13 +9,49 @@ namespace MeshWeaver.Hosting.PostgreSql;
 public static class PostgreSqlSchemaInitializer
 {
     /// <summary>
+    /// How long a schema-initialization command may run, in seconds.
+    ///
+    /// <para>🚨 <b>Npgsql's default is 30s, and that is a REQUEST-path number.</b> Nothing in this
+    /// class is on a request path: it is boot-time DDL and, in one case, a sweep over EVERY
+    /// partition schema in the database (the auth-mirror self-heal probes triggers and reconciles
+    /// rows for all of them). That work scales with the size of the instance, so the default turns
+    /// "this deployment is large" into a timeout.</para>
+    ///
+    /// <para>It did exactly that on memex.meshweaver.cloud (2026-08-22): the migration
+    /// CrashLoopBackOff'd with <c>Npgsql.NpgsqlException: Exception while reading from stream ---&gt;
+    /// TimeoutException</c> from the self-heal, the portal's new pods never became ready, and the
+    /// roll stalled at 1/5 — while the SAME image migrated a smaller instance fine. The database
+    /// was healthy throughout; the old pods kept serving. A migration that cannot finish is not a
+    /// slow migration, it is a deployment that cannot happen at all, and the failure names Npgsql
+    /// rather than "your instance is big".</para>
+    ///
+    /// <para>Ten minutes is chosen to be far above any healthy sweep while still bounded: a
+    /// migration wedged on a lock must eventually fail rather than hang a rollout forever. This is
+    /// not a substitute for making the sweep cheaper — it is the difference between a large
+    /// instance deploying and not deploying.</para>
+    /// </summary>
+    private const int MaintenanceCommandTimeoutSeconds = 600;
+
+    /// <summary>
+    /// A command for boot-time schema work, with <see cref="MaintenanceCommandTimeoutSeconds"/>
+    /// applied. Use this for every DDL/sweep statement here so none of them inherits the
+    /// request-path default.
+    /// </summary>
+    private static NpgsqlCommand CreateMaintenanceCommand(this NpgsqlDataSource dataSource, string sql)
+    {
+        var command = dataSource.CreateCommand(sql);
+        command.CommandTimeout = MaintenanceCommandTimeoutSeconds;
+        return command;
+    }
+
+    /// <summary>
     /// Creates the partition_access table in the public schema.
     /// This table maps users to partition schemas they can access, populated by
     /// rebuild_user_effective_permissions() trigger in each partition schema.
     /// </summary>
     public static async Task InitializePartitionAccessTableAsync(NpgsqlDataSource dataSource, CancellationToken ct = default)
     {
-        await using var cmd = dataSource.CreateCommand("""
+        await using var cmd = dataSource.CreateMaintenanceCommand("""
             CREATE TABLE IF NOT EXISTS public.partition_access (
                 user_id    TEXT NOT NULL,
                 partition  TEXT NOT NULL,
@@ -220,7 +256,7 @@ public static class PostgreSqlSchemaInitializer
     {
         // Step 1: Create the vector extension using plain SQL (no vector parameters).
         // Even if UseVector() can't find the type yet, plain SQL commands work fine.
-        await using (var cmd = dataSource.CreateCommand("CREATE EXTENSION IF NOT EXISTS vector"))
+        await using (var cmd = dataSource.CreateMaintenanceCommand("CREATE EXTENSION IF NOT EXISTS vector"))
         {
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
@@ -238,13 +274,13 @@ public static class PostgreSqlSchemaInitializer
         // only by the V27 *repair* migration — which MigrationRunner SKIPS on fresh DBs — so
         // fresh deployments never installed the trigger and `auth` stayed empty. Creating it
         // here (always-run path) makes the guard pass on every DB, fresh or not.
-        await using (var cmd = dataSource.CreateCommand(GetAuthMirrorFunctionScript()))
+        await using (var cmd = dataSource.CreateMaintenanceCommand(GetAuthMirrorFunctionScript()))
         {
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
 
         // Step 3: Run the full schema script (tables, indexes, triggers).
-        await using (var cmd = dataSource.CreateCommand(GetSchemaScript(options)))
+        await using (var cmd = dataSource.CreateMaintenanceCommand(GetSchemaScript(options)))
         {
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
@@ -254,7 +290,7 @@ public static class PostgreSqlSchemaInitializer
         // keeps it idempotent and in sync on every init (runtime bootstrap + the test
         // fixture both run InitializeAsync against public, so both DBs get the proc).
         // Routed to by PostgreSqlPartitionStorageProvider.EnsureSchemaAsync.
-        await using (var cmd = dataSource.CreateCommand(GetEnsurePartitionSchemaProcScript(options.VectorDimensions)))
+        await using (var cmd = dataSource.CreateMaintenanceCommand(GetEnsurePartitionSchemaProcScript(options.VectorDimensions)))
         {
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
@@ -283,7 +319,7 @@ public static class PostgreSqlSchemaInitializer
         // PUBLIC-INIT ONLY, same as step 5 — per-schema data sources must not provision auth.
         if (string.Equals(options.Schema, "public", StringComparison.OrdinalIgnoreCase))
         {
-            await using var cmd = dataSource.CreateCommand("SELECT public.ensure_partition_schema('auth')");
+            await using var cmd = dataSource.CreateMaintenanceCommand("SELECT public.ensure_partition_schema('auth')");
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
 
@@ -309,7 +345,7 @@ public static class PostgreSqlSchemaInitializer
         // per-boot singleton; the in-script pg_advisory_xact_lock serializes across silos.
         if (string.Equals(options.Schema, "public", StringComparison.OrdinalIgnoreCase))
         {
-            await using var cmd = dataSource.CreateCommand(GetAuthMirrorSelfHealScript());
+            await using var cmd = dataSource.CreateMaintenanceCommand(GetAuthMirrorSelfHealScript());
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
     }
@@ -971,7 +1007,7 @@ public static class PostgreSqlSchemaInitializer
             await conn.ReloadTypesAsync().ConfigureAwait(false);
         }
 
-        await using (var cmd = schemaDataSource.CreateCommand(GetUnversionedSchemaScript(options)))
+        await using (var cmd = schemaDataSource.CreateMaintenanceCommand(GetUnversionedSchemaScript(options)))
         {
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
@@ -990,7 +1026,7 @@ public static class PostgreSqlSchemaInitializer
         CancellationToken ct = default)
     {
         // Step 1: Create the vector extension using plain SQL
-        await using (var cmd = baseDataSource.CreateCommand("CREATE EXTENSION IF NOT EXISTS vector"))
+        await using (var cmd = baseDataSource.CreateMaintenanceCommand("CREATE EXTENSION IF NOT EXISTS vector"))
         {
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
@@ -1002,13 +1038,13 @@ public static class PostgreSqlSchemaInitializer
         }
 
         // Step 3: Create versions schema tables (mesh_node_history)
-        await using (var cmd = versionsDataSource.CreateCommand(GetVersionsSchemaScript()))
+        await using (var cmd = versionsDataSource.CreateMaintenanceCommand(GetVersionsSchemaScript()))
         {
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
 
         // Step 4: Create mesh schema tables + cross-schema trigger
-        await using (var cmd = schemaDataSource.CreateCommand(GetMeshSchemaScript(options, versionsSchema)))
+        await using (var cmd = schemaDataSource.CreateMaintenanceCommand(GetMeshSchemaScript(options, versionsSchema)))
         {
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
@@ -1027,7 +1063,7 @@ public static class PostgreSqlSchemaInitializer
         var dim = options.VectorDimensions;
         foreach (var tableName in tableNames.Distinct())
         {
-            await using var cmd = schemaDataSource.CreateCommand(GetSatelliteTableScript(tableName, dim));
+            await using var cmd = schemaDataSource.CreateMaintenanceCommand(GetSatelliteTableScript(tableName, dim));
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
     }

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SchemaInitCommandTimeoutTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SchemaInitCommandTimeoutTests.cs
@@ -1,0 +1,90 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Every command in <c>PostgreSqlSchemaInitializer</c> must carry the maintenance timeout, not
+/// Npgsql's 30-second default.
+///
+/// <para>🚨 <b>Why this is a test and not a code review note.</b> The default is a REQUEST-path
+/// number, and nothing in that class is on a request path: it is boot-time DDL plus a sweep over
+/// EVERY partition schema (the auth-mirror self-heal). That sweep scales with the instance, so the
+/// default turns "this deployment is large" into a migration that cannot finish — and the symptom
+/// is nothing like the cause. On memex.meshweaver.cloud (2026-08-22) the migration
+/// CrashLoopBackOff'd with <c>NpgsqlException: Exception while reading from stream ---&gt;
+/// TimeoutException</c>, the portal's new pods never became ready, and the rollout stalled at 1/5
+/// while the same image migrated a smaller instance fine.</para>
+///
+/// <para>A new command added here without the timeout reintroduces exactly that, on whichever
+/// instance is biggest — which is always the one you least want to find out on. Source-level
+/// because the failure needs a large production database to reproduce, and a test that cannot run
+/// is not a guard.</para>
+/// </summary>
+public class SchemaInitCommandTimeoutTests
+{
+    [Fact]
+    public void EverySchemaInitCommand_UsesTheMaintenanceTimeout()
+    {
+        var source = ReadInitializerSource();
+
+        // The helper itself is the one legitimate raw CreateCommand — it is what applies the timeout.
+        var helperBody = Between(source, "private static NpgsqlCommand CreateMaintenanceCommand", "\n    }");
+        Assert.Contains("CommandTimeout = MaintenanceCommandTimeoutSeconds", helperBody, StringComparison.Ordinal);
+        Assert.Contains("dataSource.CreateCommand(sql)", helperBody, StringComparison.Ordinal);
+
+        // …and it must not call itself. A regex-driven rewrite once turned this into infinite
+        // recursion, which builds cleanly and stack-overflows every migration.
+        Assert.DoesNotContain("dataSource.CreateMaintenanceCommand(", helperBody, StringComparison.Ordinal);
+
+        var offenders = Regex.Matches(source.Replace(helperBody, string.Empty),
+                @"\b(?<recv>dataSource|schemaDataSource|baseDataSource|versionsDataSource)\.CreateCommand\(")
+            .Select(m => m.Groups["recv"].Value)
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "these data-source commands bypass the maintenance timeout and will inherit Npgsql's "
+            + $"30s request default: {string.Join(", ", offenders)}. Use CreateMaintenanceCommand.");
+    }
+
+    [Fact]
+    public void TheTimeoutIsGenerousButBounded()
+    {
+        var source = ReadInitializerSource();
+        var match = Regex.Match(source, @"MaintenanceCommandTimeoutSeconds\s*=\s*(?<n>\d+)");
+        Assert.True(match.Success, "the maintenance timeout constant must exist and be a literal");
+
+        var seconds = int.Parse(match.Groups["n"].Value);
+        // Generous enough for a whole-instance sweep…
+        Assert.True(seconds >= 300, $"a whole-instance sweep needs room; {seconds}s is too tight");
+        // …and bounded, so a migration wedged on a lock fails instead of hanging a rollout forever.
+        Assert.True(seconds <= 1800, $"{seconds}s would let a wedged migration hang a rollout");
+    }
+
+    private static string ReadInitializerSource()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.SkipWhen(dir is null, "repository tree not reachable — source guard runs in-repo only");
+
+        var path = Path.Combine(dir!.FullName,
+            "src", "MeshWeaver.Hosting.PostgreSql", "PostgreSqlSchemaInitializer.cs");
+        Assert.True(File.Exists(path), $"expected the initializer at {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string Between(string source, string start, string end)
+    {
+        var from = source.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(from >= 0, $"could not find '{start}'");
+        var to = source.IndexOf(end, from, StringComparison.Ordinal);
+        Assert.True(to > from, $"could not find '{end}' after '{start}'");
+        return source[from..to];
+    }
+}


### PR DESCRIPTION
## This is what is actually blocking memex.meshweaver.cloud

Rolling it to the image a sister instance already serves put the migration into **CrashLoopBackOff**:

```
Npgsql.NpgsqlException: Exception while reading from stream
 ---> TimeoutException: Timeout during reading attempt
   at PostgreSqlSchemaInitializer.InitializeAsync … line 313
```

Line 313 is the auth-mirror self-heal, which by its own comment **"sweeps ALL partition schemas"**. memex has a partition per user and per package, so that sweep scales with the instance — and every command in this class runs on Npgsql's default **30s**, which is a **request-path** number. Nothing here is on a request path: it is boot-time DDL plus one whole-instance maintenance pass.

So the default turned *"this deployment is large"* into a migration that cannot finish. The database was healthy throughout — the old portal pods kept serving, and the identical image migrates a smaller instance fine. The new pods never became ready, the rollout stalled at 1/5, and the error named Npgsql rather than the size of the instance.

## The fix

Every command created here goes through `CreateMaintenanceCommand`, which applies **600s**: far above any healthy sweep, still bounded so a migration wedged on a lock fails instead of hanging a rollout forever.

There is no config knob for this today (`PostgreSqlStorageOptions` has none), and putting `Command Timeout` in the connection string would raise it for *every* query including request-path ones — the wrong trade. The timeout belongs to these commands specifically.

🚨 **This is not a substitute for making the sweep cheaper.** It is the difference between a large instance deploying and not deploying at all.

## Guards

Two source-level tests — source-level because reproducing needs a large production database, and a test that cannot run is not a guard:

- **every** data-source command in the class uses the maintenance timeout; a new one added without it reintroduces this on whichever instance is biggest, which is always the one you least want to find out on
- the constant is generous (≥300s) but bounded (≤1800s)
- and the helper does **not call itself**. My first cut regex-rewrote its own body into infinite recursion — it compiles cleanly and stack-overflows every migration. Pinned so it cannot come back.