### PR TITLE
Name the doc-index nav pane via Id, not Area

### DIFF
--- a/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
@@ -201,7 +201,10 @@ public static class MarkdownOverviewLayoutArea
         return Controls.Splitter
             .WithStyle("height: auto; flex: 1 0 auto;")
             .WithSkin(s => s.WithOrientation(Orientation.Horizontal).WithWidth("100%"))
-            .WithView(nav, x => x.WithArea(NavigationArea)
+            // WithId, not WithArea: the addressable area path is {context}/{Id} — PrepareRendering
+            // OVERWRITES Area from Id, so naming Area here would leave the pane on an auto id and
+            // break every consumer addressing …/Navigation (Copilot on #2098).
+            .WithView(nav, x => x.WithId(NavigationArea)
                 .AddSkin(new SplitterPaneSkin().WithSize("260px").WithMin("180px").WithMax("480px").WithCollapsible(true)))
             .WithView(
                 Controls.Stack.WithStyle("min-width: 0; padding-left: 16px;").WithView(content),


### PR DESCRIPTION
Follow-up to #2098, from its Copilot review (correct): the addressable area path is `{context}/{Id}` — `ContainerControl.PrepareRendering` overwrites each child's `Area` from its `Id`, so `WithArea(NavigationArea)` left the nav pane on an auto id and consumers addressing `…/Navigation` lost the menu. `WithId` is exactly what the string-area `WithView` overload has always set. The Edu twin lands in MeshWeaver.Plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)