### PR TITLE
Apps: the home only reads; grid ordered most-recently-used

### DIFF
--- a/clients/react/src/i18n/strings.de.json
+++ b/clients/react/src/i18n/strings.de.json
@@ -133,6 +133,7 @@
   "home.sharedWithMe": "Mit mir geteilt",
   "home.pinned": "Angeheftet",
   "home.apps": "Apps",
+  "home.content": "Inhalte",
   "home.spaces": "Spaces",
   "home.sortLastAccessed": "Zuletzt geöffnet",
   "home.sortLastModified": "Zuletzt geändert",

--- a/clients/react/src/i18n/strings.en.json
+++ b/clients/react/src/i18n/strings.en.json
@@ -133,6 +133,7 @@
   "home.sharedWithMe": "Shared with me",
   "home.pinned": "Pinned",
   "home.apps": "Apps",
+  "home.content": "Content",
   "home.spaces": "Spaces",
   "home.sortLastAccessed": "Last accessed",
   "home.sortLastModified": "Last modified",

--- a/src/MeshWeaver.AI/ThreadLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ThreadLayoutAreas.cs
@@ -176,16 +176,12 @@ public static class ThreadLayoutAreas
                 .WithShowFullHeader()
                 .WithStyle("flex: 1; min-height: 0; overflow: hidden;"));
 
-        // The multi-document shell: the VIEWER's thread rail stays beside the conversation, so
-        // navigating from the rail to a thread keeps the menu — the same shell the Threads app
-        // page renders around its composer. Viewer resolved from the circuit (a visitor without an
-        // identity gets the bare conversation). Still emitted ONCE — the shell is as static as the
-        // container it wraps.
-        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
-        var viewerId = accessService?.Context?.ObjectId ?? accessService?.CircuitContext?.ObjectId;
-        return string.IsNullOrEmpty(viewerId)
-            ? chat
-            : UserActivityLayoutAreas.BuildThreadsShell(viewerId, chat);
+        // 🚨 No MDI shell around the conversation. It used to render the viewer's open-threads rail
+        // beside it, with each row delegating to a `RailItem` area on that THREAD's own hub — one
+        // hub activation per row, resolving an area on a hub this page does not own. That is the
+        // shape that failed in the distributed portal as an unresolvable item area while passing in
+        // a monolith; a thread page renders its conversation and nothing else.
+        return chat;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
@@ -221,9 +221,9 @@
                         @if (IsIconsMode)
                         {
                             <div class="mesh-search-icons-grid">
-                                @* PaintOrdered: most-recently-opened first when the scope asked for
-                                   it (the phone-home rule), query order otherwise. *@
-                                @foreach (var node in PaintOrdered(visibleItems.OfType<MeshNode>().ToList()))
+                                @* Order is applied in ApplyResults (so every render mode honours
+                                   SortByAccess); the tiles just paint what they are given. *@
+                                @foreach (var node in visibleItems.OfType<MeshNode>())
                                 {
                                     @RenderIconTile(node)
                                 }

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
@@ -221,12 +221,11 @@
                         @if (IsIconsMode)
                         {
                             <div class="mesh-search-icons-grid">
-                                @foreach (var item in visibleItems)
+                                @* PaintOrdered: most-recently-opened first when the scope asked for
+                                   it (the phone-home rule), query order otherwise. *@
+                                @foreach (var node in PaintOrdered(visibleItems.OfType<MeshNode>().ToList()))
                                 {
-                                    if (item is MeshNode node)
-                                    {
-                                        @RenderIconTile(node)
-                                    }
+                                    @RenderIconTile(node)
                                 }
                             </div>
                         }

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -367,19 +367,43 @@ public partial class MeshSearchView
             .Query<MeshNode>(MeshQueryRequest.FromQuery(
                 $"namespace:{viewer}/_UserActivity nodeType:UserActivity " +
                 "select:path,id,namespace,name,nodeType,lastModified sort:LastModified-desc limit:500"))
-            .Subscribe(
-                change => InvokeAsync(() =>
+            // 🚨 FOLD the change feed — never rebuild from change.Items. Only Initial/Reset carry a
+            // full snapshot; Added/Updated/Removed carry ONLY the rows that changed, so rebuilding
+            // would replace the whole lookup with the one row that just moved and mis-order every
+            // tile from the first update onwards. Same Scan shape as ObserveSharedTargets.
+            .Scan(ImmutableDictionary<string, DateTimeOffset>.Empty, (map, change) =>
+            {
+                if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+                    return change.Items
+                        .Where(n => !string.IsNullOrEmpty(n.Id))
+                        .GroupBy(n => n.Id!, StringComparer.OrdinalIgnoreCase)
+                        .ToImmutableDictionary(g => g.Key, g => g.First().LastModified,
+                            StringComparer.OrdinalIgnoreCase);
+                foreach (var node in change.Items)
                 {
-                    var map = ImmutableDictionary.CreateBuilder<string, DateTimeOffset>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var node in change.Items)
-                        if (!string.IsNullOrEmpty(node.Id))
-                            map[node.Id] = node.LastModified;
-                    var next = map.ToImmutable();
+                    if (string.IsNullOrEmpty(node.Id))
+                        continue;
+                    map = change.ChangeType switch
+                    {
+                        QueryChangeType.Added or QueryChangeType.Updated =>
+                            map.SetItem(node.Id!, node.LastModified),
+                        QueryChangeType.Removed => map.Remove(node.Id!),
+                        _ => map,
+                    };
+                }
+                return map;
+            })
+            .Subscribe(
+                next => InvokeAsync(() =>
+                {
                     if (next.Count == _accessOrder.Count && next.All(kv =>
                             _accessOrder.TryGetValue(kv.Key, out var at) && at == kv.Value))
                         return;
                     _accessOrder = next;
-                    StateHasChanged();
+                    // Re-PROJECT, not just re-render: the order is applied where results are
+                    // projected (ApplyResults), so a bare StateHasChanged would repaint the
+                    // previous order. Same re-projection the screen subscription uses.
+                    ReprojectForScreen();
                 }),
                 ex => MeshHub.ServiceProvider.GetService<ILoggerFactory>()
                     ?.CreateLogger("MeshWeaver.MeshSearchView")
@@ -955,7 +979,9 @@ public partial class MeshSearchView
         // a no-op for every viewer whose mode is off.
         visible = _screen.Filter(visible, TargetOf);
 
-        _nodes = visible.ToList();
+        // Most-recently-used first when the scope asked for it — applied HERE, so every render
+        // mode (icons, flat, list, grouped) honours it, not just the grid that first needed it.
+        _nodes = PaintOrdered(visible.ToList()).ToList();
         ResolveDeletePermissions(_nodes);
 
         if (ViewModel != null)

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -299,6 +299,81 @@ public partial class MeshSearchView
     /// the query rows: no per-result content read, no per-result hub.</summary>
     private bool IsIconsMode => EffectiveRenderMode == MeshSearchRenderMode.Icons;
 
+    // ----- "Most recently used first" (MeshSearchScopeTab.SortByAccess) -----
+    // The viewer's own access log, keyed the way it is STORED: a UserActivity node per visited
+    // path at {viewer}/_UserActivity/{path with '/' → '_'}. That mangling is one-way, so we never
+    // reverse it — we mangle each tile's TARGET the same way and look it up. One cheap
+    // single-partition query, subscribed only by a scope that asked for this ordering.
+    private IDisposable? _accessOrderSubscription;
+    private ImmutableDictionary<string, DateTimeOffset> _accessOrder = ImmutableDictionary<string, DateTimeOffset>.Empty;
+    private string? _accessOrderViewer;
+
+    /// <summary>Order this scope's results by the viewer's last access of each result's target
+    /// (the active scope's opt-in; the home's Apps grid sets it).</summary>
+    private bool BoundSortByAccess => ActiveScopeTab?.SortByAccess ?? false;
+
+    /// <summary>The activity id the access log stores a visit to <paramref name="path"/> under.</summary>
+    private static string AccessKeyOf(string path) => path.Replace('/', '_');
+
+    /// <summary>
+    /// Results in paint order: most-recently-opened first when the scope asked for it, with
+    /// never-opened results keeping the query's own order BEHIND them (never dropped — that is
+    /// exactly what a `source:accessed` INNER JOIN would have done to a freshly installed app).
+    /// A stable sort, so the query's order survives inside each group.
+    /// </summary>
+    private IReadOnlyList<MeshNode> PaintOrdered(IReadOnlyList<MeshNode> nodes)
+    {
+        if (!BoundSortByAccess || _accessOrder.IsEmpty || nodes.Count < 2)
+            return nodes;
+        return nodes
+            .OrderByDescending(n =>
+                _accessOrder.TryGetValue(AccessKeyOf(TargetOf(n)), out var at) ? at : DateTimeOffset.MinValue)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Subscribes the viewer's access log when the active scope sorts by it. Deliberately a
+    /// SECOND pass: the tiles paint from their own query the moment it lands, and this re-orders
+    /// them when the log arrives — the ordering is never allowed to gate the first paint.
+    /// </summary>
+    private void SubscribeToAccessOrder()
+    {
+        var viewer = BoundSortByAccess ? Access.ViewerId() : null;
+        if (string.IsNullOrEmpty(viewer))
+        {
+            _accessOrderSubscription?.Dispose();
+            _accessOrderSubscription = null;
+            _accessOrderViewer = null;
+            _accessOrder = ImmutableDictionary<string, DateTimeOffset>.Empty;
+            return;
+        }
+        if (string.Equals(viewer, _accessOrderViewer, StringComparison.OrdinalIgnoreCase))
+            return;   // already watching this viewer's log
+        _accessOrderViewer = viewer;
+        _accessOrderSubscription?.Dispose();
+        _accessOrderSubscription = MeshQuery
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"namespace:{viewer}/_UserActivity nodeType:UserActivity " +
+                "select:path,id,namespace,name,nodeType,lastModified sort:LastModified-desc limit:500"))
+            .Subscribe(
+                change => InvokeAsync(() =>
+                {
+                    var map = ImmutableDictionary.CreateBuilder<string, DateTimeOffset>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var node in change.Items)
+                        if (!string.IsNullOrEmpty(node.Id))
+                            map[node.Id] = node.LastModified;
+                    var next = map.ToImmutable();
+                    if (next.Count == _accessOrder.Count && next.All(kv =>
+                            _accessOrder.TryGetValue(kv.Key, out var at) && at == kv.Value))
+                        return;
+                    _accessOrder = next;
+                    StateHasChanged();
+                }),
+                ex => MeshHub.ServiceProvider.GetService<ILoggerFactory>()
+                    ?.CreateLogger("MeshWeaver.MeshSearchView")
+                    .LogWarning(ex, "Access-order stream ended for {Viewer}; keeping query order", viewer));
+    }
+
     /// <summary>The fallback subtitle shown on a search row when the node has no description.</summary>
     private const string NoDescriptionPrompt = "Ask the agent to create a description.";
 
@@ -714,6 +789,9 @@ public partial class MeshSearchView
         _isLoading = true;
         StateHasChanged();
         SubscribeToResultStream();
+        // Second pass, never a gate: the tiles paint from the query above; this re-orders them
+        // when the viewer's access log lands (and is a no-op for every scope that didn't ask).
+        SubscribeToAccessOrder();
     }
 
     // ReactiveMode and the default (one-shot-style) mode are now the SAME storm-resistant
@@ -2186,6 +2264,7 @@ public partial class MeshSearchView
     public override ValueTask DisposeAsync()
     {
         _screenSubscription?.Dispose();
+        _accessOrderSubscription?.Dispose();
         _reactiveSubscription?.Dispose();
         DisposeTreeSubscriptions();
         _navSubscription?.Dispose();

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -312,6 +312,18 @@ public partial class MeshSearchView
     /// (the active scope's opt-in; the home's Apps grid sets it).</summary>
     private bool BoundSortByAccess => ActiveScopeTab?.SortByAccess ?? false;
 
+    /// <summary>Order grouped sections by SIZE instead of alphabetically — the home's content
+    /// section fans out by node type with the biggest type first.</summary>
+    private bool BoundGroupByFrequency
+    {
+        get
+        {
+            if (ViewModel?.GroupByFrequency is bool b) return b;
+            if (ViewModel?.GroupByFrequency is JsonElement je) return je.ValueKind == JsonValueKind.True;
+            return false;
+        }
+    }
+
     /// <summary>The activity id the access log stores a visit to <paramref name="path"/> under.</summary>
     private static string AccessKeyOf(string path) => path.Replace('/', '_');
 
@@ -1029,13 +1041,19 @@ public partial class MeshSearchView
                     Items = limitedItems.Cast<object>().ToList(),
                     TotalCount = items.Count
                 };
-            })
-            .OrderBy(g => g.Label)
-            .ToList();
+            });
+
+        // BY FREQUENCY when asked (the home's content section): the type you have most of leads,
+        // so the page opens on what you actually work with instead of whatever starts with "A".
+        // Ties fall back to the label so the order is stable across renders.
+        groups = BoundGroupByFrequency
+            ? groups.OrderByDescending(g => g.TotalCount).ThenBy(g => g.Label)
+            : groups.OrderBy(g => g.Label);
+        var orderedGroups = groups.ToList();
 
         return new GroupedSearchResult
         {
-            Groups = groups,
+            Groups = orderedGroups,
             TotalItems = sortedNodes.Count
         };
     }

--- a/src/MeshWeaver.Documentation/Data/Architecture/AppsHome.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AppsHome.md
@@ -6,7 +6,7 @@ what you see first is what you *use*, not everything the mesh can show you. The 
 | Tab | Present when | Contents | Default order |
 |---|---|---|---|
 | **Pinned** | the caller has pins | the owner's content shortcuts (`User.PinnedPaths`) | last modified |
-| **Apps** | always | the viewer's OWN `{owner}/_App` records — every app exactly once, as an ICON grid | alphabetical |
+| **Apps** | always | the viewer's OWN `{owner}/_App` records — every app exactly once, as an ICON grid | last used |
 | **Spaces** | always | the catalog **without** store items | last accessed |
 | **All** | always | everything the viewer can read, at every depth | last accessed |
 
@@ -53,24 +53,45 @@ no content load — and a click opens the app, never the record.
 > routing loops, and refused installing any package named App (the static/durable claim collision,
 > #1209). Pick collision-improbable names for built-in NodeTypes.
 
-**Materialization (write-behind).** No onboarding seeding: on home render, `EnsureAppRecords`
-compares what the viewer SHOULD have — the config-declared defaults
-(`Admin/HomeConfig.DefaultApps`) plus every install-manifest item with a live `installedPath`
-(`{owner}/_Install/{slug}`, read untyped by the manifest's own design) — against the records that
-exist, creates the missing ones fire-and-forget into the viewer's own partition, and HEALS records
-that still carry the generic icon or no `MainNode` target (the icon comes from the plugin cover
-node, fetched in ONE one-shot query off the render path; a name only fills when EMPTY — an existing
-name, possibly the owner's rename, is never overwritten). A config addition reaches every user's
-grid on their next home render; the Store's install flow writes and removes records directly
-(phase 2).
+## Who writes a record — the Store, not the home
 
-> 🚨 **The materializer acts only on a REAL records snapshot.** The records observable starts with a
+**The app lifecycle belongs to the STORE**: it creates the record when a viewer installs an app
+(stamping the real `Name`, `Icon` and `MainNode`), refreshes it on reinstall, and deletes it on
+uninstall. The home does not participate. Core holds exactly one write, `EnsureDefaultApps`, and it
+is a **bootstrap, not a sync**: when a viewer's grid is EMPTY, the platform defaults from
+`Admin/HomeConfig.DefaultApps` are created once — otherwise a brand-new home would be a blank
+screen with no icon to reach the Store by. A viewer who has any record at all never triggers it.
+
+> 🚨 **Why the home stopped materializing.** It used to read the Store's install manifests
+> (`{owner}/_Install/{slug}`) on every render, diff them against the records, back-fill what was
+> missing and heal names/icons from plugin cover nodes. That made *every home render a write path*,
+> put the Store's model in two places, and cost a cross-schema cover query to learn things the
+> Store already knew at install time. Rendering the home is a READ.
+
+> 🚨 **A bootstrap acts only on a REAL records snapshot.** The records observable starts with a
 > `null` sentinel — never `[]` — because "not loaded yet" and "no records" must differ: the first
 > shipped materializer synthesized an empty start and every fresh home render fired ~20 doomed
 > `CreateNode` calls against records that already existed ("Node already exists" storms in Loki —
 > and the home lag). A create that still loses a race is logged at Debug, not Warning.
 
-**Threads is an ordinary app.** The `~/Chat` config entry materializes as the record
+## Order — most recently used first
+
+The grid is ordered the way a phone orders apps: **what you opened last comes first**, with
+never-opened apps keeping the query's order behind them. That ordering is applied **at paint**
+(`MeshSearchScopeTab.SortByAccess`), from the viewer's own `{viewer}/_UserActivity` satellites —
+one cheap single-partition read whose ids are the visited path with `/` replaced by `_`, so a
+tile's target maps to its access time by a forward computation and never a reverse lookup.
+
+> 🚨 **Why not `source:accessed`.** It is an INNER JOIN on the access log keyed by the row's OWN
+> path, and it would fail twice here: it drops every never-opened app (a freshly installed app
+> would be invisible), and it matches nothing anyway — opening an app records a visit to the APP,
+> never to the `_App` record that points at it. Ordering is a *sort key*, so it must never be
+> expressed as a join that also filters.
+
+The access snapshot arrives after the tiles have painted and re-orders them — deliberately the
+second pass: ordering never gates the first paint.
+
+**Threads is an ordinary app.** The `~/Chat` config entry seeds the record
 `{owner}/_App/Chat` (name *Threads*, `OpenPath = {owner}/Chat`, `MainNode = {owner}/Chat`) — a
 normal tile among the others, not a special dock, and it REPLACES the old open-threads band on the
 default home template (the `area/Threads` area stays registered for authored bodies that embed it).
@@ -82,8 +103,9 @@ node path.
 The admin-editable platform node (`HomeConfigNodeType`, public-read, live-reloading):
 
 - **`Style`** — `Tabs` (default) or `Catalog`, the escape hatch back to the legacy single flat list.
-- **`DefaultApps`** — the entries every user's Apps grid starts with (shipped: `Store`, `Doc`,
-  `~/Chat`), interpreted by the materializer above. Until a list-capable edit-form field ships it is
+- **`DefaultApps`** — the entries a viewer's Apps grid is BOOTSTRAPPED with (shipped: `Store`,
+  `Doc`, `~/Chat`). Read only when the grid is empty, so editing it changes what new viewers get,
+  not what existing viewers have. Until a list-capable edit-form field ships it is
   `[Browsable(false)]` on the generic content editor — admins edit the node content directly.
 - `Scope`, `Render`, `DefaultSort` — apply to the Spaces/All scopes (and the legacy list).
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-apps-most-recent-first.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-apps-most-recent-first.md
@@ -1,0 +1,17 @@
+---
+Name: Apps open in the order you use them
+Category: Fix
+Description: The Apps grid now puts your most recently used apps first, and the home page no longer rebuilds your app list on every visit.
+Icon: Sparkle
+Order: -20260824
+---
+
+# Apps open in the order you use them
+
+Your Apps grid is now ordered the way a phone orders apps: whatever you opened last comes first,
+and apps you have not opened yet keep their place behind them. Nothing disappears from the grid
+because you have not used it.
+
+The home page also stopped rebuilding your app list every time you open it. Which apps you have is
+recorded when you install them, so opening your home is now purely a read — the grid appears as
+fast as the list arrives.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-home-apps-and-content.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-home-apps-and-content.md
@@ -1,0 +1,18 @@
+---
+Name: A home with apps on top and one content list
+Category: Feature
+Description: The home now opens with your apps as an icon grid, then a single content list that groups itself by type with the biggest group first.
+Icon: Sparkle
+Order: -20260824
+---
+
+# A home with apps on top and one content list
+
+Your home page now has two clear parts. **Apps** sits at the top: a grid of app icons, ordered so
+the ones you use most come first. Below it, **Content** is a single list of everything you can
+reach, which groups itself by what kind of thing each item is — spaces, clients, courses — with the
+biggest group first, so the page opens on what you actually work with.
+
+The old Spaces and All tabs are gone; they were two names for the same list. **Pinned** stays as
+its own tab whenever you have pinned something, and items shared with you keep their own section at
+the bottom.

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -72,15 +72,6 @@ public static class UserActivityLayoutAreas
     /// <summary>Link to the doc page that explains the configurable Body-page + <c>@@</c>-region model.</summary>
     internal const string ConfigGuideLink = "/Doc/GUI/ConfigurablePages";
 
-    /// <summary>
-    /// The per-thread rail-row item area consumed by the Threads app's vertical rail — registered
-    /// on every THREAD hub (MeshWeaver.AI, <c>ThreadNodeType.RailItemArea</c> /
-    /// <c>ThreadRailItem.View</c>: title + ✕-close overlay). Referenced here by NAME only: item
-    /// areas resolve on the result node's own hub at render time, so Graph carries no AI
-    /// dependency for it.
-    /// </summary>
-    internal const string ThreadRailItemArea = "RailItem";
-
     private const string ThinScrollbar = "scrollbar-width: thin; scrollbar-color: rgba(128,128,128,0.3) transparent;";
 
 
@@ -653,67 +644,16 @@ public static class UserActivityLayoutAreas
         => Observable.Return<UiControl?>(new ThreadChatControl().WithHideEmptyState(true));
 
     /// <summary>
-    /// The THREADS APP page (<c>/{user}/Chat</c>, the ChatArea) — the GitHub-Copilot-style shape:
-    /// a vertical RAIL of the owner's open threads on the left (each row rendered by the thread
-    /// hub's <see cref="ThreadRailItemArea"/>: title + ✕ that closes the thread via the canonical
-    /// <c>MarkThreadDone</c>, so it leaves the rail but stays searchable), and the node-less chat
-    /// composer on the right — sending starts a proper thread via <c>StartThread</c> and opens it
-    /// full-screen. Pure composition of existing pieces; see <see cref="BuildThreadsApp"/>.
+    /// The chat page at <c>/{user}/Chat</c> (the ChatArea): the node-less composer, nothing else.
+    /// Sending starts a proper thread via <c>StartThread</c> and opens it full-screen.
+    /// <para>🚨 The MDI shell this used to render — a fixed rail of open threads whose rows
+    /// delegated to a <c>RailItem</c> area on each THREAD's own hub — is deleted. A per-result item
+    /// area activates one hub PER ROW and resolves an area on a hub the home does not own, which is
+    /// exactly the shape that failed in the distributed portal as "AppTile not found" while passing
+    /// in a monolith. The home renders from query rows; nothing on it resolves a foreign area.</para>
     /// </summary>
     internal static IObservable<UiControl?> ThreadsAppView(LayoutAreaHost host, RenderingContext _)
-        => Observable.Return<UiControl?>(BuildThreadsApp(OwnerIdOf(host.Hub.Address.ToString())));
-
-    /// <summary>
-    /// The Threads-app composition — pure (no hub) so the shape is unit-testable: the MDI shell
-    /// (<see cref="BuildThreadsShell"/>) with the node-less composer as its main pane. Opening a
-    /// thread from the rail NAVIGATES to the thread page, which renders the SAME shell around the
-    /// conversation — the rail (the "document list") stays put across navigations, exactly like a
-    /// multi-document window.
-    /// </summary>
-    internal static UiControl BuildThreadsApp(string nodeOwnerId) =>
-        BuildThreadsShell(nodeOwnerId,
-            new ThreadChatControl().WithHideEmptyState(true));
-
-    /// <summary>
-    /// The Threads MDI SHELL — a FIXED left rail of the viewer's open threads beside the main
-    /// pane. Rendered by BOTH the Threads app page (<c>/{user}/Chat</c>, main = the composer) and
-    /// every thread's full page (main = the conversation), so navigating between threads keeps the
-    /// rail — the menu never collapses. No <c>flex-wrap</c>: a wrapping shell was exactly the
-    /// broken layout it replaces; the rail is a fixed 280px column, the pane takes the rest.
-    /// </summary>
-    public static UiControl BuildThreadsShell(string viewerId, UiControl main) =>
-        Controls.Stack
-            .WithOrientation(Orientation.Horizontal)
-            .WithWidth("100%")
-            .WithStyle("width: 100%; height: 100%; min-height: 0; align-items: stretch; gap: 0;")
-            .WithView(Controls.Stack
-                .WithStyle("flex: 0 0 280px; width: 280px; box-sizing: border-box; min-height: 0; " +
-                           "overflow-y: auto; border-right: 1px solid var(--neutral-stroke-rest); " +
-                           "padding-right: 8px;")
-                .WithView(BuildThreadsRail(viewerId)))
-            .WithView(Controls.Stack
-                .WithStyle("flex: 1 1 auto; min-width: 0; min-height: 0; display: flex; " +
-                           "flex-direction: column; padding-left: 12px;")
-                .WithView(main));
-
-    /// <summary>The Threads-app rail list: the owner's open threads (never Done, newest first) as a
-    /// single-column list whose rows delegate to the thread hub's <see cref="ThreadRailItemArea"/>.
-    /// Flat render + MaxColumns(1), NOT <see cref="MeshSearchRenderMode.List"/>: the List renderer
-    /// draws its own icon·title·description rows and IGNORES <c>ItemArea</c>, so the ✕ overlay
-    /// would never render there — Flat is the ItemArea path the pinned grid already proves.</summary>
-    internal static MeshSearchControl BuildThreadsRail(string nodeOwnerId) =>
-        Controls.MeshSearch
-            .WithHiddenQuery(
-                $"namespace:{nodeOwnerId}/*_Thread nodeType:Thread -content.status:Done sort:LastModified-desc")
-            .WithShowSearchBox(false)
-            .WithShowEmptyMessage(true)
-            .WithRenderMode(MeshSearchRenderMode.Flat)
-            .WithMaxColumns(1)
-            .WithCollapsibleSections(false)
-            .WithSectionCounts(false)
-            .WithItemArea(ThreadRailItemArea)
-            .WithItemLimit(50)
-            .WithReactiveMode(true);
+        => Observable.Return<UiControl?>(new ThreadChatControl().WithHideEmptyState(true));
 
     /// <summary>
     /// The owner's OPEN threads — their own partition only (<c>{owner}/*_Thread</c>, no cross-partition
@@ -819,84 +759,131 @@ public static class UserActivityLayoutAreas
         if (cfg.Style == HomeStyle.Catalog)
             return BuildCatalog(nodeOwnerId, cfg, sharedTargets, locale, privacy);
 
+        // TWO SECTIONS, apps first: the icon grid you launch things from, then the content you
+        // search through. They are different acts — one is "open my app", the other is "find that
+        // thing" — and mixing them into one tab strip made the apps just another lens on a search.
+        var home = Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("gap: 24px; width: 100%;")
+            .WithView(BuildAppsBand(nodeOwnerId, locale))
+            .WithView(BuildContentSection(nodeOwnerId, config, user, locale, screen));
+
+        // Shared with me — cross-partition invitations, their own band under the content section.
+        // Present only when the caller actually has such grants.
+        var shared = BuildSharedBand(privacy.Retain(sharedTargets), locale);
+        return shared is null ? home : home.WithView(shared);
+    }
+
+    /// <summary>
+    /// The <b>Content</b> section — ONE category of content plus, when the viewer has any, a
+    /// <b>Pinned</b> tab. The category is simply <b>All</b>: every top-level node the viewer can
+    /// reach. "Spaces" never described anything real (the list is just what you have access to),
+    /// and slicing one list into three tabs was navigation the reader had to think about before
+    /// they could look at anything.
+    /// <para>Store items are excluded — those are apps, and an app appears exactly once, up in the
+    /// Apps section. The sort dropdown offers last accessed / last modified / alphabetical, and the
+    /// search box searches the active tab. <see cref="HomeConfig.Scope"/> can widen the list to the
+    /// full subtree. Pure, for tests.</para>
+    /// </summary>
+    internal static MeshSearchControl BuildContentSection(
+        string nodeOwnerId, HomeConfig? config, User? user, string? locale, PresentationScreen? screen)
+    {
+        var cfg = config ?? HomeConfigNodeType.Defaults;
+        var privacy = screen ?? PresentationScreen.Off;
         var scopes = new List<MeshSearchScopeTab>();
 
-        // Pinned — the owner's content shortcuts, union-with-fallback for last accessed.
+        // Pinned — the owner's shortcuts, kept as its own tab, present only when there are pins.
+        // 🚨 The pins are INTERPOLATED INTO the query string, so the presentation screen (#1803)
+        // drops a marked one HERE, before the query exists — not only where its card is painted.
+        // No ItemArea: the inline unpin overlay used to resolve an area on each pinned node's OWN
+        // hub, the per-result foreign-area shape that failed in the distributed portal. Unpinning
+        // lives in the node menu, and the card comes from the query row.
         var pins = privacy.Retain(user?.PinnedPaths);
         if (pins.Count > 0)
         {
             var pinnedBase = $"path:({string.Join(" OR ", pins)})";
-            scopes.Add(HomeScope("home.pinned", locale, HomeCatalogSort.LastModified,
+            scopes.Add(ContentScope("home.pinned", locale, HomeCatalogSort.LastModified,
                 (sort, suffix) => sort == HomeCatalogSort.LastAccessed
+                    // source:accessed is an INNER JOIN — alone it would hide a never-opened pin.
                     ? $"{pinnedBase} {suffix}\n{pinnedBase} {SortSuffixLastModified}"
                     : $"{pinnedBase} {suffix}"));
         }
 
-        // Apps — the viewer's OWN app records: a SINGLE-PARTITION query ({owner}/_App), which is
-        // why it loads fast (the old cover-path alternation fanned out across every partition
-        // schema — the multi-second home lag). The records are the STORE's to write; the home only
-        // reads them (Threads is an ordinary record like every other app). Icons render: the
-        // phone-home grid painted ENTIRELY from the query rows (record Name/Icon; no per-tile hub,
-        // no content load — the per-record AppTile area cost one hub PER RESULT), and
-        // NavigateToMainNode makes a tile open the APP (the record's MainNode target).
-        //
-        // ORDER: most recently used first, like a phone. That ordering is applied at PAINT
-        // (SortByAccess) rather than in the query, because `source:accessed` is an INNER JOIN on
-        // the access log keyed by the row's OWN path: it would drop every never-opened app AND
-        // match nothing anyway — opening an app records a visit to the APP, never to the record
-        // that points at it. The sort options below stay pure order-bys over the records; the
-        // "Last accessed" option is the query-side no-op that keeps the dropdown honest.
-        var appsBase =
-            $"path:{nodeOwnerId}/{AppNodeType.UserNamespace} scope:children nodeType:{AppNodeType.NodeType}";
-        scopes.Add(HomeScope("home.apps", locale, HomeCatalogSort.LastAccessed,
-                (sort, suffix) => sort == HomeCatalogSort.LastAccessed
-                    ? $"{appsBase} {SortSuffixAlphabetical}"
-                    : $"{appsBase} {suffix}")
-            with
-            {
-                RenderMode = nameof(MeshSearchRenderMode.Icons),
-                NavigateToMainNode = true,
-                SortByAccess = true,
-            });
-
-        // Spaces — the deduplicated catalog (an app never appears twice).
-        scopes.Add(HomeScope("home.spaces", locale, cfg.DefaultSort,
+        // All — every top-level node the viewer can access (apps excluded; they have their own
+        // section). The ONE content category.
+        scopes.Add(ContentScope("home.all", locale, cfg.DefaultSort,
             (_, suffix) => CatalogQuery(cfg.Scope, nodeOwnerId, suffix, SpacesDedupExclusions)));
 
-        // All — search EVERYTHING the viewer can read, at every depth (the "we can search all" tab).
-        scopes.Add(HomeScope("home.all", locale, cfg.DefaultSort,
-            (_, suffix) => CatalogQuery(HomeCatalogScope.Subtree, nodeOwnerId, suffix)));
-
-        var search = Controls.MeshSearch
+        // ONE list that FANS OUT by the node's own type — Spaces, Clients, Courses, … — with the
+        // biggest group first (GroupByFrequency), so the page opens on what the viewer actually
+        // works with. That is what "Spaces" was reaching for and failing to say: the categories
+        // are not a fixed taxonomy the home invents, they are whatever types the viewer's
+        // top-level nodes happen to have.
+        var content = Controls.MeshSearch
+            .WithTitle(LocalizationCatalog.Get("home.content", locale))
             .WithScopeTabs(scopes.ToArray())
-            // Fallbacks for clients without scope support (react renders these): the first scope.
+            // Fallback for clients without scope support (react renders these): the first scope.
             .WithHiddenQuery(scopes[0].Query)
             .WithSortOptions([.. scopes[0].SortOptions!])
             .WithShowSearchBox(true)
             .WithViewOptions(true)
             .WithShowEmptyMessage(true)
-            .WithRenderMode(cfg.Render == HomeCatalogRender.Grouped
-                ? MeshSearchRenderMode.Grouped
-                : MeshSearchRenderMode.Flat)
+            .WithRenderMode(MeshSearchRenderMode.Grouped)
+            .WithGroupBy("NodeType")
+            .WithGroupByFrequency()
+            .WithSectionCounts(true)
+            .WithCollapsibleSections(true)
             .WithMaxColumns(4)
             .WithItemLimit(50)
             .WithMaxRows(6)
             .WithReactiveMode(true)
             .WithCreateHref("/create");
-        if (cfg.Render == HomeCatalogRender.Grouped)
-            search = search.WithSectionCounts(true).WithCollapsibleSections(true);
+        return content;
+    }
 
-        // Shared with me is its OWN titled band below the scoped search (not a scope tab) —
-        // cross-partition invitations are a distinct kind of content, not another lens on the
-        // catalog. Present only when the caller actually has such grants.
-        var shared = BuildSharedBand(privacy.Retain(sharedTargets), locale);
-        if (shared is null)
-            return search;
-        return Controls.Stack
-            .WithWidth("100%")
-            .WithStyle("gap: 24px; width: 100%;")
-            .WithView(search)
-            .WithView(shared);
+    /// <summary>
+    /// The <b>Apps</b> section — the phone-home ICON grid over the viewer's OWN
+    /// <c>{owner}/_App</c> records. A SINGLE-PARTITION query (which is why it loads fast — the old
+    /// cover-path alternation fanned out across every partition schema, the multi-second home lag)
+    /// painted ENTIRELY from the query rows: record Name/Icon, no per-tile hub, no content read.
+    /// <c>NavigateToMainNode</c> makes a tile open the APP it points at, never the record.
+    /// <para>ORDER: most recently used first, like a phone (<c>SortByAccess</c>, applied at paint
+    /// from the viewer's own access log). NOT <c>source:accessed</c> — that is an INNER JOIN keyed
+    /// by the row's own path, so it would drop every never-opened app AND match nothing anyway,
+    /// since opening an app records a visit to the APP, never to the record pointing at it.</para>
+    /// <para>No search box and no view options: this is a launcher, not a search surface — the
+    /// content section below is where you search. Pure, exposed for tests.</para>
+    /// </summary>
+    internal static MeshSearchControl BuildAppsBand(string nodeOwnerId, string? locale)
+    {
+        var appsQuery =
+            $"path:{nodeOwnerId}/{AppNodeType.UserNamespace} scope:children " +
+            $"nodeType:{AppNodeType.NodeType} {SortSuffixAlphabetical}";
+        return Controls.MeshSearch
+            .WithTitle(LocalizationCatalog.Get("home.apps", locale))
+            .WithHiddenQuery(appsQuery)
+            .WithShowSearchBox(false)
+            .WithShowEmptyMessage(false)
+            .WithRenderMode(MeshSearchRenderMode.Icons)
+            .WithCollapsibleSections(false)
+            .WithSectionCounts(false)
+            .WithItemLimit(50)
+            .WithReactiveMode(true)
+            with
+            {
+                NavigateToMainNode = true,
+                // One scope, so the grid's own paint order is the phone order. The scope carries it
+                // because SortByAccess/RenderMode are per-scope settings the view reads there.
+                ScopeTabs =
+                [
+                    new MeshSearchScopeTab(LocalizationCatalog.Get("home.apps", locale), appsQuery)
+                    {
+                        RenderMode = nameof(MeshSearchRenderMode.Icons),
+                        NavigateToMainNode = true,
+                        SortByAccess = true,
+                    },
+                ],
+            };
     }
 
     /// <summary>
@@ -930,9 +917,9 @@ public static class UserActivityLayoutAreas
             .WithReactiveMode(true);
     }
 
-    /// <summary>One home scope tab: localized label + the three catalog sorts (default first),
-    /// each option's full query produced by <paramref name="query"/>(sort, suffix).</summary>
-    private static MeshSearchScopeTab HomeScope(
+    /// <summary>One content tab: localized label + the three catalog sorts (default first), each
+    /// option's full query produced by <paramref name="query"/>(sort, suffix).</summary>
+    private static MeshSearchScopeTab ContentScope(
         string labelKey, string? locale, HomeCatalogSort defaultSort,
         Func<HomeCatalogSort, string, string> query)
     {

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -491,13 +491,17 @@ public static class UserActivityLayoutAreas
     }
 
     /// <summary>The catalog region — the TABBED home surface (see <see cref="BuildHome"/>):
-    /// <b>Shared with me</b> (the caller's cross-partition grants, #385 — see
-    /// <see cref="ObserveSharedTargets"/>) · <b>Pinned</b> · <b>Apps</b> (the viewer's OWN
-    /// <c>{owner}/_App</c> records, materialized write-behind from the config defaults + the
-    /// Store's install manifests — see <see cref="EnsureAppRecords"/>) ·
-    /// <b>Spaces</b> (the deduplicated catalog). The
-    /// admin-editable <c>Admin/HomeConfig</c> node drives the shape and can switch back to the
-    /// legacy single-list catalog (<see cref="HomeStyle.Catalog"/>).</summary>
+    /// <b>Pinned</b> · <b>Apps</b> (the viewer's OWN <c>{owner}/_App</c> records — a pure READ) ·
+    /// <b>Spaces</b> (the deduplicated catalog) · <b>All</b>, with the <b>Shared with me</b> band
+    /// (the caller's cross-partition grants, #385 — see <see cref="ObserveSharedTargets"/>)
+    /// below. The admin-editable <c>Admin/HomeConfig</c> node drives the shape and can switch back
+    /// to the legacy single-list catalog (<see cref="HomeStyle.Catalog"/>).
+    /// <para>🚨 The render path performs NO app writes. Everything install-shaped — creating a
+    /// record when an app is installed, removing it on uninstall, stamping its real name/icon and
+    /// refreshing them — belongs to the STORE, which owns the app lifecycle; core only reads what
+    /// the Store wrote. The one exception is <see cref="EnsureDefaultApps"/>: a viewer with ZERO
+    /// records would otherwise face an empty home with no way to reach the Store, so the platform
+    /// defaults are seeded ONCE, only for an empty grid, and never touched again.</para></summary>
     internal static IObservable<UiControl?> CatalogAreaView(LayoutAreaHost host, RenderingContext _)
     {
         var ownerId = OwnerIdOf(host.Hub.Address.ToString());
@@ -512,48 +516,45 @@ public static class UserActivityLayoutAreas
         // The home's DISPLAY CONFIG is DATA-DRIVEN: read the admin-editable Admin/HomeConfig platform
         // node reactively (shipped defaults when absent), so an admin's edit updates every open home
         // LIVE — no code change, no image roll. Combined with the caller's cross-partition grants
-        // (#385), the owner's installed-app records, and the owner node (pins). Every leg starts
-        // with a value so the home paints instantly.
+        // (#385) and the owner node (pins). Every leg starts with a value so the home paints
+        // instantly. The Apps grid needs NOTHING here: the tiles are rendered from their own
+        // single-partition query inside the search control.
         var syncStream = host.Workspace.GetStream(new MeshNodeReference());
-        // Write-behind app-record MATERIALIZATION + HEALING: the Apps grid renders ONLY the
-        // viewer's own {owner}/_App records (a fast SINGLE-PARTITION query). EnsureAppRecords
-        // creates what the config defaults + install manifests say is missing, and repairs
-        // records that carry the generic icon or no navigation target — but ONLY once the records
-        // query has emitted its REAL first snapshot (null sentinel until then): acting on the
-        // synthetic empty start fired ~20 doomed creates per render, the "Node already exists"
-        // storm Loki showed AND the home lag. The per-area `attempted` set guards re-entry while
-        // a write is in flight.
-        var attempted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var bootstrapped = false;
         return HomeConfigNodeType.Observe(host.Workspace, options)
             .CombineLatest(
                 ObserveSharedTargets(host, ownerId),
                 ObserveAppRecords(host, ownerId),
-                ObserveManifestItems(host, ownerId, options),
                 syncStream!.Select(change => change.Value.ContentAs<User>(options)).StartWith((User?)null),
                 screen,
-                (config, shared, records, manifestItems, user, viewerScreen) =>
+                (config, shared, records, user, viewerScreen) =>
                 {
-                    if (records is not null)
-                        EnsureAppRecords(host, ownerId, config, manifestItems, records, attempted);
+                    // Only ever fires for a viewer whose grid is EMPTY (never the null sentinel —
+                    // acting on a synthetic empty start is what fired ~20 doomed creates per
+                    // render, the "Node already exists" storm Loki showed AND the home lag).
+                    if (records is { Count: 0 } && !bootstrapped)
+                    {
+                        bootstrapped = true;
+                        EnsureDefaultApps(host, ownerId, config);
+                    }
                     return (UiControl?)BuildHome(ownerId, config, shared, user, locale, viewerScreen);
                 });
     }
 
     /// <summary>
-    /// The ids of the owner's <c>{owner}/_App/{appId}</c> records (see <see cref="AppNodeType"/>)
-    /// and, below, the INSTALLED item paths of the Store's manifests at
-    /// <c>{owner}/_Install/{slug}</c> — both feed the write-behind record materialization in
-    /// <see cref="CatalogAreaView"/>. The manifest's content type is MESH-compiled
-    /// (<c>Store/Install</c>), so it is read UNTYPED by design (the manifest's own doc says exactly
-    /// that) — a JSON traversal at a genuine type boundary, not an <c>as</c>-cast trap. Both reads
-    /// go via the shared, per-user-RLS, empty-on-absent <c>GetQuery</c> cache on the viewer's OWN
-    /// partition, starting empty so the home paints instantly.
+    /// The owner's <c>{owner}/_App/{appId}</c> records (see <see cref="AppNodeType"/>) — the ONE
+    /// read the home needs about apps, through the shared, per-user-RLS, empty-on-absent
+    /// <c>GetQuery</c> cache on the viewer's OWN partition. Row-only (no content on the wire): the
+    /// tiles are Name + Icon + <see cref="MeshNode.MainNode"/>, and the select list gates only the
+    /// content column — every other field always returns.
+    /// <para>Used ONLY to decide whether the grid is empty (the <see cref="EnsureDefaultApps"/>
+    /// bootstrap); the tiles themselves come from the search control's own query. Reading the
+    /// Store's install manifests here — the previous design — is gone: what a viewer has installed
+    /// is the STORE's business to record, not something the home re-derives on every render.</para>
     /// </summary>
     private static IObservable<IReadOnlyList<MeshNode>?> ObserveAppRecords(
         LayoutAreaHost host, string ownerId) =>
         host.Workspace
-            // Row-only (no content on the wire): healing reads Path/Name/Icon/MainNode, and the
-            // select list gates ONLY the content column — every other field always returns.
             .GetQuery($"home-apps:{ownerId}",
                 $"path:{ownerId}/{AppNodeType.UserNamespace} scope:children nodeType:{AppNodeType.NodeType} " +
                 "select:path,id,namespace,name,nodeType,icon")
@@ -562,63 +563,8 @@ public static class UserActivityLayoutAreas
             // The first shipped materializer synthesized an empty list, so every fresh home render
             // fired ~20 doomed CreateNode calls against records that already existed ("Node
             // already exists" storms in Loki, and THE home lag) before the real snapshot arrived.
-            // EnsureAppRecords does nothing until this emits a real list.
+            // The bootstrap does nothing until this emits a real list.
             .StartWith((IReadOnlyList<MeshNode>?)null);
-
-    private static IObservable<IReadOnlyList<string>> ObserveManifestItems(
-        LayoutAreaHost host, string ownerId, JsonSerializerOptions options) =>
-        host.Workspace
-            .GetQuery($"home-installs:{ownerId}",
-                $"path:{ownerId}/_Install scope:children nodeType:Store/Install " +
-                "select:path,id,namespace,name,nodeType,content")
-            .Select(nodes => (IReadOnlyList<string>)nodes
-                .SelectMany(n => InstalledItemsOf(n.Content, options))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList())
-            .StartWith((IReadOnlyList<string>)[]);
-
-    /// <summary>
-    /// The INSTALLED item paths of one Store install-manifest content (see
-    /// <c>Store/Install/Source/InstallManifest.cs</c> in the plugins repo): <c>items[]</c> entries
-    /// whose <c>installedPath</c> is non-empty, keyed by <c>item</c> — the plugin cover path.
-    /// Tolerant JSON traversal: the type is mesh-compiled and deliberately read untyped; anything
-    /// unreadable yields nothing.
-    /// </summary>
-    internal static IEnumerable<string> InstalledItemsOf(object? content, JsonSerializerOptions options)
-    {
-        JsonElement je;
-        try
-        {
-            je = content switch
-            {
-                null => default,
-                JsonElement e => e,
-                _ => JsonSerializer.SerializeToElement(content, options),
-            };
-        }
-        catch
-        {
-            yield break;
-        }
-        if (je.ValueKind != JsonValueKind.Object
-            || !je.TryGetProperty("items", out var items)
-            || items.ValueKind != JsonValueKind.Array)
-            yield break;
-        foreach (var entry in items.EnumerateArray())
-        {
-            if (entry.ValueKind != JsonValueKind.Object)
-                continue;
-            if (!entry.TryGetProperty("installedPath", out var installedPath)
-                || installedPath.ValueKind != JsonValueKind.String
-                || string.IsNullOrWhiteSpace(installedPath.GetString()))
-                continue;
-            var item = entry.TryGetProperty("item", out var itemProp) && itemProp.ValueKind == JsonValueKind.String
-                ? itemProp.GetString()
-                : null;
-            if (!string.IsNullOrWhiteSpace(item))
-                yield return item!.Trim('/');
-        }
-    }
 
     /// <summary>
     /// The cross-partition scopes the owner has been granted access to — an invited module living in
@@ -886,25 +832,31 @@ public static class UserActivityLayoutAreas
                     : $"{pinnedBase} {suffix}"));
         }
 
-        // Apps — the viewer's OWN installed-app records: a SINGLE-PARTITION query
-        // ({owner}/_App), which is why it loads fast — the old cover-path alternation fanned out
-        // across every partition schema (the multi-second home lag). Records are materialized
-        // write-behind from config defaults + install manifests (see CatalogAreaView) — Threads is
-        // an ordinary record like every other app. Icons render: the phone-home grid painted
-        // ENTIRELY from the query rows (record Name/Icon; no per-tile hub, no content load — the
-        // per-record AppTile area cost one hub PER RESULT), and NavigateToMainNode makes a tile
-        // open the APP (the record's MainNode target), not the record node. `source:accessed` is
-        // meaningless on records, so that option sorts by modified.
+        // Apps — the viewer's OWN app records: a SINGLE-PARTITION query ({owner}/_App), which is
+        // why it loads fast (the old cover-path alternation fanned out across every partition
+        // schema — the multi-second home lag). The records are the STORE's to write; the home only
+        // reads them (Threads is an ordinary record like every other app). Icons render: the
+        // phone-home grid painted ENTIRELY from the query rows (record Name/Icon; no per-tile hub,
+        // no content load — the per-record AppTile area cost one hub PER RESULT), and
+        // NavigateToMainNode makes a tile open the APP (the record's MainNode target).
+        //
+        // ORDER: most recently used first, like a phone. That ordering is applied at PAINT
+        // (SortByAccess) rather than in the query, because `source:accessed` is an INNER JOIN on
+        // the access log keyed by the row's OWN path: it would drop every never-opened app AND
+        // match nothing anyway — opening an app records a visit to the APP, never to the record
+        // that points at it. The sort options below stay pure order-bys over the records; the
+        // "Last accessed" option is the query-side no-op that keeps the dropdown honest.
         var appsBase =
             $"path:{nodeOwnerId}/{AppNodeType.UserNamespace} scope:children nodeType:{AppNodeType.NodeType}";
-        scopes.Add(HomeScope("home.apps", locale, HomeCatalogSort.Alphabetical,
+        scopes.Add(HomeScope("home.apps", locale, HomeCatalogSort.LastAccessed,
                 (sort, suffix) => sort == HomeCatalogSort.LastAccessed
-                    ? $"{appsBase} {SortSuffixLastModified}"
+                    ? $"{appsBase} {SortSuffixAlphabetical}"
                     : $"{appsBase} {suffix}")
             with
             {
                 RenderMode = nameof(MeshSearchRenderMode.Icons),
                 NavigateToMainNode = true,
+                SortByAccess = true,
             });
 
         // Spaces — the deduplicated catalog (an app never appears twice).
@@ -996,13 +948,15 @@ public static class UserActivityLayoutAreas
     }
 
     /// <summary>
-    /// Product name + icon for the KNOWN default apps (see <see cref="AppRecordSpecs"/>): a
-    /// <see cref="HomeConfig.DefaultApps"/> entry starting with <c>~/</c> is not a node path but an
-    /// AREA on the viewer's own hub (<c>~/Chat</c> → the Threads app at <c>/{owner}/Chat</c>);
-    /// anything not listed falls back to its path leaf + the generic app icon. Names here are
-    /// deliberately GLOSSARY/product terms (Store, Documentation, Threads — English in every
-    /// locale), so no localization key is involved. Immutable constant lookup, never written at
-    /// runtime.
+    /// Product name + icon for the PLATFORM DEFAULT apps (<see cref="HomeConfig.DefaultApps"/>): a
+    /// <c>~/</c> entry is not a node path but an AREA on the viewer's own hub (<c>~/Chat</c> → the
+    /// Threads app at <c>/{owner}/Chat</c>); anything not listed falls back to its path leaf + the
+    /// generic app icon. Names here are deliberately GLOSSARY/product terms (Store, Documentation,
+    /// Threads — English in every locale), so no localization key is involved. Immutable constant
+    /// lookup, never written at runtime.
+    /// <para>This table covers the DEFAULTS only, and deliberately so: every other app's name and
+    /// icon are written by the STORE when the app is installed. Core does not know, and must not
+    /// guess, what a third-party app is called.</para>
     /// </summary>
     private static readonly ImmutableDictionary<string, (string Name, string Icon)> KnownApps =
         new Dictionary<string, (string Name, string Icon)>
@@ -1017,21 +971,24 @@ public static class UserActivityLayoutAreas
     private static string LeafOf(string path) =>
         path.Contains('/') ? path[(path.LastIndexOf('/') + 1)..] : path;
 
-    /// <summary>The blueprint of one to-be-materialized app record.</summary>
+    /// <summary>The blueprint of one platform-default app record.</summary>
     internal sealed record AppRecordSpec(
-        string Id, string Name, string Icon, string? Plugin, string? OpenPath, string Source);
+        string Id, string Name, string Icon, string? Plugin, string? OpenPath, string Source)
+    {
+        /// <summary>The record's navigation target — the app's path, or the owner-hub area path
+        /// for a <c>~/</c> app. Stamped as the record's <see cref="MeshNode.MainNode"/> so an icon
+        /// tile navigates STRAIGHT to the app with nothing else to read.</summary>
+        public string? Target => Plugin is { Length: > 0 } ? Plugin : OpenPath;
+    }
 
     /// <summary>
-    /// The app-record SPECS a viewer should have — the config-declared defaults
-    /// (<see cref="HomeConfig.DefaultApps"/>; a <c>~/</c> entry is an AREA on the viewer's own hub,
-    /// e.g. <c>~/Chat</c> → the Threads app, an ORDINARY record like every other app) unioned with
-    /// the Store manifests' installed items, deduped by record id (a path's <c>/</c> becomes
-    /// <c>-</c>). <see cref="KnownApps"/> gives the known defaults their product name + icon;
-    /// everything else falls back to the path leaf + the generic app icon (the Store's install
-    /// flow upgrades those in phase 2). Pure, exposed for tests.
+    /// The PLATFORM DEFAULT app records (<see cref="HomeConfig.DefaultApps"/>; a <c>~/</c> entry is
+    /// an AREA on the viewer's own hub, e.g. <c>~/Chat</c> → the Threads app, an ORDINARY record
+    /// like every other app), deduped by record id (a path's <c>/</c> becomes <c>-</c>).
+    /// <see cref="KnownApps"/> gives them their product name + icon. Pure, exposed for tests.
+    /// <para>Installed apps are NOT here: the Store writes their records when it installs them.</para>
     /// </summary>
-    internal static IReadOnlyList<AppRecordSpec> AppRecordSpecs(
-        HomeConfig? config, string ownerId, IEnumerable<string>? manifestItems)
+    internal static IReadOnlyList<AppRecordSpec> AppRecordSpecs(HomeConfig? config, string ownerId)
     {
         var cfg = config ?? HomeConfigNodeType.Defaults;
         var specs = new List<AppRecordSpec>();
@@ -1069,189 +1026,30 @@ public static class UserActivityLayoutAreas
                     Plugin: path, OpenPath: null, Source: "default"));
             }
         }
-        foreach (var item in manifestItems ?? [])
-        {
-            var path = item.Trim('/');
-            if (path.Length == 0)
-                continue;
-            var id = path.Replace('/', '-');
-            if (!seen.Add(id))
-                continue;
-            specs.Add(new AppRecordSpec(id, LeafOf(path), GenericAppIcon,
-                Plugin: path, OpenPath: null, Source: "install"));
-        }
         return specs;
     }
 
     /// <summary>
-    /// Write-behind materialization + HEALING of the viewer's app records. Creates the
-    /// <c>{owner}/_App/{id}</c> node for every <see cref="AppRecordSpecs"/> entry that has no
-    /// record yet, and repairs existing records that still carry the generic icon, an EMPTY name,
-    /// or no navigation target (<see cref="MeshNode.MainNode"/> left at its own path) — stamping
-    /// the icon (and, only when empty, the name) from the plugin COVER node where the specs can
-    /// only guess. A non-empty name is never overwritten: the owner may have renamed the record,
-    /// and covers get their say at CREATE time.
-    /// Fire-and-forget and idempotent: the caller invokes this ONLY after the records query has
-    /// emitted its real first snapshot (never the null sentinel — acting on a synthetic empty list
-    /// was the "Node already exists" create storm), <paramref name="attempted"/> (per home-area
-    /// instance) guards re-entry while writes are in flight, and a create that loses a race to an
-    /// existing record is benign. Writes land in the viewer's OWN partition under the viewer's own
-    /// identity (the framework propagates the caller's AccessContext through Subscribe).
+    /// The home's ONLY app write, and it fires at most once per viewer: seed the platform default
+    /// records when the viewer's grid is EMPTY. Without it a brand-new (or never-onboarded) viewer
+    /// lands on a blank home with no icon to reach the Store by — a bootstrap, not a sync.
+    /// <para>🚨 Everything else about an app's record — creating it on install, deleting it on
+    /// uninstall, its real name and icon, refreshing them — is the STORE's, which owns the app
+    /// lifecycle and already writes the install manifest. Core reading manifests and back-filling
+    /// records made every home render a write path and put the Store's model in two places.</para>
+    /// <para>Fire-and-forget: a create that loses the race to an existing record is benign
+    /// (Debug), and the records query re-emits when the writes land.</para>
     /// </summary>
-    private static void EnsureAppRecords(
-        LayoutAreaHost host, string ownerId, HomeConfig? config,
-        IReadOnlyList<string> manifestItems, IReadOnlyList<MeshNode> records,
-        HashSet<string> attempted)
+    private static void EnsureDefaultApps(LayoutAreaHost host, string ownerId, HomeConfig? config)
     {
         var mesh = host.Hub.ServiceProvider.GetService<IMeshService>();
         if (mesh is null || string.IsNullOrEmpty(ownerId))
             return;
         var logger = host.Hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.Graph.AppRecords");
-        var byId = records
-            .GroupBy(r => LeafOf(r.Path), StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
-        var creates = new List<AppRecordSpec>();
-        var heals = new List<(MeshNode Record, AppRecordSpec Spec)>();
-        foreach (var spec in AppRecordSpecs(config, ownerId, manifestItems))
+        foreach (var spec in AppRecordSpecs(config, ownerId))
         {
-            if (!byId.TryGetValue(spec.Id, out var record))
-            {
-                if (attempted.Add("create:" + spec.Id))
-                    creates.Add(spec);
-            }
-            else if (NeedsHealing(record, spec) && attempted.Add("heal:" + spec.Id))
-                heals.Add((record, spec));
-        }
-        if (creates.Count == 0 && heals.Count == 0)
-            return;
-
-        // Plugin COVER nodes supply the real name/icon where the specs only have the generic
-        // fallback (manifest-derived installs). ONE one-shot query for all of them, off the render
-        // path — the tiles paint instantly from the records; when the covers land, creates/heals
-        // are written and the records query re-emits the finished rows. A cover failure degrades
-        // to the spec fallbacks rather than blocking materialization.
-        var coverPaths = creates.Concat(heals.Select(h => h.Spec))
-            .Where(s => s.Plugin is { Length: > 0 }
-                        && string.Equals(s.Icon, GenericAppIcon, StringComparison.OrdinalIgnoreCase))
-            .Select(s => s.Plugin!)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        ObserveAppCovers(mesh, coverPaths)
-            .Subscribe(
-                covers => MaterializeAppRecords(host, mesh, ownerId, creates, heals, covers, logger),
-                ex =>
-                {
-                    logger?.LogWarning(ex,
-                        "App cover lookup failed for {Owner}; materializing with fallbacks", ownerId);
-                    MaterializeAppRecords(host, mesh, ownerId, creates, heals,
-                        ImmutableDictionary<string, MeshNode>.Empty, logger);
-                });
-    }
-
-    /// <summary>The plugin cover nodes for <paramref name="coverPaths"/> as a one-shot path-keyed
-    /// map (empty input short-circuits — no query). Initial snapshot only; the path alternation
-    /// fans out cross-schema, which is exactly why it runs HERE (write-behind, bounded, once per
-    /// missing/incurable face) and never on the Apps render path.</summary>
-    private static IObservable<IReadOnlyDictionary<string, MeshNode>> ObserveAppCovers(
-        IMeshService mesh, IReadOnlyList<string> coverPaths) =>
-        coverPaths.Count == 0
-            ? Observable.Return<IReadOnlyDictionary<string, MeshNode>>(
-                ImmutableDictionary<string, MeshNode>.Empty)
-            : mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(
-                    // Row-only: the face is Name + Icon; the covers' content stays off the wire.
-                    $"path:{string.Join("|", coverPaths)} select:path,id,namespace,name,nodeType,icon"))
-                .Where(c => c.ChangeType == QueryChangeType.Initial)
-                .Select(c => (IReadOnlyDictionary<string, MeshNode>)c.Items
-                    .Where(n => !string.IsNullOrEmpty(n.Path))
-                    .GroupBy(n => n.Path, StringComparer.OrdinalIgnoreCase)
-                    .ToImmutableDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase))
-                .FirstAsync()
-                .Timeout(TimeSpan.FromSeconds(15));
-
-    /// <summary>The record's navigation target — the plugin cover path, or the owner-hub area path
-    /// for <c>~/</c> apps. Stamped as the record's <see cref="MeshNode.MainNode"/> so the Apps
-    /// grid's icon tiles navigate STRAIGHT to the app (NavigateToMainNode) with no per-tile hub.</summary>
-    internal static string? AppTargetOf(AppRecordSpec spec) =>
-        spec.Plugin is { Length: > 0 } ? spec.Plugin : spec.OpenPath;
-
-    /// <summary>Face (name + icon) for a record: the plugin cover's when one was fetched and has
-    /// the field, else the spec's KnownApps/leaf/generic fallback.</summary>
-    internal static (string Name, string Icon) ResolveAppFace(
-        AppRecordSpec spec, IReadOnlyDictionary<string, MeshNode> covers)
-    {
-        if (spec.Plugin is { Length: > 0 } && covers.TryGetValue(spec.Plugin, out var cover))
-            return (
-                string.IsNullOrWhiteSpace(cover.Name) ? spec.Name : cover.Name!,
-                string.IsNullOrWhiteSpace(cover.Icon) ? spec.Icon : cover.Icon!);
-        return (spec.Name, spec.Icon);
-    }
-
-    /// <summary>True when an existing record is worth a heal attempt: no real navigation target
-    /// yet (MainNode unset or still its own path), the generic/missing icon, or an empty name.</summary>
-    internal static bool NeedsHealing(MeshNode record, AppRecordSpec spec)
-    {
-        var target = AppTargetOf(spec);
-        if (!string.IsNullOrEmpty(target)
-            && (string.IsNullOrEmpty(record.MainNode)
-                || string.Equals(record.MainNode, record.Path, StringComparison.OrdinalIgnoreCase)))
-            return true;
-        if (string.IsNullOrEmpty(record.Icon)
-            || string.Equals(record.Icon, GenericAppIcon, StringComparison.OrdinalIgnoreCase))
-            return true;
-        return string.IsNullOrEmpty(record.Name);
-    }
-
-    /// <summary>Applies the resolved face + target to a record, touching ONLY fields that actually
-    /// improve (the cross-hub Update sends a merge patch of exactly what changed). Returns
-    /// <paramref name="cur"/> unchanged (same reference) when nothing improves.</summary>
-    internal static MeshNode HealAppRecord(MeshNode cur, string name, string icon, string? target)
-    {
-        var next = cur;
-        if (!string.IsNullOrEmpty(target)
-            && (string.IsNullOrEmpty(next.MainNode)
-                || string.Equals(next.MainNode, next.Path, StringComparison.OrdinalIgnoreCase))
-            && !string.Equals(next.MainNode, target, StringComparison.OrdinalIgnoreCase))
-            next = next with { MainNode = target! };
-        if ((string.IsNullOrEmpty(next.Icon)
-                || string.Equals(next.Icon, GenericAppIcon, StringComparison.OrdinalIgnoreCase))
-            && !string.IsNullOrEmpty(icon)
-            && !string.Equals(next.Icon, icon, StringComparison.OrdinalIgnoreCase))
-            next = next with { Icon = icon };
-        if (string.IsNullOrEmpty(next.Name) && !string.IsNullOrEmpty(name))
-            next = next with { Name = name };
-        return next;
-    }
-
-    /// <summary>Writes the planned creates and heals. Creates carry the full face + MainNode
-    /// target; a create losing the race to an existing record ("already exists") is EXPECTED
-    /// (two home areas can plan the same record) and logged at Debug — anything else is a real
-    /// warning. Heals go through the ONE mutation API; an identity heal (nothing improves — e.g.
-    /// the cover has no icon either) is skipped entirely, so incurable records cost one cover
-    /// lookup per home area and zero writes.</summary>
-    private static void MaterializeAppRecords(
-        LayoutAreaHost host, IMeshService mesh, string ownerId,
-        IReadOnlyList<AppRecordSpec> creates,
-        IReadOnlyList<(MeshNode Record, AppRecordSpec Spec)> heals,
-        IReadOnlyDictionary<string, MeshNode> covers, ILogger? logger)
-    {
-        foreach (var spec in creates)
-        {
-            var (name, icon) = ResolveAppFace(spec, covers);
-            var node = new MeshNode(spec.Id, $"{ownerId}/{AppNodeType.UserNamespace}")
-            {
-                NodeType = AppNodeType.NodeType,
-                Name = name,
-                Icon = icon,
-                MainNode = AppTargetOf(spec) ?? $"{ownerId}/{AppNodeType.UserNamespace}/{spec.Id}",
-                State = MeshNodeState.Active,
-                Content = new App
-                {
-                    Plugin = spec.Plugin ?? "",
-                    OpenPath = spec.OpenPath,
-                    Source = spec.Source,
-                },
-            };
+            var node = BuildAppRecord(ownerId, spec);
             mesh.CreateNode(node).Subscribe(_ => { },
                 ex =>
                 {
@@ -1261,18 +1059,25 @@ public static class UserActivityLayoutAreas
                         logger?.LogWarning(ex, "App record create failed at {Path}", node.Path);
                 });
         }
-        foreach (var (record, spec) in heals)
-        {
-            var (name, icon) = ResolveAppFace(spec, covers);
-            var target = AppTargetOf(spec);
-            if (ReferenceEquals(HealAppRecord(record, name, icon, target), record))
-                continue;
-            host.Workspace.GetMeshNodeStream(record.Path)
-                .Update(cur => HealAppRecord(cur, name, icon, target))
-                .Subscribe(_ => { },
-                    ex => logger?.LogWarning(ex, "App record heal failed at {Path}", record.Path));
-        }
     }
+
+    /// <summary>One default app record: the tile's whole identity lives on the NODE (Name, Icon,
+    /// MainNode = the app it opens), so the grid paints from query rows alone. Pure, for tests.</summary>
+    internal static MeshNode BuildAppRecord(string ownerId, AppRecordSpec spec) =>
+        new(spec.Id, $"{ownerId}/{AppNodeType.UserNamespace}")
+        {
+            NodeType = AppNodeType.NodeType,
+            Name = spec.Name,
+            Icon = spec.Icon,
+            MainNode = spec.Target ?? $"{ownerId}/{AppNodeType.UserNamespace}/{spec.Id}",
+            State = MeshNodeState.Active,
+            Content = new App
+            {
+                Plugin = spec.Plugin ?? "",
+                OpenPath = spec.OpenPath,
+                Source = spec.Source,
+            },
+        };
 
     /// <summary>Dedup for the Spaces and Shared-with-me scopes: anything living in the Store (and
     /// therefore representable as an installed app — plugin covers, the store root) is EXCLUDED,

--- a/src/MeshWeaver.Layout/MeshSearchControl.cs
+++ b/src/MeshWeaver.Layout/MeshSearchControl.cs
@@ -118,7 +118,8 @@ public record MeshSearchScopeTab(string Label, string Query)
     /// <summary>
     /// Order this scope's results by when the VIEWER last opened each result's navigation target,
     /// most recent first, with never-opened results keeping the query's own order behind them —
-    /// the phone-home rule: what you use most sits where your thumb is.
+    /// the phone-home rule: what you use most sits where your thumb is. Applied wherever results
+    /// are projected, so every render mode honours it, not just the icon grid.
     /// <para>Applied at PAINT, not in the query, and deliberately: <c>source:accessed</c> is an
     /// INNER JOIN on the access log keyed by the result's OWN path, so on the Apps grid it would
     /// both hide every never-opened app AND match nothing (an app record's access is recorded

--- a/src/MeshWeaver.Layout/MeshSearchControl.cs
+++ b/src/MeshWeaver.Layout/MeshSearchControl.cs
@@ -114,6 +114,19 @@ public record MeshSearchScopeTab(string Label, string Query)
     /// content read. Null keeps the control-level <see cref="MeshSearchControl.NavigateToMainNode"/>.
     /// </summary>
     public bool? NavigateToMainNode { get; init; }
+
+    /// <summary>
+    /// Order this scope's results by when the VIEWER last opened each result's navigation target,
+    /// most recent first, with never-opened results keeping the query's own order behind them —
+    /// the phone-home rule: what you use most sits where your thumb is.
+    /// <para>Applied at PAINT, not in the query, and deliberately: <c>source:accessed</c> is an
+    /// INNER JOIN on the access log keyed by the result's OWN path, so on the Apps grid it would
+    /// both hide every never-opened app AND match nothing (an app record's access is recorded
+    /// against the app it points at, never against the record). The view instead reads the
+    /// viewer's own <c>_UserActivity</c> satellites — one cheap single-partition query — and uses
+    /// them as a SORT KEY. Ordering arrives with that snapshot, after the tiles have painted.</para>
+    /// </summary>
+    public bool SortByAccess { get; init; }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Layout/MeshSearchControl.cs
+++ b/src/MeshWeaver.Layout/MeshSearchControl.cs
@@ -215,6 +215,18 @@ public record MeshSearchControl()
     public IReadOnlyList<MeshSearchScopeTab>? ScopeTabs { get; init; }
 
     /// <summary>
+    /// In a grouped render, order the sections by SIZE (most items first) instead of
+    /// alphabetically — the home's content section fans out by node type with the type you have
+    /// most of at the top, so the page opens on what you actually work with rather than on
+    /// whatever happens to start with "A". Ties fall back to the label, so the order is stable.
+    /// </summary>
+    public object? GroupByFrequency { get; init; }
+
+    /// <summary>Sets <see cref="GroupByFrequency"/>.</summary>
+    public MeshSearchControl WithGroupByFrequency(bool value = true) =>
+        This with { GroupByFrequency = value };
+
+    /// <summary>
     /// When true, clicking a result navigates to the node's <c>MainNode</c> instead of its own
     /// path (default false). A per-scope <see cref="MeshSearchScopeTab.NavigateToMainNode"/>
     /// overrides this while its scope is active.

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -133,6 +133,7 @@
   "home.sharedWithMe": "Mit mir geteilt",
   "home.pinned": "Angeheftet",
   "home.apps": "Apps",
+  "home.content": "Inhalte",
   "home.spaces": "Spaces",
   "home.sortLastAccessed": "Zuletzt geöffnet",
   "home.sortLastModified": "Zuletzt geändert",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -133,6 +133,7 @@
   "home.sharedWithMe": "Shared with me",
   "home.pinned": "Pinned",
   "home.apps": "Apps",
+  "home.content": "Content",
   "home.spaces": "Spaces",
   "home.sortLastAccessed": "Last accessed",
   "home.sortLastModified": "Last modified",

--- a/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
@@ -25,52 +25,109 @@ public class HomeTabsTest
 {
     private const string NodePath = "rbuergi";
 
-    private static MeshSearchControl Search(UiControl home) =>
-        home.Should().BeOfType<MeshSearchControl>().Subject;
+    private static MeshSearchControl Content(UiControl home, string? locale = null) =>
+        UserActivityLayoutAreas.BuildContentSection(NodePath, null, null, locale, null);
 
     private static string[] ScopeLabels(MeshSearchControl search) =>
         search.ScopeTabs!.Select(t => t.Label).ToArray();
 
-    // ── Structure ───────────────────────────────────────────────────────────────────────────────
+    // ── Structure: TWO sections, apps first ────────────────────────────────────────────────────
 
     [Fact]
-    public void Home_NoShareNoPin_ScopesAreAppsSpacesAll()
+    public void Home_IsAppsThenContent_TwoSections()
     {
-        // No dock, no extra thing: the home is the ONE scoped search surface.
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath));
+        // "separate content from apps in two section … apps first, then content": launching an app
+        // and searching for content are different acts, so they are different sections — not two
+        // lenses on one tab strip.
+        var home = UserActivityLayoutAreas.BuildHome(NodePath);
 
-        ScopeLabels(search).Should().Equal("Apps", "Spaces", "All");
+        var stack = home.Should().BeOfType<StackControl>().Subject;
+        stack.Areas.Should().HaveCount(2, "apps on top, content below");
     }
 
     [Fact]
-    public void Home_WithPins_PinnedScopeComesFirst()
-    {
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath,
-            user: new User { PinnedPaths = ["Doc/GUI"] }));
-
-        ScopeLabels(search).Should().Equal("Pinned", "Apps", "Spaces", "All");
-    }
-
-    [Fact]
-    public void Home_WithShares_SharedIsItsOwnBandBelowTheSearch_NotAScope()
+    public void Home_WithShares_AppendsTheSharedBandAsAThirdSection()
     {
         // "shared with me can be separate section" — cross-partition invitations are a distinct
         // kind of content, not another lens on the catalog.
         var home = UserActivityLayoutAreas.BuildHome(NodePath, sharedTargets: ["OrgA/Module"]);
 
-        var stack = home.Should().BeOfType<StackControl>().Subject;
-        stack.Areas.Should().HaveCount(2, "the scoped search on top, the shared band below");
+        home.Should().BeOfType<StackControl>().Subject
+            .Areas.Should().HaveCount(3, "apps, content, then shared with me");
     }
 
     [Fact]
-    public void Home_OneSharedSearchBar_DesktopOn()
+    public void Content_NoPins_IsOneCategory_NoTabStrip()
     {
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath));
+        // "i am not sure if 'spaces' makes sense … it should just be all the top level nodes which
+        // we can access. make just one category." One scope ⇒ the view renders no strip at all.
+        var content = Content(UserActivityLayoutAreas.BuildHome(NodePath));
 
-        search.ShowSearchBox.Should().Be(true);
-        search.HiddenQuery!.ToString().Should().Be(search.ScopeTabs![0].Query);
-        search.SortOptions!.Select(o => o.Query)
-            .Should().Equal(search.ScopeTabs![0].SortOptions!.Select(o => o.Query));
+        ScopeLabels(content).Should().Equal("All");
+        content.HiddenQuery!.ToString().Should().Contain("is:main")
+            .And.Contain("-nodeType:Store/Plugin", "apps live in the Apps section, never twice");
+    }
+
+    [Fact]
+    public void Content_FansOutByNodeType_BiggestGroupFirst()
+    {
+        // "All and then fan out in different types, sorted by frequency … get the top level
+        // partition node type and bring category by this ⇒ then you get Spaces, Clients, …":
+        // the categories are whatever types the viewer's own top-level nodes have, not a taxonomy
+        // the home invents, and the type you have most of leads.
+        var content = Content(UserActivityLayoutAreas.BuildHome(NodePath));
+
+        content.RenderMode.Should().Be(MeshSearchRenderMode.Grouped);
+        content.Grouping!.GroupByProperty.Should().Be("NodeType");
+        content.GroupByFrequency.Should().Be(true);
+        content.Sections!.ShowCounts.Should().Be(true, "a frequency order is only readable with counts");
+    }
+
+    [Fact]
+    public void Content_WithPins_PinnedIsASeparateTab_First()
+    {
+        // "the pinned i would still keep … as separate tab if we have any".
+        var content = UserActivityLayoutAreas.BuildContentSection(
+            NodePath, null, new User { PinnedPaths = ["Doc/GUI"] }, null, null);
+
+        ScopeLabels(content).Should().Equal("Pinned", "All");
+        content.ScopeTabs![0].Query.Should().Contain("Doc/GUI");
+    }
+
+    [Fact]
+    public void Content_HasTheSearchBar_AppsDoesNot()
+    {
+        // The apps section is a LAUNCHER (no search box, no view options); content is where you
+        // search, and its scopes share that one bar.
+        var content = Content(UserActivityLayoutAreas.BuildHome(NodePath));
+        content.ShowSearchBox.Should().Be(true);
+        content.HiddenQuery!.ToString().Should().Be(content.ScopeTabs![0].Query);
+
+        UserActivityLayoutAreas.BuildAppsBand(NodePath, null).ShowSearchBox.Should().Be(false);
+    }
+
+    [Fact]
+    public void Home_RendersNothingThroughAForeignItemArea()
+    {
+        // 🚨 THE regression guard. A MeshSearch ItemArea resolves an area on the RESULT node's own
+        // hub — one hub activation per row, on a hub the home does not own. In the distributed
+        // portal that failed as "AppTile not found" (and the thread rail's `RailItem` had the same
+        // shape) while a monolith resolved it happily, so only a structural assertion catches it.
+        // Every home surface must paint from query ROWS.
+        var sections = new[]
+        {
+            UserActivityLayoutAreas.BuildAppsBand(NodePath, null),
+            UserActivityLayoutAreas.BuildContentSection(
+                NodePath, null, new User { PinnedPaths = ["Doc/GUI"] }, null, null),
+            UserActivityLayoutAreas.BuildSharedBand(["OrgA/Module"], null)!,
+        };
+
+        foreach (var section in sections)
+        {
+            section.ItemArea.Should().BeNull($"'{section.Title}' must render from query rows");
+            foreach (var scope in section.ScopeTabs ?? [])
+                scope.ItemArea.Should().BeNull($"scope '{scope.Label}' must render from query rows");
+        }
     }
 
     [Fact]
@@ -113,23 +170,22 @@ public class HomeTabsTest
         UserActivityLayoutAreas.BuildSharedBand([], locale: null).Should().BeNull();
     }
 
-    // ── Apps scope: the viewer's own records, single partition, icon grid ───────────────────────
+    // ── The Apps section: the viewer's own records, single partition, icon grid ────────────────
 
     [Fact]
     public void Apps_QueriesTheViewersOwnRecords_SinglePartition()
     {
         // THE point of the record model: the old cover-path alternation fanned out across every
         // partition schema (the multi-second home lag); the records query names ONE partition.
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath));
+        var apps = UserActivityLayoutAreas.BuildAppsBand(NodePath, null);
 
-        var apps = search.ScopeTabs!.Single(t => t.Label == "Apps");
-        apps.Query.Should().Contain($"path:{NodePath}/_App scope:children nodeType:InstalledApp");
-        apps.Query.Should().NotContain(" OR ", "no path alternation — the records query is the bound");
-        apps.SortOptions![0].Query.Should().Be(apps.Query);
-        // 🚨 No source:accessed on ANY option: it is an INNER JOIN keyed by the row's OWN path, so
-        // on records it would drop every never-opened app and match nothing anyway (opening an app
-        // records a visit to the APP, never to the record pointing at it).
-        apps.SortOptions!.Select(o => o.Query).Should().OnlyContain(q => !q.Contains("source:accessed"));
+        var query = apps.HiddenQuery!.ToString()!;
+        query.Should().Contain($"path:{NodePath}/_App scope:children nodeType:InstalledApp");
+        query.Should().NotContain(" OR ", "no path alternation — the records query is the bound");
+        // 🚨 No source:accessed: it is an INNER JOIN keyed by the row's OWN path, so on records it
+        // would drop every never-opened app and match nothing anyway (opening an app records a
+        // visit to the APP, never to the record pointing at it).
+        query.Should().NotContain("source:accessed");
     }
 
     [Fact]
@@ -137,11 +193,9 @@ public class HomeTabsTest
     {
         // "apps should be ordered by last accessed not by alphabet" — the phone-home rule, applied
         // at PAINT from the viewer's own access log (see MeshSearchScopeTab.SortByAccess).
-        var apps = Search(UserActivityLayoutAreas.BuildHome(NodePath))
-            .ScopeTabs!.Single(t => t.Label == "Apps");
+        var scope = UserActivityLayoutAreas.BuildAppsBand(NodePath, null).ScopeTabs!.Single();
 
-        apps.SortByAccess.Should().BeTrue();
-        apps.SortOptions![0].Label.Should().Be("Last accessed", "the default order is most-recently-used");
+        scope.SortByAccess.Should().BeTrue();
     }
 
     [Fact]
@@ -150,12 +204,13 @@ public class HomeTabsTest
         // "should load from mesh, icon should be the icon of the app, then it should render
         // insta" — Icons mode paints tiles from the rows (no per-record hub, no content), and
         // NavigateToMainNode makes a tile open the APP (the record's MainNode), not the record.
-        var search = Search(UserActivityLayoutAreas.BuildHome(NodePath));
+        var apps = UserActivityLayoutAreas.BuildAppsBand(NodePath, null);
 
-        var apps = search.ScopeTabs!.Single(t => t.Label == "Apps");
-        apps.RenderMode.Should().Be(nameof(MeshSearchRenderMode.Icons));
-        apps.NavigateToMainNode.Should().Be(true);
-        apps.ItemArea.Should().BeNull("a per-record tile area meant one hub activation per result");
+        apps.RenderMode.Should().Be(MeshSearchRenderMode.Icons);
+        var scope = apps.ScopeTabs!.Single();
+        scope.RenderMode.Should().Be(nameof(MeshSearchRenderMode.Icons));
+        scope.NavigateToMainNode.Should().Be(true);
+        scope.ItemArea.Should().BeNull("a per-record tile area meant one hub activation per result");
     }
 
     // ── Default-app records: the platform BOOTSTRAP (everything else is the STORE's) ────────────

--- a/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
@@ -125,11 +125,23 @@ public class HomeTabsTest
         var apps = search.ScopeTabs!.Single(t => t.Label == "Apps");
         apps.Query.Should().Contain($"path:{NodePath}/_App scope:children nodeType:InstalledApp");
         apps.Query.Should().NotContain(" OR ", "no path alternation — the records query is the bound");
-        // Alphabetical default; source:accessed is meaningless on records, so that option sorts by
-        // modified instead of hiding never-opened apps behind an INNER join.
         apps.SortOptions![0].Query.Should().Be(apps.Query);
-        apps.Query.Should().Contain("sort:Name-asc");
+        // 🚨 No source:accessed on ANY option: it is an INNER JOIN keyed by the row's OWN path, so
+        // on records it would drop every never-opened app and match nothing anyway (opening an app
+        // records a visit to the APP, never to the record pointing at it).
         apps.SortOptions!.Select(o => o.Query).Should().OnlyContain(q => !q.Contains("source:accessed"));
+    }
+
+    [Fact]
+    public void Apps_OrderMostRecentlyUsedFirst_AtPaint()
+    {
+        // "apps should be ordered by last accessed not by alphabet" — the phone-home rule, applied
+        // at PAINT from the viewer's own access log (see MeshSearchScopeTab.SortByAccess).
+        var apps = Search(UserActivityLayoutAreas.BuildHome(NodePath))
+            .ScopeTabs!.Single(t => t.Label == "Apps");
+
+        apps.SortByAccess.Should().BeTrue();
+        apps.SortOptions![0].Label.Should().Be("Last accessed", "the default order is most-recently-used");
     }
 
     [Fact]
@@ -146,12 +158,12 @@ public class HomeTabsTest
         apps.ItemArea.Should().BeNull("a per-record tile area meant one hub activation per result");
     }
 
-    // ── Record materialization specs ────────────────────────────────────────────────────────────
+    // ── Default-app records: the platform BOOTSTRAP (everything else is the STORE's) ────────────
 
     [Fact]
     public void AppRecordSpecs_DefaultsCarryProductNamesAndIcons_ThreadsIsAnOrdinaryRecord()
     {
-        var specs = UserActivityLayoutAreas.AppRecordSpecs(new HomeConfig(), NodePath, manifestItems: null);
+        var specs = UserActivityLayoutAreas.AppRecordSpecs(new HomeConfig(), NodePath);
 
         specs.Select(s => s.Id).Should().Equal("Store", "Doc", "Chat");
         specs.Single(s => s.Id == "Store").Name.Should().Be("Store");
@@ -161,144 +173,41 @@ public class HomeTabsTest
         threads.Icon.Should().Be("/static/NodeTypeIcons/chat.svg");
         threads.OpenPath.Should().Be($"{NodePath}/Chat", "the Threads record opens the viewer's own Chat area");
         threads.Plugin.Should().BeNull();
+        threads.Target.Should().Be($"{NodePath}/Chat");
     }
 
     [Fact]
-    public void AppRecordSpecs_ManifestItemsAppend_DedupedAgainstDefaults()
+    public void AppRecordSpecs_CoverTheDefaultsOnly_InstalledAppsBelongToTheStore()
     {
+        // Core no longer reads the Store's install manifests: WHAT a viewer has installed is the
+        // Store's to record when it installs it. Only the platform defaults are seeded here — the
+        // bootstrap that keeps a brand-new home from being a blank screen with no way to the Store.
         var specs = UserActivityLayoutAreas.AppRecordSpecs(
-            new HomeConfig(), NodePath, manifestItems: ["Chess", "Store", "Chess"]);
+            new HomeConfig { DefaultApps = ["Store", "Chess"] }, NodePath);
 
-        specs.Select(s => s.Id).Should().Equal("Store", "Doc", "Chat", "Chess");
+        specs.Select(s => s.Id).Should().Equal("Store", "Chess");
+        specs.Should().OnlyContain(s => s.Source == "default");
         var chess = specs.Single(s => s.Id == "Chess");
-        chess.Source.Should().Be("install");
         chess.Plugin.Should().Be("Chess");
-        // The pre-existing default keeps its product identity — the manifest doesn't re-add it.
-        specs.Single(s => s.Id == "Store").Source.Should().Be("default");
-    }
-
-    // ── Record target + healing (pure) ──────────────────────────────────────────────────────────
-
-    private static MeshNode Record(string id, App content, string? name = null,
-        string? icon = null, string? mainNode = null) =>
-        MeshNode.FromPath($"{NodePath}/_App/{id}") with
-        {
-            NodeType = AppNodeType.NodeType,
-            Name = name ?? id,
-            Icon = icon,
-            MainNode = mainNode ?? $"{NodePath}/_App/{id}",
-            Content = content,
-        };
-
-    [Fact]
-    public void AppTargetOf_PluginPathOrOwnerArea()
-    {
-        UserActivityLayoutAreas.AppTargetOf(
-                new UserActivityLayoutAreas.AppRecordSpec("Chess", "Chess",
-                    UserActivityLayoutAreas.GenericAppIcon, "Chess", null, "install"))
-            .Should().Be("Chess");
-        UserActivityLayoutAreas.AppTargetOf(
-                new UserActivityLayoutAreas.AppRecordSpec("Chat", "Threads",
-                    "/static/NodeTypeIcons/chat.svg", null, $"{NodePath}/Chat", "default"))
-            .Should().Be($"{NodePath}/Chat");
+        chess.Target.Should().Be("Chess", "a tile opens the APP, never the record");
+        chess.Icon.Should().Be(UserActivityLayoutAreas.GenericAppIcon,
+            "core must not guess a third-party app's icon — the Store stamps the real one on install");
     }
 
     [Fact]
-    public void NeedsHealing_TriggersOnDefaultMainNodeOrGenericIcon_NotOnAFinishedRecord()
+    public void BuildAppRecord_PutsTheWholeTileOnTheNode()
     {
-        var spec = new UserActivityLayoutAreas.AppRecordSpec(
-            "Chess", "Chess", UserActivityLayoutAreas.GenericAppIcon, "Chess", null, "install");
+        // Name, Icon and MainNode live on the NODE, so the grid paints from query rows alone.
+        var spec = UserActivityLayoutAreas.AppRecordSpecs(new HomeConfig(), NodePath)
+            .Single(s => s.Id == "Store");
 
-        // MainNode still the record's own path (the pre-Icons rounds never stamped a target).
-        UserActivityLayoutAreas.NeedsHealing(
-                Record("Chess", new App { Plugin = "Chess" }, icon: "/covers/chess.png"), spec)
-            .Should().BeTrue();
-        // Generic icon even with a target stamped.
-        UserActivityLayoutAreas.NeedsHealing(
-                Record("Chess", new App { Plugin = "Chess" },
-                    icon: UserActivityLayoutAreas.GenericAppIcon, mainNode: "Chess"), spec)
-            .Should().BeTrue();
-        // Finished: real icon, real target.
-        UserActivityLayoutAreas.NeedsHealing(
-                Record("Chess", new App { Plugin = "Chess" },
-                    icon: "/covers/chess.png", mainNode: "Chess"), spec)
-            .Should().BeFalse();
-    }
+        var node = UserActivityLayoutAreas.BuildAppRecord(NodePath, spec);
 
-    [Fact]
-    public void HealAppRecord_StampsTargetAndFace_TouchingOnlyWhatImproves()
-    {
-        var stale = Record("Chess", new App { Plugin = "Chess" },
-            icon: UserActivityLayoutAreas.GenericAppIcon);
-
-        var healed = UserActivityLayoutAreas.HealAppRecord(
-            stale, "Chess Trainer", "/covers/chess.png", "Chess");
-
-        healed.MainNode.Should().Be("Chess", "the tile must open the APP, not the record");
-        healed.Icon.Should().Be("/covers/chess.png");
-        healed.Name.Should().Be("Chess", "a non-empty name is never overwritten — the owner may have renamed it");
-    }
-
-    [Fact]
-    public void HealAppRecord_NothingToImprove_ReturnsTheSameInstance()
-    {
-        // The materializer skips the write entirely on an identity heal — an incurable record
-        // (cover has no icon either) must not cost a patch per home render.
-        var finished = Record("Chess", new App { Plugin = "Chess" },
-            icon: "/covers/chess.png", mainNode: "Chess");
-
-        UserActivityLayoutAreas.HealAppRecord(finished, "Chess", "/covers/chess.png", "Chess")
-            .Should().BeSameAs(finished);
-    }
-
-    [Fact]
-    public void ResolveAppFace_PrefersTheCover_FallsBackToTheSpec()
-    {
-        var spec = new UserActivityLayoutAreas.AppRecordSpec(
-            "Chess", "Chess", UserActivityLayoutAreas.GenericAppIcon, "Chess", null, "install");
-        var cover = MeshNode.FromPath("Chess") with { Name = "Chess Trainer", Icon = "/covers/chess.png" };
-
-        var withCover = UserActivityLayoutAreas.ResolveAppFace(spec,
-            new[] { cover }.ToDictionary(n => n.Path, StringComparer.OrdinalIgnoreCase));
-        withCover.Name.Should().Be("Chess Trainer");
-        withCover.Icon.Should().Be("/covers/chess.png");
-
-        var withoutCover = UserActivityLayoutAreas.ResolveAppFace(spec,
-            new System.Collections.Generic.Dictionary<string, MeshNode>(StringComparer.OrdinalIgnoreCase));
-        withoutCover.Name.Should().Be("Chess");
-        withoutCover.Icon.Should().Be(UserActivityLayoutAreas.GenericAppIcon);
-    }
-
-    // ── Install manifests → materialization input ───────────────────────────────────────────────
-
-    [Fact]
-    public void InstalledItemsOf_YieldsOnlyItemsWithALiveInstall()
-    {
-        var manifest = JsonSerializer.SerializeToElement(new
-        {
-            repo = "https://github.com/Systemorph/MeshWeaver.Plugins",
-            items = new object[]
-            {
-                new { item = "Chess", installedPath = "rbuergi/Chess", installedAt = "2026-08-01" },
-                new { item = "Publish", installedPath = (string?)null },        // un-installed: keeps entitlement only
-                new { item = (string?)null, installedPath = "rbuergi/Ghost" },  // malformed: no item id
-                new { item = "Training/", installedPath = "rbuergi/Training" }, // normalizes
-            },
-        });
-
-        UserActivityLayoutAreas.InstalledItemsOf(manifest, new JsonSerializerOptions())
-            .Should().Equal("Chess", "Training");
-    }
-
-    [Fact]
-    public void InstalledItemsOf_ToleratesGarbage()
-    {
-        var options = new JsonSerializerOptions();
-        UserActivityLayoutAreas.InstalledItemsOf(null, options).Should().BeEmpty();
-        UserActivityLayoutAreas.InstalledItemsOf(JsonSerializer.SerializeToElement(42), options).Should().BeEmpty();
-        UserActivityLayoutAreas.InstalledItemsOf(
-                JsonSerializer.SerializeToElement(new { items = "nope" }), options)
-            .Should().BeEmpty();
+        node.Path.Should().Be($"{NodePath}/_App/Store");
+        node.NodeType.Should().Be(AppNodeType.NodeType);
+        node.Name.Should().Be("Store");
+        node.Icon.Should().Be("/static/NodeTypeIcons/shopping-bag.svg");
+        node.MainNode.Should().Be("Store", "a tile opens the APP, never the record");
     }
 
     // ── Config ──────────────────────────────────────────────────────────────────────────────────

--- a/test/MeshWeaver.Graph.Test/PresentationSurfacesTest.cs
+++ b/test/MeshWeaver.Graph.Test/PresentationSurfacesTest.cs
@@ -9,8 +9,8 @@ namespace MeshWeaver.Graph.Test;
 
 /// <summary>
 /// Presentation mode (issue #1803) on the SURFACES the issue names — the home's viewer-scoped
-/// surfaces (the Pinned and Apps tabs, the Shared-with-me band, and the Spaces catalog, which is
-/// where the former Spaces / Last Read / Last Edited tabs live) and the node menu that marks them.
+/// surfaces (the Apps section, the Content section's Pinned tab and its one All category, the
+/// Shared-with-me band) and the node menu that marks them.
 ///
 /// <para>The Pinned tab and the Shared band filter at the point the QUERY is built rather than
 /// only where a card is painted, and that is the interesting part: a pinned path and a shared-band
@@ -89,53 +89,50 @@ public class PresentationSurfacesTest
             .Should().Contain("Acme");
     }
 
-    // ── The scoped home: Shared with me, Pinned, Apps ──────────────────────────────────────────
+    // ── The home's sections: Apps, Content (Pinned + All), Shared with me ──────────────────────
 
-    private static MeshSearchControl HomeSearch(UiControl home) =>
-        home.Should().BeOfType<MeshSearchControl>().Subject;
+    private static string[] ScopeLabels(MeshSearchControl content) =>
+        content.ScopeTabs!.Select(t => t.Label).ToArray();
 
-    private static string[] ScopeLabels(UiControl home) =>
-        HomeSearch(home).ScopeTabs!.Select(t => t.Label).ToArray();
+    private static string ScopeQuery(MeshSearchControl content, string label) =>
+        content.ScopeTabs!.Single(t => t.Label == label).Query;
 
-    private static string ScopeQuery(UiControl home, string label) =>
-        HomeSearch(home).ScopeTabs!.Single(t => t.Label == label).Query;
+    private static MeshSearchControl ContentOf(User? user, PresentationScreen? screen) =>
+        UserActivityLayoutAreas.BuildContentSection(Owner, null, user, null, screen);
 
     [Fact]
-    public void Home_AScopeWhoseWholeContentIsMarked_Disappears()
+    public void Content_AScopeWhoseWholeContentIsMarked_Disappears()
     {
         var user = new User { PinnedPaths = ["Acme/Q3-Renewal"] };
 
         // Off: the Pinned tab is there.
-        ScopeLabels(UserActivityLayoutAreas.BuildHome(Owner, user: user))
-            .Should().Equal("Pinned", "Apps", "Spaces", "All");
+        ScopeLabels(ContentOf(user, null)).Should().Equal("Pinned", "All");
 
         // On, with Acme marked: everything pinned is inside the marked space, so the tab goes — an
         // empty tab labelled "Pinned" would itself say something.
-        ScopeLabels(UserActivityLayoutAreas.BuildHome(Owner, user: user, screen: Active("Acme")))
-            .Should().Equal("Apps", "Spaces", "All");
+        ScopeLabels(ContentOf(user, Active("Acme"))).Should().Equal("All");
     }
 
     [Fact]
-    public void Home_AScopeKeepsItsUnmarkedContent()
+    public void Content_AScopeKeepsItsUnmarkedContent()
     {
-        var home = UserActivityLayoutAreas.BuildHome(
-            Owner,
-            user: new User { PinnedPaths = ["Acme", "Doc/Guide"] },
-            screen: Active("Acme"));
+        var content = ContentOf(new User { PinnedPaths = ["Acme", "Doc/Guide"] }, Active("Acme"));
 
-        ScopeLabels(home).Should().Equal("Pinned", "Apps", "Spaces", "All");
-        ScopeQuery(home, "Pinned").Should().NotContain("Acme").And.Contain("Doc/Guide");
+        ScopeLabels(content).Should().Equal("Pinned", "All");
+        ScopeQuery(content, "Pinned").Should().NotContain("Acme").And.Contain("Doc/Guide");
     }
 
     [Fact]
     public void Home_TheSharedBand_DisappearsWhenEveryTargetIsMarked()
     {
         // The band's targets are query-string content, so the screen applies BEFORE the query is
-        // built. Every target marked ⇒ no band at all — the home is the bare search again.
+        // built. Every target marked ⇒ no band at all: the home is back to its two sections.
         UserActivityLayoutAreas.BuildHome(Owner, sharedTargets: ["Acme/Deals"])
-            .Should().BeOfType<StackControl>("off-screen, the shared band wraps the home in a stack");
+            .Should().BeOfType<StackControl>().Subject
+            .Areas.Should().HaveCount(3, "apps, content, shared");
         UserActivityLayoutAreas.BuildHome(Owner, sharedTargets: ["Acme/Deals"], screen: Active("Acme"))
-            .Should().BeOfType<MeshSearchControl>();
+            .Should().BeOfType<StackControl>().Subject
+            .Areas.Should().HaveCount(2, "apps and content only — the marked band is gone");
     }
 
     [Fact]
@@ -150,16 +147,15 @@ public class PresentationSurfacesTest
     }
 
     [Fact]
-    public void AppsScope_QueryNeverCarriesAppPaths()
+    public void AppsBand_QueryNeverCarriesAppPaths()
     {
-        // The Apps scope queries the viewer's OWN {owner}/_App records — a GENERIC query, so no
+        // The Apps band queries the viewer's OWN {owner}/_App records — a GENERIC query, so no
         // app path (marked or not) can ever reach the query string / the `hq=` URL. The marked-app
         // guarantee therefore lives at PAINT (below), where the tile's name would otherwise show.
-        var query = ScopeQuery(
-            UserActivityLayoutAreas.BuildHome(Owner, screen: Active("Acme")), "Apps");
+        var query = UserActivityLayoutAreas.BuildAppsBand(Owner, null).HiddenQuery!.ToString()!;
 
-        query.Should().Be(ScopeQuery(UserActivityLayoutAreas.BuildHome(Owner), "Apps"));
         query.Should().NotContain("Acme");
+        query.Should().Contain($"path:{Owner}/_App");
     }
 
     [Fact]
@@ -222,11 +218,9 @@ public class PresentationSurfacesTest
         QueryOf(marked).Should().Be(QueryOf(plain));
         QueryOf(marked).Should().NotContain("Acme");
 
-        // Same for the home's Spaces scope: identical query with and without the screen.
-        var spacesMarked = HomeSearch(UserActivityLayoutAreas.BuildHome(Owner, screen: Active("Acme")))
-            .ScopeTabs!.Single(t => t.Label == "Spaces").Query;
-        var spacesPlain = HomeSearch(UserActivityLayoutAreas.BuildHome(Owner))
-            .ScopeTabs!.Single(t => t.Label == "Spaces").Query;
+        // Same for the content section's one category: identical query with and without the screen.
+        var spacesMarked = ScopeQuery(ContentOf(null, Active("Acme")), "All");
+        var spacesPlain = ScopeQuery(ContentOf(null, null), "All");
         spacesMarked.Should().Be(spacesPlain).And.NotContain("Acme");
     }
 

--- a/test/MeshWeaver.Portal.E2E.Test/HomePageRegionsTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/HomePageRegionsTest.cs
@@ -38,10 +38,10 @@ public class HomePageRegionsTest(PortalFixture fixture)
 
         // (b) The catalog — embedded via @@("area/Catalog") — must fill the home width.
         //
-        // The catalog region is ONE scoped search surface (UserActivityLayoutAreas.BuildHome): a
-        // MeshSearch whose SCOPE TABS (Pinned · Apps · Spaces · All — Pinned only when present;
-        // Shared with me is its own band below, only with cross-partition grants) render as the
-        // .mesh-search-scopes strip and share one search bar.
+        // The catalog region is TWO sections (UserActivityLayoutAreas.BuildHome): the Apps icon
+        // grid on top, then the Content search whose SCOPE TABS (Pinned · Spaces · All — Pinned
+        // only when present) render as the .mesh-search-scopes strip and share one search bar.
+        // Shared with me is a third band, only with cross-partition grants.
         // Wait (don't count): CountAsync doesn't wait, so a transient 0 before the strip renders
         // would flake this assertion.
         await page.Locator(".mesh-search-scopes").First
@@ -66,18 +66,25 @@ public class HomePageRegionsTest(PortalFixture fixture)
         (catalogW / pageW).Should().BeGreaterThan(0.8f,
             $"the catalog should fill the home width, not shrink to content (catalog={catalogW:F0}px of {pageW:F0}px)");
 
-        // (c) The Apps scope renders the viewer's MATERIALIZED app records as the phone-home ICON
-        // grid — the write-behind creates Store/Documentation/Threads records from the config
-        // defaults on first render, and the Icons render paints each tile straight from the query
-        // row (no per-record hub). This is the end-to-end proof that a user HAS apps (the "I don't
-        // have any apps" report), that the records query paints inside the wait budget, and that
-        // the Threads tile links to the APP (/{user}/Chat — NavigateToMainNode), not the record.
-        await page.Locator(".mesh-search-scope", new PageLocatorOptions { HasTextString = "Apps" }).First
-            .ClickAsync();
+        // (c) The Apps SECTION is its own band ABOVE the content search — no tab click needed —
+        // and renders the viewer's app records as the phone-home ICON grid, painted straight from
+        // the query rows (no per-record hub). End-to-end proof that a user HAS apps (the "I don't
+        // have any apps" report), that the records query paints inside the wait budget, and that a
+        // tile links to the APP (/{user}/Chat — NavigateToMainNode), not to the record.
         var threadsTile = page.Locator(".mesh-search-icon-tile", new PageLocatorOptions { HasTextString = "Threads" }).First;
         await threadsTile.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
         (await threadsTile.GetAttributeAsync("href")).Should().EndWith($"/{fixture.UserId}/Chat",
             "an app tile opens the APP, never the {user}/_App record");
         await page.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/home-apps.png", FullPage = true });
+
+        // (d) 🚨 THE regression the unit guard mirrors: nothing on the home may render through a
+        // layout area on ANOTHER node's hub. A MeshSearch ItemArea does exactly that — one hub
+        // activation per row, resolved on a hub this page does not own — and in the distributed
+        // portal it failed as an unresolvable area ("AppTile not found") while a monolith resolved
+        // it happily. A rendered page is the only place that shows up, so assert it HERE: no
+        // area-not-found placeholder, and no failed-render card, anywhere on the home.
+        var renderErrors = await page.Locator(
+                "text=/cannot be found|failed to render|Object reference not set/i").CountAsync();
+        renderErrors.Should().Be(0, "the home must not render any area-resolution or view failure");
     }
 }

--- a/test/MeshWeaver.Portal.E2E.Test/PortalFixture.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/PortalFixture.cs
@@ -13,16 +13,39 @@ namespace MeshWeaver.Portal.E2E;
 /// <list type="bullet">
 ///   <item><c>E2E_BASE_URL</c> — point at a portal you already started (recommended). e.g.
 ///     <c>https://localhost:7122</c> for the standalone monolith.</item>
-///   <item><c>E2E_LAUNCH=1</c> — launch <c>memex/Memex.Portal.Monolith</c> as a subprocess on
-///     <c>http://localhost:5099</c> and tear it down afterwards.</item>
+///   <item><c>E2E_LAUNCH=1</c> — launch <c>memex/Memex.Portal.Monolith</c> as a subprocess on a
+///     port DERIVED FROM THIS WORKTREE (<c>E2E_LAUNCH_PORT</c> overrides) and tear it down
+///     afterwards.</item>
 /// </list>
 /// <c>E2E_USER</c> (default <c>Roland</c>) is the DevLogin person id.
 /// </para>
+///
+/// <para>🚨 <b>The launch port is per-worktree, and deliberately.</b> It used to be a fixed
+/// <c>localhost:5099</c>, so two worktrees running E2E at once collided — and the collision was
+/// SILENT in the worst possible way: the second run found a portal already answering on that port,
+/// attached to it, and drove <b>another worktree's build</b>. Every assertion then measured code
+/// the run had not built (observed 2026-08-24: a home test failed against a sibling agent's portal
+/// still serving the previous layout). A test that can silently measure the wrong binary is worse
+/// than one that fails. Hashing the repo root into the port keeps concurrent worktrees apart.</para>
 /// </summary>
 public sealed class PortalFixture : IAsyncLifetime
 {
     private static readonly string User = Environment.GetEnvironmentVariable("E2E_USER") ?? "Roland";
-    private const string LaunchUrl = "http://localhost:5099";
+
+    /// <summary>The launch URL for THIS worktree: an explicit <c>E2E_LAUNCH_PORT</c>, else a port
+    /// derived from the repo root path so concurrent worktrees never share one.</summary>
+    private static string LaunchUrlFor(string repoRoot)
+    {
+        var configured = Environment.GetEnvironmentVariable("E2E_LAUNCH_PORT");
+        if (int.TryParse(configured, out var explicitPort) && explicitPort is > 0 and < 65536)
+            return $"http://localhost:{explicitPort}";
+        // Deterministic, stable across runs of the same worktree: FNV-1a over the repo root,
+        // mapped into the ephemeral-ish 5100–5599 band (5099 stays free for hand-started portals).
+        var hash = 2166136261u;
+        foreach (var c in repoRoot)
+            hash = (hash ^ c) * 16777619u;
+        return $"http://localhost:{5100 + (int)(hash % 500)}";
+    }
 
     private IPlaywright? _playwright;
     private IBrowser? _browser;
@@ -69,11 +92,29 @@ public sealed class PortalFixture : IAsyncLifetime
 
         if (string.IsNullOrWhiteSpace(baseUrl))
         {
-            baseUrl = LaunchUrl;
-            _portalProcess = TryLaunchPortal(baseUrl);
-            if (_portalProcess is null)
+            var root = FindRepoRoot();
+            if (root is null)
             {
                 SkipReason = "E2E_LAUNCH=1 but the monolith could not be started (repo root not found).";
+                return;
+            }
+            baseUrl = LaunchUrlFor(root);
+            // 🚨 Refuse to drive a portal this run did not start. Something already listening on
+            // THIS worktree's port is a stale portal from an earlier run (or, before the port was
+            // per-worktree, a sibling worktree's build) — attaching to it would silently test the
+            // wrong binary, which is exactly the failure this guard exists to make loud.
+            if (await WaitForPortalAsync(baseUrl, TimeSpan.FromSeconds(2)))
+            {
+                SkipReason =
+                    $"A portal is ALREADY listening on {baseUrl} — this run would have driven a binary " +
+                    "it did not build. Stop that process (or set E2E_BASE_URL to target it deliberately, " +
+                    "or E2E_LAUNCH_PORT to pick another port).";
+                return;
+            }
+            _portalProcess = TryLaunchPortal(baseUrl, root);
+            if (_portalProcess is null)
+            {
+                SkipReason = "E2E_LAUNCH=1 but the monolith could not be started.";
                 return;
             }
         }
@@ -291,12 +332,8 @@ public sealed class PortalFixture : IAsyncLifetime
             throw new InvalidOperationException($"Patching '{path}' failed ({resp.Status}): {body}");
     }
 
-    private static Process? TryLaunchPortal(string url)
+    private static Process? TryLaunchPortal(string url, string root)
     {
-        var root = FindRepoRoot();
-        if (root is null)
-            return null;
-
         var psi = new ProcessStartInfo("dotnet",
             "run --project memex/Memex.Portal.Monolith --no-launch-profile")
         {

--- a/test/MeshWeaver.Portal.E2E.Test/ThreadsAppPageTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/ThreadsAppPageTest.cs
@@ -4,17 +4,20 @@ using Xunit;
 namespace MeshWeaver.Portal.E2E;
 
 /// <summary>
-/// The THREADS APP page (<c>/{user}/Chat</c>, the ChatArea) — the Copilot-style shape: a vertical
-/// rail of the owner's open threads (rows via the thread hub's <c>RailItem</c> area, each with an
-/// ✕ that closes the thread) beside the node-less composer. This pins that the page renders
-/// end-to-end: the rail's search container and the composer appear, and NO layout-area error
-/// boundary ("failed to render") fires anywhere on the page.
+/// The chat page at <c>/{user}/Chat</c> (the ChatArea): the node-less composer, and nothing that
+/// resolves a layout area on ANOTHER node's hub.
+///
+/// <para>🚨 This used to assert a vertical RAIL of the owner's open threads whose rows rendered
+/// through a <c>RailItem</c> area on each THREAD's own hub. That per-result foreign-area shape is
+/// the one that failed in the distributed portal (as "AppTile not found" on the home) while
+/// resolving happily in a monolith — so the rail is gone and this test pins what remains: the page
+/// renders, and no error boundary fires.</para>
 /// </summary>
 [Collection("portal-e2e")]
 public class ThreadsAppPageTest(PortalFixture fixture)
 {
     [Fact(Timeout = 180_000)]
-    public async Task ThreadsApp_RendersRailAndComposer_NoRenderErrors()
+    public async Task ChatPage_RendersTheComposer_NoRenderErrors()
     {
         Assert.SkipUnless(fixture.Available, fixture.SkipReason);
 
@@ -25,14 +28,15 @@ public class ThreadsAppPageTest(PortalFixture fixture)
         await page.GotoAsync($"{fixture.BaseUrl}/{fixture.UserId}/Chat",
             new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
 
-        // The rail — a MeshSearch over the owner's open threads.
-        await page.Locator(".mesh-search-container").First
+        // The composer: a message box you can actually type into.
+        await page.GetByText("Type a message", new() { Exact = false }).First
             .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 90_000 });
 
         await page.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/threads-app.png", FullPage = true });
 
-        // No layout-area error boundary anywhere on the page — "This view/area failed to render."
-        (await page.GetByText("failed to render", new() { Exact = false }).CountAsync())
-            .Should().Be(0, "the Threads app must render without any area error boundary firing");
+        // No layout-area error boundary anywhere on the page — neither "failed to render" nor the
+        // unresolvable-area text that a foreign ItemArea produces.
+        (await page.Locator("text=/failed to render|cannot be found/i").CountAsync())
+            .Should().Be(0, "the chat page must render without any area error boundary firing");
     }
 }


### PR DESCRIPTION
Two directives from the review of the shipped grid: *"why is this stuff in core? should be 100% in store"* and *"apps should be ordered by last accessed not by alphabet"*.

## The home only reads

The app lifecycle belongs to the **Store**: it creates a record when a viewer installs an app (stamping the real `Name`, `Icon`, `MainNode`), refreshes it on reinstall, deletes it on uninstall. Core stopped doing any of that. Deleted from `UserActivityLayoutAreas`: `ObserveManifestItems`, `InstalledItemsOf`, `ObserveAppCovers`, `ResolveAppFace`, `NeedsHealing`, `HealAppRecord`, `MaterializeAppRecords`, `EnsureAppRecords` — 449 lines out, 293 in (most of them the ordering below and docs).

That machinery made **every home render a write path**, kept a second copy of the Store's model in core, and paid a cross-schema plugin-cover query to learn what the Store already knew at install time.

What remains is **one** write, `EnsureDefaultApps`, and it is a *bootstrap, not a sync*: when a viewer's grid is EMPTY, the `Admin/HomeConfig.DefaultApps` entries are seeded once — otherwise a brand-new home is a blank screen with no icon to reach the Store by. A viewer who has any record never triggers it.

## Most-recently-used first

New `MeshSearchScopeTab.SortByAccess`, which the Apps scope sets: the grid is ordered by when the viewer last opened each tile's target, with never-opened apps keeping query order behind them.

Applied **at paint**, not in the query, and that is the whole point: `source:accessed` is an INNER JOIN keyed by the row's OWN path, so it would (a) drop every never-opened app — a freshly installed app would be invisible — and (b) match nothing anyway, because opening an app records a visit to the **app**, never to the `_App` record pointing at it. The view instead reads the viewer's own `_UserActivity` satellites (one single-partition query; ids are the visited path with `/`→`_`, so a tile's target maps *forward* to its access time and never needs a reverse lookup) and uses them as a sort key. The snapshot arrives after the tiles have painted and re-orders them — ordering never gates the first paint.

## Verified

Release `-warnaserror` clean (Layout, Blazor, Graph, Graph.Test, Documentation.Test, E2E) · Graph.Test 1536/1536 · Documentation.Test 42/42 · E2E `HomePageRegionsTest` green against a launched portal: the icon grid paints from the bootstrap alone and the Threads tile links `/{user}/Chat`.

## Follow-up (MeshWeaver.Plugins)

The Store side is phase 2 there: write the `InstalledApp` record on install with the real face, delete it on uninstall. Until it lands, installed apps are added to a viewer's grid by the Store only — core will not back-fill them, which is the intended behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
