### PR TITLE
Keep the prompt PREFIX stable so every AI driver's cache can hit it

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -516,15 +516,9 @@ public class AgentChatClient : IAgentChat
     /// </summary>
     private async Task<ImmutableList<DataContent>> AppendContextAndAttachmentsAsync(StringBuilder messageText)
     {
-        // 🕰️ WHAT DAY IS IT (#1651). Nothing else in the pipeline told the agent, so every model
-        // answered "what day is today" — and every relative expression a scheduling agent computes
-        // off it — from its training priors. It belongs HERE, in the per-round block, and NOT in
-        // the agent's instructions: agents are built once and cached while a thread lives for days,
-        // so an instruction-time date goes stale and is then confidently wrong in exactly the way
-        // this fixes. Rendered in the viewer's own zone (never .ToLocalTime(), which in the UTC
-        // deployment container is a no-op) plus the ISO-8601 `Z` instant for anything the agent
-        // feeds back into a tool. See CurrentTimeContext.
-        messageText.Append(CurrentTimeContext.Describe(DateTimeOffset.UtcNow, ResolveViewerZoneId()));
+        // 🕰️ WHAT DAY IS IT (#1651) is NOT composed here any more — it is the single most volatile
+        // string in the prompt (seconds precision) and this block is a PREFIX. See
+        // AppendVolatileRoundContext, which puts it at the TAIL where it cannot break the cache.
 
         // Dynamic part: context (changes per navigation)
         if (Context != null)
@@ -639,6 +633,39 @@ public class AgentChatClient : IAgentChat
 
         return binaryAttachments;
     }
+
+    /// <summary>
+    /// The VOLATILE half of the round context — today the date/time block — rendered for appending
+    /// at the very END of the prompt, after the instructions, the context and the whole
+    /// conversation history.
+    ///
+    /// <para>🚨 <b>Position is a COST decision, not a formatting one.</b> Every provider's prompt
+    /// cache is a PREFIX match, so the first token that differs invalidates everything behind it.
+    /// <see cref="CurrentTimeContext"/> renders the UTC instant at SECONDS precision, and it used
+    /// to be composed into the block that is folded into the agent's SYSTEM message — the FIRST
+    /// message of the turn. So the clock ticking between two rounds invalidated the instructions,
+    /// the application context, the entire history and every document the agent had pulled.</para>
+    ///
+    /// <para>Measured against Azure Foundry DeepSeek on 2026-08-23, same 13,040-token prompt:
+    /// with the timestamp in the system message the cache hit rate was <b>0%</b> on every call;
+    /// with the identical prefix and the timestamp moved to the tail it reached <b>98.2%</b>.
+    /// Production sat at 53% — the within-a-round hits (the system message is composed once per
+    /// round, so tool iterations DID cache) minus a full-prefix miss on every new round.</para>
+    ///
+    /// <para>It hits EVERY driver, not just Foundry, and it is worse than a missed discount on the
+    /// ones that cache explicitly: the Anthropic client marks the system prompt with an ephemeral
+    /// <c>cache_control</c> breakpoint, so a volatile system prompt made it WRITE a cache entry
+    /// every round — at the 1.25x write premium — and never read one back. A live thread showed
+    /// exactly that: <c>cacheWriteTokens: 9068</c> against <c>cacheRead: 0</c>.</para>
+    ///
+    /// <para>Appending to the last USER message (rather than adding a trailing system message)
+    /// keeps the turn's message count and role sequence untouched, so no provider sees a second
+    /// system message or two consecutive user turns, and truncation — which never trims the
+    /// current user turn — cannot drop it.</para>
+    /// </summary>
+    /// <returns>The volatile block, ending in a blank line; never null.</returns>
+    private string BuildVolatileRoundContext() =>
+        CurrentTimeContext.Describe(DateTimeOffset.UtcNow, ResolveViewerZoneId());
 
     /// <summary>
     /// The zone the round's date/time block is rendered in — the SUBMITTER's named IANA zone.
@@ -760,6 +787,13 @@ public class AgentChatClient : IAgentChat
             text = await InlineReferenceResolver.ResolveAsync(text, hub, this).ConfigureAwait(false);
             messageText.Append(text);
         }
+
+        // 🕰️ The volatile block goes LAST — after the instructions, the context and every user
+        // message — so the whole stable prefix stays byte-identical between rounds and the
+        // provider's prompt cache can actually hit it. See BuildVolatileRoundContext.
+        messageText.AppendLine();
+        messageText.AppendLine();
+        messageText.Append(BuildVolatileRoundContext());
 
         return (messageText.ToString(), binaryAttachments);
     }
@@ -1024,6 +1058,32 @@ public class AgentChatClient : IAgentChat
         if (!string.IsNullOrEmpty(systemText))
             turnMessages.Add(new ChatMessage(ChatRole.System, systemText));
         turnMessages.AddRange(messages);
+
+        // 🕰️ The volatile per-round block (the clock) rides on the LAST USER message, i.e. the
+        // TAIL of the prompt — never in the system message, which is the cached prefix. Appending
+        // to an existing message rather than adding a trailing one keeps the message count and the
+        // role sequence exactly as every provider expects. See BuildVolatileRoundContext.
+        var volatileIdx = turnMessages.FindLastIndex(m => m.Role == ChatRole.User);
+        if (volatileIdx >= 0)
+        {
+            var target = turnMessages[volatileIdx];
+            var withClock = new List<AIContent>(target.Contents)
+            {
+                new TextContent("\n\n" + BuildVolatileRoundContext()),
+            };
+            turnMessages[volatileIdx] = new ChatMessage(ChatRole.User, withClock)
+            {
+                AuthorName = target.AuthorName,
+            };
+        }
+        else if (!string.IsNullOrEmpty(systemText))
+        {
+            // No user turn to hang it on (a tool-only or seeded round). Fall back to the system
+            // message so the agent still knows the date — correctness beats the cache hit here,
+            // and this branch does not occur on a normal conversational round.
+            turnMessages[0] = new ChatMessage(ChatRole.System, systemText + "\n\n" + BuildVolatileRoundContext());
+        }
+
         // Binary attachments (images/PDFs) ride on the last user message so the model receives them.
         if (!binaryAttachments.IsEmpty)
         {

--- a/src/MeshWeaver.AI/AgentConfiguration.cs
+++ b/src/MeshWeaver.AI/AgentConfiguration.cs
@@ -126,8 +126,13 @@ public record AgentConfiguration : ILocalizedNodeText
     /// single turn. Maps directly onto
     /// <c>Microsoft.Extensions.AI.FunctionInvokingChatClient.MaximumIterationsPerRequest</c>
     /// (wired in <see cref="ChatClientAgentFactory"/>). When <c>null</c> (the default) the
-    /// Microsoft.Extensions.AI default applies — high enough that a high-volume agent can
-    /// issue hundreds of tool calls in one round before it engages. Set a small value
+    /// Microsoft.Extensions.AI default applies, which is <b>40</b> — a plain <c>int</c>, measured
+    /// against Microsoft.Extensions.AI 10.8.3, NOT unbounded and not "hundreds" as this comment
+    /// claimed until 2026-08-23. That wrong number matters: it makes an expensive round look
+    /// like a runaway loop, when 40 iterations over a large document is simply what the cap
+    /// already allows (~40 × ~40k context ≈ the 1.6M prompt tokens/round measured in production).
+    /// The lever on THAT cost is prompt caching, not a lower cap — see
+    /// <c>AgentChatClient.BuildVolatileRoundContext</c>. Set a small value
     /// (e.g. 20–30) for such agents to force natural break points: on reaching the cap the
     /// framework strips tools on the final iteration (its
     /// <c>PrepareOptionsForLastIteration</c> path) so the model returns a graceful final

--- a/src/MeshWeaver.AI/ModelDefinition.cs
+++ b/src/MeshWeaver.AI/ModelDefinition.cs
@@ -100,6 +100,29 @@ public record ModelDefinition
     public decimal? OutputPricePerMillionTokens { get; init; }
 
     /// <summary>
+    /// Price charged per ONE MILLION cache-READ (cache-hit) prompt tokens, in
+    /// <see cref="Currency"/>. Null falls back to the Anthropic-standard 0.1x of
+    /// <see cref="InputPricePerMillionTokens"/>.
+    ///
+    /// <para>Authorable because the 0.1x convention is NOT universal, and on a cache-heavy
+    /// workload the difference is the whole bill rather than a rounding error: Azure Foundry
+    /// bills DeepSeek cache reads on a separate meter at exactly <b>1/12</b> of the input rate
+    /// (1.4274 → 0.11895 CHF/M, derived from four independent days of Cost Management data with
+    /// cache ratios from 33% to 76%, identical to four decimals).</para>
+    /// </summary>
+    [System.ComponentModel.Description("Cache-read price per 1M tokens (blank = 0.1x input)")]
+    public decimal? CacheReadPricePerMillionTokens { get; init; }
+
+    /// <summary>
+    /// Price charged per ONE MILLION cache-WRITE (cache-creation) prompt tokens, in
+    /// <see cref="Currency"/>. Null falls back to the Anthropic-standard 1.25x of
+    /// <see cref="InputPricePerMillionTokens"/> (its 5-minute TTL rate). Providers on the OpenAI
+    /// wire report no separate cache write at all, so this stays null for them.
+    /// </summary>
+    [System.ComponentModel.Description("Cache-write price per 1M tokens (blank = 1.25x input)")]
+    public decimal? CacheWritePricePerMillionTokens { get; init; }
+
+    /// <summary>
     /// ISO currency code the per-million prices are denominated in (e.g.
     /// <c>USD</c>, <c>EUR</c>, <c>CHF</c>). Null defaults to <c>USD</c> in the
     /// cost summaries.

--- a/src/MeshWeaver.AI/ModelPriceCatalog.cs
+++ b/src/MeshWeaver.AI/ModelPriceCatalog.cs
@@ -60,7 +60,14 @@ public static class ModelPriceCatalog
             if (def is not { InputPricePerMillionTokens: { } input, OutputPricePerMillionTokens: { } output })
                 continue;
 
-            var rate = new ModelPriceRate(input, output, def.Currency ?? "USD");
+            // Cache rates ride along when authored; null keeps ModelPriceRate's 0.1x / 1.25x
+            // fallbacks. Dropping them here is what left a cache-heavy model billed at the
+            // Anthropic convention instead of its own (Foundry DeepSeek reads are 1/12, not 1/10).
+            var rate = new ModelPriceRate(input, output, def.Currency ?? "USD")
+            {
+                CacheReadPerMillion = def.CacheReadPricePerMillionTokens,
+                CacheWritePerMillion = def.CacheWritePricePerMillionTokens,
+            };
             if (!string.IsNullOrEmpty(def.Id) && !builder.ContainsKey(def.Id))
                 builder.Add(def.Id, rate);
             if (!string.IsNullOrEmpty(node.Path) && !builder.ContainsKey(node.Path!))

--- a/src/MeshWeaver.AI/ModelPricing.cs
+++ b/src/MeshWeaver.AI/ModelPricing.cs
@@ -98,9 +98,13 @@ public static class ModelPricing
             // API rates. USD per 1M tokens (standard / non-cached). ⚠️ VERIFY against the Azure
             // AI Foundry rate card for the resource — region/contract rates can differ, and the
             // Flash / V3-0324 figures below are estimates pending confirmation.
-            ["DeepSeek-V4-Pro"] = new(1.75m, 3.48m, Usd),
-            ["DeepSeek-V3-0324"] = new(0.95m, 2.40m, Usd),   // deepseek-chat; deprecates 2026-07-24 — estimate
-            ["DeepSeek-V4-Flash"] = new(0.55m, 1.10m, Usd),  // cheapest tier — estimate
+            // 🚨 Cache reads are billed on their own meter at exactly 1/12 of input — NOT the
+            // Anthropic 0.1x the fallback would apply. Derived from Azure Cost Management over
+            // four independent days (cache ratios 33%–76%), identical to four decimals:
+            // V4-Pro 1.4274 → 0.11895 CHF/M. The USD figures here are those CHF rates at ~1.22.
+            ["DeepSeek-V4-Pro"] = new(1.75m, 3.48m, Usd) { CacheReadPerMillion = 1.75m / 12m },
+            ["DeepSeek-V3-0324"] = new(0.95m, 2.40m, Usd) { CacheReadPerMillion = 0.95m / 12m },   // deepseek-chat; deprecates 2026-07-24 — estimate
+            ["DeepSeek-V4-Flash"] = new(0.55m, 1.10m, Usd) { CacheReadPerMillion = 0.55m / 12m },  // cheapest tier — estimate
             // Moonshot Kimi K2.6 (preview on Azure AI Foundry).
             ["Kimi-K2.6"] = new(0.95m, 4.00m, Usd),
 
@@ -160,7 +164,11 @@ public static class ModelPricing
     public static ModelPriceRate? Resolve(string? modelId, ModelDefinition? node)
     {
         if (node is { InputPricePerMillionTokens: { } inPrice, OutputPricePerMillionTokens: { } outPrice })
-            return new ModelPriceRate(inPrice, outPrice, node.Currency ?? Usd);
+            return new ModelPriceRate(inPrice, outPrice, node.Currency ?? Usd)
+            {
+                CacheReadPerMillion = node.CacheReadPricePerMillionTokens,
+                CacheWritePerMillion = node.CacheWritePricePerMillionTokens,
+            };
         return Default(modelId);
     }
 }

--- a/test/MeshWeaver.AI.Test/CachePriceResolutionTest.cs
+++ b/test/MeshWeaver.AI.Test/CachePriceResolutionTest.cs
@@ -1,0 +1,108 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Collections.Generic;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the CACHE-RATE half of the DeepSeek cost defect: a cache-read price authored on a
+/// <c>LanguageModel</c> node, or shipped in the built-in table, must reach
+/// <see cref="ModelPriceRate"/> instead of silently falling back to the Anthropic 0.1x convention.
+///
+/// <para>The 0.1x fallback is not universal. Azure Foundry bills DeepSeek cache reads on a
+/// separate meter at exactly <b>1/12</b> of the input rate — derived from Azure Cost Management
+/// over four independent days whose cache ratios ranged 33%–76%, agreeing to four decimals
+/// (V4-Pro: 1.4274 input → 0.11895 cached CHF/M). On a workload that is ~98% cache reads the
+/// difference between 1/10 and 1/12 stops being a rounding error.</para>
+/// </summary>
+public class CachePriceResolutionTest
+{
+    /// <summary>The built-in table must carry DeepSeek's real 1/12 read rate, not the 0.1x default.</summary>
+    [Fact]
+    public void BuiltInDefaults_PriceDeepSeekCacheReadsAtOneTwelfth()
+    {
+        var rate = ModelPricing.Default("DeepSeek-V4-Pro");
+
+        rate.Should().NotBeNull();
+        rate!.CacheReadPerMillion.Should().Be(1.75m / 12m,
+            "Azure bills Foundry DeepSeek cache reads at exactly 1/12 of input, not the "
+            + "Anthropic-standard 0.1x the fallback would otherwise apply");
+    }
+
+    /// <summary>An authored node price must win over the built-in table — including the cache rates.</summary>
+    [Fact]
+    public void AuthoredNodePrice_CarriesCacheRatesIntoTheRate()
+    {
+        var node = new MeshNode("m", "Provider/AzureFoundry")
+        {
+            NodeType = LanguageModelNodeType.NodeType,
+            Content = new ModelDefinition
+            {
+                Id = "priced-model",
+                Provider = "AzureFoundry",
+                InputPricePerMillionTokens = 12m,
+                OutputPricePerMillionTokens = 24m,
+                CacheReadPricePerMillionTokens = 1m,
+                CacheWritePricePerMillionTokens = 15m,
+                Currency = "CHF",
+            },
+        };
+
+        var catalog = ModelPriceCatalog.FromNodes([node], JsonSerializerOptions.Default);
+        var rate = ModelPriceCatalog.RateFor("priced-model", catalog);
+
+        rate.Should().NotBeNull();
+        rate!.CacheReadPerMillion.Should().Be(1m, "the authored cache-read price must not be dropped");
+        rate.CacheWritePerMillion.Should().Be(15m, "the authored cache-write price must not be dropped");
+    }
+
+    /// <summary>
+    /// A node priced WITHOUT cache rates still falls back to the 0.1x / 1.25x convention — the
+    /// change adds precision where it is authored, it does not make unpriced models free.
+    /// </summary>
+    [Fact]
+    public void NodeWithoutCacheRates_KeepsTheConventionalFallback()
+    {
+        var node = new MeshNode("m", "Provider/X")
+        {
+            NodeType = LanguageModelNodeType.NodeType,
+            Content = new ModelDefinition
+            {
+                Id = "plain-model",
+                Provider = "X",
+                InputPricePerMillionTokens = 10m,
+                OutputPricePerMillionTokens = 20m,
+            },
+        };
+
+        var catalog = ModelPriceCatalog.FromNodes([node], JsonSerializerOptions.Default);
+        var rate = ModelPriceCatalog.RateFor("plain-model", catalog);
+
+        rate.Should().NotBeNull();
+        rate!.CacheReadPerMillion.Should().BeNull("null means 'use the 0.1x convention'");
+
+        // 1M cache reads at the conventional 0.1x of a 10/M input rate = 1.00.
+        rate.Cost(1_000_000, 0, 1_000_000, 0).Should().Be(1.00m);
+    }
+
+    /// <summary>
+    /// The arithmetic that was wrong in production, at the CORRECT rate: 98% cache reads on
+    /// DeepSeek-V4-Pro cost a fraction of the same prompt billed entirely at 1x.
+    /// </summary>
+    [Fact]
+    public void CacheAwareCost_CollapsesOnACacheHeavyRound()
+    {
+        var rate = ModelPricing.Default("DeepSeek-V4-Pro")!;
+        const long input = 1_000_000;
+        var cached = (long)(input * 0.98);
+
+        var blind = rate.Cost(input, 1_000);                      // every prompt token at 1x
+        var aware = rate.Cost(input, 1_000, cached, 0);           // 98% at 1/12
+
+        aware.Should().BeLessThan(blind / 5,
+            "a 98%-cached round is the measured steady state once the prompt prefix is stable");
+    }
+}

--- a/test/MeshWeaver.AI.Test/PromptCachePrefixStabilityTest.cs
+++ b/test/MeshWeaver.AI.Test/PromptCachePrefixStabilityTest.cs
@@ -1,0 +1,280 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.ShortGuid;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the PROMPT-CACHE PREFIX invariant: nothing that changes between two rounds may sit in
+/// the cached prefix — the system message and everything before the current user turn.
+///
+/// <para>🚨 Why this is a test and not a comment. Every provider's prompt cache is a PREFIX
+/// match, so the first differing token invalidates everything behind it.
+/// <see cref="CurrentTimeContext"/> renders the UTC instant at SECONDS precision, and it used to
+/// be composed into the block folded into the agent's SYSTEM message — the FIRST message of the
+/// turn. The clock ticking between two rounds therefore invalidated the instructions, the
+/// application context, the whole conversation history and every document the agent had pulled.</para>
+///
+/// <para>Measured against Azure Foundry DeepSeek on 2026-08-23, same 13,040-token prompt: with
+/// the timestamp in the system message the hit rate was <b>0%</b> on every call; with an
+/// identical prefix and the timestamp at the tail it reached <b>98.2%</b>. Production sat at 53%.</para>
+///
+/// <para>It is worse than a lost discount on drivers that cache EXPLICITLY: the Anthropic client
+/// marks the system prompt with an ephemeral <c>cache_control</c> breakpoint, so a volatile system
+/// prompt made it WRITE a cache entry every round at the 1.25x premium and never read one back —
+/// a live thread showed <c>cacheWriteTokens: 9068</c> against <c>cacheRead: 0</c>.</para>
+///
+/// <para>The failure is entirely silent — correct answers, correct token counts, just a bill
+/// several times larger than it should be — so only an assertion keeps it fixed.</para>
+/// </summary>
+public class PromptCachePrefixStabilityTest : MonolithMeshTestBase
+{
+    private static readonly string TestDataPath = Path.Combine(AppContext.BaseDirectory, "TestData");
+
+    public PromptCachePrefixStabilityTest(ITestOutputHelper output) : base(output) { }
+
+    protected override bool ShareMeshAcrossTests => true;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        builder
+            .UseMonolithMesh()
+            .AddFileSystemPersistence(TestDataPath)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IChatClientFactory>(new CapturingFactory());
+                return services;
+            })
+            .AddGraph()
+            .AddAI()
+            .ConfigureDefaultNodeHub(config => config.AddDefaultLayoutAreas());
+
+    #region capture harness
+
+    private sealed class CapturingClient(List<ChatMessage> capture) : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            capture.AddRange(messages);
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "OK")));
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            capture.AddRange(messages);
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "OK");
+            await Task.CompletedTask;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) =>
+            serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingFactory : IChatClientFactory
+    {
+        public List<ChatMessage> Captured { get; } = [];
+        public string Name => "CapturingFactory";
+        public IReadOnlyList<string> Models => ["capturing-model"];
+        public int Order => 0;
+
+        public ChatClientAgent CreateAgent(
+            AgentConfiguration config, IAgentChat chat,
+            IReadOnlyDictionary<string, ChatClientAgent> existingAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents, string? modelName = null)
+            => new(chatClient: new CapturingClient(Captured),
+                instructions: config.Instructions ?? "Test assistant.",
+                name: config.Id, description: config.Description ?? config.Id,
+                tools: [], loggerFactory: null, services: null);
+
+        public Task<ChatClientAgent> CreateAgentAsync(
+            AgentConfiguration config, IAgentChat chat,
+            IReadOnlyDictionary<string, ChatClientAgent> existingAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents, string? modelName = null)
+            => Task.FromResult(CreateAgent(config, chat, existingAgents, hierarchyAgents, modelName));
+    }
+
+    private static string TextOf(ChatMessage m) =>
+        m.Text ?? string.Join("", m.Contents.OfType<TextContent>().Select(t => t.Text));
+
+    private async Task<(AgentChatClient Chat, CapturingFactory Factory)> SetupAsync(CancellationToken ct)
+    {
+        var factory = (CapturingFactory)Mesh.ServiceProvider.GetRequiredService<IChatClientFactory>();
+        var agentChat = new AgentChatClient(Mesh.ServiceProvider);
+        await agentChat.Initialize("ACME").WhenInitialized.FirstAsync().ToTask(ct);
+        agentChat.SetThreadId($"ACME/{Guid.NewGuid().AsString()}");
+        var agents = await agentChat.GetOrderedAgentsAsync();
+        agents.Should().NotBeEmpty();
+        agentChat.SetSelectedAgent(agents[0].Name);
+        return (agentChat, factory);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// STREAMING path (what the chat UI actually runs). The clock must NOT be in the system
+    /// message — that message is the cached prefix, and a seconds-precision timestamp in it
+    /// invalidates the instructions, the history and every document behind it on every round.
+    /// </summary>
+    [Fact]
+    public async Task Streaming_TheClock_IsNotInTheSystemMessage()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (agentChat, factory) = await SetupAsync(ct);
+
+        await foreach (var _ in agentChat.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "hello")], ct)) { }
+
+        var system = factory.Captured.Where(m => m.Role == ChatRole.System).Select(TextOf).ToList();
+        system.Should().NotBeEmpty("the streaming turn folds instructions + context into a system message");
+
+        foreach (var s in system)
+            s.Should().NotContain(CurrentTimeContext.Heading,
+                "the system message is the CACHED PREFIX — a seconds-precision timestamp in it "
+                + "invalidates everything behind it (0% vs 98.2% measured on Foundry DeepSeek)");
+    }
+
+    /// <summary>Streaming: the clock still reaches the model, riding the LAST USER message (the tail).</summary>
+    [Fact]
+    public async Task Streaming_TheClock_RidesTheLastUserMessage()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (agentChat, factory) = await SetupAsync(ct);
+
+        await foreach (var _ in agentChat.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "hello")], ct)) { }
+
+        var lastUser = factory.Captured.LastOrDefault(m => m.Role == ChatRole.User);
+        lastUser.Should().NotBeNull();
+        TextOf(lastUser!).Should().Contain(CurrentTimeContext.Heading,
+            "the agent still needs the date — it moved to the tail, it did not disappear (#1651)");
+    }
+
+    /// <summary>
+    /// Streaming: the system message is byte-identical across two rounds of the SAME thread.
+    /// This is the property the cache keys on, and the one a future edit is most likely to break
+    /// by adding "just one more" dynamic line to the system block.
+    ///
+    /// <para>⚠️ On its own this cannot catch a CLOCK regression, and the limitation is recorded
+    /// here rather than discovered later: two rounds run milliseconds apart, so a re-introduced
+    /// seconds-precision timestamp usually renders identically in both and this test still passes.
+    /// Verified by mutation on 2026-08-23 — putting the clock back in the prefix left this test
+    /// green while <see cref="Streaming_TheClock_IsNotInTheSystemMessage"/> and both non-streaming
+    /// tests failed. Those three are the load-bearing ones for the clock; this one guards the
+    /// broader invariant (any per-round value creeping into the system block — a counter, a GUID,
+    /// a re-serialised context) that they would not notice.</para>
+    /// </summary>
+    [Fact]
+    public async Task Streaming_TheCachedPrefix_IsIdenticalAcrossRounds()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (agentChat, factory) = await SetupAsync(ct);
+
+        await foreach (var _ in agentChat.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "first")], ct)) { }
+        var first = factory.Captured.Where(m => m.Role == ChatRole.System).Select(TextOf).ToList();
+        first.Should().NotBeEmpty("guards against a vacuous comparison of two empty lists");
+
+        factory.Captured.Clear();
+        await foreach (var _ in agentChat.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "second")], ct)) { }
+        var second = factory.Captured.Where(m => m.Role == ChatRole.System).Select(TextOf).ToList();
+
+        second.Should().Equal(first,
+            "the system message IS the cached prefix; if it differs between two rounds of the "
+            + "same thread the provider re-charges full price for the whole prompt");
+    }
+
+    /// <summary>
+    /// NON-STREAMING path assembles ONE combined user message instead of a system message, so the
+    /// same invariant reads as ordering: the clock must come AFTER the user's own text, i.e. at
+    /// the very tail of the assembled prompt.
+    /// </summary>
+    [Fact]
+    public async Task NonStreaming_TheClock_ComesAfterTheUserText()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (agentChat, factory) = await SetupAsync(ct);
+
+        const string userText = "what is the launch status?";
+        await foreach (var _ in agentChat.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, userText)], ct)) { }
+
+        var prompt = factory.Captured.Where(m => m.Role == ChatRole.User).Select(TextOf).LastOrDefault();
+        prompt.Should().NotBeNullOrEmpty();
+
+        var clockIdx = prompt!.IndexOf(CurrentTimeContext.Heading, StringComparison.Ordinal);
+        var userIdx = prompt.IndexOf(userText, StringComparison.Ordinal);
+
+        clockIdx.Should().BeGreaterThan(0, "the agent still needs the date (#1651)");
+        userIdx.Should().BeGreaterThanOrEqualTo(0, "the user's text is in the assembled prompt");
+        clockIdx.Should().BeGreaterThan(userIdx,
+            "the volatile clock belongs at the TAIL; everything before it is the prefix a "
+            + "provider can cache across rounds");
+    }
+
+    /// <summary>
+    /// Non-streaming: the stable PREFIX — everything before the clock — is identical across two
+    /// rounds once the user's own text is discounted. Compares the segment that precedes the
+    /// clock heading, which is exactly what a prefix cache would match on.
+    /// </summary>
+    [Fact]
+    public async Task NonStreaming_ThePrefixBeforeTheClock_IsStableAcrossRounds()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (agentChat, factory) = await SetupAsync(ct);
+
+        // 🚨 The markers must be strings that CANNOT occur in the agent's own instructions.
+        // "first"/"second" do — the built-in Assistant prompt says "from the first user message
+        // to the last reply" — so normalising them rewrote the instructions in round one only and
+        // failed this test on its own substitution rather than on the prompt.
+        const string firstMarker = "ZZQ-ROUND-ONE";
+        const string secondMarker = "ZZQ-ROUND-TWO";
+
+        static string PrefixOf(string prompt, string userText)
+        {
+            var idx = prompt.IndexOf(CurrentTimeContext.Heading, StringComparison.Ordinal);
+            idx.Should().BeGreaterThan(0, "the clock must be present to split on");
+            return prompt[..idx].Replace(userText, "<USER>", StringComparison.Ordinal);
+        }
+
+        await foreach (var _ in agentChat.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, firstMarker)], ct)) { }
+        var firstPrompt = factory.Captured.Where(m => m.Role == ChatRole.User).Select(TextOf).Last();
+        var firstPrefix = PrefixOf(firstPrompt, firstMarker);
+        firstPrefix.Should().NotBeNullOrWhiteSpace("guards against comparing two empty strings");
+        firstPrefix.Should().Contain("<USER>", "the marker must actually be found and normalised");
+
+        factory.Captured.Clear();
+        await foreach (var _ in agentChat.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, secondMarker)], ct)) { }
+        var secondPrompt = factory.Captured.Where(m => m.Role == ChatRole.User).Select(TextOf).Last();
+
+        PrefixOf(secondPrompt, secondMarker).Should().Be(firstPrefix,
+            "with the clock at the tail, everything ahead of it is byte-identical between "
+            + "rounds — that segment is what the provider's prompt cache can hit");
+    }
+}

--- a/test/MeshWeaver.AI.Test/RoundCompletionHonestyTest.cs
+++ b/test/MeshWeaver.AI.Test/RoundCompletionHonestyTest.cs
@@ -223,9 +223,17 @@ public class RoundCompletionHonestyTest(ITestOutputHelper output) : AITestBase(o
             IEnumerable<ChatMessage> messages, ChatOptions? options = null,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            // 🚨 Match the MARKER, not the whole message text. A round legitimately injects
+            // per-round context onto the user message — the non-streaming path always has, and
+            // since the prompt-cache fix the streaming path appends the clock there too (the
+            // volatile block must sit at the TAIL, outside the cached prefix). An exact
+            // `switch (wholeText)` therefore silently fell through to the healthy script, and the
+            // three honesty cases asserted against a round that had never been scripted to fail.
+            // The marker is the first line; everything after it is injected context.
             var script = messages
                 .Where(m => m.Role == ChatRole.User)
                 .Select(m => m.Text ?? string.Empty)
+                .Select(t => t.Split('\n')[0].Trim())
                 .LastOrDefault(t => t.StartsWith("script:", StringComparison.Ordinal))
                 ?? HealthyRoundPrompt;
 


### PR DESCRIPTION
## The bug

The clock was the most volatile string in the prompt, sitting in the least volatile place.

`CurrentTimeContext` renders the UTC instant at **seconds** precision, and it was composed into the block folded into the agent's **system message** — the first message of the turn. Every provider's prompt cache is a **prefix** match, so each tick invalidated the instructions, the application context, the whole conversation history, and every document the agent had pulled.

Measured against Azure Foundry DeepSeek, same 13,040-token prompt:

| prefix shape | call 1 | call 2 | call 3 |
|---|---:|---:|---:|
| timestamp inside the system message (before) | 0% | 0% | — |
| stable prefix, timestamp at the tail (after) | 0% | 0% | **98.2%** |

(First two are cache warm-up — Foundry writes the entry asynchronously.) Production sat at **53%**: the within-a-round hits — the system message is composed once per round, so tool iterations *did* cache — minus a full-prefix miss on every new round.

## Why this is in the shared assembly, not a driver

It hits **every** driver, and it is *worse* on the ones that cache explicitly. `AnthropicChatClient` marks the system prompt with an ephemeral `cache_control` breakpoint, so a volatile system prompt made it **write** a cache entry every round — at the 1.25x write premium — and never read one back. A live thread shows exactly that:

```
claude-sonnet-4-6 → cacheWriteTokens: 9068,  cacheRead: 0
```

I had previously cited that record as evidence caching worked. It was this bug.

## The fix

The volatile block now rides the **last user message**, in both the streaming and non-streaming paths. Appending to an existing message rather than adding a trailing one keeps the message count and role sequence untouched — no provider sees a second system message or two consecutive user turns (which our custom Anthropic client would reject) — and truncation, which always keeps the newest message, cannot drop it.

## Also here, because it is the same bill

- **Exact cache rates.** `ModelDefinition` gains `CacheReadPricePerMillionTokens` / `CacheWritePricePerMillionTokens`, wired through `ModelPriceCatalog.FromNodes` and `ModelPricing.Resolve`. The 0.1x Anthropic convention is not universal — Azure bills Foundry DeepSeek cache reads at exactly **1/12** of input (1.4274 → 0.11895 CHF/M, derived from four independent days of Cost Management data with cache ratios 33%–76%, identical to four decimals). The built-in DeepSeek rows carry it.

- **`MaxToolCallsPerRound` — a correction, not a change.** The comment claimed the M.E.AI default is "high enough that a high-volume agent can issue hundreds of tool calls in one round". It is **40**, a plain `int` (measured against 10.8.3). That wrong number makes an expensive round read as a runaway loop when it is simply 40 iterations over a large document (~40 × ~40k ≈ the 1.6M prompt tokens/round seen in production). The lever on that cost is the cache, not a lower cap — so the comment is corrected and the cap left alone. Lowering it would truncate real work mid-task; that is a product call.

## One test changed, and why

`RoundCompletionHonestyTest`'s fake selected its script with an exact `switch` on the **whole** user message text. With the clock appended there, all three honesty cases fell through to `HealthyRoundPrompt` — they were asserting "this round must NOT report success" against a round scripted to succeed. The fake now matches the marker (first line). Verified they exercise the intended scripts again:

```
[script:unfinished-tool-call]  Status=Error       ← was falling through to healthy
[script:failed-tool-result]    "I could not create the event; the calendar rejected the payload."
[script:silent-closing-turn]   Status=Error
[script:healthy-round]         Status=Completed
```

That coupling was already latent: the non-streaming path has always injected context into the user message, so the assumption only ever held for streaming. The honesty assertions themselves are untouched.

## Tests

Nine new across both paths. **Mutation-checked** — reinstating the defect fails three of them. The fourth (prefix identical across rounds) cannot catch a sub-second clock regression on its own, since two rounds usually render the same second; its doc comment says so rather than letting it look load-bearing, and it guards the broader "no per-round value in the system block" invariant instead.

Full `MeshWeaver.AI.Test`: **1219 passed, 0 failed, 3 skipped.**

## Related

Companion to Systemorph/MeshWeaver.Plugins#611, which put Foundry chat on the OpenAI wire so the cache hits are *reported* at all. This one makes them actually happen.