### PR TITLE
The line now building is rc8 — rc7 shipped and the bump was missed

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -71,12 +71,19 @@
          dependency closures (#1914/#1919/#1923), and whose platform has shed the module-only
          Azure/OpenAI dependencies.
 
-         v3.0.0-rc7 is the line NOW BUILDING — the release in which the optional GUI and voice
+         v3.0.0-rc7 shipped 2026-08-22 — the release in which the optional GUI and voice
          surfaces stop riding the app closure: all five Blazor view packs (#2018/#2021) and
          Speech (#2028) ship under modules/<Name>/ and activate through Modules:Assemblies, with
-         their static web assets served from the module (#1724/#1987/#2017/#2020). Its tag is
-         created only when rc7 is released — never tag it early, the v*.*.* tag IS the trigger
-         for the NuGet + image publish.
+         their static web assets served from the module (#1724/#1987/#2017/#2020).
+
+         v3.0.0-rc8 is the line NOW BUILDING — the release that makes the extraction OPERABLE:
+         the registry shelf accepts modules for platforms newer than itself (the rc7 three-way
+         deadlock: image ships no modules → only the registry delivers them → the registry
+         refused to carry them until it updated → it could not update without them), CD goes RED
+         when a red main switches it off (#2069), the transient-probe dispose race is gone
+         (#2068), provisioning gets its inverse (Plugins #585), and the hosting operator is
+         enabled on the control instance. Its tag is created only when rc8 is released — never
+         tag it early, the v*.*.* tag IS the trigger for the NuGet + image publish.
 
          🚨 BUMP THIS THE MOMENT A LINE IS TAGGED, in the same session. rc6 was released while
          this property still read rc6, so every continuous build afterwards kept stamping a
@@ -90,7 +97,7 @@
          it publishes are the ones the platform still builds. Do not "fill in" rc4 later: the
          version never shipped, and minting a tag for it now would publish that superseded
          content set for real. -->
-    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc7</PlatformVersion>
+    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc8</PlatformVersion>
   </PropertyGroup>
   <!-- Multi-arch container publish race fix (main-cd / release-images / edge-images pass
        -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK's _PublishMultiArchContainers


### PR DESCRIPTION
"🚨 BUMP THIS THE MOMENT A LINE IS TAGGED, in the same session." — rc7's tag was cut this morning and the property still read rc7, so every ci build since stamps a version that is already published (the recorded rc6 mistake, repeated).

Bumps `PlatformVersion` → `3.0.0-rc8` and writes the line's charter: the release that makes the module extraction OPERABLE — registry shelf accepts future-floor modules, CD pages on a red main (#2069), the probe dispose race is gone (#2068), provisioning gets its inverse (Plugins #585), the hosting operator is live on the control instance.