### PR TITLE
Rail polish: edge line, tree guides, quieter toggle, breathing room

### DIFF
--- a/src/MeshWeaver.Blazor/Components/NavGroup.razor.css
+++ b/src/MeshWeaver.Blazor/Components/NavGroup.razor.css
@@ -73,9 +73,13 @@
         transform: rotate(90deg);
     }
 
-/* Children indent under their group; the child links are NavLink components, hence ::deep. */
+/* Children indent under their group, along a tree guide that runs down from the heading's icon —
+   the line is what makes three levels readable at a glance instead of a wall of rows. */
 .mw-nav-group-items {
     display: flex;
     flex-direction: column;
-    padding-left: 16px;
+    gap: 2px;
+    margin-left: 19px;
+    padding-left: 6px;
+    border-left: 1px solid var(--neutral-stroke-divider-rest, rgba(128, 128, 128, 0.25));
 }

--- a/src/MeshWeaver.Blazor/Components/NavMenuView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/NavMenuView.razor.css
@@ -12,6 +12,8 @@
 .navmenu.rail {
     overflow: hidden;
     transition: width 0.15s ease, min-width 0.15s ease;
+    /* The edge the rail collapses toward — without it the tree floats unanchored in the page. */
+    border-right: 1px solid var(--neutral-stroke-divider-rest, rgba(128, 128, 128, 0.25));
 }
 
 /* The collapse/expand control. Expanded it sits top-right of the rail, at the seam it collapses
@@ -21,15 +23,17 @@
     align-items: center;
     justify-content: center;
     flex: 0 0 auto;
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
     padding: 0;
-    margin: 2px;
+    margin: 6px 6px 0 0;
     background: transparent;
     border: none;
     border-radius: 4px;
     cursor: pointer;
     align-self: flex-end;
+    /* Hint-colored at rest so the control doesn't compete with the index itself. */
+    color: var(--neutral-foreground-hint, var(--neutral-foreground-rest));
 }
 
     .navmenu-toggle:hover {
@@ -47,5 +51,6 @@
     overflow-y: auto;
     display: flex;
     flex-direction: column;
-    padding: 4px;
+    padding: 4px 8px 8px 8px;
+    gap: 2px;
 }


### PR DESCRIPTION
Follow-up to #2092, from actually rendering the new rail and looking at it (screenshots below re-created via headless Chromium from the components' exact markup + CSS, dark and light, expanded + collapsed).

- The rail carries a **right edge line**, so the index reads as a panel instead of a tree floating unanchored in the page.
- Group children hang on a **tree guide** running down from the heading's icon — hierarchy visible at a glance.
- The collapse toggle is 28px and **hint-colored at rest**, so it stops competing with the index it controls.
- 2px row gaps and proper list padding.

CSS only, no markup change; tokens carry neutral fallbacks. `MeshWeaver.Blazor` builds clean; the DOM-level `MeshIconRenderingTest` suite is untouched by a CSS-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)