### PR TITLE
CD goes RED when it skips because main's required check settled red

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1583,11 +1583,29 @@ jobs:
             exit 1
           fi
 
+          # 🚨 THE OTHER INVISIBLE STATE — the push path's ⛔ branch. CD enters via workflow_run,
+          # i.e. only after Build-and-Test COMPLETED on main, so GREEN != true here is a suite
+          # that has SETTLED red — never one still running. The gate then records "⛔ nothing
+          # will be built" in the step summary and the run ends SUCCESS: continuous delivery is
+          # switched off for every commit until someone happens to open the summary. Measured
+          # 2026-08-22: one flaky shard on 1b0b834 kept CD reporting green no-ops from 11:48
+          # while both production instances waited on the release it was not building. A red
+          # main is an incident for a continuously-delivered product; this run must be RED so
+          # alert-on-failure files it. (A rerun that goes green fires a fresh workflow_run,
+          # which publishes and supersedes this alarm — nothing to un-stick by hand.)
+          if [ "$REASON" = "push" ] && [ "$PUBLISH" != "true" ] && [ "$GREEN" != "true" ]; then
+            echo "::error::the required check on main \`$SHORT\` settled RED, so this CD run built nothing — delivery is OFF until main is green again. Re-run the failed Build-and-Test jobs (a green rerun re-enters CD by itself); if the failure is real, fixing main IS the release path."
+            exit 1
+          fi
+
           echo "OK — either something was published, or not publishing was the correct answer."
 
   alert-on-failure:
     name: "Alert: CD failed on main"
-    needs: [gate, portal-image, migration-image, plugin-test-image, portal-next-image, promote, verify-images, publish-bake]
+    # delivery-verdict is in this list ON PURPOSE: it is the job that turns the two
+    # invisible do-nothing states (green-but-stuck reconcile, red-main push) into failures,
+    # and a failure nobody is paged for is still invisible.
+    needs: [gate, portal-image, migration-image, plugin-test-image, portal-next-image, promote, verify-images, publish-bake, delivery-verdict]
     if: failure()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -136,9 +136,28 @@ silent:
    Build-and-Test**. But its `event` is `workflow_dispatch`, not `push`, so the `workflow_run` gate
    still skips. It is the most convincing possible "it shipped" signal, with no image behind it.
 
-**Neither is terminal now**, because the reconciler reads the *check on the commit* rather than the
-event that produced it — so a dispatched Build-and-Test does eventually lead to an image, within one
-reconcile tick. To kick CD by hand, use its own door:
+3. **Build-and-Test settled RED on main.** CD's push path then decides "⛔ nothing will be built" —
+   and until 2026-08-22 that run ended **SUCCESS**, with the refusal visible only in its step
+   summary. One flaky shard (`ProbeHubCostTest`, a probe hub racing its own dispose — fixed the
+   same day) kept CD reporting green no-ops for hours while both production instances waited on
+   the release it was not building. Since then `delivery-verdict` FAILS on that state and
+   `alert-on-failure` pages it: **a red main is an incident for a continuously-delivered product,
+   never a quiet skip.** The operator move is unchanged by the alarm: read the failing test; a
+   flake → `gh run rerun <id> --failed` (a green rerun fires a fresh `workflow_run`, which
+   publishes by itself); a real failure → fixing main IS the release path.
+
+Two diagnosis cheats, both learned the hard way on 2026-08-22:
+
+- **A CD run with ZERO jobs** ("This run likely failed because of a workflow file issue") means the
+  workflow FILE is invalid — every run since the breaking merge produced nothing. The classic cause
+  is a `needs:` naming a deleted job. Parse before pushing:
+  `python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/main-cd.yml')); jobs=set(d['jobs']); print([(n,dep) for n,j in d['jobs'].items() for dep in ([j.get('needs')] if isinstance(j.get('needs'),str) else j.get('needs') or []) if dep not in jobs])"`
+- **A green CD run whose jobs are all `skipped`** shipped nothing by decision — read the `Decide`
+  step's last line for which branch fired, and believe that line over the tick.
+
+**Neither of the first two is terminal now**, because the reconciler reads the *check on the
+commit* rather than the event that produced it — so a dispatched Build-and-Test does eventually
+lead to an image, within one reconcile tick. To kick CD by hand, use its own door:
 
 ```bash
 gh workflow run main-cd.yml --ref main     # heals HEAD; cannot publish an untested tree


### PR DESCRIPTION
## The trap

The push path's ⛔ branch — *"Consolidate test results on $SHORT is failure — nothing will be built"* — recorded its decision in the step summary and ended **SUCCESS**. A red main therefore switched continuous delivery off silently: every CD run green, zero images produced. Measured 2026-08-22 from 11:48 on `1b0b834` (one flaky shard), while both production instances waited on the release CD was not building. The reconciler's unhealable alarm only fires after 120 min.

## Why failing loudly cannot cry wolf

CD enters via `workflow_run` — only after Build-and-Test **completed** on main. So `GREEN != true` on the push path always means a suite that **settled red**, never one still running. And a rerun that goes green fires a fresh `workflow_run`, which publishes and supersedes the alarm — nothing to un-stick by hand.

## Changes

- `delivery-verdict` fails on push + red-settled check + nothing published — its second invisible do-nothing state, beside the existing green-but-stuck-reconcile one.
- `alert-on-failure` now `needs: delivery-verdict`, so both verdict failures file the ci-failure issue instead of merely being red.

Every `needs:` verified against the job set (no dangling entries); YAML parses.

Companion: #2068 fixes the flake itself (`ProbeHubCostTest` — a probe hub racing its own dispose).