### PR TITLE
feat(portal): ?hint=chat pulses the header chat toggle

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
@@ -166,7 +166,7 @@
             </div>
             <AuthorizeView>
                 <Authorized>
-                    <div class="side-panel-toggle">
+                    <div class="side-panel-toggle @(ChatHintActive ? "chat-hint-pulse" : null)">
                         @* Context-aware icon: open → close-panel; closed on a thread → show-context;
                            closed elsewhere → chat (open a new conversation). *@
                         <FluentButton BackgroundColor="transparent" OnClick="ToggleSidePanel" Title="@SidePanelToggleTitle">

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
@@ -697,18 +697,23 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
         var query = new Uri(uri, UriKind.RelativeOrAbsolute).IsAbsoluteUri
             ? new Uri(uri).Query
             : uri.Contains('?') ? uri[uri.IndexOf('?')..] : "";
-        if (!query.Contains("hint=chat", StringComparison.OrdinalIgnoreCase))
+        // Exact key=value match — `hint=chatty` (or a `foo-hint=chat` key) must not pulse.
+        var hinted = query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Any(pair => string.Equals(pair, "hint=chat", StringComparison.OrdinalIgnoreCase));
+        if (!hinted)
             return;
         _chatHintCts?.Cancel();
         var cts = _chatHintCts = new CancellationTokenSource();
         ChatHintActive = true;
         InvokeAsync(StateHasChanged);
-        _ = Task.Delay(TimeSpan.FromSeconds(6), cts.Token).ContinueWith(t =>
-        {
-            if (t.IsCanceled) return;
-            ChatHintActive = false;
-            InvokeAsync(StateHasChanged);
-        }, TaskScheduler.Default);
+        _ = Task.Delay(TimeSpan.FromSeconds(6), cts.Token).ContinueWith(_ =>
+            // State flips on the renderer context — never from the timer's background thread.
+            InvokeAsync(() =>
+            {
+                if (cts.IsCancellationRequested) return;
+                ChatHintActive = false;
+                StateHasChanged();
+            }), TaskContinuationOptions.OnlyOnRanToCompletion);
     }
 
     /// <summary>Stops the pulse — the user found the toggle (clicked it), which is the hint's job done.</summary>

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
@@ -195,6 +195,7 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
         // panel's own thread during a running round can't trip it (the "chat vanishes during
         // execution" bug the nav-context path had to guard against with SameThreadIdentity).
         NavigationManager.LocationChanged += OnLocationChanged;
+        CheckChatHint(NavigationManager.Uri);
         _nodeMenuSubscription = MenuItemsProvider.GetMenu(NodeMenuContext).Subscribe(items =>
         {
             _nodeMenuItems = items;
@@ -676,6 +677,58 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
 
     private NavigationContext? _currentNavContext;
 
+    // ─────────────────────── "Where is the chat?" hint (?hint=chat) ───────────────────────
+    // Content pages cannot reach into the portal chrome, so a page that wants to POINT at the
+    // ever-present chat entry (course lessons: "the chat is always one click away in the top
+    // menu") links its own URL with `?hint=chat`. Landing on such a URL pulses the header's
+    // side-panel/chat toggle for a few seconds — a visual "it's THIS one" — and nothing else:
+    // no navigation, no panel state change, and clicking the toggle dismisses the pulse.
+
+    /// <summary>True while the header chat toggle is pulsing (see <see cref="CheckChatHint"/>).</summary>
+    protected bool ChatHintActive { get; private set; }
+
+    private CancellationTokenSource? _chatHintCts;
+
+    /// <summary>Arms the chat-toggle pulse when <paramref name="uri"/> carries <c>hint=chat</c>.
+    /// The pulse self-dismisses after a few seconds so a shared or bookmarked hint link cannot
+    /// leave the chrome blinking forever.</summary>
+    private void CheckChatHint(string uri)
+    {
+        var query = new Uri(uri, UriKind.RelativeOrAbsolute).IsAbsoluteUri
+            ? new Uri(uri).Query
+            : uri.Contains('?') ? uri[uri.IndexOf('?')..] : "";
+        if (!query.Contains("hint=chat", StringComparison.OrdinalIgnoreCase))
+            return;
+        _chatHintCts?.Cancel();
+        var cts = _chatHintCts = new CancellationTokenSource();
+        ChatHintActive = true;
+        InvokeAsync(StateHasChanged);
+        _ = Task.Delay(TimeSpan.FromSeconds(6), cts.Token).ContinueWith(t =>
+        {
+            if (t.IsCanceled) return;
+            ChatHintActive = false;
+            InvokeAsync(StateHasChanged);
+        }, TaskScheduler.Default);
+    }
+
+    /// <summary>Stops the pulse — the user found the toggle (clicked it), which is the hint's job done.</summary>
+    private void DismissChatHint()
+    {
+        if (!ChatHintActive) return;
+        _chatHintCts?.Cancel();
+        ChatHintActive = false;
+    }
+
+
+    /// <summary>
+    /// Collapses the side pane when the MAIN view navigates to a thread node. Fired on the real
+    /// <see cref="NavigationManager.LocationChanged"/> event (a genuine URL navigation) — never the
+    /// nav-context stream — so a background context re-emission during a running round cannot collapse
+    /// the active side-panel chat (the recurring "chat disappears during execution" bug). An unsent
+    /// new-chat composer (empty <c>ContentPath</c>) is preserved: it is not an opened thread. This
+    /// implements "opening a thread in the main pane collapses the side pane" for EVERY entry point
+    /// (composer full-screen submit, Open-Full-Screen, a thread link) since they all navigate.
+    /// </summary>
     /// <summary>
     /// Collapses the side pane when the MAIN view navigates to a thread node. Fired on the real
     /// <see cref="NavigationManager.LocationChanged"/> event (a genuine URL navigation) — never the
@@ -687,6 +740,7 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
     /// </summary>
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
     {
+        CheckChatHint(e.Location);
         if (!isAuthenticated || !SidePanelState.IsVisible || string.IsNullOrEmpty(SidePanelState.ContentPath))
             return;
         var path = NavigationManager.ToBaseRelativePath(e.Location);
@@ -848,6 +902,7 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
     /// <returns>A task that completes once panel state and size have been applied.</returns>
     public async Task ToggleSidePanel()
     {
+        DismissChatHint();
         var contextPath = CurrentThreadContextPath();
 
         // On a thread in the main view → the side panel is a peek of the thread's context node.

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
@@ -573,3 +573,17 @@
 ::deep img.contrib-menu-icon {
     filter: invert(1);
 }
+
+/* ─────────── "Where is the chat?" hint (?hint=chat → PortalLayoutBase.CheckChatHint) ───────────
+   A content page cannot reach into the chrome, so a lesson that says "the chat lives in the top
+   menu" links itself with ?hint=chat and the toggle pulses for a few seconds. The ring must read
+   in both themes, so it rides on the accent token rather than a literal color. */
+.side-panel-toggle.chat-hint-pulse {
+    border-radius: 6px;
+    animation: chat-hint-pulse 1.2s ease-in-out 5;
+}
+
+@@keyframes chat-hint-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 transparent; }
+    50% { box-shadow: 0 0 0 5px var(--accent-fill-rest); }
+}

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
@@ -583,7 +583,7 @@
     animation: chat-hint-pulse 1.2s ease-in-out 5;
 }
 
-@@keyframes chat-hint-pulse {
+@keyframes chat-hint-pulse {
     0%, 100% { box-shadow: 0 0 0 0 transparent; }
     50% { box-shadow: 0 0 0 5px var(--accent-fill-rest); }
 }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-chat-hint-pulse.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-chat-hint-pulse.md
@@ -1,0 +1,14 @@
+---
+Name: Pages can point at the chat
+Category: What's New
+Description: A link with ?hint=chat makes the header's chat button pulse for a few seconds — course pages use it to show newcomers where the conversation lives.
+Icon: Sparkle
+---
+
+# Pages can point at the chat
+
+Course lessons keep telling newcomers that the chat is "always one click away in the top menu" —
+and until now the page had no way to *show* them. A page can now link its own URL with
+`?hint=chat`: landing on such a link makes the header's chat toggle pulse gently for a few
+seconds, so the eye finds it. Nothing else happens — no navigation, no panel opening — and
+clicking the toggle (or just waiting) ends the pulse.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-chat-hint-pulse.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-chat-hint-pulse.md
@@ -1,6 +1,7 @@
 ---
 Name: Pages can point at the chat
-Category: What's New
+Category: Feature
+Order: -20260824
 Description: A link with ?hint=chat makes the header's chat button pulse for a few seconds — course pages use it to show newcomers where the conversation lives.
 Icon: Sparkle
 ---


### PR DESCRIPTION
Content pages cannot reach into the portal chrome, so a course lesson that says *"the chat is always one click away in the top menu"* had no way to **show** a newcomer which button that is.

This adds a tiny, inert hint affordance: a page links **its own URL with `?hint=chat`**, and landing on it makes the header's side-panel/chat toggle **pulse for ~6 seconds** (an accent-token ring, so it reads in both themes), then self-dismisses; clicking the toggle dismisses it immediately. No navigation, no panel-state change — a pointer, not a behavior.

- `PortalLayoutBase.razor.cs`: `CheckChatHint` armed from `OnInitialized` + `LocationChanged`; `DismissChatHint` on `ToggleSidePanel`; CTS-guarded 6-second self-dismiss.
- `PortalLayoutBase.razor`: conditional `chat-hint-pulse` class on `.side-panel-toggle`.
- `PortalLayoutBase.razor.css`: the keyframes (5 × 1.2 s, `var(--accent-fill-rest)` ring).
- What's New entry included.

Built with `-warnaserror`. First consumer: the education repo's Agentic Business Primer lesson 1 (link lands after this ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)