### PR TITLE
feat(AI): price the OpenRouter frontier models (glm-5.3, gpt-5.2, gemini-3, claude-5, deepseek/grok/qwen)

### DIFF
--- a/src/MeshWeaver.AI/ModelPricing.cs
+++ b/src/MeshWeaver.AI/ModelPricing.cs
@@ -114,6 +114,20 @@ public static class ModelPricing
             // Rates as published by the OpenRouter model API, 2026-08.
             ["z-ai/glm-5.2"] = new(0.6286m, 1.9756m, Usd),
             ["moonshotai/kimi-k3"] = new(3.00m, 15.00m, Usd),
+            // The converged frontier catalog fronted through the single funded OpenRouter key
+            // (no per-provider credentials): GLM 5.3, GPT-5, Gemini 3, Claude 5, DeepSeek, Grok,
+            // Qwen. Rates as published by the OpenRouter model API, 2026-08 (per 1M tokens,
+            // standard / non-cached). Same backstop caveat as above — the node price wins.
+            ["z-ai/glm-5.3"] = new(1.4m, 4.4m, Usd),
+            ["openai/gpt-5.2"] = new(1.75m, 14.0m, Usd),
+            ["openai/gpt-5-mini"] = new(0.25m, 2.0m, Usd),
+            ["google/gemini-3.1-pro-preview"] = new(2.0m, 12.0m, Usd),
+            ["google/gemini-3.7-flash"] = new(0.375m, 1.875m, Usd),
+            ["anthropic/claude-opus-5"] = new(5.0m, 25.0m, Usd),
+            ["anthropic/claude-sonnet-5"] = new(2.0m, 10.0m, Usd),
+            ["deepseek/deepseek-v4-pro"] = new(0.5262m, 1.0524m, Usd),
+            ["x-ai/grok-4.6"] = new(2.0m, 6.0m, Usd),
+            ["qwen/qwen3-max"] = new(0.78m, 3.9m, Usd),
         }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>


### PR DESCRIPTION
Adds default per-1M-token rates to `ModelPricing.Defaults` (OpenRouter section) for the converged frontier model catalog we're routing through the **single funded OpenRouter key** (no new per-provider credentials):

| id | in | out |
|---|---|---|
| z-ai/glm-5.3 | 1.4 | 4.4 |
| openai/gpt-5.2 | 1.75 | 14.0 |
| openai/gpt-5-mini | 0.25 | 2.0 |
| google/gemini-3.1-pro-preview | 2.0 | 12.0 |
| google/gemini-3.7-flash | 0.375 | 1.875 |
| anthropic/claude-opus-5 | 5.0 | 25.0 |
| anthropic/claude-sonnet-5 | 2.0 | 10.0 |
| deepseek/deepseek-v4-pro | 0.5262 | 1.0524 |
| x-ai/grok-4.6 | 2.0 | 6.0 |
| qwen/qwen3-max | 0.78 | 3.9 |

Rates verified against the OpenRouter model API. `BuiltInLanguageModelProvider` seeds `ModelPricing.Default(id)` onto each LanguageModel node at catalog-build time, so a model that isn't in this table bills **$0** in the cost surfaces — these rows give the newly-enabled OpenRouter models a real cost out of the box. Existing `z-ai/glm-5.2` and `moonshotai/kimi-k3` rows kept as harmless fallbacks (the authored node price still wins via ModelPriceCatalog).

Pairs with a Memex-repo config PR that enables these ids in both instances' OpenRouter model lists.

**Gates:** `dotnet build MeshWeaver.AI` — 0 warnings / 0 errors (warnings-as-errors). `dotnet test MeshWeaver.AI.Test` (pricing/catalog/cache) — 97/97 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)