### PR TITLE
fix: Apps = the viewer's own _App records (instant); Threads a normal app; MDI thread shell

### DIFF
--- a/src/MeshWeaver.AI/ThreadLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ThreadLayoutAreas.cs
@@ -168,13 +168,24 @@ public static class ThreadLayoutAreas
         SubscribeThreadVm(host, hubPath);
 
         // Static container — never rebuilt
-        return Controls.Stack
+        var chat = Controls.Stack
             .WithWidth("100%")
             .WithStyle("flex: 1; min-height: 0; display: flex; flex-direction: column;")
             .WithView(new ThreadChatControl()
                 .WithThreadViewModel(new JsonPointerReference(LayoutAreaReference.GetDataPointer(ThreadDataKey)))
                 .WithShowFullHeader()
                 .WithStyle("flex: 1; min-height: 0; overflow: hidden;"));
+
+        // The multi-document shell: the VIEWER's thread rail stays beside the conversation, so
+        // navigating from the rail to a thread keeps the menu — the same shell the Threads app
+        // page renders around its composer. Viewer resolved from the circuit (a visitor without an
+        // identity gets the bare conversation). Still emitted ONCE — the shell is as static as the
+        // container it wraps.
+        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
+        var viewerId = accessService?.Context?.ObjectId ?? accessService?.CircuitContext?.ObjectId;
+        return string.IsNullOrEmpty(viewerId)
+            ? chat
+            : UserActivityLayoutAreas.BuildThreadsShell(viewerId, chat);
     }
 
     /// <summary>

--- a/src/MeshWeaver.AI/ThreadRailItem.cs
+++ b/src/MeshWeaver.AI/ThreadRailItem.cs
@@ -44,34 +44,34 @@ public static class ThreadRailItem
     {
         var title = node?.Name ?? (hubPath.Contains('/') ? hubPath[(hubPath.LastIndexOf('/') + 1)..] : hubPath);
 
-        var row = Controls.Stack
-            .WithStyle("position: relative; width: 100%; box-sizing: border-box;")
+        // Title and ✕ are SIBLINGS in one flex row — never an overlay. The previous
+        // absolutely-positioned ✕ sat on top of the full-width navigation button and its click
+        // reached the NAV surface instead of closing the thread (the "✕ navigates" bug); as a
+        // sibling, each button owns its own hit area unambiguously.
+        return Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithStyle("width: 100%; box-sizing: border-box; align-items: center; gap: 4px;")
             .WithView(Controls.Button(title)
                 .WithAppearance(Appearance.Stealth)
                 .WithNavigateToHref($"/{hubPath}")
-                .WithStyle("width: 100%; justify-content: flex-start; text-align: left; " +
-                           "padding: 8px 36px 8px 12px; overflow: hidden; " +
-                           "text-overflow: ellipsis; white-space: nowrap;"));
-
-        // ✕ overlaid INSIDE the row, top-right — an absolutely-positioned wrapper Stack, the same
-        // shape as the pinned card's unpin toggle (a position:absolute style on the button alone
-        // stays in flex flow). MarkThreadDone is the canonical, self-subscribing close: it refuses
-        // while a round is executing and logs its own failures.
-        var close = Controls.Stack
-            .WithStyle("position: absolute; top: 6px; right: 6px; z-index: 5;")
+                .WithStyle("flex: 1 1 auto; min-width: 0; justify-content: flex-start; " +
+                           "text-align: left; padding: 8px 8px 8px 12px; overflow: hidden; " +
+                           "text-overflow: ellipsis; white-space: nowrap;"))
+            // MarkThreadDone is the canonical, self-subscribing close: the thread leaves the rail
+            // reactively (the rail's query excludes Done) while staying searchable/reopenable. It
+            // refuses while a round is executing and logs its own failures.
             .WithView(Controls.Button("")
                 .WithIconStart(FluentIcons.Dismiss())
                 // Label = the button's aria-label/tooltip (ButtonView): the icon-only ✕ still
-                // needs an accessible, localized name for screen readers (Copilot review).
+                // needs an accessible, localized name for screen readers.
                 .WithLabel(LocalizationCatalog.Get("thread.close", locale))
                 .WithAppearance(Appearance.Stealth)
-                .WithStyle("min-width: 24px; width: 24px; height: 24px; padding: 0; border-radius: 50%;")
+                .WithStyle("flex: 0 0 auto; min-width: 24px; width: 24px; height: 24px; " +
+                           "padding: 0; border-radius: 50%;")
                 .WithClickAction(ctx =>
                 {
                     ctx.Host.Hub.MarkThreadDone(hubPath, done: true);
                     return Task.CompletedTask;
                 }));
-
-        return row.WithView(close);
     }
 }

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -1177,6 +1177,9 @@ public partial class MeshSearchView
     {
         get
         {
+            // The active SCOPE's item area wins (e.g. the home's Apps scope renders its records
+            // through AppTile); the control-level one is the scope-less fallback.
+            if (ActiveScopeTab?.ItemArea is { Length: > 0 } scoped) return scoped;
             if (ViewModel?.ItemArea is string s) return s;
             if (ViewModel?.ItemArea is JsonElement je && je.ValueKind == JsonValueKind.String)
                 return je.GetString();

--- a/src/MeshWeaver.Documentation/Data/Architecture/AppsHome.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AppsHome.md
@@ -1,31 +1,41 @@
 # The Apps Home
 
-The user home's catalog region is a **tabbed surface** — the phone-home model: what you see first
-is what you *use*, not everything the mesh can show you. The tabs, in order:
+The user home's catalog region is ONE search surface whose **scope tabs** are the phone-home tabs —
+what you see first is what you *use*, not everything the mesh can show you. The tabs, in order:
 
 | Tab | Present when | Contents | Default order |
 |---|---|---|---|
-| **Shared with me** | the caller has cross-partition grants | modules in OTHER partitions the caller was invited into (#385) | last accessed |
+| **Shared with me** | the caller has cross-partition grants | modules in OTHER partitions the caller was invited into (#385) — minus store items and `User` roots | last accessed |
 | **Pinned** | the caller has pins | the owner's content shortcuts (`User.PinnedPaths`) | last modified |
-| **Apps** | always | the platform's default apps ∪ the owner's installed apps — every app **exactly once** | alphabetical |
+| **Apps** | always | the viewer's OWN `{owner}/_App` records — every app exactly once | alphabetical |
 | **Spaces** | always | the catalog **without** store items | last accessed |
+| **All** | always | everything the viewer can read, at every depth | last accessed |
 
-Every listing tab offers the three sort options (last accessed · last modified · alphabetical).
-The whole surface is built by `UserActivityLayoutAreas.BuildHome` (`src/MeshWeaver.Graph`), pure and
-unit-tested (`HomeTabsTest`); the reactive shell is `CatalogAreaView`, which combines the config,
-the caller's grants, the installed-app records, and the owner node.
+Because the scopes live INSIDE one `MeshSearchControl` (`MeshSearchScopeTab`), the search bar is
+shared: the typed term survives tab switches and every tab is searchable — including All. The
+search input renders on desktop and hides on mobile (the chrome search covers phones); search box
+and the ordering controls share one header row. The whole surface is built by
+`UserActivityLayoutAreas.BuildHome` (`src/MeshWeaver.Graph`), pure and unit-tested
+(`HomeTabsTest`); the reactive shell is `CatalogAreaView`.
 
-## Installed apps — `{user}/_App/{appId}`, a REGULAR node
+## Installed apps — `{user}/_App/{appId}` records, the grid's ONLY data source
 
 One node per icon, nodeType **`InstalledApp`**, stored at `{user}/_App/{appId}` as an ordinary
 `mesh_nodes` row: deliberately **not a satellite** (no `IsSatelliteType`, no `SatelliteTableMapping`
-entry — an unmapped `_` segment routes to the partition table, and the `_` prefix already keeps it
-out of the search context). This is the same shape as `{user}/_Memex/AiSettings`.
+entry — an unmapped `_` segment routes to the partition table, and the `_` prefix keeps it out of
+the search context). This is the same shape as `{user}/_Memex/AiSettings`.
 
-The content record (`App`, `MeshWeaver.Mesh.Contract`) carries **presence and placement only** —
-the `Plugin` path (the app's identity, usually a Store cover), `Order`, an optional `OpenPath`
-override, and `Source`. Name, icon, and translations resolve **live** from the plugin node; tile
-state is derived at render time. Nothing is copied, so nothing can drift.
+**The record carries the tile.** The node's `Name`/`Icon` are the tile's display identity (stamped
+at materialization; the Store's install flow refreshes them on (re)install), and the `App` content
+carries the wiring — `Plugin` (the app's path) or `OpenPath` (an area on the viewer's own hub),
+plus `Order` and `Source`. The tile renders through the record's own **`AppTile`** area
+(`AppTileLayoutArea`): click opens the app, never the record.
+
+> 🚨 **Why records, not cover nodes.** The first grid queried the Store plugin COVER nodes via a
+> top-level path alternation (`path:(Store OR Doc OR …)`). A top-level path has no partition hint,
+> so that query fanned out across EVERY partition schema — a multi-second home load. The records
+> query names ONE partition (`path:{owner}/_App scope:children`) and paints instantly. When a tile
+> needs data of the target node, copy it onto the record at write time — never join at render time.
 
 > 🚨 **Why the nodeType is `InstalledApp`, not `App`.** A built-in NodeType's definition node claims
 > the TOP-LEVEL PATH of its name (`AddMeshNodes`), and `App`/`app` is a name real content uses. A
@@ -33,68 +43,67 @@ state is derived at render time. Nothing is copied, so nothing can drift.
 > routing loops, and refused installing any package named App (the static/durable claim collision,
 > #1209). Pick collision-improbable names for built-in NodeTypes.
 
-**Writers:** the Store's install flow creates the record when a viewer Gets/Adds an app; removing
-the icon deletes the node — never the entitlement. The platform's default apps are **not** written
-as nodes at all: they come from config at render time.
+**Materialization (write-behind).** No onboarding seeding: on home render, `EnsureAppRecords`
+compares what the viewer SHOULD have — the config-declared defaults
+(`Admin/HomeConfig.DefaultApps`) plus every install-manifest item with a live `installedPath`
+(`{owner}/_Install/{slug}`, read untyped by the manifest's own design) — against the records that
+exist, and creates the missing ones fire-and-forget into the viewer's own partition. A config
+addition reaches every user's grid on their next home render; the Store's install flow writes and
+removes records directly (phase 2).
+
+**Threads is an ordinary app.** The `~/Chat` config entry materializes as the record
+`{owner}/_App/Chat` (name *Threads*, `OpenPath = {owner}/Chat`) — a normal tile among the others,
+not a special dock. A `~/`-prefixed `DefaultApps` entry always means "an area on the viewer's own
+hub" rather than a node path.
 
 ## The config — `Admin/HomeConfig`
 
-The admin-editable platform node (`HomeConfigNodeType`, public-read, live-reloading) drives the
-whole surface without an image roll:
+The admin-editable platform node (`HomeConfigNodeType`, public-read, live-reloading):
 
-- **`Style`** — `Tabs` (the default) or `Catalog`, the escape hatch back to the legacy single flat
-  list (`BuildCatalog`).
-- **`DefaultApps`** — the paths every user's Apps tab starts with (shipped: `Store`, `Doc`,
-  `~/Chat`). A **render-time union** with the owner's `_App` records, deduped — no seeding, and an
-  admin's edit updates every open home live. An entry starting with **`~/`** declares an AREA on
-  the *viewer's own hub* instead of a node path (`~/Chat` → the Threads app at `/{owner}/Chat`),
-  rendered as a fixed "dock" tile ahead of the node grid (`BuildSystemAppTile`).
-  Until a list-capable edit-form field ships, `DefaultApps` is `[Browsable(false)]` on the generic
-  content editor — admins edit it on the node content directly (MCP `patch` on `Admin/HomeConfig`).
-- `Scope`, `Render`, `DefaultSort` — unchanged, applying to the Spaces tab (and the legacy list).
+- **`Style`** — `Tabs` (default) or `Catalog`, the escape hatch back to the legacy single flat list.
+- **`DefaultApps`** — the entries every user's Apps grid starts with (shipped: `Store`, `Doc`,
+  `~/Chat`), interpreted by the materializer above. Until a list-capable edit-form field ships it is
+  `[Browsable(false)]` on the generic content editor — admins edit the node content directly.
+- `Scope`, `Render`, `DefaultSort` — apply to the Spaces/All scopes (and the legacy list).
 
-**The dedup rule:** an app is represented exactly once. The Spaces tab excludes
-`-nodeType:Store/Plugin -nodeType:Store/Catalog` — anything living in the Store is reachable in
-the Store and (when installed) on the Apps tab, never listed twice. And no tab embeds its own
-search box: every client's chrome already carries the global search, and doubling it is the
-two-search-bars problem on the mobile clients.
-
-**The Store itself is an app.** Signed-in users reach it as the 🏪 tile (a config default), not a
-header anchor; only the anonymous header keeps a Store link — visitors have no home grid, and the
-storefront is the public sales surface.
+**The dedup rule:** an app is represented exactly once. The Spaces and Shared-with-me scopes exclude
+`-nodeType:Store/Plugin -nodeType:Store/Catalog`; Shared-with-me also excludes `-nodeType:User` — a
+grant that resolves to another user's home partition must not list that person's space as shared
+content. **The Store itself is an app** (a config default); only the anonymous header keeps a Store
+link.
 
 ## Sort semantics — why last-accessed is a two-leg union
 
 `source:accessed` is an **INNER join** on the caller's access log: a pure accessed-sorted query
-HIDES anything never opened — a fresh invitation, a never-launched app, the exact items those tabs
-exist to surface. The last-accessed sort option is therefore a newline-joined, path-keyed UNION:
-the accessed-ranked leg first, a plain leg as completeness fallback (the engine dedupes by path).
-Nothing is ever hidden by a sort.
+HIDES anything never opened. The last-accessed option on the Shared scope is therefore a
+newline-joined, path-keyed UNION — the accessed-ranked leg first, a plain leg as completeness
+fallback. On the Apps scope, `source:accessed` is meaningless for records, so that option sorts by
+last modified instead.
 
-## The Threads app
+## The Threads app — a multi-document shell
 
-`/{user}/Chat` (the ChatArea) is the **Threads app** — a vertical rail of the owner's open threads
-beside the node-less composer (`BuildThreadsApp`). Each rail row renders on the *thread's own hub*
-via the `RailItem` area (`ThreadRailItem`, `MeshWeaver.AI`): the title navigates to the thread, and
-an **✕ closes it** through the canonical `MarkThreadDone` — the rail's query excludes
+`/{user}/Chat` (the ChatArea) and EVERY thread's full page render the same
+**`BuildThreadsShell`**: a fixed 280px rail of the viewer's open threads beside the main pane
+(composer on the app page, the conversation on a thread page). Navigating from the rail to a thread
+is REAL navigation — and the destination renders the shell again, so the rail never collapses,
+exactly like switching documents in a multi-document window.
+
+Rail rows (`ThreadRailItem`, on each thread's own hub) are title + ✕ **siblings** — never an
+overlay: an absolutely-positioned ✕ over a full-width navigation button loses its clicks to the nav
+surface. The ✕ closes through the canonical `MarkThreadDone`; the rail's query excludes
 `content.status:Done`, so a closed thread leaves the list reactively while staying searchable and
 reopenable. Closing never deletes.
 
-Two render details that matter: the rail is `Flat + MaxColumns(1) + ItemArea` — the `List` render
-mode draws its own rows and **ignores** item areas, so the ✕ could never render there; and the
-icon-only ✕ carries `ButtonControl.Label` (the aria-label) with the localized `thread.close`.
+## Presentation mode (#1803)
 
-## What comes next
-
-Store integration lives in the MeshWeaver.Plugins repo (mesh-compiled — invisible to CI): the
-install flow writes the `InstalledApp` record after `WriteManifest`, an **Add** action covers
-open-only domain plugins, uninstall removes the tile, and `Tile`/`Setup` declarations on
-`PluginContent` decide which of the store's items surface as apps at all — the ~20 auto-installed
-platform capabilities never mint icons.
+The Shared and Pinned scope queries interpolate viewer paths, so the screen filters them BEFORE the
+query is built. The Apps records query is generic — no app path can reach a query string or URL —
+so the screen filters **at the tile**: `AppTileLayoutArea.BuildTile` renders nothing for a marked
+target. The Spaces/All queries stay untouched and filter where results are painted.
 
 ## See also
 
 - [Configurable Home & Space Pages](/Doc/GUI/ConfigurablePages) — the `Body` + `@@`-region model the home is built on
-- [Mesh Search & Catalogs](/Doc/GUI/MeshSearch) — the search control behind every tab
+- [Mesh Search & Catalogs](/Doc/GUI/MeshSearch) — the search control behind every scope
 - [Thread Operations](../ThreadOperations) — the canonical thread mutation surface (`MarkThreadDone` et al.)
 - [Localization](../Localization) — why every tab label and sort option resolves off `AccessContext.Locale`

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-23-apps-instant.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-23-apps-instant.md
@@ -1,0 +1,15 @@
+---
+Name: Your apps, instantly
+Category: Fix
+Description: The Apps tab now shows everything you have installed, loads instantly, Threads is a regular app, and the thread list stays put while you switch conversations.
+Icon: Apps
+Order: -20260823
+---
+
+# Your apps, instantly
+
+The Apps tab now really shows **your** apps — everything you've installed plus the platform
+defaults — and it loads instantly (it reads your own records instead of scanning the whole mesh).
+**Threads** is a regular app tile like any other. In the Threads app, the conversation list stays
+on the left while you switch threads — like a multi-document window — and the ✕ on a thread now
+closes it (it stays findable in search and can be reopened).

--- a/src/MeshWeaver.Graph/AppTileLayoutArea.cs
+++ b/src/MeshWeaver.Graph/AppTileLayoutArea.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.Domain;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// The APP TILE renderer — one card of the home's Apps grid, rendered from the viewer's own
+/// <c>InstalledApp</c> RECORD (<c>{user}/_App/{appId}</c>, see <see cref="Configuration.AppNodeType"/>):
+/// the record carries the tile's name and icon, and its <see cref="App.OpenPath"/> /
+/// <see cref="App.Plugin"/> is where the card NAVIGATES — never the record node itself. Rendering
+/// from the record (not the target's cover node) is what makes the Apps grid a SINGLE-PARTITION
+/// query: the old cover-based grid resolved a top-level path alternation across every partition
+/// schema, the multi-second home lag. Registered on the record's own hub and consumed as the Apps
+/// scope's per-item area.
+/// </summary>
+public static class AppTileLayoutArea
+{
+    /// <summary>Area name, consumed via <c>MeshSearchScopeTab.ItemArea</c>.</summary>
+    public const string AppTileArea = "AppTile";
+
+    /// <summary>The tile renderer — runs on the record's own hub. The viewer's presentation screen
+    /// (#1803) filters HERE: the Apps query is generic (<c>{owner}/_App</c>), so no marked path can
+    /// reach a query string — the tile is where a marked app's name would otherwise be painted,
+    /// and a marked target renders nothing.</summary>
+    public static IObservable<UiControl?> View(LayoutAreaHost host, RenderingContext _)
+    {
+        var hubPath = host.Hub.Address.ToString();
+        var options = host.Hub.JsonSerializerOptions;
+        return host.Workspace.GetStream<MeshNode>()!
+            .CombineLatest(host.ViewerScreen(),
+                (nodes, screen) => BuildTile(
+                    nodes?.FirstOrDefault(n => n.Path == hubPath), hubPath, options, screen))
+            .StartWith(BuildSkeleton(hubPath));
+    }
+
+    /// <summary>A compact loading skeleton so the grid doesn't jump while a record hub warms up.</summary>
+    private static UiControl BuildSkeleton(string hubPath)
+    {
+        var shortName = hubPath.Contains('/') ? hubPath[(hubPath.LastIndexOf('/') + 1)..] : hubPath;
+        return Controls.Stack
+            .WithStyle("width: 100%; min-height: 92px; padding: 10px 12px; box-sizing: border-box; " +
+                       "display: flex; justify-content: center; opacity: 0.6;")
+            .WithView(Controls.Markdown($"**{shortName}**"));
+    }
+
+    /// <summary>
+    /// The card: title + icon come from the RECORD; the click target is the app itself —
+    /// <see cref="App.OpenPath"/> when set, else the <see cref="App.Plugin"/> path. A target the
+    /// viewer's presentation screen marks renders NOTHING (the marked name must not be painted).
+    /// Pure and null-tolerant, exposed for tests.
+    /// </summary>
+    internal static UiControl? BuildTile(
+        MeshNode? node, string hubPath, JsonSerializerOptions options, PresentationScreen? screen = null)
+    {
+        var app = node.ContentAs<App>(options);
+        var target = (app?.OpenPath ?? app?.Plugin ?? "").Trim('/');
+        if (target.Length > 0 && (screen ?? PresentationScreen.Off).Retain([target]).Count == 0)
+            return null;
+        var title = node?.Name
+                    ?? (hubPath.Contains('/') ? hubPath[(hubPath.LastIndexOf('/') + 1)..] : hubPath);
+        if (target.Length == 0)
+            // A record without a target renders inert rather than navigating to the record itself.
+            return new MeshNodeCardControl(hubPath, Title: title,
+                ImageUrl: node?.Icon ?? "/static/NodeTypeIcons/puzzlepiece.svg", DisableNavigation: true);
+        return new MeshNodeCardControl(target, Title: title,
+            ImageUrl: node?.Icon ?? "/static/NodeTypeIcons/puzzlepiece.svg");
+    }
+}

--- a/src/MeshWeaver.Graph/AppTileLayoutArea.cs
+++ b/src/MeshWeaver.Graph/AppTileLayoutArea.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text.Json;
+using MeshWeaver.Data;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Layout.Domain;
@@ -25,18 +26,19 @@ public static class AppTileLayoutArea
     /// <summary>Area name, consumed via <c>MeshSearchScopeTab.ItemArea</c>.</summary>
     public const string AppTileArea = "AppTile";
 
-    /// <summary>The tile renderer — runs on the record's own hub. The viewer's presentation screen
-    /// (#1803) filters HERE: the Apps query is generic (<c>{owner}/_App</c>), so no marked path can
-    /// reach a query string — the tile is where a marked app's name would otherwise be painted,
-    /// and a marked target renders nothing.</summary>
+    /// <summary>The tile renderer — runs on the record's own hub, reading the hub's OWN node via
+    /// the dedicated <see cref="MeshNodeReference"/> reducer (never a whole-collection scan). The
+    /// viewer's presentation screen (#1803) filters HERE: the Apps query is generic
+    /// (<c>{owner}/_App</c>), so no marked path can reach a query string — the tile is where a
+    /// marked app's name would otherwise be painted, and a marked target renders nothing.</summary>
     public static IObservable<UiControl?> View(LayoutAreaHost host, RenderingContext _)
     {
         var hubPath = host.Hub.Address.ToString();
         var options = host.Hub.JsonSerializerOptions;
-        return host.Workspace.GetStream<MeshNode>()!
+        var syncStream = host.Workspace.GetStream(new MeshNodeReference());
+        return syncStream!
             .CombineLatest(host.ViewerScreen(),
-                (nodes, screen) => BuildTile(
-                    nodes?.FirstOrDefault(n => n.Path == hubPath), hubPath, options, screen))
+                (change, screen) => BuildTile(change.Value, hubPath, options, screen))
             .StartWith(BuildSkeleton(hubPath));
     }
 

--- a/src/MeshWeaver.Graph/Configuration/AppNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/AppNodeType.cs
@@ -1,4 +1,5 @@
 using MeshWeaver.Data;
+using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
 
 namespace MeshWeaver.Graph.Configuration;
@@ -51,5 +52,9 @@ public static class AppNodeType
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<App>())
+            // The record's tile renderer (the home's Apps grid renders records, not cover nodes —
+            // that is what keeps the Apps query single-partition and fast).
+            .AddLayout(layout => layout
+                .WithView(AppTileLayoutArea.AppTileArea, AppTileLayoutArea.View))
     };
 }

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -492,9 +492,10 @@ public static class UserActivityLayoutAreas
 
     /// <summary>The catalog region — the TABBED home surface (see <see cref="BuildHome"/>):
     /// <b>Shared with me</b> (the caller's cross-partition grants, #385 — see
-    /// <see cref="ObserveSharedTargets"/>) · <b>Pinned</b> · <b>Apps</b> (the config-declared
-    /// default apps ∪ the owner's installed <c>App</c> records — see
-    /// <see cref="ObserveInstalledApps"/>) · <b>Spaces</b> (the deduplicated catalog). The
+    /// <see cref="ObserveSharedTargets"/>) · <b>Pinned</b> · <b>Apps</b> (the viewer's OWN
+    /// <c>{owner}/_App</c> records, materialized write-behind from the config defaults + the
+    /// Store's install manifests — see <see cref="EnsureAppRecords"/>) ·
+    /// <b>Spaces</b> (the deduplicated catalog). The
     /// admin-editable <c>Admin/HomeConfig</c> node drives the shape and can switch back to the
     /// legacy single-list catalog (<see cref="HomeStyle.Catalog"/>).</summary>
     internal static IObservable<UiControl?> CatalogAreaView(LayoutAreaHost host, RenderingContext _)
@@ -514,56 +515,61 @@ public static class UserActivityLayoutAreas
         // (#385), the owner's installed-app records, and the owner node (pins). Every leg starts
         // with a value so the home paints instantly.
         var syncStream = host.Workspace.GetStream(new MeshNodeReference());
+        // Write-behind app-record MATERIALIZATION: the Apps grid renders ONLY the viewer's own
+        // {owner}/_App records (a fast SINGLE-PARTITION query — the old cover-path alternation
+        // fanned out across every partition schema, the multi-second home lag). Whatever the
+        // config defaults and the Store's install manifests say the viewer HAS but no record
+        // exists for yet is created here, fire-and-forget and idempotent: the per-area `attempted`
+        // set guards re-entry while a create is in flight, and the records query re-emits when a
+        // create lands.
+        var attempted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         return HomeConfigNodeType.Observe(host.Workspace, options)
             .CombineLatest(
                 ObserveSharedTargets(host, ownerId),
-                ObserveInstalledApps(host, ownerId, options),
+                ObserveAppRecordIds(host, ownerId),
+                ObserveManifestItems(host, ownerId, options),
                 syncStream!.Select(change => change.Value.ContentAs<User>(options)).StartWith((User?)null),
                 screen,
-                (config, shared, installedApps, user, viewerScreen) =>
-                    (UiControl?)BuildHome(ownerId, config, shared, installedApps, user, locale, viewerScreen));
+                (config, shared, recordIds, manifestItems, user, viewerScreen) =>
+                {
+                    EnsureAppRecords(host, ownerId, config, manifestItems, recordIds, attempted);
+                    return (UiControl?)BuildHome(ownerId, config, shared, user, locale, viewerScreen);
+                });
     }
 
     /// <summary>
-    /// The owner's installed apps, from BOTH per-user records: the <c>{owner}/_App/{appId}</c>
-    /// nodes (see <see cref="AppNodeType"/>, projected to <see cref="App.Plugin"/> paths in
-    /// <see cref="App.Order"/>) UNIONED with the Store's install manifests at
-    /// <c>{owner}/_Install/{slug}</c> — every item whose <c>installedPath</c> is live IS an
-    /// installed app, which is what puts a user's existing installs (incl. the auto-installed
-    /// standard packs) on the Apps scope before the Store's install flow writes <c>_App</c>
-    /// records. The manifest's content type is MESH-compiled (<c>Store/Install</c>), so it is read
-    /// UNTYPED here by design (the manifest's own doc says exactly that) — a JSON traversal at a
-    /// genuine type boundary, not an <c>as</c>-cast trap. Both reads go via the shared,
-    /// per-user-RLS, empty-on-absent <c>GetQuery</c> cache, starting empty so the home paints
-    /// instantly and installs land reactively.
+    /// The ids of the owner's <c>{owner}/_App/{appId}</c> records (see <see cref="AppNodeType"/>)
+    /// and, below, the INSTALLED item paths of the Store's manifests at
+    /// <c>{owner}/_Install/{slug}</c> — both feed the write-behind record materialization in
+    /// <see cref="CatalogAreaView"/>. The manifest's content type is MESH-compiled
+    /// (<c>Store/Install</c>), so it is read UNTYPED by design (the manifest's own doc says exactly
+    /// that) — a JSON traversal at a genuine type boundary, not an <c>as</c>-cast trap. Both reads
+    /// go via the shared, per-user-RLS, empty-on-absent <c>GetQuery</c> cache on the viewer's OWN
+    /// partition, starting empty so the home paints instantly.
     /// </summary>
-    private static IObservable<IReadOnlyList<string>> ObserveInstalledApps(
-        LayoutAreaHost host, string ownerId, JsonSerializerOptions options)
-    {
-        var appRecords = host.Workspace
+    private static IObservable<IReadOnlyList<string>> ObserveAppRecordIds(
+        LayoutAreaHost host, string ownerId) =>
+        host.Workspace
             .GetQuery($"home-apps:{ownerId}",
                 $"path:{ownerId}/{AppNodeType.UserNamespace} scope:children nodeType:{AppNodeType.NodeType} " +
-                "select:path,id,namespace,name,nodeType,content")
-            .Select(nodes => nodes
-                .Select(n => n.ContentAs<App>(options))
-                .Where(app => !string.IsNullOrWhiteSpace(app?.Plugin))
-                .OrderBy(app => app!.Order)
-                .Select(app => app!.Plugin.Trim('/'))
-                .Where(p => p.Length > 0)
+                "select:path,id,namespace,name,nodeType")
+            .Select(nodes => (IReadOnlyList<string>)nodes
+                .Select(n => n.Id)
+                .Where(id => !string.IsNullOrEmpty(id))
                 .ToList())
-            .StartWith([]);
-        var manifests = host.Workspace
+            .StartWith((IReadOnlyList<string>)[]);
+
+    private static IObservable<IReadOnlyList<string>> ObserveManifestItems(
+        LayoutAreaHost host, string ownerId, JsonSerializerOptions options) =>
+        host.Workspace
             .GetQuery($"home-installs:{ownerId}",
                 $"path:{ownerId}/_Install scope:children nodeType:Store/Install " +
                 "select:path,id,namespace,name,nodeType,content")
-            .Select(nodes => nodes.SelectMany(n => InstalledItemsOf(n.Content, options)).ToList())
-            .StartWith([]);
-        return appRecords.CombineLatest(manifests,
-            (records, installed) => (IReadOnlyList<string>)records
-                .Concat(installed)
+            .Select(nodes => (IReadOnlyList<string>)nodes
+                .SelectMany(n => InstalledItemsOf(n.Content, options))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList());
-    }
+                .ToList())
+            .StartWith((IReadOnlyList<string>)[]);
 
     /// <summary>
     /// The INSTALLED item paths of one Store install-manifest content (see
@@ -706,30 +712,37 @@ public static class UserActivityLayoutAreas
         => Observable.Return<UiControl?>(BuildThreadsApp(OwnerIdOf(host.Hub.Address.ToString())));
 
     /// <summary>
-    /// The Threads-app composition — pure (no hub) so the shape is unit-testable: a horizontal
-    /// stack of (rail, composer). The rail is the SAME open-threads query as the home band
-    /// (<c>-content.status:Done</c>, newest first) rendered as a single-column list whose rows
-    /// delegate to <see cref="ThreadRailItemArea"/>; closing a thread removes it reactively (the
-    /// query excludes Done). <c>flex-wrap</c> lets the composer drop below the rail on narrow
-    /// (mobile) widths.
+    /// The Threads-app composition — pure (no hub) so the shape is unit-testable: the MDI shell
+    /// (<see cref="BuildThreadsShell"/>) with the node-less composer as its main pane. Opening a
+    /// thread from the rail NAVIGATES to the thread page, which renders the SAME shell around the
+    /// conversation — the rail (the "document list") stays put across navigations, exactly like a
+    /// multi-document window.
     /// </summary>
-    internal static UiControl BuildThreadsApp(string nodeOwnerId)
-    {
-        var rail = Controls.Stack
-            .WithStyle("flex: 0 1 320px; min-width: 240px; box-sizing: border-box;")
-            .WithView(BuildThreadsRail(nodeOwnerId));
+    internal static UiControl BuildThreadsApp(string nodeOwnerId) =>
+        BuildThreadsShell(nodeOwnerId,
+            new ThreadChatControl().WithHideEmptyState(true));
 
-        var composer = Controls.Stack
-            .WithStyle("flex: 1 1 480px; min-width: 320px;")
-            .WithView(new ThreadChatControl().WithHideEmptyState(true));
-
-        return Controls.Stack
+    /// <summary>
+    /// The Threads MDI SHELL — a FIXED left rail of the viewer's open threads beside the main
+    /// pane. Rendered by BOTH the Threads app page (<c>/{user}/Chat</c>, main = the composer) and
+    /// every thread's full page (main = the conversation), so navigating between threads keeps the
+    /// rail — the menu never collapses. No <c>flex-wrap</c>: a wrapping shell was exactly the
+    /// broken layout it replaces; the rail is a fixed 280px column, the pane takes the rest.
+    /// </summary>
+    public static UiControl BuildThreadsShell(string viewerId, UiControl main) =>
+        Controls.Stack
             .WithOrientation(Orientation.Horizontal)
             .WithWidth("100%")
-            .WithStyle("gap: 16px; width: 100%; align-items: stretch; flex-wrap: wrap;")
-            .WithView(rail)
-            .WithView(composer);
-    }
+            .WithStyle("width: 100%; height: 100%; min-height: 0; align-items: stretch; gap: 0;")
+            .WithView(Controls.Stack
+                .WithStyle("flex: 0 0 280px; width: 280px; box-sizing: border-box; min-height: 0; " +
+                           "overflow-y: auto; border-right: 1px solid var(--neutral-stroke-rest); " +
+                           "padding-right: 8px;")
+                .WithView(BuildThreadsRail(viewerId)))
+            .WithView(Controls.Stack
+                .WithStyle("flex: 1 1 auto; min-width: 0; min-height: 0; display: flex; " +
+                           "flex-direction: column; padding-left: 12px;")
+                .WithView(main));
 
     /// <summary>The Threads-app rail list: the owner's open threads (never Done, newest first) as a
     /// single-column list whose rows delegate to the thread hub's <see cref="ThreadRailItemArea"/>.
@@ -825,19 +838,20 @@ public static class UserActivityLayoutAreas
     /// The home surface — ONE search control whose SCOPE TABS are the phone-home tabs:
     /// <b>Shared with me</b> (only with cross-partition grants; store items excluded — the
     /// auto-entitlement grants made every plugin partition read as "shared", but an app belongs on
-    /// Apps) · <b>Pinned</b> (only with pins) · <b>Apps</b> (default apps ∪ installed apps, every
-    /// app exactly once) · <b>Spaces</b> (the catalog without store items) · <b>All</b>
+    /// Apps) · <b>Pinned</b> (only with pins) · <b>Apps</b> (the viewer's OWN
+    /// <c>{owner}/_App</c> RECORDS, materialized from config defaults + install manifests — a
+    /// single-partition query, so it loads fast, with Threads a NORMAL app record like every
+    /// other) · <b>Spaces</b> (the catalog without store items) · <b>All</b>
     /// (everything the viewer can read, at every depth). Because the scopes live INSIDE one
     /// <see cref="MeshSearchControl"/>, the search bar is shared: the typed term survives tab
     /// switches and every tab is searchable — including All. The search input renders on desktop
-    /// and hides on mobile (the view's responsive rule); the <c>~/</c> system tiles (Threads)
-    /// render as a small dock row above the search. <see cref="HomeStyle.Catalog"/> switches back
-    /// to the legacy single-list <see cref="BuildCatalog"/>. Pure (no hub) so the shape is
+    /// and hides on mobile (the view's responsive rule). <see cref="HomeStyle.Catalog"/> switches
+    /// back to the legacy single-list <see cref="BuildCatalog"/>. Pure (no hub) so the shape is
     /// unit-testable without standing up a hub.
     /// </summary>
     internal static UiControl BuildHome(
         string nodeOwnerId, HomeConfig? config = null, IReadOnlyList<string>? sharedTargets = null,
-        IReadOnlyList<string>? installedApps = null, User? user = null, string? locale = null,
+        User? user = null, string? locale = null,
         PresentationScreen? screen = null)
     {
         var cfg = config ?? HomeConfigNodeType.Defaults;
@@ -882,17 +896,20 @@ public static class UserActivityLayoutAreas
                     : $"{pinnedBase} {suffix}"));
         }
 
-        // Apps — the config-declared defaults ∪ the owner's installed apps, budgeted to 24 TOTAL
-        // (dock tiles included) with the path query itself bounded. `~/` entries become the dock.
-        var (systemAreas, appPaths) = AppEntries(cfg, installedApps, privacy);
-        if (appPaths.Count > 0)
-        {
-            var appsBase = BuildAppsBaseQuery(appPaths);
-            scopes.Add(HomeScope("home.apps", locale, HomeCatalogSort.Alphabetical,
+        // Apps — the viewer's OWN installed-app records: a SINGLE-PARTITION query
+        // ({owner}/_App), which is why it loads fast — the old cover-path alternation fanned out
+        // across every partition schema (the multi-second home lag). Records are materialized
+        // write-behind from config defaults + install manifests (see CatalogAreaView) — Threads is
+        // an ordinary record like every other app — and each renders through its AppTile area
+        // (name/icon from the record; click opens the app; the presentation screen filters at the
+        // tile). `source:accessed` is meaningless on records, so that option sorts by modified.
+        var appsBase =
+            $"path:{nodeOwnerId}/{AppNodeType.UserNamespace} scope:children nodeType:{AppNodeType.NodeType}";
+        scopes.Add(HomeScope("home.apps", locale, HomeCatalogSort.Alphabetical,
                 (sort, suffix) => sort == HomeCatalogSort.LastAccessed
-                    ? $"{appsBase} {suffix}\n{appsBase} {SortSuffixAlphabetical}"
-                    : $"{appsBase} {suffix}"));
-        }
+                    ? $"{appsBase} {SortSuffixLastModified}"
+                    : $"{appsBase} {suffix}")
+            with { ItemArea = AppTileLayoutArea.AppTileArea });
 
         // Spaces — the deduplicated catalog (an app never appears twice).
         scopes.Add(HomeScope("home.spaces", locale, cfg.DefaultSort,
@@ -920,15 +937,7 @@ public static class UserActivityLayoutAreas
             .WithCreateHref("/create");
         if (cfg.Render == HomeCatalogRender.Grouped)
             search = search.WithSectionCounts(true).WithCollapsibleSections(true);
-
-        var dock = BuildDock(nodeOwnerId, systemAreas);
-        if (dock is null)
-            return search;
-        return Controls.Stack
-            .WithWidth("100%")
-            .WithStyle("gap: 12px; width: 100%;")
-            .WithView(dock)
-            .WithView(search);
+        return search;
     }
 
     /// <summary>One home scope tab: localized label + the three catalog sorts (default first),
@@ -949,101 +958,133 @@ public static class UserActivityLayoutAreas
     }
 
     /// <summary>
-    /// System-app declarations: a <see cref="HomeConfig.DefaultApps"/> entry starting with
-    /// <c>~/</c> is not a node path but an AREA on the viewer's own hub (<c>~/Chat</c> →
-    /// <c>/{owner}/Chat</c>), rendered as a fixed "dock" tile ahead of the node grid. The map
-    /// gives known areas their product name + icon; an unknown <c>~/X</c> falls back to the
-    /// segment name and the generic app icon. Labels here are deliberately GLOSSARY terms
-    /// (Thread/Threads stay English in every locale), so no localization key is involved.
-    /// Immutable constant lookup, never written at runtime.
+    /// Product name + icon for the KNOWN default apps (see <see cref="AppRecordSpecs"/>): a
+    /// <see cref="HomeConfig.DefaultApps"/> entry starting with <c>~/</c> is not a node path but an
+    /// AREA on the viewer's own hub (<c>~/Chat</c> → the Threads app at <c>/{owner}/Chat</c>);
+    /// anything not listed falls back to its path leaf + the generic app icon. Names here are
+    /// deliberately GLOSSARY/product terms (Store, Documentation, Threads — English in every
+    /// locale), so no localization key is involved. Immutable constant lookup, never written at
+    /// runtime.
     /// </summary>
-    private static readonly ImmutableDictionary<string, (string Label, string Icon)> SystemAppTiles =
-        new Dictionary<string, (string Label, string Icon)>
+    private static readonly ImmutableDictionary<string, (string Name, string Icon)> KnownApps =
+        new Dictionary<string, (string Name, string Icon)>
         {
+            ["Store"] = ("Store", "/static/NodeTypeIcons/shopping-bag.svg"),
+            ["Doc"] = ("Documentation", "/static/NodeTypeIcons/book.svg"),
             ["~/" + ChatArea] = ("Threads", "/static/NodeTypeIcons/chat.svg"),
         }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
+    private const string GenericAppIcon = "/static/NodeTypeIcons/puzzlepiece.svg";
+
+    private static string LeafOf(string path) =>
+        path.Contains('/') ? path[(path.LastIndexOf('/') + 1)..] : path;
+
+    /// <summary>The blueprint of one to-be-materialized app record.</summary>
+    internal sealed record AppRecordSpec(
+        string Id, string Name, string Icon, string? Plugin, string? OpenPath, string Source);
+
     /// <summary>
-    /// The app ENTRY LIST — the config-declared defaults (<see cref="HomeConfig.DefaultApps"/> —
-    /// e.g. <c>Store</c>, which replaces the old hard-coded header entry, <c>Doc</c>, and the
-    /// <c>~/Chat</c> Threads app) unioned with the owner's installed apps, deduped, budgeted, and
-    /// split into (<c>~/</c> system AREAS → the dock, node PATHS → the Apps scope query).
-    /// The presentation screen (#1803) drops marked paths HERE, before they reach a query string —
-    /// a <c>~/</c> entry names no node, so there is nothing for the screen to match.
-    /// The phone-home budget: at most 24 tiles TOTAL — dock AND grid together — sliced BEFORE the
-    /// split, so dock tiles count against the budget and the path query itself is bounded.
+    /// The app-record SPECS a viewer should have — the config-declared defaults
+    /// (<see cref="HomeConfig.DefaultApps"/>; a <c>~/</c> entry is an AREA on the viewer's own hub,
+    /// e.g. <c>~/Chat</c> → the Threads app, an ORDINARY record like every other app) unioned with
+    /// the Store manifests' installed items, deduped by record id (a path's <c>/</c> becomes
+    /// <c>-</c>). <see cref="KnownApps"/> gives the known defaults their product name + icon;
+    /// everything else falls back to the path leaf + the generic app icon (the Store's install
+    /// flow upgrades those in phase 2). Pure, exposed for tests.
     /// </summary>
-    internal static (IReadOnlyList<string> SystemAreas, IReadOnlyList<string> Paths) AppEntries(
-        HomeConfig? config, IReadOnlyList<string>? installedApps, PresentationScreen? screen = null)
+    internal static IReadOnlyList<AppRecordSpec> AppRecordSpecs(
+        HomeConfig? config, string ownerId, IEnumerable<string>? manifestItems)
     {
         var cfg = config ?? HomeConfigNodeType.Defaults;
-        var entries = (screen ?? PresentationScreen.Off)
-            .Filter(
-                (cfg.DefaultApps ?? [])
-                    .Concat(installedApps ?? [])
-                    .Where(p => !string.IsNullOrWhiteSpace(p))
-                    .Select(p => p.StartsWith("~/", StringComparison.Ordinal) ? p : p.Trim('/'))
-                    .Where(p => p.Length > 0)
-                    .Distinct(StringComparer.OrdinalIgnoreCase),
-                p => p.StartsWith("~/", StringComparison.Ordinal) ? null : p)
-            .ToList();
-        const int AppBudget = 24;
-        if (entries.Count > AppBudget)
-            entries = entries.Take(AppBudget).ToList();
-        return (
-            entries.Where(p => p.StartsWith("~/", StringComparison.Ordinal)).ToList(),
-            entries.Where(p => !p.StartsWith("~/", StringComparison.Ordinal)).ToList());
-    }
-
-    /// <summary>The system-app dock — one compact row of <see cref="BuildSystemAppTile"/> cards for
-    /// the <c>~/</c> entries, rendered ABOVE the home's search surface (scope-independent, like a
-    /// phone's dock). Null when there are none.</summary>
-    internal static UiControl? BuildDock(string nodeOwnerId, IReadOnlyList<string> systemAreas)
-    {
-        if (systemAreas.Count == 0)
-            return null;
-        var tiles = Controls.Stack
-            .WithOrientation(Orientation.Horizontal)
-            .WithWidth("100%")
-            .WithStyle("gap: 12px; width: 100%; flex-wrap: wrap;");
-        var any = false;
-        foreach (var area in systemAreas)
+        var specs = new List<AppRecordSpec>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var raw in cfg.DefaultApps ?? [])
         {
-            var tile = BuildSystemAppTile(nodeOwnerId, area);
-            if (tile is null)
+            if (string.IsNullOrWhiteSpace(raw))
                 continue;
-            any = true;
-            tiles = tiles.WithView(Controls.Stack
-                .WithStyle("flex: 0 1 240px; min-width: 200px;")
-                .WithView(tile));
+            if (raw.StartsWith("~/", StringComparison.Ordinal))
+            {
+                var segment = raw[2..].Trim('/');
+                if (segment.Length == 0)
+                    continue;
+                var id = segment.Replace('/', '-');
+                if (!seen.Add(id))
+                    continue;
+                var (name, icon) = KnownApps.TryGetValue("~/" + segment, out var known)
+                    ? known
+                    : (segment, GenericAppIcon);
+                specs.Add(new AppRecordSpec(id, name, icon,
+                    Plugin: null, OpenPath: $"{ownerId}/{segment}", Source: "default"));
+            }
+            else
+            {
+                var path = raw.Trim('/');
+                if (path.Length == 0)
+                    continue;
+                var id = path.Replace('/', '-');
+                if (!seen.Add(id))
+                    continue;
+                var (name, icon) = KnownApps.TryGetValue(path, out var known)
+                    ? known
+                    : (LeafOf(path), GenericAppIcon);
+                specs.Add(new AppRecordSpec(id, name, icon,
+                    Plugin: path, OpenPath: null, Source: "default"));
+            }
         }
-        return any ? tiles : null;
+        foreach (var item in manifestItems ?? [])
+        {
+            var path = item.Trim('/');
+            if (path.Length == 0)
+                continue;
+            var id = path.Replace('/', '-');
+            if (!seen.Add(id))
+                continue;
+            specs.Add(new AppRecordSpec(id, LeafOf(path), GenericAppIcon,
+                Plugin: path, OpenPath: null, Source: "install"));
+        }
+        return specs;
     }
-
-    /// <summary>Pure query core of the Apps grid, exposed for tests.</summary>
-    internal static string BuildAppsBaseQuery(IReadOnlyList<string> paths) =>
-        $"path:({string.Join(" OR ", paths)})";
 
     /// <summary>
-    /// One system-app "dock" tile for a <c>~/</c> entry (<see cref="SystemAppTiles"/>): a static
-    /// card whose identity is an AREA on the viewer's own hub, not a node — no hub resolves it, so
-    /// the title/icon are baked here and the click navigates to <c>/{owner}/{area}</c>. Returns
-    /// null for a malformed entry (<c>~/</c> with no segment).
+    /// Write-behind materialization of the viewer's app records: creates the
+    /// <c>{owner}/_App/{id}</c> node for every <see cref="AppRecordSpecs"/> entry that has no
+    /// record yet. Fire-and-forget and idempotent — <paramref name="attempted"/> (per home-area
+    /// instance) guards re-entry while a create is in flight, and a create that loses a race to an
+    /// existing record just logs. Writes land in the viewer's OWN partition under the viewer's own
+    /// identity (the framework propagates the caller's AccessContext through Subscribe).
     /// </summary>
-    internal static MeshNodeCardControl? BuildSystemAppTile(string nodeOwnerId, string entry)
+    private static void EnsureAppRecords(
+        LayoutAreaHost host, string ownerId, HomeConfig? config,
+        IReadOnlyList<string> manifestItems, IReadOnlyList<string> recordIds,
+        HashSet<string> attempted)
     {
-        if (!entry.StartsWith("~/", StringComparison.Ordinal))
-            return null;
-        var segment = entry[2..].Trim('/');
-        if (segment.Length == 0)
-            return null;
-        // Look up by the NORMALIZED key, not the raw entry: a config value like "~/Chat/" must
-        // still resolve the known Threads tile instead of silently falling back to the generic
-        // icon/label (Copilot review, PR #1993).
-        var (label, icon) = SystemAppTiles.TryGetValue("~/" + segment, out var known)
-            ? known
-            : (segment, "/static/NodeTypeIcons/puzzlepiece.svg");
-        return new MeshNodeCardControl($"{nodeOwnerId}/{segment}", Title: label, ImageUrl: icon);
+        var mesh = host.Hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null || string.IsNullOrEmpty(ownerId))
+            return;
+        var logger = host.Hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Graph.AppRecords");
+        var existing = new HashSet<string>(recordIds, StringComparer.OrdinalIgnoreCase);
+        foreach (var spec in AppRecordSpecs(config, ownerId, manifestItems))
+        {
+            if (existing.Contains(spec.Id) || !attempted.Add(spec.Id))
+                continue;
+            var node = new MeshNode(spec.Id, $"{ownerId}/{AppNodeType.UserNamespace}")
+            {
+                NodeType = AppNodeType.NodeType,
+                Name = spec.Name,
+                Icon = spec.Icon,
+                State = MeshNodeState.Active,
+                Content = new App
+                {
+                    Plugin = spec.Plugin ?? "",
+                    OpenPath = spec.OpenPath,
+                    Source = spec.Source,
+                },
+            };
+            mesh.CreateNode(node).Subscribe(_ => { },
+                ex => logger?.LogWarning(ex,
+                    "App record create failed at {Path}", node.Path));
+        }
     }
 
     /// <summary>Dedup for the Spaces and Shared-with-me scopes: anything living in the Store (and

--- a/src/MeshWeaver.Layout/MeshSearchControl.cs
+++ b/src/MeshWeaver.Layout/MeshSearchControl.cs
@@ -83,6 +83,13 @@ public record MeshSearchScopeTab(string Label, string Query)
     /// while this scope is active (first = this scope's default). Null keeps the control-level set.
     /// </summary>
     public IReadOnlyList<MeshSearchSortOption>? SortOptions { get; init; }
+
+    /// <summary>
+    /// Per-item layout area used while this scope is active, REPLACING the control-level
+    /// <see cref="MeshSearchControl.ItemArea"/> (e.g. the home's Apps scope renders its
+    /// installed-app records through their <c>AppTile</c> area). Null keeps the control-level one.
+    /// </summary>
+    public string? ItemArea { get; init; }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/App.cs
+++ b/src/MeshWeaver.Mesh.Contract/App.cs
@@ -7,14 +7,16 @@ namespace MeshWeaver.Mesh;
 /// A per-user <b>installed app</b> record — one node per icon on the owner's Apps grid, stored as a
 /// REGULAR mesh node (no satellite mapping, <c>mesh_nodes</c> table) at
 /// <c>{user}/_App/{appId}</c> (the same non-satellite dotfile shape as <c>{user}/_Memex/…</c>).
-/// The record captures <b>presence and placement only</b>: the app's identity is the
-/// <see cref="Plugin"/> node path, and everything display-worthy (name, icon, description,
-/// translations) resolves LIVE from that node — never copied here, so nothing can drift. Tile
-/// state (needs install / needs setup / open) is likewise derived at render time from the
-/// viewer's install manifests, never stored.
-/// <para>The Apps grid a user sees is the UNION of the platform's config-declared default apps
-/// (<c>Admin/HomeConfig.DefaultApps</c>) and the owner's own <c>App</c> nodes — so defaults need
-/// no seeding and an admin's config edit updates every home live.</para>
+/// The record's NODE carries the tile's display identity (<c>MeshNode.Name</c> /
+/// <c>MeshNode.Icon</c>, stamped at materialization) and this CONTENT carries the wiring — which
+/// app the tile opens. Rendering entirely from the record is deliberate: it makes the Apps grid a
+/// SINGLE-PARTITION query over <c>{owner}/_App</c> (the cover-node model it replaced resolved a
+/// top-level path alternation across every partition schema — a multi-second home load). The
+/// Store's install flow refreshes a record's name/icon when it (re)installs an app.
+/// <para>Records are MATERIALIZED write-behind on home render from the platform's config-declared
+/// default apps (<c>Admin/HomeConfig.DefaultApps</c>) and the viewer's Store install manifests —
+/// no onboarding seeding, and a config addition reaches every user's grid on their next home
+/// render.</para>
 /// </summary>
 public record App
 {

--- a/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using Xunit;
 
@@ -12,21 +13,16 @@ namespace MeshWeaver.Graph.Test;
 /// <summary>
 /// The home surface (<see cref="UserActivityLayoutAreas.BuildHome"/>) — ONE
 /// <see cref="MeshSearchControl"/> whose SCOPE TABS are the phone-home tabs: Shared with me (only
-/// with grants, store items excluded) · Pinned (only with pins) · Apps (default ∪ installed apps,
-/// 24-budgeted) · Spaces (catalog without store items) · All (everything, every depth). The scopes
-/// share one search bar by construction — the typed term survives tab switches and every tab is
-/// searchable. The search input is desktop-only (the view hides it on mobile); the <c>~/</c>
-/// system tiles render as a dock row above the search. <see cref="HomeStyle.Catalog"/> switches
-/// back to the legacy single list (covered by <see cref="HomeCatalogTest"/>).
+/// with grants; store items and User roots excluded) · Pinned (only with pins) · Apps (the
+/// viewer's OWN <c>{owner}/_App</c> records — a SINGLE-PARTITION query, which is why it loads
+/// fast; records are materialized from config defaults + install manifests, and Threads is an
+/// ordinary record) · Spaces (catalog without store items) · All (everything, every depth). The
+/// scopes share one search bar by construction. <see cref="HomeStyle.Catalog"/> switches back to
+/// the legacy single list (covered by <see cref="HomeCatalogTest"/>).
 /// </summary>
 public class HomeTabsTest
 {
     private const string NodePath = "rbuergi";
-
-    /// <summary>A config whose DefaultApps carry no ~/ entry, so BuildHome returns the bare search
-    /// control (no dock stack) and its scopes are directly assertable.</summary>
-    private static HomeConfig NoDock(params string[] apps) =>
-        new() { DefaultApps = apps.Length > 0 ? apps : ["Store", "Doc"] };
 
     private static MeshSearchControl Search(UiControl home) =>
         home.Should().BeOfType<MeshSearchControl>().Subject;
@@ -37,18 +33,10 @@ public class HomeTabsTest
     // ── Structure ───────────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Home_Default_IsDockPlusOneSearchSurface()
-    {
-        // Shipped DefaultApps include ~/Chat → a dock row above ONE search control.
-        UserActivityLayoutAreas.BuildHome(NodePath)
-            .Should().BeOfType<StackControl>().Subject
-            .Areas.Should().HaveCount(2, "system-tile dock + the single scoped search surface");
-    }
-
-    [Fact]
     public void Home_NoShareNoPin_ScopesAreAppsSpacesAll()
     {
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock()));
+        // No dock, no extra thing: the home is the ONE scoped search surface.
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath));
 
         ScopeLabels(search).Should().Equal("Apps", "Spaces", "All");
     }
@@ -56,7 +44,7 @@ public class HomeTabsTest
     [Fact]
     public void Home_WithSharesAndPins_ScopeOrder()
     {
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock(),
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath,
             sharedTargets: ["OrgA/Module"], user: new User { PinnedPaths = ["Doc/GUI"] }));
 
         ScopeLabels(search).Should().Equal("Shared with me", "Pinned", "Apps", "Spaces", "All");
@@ -65,10 +53,7 @@ public class HomeTabsTest
     [Fact]
     public void Home_OneSharedSearchBar_DesktopOn()
     {
-        // The bar is ON (the view hides the input responsively on mobile); the control-level
-        // hidden query and sort options are the FIRST scope's — the fallback contract for clients
-        // without scope support.
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock(),
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath,
             sharedTargets: ["OrgA/Module"]));
 
         search.ShowSearchBox.Should().Be(true);
@@ -90,13 +75,9 @@ public class HomeTabsTest
     // ── Shared-with-me scope ────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Shared_ExcludesStoreItems_AndKeepsTheCompletenessFallback()
+    public void Shared_ExcludesStoreItemsAndUserRoots_AndKeepsTheCompletenessFallback()
     {
-        // The silent per-viewer entitlement grants (StandardPacks) made every plugin partition
-        // read as "shared with me" — store items are excluded here because an app is represented
-        // on the Apps scope, exactly once. And source:accessed is an INNER join, so the default
-        // last-accessed option stays a two-leg union with a plain fallback.
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock(),
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath,
             sharedTargets: ["OrgA/Module", "OrgB/Deck"]));
 
         var shared = search.ScopeTabs![0];
@@ -115,112 +96,105 @@ public class HomeTabsTest
         }
     }
 
-    // ── Apps scope ──────────────────────────────────────────────────────────────────────────────
+    // ── Apps scope: the viewer's own records, single partition ──────────────────────────────────
 
     [Fact]
-    public void Apps_UnionsConfigDefaultsAndInstalled_EachAppExactlyOnce()
+    public void Apps_QueriesTheViewersOwnRecords_SinglePartition()
     {
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock(),
-            installedApps: ["Chess", "store", "Chess"]));
+        // THE point of the record model: the old cover-path alternation fanned out across every
+        // partition schema (the multi-second home lag); the records query names ONE partition.
+        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath));
 
         var apps = search.ScopeTabs!.Single(t => t.Label == "Apps");
-        // Defaults (Store, Doc) ∪ installed (Chess) — "store" dedupes case-insensitively.
-        apps.Query.Should().Contain("path:(Store OR Doc OR Chess)");
-        apps.Query.Should().NotContain("store OR");
-        // Default order alphabetical; all three sorts offered, scope-locally.
+        apps.Query.Should().Contain($"path:{NodePath}/_App scope:children nodeType:InstalledApp");
+        apps.Query.Should().NotContain(" OR ", "no path alternation — the records query is the bound");
+        apps.ItemArea.Should().Be(AppTileLayoutArea.AppTileArea,
+            "records render through their tile area, never as generic record cards");
+        // Alphabetical default; source:accessed is meaningless on records, so that option sorts by
+        // modified instead of hiding never-opened apps behind an INNER join.
         apps.SortOptions![0].Query.Should().Be(apps.Query);
         apps.Query.Should().Contain("sort:Name-asc");
-        apps.SortOptions.Should().HaveCount(3);
+        apps.SortOptions!.Select(o => o.Query).Should().OnlyContain(q => !q.Contains("source:accessed"));
+    }
+
+    // ── Record materialization specs ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AppRecordSpecs_DefaultsCarryProductNamesAndIcons_ThreadsIsAnOrdinaryRecord()
+    {
+        var specs = UserActivityLayoutAreas.AppRecordSpecs(new HomeConfig(), NodePath, manifestItems: null);
+
+        specs.Select(s => s.Id).Should().Equal("Store", "Doc", "Chat");
+        specs.Single(s => s.Id == "Store").Name.Should().Be("Store");
+        specs.Single(s => s.Id == "Doc").Name.Should().Be("Documentation");
+        var threads = specs.Single(s => s.Id == "Chat");
+        threads.Name.Should().Be("Threads");
+        threads.Icon.Should().Be("/static/NodeTypeIcons/chat.svg");
+        threads.OpenPath.Should().Be($"{NodePath}/Chat", "the Threads record opens the viewer's own Chat area");
+        threads.Plugin.Should().BeNull();
     }
 
     [Fact]
-    public void Apps_BudgetOf24_BoundsTheQueryItself()
+    public void AppRecordSpecs_ManifestItemsAppend_DedupedAgainstDefaults()
     {
-        var many = NoDock(Enumerable.Range(1, 30).Select(i => $"P{i}").ToArray());
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, many));
+        var specs = UserActivityLayoutAreas.AppRecordSpecs(
+            new HomeConfig(), NodePath, manifestItems: ["Chess", "Store", "Chess"]);
 
-        var apps = search.ScopeTabs!.Single(t => t.Label == "Apps");
-        var firstLeg = apps.Query.Split('\n')[0];
-        firstLeg.Split(" OR ").Should().HaveCount(24, "the AppBudget slice bounds the path alternation");
-        firstLeg.Should().NotContain("P25", "entries beyond the budget are dropped in config order");
+        specs.Select(s => s.Id).Should().Equal("Store", "Doc", "Chat", "Chess");
+        var chess = specs.Single(s => s.Id == "Chess");
+        chess.Source.Should().Be("install");
+        chess.Plugin.Should().Be("Chess");
+        // The pre-existing default keeps its product identity — the manifest doesn't re-add it.
+        specs.Single(s => s.Id == "Store").Source.Should().Be("default");
     }
 
-    [Fact]
-    public void AppEntries_BudgetCountsDockTiles_SliceBeforeTheSplit()
-    {
-        var cfg = new HomeConfig
+    // ── The tile ────────────────────────────────────────────────────────────────────────────────
+
+    private static MeshNode Record(string id, App content, string? name = null, string? icon = null) =>
+        MeshNode.FromPath($"{NodePath}/_App/{id}") with
         {
-            DefaultApps = new[] { "~/Chat" }
-                .Concat(Enumerable.Range(1, 30).Select(i => $"P{i}"))
-                .ToList(),
+            NodeType = AppNodeType.NodeType,
+            Name = name ?? id,
+            Icon = icon,
+            Content = content,
         };
 
-        var (systemAreas, paths) = UserActivityLayoutAreas.AppEntries(cfg, installedApps: null);
-
-        systemAreas.Should().Equal("~/Chat");
-        paths.Should().HaveCount(23, "24 total minus the dock tile — dock counts against the budget");
-    }
-
-    // ── Spaces + All scopes ─────────────────────────────────────────────────────────────────────
-
     [Fact]
-    public void Spaces_ExcludesStoreItems_TheDedupRule()
+    public void AppTile_NavigatesToThePluginOrOpenPath_NeverTheRecord()
     {
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock()));
+        var options = new JsonSerializerOptions();
 
-        var spaces = search.ScopeTabs!.Single(t => t.Label == "Spaces");
-        foreach (var option in spaces.SortOptions!)
-        {
-            option.Query.Should().Contain("-nodeType:Store/Plugin");
-            option.Query.Should().Contain("-nodeType:Store/Catalog");
-        }
-    }
+        var plugin = AppTileLayoutArea.BuildTile(
+                Record("Chess", new App { Plugin = "Chess" }, name: "Chess"),
+                $"{NodePath}/_App/Chess", options)
+            .Should().BeOfType<MeshNodeCardControl>().Subject;
+        plugin.NodePath.Should().Be("Chess", "the tile opens the APP, not the record");
+        plugin.Title.Should().Be("Chess");
 
-    [Fact]
-    public void All_SearchesEverything_AtEveryDepth()
-    {
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath, NoDock()));
-
-        var all = search.ScopeTabs!.Last();
-        all.Label.Should().Be("All");
-        all.Query.Should().Contain("is:main context:search");
-        all.Query.Should().NotContain("namespace:", "All is the SUBTREE query — everything, every depth");
-        all.Query.Should().NotContain("-nodeType:Store/Plugin", "the All scope hides nothing");
-    }
-
-    // ── System (dock) tiles ─────────────────────────────────────────────────────────────────────
-
-    [Theory]
-    [InlineData("~/Chat")]
-    [InlineData("~/Chat/")]   // extra slashes normalize — the known-tile lookup keys on the TRIMMED segment
-    public void SystemTile_ThreadsDockTile_TargetsTheViewersChatArea(string entry)
-    {
-        var tile = UserActivityLayoutAreas.BuildSystemAppTile(NodePath, entry);
-
-        tile.Should().NotBeNull();
-        tile!.NodePath.Should().Be($"{NodePath}/Chat", "the tile opens the viewer's own Threads app");
-        tile.Title.Should().Be("Threads");
-        tile.ImageUrl.Should().Be("/static/NodeTypeIcons/chat.svg");
+        var threads = AppTileLayoutArea.BuildTile(
+                Record("Chat", new App { OpenPath = $"{NodePath}/Chat" }, name: "Threads",
+                    icon: "/static/NodeTypeIcons/chat.svg"),
+                $"{NodePath}/_App/Chat", options)
+            .Should().BeOfType<MeshNodeCardControl>().Subject;
+        threads.NodePath.Should().Be($"{NodePath}/Chat");
+        threads.ImageUrl.Should().Be("/static/NodeTypeIcons/chat.svg");
     }
 
     [Fact]
-    public void SystemTile_UnknownAreaFallsBack_MalformedIsNull()
+    public void AppTile_WithoutATarget_RendersInert()
     {
-        var unknown = UserActivityLayoutAreas.BuildSystemAppTile(NodePath, "~/Foo");
-        unknown!.Title.Should().Be("Foo");
-        unknown.ImageUrl.Should().Be("/static/NodeTypeIcons/puzzlepiece.svg");
+        var tile = AppTileLayoutArea.BuildTile(
+                Record("Broken", new App()), $"{NodePath}/_App/Broken", new JsonSerializerOptions())
+            .Should().BeOfType<MeshNodeCardControl>().Subject;
 
-        UserActivityLayoutAreas.BuildSystemAppTile(NodePath, "~/").Should().BeNull();
-        UserActivityLayoutAreas.BuildSystemAppTile(NodePath, "Store").Should().BeNull();
+        tile.DisableNavigation.Should().Be(true, "a record without a target must not navigate to itself");
     }
 
-    // ── Install manifests → installed apps ──────────────────────────────────────────────────────
+    // ── Install manifests → materialization input ───────────────────────────────────────────────
 
     [Fact]
     public void InstalledItemsOf_YieldsOnlyItemsWithALiveInstall()
     {
-        // The Store's per-user install manifest ({owner}/_Install/{slug}) is mesh-compiled and read
-        // UNTYPED by design: items[] with a non-empty installedPath ARE the installed apps.
         var manifest = JsonSerializer.SerializeToElement(new
         {
             repo = "https://github.com/Systemorph/MeshWeaver.Plugins",

--- a/test/MeshWeaver.Graph.Test/PresentationSurfacesTest.cs
+++ b/test/MeshWeaver.Graph.Test/PresentationSurfacesTest.cs
@@ -1,5 +1,7 @@
 using System.Linq;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using Xunit;
 
@@ -88,10 +90,6 @@ public class PresentationSurfacesTest
 
     // ── The scoped home: Shared with me, Pinned, Apps ──────────────────────────────────────────
 
-    /// <summary>A config with no ~/ entry, so BuildHome returns the bare scoped search control.</summary>
-    private static HomeConfig NoDock(params string[] apps) =>
-        new() { DefaultApps = apps.Length > 0 ? apps : ["Store", "Doc"] };
-
     private static MeshSearchControl HomeSearch(UiControl home) =>
         home.Should().BeOfType<MeshSearchControl>().Subject;
 
@@ -108,13 +106,13 @@ public class PresentationSurfacesTest
 
         // Off: both viewer-scoped tabs are there.
         ScopeLabels(UserActivityLayoutAreas.BuildHome(
-                Owner, NoDock(), sharedTargets: ["Acme/Deals"], user: user))
+                Owner, sharedTargets: ["Acme/Deals"], user: user))
             .Should().Equal("Shared with me", "Pinned", "Apps", "Spaces", "All");
 
         // On, with Acme marked: everything in both of them is inside the marked space, so both tabs
         // go — an empty tab labelled "Pinned" would itself say something.
         ScopeLabels(UserActivityLayoutAreas.BuildHome(
-                Owner, NoDock(), sharedTargets: ["Acme/Deals"], user: user, screen: Active("Acme")))
+                Owner, sharedTargets: ["Acme/Deals"], user: user, screen: Active("Acme")))
             .Should().Equal("Apps", "Spaces", "All");
     }
 
@@ -122,7 +120,7 @@ public class PresentationSurfacesTest
     public void Home_AScopeKeepsItsUnmarkedContent()
     {
         var home = UserActivityLayoutAreas.BuildHome(
-            Owner, NoDock(),
+            Owner,
             sharedTargets: ["Acme/Deals", "Northwind/Sales"],
             user: new User { PinnedPaths = ["Acme", "Doc/Guide"] },
             screen: Active("Acme"));
@@ -137,59 +135,47 @@ public class PresentationSurfacesTest
         painted.Should().Equal("Northwind/Sales");
 
         var home = UserActivityLayoutAreas.BuildHome(
-            Owner, NoDock(), sharedTargets: ["Acme/Deals", "Northwind/Sales"], screen: Active("Acme"));
+            Owner, sharedTargets: ["Acme/Deals", "Northwind/Sales"], screen: Active("Acme"));
         ScopeQuery(home, "Shared with me")
             .Should().NotContain("Acme").And.Contain("Northwind/Sales");
     }
 
     [Fact]
-    public void AppsScope_DropsAMarkedApp_BeforeItReachesTheQuery()
+    public void AppsScope_QueryNeverCarriesAppPaths()
     {
-        // An installed app's path is interpolated into `path:(…)`, so a marked one must never get
-        // that far.
-        var home = UserActivityLayoutAreas.BuildHome(
-            Owner, NoDock("Store"), installedApps: ["Chess", "Acme"], screen: Active("Acme"));
+        // The Apps scope queries the viewer's OWN {owner}/_App records — a GENERIC query, so no
+        // app path (marked or not) can ever reach the query string / the `hq=` URL. The marked-app
+        // guarantee therefore lives at the TILE (below), where the name would otherwise be painted.
+        var query = ScopeQuery(
+            UserActivityLayoutAreas.BuildHome(Owner, screen: Active("Acme")), "Apps");
 
-        var query = ScopeQuery(home, "Apps");
-        query.Should().Contain("Store").And.Contain("Chess");
+        query.Should().Be(ScopeQuery(UserActivityLayoutAreas.BuildHome(Owner), "Apps"));
         query.Should().NotContain("Acme");
     }
 
     [Fact]
-    public void AppEntries_LeaveSystemAreasAlone()
+    public void AppTile_HidesAMarkedApp_AndPaintsItAgainWhenTheModeIsOff()
     {
-        // A "~/" entry is a system AREA, not a mesh path — it names no node, so there is nothing for
-        // the screen to match and it must pass through even while the mode is up. Asserted because
-        // the code only says it in a comment, and a comment is not a test.
-        // Marking the system area TOO (a viewer can type anything into their own profile) must not
-        // make it disappear, and marking the only real app must not take the dock with it.
-        var (systemAreas, paths) = UserActivityLayoutAreas.AppEntries(
-            new HomeConfig { DefaultApps = ["~/Settings"] },
-            installedApps: ["Acme"],
-            screen: Active("Acme", "~/Settings"));
+        var options = new System.Text.Json.JsonSerializerOptions();
+        var record = MeshNode.FromPath($"{Owner}/_App/Acme") with
+        {
+            NodeType = AppNodeType.NodeType,
+            Name = "Acme",
+            Content = new App { Plugin = "Acme" },
+        };
 
-        systemAreas.Should().Equal("~/Settings");
-        paths.Should().BeEmpty("every MESH path was screened away; the system-area dock survives");
-        // And the home still renders the dock (a stack above the search), never a query carrying
-        // the marked name.
-        var home = UserActivityLayoutAreas.BuildHome(
-            Owner,
-            new HomeConfig { DefaultApps = ["~/Settings"] },
-            installedApps: ["Acme"],
-            screen: Active("Acme", "~/Settings"));
-        home.Should().BeOfType<StackControl>("the dock survives the screen").Subject
-            .Areas.Should().HaveCount(2, "dock + the scoped search surface");
-    }
-
-    [Fact]
-    public void AppEntries_AreUnchangedWhenTheModeIsOff()
-    {
-        var (_, paths) = UserActivityLayoutAreas.AppEntries(
-            new HomeConfig { DefaultApps = ["Store"] },
-            installedApps: ["Acme"],
-            screen: PresentationScreen.For(false, ["Acme"]));
-
-        paths.Should().Contain("Acme");
+        // Mode on + marked: the tile renders NOTHING — the marked name is never painted.
+        AppTileLayoutArea.BuildTile(record, record.Path, options, Active("Acme"))
+            .Should().BeNull();
+        // A pin INSIDE the marked space hides too (prefix semantics come from the screen itself).
+        var deep = record with { Content = new App { Plugin = "Acme/Deals" } };
+        AppTileLayoutArea.BuildTile(deep, record.Path, options, Active("Acme"))
+            .Should().BeNull();
+        // Mode off (marks curated but not presenting) and no screen at all: the tile paints.
+        AppTileLayoutArea.BuildTile(record, record.Path, options, PresentationScreen.For(false, ["Acme"]))
+            .Should().NotBeNull();
+        AppTileLayoutArea.BuildTile(record, record.Path, options)
+            .Should().NotBeNull();
     }
 
     // ── The legacy single-list catalog ─────────────────────────────────────────────────────────
@@ -228,9 +214,9 @@ public class PresentationSurfacesTest
         QueryOf(marked).Should().NotContain("Acme");
 
         // Same for the home's Spaces scope: identical query with and without the screen.
-        var spacesMarked = HomeSearch(UserActivityLayoutAreas.BuildHome(Owner, NoDock(), screen: Active("Acme")))
+        var spacesMarked = HomeSearch(UserActivityLayoutAreas.BuildHome(Owner, screen: Active("Acme")))
             .ScopeTabs!.Single(t => t.Label == "Spaces").Query;
-        var spacesPlain = HomeSearch(UserActivityLayoutAreas.BuildHome(Owner, NoDock()))
+        var spacesPlain = HomeSearch(UserActivityLayoutAreas.BuildHome(Owner))
             .ScopeTabs!.Single(t => t.Label == "Spaces").Query;
         spacesMarked.Should().Be(spacesPlain).And.NotContain("Acme");
     }

--- a/test/MeshWeaver.Portal.E2E.Test/HomePageRegionsTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/HomePageRegionsTest.cs
@@ -64,5 +64,16 @@ public class HomePageRegionsTest(PortalFixture fixture)
         float pageW = doc.GetProperty("page").GetSingle();
         (catalogW / pageW).Should().BeGreaterThan(0.8f,
             $"the catalog should fill the home width, not shrink to content (catalog={catalogW:F0}px of {pageW:F0}px)");
+
+        // (c) The Apps scope renders the viewer's MATERIALIZED app records — the write-behind
+        // creates Store/Documentation/Threads records from the config defaults on first render,
+        // and each record paints through its AppTile area. This is the end-to-end proof that a
+        // user HAS apps (the "I don't have any apps" report) and that the records query returns
+        // fast enough to paint tiles inside the wait budget.
+        await page.Locator(".mesh-search-scope", new PageLocatorOptions { HasTextString = "Apps" }).First
+            .ClickAsync();
+        await page.GetByText("Threads", new() { Exact = true }).First
+            .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+        await page.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/home-apps.png", FullPage = true });
     }
 }


### PR DESCRIPTION
Per Roland's report on the shipped home (no apps visible; ~5s Apps lag; Threads an "extra thing"; the thread rail collapses on navigation; ✕ navigates instead of closing):

- **Root cause of the lag**: the Apps grid queried plugin COVER nodes via a top-level path alternation — no partition hint, so it fanned out across every partition schema. The Apps scope now queries the viewer's **own `{owner}/_App` records: one schema, instant**. Records are **materialized write-behind** on home render (`EnsureAppRecords`) from the config defaults + the Store's install manifests — so a user's existing installs (incl. the auto-installed standard packs) appear as apps: the "don't I have anything installed?" fix.
- Each record renders through its **AppTile** area (name/icon from the record; click opens the app, never the record). `MeshSearchScopeTab` gains a per-scope `ItemArea` for exactly this. The presentation screen (#1803) filters **at the tile** — the generic records query carries no app path, so nothing marked can ever reach a query string or URL.
- **Threads is an ordinary app record** (`{owner}/_App/Chat` → `/{owner}/Chat`) — the `~/` dock special-case, `AppEntries`, `BuildDock`, `SystemAppTiles` and `BuildAppsBaseQuery` are deleted.
- **Threads MDI**: `BuildThreadsShell` (fixed 280px rail + main pane, no wrap) renders on BOTH the `/{user}/Chat` page (composer) and every thread's full page (conversation) — navigating between threads **keeps the rail**; the menu never collapses. Rail rows are title + ✕ **siblings**: the absolutely-positioned ✕ sat over the nav button and its click navigated instead of closing — as a sibling it reliably closes via `MarkThreadDone`.

**Verified in a real browser** (E2E fixture, launched Monolith): the Apps tab paints the materialized **Documentation / Store / Threads** tiles — screenshot-checked, including a new permanent assertion that clicks the Apps tab and waits for the tiles; the Threads page renders rail + composer with zero error boundaries. 57/57 home/privacy unit tests green (specs, tile targets, tile-level screen filter); `dotnet build -c Release -warnaserror` (AI + Graph + Layout + Blazor + Monolith + E2E) clean.

What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)