### PR TITLE
The registry shelf accepts modules for platforms newer than itself

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -208,11 +208,19 @@ public static class PluginBundleEndpoints
                     return Results.Json(new { error = decline }, statusCode: StatusCodes.Status400BadRequest);
                 }
 
+                ModuleLandingOutcome outcome;
                 try
                 {
-                    // The floor gate and the same-identity trap-door hold HERE, at placement —
-                    // one owner for each rule. A refusal surfaces as the observable's error.
-                    await landing.LandModule(
+                    // 🚨 The SHELF landing, not the adopt one (2026-08-22): publishing stocks the
+                    // registry's warehouse, and a warehouse may carry modules for platforms NEWER
+                    // than itself. An above-floor upload therefore lands as HELD — bytes on the
+                    // shelf, served to consumers (whose own install path applies the floor
+                    // against THEIR platform), excluded from this instance's boot until a
+                    // platform update satisfies the floor — instead of the 409 that deadlocked
+                    // extracted modules against the very platform update that needed them
+                    // (rc6→rc7, 2026-08-22). Real refusals (the app-closure same-identity
+                    // trap-door, malformed names) still surface as the observable's error.
+                    outcome = await landing.ShelveModule(
                         accepted.Module, accepted.Files,
                         frameworkMvid: accepted.FrameworkMvid,
                         packagePath: accepted.PackagePath,
@@ -228,19 +236,32 @@ public static class PluginBundleEndpoints
                         statusCode: StatusCodes.Status409Conflict);
                 }
 
-                logger?.LogInformation(
-                    "Module publish: landed '{Module}' for {Plugin} ({Files} file(s), version {Version}, "
-                    + "floor {Floor}) — it serves from this registry and loads here on the next restart",
-                    accepted.Module, plugin, accepted.Files.Count,
-                    accepted.Version ?? "(unversioned)", accepted.MinMeshVersion ?? "(none)");
+                if (outcome.Held)
+                    logger?.LogInformation(
+                        "Module publish: SHELVED '{Module}' for {Plugin} ({Files} file(s), version "
+                        + "{Version}) — HELD from local activation ({Reason}); it serves from this "
+                        + "registry, and this instance loads it once its platform satisfies the floor",
+                        accepted.Module, plugin, accepted.Files.Count,
+                        accepted.Version ?? "(unversioned)", outcome.HoldReason);
+                else
+                    logger?.LogInformation(
+                        "Module publish: landed '{Module}' for {Plugin} ({Files} file(s), version {Version}, "
+                        + "floor {Floor}) — it serves from this registry and loads here on the next restart",
+                        accepted.Module, plugin, accepted.Files.Count,
+                        accepted.Version ?? "(unversioned)", accepted.MinMeshVersion ?? "(none)");
 
+                // held/holdReason let the publisher tell "shelved, will serve" apart from
+                // "activated here"; pendingRestart is honest for the held case — a restart of
+                // THIS instance would not load a held module, so nothing is pending on one.
                 return Results.Json(new
                 {
                     plugin,
                     module = accepted.Module,
                     version = accepted.Version,
                     files = accepted.Files.Count,
-                    pendingRestart = true,
+                    held = outcome.Held,
+                    holdReason = outcome.HoldReason,
+                    pendingRestart = !outcome.Held,
                 });
             })
             .AllowAnonymous();
@@ -671,9 +692,11 @@ public static class PluginBundleEndpoints
     /// <summary>
     /// Which of the installed packages' declared modules this instance can serve right now:
     /// plugin id → module assembly name, for exactly the entries whose bytes exist under
-    /// <c>modules/&lt;name&gt;/</c> and pass the platform-floor gate (<see cref="ModuleBundleSource"/>
-    /// — the same <see cref="ModulePlatformFloor"/> check boot applies, so a registry never serves
-    /// a landing its own boot skips). One activation-sidecar read for the whole index.
+    /// <c>modules/&lt;name&gt;/</c> and were not uninstalled (<see cref="ModuleBundleSource"/>).
+    /// A HELD landing — floor above THIS instance's platform, the registry-shelf state (2026-08-22) —
+    /// is listed too, deliberately: the index surfaces its <c>minMeshVersion</c> and each
+    /// consumer's own gate decides loadability THERE, before a byte travels. One
+    /// activation-sidecar read for the whole index.
     /// </summary>
     private static IObservable<IReadOnlyDictionary<string, string>> ServableModules(
         IMessageHub rootHub, IReadOnlyList<BundleEntry> packages)
@@ -687,8 +710,7 @@ public static class PluginBundleEndpoints
         return landing.GetActivation().Take(1)
             .Select(activation => (IReadOnlyDictionary<string, string>)declaring
                 .Where(p => ModuleBundleSource.Collect(
-                        landing.BaseDirectory, p.Module!, activation,
-                        ModulePlatformFloor.DeclineReason)
+                        landing.BaseDirectory, p.Module!, activation)
                     .DeclineReason is null)
                 .ToDictionary(p => p.PluginId, p => p.Module!, StringComparer.OrdinalIgnoreCase));
     }
@@ -919,9 +941,11 @@ public static class PluginBundleEndpoints
     /// <summary>
     /// The MODULE closure files this bundle carries (#1664) — the instance's own
     /// <c>modules/&lt;name&gt;/</c> bytes, resolved through <see cref="ModuleBundleSource"/> (which
-    /// refuses uninstalled and framework-stale landings). Empty for a package that declares no
-    /// module or whose bytes this instance cannot serve — the bundle then simply has no module
-    /// section, which a consumer reads as "nothing to land".
+    /// refuses uninstalled landings; a HELD landing — floor above this instance's platform, the
+    /// registry-shelf state, 2026-08-22 — is served, its floor riding the manifest for the CONSUMER's
+    /// gate). Empty for a package that declares no module or whose bytes this instance cannot
+    /// serve — the bundle then simply has no module section, which a consumer reads as "nothing
+    /// to land".
     /// </summary>
     private static IObservable<IReadOnlyList<string>> ModuleFiles(
         IMessageHub rootHub, BundleEntry package)
@@ -937,8 +961,7 @@ public static class PluginBundleEndpoints
             .Select(activation =>
             {
                 var (files, decline) = ModuleBundleSource.Collect(
-                    landing.BaseDirectory, package.Module!, activation,
-                    ModulePlatformFloor.DeclineReason);
+                    landing.BaseDirectory, package.Module!, activation);
                 if (decline is not null)
                     logger?.LogInformation(
                         "Plugin bundles: {Plugin} declares module '{Module}' but it is not served: {Reason}",

--- a/src/MeshWeaver.PluginCatalog/ModuleActivationStatus.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivationStatus.cs
@@ -34,27 +34,42 @@ public static class ModuleActivationStatus
 {
     /// <summary>
     /// The enabled entries in <paramref name="activation"/> whose assembly is not among
-    /// <paramref name="loadedAssemblyNames"/>.
+    /// <paramref name="loadedAssemblyNames"/> — and which a restart would actually load.
     ///
     /// <para>A DISABLED entry is never pending: it is the record of an uninstall, and its module
     /// being absent from this process is the outcome, not a to-do. (An uninstall that has not taken
     /// effect yet — the module still loaded — is deliberately not reported either: nothing is
     /// missing from the user's point of view, and reporting it would put an alarming "restart
     /// required" on a package that has just been removed.)</para>
+    ///
+    /// <para>🚨 A HELD entry — one whose recorded platform floor <paramref name="platformGate"/>
+    /// refuses — is not pending either (2026-08-22). "Pending" is a promise: a restart activates this.
+    /// For a held entry that promise is false — boot applies the SAME gate and skips it — so
+    /// reporting it would put a permanent "restart required" on the surface that no restart can
+    /// ever clear (a registry SHELVES modules for platforms newer than itself, and the hold lasts
+    /// until a platform update; the update is itself a restart, at which point the entry loads and
+    /// leaves this question entirely). The gate is a parameter for the same reason boot's is:
+    /// production passes <see cref="ModulePlatformFloor.DeclineReason(string?)"/>, and there is
+    /// never a second notion of the module platform requirement.</para>
     /// </summary>
     /// <param name="activation">The persisted activation list.</param>
     /// <param name="loadedAssemblyNames">Assembly SIMPLE names loaded in this process.</param>
+    /// <param name="platformGate">Returns WHY a recorded platform FLOOR is not satisfied by the
+    /// running platform, or null when it is (an absent floor is always satisfied).</param>
     public static ImmutableList<PendingModuleActivation> NotYetLoaded(
         ModuleActivationList activation,
-        IReadOnlySet<string> loadedAssemblyNames)
+        IReadOnlySet<string> loadedAssemblyNames,
+        Func<string?, string?> platformGate)
     {
         ArgumentNullException.ThrowIfNull(activation);
         ArgumentNullException.ThrowIfNull(loadedAssemblyNames);
+        ArgumentNullException.ThrowIfNull(platformGate);
 
         return activation.Entries
             .Where(entry => entry.Enabled
                 && !string.IsNullOrWhiteSpace(entry.Name)
-                && !loadedAssemblyNames.Contains(entry.Name))
+                && !loadedAssemblyNames.Contains(entry.Name)
+                && platformGate(entry.MinMeshVersion) is null)
             .Select(entry => new PendingModuleActivation(entry.Name, entry.PackagePath, entry.Version))
             .ToImmutableList();
     }

--- a/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
@@ -6,10 +6,23 @@ namespace MeshWeaver.PluginCatalog;
 /// What a REGISTRY instance can serve as a module bundle (#1664 Slice C, the serving half): the
 /// files under its own <c>modules/&lt;name&gt;/</c> — the very bytes this deployment loads and runs,
 /// which is the same philosophy the NodeType bundle lane established ("the inputs ARE the storage").
-/// A module is servable exactly when this deployment's own boot would load it: not uninstalled,
-/// its declared platform FLOOR satisfied here, its entry DLL present. The MVID a landing recorded
-/// is diagnostic and never withholds a serve — modules bind by simple name, and a consumer's own
-/// floor gate (against the floor this serve surfaces) is what protects IT.
+/// A module is servable exactly when its bytes are here and it was not uninstalled: entry DLL
+/// present, activation entry (if any) enabled. The MVID a landing recorded is diagnostic and never
+/// withholds a serve — modules bind by simple name.
+///
+/// <para>🚨 <b>The serving side applies NO platform-floor gate of its own (2026-08-22)</b> — the shelf
+/// deliberately carries modules for platforms NEWER than the instance serving them. The old rule
+/// ("a registry must never fan out a module it could not load itself") read as caution and was a
+/// deadlock: modules extracted from the platform image declared a floor above the registry's own
+/// version, the publish path refused to carry them, and the registry could not update to that
+/// version because its <c>Modules:Required</c> gate held the rollout for exactly those absent
+/// modules. The floor is the CONSUMER's gate, applied against the CONSUMER's platform — it rides
+/// the bundle index and the bundle manifest, and every consumer checks it three times
+/// (<c>ModuleUpdateDecision.Decide</c> before any download, <c>PluginBundleClient.LandFromBundle</c>
+/// against the manifest, <see cref="ModuleLandingService"/> at placement) — so serving above-floor
+/// bytes costs a below-floor consumer zero bytes and can never land where they would not load. A
+/// serve-side floor re-check would be a SECOND notion of the same gate, wrong for the warehouse
+/// role by construction.</para>
 ///
 /// <para>Pure decision + one directory listing — no mesh, no HTTP — so the serve rules are
 /// pinnable with a temp directory.</para>
@@ -25,16 +38,11 @@ public static class ModuleBundleSource
     /// <param name="moduleName">The module's entry-assembly name without extension.</param>
     /// <param name="activation">The deployment's activation sidecar list (empty for a module that
     /// ships with the image — image modules have no sidecar entry).</param>
-    /// <param name="platformGate">Returns WHY a recorded platform FLOOR is not satisfied by THIS
-    /// process, or null when it is (an absent floor is always satisfied) — production passes
-    /// <see cref="ModulePlatformFloor.DeclineReason(string?)"/>, the same gate boot applies, so a
-    /// registry never serves a landing its own boot skips.</param>
     /// <returns>Absolute file paths (entry DLL first) or the decline reason.</returns>
     public static (IReadOnlyList<string> Files, string? DeclineReason) Collect(
         string baseDirectory,
         string moduleName,
-        ModuleActivationList activation,
-        Func<string?, string?> platformGate)
+        ModuleActivationList activation)
     {
         if (string.IsNullOrWhiteSpace(moduleName)
             || moduleName is "." or ".."
@@ -46,16 +54,16 @@ public static class ModuleBundleSource
             string.Equals(e.Name, moduleName, StringComparison.OrdinalIgnoreCase));
         if (entry is { Enabled: false })
             return ([], $"module '{moduleName}' is uninstalled on this instance");
-        if (entry is not null && platformGate(entry.MinMeshVersion) is { } unsatisfied)
-            // The landed module's declared floor is not satisfied HERE (the platform rolled back
-            // below it) — these are exactly the bytes this instance's own boot union skips, and a
-            // registry must never fan out a module it could not load itself.
-            return ([], $"module '{moduleName}' is not loadable on this instance: {unsatisfied}");
+        // 🚨 Deliberately NO floor check on the entry here — a HELD landing (floor above this
+        // instance's platform, ShelveModule) and a landing the platform rolled back below are
+        // both SERVED: their recorded floor rides the index and the manifest, and the consumer's
+        // own gate is what decides loadability THERE. See the type doc for why a serve-side floor
+        // was the deadlock.
 
         // The entry's GENERATION directory is the newest landed content — the one resolution
         // rule (ModuleDirectoryFor), shared with boot. Serving follows the pointer immediately,
         // so consumers fetch what was PUBLISHED even while this process still runs an older
-        // generation it loaded at ITS boot.
+        // generation it loaded at ITS boot (or, for a held landing, none at all).
         var folder = ModuleLandingService.ModuleDirectoryFor(baseDirectory, moduleName, entry);
         var entryDll = Path.Combine(folder, moduleName + ".dll");
         if (!File.Exists(entryDll))

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -21,6 +21,19 @@ namespace MeshWeaver.PluginCatalog;
 /// as DIAGNOSTIC metadata only — modules bind by simple name, and their contract is API
 /// compatibility, not build identity (that strict gate belongs to the NodeType bake lane).</para>
 ///
+/// <para><b>…except on the SHELF lane, where an unsatisfied floor HOLDS instead of refusing.</b>
+/// <see cref="ShelveModule"/> is the PUBLISH path's entry (the registry stocking its warehouse):
+/// a warehouse may carry modules for platforms newer than itself, so above-floor bytes land and
+/// their activation entry is recorded — but nothing here loads them: boot re-applies the SAME
+/// floor gate per entry (<see cref="ModuleActivationBoot.ComputeEffectiveModuleEntries"/>) and
+/// skips a held entry loudly, until a platform update satisfies the floor and the very same boot
+/// check activates it. There is deliberately NO persisted "held" flag — held-ness is DERIVED from
+/// the recorded floor against the running platform at each decision point, so it can never go
+/// stale when the platform moves (the one-notion rule again). <see cref="LandModule"/> — the
+/// direct-adopt funnel — keeps refusing: an instance must never hold bytes its own next boot
+/// would try to load into an unsatisfied platform… which for the adopt path is the point of the
+/// install, so a hold there would be a package whose binary half silently never arrives.</para>
+///
 /// <para><b>The same-identity trap-door is refused too.</b> <c>MeshBuilder.ResolveModulePath</c>
 /// resolves <c>modules/&lt;name&gt;/&lt;name&gt;.dll</c> BEFORE the app folder, so landing a
 /// module named after an APP-CLOSURE assembly (e.g. <c>MeshWeaver.Graph</c>) would silently
@@ -153,9 +166,56 @@ public sealed class ModuleLandingService : IDisposable
         => pool.InvokeBlocking(_ =>
         {
             LandCore(name, assemblies, frameworkMvid, packagePath, version, minMeshVersion,
-                staticAssets);
+                staticAssets, holdAboveFloor: false);
             return Unit.Default;
         });
+
+    /// <summary>
+    /// Lands a module onto the REGISTRY SHELF (2026-08-22) — the publish path's entry, identical to
+    /// <see cref="LandModule"/> in every rule but one: an UNSATISFIED platform floor lands the
+    /// bytes and records the activation entry as HELD instead of refusing.
+    ///
+    /// <para><b>Why the two paths must differ.</b> The landing serves two roles: adopting a module
+    /// for THIS runtime (the install funnel — the floor refusal is exactly right there, declined
+    /// bytes must never reach a disk the next boot loads from), and STOCKING the registry's shelf
+    /// (the publish endpoint). Applying the adopt rule to the shelf produced a three-way deadlock,
+    /// measured in production 2026-08-22: modules extracted from the platform image declared
+    /// <c>minMeshVersion: 3.0.0-rc7</c>, the registry ran rc6 and 409'd every upload — while its
+    /// own <c>Modules:Required</c> gate held the rc7 rollout for exactly those absent modules.
+    /// The image doesn't ship them → only the registry can deliver them → the registry refuses to
+    /// even CARRY them until it updates → it can't update without them.</para>
+    ///
+    /// <para><b>What "held" means mechanically — no new state, the existing gates ARE the hold.</b>
+    /// The bytes go into a generation directory and the entry is recorded (enabled, floor
+    /// included) exactly as for an active landing, so the serve side lists and serves them to
+    /// consumers, whose own fetch/land chain applies the floor against THEIR platform. This
+    /// process's boot does NOT load them: the per-entry floor gate in
+    /// <see cref="ModuleActivationBoot.ComputeEffectiveModuleEntries"/> skips the entry with a
+    /// loud line naming both versions — and flips it to loaded, on that same normal path, at the
+    /// first boot whose platform satisfies the floor (a platform update IS a restart, so no
+    /// separate reconcile is needed). The one deliberate difference in the record:
+    /// <c>PendingRestart</c> is NOT raised for a held landing — a restart cannot activate it, and
+    /// a "restart required" no restart can clear is a false prompt
+    /// (<see cref="ModuleActivationStatus.NotYetLoaded"/> excludes held entries for the same
+    /// reason).</para>
+    ///
+    /// <para>Every other refusal is unchanged — in particular the app-closure same-identity
+    /// trap-door still refuses even in shelf mode, because a held module DOES load eventually and
+    /// would shadow the platform binary then. Cold; the outcome says whether the landing was held
+    /// and why, so the publish endpoint can tell its caller "shelved, will serve" apart from
+    /// "activated here".</para>
+    /// </summary>
+    public IObservable<ModuleLandingOutcome> ShelveModule(
+        string name,
+        IReadOnlyList<(string FileName, byte[] Bytes)> assemblies,
+        string? frameworkMvid = null,
+        string? packagePath = null,
+        string? version = null,
+        string? minMeshVersion = null,
+        IReadOnlyList<(string RelativePath, byte[] Bytes)>? staticAssets = null)
+        => pool.InvokeBlocking(_ =>
+            LandCore(name, assemblies, frameworkMvid, packagePath, version, minMeshVersion,
+                staticAssets, holdAboveFloor: true));
 
     /// <summary>
     /// Validates one module-relative asset path: forward slashes, no rooting, no traversal, and
@@ -198,14 +258,15 @@ public sealed class ModuleLandingService : IDisposable
             return Unit.Default;
         });
 
-    private void LandCore(
+    private ModuleLandingOutcome LandCore(
         string name,
         IReadOnlyList<(string FileName, byte[] Bytes)> assemblies,
         string? frameworkMvid,
         string? packagePath,
         string? version,
         string? minMeshVersion,
-        IReadOnlyList<(string RelativePath, byte[] Bytes)>? staticAssets = null)
+        IReadOnlyList<(string RelativePath, byte[] Bytes)>? staticAssets,
+        bool holdAboveFloor)
     {
         foreach (var (relativePath, _) in staticAssets ?? [])
             ValidateAssetPath(relativePath, name);
@@ -225,17 +286,22 @@ public sealed class ModuleLandingService : IDisposable
                 $"Module '{name}': the assembly list does not contain its entry '{entryDll}' — "
                 + "such a folder could never load.", nameof(assemblies));
 
-        // 🚨 THE PLATFORM-FLOOR GATE, at placement — the same pure function the serve and fetch
+        // 🚨 THE PLATFORM-FLOOR GATE, at placement — the same pure function the fetch and boot
         // sides gate on (ModulePlatformFloor), so there is never a second notion of the module
         // platform requirement. Deliberately NOT MVID equality: modules bind by simple name and
         // their contract is API compatibility — the strict MVID gate is bake semantics and stays
-        // with the NodeType lane. Declining an unsatisfied floor is always safe; landing on faith
-        // is not: the missing API would surface only at the next boot, as a
-        // MissingMethodException with nothing connecting it to the install that caused it.
-        if (ModulePlatformFloor.DeclineReason(minMeshVersion) is { } reason)
+        // with the NodeType lane. On the ADOPT path, declining an unsatisfied floor is always
+        // safe; landing on faith is not: the missing API would surface only at the next boot, as
+        // a MissingMethodException with nothing connecting it to the install that caused it. On
+        // the SHELF path (holdAboveFloor — the publish endpoint, see ShelveModule) the same
+        // verdict HOLDS instead of refusing: the bytes land for CONSUMERS, whose own gates apply
+        // this very function against their platforms, while this process's boot keeps applying it
+        // per entry and so never loads what it records here.
+        var held = ModulePlatformFloor.DeclineReason(minMeshVersion);
+        if (held is not null && !holdAboveFloor)
         {
-            logger?.LogWarning("Module '{Name}' REFUSED at landing: {Reason}", name, reason);
-            throw new InvalidOperationException($"Module '{name}' refused: {reason}");
+            logger?.LogWarning("Module '{Name}' REFUSED at landing: {Reason}", name, held);
+            throw new InvalidOperationException($"Module '{name}' refused: {held}");
         }
 
         // 🚨 The same-identity trap-door: modules/<name>/<name>.dll wins over the app folder in
@@ -308,15 +374,29 @@ public sealed class ModuleLandingService : IDisposable
             Entries = list.Entries
                 .RemoveAll(e => string.Equals(e.Name, name, StringComparison.OrdinalIgnoreCase))
                 .Add(entry),
-            PendingRestart = true,
+            // A HELD landing does not raise the restart signal: a restart cannot activate it (the
+            // boot gate skips the entry until the platform satisfies its floor), so "restart
+            // required" would be a prompt no restart can clear. The platform update that DOES
+            // satisfy the floor is itself a restart, which activates the entry with no flag.
+            PendingRestart = held is null || list.PendingRestart,
         });
 
-        logger?.LogInformation(
-            "Module '{Name}' LANDED into modules/{Generation}/ ({Count} assemblies, floor "
-            + "{MinMeshVersion}, platform {Running}; built against framework MVID "
-            + "{FrameworkMvid} — diagnostic) — activation recorded, RESTART REQUIRED to load it",
-            name, generation, assemblies.Count, minMeshVersion ?? "(none)",
-            ModulePlatformFloor.RunningVersion ?? "(unknown)", frameworkMvid ?? "(unrecorded)");
+        if (held is null)
+            logger?.LogInformation(
+                "Module '{Name}' LANDED into modules/{Generation}/ ({Count} assemblies, floor "
+                + "{MinMeshVersion}, platform {Running}; built against framework MVID "
+                + "{FrameworkMvid} — diagnostic) — activation recorded, RESTART REQUIRED to load it",
+                name, generation, assemblies.Count, minMeshVersion ?? "(none)",
+                ModulePlatformFloor.RunningVersion ?? "(unknown)", frameworkMvid ?? "(unrecorded)");
+        else
+            logger?.LogInformation(
+                "Module '{Name}' SHELVED into modules/{Generation}/ ({Count} assemblies) but HELD "
+                + "from local activation: {Reason}. It SERVES to consumers from here; this "
+                + "process's boot skips it until a platform update satisfies the floor, and that "
+                + "same boot then loads it",
+                name, generation, assemblies.Count, held);
+
+        return new ModuleLandingOutcome(Held: held is not null, HoldReason: held);
     }
 
     private void RemoveCore(string name)
@@ -378,3 +458,14 @@ public sealed class ModuleLandingService : IDisposable
     /// <inheritdoc />
     public void Dispose() => pool.Dispose();
 }
+
+/// <summary>
+/// What a landing did — the answer the publish endpoint relays, so a publisher can tell
+/// "shelved, will serve" apart from "activated here" (2026-08-22).
+/// </summary>
+/// <param name="Held">True when the bytes landed but this process's own activation is HELD —
+/// the module's declared floor exceeds the running platform, so boot skips the entry until a
+/// platform update satisfies it. False = the ordinary landing: loads at the next restart.</param>
+/// <param name="HoldReason">Why the activation is held, naming both versions
+/// (<see cref="ModulePlatformFloor.DeclineReason(string?)"/>'s text), or null when not held.</param>
+public sealed record ModuleLandingOutcome(bool Held, string? HoldReason);

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -84,7 +84,11 @@ public sealed class PendingModuleActivations(string moduleRoot)
             return new ModuleActivationReport([], corrupt);
 
         return new ModuleActivationReport(
-            ModuleActivationStatus.NotYetLoaded(activation, loadedAssemblyNames));
+            // The ONE platform gate (ModulePlatformFloor), threaded here as boot threads it: a
+            // HELD entry (floor above this platform — the registry shelf, 2026-08-22) must not read
+            // as "restart required", because the boot this report promises would skip it.
+            ModuleActivationStatus.NotYetLoaded(
+                activation, loadedAssemblyNames, ModulePlatformFloor.DeclineReason));
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Api;
+using MeshWeaver.Plugin.Packaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using PackagingManifest = MeshWeaver.Plugin.Packaging.PluginManifest;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The registry SHELF over the publish route (2026-08-22): a module whose declared platform floor
+/// exceeds the registry's own version is ACCEPTED and held, never 409'd.
+///
+/// <para><b>The deadlock the old behaviour produced (2026-08-22).</b> Modules extracted from the
+/// platform image declared <c>minMeshVersion: 3.0.0-rc7</c> while the registry ran rc6, so the
+/// publish endpoint answered every upload 409 — and the registry could not update to rc7 because
+/// its <c>Modules:Required</c> gate held the rollout for exactly those absent modules. Image
+/// doesn't ship them → only the registry can deliver them → the registry refuses to CARRY them
+/// until it updates → it can't update without them. The shelf semantics break the cycle: the
+/// warehouse carries modules for platforms newer than itself, serves them to consumers (whose own
+/// install path gates on THEIR platform), and activates its own copy at the first boot whose
+/// platform satisfies the floor.</para>
+///
+/// <para>Driven over a real HTTP pipeline (TestServer) like <see cref="PluginBundleAuthTest"/>,
+/// because the claim under test is the ROUTE's answer — a publisher must be able to tell
+/// "shelved, will serve" (200, <c>held: true</c>) apart from "activated here" (200,
+/// <c>held: false</c>) and from a real refusal (409).</para>
+/// </summary>
+public class ModulePublishShelfTest : IDisposable
+{
+    private const string Token = "shelf-test-token";
+
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-shelf-" + Guid.NewGuid().ToString("N"));
+
+    /// <summary>Creates the per-test landing root the shelf writes into.</summary>
+    public ModulePublishShelfTest() => Directory.CreateDirectory(root);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+    }
+
+    /// <summary>A packed module bundle the route can read, declaring the given floor.</summary>
+    private static byte[] Bundle(string? minMeshVersion)
+    {
+        var manifestJson = JsonSerializer.Serialize(new
+        {
+            plugin = "SpeechPkg",
+            version = "1.0.0",
+            frameworkMvid = "test-build",
+            module = new
+            {
+                assemblyName = "MeshWeaver.Speech",
+                assemblies = new[] { "MeshWeaver.Speech.dll" },
+                minMeshVersion,
+            },
+        });
+
+        var buffer = new MemoryStream();
+        NuGetPackageWriter.Write(
+            buffer,
+            new PackagingManifest("SpeechPkg", "MeshWeaver.Plugin.SpeechPkg", "1.0.0", "SpeechPkg", null, []),
+            "3.0.0",
+            [
+                new NuGetPackageWriter.Entry(
+                    NuGetPackageWriter.ModuleEntryPathFor("MeshWeaver.Speech.dll"),
+                    () => new MemoryStream("SPEECH"u8.ToArray())),
+            ],
+            manifestJson);
+        return buffer.ToArray();
+    }
+
+    private async Task<HttpResponseMessage> Publish(string? minMeshVersion)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        // The publish route is mapped only when a token is configured; the shelf lands into this
+        // test's own temp root, never the testhost's bin (the sidecar is a persistent file).
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [ModulePublish.TokenConfigKey] = Token,
+        });
+        builder.Services.AddSingleton(new ModuleLandingService(baseDirectory: root));
+
+        var app = builder.Build();
+        app.MapPluginBundles();
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            PluginBundleEndpoints.RoutePrefix + "/SpeechPkg?packagePath=Plugins/SpeechPkg");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + Token);
+        request.Content = new ByteArrayContent(Bundle(minMeshVersion));
+        return await client.SendAsync(request);
+    }
+
+    /// <summary>
+    /// 🚨 The shelf acceptance: an above-floor publish answers 200 with <c>held: true</c> and the
+    /// reason — the exact upload that used to 409 into the deadlock. The bytes are on the shelf,
+    /// the entry is recorded (which is what makes the index list it for consumers), and NOTHING
+    /// locally activates: PendingRestart stays down, because a restart of this instance cannot
+    /// load a held module.
+    /// </summary>
+    [Fact]
+    public async Task AnAboveFloorPublish_IsShelvedAndHeld_Not409d()
+    {
+        using var response = await Publish(minMeshVersion: "999.0.0");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.True(body.RootElement.GetProperty("held").GetBoolean());
+        var reason = body.RootElement.GetProperty("holdReason").GetString();
+        Assert.Contains("999.0.0", reason);
+        Assert.Contains(ModulePlatformFloor.RunningVersion!, reason);
+        Assert.False(body.RootElement.GetProperty("pendingRestart").GetBoolean(),
+            "a restart cannot activate a held module, so nothing is pending on one");
+
+        // The shelf state on disk: bytes in a generation directory, entry recorded with its
+        // floor (held-ness is DERIVED from it — boot re-gates the same entry), no restart flag.
+        var list = ModuleActivationSidecar.Read(root);
+        var entry = Assert.Single(list.Entries);
+        Assert.Equal("MeshWeaver.Speech", entry.Name);
+        Assert.True(entry.Enabled);
+        Assert.Equal("999.0.0", entry.MinMeshVersion);
+        Assert.False(list.PendingRestart);
+        Assert.True(File.Exists(Path.Combine(
+            ModuleLandingService.ModuleDirectoryFor(root, "MeshWeaver.Speech", entry),
+            "MeshWeaver.Speech.dll")));
+
+        // …and the SERVE side lists exactly this held landing for consumers — the same Collect
+        // the index and the download route resolve through, against the state the route wrote.
+        var (files, decline) = ModuleBundleSource.Collect(root, "MeshWeaver.Speech", list);
+        Assert.Null(decline);
+        Assert.Single(files);
+    }
+
+    /// <summary>A publish whose floor this platform satisfies is the unchanged behaviour:
+    /// activated here (restart-as-activation), not held.</summary>
+    [Fact]
+    public async Task AFloorSatisfiedPublish_LandsAsBefore()
+    {
+        using var response = await Publish(minMeshVersion: "0.0.1");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.False(body.RootElement.GetProperty("held").GetBoolean());
+        Assert.True(body.RootElement.GetProperty("pendingRestart").GetBoolean());
+
+        var list = ModuleActivationSidecar.Read(root);
+        Assert.True(list.PendingRestart, "an activated landing loads at the next restart");
+        Assert.Equal("0.0.1", Assert.Single(list.Entries).MinMeshVersion);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationBootTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationBootTest.cs
@@ -94,6 +94,41 @@ public class ModuleActivationBootTest
             "the skip must name both versions — the entry stays for when the platform moves forward");
     }
 
+    /// <summary>
+    /// 🚨 The FLIP that finishes the registry-shelf story (2026-08-22): a HELD entry — shelved by the
+    /// publish path while its floor exceeded the platform — activates on the NORMAL boot path the
+    /// moment a platform update satisfies the floor. Same entry, same gate, no extra state and no
+    /// separate reconcile: held-ness is DERIVED from the recorded floor against whatever platform
+    /// is running, so the platform update (which is itself a restart) is the whole flip. This is
+    /// the same computation the skip test above pins from the other side.
+    /// </summary>
+    [Fact]
+    public void AHeldEntry_ActivatesOnceThePlatformSatisfiesItsFloor()
+    {
+        // The very entry ShelveModule records for an above-floor publish: enabled, floor recorded.
+        var held = List(Store("MeshWeaver.Speech", floor: "3.0.0-rc7"));
+
+        // While the registry still runs rc6, boot skips it — loudly, naming the floor.
+        var skips = new List<(string Module, string Reason)>();
+        ModuleActivationBoot.ComputeEffectiveModuleEntries(
+                [], held,
+                floor => ModulePlatformFloor.DeclineReason(floor, "3.0.0-rc6"),
+                AllDllsExist,
+                (m, r) => skips.Add((m, r)))
+            .Should().BeEmpty("a held module must not load into a platform below its floor");
+        skips.Should().ContainSingle().Subject.Reason.Should()
+            .Contain("3.0.0-rc7").And.Contain("3.0.0-rc6");
+
+        // The platform updates to rc7 — the SAME entry now passes the SAME gate and loads.
+        var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+            [], held,
+            floor => ModulePlatformFloor.DeclineReason(floor, "3.0.0-rc7"),
+            AllDllsExist);
+        effective.Select(m => m.Entry).Should().Equal("MeshWeaver.Speech.dll");
+        effective.Single().Landed.Should().NotBeNull(
+            "it activates as the store-landed module it is, resolving to its own generation");
+    }
+
     [Fact]
     public void NoRecordedFloor_Loads_AbsenceIsNoConstraint()
     {

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationStatusTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationStatusTest.cs
@@ -34,6 +34,11 @@ public class ModuleActivationStatusTest : IDisposable
     private static IReadOnlySet<string> Loaded(params string[] names) =>
         names.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>A satisfied platform gate — the state of every pre-shelf test, kept explicit
+    /// because the gate is a required input: pending-ness PROMISES that a restart loads the
+    /// module, and only the floor gate can keep that promise honest (2026-08-22).</summary>
+    private static readonly Func<string?, string?> FloorSatisfied = _ => null;
+
     // ── the pure derivation ─────────────────────────────────────────────────────────────────────
 
     [Fact]
@@ -48,7 +53,8 @@ public class ModuleActivationStatusTest : IDisposable
                     new ModuleActivationEntry { Name = "MeshWeaver.Loaded" },
                 ],
             },
-            Loaded("MeshWeaver.Loaded"));
+            Loaded("MeshWeaver.Loaded"),
+            FloorSatisfied);
 
         pending.Should().ContainSingle();
         pending[0].Name.Should().Be("MeshWeaver.Acme");
@@ -69,7 +75,8 @@ public class ModuleActivationStatusTest : IDisposable
                 PendingRestart = false,
                 Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Acme" }],
             },
-            Loaded("MeshWeaver.Something.Else"));
+            Loaded("MeshWeaver.Something.Else"),
+            FloorSatisfied);
 
         pending.Should().ContainSingle();
     }
@@ -84,7 +91,8 @@ public class ModuleActivationStatusTest : IDisposable
                     PendingRestart = true,
                     Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Acme" }],
                 },
-                Loaded("MeshWeaver.Acme"))
+                Loaded("MeshWeaver.Acme"),
+                FloorSatisfied)
             .Should().BeEmpty();
     }
 
@@ -97,8 +105,40 @@ public class ModuleActivationStatusTest : IDisposable
                 {
                     Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Removed", Enabled = false }],
                 },
-                Loaded())
+                Loaded(),
+                FloorSatisfied)
             .Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// 🚨 A HELD entry (2026-08-22) — floor above the running platform, the registry-shelf state — is
+    /// NOT pending: "pending" promises that a restart loads the module, and boot's floor gate
+    /// would skip this one, so the prompt could never be cleared by the restart it asks for. The
+    /// moment the platform satisfies the floor (same entry, same gate), the promise becomes true
+    /// and the entry IS pending — until the boot that reported it loads it.
+    /// </summary>
+    [Fact]
+    public void AHeldEntry_IsNotPending_UntilThePlatformSatisfiesItsFloor()
+    {
+        var list = new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry
+            {
+                Name = "MeshWeaver.Speech", MinMeshVersion = "3.0.0-rc7",
+            }],
+        };
+
+        ModuleActivationStatus.NotYetLoaded(list, Loaded(),
+                floor => ModulePlatformFloor.DeclineReason(floor, "3.0.0-rc6"))
+            .Should().BeEmpty(
+                "a restart cannot activate a held module — reporting it would be a permanent "
+                + "restart prompt no restart can clear");
+
+        ModuleActivationStatus.NotYetLoaded(list, Loaded(),
+                floor => ModulePlatformFloor.DeclineReason(floor, "3.0.0-rc7"))
+            .Should().ContainSingle(
+                "once the platform satisfies the floor, the restart promise is honest again")
+            .Subject.Name.Should().Be("MeshWeaver.Speech");
     }
 
     [Fact]
@@ -106,7 +146,8 @@ public class ModuleActivationStatusTest : IDisposable
     {
         ModuleActivationStatus.NotYetLoaded(
                 new ModuleActivationList { Entries = [new ModuleActivationEntry { Name = "MeshWeaver.ACME" }] },
-                Loaded("meshweaver.acme"))
+                Loaded("meshweaver.acme"),
+                FloorSatisfied)
             .Should().BeEmpty();
     }
 

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleBundleSourceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleBundleSourceTest.cs
@@ -9,19 +9,18 @@ using Xunit;
 namespace MeshWeaver.PluginCatalog.Test;
 
 /// <summary>
-/// The registry's serve rules for module bundles (#1664 Slice C, the serving half): a registry may
-/// only fan out module bytes it could load itself — its own <c>modules/&lt;name&gt;/</c> tree,
-/// gated on the activation sidecar exactly as boot is (the platform FLOOR; the recorded MVID is
-/// diagnostic and never withholds a serve).
+/// The registry's serve rules for module bundles (#1664 Slice C, the serving half): a registry
+/// fans out the module bytes on its SHELF — its own <c>modules/&lt;name&gt;/</c> tree, minus what
+/// was uninstalled. 🚨 Deliberately NO serve-side platform-floor gate (2026-08-22): the shelf carries
+/// modules for platforms NEWER than the instance serving them (that inversion is what broke the
+/// publish/update deadlock — see <see cref="ModuleBundleSource"/>'s type doc); the floor rides
+/// the index and manifest, and the CONSUMER's own gate is what decides loadability there. The
+/// recorded MVID is diagnostic and never withholds a serve.
 /// </summary>
 public class ModuleBundleSourceTest : IDisposable
 {
     private readonly string baseDirectory =
         Path.Combine(Path.GetTempPath(), "mw-bundle-src-" + Guid.NewGuid().ToString("N"));
-
-    /// <summary>The production gate bound to a fixed running platform version.</summary>
-    private static string? Gate(string? floor) =>
-        ModulePlatformFloor.DeclineReason(floor, "3.2.0");
 
     public ModuleBundleSourceTest() => Directory.CreateDirectory(baseDirectory);
 
@@ -51,7 +50,7 @@ public class ModuleBundleSourceTest : IDisposable
         LayOut("MeshWeaver.Social", "MeshWeaver.Social.pdb", "Aux.dll", "readme.txt");
 
         var (files, decline) = ModuleBundleSource.Collect(
-            baseDirectory, "MeshWeaver.Social", Activation(), Gate);
+            baseDirectory, "MeshWeaver.Social", Activation());
 
         Assert.Null(decline);
         Assert.Equal("MeshWeaver.Social.dll", Path.GetFileName(files[0]));
@@ -71,8 +70,7 @@ public class ModuleBundleSourceTest : IDisposable
             Activation(new ModuleActivationEntry
             {
                 Name = "MeshWeaver.Social", MinMeshVersion = "3.0.0",
-            }),
-            Gate);
+            }));
 
         Assert.Null(decline);
         Assert.Single(files);
@@ -94,19 +92,22 @@ public class ModuleBundleSourceTest : IDisposable
                 Name = "MeshWeaver.Social",
                 FrameworkMvid = "ffff9999ffff9999ffff9999ffff9999",
                 MinMeshVersion = "3.0.0",
-            }),
-            Gate);
+            }));
 
         Assert.Null(decline);
         Assert.Single(files);
     }
 
     [Fact]
-    public void ALandingWhoseFloorExceedsTheRunningPlatform_IsRefused()
+    public void ALandingWhoseFloorExceedsTheRunningPlatform_IsStillServed()
     {
-        // The platform rolled BACK below the module's declared requirement: these are exactly the
-        // bytes this instance's own boot union skips, and a registry must never fan out a module
-        // it could not load itself.
+        // 🚨 The SHELF inversion (2026-08-22). This entry is either a HELD publish (a module for a
+        // platform newer than this registry — the extracted-modules deadlock case) or a landing
+        // the platform rolled back below; in both states this instance's own boot skips it while
+        // the shelf SERVES it. The old serve-side refusal ("never fan out a module it could not
+        // load itself") is exactly what deadlocked the registry against the platform update that
+        // needed these modules: the floor is the CONSUMER's gate, applied against the consumer's
+        // platform off the index/manifest — never the warehouse's.
         LayOut("MeshWeaver.Social");
 
         var (files, decline) = ModuleBundleSource.Collect(
@@ -114,11 +115,10 @@ public class ModuleBundleSourceTest : IDisposable
             Activation(new ModuleActivationEntry
             {
                 Name = "MeshWeaver.Social", MinMeshVersion = "9.0.0",
-            }),
-            Gate);
+            }));
 
-        Assert.Empty(files);
-        Assert.Contains("9.0.0", decline);
+        Assert.Null(decline);
+        Assert.Single(files);
     }
 
     [Fact]
@@ -131,8 +131,7 @@ public class ModuleBundleSourceTest : IDisposable
             Activation(new ModuleActivationEntry
             {
                 Name = "MeshWeaver.Social", Enabled = false,
-            }),
-            Gate);
+            }));
 
         Assert.Empty(files);
         Assert.Contains("uninstalled", decline);
@@ -147,7 +146,7 @@ public class ModuleBundleSourceTest : IDisposable
         Directory.CreateDirectory(Path.Combine(baseDirectory, "modules", "MeshWeaver.Social"));
 
         var (files, decline) = ModuleBundleSource.Collect(
-            baseDirectory, "MeshWeaver.Social", Activation(), Gate);
+            baseDirectory, "MeshWeaver.Social", Activation());
 
         Assert.Empty(files);
         Assert.Contains("does not exist", decline);
@@ -160,7 +159,7 @@ public class ModuleBundleSourceTest : IDisposable
     [InlineData("..")]
     public void AnInvalidModuleName_IsRefused(string name)
     {
-        var (files, decline) = ModuleBundleSource.Collect(baseDirectory, name, Activation(), Gate);
+        var (files, decline) = ModuleBundleSource.Collect(baseDirectory, name, Activation());
 
         Assert.Empty(files);
         Assert.NotNull(decline);

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
@@ -124,6 +124,83 @@ public class ModuleLandingServiceTest : IDisposable
         ModuleActivationSidecar.Read(baseDirectory).Entries.Should().BeEmpty();
     }
 
+    /// <summary>
+    /// 🚨 The SHELF lane (2026-08-22): the publish path lands an above-floor module as HELD — bytes on
+    /// disk, activation entry recorded (that is what makes the serve side list it for consumers,
+    /// whose own gates apply the floor against THEIR platforms) — while nothing here loads it:
+    /// PendingRestart is NOT raised, because a restart of THIS process cannot activate a held
+    /// entry (boot's floor gate skips it), and a "restart required" no restart can clear is a
+    /// false prompt. The adopt path refusing the same floor is pinned above
+    /// (<see cref="LandModule_PlatformBelowDeclaredFloor_Refuses_NamingBothVersions"/>) — the two
+    /// paths differing on exactly this one verdict IS the design.
+    /// </summary>
+    [Fact]
+    public async Task ShelveModule_PlatformBelowDeclaredFloor_LandsBytesAsHeld_WithoutPendingRestart()
+    {
+        using var service = Service;
+
+        var outcome = await service
+            .ShelveModule("Acme.Widgets", [("Acme.Widgets.dll", [1, 2])],
+                LiveFrameworkMvid, packagePath: "Plugins/acme-widgets", version: "2.0.0",
+                minMeshVersion: "999.0.0")
+            .FirstAsync().ToTask();
+
+        outcome.Held.Should().BeTrue("the floor exceeds the running platform — shelved, not activated");
+        outcome.HoldReason.Should().Contain("999.0.0").And.Contain(
+            ModulePlatformFloor.RunningVersion!,
+            "the hold reason names BOTH versions so the publisher can see which side is behind");
+
+        var list = ModuleActivationSidecar.Read(baseDirectory);
+        var entry = list.Entries.Should().ContainSingle(
+            "the entry is what the serve side lists and what boot re-gates").Subject;
+        entry.Enabled.Should().BeTrue("held is DERIVED from the floor, never a disabled entry");
+        entry.MinMeshVersion.Should().Be("999.0.0",
+            "the recorded floor is the ONE fact held-ness derives from — boot, the serve index "
+            + "and the pending-restart surface all read it");
+        entry.Version.Should().Be("2.0.0");
+        var dir = ModuleLandingService.ModuleDirectoryFor(baseDirectory, "Acme.Widgets", entry);
+        File.ReadAllBytes(Path.Combine(dir, "Acme.Widgets.dll")).Should().Equal([1, 2],
+            "the bytes ARE on the shelf — that is the whole point of the hold");
+        list.PendingRestart.Should().BeFalse(
+            "a restart cannot activate a held module, so nothing is pending on one");
+    }
+
+    [Fact]
+    public async Task ShelveModule_FloorSatisfied_IsAnOrdinaryLanding()
+    {
+        using var service = Service;
+
+        var outcome = await service
+            .ShelveModule("Acme.Widgets", [("Acme.Widgets.dll", [7])],
+                LiveFrameworkMvid, version: "2.0.0", minMeshVersion: "0.0.1")
+            .FirstAsync().ToTask();
+
+        outcome.Held.Should().BeFalse("a satisfied floor shelves and activates in one landing");
+        outcome.HoldReason.Should().BeNull();
+        var list = ModuleActivationSidecar.Read(baseDirectory);
+        list.Entries.Should().ContainSingle().Subject.Enabled.Should().BeTrue();
+        list.PendingRestart.Should().BeTrue("the ordinary landing loads at the next restart");
+    }
+
+    [Fact]
+    public async Task ShelveModule_AppClosureNameCollision_StillRefuses()
+    {
+        // A held module DOES load eventually (the platform update satisfies its floor), so the
+        // same-identity trap-door must hold on the shelf lane too — shelving a module named after
+        // an app-closure assembly would shadow the platform's own binary at exactly that boot.
+        File.WriteAllBytes(Path.Combine(baseDirectory, "Acme.Platform.dll"), [1]);
+
+        using var service = Service;
+        var act = () => service
+            .ShelveModule("Acme.Platform", [("Acme.Platform.dll", [2])],
+                LiveFrameworkMvid, minMeshVersion: "999.0.0")
+            .FirstAsync().ToTask();
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .Which.Message.Should().Contain("Acme.Platform.dll");
+        Directory.Exists(Path.Combine(baseDirectory, "modules", "Acme.Platform")).Should().BeFalse();
+    }
+
     [Fact]
     public async Task LandModule_ForeignBuiltAgainstMvid_Lands_TheMvidIsDiagnosticOnly()
     {

--- a/test/MeshWeaver.PluginCatalog.Test/PendingLandingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PendingLandingTest.cs
@@ -100,7 +100,7 @@ public class PendingLandingTest : IDisposable
         };
 
         var (files, decline) = ModuleBundleSource.Collect(
-            root, "MeshWeaver.Widget", activation, _ => null);
+            root, "MeshWeaver.Widget", activation);
 
         Assert.Null(decline);
         Assert.All(files, f => Assert.Contains("MeshWeaver.Widget@gen00001", f));
@@ -114,7 +114,7 @@ public class PendingLandingTest : IDisposable
         Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "CURRENT");
 
         var (files, decline) = ModuleBundleSource.Collect(
-            root, "MeshWeaver.Widget", new ModuleActivationList(), _ => null);
+            root, "MeshWeaver.Widget", new ModuleActivationList());
 
         Assert.Null(decline);
         Assert.Equal("CURRENT", File.ReadAllText(files[0]));


### PR DESCRIPTION
## The deadlock this removes (measured in production, 2026-08-22)

Five modules extracted out of the platform image (MeshWeaver.Speech, the Blazor view packs) declare `minMeshVersion: 3.0.0-rc7`. The registry (memex.meshweaver.cloud) ran `3.0.0-rc6`, so the module publish endpoint answered every upload:

```
409 {"error":"Module 'MeshWeaver.Speech' refused: the module requires platform 3.0.0-rc7 or newer but this deployment runs 3.0.0-rc6 — it becomes installable after the platform updates"}
```

Meanwhile the registry could not UPDATE to rc7, because its `Modules:Required` gate held the rollout for exactly those absent modules. A three-way deadlock: the image doesn't ship them → only the registry can deliver them → the registry refuses to even CARRY them until it updates → it can't update without them. Broken that day by a manual override; this change removes the deadlock class.

## The design defect

`ModuleLandingService.LandModule` served two roles with one rule:

1. **Adopt for MY OWN runtime** — the floor refusal is exactly right: declined bytes must never reach a disk the next boot loads into an older platform.
2. **Stock the REGISTRY SHELF** (the publish endpoint) — there the refusal is wrong: a warehouse may carry modules for platforms newer than itself.

## The fix: land-without-activating, with no new state

- **`ModuleLandingService.ShelveModule`** (the publish path's entry): identical to `LandModule` except an unsatisfied floor lands the bytes and records the activation entry as **held** instead of refusing. Held-ness is **derived** from the recorded `MinMeshVersion` against the running platform at each decision point — deliberately no persisted flag, so it can never go stale when the platform moves (the "one notion of the floor" rule). `PendingRestart` is NOT raised for a held landing: a restart cannot activate it, so the prompt would be one no restart can clear.
- **Boot already excludes held entries** — `ModuleActivationBoot.ComputeEffectiveModuleEntries` applies the same `ModulePlatformFloor.DeclineReason` per entry and skips loudly, naming both versions. **The flip to active is that same boot check**: the platform update that satisfies the floor is itself a restart, so the held entry loads on the normal path with no separate reconcile (pinned in `AHeldEntry_ActivatesOnceThePlatformSatisfiesItsFloor`). The registry's own `ModuleUpdateDecision` reconcile answers `SkipPlatformBelowFloor` / `SkipUpToDate` around it, never re-downloading.
- **The serve side stops gating on its own floor** — `ModuleBundleSource.Collect` drops the serve-side floor check (the old "a registry must never fan out a module it could not load itself" is exactly the warehouse-role inversion). The floor rides the bundle index (`minMeshVersion`) and the bundle manifest, and every consumer already checks it three times: `ModuleUpdateDecision.Decide` before any download, `PluginBundleClient.LandFromBundle` against the manifest, and `ModuleLandingService` at placement — so a below-floor consumer pays zero bytes.
- **The publish endpoint returns 200 for a held landing** with `held: true`, `holdReason` (naming both versions), `pendingRestart: false`, and logs `SHELVED … HELD from local activation`. Real refusals (app-closure same-identity trap-door, malformed names) still 409.
- **The direct-adopt path keeps refusing exactly as today** — `PluginBundleClient.AdoptModule → LandModule` is unchanged (pinned by the existing `ABundleWhoseFloorExceedsThisPlatform_IsRefused_NothingReachesDisk` and `LandModule_PlatformBelowDeclaredFloor_Refuses_NamingBothVersions`).
- **`ModuleActivationStatus.NotYetLoaded` becomes floor-aware**: a held entry is not "pending restart" (the promise "a restart activates this" would be false), and becomes pending the moment the platform satisfies its floor.

## Tests (executed)

- `ModuleLandingServiceTest`: `ShelveModule_PlatformBelowDeclaredFloor_LandsBytesAsHeld_WithoutPendingRestart`, `ShelveModule_FloorSatisfied_IsAnOrdinaryLanding`, `ShelveModule_AppClosureNameCollision_StillRefuses` (adopt refusal already pinned).
- `ModulePublishShelfTest` (new, TestServer over the real route): above-floor publish → 200 `held:true` + reason + bytes/entry on disk + `ModuleBundleSource.Collect` serves it; satisfied floor → unchanged (200, `pendingRestart:true`).
- `ModuleBundleSourceTest.ALandingWhoseFloorExceedsTheRunningPlatform_IsStillServed` (inverted from `_IsRefused`).
- `ModuleActivationBootTest.AHeldEntry_ActivatesOnceThePlatformSatisfiesItsFloor` (the flip, rc6→rc7).
- `ModuleActivationStatusTest.AHeldEntry_IsNotPending_UntilThePlatformSatisfiesItsFloor`.

**Non-vacuity, checked by mutation against the real suites:**

- Re-arming the old serve-side floor gate in `Collect` → 3 red, including `ALandingWhoseFloorExceedsTheRunningPlatform_IsStillServed`.
- Making the shelf refuse like adopt (`if (held is not null)`) → 2 red: `ShelveModule_PlatformBelowDeclaredFloor_LandsBytesAsHeld_WithoutPendingRestart`, `ShelveModule_AppClosureNameCollision_StillRefuses`.

Both mutations reverted; full `MeshWeaver.PluginCatalog.Test` and `Memex.Portal.Shared.Test` projects run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
