### PR TITLE
Portal: make the app's CSP authoritative (fixes CSP-without-fallback on every page)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1148,8 +1148,15 @@ public static class MemexConfiguration
                 headers["Permissions-Policy"] =
                     "accelerometer=(), camera=(), geolocation=(), gyroscope=(), " +
                     "magnetometer=(), microphone=(), payment=(), usb=()";
-                if (!headers.ContainsKey("Content-Security-Policy"))
-                    headers["Content-Security-Policy"] =
+                // SET, never defer. Something earlier in the pipeline emits a bare
+                // `frame-ancestors 'self'` on HTML responses (API responses get the full
+                // policy), and a ContainsKey guard here silently yielded to it — so every
+                // page shipped an anti-clickjacking directive with no fetch-directive
+                // fallback (ZAP 10055) while /api/* was correctly covered. This callback is
+                // registered earliest, so it runs LAST and its value wins. The policy below
+                // is a strict superset: it includes frame-ancestors 'self', so nothing the
+                // shorter header expressed is lost.
+                headers["Content-Security-Policy"] =
                         "default-src 'self'; " +
                         "base-uri 'self'; " +
                         "object-src 'none'; " +


### PR DESCRIPTION
## Problem
The security-headers middleware guarded the CSP with `if (!headers.ContainsKey("Content-Security-Policy"))`. Something earlier in the pipeline emits a bare `frame-ancestors 'self'` on **HTML** responses, so the guard silently yielded — every page shipped an anti-clickjacking directive with **no fetch-directive fallback** (ZAP rule 10055, 12 instances), while `/api/*` correctly got the complete policy.

Verified directly against the running pod (bypassing the ingress, which I had wrongly suspected):
```
/api/version    -> default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; ...
/               -> frame-ancestors 'self'
/Store          -> frame-ancestors 'self'
/app            -> frame-ancestors 'self'
/login          -> frame-ancestors 'self'
```

## Fix
Set the header rather than defer. The callback is registered earliest, so it runs **last** among `OnStarting` callbacks and its value wins. The policy is a **strict superset** — it already contains `frame-ancestors 'self'` — so nothing the shorter header expressed is lost, and clickjacking protection is unchanged.

## Verification
- ✅ `dotnet build Memex.Portal.Shared` — 0 warnings, 0 errors
- The enforced policy was previously validated against live traffic in report-only mode with **zero** violations, so enforcing the full policy cannot break legitimate behaviour.
- After deploy: ZAP rule 10055 should clear on all pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)