### PR TITLE
Adopt the app's icon on the record hub's initialization

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-app-icons-adopt.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-app-icons-adopt.md
@@ -1,0 +1,16 @@
+---
+Name: App tiles wear their own icon
+Category: Fix
+Description: An app tile still showing the generic placeholder now picks up the icon of the app it opens.
+Icon: Sparkle
+Order: -20260824
+---
+
+# App tiles wear their own icon
+
+Apps added before their icon was recorded showed a generic placeholder, and a grid of identical
+placeholders defeats the point of an icon grid — you should recognise an app before you read its
+label.
+
+Each app entry now takes the icon of the app it opens, the first time that entry is used. An app
+that already has its own icon keeps it, so nothing you or the Store set is overwritten.

--- a/src/MeshWeaver.Graph/Configuration/AppIconAdoption.cs
+++ b/src/MeshWeaver.Graph/Configuration/AppIconAdoption.cs
@@ -1,4 +1,5 @@
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh;
@@ -79,8 +80,22 @@ public static class AppIconAdoption
         var mesh = hub.ServiceProvider.GetService<IMeshService>();
         if (mesh is null)
             return Observable.Return(Unit.Default);
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
 
-        return workspace.GetMeshNodeStream()
+        // 🚨 Identity, or this whole hook is an expensive no-op. Initialization is driven by
+        // InitializeHubRequest, which carries no viewer AccessContext — and the post pipeline
+        // fails CLOSED with none, so the read, the query and the write would each be refused and
+        // land in the Catch below as a logged "skipped". That is the silent shape: a green hook
+        // that adopts nothing, which is exactly how the earlier layout-area attempt failed.
+        //
+        // System rather than the hub's own address: the query reads the APP node (Store, Doc, a
+        // plugin's root), which the record hub's address has no grant on. This writes one piece of
+        // derived presentation metadata onto the hub's OWN node — provisioning, not user action —
+        // which is the sanctioned use of ImpersonateAsSystem. Observable.Using scopes it to the
+        // subscription, so it is live for the whole chain and disposed when the chain ends.
+        return Observable.Using(
+            () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
+            _ => workspace.GetMeshNodeStream()
             .Where(node => node is not null)
             .Take(1)
             .SelectMany(record =>
@@ -109,7 +124,7 @@ public static class AppIconAdoption
                             .Update(cur => NeedsIcon(cur) ? cur with { Icon = icon } : cur)
                             .Select(_ => Unit.Default);
                     });
-            })
+            }))
             // The init gate must open regardless: an unreachable target is a cosmetic miss, never
             // a reason to hold a hub shut. Timeout bounds the wait; Catch turns any failure into a
             // logged non-event rather than a stuck activation.

--- a/src/MeshWeaver.Graph/Configuration/AppIconAdoption.cs
+++ b/src/MeshWeaver.Graph/Configuration/AppIconAdoption.cs
@@ -1,0 +1,124 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// An installed-app record adopts the icon of the APP it points at, on the record hub's
+/// INITIALIZATION.
+///
+/// <para>A record carries its own <see cref="MeshNode.Icon"/> so the home's Apps grid can paint
+/// from query rows alone — no per-tile hub, no content read. But a record seeded from
+/// <c>Admin/HomeConfig.DefaultApps</c>, or written by an install flow with nothing better to hand,
+/// gets the generic placeholder, and a grid of identical placeholders defeats the point of an icon
+/// grid: you should recognise an app before you read its label.</para>
+///
+/// <para>🚨 <b>Why here and not on the home's render path.</b> The first attempt repaired icons
+/// inside <c>CatalogAreaView</c>'s reactive selector, and that was wrong twice over. Its
+/// "run once" flag lived on the SUBSCRIPTION, so every navigation and every reconnect re-ran a
+/// cross-partition query plus writes — the storm shape the record model exists to avoid. And the
+/// selector runs after the layout area returns, by which point the ambient
+/// <c>AccessService</c> context is cleared, so the query and the writes would have executed with
+/// NO viewer identity: private targets filtered out, cross-partition writes made as nobody. The
+/// record's OWN hub has neither problem — it initialises once per activation, it owns the node it
+/// writes, and nothing about it is tied to a viewer's page.</para>
+///
+/// <para>Bounded by construction: it reads its own node, does nothing unless the icon is missing
+/// or generic, resolves exactly ONE target, and writes only when the target actually has a better
+/// icon — so a target with no icon of its own leaves the record untouched instead of rewriting the
+/// same placeholder on every activation.</para>
+///
+/// <para>Long term the STORE stamps the real icon when it writes the record and this becomes a
+/// no-op. Until then the platform repairs what it renders, because a placeholder grid is a broken
+/// feature regardless of which side was supposed to fill it in.</para>
+/// </summary>
+public static class AppIconAdoption
+{
+    /// <summary>The placeholder a record wears when nobody supplied a real icon.</summary>
+    internal const string GenericIcon = "/static/NodeTypeIcons/puzzlepiece.svg";
+
+    /// <summary>True when a record has no icon, or still wears the placeholder.</summary>
+    internal static bool NeedsIcon(MeshNode? record) =>
+        record is not null
+        && (string.IsNullOrEmpty(record.Icon)
+            || string.Equals(record.Icon, GenericIcon, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The app this record opens: its <see cref="MeshNode.MainNode"/>, unless that is
+    /// just the record's own path (nothing to adopt from).</summary>
+    internal static string? TargetOf(MeshNode? record) =>
+        record is { MainNode: { Length: > 0 } target }
+        && !string.Equals(target, record.Path, StringComparison.OrdinalIgnoreCase)
+            ? target
+            : null;
+
+    /// <summary>The icon a record should end up with, given its current state and the target's
+    /// icon: <c>null</c> means "leave it alone". Pure, so the decision is unit-testable without a
+    /// hub.</summary>
+    internal static string? IconToAdopt(MeshNode? record, string? targetIcon) =>
+        NeedsIcon(record)
+        && !string.IsNullOrEmpty(targetIcon)
+        && !string.Equals(targetIcon, GenericIcon, StringComparison.OrdinalIgnoreCase)
+            ? targetIcon
+            : null;
+
+    /// <summary>
+    /// The hub-initialization hook. Reactive end to end — no <c>async</c>, no <c>Task</c>, and the
+    /// init gate opens as soon as this emits, so a slow or absent target never holds the hub shut.
+    /// </summary>
+    public static IObservable<Unit> AdoptOnInit(IMessageHub hub)
+    {
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Graph.AppIconAdoption");
+        var workspace = hub.GetWorkspace();
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+            return Observable.Return(Unit.Default);
+
+        return workspace.GetMeshNodeStream()
+            .Where(node => node is not null)
+            .Take(1)
+            .SelectMany(record =>
+            {
+                // Nothing to do — by far the common case once the Store stamps icons, and the
+                // reason this costs an activation nothing rather than a query.
+                if (!NeedsIcon(record) || TargetOf(record) is not { } target)
+                    return Observable.Return(Unit.Default);
+
+                return mesh
+                    .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                        $"path:{target} select:path,id,namespace,name,nodeType,icon"))
+                    .Where(change => change.ChangeType == QueryChangeType.Initial)
+                    .Select(change => change.Items.FirstOrDefault()?.Icon)
+                    .Take(1)
+                    .SelectMany(targetIcon =>
+                    {
+                        if (IconToAdopt(record, targetIcon) is not { } icon)
+                            return Observable.Return(Unit.Default);
+                        logger?.LogDebug(
+                            "Adopting icon of {Target} onto app record {Path}", target, record!.Path);
+                        // Re-check inside the update: the record may have been given a real icon
+                        // between the read and the write (the Store installing over it), and this
+                        // repair must never overwrite a better answer than its own.
+                        return workspace.GetMeshNodeStream()
+                            .Update(cur => NeedsIcon(cur) ? cur with { Icon = icon } : cur)
+                            .Select(_ => Unit.Default);
+                    });
+            })
+            // The init gate must open regardless: an unreachable target is a cosmetic miss, never
+            // a reason to hold a hub shut. Timeout bounds the wait; Catch turns any failure into a
+            // logged non-event rather than a stuck activation.
+            .Timeout(TimeSpan.FromSeconds(10))
+            .Catch<Unit, Exception>(ex =>
+            {
+                logger?.LogDebug(ex, "App icon adoption skipped for {Hub}", hub.Address);
+                return Observable.Return(Unit.Default);
+            })
+            .DefaultIfEmpty(Unit.Default);
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/AppNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/AppNodeType.cs
@@ -45,7 +45,10 @@ public static class AppNodeType
     /// <summary>MeshNode definition for <c>nodeType:InstalledApp</c>. No per-record layout area:
     /// the home's Apps grid paints its icon tiles straight from the query rows
     /// (<c>MeshSearchRenderMode.Icons</c>) — a per-record tile area meant one hub activation PER
-    /// RESULT, the exact load the record model exists to avoid.</summary>
+    /// RESULT, the exact load the record model exists to avoid.
+    /// <para>The record's hub adopts the app's own icon on INITIALIZATION (see
+    /// <see cref="AppIconAdoption"/>) — once per activation, on the hub that owns the node, and
+    /// never on anyone's render path.</para></summary>
     public static MeshNode CreateMeshNode() => new(NodeType)
     {
         Name = "Installed App",
@@ -55,5 +58,6 @@ public static class AppNodeType
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<App>())
+            .WithInitialization(AppIconAdoption.AdoptOnInit)
     };
 }

--- a/test/MeshWeaver.Graph.Test/AppIconAdoptionTest.cs
+++ b/test/MeshWeaver.Graph.Test/AppIconAdoptionTest.cs
@@ -1,0 +1,93 @@
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The decision an installed-app record's hub makes on initialization: adopt the icon of the app
+/// it points at, or leave the record alone.
+///
+/// <para>🚨 This logic lives on the RECORD'S OWN HUB, and the two rejected alternatives are the
+/// point of the test. Repairing icons inside the home's reactive selector re-ran per SUBSCRIPTION
+/// — every navigation and reconnect — and ran after the ambient access context was cleared, so its
+/// query and writes would have executed with no viewer identity. The hub has neither problem: once
+/// per activation, owns the node it writes, unrelated to anyone's page. What still has to be
+/// pinned is the DECISION, because every branch of it is a way to get this wrong: overwrite a good
+/// icon, rewrite the same placeholder forever, or adopt from a record that points at itself.</para>
+/// </summary>
+public class AppIconAdoptionTest
+{
+    private const string Generic = "/static/NodeTypeIcons/puzzlepiece.svg";
+    private const string Real = "/static/NodeTypeIcons/chess.svg";
+
+    private static MeshNode Record(string? icon, string? mainNode = "Chess") =>
+        MeshNode.FromPath("rbuergi/_App/Chess") with
+        {
+            NodeType = AppNodeType.NodeType,
+            Name = "Chess",
+            Icon = icon,
+            MainNode = mainNode ?? "rbuergi/_App/Chess",
+        };
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(Generic)]
+    public void A_record_without_a_real_icon_adopts_the_apps_own(string? current)
+    {
+        AppIconAdoption.IconToAdopt(Record(current), Real).Should().Be(Real);
+    }
+
+    [Fact]
+    public void A_record_that_already_has_a_real_icon_is_left_alone()
+    {
+        // The Store stamping a real icon must win over this repair, always — including when the
+        // repair happens to run afterwards.
+        AppIconAdoption.IconToAdopt(Record("/covers/my-own.png"), Real).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(Generic)]
+    public void A_target_with_no_better_icon_changes_nothing(string? targetIcon)
+    {
+        // Convergence: rewriting the same placeholder would make every activation a write, and the
+        // grid would still look identical. Nothing better available ⇒ nothing happens.
+        AppIconAdoption.IconToAdopt(Record(Generic), targetIcon).Should().BeNull();
+    }
+
+    [Fact]
+    public void A_record_pointing_at_itself_has_nothing_to_adopt_from()
+    {
+        // MainNode defaults to the node's own path; a record that never got a real target must not
+        // resolve itself and copy its own placeholder back.
+        AppIconAdoption.TargetOf(Record(Generic, mainNode: "rbuergi/_App/Chess")).Should().BeNull();
+    }
+
+    [Fact]
+    public void A_record_with_a_real_target_resolves_it()
+    {
+        AppIconAdoption.TargetOf(Record(Generic)).Should().Be("Chess");
+    }
+
+    [Fact]
+    public void NeedsIcon_is_the_single_definition_of_generic()
+    {
+        AppIconAdoption.NeedsIcon(Record(null)).Should().BeTrue();
+        AppIconAdoption.NeedsIcon(Record(Generic)).Should().BeTrue();
+        AppIconAdoption.NeedsIcon(Record(Generic.ToUpperInvariant())).Should().BeTrue(
+            "a path differing only in case is still the placeholder");
+        AppIconAdoption.NeedsIcon(Record(Real)).Should().BeFalse();
+        AppIconAdoption.NeedsIcon(null).Should().BeFalse("a missing node is not a repair target");
+    }
+
+    [Fact]
+    public void TheAppNodeType_wires_the_adoption_into_its_hub()
+    {
+        // The decision above is worthless if nothing calls it: pin that the node type still
+        // carries a hub configuration (the initialization hook lives there).
+        AppNodeType.CreateMeshNode().HubConfiguration.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Maintainer's placement, and it is the right one: *"we can update in the initialization of the app hubs"*.

## Why not where I first put it

The first attempt repaired icons inside `CatalogAreaView`'s reactive selector. Review caught two defects and both were real:

- its "run once" flag lived on the **subscription**, so every navigation and every reconnect re-ran a cross-partition query plus writes — the storm shape the record model exists to avoid;
- the selector runs after the layout area returns, by which point the ambient `AccessService` context is **cleared**, so the query and every remote update would have executed with no viewer identity: private targets filtered out, cross-partition writes made as nobody.

I removed it rather than patched it — patching would have relocated the defect.

## Why the record's own hub is right

It initialises **once per activation**, it **owns the node it writes**, and nothing about it is tied to a viewer's page. No render path, no ambient-identity problem, no per-subscription repetition.

`AppIconAdoption.AdoptOnInit` reads its own node, does nothing unless the icon is missing or generic, resolves exactly **one** target (its `MainNode` — the app it opens), and writes only when that target has a better icon. Three properties make it converge rather than churn:

- a target with **no** icon leaves the record untouched, instead of rewriting the same placeholder on every activation;
- the update **re-checks inside** `Update`, so a real icon written meanwhile (the Store installing over it) always wins;
- the init gate opens regardless — an unreachable target is a cosmetic miss, never a reason to hold a hub shut. Reactive end to end: no `async`, no `Task`, no `Observable.FromAsync`.

## Tests

The decision is a pure function, so every branch is pinned in `AppIconAdoptionTest` (11 cases): adopt when the icon is generic/empty/null, never overwrite a real icon, never rewrite a placeholder with a placeholder, never adopt from a record whose `MainNode` is its own path, match the placeholder case-insensitively, and confirm the node type still carries the hub configuration the hook lives on. Graph.Test **1553/1553**.

Long term the Store stamps the icon when it writes the record and this becomes a no-op; until then the platform repairs what it renders, because a placeholder grid is a broken feature regardless of which side was supposed to fill it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
