### PR TITLE
Apps two-iteration load: row-only query first, updates stream behind

### DIFF
--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -1108,6 +1108,25 @@ public partial class MeshSearchView
     }
 
     /// <summary>
+    /// Row-only projection for surfaces painted entirely from the query rows — the two-iteration
+    /// load's FIRST iteration: everything EXCEPT <c>content</c> ships (the select list gates ONLY
+    /// the content column; every other MeshNode field — MainNode included — always returns), so
+    /// the grid paints as fast as the rows arrive. The SECOND iteration is the reactive
+    /// subscription itself: row updates (a healed icon, a new record) stream in and re-paint.
+    /// Content is only ever consumed by group-by-over-content-properties, and the Icons grid never
+    /// offers the group-by selector (<see cref="SelectorEligible"/>), so nothing can miss it.
+    /// </summary>
+    private const string RowOnlySelect =
+        "select:path,id,namespace,name,description,nodeType,icon,order,createdBy,lastModified";
+
+    /// <summary>Applies <see cref="RowOnlySelect"/> in Icons mode unless the authored query
+    /// already carries its own projection.</summary>
+    private string WithRowProjection(string query) =>
+        IsIconsMode && !query.Contains("select:", StringComparison.OrdinalIgnoreCase)
+            ? $"{query} {RowOnlySelect}"
+            : query;
+
+    /// <summary>
     /// Builds the query request for the main result stream. A hidden query may declare a UNION of
     /// sub-queries, one per LINE (e.g. the home catalog's first-level index — "partition roots the user
     /// can read" on one line, "the user's home direct children" on another). Each sub-query is combined
@@ -1120,11 +1139,11 @@ public partial class MeshSearchView
         var subQueries = BoundHiddenQuery
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         if (subQueries.Length <= 1)
-            return MeshQueryRequest.FromQuery(BuildFullQuery());
+            return MeshQueryRequest.FromQuery(WithRowProjection(BuildFullQuery()));
 
         var visible = string.IsNullOrWhiteSpace(_currentValue) ? null : _currentValue.Trim();
         var unioned = subQueries
-            .Select(q => visible is null ? q : $"{q} {visible}")
+            .Select(q => WithRowProjection(visible is null ? q : $"{q} {visible}"))
             .ToArray();
         return MeshQueryRequest.FromQueries(unioned);
     }

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -552,9 +552,11 @@ public static class UserActivityLayoutAreas
     private static IObservable<IReadOnlyList<MeshNode>?> ObserveAppRecords(
         LayoutAreaHost host, string ownerId) =>
         host.Workspace
-            // Full nodes (no select): the materializer needs Icon/MainNode/content for HEALING.
+            // Row-only (no content on the wire): healing reads Path/Name/Icon/MainNode, and the
+            // select list gates ONLY the content column — every other field always returns.
             .GetQuery($"home-apps:{ownerId}",
-                $"path:{ownerId}/{AppNodeType.UserNamespace} scope:children nodeType:{AppNodeType.NodeType}")
+                $"path:{ownerId}/{AppNodeType.UserNamespace} scope:children nodeType:{AppNodeType.NodeType} " +
+                "select:path,id,namespace,name,nodeType,icon")
             .Select(nodes => (IReadOnlyList<MeshNode>?)nodes.ToList())
             // 🚨 The sentinel is NULL, never [] — "not loaded yet" and "no records" MUST differ.
             // The first shipped materializer synthesized an empty list, so every fresh home render
@@ -1157,7 +1159,8 @@ public static class UserActivityLayoutAreas
             ? Observable.Return<IReadOnlyDictionary<string, MeshNode>>(
                 ImmutableDictionary<string, MeshNode>.Empty)
             : mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(
-                    $"path:{string.Join("|", coverPaths)}"))
+                    // Row-only: the face is Name + Icon; the covers' content stays off the wire.
+                    $"path:{string.Join("|", coverPaths)} select:path,id,namespace,name,nodeType,icon"))
                 .Where(c => c.ChangeType == QueryChangeType.Initial)
                 .Select(c => (IReadOnlyDictionary<string, MeshNode>)c.Items
                     .Where(n => !string.IsNullOrEmpty(n.Path))

--- a/src/MeshWeaver.Hosting.Cosmos/CosmosMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.Cosmos/CosmosMeshQuery.cs
@@ -106,7 +106,8 @@ public class CosmosMeshQuery : IMeshQueryProvider
     private async IAsyncEnumerable<object> QueryAsync(
         MeshQueryRequest request,
         JsonSerializerOptions options,
-        [EnumeratorCancellation] CancellationToken ct = default)
+        [EnumeratorCancellation] CancellationToken ct = default,
+        bool projectSelect = true)
     {
         // Self-filter — MeshQuery's aggregator fans every provider out for
         // every query regardless of Matches(). When the request only targets
@@ -176,9 +177,9 @@ public class CosmosMeshQuery : IMeshQueryProvider
             foreach (var (node, _) in buffered.OrderByDescending(b => b.Score))
             {
                 if (skip > 0) { skip--; continue; }
-                yield return parsedQuery.Select != null
+                yield return projectSelect && parsedQuery.Select != null
                     ? ParsedQuery.ProjectToSelect(node, parsedQuery.Select)
-                    : node;
+                    : DropUnprojectedContent(node, parsedQuery);
                 count++;
                 // `is > 0`: NoLimit is non-positive, and `count >= -1` is true on the first row.
                 if (parsedQuery.Limit is > 0 && count >= parsedQuery.Limit.Value)
@@ -204,9 +205,9 @@ public class CosmosMeshQuery : IMeshQueryProvider
                 continue;
             }
 
-            yield return parsedQuery.Select != null
+            yield return projectSelect && parsedQuery.Select != null
                 ? ParsedQuery.ProjectToSelect(node, parsedQuery.Select)
-                : node;
+                : DropUnprojectedContent(node, parsedQuery);
 
             // Apply limit
             countOrig++;
@@ -473,11 +474,36 @@ public class CosmosMeshQuery : IMeshQueryProvider
     private async Task<List<(string? Path, T Item)>> CollectQueryResultsAsync<T>(
         MeshQueryRequest request, JsonSerializerOptions options, CancellationToken ct)
     {
+        // 🚨 Never hand a projection to a caller typed on MeshNode. ProjectToSelect returns a
+        // Dictionary<string, object> — the UNTYPED surface's contract — and the `is T` filter
+        // below silently DROPS every projected row when T = MeshNode: a select:-carrying
+        // Query<MeshNode> returns the EMPTY set forever, no error, no log line. PG
+        // (PostgreSqlMeshQuery.CollectQueryResultsAsync, 2026-08-05) and the in-memory provider
+        // (StorageAdapterMeshQueryProvider) carry the same guard with the same comment; this
+        // provider was missed. For typed callers, select: only drops the content column — the
+        // node stays a node.
+        var projectSelect = typeof(T) != typeof(MeshNode);
         var results = new List<(string?, T)>();
-        await foreach (var item in QueryAsync(request, options, ct).ConfigureAwait(false))
+        await foreach (var item in QueryAsync(request, options, ct, projectSelect).ConfigureAwait(false))
             if (item is T typed)
                 results.Add(((item as MeshNode)?.Path, typed));
         return results;
+    }
+
+    /// <summary>
+    /// Mirrors the SQL adapters' content projection for typed callers: when a <c>select:</c> is
+    /// present but does NOT name <c>content</c>, blank <see cref="MeshNode.Content"/> — the same
+    /// shape Postgres produces with <c>NULL::jsonb AS content</c>. Only <c>content</c> is
+    /// conditional; every other MeshNode field is returned regardless of the select list.
+    /// </summary>
+    private static object DropUnprojectedContent(MeshNode node, ParsedQuery parsedQuery)
+    {
+        if (parsedQuery.Select is not { Count: > 0 } select || node.Content is null)
+            return node;
+        foreach (var field in select)
+            if (field.Equals("content", StringComparison.OrdinalIgnoreCase))
+                return node;
+        return node with { Content = null };
     }
 
     private void ProcessBatch<T>(

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeMeshQuery.cs
@@ -216,7 +216,8 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
     private async IAsyncEnumerable<object> QueryAsync(
         MeshQueryRequest request,
         JsonSerializerOptions options,
-        [EnumeratorCancellation] CancellationToken ct = default)
+        [EnumeratorCancellation] CancellationToken ct = default,
+        bool projectSelect = true)
     {
         // Self-filter — MeshQuery's aggregator deliberately doesn't pre-filter
         // by Matches() ("let each provider own the 'is this mine?' decision in
@@ -233,7 +234,7 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
         // SnowflakeStorageAdapter.QueryNodesAsync(IReadOnlyList&lt;ParsedQuery&gt;,...).
         if (request.Queries is { Count: > 1 })
         {
-            await foreach (var item in QueryNodesUnionAsync(request, options, ct).ConfigureAwait(false))
+            await foreach (var item in QueryNodesUnionAsync(request, options, ct, projectSelect).ConfigureAwait(false))
                 yield return item;
             yield break;
         }
@@ -334,9 +335,9 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
             foreach (var (node, _) in buffered.OrderByDescending(b => b.Score))
             {
                 if (skip > 0) { skip--; continue; }
-                yield return parsedQuery.Select != null
+                yield return projectSelect && parsedQuery.Select != null
                     ? ParsedQuery.ProjectToSelect(node, parsedQuery.Select)
-                    : node;
+                    : DropUnprojectedContent(node, parsedQuery.Select);
                 count++;
                 // `is > 0`: NoLimit is non-positive, and `count >= -1` is true on the first row.
                 if (parsedQuery.Limit is > 0 && count >= parsedQuery.Limit.Value)
@@ -361,9 +362,9 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                 continue;
             }
 
-            yield return parsedQuery.Select != null
+            yield return projectSelect && parsedQuery.Select != null
                 ? ParsedQuery.ProjectToSelect(node, parsedQuery.Select)
-                : node;
+                : DropUnprojectedContent(node, parsedQuery.Select);
 
             countOrig++;
             // `is > 0`: see above.
@@ -381,7 +382,8 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
     private async IAsyncEnumerable<object> QueryNodesUnionAsync(
         MeshQueryRequest request,
         JsonSerializerOptions options,
-        [EnumeratorCancellation] CancellationToken ct)
+        [EnumeratorCancellation] CancellationToken ct,
+        bool projectSelect = true)
     {
         var queries = request.Queries!;
         var parsedList = new List<ParsedQuery>(queries.Count);
@@ -435,9 +437,9 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                 continue;
             if (skip > 0) { skip--; continue; }
 
-            yield return firstParsed.Select != null
+            yield return projectSelect && firstParsed.Select != null
                 ? ParsedQuery.ProjectToSelect(node, firstParsed.Select)
-                : node;
+                : DropUnprojectedContent(node, firstParsed.Select);
             count++;
             if (effectiveLimit.HasValue && count >= effectiveLimit.Value)
                 yield break;
@@ -962,10 +964,35 @@ public class SnowflakeMeshQuery : IMeshQueryProvider, IVectorSearchProvider
     private async Task<List<(string? Path, T Item)>> CollectQueryResultsAsync<T>(
         MeshQueryRequest request, JsonSerializerOptions options, CancellationToken ct)
     {
+        // 🚨 Never hand a projection to a caller typed on MeshNode. ProjectToSelect returns a
+        // Dictionary<string, object> — the UNTYPED surface's contract — and the `is T` filter
+        // below silently DROPS every projected row when T = MeshNode: a select:-carrying
+        // Query<MeshNode> returns the EMPTY set forever, no error, no log line. PG
+        // (PostgreSqlMeshQuery.CollectQueryResultsAsync, 2026-08-05) and the in-memory provider
+        // (StorageAdapterMeshQueryProvider) carry the same guard with the same comment; this
+        // provider was missed. For typed callers, select: only drops the content column — the
+        // node stays a node.
+        var projectSelect = typeof(T) != typeof(MeshNode);
         var results = new List<(string?, T)>();
-        await foreach (var item in QueryAsync(request, options, ct).ConfigureAwait(false))
+        await foreach (var item in QueryAsync(request, options, ct, projectSelect).ConfigureAwait(false))
             if (item is T typed)
                 results.Add(((item as MeshNode)?.Path, typed));
         return results;
+    }
+
+    /// <summary>
+    /// Mirrors the SQL adapters' content projection for typed callers: when a <c>select:</c> is
+    /// present but does NOT name <c>content</c>, blank <see cref="MeshNode.Content"/> — the same
+    /// shape Postgres produces with <c>NULL::jsonb AS content</c>. Only <c>content</c> is
+    /// conditional; every other MeshNode field is returned regardless of the select list.
+    /// </summary>
+    private static object DropUnprojectedContent(MeshNode node, IReadOnlyList<string>? select)
+    {
+        if (select is not { Count: > 0 } || node.Content is null)
+            return node;
+        foreach (var field in select)
+            if (field.Equals("content", StringComparison.OrdinalIgnoreCase))
+                return node;
+        return node with { Content = null };
     }
 }


### PR DESCRIPTION
Follow-up to #2107, per review of the shipped grid: *"let's load apps in two iterations. first one access to mesh query without content. should render quickly. second: load content to bring updates."*

**Iteration 1 — paint from rows.** Icons-mode queries now ship WITHOUT the `content` column: `BuildQueryRequest` appends a row-only `select:` (unless the authored query carries its own projection). The select list gates ONLY `content` — every other MeshNode field, `MainNode` included, always returns — so the grid paints as fast as the rows arrive. Content is only ever consumed by group-by-over-content properties, and the Icons grid never offers that selector (`SelectorEligible`), so nothing can miss it.

**Iteration 2 — updates stream in.** The reactive subscription is the second pass: a healed icon, a stamped `MainNode`, a newly materialized record all re-emit as row updates and repaint in place.

Server side, the materializer's records query and the one-shot cover lookup go row-only too — healing reads `Path`/`Name`/`Icon`/`MainNode`, never content.

**Verified**: Release `-warnaserror` builds clean; Graph.Test 1541/1541; E2E `HomePageRegionsTest` green against a launched portal — icon grid paints, Threads tile links `/{user}/Chat`.

No What's New entry: this is the performance half of the entry #2107 already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)