### PR TITLE
fix(#1782 gap 2): the REGISTRY anchors entitlement; the install record is a cache

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -43,14 +43,24 @@ namespace Memex.Portal.Shared.Api;
 /// this one is already what purchases are recorded against.</para>
 ///
 /// <para>🚨 <b>The key is TWO decisions, and for a long time only the first one ran (#1772).</b> The
-/// filter below authenticates — a valid <c>mwi_</c> key or 401 — and <see cref="IsGranted"/>
+/// filter below authenticates — a valid <c>mwi_</c> key or 401 — and <see cref="Decide"/>
 /// authorizes, per package, on <b>both</b> routes. Until #1772 the authenticated caller was written
 /// into <see cref="HttpContext.Items"/> and never read back, so any registered instance could
 /// download every installed package's bundle, paid courses included, while this very paragraph said
 /// otherwise. An instance key is provisioned to every registered installation; it is identity, never
-/// entitlement. The grant model is <see cref="PluginGrantEntry"/> matched against the install
-/// record's <see cref="PackageManifest.Source"/> — the same match <c>InstallByDefault</c> and
-/// <c>/api/plugins</c> make, so there is exactly one thing to keep honest.</para>
+/// entitlement. The grant model is <see cref="PluginGrantEntry"/> — the same match
+/// <c>InstallByDefault</c> and <c>/api/plugins</c> make, so there is exactly one thing to keep
+/// honest.</para>
+///
+/// <para>🚨 <b>The (source, package) binding the grant is matched against is anchored on the
+/// REGISTRY (#1782 gap 2), not on this instance's install records.</b> It used to come from the
+/// record's <see cref="PackageManifest.Source"/> and from nowhere else, which made two things true
+/// that should not have been: a package this instance had not itself installed could not be served
+/// at all (however plainly its content sat here), and "I cannot tell which source this is from" was
+/// answered as "you are not entitled to it". The record is now read as what it is — a CACHE of the
+/// registry's binding — and its absence sends the question upstream. See
+/// <see cref="PackageEntitlementAnchor"/> for the three outcomes and
+/// <see cref="PackageOriginAnchor"/> for the read; the GRANT match itself is untouched.</para>
 ///
 /// <para>🚨 <b>A refusal is byte-identical to "no such bundle"</b> (<see cref="NoSuchBundle"/>), and
 /// an ungranted package is absent from the index. The URL scheme is fully predictable, so a
@@ -116,7 +126,7 @@ public static class PluginBundleEndpoints
         group.MapGet("/{plugin}/{version}",
             (HttpContext http, string plugin, string version, CancellationToken ct) =>
                 Bundle(
-                    RootHub(http), plugin, version,
+                    http, RootHub(http), plugin, version,
                     Requested(http, "identity", FrameworkMvid),
                     Requested(http, "arch", ReleaseArchitecture.Live),
                     Caller(http),
@@ -248,26 +258,44 @@ public static class PluginBundleEndpoints
         http.Items.TryGetValue(CallerItemKey, out var value) ? value as AuthenticatedInstance : null;
 
     /// <summary>
-    /// 🚨 <b>THE PER-PACKAGE AUTHORIZATION</b> (#1772) — whether <paramref name="caller"/> may pull
-    /// <paramref name="package"/>, decided by the admin-owned <see cref="PluginGrant"/> its key
-    /// resolved to.
+    /// 🚨 <b>THE PER-PACKAGE AUTHORIZATION</b> (#1772), now anchored on the REGISTRY (#1782 gap 2) —
+    /// whether <paramref name="caller"/> may pull <paramref name="package"/>, decided by the
+    /// admin-owned <see cref="PluginGrant"/> its key resolved to.
     ///
-    /// <para>The grant is a set of <c>(source, package)</c> pairs, so the install record's
-    /// <see cref="PackageManifest.Source"/> — the registry source it was installed FROM — is what the
-    /// entry is matched against. Exactly the reading <c>PluginRegistryEndpoints</c> applies to its
-    /// listing and <c>InstanceAutoRegistrationService</c> applies to <c>InstallByDefault</c>; a
-    /// second, bundle-specific notion of entitlement would be a second thing to keep in step with
-    /// what purchases are recorded against.</para>
+    /// <para>The grant is a set of <c>(source, package)</c> pairs, and the whole question is where
+    /// the <c>source</c> half comes from. It used to come from the install record's
+    /// <see cref="PackageManifest.Source"/> and nowhere else — so a package this instance had not
+    /// itself installed had NO binding, and "I cannot tell which source this is from" came out as
+    /// "you are not entitled to it". <see cref="PackageEntitlementAnchor"/> inverts that: the
+    /// registry's own catalog is the authority, the install record is a cache of it, and a cache
+    /// miss asks upstream. The GRANT match is untouched — the same
+    /// <see cref="AuthenticatedInstance.Allows(string,string)"/> <c>/api/plugins</c> and <c>InstallByDefault</c>
+    /// make.</para>
     ///
-    /// <para>🚨 <b>An unstamped source fails CLOSED.</b> A record whose <c>Source</c> is null (one
-    /// written before the field existed, or installed from something that is not a configured
-    /// registry source) matches no entry at all — <see cref="PluginGrantEntry.Matches"/> compares the
-    /// source name, and <c>""</c> equals none of them. "Cannot determine" is a refusal, never a pass.
-    /// The consumer's own <c>PluginBundleClient</c> reads the resulting 404 as "no prebuilt bundle —
-    /// will compile", so the cost of that refusal is a compile, never a failed install.</para>
+    /// <para>🚨 <b>An unstamped record no longer fails dark.</b> A record whose <c>Source</c> is null
+    /// used to match no grant entry at all and was servable to nobody, silently. Now it simply
+    /// carries no CACHED binding, so the anchor answers for it — from the registry's catalog, never
+    /// from an invented source. If the anchor cannot be consulted either, the outcome is
+    /// <see cref="EntitlementOutcome.Indeterminate"/>: the bytes are still withheld (the consumer's
+    /// <c>PluginBundleClient</c> reads that 404 as "no prebuilt bundle — will compile", so the cost
+    /// is a compile), but it is recorded as UNKNOWN rather than asserted as a denial.</para>
+    ///
+    /// <para>🚨 <b>A caller the filter did not stamp is granted NOTHING</b>, and that is a real
+    /// negative rather than an unanswerable one: there is no anonymous branch on these routes, so a
+    /// null caller can only mean a route mapped outside the group (#1772).</para>
     /// </summary>
-    private static bool IsGranted(AuthenticatedInstance? caller, BundleEntry package) =>
-        caller is not null && caller.Allows(package.Source ?? "", package.PluginId);
+    private static EntitlementDecision Decide(
+        AuthenticatedInstance? caller, BundleEntry package, PackageOriginSnapshot anchor) =>
+        caller is null
+            ? new EntitlementDecision(
+                package.PluginId, EntitlementOutcome.Denied, EntitlementAnchorKind.None, null, true,
+                "no authenticated caller was stamped — these routes have no anonymous branch")
+            : PackageEntitlementAnchor.Resolve(
+                package.PluginId,
+                anchor.SourceOf(package.PluginId),
+                package.Source,
+                anchor.IsComplete,
+                source => caller.Allows(source, package.PluginId));
 
     /// <summary>
     /// 🚨 The ONE answer for a bundle this caller cannot have — used for "no such package", "no such
@@ -295,6 +323,32 @@ public static class PluginBundleEndpoints
         http.RequestServices.GetRequiredService<IMessageHub>();
 
     /// <summary>
+    /// 🚨 The ENTITLEMENT ANCHOR (#1782 gap 2) — the registry's own catalog, read as the authority
+    /// on which source carries which package.
+    ///
+    /// <para>Resolved from the REQUEST's services first, then the mesh's, exactly like
+    /// <c>ModuleLandingService</c>: it lets a host wire a different anchor (a test, an instance
+    /// serving a curated subset) without a second resolution rule. An instance with no anchor
+    /// registered at all is an authority on nothing — <see cref="AnchorState.Unconfigured"/>, which
+    /// falls back to the local cache and never to a denial.</para>
+    /// </summary>
+    private static PackageOriginAnchor? Anchor(HttpContext http) =>
+        http.RequestServices.GetService<PackageOriginAnchor>()
+        ?? RootHub(http).ServiceProvider.GetService<PackageOriginAnchor>();
+
+    /// <summary>The record that makes a degraded entitlement answer legible (#1782 gap 2). Same
+    /// two-step resolution as <see cref="Anchor"/>.</summary>
+    private static PackageEntitlementLedger? Ledger(HttpContext http) =>
+        http.RequestServices.GetService<PackageEntitlementLedger>()
+        ?? RootHub(http).ServiceProvider.GetService<PackageEntitlementLedger>();
+
+    /// <summary>Reads the anchor, or reports it unconfigured when this instance registers none.</summary>
+    private static IObservable<PackageOriginSnapshot> ReadAnchor(PackageOriginAnchor? anchor) =>
+        anchor?.Read()
+        ?? Observable.Return(
+            PackageOriginSnapshot.Empty(AnchorState.Unconfigured, DateTimeOffset.UtcNow));
+
+    /// <summary>
     /// What this instance can serve, and the framework identity it serves it for.
     ///
     /// <para>The framework MVID is at the TOP, not per-bundle: every assembly here was produced by
@@ -306,24 +360,37 @@ public static class PluginBundleEndpoints
     /// through an ingress, a port-forward or a custom domain must advertise the host the caller
     /// actually used, or every follow-up request goes somewhere it cannot reach.</para>
     ///
-    /// <para>🚨 <b>Scoped to what the caller was GRANTED</b> (#1772, <see cref="IsGranted"/>) — an
+    /// <para>🚨 <b>Scoped to what the caller was GRANTED</b> (#1772, <see cref="Decide"/>) — an
     /// ungranted package is simply not listed, so a caller cannot even learn it is installed here.
     /// That is what makes the download route's refusal non-informative: with the index filtered, "not
     /// in your index" and "404 on fetch" agree, and neither confirms existence. A caller granted
     /// nothing gets an empty <c>bundles</c> array, indistinguishable from a registry with nothing
     /// installed.</para>
+    ///
+    /// <para>🚨 <b>Only the DEGRADED decisions are recorded here</b> (#1782 gap 2). An index request
+    /// resolves every servable package at once and is polled by every consumer, so recording all of
+    /// them would fill a bounded ledger with routine grants and evict the answers worth keeping. The
+    /// download route records every decision it makes — one per actual fetch.</para>
     /// </summary>
     private static Task<IResult> Index(
         HttpContext http, IMessageHub rootHub, AuthenticatedInstance? caller, CancellationToken ct)
     {
         var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}";
+        var ledger = Ledger(http);
 
-        return ServableEntries(rootHub, ct)
-            .Select(servable =>
+        return Servable(rootHub, Anchor(http), ct)
+            .Select(state =>
             {
-                var granted = (IReadOnlyList<BundleEntry>)servable
-                    .Where(p => IsGranted(caller, p)).ToArray();
-                WarnAboutAnEmptyIndex(rootHub, caller, servable, granted);
+                var decisions = state.Entries
+                    .Select(entry => (Entry: entry, Decision: Decide(caller, entry, state.Anchor)))
+                    .ToArray();
+                foreach (var (_, decision) in decisions.Where(d => d.Decision.IsDegraded))
+                    ledger?.Record(decision);
+                WarnAboutDegradedResolution(rootHub, caller, state.Anchor,
+                    decisions.Select(d => d.Decision).ToArray());
+                var granted = (IReadOnlyList<BundleEntry>)decisions
+                    .Where(d => d.Decision.Serves).Select(d => d.Entry).ToArray();
+                WarnAboutAnEmptyIndex(rootHub, caller, state.Entries, granted);
                 return granted;
             })
             .SelectMany(packages => ServableModules(rootHub, packages)
@@ -359,7 +426,7 @@ public static class PluginBundleEndpoints
 
     /// <summary>
     /// 🚨 Names, on the index request, every install record with NO <see cref="BundleEntry.Source"/>
-    /// — the records <see cref="IsGranted"/> can never match, and which are therefore servable to
+    /// — the records <see cref="Decide"/> can never match, and which are therefore servable to
     /// nobody.
     ///
     /// <para>It belongs HERE rather than only on the download path, because the filtered index means
@@ -370,45 +437,133 @@ public static class PluginBundleEndpoints
     /// lane carries its source.</para>
     /// </summary>
     /// <summary>
-    /// Everything this registry can serve: its own INSTALL RECORDS (the catalog lane) UNIONED
-    /// with the modules PUBLISHED onto it (the activation sidecar — entries whose
-    /// <c>PackagePath</c> stamps the source a <c>PluginGrant</c> matches on). The union is what
-    /// makes a GitSync-native registry serve at all: memex-cloud provisions its packages as
-    /// Spaces and never runs the catalog install, so it has NO install records — with a
-    /// record-only index its bundle feed was permanently empty and every consumer read
-    /// SkipNoBundle (found live, 2026-08-20, the first real remote consumer). Records win on a
-    /// PluginId collision — a deliberate install is more intentional than a publish.
+    /// Everything this registry can serve, and the state of the anchor the entitlement decision
+    /// will be made against.
+    ///
+    /// <para>THREE contributors, in precedence order:</para>
+    /// <list type="number">
+    ///   <item>its own INSTALL RECORDS (the catalog lane) — a deliberate install is the most
+    ///     intentional statement, so it wins a <c>PluginId</c> collision;</item>
+    ///   <item>the modules PUBLISHED onto it (the activation sidecar). The union with (1) is what
+    ///     makes a GitSync-native registry serve at all: memex-cloud provisions its packages as
+    ///     Spaces and never runs the catalog install, so it has NO install records — with a
+    ///     record-only index its bundle feed was permanently empty and every consumer read
+    ///     SkipNoBundle (found live, 2026-08-20, the first real remote consumer);</item>
+    ///   <item>🚨 the packages the REGISTRY ANCHOR advertises whose content this instance actually
+    ///     holds (#1782 gap 2). This is the half that could not exist before the anchor: a package
+    ///     provisioned as a Space, with compiled NodeTypes and no install record and no published
+    ///     module, had nothing to bind a grant to and was therefore unreachable through the index
+    ///     however plainly it was installed.</item>
+    /// </list>
+    ///
+    /// <para>🚨 The sidecar's <c>PackagePath</c> source in (2) is now read as a CACHED claim rather
+    /// than as authority — <see cref="Decide"/> lets the anchor override it whenever the registry
+    /// carries the package. It is the publisher's own assertion about which source it belongs to,
+    /// and believing an uploader's assertion outright is exactly the invented anchor #1782 warned
+    /// would weaken #1777.</para>
     /// </summary>
-    private static IObservable<IReadOnlyList<BundleEntry>> ServableEntries(
-        IMessageHub rootHub, CancellationToken ct) =>
+    private static IObservable<(IReadOnlyList<BundleEntry> Entries, PackageOriginSnapshot Anchor)> Servable(
+        IMessageHub rootHub, PackageOriginAnchor? anchor, CancellationToken ct) =>
         InstalledPackages(rootHub, ct)
             .Do(packages => WarnAboutUnstampedRecords(rootHub, packages))
-            .SelectMany(records =>
-            {
-                var landing = rootHub.ServiceProvider.GetService<ModuleLandingService>();
-                if (landing is null)
-                    return Observable.Return(records);
-                return landing.GetActivation().Take(1).Select(activation =>
+            .SelectMany(records => WithPublishedModules(rootHub, records))
+            .SelectMany(local => ReadAnchor(anchor)
+                .SelectMany(snapshot => WithAnchoredPackages(rootHub, local, snapshot)
+                    .Select(entries => (Entries: entries, Anchor: snapshot))));
+
+    /// <summary>Contributor (2): the modules published onto this instance that no install record
+    /// already covers.</summary>
+    private static IObservable<IReadOnlyList<BundleEntry>> WithPublishedModules(
+        IMessageHub rootHub, IReadOnlyList<BundleEntry> records)
+    {
+        var landing = rootHub.ServiceProvider.GetService<ModuleLandingService>();
+        if (landing is null)
+            return Observable.Return(records);
+        return landing.GetActivation().Take(1).Select(activation =>
+        {
+            var recorded = records.Select(r => r.PluginId)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var published = activation.Entries
+                .Where(e => e.Enabled
+                    && !string.IsNullOrWhiteSpace(e.Version)
+                    && e.PackagePath?.Split('/') is { Length: 2 } segments
+                    && !recorded.Contains(segments[1]))
+                .Select(e =>
                 {
-                    var recorded = records.Select(r => r.PluginId)
-                        .ToHashSet(StringComparer.OrdinalIgnoreCase);
-                    var published = activation.Entries
-                        .Where(e => e.Enabled
-                            && !string.IsNullOrWhiteSpace(e.Version)
-                            && e.PackagePath?.Split('/') is { Length: 2 } segments
-                            && !recorded.Contains(segments[1]))
-                        .Select(e =>
-                        {
-                            var segments = e.PackagePath!.Split('/');
-                            return new BundleEntry(
-                                segments[1], e.Version!, segments[1],
-                                Module: e.Name,
-                                MinMeshVersion: e.MinMeshVersion,
-                                Source: segments[0]);
-                        });
-                    return (IReadOnlyList<BundleEntry>)records.Concat(published).ToArray();
+                    var segments = e.PackagePath!.Split('/');
+                    return new BundleEntry(
+                        segments[1], e.Version!, segments[1],
+                        Module: e.Name,
+                        MinMeshVersion: e.MinMeshVersion,
+                        Source: segments[0]);
                 });
-            });
+            return (IReadOnlyList<BundleEntry>)records.Concat(published).ToArray();
+        });
+    }
+
+    /// <summary>
+    /// Contributor (3): the packages the anchor advertises that nothing local already covers — the
+    /// gap-2 half.
+    ///
+    /// <para>🚨 <b>Gated on this instance actually HOLDING the package's partition</b>, because the
+    /// bundle is assembled from the NodeType assemblies under it. Advertising a package whose
+    /// content is not here would hand every consumer an empty archive to download and then count as
+    /// a miss — an index full of bundles that cannot carry anything is a worse answer than a
+    /// filtered one.</para>
+    ///
+    /// <para>🚨 …and that gate FAILS OPEN. If the partition list comes back empty — the query could
+    /// not answer, or this mesh does not register partitions the way it is read here — the
+    /// candidates are kept rather than dropped. A gate whose inability to answer removes entries is
+    /// the very shape this change exists to remove; it is an optimization, and an optimization must
+    /// never be the thing that denies.</para>
+    /// </summary>
+    private static IObservable<IReadOnlyList<BundleEntry>> WithAnchoredPackages(
+        IMessageHub rootHub, IReadOnlyList<BundleEntry> local, PackageOriginSnapshot anchor)
+    {
+        var covered = local.Select(e => e.PluginId).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var candidates = anchor.Origins.Values
+            .Where(origin => !covered.Contains(origin.PackageId)
+                && !string.IsNullOrWhiteSpace(origin.ReleasedVersion))
+            .ToArray();
+        if (candidates.Length == 0)
+            return Observable.Return(local);
+
+        return HeldPartitions(rootHub).Select(held =>
+        {
+            var servable = held.Count == 0
+                ? candidates
+                : candidates.Where(origin => held.Contains(origin.Partition)).ToArray();
+            return (IReadOnlyList<BundleEntry>)local
+                .Concat(servable.Select(origin => new BundleEntry(
+                    PackagingManifest.IdPrefix + origin.PackageId,
+                    origin.ReleasedVersion!,
+                    origin.PackageId,
+                    Module: origin.Module,
+                    MinMeshVersion: origin.MinMeshVersion,
+                    // No CACHED binding: this entry exists only because the anchor advertises it,
+                    // and Decide reads that binding straight off the snapshot.
+                    Source: null)))
+                .ToArray();
+        });
+    }
+
+    /// <summary>
+    /// The partitions this mesh holds, from the <c>Admin/Partition</c> registry every Space writes.
+    /// An empty set means "could not answer" as much as "none", and both callers treat it that way
+    /// (see <see cref="WithAnchoredPackages"/>) — never as evidence of absence.
+    /// </summary>
+    private static IObservable<IReadOnlySet<string>> HeldPartitions(IMessageHub rootHub) =>
+        rootHub.ServiceProvider.GetRequiredService<IMeshService>()
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"namespace:{PartitionNodeType.Namespace} nodeType:{PartitionNodeType.NodeType}"))
+            .Where(c => c.ChangeType == QueryChangeType.Initial)
+            .Take(1)
+            .Select(c => (IReadOnlySet<string>)c.Items
+                .Select(node => node.Id)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase))
+            .Catch((Exception _) =>
+                Observable.Return((IReadOnlySet<string>)new HashSet<string>(StringComparer.OrdinalIgnoreCase)));
 
     /// <summary>
     /// 🚨 Says so when an index request serves NOTHING — the one outcome that is silent on both
@@ -452,6 +607,47 @@ public static class PluginBundleEndpoints
                 caller?.Instance.InstanceId ?? "an unauthenticated caller", servable.Count);
     }
 
+    /// <summary>
+    /// 🚨 Says so when entitlement was resolved WITHOUT the anchor (#1782 gap 2) — the state that
+    /// otherwise looks exactly like a normal day from both sides.
+    ///
+    /// <para>A registry that cannot list its sources still answers every request: granted packages
+    /// keep flowing from the cached bindings, and the packages nothing ever observed simply do not
+    /// appear. Nothing is red, nothing 500s, and the one difference — that some answers were
+    /// guesses the system declined to make — is invisible unless it is said out loud. The two
+    /// degradations get different lines because they need different responses: an anchor that
+    /// cannot be read at all is an operational failure to go and fix, while an UNKNOWN package is
+    /// the consumer-visible consequence of it.</para>
+    /// </summary>
+    private static void WarnAboutDegradedResolution(
+        IMessageHub rootHub, AuthenticatedInstance? caller, PackageOriginSnapshot anchor,
+        IReadOnlyList<EntitlementDecision> decisions)
+    {
+        if (anchor.IsComplete)
+            return;
+
+        var logger = rootHub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(PluginBundleEndpoints));
+        if (logger is null)
+            return;
+
+        var unknown = decisions
+            .Where(d => d.Outcome == EntitlementOutcome.Indeterminate).ToArray();
+        logger.LogWarning(
+            "Plugin bundles: entitlement for {Instance} was resolved WITHOUT a complete registry "
+            + "answer — {Anchor}. {Cached} package(s) were answered from a previously observed "
+            + "binding (served as before, deliberately: an unreachable registry is not evidence of "
+            + "a missing entitlement) and {Unknown} could not be answered at all — those are "
+            + "UNKNOWN, not denials: {Names}",
+            caller?.Instance.InstanceId ?? "an unauthenticated caller",
+            anchor.Describe(),
+            decisions.Count(d => d.Anchor == EntitlementAnchorKind.Cache),
+            unknown.Length,
+            unknown.Length == 0
+                ? "(none)"
+                : string.Join(", ", unknown.Select(d => d.PackageId).Take(MissesReported)));
+    }
+
     private static void WarnAboutUnstampedRecords(
         IMessageHub rootHub, IReadOnlyList<BundleEntry> packages)
     {
@@ -462,9 +658,12 @@ public static class PluginBundleEndpoints
         rootHub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger(typeof(PluginBundleEndpoints))
             .LogWarning(
-                "Plugin bundles: {Count} install record(s) carry no registry source, so no "
-                + "PluginGrant can match them and their bundles are servable to NO instance: "
-                + "{Packages}. Re-install them through the registry to stamp the source (#1772).",
+                "Plugin bundles: {Count} install record(s) carry no registry source, so they have "
+                + "no CACHED binding and their entitlement can only be answered by the registry "
+                + "anchor: {Packages}. Before #1782 gap 2 that made them servable to NO instance, "
+                + "silently; they are now resolved upstream, and become UNKNOWN only when the "
+                + "anchor is unreachable too. Re-install them through the registry to stamp the "
+                + "source (#1772) and the answer stops depending on the registry being up.",
                 unstamped.Length,
                 string.Join(", ", unstamped.Select(p => p.PluginId).Take(MissesReported)));
     }
@@ -514,10 +713,13 @@ public static class PluginBundleEndpoints
     /// answers <see cref="NoSuchBundle"/>; which of the three it was goes to the log only.</para>
     /// </summary>
     private static Task<IResult> Bundle(
-        IMessageHub rootHub, string plugin, string version, string identity, string architecture,
-        AuthenticatedInstance? caller, CancellationToken ct) =>
-        ServableEntries(rootHub, ct)
-            .SelectMany(packages =>
+        HttpContext http, IMessageHub rootHub, string plugin, string version, string identity,
+        string architecture, AuthenticatedInstance? caller, CancellationToken ct)
+    {
+        var anchorService = Anchor(http);
+        var ledger = Ledger(http);
+        return Servable(rootHub, anchorService, ct)
+            .SelectMany(state =>
             {
                 // Named apart from the query-string reader Requested(HttpContext, …) above — one
                 // shadowing the other reads as a call to the wrong thing.
@@ -525,30 +727,45 @@ public static class PluginBundleEndpoints
                     string.Equals(p.PluginId, plugin, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(p.Version, version, StringComparison.OrdinalIgnoreCase);
 
-                var match = packages.FirstOrDefault(p => IsAsked(p) && IsGranted(caller, p));
-                if (match is not null)
-                    return Assemble(rootHub, match, identity, architecture);
+                var asked = state.Entries.FirstOrDefault(IsAsked);
+
+                // 🚨 The entitlement question is answered even when this instance holds nothing that
+                // matches, and it is answered the SAME way — because "I hold no bytes for it" and
+                // "you may not have it" are different facts and the second must never be inferred
+                // from the first. A package with no local entry has no cached binding, so the
+                // decision falls to the anchor: granted, denied, or UNKNOWN.
+                var decision = Decide(
+                    caller,
+                    asked ?? new BundleEntry(plugin, version, plugin),
+                    state.Anchor);
+                // Every download decision is recorded — one per actual fetch, which is the rate a
+                // bounded diagnostic can carry and the granularity an operator asks about.
+                ledger?.Record(decision);
+
+                if (asked is not null && decision.Serves)
+                    return Assemble(rootHub, asked, identity, architecture);
 
                 // The refusal is uniform on the wire; the LOG is where it is diagnosable, naming
-                // which instance asked and whether the record exists at all — including the
-                // fail-closed case an operator would otherwise chase for hours: an install record
-                // with no Source stamped can be granted by nobody (see IsGranted).
-                var installed = packages.FirstOrDefault(IsAsked);
+                // which instance asked, what the entitlement answer actually was, and whether this
+                // instance holds anything to serve. 🚨 The two halves are reported separately: an
+                // Indeterminate outcome is NOT a refusal of entitlement, and reporting it as one is
+                // how an unreachable registry would come to read as an unpaid customer.
                 rootHub.ServiceProvider.GetService<ILoggerFactory>()
                     ?.CreateLogger(typeof(PluginBundleEndpoints))
                     .LogWarning(
-                        "Plugin bundles: {Plugin}@{Version} refused for instance {Instance} — {Reason}",
+                        "Plugin bundles: {Plugin}@{Version} not served to instance {Instance} — "
+                        + "entitlement: {Decision}; bytes: {Bytes}. Anchor: {Anchor}",
                         plugin, version, caller?.Instance.InstanceId ?? "(none)",
-                        installed is null
-                            ? "no such install record on this instance"
-                            : installed.Source is { Length: > 0 } source
-                                ? $"installed from source '{source}', which this instance's grant does not cover"
-                                : "the install record carries NO source, so no grant entry can match it "
-                                  + "(re-install it through the registry to stamp one)");
+                        decision.Describe(),
+                        asked is null
+                            ? "this instance holds no servable entry at that id and version"
+                            : "held",
+                        state.Anchor.Describe());
                 return Observable.Return(NoSuchBundle());
             })
             .FirstAsync()
             .ToTask(ct);
+    }
 
     /// <summary>
     /// Reads the plugin's nodes and their assemblies, then builds the archive.
@@ -846,7 +1063,7 @@ public static class PluginBundleEndpoints
     /// question a distribution index is asked.</para>
     ///
     /// <para>🚨 <b>Unscoped by design — every caller of this method must apply
-    /// <see cref="IsGranted"/>.</b> It is the full inventory, which is precisely what no caller may
+    /// <see cref="Decide"/>.</b> It is the full inventory, which is precisely what no caller may
     /// see; the grant filter lives at the two route handlers because the download route also needs
     /// the unfiltered list to write a diagnosable log line. The <see cref="BundleEntry.Source"/> each
     /// entry carries is the only input that decision needs.</para>
@@ -876,11 +1093,15 @@ public static class PluginBundleEndpoints
     /// <param name="PluginId">The plugin's catalog id — also the id a grant entry names.</param>
     /// <param name="Module">The compiled module the install record declares, or null.</param>
     /// <param name="MinMeshVersion">The module's declared platform floor, or null.</param>
-    /// <param name="Source">🚨 The registry source name the package was installed from
-    /// (<see cref="PackageManifest.Source"/>) — the half of the grant pair that is NOT the package
-    /// id, and therefore the input to <see cref="IsGranted"/>. Null on a record written before the
-    /// field existed or installed from something that is not a configured source: it then matches no
-    /// grant entry, which is the fail-closed answer (#1772).</param>
+    /// <param name="Source">🚨 The CACHED registry-source binding — what a local observation says
+    /// this package came from (<see cref="PackageManifest.Source"/> on an install record, the
+    /// declared package path on a published module). It is the half of the grant pair that is not
+    /// the package id, but it is no longer the authority on it: <see cref="Decide"/> prefers the
+    /// registry anchor and uses this when the anchor does not carry the package or cannot be
+    /// consulted (#1782 gap 2). Null on a record written before the field existed, on something
+    /// installed from a source that is not configured, and on an entry that exists only because the
+    /// anchor advertises it — in every one of those cases the absence sends the question upstream
+    /// rather than answering it.</param>
     private sealed record BundleEntry(
         string PackageId, string Version, string PluginId, string? Module = null,
         string? MinMeshVersion = null, string? Source = null);

--- a/memex/aspire/Memex.Portal.Distributed/EntitlementAnchorHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.Distributed/EntitlementAnchorHealthCheck.cs
@@ -1,0 +1,48 @@
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Memex.Portal.Distributed;
+
+/// <summary>
+/// Reports whether this instance is answering package entitlement against the REGISTRY ANCHOR, or
+/// falling back to cached bindings because the anchor cannot be reached (#1782 gap 2).
+///
+/// <para>🚨 <b>Why a surface at all.</b> Every refusal on the bundle routes is byte-identical on the
+/// wire (#1777) — deliberately, because a distinguishable refusal would be an inventory oracle over
+/// the whole catalogue. That is exactly right for the caller and blind for the operator: "not
+/// granted", "no such package" and "I could not reach the registry to find out" leave the same
+/// trace. Without a surface, an anchor that has been down for a day looks precisely like a day on
+/// which nobody asked for anything they were not entitled to.</para>
+///
+/// <para>🚨 <b>DEGRADED, never Unhealthy.</b> A degraded answer is a CORRECT answer: a caller whose
+/// entitlement was previously observed keeps being served, deliberately, because an unreachable
+/// registry is not evidence of a missing purchase. Failing readiness would turn "the registry is
+/// briefly unlistable" into an outage of this instance — strictly worse than the degradation, and
+/// the same reasoning <see cref="BundleAdoptionHealthCheck"/> applies to a fetch miss.</para>
+///
+/// <para>🚨 <b>"Nothing was ever asked" is its own answer.</b> An instance that serves no bundles
+/// resolves no entitlements, and reporting that as a clean sweep would make the absence of the lane
+/// look like the success of it.</para>
+/// </summary>
+public sealed class EntitlementAnchorHealthCheck(
+    PackageEntitlementLedger ledger, PackageOriginAnchor anchor) : IHealthCheck
+{
+    /// <inheritdoc />
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        // The anchor's own last observation is read WITHOUT triggering a read: a health probe must
+        // not be the thing that goes to GitHub, and a probe that could fail on its own I/O would
+        // report on itself rather than on the lane.
+        var observed = anchor.LastObserved;
+        var description = observed is null
+            ? $"{ledger.Describe()}; the registry anchor has not been read in this process yet"
+            : $"{ledger.Describe()}; {observed.Describe()}";
+
+        var degraded = !ledger.Degraded.IsEmpty
+                       || observed is { IsComplete: false, State: not AnchorState.Unconfigured };
+        return Task.FromResult(degraded
+            ? HealthCheckResult.Degraded(description)
+            : HealthCheckResult.Healthy(description));
+    }
+}

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -415,7 +415,13 @@ builder.Services.AddHealthChecks()
     // deployment declares Modules:Required.
     .AddCheck("required_modules",
         new Memex.Portal.Distributed.RequiredModulesHealthCheck(builder.Configuration))
-    .AddCheck<Memex.Portal.Distributed.BundleAdoptionHealthCheck>("bundle_adoption");
+    .AddCheck<Memex.Portal.Distributed.BundleAdoptionHealthCheck>("bundle_adoption")
+    // 🚨 The other half of the same blindness (#1782 gap 2). Adoption's miss is invisible because
+    // a lazy compile absorbs it; an entitlement answer's degradation is invisible because every
+    // refusal is byte-identical on the wire by design. DEGRADED, never Unhealthy: serving a
+    // previously observed entitlement while the registry is unreachable is the CORRECT answer, and
+    // failing readiness over it would turn a brief registry outage into one of ours.
+    .AddCheck<Memex.Portal.Distributed.EntitlementAnchorHealthCheck>("entitlement_anchor");
 
 // The same shape, one dependency further out: DbVersionGate proves the MESH database is
 // migrated; this proves the ORLEANS database is provisioned. They are different databases,

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -256,21 +256,71 @@ download every installed package's bundle, paid courses included, while this ver
 otherwise. An instance key is issued to every registered installation: it is identity, never
 entitlement.
 
-The authorization is `PluginGrantEntry` matched against the **install record's `Source`** — the
-registry source the package was installed from — exactly as `/api/plugins` scopes its listing and
-`InstallByDefault` scopes its selection. Consequences worth knowing:
+The authorization is `PluginGrantEntry` matched against a `(source, package)` pair, exactly as
+`/api/plugins` scopes its listing and `InstallByDefault` scopes its selection. Consequences worth
+knowing:
 
 - **The index is scoped too.** An ungranted package is not listed, so a caller cannot learn it is
   installed here. That is what makes the download refusal non-informative.
 - **A refusal is byte-identical to "no such bundle"** — same status, same empty body, same headers.
   Bundle URLs are fully predictable, so a distinguishable refusal is an inventory oracle over the
-  whole catalogue; `/api/content` closed the same hole in #587. WHICH of the three it was (unknown
-  package, unknown version, ungranted) goes to the **log**, never the response.
-- **An unstamped `Source` is servable to nobody.** It matches no grant entry, and "cannot determine"
-  is a refusal. `PluginBundleClient` reads the resulting 404 as "no prebuilt bundle — will compile",
-  so the cost is a compile, never a failed install. The stamp is carried forward across re-installs
-  (`PackageInstaller.SeedSource`): an update rebuilt from a source-less catalog entry must not erase
-  the field the check reads, or the lane goes dark silently.
+  whole catalogue; `/api/content` closed the same hole in #587. WHICH of the refusals it was goes to
+  the **log**, never the response.
+
+### The entitlement anchor is the REGISTRY (#1782 gap 2)
+
+The `source` half of that pair used to come from the **install record** and from nowhere else. Two
+things followed, and both were wrong:
+
+1. a package this instance had not itself installed had **no binding at all**, so it could not be
+   served however plainly its content sat here — which is the permanent state of a registry that
+   provisions its packages as Spaces (memex-cloud never runs the catalog install, so it has no
+   install records);
+2. "I cannot tell which source this is from" was answered as **"you are not entitled to it"** — a
+   check whose inability to answer is indistinguishable from a negative answer, applied to the most
+   expensive thing it could be applied to: a purchase, read as no purchase.
+
+So the anchor is the registry's own catalog — the same `PackageSources` listing `/api/plugins`
+serves — and the install record is what it always was, a **cache** of that binding:
+
+```
+anchor:   the entitlement record at the registry
+local:    install record = cache
+absent:   "ask upstream" — never "not entitled"
+```
+
+`PackageEntitlementAnchor.Resolve` is the whole rule, pure, with **three** outcomes:
+
+| the binding comes from | outcome |
+|---|---|
+| the **registry** carries the package | `Granted` / `Denied`, `Anchor = Registry` — authoritative, and it overrides a disagreeing cache |
+| only a **local observation** does (an install record's stamped source, a published module's declared path) | `Granted` / `Denied`, `Anchor = Cache` |
+| **nothing** binds it, and the registry answered in full | `Denied` — its silence about a package IS an observation |
+| **nothing** binds it, and the registry could not be asked | 🚨 `Indeterminate` — **UNKNOWN, not a denial** |
+
+The third state withholds the bytes like a denial does; it differs in what it **claims**. An
+instance being unable to ask is not a customer failing to buy, and the difference is recorded
+(`PackageEntitlementLedger`) and surfaced (`entitlement_anchor` health check, **Degraded** — never
+Unhealthy, because serving a previously observed entitlement while the registry is down is the
+*correct* answer, and failing readiness over it would turn a brief registry outage into one of
+ours).
+
+**#1777 is untouched.** The grant match is the same `AuthenticatedInstance.Allows`, no source is
+ever invented, and the route still has exactly two wire outcomes — the bytes, or the one
+byte-identical `NoSuchBundle()`. If anything it tightens: a published module's *self-declared*
+package path used to be believed outright and is now overridden by the registry's binding whenever
+the registry carries the package.
+
+- **Air-gapped is a stated answer, not a silent one.** An instance with no configured sources is
+  `Unconfigured` — an authority on nothing, deliberately not "the registry carries no such package".
+  Its cached bindings still serve; anything it has never observed is `Indeterminate` and says so.
+- **An unstamped `Source` no longer fails dark.** A record written before the field existed simply
+  carries no cached binding, so the anchor answers for it. Stamping it still matters
+  (`PackageInstaller.SeedSource` carries it forward across re-installs) because it is what keeps the
+  answer working when the registry is *not* reachable.
+- **A snapshot window is not an entitlement term.** The anchor reuses an authoritative listing for
+  60s (`PluginCatalog:AnchorFreshnessSeconds`); its expiry triggers a *read*, never a refusal.
+  Entitlements remain eternal.
 
 **The portal serves the bytes rather than handing out storage access.** `BlobAssemblyStore` is
 already the durable transport — one blob per `(nodeTypePath, version)`, hydrated into a process-local

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-entitlement-follows-the-account.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-22-entitlement-follows-the-account.md
@@ -1,0 +1,58 @@
+---
+Name: What you bought follows your account, not the server
+Category: Fix
+Description: A package you are entitled to is no longer refused by an instance simply because nothing has installed it there yet.
+Icon: Sparkle
+Order: -20260822
+---
+
+# What you bought follows your account, not the server
+
+When one MeshWeaver installation asks another for a package's prebuilt code, the serving side has to
+answer a question first: *is this installation entitled to this package?*
+
+It used to answer that question by looking at its own records of what **it** had installed. That
+works right up until the package it is being asked for is one it never installed itself — a package
+provisioned straight from its repository, say, or one on a brand-new installation where nothing has
+been set up yet. In that case there was nothing to look at, and "I cannot tell" came out as **"you
+are not entitled to it"**.
+
+That is the wrong answer to give, and it is wrong in the most expensive direction: entitlement is a
+fact about the **account**, not about which server happens to be answering. Something already paid
+for should not read as unpaid because a particular machine has not caught up.
+
+## What changed
+
+The question now goes to the registry, which is where entitlement actually lives. The serving
+instance's own records are still used — they are quick, and they work offline — but as a **cache**:
+if they have nothing to say, the question is passed upstream instead of being answered with a no.
+
+There are now three possible answers rather than two:
+
+- **Entitled** — the bytes are served.
+- **Not entitled** — nothing is served, exactly as before. Holding a licence to one source still
+  does not confer a paid package sitting beside it.
+- **Unknown** — the registry could not be reached and nothing here has ever seen this package
+  before. Nothing is served, because there is no answer to serve from; but it is recorded as
+  *unknown*, and never claimed as a refusal.
+
+## If the registry cannot be reached
+
+Anything whose entitlement was seen here before keeps working. That is deliberate: a registry being
+briefly unreachable is not evidence that somebody's purchase has evaporated.
+
+The degraded state is **visible** rather than something you have to deduce. A new
+`entitlement_anchor` health check reports **Degraded** while answers are coming from cached
+observations, and names how many questions could not be answered at all. It never reports Unhealthy
+— continuing to serve what was already known good is the right behaviour, and taking the instance
+out of rotation over it would be worse than the degradation.
+
+An installation with no registry configured at all now says so plainly, instead of behaving as
+though it were an authority that had checked and found nothing.
+
+## What did not change
+
+Nothing about what a caller can *see*. A refusal is still byte-for-byte identical to "there is no
+such package", the index still lists only what the caller may have, and the reason is still written
+to the log where only an operator can read it — an installation cannot use these routes to discover
+what else a registry carries.

--- a/src/MeshWeaver.PluginCatalog/PackageEntitlementAnchor.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageEntitlementAnchor.cs
@@ -1,0 +1,281 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// WHERE the <c>(source, package)</c> binding an entitlement decision was made against came from.
+///
+/// <para>🚨 This exists so that a CACHE can say it is a cache. Before #1782 gap 2 the only binding
+/// available was the local install record's <see cref="PackageManifest.Source"/>, and it was read
+/// as if it were the authority — so a package with no record had no binding, and "I cannot tell
+/// which source this is from" came out as "you are not entitled to it". The provenance is now part
+/// of every answer, because an unlabelled cache silently becomes the anchor again by accident.</para>
+/// </summary>
+public enum EntitlementAnchorKind
+{
+    /// <summary>The binding came from the REGISTRY — the configured package sources this instance
+    /// serves, i.e. the same catalog <c>/api/plugins</c> lists. This is the anchor.</summary>
+    Registry,
+
+    /// <summary>The binding came from a LOCAL observation — an install record's stamped source, or
+    /// a published module's declared package path. Trustworthy, but a cache: it says where the
+    /// package came from when it was last observed here, not where the registry carries it now.</summary>
+    Cache,
+
+    /// <summary>There was no binding at all: the registry does not carry the package and nothing
+    /// local ever observed it.</summary>
+    None,
+}
+
+/// <summary>
+/// The THREE answers an entitlement question can have.
+///
+/// <para>🚨 <b>Two of them are not "no".</b> A check whose inability to answer is indistinguishable
+/// from a negative answer is the failure mode this codebase found eight instances of on 2026-08-21
+/// (<c>if: vars.X != ''</c> skipping a gate green; a health check Healthy while the bake was
+/// NotStarted; <c>bundle is null</c> returning a bare <c>0</c>). Applied to entitlement it is the
+/// most expensive version of that bug — a purchase that reads as no purchase.</para>
+/// </summary>
+public enum EntitlementOutcome
+{
+    /// <summary>The caller may have the package.</summary>
+    Granted,
+
+    /// <summary>The caller may NOT have it, and that is a real observation: a binding was found and
+    /// the caller's grant does not cover it (or the registry was asked in full and carries no such
+    /// package, with nothing local ever having observed one).</summary>
+    Denied,
+
+    /// <summary>🚨 <b>The third state.</b> The anchor could not be consulted and nothing local ever
+    /// observed this package, so entitlement is UNKNOWN. On the wire it is still a refusal — the
+    /// bytes are not served — but it is a STATED one: recorded, counted and surfaced as degraded,
+    /// never asserted as "not entitled".</summary>
+    Indeterminate,
+}
+
+/// <summary>
+/// One entitlement question, answered — with the provenance of the binding it was answered from.
+/// </summary>
+/// <param name="PackageId">The package that was asked about.</param>
+/// <param name="Outcome">The answer.</param>
+/// <param name="Anchor">Where the binding came from.</param>
+/// <param name="Source">The registry source the package was bound to, when there was one.</param>
+/// <param name="AnchorAvailable">Whether the authoritative anchor answered IN FULL — every
+/// configured source listed. False means an ABSENCE from the anchor proves nothing, which is
+/// exactly why an absence must not deny.</param>
+/// <param name="Reason">One sentence, for a log line or a ledger entry.</param>
+public sealed record EntitlementDecision(
+    string PackageId,
+    EntitlementOutcome Outcome,
+    EntitlementAnchorKind Anchor,
+    string? Source,
+    bool AnchorAvailable,
+    string Reason)
+{
+    /// <summary>Whether the bytes are served. ONLY <see cref="EntitlementOutcome.Granted"/> serves —
+    /// the third state withholds them like a denial does, and differs in what it CLAIMS, not in
+    /// what it hands over.</summary>
+    public bool Serves => Outcome == EntitlementOutcome.Granted;
+
+    /// <summary>Whether this answer came from the anchor rather than from the cache.</summary>
+    public bool IsAuthoritative => Anchor == EntitlementAnchorKind.Registry;
+
+    /// <summary>
+    /// Whether this answer was reached in a DEGRADED way — the anchor could not be consulted in
+    /// full, so the decision rests on a cached observation, or on nothing at all. Not a failure:
+    /// a degraded grant is the correct, deliberately non-blocking answer for a caller whose
+    /// entitlement was previously observed. It is reported so the degradation is legible rather
+    /// than inferred from a quiet day.
+    /// </summary>
+    public bool IsDegraded => !AnchorAvailable || Outcome == EntitlementOutcome.Indeterminate;
+
+    /// <summary>One line, for a log or a health payload.</summary>
+    public string Describe() =>
+        $"{PackageId}: {Outcome} (anchor={Anchor}"
+        + (Source is { Length: > 0 } source ? $", source='{source}'" : string.Empty)
+        + (AnchorAvailable ? string.Empty : ", registry NOT reachable in full")
+        + $") — {Reason}";
+}
+
+/// <summary>
+/// 🚨 <b>THE ENTITLEMENT ANCHOR (#1782 gap 2).</b> Decides whether a caller may pull a package,
+/// from a <c>(source, package)</c> binding whose AUTHORITY is the registry — with the local install
+/// record demoted to what it always was, a cache.
+///
+/// <para><b>The decision recorded on #1782 (maintainer, 2026-08-22):</b></para>
+/// <code>
+/// anchor:   the entitlement record at the registry
+/// local:    install record = cache
+/// absent:   "ask upstream" — never "not entitled"
+/// </code>
+///
+/// <para>Entitlement is a fact about the ACCOUNT, not about which instance happens to be serving.
+/// Anchoring it on the serving instance's install records is what denied a paying customer on a
+/// fresh instance simply because nothing had installed there yet — and it is what made gap 2
+/// unfixable, since a package the registry has not itself installed has no record to bind to.</para>
+///
+/// <para>🚨 <b>What this does NOT weaken (#1777).</b> The decision is still
+/// <c>PluginGrant.Allows(source, packageId)</c> against the admin-owned grant the caller's instance
+/// key resolves to — the same one match <c>/api/plugins</c> and <c>InstallByDefault</c> make. What
+/// changed is only WHERE the <c>source</c> half comes from: the registry's own catalog first, the
+/// install record as a fallback. No source is ever invented, no second notion of entitlement is
+/// introduced, and the wire behaviour is unchanged — a non-granting outcome answers exactly the one
+/// refusal <c>NoSuchBundle()</c> the caller cannot distinguish from a package that does not exist.
+/// If anything it TIGHTENS: a published module's self-declared package path used to be believed
+/// outright, and is now overridden by the registry's binding whenever the registry carries the
+/// package.</para>
+///
+/// <para>Pure and total: no hub, no I/O, no clock. The registry read that FEEDS it lives in
+/// <see cref="PackageOriginAnchor"/>, behind the sanctioned async boundary.</para>
+/// </summary>
+public static class PackageEntitlementAnchor
+{
+    /// <summary>
+    /// Resolves one package for one caller.
+    /// </summary>
+    /// <param name="packageId">The package being asked for.</param>
+    /// <param name="anchorSource">The source the REGISTRY binds this package to, or null when the
+    /// registry does not carry it (or could not be asked).</param>
+    /// <param name="cachedSource">The source a LOCAL observation binds it to — an install record's
+    /// stamped source, or a published module's declared package path — or null when there is none.
+    /// 🚨 Its absence is never a denial; it simply means the answer must come from the anchor.</param>
+    /// <param name="anchorAvailable">Whether every configured source answered. False ⇒ an ABSENCE
+    /// from <paramref name="anchorSource"/> proves nothing.</param>
+    /// <param name="allows">The caller's grant, as a predicate over the resolved source. This is
+    /// <c>AuthenticatedInstance.Allows(source, packageId)</c> and nothing else — the anchor decides
+    /// which source is asked about, never whether the grant covers it.</param>
+    public static EntitlementDecision Resolve(
+        string packageId,
+        string? anchorSource,
+        string? cachedSource,
+        bool anchorAvailable,
+        Func<string, bool> allows)
+    {
+        ArgumentNullException.ThrowIfNull(allows);
+
+        // 1 — THE ANCHOR ANSWERED. A binding the registry itself carries is authoritative whether or
+        //     not every OTHER source could be listed: a listing is an observation, and one source
+        //     being down cannot make another source's answer less true. This branch also overrides a
+        //     disagreeing cache, which is the whole point of having an anchor.
+        if (anchorSource is { Length: > 0 } fromRegistry)
+            return new EntitlementDecision(
+                packageId,
+                allows(fromRegistry) ? EntitlementOutcome.Granted : EntitlementOutcome.Denied,
+                EntitlementAnchorKind.Registry,
+                fromRegistry,
+                anchorAvailable,
+                $"the registry carries '{packageId}' in source '{fromRegistry}', and the caller's "
+                + $"grant {(allows(fromRegistry) ? "covers" : "does not cover")} it");
+
+        // 2 — THE CACHE ANSWERED. Either the registry does not carry it (a package installed from a
+        //     source that is no longer configured, or published straight onto this instance) or the
+        //     registry could not be asked. A local observation is a real observation: it is what a
+        //     previous, successful resolution wrote down. Answering from it is what "fail toward not
+        //     blocking a viewer whose entitlement was previously observed" means in practice.
+        if (cachedSource is { Length: > 0 } fromCache)
+            return new EntitlementDecision(
+                packageId,
+                allows(fromCache) ? EntitlementOutcome.Granted : EntitlementOutcome.Denied,
+                EntitlementAnchorKind.Cache,
+                fromCache,
+                anchorAvailable,
+                anchorAvailable
+                    ? $"the registry does not carry '{packageId}'; a local record binds it to source "
+                      + $"'{fromCache}', and the caller's grant "
+                      + $"{(allows(fromCache) ? "covers" : "does not cover")} it"
+                    : $"the registry could not be consulted in full; the last local observation binds "
+                      + $"'{packageId}' to source '{fromCache}', and the caller's grant "
+                      + $"{(allows(fromCache) ? "covers" : "does not cover")} it");
+
+        // 3 — NOBODY BINDS IT, and the registry was asked IN FULL. That is a real negative: this
+        //     registry carries no such package and nothing here ever installed one. A caller that is
+        //     genuinely not entitled must still see nothing, and this is the branch that says so.
+        if (anchorAvailable)
+            return new EntitlementDecision(
+                packageId, EntitlementOutcome.Denied, EntitlementAnchorKind.None, null, true,
+                $"no configured source carries '{packageId}' and no local record observes it — "
+                + "there is nothing here to be entitled to");
+
+        // 4 — 🚨 THE THIRD STATE. The anchor could not be consulted and nothing was ever observed
+        //     locally, so entitlement is UNKNOWN. The bytes are withheld (there is no answer to
+        //     serve from), but the outcome is not a denial and must never be reported as one: an
+        //     air-gapped or cut-off instance being unable to ASK is not the customer failing to buy.
+        return new EntitlementDecision(
+            packageId, EntitlementOutcome.Indeterminate, EntitlementAnchorKind.None, null, false,
+            $"the registry could not be consulted and nothing here has ever observed '{packageId}', "
+            + "so entitlement is UNKNOWN — this is not a denial");
+    }
+}
+
+/// <summary>
+/// 🚨 <b>The record that makes a degraded entitlement answer legible instead of inferred</b>
+/// (#1782 gap 2).
+///
+/// <para>Every refusal on the bundle routes is byte-identical on the wire (#1777), which is exactly
+/// right for the caller and exactly wrong for the operator: "not granted", "no such package" and
+/// "I could not reach the registry to find out" all leave the same trace. The log distinguishes
+/// them, but a log line is not countable after it rotates, and the outcome that matters most —
+/// the third state — is the one that looks most like a quiet day.</para>
+///
+/// <para>So decisions are RECORDED. Process-scoped, bounded, appended under
+/// <see cref="ImmutableInterlocked"/>. Same shape and the same rules as
+/// <see cref="BundleAdoptionLedger"/> — a diagnostic, never a source of truth; nothing decides
+/// anything from it.</para>
+/// </summary>
+public sealed class PackageEntitlementLedger
+{
+    /// <summary>How many decisions are kept — the last N answer "is the anchor working now", which
+    /// is the question, while an unbounded list would answer it and also leak.</summary>
+    public const int Capacity = 500;
+
+    private ImmutableList<EntitlementDecision> decisions = ImmutableList<EntitlementDecision>.Empty;
+
+    /// <summary>Records one decision. Thread-safe; never throws.</summary>
+    public void Record(EntitlementDecision decision)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        ImmutableInterlocked.Update(ref decisions, current =>
+        {
+            var next = current.Add(decision);
+            return next.Count > Capacity ? next.RemoveRange(0, next.Count - Capacity) : next;
+        });
+    }
+
+    /// <summary>Every recorded decision, oldest first.</summary>
+    public ImmutableList<EntitlementDecision> Decisions => Volatile.Read(ref decisions);
+
+    /// <summary>The decisions reached without a full authoritative answer — the degraded ones.</summary>
+    public ImmutableList<EntitlementDecision> Degraded =>
+        Decisions.Where(d => d.IsDegraded).ToImmutableList();
+
+    /// <summary>The decisions that could not be answered at all.</summary>
+    public ImmutableList<EntitlementDecision> Indeterminate =>
+        Decisions.Where(d => d.Outcome == EntitlementOutcome.Indeterminate).ToImmutableList();
+
+    /// <summary>
+    /// The one line every surface renders.
+    ///
+    /// <para>🚨 "Nothing was ever asked" and "everything was answered authoritatively" are DIFFERENT
+    /// sentences. An instance that serves no bundles never resolves an entitlement, and reporting
+    /// that as a clean sweep would make the absence of the lane look like the success of it — the
+    /// same rule <see cref="BundleAdoptionLedger.Describe"/> follows.</para>
+    /// </summary>
+    /// <param name="maxNamed">How many degraded decisions are named before the line truncates.</param>
+    public string Describe(int maxNamed = 10)
+    {
+        var all = Decisions;
+        if (all.IsEmpty)
+            return "no package entitlement has been resolved in this process";
+
+        var degraded = all.Where(d => d.IsDegraded).ToArray();
+        if (degraded.Length == 0)
+            return $"{all.Count} entitlement decision(s), all answered against the registry anchor";
+
+        var unknown = degraded.Count(d => d.Outcome == EntitlementOutcome.Indeterminate);
+        return $"{all.Count} entitlement decision(s), {degraded.Length} reached WITHOUT a full "
+            + $"registry answer ({unknown} could not be answered at all — those are UNKNOWN, not "
+            + "denials): "
+            + string.Join("; ", degraded.Take(Math.Max(1, maxNamed)).Select(d => d.Describe()))
+            + (degraded.Length > maxNamed ? $", …(+{degraded.Length - maxNamed})" : string.Empty);
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/PackageOriginAnchor.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageOriginAnchor.cs
@@ -1,0 +1,290 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// One package as the REGISTRY carries it — the authoritative half of the
+/// <c>(source, package)</c> pair a <see cref="MeshWeaver.Mesh.Security.PluginGrant"/> is matched
+/// against, plus the few fields a bundle index needs to advertise it.
+/// </summary>
+/// <param name="PackageId">The package's catalog id.</param>
+/// <param name="Source">🚨 The configured source name it is carried in — the anchor.</param>
+/// <param name="ReleasedVersion">Its released SemVer, or null when it has none (not servable).</param>
+/// <param name="Module">The compiled module it declares, or null.</param>
+/// <param name="MinMeshVersion">That module's declared platform floor, or null.</param>
+/// <param name="TargetPartition">The partition the package installs into, when it declares one —
+/// what a serving instance checks to know whether it holds this package's content at all.</param>
+public sealed record PackageOrigin(
+    string PackageId,
+    string Source,
+    string? ReleasedVersion,
+    string? Module,
+    string? MinMeshVersion,
+    string? TargetPartition = null)
+{
+    /// <summary>The partition this package's content lives in — its declared
+    /// <see cref="TargetPartition"/>, else its id (what a node-native repo's folder name is).</summary>
+    public string Partition =>
+        TargetPartition is { Length: > 0 } declared ? declared : PackageId;
+}
+
+/// <summary>
+/// How completely the anchor could be read. 🚨 Only <see cref="Authoritative"/> makes an ABSENCE
+/// meaningful — under every other state "the registry does not carry it" is a thing we could not
+/// establish, not a thing we observed.
+/// </summary>
+public enum AnchorState
+{
+    /// <summary>Every configured source listed successfully. An absence from this snapshot is a
+    /// real negative.</summary>
+    Authoritative,
+
+    /// <summary>At least one source failed, but earlier observations are being carried forward. The
+    /// bindings present are real; an absence proves nothing.</summary>
+    Stale,
+
+    /// <summary>No source could be listed and nothing was ever observed. The anchor is silent.</summary>
+    Unreachable,
+
+    /// <summary>This instance configures no package sources at all, so it is an authority on
+    /// nothing. 🚨 Deliberately NOT folded into <see cref="Authoritative"/>: "I have no sources"
+    /// answering "the registry carries no such package" is precisely the absence-denies bug.</summary>
+    Unconfigured,
+}
+
+/// <summary>
+/// What the registry carried, when it was asked, and how well it answered.
+/// </summary>
+/// <param name="State">How completely it was read.</param>
+/// <param name="Origins">Package id → its origin, keyed case-insensitively (a lookup convenience;
+/// the authorization comparison itself stays <see cref="MeshWeaver.Mesh.Security.PluginGrantEntry.Matches"/>'s).</param>
+/// <param name="ObservedAt">When the newest contributing read happened.</param>
+/// <param name="Failure">Why the read was not complete, when it was not.</param>
+public sealed record PackageOriginSnapshot(
+    AnchorState State,
+    ImmutableDictionary<string, PackageOrigin> Origins,
+    DateTimeOffset ObservedAt,
+    string? Failure)
+{
+    /// <summary>🚨 Whether an ABSENCE from <see cref="Origins"/> may be read as a negative.</summary>
+    public bool IsComplete => State == AnchorState.Authoritative;
+
+    /// <summary>The source the registry binds <paramref name="packageId"/> to, or null.</summary>
+    public string? SourceOf(string packageId) =>
+        Origins.TryGetValue(packageId, out var origin) ? origin.Source : null;
+
+    /// <summary>One line, for a log or a health payload.</summary>
+    public string Describe() => State switch
+    {
+        AnchorState.Authoritative =>
+            $"registry anchor: {Origins.Count} package(s), read in full at {ObservedAt:O}",
+        AnchorState.Stale =>
+            $"registry anchor DEGRADED: carrying {Origins.Count} previously observed package(s) — "
+            + $"the last full read failed ({Failure})",
+        AnchorState.Unreachable =>
+            $"registry anchor UNREACHABLE and nothing was ever observed ({Failure})",
+        _ =>
+            "registry anchor NOT CONFIGURED — this instance declares no package sources, so it is "
+            + "an authority on no package",
+    };
+
+    /// <summary>An empty snapshot in <paramref name="state"/>.</summary>
+    public static PackageOriginSnapshot Empty(AnchorState state, DateTimeOffset at, string? failure = null) =>
+        new(state,
+            ImmutableDictionary.Create<string, PackageOrigin>(StringComparer.OrdinalIgnoreCase),
+            at, failure);
+}
+
+/// <summary>
+/// 🚨 <b>Reads the ENTITLEMENT ANCHOR</b> (#1782 gap 2): the packages this instance's configured
+/// sources carry, and which source carries each — the binding
+/// <see cref="PackageEntitlementAnchor.Resolve"/> decides against.
+///
+/// <para>It is deliberately the SAME reading <c>/api/plugins</c> serves its catalog from
+/// (<see cref="PackageSources.FromConfiguration"/> → <see cref="IPackageSource.ListPackages"/>), so
+/// "which source is this package from" has one answer on this instance rather than one per surface.
+/// On a registry that holds the git credential those sources are the plugin repos; on a downstream
+/// instance they are the registry it pulls from. Either way the anchor is upstream of the local
+/// install records, which is the whole point — a record is a cache of this answer, and its absence
+/// must send us HERE rather than to a refusal.</para>
+///
+/// <para>🚨 <b>The failure path never produces a denial.</b> A source that will not list makes the
+/// snapshot <see cref="AnchorState.Stale"/> (or <see cref="AnchorState.Unreachable"/>), and every
+/// consumer of the snapshot reads <see cref="PackageOriginSnapshot.IsComplete"/> before treating an
+/// absence as an answer. The last successful observation is retained precisely so a previously
+/// observed entitlement keeps working while the anchor is down.</para>
+///
+/// <para>🚨 <b>The freshness window is a SNAPSHOT window, not an entitlement expiry.</b> Entitlements
+/// are eternal and nothing here introduces a term: the window only says how long an authoritative
+/// listing may be reused before the sources are asked again, and its expiry triggers a READ, never
+/// a refusal. Conflating the two would smuggle in exactly the expiry the Store model forbids.</para>
+///
+/// <para>No <c>async</c>: the sources are already <see cref="IObservable{T}"/>-shaped and their
+/// genuinely-async leaves (git, HTTP) sit behind <see cref="MeshWeaver.Mesh.Threading.IIoPool"/>
+/// inside them.</para>
+/// </summary>
+public sealed class PackageOriginAnchor
+{
+    /// <summary>How long an authoritative listing is reused before the sources are asked again.
+    /// Config key <c>PluginCatalog:AnchorFreshnessSeconds</c>; 0 or negative disables reuse.</summary>
+    public const string FreshnessConfigKey = "PluginCatalog:AnchorFreshnessSeconds";
+
+    /// <summary>The default snapshot window — long enough that a boot-time stampede of consumers
+    /// costs one listing, short enough that a newly published package appears within a minute.</summary>
+    public static readonly TimeSpan DefaultFreshness = TimeSpan.FromSeconds(60);
+
+    private readonly Func<IReadOnlyList<ConfiguredPackageSource>> sources;
+    private readonly TimeSpan freshness;
+    private readonly Func<DateTimeOffset> clock;
+    private readonly ILogger? logger;
+    private PackageOriginSnapshot? last;
+
+    /// <summary>The DI constructor — reads the instance's configured package sources.</summary>
+    /// <param name="hub">The root hub the sources are built against.</param>
+    /// <param name="configuration">Where <c>PluginCatalog:Sources</c> lives.</param>
+    /// <param name="loggerFactory">Diagnostics.</param>
+    public PackageOriginAnchor(
+        IMessageHub hub, IConfiguration configuration, ILoggerFactory? loggerFactory = null)
+        : this(
+            () => PackageSources.FromConfiguration(
+                hub, configuration, loggerFactory?.CreateLogger<PackageOriginAnchor>()),
+            Freshness(configuration),
+            () => DateTimeOffset.UtcNow,
+            loggerFactory?.CreateLogger<PackageOriginAnchor>())
+    {
+    }
+
+    /// <summary>The seam constructor — the sources, the window and the clock are arguments so the
+    /// anchor's degraded behaviour can be exercised without a registry, a repo or a wait.</summary>
+    /// <param name="sources">The configured sources to list.</param>
+    /// <param name="freshness">The snapshot window (not an entitlement term).</param>
+    /// <param name="clock">Reads "now".</param>
+    /// <param name="logger">Diagnostics.</param>
+    public PackageOriginAnchor(
+        Func<IReadOnlyList<ConfiguredPackageSource>> sources,
+        TimeSpan freshness,
+        Func<DateTimeOffset> clock,
+        ILogger? logger = null)
+    {
+        this.sources = sources ?? throw new ArgumentNullException(nameof(sources));
+        this.freshness = freshness;
+        this.clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        this.logger = logger;
+    }
+
+    /// <summary>The most recent snapshot, or null when the anchor has never been read.</summary>
+    public PackageOriginSnapshot? LastObserved => Volatile.Read(ref last);
+
+    /// <summary>
+    /// Reads the anchor. Emits exactly once and completes; never faults — every failure becomes a
+    /// non-authoritative snapshot, because a throw here would turn "I could not ask" into an error
+    /// the caller would have to decide something from, and the only safe decision from an error is
+    /// the denial this whole change exists to remove.
+    /// </summary>
+    public IObservable<PackageOriginSnapshot> Read() => Observable.Defer(() =>
+    {
+        var now = clock();
+        if (Volatile.Read(ref last) is { State: AnchorState.Authoritative } fresh
+            && freshness > TimeSpan.Zero && now - fresh.ObservedAt < freshness)
+            return Observable.Return(fresh);
+
+        IReadOnlyList<ConfiguredPackageSource> configured;
+        try
+        {
+            configured = sources();
+        }
+        catch (Exception exception)
+        {
+            logger?.LogWarning(exception, "Entitlement anchor: the configured sources could not be built");
+            return Observable.Return(Degrade(now, exception.Message));
+        }
+
+        if (configured.Count == 0)
+            // Not an authority on anything. Recorded rather than cached, so a source list appearing
+            // later is picked up on the next read.
+            return Observable.Return(PackageOriginSnapshot.Empty(AnchorState.Unconfigured, now));
+
+        var listings = configured.Select(source => source.Source
+            .ListPackages(source.GitRef)
+            .Take(1)
+            .Select(packages => (Source: source, Packages: packages, Failure: (string?)null))
+            .Catch((Exception exception) =>
+            {
+                logger?.LogWarning(exception,
+                    "Entitlement anchor: listing source {Name} @ {Ref} failed — an ABSENCE from this "
+                    + "read is therefore not evidence that a package is uncarried",
+                    source.Name, source.GitRef);
+                return Observable.Return((
+                    Source: source,
+                    Packages: (IReadOnlyList<PackageManifest>)[],
+                    Failure: (string?)exception.Message));
+            }));
+
+        return listings.CombineLatest()
+            .Take(1)
+            .Select(perSource => Observe(perSource, clock()));
+    });
+
+    /// <summary>Folds one read into a snapshot and remembers it.</summary>
+    private PackageOriginSnapshot Observe(
+        IReadOnlyList<(ConfiguredPackageSource Source, IReadOnlyList<PackageManifest> Packages, string? Failure)> perSource,
+        DateTimeOffset now)
+    {
+        var failures = perSource.Where(x => x.Failure is not null)
+            .Select(x => $"{x.Source.Name}: {x.Failure}").ToArray();
+
+        var observed = ImmutableDictionary.CreateBuilder<string, PackageOrigin>(
+            StringComparer.OrdinalIgnoreCase);
+        // The FIRST configured source wins on an id collision — the same precedence the merged
+        // catalog applies, so the anchor and the listing can never disagree about which source a
+        // package belongs to.
+        foreach (var (source, packages, _) in perSource)
+        foreach (var package in packages.Where(p => !string.IsNullOrWhiteSpace(p.Id)))
+            observed.TryAdd(
+                package.Id,
+                new PackageOrigin(
+                    package.Id, source.Name, package.ReleasedVersion, package.Module,
+                    package.MinMeshVersion, package.TargetPartition));
+
+        if (failures.Length == 0)
+        {
+            var snapshot = new PackageOriginSnapshot(
+                AnchorState.Authoritative, observed.ToImmutable(), now, null);
+            Volatile.Write(ref last, snapshot);
+            return snapshot;
+        }
+
+        // A partial read: what WAS listed is real, so keep it — merged over whatever was observed
+        // before, so a package that has been seen once does not vanish because a different source
+        // is down. The state stays non-authoritative, which is what stops an absence from denying.
+        var carried = Volatile.Read(ref last)?.Origins
+                      ?? ImmutableDictionary.Create<string, PackageOrigin>(StringComparer.OrdinalIgnoreCase);
+        var merged = carried.SetItems(observed);
+        var degraded = new PackageOriginSnapshot(
+            merged.IsEmpty ? AnchorState.Unreachable : AnchorState.Stale,
+            merged, now, string.Join("; ", failures));
+        Volatile.Write(ref last, degraded);
+        return degraded;
+    }
+
+    /// <summary>The snapshot for "the sources themselves could not be built" — carries forward
+    /// whatever was previously observed rather than presenting an empty authority.</summary>
+    private PackageOriginSnapshot Degrade(DateTimeOffset now, string failure)
+    {
+        var carried = Volatile.Read(ref last)?.Origins
+                      ?? ImmutableDictionary.Create<string, PackageOrigin>(StringComparer.OrdinalIgnoreCase);
+        var snapshot = new PackageOriginSnapshot(
+            carried.IsEmpty ? AnchorState.Unreachable : AnchorState.Stale, carried, now, failure);
+        Volatile.Write(ref last, snapshot);
+        return snapshot;
+    }
+
+    private static TimeSpan Freshness(IConfiguration configuration) =>
+        int.TryParse(configuration?[FreshnessConfigKey], out var seconds)
+            ? TimeSpan.FromSeconds(seconds)
+            : DefaultFreshness;
+}

--- a/src/MeshWeaver.PluginCatalog/PackageOriginAnchor.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageOriginAnchor.cs
@@ -211,17 +211,14 @@ public sealed class PackageOriginAnchor
         var listings = configured.Select(source => source.Source
             .ListPackages(source.GitRef)
             .Take(1)
-            .Select(packages => (Source: source, Packages: packages, Failure: (string?)null))
+            .Select(packages => new SourceListing(source, packages, null))
             .Catch((Exception exception) =>
             {
                 logger?.LogWarning(exception,
                     "Entitlement anchor: listing source {Name} @ {Ref} failed — an ABSENCE from this "
                     + "read is therefore not evidence that a package is uncarried",
                     source.Name, source.GitRef);
-                return Observable.Return((
-                    Source: source,
-                    Packages: (IReadOnlyList<PackageManifest>)[],
-                    Failure: (string?)exception.Message));
+                return Observable.Return(new SourceListing(source, [], exception.Message));
             }));
 
         return listings.CombineLatest()
@@ -230,9 +227,7 @@ public sealed class PackageOriginAnchor
     });
 
     /// <summary>Folds one read into a snapshot and remembers it.</summary>
-    private PackageOriginSnapshot Observe(
-        IReadOnlyList<(ConfiguredPackageSource Source, IReadOnlyList<PackageManifest> Packages, string? Failure)> perSource,
-        DateTimeOffset now)
+    private PackageOriginSnapshot Observe(IList<SourceListing> perSource, DateTimeOffset now)
     {
         var failures = perSource.Where(x => x.Failure is not null)
             .Select(x => $"{x.Source.Name}: {x.Failure}").ToArray();
@@ -242,12 +237,12 @@ public sealed class PackageOriginAnchor
         // The FIRST configured source wins on an id collision — the same precedence the merged
         // catalog applies, so the anchor and the listing can never disagree about which source a
         // package belongs to.
-        foreach (var (source, packages, _) in perSource)
-        foreach (var package in packages.Where(p => !string.IsNullOrWhiteSpace(p.Id)))
+        foreach (var listing in perSource)
+        foreach (var package in listing.Packages.Where(p => !string.IsNullOrWhiteSpace(p.Id)))
             observed.TryAdd(
                 package.Id,
                 new PackageOrigin(
-                    package.Id, source.Name, package.ReleasedVersion, package.Module,
+                    package.Id, listing.Source.Name, package.ReleasedVersion, package.Module,
                     package.MinMeshVersion, package.TargetPartition));
 
         if (failures.Length == 0)
@@ -282,6 +277,11 @@ public sealed class PackageOriginAnchor
         Volatile.Write(ref last, snapshot);
         return snapshot;
     }
+
+    /// <summary>One source's contribution to a read — named rather than a tuple so the nullable
+    /// failure survives the inference through CombineLatest.</summary>
+    private sealed record SourceListing(
+        ConfiguredPackageSource Source, IReadOnlyList<PackageManifest> Packages, string? Failure);
 
     private static TimeSpan Freshness(IConfiguration configuration) =>
         int.TryParse(configuration?[FreshnessConfigKey], out var seconds)

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -4,6 +4,7 @@ using MeshWeaver.Graph;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -144,7 +145,22 @@ public static class PluginCatalogConfigurationExtensions
                 // completely that the lane can go dark while every surface looks like a healthy
                 // day; that is exactly what 2026-08-20 was. A plain singleton, process-scoped and
                 // bounded: a diagnostic, never a source of truth.
-                .AddSingleton<BundleAdoptionLedger>())
+                .AddSingleton<BundleAdoptionLedger>()
+                // 🚨 THE ENTITLEMENT ANCHOR (#1782 gap 2) — the registry's own catalog, read as the
+                // authority on which SOURCE carries which package. A local install record is a
+                // cache of that binding, and a cache miss must send the question upstream rather
+                // than answer "not entitled". Singleton because it keeps the last successful
+                // observation, which is what keeps a previously observed entitlement working while
+                // the registry is unreachable.
+                .AddSingleton(sp => new PackageOriginAnchor(
+                    sp.GetRequiredService<IMessageHub>(),
+                    sp.GetService<IConfiguration>() ?? new ConfigurationBuilder().Build(),
+                    sp.GetService<ILoggerFactory>()))
+                // …and the record that makes a degraded entitlement answer legible. Every refusal
+                // on the bundle routes is byte-identical on the wire (#1777), which is right for
+                // the caller and blind for the operator: "not granted" and "I could not reach the
+                // registry to find out" leave the same trace. Bounded, process-scoped diagnostic.
+                .AddSingleton<PackageEntitlementLedger>())
             .ConfigureHub(config =>
             {
                 config.TypeRegistry.AddPluginCatalogTypes();

--- a/test/Memex.Portal.Shared.Test/PluginBundleAnchorTest.cs
+++ b/test/Memex.Portal.Shared.Test/PluginBundleAnchorTest.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Api;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>THE ENTITLEMENT ANCHOR, END TO END</b> (#1782 gap 2) — the registry answers, the local
+/// install record is a cache, and its absence never denies.
+///
+/// <para><see cref="PluginBundleEntitlementTest"/> pins the gate itself (#1772/#1777): only granted
+/// packages are served, and every refusal is byte-identical to "no such bundle". That fixture is
+/// unchanged and still passes — this one pins the half it could not express, because before the
+/// anchor there was nothing to express it WITH: the <c>(source, package)</c> binding came from the
+/// install record and from nowhere else, so a package the serving instance had not itself installed
+/// had nothing to match a grant against, and "I cannot tell which source this is from" came out as
+/// "you are not entitled to it".</para>
+///
+/// <para><b>Everything below the anchor is REAL</b> — the same production path
+/// <see cref="PluginBundleEntitlementTest"/> exercises: instances registered through
+/// <see cref="MeshWeaverInstanceService.Register"/> (real minted key, real <c>DefaultGrants</c>
+/// seed into the admin-owned grant node), install records written and removed by
+/// <see cref="PackageInstaller"/>, the key resolved by the production
+/// <see cref="InstanceRegistryAuthenticator"/> over a real HTTP request. Only the registry SOURCE is
+/// a stub, and it has to be: the two states that matter most are a registry that carries a package
+/// this instance never installed, and one that will not answer at all.</para>
+/// </summary>
+public class PluginBundleAnchorTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The package whose install record is REMOVED — the cache, deleted — while the
+    /// registry keeps carrying it.</summary>
+    private const string AnchoredPackage = "BundleAnchored";
+
+    /// <summary>The paid package beside it, carried by the registry in a source this caller does
+    /// not hold.</summary>
+    private const string PaidPackage = "BundleAnchoredPaid";
+
+    /// <summary>Never installed, never advertised — the package nothing has ever observed.</summary>
+    private const string UnknownPackage = "BundleNeverHeardOf";
+
+    private const string PlatformSource = "Plugins";
+    private const string PaidSource = "Education";
+    private const string Version = "1.4.0";
+
+    private const string GrantedInstance = "anchor-consumer-granted";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog();
+
+    // ── the real registration + install path (identical to PluginBundleEntitlementTest) ────────
+
+    private Task<string> RegisterInstance(string instanceId, params string[] defaultGrants) =>
+        new MeshWeaverInstanceService(
+                Mesh.ServiceProvider.GetRequiredService<MeshWeaver.Mesh.Services.IMeshService>(),
+                Mesh,
+                Mesh.ServiceProvider.GetRequiredService<ILogger<MeshWeaverInstanceService>>(),
+                new ConfigurationBuilder()
+                    .AddInMemoryCollection(defaultGrants.Select((entry, i) =>
+                        new KeyValuePair<string, string?>(
+                            $"{MeshWeaverInstanceService.DefaultGrantsConfigKey}:{i}", entry)))
+                    .Build())
+            .Register("anchor-owner", "Anchor Owner", "owner@test.com", instanceId, instanceId)
+            .Select(r => r.RawKey)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(60))
+            .ToTask();
+
+    private Task<InstallResult> InstallPackage(string id, string? source) =>
+        PackageInstaller.Install(
+                Mesh,
+                new PackageManifest
+                {
+                    Id = id,
+                    Name = id,
+                    Kind = PackageKind.Content,
+                    TargetPartition = id,
+                    SourceFolder = id,
+                    Version = "1.0.0",
+                    ReleasedVersion = Version,
+                    Source = source,
+                },
+                [new PackageFile($"{id}/Doc.md", $"# {id}")],
+                "HEAD")
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(120))
+            .ToTask();
+
+    /// <summary>Removes the install record through the installer's own sanctioned route — the
+    /// CACHE, deleted, leaving the installed content and its partition exactly where they were.</summary>
+    private Task<bool> RemoveInstallRecord(string id) =>
+        PackageInstaller.RemoveInstalledRecord(Mesh, id)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(60))
+            .ToTask();
+
+    // ── the host, with a stub ANCHOR ──────────────────────────────────────────────────────────
+
+    private PackageEntitlementLedger ledger = new();
+
+    /// <summary>
+    /// The bundle routes on a TestServer wired to the REAL mesh, plus a stub registry anchor.
+    ///
+    /// <para>The anchor is registered on the REQUEST's services, which is exactly how a host
+    /// overrides it in production shapes too (<c>PluginBundleEndpoints.Anchor</c> reads
+    /// <c>RequestServices</c> first, then the mesh's — the same two-step
+    /// <c>ModuleLandingService</c> uses).</para>
+    /// </summary>
+    private async Task<WebApplication> StartBundleHost(params ConfiguredPackageSource[] sources)
+    {
+        ledger = new PackageEntitlementLedger();
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<IMessageHub>(Mesh);
+        builder.Services.AddSingleton(new InstanceRegistryAuthenticator(
+            Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<InstanceRegistryAuthenticator>>()));
+        builder.Services.AddSingleton(ledger);
+        builder.Services.AddSingleton(new PackageOriginAnchor(
+            () => sources,
+            // No reuse window: every request re-reads, so a source that starts failing mid-test is
+            // actually observed failing rather than answered from a snapshot.
+            TimeSpan.Zero,
+            () => DateTimeOffset.UtcNow,
+            Mesh.ServiceProvider.GetRequiredService<ILogger<PackageOriginAnchor>>()));
+
+        var app = builder.Build();
+        app.MapPluginBundles();
+        await app.StartAsync();
+        return app;
+    }
+
+    private static async Task<HttpResponseMessage> Get(WebApplication app, string route, string key)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, route);
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {key}");
+        return await app.GetTestClient().SendAsync(request);
+    }
+
+    private static string BundleRoute(string plugin) =>
+        $"{PluginBundleEndpoints.RoutePrefix}/{plugin}/{Version}";
+
+    private static string IndexRoute => PluginBundleEndpoints.RoutePrefix + "/index.json";
+
+    private static async Task<IReadOnlyList<string>> IndexedPlugins(HttpResponseMessage response)
+    {
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return json.RootElement.GetProperty("bundles").EnumerateArray()
+            .Select(b => b.GetProperty("plugin").GetString()!)
+            .ToArray();
+    }
+
+    // ── the assertions ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 <b>THE ISSUE, end to end: an entitled caller with NO install record is not denied.</b>
+    ///
+    /// <para>The package is installed the production way and then its install RECORD is removed —
+    /// the cache, deleted, while the content and its partition stay exactly where they are. That is
+    /// the state a registry which provisions its packages as Spaces is permanently in (memex-cloud
+    /// never runs the catalog install, so it has no install records at all), and it is the state a
+    /// fresh instance is in for a package a customer has already paid for.</para>
+    ///
+    /// <para>Pre-fix the answer was 404 with the package absent from the index, because the grant
+    /// had nothing to match against. It must now resolve upstream and serve.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task AnEntitledCallerWithNoInstallRecordIsStillServed()
+    {
+        await InstallPackage(AnchoredPackage, PlatformSource);
+        (await RemoveInstallRecord(AnchoredPackage)).Should().BeTrue(
+            "the test's premise is that the CACHE is gone");
+
+        var key = await RegisterInstance(GrantedInstance, $"{PlatformSource}/*");
+
+        var app = await StartBundleHost(Carrying(PlatformSource, AnchoredPackage));
+        await using var _ = app;
+
+        using var index = await Get(app, IndexRoute, key);
+        index.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await IndexedPlugins(index)).Should().Contain(AnchoredPackage,
+            "the registry carries this package and the caller's grant covers that source — the "
+            + "absence of a local install record is not evidence of anything");
+
+        using var served = await Get(app, BundleRoute(AnchoredPackage), key);
+        served.StatusCode.Should().Be(HttpStatusCode.OK,
+            "🚨 a purchase must not read as no purchase merely because nothing has installed here");
+
+        ledger.Decisions.Should().Contain(
+            d => d.PackageId == AnchoredPackage
+                 && d.Outcome == EntitlementOutcome.Granted
+                 && d.Anchor == EntitlementAnchorKind.Registry,
+            "and the answer must say it came from the anchor, not from a cache");
+    }
+
+    /// <summary>
+    /// 🚨 <b>An UNREACHABLE registry produces the third state, never a denial.</b>
+    ///
+    /// <para>Two halves, and they need different answers. A package whose entitlement was
+    /// PREVIOUSLY OBSERVED here — the install record still carries its stamped source — keeps being
+    /// served, from a decision that says out loud that it came from a cache. A package nothing has
+    /// ever observed cannot be served (there is no answer to serve from), but it resolves
+    /// <see cref="EntitlementOutcome.Indeterminate"/>: UNKNOWN, recorded, and never asserted as
+    /// "not entitled".</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task AnUnreachableRegistryDoesNotDeny()
+    {
+        await InstallPackage(AnchoredPackage, PlatformSource);
+        var key = await RegisterInstance(GrantedInstance, $"{PlatformSource}/*");
+
+        var app = await StartBundleHost(Failing(PlatformSource, "the registry is down"));
+        await using var _ = app;
+
+        using var served = await Get(app, BundleRoute(AnchoredPackage), key);
+        served.StatusCode.Should().Be(HttpStatusCode.OK,
+            "fail toward not blocking a caller whose entitlement was previously observed — an "
+            + "unreachable registry is not evidence of a missing purchase");
+        ledger.Decisions.Should().Contain(
+            d => d.PackageId == AnchoredPackage
+                 && d.Outcome == EntitlementOutcome.Granted
+                 && d.Anchor == EntitlementAnchorKind.Cache
+                 && d.IsDegraded,
+            "🚨 …and the cache must say it is a cache, or it silently becomes the anchor again");
+
+        using var unknown = await Get(app, BundleRoute(UnknownPackage), key);
+        unknown.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "the bytes are withheld — the third state differs in what it CLAIMS, not in what it "
+            + "hands over");
+        ledger.Decisions.Should().Contain(
+            d => d.PackageId == UnknownPackage && d.Outcome == EntitlementOutcome.Indeterminate,
+            "🚨 and the recorded answer is UNKNOWN, not Denied: 'I could not find out' and 'you did "
+            + "not buy it' must never be the same fact");
+        ledger.Decisions.Should().NotContain(
+            d => d.PackageId == UnknownPackage && d.Outcome == EntitlementOutcome.Denied);
+        ledger.Describe().Should().Contain("UNKNOWN, not denials",
+            "the degradation has to be legible rather than inferred from a quiet day");
+    }
+
+    /// <summary>
+    /// 🚨 The deny direction, which must not be lost: a caller who is genuinely not entitled still
+    /// sees nothing — including when the ANCHOR is the thing that carries the package.
+    ///
+    /// <para>This is the paid-content boundary the anchor could otherwise have widened: the
+    /// registry advertises a package to everyone who can read its catalog, and holding
+    /// <c>Plugins/*</c> must still not sweep in a 900 CHF course from <c>Education</c>.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task ACallerWhoIsNotEntitledStillSeesNothing()
+    {
+        await InstallPackage(PaidPackage, PaidSource);
+        var key = await RegisterInstance(GrantedInstance, $"{PlatformSource}/*");
+
+        var app = await StartBundleHost(
+            Carrying(PaidSource, PaidPackage), Carrying(PlatformSource, AnchoredPackage));
+        await using var _ = app;
+
+        using var index = await Get(app, IndexRoute, key);
+        (await IndexedPlugins(index)).Should().NotContain(PaidPackage,
+            "a caller must not even learn that an ungranted package is carried here");
+
+        using var refused = await Get(app, BundleRoute(PaidPackage), key);
+        refused.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        ledger.Decisions.Should().Contain(
+            d => d.PackageId == PaidPackage
+                 && d.Outcome == EntitlementOutcome.Denied
+                 && d.Anchor == EntitlementAnchorKind.Registry,
+            "the anchor was consulted in full and the grant does not cover the source it names — "
+            + "that is a real denial, and the rule must still be able to produce one");
+    }
+
+    /// <summary>
+    /// #1777 is not weakened: with the anchor in play, a refusal is still byte-identical to the
+    /// answer for a package that does not exist — status, body, content headers and header names.
+    ///
+    /// <para>The anchor adds STATES, never wire outcomes: the route still answers with the bytes or
+    /// with the one <c>NoSuchBundle()</c>. Here the two refusals are reached by different internal
+    /// paths on purpose — one Denied against the registry, one Indeterminate because nothing binds
+    /// it — which is exactly the pair a distinguishable refusal would leak.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task TheThirdStateIsIndistinguishableOnTheWire()
+    {
+        await InstallPackage(PaidPackage, PaidSource);
+        var key = await RegisterInstance(GrantedInstance, $"{PlatformSource}/*");
+
+        var app = await StartBundleHost(Failing(PlatformSource, "the registry is down"));
+        await using var _ = app;
+
+        // Denied — a cached binding this caller's grant does not cover.
+        using var denied = await Get(app, BundleRoute(PaidPackage), key);
+        // Indeterminate — nothing binds it and the anchor cannot be asked.
+        using var indeterminate = await Get(app, BundleRoute(UnknownPackage), key);
+
+        denied.StatusCode.Should().Be(indeterminate.StatusCode);
+        (await denied.Content.ReadAsByteArrayAsync())
+            .Should().Equal(await indeterminate.Content.ReadAsByteArrayAsync(),
+                "a body that revealed WHICH refusal this was would be the inventory oracle #1777 "
+                + "closed, rebuilt out of the new states");
+        denied.Content.Headers.ContentType?.ToString()
+            .Should().Be(indeterminate.Content.Headers.ContentType?.ToString());
+        denied.Content.Headers.ContentLength
+            .Should().Be(indeterminate.Content.Headers.ContentLength);
+        denied.Headers.Select(h => h.Key).OrderBy(k => k, StringComparer.Ordinal)
+            .Should().Equal(
+                indeterminate.Headers.Select(h => h.Key).OrderBy(k => k, StringComparer.Ordinal));
+
+        // …and the distinction lives where the caller cannot read it.
+        ledger.Decisions.Should().Contain(d => d.PackageId == PaidPackage
+            && d.Outcome == EntitlementOutcome.Denied);
+        ledger.Decisions.Should().Contain(d => d.PackageId == UnknownPackage
+            && d.Outcome == EntitlementOutcome.Indeterminate);
+    }
+
+    // ── stub sources ──────────────────────────────────────────────────────────────────────────
+
+    private static ConfiguredPackageSource Carrying(string source, params string[] packageIds) =>
+        new(
+            new StubSource(
+                packageIds.Select(id => new PackageManifest
+                {
+                    Id = id,
+                    Name = id,
+                    ReleasedVersion = Version,
+                    TargetPartition = id,
+                }).ToArray(),
+                null),
+            "HEAD", source);
+
+    private static ConfiguredPackageSource Failing(string source, string message) =>
+        new(new StubSource(null, new InvalidOperationException(message)), "HEAD", source);
+
+    /// <summary>A package source that lists exactly what it is told to, or refuses to list at
+    /// all — standing in for the registry's own catalog read.</summary>
+    private sealed class StubSource(IReadOnlyList<PackageManifest>? packages, Exception? failure)
+        : IPackageSource
+    {
+        public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
+            failure is null
+                ? Observable.Return(packages ?? [])
+                : Observable.Throw<IReadOnlyList<PackageManifest>>(failure);
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(
+            PackageManifest package, string gitRef) =>
+            Observable.Return<IReadOnlyList<PackageFile>>([]);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/PackageEntitlementAnchorTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PackageEntitlementAnchorTest.cs
@@ -1,0 +1,397 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// 🚨 <b>THE ENTITLEMENT ANCHOR</b> (#1782 gap 2) — that the REGISTRY answers, that a local install
+/// record is only a cache, and that the absence of one never comes out as "not entitled".
+///
+/// <para>The rule these pin is the maintainer's decision on the issue:</para>
+/// <code>
+/// anchor:   the entitlement record at the registry
+/// local:    install record = cache
+/// absent:   "ask upstream" — never "not entitled"
+/// </code>
+///
+/// <para>Pure: no hub, no HTTP, no clock. <c>PluginBundleEntitlementTest</c> pins the same rule end
+/// to end over a real registration, a real grant and a real HTTP round trip; these pin the decision
+/// itself, including the two branches that a live test cannot force — a registry that will not
+/// answer, and a package nothing has ever observed.</para>
+/// </summary>
+public class PackageEntitlementAnchorTest
+{
+    private const string Package = "SomePaidCourse";
+    private const string PlatformSource = "Plugins";
+    private const string PaidSource = "Education";
+
+    /// <summary>A caller granted exactly one source — the shape a real registration has.</summary>
+    private static Func<string, bool> GrantOf(string source) =>
+        candidate => string.Equals(candidate, source, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>A caller granted nothing. "Registering is identity, not entitlement."</summary>
+    private static Func<string, bool> GrantsNothing => _ => false;
+
+    // ── the load-bearing direction: absence must not deny ──────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 <b>An entitled caller with NO local install record is served.</b>
+    ///
+    /// <para>This is the whole issue. The binding used to come from the install record and from
+    /// nowhere else, so a package the serving instance had not itself installed had nothing to match
+    /// a grant against — and the answer to "I cannot tell which source this is from" was "you are
+    /// not entitled to it". A paying customer on a fresh instance is denied by that rule for no
+    /// reason other than that nothing has installed there yet.</para>
+    /// </summary>
+    [Fact]
+    public void EntitledWithNoLocalRecordIsGrantedFromTheAnchor()
+    {
+        var decision = PackageEntitlementAnchor.Resolve(
+            Package,
+            anchorSource: PlatformSource,
+            cachedSource: null,
+            anchorAvailable: true,
+            GrantOf(PlatformSource));
+
+        decision.Outcome.Should().Be(EntitlementOutcome.Granted,
+            "the registry carries the package and the caller's grant covers that source — the "
+            + "absence of a local install record says nothing about entitlement");
+        decision.Anchor.Should().Be(EntitlementAnchorKind.Registry);
+        decision.IsAuthoritative.Should().BeTrue();
+        decision.IsDegraded.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 🚨 <b>An unreachable registry produces the THIRD state, not a denial.</b>
+    ///
+    /// <para>Nothing was ever observed here and the anchor cannot be asked, so entitlement is
+    /// UNKNOWN. The bytes are still withheld — there is no answer to serve from — but the outcome
+    /// must not be reported as a refusal of entitlement, because an instance being unable to ASK is
+    /// not a customer failing to buy. That is the difference between a stated degradation and the
+    /// silent-failure family this whole change exists to leave.</para>
+    /// </summary>
+    [Fact]
+    public void AnUnreachableRegistryAnswersUnknownRatherThanDenied()
+    {
+        var decision = PackageEntitlementAnchor.Resolve(
+            Package,
+            anchorSource: null,
+            cachedSource: null,
+            anchorAvailable: false,
+            GrantOf(PlatformSource));
+
+        decision.Outcome.Should().Be(EntitlementOutcome.Indeterminate,
+            "'I could not find out' and 'you did not buy it' are different answers, and only one of "
+            + "them may be asserted");
+        decision.Outcome.Should().NotBe(EntitlementOutcome.Denied);
+        decision.Anchor.Should().Be(EntitlementAnchorKind.None);
+        decision.IsDegraded.Should().BeTrue("an unanswerable question must be legible, not inferred");
+        decision.Serves.Should().BeFalse("the third state still withholds the bytes — it differs in "
+            + "what it CLAIMS, not in what it hands over");
+        decision.Reason.Should().Contain("not a denial");
+    }
+
+    /// <summary>
+    /// An unreachable registry does not block a caller whose entitlement WAS previously observed:
+    /// the cached binding answers, and says it is a cache.
+    /// </summary>
+    [Fact]
+    public void AnUnreachableRegistryFallsBackToThePreviouslyObservedBinding()
+    {
+        var decision = PackageEntitlementAnchor.Resolve(
+            Package,
+            anchorSource: null,
+            cachedSource: PlatformSource,
+            anchorAvailable: false,
+            GrantOf(PlatformSource));
+
+        decision.Outcome.Should().Be(EntitlementOutcome.Granted,
+            "fail toward not blocking a viewer whose entitlement was previously observed");
+        decision.Anchor.Should().Be(EntitlementAnchorKind.Cache);
+        decision.IsAuthoritative.Should().BeFalse(
+            "🚨 a cache must be able to say it is a cache — otherwise it silently becomes the anchor "
+            + "again by accident");
+        decision.IsDegraded.Should().BeTrue();
+    }
+
+    // ── the deny direction, which must not be lost ─────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 A caller who is genuinely not entitled still sees nothing — the anchor carries the package,
+    /// in a source their grant does not cover. This is the paid-content boundary: holding
+    /// <c>Plugins/*</c> must not sweep in a 900 CHF course from <c>Education</c>.
+    /// </summary>
+    [Fact]
+    public void NotEntitledIsStillDenied()
+    {
+        var decision = PackageEntitlementAnchor.Resolve(
+            Package,
+            anchorSource: PaidSource,
+            cachedSource: null,
+            anchorAvailable: true,
+            GrantOf(PlatformSource));
+
+        decision.Outcome.Should().Be(EntitlementOutcome.Denied);
+        decision.Anchor.Should().Be(EntitlementAnchorKind.Registry);
+        decision.Serves.Should().BeFalse();
+    }
+
+    /// <summary>A caller granted nothing is denied whatever the binding says.</summary>
+    [Fact]
+    public void AGrantOfNothingIsDeniedFromEitherAnchor()
+    {
+        PackageEntitlementAnchor.Resolve(Package, PlatformSource, null, true, GrantsNothing)
+            .Outcome.Should().Be(EntitlementOutcome.Denied);
+        PackageEntitlementAnchor.Resolve(Package, null, PlatformSource, false, GrantsNothing)
+            .Outcome.Should().Be(EntitlementOutcome.Denied,
+                "a degraded answer is still an answer — falling back to the cache does not widen a "
+                + "grant, it only decides which source the grant is asked about");
+    }
+
+    /// <summary>
+    /// The registry answered IN FULL and carries no such package, and nothing local ever observed
+    /// one. That is a real negative, and it must stay one — a rule that never denies is not an
+    /// entitlement check.
+    /// </summary>
+    [Fact]
+    public void AFullRegistryAnswerWithNoSuchPackageIsARealDenial()
+    {
+        var decision = PackageEntitlementAnchor.Resolve(
+            Package, anchorSource: null, cachedSource: null, anchorAvailable: true,
+            GrantOf(PlatformSource));
+
+        decision.Outcome.Should().Be(EntitlementOutcome.Denied,
+            "the anchor was consulted completely — its silence about this package IS an observation");
+        decision.Anchor.Should().Be(EntitlementAnchorKind.None);
+        decision.IsDegraded.Should().BeFalse();
+    }
+
+    // ── provenance: the anchor outranks the cache, and staleness is visible ────────────────────
+
+    /// <summary>
+    /// 🚨 When both bind the package, the ANCHOR decides — including when they disagree. A cache
+    /// that outranked the registry would be the anchor by another name, and a package moved between
+    /// sources would keep resolving against a binding nobody maintains.
+    /// </summary>
+    [Fact]
+    public void TheAnchorOverridesADisagreeingCache()
+    {
+        // The cache still says "Plugins" (where it was installed from); the registry now carries it
+        // in the paid source. The caller holds only Plugins/*.
+        var decision = PackageEntitlementAnchor.Resolve(
+            Package,
+            anchorSource: PaidSource,
+            cachedSource: PlatformSource,
+            anchorAvailable: true,
+            GrantOf(PlatformSource));
+
+        decision.Outcome.Should().Be(EntitlementOutcome.Denied,
+            "a stale cached binding must not keep granting what the registry has moved behind a "
+            + "source this caller does not hold");
+        decision.Source.Should().Be(PaidSource);
+        decision.Anchor.Should().Be(EntitlementAnchorKind.Registry);
+    }
+
+    /// <summary>
+    /// A binding the anchor DID return is authoritative even when a different source failed to
+    /// list: one source being down cannot make another source's answer less true. Only an ABSENCE
+    /// loses its meaning.
+    /// </summary>
+    [Fact]
+    public void APartialReadStillAnchorsWhatItDidReturn()
+    {
+        var decision = PackageEntitlementAnchor.Resolve(
+            Package, anchorSource: PlatformSource, cachedSource: null, anchorAvailable: false,
+            GrantOf(PlatformSource));
+
+        decision.Anchor.Should().Be(EntitlementAnchorKind.Registry);
+        decision.Outcome.Should().Be(EntitlementOutcome.Granted);
+        decision.IsDegraded.Should().BeTrue("the READ was incomplete, and that stays reportable even "
+            + "though this particular answer did not need the missing part");
+    }
+
+    // ── the ledger ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 "Nothing was ever asked" and "everything was answered authoritatively" are different
+    /// sentences — the same rule <c>BundleAdoptionLedger</c> follows. Reporting an instance that
+    /// resolves nothing as a clean sweep makes the absence of the lane look like the success of it.
+    /// </summary>
+    [Fact]
+    public void TheLedgerDistinguishesSilenceFromSuccess()
+    {
+        var ledger = new PackageEntitlementLedger();
+        ledger.Describe().Should().Contain("no package entitlement has been resolved");
+
+        ledger.Record(PackageEntitlementAnchor.Resolve(
+            Package, PlatformSource, null, true, GrantOf(PlatformSource)));
+        ledger.Describe().Should().Contain("all answered against the registry anchor");
+        ledger.Degraded.Should().BeEmpty();
+
+        ledger.Record(PackageEntitlementAnchor.Resolve("Other", null, null, false, GrantsNothing));
+        ledger.Degraded.Should().HaveCount(1);
+        ledger.Indeterminate.Should().HaveCount(1);
+        ledger.Describe().Should().Contain("UNKNOWN, not denials");
+    }
+
+    /// <summary>Bounded — a diagnostic on a long-lived process answers "is the anchor working now",
+    /// and an unbounded list would answer it and also leak.</summary>
+    [Fact]
+    public void TheLedgerIsBounded()
+    {
+        var ledger = new PackageEntitlementLedger();
+        for (var i = 0; i < PackageEntitlementLedger.Capacity + 25; i++)
+            ledger.Record(PackageEntitlementAnchor.Resolve(
+                $"P{i}", PlatformSource, null, true, GrantOf(PlatformSource)));
+
+        ledger.Decisions.Count.Should().Be(PackageEntitlementLedger.Capacity);
+        ledger.Decisions[^1].PackageId.Should()
+            .Be($"P{PackageEntitlementLedger.Capacity + 24}", "the NEWEST are the ones kept");
+    }
+
+    // ── the READ that feeds the anchor ─────────────────────────────────────────────────────────
+
+    /// <summary>An instance that configures no sources is an authority on nothing — deliberately
+    /// NOT "the registry carries no such package".</summary>
+    [Fact]
+    public async Task NoConfiguredSourcesIsUnconfiguredRatherThanAuthoritative()
+    {
+        var anchor = new PackageOriginAnchor(() => [], TimeSpan.Zero, () => DateTimeOffset.UnixEpoch);
+        var snapshot = await anchor.Read().FirstAsync().ToTask();
+
+        snapshot.State.Should().Be(AnchorState.Unconfigured);
+        snapshot.IsComplete.Should().BeFalse(
+            "🚨 'I have no sources' answering 'the registry carries no such package' is precisely "
+            + "the absence-denies bug");
+    }
+
+    /// <summary>A source that lists successfully binds its packages, and the snapshot is complete —
+    /// so an absence from it is a real negative.</summary>
+    [Fact]
+    public async Task ASuccessfulReadIsAuthoritative()
+    {
+        var anchor = Anchor(Listing(PlatformSource, Manifest(Package, "1.4.0")));
+        var snapshot = await anchor.Read().FirstAsync().ToTask();
+
+        snapshot.State.Should().Be(AnchorState.Authoritative);
+        snapshot.IsComplete.Should().BeTrue();
+        snapshot.SourceOf(Package).Should().Be(PlatformSource);
+        snapshot.SourceOf("NeverPublished").Should().BeNull();
+    }
+
+    /// <summary>
+    /// 🚨 A source that will not list makes the snapshot NON-authoritative — and never throws.
+    /// A fault here would have to be turned into a decision by the caller, and the only safe
+    /// decision from an exception is the denial this change exists to remove.
+    /// </summary>
+    [Fact]
+    public async Task AFailingSourceDegradesRatherThanFaults()
+    {
+        var anchor = Anchor(Failing(PlatformSource, "GitHub said 502"));
+        var snapshot = await anchor.Read().FirstAsync().ToTask();
+
+        snapshot.State.Should().Be(AnchorState.Unreachable,
+            "nothing was listed and nothing had ever been observed");
+        snapshot.IsComplete.Should().BeFalse();
+        snapshot.Failure.Should().Contain("GitHub said 502");
+    }
+
+    /// <summary>
+    /// The previously observed bindings survive a failure — that is the mechanism behind "fail
+    /// toward not blocking a viewer whose entitlement was previously observed".
+    /// </summary>
+    [Fact]
+    public async Task APreviousObservationSurvivesTheNextFailure()
+    {
+        var failing = false;
+        var anchor = new PackageOriginAnchor(
+            () =>
+            [
+                new ConfiguredPackageSource(
+                    new StubSource(
+                        failing ? null : [Manifest(Package, "1.4.0")],
+                        failing ? new InvalidOperationException("registry down") : null),
+                    "HEAD", PlatformSource),
+            ],
+            // 🚨 No reuse window: the second read must genuinely go back to the source, or this test
+            // would pass by reading the cached snapshot and prove nothing.
+            TimeSpan.Zero, () => DateTimeOffset.UnixEpoch);
+
+        (await anchor.Read().FirstAsync().ToTask()).SourceOf(Package).Should().Be(PlatformSource);
+
+        failing = true;
+        var degraded = await anchor.Read().FirstAsync().ToTask();
+
+        degraded.State.Should().Be(AnchorState.Stale);
+        degraded.IsComplete.Should().BeFalse("an ABSENCE from a partial read proves nothing");
+        degraded.SourceOf(Package).Should().Be(PlatformSource,
+            "what was observed before is still what was observed — the registry going down does not "
+            + "un-publish a package");
+    }
+
+    /// <summary>
+    /// 🚨 The freshness window reuses a LISTING; it is not an entitlement term. Entitlements are
+    /// eternal, and the window's expiry triggers a read, never a refusal.
+    /// </summary>
+    [Fact]
+    public async Task TheFreshnessWindowReusesAListingAndExpiresIntoAReadNotARefusal()
+    {
+        var reads = 0;
+        var now = DateTimeOffset.UnixEpoch;
+        var anchor = new PackageOriginAnchor(
+            () =>
+            {
+                reads++;
+                return [new ConfiguredPackageSource(
+                    new StubSource([Manifest(Package, "1.4.0")], null), "HEAD", PlatformSource)];
+            },
+            TimeSpan.FromSeconds(60), () => now);
+
+        await anchor.Read().FirstAsync().ToTask();
+        await anchor.Read().FirstAsync().ToTask();
+        reads.Should().Be(1, "an authoritative listing inside the window is reused");
+
+        now = now.AddMinutes(5);
+        var afterExpiry = await anchor.Read().FirstAsync().ToTask();
+        reads.Should().Be(2, "the window's expiry asks the sources again");
+        afterExpiry.IsComplete.Should().BeTrue(
+            "…and the answer is an authoritative snapshot, never a refusal — a cache TTL is not an "
+            + "entitlement expiry");
+        afterExpiry.SourceOf(Package).Should().Be(PlatformSource);
+    }
+
+    // ── stubs ─────────────────────────────────────────────────────────────────────────────────
+
+    private static PackageManifest Manifest(string id, string released) =>
+        new() { Id = id, Name = id, ReleasedVersion = released, TargetPartition = id };
+
+    private static PackageOriginAnchor Anchor(ConfiguredPackageSource source) =>
+        new(() => [source], TimeSpan.Zero, () => DateTimeOffset.UnixEpoch);
+
+    private static ConfiguredPackageSource Listing(string name, params PackageManifest[] packages) =>
+        new(new StubSource(packages, null), "HEAD", name);
+
+    private static ConfiguredPackageSource Failing(string name, string message) =>
+        new(new StubSource(null, new InvalidOperationException(message)), "HEAD", name);
+
+    /// <summary>A package source that lists exactly what it is told to, or refuses to list at all.</summary>
+    private sealed class StubSource(IReadOnlyList<PackageManifest>? packages, Exception? failure)
+        : IPackageSource
+    {
+        public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
+            failure is null
+                ? Observable.Return(packages ?? [])
+                : Observable.Throw<IReadOnlyList<PackageManifest>>(failure);
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(
+            PackageManifest package, string gitRef) =>
+            Observable.Return<IReadOnlyList<PackageFile>>([]);
+    }
+}


### PR DESCRIPTION
Addresses **#1782 gap 2**, per the maintainer's decision recorded on the issue (2026-08-22). Gap 4 is out of scope and #1782 stays open for it.

```
anchor:   the entitlement record at the registry
local:    install record = cache
absent:   "ask upstream" — never "not entitled"
```

## What anchors the check now

The bundle routes authorize with `PluginGrantEntry`, which is a set of `(source, package)` pairs. The whole question is where the **`source` half** comes from — and it came from the local install record's `PackageManifest.Source` and from nowhere else. Two things followed from that, and both were wrong:

1. **A package this instance had not itself installed had no binding at all**, so it could not be served however plainly its content sat here. That is the *permanent* state of a GitSync-native registry: memex-cloud provisions its packages as Spaces and never runs the catalog install, so it has no install records. This is gap 2's literal sentence — *"finding the entitlement anchor for a package the serving instance has no install record for"*.
2. **"I cannot tell which source this is from" came out as "you are not entitled to it"** — a check whose inability to answer is indistinguishable from a negative answer, applied to the most expensive thing it could be: a purchase, read as no purchase.

So the **anchor is the registry's own catalog** — `PackageSources.FromConfiguration` → `IPackageSource.ListPackages`, the exact reading `/api/plugins` already serves its listing from, so "which source carries this package" has one answer per instance rather than one per surface. On a registry holding the git credential those sources are the plugin repos; on a downstream instance they are the registry it pulls from. Either way the anchor is *upstream of the local records*. The install record is demoted to what it always was: a cache of that binding, consulted when the anchor does not carry the package or cannot be reached.

`PackageEntitlementAnchor.Resolve` is the whole rule — pure, no hub, no clock, no I/O:

| the binding comes from | outcome |
|---|---|
| the **registry** carries it | `Granted`/`Denied`, `Anchor = Registry` — authoritative, and it overrides a disagreeing cache |
| only a **local observation** does | `Granted`/`Denied`, `Anchor = Cache` |
| **nothing**, and the registry answered in full | `Denied` — its silence about a package IS an observation |
| **nothing**, and the registry could not be asked | 🚨 `Indeterminate` — UNKNOWN, **not** a denial |

The index gains a third contributor to match: packages the anchor advertises **whose partition this instance actually holds**. That gate deliberately **fails open** — an empty partition list means "could not answer" as much as "none", and a gate whose inability to answer removes entries is the shape this PR exists to remove. It is an optimization (it stops an index full of bundles that could carry no bytes), and an optimization must never be the thing that denies.

## The unreachable-registry answer

It is a **third state**, and it is legible rather than inferred:

- **Previously observed → not blocked.** A cached binding still answers, labelled `Anchor = Cache`. A registry being briefly unlistable is not evidence that a purchase evaporated. The last successful snapshot is retained across failures precisely for this (`AnchorState.Stale`).
- **Never observed → `Indeterminate`.** The bytes are withheld — there is no answer to serve from — but the outcome is recorded as UNKNOWN and never asserted as a refusal. It differs from a denial in what it **claims**, not in what it hands over.
- **Air-gapped / no sources configured → `Unconfigured`**, deliberately not folded into "authoritative". An instance that configures nothing is an authority on nothing; its cached bindings still serve and anything it has never observed is UNKNOWN and says so. That is the stated answer for the air-gapped case: *supported, degraded, and it tells you which*.
- **Nothing ever faults.** `PackageOriginAnchor.Read()` turns every failure into a non-authoritative snapshot, because the only safe decision a caller can make from an exception is the denial this change removes.
- **Made visible**: `PackageEntitlementLedger` (bounded, process-scoped, `ImmutableInterlocked` — the same shape and rules as #2041's `BundleAdoptionLedger`, and the same "nothing was ever asked ≠ everything succeeded" rule), plus an `entitlement_anchor` health check reporting **Degraded**, never Unhealthy: continuing to serve a previously observed entitlement is the *correct* behaviour, and failing readiness over it would turn a brief registry outage into one of ours. Two distinct log lines too, because "the anchor is unreadable" (go fix it) and "this package is UNKNOWN" (the consumer-visible consequence) need different responses.

Why a surface at all: **every refusal on these routes is byte-identical on the wire by design (#1777)**, which is exactly right for the caller and blind for the operator — "not granted", "no such package" and "I could not reach the registry to find out" leave the same trace. Without a ledger, an anchor that has been down for a day looks precisely like a day on which nobody asked for anything they were not entitled to.

## How #1777 is preserved

#1777 established that the bundle routes are **authorization**-checked, and that all three refusal reasons are indistinguishable on status, body bytes and headers.

- **The grant match is untouched** — the same `AuthenticatedInstance.Allows(source, packageId)` against the same admin-owned `PluginGrant`, the same match `/api/plugins` and `InstallByDefault` make. No second notion of entitlement was introduced. Only *which source is asked about* moved.
- **No source is ever invented.** `Resolve` decides from a binding the registry returned or a binding a local observation wrote; there is no branch that synthesizes one. #1782's own 🚨 warned that inventing an anchor would weaken #1777 — this takes the registry's, which is the one thing that is already authoritative.
- **The wire still has exactly two outcomes**: the bytes, or the one `NoSuchBundle()`. `Indeterminate` withholds like a denial and adds no distinguishable answer. `TheThirdStateIsIndistinguishableOnTheWire` asserts this on status, body bytes, `Content-Type`, `Content-Length` and header names — between two refusals reached by *deliberately different internal paths* (one `Denied` against a cached binding, one `Indeterminate` with nothing binding it), which is precisely the pair a leak would expose.
- **The index stays filtered**, so "absent from your index" and "404 on fetch" still agree.
- **It tightens in one place.** #1948's sidecar union believed a published module's *self-declared* `PackagePath` source outright — an uploader's assertion used as an entitlement anchor. It is now read as a cached claim that the registry's binding overrides whenever the registry carries the package.
- **The one relaxation, stated plainly**: an install record with **no** `Source` used to match no grant entry and be servable to nobody, silently. It now has no *cached* binding, so the anchor answers for it — from the registry's catalog, never from a guess — and becomes `Indeterminate` only when the anchor is unreachable too. `PackageInstaller.SeedSource` still matters, because a stamped source is what keeps the answer working when the registry is *not* reachable.

## Existing shape not broken

- **A purchase is still TWO writes.** Nothing here writes an entitlement, a grant or an `_Access` node. This is a read-side resolution on the serving instance; `Entitlements.GrantEntitlement` / `PluginGate.Enroll` are untouched and no third write path was added.
- **Entitlements stay eternal.** The anchor's freshness window (60s, `PluginCatalog:AnchorFreshnessSeconds`) reuses a *listing*; its expiry triggers a **read**, never a refusal, and `TheFreshnessWindowReusesAListingAndExpiresIntoAReadNotARefusal` pins exactly that. A cache TTL is not an entitlement expiry and the two are not conflated anywhere — the only term in the model remains `PluginGrantEntry.ExpiresAt`, which this does not touch.
- **No async.** `IObservable<T>` end to end; the genuinely-async leaves (git, HTTP) already sit behind `IIoPool` inside the package sources, and nothing was added above them.

## Tests — and the proof they are worth something

**`PackageEntitlementAnchorTest` (15)** — the decision and the read, pure. Both directions of every branch: entitled-with-no-record → `Granted/Registry`; unreachable → `Indeterminate` and explicitly *not* `Denied`; previously-observed → `Granted/Cache` with `IsAuthoritative == false`; genuinely-unentitled → `Denied`; a full registry answer carrying no such package → a **real** denial (a rule that never denies is not an entitlement check); the anchor overriding a stale cache; a partial read still anchoring what it *did* return; the ledger's silence-vs-success distinction and its bound; and the read's four states.

**`PluginBundleAnchorTest` (4)** — end to end on a TestServer wired to the real mesh. Instances registered through `MeshWeaverInstanceService.Register` (real minted key, real `DefaultGrants` seed into the admin-owned grant node), install records written **and removed** by `PackageInstaller`'s own sanctioned routes, the key resolved by the production `InstanceRegistryAuthenticator` over a real HTTP request. Only the registry source is a stub, and it has to be — the two states that matter most are a registry carrying a package this instance never installed, and one that will not answer at all.

The load-bearing one installs a package the production way and then **removes its install record** — the cache, deleted, content and partition left exactly where they were — and asserts the entitled caller is still indexed and still served.

🚨 **All four FAIL against `origin/main`'s `PluginBundleEndpoints.cs`.** I reverted that one file to its pre-fix state, rebuilt, and ran them:

```
Failed AnEntitledCallerWithNoInstallRecordIsStillServed [416 ms]
  Expected collection {} to contain "BundleAnchored" because the registry carries this
  package and the caller's grant covers that source — the absence of a local install
  record is not evidence of anything.
Failed AnUnreachableRegistryDoesNotDeny [1 s]
  Expected collection to contain an item matching the predicate because 🚨 …and the cache
  must say it is a cache, or it silently becomes the anchor again.
Failed ACallerWhoIsNotEntitledStillSeesNothing [479 ms]
  Expected collection to contain an item matching the predicate because the anchor was
  consulted in full and the grant does not cover the source it names — that is a real
  denial, and the rule must still be able to produce one.
Failed TheThirdStateIsIndistinguishableOnTheWire [520 ms]
  Expected collection to contain an item matching the predicate.
Failed!  - Failed: 4, Passed: 0, Skipped: 0, Total: 4
```

The first line **is gap 2**: an empty index for a package that is plainly installed here.

The pure suite is non-vacuous too — flipping branch 4 of `Resolve` from `Indeterminate` to `Denied` (the exact bug this PR exists to prevent) fails two of the fifteen with `Expected value to be Indeterminate … but found Denied`; restored and green again.

**Regression, all after the change**: `MeshWeaver.PluginCatalog.Test` **593/593**, `Memex.Portal.Shared.Test` **358/358** (including `PluginBundleEntitlementTest`, `PluginBundleAuthTest` and `PluginBundleLaneResolutionTest` — the #1772/#1777/#1751 pins — untouched and passing), Documentation link/WhatsNew guards 2/2. `-c Release -warnaserror` clean on every touched project.

## Docs

`Doc/Architecture/PluginPackaging` gains an *"The entitlement anchor is the REGISTRY"* section with the three-outcome table, the #1777-preservation argument and the air-gapped/freshness notes. What's New: `Category: Fix` — an operator can notice this (a package that used to 404 is now served, and a new `entitlement_anchor` health check can read Degraded).

## Deliberately left

- **No change to `MeshWeaver.Plugins`' `Store` package, and it is not an omission.** I checked the two places the same rule would apply and both already follow it: `InstallStatus` treats a missing viewer install record as `InstallState.Missing` → *repair silently*, never a denial; and `StoreManifestSource` keeps the last successful registry listing when a read fails (`Scan(… next ?? last)`) rather than degrading to an empty catalog. Adding machinery there would be a second implementation of a rule already held.
- **Viewer-level entitlement (`{plugin}/_Entitlements/{viewer}`) is still per-mesh.** Anchoring *that* on the registry is a genuinely different problem — it needs a cross-instance account identity, which does not exist today — and the issue scopes gap 2 to the instance-key bundle routes. Worth its own issue rather than a rider on this one.
- **The `entitlement_anchor` health check has no test of its own** (`Memex.Portal.Distributed` has no test project). Its logic is a two-line fold over `PackageEntitlementLedger` and `PackageOriginSnapshot.Describe()`, both of which are covered.
- **One behaviour change worth watching on memex**: the bundle index now reads the configured sources (≤ once per 60s per process). If they are unreachable the index degrades to cached bindings rather than failing, which is the intended shape — but it is a new dependency on that path and the health check is where it will show.

Ordering: this is a single-repo change; nothing in `MeshWeaver.Plugins` needs to land with it.

Refs #1782. Does not close it — gap 4 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
