### PR TITLE
Serve the pre-compressed assets we already build

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1210,7 +1210,25 @@ public static class MemexConfiguration
             return next();
         });
 
-        // Static files middleware must run before routing to serve _content/* paths from RCLs
+        app.UseRouting();
+
+        // 🚨 The static-file middleware runs AFTER UseRouting, and that ordering is the whole
+        // point: StaticFileMiddleware skips a request whose ENDPOINT has already been selected, so
+        // everything in the build-time static-asset manifest is answered by MapStaticAssets below
+        // — pre-compressed (brotli) off a per-encoding endpoint, fingerprinted, with
+        // `Cache-Control: immutable`. Registered before routing (as it was until 2026-08-24) this
+        // middleware short-circuits FIRST and serves those same files raw: measured on prod,
+        // `_framework/blazor.web.js` came back 200,645 bytes with NO content-encoding and NO
+        // cache-control, and `_content/MeshWeaver.Blazor/*.css` likewise — every asset at full
+        // size, revalidated on every load, while the pre-compressed copies sat unused in the
+        // image. The old comment here claimed the early registration was needed to serve RCL
+        // `_content/*` paths; it is not — those are IN the manifest, which is exactly why
+        // MeshModuleStaticAssetExtensions has to hand-roll its own encoding negotiation for the
+        // modules that are NOT.
+        //
+        // What still needs the middleware: anything with no endpoint — the React SPA under /app,
+        // and files that reach wwwroot outside the manifest. Those match no endpoint, so the
+        // middleware serves them exactly as before.
         app.UseStaticFiles();
 
         // …and the same for modules that ship via modules/<Name>/ rather than a ProjectReference,
@@ -1218,8 +1236,6 @@ public static class MemexConfiguration
         // host's own UseStaticFiles so the platform copy of any shared dependency answers first —
         // the module lane never shadows a platform asset.
         app.UseMeshModuleStaticAssets();
-
-        app.UseRouting();
 
         // gRPC-web middleware — lets browsers / React Native reach the mesh gRPC service
         // (Connect+Deliver split) without HTTP/2 bidi. Must sit between UseRouting and the

--- a/src/MeshWeaver.Blazor/Infrastructure/NonfileRouteConstraint.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/NonfileRouteConstraint.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.Blazor.Infrastructure;
 
@@ -54,7 +56,41 @@ public class NonfileRouteConstraint : IRouteConstraint
         if (slashIndex >= 0)
             firstSegment = firstSegment[..slashIndex];
 
-        return !ExcludedPrefixes.Contains(firstSegment.ToString());
+        if (ExcludedPrefixes.Contains(firstSegment.ToString()))
+            return false;
+
+        // 🚨 A path that IS a real file in webroot is never a page route. The prefix list above
+        // only covers the KNOWN asset roots (_framework, _content, …); anything else physically
+        // present — a hand-dropped wwwroot file, a published SPA bundle, an asset outside the
+        // build-time manifest — would otherwise match this catch-all, and since the static-file
+        // middleware runs AFTER routing (so MapStaticAssets can serve the pre-compressed copies)
+        // it SKIPS a request whose endpoint is already selected. The file would then be answered
+        // with the Blazor shell: HTTP 200, wrong bytes, no error anywhere.
+        //
+        // Deliberately an existence check and NOT a "does the last segment contain a dot" test:
+        // mesh Document nodes legitimately end in .pdf/.docx/.txt, and rejecting dotted paths is
+        // exactly the agentic-pensions#10 regression this class was written to fix.
+        return !FileExistsInWebRoot(httpContext, path);
+    }
+
+    /// <summary>True when <paramref name="path"/> resolves to a file that physically exists in the
+    /// host's web root. Absent an <see cref="IWebHostEnvironment"/> (constraint evaluated outside a
+    /// request), the answer is false — the prefix rules alone then decide, exactly as before.</summary>
+    private static bool FileExistsInWebRoot(HttpContext? httpContext, string path)
+    {
+        var webRoot = httpContext?.RequestServices?.GetService<IWebHostEnvironment>()?.WebRootFileProvider;
+        if (webRoot is null || path.Length == 0)
+            return false;
+        try
+        {
+            return webRoot.GetFileInfo(path).Exists;
+        }
+        catch (Exception)
+        {
+            // A malformed or traversal-shaped path makes the provider throw; that is not a file,
+            // and a routing constraint must never be the thing that 500s a request.
+            return false;
+        }
     }
 }
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-faster-page-loads.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-faster-page-loads.md
@@ -10,8 +10,8 @@ Order: -20260824
 
 The portal already built compressed copies of its scripts and stylesheets, but was serving the
 uncompressed originals — and telling your browser nothing about caching them, so every visit
-re-downloaded the lot. It now serves the compressed copies with proper validation.
+re-downloaded the lot. It now serves the compressed copies, with caching instructions.
 
-The single largest file drops from about 200 KB to about 56 KB, and repeat visits revalidate
-instead of re-downloading. Nothing about the pages themselves changed; there is just far less to
-fetch before they appear.
+The single largest file drops from about 200 KB to about 56 KB, and versioned assets are held in
+your browser's cache rather than fetched again. Nothing about the pages themselves changed; there
+is just far less to fetch before they appear.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-faster-page-loads.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-faster-page-loads.md
@@ -1,0 +1,17 @@
+---
+Name: Pages load lighter
+Category: Fix
+Description: The portal now serves its compressed, cacheable copies of the framework and component assets instead of the full-size originals.
+Icon: Sparkle
+Order: -20260824
+---
+
+# Pages load lighter
+
+The portal already built compressed copies of its scripts and stylesheets, but was serving the
+uncompressed originals — and telling your browser nothing about caching them, so every visit
+re-downloaded the lot. It now serves the compressed copies with proper validation.
+
+The single largest file drops from about 200 KB to about 56 KB, and repeat visits revalidate
+instead of re-downloading. Nothing about the pages themselves changed; there is just far less to
+fetch before they appear.

--- a/test/MeshWeaver.Hosting.Blazor.Test/CatchAllPageRoutingTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/CatchAllPageRoutingTest.cs
@@ -45,6 +45,7 @@ public class CatchAllPageRoutingTest : IAsyncLifetime
     private string webRoot = null!;
 
     private const string StaticAssetContent = "/* probe asset */";
+    private const string NestedAssetContent = "/* nested probe asset */";
 
     public async ValueTask InitializeAsync()
     {
@@ -53,6 +54,9 @@ public class CatchAllPageRoutingTest : IAsyncLifetime
         webRoot = Path.Combine(AppContext.BaseDirectory, "catchall-routing-webroot");
         Directory.CreateDirectory(webRoot);
         await File.WriteAllTextAsync(Path.Combine(webRoot, "probe-asset.css"), StaticAssetContent);
+        var nested = Path.Combine(webRoot, "probe-folder");
+        Directory.CreateDirectory(nested);
+        await File.WriteAllTextAsync(Path.Combine(nested, "nested-asset.css"), NestedAssetContent);
 
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -64,11 +68,18 @@ public class CatchAllPageRoutingTest : IAsyncLifetime
 
         var webApp = builder.Build();
 
-        // Mirrors the portal pipeline (MemexConfiguration.StartPortalApplication):
-        // static files BEFORE routing, then the razor-component endpoints with the
+        // Mirrors the portal pipeline (MemexConfiguration.StartPortalApplication): routing FIRST,
+        // then the static-file middleware, then the razor-component endpoints with the
         // static-asset exclusion applied to the root catch-all page endpoint.
-        webApp.UseStaticFiles();
+        //
+        // 🚨 The order is the portal's and must stay the portal's. Static files run AFTER routing
+        // so MapStaticAssets can answer manifest assets off its per-encoding endpoints (the
+        // pre-compressed copies); StaticFileMiddleware then skips any request whose endpoint is
+        // already selected. That is precisely why the catch-all must refuse a path that is a real
+        // file — otherwise the shell answers it — which is what
+        // RealStaticAsset_IsServedByStaticFileMiddleware pins below.
         webApp.UseRouting();
+        webApp.UseStaticFiles();
         webApp.UseAntiforgery();
         webApp.MapRazorComponents<RouterProbeApp>()
             .AddAdditionalAssemblies(typeof(ApplicationPage).Assembly)
@@ -142,11 +153,40 @@ public class CatchAllPageRoutingTest : IAsyncLifetime
     [Fact]
     public async Task RealStaticAsset_IsServedByStaticFileMiddleware()
     {
+        // 🚨 THE regression guard for the static-asset ordering. The catch-all is `/{**Path}` and
+        // the prefix list covers only the KNOWN asset roots, so a webroot file under no such
+        // prefix ("probe-asset.css") used to match the page endpoint — harmless while the
+        // middleware ran first, fatal once it runs after routing, because it then skips a request
+        // whose endpoint is already selected and the file is answered with the Blazor shell:
+        // HTTP 200, wrong bytes, nothing in any log. The constraint refuses paths that physically
+        // exist, so the file wins.
         var (status, body) = await GetAsync("/probe-asset.css");
 
         status.Should().Be(HttpStatusCode.OK);
         body.Should().Be(StaticAssetContent,
-            because: "physical static assets are served by the static-file middleware ahead of routing");
+            because: "a path that IS a real webroot file must never be swallowed by the catch-all page");
     }
 
+    [Fact]
+    public async Task RealStaticAsset_InASubfolder_IsAlsoServed()
+    {
+        // The same rule one level down — a published SPA bundle or a hand-dropped asset folder.
+        var (status, body) = await GetAsync("/probe-folder/nested-asset.css");
+
+        status.Should().Be(HttpStatusCode.OK);
+        body.Should().Be(NestedAssetContent,
+            because: "the existence check is per PATH, not just for root-level files");
+    }
+
+    [Fact]
+    public async Task MeshPathThatLooksLikeAFile_ButIsNotOne_StillReachesThePage()
+    {
+        // The other half of the contract: the constraint must reject only paths that ACTUALLY
+        // exist on disk. A Document node whose slug ends in .pdf is a mesh path, not a file, and
+        // must still render the page — the agentic-pensions#10 regression in reverse.
+        var (_, body) = await GetAsync("/AgenticPension/content/_Documents/not-on-disk.pdf");
+
+        body.Should().Contain($"{RouterProbeApp.FoundMarker}{nameof(ApplicationPage)}",
+            because: "only a physically present file may be withheld from the catch-all");
+    }
 }


### PR DESCRIPTION
Answers the maintainer's question *"page takes forever to load — are libraries not pre-baked?"*: they **are** pre-baked, and the portal was not serving them.

## The defect

`MapStaticAssets()` serves the build-time **pre-compressed** (brotli/gzip), fingerprinted, immutably-cached copies off a per-encoding endpoint manifest. It never got the request: `app.UseStaticFiles()` was registered **before** `UseRouting()`, so the plain middleware short-circuited first and shipped the identity files raw.

Measured on prod (memex.meshweaver.cloud), before:

| asset | bytes | content-encoding | cache-control |
|---|---|---|---|
| `_framework/blazor.web.js` | 200,645 | *(none)* | *(none)* |
| `_content/MeshWeaver.Blazor/standard-page-layout.css` | 20,711 | *(none)* | *(none)* — ETag only |
| `/static/NodeTypeIcons/chat.svg` | 533 | — | `max-age=2592000, immutable` ✅ |

So every framework/RCL asset shipped at full size **and** revalidated on every load, while the compressed copies sat unused in the image. The comment claiming the early registration was needed to serve RCL `_content/*` paths was wrong — those are *in* the manifest, which is precisely why `MeshModuleStaticAssetExtensions` has to hand-roll its own encoding negotiation for the module assets that are **not**.

## The fix

`StaticFileMiddleware` skips a request whose **endpoint is already selected**, so moving both static-file registrations after `UseRouting()` lets the manifest endpoints answer, while the middleware still serves everything with no endpoint — the React SPA under `/app`, and anything reaching `wwwroot` outside the manifest. Their relative order (host first, then modules) is preserved, and they still run before authentication, exactly as before.

## Verified locally (Release build, real portal)

- `_framework/blazor.web.js`: **200,538 → 55,600 bytes** with `Content-Encoding` (gzip locally; a Release publish serves brotli, smaller still)
- `_content/MeshWeaver.Blazor/standard-page-layout.css`: now `Content-Encoding` + validation
- Regression: `/app` SPA serves (200, 43,521 bytes) and `/static/NodeTypeIcons/chat.svg` serves — both are the no-endpoint paths the middleware still owns
- `HomePageRegionsTest` e2e green against a portal launched from this build

🤖 Generated with [Claude Code](https://claude.com/claude-code)