### PR TITLE
Nav a11y: decorative icons aria-hidden, active links aria-current

### DIFF
--- a/src/MeshWeaver.Blazor/Components/MeshIcon.razor
+++ b/src/MeshWeaver.Blazor/Components/MeshIcon.razor
@@ -11,23 +11,32 @@
    Inline SVG renders VERBATIM (sized via MeshNodeImageHelper.SizeInlineSvg), so a
    stroke='currentColor' outline icon inherits the surrounding text color and is theme-correct by
    construction; a URL icon is an <img> and must carry its own colors (the shipped
-   /static/NodeTypeIcons glyphs are self-colored tiles for exactly that reason). *@
+   /static/NodeTypeIcons glyphs are self-colored tiles for exactly that reason).
+
+   This is the TYPED twin of NodeIcon.razor and shares its ARIA pattern — decorative by default
+   (Alt empty → aria-hidden), named → role="img" + aria-label. The two differ on Fluent names,
+   which is why both exist: NodeIcon resolves a name to a SHIPPED glyph URL (total, falls back to
+   the neutral box), while this renders the real FluentIcon component — required for the typed
+   FluentIcons.* the Settings menus declare, which have no shipped twin. Keep the ARIA and sizing
+   conventions of the two in step. *@
 
 @if (FluentIcon is { } fluent)
 {
-    <FluentIcon Value="@fluent" Width="@($"{Size}px")" Style="fill: currentColor; flex-shrink: 0;" />
+    <span style="display: inline-flex; flex-shrink: 0;" role="@SpanRole" aria-label="@SpanLabel" aria-hidden="@SpanHidden">
+        <FluentIcon Value="@fluent" Width="@($"{Size}px")" Style="fill: currentColor; flex-shrink: 0;" />
+    </span>
 }
 else if (Value is { Provider: Icon.UrlProvider } urlIcon)
 {
-    <img src="@urlIcon.Id" alt="" style="width: @(Size)px; height: @(Size)px; flex-shrink: 0; vertical-align: middle;" />
+    <img src="@urlIcon.Id" alt="@Alt" style="width: @(Size)px; height: @(Size)px; flex-shrink: 0; vertical-align: middle;" />
 }
 else if (Value is { Provider: Icon.InlineSvgProvider } svgIcon)
 {
-    <span style="display: inline-flex; flex-shrink: 0; vertical-align: middle;">@((MarkupString)MeshNodeImageHelper.SizeInlineSvg(svgIcon.Id, Size))</span>
+    <span style="display: inline-flex; flex-shrink: 0; vertical-align: middle;" role="@SpanRole" aria-label="@SpanLabel" aria-hidden="@SpanHidden">@((MarkupString)MeshNodeImageHelper.SizeInlineSvg(svgIcon.Id, Size))</span>
 }
 else if (Value is { Provider: Icon.TextProvider } textIcon)
 {
-    <span style="font-size: @(Size - 4)px; line-height: @(Size)px; flex-shrink: 0; vertical-align: middle;">@textIcon.Id</span>
+    <span style="font-size: @(Size - 4)px; line-height: @(Size)px; flex-shrink: 0; vertical-align: middle;" role="@SpanRole" aria-label="@SpanLabel" aria-hidden="@SpanHidden">@textIcon.Id</span>
 }
 
 @code {
@@ -37,5 +46,23 @@ else if (Value is { Provider: Icon.TextProvider } textIcon)
     /// <summary>Rendered size in pixels (square).</summary>
     [Parameter] public int Size { get; set; } = 20;
 
+    /// <summary>
+    /// Accessible name. Empty (the default) marks the icon DECORATIVE — hidden from assistive
+    /// tech, so a screen reader announces only the label beside it, not the glyph too.
+    /// </summary>
+    [Parameter] public string Alt { get; set; } = "";
+
     private Microsoft.FluentUI.AspNetCore.Components.Icon? FluentIcon => Value?.ToFluentIcon();
+
+    // Same pattern as NodeIcon.razor: the <img> branch gets its semantics from alt=""/alt="…" for
+    // free; the <span> branches carry no implicit role, so a decorative icon is aria-hidden and a
+    // named one is role="img" + label. Blazor drops null-valued attributes, so each branch emits
+    // exactly one of the two.
+    private bool Decorative => string.IsNullOrEmpty(Alt);
+
+    private string? SpanRole => Decorative ? null : "img";
+
+    private string? SpanLabel => Decorative ? null : Alt;
+
+    private string? SpanHidden => Decorative ? "true" : null;
 }

--- a/src/MeshWeaver.Blazor/Components/NavLink.razor
+++ b/src/MeshWeaver.Blazor/Components/NavLink.razor
@@ -9,14 +9,14 @@
 
 @if (IsInMenuContext)
 {
-    <a href="@Href" class="@MenuLinkClass" style="@Style" @onclick="OnClick">
+    <a href="@Href" class="@MenuLinkClass" style="@Style" aria-current="@AriaCurrent" @onclick="OnClick">
         <MeshIcon Value="@Icon" />
         <span>@Title</span>
     </a>
 }
 else
 {
-    <a href="@Href" class="@RailClass" style="@Style" title="@Title" @onclick="OnClick">
+    <a href="@Href" class="@RailClass" style="@Style" title="@Title" aria-current="@AriaCurrent" @onclick="OnClick">
         <span class="mw-nav-icon"><MeshIcon Value="@Icon" /></span>
         <span class="mw-nav-label">@Title</span>
     </a>
@@ -31,4 +31,10 @@ else
 
     /// <summary>The rail link's classes: base + active state + the author-declared <c>Class</c>.</summary>
     private string RailClass => $"mw-nav-link{(IsActive ? " active" : "")}{ClassSuffix}";
+
+    /// <summary>
+    /// The active entry announces its state to assistive tech, not only visually — Blazor drops
+    /// the attribute entirely when this is null.
+    /// </summary>
+    private string? AriaCurrent => IsActive ? "page" : null;
 }

--- a/src/MeshWeaver.Blazor/Components/NodeIcon.razor
+++ b/src/MeshWeaver.Blazor/Components/NodeIcon.razor
@@ -10,7 +10,9 @@
    is always something renderable and a caller can never re-create the broken case.
 
    This is the Blazor mirror of the React client's MeshIcon (clients/react/src/controls/MeshIcon.tsx),
-   which dispatches on the same classification — keep the two in step.
+   which dispatches on the same classification — keep the two in step. Its TYPED twin is
+   MeshIcon.razor (a parsed Domain.Icon, rendering real FluentIcon glyphs instead of resolving
+   names to shipped URLs) — keep the ARIA and sizing conventions in step with that one too.
 
    Sizing is INLINE (from Size), not from the caller's CSS class: this component's markup lives in its
    own CSS-isolation scope, so a scoped `.my-icon { width: … }` in the parent would not reach it. The

--- a/test/MeshWeaver.Hosting.Blazor.Test/MeshIconRenderingTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/MeshIconRenderingTest.cs
@@ -78,6 +78,16 @@ public class MeshIconRenderingTest
     }
 
     [Fact]
+    public async Task DecorativeByDefault_HiddenFromAssistiveTech()
+    {
+        // Nav icons sit beside a text label; without aria-hidden a screen reader announces both.
+        var html = await RenderAsync("<svg viewBox='0 0 24 24'><path d='M0 0h24v24H0z'/></svg>");
+
+        Assert.Contains("aria-hidden=\"true\"", html);
+        Assert.DoesNotContain("role=\"img\"", html);
+    }
+
+    [Fact]
     public async Task UnknownFluentName_AndNull_RenderNothing_NeverThrow()
     {
         Assert.Equal(string.Empty, (await RenderAsync("NotARealIconName")).Trim());


### PR DESCRIPTION
Follow-up to #2092, addressing both Copilot findings (valid):

- **MeshIcon** had no ARIA semantics, so screen readers announced the glyph in addition to the link text. It now follows `NodeIcon.razor`'s pattern: decorative by default (empty `Alt` → `aria-hidden` on the span branches, `alt=""` on the img), `role="img"` + `aria-label` when `Alt` is provided. The two components now cross-reference each other so the conventions stay in step.
- The active **NavLink** carries `aria-current="page"` — the state FluentNavLink exposed and the custom anchor dropped.

Tested: `MeshIconRenderingTest` extended with a DOM-level aria-hidden assertion; full `MeshWeaver.Hosting.Blazor.Test` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)