### PR TITLE
docs(skill): the share-email PDF limitation is stale — embeds DO render

### DIFF
--- a/content/ai/Skill/share-email.md
+++ b/content/ai/Skill/share-email.md
@@ -68,8 +68,27 @@ Graph is the system of record and always current. **Do not ingest, sync or mirro
 
 All Graph calls go through `IIoPool` and return `IObservable<T>`; never `async`/`await` in hub or Blazor code, never `Observable.FromAsync`.
 
-# 5. Known limitation — state it honestly
+# 5. What each path does with embedded areas and raw HTML
 
-**Export to PDF and DOCX do NOT render embedded layout areas.** The document builder's Markdig pipeline omits the layout-area extension, so an `@@("area:…")` embed prints as **literal source text**; the pixel deck path prints it **blank**. Only the email/HTML path resolves areas. If a user needs a PDF of a document with embedded views, tell them this rather than letting them send a broken document.
+**Embedded layout areas DO render in a PDF export.** `DocumentBuilder` resolves them
+(`LayoutAreaComponentInfo` → `ResolveArea`), and an area that resolved to nothing carries a visible
+notice rather than disappearing. Verified 2026-08-23 on a document with five `@@("area:OgCard…")`
+embeds: every card printed with its title, description and link. This section previously claimed the
+opposite — that an embed prints as literal source text — which was true before the resolution pass
+existed and is not true now. Do not repeat it.
+
+**Raw HTML in the document body renders too, since MeshWeaver.Plugins#606.** Before that fix
+`DocumentBuilder` downgraded every `HtmlBlock` to a code block, so a document whose layout is raw
+HTML — hero bands, styled callouts, HTML tables, inline SVG — printed its own markup. If you meet
+that symptom, the deployment is running a module build older than #606, not hitting a design limit.
+
+**What genuinely does not survive a PDF**, and is worth saying to a user up front:
+
+- the **pixel deck path** prints an unresolved embed **blank**;
+- **anything resolved in the browser after first render** — a layout area is resolved server-side for
+  the export, so a view that only fills in from a live circuit has nothing to contribute;
+- the **email** path is the one that downgrades on purpose: `HtmlDowngrade` strips `svg` and `style`
+  because Outlook renders through the Word engine. So a document whose diagrams are inline SVG is
+  **better as a PDF** and worse as an email body — the opposite of what this section used to imply.
 
 Reference: [Sending Email](/Doc/Architecture/SendingEmail).


### PR DESCRIPTION
`/share-email` §5 told every agent that:

> **Export to PDF and DOCX do NOT render embedded layout areas.** …an `@@("area:…")` embed prints as **literal source text**… If a user needs a PDF of a document with embedded views, **tell them this rather than letting them send a broken document.**

That was true before `DocumentBuilder` gained its resolution pass. It is not true now — `LayoutAreaComponentInfo` → `ResolveArea` resolves embeds, and an area that resolved to nothing carries a visible notice rather than vanishing.

**Verified rather than assumed**: a real PDF export of a document carrying five `@@("area:OgCard…")` embeds printed every card with its title, description and link.

## Why this one mattered

The section is not passive documentation — it instructs the agent to **talk the user out of the export**. A stale warning there steers people away from the artifact that actually works, which is exactly what happened: it was quoted at a user this week as a reason a PDF would be broken.

## What replaces it

The three things that are *genuinely* lossy, so the section still earns its place:

- the **pixel deck path** prints an unresolved embed **blank**;
- anything resolved in the browser **after** first render has nothing to contribute to a server-side export;
- the **email** path is the one that downgrades on purpose — `HtmlDowngrade` strips `svg` and `style` for Outlook's Word engine.

That last point **inverts the old advice**: a document whose diagrams are inline SVG is *better* as a PDF and worse as an email body.

It also records that raw HTML in a document body renders since MeshWeaver.Plugins#606, so an agent meeting the old symptom knows it means a **stale module build**, not a design limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)