### PR TITLE
Icons carry a backplate structurally: generate one at the render seam when absent

### DIFF
--- a/clients/react/src/controls/iconValue.test.ts
+++ b/clients/react/src/controls/iconValue.test.ts
@@ -3,7 +3,7 @@
 // ("most SVGs are not showing").
 
 import { describe, expect, it } from "vitest";
-import { classifyIcon, iconForRendering, isEmojiIcon, isIconUrl } from "./iconValue.js";
+import { backplatePalette, classifyIcon, ensureBackplate, hasBackplate, iconForRendering, isEmojiIcon, isIconUrl } from "./iconValue.js";
 
 describe("classifyIcon", () => {
   it("classifies inline SVG documents", () => {
@@ -59,5 +59,55 @@ describe("node-icon helpers", () => {
   it("isIconUrl accepts rooted paths and extensions", () => {
     expect(isIconUrl("/static/NodeTypeIcons/space.svg")).toBe(true);
     expect(isIconUrl("Document")).toBe(false);
+  });
+});
+
+// Mirrors the server's IconBackplateTest (MeshWeaver.Graph.Test) — the policy is shared and the
+// two implementations must not drift: same detection, same palette, same deterministic hue.
+describe("ensureBackplate", () => {
+  const monochrome =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16v16H4z"/></svg>';
+  const plated =
+    "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><rect width='24' height='24' rx='5' fill='#4338CA'/><path d='M10 5.5V10' stroke='#fff'/></svg>";
+
+  it("leaves an authored plate untouched", () => {
+    expect(ensureBackplate(plated)).toBe(plated);
+  });
+
+  it("leaves a thread identicon (full-bleed rect on its own canvas) untouched", () => {
+    const identicon =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#e8f4fd"/><rect x="20" y="20" width="20" height="20" fill="#0078d4"/></svg>';
+    expect(ensureBackplate(identicon)).toBe(identicon);
+  });
+
+  it("plates a monochrome outline and recolors currentColor to white", () => {
+    const out = ensureBackplate(monochrome);
+    expect(out.startsWith("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><rect width='24' height='24' rx='5'")).toBe(true);
+    expect(out).not.toContain("currentColor");
+    expect(out).toContain('stroke="#fff"');
+    expect(out).toContain("<svg x='3' y='3' width='18' height='18'");
+    expect(out).toContain('viewBox="0 0 24 24"'); // the glyph keeps its own coordinate system
+  });
+
+  it("is deterministic and draws its hue from the shared palette", () => {
+    const one = ensureBackplate(monochrome);
+    expect(ensureBackplate(monochrome)).toBe(one);
+    expect(backplatePalette.some((hue) => one.includes(`fill='${hue}'`))).toBe(true);
+  });
+
+  it("does not mistake rx or a small ornamental rect for a plate", () => {
+    expect(hasBackplate("<svg viewBox='0 0 24 24'><rect x='9' y='9' width='6' height='6' fill='#333'/></svg>")).toBe(false);
+    // rx='5' on an authored plate must not be read as x='5' (the C# bug this pins).
+    expect(hasBackplate(plated)).toBe(true);
+  });
+
+  it("does not count a fill='none' full-canvas rect as a plate", () => {
+    expect(hasBackplate("<svg viewBox='0 0 24 24'><rect width='24' height='24' fill='none' stroke='currentColor'/></svg>")).toBe(false);
+  });
+
+  it("classifyIcon routes inline svg through the plate", () => {
+    const out = classifyIcon(monochrome);
+    expect(out.kind).toBe("svg");
+    expect(out.text).toContain("<rect width='24' height='24' rx='5'");
   });
 });

--- a/clients/react/src/controls/iconValue.ts
+++ b/clients/react/src/controls/iconValue.ts
@@ -57,6 +57,123 @@ export function isEmojiIcon(value: string): boolean {
   return !isLettersOnlyName(value);
 }
 
+// ---- Icon backplate policy — EXACTLY the server's IconBackplate (MeshWeaver.Graph), keep in step.
+// Every inline-svg icon renders on a full-bleed rounded plate: an icon authored without one gets a
+// generated plate here (hue = stable FNV-1a hash of the markup over the shared palette,
+// currentColor recolored to white), so a monochrome outline can never vanish on one theme. Icons
+// that already paint a plate — authored store marks, thread identicons — pass through unchanged.
+
+/** The shared plate palette — same hues, same ORDER as IconBackplate.Palette (the hash indexes it). */
+export const backplatePalette = [
+  "#4338ca", // indigo
+  "#1f6feb", // blue
+  "#0e7490", // cyan
+  "#0f766e", // teal
+  "#15803d", // green
+  "#b45309", // amber
+  "#b91c1c", // red
+  "#be185d", // pink
+  "#7c3aed", // violet
+  "#334155", // slate
+];
+
+/** Stable FNV-1a (32-bit, UTF-16 code units — identical to the C# char loop) into the palette. */
+export function backplateHue(seed: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    hash = Math.imul(hash ^ seed.charCodeAt(i), 0x01000193) >>> 0;
+  }
+  return backplatePalette[hash % backplatePalette.length];
+}
+
+function attrOf(attrs: string, name: string): string | null {
+  // Lookbehind keeps `x` from reading rx="16" and `width` from reading stroke-width.
+  const m = new RegExp(`(?<![-\\w])${name}\\s*=\\s*(["'])(.*?)\\1`, "i").exec(attrs);
+  return m ? m[2].trim() : null;
+}
+
+function numberOf(attrs: string, name: string, fallback: number): number {
+  const raw = attrOf(attrs, name);
+  if (raw == null) return fallback;
+  if (raw.endsWith("%")) {
+    const pct = Number.parseFloat(raw.slice(0, -1));
+    return Number.isFinite(pct) ? (fallback * pct) / 100 : fallback;
+  }
+  const v = Number.parseFloat(raw);
+  return Number.isFinite(v) ? v : fallback;
+}
+
+function canvasOf(svg: string): { w: number; h: number } {
+  const open = /<svg\b([^>]*)>/i.exec(svg);
+  if (!open) return { w: 24, h: 24 };
+  const attrs = open[1];
+  const viewBox = attrOf(attrs, "viewBox");
+  if (viewBox) {
+    const parts = viewBox.split(/[\s,]+/).filter(Boolean);
+    if (parts.length === 4) {
+      const vw = Number.parseFloat(parts[2]);
+      const vh = Number.parseFloat(parts[3]);
+      if (vw > 0 && vh > 0) return { w: vw, h: vh };
+    }
+  }
+  const w = numberOf(attrs, "width", 24);
+  const h = numberOf(attrs, "height", 24);
+  return { w: w > 0 ? w : 24, h: h > 0 ? h : 24 };
+}
+
+/** Whether the svg already paints a full-bleed plate: first drawable is a rect (or circle)
+ *  covering ≥90% of its OWN canvas with a real fill (IconBackplate.HasBackplate). */
+export function hasBackplate(svg: string): boolean {
+  if (!svg || !svg.trim()) return false;
+  const { w: cw, h: ch } = canvasOf(svg);
+  const first = /<(rect|circle|ellipse|path|polygon|polyline|line|text)\b([^>]*?)\/?>/i.exec(svg);
+  if (!first) return false;
+  const [, tag, attrs] = first;
+  const fill = attrOf(attrs, "fill");
+  if (fill === "none" || fill === "transparent") return false;
+  const threshold = 0.9;
+  if (tag.toLowerCase() === "rect") {
+    return (
+      numberOf(attrs, "width", cw) >= cw * threshold &&
+      numberOf(attrs, "height", ch) >= ch * threshold &&
+      numberOf(attrs, "x", 0) <= cw * (1 - threshold) &&
+      numberOf(attrs, "y", 0) <= ch * (1 - threshold)
+    );
+  }
+  if (tag.toLowerCase() === "circle") {
+    return numberOf(attrs, "r", 0) >= (Math.min(cw, ch) * threshold) / 2;
+  }
+  return false;
+}
+
+/** The one entry point (IconBackplate.Ensure): plated svg unchanged; anything else wrapped on a
+ *  generated rx=5 plate, the original nested inset-3 with its own viewBox intact. */
+export function ensureBackplate(svg: string): string {
+  if (!svg || !isInlineSvg(svg) || hasBackplate(svg)) return svg;
+  const hue = backplateHue(svg);
+  let inner = svg.replace(/currentColor/gi, "#fff");
+  const open = /<svg\b([^>]*)>/i.exec(inner);
+  if (open) {
+    const attrs = open[1];
+    const hadViewBox = attrOf(attrs, "viewBox") != null;
+    const { w, h } = canvasOf(inner);
+    const kept = attrs.replace(/\s+(x|y|width|height)\s*=\s*(["']).*?\2/gi, "");
+    const viewBox = hadViewBox ? "" : ` viewBox='0 0 ${w} ${h}'`;
+    inner =
+      inner.slice(0, open.index) +
+      `<svg x='3' y='3' width='18' height='18'${viewBox}${kept}>` +
+      inner.slice(open.index + open[0].length);
+  }
+  return (
+    "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>" +
+    "<rect width='24' height='24' rx='5' fill='" +
+    hue +
+    "' stroke='none'/>" +
+    inner +
+    "</svg>"
+  );
+}
+
 /** Legacy Fluent icon names on NODE icons render as nothing. EXACTLY the server's
  *  MeshNodeImageHelper.IsFluentIconName: ASCII letters only, starting UPPERCASE ("Document",
  *  "ArrowLeft") — lowercase-start or digit-carrying values are NOT filtered. */
@@ -96,7 +213,7 @@ export function classifyIcon(value: Json): ClassifiedIcon {
   }
   const s = value == null ? "" : String(value);
   if (!s) return { kind: "none", text: "" };
-  if (isInlineSvg(s)) return { kind: "svg", text: s };
+  if (isInlineSvg(s)) return { kind: "svg", text: ensureBackplate(s) };
   if (isIconUrl(s)) return { kind: "url", text: s };
   if (isEmojiIcon(s)) return { kind: "emoji", text: s };
   // Any letters-only word tries the curated Fluent map (layout-area icon props carry lowercase

--- a/src/MeshWeaver.Graph/IconBackplate.cs
+++ b/src/MeshWeaver.Graph/IconBackplate.cs
@@ -1,0 +1,230 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// The icon-backplate policy, made structural: every inline-svg icon the portal renders sits on a
+/// full-bleed rounded backplate, and an icon authored WITHOUT one gets a generated plate at the
+/// render seam instead of silently disappearing on the theme it was not authored for.
+///
+/// <para>🚨 Why this exists: a monochrome <c>currentColor</c> outline — or a dark-hued pictorial —
+/// renders invisibly on one of the two themes (the AppleMusic mark vanished in dark mode,
+/// 2026-08-22). The store's icon language (a colored mark on a brand-hue <c>rx=5</c> plate with
+/// white detail) is exactly the form that is legible on BOTH grounds, so rather than auditing every
+/// authored icon forever, the renderer guarantees the shape: an icon that already paints a
+/// full-bleed plate passes through untouched, and one that does not is wrapped — plate in a hue
+/// derived deterministically from the markup itself, <c>currentColor</c> recolored to white so the
+/// glyph reads on the plate.</para>
+///
+/// <para>Pure and total: string in, string out, no services, no randomness — the hue is a stable
+/// FNV-1a hash over the markup, so the same icon gets the same plate on every render, every
+/// circuit, and in the browser tab (<see cref="MeshNodeImageHelper.IconLinkFor"/>). Thread
+/// identicons (<c>ThreadIconGenerator</c>) already open with a full-bleed rect and pass through
+/// unchanged.</para>
+/// </summary>
+public static partial class IconBackplate
+{
+    /// <summary>
+    /// The plate hues a generated backplate draws from — mid-tone brand hues on which white detail
+    /// stays legible, matching the palette the authored store marks already use. Order matters:
+    /// <see cref="HueFor"/> indexes into it by hash, so reordering re-colors every generated plate.
+    /// </summary>
+    public static readonly IReadOnlyList<string> Palette =
+    [
+        "#4338ca", // indigo
+        "#1f6feb", // blue
+        "#0e7490", // cyan
+        "#0f766e", // teal
+        "#15803d", // green
+        "#b45309", // amber
+        "#b91c1c", // red
+        "#be185d", // pink
+        "#7c3aed", // violet
+        "#334155", // slate
+    ];
+
+    /// <summary>The corner radius of a generated plate on the canonical 24-unit canvas.</summary>
+    public const int CornerRadius = 5;
+
+    /// <summary>The inset of the original glyph inside a generated plate, on the 24-unit canvas.</summary>
+    public const int GlyphInset = 3;
+
+    /// <summary>
+    /// A full-bleed shape must cover at least this fraction of the canvas (per axis) to count as a
+    /// backplate — an ornamental rect in a corner is glyph detail, not a plate.
+    /// </summary>
+    public const double CoverageThreshold = 0.9;
+
+    /// <summary>
+    /// The plate hue for <paramref name="seed"/> — a stable FNV-1a hash over the string, indexed
+    /// into <see cref="Palette"/>. Deterministic so an icon keeps its hue across renders, circuits
+    /// and deploys; seeded by the markup itself so no caller has to thread a node identity through.
+    /// </summary>
+    public static string HueFor(string seed)
+    {
+        // FNV-1a, 32-bit — tiny, allocation-free, and stable across runtimes (string.GetHashCode is
+        // deliberately randomized per process and must never leak into rendered output).
+        var hash = 2166136261u;
+        foreach (var ch in seed)
+        {
+            hash ^= ch;
+            hash *= 16777619u;
+        }
+        return Palette[(int)(hash % (uint)Palette.Count)];
+    }
+
+    /// <summary>
+    /// Whether <paramref name="svg"/> already paints its own full-bleed backplate: its first
+    /// drawable element is a rect (or circle) covering at least <see cref="CoverageThreshold"/> of
+    /// the canvas with a real fill. Measured against the icon's OWN canvas (viewBox, else
+    /// width/height, else 24), so a 32- or 100-unit identicon is judged on its own scale.
+    /// </summary>
+    public static bool HasBackplate(string svg)
+    {
+        if (string.IsNullOrWhiteSpace(svg))
+            return false;
+        var (canvasW, canvasH) = CanvasOf(svg);
+        var first = FirstDrawable().Match(svg);
+        if (!first.Success)
+            return false;
+        var tag = first.Groups["tag"].Value;
+        var attrs = first.Groups["attrs"].Value;
+        var fill = AttrOf(attrs, "fill");
+        if (fill is "none" or "transparent")
+            return false;
+        if (tag == "rect")
+        {
+            var w = NumberOf(attrs, "width", canvasW);
+            var h = NumberOf(attrs, "height", canvasH);
+            var x = NumberOf(attrs, "x", 0);
+            var y = NumberOf(attrs, "y", 0);
+            return w >= canvasW * CoverageThreshold
+                   && h >= canvasH * CoverageThreshold
+                   && x <= canvasW * (1 - CoverageThreshold)
+                   && y <= canvasH * (1 - CoverageThreshold);
+        }
+        if (tag == "circle")
+        {
+            var r = NumberOf(attrs, "r", 0);
+            return r >= Math.Min(canvasW, canvasH) * CoverageThreshold / 2;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// The one entry point: <paramref name="svg"/> unchanged when it is not inline svg or already
+    /// carries a plate; otherwise the same glyph on a generated <c>rx=5</c> plate. The original
+    /// markup becomes a nested <c>&lt;svg&gt;</c> inset by <see cref="GlyphInset"/> — nesting keeps
+    /// the original viewBox math intact for ANY canvas size (20, 24, 48, 100 are all authored in
+    /// the wild), so no coordinate rewriting can corrupt a path. <c>currentColor</c> is recolored
+    /// to white: on a plate it must read as detail, not inherit the surrounding text color.
+    /// </summary>
+    public static string Ensure(string? svg)
+    {
+        if (string.IsNullOrWhiteSpace(svg) || !svg.TrimStart().StartsWith("<svg", StringComparison.OrdinalIgnoreCase))
+            return svg ?? "";
+        if (HasBackplate(svg))
+            return svg;
+
+        var hue = HueFor(svg);
+        var inner = svg.Replace("currentColor", "#fff", StringComparison.OrdinalIgnoreCase);
+        inner = InsetRoot(inner);
+        return "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>"
+               + $"<rect width='24' height='24' rx='{CornerRadius}' fill='{hue}' stroke='none'/>"
+               + inner
+               + "</svg>";
+    }
+
+    /// <summary>
+    /// Rewrites the root <c>&lt;svg&gt;</c> tag of <paramref name="svg"/> so it nests inside the
+    /// 24-unit plate: its own x/y/width/height (if any) are dropped — they would size the nested
+    /// svg absolutely and defeat the inset — and replaced with the plate-relative box; a missing
+    /// viewBox is synthesized from the authored width/height (else the canonical 24) so the glyph
+    /// scales instead of clipping.
+    /// </summary>
+    private static string InsetRoot(string svg)
+    {
+        var open = RootTag().Match(svg);
+        if (!open.Success)
+            return svg;
+        var attrs = open.Groups["attrs"].Value;
+        var hadViewBox = AttrOf(attrs, "viewBox") is not null;
+        var (w, h) = CanvasOf(svg);
+
+        // Drop the attributes the wrapper owns; keep everything else (xmlns, fill, stroke, …).
+        var kept = SizingAttr().Replace(attrs, "");
+        var inset = GlyphInset;
+        var span = 24 - 2 * inset;
+        var viewBox = hadViewBox
+            ? ""
+            : $" viewBox='0 0 {Fmt(w)} {Fmt(h)}'";
+        return svg[..open.Index]
+               + $"<svg x='{inset}' y='{inset}' width='{span}' height='{span}'{viewBox}{kept}>"
+               + svg[(open.Index + open.Length)..];
+    }
+
+    private static string Fmt(double value) => value.ToString("0.##", CultureInfo.InvariantCulture);
+
+    /// <summary>The canvas size of <paramref name="svg"/>: viewBox width/height, else the root's
+    /// width/height attributes, else the canonical 24×24.</summary>
+    private static (double Width, double Height) CanvasOf(string svg)
+    {
+        var open = RootTag().Match(svg);
+        if (!open.Success)
+            return (24, 24);
+        var attrs = open.Groups["attrs"].Value;
+        var viewBox = AttrOf(attrs, "viewBox");
+        if (viewBox is not null)
+        {
+            var parts = viewBox.Split([' ', ','], StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 4
+                && double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var vw)
+                && double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var vh)
+                && vw > 0 && vh > 0)
+                return (vw, vh);
+        }
+        var w = NumberOf(attrs, "width", 24);
+        var h = NumberOf(attrs, "height", 24);
+        return (w > 0 ? w : 24, h > 0 ? h : 24);
+    }
+
+    /// <summary>One attribute's value out of a tag's attribute text, quote-style agnostic. The
+    /// lookbehind keeps a short name from matching inside a longer one — <c>x</c> must not read
+    /// <c>rx="16"</c>, nor <c>width</c> read <c>stroke-width</c>.</summary>
+    private static string? AttrOf(string attrs, string name)
+    {
+        var match = Regex.Match(
+            attrs,
+            @"(?<![-\w])" + name + @"\s*=\s*([""'])(?<v>.*?)\1",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        return match.Success ? match.Groups["v"].Value.Trim() : null;
+    }
+
+    /// <summary>A numeric attribute, tolerating <c>%</c> (relative to <paramref name="canvas"/>).</summary>
+    private static double NumberOf(string attrs, string name, double fallback, double? canvas = null)
+    {
+        var raw = AttrOf(attrs, name);
+        if (raw is null)
+            return fallback;
+        if (raw.EndsWith('%')
+            && double.TryParse(raw[..^1], NumberStyles.Float, CultureInfo.InvariantCulture, out var pct))
+            return (canvas ?? fallback) * pct / 100;
+        return double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)
+            ? value
+            : fallback;
+    }
+
+    [GeneratedRegex(@"<svg\b(?<attrs>[^>]*)>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex RootTag();
+
+    [GeneratedRegex(
+        @"<(?<tag>rect|circle|ellipse|path|polygon|polyline|line|text)\b(?<attrs>[^>]*?)/?>",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex FirstDrawable();
+
+    [GeneratedRegex(
+        @"\s+(x|y|width|height)\s*=\s*([""']).*?\2",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SizingAttr();
+}

--- a/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
+++ b/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
@@ -157,7 +157,13 @@ public static class MeshNodeImageHelper
         var parsed = DomainIcon.Parse(value);
         return parsed?.Provider switch
         {
-            DomainIcon.InlineSvgProvider => new RenderableIcon(IconRenderKind.InlineSvg, parsed.Id),
+            // Inline svg passes through the backplate policy: an icon without a full-bleed plate
+            // gets a generated one here, at the ONE seam every surface classifies through, so a
+            // currentColor outline or a dark pictorial can never render invisibly on one theme
+            // (IconBackplate). Icons that already paint a plate — every authored store mark, every
+            // thread identicon — pass through byte-identical.
+            DomainIcon.InlineSvgProvider => new RenderableIcon(
+                IconRenderKind.InlineSvg, IconBackplate.Ensure(parsed.Id)),
             DomainIcon.UrlProvider => new RenderableIcon(IconRenderKind.Image, parsed.Id),
             DomainIcon.TextProvider => new RenderableIcon(IconRenderKind.Glyph, parsed.Id),
             DomainIcon.FluentProvider when ShippedIconFor(parsed.Id) is { } url
@@ -344,9 +350,13 @@ public static class MeshNodeImageHelper
         var cluster = glyph.Length == 0
             ? glyph
             : glyph[..StringInfo.GetNextTextElementLength(glyph)];
+        // The glyph sits on a generated plate (hue stable per glyph) for the same reason inline
+        // svg does: a favicon renders on whatever the browser's tab strip paints, and the plate is
+        // what keeps it legible there. Text is white for the rare monogram; an emoji ignores fill.
         return "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 32 32\">"
+               + "<rect width=\"32\" height=\"32\" rx=\"7\" fill=\"" + IconBackplate.HueFor(cluster) + "\"/>"
                + "<text x=\"16\" y=\"17\" text-anchor=\"middle\" dominant-baseline=\"central\" "
-               + "font-size=\"28\">" + XmlEscape(cluster) + "</text></svg>";
+               + "font-size=\"24\" fill=\"#fff\">" + XmlEscape(cluster) + "</text></svg>";
     }
 
     /// <summary>Escapes the five XML markup characters so a glyph like <c>R&amp;D</c> still yields

--- a/test/MeshWeaver.Graph.Test/IconBackplateTest.cs
+++ b/test/MeshWeaver.Graph.Test/IconBackplateTest.cs
@@ -1,0 +1,159 @@
+using MeshWeaver.Graph;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The backplate policy is structural: an inline-svg icon WITHOUT a full-bleed plate gets a
+/// generated one at the render seam; one WITH a plate — every authored store mark, every thread
+/// identicon — passes through byte-identical. These pin both halves plus the wrapping mechanics
+/// (viewBox preservation, sizing-attr removal, currentColor recolor, determinism), because a wrong
+/// answer here renders an invisible icon on one theme and nothing errors.
+/// </summary>
+public class IconBackplateTest
+{
+    private const string MonochromeOutline =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" "
+        + "stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M4 4h16v16H4z\"/></svg>";
+
+    private const string AuthoredPlate =
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>"
+        + "<rect width='24' height='24' rx='5' fill='#4338CA'/>"
+        + "<path d='M10 5.5V10' stroke='#fff'/></svg>";
+
+    [Fact]
+    public void AuthoredPlate_PassesThroughUnchanged()
+        => IconBackplate.Ensure(AuthoredPlate).Should().BeSameAs(AuthoredPlate);
+
+    [Fact]
+    public void ThreadIdenticon_FullBleedRectOnItsOwnCanvas_PassesThroughUnchanged()
+    {
+        // ThreadIconGenerator writes a 0 0 100 100 canvas with a full-bleed rect — the plate test
+        // must measure against the icon's OWN canvas, not a hardcoded 24.
+        var identicon = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">"
+                        + "<rect width=\"100\" height=\"100\" fill=\"#e8f4fd\"/>"
+                        + "<rect x=\"20\" y=\"20\" width=\"20\" height=\"20\" fill=\"#0078d4\"/></svg>";
+        IconBackplate.Ensure(identicon).Should().BeSameAs(identicon);
+    }
+
+    [Fact]
+    public void MonochromeOutline_GetsPlate_AndWhiteDetail()
+    {
+        var plated = IconBackplate.Ensure(MonochromeOutline);
+        plated.Should().StartWith("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>"
+                                  + "<rect width='24' height='24' rx='5'");
+        plated.Should().NotContain("currentColor", "on a plate the glyph must be white, not inherit text color");
+        plated.Should().Contain("stroke=\"#fff\"");
+        // The original glyph is nested, inset, and keeps its own viewBox so path math is untouched.
+        plated.Should().Contain("<svg x='3' y='3' width='18' height='18'");
+        plated.Should().Contain("viewBox=\"0 0 24 24\"");
+        plated.Should().Contain("<path d=\"M4 4h16v16H4z\"/>");
+    }
+
+    [Fact]
+    public void PlateHue_IsFromThePalette_AndDeterministic()
+    {
+        var one = IconBackplate.Ensure(MonochromeOutline);
+        var two = IconBackplate.Ensure(MonochromeOutline);
+        two.Should().Be(one, "the hue is a stable hash of the markup — same icon, same plate, every render");
+        IconBackplate.Palette.Should().Contain(hue => one.Contains($"fill='{hue}'"));
+    }
+
+    [Fact]
+    public void FirstRectWithFillNone_IsNotAPlate()
+    {
+        // A full-canvas rect with fill='none' paints nothing — the icon still needs a plate.
+        var outline = "<svg viewBox='0 0 24 24'><rect width='24' height='24' fill='none' stroke='currentColor'/></svg>";
+        IconBackplate.HasBackplate(outline).Should().BeFalse();
+        IconBackplate.Ensure(outline).Should().StartWith("<svg xmlns='http://www.w3.org/2000/svg'");
+    }
+
+    [Fact]
+    public void SmallOrnamentalRect_IsNotAPlate()
+        => IconBackplate.HasBackplate(
+                "<svg viewBox='0 0 24 24'><rect x='9' y='9' width='6' height='6' fill='#333'/></svg>")
+            .Should().BeFalse();
+
+    [Fact]
+    public void PercentWidthRect_CountsAsPlate()
+        => IconBackplate.HasBackplate(
+                "<svg viewBox='0 0 24 24'><rect width='100%' height='100%' fill='#4338ca'/></svg>")
+            .Should().BeTrue();
+
+    [Fact]
+    public void FullBleedCircle_CountsAsPlate()
+        => IconBackplate.HasBackplate(
+                "<svg viewBox='0 0 24 24'><circle cx='12' cy='12' r='12' fill='#0f766e'/></svg>")
+            .Should().BeTrue();
+
+    [Fact]
+    public void ForeignCanvas_KeepsItsViewBox_InsideThePlate()
+    {
+        var fortyEight = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'>"
+                         + "<path d='M8 8h32v32H8z' fill='currentColor'/></svg>";
+        var plated = IconBackplate.Ensure(fortyEight);
+        plated.Should().Contain("viewBox='0 0 48 48'", "the glyph's own coordinate system must survive");
+        plated.Should().Contain("<svg x='3' y='3' width='18' height='18'");
+    }
+
+    [Fact]
+    public void NoViewBox_SynthesizedFromAuthoredSize()
+    {
+        var sized = "<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20'>"
+                    + "<path d='M2 2h16v16H2z' fill='currentColor'/></svg>";
+        var plated = IconBackplate.Ensure(sized);
+        plated.Should().Contain("viewBox='0 0 20 20'", "without a viewBox the nested svg would clip instead of scale");
+        // The authored width/height are the wrapper's to own — they must not remain and fight the inset.
+        plated.Should().NotContain("width='20'");
+    }
+
+    [Fact]
+    public void RootAttributes_OtherThanSizing_ArePreserved()
+    {
+        var branded = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' "
+                      + "stroke='#7c3aed' stroke-width='1.6'><path d='M4 4h16'/></svg>";
+        var plated = IconBackplate.Ensure(branded);
+        plated.Should().Contain("stroke='#7c3aed'");
+        plated.Should().Contain("stroke-width='1.6'", "stroke-width must not be mistaken for a width attribute");
+        plated.Should().Contain("fill='none'");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("🎯")]
+    [InlineData("Document")]
+    [InlineData("/static/NodeTypeIcons/box.svg")]
+    public void NonSvgValues_PassThrough(string? value)
+        => IconBackplate.Ensure(value).Should().Be(value ?? "");
+
+    [Fact]
+    public void MalformedSvg_NeverThrows()
+    {
+        // Icon values are node content — arbitrary text must degrade, not fault the render path.
+        Action act = () => IconBackplate.Ensure("<svg><rect");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ResolveRenderable_PlatesInlineSvg_AtTheSeam()
+    {
+        var resolved = MeshNodeImageHelper.ResolveRenderable(MonochromeOutline);
+        resolved.Kind.Should().Be(IconRenderKind.InlineSvg);
+        resolved.Value.Should().Contain("<rect width='24' height='24' rx='5'");
+    }
+
+    [Fact]
+    public void ResolveRenderable_LeavesPlatedSvg_Untouched()
+        => MeshNodeImageHelper.ResolveRenderable(AuthoredPlate).Value.Should().BeSameAs(AuthoredPlate);
+
+    [Fact]
+    public void FaviconGlyph_SitsOnAPlate()
+    {
+        var link = MeshNodeImageHelper.IconLinkFor("🎯");
+        link.Type.Should().Be(MeshNodeImageHelper.SvgMediaType);
+        var svg = Uri.UnescapeDataString(link.Href["data:image/svg+xml,".Length..]);
+        svg.Should().Contain("<rect width=\"32\" height=\"32\" rx=\"7\"");
+        svg.Should().Contain("🎯");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/MeshNodeImageHelperTest.cs
+++ b/test/MeshWeaver.Graph.Test/MeshNodeImageHelperTest.cs
@@ -280,14 +280,18 @@ public class MeshNodeImageHelperTest
     [Fact]
     public void IconLinkFor_InlineSvg_BecomesADataUri()
     {
-        const string svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\"></svg>";
+        // A plated icon (the authored store form) travels byte for byte; an icon WITHOUT a plate
+        // gets one generated at the same seam the app renders through (IconBackplate), so the tab
+        // and the page still cannot disagree.
+        const string svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\">"
+                           + "<rect width=\"20\" height=\"20\" rx=\"4\" fill=\"#4338ca\"/></svg>";
 
         var link = MeshNodeImageHelper.IconLinkFor(svg);
 
         link.Type.Should().Be("image/svg+xml");
         link.Href.Should().StartWith("data:image/svg+xml,");
         Uri.UnescapeDataString(link.Href["data:image/svg+xml,".Length..])
-            .Should().Be(svg, "the node's icon travels byte for byte — only its transport changes");
+            .Should().Be(svg, "a plated icon travels byte for byte — only its transport changes");
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Every inline-svg icon the portal renders now sits on a full-bleed rounded backplate — and an icon authored **without** one gets a generated plate at the render seam, instead of silently disappearing on the theme it was not authored for (the AppleMusic mark vanished in dark mode, 2026-08-22).

- **`IconBackplate` (MeshWeaver.Graph)** — pure, total, deterministic: detects an existing full-bleed plate (first drawable measured against the icon's **own** canvas, so 100-unit thread identicons pass through byte-identical); otherwise wraps the glyph on an `rx=5` plate whose hue is a stable FNV-1a hash of the markup over a 10-hue brand palette, recolors `currentColor` → white, and **nests** the original svg with its own viewBox intact so no coordinate rewriting can corrupt a path (20/24/48/100-unit canvases all exist in the wild).
- Wired at the **one seam** everything classifies through: `MeshNodeImageHelper.ResolveRenderable` (cards, chips, pickers, nav, thumbnails-fallback, favicon links). Favicon text glyphs sit on the same plate.
- **React mirror** in `clients/react/src/controls/iconValue.ts` (`ensureBackplate`, applied in `classifyIcon`) — same palette, same order, same hash, so Blazor and React can never disagree about an icon.
- The attribute parser anchors on a word boundary — `rx="16"` must never be read as `x="16"` (the first test run caught exactly this); pinned on both sides.

## Why not sweep the authored icons instead

66 icons in MeshWeaver.Plugins alone lack a plate today, and every future plugin can add more. The renderer guaranteeing the shape is the robust form of the policy; authoring a plate stays preferred (the author controls the hue) and authored plates pass through untouched.

## Tests

- `IconBackplateTest` (17 cases): pass-through of authored plates + identicons, wrapping mechanics, foreign canvases, viewBox synthesis, %-widths, fill=none, malformed input never throws, determinism, seam integration.
- Full `MeshWeaver.Graph.Test`: 1539/1539 green. React: 268/268 green, `tsc --noEmit` clean.
- One existing expectation updated: `IconLinkFor_InlineSvg_BecomesADataUri` fed an **empty** svg and asserted byte-for-byte transport — an empty glyph now gets a generated plate by design; the byte-for-byte claim is pinned on a plated icon instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)