### PR TITLE
Center the collapsed rail toggle exactly

### DIFF
--- a/src/MeshWeaver.Blazor/Components/NavMenuView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/NavMenuView.razor.css
@@ -42,6 +42,9 @@
 
 .rail-collapsed .navmenu-toggle {
     align-self: center;
+    /* The expanded state's right margin would push the centered button 3px off-center
+       in the 44px strip. */
+    margin: 6px 0 0 0;
 }
 
 /* The item list: NavLink / NavGroup components stack vertically and scroll internally. */


### PR DESCRIPTION
One-line follow-up to #2096, from its Copilot review (valid): the expanded state's asymmetric `margin: 6px 6px 0 0` survived into `.rail-collapsed`, leaving the centered button 3px off-center in the 44px strip. The collapsed override now resets the horizontal margins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)