### PR TITLE
fix(ea): make /auth/ea/connect idempotent — skip forced re-consent when a grant is stored

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/EaConsentController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaConsentController.cs
@@ -50,10 +50,19 @@ public sealed class EaConsentController(
     private string CallbackUri => $"{Request.Scheme}://{Request.Host}/{BasePath}/{CallbackAction}";
 
     [HttpGet(ConnectAction)]
-    public IActionResult Connect([FromQuery] string? returnUrl = null)
+    public async Task<IActionResult> Connect(
+        [FromQuery] string? returnUrl = null, [FromQuery] bool force = false, CancellationToken ct = default)
     {
         if (!ea.IsConfigured) return BadRequest("The Executive Assistant Graph integration is not configured.");
-        if (string.IsNullOrEmpty(access.Context?.ObjectId)) return Unauthorized();
+        var userId = access.Context?.ObjectId;
+        if (string.IsNullOrEmpty(userId)) return Unauthorized();
+        // Already connected → nothing to consent: bounce straight back to the caller instead of
+        // forcing Microsoft's dialog (BuildConsentUrl carries prompt=consent) on a user whose
+        // grant is stored — visiting the connect link twice used to re-prompt every time and read
+        // as "my consent is not saved". ?force=true still runs the full consent deliberately
+        // (scope additions, credential rotation, a revoked grant the stored token hides).
+        if (!force && await ea.IsConnectedAsync(userId, ct))
+            return Redirect(string.IsNullOrEmpty(returnUrl) ? "/" : returnUrl);
         return Redirect(ea.BuildConsentUrl(Uri.EscapeDataString(returnUrl ?? "/"), CallbackUri));
     }
 

--- a/memex/Memex.Portal.Shared/Authentication/EaConsentController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaConsentController.cs
@@ -49,6 +49,48 @@ public sealed class EaConsentController(
 
     private string CallbackUri => $"{Request.Scheme}://{Request.Host}/{BasePath}/{CallbackAction}";
 
+    /// <summary>
+    /// Reduces a caller-supplied return target to a SAME-SITE relative path, or <c>"/"</c>.
+    ///
+    /// <para>🚨 Both redirect sites take their target from the request — <c>?returnUrl=</c> on
+    /// connect, and <c>state</c> on the callback, which is just that value round-tripped through
+    /// the identity provider. Handing either straight to <c>Redirect</c> is an OPEN REDIRECT:
+    /// <c>/auth/ea/connect?returnUrl=https://phish.example</c> would bounce an authenticated user
+    /// off-site, and the already-connected fast path makes it a single hop with no dialog in
+    /// between — the shape phishing wants, wearing our domain in the link.</para>
+    ///
+    /// <para>Accepted: a rooted relative path (<c>/x/y?q=1#f</c>). Rejected — and collapsed to the
+    /// home page — is everything else: absolute URLs (<c>https://…</c>, and any other scheme
+    /// including <c>javascript:</c>), <b>protocol-relative</b> <c>//host/path</c> (a URL the
+    /// browser resolves against the current scheme, which is why checking only for a leading
+    /// <c>/</c> is not enough), backslash variants (<c>/\host</c>) that some browsers normalise
+    /// into an authority, and anything that is not rooted at all.</para>
+    ///
+    /// <para>The rule is ASP.NET's own <c>IsLocalUrl</c> algorithm, spelled out here rather than
+    /// delegated to <c>Url.IsLocalUrl</c>: <see cref="ControllerBase.Url"/> is populated by MVC's
+    /// activator, so it is NULL for a controller constructed directly, and a security check that
+    /// throws a <see cref="NullReferenceException"/> depending on how the type was built is a
+    /// worse failure than the one it guards. Static and total — every variant below is pinned by
+    /// <c>EaConnectOpenRedirectTest</c>, which is the part that makes a hand-written rule
+    /// trustworthy.</para>
+    /// </summary>
+    internal static string SafeReturnUrl(string? candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+            return "/";
+        // Rooted paths only. The second character decides: "//host" is protocol-relative (the
+        // browser resolves it against the current scheme and leaves the site), and "/\host" is
+        // normalised into an authority by some browsers — both are off-site despite the leading
+        // slash that a naive prefix test would accept.
+        if (candidate[0] == '/')
+            return candidate.Length == 1 || (candidate[1] != '/' && candidate[1] != '\\')
+                ? candidate
+                : "/";
+        // Anything else — absolute (https://…, javascript:, mailto:) or an unrooted relative path
+        // whose resolution depends on the current page — is refused.
+        return "/";
+    }
+
     [HttpGet(ConnectAction)]
     public async Task<IActionResult> Connect(
         [FromQuery] string? returnUrl = null, [FromQuery] bool force = false, CancellationToken ct = default)
@@ -61,16 +103,23 @@ public sealed class EaConsentController(
         // grant is stored — visiting the connect link twice used to re-prompt every time and read
         // as "my consent is not saved". ?force=true still runs the full consent deliberately
         // (scope additions, credential rotation, a revoked grant the stored token hides).
+        // Sanitised BEFORE either use: the fast path redirects to it directly, and the consent
+        // path round-trips it through the IdP as `state` and redirects to it on the way back —
+        // so an unsanitised value is an open redirect on both routes, not just the visible one.
+        var safeReturnUrl = SafeReturnUrl(returnUrl);
         if (!force && await ea.IsConnectedAsync(userId, ct))
-            return Redirect(string.IsNullOrEmpty(returnUrl) ? "/" : returnUrl);
-        return Redirect(ea.BuildConsentUrl(Uri.EscapeDataString(returnUrl ?? "/"), CallbackUri));
+            return Redirect(safeReturnUrl);
+        return Redirect(ea.BuildConsentUrl(Uri.EscapeDataString(safeReturnUrl), CallbackUri));
     }
 
     [HttpGet(CallbackAction)]
     public async Task<IActionResult> Callback(
         [FromQuery] string? code, [FromQuery] string? state, [FromQuery] string? error, CancellationToken ct)
     {
-        var returnUrl = string.IsNullOrEmpty(state) ? "/" : Uri.UnescapeDataString(state);
+        // `state` is whatever came back from the IdP — treated as untrusted input, exactly like
+        // the query parameter it originated from. Re-sanitised here rather than trusted because
+        // it left our process in between.
+        var returnUrl = SafeReturnUrl(string.IsNullOrEmpty(state) ? null : Uri.UnescapeDataString(state));
         var userId = access.Context?.ObjectId;
         if (string.IsNullOrEmpty(userId)) return Unauthorized();
 

--- a/test/Memex.Portal.Shared.Test/EaConnectOpenRedirectTest.cs
+++ b/test/Memex.Portal.Shared.Test/EaConnectOpenRedirectTest.cs
@@ -1,0 +1,128 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The consent endpoints must never redirect off-site.
+///
+/// <para><b>Why this test exists.</b> Both redirect targets come from the request:
+/// <c>?returnUrl=</c> on <c>/auth/ea/connect</c>, and the OAuth <c>state</c> on the callback —
+/// which is that same value round-tripped through the identity provider. Passing either straight
+/// to <c>Redirect</c> is an open redirect, and the already-connected fast path turns it into a
+/// SINGLE hop with no dialog in between: <c>/auth/ea/connect?returnUrl=https://phish.example</c>
+/// sends an authenticated user off-site behind our own domain. Caught in review on #2101 before
+/// it merged.</para>
+///
+/// <para>The variants below are the ones a prefix check ("does it start with '/'?") lets through:
+/// <c>//host</c> is protocol-relative and resolves against the current scheme, and <c>/\host</c>
+/// is normalised into an authority by some browsers. The controller implements ASP.NET's own
+/// IsLocalUrl rule directly (its <c>Url</c> helper is null for a directly-constructed controller,
+/// and a security check that NREs depending on how the type was built is worse than the hole it
+/// closes) — so these cases are what make the hand-written rule trustworthy.</para>
+/// </summary>
+public class EaConnectOpenRedirectTest
+{
+    private sealed class FakeEaGraphAuth(bool connected) : IEaGraphAuth
+    {
+        public string? LastState { get; private set; }
+        public bool IsConfigured => true;
+        public string ConnectPath => EaConsentController.ConnectPath;
+
+        public string BuildConsentUrl(string state, string redirectUri)
+        {
+            LastState = state;
+            return "https://login.microsoftonline.example/consent?state=" + state;
+        }
+
+        public Task<bool> ExchangeAndStoreAsync(
+            string code, string redirectUri, string userObjectId, CancellationToken ct) =>
+            Task.FromResult(true);
+
+        public Task<string?> GetAccessTokenAsync(string userObjectId, CancellationToken ct) =>
+            Task.FromResult<string?>(connected ? "token" : null);
+
+        public Task<bool> IsConnectedAsync(string userObjectId, CancellationToken ct) =>
+            Task.FromResult(connected);
+    }
+
+    private static EaConsentController Controller(FakeEaGraphAuth ea)
+    {
+        var access = new AccessService();
+        access.SetContext(new AccessContext { ObjectId = "user-1" });
+        return new EaConsentController(ea, access, NullLogger<EaConsentController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    Request = { Scheme = "https", Host = new HostString("memex.example") },
+                },
+            },
+        };
+    }
+
+    [Theory]
+    [InlineData("https://phish.example")]          // absolute, the headline case
+    [InlineData("http://phish.example/steal")]
+    [InlineData("//phish.example")]                // protocol-relative — a leading '/' is not enough
+    [InlineData("//phish.example/path?a=b")]
+    [InlineData("/\\phish.example")]               // backslash variant some browsers normalise
+    [InlineData("javascript:alert(1)")]            // not a navigation target at all
+    [InlineData("mailto:a@b.example")]
+    [InlineData("rbuergi")]                        // not rooted — ambiguous, so refused
+    public async Task An_offsite_returnUrl_never_reaches_the_redirect(string hostile)
+    {
+        // The already-connected path is the dangerous one: no consent dialog stands between the
+        // click and the redirect.
+        var result = await Controller(new FakeEaGraphAuth(connected: true)).Connect(returnUrl: hostile);
+
+        result.Should().BeOfType<RedirectResult>()
+            .Which.Url.Should().Be("/",
+                $"'{hostile}' must collapse to the home page, never be redirected to");
+    }
+
+    [Fact]
+    public async Task An_offsite_returnUrl_is_not_smuggled_through_the_consent_state_either()
+    {
+        // The not-connected path hands returnUrl to the IdP as `state` and redirects to it on the
+        // way back — sanitising only the visible redirect would leave that route open.
+        var ea = new FakeEaGraphAuth(connected: false);
+
+        await Controller(ea).Connect(returnUrl: "https://phish.example");
+
+        ea.LastState.Should().Be("%2F",
+            "the state carried to the identity provider is the SANITISED target, url-escaped");
+    }
+
+    [Fact]
+    public async Task A_hostile_state_coming_back_from_the_provider_is_refused()
+    {
+        // `state` re-enters as untrusted input: it left our process, so it is re-sanitised rather
+        // than trusted on the strength of having been ours once.
+        var result = await Controller(new FakeEaGraphAuth(connected: true))
+            .Callback(code: null, state: "https%3A%2F%2Fphish.example", error: "access_denied",
+                ct: CancellationToken.None);
+
+        result.Should().BeOfType<RedirectResult>().Which.Url.Should().Be("/");
+    }
+
+    [Theory]
+    [InlineData("/rbuergi")]
+    [InlineData("/rbuergi/Chat?from=ea#top")]
+    [InlineData("/")]
+    public async Task A_same_site_returnUrl_is_preserved_exactly(string friendly)
+    {
+        // The guard must not be so blunt that it breaks the feature it protects.
+        var result = await Controller(new FakeEaGraphAuth(connected: true)).Connect(returnUrl: friendly);
+
+        result.Should().BeOfType<RedirectResult>().Which.Url.Should().Be(friendly);
+    }
+}

--- a/test/Memex.Portal.Shared.Test/EaConnectReconsentTest.cs
+++ b/test/Memex.Portal.Shared.Test/EaConnectReconsentTest.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the consent flow's idempotence: a user whose Executive-Assistant grant is already stored
+/// is NOT sent back through Microsoft's consent dialog when they hit <c>/auth/ea/connect</c> again.
+///
+/// <para><b>Why this test exists.</b> <c>BuildConsentUrl</c> deliberately carries
+/// <c>prompt=consent</c> (the first connect must mint a refresh token for every scope), and
+/// <c>Connect</c> used to redirect there unconditionally. Every visit to the connect link —
+/// a second click on the EA's "please connect" hint, a bookmarked URL — re-ran the full Microsoft
+/// consent, and users read the repeat dialog as "my consent was never saved" (reported 2026-08-23).
+/// The grant WAS stored; only the entry point ignored it.</para>
+/// </summary>
+public class EaConnectReconsentTest
+{
+    private sealed class FakeEaGraphAuth(bool connected) : IEaGraphAuth
+    {
+        public bool ConsentUrlBuilt { get; private set; }
+
+        public bool IsConfigured => true;
+        public string ConnectPath => EaConsentController.ConnectPath;
+
+        public string BuildConsentUrl(string state, string redirectUri)
+        {
+            ConsentUrlBuilt = true;
+            return "https://login.microsoftonline.example/consent?state=" + state;
+        }
+
+        public Task<bool> ExchangeAndStoreAsync(
+            string code, string redirectUri, string userObjectId, CancellationToken ct) =>
+            Task.FromResult(true);
+
+        public Task<string?> GetAccessTokenAsync(string userObjectId, CancellationToken ct) =>
+            Task.FromResult<string?>(connected ? "token" : null);
+
+        public Task<bool> IsConnectedAsync(string userObjectId, CancellationToken ct) =>
+            Task.FromResult(connected);
+    }
+
+    private static EaConsentController Controller(FakeEaGraphAuth ea)
+    {
+        var access = new AccessService();
+        access.SetContext(new AccessContext { ObjectId = "user-1" });
+        var controller = new EaConsentController(ea, access, NullLogger<EaConsentController>.Instance)
+        {
+            // A real request context so the not-connected branch can compose its callback URI.
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    Request = { Scheme = "https", Host = new HostString("memex.example") },
+                },
+            },
+        };
+        return controller;
+    }
+
+    [Fact]
+    public async Task An_already_connected_user_bounces_back_without_a_Microsoft_round_trip()
+    {
+        var ea = new FakeEaGraphAuth(connected: true);
+
+        var result = await Controller(ea).Connect(returnUrl: "/rbuergi");
+
+        result.Should().BeOfType<RedirectResult>()
+            .Which.Url.Should().Be("/rbuergi",
+                "a stored grant means there is nothing to consent — the connect link must be "
+                + "idempotent, not a forced prompt=consent round trip");
+        ea.ConsentUrlBuilt.Should().BeFalse("the consent URL must not even be composed");
+    }
+
+    [Fact]
+    public async Task Force_still_runs_the_full_consent_for_a_connected_user()
+    {
+        var ea = new FakeEaGraphAuth(connected: true);
+
+        var result = await Controller(ea).Connect(returnUrl: "/rbuergi", force: true);
+
+        result.Should().BeOfType<RedirectResult>()
+            .Which.Url.Should().StartWith("https://login.microsoftonline.example/consent",
+                "?force=true is the deliberate re-consent escape hatch (scope additions, rotation)");
+    }
+
+    [Fact]
+    public async Task A_not_yet_connected_user_is_sent_to_the_Microsoft_consent()
+    {
+        var ea = new FakeEaGraphAuth(connected: false);
+
+        var result = await Controller(ea).Connect(returnUrl: "/rbuergi");
+
+        result.Should().BeOfType<RedirectResult>()
+            .Which.Url.Should().StartWith("https://login.microsoftonline.example/consent");
+        ea.ConsentUrlBuilt.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## What changed

`EaConsentController.Connect` now checks `IsConnectedAsync` first: an already-connected user is redirected straight back to `returnUrl` instead of being pushed through Microsoft's consent dialog again (`BuildConsentUrl` forces `prompt=consent`, which is right for the FIRST connect but made every later visit re-prompt). `?force=true` preserves the deliberate full re-consent (scope additions, credential rotation).

## Why

Reported on memex.meshweaver.cloud (2026-08-23): "each time I need to consent on behalf of my org — is it not saved?" The grant was saved (encrypted refresh token per user); only the connect entry point ignored it and forced the dialog on every visit.

## How it was tested

- New `EaConnectReconsentTest` (3 cases: connected → bounce without composing a consent URL; connected + force → consent; not connected → consent) against a fake `IEaGraphAuth` with a real `AccessService` context.
- `dotnet build Memex.Portal.Shared -c Release -p:CIRun=true -warnaserror` clean; `dotnet test --filter EaConnect` → 7/7 (new + existing route pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)