### PR TITLE
Fix dead @@keyframes in scoped CSS — five loading animations were silently static

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -202,7 +202,7 @@
     width: 60%;
     animation: thread-msg-skeleton-pulse 1.4s ease-in-out infinite;
 }
-@@keyframes thread-msg-skeleton-pulse {
+@keyframes thread-msg-skeleton-pulse {
     0%, 100% { opacity: 0.35; }
     50%      { opacity: 0.15; }
 }
@@ -880,7 +880,7 @@ button.thread-chat-status-item {
     animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 
-@@keyframes skeleton-pulse {
+@keyframes skeleton-pulse {
     0%, 100% { opacity: 0.3; }
     50% { opacity: 0.15; }
 }
@@ -1417,7 +1417,7 @@ button.thread-chat-status-item {
     animation: thread-msg-delegation-pulse-anim 1.4s ease-in-out infinite;
 }
 
-@@keyframes thread-msg-delegation-pulse-anim {
+@keyframes thread-msg-delegation-pulse-anim {
     0%, 100% { opacity: 0.4; }
     50%      { opacity: 1;   }
 }
@@ -1548,7 +1548,7 @@ button.thread-chat-status-item {
     animation: thread-runtime-subthread-pulse-anim 1.4s ease-in-out infinite;
 }
 
-@@keyframes thread-runtime-subthread-pulse-anim {
+@keyframes thread-runtime-subthread-pulse-anim {
     0%, 100% { opacity: 0.3; transform: scale(0.85); }
     50%      { opacity: 1;   transform: scale(1.15); }
 }

--- a/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.css
@@ -26,7 +26,7 @@
     animation-delay: 0s;
 }
 
-@@keyframes dots-blink {
+@keyframes dots-blink {
     0%, 80%, 100% {
         opacity: 0.25;
         transform: scale(0.8);

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-loading-pulse-animations.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-loading-pulse-animations.md
@@ -1,0 +1,18 @@
+---
+Name: Loading pulses actually pulse now
+Category: Fix
+Description: Five loading and progress animations — the chat message skeletons, the delegation and sub-thread pulses, and the area loading dots — were silently static because their keyframes never parsed; they animate again.
+Icon: Sparkle
+Order: -20260824
+---
+
+# Loading pulses actually pulse now
+
+Several "something is happening" indicators were quietly frozen: the skeleton placeholders while
+a chat message loads, the pulse on a delegated call and on a running sub-thread, and the three
+blinking dots while a layout area loads. Their animations referred to keyframes written with a
+Razor escape (`@@keyframes`) inside plain CSS files, where that escape is not processed — so the
+keyframes never parsed and the elements just sat still.
+
+The keyframes are plain CSS again, and every one of those indicators moves — so a loading page
+looks like a loading page instead of a stuck one.


### PR DESCRIPTION
## What

The Razor `@@` escape is only processed in `.razor` files; in `.razor.css` it is literal CSS, so `@@keyframes` never parses and every `animation:` referencing those keyframes silently does nothing (no error anywhere — the element just sits still).

- `ThreadChatView.razor.css`: 4 escaped keyframes un-escaped — `thread-msg-skeleton-pulse`, `skeleton-pulse`, `thread-msg-delegation-pulse-anim`, `thread-runtime-subthread-pulse-anim`. The file already documents the single-`@` rule for its other keyframes (the comment about moving styles out of the inline `<style>` block); these four were leftovers.
- `NamedAreaView.razor.css`: same leftover on `dots-blink` — the three loading dots of every layout area never blinked.
- Repo-wide sweep: no other `.razor.css` carries `@@keyframes`.
- What's New entry included (Fix).

Flagged during PR #2114's review (chat-hint pulse) and picked up by the education repo's cross-course design-flaw sweep.

⚠️ Org Actions budget is currently exhausted — CI will not start until it is raised; do not merge before a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)