### PR TITLE
Doc index: a resizable splitter pane, not a fixed-width stack

### DIFF
--- a/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
@@ -184,19 +184,28 @@ public static class MarkdownOverviewLayoutArea
         // A module that OWNS this page supplied the whole index — rendered by the shared rail, whose
         // shape is pinned by SuppliedNavigationRail's tests. Nothing supplied → core's default list
         // of the node's own children, unchanged, so docs and spaces are untouched by this.
+        // The nav renders NON-collapsible: the Splitter below owns both resize and collapse.
         var nav = supplied is { Entries.Count: > 0 }
             ? SuppliedNavigationRail.Render(
-                SuppliedNavigationRail.Plan(supplied, host.Hub.Address.ToString()))
+                SuppliedNavigationRail.Plan(supplied, host.Hub.Address.ToString()), collapsible: false)
             : Controls.NavMenu
-                .WithSkin(s => s.WithWidth(240).WithCollapsible(true))
+                .WithSkin(s => s.WithCollapsible(false))
                 .WithNavGroup(BuildChildrenGroup(host, node, subNodes));
 
-        return Controls.Stack
-            .WithOrientation(Orientation.Horizontal)
-            .WithWidth("100%")
-            .WithStyle("gap: 24px; align-items: flex-start;")
-            .WithView(nav, NavigationArea)
-            .WithView(Controls.Stack.WithStyle("flex: 1; min-width: 0;").WithView(content));
+        // A SPLITTER, not a Stack — the same idiom as the Settings pages, and for the same reason:
+        // the divider is a real, draggable resize handle (FluentMultiSplitter, client-side), and
+        // its collapse arrow replaces the rail's own toggle. A fixed-width Stack answered "the
+        // index is page-wide" but not "let me choose how wide" (user report 2026-08-23). Styles
+        // mirror SettingsLayoutArea: the splitter takes its content height and the page scrolls
+        // as a whole.
+        return Controls.Splitter
+            .WithStyle("height: auto; flex: 1 0 auto;")
+            .WithSkin(s => s.WithOrientation(Orientation.Horizontal).WithWidth("100%"))
+            .WithView(nav, x => x.WithArea(NavigationArea)
+                .AddSkin(new SplitterPaneSkin().WithSize("260px").WithMin("180px").WithMax("480px").WithCollapsible(true)))
+            .WithView(
+                Controls.Stack.WithStyle("min-width: 0; padding-left: 16px;").WithView(content),
+                skin => skin.WithSize("*"));
     }
 
     // Core's default: the node's own children, one flat list.

--- a/test/MeshWeaver.FutuRe.Test/FutuReAnalysisTest.cs
+++ b/test/MeshWeaver.FutuRe.Test/FutuReAnalysisTest.cs
@@ -928,14 +928,16 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
             .Should().Within(30.Seconds())
             .Match(x => x is not null);
 
-        var stack = control.Should().BeOfType<StackControl>().Subject;
-        Output.WriteLine($"Stack has {stack.Areas?.Count} areas");
+        control.Should().BeAssignableTo<IContainerControl>(
+            "the Overview root is a container — a plain Stack without sub-nodes, or the resizable "
+            + "side-menu SPLITTER when sub-nodes render (MarkdownOverviewLayoutArea.BuildWithSubNodeNav)");
+        Output.WriteLine($"{control!.GetType().Name} has {((IContainerControl)control).Areas?.Count} areas");
 
-        // Find the markdown body control ANYWHERE in the Overview control tree. A node WITH sub-nodes
-        // renders the collapsible side-menu wrapper (MarkdownOverviewLayoutArea.BuildWithSubNodeNav),
-        // which nests the body inside a content column — so it may be a direct child (no sub-nodes) or
-        // a grandchild (side menu present). The Overview body is a CollaborativeMarkdownControl (value
-        // in `Value`); legacy areas may still produce MarkdownControl (`Markdown`). Accept either.
+        // Find the markdown body control ANYWHERE in the Overview control tree, walking EVERY
+        // container kind — the wrapper changed from Stack to Splitter once (for drag-resize) and a
+        // walk pinned to one container type reported the body missing when it was merely re-parented.
+        // The Overview body is a CollaborativeMarkdownControl (value in `Value`); legacy areas may
+        // still produce MarkdownControl (`Markdown`). Accept either.
         async Task<string?> FindMarkdown(UiControl? c)
         {
             switch (c)
@@ -944,8 +946,8 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
                     return mc.Markdown?.ToString();
                 case CollaborativeMarkdownControl cmc:
                     return cmc.Value?.ToString();
-                case StackControl sc:
-                    foreach (var area in sc.Areas ?? [])
+                case IContainerControl cc:
+                    foreach (var area in cc.Areas ?? [])
                     {
                         var childKey = area.Area?.ToString();
                         if (string.IsNullOrEmpty(childKey)) continue;
@@ -962,7 +964,7 @@ public class FutuReAnalysisTest(ITestOutputHelper output) : MonolithMeshTestBase
             }
         }
 
-        var markdown = await FindMarkdown(stack);
+        var markdown = await FindMarkdown(control);
 
         markdown.Should().NotBeNullOrEmpty(
             "Overview should contain a markdown body control (MarkdownControl or CollaborativeMarkdownControl), " +


### PR DESCRIPTION
"Still cannot resize" (user report, on the live doc index): the markdown Overview composed nav + content in a plain `Stack`, so the rail had no resize handle — #2092's fixed width answered "the index is page-wide" but not "let me choose how wide".

`BuildWithSubNodeNav` now composes the **same Splitter idiom as the Settings pages** (`FluentMultiSplitter` — the divider is a real, client-side drag handle; 260px default, 180–480px range; the pane's collapse arrow replaces the rail's own toggle, so the nav renders non-collapsible inside it). The nav pane keeps the `Navigation` area name. The Edu page rail gets the identical change in MeshWeaver.Plugins.

Tests: Graph suite 1539 green. FutuRe's Overview walk was pinned to `StackControl` (would report "markdown missing" on re-parenting); it now walks `IContainerControl` generally and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)