### PR TITLE
Fix the doc/course index rail: fixed width, real toggle button, node icons

### DIFF
--- a/src/MeshWeaver.Blazor/Components/NavGroup.razor
+++ b/src/MeshWeaver.Blazor/Components/NavGroup.razor
@@ -1,17 +1,38 @@
 @using Icon = MeshWeaver.Domain.Icon
 @inherits SkinnedView<NavGroupControl, NavGroupSkin, NavGroup>
 
-<FluentNavGroup Href="@Href" Icon="@Icon?.ToFluentIcon()" Title="@Title" Class="@Class" Style="@Style" Expanded="@Expanded">
-    
-    <DispatchView ViewModel="@ViewModel" Stream="@Stream" Area="@Area" />
+@* A Fluent icon name goes through FluentNavGroup's own Icon slot; the other icon forms a node can
+   carry (image URL, inline SVG, emoji — what MeshNodeImageHelper.ResolveNodeIcon returns) have no
+   Fluent component, so they render through the TitleTemplate with the shared NodeIconGlyph —
+   otherwise a group heading silently loses the icon every link beside it shows. *@
+@if (FluentIcon is null && Icon is not null)
+{
+    <FluentNavGroup Href="@Href" Title="@Title" Class="@Class" Style="@Style" Expanded="@Expanded">
+        <TitleTemplate>
+            <NodeIconGlyph Value="@Icon" />
+            <span>@Title</span>
+        </TitleTemplate>
+        <ChildContent>
+            <DispatchView ViewModel="@ViewModel" Stream="@Stream" Area="@Area" />
+        </ChildContent>
+    </FluentNavGroup>
+}
+else
+{
+    <FluentNavGroup Href="@Href" Icon="@FluentIcon" Title="@Title" Class="@Class" Style="@Style" Expanded="@Expanded">
 
-</FluentNavGroup>
+        <DispatchView ViewModel="@ViewModel" Stream="@Stream" Area="@Area" />
+
+    </FluentNavGroup>
+}
 
 @code{
     protected string? Title;
     protected string? Href;
     protected Icon? Icon;
     private bool Expanded;
+
+    private Microsoft.FluentUI.AspNetCore.Components.Icon? FluentIcon => Icon?.ToFluentIcon();
 
     protected override void BindData()
     {

--- a/src/MeshWeaver.Blazor/Components/NavLink.razor
+++ b/src/MeshWeaver.Blazor/Components/NavLink.razor
@@ -1,4 +1,3 @@
-@using MeshWeaver.Graph
 @inherits NavItemView<NavLinkControl, NavLink>
 
 @if (IsInMenuContext)
@@ -10,7 +9,7 @@
         }
         else
         {
-            @RawIcon
+            <NodeIconGlyph Value="@Icon" />
         }
         <span>@Title</span>
     </a>
@@ -18,7 +17,7 @@
 else
 {
     <FluentNavLink Href="@Href" Icon="@ResolvedFluentIcon" OnClick="@OnClick"
-                   Class="@NavLinkClass" Style="@Style">@RawIcon@Title</FluentNavLink>
+                   Class="@NavLinkClass" Style="@Style"><NodeIconGlyph Value="@Icon" />@Title</FluentNavLink>
 }
 
 @code {
@@ -45,25 +44,4 @@ else
             return string.IsNullOrEmpty(joined) ? null : joined;
         }
     }
-
-    // A MeshNode.Icon travels as a raw string and Icon.Parse classifies it (see Domain.Icon):
-    // Fluent names render through the FluentIcon slot above; the other forms render here with the
-    // SAME mechanism the node cards/thumbnails use — an image URL / data URI as <img>, inline
-    // <svg> markup verbatim (sized via MeshNodeImageHelper.SizeInlineSvg), and a text glyph
-    // (emoji) as text. Anything else renders nothing — never a throw, never a per-render log.
-    private RenderFragment RawIcon => __builder =>
-    {
-        if (Icon is { Provider: MeshWeaver.Domain.Icon.UrlProvider } urlIcon)
-        {
-            <img src="@urlIcon.Id" alt="" style="width: 20px; height: 20px; flex-shrink: 0; vertical-align: middle;" />
-        }
-        else if (Icon is { Provider: MeshWeaver.Domain.Icon.InlineSvgProvider } svgIcon)
-        {
-            <span style="display: inline-flex; flex-shrink: 0; vertical-align: middle;">@((MarkupString)MeshNodeImageHelper.SizeInlineSvg(svgIcon.Id, 20))</span>
-        }
-        else if (Icon is { Provider: MeshWeaver.Domain.Icon.TextProvider } textIcon)
-        {
-            <span style="font-size: 16px; flex-shrink: 0; vertical-align: middle;">@textIcon.Id</span>
-        }
-    };
 }

--- a/src/MeshWeaver.Blazor/Components/NavMenuView.razor
+++ b/src/MeshWeaver.Blazor/Components/NavMenuView.razor
@@ -2,35 +2,67 @@
 @inherits SkinnedView<NavMenuControl, NavMenuSkin, NavMenuView>
 @inject AccessService Access
 
-<div class="navmenu @Class" style="@Style">
+<div class="navmenu @(Collapsible ? (Expanded ? "rail" : "rail rail-collapsed") : null) @Class" style="@RootStyle">
     @if (Collapsible)
     {
-        <div class="navmenu-toggle-container">
-            <!-- Bind the checkbox's checked state to Expanded -->
-            <input type="checkbox"
-                   title="@Access.Localize("menu.expandCollapse")"
-                   id="navmenu-toggle"
-                   class="navmenu-icon"
-                   @bind="Expanded" />
-            <label for="navmenu-toggle" class="navmenu-icon">
-                <FluentIcon Value="@(new Size20.Navigation())" Color="Color.Neutral" />
-            </label>
-        </div>
+        @* A real button, not the checkbox+label hack: the checkbox rendered as a visible, focusable
+           control beside the icon (nothing ever hid it), and a button is what this IS. The icon says
+           what the click DOES (contract/expand the panel) rather than "menu". *@
+        <button type="button"
+                class="navmenu-toggle"
+                title="@Access.Localize("menu.expandCollapse")"
+                aria-label="@Access.Localize("menu.expandCollapse")"
+                aria-expanded="@Expanded"
+                @onclick="ToggleExpanded">
+            <FluentIcon Value="@ToggleIcon" Color="Color.Neutral" />
+        </button>
     }
-    <nav class="sitenav @(Expanded ? "expanded" : "collapsed")" aria-labelledby="main-menu">
-        <FluentNavMenu Id="main-menu"
-                       Title="@Access.Localize("menu.mainMenu")"
-                       CustomToggle="true"
-                       @bind-Expanded="Expanded">
-            <DispatchView ViewModel="@ViewModel" Stream="@Stream" Area="@Area" />
-        </FluentNavMenu>
-    </nav>
+    @if (Expanded || !Collapsible)
+    {
+        <nav class="sitenav" aria-labelledby="main-menu">
+            <FluentNavMenu Id="main-menu"
+                           Title="@Access.Localize("menu.mainMenu")"
+                           CustomToggle="true"
+                           Expanded="true">
+                <DispatchView ViewModel="@ViewModel" Stream="@Stream" Area="@Area" />
+            </FluentNavMenu>
+        </nav>
+    }
 </div>
 
 @code {
     private bool Expanded = true;
     private int? Width { get; set; }
     public bool Collapsible { get; set; }
+
+    /// <summary>
+    /// Width of the collapsed rail: just the toggle button. Wide enough to be an obvious click
+    /// target — the affordance the old collapse (which left nothing visible) did not have.
+    /// </summary>
+    private const int CollapsedWidth = 44;
+
+    private Microsoft.FluentUI.AspNetCore.Components.Icon ToggleIcon =>
+        Expanded ? new Size20.PanelLeftContract() : new Size20.PanelLeftExpand();
+
+    private void ToggleExpanded() => Expanded = !Expanded;
+
+    /// <summary>
+    /// The collapsible rail gets a FIXED width in BOTH states — the skin's width expanded,
+    /// <see cref="CollapsedWidth"/> collapsed. Without it the rail was sized by its content, so a
+    /// long title made the whole index page-width and toggling a group made the rail jump.
+    /// Non-collapsible menus (Settings panes inside a Splitter) keep sizing to their pane.
+    /// </summary>
+    private string? RootStyle
+    {
+        get
+        {
+            if (!Collapsible)
+                return Style;
+            var width = Expanded ? Width ?? 250 : CollapsedWidth;
+            var sized = $"width: {width}px; min-width: {width}px; flex: 0 0 {width}px;";
+            return string.IsNullOrEmpty(Style) ? sized : $"{sized} {Style}";
+        }
+    }
 
     protected override void BindData()
     {

--- a/src/MeshWeaver.Blazor/Components/NavMenuView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/NavMenuView.razor.css
@@ -7,57 +7,43 @@
     min-height: 0;
 }
 
+/* The collapsible rail variant (docs / course indexes). Both states carry a fixed inline width
+   (see RootStyle), so the transition animates between two known widths instead of a content jump. */
+.navmenu.rail {
+    overflow: hidden;
+    transition: width 0.15s ease, min-width 0.15s ease;
+}
+
+/* The collapse/expand control. Expanded it sits top-right of the rail, at the seam it collapses
+   toward; collapsed it IS the rail — centered in the slim strip, visibly clickable. */
+.navmenu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    margin: 2px;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    align-self: flex-end;
+}
+
+    .navmenu-toggle:hover {
+        background-color: var(--neutral-fill-stealth-hover);
+    }
+
+.rail-collapsed .navmenu-toggle {
+    align-self: center;
+}
+
 .sitenav {
     flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
-}
-
-.navbar-toggler {
-    background-color: rgba(255, 255, 255, 0.1);
-}
-
-.top-row {
-    height: 3.5rem;
-    background-color: rgba(0,0,0,0.4);
-}
-
-.navbar-brand {
-    font-size: 1.1rem;
-}
-
-.oi {
-    width: 2rem;
-    font-size: 1.1rem;
-    vertical-align: text-top;
-    top: -2px;
-}
-
-.nav-item {
-    font-size: 0.9rem;
-    padding-bottom: 0.5rem;
-}
-
-    .nav-item:first-of-type {
-        padding-top: 1rem;
-    }
-
-    .nav-item:last-of-type {
-        padding-bottom: 1rem;
-    }
-
-    .nav-item ::deep a {
-        color: #d7d7d7;
-        border-radius: 4px;
-        height: 3rem;
-        display: flex;
-        align-items: center;
-        line-height: 3rem;
-    }
-
-.nav-item ::deep a.active {
-    background-color: rgba(255,255,255,0.25);
-    color: white;
 }
 
 /* Highlight the currently selected NavLink (set via NavLinkControl.WithIsActive)
@@ -81,11 +67,6 @@
     border-radius: 2px;
 }
 
-.nav-item ::deep a:hover {
-    background-color: rgba(255,255,255,0.1);
-    color: white;
-}
-
 /* FluentUI caps every nav label at `width: calc(100% - 70px)` — a FIXED reserve for the
    icon/chevron — so labels ellipsis-truncate while up to ~70px of empty space sits to their
    right. It is most visible on the indented Settings sub-items ("Access Control" → "Access ...")
@@ -97,15 +78,4 @@
     width: auto;
     flex: 1 1 auto;
     min-width: 0;
-}
-
-@media (min-width: 641px) {
-    .navbar-toggler {
-        display: none;
-    }
-
-    .collapse {
-        /* Never collapse the sidebar for wide screens */
-        display: block;
-    }
 }

--- a/src/MeshWeaver.Blazor/Components/NodeIconGlyph.razor
+++ b/src/MeshWeaver.Blazor/Components/NodeIconGlyph.razor
@@ -1,0 +1,26 @@
+@using MeshWeaver.Graph
+@using Icon = MeshWeaver.Domain.Icon
+
+@* A MeshNode icon in its NON-Fluent forms, with the SAME mechanism the node cards/thumbnails
+   use: an image URL / data URI as <img>, inline <svg> markup verbatim (sized via
+   MeshNodeImageHelper.SizeInlineSvg), and a text glyph (emoji) as text. Fluent icon names render
+   NOTHING here — callers render those through <FluentIcon> (Icon.ToFluentIcon), which is theme-
+   aware. Anything else renders nothing — never a throw, never a per-render log. *@
+
+@if (Value is { Provider: Icon.UrlProvider } urlIcon)
+{
+    <img src="@urlIcon.Id" alt="" style="width: 20px; height: 20px; flex-shrink: 0; vertical-align: middle;" />
+}
+else if (Value is { Provider: Icon.InlineSvgProvider } svgIcon)
+{
+    <span style="display: inline-flex; flex-shrink: 0; vertical-align: middle;">@((MarkupString)MeshNodeImageHelper.SizeInlineSvg(svgIcon.Id, 20))</span>
+}
+else if (Value is { Provider: Icon.TextProvider } textIcon)
+{
+    <span style="font-size: 16px; flex-shrink: 0; vertical-align: middle;">@textIcon.Id</span>
+}
+
+@code {
+    /// <summary>The icon to render, or null for nothing.</summary>
+    [Parameter] public Icon? Value { get; set; }
+}

--- a/src/MeshWeaver.Graph/INodeNavigationProvider.cs
+++ b/src/MeshWeaver.Graph/INodeNavigationProvider.cs
@@ -57,6 +57,13 @@ public record NodeNavigation(string Title, IReadOnlyList<NodeNavigationEntry> En
     /// are on is a dead control.
     /// </summary>
     public string? TitlePath { get; init; }
+
+    /// <summary>
+    /// Optional icon for the heading — typically the indexed root's own icon (resolve it with
+    /// <c>MeshNodeImageHelper.ResolveNodeIcon</c> so a node without one still reads as its type).
+    /// Null renders a plain text heading.
+    /// </summary>
+    public string? Icon { get; init; }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
@@ -205,6 +205,10 @@ public static class MarkdownOverviewLayoutArea
     {
         var group = new NavGroupControl(node?.Name ?? host.Localize("nav.contents"))
             .WithSkin(s => s.WithExpanded(true));
+        // The heading shows the DOCUMENT's icon, same resolution as its children below — without it
+        // the doc title was the one line of the index with no icon.
+        if (MeshNodeImageHelper.ResolveNodeIcon(node) is { } groupIcon)
+            group = group.WithIcon(groupIcon);
         foreach (var child in subNodes)
         {
             var href = $"/{child.Path}";

--- a/src/MeshWeaver.Graph/SuppliedNavigationRail.cs
+++ b/src/MeshWeaver.Graph/SuppliedNavigationRail.cs
@@ -51,7 +51,9 @@ public static class SuppliedNavigationRail
     /// <param name="Path">The node the group stands for.</param>
     /// <param name="Expanded">Open only when the reader is at or below <paramref name="Path"/>.</param>
     /// <param name="Links">The entry's own link first, then its children.</param>
-    public sealed record RailGroup(string Label, string Path, bool Expanded, IReadOnlyList<RailLink> Links);
+    /// <param name="Icon">The entry's icon, if it has one — the heading shows it, so a group reads
+    /// like the links beside it instead of losing its icon by having children.</param>
+    public sealed record RailGroup(string Label, string Path, bool Expanded, IReadOnlyList<RailLink> Links, string? Icon = null);
 
     /// <summary>The whole rail: the heading link, flat entries, then the groups.</summary>
     /// <param name="Home">The index root — a link, not a collapsible heading.</param>
@@ -79,7 +81,7 @@ public static class SuppliedNavigationRail
             // {Root}" — a rendering error for what is really a missing node.
             root is null ? null : "/" + root,
             root is not null && string.Equals(root, currentPath, StringComparison.Ordinal),
-            null);
+            supplied.Icon);
 
         var pages = new List<RailLink>();
         var groups = new List<RailGroup>();
@@ -94,7 +96,7 @@ public static class SuppliedNavigationRail
 
             var links = new List<RailLink> { Link(entry) };
             links.AddRange(entry.Children.Select(Link));
-            groups.Add(new RailGroup(entry.Label, entry.Path, IsAtOrBelow(currentPath, entry.Path), links));
+            groups.Add(new RailGroup(entry.Label, entry.Path, IsAtOrBelow(currentPath, entry.Path), links, entry.Icon));
         }
 
         return new Rail(home, pages, groups);
@@ -124,6 +126,8 @@ public static class SuppliedNavigationRail
             // how clicking the index title used to collapse the whole index. The group's own page
             // is the first LINK inside it.
             var rendered = new NavGroupControl(group.Label).WithSkin(s => s.WithExpanded(group.Expanded));
+            if (group.Icon is not null)
+                rendered = rendered.WithIcon(group.Icon);
             foreach (var link in group.Links)
                 rendered = rendered.WithView(RenderLink(link));
             menu = menu.WithNavGroup(rendered);

--- a/test/MeshWeaver.Graph.Test/SuppliedNavigationRailTest.cs
+++ b/test/MeshWeaver.Graph.Test/SuppliedNavigationRailTest.cs
@@ -141,6 +141,19 @@ public class SuppliedNavigationRailTest
     }
 
     [Fact]
+    public void TheHeadingAndTheGroupsKeepTheirIcons()
+    {
+        var rail = SuppliedNavigationRail.Plan(Supplied() with { Icon = "🎓" }, "Course/L1");
+
+        rail.Home.Icon.Should().Be("🎓", "the heading shows the indexed root's own icon");
+        rail.Groups.Single(g => g.Path == "Course/L1").Icon.Should().Be("📘",
+            "an entry that becomes a group keeps its icon on the heading instead of losing it "
+            + "for having children");
+        rail.Groups.Single(g => g.Path == "Course/L2").Icon.Should().BeNull(
+            "no icon supplied renders a plain heading");
+    }
+
+    [Fact]
     public void ItRendersAsOneCollapsibleNavMenu()
     {
         var menu = SuppliedNavigationRail.Render(SuppliedNavigationRail.Plan(Supplied(), "Course/L1"));


### PR DESCRIPTION
The left-hand index of a multipart document (and of a course page) had five visible defects, reported together on a live doc (2026-08-22):

| Defect | Cause | Fix |
|---|---|---|
| Index way too wide, and its width JUMPED when a group toggled | `NavMenuView` bound the skin's `Width` and never applied it — the pane was sized by its content | The collapsible rail carries a fixed inline width in **both** states (skin width expanded, 44px strip collapsed), with a width transition |
| Raw checkbox rendered beside the hamburger | the checkbox+label toggle hack, with no CSS ever hiding the input | a real `<button>` (accessible: `aria-expanded`, localized title) |
| Hamburger consumed a dead row and said nothing | generic `Navigation` glyph, own container row | `PanelLeftContract`/`PanelLeftExpand` icons say what the click does; the button is a compact 32px control inside the rail |
| Collapsed rail gave no hint it could expand | collapse left nothing visible | the collapsed state IS a 44px strip with the expand button centered in it |
| Node icons missing on group headings and the index heading | `NavGroup` rendered only Fluent icon names — node icons resolve to URLs/inline SVG/emoji; the rail plan never carried heading icons | non-Fluent forms render via the shared `NodeIconGlyph` (extracted from `NavLink`) through a `TitleTemplate`; the plan carries `NodeNavigation.Icon`, `RailGroup.Icon`, and the default child-list heading gets the document's resolved icon |

Settings/Code/NodeType panes (`WithCollapsible(false)` inside Splitter panes) are untouched — the width/collapse behavior applies only to the collapsible rail variant. Dead bootstrap-template selectors dropped from the scoped CSS.

Tests: `SuppliedNavigationRailTest` extended (heading + group icons); Graph suite 1519 green, Hosting.Blazor 420 green.

The Edu-side twin (resolving node icons through `MeshNodeImageHelper.ResolveNodeIcon` so course rail entries stop rendering iconless) lands in MeshWeaver.Plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)