### PR TITLE
JS clients: the home design — scope tabs, phone-home Icons grid, MRU apps, grouped content

### DIFF
--- a/clients/portal-next/src/client/live.ts
+++ b/clients/portal-next/src/client/live.ts
@@ -140,7 +140,9 @@ export async function connectLive(baseUrl: string = window.location.origin): Pro
   const runTranscribe = (audio: Blob, language?: string) => transcribe(baseUrl, rawToken, audio, language);
   return {
     connection,
-    ops: adaptOps(mesh, runQuery, runAutocomplete, runRenderMarkdown, runStartKernel, runListContent, runUploadContent, runTranscribe),
+    // userId ON the ops too: viewer-scoped reads inside the shared renderer (the home Apps
+    // grid's most-recently-used ordering) resolve the viewer through MeshOps.userId.
+    ops: { ...adaptOps(mesh, runQuery, runAutocomplete, runRenderMarkdown, runStartKernel, runListContent, runUploadContent, runTranscribe), userId },
     userId,
     getNode: (path: string) => mesh.get(path).then((n) => n.raw as MeshNodeRow).catch(() => null),
     queryNodes: runQuery,

--- a/clients/portal/src/live.ts
+++ b/clients/portal/src/live.ts
@@ -82,7 +82,9 @@ export async function connectLive(baseUrl: string = window.location.origin): Pro
 
   return {
     connection,
-    ops: adaptOps(mesh, runQuery, runAutocomplete, runRenderMarkdown, runStartKernel, runListContent, runUploadContent),
+    // userId ON the ops too: viewer-scoped reads inside the shared renderer (the home Apps
+    // grid's most-recently-used ordering) resolve the viewer through MeshOps.userId.
+    ops: { ...adaptOps(mesh, runQuery, runAutocomplete, runRenderMarkdown, runStartKernel, runListContent, runUploadContent), userId },
     userId,
     close: () => connection.close(),
   };

--- a/clients/react-native/src/liveOps.ts
+++ b/clients/react-native/src/liveOps.ts
@@ -168,6 +168,9 @@ export function buildMeshOps(connection: MeshWebConnection, baseUrl: string, par
   // shell had right and the web shells did not.
   const rest = new MeshRest({ baseUrl, token });
   return {
+    // The viewer's partition doubles as their mesh id — viewer-scoped reads (the home Apps
+    // grid's most-recently-used ordering over {viewer}/_UserActivity) resolve it from here.
+    userId: partition,
     watch: (path: string) => watchNode(mesh, path),
     startThread: (namespacePath: string, userText: string, opts?: ThreadSubmitOptions) =>
       mesh.startThread(namespacePath, userText, opts),

--- a/clients/react-native/src/rnMeshLive.test.tsx
+++ b/clients/react-native/src/rnMeshLive.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "@meshweaver/react/core";
 
 import { rnPack } from "./rnPack";
+import { NavContext } from "./nav";
 
 // Assert against the CATALOG, not a literal — that also pins that these strings are localized.
 const en = (key: string) => localize(key, "en");
@@ -350,5 +351,140 @@ describe("MeshSearch union queries", () => {
     // Deduped by path in DECLARATION order: the first batch's "Both" wins, the duplicate is dropped.
     expect(text).toContain("BothFirst");
     expect(text).not.toContain("BothDup");
+  });
+});
+
+// ---- MeshSearch home design (scope tabs · Icons grid · SortByAccess · grouped sections) --------
+
+describe("MeshSearch home design", () => {
+  const appRows = [
+    { path: "u1/_App/alpha", id: "alpha", name: "Alpha", nodeType: "InstalledApp", mainNode: "store/Alpha", icon: "🅰" },
+    { path: "u1/_App/beta", id: "beta", name: "Beta", nodeType: "InstalledApp", mainNode: "store/Beta", icon: "🅱" },
+  ];
+  const appsScope = {
+    label: "Apps",
+    query: "path:u1/_App scope:children nodeType:InstalledApp",
+    renderMode: "Icons",
+    navigateToMainNode: true,
+  };
+
+  it("a SINGLE scope applies its settings without a strip: Icons tiles, row-only select, mainNode target", async () => {
+    const search = vi.fn(async () => appRows);
+    const ops = fakeOps({ search });
+    const navigate = vi.fn();
+    let r!: TestRenderer.ReactTestRenderer;
+    await TestRenderer.act(async () => {
+      r = TestRenderer.create(
+        <NavContext.Provider value={navigate}>
+          <RegistryProvider pack={rnPack}>
+            <MeshOpsProvider ops={ops}>
+              <ScopeProvider
+                source={
+                  new StaticAreaSource({
+                    areas: {
+                      main: {
+                        $type: "MeshSearch",
+                        hiddenQuery: appsScope.query,
+                        showSearchBox: false,
+                        scopeTabs: [appsScope],
+                      } as never,
+                    },
+                  })
+                }
+                area="main"
+              >
+                <RenderArea areaKey="main" />
+              </ScopeProvider>
+            </MeshOpsProvider>
+          </RegistryProvider>
+        </NavContext.Provider>,
+      );
+    });
+    await TestRenderer.act(async () => {
+      await new Promise((res) => setTimeout(res, 300)); // the 250 ms search debounce
+    });
+    const j = r.toJSON() as Json;
+    // Row-only: the icon grid never pulls content over the wire.
+    expect(search).toHaveBeenCalledWith(
+      "path:u1/_App scope:children nodeType:InstalledApp select:path,id,namespace,name,nodeType,icon,mainNode",
+      undefined,
+    );
+    const text = allText(j).join("\n");
+    expect(text).toContain("Alpha");
+    expect(text).toContain("Beta");
+    // One tab ⇒ no tab strip.
+    expect([...walk(j)].some((n) => n.props?.accessibilityRole === "tablist")).toBe(false);
+    // Pressing a tile navigates to the row's mainNode (the APP), never the record.
+    const tile = r.root.findAll((n) => n.props?.accessibilityLabel === "Alpha")[0];
+    await TestRenderer.act(async () => {
+      tile.props.onPress();
+    });
+    expect(navigate).toHaveBeenCalledWith({ address: "store/Alpha", area: "" });
+  });
+
+  it("SortByAccess orders most-recently-used first from the viewer's access log, keeping never-opened tiles", async () => {
+    const search = vi.fn(async (q: string) =>
+      q.includes("_UserActivity")
+        ? [{ id: "store_Beta", lastModified: "2026-08-20T10:00:00Z", path: "u1/_UserActivity/store_Beta", nodeType: "UserActivity" }]
+        : appRows,
+    );
+    const ops = fakeOps({ search, userId: "u1" });
+    const j = await renderLive(
+      {
+        areas: {
+          main: {
+            $type: "MeshSearch",
+            hiddenQuery: appsScope.query,
+            showSearchBox: false,
+            scopeTabs: [{ ...appsScope, sortByAccess: true }],
+          } as never,
+        },
+      },
+      ops,
+    );
+    await TestRenderer.act(async () => {
+      await new Promise((res) => setTimeout(res, 300));
+    });
+    // The access log was read row-only from the viewer's own partition…
+    expect(search.mock.calls.some((c) => String(c[0]).startsWith("namespace:u1/_UserActivity nodeType:UserActivity"))).toBe(true);
+    // …and Beta (opened — its TARGET store/Beta is logged, '/'→'_') leads while Alpha stays.
+    const labels = allText(j).filter((t2) => t2 === "Alpha" || t2 === "Beta");
+    expect(labels).toEqual(["Beta", "Alpha"]);
+  });
+
+  it("renders the strip for 2+ scopes and groups by nodeType with counts, biggest group first", async () => {
+    const search = vi.fn(async () => [
+      { path: "a/1", name: "One", nodeType: "Story" },
+      { path: "a/2", name: "Two", nodeType: "Space" },
+      { path: "a/3", name: "Three", nodeType: "Space" },
+    ]);
+    const ops = fakeOps({ search });
+    const j = await renderLive(
+      {
+        areas: {
+          main: {
+            $type: "MeshSearch",
+            hiddenQuery: "is:main",
+            renderMode: "Grouped",
+            groupByFrequency: true,
+            showSearchBox: false,
+            grouping: { groupByProperty: "NodeType" },
+            scopeTabs: [
+              { label: "All", query: "is:main" },
+              { label: "Pinned", query: "path:(a/1)" },
+            ],
+          } as never,
+        },
+      },
+      ops,
+    );
+    await TestRenderer.act(async () => {
+      await new Promise((res) => setTimeout(res, 300));
+    });
+    expect([...walk(j)].some((n) => n.props?.accessibilityRole === "tablist")).toBe(true);
+    const text = allText(j);
+    // Counts on the section headers, biggest group first.
+    const headers = text.filter((t2) => /\(\d\)$/.test(t2));
+    expect(headers).toEqual(["Space (2)", "Story (1)"]);
   });
 });

--- a/clients/react-native/src/rnMeshLive.tsx
+++ b/clients/react-native/src/rnMeshLive.tsx
@@ -10,16 +10,29 @@
 // state — no crash, no fake data.
 
 import { useEffect, useMemo, useState } from "react";
-import { View, Text, TextInput, Pressable, ScrollView, ActivityIndicator, StyleSheet } from "react-native";
+import { View, Text, TextInput, Pressable, ScrollView, ActivityIndicator, Image, StyleSheet } from "react-native";
+import { SvgXml } from "react-native-svg";
 import {
+  accessLogQuery,
+  buildGroups,
+  classifyIcon,
+  mergeUnionResults,
+  paintOrdered,
+  parseScopeTabs,
+  toAccessOrder,
+  toSearchResult,
+  unionQueries,
   useLocalize,
   useMeshOps,
   useResolve,
   str,
   useText,
+  withRowOnlySelect,
   type ControlComponent,
   type MeshNodeState,
   type MeshOps,
+  type MeshSearchResult,
+  type MeshSearchScope,
 } from "@meshweaver/react/core";
 import { useNavigate } from "./nav";
 import { useTheme } from "./theme";
@@ -99,29 +112,13 @@ function useDebounced<T>(value: T, ms: number): T {
   return v;
 }
 
-interface NodeResult {
-  path: string;
-  name: string;
-  nodeType: string;
-  description: string;
-}
-
-function toNodeResult(r: Record<string, unknown>): NodeResult {
-  const content = (r.content ?? {}) as Record<string, unknown>;
-  return {
-    path: s(r.path),
-    name: s(r.name) || s(r.path).split("/").pop() || s(r.path),
-    nodeType: s(r.nodeType),
-    description: s(r.description ?? content.description),
-  };
-}
-
 // A hidden query can be a newline-joined UNION of sub-queries (the server declares the home
 // catalog that way; Blazor's MeshSearchView issues them as one MeshQueryRequest union, but the
 // REST verb takes ONE query per call — a newline-joined string parses to nothing server-side).
-// Run each line, concatenate in declaration order, dedupe by path.
-function useMeshQuery(ops: MeshOps | null, queries: string[], basePath?: string): { results: NodeResult[]; loading: boolean } {
-  const [state, setState] = useState<{ results: NodeResult[]; loading: boolean }>({ results: [], loading: false });
+// Run each line, concatenate in declaration order, dedupe by path — mergeUnionResults, the same
+// shared-model half the web pack uses.
+function useMeshQuery(ops: MeshOps | null, queries: string[], basePath?: string): { results: MeshSearchResult[]; loading: boolean } {
+  const [state, setState] = useState<{ results: MeshSearchResult[]; loading: boolean }>({ results: [], loading: false });
   const key = queries.join("\n");
   useEffect(() => {
     if (!ops?.search || queries.length === 0) {
@@ -133,15 +130,7 @@ function useMeshQuery(ops: MeshOps | null, queries: string[], basePath?: string)
     Promise.all(queries.map((q) => ops.search!(q, basePath || undefined)))
       .then((batches) => {
         if (!live) return;
-        const seen = new Set<string>();
-        const merged: NodeResult[] = [];
-        for (const rs of batches)
-          for (const n of rs.map(toNodeResult))
-            if (n.path.length > 0 && !seen.has(n.path)) {
-              seen.add(n.path);
-              merged.push(n);
-            }
-        setState({ results: merged, loading: false });
+        setState({ results: mergeUnionResults(batches), loading: false });
       })
       .catch(() => {
         if (live) setState({ results: [], loading: false });
@@ -152,6 +141,35 @@ function useMeshQuery(ops: MeshOps | null, queries: string[], basePath?: string)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ops, key, basePath]);
   return state;
+}
+
+/**
+ * The viewer's own access log as {activityId → accessed-at ms} — fetched only when a scope asked
+ * for access ordering and the host exposes the viewer's id (ops.userId). Null until it lands, so
+ * the tiles paint from their own query first and re-order when the log arrives.
+ */
+function useAccessOrder(ops: MeshOps | null, enabled: boolean): Map<string, number> | null {
+  const viewer = enabled ? s(ops?.userId) : "";
+  const [map, setMap] = useState<Map<string, number> | null>(null);
+  useEffect(() => {
+    if (!viewer || !ops?.search) {
+      setMap(null);
+      return;
+    }
+    let live = true;
+    ops
+      .search(accessLogQuery(viewer), undefined, 500)
+      .then((rows) => {
+        if (live) setMap(toAccessOrder(rows));
+      })
+      .catch(() => {
+        /* keep the query's own order */
+      });
+    return () => {
+      live = false;
+    };
+  }, [ops, viewer]);
+  return map;
 }
 
 // ── ThreadChat ───────────────────────────────────────────────────────────────
@@ -292,37 +310,172 @@ const ThreadChat: ControlComponent = ({ control }) => {
 
 // ── MeshSearch ───────────────────────────────────────────────────────────────
 
+/** The tile/row icon: the node's Icon column (SVG / URL / emoji) or the initial bubble — the
+ *  native mapping of the web pack's NodeResultIcon fallback chain. */
+function ResultIcon({ node, size, radius }: { node: MeshSearchResult; size: number; radius: number }) {
+  const value = node.icon || node.thumbnail || "";
+  const classified = classifyIcon(value as never);
+  const box = { width: size, height: size, borderRadius: radius, overflow: "hidden" as const, alignItems: "center" as const, justifyContent: "center" as const };
+  switch (classified.kind) {
+    case "svg":
+      return (
+        <View style={box}>
+          <SvgXml xml={classified.text} width={Math.round(size * 0.6)} height={Math.round(size * 0.6)} />
+        </View>
+      );
+    case "url":
+      return <Image source={{ uri: classified.text }} style={{ ...box, resizeMode: "cover" }} />;
+    case "emoji":
+      return (
+        <View style={box}>
+          <Text style={{ fontSize: Math.round(size * 0.55), lineHeight: Math.round(size * 0.7) }}>{classified.text}</Text>
+        </View>
+      );
+    default:
+      return (
+        <View style={[box, styles.iconInitialBox]}>
+          <Text style={{ fontSize: Math.round(size * 0.4), fontWeight: "600", color: "#616161" }}>
+            {(node.name.trim()[0] ?? "?").toUpperCase()}
+          </Text>
+        </View>
+      );
+  }
+}
+
+/** One tile of the phone-home ICON grid (Icons render mode): a large rounded icon with the name
+ *  underneath, navigating to the row's TARGET — painted entirely from the query row. */
+function IconTile({ node, target }: { node: MeshSearchResult; target: string }) {
+  const navigate = useNavigate();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={node.name}
+      style={styles.iconTile}
+      onPress={() => navigate({ address: target, area: "" })}
+    >
+      <View style={styles.iconBox}>
+        <ResultIcon node={node} size={64} radius={16} />
+      </View>
+      <Text style={styles.iconLabel} numberOfLines={2}>
+        {node.name}
+      </Text>
+    </Pressable>
+  );
+}
+
 /**
- * Live mesh search: the hidden query (the control's server-declared filter) is combined with the
- * user's visible term and run through `ops.search`, exactly as the web pack does.
+ * Live mesh search — the native twin of the web pack's MeshSearchView, over the SAME shared model
+ * (@meshweaver/react/core meshSearchModel): scope tabs (a strip only for 2+ tabs; one tab still
+ * applies its settings), newline-joined UNION queries issued per line, the Icons phone-home grid
+ * painted from query rows (row-only select), NavigateToMainNode, most-recently-used-first
+ * ordering from the viewer's own access log (SortByAccess), and grouped-by-type sections with
+ * counts, biggest group first (GroupByFrequency).
  */
 const MeshSearch: ControlComponent = ({ control }) => {
   const t = useLocalize();
   const ops = useMeshOps();
   const navigate = useNavigate();
   const title = useText(control.title);
-  const hiddenQuery = s(useResolve(control.hiddenQuery));
+  const controlHiddenQuery = s(useResolve(control.hiddenQuery));
   const initialVisible = s(useResolve(control.visibleQuery));
   const placeholder = s(useResolve(control.placeholder)) || t("common.typeToSearch");
   const ns = s(useResolve(control.namespace));
+  const controlRenderMode = s(useResolve(control.renderMode)) || "Flat";
   const showSearchBox = useResolve(control.showSearchBox) !== false;
   const liveSearch = useResolve(control.liveSearch) !== false;
   const excludeBasePath = useResolve(control.excludeBasePath) !== false;
   const showEmptyMessage = useResolve(control.showEmptyMessage) !== false;
+  const controlNavigateToMainNode = useResolve(control.navigateToMainNode) === true;
+  const groupByFrequency = useResolve(control.groupByFrequency) === true;
+  const sections = (control.sections ?? {}) as Record<string, unknown>;
+  const showCounts = sections.showCounts !== false;
+  const grouping = (control.grouping ?? {}) as Record<string, unknown>;
+
+  // Scope tabs — active tab tracked by LABEL (a bare index could re-point on a list change);
+  // a vanished label clamps to the first tab. A single tab renders no strip but still applies
+  // its settings (the home's Apps band: Icons + SortByAccess on one scope).
+  const scopeTabs = useMemo(() => parseScopeTabs(control.scopeTabs), [control.scopeTabs]);
+  const [activeScopeLabel, setActiveScopeLabel] = useState<string | null>(null);
+  const activeScopeIndex = Math.max(
+    0,
+    scopeTabs.findIndex((sc) => sc.label === activeScopeLabel),
+  );
+  const scope: MeshSearchScope | null = scopeTabs[activeScopeIndex] ?? null;
+
+  const hiddenQuery = scope ? scope.query : controlHiddenQuery;
+  const renderMode = scope?.renderMode ?? controlRenderMode;
+  const navigateToMainNode = scope?.navigateToMainNode ?? controlNavigateToMainNode;
+  const sortByAccess = scope?.sortByAccess ?? false;
+  const isIcons = renderMode === "Icons";
+  const isGrouped = renderMode === "Grouped";
 
   const [visible, setVisible] = useState(initialVisible);
   const [submitted, setSubmitted] = useState(initialVisible);
   const term = useDebounced(liveSearch ? visible : submitted, 250);
-  // The hidden query's newline-separated sub-queries each get the visible term appended.
-  const hiddenLines = hiddenQuery.split("\n").map((l) => l.trim()).filter(Boolean);
-  const queries = (hiddenLines.length ? hiddenLines : [""])
-    .map((l) => [l, term.trim()].filter(Boolean).join(" "))
-    .filter(Boolean);
+  // Each UNION leg gets the visible term appended; the icon grid ships row-only (`select:`
+  // without content) unless the authored query already selects.
+  const queries = unionQueries(hiddenQuery, term, (leg) => withRowOnlySelect(leg, isIcons));
   const { results, loading } = useMeshQuery(ops, queries, ns);
-  const items = excludeBasePath && ns ? results.filter((n) => n.path !== ns) : results;
+
+  const accessOrder = useAccessOrder(ops, sortByAccess);
+  const targetOf = (n: MeshSearchResult) => (navigateToMainNode && n.mainNode ? n.mainNode : n.path);
+  let items = excludeBasePath && ns ? results.filter((n) => n.path !== ns) : results;
+  if (sortByAccess) items = paintOrdered(items, accessOrder, targetOf);
+
+  const groupBy = s(grouping.groupByProperty) || "NodeType";
+  const groups = buildGroups(items, isGrouped, groupBy, groupByFrequency);
+  const skipHeaders = groups.length === 1;
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set());
+  const toggleCollapsed = (key: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+  const renderItems = (groupItems: MeshSearchResult[]) =>
+    isIcons ? (
+      <View style={styles.iconsGrid}>
+        {groupItems.map((n) => (
+          <IconTile key={n.path} node={n} target={targetOf(n)} />
+        ))}
+      </View>
+    ) : (
+      <View style={{ gap: 8 }}>
+        {groupItems.map((n) => (
+          <Pressable key={n.path} style={styles.resultRow} onPress={() => navigate({ address: targetOf(n), area: "" })}>
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+              <ResultIcon node={n} size={28} radius={6} />
+              <Text style={styles.resultName}>{n.name}</Text>
+            </View>
+            {n.description ? <Text style={styles.muted}>{n.description}</Text> : null}
+            <Text style={styles.resultPath}>{n.path}</Text>
+          </Pressable>
+        ))}
+      </View>
+    );
 
   return (
     <View style={{ gap: 8 }}>
+      {scopeTabs.length > 1 ? (
+        <View style={styles.scopeRow} accessibilityRole="tablist">
+          {scopeTabs.map((tab, i) => (
+            <Pressable
+              key={tab.label || String(i)}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: i === activeScopeIndex }}
+              style={[styles.scopeTab, i === activeScopeIndex && styles.scopeTabActive]}
+              onPress={() => {
+                setActiveScopeLabel(tab.label);
+                setCollapsed(new Set());
+              }}
+            >
+              <Text style={[styles.scopeTabText, i === activeScopeIndex && styles.scopeTabTextActive]}>{tab.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
       {title ? <Text style={styles.sectionTitle}>{title}</Text> : null}
       {showSearchBox ? (
         <View style={styles.searchRow}>
@@ -339,13 +492,21 @@ const MeshSearch: ControlComponent = ({ control }) => {
       ) : null}
       {loading ? <ActivityIndicator /> : null}
       {!loading && items.length === 0 && showEmptyMessage ? <Text style={styles.muted}>{t("common.noResults")}</Text> : null}
-      {items.map((n) => (
-        <Pressable key={n.path} style={styles.resultRow} onPress={() => navigate({ address: n.path, area: "" })}>
-          <Text style={styles.resultName}>{n.name}</Text>
-          {n.description ? <Text style={styles.muted}>{n.description}</Text> : null}
-          <Text style={styles.resultPath}>{n.path}</Text>
-        </Pressable>
-      ))}
+      {groups.map((group) => {
+        const isCollapsed = collapsed.has(group.key);
+        const headerLabel = showCounts ? `${group.label} (${group.items.length})` : group.label;
+        return (
+          <View key={group.key || "·"} style={{ gap: 6 }}>
+            {!skipHeaders ? (
+              <Pressable style={styles.groupHeader} onPress={() => toggleCollapsed(group.key)}>
+                <Text style={styles.groupChevron}>{isCollapsed ? "▶" : "▼"}</Text>
+                <Text style={styles.groupLabel}>{headerLabel}</Text>
+              </Pressable>
+            ) : null}
+            {!isCollapsed ? renderItems(group.items) : null}
+          </View>
+        );
+      })}
     </View>
   );
 };
@@ -358,7 +519,7 @@ const MeshNodeCollection: ControlComponent = ({ control }) => {
   const ops = useMeshOps();
   const navigate = useNavigate();
   const queries = (Array.isArray(control.queries) ? control.queries : []).map(s).filter(Boolean);
-  const [items, setItems] = useState<NodeResult[] | null>(null);
+  const [items, setItems] = useState<MeshSearchResult[] | null>(null);
 
   const key = queries.join("|");
   useEffect(() => {
@@ -370,17 +531,7 @@ const MeshNodeCollection: ControlComponent = ({ control }) => {
     Promise.all(queries.map((q) => ops.search!(q)))
       .then((batches) => {
         if (!live) return;
-        const seen = new Set<string>();
-        const flat: NodeResult[] = [];
-        for (const rows of batches)
-          for (const r of rows) {
-            const n = toNodeResult(r);
-            if (n.path && !seen.has(n.path)) {
-              seen.add(n.path);
-              flat.push(n);
-            }
-          }
-        setItems(flat);
+        setItems(mergeUnionResults(batches));
       })
       .catch(() => live && setItems([]));
     return () => {
@@ -549,6 +700,22 @@ const styles = StyleSheet.create({
   resultRow: { gap: 2, padding: 10, borderWidth: 1, borderColor: "#e1e1e1", borderRadius: 6, backgroundColor: "white" },
   resultName: { fontSize: 14, fontWeight: "600", color: "#242424" },
   resultPath: { fontSize: 11, color: "#8a8886" },
+  // scope tabs (the home's shared search bar across scopes)
+  scopeRow: { flexDirection: "row", gap: 4, borderBottomWidth: 1, borderBottomColor: "#d1d1d1" },
+  scopeTab: { paddingVertical: 8, paddingHorizontal: 12, borderBottomWidth: 2, borderBottomColor: "transparent" },
+  scopeTabActive: { borderBottomColor: "#0f6cbd" },
+  scopeTabText: { fontSize: 14, color: "#242424" },
+  scopeTabTextActive: { color: "#0f6cbd", fontWeight: "600" },
+  // the phone-home icon grid (Icons render mode)
+  iconsGrid: { flexDirection: "row", flexWrap: "wrap", gap: 8, paddingVertical: 8 },
+  iconTile: { width: 88, alignItems: "center", gap: 6, padding: 4, borderRadius: 12 },
+  iconBox: { width: 64, height: 64, borderRadius: 16, alignItems: "center", justifyContent: "center", backgroundColor: "#f0f0f0", borderWidth: 1, borderColor: "#e1e1e1", overflow: "hidden" },
+  iconLabel: { fontSize: 12, lineHeight: 15, textAlign: "center", color: "#242424" },
+  iconInitialBox: { backgroundColor: "#f0f0f0" },
+  // grouped sections (the home's content fan-out by type)
+  groupHeader: { flexDirection: "row", alignItems: "center", gap: 6, paddingVertical: 4 },
+  groupChevron: { fontSize: 10, color: "#616161" },
+  groupLabel: { fontSize: 14, fontWeight: "600", color: "#242424" },
   // appearance
   modeRow: { flexDirection: "row", gap: 8 },
   modeChip: { paddingVertical: 8, paddingHorizontal: 14, borderRadius: 16, borderWidth: 1, borderColor: "#ccc" },

--- a/clients/react-native/src/rnMeshLive.tsx
+++ b/clients/react-native/src/rnMeshLive.tsx
@@ -521,7 +521,9 @@ const MeshNodeCollection: ControlComponent = ({ control }) => {
   const queries = (Array.isArray(control.queries) ? control.queries : []).map(s).filter(Boolean);
   const [items, setItems] = useState<MeshSearchResult[] | null>(null);
 
-  const key = queries.join("|");
+  // JSON.stringify: an unambiguous identity for the query LIST — a bare join can collide
+  // (["a","bc"] vs ["ab","c"]) and leave stale results on a list change.
+  const key = JSON.stringify(queries);
   useEffect(() => {
     if (!ops?.search || queries.length === 0) {
       setItems([]);

--- a/clients/react/src/controls/meshLive.test.tsx
+++ b/clients/react/src/controls/meshLive.test.tsx
@@ -72,6 +72,154 @@ describe("MeshSearch — query-backed results (Blazor MeshSearchView parity)", (
   });
 });
 
+describe("MeshSearch — the home design (scope tabs, Icons grid, SortByAccess, grouped sections)", () => {
+  const appRows = [
+    { path: "u1/_App/alpha", id: "alpha", name: "Alpha", nodeType: "InstalledApp", mainNode: "store/Alpha", icon: "🅰" },
+    { path: "u1/_App/beta", id: "beta", name: "Beta", nodeType: "InstalledApp", mainNode: "store/Beta", icon: "🅱" },
+  ];
+
+  it("renders the scope-tab strip for 2+ tabs; switching swaps the query while the term stays", async () => {
+    const search = vi.fn(async (query: string) =>
+      query.startsWith("nodeType:Pin") ? [nodes[0]] : query.startsWith("nodeType:All") ? [nodes[1]] : [],
+    );
+    const ops = { ...fakeOps([]), search } as unknown as MeshOps;
+    view(
+      {
+        $type: "MeshSearch",
+        hiddenQuery: "nodeType:All",
+        visibleQuery: "laptop",
+        scopeTabs: [
+          { label: "All", query: "nodeType:All" },
+          { label: "Pinned", query: "nodeType:Pin" },
+        ],
+      },
+      ops,
+    );
+    expect(await screen.findByText("Second story")).toBeTruthy();
+    // The strip renders both tabs; the first is active.
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((el) => el.textContent)).toEqual(["All", "Pinned"]);
+    expect(tabs[0].getAttribute("aria-selected")).toBe("true");
+    fireEvent.click(tabs[1]);
+    expect(await screen.findByText("First story")).toBeTruthy();
+    // The scope's query replaced the base — with the typed term still appended (shared search bar).
+    await waitFor(() => expect(search).toHaveBeenCalledWith("nodeType:Pin laptop", undefined));
+  });
+
+  it("a SINGLE scope tab renders no strip but still applies its settings (Icons + NavigateToMainNode + row-only select)", async () => {
+    const search = vi.fn(async () => appRows);
+    const ops = { ...fakeOps([]), search } as unknown as MeshOps;
+    view(
+      {
+        $type: "MeshSearch",
+        hiddenQuery: "path:u1/_App scope:children nodeType:InstalledApp",
+        showSearchBox: false,
+        scopeTabs: [
+          {
+            label: "Apps",
+            query: "path:u1/_App scope:children nodeType:InstalledApp",
+            renderMode: "Icons",
+            navigateToMainNode: true,
+          },
+        ],
+      },
+      ops,
+    );
+    expect(await screen.findByText("Alpha")).toBeTruthy();
+    expect(screen.queryByRole("tab")).toBeNull(); // one tab ⇒ no strip
+    // Row-only: the icon grid must never pull content over the wire.
+    expect(search).toHaveBeenCalledWith(
+      "path:u1/_App scope:children nodeType:InstalledApp select:path,id,namespace,name,nodeType,icon,mainNode",
+      undefined,
+    );
+    // A tile navigates to the row's mainNode (the APP), never the record.
+    expect(screen.getByText("Alpha").closest("a")?.getAttribute("href")).toBe("/store/Alpha");
+  });
+
+  it("SortByAccess orders most-recently-used first from the viewer's access log, keeping never-opened items", async () => {
+    const search = vi.fn(async (query: string) =>
+      query.includes("_UserActivity")
+        ? [{ id: "store_Beta", lastModified: "2026-08-20T10:00:00Z", path: "u1/_UserActivity/store_Beta", nodeType: "UserActivity" }]
+        : appRows,
+    );
+    const ops = { ...fakeOps([]), search, userId: "u1" } as unknown as MeshOps;
+    view(
+      {
+        $type: "MeshSearch",
+        hiddenQuery: "path:u1/_App scope:children nodeType:InstalledApp",
+        showSearchBox: false,
+        scopeTabs: [
+          {
+            label: "Apps",
+            query: "path:u1/_App scope:children nodeType:InstalledApp",
+            renderMode: "Icons",
+            navigateToMainNode: true,
+            sortByAccess: true,
+          },
+        ],
+      },
+      ops,
+    );
+    // Beta was opened (its TARGET store/Beta is in the access log, mangled '/'→'_'); Alpha never —
+    // Beta leads, Alpha stays (a source:accessed INNER JOIN would have dropped it).
+    await waitFor(() => {
+      const labels = screen
+        .getAllByText(/Alpha|Beta/)
+        .map((el) => el.textContent)
+        .filter((t): t is string => t === "Alpha" || t === "Beta");
+      expect(labels).toEqual(["Beta", "Alpha"]);
+    });
+    expect(search).toHaveBeenCalledWith(
+      "namespace:u1/_UserActivity nodeType:UserActivity select:path,id,namespace,name,nodeType,lastModified sort:LastModified-desc limit:500",
+      undefined,
+      500,
+    );
+  });
+
+  it("Grouped mode buckets by nodeType with counts, biggest group first under groupByFrequency", async () => {
+    const rows = [
+      { path: "a/1", name: "One", nodeType: "Story" },
+      { path: "a/2", name: "Two", nodeType: "Space" },
+      { path: "a/3", name: "Three", nodeType: "Space" },
+    ];
+    const ops = fakeOps(rows);
+    view(
+      {
+        $type: "MeshSearch",
+        hiddenQuery: "is:main",
+        renderMode: "Grouped",
+        groupByFrequency: true,
+        showSearchBox: false,
+        grouping: { groupByProperty: "NodeType" },
+      },
+      ops,
+    );
+    expect(await screen.findByText("Space (2)")).toBeTruthy();
+    expect(screen.getByText("Story (1)")).toBeTruthy();
+    // Biggest group leads.
+    const headers = screen.getAllByText(/\(\d\)$/).map((el) => el.textContent);
+    expect(headers).toEqual(["Space (2)", "Story (1)"]);
+  });
+
+  it("a newline-joined UNION hidden query issues each leg separately and merges deduped", async () => {
+    const search = vi.fn(async (query: string) =>
+      query.startsWith("namespace: ") || query === "namespace:"
+        ? [{ path: "Doc", name: "DocRoot", nodeType: "Group" }, { path: "Both", name: "BothFirst", nodeType: "Group" }]
+        : [{ path: "u1/x", name: "OwnItem", nodeType: "Group" }, { path: "Both", name: "BothDup", nodeType: "Group" }],
+    );
+    const ops = { ...fakeOps([]), search } as unknown as MeshOps;
+    view(
+      { $type: "MeshSearch", hiddenQuery: "namespace: is:main\nnamespace:u1 is:main", showSearchBox: false },
+      ops,
+    );
+    expect(await screen.findByText("DocRoot")).toBeTruthy();
+    expect(screen.getByText("OwnItem")).toBeTruthy();
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(screen.getAllByText("BothFirst")).toHaveLength(1); // deduped by path, first leg wins
+    expect(screen.queryByText("BothDup")).toBeNull();
+  });
+});
+
 describe("MeshNodeCollection — compact cards from queries (Blazor MeshNodeCollectionView parity)", () => {
   it("runs all queries, merges by path, and renders avatar cards (name + type) linking to the node", async () => {
     const byQuery = {

--- a/clients/react/src/controls/meshLive.tsx
+++ b/clients/react/src/controls/meshLive.tsx
@@ -2,8 +2,10 @@
 //
 //   - MeshSearchView ← src/MeshWeaver.Blazor/Components/MeshSearchView.razor
 //       MeshSearchControl wire: { title, hiddenQuery (always applied), visibleQuery (user-editable),
-//       placeholder, namespace, renderMode ("Flat"|"List"|…), maxColumns, showSearchBox, liveSearch,
-//       excludeBasePath, showEmptyMessage, showLoadingIndicator, createHref }
+//       placeholder, namespace, renderMode ("Flat"|"List"|"Grouped"|"Icons"|…), maxColumns,
+//       minItemWidth, showSearchBox, showViewOptions, liveSearch, excludeBasePath, showEmptyMessage,
+//       showLoadingIndicator, createHref, scopeTabs, sortOptions, navigateToMainNode,
+//       groupByFrequency, grouping, sections, grid }
 //   - MeshNodeCollectionView ← Components/MeshNodeCollectionView.razor
 //       MeshNodeCollectionControl wire: { queries: string[], deletable, showAdd }
 //
@@ -11,41 +13,41 @@
 // surface the ThreadChat agent/model selectors use), so any host that wires a MeshOpsProvider gets
 // live results; tests inject a fake. Without ops the search renders its box only and the collection
 // shows its empty state — no crash, no fake data.
+//
+// The home-design semantics (scope tabs, union queries, the Icons grid, NavigateToMainNode,
+// SortByAccess, grouped-by-type sections) live in the PURE shared model
+// (controls/meshSearchModel.ts) so this pack and the RN pack cannot drift on them; this file is
+// only the Fluent DOM rendering. One deliberate departure from a former version of this pack:
+// MaxColumns is a CAP (auto-fill with a percentage minimum — the Blazor CardGridStyle formula),
+// never an exact `repeat(n, …)` count, which squeezed cards to slivers on narrow screens.
 
-import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Avatar, Badge, Button, Card, Input, Link, Spinner, Text } from "@fluentui/react-components";
 import { Add20Regular, Search20Regular } from "@fluentui/react-icons";
 import type { UiControl } from "../area/types.js";
 import { useResolve } from "../area/context.js";
 import { useMeshLink } from "../area/navigation.js";
+import { useLocalize } from "../i18n/LocaleContext.js";
 import { useMeshOps, type MeshOps } from "../live/meshOps.js";
 import { str, useText } from "./common.js";
 import { AddressAreaEmbed } from "./display.js";
 import { iconForRendering } from "./iconValue.js";
 import { InitialBubble, MeshIcon } from "./MeshIcon.js";
-
-interface NodeResult {
-  path: string;
-  name: string;
-  nodeType: string;
-  description: string;
-  /** The node's renderable icon (inline SVG / URL / emoji; legacy Fluent names filtered). */
-  icon?: string;
-  thumbnail?: string;
-}
-
-function toNodeResult(r: Record<string, unknown>): NodeResult {
-  const content = (r.content ?? {}) as Record<string, unknown>;
-  return {
-    path: str(r.path),
-    name: str(r.name) || str(r.path).split("/").pop() || str(r.path),
-    nodeType: str(r.nodeType),
-    description: str(r.description ?? content.description),
-    icon: iconForRendering(str(r.icon ?? content.icon)) ?? undefined,
-    thumbnail: str(content.thumbnailUrl ?? content.imageUrl) || undefined,
-  };
-}
+import {
+  accessLogQuery,
+  buildGroups,
+  mergeUnionResults,
+  paintOrdered,
+  parseScopeTabs,
+  parseSortOptions,
+  toAccessOrder,
+  toSearchResult,
+  unionQueries,
+  withRowOnlySelect,
+  type MeshSearchResult,
+  type MeshSearchScope,
+} from "./meshSearchModel.js";
 
 /** Debounced value — live-search keystrokes coalesce before hitting the mesh. */
 function useDebounced<T>(value: T, ms: number): T {
@@ -57,21 +59,29 @@ function useDebounced<T>(value: T, ms: number): T {
   return v;
 }
 
-/** Run a mesh query through MeshOps.search; empty results when ops/search are absent. */
-function useMeshQuery(ops: MeshOps | null, query: string, basePath?: string): { results: NodeResult[]; loading: boolean } {
-  const [state, setState] = useState<{ results: NodeResult[]; loading: boolean }>({ results: [], loading: false });
+/**
+ * Run one or more mesh queries through MeshOps.search — a newline-joined UNION issues each line
+ * separately (the search verb takes ONE query per call), concatenating in declaration order and
+ * deduping by path. Empty results when ops/search are absent.
+ */
+function useMeshQuery(
+  ops: MeshOps | null,
+  queries: string[],
+  basePath?: string,
+): { results: MeshSearchResult[]; loading: boolean } {
+  const [state, setState] = useState<{ results: MeshSearchResult[]; loading: boolean }>({ results: [], loading: false });
+  const key = queries.join("\n");
   useEffect(() => {
-    if (!ops?.search || !query) {
+    if (!ops?.search || queries.length === 0) {
       setState({ results: [], loading: false });
       return;
     }
     let live = true;
     setState((s) => ({ ...s, loading: true }));
-    ops
-      .search(query, basePath || undefined)
-      .then((rs) => {
+    Promise.all(queries.map((q) => ops.search!(q, basePath || undefined)))
+      .then((batches) => {
         if (!live) return;
-        setState({ results: rs.map(toNodeResult).filter((n) => n.path.length > 0), loading: false });
+        setState({ results: mergeUnionResults(batches), loading: false });
       })
       .catch(() => {
         if (live) setState({ results: [], loading: false });
@@ -79,11 +89,42 @@ function useMeshQuery(ops: MeshOps | null, query: string, basePath?: string): { 
     return () => {
       live = false;
     };
-  }, [ops, query, basePath]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ops, key, basePath]);
   return state;
 }
 
-// ---- MeshSearch -----------------------------------------------------------------------------------
+/**
+ * The viewer's own access log as a lookup {activityId → accessed-at ms} — ONE cheap
+ * single-partition query, fetched only when a scope asked for access ordering and the host
+ * exposes the viewer's id (ops.userId). Null until it lands, so the tiles paint from their own
+ * query first and re-order when the log arrives (the ordering never gates the first paint).
+ */
+function useAccessOrder(ops: MeshOps | null, enabled: boolean): Map<string, number> | null {
+  const viewer = enabled ? str(ops?.userId) : "";
+  const [map, setMap] = useState<Map<string, number> | null>(null);
+  useEffect(() => {
+    if (!viewer || !ops?.search) {
+      setMap(null);
+      return;
+    }
+    let live = true;
+    ops
+      .search(accessLogQuery(viewer), undefined, 500)
+      .then((rows) => {
+        if (live) setMap(toAccessOrder(rows));
+      })
+      .catch(() => {
+        /* keep the query's own order */
+      });
+    return () => {
+      live = false;
+    };
+  }, [ops, viewer]);
+  return map;
+}
+
+// ---- MeshSearch ----------------------------------------------------------------------------------
 
 /**
  * A per-item ITEM-AREA card — the Blazor MeshSearchView ItemArea mode: the item delegates its
@@ -92,7 +133,7 @@ function useMeshQuery(ops: MeshOps | null, query: string, basePath?: string): { 
  * MeshNodeCard already navigates — wrapping it would nest <a> inside <a> (HTML splits those,
  * duplicating every card link).
  */
-function ItemAreaCard({ node, itemArea }: { node: NodeResult; itemArea: string }): ReactNode {
+function ItemAreaCard({ node, itemArea }: { node: MeshSearchResult; itemArea: string }): ReactNode {
   // minHeight keeps every cell the same card height whether the embedded area has resolved to its
   // card or is still on its (compact) loading skeleton — so the grid row never jumps or leaves a
   // collapsed, half-height cell. display:flex + the child stretching fills the slot.
@@ -108,10 +149,10 @@ function ItemAreaCard({ node, itemArea }: { node: NodeResult; itemArea: string }
 
 /** The node's list/card icon — its Icon field (SVG/URL/emoji), the thumbnail, or the initial
  *  bubble, exactly the fallback chain Blazor's MeshSearchView applies per row. */
-function NodeResultIcon({ node, size }: { node: NodeResult; size: number }): ReactNode {
+function NodeResultIcon({ node, size }: { node: MeshSearchResult; size: number }): ReactNode {
   return (
     <MeshIcon
-      value={node.icon ?? node.thumbnail ?? null}
+      value={iconForRendering(node.icon) ?? node.thumbnail ?? null}
       size={size}
       style={{ borderRadius: 6 }}
       fallback={<InitialBubble name={node.name} size={size} style={{ borderRadius: 6 }} />}
@@ -119,8 +160,8 @@ function NodeResultIcon({ node, size }: { node: NodeResult; size: number }): Rea
   );
 }
 
-function ResultCard({ node }: { node: NodeResult }): ReactNode {
-  const link = useMeshLink(`/${node.path}`);
+function ResultCard({ node, target }: { node: MeshSearchResult; target: string }): ReactNode {
+  const link = useMeshLink(`/${target}`);
   return (
     <Link href={link.href} onClick={link.onClick} style={{ textDecoration: "none" }}>
       <Card style={{ padding: 12, gap: 4, height: "100%" }}>
@@ -146,8 +187,8 @@ function ResultCard({ node }: { node: NodeResult }): ReactNode {
 }
 
 // The Blazor search-result row: 40px node icon, name over description, type badge on the right.
-function ResultRow({ node }: { node: NodeResult }): ReactNode {
-  const link = useMeshLink(`/${node.path}`);
+function ResultRow({ node, target }: { node: MeshSearchResult; target: string }): ReactNode {
+  const link = useMeshLink(`/${target}`);
   return (
     <div
       style={{
@@ -191,39 +232,258 @@ function ResultRow({ node }: { node: NodeResult }): ReactNode {
   );
 }
 
+/**
+ * One tile of the phone-home ICON grid (Icons mode): a large rounded icon with the name
+ * underneath, navigating to the row's TARGET (its mainNode under NavigateToMainNode) — everything
+ * comes from the query ROW (name/icon are result columns), never from the node's content or a
+ * per-result hub. The Blazor mesh-search-icon-tile twin.
+ */
+function IconTile({ node, target }: { node: MeshSearchResult; target: string }): ReactNode {
+  const link = useMeshLink(`/${target}`);
+  return (
+    <a
+      href={link.href}
+      onClick={link.onClick}
+      title={node.name}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 8,
+        padding: "8px 4px",
+        borderRadius: 12,
+        textDecoration: "none",
+        color: "inherit",
+      }}
+    >
+      <div
+        style={{
+          width: 64,
+          height: 64,
+          borderRadius: 16,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "var(--colorNeutralBackground3)",
+          border: "1px solid var(--colorNeutralStroke2)",
+          overflow: "hidden",
+          flexShrink: 0,
+        }}
+      >
+        <MeshIcon
+          value={iconForRendering(node.icon) ?? node.thumbnail ?? null}
+          size={64}
+          style={{ borderRadius: 16, objectFit: "cover" }}
+          fallback={<InitialBubble name={node.name} size={64} style={{ borderRadius: 16, fontSize: 26 }} />}
+        />
+      </div>
+      <Text
+        size={200}
+        style={{
+          textAlign: "center",
+          maxWidth: "100%",
+          overflow: "hidden",
+          display: "-webkit-box",
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: "vertical",
+          wordBreak: "break-word",
+          lineHeight: 1.25,
+        }}
+      >
+        {node.name}
+      </Text>
+    </a>
+  );
+}
+
+function num(v: unknown): number {
+  const n = Math.trunc(Number(v));
+  return Number.isFinite(n) ? n : 0;
+}
+
 export function MeshSearchView({ control }: { control: UiControl }): ReactNode {
   const ops = useMeshOps();
+  const t = useLocalize();
   const title = useText(control.title);
-  const hiddenQuery = str(useResolve(control.hiddenQuery));
+  const controlHiddenQuery = str(useResolve(control.hiddenQuery));
   const initialVisible = str(useResolve(control.visibleQuery));
-  const placeholder = str(useResolve(control.placeholder)) || "Search the mesh…";
+  const placeholder = str(useResolve(control.placeholder)) || t("common.typeToSearch");
   const ns = str(useResolve(control.namespace));
-  const renderMode = str(useResolve(control.renderMode)) || "Flat";
+  const controlRenderMode = str(useResolve(control.renderMode)) || "Flat";
   const showSearchBox = useResolve(control.showSearchBox) !== false;
+  const showViewOptions = useResolve(control.showViewOptions) === true;
   const liveSearch = useResolve(control.liveSearch) !== false;
   const excludeBasePath = useResolve(control.excludeBasePath) !== false;
   const showEmptyMessage = useResolve(control.showEmptyMessage) !== false;
   const showLoading = useResolve(control.showLoadingIndicator) !== false;
   const createHref = str(useResolve(control.createHref));
-  const itemArea = str(useResolve(control.itemArea));
-  // Honour MaxColumns like Blazor does (WithMaxColumns) — without it the auto-fill grid sprawls to
-  // 6-8 narrow columns on a wide screen, so the Pinned/Threads rows never line up with the Blazor
-  // layout. GridSpacing (WithGridSpacing) sets the gap.
-  const maxColumns = Math.trunc(Number(useResolve(control.maxColumns))) || 0;
-  const gridSpacing = Math.trunc(Number(useResolve(control.gridSpacing))) || 12;
+  const controlItemArea = str(useResolve(control.itemArea));
+  const controlNavigateToMainNode = useResolve(control.navigateToMainNode) === true;
+  const groupByFrequency = useResolve(control.groupByFrequency) === true;
+  const maxColumns = num(useResolve(control.maxColumns));
+  const minItemWidth = num(useResolve(control.minItemWidth));
+  const grid = (control.grid ?? {}) as Record<string, unknown>;
+  const gridSpacing = num(grid.spacing);
+  const sections = (control.sections ?? {}) as Record<string, unknown>;
+  const showCounts = sections.showCounts !== false;
+  const collapsible = sections.collapsible !== false;
+  const itemLimit = num(sections.itemLimit);
+  const maxRows = num(sections.maxRows);
+  const grouping = (control.grouping ?? {}) as Record<string, unknown>;
+
+  // Scope tabs: the active tab is tracked by LABEL (the list is reactive — a bare index could
+  // silently re-point at a different scope on a list change); a vanished label clamps to the
+  // first tab. The strip renders only for 2+ tabs; a single tab still applies its settings.
+  const scopeTabs = useMemo(() => parseScopeTabs(control.scopeTabs), [control.scopeTabs]);
+  const [activeScopeLabel, setActiveScopeLabel] = useState<string | null>(null);
+  const activeScopeIndex = Math.max(
+    0,
+    scopeTabs.findIndex((s) => s.label === activeScopeLabel),
+  );
+  const scope: MeshSearchScope | null = scopeTabs[activeScopeIndex] ?? null;
+
+  // Sort-by dropdown: the scope's own options REPLACE the control-level set; the selection resets
+  // to the scope default on a scope switch (SelectScope semantics). Each option carries a FULL
+  // hidden query, so picking one swaps the base query.
+  const controlSortOptions = useMemo(() => parseSortOptions(control.sortOptions), [control.sortOptions]);
+  const sortOptions = scope?.sortOptions.length ? scope.sortOptions : controlSortOptions;
+  const [sortLabel, setSortLabel] = useState<string | null>(null);
+  const activeSort = (sortLabel && sortOptions.find((o) => o.label === sortLabel)) || null;
+
+  const hiddenQuery = activeSort?.query ?? (scope ? scope.query : controlHiddenQuery);
+  const renderMode = scope?.renderMode ?? controlRenderMode;
+  const itemArea = scope?.itemArea ?? controlItemArea;
+  const navigateToMainNode = scope?.navigateToMainNode ?? controlNavigateToMainNode;
+  const sortByAccess = scope?.sortByAccess ?? false;
+  const isIcons = renderMode === "Icons";
+  const isList = renderMode === "List";
+  const isGrouped = renderMode === "Grouped";
 
   const createLink = useMeshLink(createHref || undefined);
   const [visible, setVisible] = useState(initialVisible);
   const [submitted, setSubmitted] = useState(initialVisible);
   const term = useDebounced(liveSearch ? visible : submitted, 250);
-  const query = [hiddenQuery, term].map((s) => s.trim()).filter(Boolean).join(" ");
-  const { results, loading } = useMeshQuery(ops, query, ns);
-  const items = excludeBasePath && ns ? results.filter((n) => n.path !== ns) : results;
-  const list = renderMode === "List";
+  // The hidden query's newline-separated UNION legs each get the visible term appended; the icon
+  // grid ships row-only (`select:` without content) unless the authored query already selects.
+  const queries = unionQueries(hiddenQuery, term, (leg) => withRowOnlySelect(leg, isIcons));
+  const { results, loading } = useMeshQuery(ops, queries, ns);
+
+  const accessOrder = useAccessOrder(ops, sortByAccess);
+  const targetOf = (n: MeshSearchResult) => (navigateToMainNode && n.mainNode ? n.mainNode : n.path);
+  let items = excludeBasePath && ns ? results.filter((n) => n.path !== ns) : results;
+  if (sortByAccess) items = paintOrdered(items, accessOrder, targetOf);
+
+  const groupBy = str(grouping.groupByProperty) || "NodeType";
+  const groups = buildGroups(items, isGrouped, groupBy, groupByFrequency);
+  const skipHeaders = groups.length === 1;
+  const [collapsedGroups, setCollapsedGroups] = useState<ReadonlySet<string>>(new Set());
+  const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<string>>(new Set());
+  const toggleCollapsed = (key: string) =>
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  const toggleExpanded = (key: string) =>
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  // MaxRows caps the visible items per group (rows × columns, Blazor GetMaxVisibleItems);
+  // "Show all N" reveals the rest.
+  const maxVisiblePerGroup = maxRows > 0 ? maxRows * (maxColumns > 0 ? maxColumns : 3) : 0;
+
+  const selectScope = (index: number) => {
+    if (index === activeScopeIndex || index < 0 || index >= scopeTabs.length) return;
+    setActiveScopeLabel(scopeTabs[index].label);
+    setSortLabel(null); // back to the scope's default (first) sort
+    setCollapsedGroups(new Set());
+    setExpandedGroups(new Set());
+  };
+
+  // The card grid: MaxColumns is a CAP via auto-fill with a percentage minimum (the Blazor
+  // CardGridStyle formula), floored at MinItemWidth (200 default) so cards never squeeze to
+  // slivers; unset → responsive auto-fill on the same floor.
+  const floor = minItemWidth > 0 ? minItemWidth : 200;
+  const gridStyle: CSSProperties = {
+    display: "grid",
+    gap: gridSpacing > 0 ? gridSpacing : 12,
+    gridTemplateColumns:
+      maxColumns === 1
+        ? "1fr"
+        : maxColumns > 1
+          ? `repeat(auto-fill, minmax(max(${(100 / maxColumns).toFixed(1)}% - 8px, ${floor}px), 1fr))`
+          : `repeat(auto-fill, minmax(${floor}px, 1fr))`,
+  };
+  // The phone-home icon grid (Blazor mesh-search-icons-grid): compact auto-fill tiles.
+  const iconsGridStyle: CSSProperties = {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(96px, 1fr))",
+    gap: "16px 8px",
+    width: "100%",
+    padding: "8px 0",
+  };
+
+  const renderItems = (groupItems: MeshSearchResult[]) =>
+    isIcons ? (
+      <div style={iconsGridStyle}>
+        {groupItems.map((n) => (
+          <IconTile key={n.path} node={n} target={targetOf(n)} />
+        ))}
+      </div>
+    ) : isList ? (
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        {groupItems.map((n) => (
+          <ResultRow key={n.path} node={n} target={targetOf(n)} />
+        ))}
+      </div>
+    ) : (
+      <div style={gridStyle}>
+        {groupItems.map((n) =>
+          itemArea ? (
+            <ItemAreaCard key={n.path} node={n} itemArea={itemArea} />
+          ) : (
+            <ResultCard key={n.path} node={n} target={targetOf(n)} />
+          ),
+        )}
+      </div>
+    );
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      {scopeTabs.length > 1 ? (
+        <div
+          role="tablist"
+          style={{ display: "flex", gap: 4, borderBottom: "1px solid var(--colorNeutralStroke2)", overflowX: "auto" }}
+        >
+          {scopeTabs.map((tab, i) => (
+            <button
+              key={tab.label || String(i)}
+              type="button"
+              role="tab"
+              aria-selected={i === activeScopeIndex}
+              onClick={() => selectScope(i)}
+              style={{
+                background: "none",
+                border: "none",
+                borderBottom: i === activeScopeIndex ? "2px solid var(--colorBrandForeground1)" : "2px solid transparent",
+                padding: "8px 12px",
+                cursor: "pointer",
+                fontSize: 14,
+                whiteSpace: "nowrap",
+                color: i === activeScopeIndex ? "var(--colorBrandForeground1)" : "inherit",
+                fontWeight: i === activeScopeIndex ? 600 : 400,
+              }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
         {title ? (
           <Text weight="semibold" size={400}>
             {title}
@@ -243,40 +503,95 @@ export function MeshSearchView({ control }: { control: UiControl }): ReactNode {
         ) : null}
         {createHref ? (
           <Link href={createLink.href} onClick={createLink.onClick}>
-            <Button icon={<Add20Regular />} appearance="subtle" aria-label="Create" />
+            <Button icon={<Add20Regular />} appearance="subtle" aria-label={t("search.createNew")} />
           </Link>
         ) : null}
+        {showViewOptions && sortOptions.length > 0 ? (
+          <label style={{ display: "inline-flex", alignItems: "center", gap: 6, marginLeft: "auto" }}>
+            <Text size={200} style={{ color: "var(--colorNeutralForeground3)" }}>
+              {t("search.sortBy")}
+            </Text>
+            <select
+              value={activeSort?.label ?? sortOptions[0].label}
+              onChange={(e) => setSortLabel(e.target.value)}
+              style={{ fontSize: 13, padding: "2px 4px" }}
+            >
+              {sortOptions.map((o) => (
+                <option key={o.label} value={o.label}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
       </div>
-      {loading && showLoading ? <Spinner size="tiny" label="Searching…" /> : null}
-      {!loading && items.length === 0 && showEmptyMessage && query ? (
+      {loading && showLoading ? <Spinner size="tiny" label={t("common.searching")} /> : null}
+      {!loading && items.length === 0 && showEmptyMessage && queries.length > 0 ? (
         <Text italic size={200}>
-          No items found.
+          {t("empty.noItemsFound")}
         </Text>
       ) : null}
-      {list ? (
-        <div style={{ display: "flex", flexDirection: "column" }}>
-          {items.map((n) => (
-            <ResultRow key={n.path} node={n} />
-          ))}
-        </div>
-      ) : (
-        <div
-          style={{
-            display: "grid",
-            gap: gridSpacing,
-            // MaxColumns set → exactly that many equal columns (Blazor parity, left-aligned, no sprawl);
-            // unset → responsive auto-fill. minmax(0,1fr) lets cards shrink instead of overflowing.
-            gridTemplateColumns:
-              maxColumns > 0
-                ? `repeat(${maxColumns}, minmax(0, 1fr))`
-                : "repeat(auto-fill, minmax(220px, 1fr))",
-          }}
-        >
-          {items.map((n) =>
-            itemArea ? <ItemAreaCard key={n.path} node={n} itemArea={itemArea} /> : <ResultCard key={n.path} node={n} />,
-          )}
-        </div>
-      )}
+      {groups.map((group) => {
+        const isCollapsed = collapsedGroups.has(group.key);
+        const isExpanded = expandedGroups.has(group.key);
+        // ItemLimit bounds what a section LOADS (per group, like Blazor's Sections.ItemLimit);
+        // MaxRows caps what it SHOWS until "Show all". The header count stays the full count.
+        const loaded = itemLimit > 0 && group.items.length > itemLimit ? group.items.slice(0, itemLimit) : group.items;
+        const capped = maxVisiblePerGroup > 0 && !isExpanded && loaded.length > maxVisiblePerGroup;
+        const visibleItems = capped ? loaded.slice(0, maxVisiblePerGroup) : loaded;
+        const headerLabel = showCounts ? `${group.label} (${group.items.length})` : group.label;
+        return (
+          <div key={group.key || "·"} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {!skipHeaders ? (
+              collapsible ? (
+                <button
+                  type="button"
+                  onClick={() => toggleCollapsed(group.key)}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    background: "none",
+                    border: "none",
+                    padding: "4px 0",
+                    cursor: "pointer",
+                    color: "inherit",
+                  }}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      display: "inline-block",
+                      fontSize: 10,
+                      transform: isCollapsed ? "none" : "rotate(90deg)",
+                      transition: "transform 0.1s",
+                    }}
+                  >
+                    &#x25b6;
+                  </span>
+                  <Text weight="semibold">{headerLabel}</Text>
+                </button>
+              ) : (
+                <Text weight="semibold" size={400}>
+                  {headerLabel}
+                </Text>
+              )
+            ) : null}
+            {!isCollapsed ? (
+              <>
+                {renderItems(visibleItems)}
+                {capped || (isExpanded && maxVisiblePerGroup > 0 && loaded.length > maxVisiblePerGroup) ? (
+                  <div>
+                    <Button appearance="subtle" size="small" onClick={() => toggleExpanded(group.key)}>
+                      {capped ? t("search.showAllCount", loaded.length) : t("common.showLess")}
+                    </Button>
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -287,7 +602,7 @@ export function MeshNodeCollectionView({ control }: { control: UiControl }): Rea
   const ops = useMeshOps();
   const queries = (Array.isArray(control.queries) ? control.queries : []).map(str).filter(Boolean);
   const showAdd = control.showAdd !== false;
-  const [items, setItems] = useState<NodeResult[] | null>(null);
+  const [items, setItems] = useState<MeshSearchResult[] | null>(null);
 
   useEffect(() => {
     if (!ops?.search || queries.length === 0) {
@@ -298,8 +613,8 @@ export function MeshNodeCollectionView({ control }: { control: UiControl }): Rea
     Promise.all(queries.map((q) => ops.search!(q).catch(() => [] as Record<string, unknown>[])))
       .then((all) => {
         if (!live) return;
-        const merged = new Map<string, NodeResult>();
-        for (const n of all.flat().map(toNodeResult)) if (n.path) merged.set(n.path, n);
+        const merged = new Map<string, MeshSearchResult>();
+        for (const n of all.flat().map(toSearchResult)) if (n.path) merged.set(n.path, n);
         setItems([...merged.values()]);
       })
       .catch(() => {
@@ -309,7 +624,7 @@ export function MeshNodeCollectionView({ control }: { control: UiControl }): Rea
       live = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ops, queries.join("")]);
+  }, [ops, queries.join("")]);
 
   if (items == null) return <Spinner size="tiny" />;
   if (items.length === 0 && !showAdd)
@@ -327,13 +642,13 @@ export function MeshNodeCollectionView({ control }: { control: UiControl }): Rea
   );
 }
 
-function CollectionRow({ node }: { node: NodeResult }): ReactNode {
+function CollectionRow({ node }: { node: MeshSearchResult }): ReactNode {
   const link = useMeshLink(`/${node.path}`);
   return (
     <Link href={link.href} onClick={link.onClick} style={{ textDecoration: "none" }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 8px", borderRadius: 6 }}>
         <MeshIcon
-          value={node.icon ?? node.thumbnail ?? null}
+          value={iconForRendering(node.icon) ?? node.thumbnail ?? null}
           size={28}
           style={{ borderRadius: "50%", overflow: "hidden" }}
           fallback={<Avatar name={node.name} size={28} />}

--- a/clients/react/src/controls/meshLive.tsx
+++ b/clients/react/src/controls/meshLive.tsx
@@ -623,8 +623,10 @@ export function MeshNodeCollectionView({ control }: { control: UiControl }): Rea
     return () => {
       live = false;
     };
+    // JSON.stringify: an unambiguous identity for the query LIST — a bare join can collide
+    // (["a","bc"] vs ["ab","c"]) and leave stale results on a list change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ops, queries.join("")]);
+  }, [ops, JSON.stringify(queries)]);
 
   if (items == null) return <Spinner size="tiny" />;
   if (items.length === 0 && !showAdd)

--- a/clients/react/src/controls/meshSearchModel.ts
+++ b/clients/react/src/controls/meshSearchModel.ts
@@ -1,0 +1,224 @@
+// Platform-neutral MeshSearch model — the pure half of the Blazor MeshSearchView port, shared by
+// the web pack (controls/meshLive.tsx) and the React-Native pack (rnMeshLive.tsx) so the two
+// cannot drift on the home-design semantics:
+//
+//   - SCOPE TABS (MeshSearchScopeTab): the strip renders only for two or more tabs; ONE tab
+//     renders no strip but still applies its settings (renderMode / itemArea / navigateToMainNode
+//     / sortByAccess) — the home's Apps band carries Icons + SortByAccess on a single scope.
+//   - UNION QUERIES: a hidden query can be a newline-joined UNION of sub-queries (the server
+//     declares the home catalog that way); the search verb takes ONE query per call, so each line
+//     is issued separately and the batches merge in declaration order, deduped by path.
+//   - ICONS row-only select: the icon grid paints from query rows (name/icon/mainNode are result
+//     columns), so the content column never belongs on the wire.
+//   - SortByAccess: most-recently-used first, computed at PAINT from the viewer's own
+//     `{viewer}/_UserActivity` satellites — the activity id is the visited path with '/' → '_',
+//     so a tile's TARGET is mangled forward and looked up (the mangling is never reversed).
+//     Never `source:accessed` in the query: that INNER JOIN hides every never-opened app.
+//   - Grouped mode: sections by NodeType (or grouping.groupByProperty) with counts, biggest
+//     group first under GroupByFrequency (ties by label, stable).
+//
+// No React, no DOM, no Fluent — everything here is directly unit-testable.
+
+function str(v: unknown): string {
+  return v == null ? "" : String(v);
+}
+
+/** One search result row — the subset of the wire MeshNode both packs paint from. */
+export interface MeshSearchResult {
+  path: string;
+  /** The row's id — the access log's UserActivity rows key their visit by it. */
+  id: string;
+  name: string;
+  nodeType: string;
+  description: string;
+  /** The node this row REPRESENTS (an app record's app) — the NavigateToMainNode target. */
+  mainNode: string;
+  /** The node's raw icon value (inline SVG / URL / emoji / name) — packs classify it themselves. */
+  icon: string;
+  thumbnail?: string;
+  lastModified?: string;
+}
+
+/** Project a wire MeshNode row into the shared result shape (name falls back to the path leaf). */
+export function toSearchResult(r: Record<string, unknown>): MeshSearchResult {
+  const content = (r.content ?? {}) as Record<string, unknown>;
+  return {
+    path: str(r.path),
+    id: str(r.id),
+    name: str(r.name) || str(r.path).split("/").pop() || str(r.path),
+    nodeType: str(r.nodeType),
+    description: str(r.description ?? content.description),
+    mainNode: str(r.mainNode),
+    icon: str(r.icon ?? content.icon),
+    thumbnail: str(content.thumbnailUrl ?? content.imageUrl) || undefined,
+    lastModified: str(r.lastModified) || undefined,
+  };
+}
+
+/** One user-selectable sort choice (MeshSearchSortOption): picking it swaps the FULL hidden query. */
+export interface MeshSearchSortOption {
+  label: string;
+  query: string;
+}
+
+/** One scope tab (MeshSearchScopeTab wire shape, camelCase). */
+export interface MeshSearchScope {
+  label: string;
+  query: string;
+  sortOptions: MeshSearchSortOption[];
+  itemArea?: string;
+  renderMode?: string;
+  navigateToMainNode?: boolean;
+  sortByAccess: boolean;
+}
+
+/** Parse the control's `sortOptions` wire value (unknown-shaped JSON in, typed list out). */
+export function parseSortOptions(raw: unknown): MeshSearchSortOption[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((o) => {
+      const r = (o ?? {}) as Record<string, unknown>;
+      return { label: str(r.label), query: str(r.query) };
+    })
+    .filter((o) => o.label.length > 0);
+}
+
+/** Parse the control's `scopeTabs` wire value. Serializer default-suppression means a false
+ *  bool arrives ABSENT — only an explicit boolean is carried through, so the pack-level
+ *  fallback (the control-level setting) still applies when a scope says nothing. */
+export function parseScopeTabs(raw: unknown): MeshSearchScope[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((t) => {
+      const r = (t ?? {}) as Record<string, unknown>;
+      return {
+        label: str(r.label),
+        query: str(r.query),
+        sortOptions: parseSortOptions(r.sortOptions),
+        itemArea: str(r.itemArea) || undefined,
+        renderMode: str(r.renderMode) || undefined,
+        navigateToMainNode: typeof r.navigateToMainNode === "boolean" ? r.navigateToMainNode : undefined,
+        sortByAccess: r.sortByAccess === true,
+      };
+    })
+    .filter((t) => t.label.length > 0 || t.query.length > 0);
+}
+
+/** Split a (possibly newline-joined UNION) hidden query into the individual queries to issue,
+ *  appending the user's typed term to EACH leg. At least one query unless everything is empty. */
+export function unionQueries(hiddenQuery: string, term: string, mapLeg: (leg: string) => string = (l) => l): string[] {
+  const lines = hiddenQuery
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return (lines.length ? lines : [""]).map((l) => [mapLeg(l), term.trim()].filter(Boolean).join(" ")).filter(Boolean);
+}
+
+/** Merge per-leg result batches in declaration order, deduping by path. */
+export function mergeUnionResults(batches: Record<string, unknown>[][]): MeshSearchResult[] {
+  const seen = new Set<string>();
+  const merged: MeshSearchResult[] = [];
+  for (const rows of batches)
+    for (const n of rows.map(toSearchResult))
+      if (n.path.length > 0 && !seen.has(n.path)) {
+        seen.add(n.path);
+        merged.push(n);
+      }
+  return merged;
+}
+
+/** Row-only select for the icon grid — applied only when the authored query has no select: of
+ *  its own (the server's RowOnlySelected guard). */
+export function withRowOnlySelect(query: string, iconsMode: boolean): string {
+  return iconsMode && !/select:/i.test(query)
+    ? `${query} select:path,id,namespace,name,nodeType,icon,mainNode`.trim()
+    : query;
+}
+
+/** The activity id the access log stores a visit to `path` under ('/' → '_', one-way). */
+export function accessKeyOf(path: string): string {
+  return path.replace(/\//g, "_");
+}
+
+/** The one cheap single-partition query for the viewer's access log (row-only, newest first). */
+export function accessLogQuery(viewerId: string): string {
+  return (
+    `namespace:${viewerId}/_UserActivity nodeType:UserActivity ` +
+    "select:path,id,namespace,name,nodeType,lastModified sort:LastModified-desc limit:500"
+  );
+}
+
+/** Fold access-log rows into the {activityId → accessed-at ms} lookup (first hit wins — the rows
+ *  arrive newest first). */
+export function toAccessOrder(rows: Record<string, unknown>[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const r of rows) {
+    const id = str(r.id);
+    const at = Date.parse(str(r.lastModified));
+    if (id && Number.isFinite(at) && !m.has(id)) m.set(id, at);
+  }
+  return m;
+}
+
+/**
+ * Results in paint order: most-recently-opened first, with never-opened results keeping the
+ * query's own order BEHIND them (never dropped — that is exactly what a `source:accessed` INNER
+ * JOIN would have done to a freshly installed app). A stable sort, so the query's order survives
+ * inside each band.
+ */
+export function paintOrdered(
+  items: MeshSearchResult[],
+  accessOrder: Map<string, number> | null,
+  targetOf: (n: MeshSearchResult) => string,
+): MeshSearchResult[] {
+  if (!accessOrder || accessOrder.size === 0 || items.length < 2) return items;
+  return [...items].sort(
+    (a, b) => (accessOrder.get(accessKeyOf(targetOf(b))) ?? 0) - (accessOrder.get(accessKeyOf(targetOf(a))) ?? 0),
+  );
+}
+
+/** One rendered section of a grouped result set. */
+export interface MeshSearchGroup {
+  key: string;
+  label: string;
+  items: MeshSearchResult[];
+}
+
+function groupValueOf(n: MeshSearchResult, property: string): string {
+  const p = property.toLowerCase();
+  if (p === "nodetype") return n.nodeType;
+  if (p === "name") return n.name;
+  const r = n as unknown as Record<string, unknown>;
+  return str(r[property] ?? r[property.charAt(0).toLowerCase() + property.slice(1)]);
+}
+
+/**
+ * Bucket results by the group-by property (NodeType default), biggest group first when
+ * `byFrequency` (ties by label, so the order is stable across renders) — the home's content
+ * section fans out by the node's own type with the type you have most of at the top. Non-grouped
+ * modes yield ONE unlabeled group, which the packs render without a header.
+ */
+export function buildGroups(
+  items: MeshSearchResult[],
+  grouped: boolean,
+  groupBy: string,
+  byFrequency: boolean,
+): MeshSearchGroup[] {
+  if (!grouped) return [{ key: "", label: "", items }];
+  const buckets = new Map<string, MeshSearchResult[]>();
+  for (const n of items) {
+    const key = groupValueOf(n, groupBy) || n.nodeType.split("/").pop() || "";
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(n);
+    else buckets.set(key, [n]);
+  }
+  const groups = [...buckets.entries()].map(([key, groupItems]) => ({
+    key,
+    label: key || groupItems[0]?.nodeType.split("/").pop() || "Items",
+    items: groupItems,
+  }));
+  groups.sort((a, b) =>
+    byFrequency ? b.items.length - a.items.length || a.label.localeCompare(b.label) : a.label.localeCompare(b.label),
+  );
+  return groups;
+}

--- a/clients/react/src/controls/meshSearchModel.ts
+++ b/clients/react/src/controls/meshSearchModel.ts
@@ -85,7 +85,9 @@ export function parseSortOptions(raw: unknown): MeshSearchSortOption[] {
 
 /** Parse the control's `scopeTabs` wire value. Serializer default-suppression means a false
  *  bool arrives ABSENT — only an explicit boolean is carried through, so the pack-level
- *  fallback (the control-level setting) still applies when a scope says nothing. */
+ *  fallback (the control-level setting) still applies when a scope says nothing. A tab without
+ *  a LABEL is dropped: the server contract makes Label positional-required, and the packs track
+ *  the active scope BY label — several ""-labelled tabs would make that selection ambiguous. */
 export function parseScopeTabs(raw: unknown): MeshSearchScope[] {
   if (!Array.isArray(raw)) return [];
   return raw
@@ -101,7 +103,7 @@ export function parseScopeTabs(raw: unknown): MeshSearchScope[] {
         sortByAccess: r.sortByAccess === true,
       };
     })
-    .filter((t) => t.label.length > 0 || t.query.length > 0);
+    .filter((t) => t.label.length > 0);
 }
 
 /** Split a (possibly newline-joined UNION) hidden query into the individual queries to issue,

--- a/clients/react/src/core.ts
+++ b/clients/react/src/core.ts
@@ -57,6 +57,26 @@ export {
   type EmbeddedAreaHandle,
   type EmbeddedAreaReference,
 } from "./render/embeddedArea.js";
+// The pure MeshSearch model (Blazor MeshSearchView semantics: scope tabs, union queries, the
+// Icons grid's row-only select, NavigateToMainNode, SortByAccess paint ordering, grouped-by-type
+// sections) — shared by the web pack and the RN pack so the two cannot drift.
+export {
+  accessKeyOf,
+  accessLogQuery,
+  buildGroups,
+  mergeUnionResults,
+  paintOrdered,
+  parseScopeTabs,
+  parseSortOptions,
+  toAccessOrder,
+  toSearchResult,
+  unionQueries,
+  withRowOnlySelect,
+  type MeshSearchGroup,
+  type MeshSearchResult,
+  type MeshSearchScope,
+  type MeshSearchSortOption,
+} from "./controls/meshSearchModel.js";
 export { getPointer, setPointer, mergePatch, resolve, bindingPointer } from "./area/pointer.js";
 export type { AreaSource, AreaTree, UiControl, Skin, NamedArea, MeshEvent, Json } from "./area/types.js";
 // Area-error classification — the TS twin of the server AreaErrorClassifier. Shells use these to make

--- a/clients/react/src/i18n/strings.de.json
+++ b/clients/react/src/i18n/strings.de.json
@@ -403,6 +403,7 @@
   "search.nodes": "Nodes",
   "search.namespaces": "Namespaces",
   "search.showAll": "Alle anzeigen →",
+  "search.showAllCount": "Alle {0} anzeigen",
   "search.empty": "Leer",
   "search.noNamespace": "Kein Namespace",
   "search.askAgentForDescription": "Den Agent bitten, eine Beschreibung zu erstellen.",

--- a/clients/react/src/i18n/strings.en.json
+++ b/clients/react/src/i18n/strings.en.json
@@ -403,6 +403,7 @@
   "search.nodes": "Nodes",
   "search.namespaces": "Namespaces",
   "search.showAll": "Show all →",
+  "search.showAllCount": "Show all {0}",
   "search.empty": "Empty",
   "search.noNamespace": "No namespace",
   "search.askAgentForDescription": "Ask the agent to create a description.",

--- a/clients/react/src/live/meshOps.tsx
+++ b/clients/react/src/live/meshOps.tsx
@@ -40,6 +40,14 @@ export interface ThreadSubmitOptions {
 }
 
 export interface MeshOps {
+  /**
+   * Optional viewing user's mesh id (their home partition) — hosts that know who is signed in
+   * expose it (the web portals learn it from the token mint's nodePath; the RN shell from its
+   * configured partition). Feeds viewer-scoped reads like the home Apps grid's
+   * most-recently-used ordering ({viewer}/_UserActivity — MeshSearchScopeTab.SortByAccess);
+   * absent → those orderings quietly keep the query's own order (no crash, no guess).
+   */
+  userId?: string;
   /** Subscribe to a node's live state — yields on every change (initial state, then updates). */
   watch(path: string): AsyncIterable<MeshNodeState>;
   /**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-js-clients-home-design.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-js-clients-home-design.md
@@ -1,0 +1,18 @@
+---
+Name: The new home on the React, React Native and Next.js clients
+Category: Feature
+Description: The web, mobile and Next.js portals now render the new home — the Apps icon grid ordered by what you use most, and the Content section grouped by type.
+Icon: Sparkle
+Order: -20260824
+---
+
+# The new home on the React, React Native and Next.js clients
+
+The redesigned home that recently landed in the portal now renders the same way in the
+JavaScript clients — the React web portal, the Next.js portal and the mobile app.
+
+The **Apps** section shows your installed apps as a phone-style icon grid: a rounded icon with the
+app's name beneath, ordered by what you opened most recently, and tapping a tile opens the app
+itself. The **Content** section below it lists everything you can reach, fanned out by type with
+the kind of content you have most of at the top, with counts on each section — and the tabs,
+search box and sort choices the portal shows now work in these clients too.

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -403,6 +403,7 @@
   "search.nodes": "Nodes",
   "search.namespaces": "Namespaces",
   "search.showAll": "Alle anzeigen →",
+  "search.showAllCount": "Alle {0} anzeigen",
   "search.empty": "Leer",
   "search.noNamespace": "Kein Namespace",
   "search.askAgentForDescription": "Den Agent bitten, eine Beschreibung zu erstellen.",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -403,6 +403,7 @@
   "search.nodes": "Nodes",
   "search.namespaces": "Namespaces",
   "search.showAll": "Show all →",
+  "search.showAllCount": "Show all {0}",
   "search.empty": "Empty",
   "search.noNamespace": "No namespace",
   "search.askAgentForDescription": "Ask the agent to create a description.",


### PR DESCRIPTION
## What

Brings the **React** (`clients/react`, used by the Vite portal + Electron), **Next.js** (`clients/portal-next`, which renders through `@meshweaver/react`) and **React Native** (`clients/react-native`) clients up to the home design the Blazor client shipped (#2103/#2107/#2112/#2115): the Apps phone-home icon grid ordered most-recently-used, and the Content section grouped by node type, biggest group first.

The JS clients previously **ignored `ScopeTabs` entirely** and silently fell back to the first hidden query — exactly the trap this closes.

## How

- **Shared pure model** `clients/react/src/controls/meshSearchModel.ts` (exported from `@meshweaver/react/core`) consumed by BOTH the web pack and the RN pack, so they cannot drift:
  - Scope tabs: strip only for 2+ tabs; a **single** tab renders no strip but still applies its settings (the Apps band carries `Icons` + `SortByAccess` + `NavigateToMainNode` on one scope). Active tab tracked by label; the typed term survives tab switches.
  - Newline-joined UNION hidden queries issue **one leg per search call**, merged in declaration order, deduped by path.
  - `Icons` render mode ships row-only (`select:` appended when the authored query has none) — no content on the wire, painted entirely from query rows.
  - `NavigateToMainNode`: a tile opens the row's `mainNode` (the app), never the record.
  - `SortByAccess`: MRU-first at **paint** from the viewer's own `{viewer}/_UserActivity` satellites (path mangled **forward**, `/`→`_`); never `source:accessed` (the INNER JOIN hides never-opened apps). Never-opened rows keep the query order behind, stable sort.
  - Grouped mode: sections by `nodeType` (or `grouping.groupByProperty`), counts in headers, biggest-first under `GroupByFrequency`, collapsible, `MaxRows` cap with "Show all N".
- **Web `MeshSearchView`**: renders all of the above with Fluent; `MaxColumns` is now a **cap** (the Blazor `CardGridStyle` auto-fill formula) instead of an exact `repeat(n, …)` count that squeezed cards to slivers; honours `MinItemWidth` and `Grid.Spacing`; Sort-by dropdown when `SortOptions` + `ShowViewOptions` are declared.
- **RN pack**: native twins — scope chips, icon tiles (SvgXml / Image / emoji / initial fallback), grouped sections with counts, mainNode navigation, MRU ordering.
- **`MeshOps.userId`** (optional): the three shells (portal, portal-next, RN `liveOps`) expose the viewer id they already knew, feeding the access-order read. Absent ⇒ query order, no crash.
- **i18n**: one new key `search.showAllCount` ("Show all {0}" / "Alle {0} anzeigen") added to BOTH server catalogs and the byte-identical `clients/react/src/i18n` mirror (drift guard stays green).

## Deliberately not ported

- The Group-by combobox / display menu of Blazor's view-options bar (the home only needs the Sort-by dropdown; grouping is already driven by the control).
- RN: the Sort-by dropdown and per-section `ItemLimit` (mobile lists are short; REST default limit already bounds them).
- The server-side `AdoptAppIcons` healing pass — server work, nothing client-side.

## Verified

- `@meshweaver/react`: typecheck, **274** vitest (5 new home-design regression tests incl. the scope-tab fallback trap), lib build
- `react-native`: typecheck, **162** vitest (3 new)
- `portal-next`: typecheck, **98** vitest, `next build`
- `portal`: `tsc --noEmit`, vite build
- .NET: `LocalizationTest` (56), `WhatsNewEntryIntegrityTest` — both against freshly built Release assemblies

What's New entry: `src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-js-clients-home-design.md` (Category: Feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)