### PR TITLE
CD could not load: alert-on-failure still needed the removed job

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1543,7 +1543,7 @@ jobs:
 
   alert-on-failure:
     name: "Alert: CD failed on main"
-    needs: [gate, portal-image, migration-image, plugin-test-image, portal-next-image, promote, verify-images, publish-bake, notify-dependents]
+    needs: [gate, portal-image, migration-image, plugin-test-image, portal-next-image, promote, verify-images, publish-bake]
     if: failure()
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
🚨 **CD has produced no images since #2054 merged.**

#2054 deleted the `notify-dependents` job but left `alert-on-failure` depending on it:

```yaml
needs: [gate, portal-image, …, publish-bake, notify-dependents]   # ← no longer exists
```

A `needs:` naming an undefined job makes the **whole workflow invalid**, so GitHub refuses to load it. Every CD run since has "failed" with **zero jobs** — three runs, no image from any of them.

That is a nastier failure than a failing job: there is no red step to open, the run simply has nothing in it, and the cause is one stale token in a nine-entry list. It also blocked the very fix (#2058) that memex.meshweaver.cloud is waiting on.

Mine, from #2054, and I should have caught it — removing a job means auditing every `needs:`.

## Fix

Dropped the reference, then checked **every** `needs:` in **every** workflow in the repo resolves to a defined job — mechanically, not by eye, because eyeballing is precisely what failed here.

That check is worth having permanently; I'll add it as a guard rather than leaving it as something to remember.