### PR TITLE
Modules__Required could not reach a container — and the guard that would have caught all three

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -286,6 +286,39 @@ data:
   # default; "empty = inert" is only true for strings.
   SelfUpdate__MinRollInterval: "{{ .Values.config.memex_portal.SelfUpdate__MinRollInterval | default "01:00:00" }}"
   WebhookInbox__Targets__0: "{{ .Values.config.memex_portal.WebhookInbox__Targets__0 }}"
+  # The MODULES a deployment refuses to run without (MeshBuilderModuleActivation.RequiredKey).
+  # The image ships a baseline list in appsettings; a deployment OVERRIDES an entry by name here,
+  # and blanks one it cannot satisfy.
+  #
+  # 🚨 Un-templated, an override is silently dropped and the health check wins anyway — the #1925
+  # defect, third occurrence. Not cosmetic here: `required_modules` reports Unhealthy, /health
+  # answers 503, the startup probe never passes and the ROLLOUT TIMES OUT with the portal never
+  # serving. That is memex-local on 2026-08-23, once the Blazor view packs and Speech became
+  # modules (#1974/#2018/#2081/#2085): the image stopped shipping five DLLs its own Required list
+  # still named, and a laptop has no registry to land them from.
+  #
+  # 🚨 Written out INDEX BY INDEX, never a range: this ConfigMap's contract is that it names every
+  # key explicitly, and EveryConfigKeySetInAValuesFile_IsBoundInTheConfigMap enforces exactly that
+  # by looking for the key. A range renders correctly and is invisible to the guard — which is how
+  # the first draft of this block passed helm and failed the test, correctly.
+  #
+  # Each index is emitted only when a deployment sets it, so an install that overrides nothing
+  # keeps the image's own list rather than blanking entry 0.
+  {{- if hasKey .Values.config.memex_portal "Modules__Required__0" }}
+  Modules__Required__0: "{{ .Values.config.memex_portal.Modules__Required__0 }}"
+  {{- end }}
+  {{- if hasKey .Values.config.memex_portal "Modules__Required__1" }}
+  Modules__Required__1: "{{ .Values.config.memex_portal.Modules__Required__1 }}"
+  {{- end }}
+  {{- if hasKey .Values.config.memex_portal "Modules__Required__2" }}
+  Modules__Required__2: "{{ .Values.config.memex_portal.Modules__Required__2 }}"
+  {{- end }}
+  {{- if hasKey .Values.config.memex_portal "Modules__Required__3" }}
+  Modules__Required__3: "{{ .Values.config.memex_portal.Modules__Required__3 }}"
+  {{- end }}
+  {{- if hasKey .Values.config.memex_portal "Modules__Required__4" }}
+  Modules__Required__4: "{{ .Values.config.memex_portal.Modules__Required__4 }}"
+  {{- end }}
   # ---- OpenAI-compatible provider (self-hosted / local: Ollama, vLLM, LM Studio, …) ----
   # Generic OpenAI-wire endpoint. Set Endpoint + Models (+ ApiKey in secrets) to seed a
   # provider + LanguageModel nodes pointing at any OpenAI-compatible gateway. Empty = inert.

--- a/deploy/homebrew/share/values.local.defaults.yaml
+++ b/deploy/homebrew/share/values.local.defaults.yaml
@@ -18,6 +18,27 @@
 
 config:
   memex_portal:
+    # ---- The view packs are MODULES now, and a laptop cannot land them ---------
+    # MeshWeaver #1974/#2018/#2081/#2085 turned Radzen, Analysis, EntityViews,
+    # GoogleMaps and Speech into modules, so the image no longer ships the five
+    # DLLs its own Modules:Required list still names. The required_modules health
+    # check then reports Unhealthy, /health answers 503, the startup probe never
+    # passes, and `memex-local update` ends in "timed out waiting for the
+    # condition" with the portal never serving.
+    #
+    # 🚨 A laptop has no registry to land them from — memex-local IS the registry,
+    # serving the developer's Plugins checkout — so "install the packages" is not
+    # available here and blanking the requirement is the sanctioned other half of
+    # what the health check itself suggests. The AKS overlays blank the same five
+    # (Memex #87/#88/#94); there the modules do land, from the real registry.
+    #
+    # Cost, stated plainly: no Radzen charts, Analysis, EntityViews, GoogleMaps or
+    # Speech on a local instance until the local lane can land a module bundle.
+    Modules__Required__0: ""
+    Modules__Required__1: ""
+    Modules__Required__2: ""
+    Modules__Required__3: ""
+    Modules__Required__4: ""
     # ---- Store-installed modules land on the PERSISTENT volume ---------------
     # A module that ships in the image is not automatically ACTIVE: /mcp, the gRPC
     # endpoint and every other module route is mapped from `Modules:Assemblies`,

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-23-a-local-portal-starts-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-23-a-local-portal-starts-again.md
@@ -1,0 +1,36 @@
+---
+Name: A local portal starts again after the view packs became modules
+Category: Fix
+Description: Five features moved out of the portal image and became separately installed modules, but the image still insisted on them — so a local install refused to start. It starts again, and the setting that says which modules are mandatory now reaches the portal at all.
+Icon: Sparkle
+Order: -20260823
+---
+
+# A local portal starts again after the view packs became modules
+
+Charts, analysis views, entity views, maps and speech recently stopped being built into the portal
+and became **modules** — separately published pieces a deployment installs. That is the intended
+direction, and on a hosted deployment nothing changed: the modules are fetched and installed, and
+the features are there.
+
+A portal running on someone's own machine has nowhere to fetch them from. Meanwhile the image still
+carried a list saying those five pieces were **mandatory**, and the portal checks that list before
+it declares itself healthy. The check was right — the pieces genuinely were missing — so the portal
+correctly refused to report healthy, and kept refusing. Every attempt to start ended the same way:
+several minutes of waiting, then a timeout, with the old portal still serving and the new one never
+taking over.
+
+The list is meant to be adjustable per deployment, precisely so an install that cannot provide a
+piece can say so. That adjustment never arrived: the setting was written in the deployment's
+configuration, and the packaging that hands configuration to the running portal had no line for it,
+so it was dropped in transit — silently, with every step reporting success.
+
+Now the setting reaches the portal, and a local install declares those five optional. It starts
+normally again; the affected features are simply absent there until a local install can fetch them.
+
+A related setting was worse than silent: the one that limits how often a portal may restart itself
+arrived as an empty value rather than a duration, which is not something a duration can be, so the
+portal stopped with an error instead of starting. It now carries a real default.
+
+Both belong to the same small family of settings that were written down but never delivered, and a
+check now fails the build when a new one joins them.

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using MeshWeaver.PluginCatalog;
 using Xunit;
 
@@ -265,6 +266,121 @@ public class PlatformBakeLaneGuard
             + string.Join(", ", missing.Select(x => $"{x.key} (set in {x.file})"))
             + ". Add each one to the configmap template — the values file alone does nothing.");
     }
+
+    /// <summary>
+    /// 🚨 The GENERAL form of the check above: <b>ANY</b> <c>config.memex_portal</c> key set in a
+    /// values file this repo ships must be BOUND in the configmap template.
+    ///
+    /// <para><b>Why the PreWarm-only version was not enough.</b> That check has existed for a
+    /// while and is correct — it is simply scoped to keys starting with <c>PreWarm__</c>, so the
+    /// same defect went on shipping under every other prefix. Three instances reached a running
+    /// deployment before this test existed:</para>
+    /// <list type="number">
+    ///   <item><c>Modules__Root</c> (#1924) — set in three AKS values files, rendered by nothing,
+    ///     so no module could ever be store-activated and <c>/mcp</c> answered 404.</item>
+    ///   <item><c>SelfUpdate__MinRollInterval</c>, <c>WebhookInbox__Targets__0</c>,
+    ///     <c>AzureFoundry__Models__3</c> (#1925/#1999) — the restart floor sat inert, and the
+    ///     typed one later crashed a portal outright on <c>'' is not a valid TimeSpan</c>.</item>
+    ///   <item><c>Modules__Required__N</c> — the AKS overlays blank five entries the image
+    ///     requires; un-templated, the override never arrived. On a laptop, where the modules
+    ///     cannot be landed instead, the health check held <c>/health</c> at 503 and every
+    ///     rollout timed out with the portal never serving.</item>
+    /// </list>
+    ///
+    /// <para>Two things make this test honest rather than noisy, and both were found by running
+    /// it:</para>
+    /// <list type="bullet">
+    ///   <item><b>Read the YAML, never the lines.</b> A line scan sweeps in the <c>secrets:</c>
+    ///     section, whose keys are legitimately bound in <c>secrets.yaml</c> under
+    ///     <c>.Values.secrets.memex_portal.*</c> — 19 false positives.</item>
+    ///   <item><b>Accept the intermediate-variable shape.</b> <c>Portal__BaseUrl</c> is emitted
+    ///     via <c>{{- $portalBaseUrl := … }}</c> so it can fall back to the ingress host. Demanding
+    ///     the literal one-line binding flags it wrongly; requiring the key to be EMITTED and its
+    ///     values path REFERENCED accepts both shapes and still cannot be satisfied by prose.</item>
+    /// </list>
+    /// </summary>
+    [Fact]
+    public void EveryConfigKeySetInAValuesFile_IsBoundInTheConfigMap()
+    {
+        var root = FindRepoRoot();
+        var configMap = File.ReadAllText(Path.Combine(
+            root, "deploy", "helm", "templates", "memex-portal", "config.yaml"));
+
+        var missing = new[]
+            {
+                Path.Combine(root, "deploy", "helm", "values.yaml"),
+                Path.Combine(root, "deploy", "aks", "values.aks.yaml"),
+                Path.Combine(root, "deploy", "homebrew", "share", "values.local.defaults.yaml"),
+            }
+            .Where(File.Exists)
+            .SelectMany(f => PortalConfigKeysOf(File.ReadAllLines(f))
+                .Select(key => (file: Path.GetFileName(f), key)))
+            .Distinct()
+            .Where(x => !IsWiredInConfigMap(configMap, x.key))
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "These config.memex_portal keys are set in a values file but never rendered by "
+            + "deploy/helm/templates/memex-portal/config.yaml. The configmap names every key "
+            + "explicitly and the Deployment's only env path is envFrom on it, so the setting "
+            + "reaches NO container — silently, with helm reporting success: "
+            + string.Join(", ", missing.Select(x => $"{x.key} (set in {x.file})"))
+            + ". Template each one — and give a TYPED key a real default, because '' is not a "
+            + "valid TimeSpan/int and crashes the portal at startup rather than reading as unset.");
+    }
+
+    /// <summary>
+    /// The keys under <c>config.memex_portal</c> of a values file — section-scoped, so the
+    /// <c>secrets:</c> block (bound in secrets.yaml, not here) never counts. Comments and nested
+    /// values are dropped; only mapping keys at the section's own indent are returned.
+    /// </summary>
+    private static IEnumerable<string> PortalConfigKeysOf(IEnumerable<string> lines)
+    {
+        var inConfig = false;
+        var inPortal = false;
+        foreach (var raw in lines)
+        {
+            if (raw.TrimStart().StartsWith('#') || raw.Trim().Length == 0)
+                continue;
+            var indent = raw.Length - raw.TrimStart().Length;
+            var line = raw.Trim();
+
+            if (indent == 0)
+            {
+                // A new top-level block ends whichever one we were in — this is what keeps
+                // `secrets:` out, and it is the whole reason the scan is section-aware.
+                inConfig = line.StartsWith("config:", StringComparison.Ordinal);
+                inPortal = false;
+                continue;
+            }
+            if (!inConfig)
+                continue;
+            if (indent == 2)
+            {
+                inPortal = line.StartsWith("memex_portal:", StringComparison.Ordinal);
+                continue;
+            }
+            if (!inPortal || indent != 4)
+                continue;
+            var colon = line.IndexOf(':');
+            if (colon <= 0)
+                continue;
+            var key = line[..colon].Trim();
+            if (key.Length > 0)
+                yield return key;
+        }
+    }
+
+    /// <summary>
+    /// Whether the configmap actually WIRES <paramref name="key"/>: it emits the key as a
+    /// configmap entry AND references its values path somewhere in the template. Both halves are
+    /// needed — emitting alone would accept a hard-coded value that ignores the deployment, and
+    /// referencing alone would accept a Helm variable computed and never written out. Together
+    /// they also accept the intermediate-variable shape, which the stricter one-line form rejects.
+    /// </summary>
+    private static bool IsWiredInConfigMap(string configMap, string key) =>
+        Regex.IsMatch(configMap, $@"^\s{{2}}{Regex.Escape(key)}:\s", RegexOptions.Multiline)
+        && configMap.Contains($".Values.config.memex_portal.{key}", StringComparison.Ordinal);
 
     /// <summary>
     /// 🚨 <b>An armed readiness gate with no sweep behind it is a SILENT LIE.</b>

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -268,6 +268,18 @@ public class PlatformBakeLaneGuard
     }
 
     /// <summary>
+    /// Keys a values file sets that reach the portal by a route OTHER than this configmap, and are
+    /// therefore legitimately unbound here. Named ONE BY ONE with the route — never a prefix, never
+    /// a whole-file exemption: an unexplained carve-out is how a guard stops being one.
+    ///
+    /// <para><c>Logging__LogLevel__Default</c> — memex-local applies verbose logging as a
+    /// DEPLOYMENT-config override after the helm release ("Applying verbose logging … as a
+    /// deployment-config override"), so it arrives as container env directly.</para>
+    /// </summary>
+    private static readonly HashSet<string> DeliveredOutOfBand =
+        new(StringComparer.Ordinal) { "Logging__LogLevel__Default" };
+
+    /// <summary>
     /// 🚨 The GENERAL form of the check above: <b>ANY</b> <c>config.memex_portal</c> key set in a
     /// values file this repo ships must be BOUND in the configmap template.
     ///
@@ -306,16 +318,24 @@ public class PlatformBakeLaneGuard
         var configMap = File.ReadAllText(Path.Combine(
             root, "deploy", "helm", "templates", "memex-portal", "config.yaml"));
 
+        // EVERY tracked file that becomes a values overlay — not only the three the chart is
+        // rendered with directly. values.deploy.example.yaml is copied to the overlay
+        // deploy/aks/scripts/deploy.sh passes, and values.local.yaml to the one memex-local
+        // generates for a new install; both carry config.memex_portal mappings, so an untemplated
+        // key added to either reaches no container in exactly the same way (Copilot review, #2104).
         var missing = new[]
             {
                 Path.Combine(root, "deploy", "helm", "values.yaml"),
                 Path.Combine(root, "deploy", "aks", "values.aks.yaml"),
+                Path.Combine(root, "deploy", "aks", "scripts", "values.deploy.example.yaml"),
                 Path.Combine(root, "deploy", "homebrew", "share", "values.local.defaults.yaml"),
+                Path.Combine(root, "deploy", "homebrew", "share", "values.local.yaml"),
             }
             .Where(File.Exists)
             .SelectMany(f => PortalConfigKeysOf(File.ReadAllLines(f))
                 .Select(key => (file: Path.GetFileName(f), key)))
             .Distinct()
+            .Where(x => !DeliveredOutOfBand.Contains(x.key))
             .Where(x => !IsWiredInConfigMap(configMap, x.key))
             .ToList();
 
@@ -378,9 +398,28 @@ public class PlatformBakeLaneGuard
     /// referencing alone would accept a Helm variable computed and never written out. Together
     /// they also accept the intermediate-variable shape, which the stricter one-line form rejects.
     /// </summary>
-    private static bool IsWiredInConfigMap(string configMap, string key) =>
-        Regex.IsMatch(configMap, $@"^\s{{2}}{Regex.Escape(key)}:\s", RegexOptions.Multiline)
-        && configMap.Contains($".Values.config.memex_portal.{key}", StringComparison.Ordinal);
+    private static bool IsWiredInConfigMap(string configMap, string key)
+    {
+        // 🚨 Judge EXECUTABLE template text only. Nine {{- /* … */}} blocks in that file name keys
+        // and their .Values paths in prose; one that writes its example line at the entries' own
+        // two-space indent satisfies BOTH halves below while templating nothing — verified by
+        // seeding exactly that shape, which this helper catches and the un-stripped form passes.
+        // "A check a comment can satisfy is not a check" (Copilot review, #2104).
+        var code = ExecutableTemplateOf(configMap);
+        return Regex.IsMatch(code, $@"^\s{{2}}{Regex.Escape(key)}:\s", RegexOptions.Multiline)
+            && code.Contains($".Values.config.memex_portal.{key}", StringComparison.Ordinal);
+    }
+
+    /// <summary>The template with its comments removed: Helm's own <c>{{/* … */}}</c> blocks —
+    /// which no '#'-stripping can reach — and YAML <c>#</c> lines.</summary>
+    private static string ExecutableTemplateOf(string template)
+    {
+        var withoutHelmComments = Regex.Replace(
+            template, @"\{\{-?\s*/\*.*?\*/\s*-?\}\}", "", RegexOptions.Singleline);
+        return string.Join("\n", withoutHelmComments
+            .Split('\n')
+            .Where(l => !l.TrimStart().StartsWith('#')));
+    }
 
     /// <summary>
     /// 🚨 <b>An armed readiness gate with no sweep behind it is a SILENT LIE.</b>


### PR DESCRIPTION
## What broke

`memex-local update` ended in `error: timed out waiting for the condition`, with the portal never serving:

```
required_modules Unhealthy: '5 required module(s) absent:
  MeshWeaver.Blazor.Radzen.dll, .Analysis.dll, .EntityViews.dll,
  .GoogleMaps.dll, MeshWeaver.Speech.dll —
  this image does not ship them and no install landed them.'
→ /health 503 → startup probe never passes → rollout times out
```

#1974/#2018/#2081/#2085 turned those five into **modules**, so the image stopped shipping DLLs its own `Modules:Required` list still names. The health check is behaving exactly as designed — `EntityViewsViewPackModuleAttribute` says a rollout that lost the pack *"must STALL on readiness"*. It stalled correctly; there was simply nothing to land.

A laptop has no registry to land them from — **memex-local IS the registry**, serving the developer's `MeshWeaver.Plugins` checkout — so "install the packages" is unavailable and delisting is the other half of what the health check itself suggests.

## Why the obvious workaround did nothing

The AKS overlays already blank these (Memex#87/#88/#94):

```yaml
Modules__Required__0: ""   # …through __4
```

**That override reaches no container.** The ConfigMap names every key explicitly, there is no catch-all range over `config.memex_portal`, and the Deployment's only env path is `envFrom` on it — so an un-templated key is dropped silently, with helm reporting success. It is inert on AKS only because those portals have a real registry and genuinely land the modules, satisfying the requirement rather than waiving it.

This is the **third occurrence** of that defect:

| key | consequence |
|---|---|
| `Modules__Root` (#1924) | no module could be store-activated; `/mcp` 404 |
| `SelfUpdate__MinRollInterval`, `WebhookInbox__Targets__0`, `AzureFoundry__Models__3` (#1925/#1999) | restart floor inert; once templated **without a default** it crashed a portal on `'' is not a valid TimeSpan` |
| `Modules__Required__0..4` | this one |

## The fix: gate the class, not the key

`PlatformBakeLaneGuard` already asserts exactly this rule — scoped to `PreWarm__*`. Widened to **every** `config.memex_portal` key.

**Red**, on this tree with the values-side blanks but no template:

```
EveryConfigKeySetInAValuesFile_IsBoundInTheConfigMap  FAILED
  Modules__Required__0..4 (set in values.local.defaults.yaml)
Failed: 1, Passed: 0
```

**Green** after templating: **42/42**, `check-chart-invariants` green on all three combinations.

Renders — an install that overrides nothing is byte-for-byte unchanged:

| combination | `Modules__Required__*` emitted |
|---|---|
| neutral chart defaults | 0 |
| AKS overlay | 0 |
| memex-local | 5 |

## Two things the test found by being run

Both are now comments in the code rather than tribal knowledge:

1. **Read the YAML section, never the lines.** A flat line scan sweeps in the `secrets:` block, whose keys are legitimately bound in `secrets.yaml` under `.Values.secrets.memex_portal.*` — 19 false positives.
2. **Emitted AND referenced**, not the literal one-line binding. `Portal__BaseUrl` is written through `{{- $portalBaseUrl := … }}` so it can fall back to the ingress host; the strict form flags it wrongly.

## …and it caught this PR's own first draft

The block originally emitted the indices from a `{{- range }}`. That renders correctly and is **invisible** to a guard that looks for the key — so helm passed and the test failed, correctly. This ConfigMap's contract is that it *names* every key, so the range was the wrong shape. Written out index by index instead, each emitted only when a deployment sets it, so no install gets entry 0 blanked out from under it.

## Verification

```
dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror   0 Warning(s) 0 Error(s)
dotnet test  test/MeshWeaver.Documentation.Test                          42/42 passed
deploy/aks/scripts/check-chart-invariants.sh                             all 3 combinations, exit 0
```

Applied to a live memex-local: ConfigMap carries the five blanks, rollout completes, `/healthz` 200, `POST /mcp` 401.

Ships a What's New entry — a portal that will not start is user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
