### PR TITLE
Fix Azure Npgsql auth selection: isAzure && !hasPassword, not a substring match

### DIFF
--- a/memex/Memex.Portal.Shared/Storage/MemexInfraOptions.cs
+++ b/memex/Memex.Portal.Shared/Storage/MemexInfraOptions.cs
@@ -50,7 +50,11 @@ public sealed record MeshPgStorageConfig
     public required string Name { get; init; }
 
     /// <summary>Connection string. May reference a secret (resolved out of the config-file value at load).
-    /// Contains <c>database.azure.com</c> ⇒ the Azure-Npgsql auth path; otherwise plain Npgsql.</summary>
+    /// Auth is selected by <c>MeshWeaver.Hosting.PostgreSql.AzurePostgres</c>: an Azure host
+    /// (<c>Host</c> ends in <c>.postgres.database.azure.com</c>) with NO password ⇒ the Entra-ID
+    /// token path; an Azure host WITH a password, or any non-Azure host ⇒ plain Npgsql. (Never a
+    /// substring match on the whole string — that both false-matches and ignores the password,
+    /// which crashes the portal when a token provider meets a password.)</summary>
     public required string ConnectionString { get; init; }
 
     /// <summary>Disabled entries are ignored by the reconciler (soft remove without deleting the entry).</summary>

--- a/memex/aspire/Memex.Database.Migration/Migrations/OrleansClusteringSetup.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/OrleansClusteringSetup.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Hosting.PostgreSql;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using System.Linq;
@@ -266,7 +267,9 @@ public static class OrleansClusteringSetup
     /// </summary>
     private static async Task EnsureDatabaseExistsAsync(string connectionString, ILogger logger)
     {
-        if (connectionString.Contains("database.azure.com", StringComparison.OrdinalIgnoreCase))
+        // Azure pre-creates databases declared in the AppHost and the app identity typically
+        // cannot CREATE DATABASE on Flexible Server — a HOST fact, independent of the auth path.
+        if (AzurePostgres.IsAzureHost(connectionString))
             return;
 
         var targetDb = new NpgsqlConnectionStringBuilder(connectionString).Database ?? "orleans";

--- a/memex/aspire/Memex.Database.Migration/Migrations/SchemaInitialization.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/SchemaInitialization.cs
@@ -26,8 +26,9 @@ public static class SchemaInitialization
         ILogger logger)
     {
         // Azure-only: grant CREATE on database to azure_pg_admin so managed identities
-        // (portal, migration) can create per-organization schemas at runtime.
-        if (connectionString.Contains("database.azure.com"))
+        // (portal, migration) can create per-organization schemas at runtime. A HOST fact
+        // (the azure_pg_admin role exists only on Azure), independent of the auth mechanism.
+        if (AzurePostgres.IsAzureHost(connectionString))
         {
             var dbName = new NpgsqlConnectionStringBuilder(connectionString).Database;
             await using var grantCmd = dataSource.CreateCommand(

--- a/memex/aspire/Memex.Database.Migration/Program.cs
+++ b/memex/aspire/Memex.Database.Migration/Program.cs
@@ -31,7 +31,10 @@ builder.AddServiceDefaults();
 
 var connectionString = builder.Configuration.GetConnectionString("memex") ?? "";
 Console.WriteLine($"[Migration] ConnectionString: {(string.IsNullOrEmpty(connectionString) ? "(empty)" : connectionString[..Math.Min(30, connectionString.Length)] + "...")}");
-if (connectionString.Contains("database.azure.com"))
+// Entra-ID token path ONLY for an Azure host with no password; an Azure host reached with a
+// password takes plain Npgsql (AddAzureNpgsqlDataSource wires a token provider that throws on
+// connect when a password is also present). See AzurePostgres for the full rationale.
+if (AzurePostgres.UsesManagedIdentityAuth(connectionString))
     builder.AddAzureNpgsqlDataSource("memex");
 else
     builder.AddNpgsqlDataSource("memex");
@@ -68,9 +71,11 @@ logger.LogInformation("Running database migration...");
 //   2. A self-managed Postgres (the pgvector container in Compose/Helm) does NOT pre-create
 //      the app database the way managed Azure Postgres does — connect to the maintenance
 //      'postgres' database and CREATE it if missing.
-// Managed Azure Postgres pre-creates the database and uses a credential provider on the
-// data source, so for that path we just probe the data source directly.
-var isAzurePg = connectionString.Contains("database.azure.com");
+// Managed Azure Postgres pre-creates the database (declared in the AppHost) and the app identity
+// typically cannot CREATE DATABASE on Flexible Server, so for that path we just probe the data
+// source directly. This is a HOST fact — true whether the connection uses a token or a password —
+// so it keys on the host, not on the auth mechanism.
+var isAzurePg = AzurePostgres.IsAzureHost(connectionString);
 var pgReadyDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(120);
 while (true)
 {

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -143,7 +143,12 @@ else
 // Single shared pool for all partition queries (schema-qualified SQL).
 // Pool size must handle parallel fan-out across all schemas.
 var connectionString = builder.Configuration.GetConnectionString("memex") ?? "";
-if (connectionString.Contains("database.azure.com"))
+// Select the Entra-ID token path ONLY for an Azure host with NO password. A fully-qualified Azure
+// host reached with username+password must take the plain Npgsql path — AddAzureNpgsqlDataSource
+// wires a token password provider, and Npgsql throws NotSupportedException on connect when a
+// password is ALSO present, which SIGABRTs the portal via PostgreSqlChangeListener. (Was a
+// substring match on the whole string, which both false-matches and ignores the password.)
+if (AzurePostgres.UsesManagedIdentityAuth(connectionString))
     builder.AddAzureNpgsqlDataSource("memex",
         configureDataSourceBuilder: dsb =>
         {
@@ -158,6 +163,10 @@ else
             dsb.UseVector();
             dsb.ConnectionStringBuilder.MaxPoolSize = 50;
             dsb.ConnectionStringBuilder.ConnectionIdleLifetime = 30;
+            // Azure Flexible Server requires SSL; enforce it on the password path too so a config
+            // string without an explicit SslMode still connects (28000: no pg_hba.conf entry …).
+            if (AzurePostgres.IsAzureHost(connectionString))
+                dsb.ConnectionStringBuilder.SslMode = SslMode.Require;
         });
 
 // Disable dev login in the distributed deployment by default (prod-safety): a real
@@ -259,6 +268,43 @@ var configurePubSubStore = useAdoNetClustering
     }))
     : null;
 
+// How the PARTITIONED persistence provider (and the change listener it spins up via the same
+// hook — see PostgreSqlPartitionStorageProvider.CreateChangeListenerDataSource) authenticates.
+// The Entra-ID token provider is wired ONLY for an Azure host with NO password; wiring it when a
+// password is present throws NotSupportedException on connect and SIGABRTs the portal. On any
+// Azure host, SSL is forced (Flexible Server requires it) whichever auth path we take.
+Action<NpgsqlDataSourceBuilder>? configurePersistenceDataSource;
+if (AzurePostgres.UsesManagedIdentityAuth(connectionString))
+    configurePersistenceDataSource = dsb =>
+    {
+        dsb.ConnectionStringBuilder.SslMode = SslMode.Require;
+        // In an AKS pod only the SERVER-SIDE credentials exist (Environment, Workload Identity,
+        // Managed Identity). Excluding the dev-machine credentials stops DefaultAzureCredential
+        // from probing — and dumping a ~30-line CredentialUnavailableException stack trace for —
+        // Azure CLI / PowerShell / azd / Visual Studio on every token acquisition (the
+        // credential-chain log noise on the portal pods). The credential that actually succeeds
+        // (Workload/Managed Identity) is unchanged.
+        var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
+        {
+            ExcludeAzureCliCredential = true,
+            ExcludeAzurePowerShellCredential = true,
+            ExcludeAzureDeveloperCliCredential = true,
+            ExcludeVisualStudioCredential = true,
+            ExcludeInteractiveBrowserCredential = true,
+        });
+        dsb.UsePeriodicPasswordProvider(async (_, ct) =>
+        {
+            var token = await credential.GetTokenAsync(
+                new Azure.Core.TokenRequestContext(["https://ossrdbms-aad.database.windows.net/.default"]), ct);
+            return token.Token;
+        }, TimeSpan.FromMinutes(4), TimeSpan.FromSeconds(10));
+    };
+else if (AzurePostgres.IsAzureHost(connectionString))
+    // Azure host reached with a password: no token provider (it would throw), but still force SSL.
+    configurePersistenceDataSource = dsb => dsb.ConnectionStringBuilder.SslMode = SslMode.Require;
+else
+    configurePersistenceDataSource = null;
+
 var address = AddressExtensions.CreateMeshAddress();
 builder.UseOrleansMeshServer(address, silo =>
     {
@@ -319,32 +365,7 @@ builder.UseOrleansMeshServer(address, silo =>
     )
     .ConfigureServices(services => services
         .AddPartitionedPostgreSqlPersistence(
-            configureDataSource: connectionString.Contains("database.azure.com")
-                ? dsb =>
-                {
-                    // In an AKS pod only the SERVER-SIDE credentials exist (Environment,
-                    // Workload Identity, Managed Identity). Excluding the dev-machine
-                    // credentials stops DefaultAzureCredential from probing — and dumping a
-                    // ~30-line CredentialUnavailableException stack trace for — Azure CLI /
-                    // PowerShell / azd / Visual Studio on every token acquisition (the
-                    // credential-chain log noise on the portal pods). The credential that
-                    // actually succeeds (Workload/Managed Identity) is unchanged.
-                    var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
-                    {
-                        ExcludeAzureCliCredential = true,
-                        ExcludeAzurePowerShellCredential = true,
-                        ExcludeAzureDeveloperCliCredential = true,
-                        ExcludeVisualStudioCredential = true,
-                        ExcludeInteractiveBrowserCredential = true,
-                    });
-                    dsb.UsePeriodicPasswordProvider(async (_, ct) =>
-                    {
-                        var token = await credential.GetTokenAsync(
-                            new Azure.Core.TokenRequestContext(["https://ossrdbms-aad.database.windows.net/.default"]), ct);
-                        return token.Token;
-                    }, TimeSpan.FromMinutes(4), TimeSpan.FromSeconds(10));
-                }
-                : null))
+            configureDataSource: configurePersistenceDataSource))
     .ConfigureMemexMesh(builder.Configuration, builder.Environment.IsDevelopment())
     .ConfigureMemexPortal(builder.Configuration)
     // 🚨 Register the "storage" SOURCE collection at mesh level — the backing store that every

--- a/src/MeshWeaver.Hosting.PostgreSql/AzurePostgres.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/AzurePostgres.cs
@@ -1,0 +1,81 @@
+using System;
+using Npgsql;
+
+namespace MeshWeaver.Hosting.PostgreSql;
+
+/// <summary>
+/// Decides — from the connection string alone — how a Postgres connection authenticates, so that
+/// every caller selects the Azure Entra-ID (managed-identity) token path by the SAME rule.
+///
+/// <para>The rule callers kept getting wrong was a substring match on the whole connection string:
+/// <c>connectionString.Contains("database.azure.com")</c>. That is wrong twice over, and the
+/// second way is a production crash:</para>
+/// <list type="number">
+/// <item>A substring can false-match a password, database or application name that merely contains
+/// the text — it does not tell you the <em>host</em> is Azure-managed.</item>
+/// <item>It ignores whether a PASSWORD is present. Aspire's <c>AddAzureNpgsqlDataSource</c> — and
+/// every hand-wired <c>UsePeriodicPasswordProvider</c> / <c>UsePasswordProvider</c> — registers a
+/// token password provider, and Npgsql throws
+/// <c>NotSupportedException: "When registering a password provider, a password or password file
+/// may not be set"</c> the instant a connection opens if the string ALSO carries a password. On
+/// the portal that surfaces as <c>PostgreSqlChangeListener</c> faulting and the process aborting
+/// (SIGABRT). So a fully-qualified Azure host reached with username+password MUST take the plain
+/// Npgsql (password) path, never the Entra path.</item>
+/// </list>
+///
+/// <para>The canonical implementation this mirrors is
+/// <c>Memex.Database.Migration/Migrations/SchemaHelpers.BuildSchemaDataSource</c>
+/// (<c>isAzure = host ends in the Azure suffix</c>; token provider wired only when
+/// <c>isAzure &amp;&amp; !hasPassword</c>).</para>
+/// </summary>
+public static class AzurePostgres
+{
+    /// <summary>The Azure Database for PostgreSQL (Flexible/Single Server) host suffix.</summary>
+    public const string HostSuffix = ".postgres.database.azure.com";
+
+    /// <summary>
+    /// True when the connection string targets an Azure-managed Postgres — its <c>Host</c> ends in
+    /// <see cref="HostSuffix"/>. A HOST test, never a substring match on the whole string: a
+    /// password or database name that happens to contain the suffix does not make a server
+    /// Azure-managed. An empty or unparseable connection string is not Azure.
+    /// </summary>
+    public static bool IsAzureHost(string? connectionString)
+        => TryParse(connectionString, out var csb)
+           && csb.Host?.EndsWith(HostSuffix, StringComparison.OrdinalIgnoreCase) == true;
+
+    /// <summary>
+    /// True when the connection must authenticate with an Azure Entra-ID (managed-identity) TOKEN
+    /// rather than a password — i.e. it targets an Azure host AND carries no password. This is the
+    /// ONLY condition under which a token password provider (<c>AddAzureNpgsqlDataSource</c> /
+    /// <c>UsePeriodicPasswordProvider</c> / <c>UsePasswordProvider</c>) may be wired; wiring it
+    /// when a password is present makes Npgsql throw on connect (see the class remarks).
+    /// </summary>
+    public static bool UsesManagedIdentityAuth(string? connectionString)
+        => TryParse(connectionString, out var csb)
+           && csb.Host?.EndsWith(HostSuffix, StringComparison.OrdinalIgnoreCase) == true
+           && string.IsNullOrEmpty(csb.Password);
+
+    /// <summary>
+    /// Parse a connection string, treating ANY failure (null/empty/whitespace, an unknown keyword,
+    /// a malformed pair) as "not a connection string we can classify" → the caller falls to the
+    /// plain path, where the real parse error surfaces when the data source is actually built.
+    /// Npgsql's parser throws several unrelated types for malformed input
+    /// (<see cref="System.ArgumentException"/>, <see cref="System.Collections.Generic.KeyNotFoundException"/>,
+    /// <see cref="FormatException"/>), so this catch is deliberately broad.
+    /// </summary>
+    private static bool TryParse(string? connectionString, out NpgsqlConnectionStringBuilder csb)
+    {
+        csb = null!;
+        if (string.IsNullOrWhiteSpace(connectionString))
+            return false;
+        try
+        {
+            csb = new NpgsqlConnectionStringBuilder(connectionString);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/AzurePostgresAuthSelectionTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/AzurePostgresAuthSelectionTests.cs
@@ -18,14 +18,14 @@ namespace MeshWeaver.Hosting.PostgreSql.Test;
 /// </summary>
 public class AzurePostgresAuthSelectionTests
 {
-    private const string AzureHost = "memexaks-pg.postgres.database.azure.com";
+    private const string AzureHost = "memexaks-pg.postgres.database.azure.com"; // local-only-guard:allow — parse-only fixture, never connects
 
     // ---- IsAzureHost: a HOST test, never a whole-string substring match --------------------
 
     [Theory]
-    [InlineData("Host=memexaks-pg.postgres.database.azure.com;Database=memex;Username=app")]
-    [InlineData("Host=memexaks-pg.postgres.database.azure.com;Database=memex;Username=app;Password=secret")]
-    [InlineData("Host=MEMEXAKS-PG.POSTGRES.DATABASE.AZURE.COM;Database=memex")] // case-insensitive suffix
+    [InlineData("Host=memexaks-pg.postgres.database.azure.com;Database=memex;Username=app")] // local-only-guard:allow
+    [InlineData("Host=memexaks-pg.postgres.database.azure.com;Database=memex;Username=app;Password=secret")] // local-only-guard:allow
+    [InlineData("Host=MEMEXAKS-PG.POSTGRES.DATABASE.AZURE.COM;Database=memex")] // case-insensitive suffix; local-only-guard:allow
     public void AzureHost_IsRecognised(string connectionString)
         => Assert.True(AzurePostgres.IsAzureHost(connectionString));
 
@@ -41,7 +41,7 @@ public class AzurePostgresAuthSelectionTests
     {
         // The suffix appears in the DATABASE and PASSWORD but the HOST is local — the substring
         // bug matched this; the host test must not.
-        const string cs = "Host=localhost;Database=database.azure.com;Username=app;Password=pw.postgres.database.azure.com";
+        const string cs = "Host=localhost;Database=database.azure.com;Username=app;Password=pw.postgres.database.azure.com"; // local-only-guard:allow — suffix in DB/password, host is local
         Assert.False(AzurePostgres.IsAzureHost(cs));
         Assert.False(AzurePostgres.UsesManagedIdentityAuth(cs));
     }

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/AzurePostgresAuthSelectionTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/AzurePostgresAuthSelectionTests.cs
@@ -1,0 +1,94 @@
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Pins <see cref="AzurePostgres"/> — the ONE rule that decides whether a Postgres connection
+/// authenticates with an Entra-ID token or a password. These are pure (no container, no fixture),
+/// so they run in the unit lane, not the <c>[Collection("PostgreSql")]</c> integration lane.
+///
+/// <para>The regression this guards is a production SIGABRT: selecting the Azure token provider by
+/// a substring match on the whole connection string wired <c>UsePeriodicPasswordProvider</c> onto
+/// a data source that ALSO carried a password (a fully-qualified Azure host reached with
+/// username+password). Npgsql then threw
+/// <c>NotSupportedException: "When registering a password provider, a password or password file
+/// may not be set"</c> on the first connect, faulting <c>PostgreSqlChangeListener</c> and aborting
+/// the portal. So the load-bearing case is
+/// <see cref="AzureHostWithPassword_DoesNotUseManagedIdentity"/>.</para>
+/// </summary>
+public class AzurePostgresAuthSelectionTests
+{
+    private const string AzureHost = "memexaks-pg.postgres.database.azure.com";
+
+    // ---- IsAzureHost: a HOST test, never a whole-string substring match --------------------
+
+    [Theory]
+    [InlineData("Host=memexaks-pg.postgres.database.azure.com;Database=memex;Username=app")]
+    [InlineData("Host=memexaks-pg.postgres.database.azure.com;Database=memex;Username=app;Password=secret")]
+    [InlineData("Host=MEMEXAKS-PG.POSTGRES.DATABASE.AZURE.COM;Database=memex")] // case-insensitive suffix
+    public void AzureHost_IsRecognised(string connectionString)
+        => Assert.True(AzurePostgres.IsAzureHost(connectionString));
+
+    [Theory]
+    [InlineData("Host=localhost;Database=memex;Username=postgres;Password=postgres")]
+    [InlineData("Host=127.0.0.1;Port=5432;Database=memex")]
+    [InlineData("Host=pgvector;Database=memex;Username=app;Password=app")] // Compose/Helm container
+    public void NonAzureHost_IsNotAzure(string connectionString)
+        => Assert.False(AzurePostgres.IsAzureHost(connectionString));
+
+    [Fact]
+    public void SuffixInPasswordOrDatabase_DoesNotFalseMatch()
+    {
+        // The suffix appears in the DATABASE and PASSWORD but the HOST is local — the substring
+        // bug matched this; the host test must not.
+        const string cs = "Host=localhost;Database=database.azure.com;Username=app;Password=pw.postgres.database.azure.com";
+        Assert.False(AzurePostgres.IsAzureHost(cs));
+        Assert.False(AzurePostgres.UsesManagedIdentityAuth(cs));
+    }
+
+    // ---- UsesManagedIdentityAuth: Azure host AND no password -------------------------------
+
+    [Fact]
+    public void AzureHostWithoutPassword_UsesManagedIdentity()
+    {
+        var cs = $"Host={AzureHost};Database=memex;Username=db_migration_identity";
+        Assert.True(AzurePostgres.IsAzureHost(cs));
+        Assert.True(AzurePostgres.UsesManagedIdentityAuth(cs));
+    }
+
+    [Fact] // THE regression guard: Azure host + password must NOT take the token path.
+    public void AzureHostWithPassword_DoesNotUseManagedIdentity()
+    {
+        var cs = $"Host={AzureHost};Database=memex;Username=app;Password=super-secret";
+        Assert.True(AzurePostgres.IsAzureHost(cs));          // still an Azure host …
+        Assert.False(AzurePostgres.UsesManagedIdentityAuth(cs)); // … but the plain (password) path
+    }
+
+    [Fact]
+    public void AzureHostWithEmptyPassword_UsesManagedIdentity()
+    {
+        // An explicit empty password is still "no password" — the token path applies.
+        var cs = $"Host={AzureHost};Database=memex;Username=app;Password=";
+        Assert.True(AzurePostgres.UsesManagedIdentityAuth(cs));
+    }
+
+    [Fact]
+    public void NonAzureHostWithoutPassword_DoesNotUseManagedIdentity()
+    {
+        const string cs = "Host=localhost;Database=memex;Username=postgres";
+        Assert.False(AzurePostgres.UsesManagedIdentityAuth(cs));
+    }
+
+    // ---- Degenerate inputs: null / empty / unparseable → not Azure (fall to plain path) -----
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("this is not a connection string ===")]
+    public void NullEmptyOrUnparseable_IsNotAzureAndNotManagedIdentity(string? connectionString)
+    {
+        Assert.False(AzurePostgres.IsAzureHost(connectionString));
+        Assert.False(AzurePostgres.UsesManagedIdentityAuth(connectionString));
+    }
+}


### PR DESCRIPTION
## What

The portal and migration selected the Azure Entra-ID token auth path by `connectionString.Contains("database.azure.com")`. That is wrong twice over, and the second way is a **production crash (SIGABRT)**:

1. A substring match on the whole connection string false-matches a password, database or application name that merely contains the text — it does not tell you the **host** is Azure-managed.
2. It ignores whether a **password** is present. Aspire's `AddAzureNpgsqlDataSource` (and hand-wired `UsePeriodicPasswordProvider`) registers a token password provider, and Npgsql throws `NotSupportedException: "When registering a password provider, a password or password file may not be set"` the instant a connection opens if the string **also** carries a password. On a fully-qualified Azure host reached with `username+password` this surfaces via `PostgreSqlChangeListenerHostedService → PostgreSqlChangeListener` faulting and the process aborting.

The correct rule already exists in `Memex.Database.Migration/Migrations/SchemaHelpers.BuildSchemaDataSource`: host ends in `.postgres.database.azure.com` **AND** password is empty. This PR lifts that rule into a shared, unit-tested predicate and applies it at every token-provider selection site.

## Changes

- **New `MeshWeaver.Hosting.PostgreSql.AzurePostgres`** (Npgsql-only; referenced by both crash-path projects):
  - `IsAzureHost(cs)` — host-suffix test (never a substring match).
  - `UsesManagedIdentityAuth(cs)` — Azure host **and** no password; the **only** condition under which a token provider may be wired. Any parse failure → not Azure (falls to the plain path).
- **Auth-selection sites** now key on `UsesManagedIdentityAuth`:
  - `Memex.Portal.Distributed/Program.cs` — the `memex` data source **and** the partitioned-persistence `configureDataSource` hook (which the change listener inherits via `PostgreSqlPartitionStorageProvider.CreateChangeListenerDataSource`).
  - `Memex.Database.Migration/Program.cs` — the migration data source.
  - On the **Azure host + password** path, `SslMode.Require` is forced (Flexible Server requires SSL; a cloned/plain builder would otherwise hit `28000: no pg_hba.conf entry … no encryption`).
- **Azure-infra sites** (readiness probe, `azure_pg_admin` GRANT, skip `CREATE DATABASE`) are host facts independent of auth — moved off the fragile substring onto `IsAzureHost`, behavior unchanged.
- **Doc comment** in `MemexInfraOptions.ConnectionString` updated to the real rule.
- **Regression test** `AzurePostgresAuthSelectionTests` pins the truth table; the load-bearing case is **Azure host + password → plain path (no token provider)**.

`SchemaHelpers.cs` is intentionally **unchanged** — it is the canonical reference this mirrors.

## Verification

- `dotnet build` (net10, warnings-as-errors) green: `MeshWeaver.Hosting.PostgreSql`, `Memex.Database.Migration`, `Memex.Portal.Distributed`, and the test project — 0 warnings / 0 errors each.
- `dotnet test` — `AzurePostgresAuthSelectionTests`: **15/15 passed**.
- Reviewed independently against the live crash traces: the `:322` hoist is confirmed to be the `configureDataSource` hook that `PostgreSqlPartitionStorageProvider.CreateChangeListenerDataSource` inherits — i.e. the exact builder that carried `UsePeriodicPasswordProvider` onto the change listener and aborted the portal (`PostgreSqlChangeListenerHostedService → PostgreSqlChangeListener → NotSupportedException`).

## Follow-up (non-blocking, tracked separately)

The 15 tests are **pure predicate tests** — they pin `IsAzureHost` / `UsesManagedIdentityAuth`, but nothing asserts that `Program.cs` still *calls* them at both wiring sites. A future edit collapsing the `:322` three-way branch back to a host-only ternary would keep all 15 green while re-hiding the second site — the exact failure mode this PR fixes. The right guard is an integration test that builds an Azure-host+password data source through the actual configurator and asserts `NpgsqlDataSourceBuilder.Build()` does **not** throw `NotSupportedException`; that requires extracting the credential configurator out of Program.cs top-level statements into a Memex-portal test project, so it is deliberately left as a follow-up rather than scope-creeping this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
