### PR TITLE
MeshWeaver.Blazor.EntityViews flips to the module lane

### DIFF
--- a/memex/Memex.Portal.Monolith/appsettings.json
+++ b/memex/Memex.Portal.Monolith/appsettings.json
@@ -30,6 +30,7 @@
     "Required": [
       "MeshWeaver.Blazor.Radzen.dll",
       "MeshWeaver.Blazor.Analysis.dll",
+      "MeshWeaver.Blazor.EntityViews.dll",
       "MeshWeaver.Blazor.GoogleMaps.dll",
       "MeshWeaver.Speech.dll"
     ],

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -47,10 +47,12 @@
          is what caught it. No portal code uses these types — the reference IS the point. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Maps\MeshWeaver.Maps.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Graph\MeshWeaver.Blazor.Graph.csproj" />
-    <!-- The entity form/edit renderers, carved out of MeshWeaver.Blazor onto the view-pack seam.
-         Referenced + registered (AddEntityViews) exactly like the Graph pack; the module-lane
-         flip (the Analysis/#1974 shape) is a separate, later step. -->
-    <ProjectReference Include="..\..\src\MeshWeaver.Blazor.EntityViews\MeshWeaver.Blazor.EntityViews.csproj" />
+    <!-- MeshWeaver.Blazor.EntityViews is deliberately NOT referenced (the Analysis/#1974 shape):
+         it ships via the registry as a module, its EntityViewsViewPackModuleAttribute registers
+         the views when the DLL is listed under Modules:Assemblies, and Modules:Required declares
+         it so a rollout that lost the pack stalls on readiness instead of shipping blank edit
+         forms. A reference here would put the DLL back in the app closure, where the module
+         landing refuses the same-identity module (409 on every instance). -->
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor.Portal\MeshWeaver.Blazor.Portal.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Blazor\MeshWeaver.Hosting.Blazor.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -7,7 +7,6 @@ using Memex.Portal.Shared.Settings;
 using Memex.Portal.Shared.Social;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MeshWeaver.AI;
-using MeshWeaver.Blazor.EntityViews;
 using MeshWeaver.Blazor.Graph;
 using MeshWeaver.Blazor.Infrastructure;
 using MeshWeaver.Hosting.Grpc;
@@ -1032,7 +1031,10 @@ public static class MemexConfiguration
                 .AddGraphViews()  // Also enables @ autocomplete in markdown editors
                 .AddChatViews()   // Register ThreadChatView
                 .AddUserProfileViews() // Register UserProfilePageView
-                .AddEntityViews() // The entity form/edit renderers (extracted from the base pack)
+                // The entity form/edit renderers (MeshWeaver.Blazor.EntityViews) are a MODULE now:
+                // the DLL's EntityViewsViewPackModuleAttribute folds AddEntityViews() when it is
+                // listed under Modules:Assemblies, and Modules:Required gates a rollout that lost
+                // it. No compiled call here — see the csproj note beside the removed reference.
             )
             .AddBlazor(layoutClient => layoutClient
                 // 🚨 The portal hub is the per-user sub-hub that hosts the

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -15,6 +15,7 @@
     "Required": [
       "MeshWeaver.Blazor.Radzen.dll",
       "MeshWeaver.Blazor.Analysis.dll",
+      "MeshWeaver.Blazor.EntityViews.dll",
       "MeshWeaver.Blazor.GoogleMaps.dll",
       "MeshWeaver.Speech.dll"
     ],

--- a/src/MeshWeaver.Blazor.EntityViews/EntityViewsViewPackModuleAttribute.cs
+++ b/src/MeshWeaver.Blazor.EntityViews/EntityViewsViewPackModuleAttribute.cs
@@ -1,0 +1,23 @@
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+
+[assembly: MeshWeaver.Blazor.EntityViews.EntityViewsViewPackModule]
+
+namespace MeshWeaver.Blazor.EntityViews;
+
+/// <summary>
+/// Module registration for the EntityViews view pack. Loading this DLL via
+/// <c>Modules:Assemblies</c> applies the pack's hub-side view registrations
+/// (<see cref="EntityViewsExtensions.AddEntityViews"/>) with no compiled call from the portal —
+/// the same lane as the Analysis/Radzen/GoogleMaps packs. Dropping the module leaves the entity
+/// form/edit controls to the escaped-HTML fallback slot, which is why the portals declare the
+/// DLL under <c>Modules:Required</c>: a rollout that lost the pack must STALL on readiness, not
+/// complete into a portal whose edit forms went blank.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class EntityViewsViewPackModuleAttribute : MeshNodeProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<Func<MessageHubConfiguration, MessageHubConfiguration>> HubConfigurations =>
+        [config => config.AddEntityViews()];
+}

--- a/src/MeshWeaver.Blazor.EntityViews/MeshWeaver.Blazor.EntityViews.csproj
+++ b/src/MeshWeaver.Blazor.EntityViews/MeshWeaver.Blazor.EntityViews.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <StaticWebAssetBasePath>_content/MeshWeaver.Blazor.EntityViews</StaticWebAssetBasePath>
+    <Description>Entity form/edit view pack for MeshWeaver: the text/number/date/choice inputs plus the Editor/EditForm/Property skin views. Ships as a module — list the DLL under Modules:Assemblies to activate.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MeshWeaver.Blazor.EntityViews/README.md
+++ b/src/MeshWeaver.Blazor.EntityViews/README.md
@@ -22,11 +22,19 @@ carved out of the base `MeshWeaver.Blazor` pack onto the view-pack seam (the
 | `EditFormSkin` | `EditFormView` |
 | `PropertySkin` | `PropertyView` |
 
-Plus the shared form-component bases (`FormComponentBase`, `InputBase`, `ListBase`) and the
-`OptionsExtension.Option` list-item model — `MeshWeaver.Blazor.Graph`'s `MeshNodePickerView`
-derives from `FormComponentBase`, which is why that pack references this one.
+The shared form-component bases (`FormComponentBase`, `InputBase`, `ListBase`) and the
+`OptionsExtension.Option` list-item model live in the BASE pack (`MeshWeaver.Blazor.Components`),
+not here: they are app-closure infrastructure shared with `MeshWeaver.Blazor.Graph`'s
+`MeshNodePickerView`, and an edge from the app-closure Graph pack into this module would drag
+this DLL back into the closure — where the module landing refuses the same-identity module.
 
 ## Registration
+
+This pack ships as a MODULE (a registry bundle, the Analysis/Radzen/GoogleMaps lane):
+`EntityViewsViewPackModuleAttribute` applies the registration when the DLL is listed under
+`Modules:Assemblies`, and the portals declare it under `Modules:Required` so a rollout that lost
+the pack stalls on readiness instead of shipping blank edit forms. Compiled-in hosts (tests) call
+it directly:
 
 ```csharp
 configuration.AddEntityViews();

--- a/src/MeshWeaver.Blazor.EntityViews/_Imports.razor
+++ b/src/MeshWeaver.Blazor.EntityViews/_Imports.razor
@@ -6,5 +6,5 @@
 @using MeshWeaver.Layout
 @using MeshWeaver.Layout.Views
 @using MeshWeaver.Messaging
-@using Option = MeshWeaver.Blazor.EntityViews.OptionsExtension.Option
+@using Option = MeshWeaver.Blazor.Components.OptionsExtension.Option
 @using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons

--- a/src/MeshWeaver.Blazor.Graph/BlazorGraphExtensions.cs
+++ b/src/MeshWeaver.Blazor.Graph/BlazorGraphExtensions.cs
@@ -30,9 +30,9 @@ public static class BlazorGraphExtensions
                 .WithView<MeshNodeCollectionControl, MeshNodeCollectionView>()
                 .WithView<MeshNodeContentEditorControl, MeshNodeContentEditorView>()
                 .WithView<MeshNodeRoleEditorControl, MeshNodeRoleEditorView>()
-                // The picker lives HERE (it is a Graph surface) but derives from the EntityViews
-                // pack's FormComponentBase — it left the base pack with the form controls because
-                // the base pack cannot reference the pack that references it.
+                // The picker lives HERE (it is a Graph surface); it derives from the base pack's
+                // FormComponentBase — the shared form infrastructure stays in the app closure so
+                // this pack never references the module-lane EntityViews pack (see the csproj).
                 .WithView<MeshNodePickerControl, MeshNodePickerView>())
             .AddMeshNavigation();  // Enable @ autocomplete in markdown editors
     }

--- a/src/MeshWeaver.Blazor.Graph/MeshNodePickerView.razor.cs
+++ b/src/MeshWeaver.Blazor.Graph/MeshNodePickerView.razor.cs
@@ -2,7 +2,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text.Json;
-using MeshWeaver.Blazor.EntityViews;
+using MeshWeaver.Blazor.Components;
 using MeshWeaver.Data;
 using MeshWeaver.Domain;
 using MeshWeaver.Layout;

--- a/src/MeshWeaver.Blazor.Graph/MeshWeaver.Blazor.Graph.csproj
+++ b/src/MeshWeaver.Blazor.Graph/MeshWeaver.Blazor.Graph.csproj
@@ -14,12 +14,13 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- 🚨 Deliberately NO reference to MeshWeaver.Blazor.EntityViews. This pack stays in the
+             APP CLOSURE while EntityViews ships as a MODULE (registry bundle) — an edge from here
+             would drag EntityViews.dll back into the closure, and the module landing refuses a
+             module whose entry DLL collides with an app-closure file. The shared form bases
+             (FormComponentBase & co.) live in the base pack for exactly this reason:
+             MeshNodePickerView inherits them from MeshWeaver.Blazor.Components. -->
         <ProjectReference Include="..\MeshWeaver.Blazor\MeshWeaver.Blazor.csproj" />
-        <!-- MeshNodePickerView derives from the EntityViews pack's FormComponentBase. A
-             pack-to-pack reference on purpose: the picker moved here (not into EntityViews)
-             because it is a GRAPH surface, and it left the base pack because the base pack
-             cannot reference the pack that references it. -->
-        <ProjectReference Include="..\MeshWeaver.Blazor.EntityViews\MeshWeaver.Blazor.EntityViews.csproj" />
         <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
         <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
         <ProjectReference Include="..\MeshWeaver.ContentCollections\MeshWeaver.ContentCollections.csproj" />

--- a/src/MeshWeaver.Blazor.Graph/_Imports.razor
+++ b/src/MeshWeaver.Blazor.Graph/_Imports.razor
@@ -5,7 +5,6 @@
 @using MeshWeaver.Blazor
 @using MeshWeaver.Blazor.Components
 @using MeshWeaver.Messaging
-@using MeshWeaver.Blazor.EntityViews
 @using MeshWeaver.Blazor.Components.Monaco
 @using MeshWeaver.Graph
 @using MeshWeaver.Layout

--- a/src/MeshWeaver.Blazor/Components/FormComponentBase.cs
+++ b/src/MeshWeaver.Blazor/Components/FormComponentBase.cs
@@ -6,7 +6,7 @@ using MeshWeaver.Domain;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.DataBinding;
 
-namespace MeshWeaver.Blazor.EntityViews;
+namespace MeshWeaver.Blazor.Components;
 
 /// <summary>
 /// Base class for data-bound form components that bind a single typed value

--- a/src/MeshWeaver.Blazor/Components/InputBase.cs
+++ b/src/MeshWeaver.Blazor/Components/InputBase.cs
@@ -2,7 +2,7 @@
 using MeshWeaver.Domain;
 using MeshWeaver.Layout;
 
-namespace MeshWeaver.Blazor.EntityViews;
+namespace MeshWeaver.Blazor.Components;
 
 /// <summary>
 /// Base class for text-input form components that carry size and length constraints

--- a/src/MeshWeaver.Blazor/Components/ListBase.cs
+++ b/src/MeshWeaver.Blazor/Components/ListBase.cs
@@ -4,8 +4,8 @@ using MeshWeaver.Json;
 using MeshWeaver.Data;
 using MeshWeaver.Layout;
 using LayoutOption=MeshWeaver.Layout.Option;
-using Option=MeshWeaver.Blazor.EntityViews.OptionsExtension.Option;
-namespace MeshWeaver.Blazor.EntityViews;
+using Option=MeshWeaver.Blazor.Components.OptionsExtension.Option;
+namespace MeshWeaver.Blazor.Components;
 
 /// <summary>
 /// Base class for list-based form components (drop-downs, radio groups, etc.) that bind a

--- a/src/MeshWeaver.Blazor/Components/OptionsExtension.cs
+++ b/src/MeshWeaver.Blazor/Components/OptionsExtension.cs
@@ -1,6 +1,6 @@
 ﻿using MeshWeaver.Reflection;
 
-namespace MeshWeaver.Blazor.EntityViews;
+namespace MeshWeaver.Blazor.Components;
 
 /// <summary>
 /// Utility class for converting layout control options into a strongly-typed
@@ -18,7 +18,16 @@ public static class OptionsExtension
     /// <param name="Icon">Optional icon identifier shown alongside the label.</param>
     public record Option(object? Item, string? Text, string? ItemString, Type ItemType, string? Icon = null);
 
-    internal static string? MapToString(object? instance, Type itemType) =>
+    /// <summary>
+    /// Maps a list item to the string the Fluent list components compare selections by — the
+    /// item's default value maps to the item TYPE's default string so an unset selection round-
+    /// trips. Public since the list views consuming it (RadioGroupView &amp; co.) moved to the
+    /// MeshWeaver.Blazor.EntityViews view pack.
+    /// </summary>
+    /// <param name="instance">The item to map, or null.</param>
+    /// <param name="itemType">The declared item type, used for the default-value fallback.</param>
+    /// <returns>The comparison string, or null for a reference-typed default.</returns>
+    public static string? MapToString(object? instance, Type itemType) =>
         instance == null || IsDefault((dynamic)instance)
             ? GetDefault(itemType)
             : instance!.ToString();


### PR DESCRIPTION
## What

PR 3 of the extraction chain (#2080 → #2081 → #2082 → this): `MeshWeaver.Blazor.EntityViews` leaves the app closure and ships as a registry module — the Analysis/#1974 shape, with both halves of an extraction: OUT of the image, and DECLARED required.

## What makes the flip REAL: the closure edge through Graph had to go

Dropping the portal's ProjectReference alone would have flipped nothing: `MeshWeaver.Blazor.Graph` (which **stays app-closure**) referenced EntityViews for `FormComponentBase`, so `EntityViews.dll` kept riding the closure transitively — and the module landing refuses a module whose entry DLL collides with an app-closure file, so the catalog package could never land (409 on every instance) while `Modules:Required` would hold every rollout on a module that could never install.

So the shared form infrastructure returns to the base pack: `FormComponentBase`, `InputBase`, `ListBase` and `OptionsExtension` move back to `src/MeshWeaver.Blazor/Components` (app-closure infrastructure, shared with Graph's `MeshNodePickerView`), and Graph's EntityViews reference is deleted with a csproj note saying why it must never come back. `OptionsExtension.MapToString` goes public — its consumers (`RadioGroupView` & co.) are cross-assembly now. The module keeps the CONCRETE renderers: the ten form inputs and the three entity-editing skin views.

**Verified on the closure itself:** `Memex.Portal.Monolith`'s Release output carries `MeshWeaver.Blazor.Graph.dll` and **no** `MeshWeaver.Blazor.EntityViews.dll` (Analysis absent too, as expected on the module lane).

## The two halves

- **Out of the image:** `Memex.Portal.Shared` drops the reference and the compiled `AddEntityViews()` call; a new `EntityViewsViewPackModuleAttribute` (`MeshNodeProviderAttribute`) folds the identical registration when the DLL is listed under `Modules:Assemblies`.
- **Declared required:** `MeshWeaver.Blazor.EntityViews.dll` joins `Modules:Required` in BOTH portals (Distributed + Monolith), beside Radzen/Analysis/GoogleMaps/Speech — `required_modules` goes Unhealthy and readiness holds a rollout that lost the pack, instead of completing into a portal whose edit forms went blank.

Test projects that name the pack's types by NAME keep their direct ProjectReferences (`ViewPackRegistrationGateTest`, `ControlStyleRenderingTest`) — a publish lane can never satisfy a by-name type reference (#2018).

## Content-surface check (the Maps/#1814/#2021 identity-fork trap)

EntityViews drags no canonical content-surface assembly out of the closure: `MeshWeaver.Application.Styles` stays (Layout + Blazor still reference it — confirmed present in the monolith output) and `FrameworkBuildIdentityTest` is 23/23 green, including `CanonicalContentSurface_IsRecordedByEverySurfaceManifestHost`.

## Verification

- Release builds green (warnings-as-errors): EntityViews, Blazor, Blazor.Graph, Memex.Portal.Shared(+Test), Memex.Portal.Monolith, Memex.LocalMesh — re-verified after merging current main.
- Suites executed: Hosting.Blazor.Test **444/444** (incl. the 13-row EntityViews gate — the pack still registers everything it claims), Layout.Test **474/474**, Graph.Test **1519/1519**, FrameworkBuildIdentity **23/23**.

## Ordering (stated here and in the package PR)

🚨 The catalog package (MeshWeaver.Plugins `EntityViews/`, whose module-bundle matrix entry builds THIS repo's `src/MeshWeaver.Blazor.EntityViews` from the platform checkout) lands **only after this merges**: publishing the bundle while the image still ships the DLL in the app closure would 409 the module landing on every instance.

Operational note for the next deploy: a portal rolling to a post-this-PR image will hold readiness (`required_modules`) until the EntityViews package is installed from the registry — that is the gate doing its job; install the package to complete the rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)