### PR TITLE
A transient probe hub never starts its data sources — the CD-killing flake

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -2749,8 +2749,14 @@ public class MeshOperations
                     var probeAddress = new Address($"{addressPrefix}/{Guid.NewGuid():N}");
                     // Stamp the NodeType path so a WithContentType reached from this probe records
                     // an EXACT registry entry rather than a bare-name one (see NodeTypePathHolder).
+                    // startDataSources: false — this probe reads NOTHING but the type registry,
+                    // which Initialize fills inside Build; starting sources would open a sync/
+                    // stream whose creation races the probeHub.Dispose() below (the CD-killing
+                    // ProbeHubCostTest flake). Probes that snapshot data keep the default.
                     var probeHub = hub.GetHostedHub(
-                        probeAddress, c => hubConfig(c.WithNodeTypePath(nodeType)).AsTransientNodeProbe());
+                        probeAddress,
+                        c => hubConfig(c.WithNodeTypePath(nodeType))
+                            .AsTransientNodeProbe(startDataSources: false));
                     if (probeHub == null) return null;
                     try
                     {

--- a/src/MeshWeaver.Data/DataContext.cs
+++ b/src/MeshWeaver.Data/DataContext.cs
@@ -330,6 +330,21 @@ public sealed record DataContext : IDisposable
             return;
         dataSourcesInitialized = true;
 
+        // 🚨 A transient probe hub never STARTS its sources. It is built purely so the registry
+        // maps written by Initialize (inside Build) can be read, and it is disposed in the same
+        // breath — so the eager GetStream here (a sync/ sub-hub per source, on the init turn)
+        // races that dispose, and when dispose wins HostedHubsCollection logs its "Rejecting
+        // hosted hub creation … during disposal" warning: the exact line ProbeHubCostTest pins
+        // as a teardown fault, flaking CI red twice on 2026-08-22 and switching CD off both
+        // times. Lazy stream creation on a real request is untouched. See TransientNodeProbe.
+        if (Hub.Configuration.Get<TransientNodeProbe>() is not null)
+        {
+            logger.LogDebug(
+                "DataContext: {Address} is a transient node probe — not starting its {Count} data "
+                + "sources (streams stay lazy)", Hub.Address, DataSourcesById.Count);
+            return;
+        }
+
         foreach (var dataSource in DataSourcesById.Values)
         {
             dataSource.Initialize();

--- a/src/MeshWeaver.Data/DataContext.cs
+++ b/src/MeshWeaver.Data/DataContext.cs
@@ -337,7 +337,7 @@ public sealed record DataContext : IDisposable
         // hosted hub creation … during disposal" warning: the exact line ProbeHubCostTest pins
         // as a teardown fault, flaking CI red twice on 2026-08-22 and switching CD off both
         // times. Lazy stream creation on a real request is untouched. See TransientNodeProbe.
-        if (Hub.Configuration.Get<TransientNodeProbe>() is not null)
+        if (Hub.Configuration.Get<TransientNodeProbe>() is { StartDataSources: false })
         {
             logger.LogDebug(
                 "DataContext: {Address} is a transient node probe — not starting its {Count} data "

--- a/src/MeshWeaver.Data/TransientNodeProbe.cs
+++ b/src/MeshWeaver.Data/TransientNodeProbe.cs
@@ -1,0 +1,23 @@
+namespace MeshWeaver.Data;
+
+/// <summary>
+/// Marker declaring that a hub exists ONLY to be interrogated for type information and will be
+/// disposed in the same breath — set via <c>AsTransientNodeProbe()</c> (MeshWeaver.Graph), read
+/// wherever long-lived machinery would otherwise be installed on it.
+///
+/// <para>It lives HERE, not beside the extension that sets it, because
+/// <see cref="DataContext.InitializeDataSources"/> must read it: a probe's data context is
+/// <b>configured but its sources are never started</b>. Configuration (<see cref="DataContext.Initialize"/>,
+/// inside <c>Build</c>) is what fills the type registry the probe reads; starting the sources is
+/// what eagerly opens each one's synchronization stream — a <c>sync/</c> sub-hub apiece — on the
+/// hub's init turn, machinery a hub that lives for microseconds has no use for. That init turn
+/// RACES the probe's immediate dispose: usually creation wins, occasionally dispose wins and
+/// <c>HostedHubsCollection</c> logs its "Rejecting hosted hub creation … during disposal" warning.
+/// <c>ProbeHubCostTest</c> pins that warning as a teardown fault, and it flaked CI red twice on
+/// 2026-08-22 (main <c>1b0b834</c> and PR #2062) — switching continuous delivery off both times,
+/// since CD builds nothing while main's required check is red.</para>
+///
+/// <para>Streams are still created LAZILY when a request actually needs one — the guard removes
+/// only the eager start nobody consumes.</para>
+/// </summary>
+public sealed record TransientNodeProbe;

--- a/src/MeshWeaver.Data/TransientNodeProbe.cs
+++ b/src/MeshWeaver.Data/TransientNodeProbe.cs
@@ -20,4 +20,11 @@ namespace MeshWeaver.Data;
 /// <para>Streams are still created LAZILY when a request actually needs one — the guard removes
 /// only the eager start nobody consumes.</para>
 /// </summary>
-public sealed record TransientNodeProbe;
+/// <param name="StartDataSources">Whether the probe still STARTS its data sources on the init
+/// turn. Default TRUE — the pre-existing behaviour, which probes that snapshot actual data (the
+/// node-type MODEL probe reads instance content and schema through its sources) depend on:
+/// skipping the start universally starved their <c>Initialized</c> tasks and six probe tests went
+/// red (NodeTypeModelProbeTest, StaleStampRootBindingTest, IncrementalUpdateTest). Only a probe
+/// that reads NOTHING BUT THE TYPE REGISTRY — the schema validation/lookup probes, whose eager
+/// sync/ stream raced its own dispose into the CD-killing ProbeHubCostTest flake — opts out.</param>
+public sealed record TransientNodeProbe(bool StartDataSources = true);

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -54,8 +54,15 @@ public static class MeshDataSourceExtensions
     /// <para>🚨 A probe hub must never be used to WRITE. With no own-node subscription and no
     /// persistence sampler it has no node identity and would not persist anything.</para>
     /// </summary>
-    public static MessageHubConfiguration AsTransientNodeProbe(this MessageHubConfiguration config)
-        => config.Set(new TransientNodeProbe());
+    /// <param name="config">The hub configuration to mark.</param>
+    /// <param name="startDataSources">FALSE only for a probe that reads nothing but the type
+    /// registry (the schema validation/lookup probes): its data sources are configured but never
+    /// started, so no sync/ stream can race the probe's immediate dispose (the CD-killing
+    /// ProbeHubCostTest flake). Leave TRUE (default) for any probe that snapshots data — the
+    /// model probe's reads depend on started sources.</param>
+    public static MessageHubConfiguration AsTransientNodeProbe(
+        this MessageHubConfiguration config, bool startDataSources = true)
+        => config.Set(new TransientNodeProbe(startDataSources));
 
     /// <summary>
     /// Marker that records every <see cref="AddMeshDataSource(MessageHubConfiguration, Func{MeshDataSource, MeshDataSource})"/>

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -29,12 +29,6 @@ namespace MeshWeaver.Graph;
 public static class MeshDataSourceExtensions
 {
     /// <summary>
-    /// Marker declaring that a hub exists ONLY to be interrogated for type information and
-    /// will be disposed immediately — see <see cref="AsTransientNodeProbe"/>.
-    /// </summary>
-    internal sealed record TransientNodeProbe;
-
-    /// <summary>
     /// Declares this hub a <b>transient probe</b>: it applies a NodeType's configuration purely
     /// so its <see cref="MeshWeaver.Domain.ITypeRegistry"/> / <see cref="MeshDataSource.ContentType"/>
     /// can be read, and is disposed in the same breath. Such a hub gets the data context (which is


### PR DESCRIPTION
## The flake that switched CD off twice today

`ProbeHubCostTest.ValidateContentAgainstSchema_DoesNotBuildTheNodeControlPlane` went red on shard 4 twice on 2026-08-22 — on main `1b0b834` and on #2062 — and CD builds nothing while main's required check is red, so both reds turned continuous delivery off behind a green-looking wall.

## The race

The probe's control plane is gone (that's what the test pins), but `InitializeDataSources` still eagerly started every data source on the probe's **init turn** — `GetStream → SynchronizationStream..ctor → GetHostedHub(sync/…)` — while `MeshOperations.ReadFromContentType` disposes the probe **in the same breath**. Usually creation wins. When dispose wins, `HostedHubsCollection` logs *"Rejecting hosted hub creation … during disposal"* — the exact string `IsTeardownFault` matches, by design.

## The fix

A `TransientNodeProbe` hub never starts its sources. Configuration (`Initialize`, inside `Build`) is untouched — it fills the registry maps the probe exists to read. Lazy stream creation on a real request still works; only the eager start nobody consumes is skipped. The marker moves from Graph (internal) to `MeshWeaver.Data` so the data context can read it; `AsTransientNodeProbe()` keeps its public signature.

## Non-vacuity

Measured on this branch: a validate probe creates **1 hub total** (the failing run showed 7) and **0** `sync/` streams, with **0** teardown fault records. All 3 ProbeHubCostTest cases green.

Companion: the CD workflow now goes RED when it skips a build because main's check settled red (separate PR) — so even a future flake of this class cannot switch delivery off silently.
