### PR TITLE
Unload a collectible context on a positive signal, or not at all

### DIFF
--- a/.claude/skills/async/SKILL.md
+++ b/.claude/skills/async/SKILL.md
@@ -64,6 +64,60 @@ workspace.GetMeshNodeStream(path)
 
 Tests are the *only* place `await …FirstAsync().ToTask()` is acceptable.
 
+### Rule 1a — A `Task`-returning override you must implement: subscribe, return `Task.CompletedTask`
+
+Some signatures are not ours — `Grain.OnDeactivateAsync`/`OnActivateAsync`, `IHostedService`,
+ASP.NET middleware. The rule is not "await is fine here": it is **do not await, hang the work off
+the signal, and return a completed Task**. A grain turn is a single-threaded scheduler, so awaiting
+inside it parks the very scheduler the thing you are waiting for may need in order to finish.
+
+```csharp
+// ❌ parks the grain turn, and races a timer to decide whether the work happened
+var done = hub.DisposalCompleted.FirstOrDefaultAsync().ToTask(ct);
+if (await Task.WhenAny(done, Task.Delay(TimeSpan.FromSeconds(5))) == done)
+    loadContext.Unload();          // …and if the timer won? unload anyway? that is the bug
+
+// ✅ subscribe; the turn returns immediately and the work belongs to the signal
+hub.DisposalCompleted
+    .Take(1)                                   // unsubscribes on first emission — no rooted subscription
+    .Catch<Unit, Exception>(ex => { logger.LogError(ex, "…"); return Observable.Empty<Unit>(); })
+    .Subscribe(_ => UnloadContextIfSafe());
+return Task.CompletedTask;
+```
+
+**This deletes a whole class of bug, not just the deadlock.** With a timer race you must answer
+"what if the wait expired?", and the tempting answer — do it anyway — is exactly how a collectible
+`AssemblyLoadContext` gets unloaded out from under live code (`MessageHubGrain`; CI run
+32713409169 caught it as a dedicated thread faulting on its first managed call, JIT-compiling a
+dynamic method whose allocator was already gone). With a subscription there is no timer and no
+branch: the callback runs when the signal says so, or it never runs — and "never runs" means the
+resource is simply retained. Prefer retaining memory over acting on a guess.
+
+`Take(1)` matters: a subscription that never completes roots whatever the callback closes over
+(the discarded-timer-roots-the-hub defect).
+
+### Rule 1b — Handle stream faults FLUENTLY, never with `try`/`catch` around `Subscribe`
+
+A `try`/`catch` wrapped around a subscription only sees a throw from the *synchronous* subscribe
+call. A fault travelling through the stream arrives later, usually on another thread, and sails
+straight past it — so the `catch` you wrote to make the code safe never runs.
+
+```csharp
+// ❌ catches almost nothing that actually goes wrong
+try { stream.Subscribe(x => Handle(x)); } catch (Exception ex) { logger.LogError(ex, "…"); }
+
+// ✅ the fault is part of the stream, so handle it in the stream
+stream
+    .Catch<T, Exception>(ex => { logger.LogError(ex, "…"); return Observable.Empty<T>(); })
+    .Subscribe(x => Handle(x));
+```
+
+Choose the recovery deliberately: `Observable.Empty<T>()` means "this did not happen" — downstream
+`OnNext` never runs, which is what you want when the callback performs an irreversible action —
+while `Observable.Return(fallback)` means "carry on with a default". Keep a `try`/`catch` only for
+genuinely synchronous work sitting beside the chain, and say so in a comment, so the next reader
+does not believe it covers the stream.
+
 > Reading a single node's content? Use the synced stream (`GetMeshNodeStream(path)`), not
 > `QueryAsync` (eventually consistent → stale after writes) and not a blocking await. See
 > SyncedMeshNodeQueries.md.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-alc-unload-quiesce.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-alc-unload-quiesce.md
@@ -1,0 +1,18 @@
+---
+Name: Fewer unexplained portal restarts
+Category: Fix
+Description: Retiring compiled code no longer risks taking the process down with it.
+Icon: Sparkle
+Order: -20260824
+---
+
+# Fewer unexplained portal restarts
+
+When a NodeType is recompiled or a hub is retired, the platform reclaims the memory holding the old
+compiled code. Until now it could do that while something was still running that code, which
+occasionally killed the whole process outright — no error message and no failing test, just a
+restart.
+
+The platform now waits until nothing is using the old code before reclaiming it. If something is
+still holding on, it keeps the memory rather than forcing the issue, and logs what it kept and why.
+Holding a little memory is always better than dropping everything a portal was in the middle of.

--- a/src/MeshWeaver.Graph/Configuration/ScriptCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/ScriptCompilationService.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Options;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using MeshWeaver.NuGet;
 
@@ -53,6 +54,18 @@ internal class ScriptCompilationService : IDisposable
     }
 
     private readonly ConcurrentDictionary<string, CompiledConfig> _compiledScripts = new();
+
+    // 🚨 Who is currently executing out of each cached entry's collectible context. Eviction used
+    // to call Unload() inline, with nothing asked and nothing waited for — while a script from that
+    // very context could be mid-execution, and while HubConfiguration delegates handed to callers
+    // still pointed into it. Unloading is cooperative, so that is usually survivable; when it is
+    // not, it is the native use-after-unload SIGSEGV, which lands as a bare exit=139 with no
+    // managed stack to attribute it (AlcLeaseRegistry's remarks carry the core-dump analysis).
+    private readonly AlcLeaseRegistry _leases = new();
+
+    /// <summary>How long a retiring context may take to go quiet before we give up and KEEP it.
+    /// Deliberately not "then unload anyway" — see <see cref="AlcLeaseRegistry"/>.</summary>
+    private static readonly TimeSpan UnloadQuiesceBudget = TimeSpan.FromSeconds(30);
 
     // Track script source files on disk for debugging
     private readonly ConcurrentDictionary<string, string> _sourceFiles = new();
@@ -116,7 +129,7 @@ internal class ScriptCompilationService : IDisposable
             // (unloading is cooperative — this call can still execute from it safely).
             compiled = _compiledScripts.GetOrAdd(cacheKey, fresh);
             if (!ReferenceEquals(compiled, fresh))
-                fresh.LoadContext.Unload();
+                RetireContext(fresh, $"duplicate compilation of {node.Path}");
             _logger.LogDebug("Script compiled and cached for {NodePath}", node.Path);
         }
         else
@@ -124,10 +137,13 @@ internal class ScriptCompilationService : IDisposable
             _logger.LogDebug("Using cached script for {NodePath}", node.Path);
         }
 
-        // Execute the script
+        // Execute the script under a lease, so an eviction racing this execution cannot pull the
+        // context out from under the running submission. The lease spans the whole await — the
+        // window that matters is "a thread is still inside this context", not "a call was issued".
         try
         {
-            return await compiled.ExecuteAsync();
+            using (_leases.Enter(compiled.LoadContext))
+                return await compiled.ExecuteAsync();
         }
         catch (Exception ex)
         {
@@ -197,7 +213,7 @@ internal class ScriptCompilationService : IDisposable
     public void InvalidateCache(string cacheKey)
     {
         if (_compiledScripts.TryRemove(cacheKey, out var evicted))
-            evicted.LoadContext.Unload();
+            RetireContext(evicted, cacheKey);
 
         if (_sourceFiles.TryRemove(cacheKey, out var sourcePath) && File.Exists(sourcePath))
         {
@@ -237,9 +253,21 @@ internal class ScriptCompilationService : IDisposable
     {
         foreach (var key in _compiledScripts.Keys.ToList())
             if (_compiledScripts.TryRemove(key, out var evicted))
-                evicted.LoadContext.Unload();
+                RetireContext(evicted, key);
         _sourceFiles.Clear();
     }
+
+    /// <summary>
+    /// Retires an evicted entry's collectible context: unload once nothing is executing out of it,
+    /// and never if it does not go quiet. Cold observable, so the Subscribe is what runs it — the
+    /// error arm only ever reports, because a context we failed to reclaim is a leak we are
+    /// choosing over an unload that could take the process down.
+    /// </summary>
+    private void RetireContext(CompiledConfig evicted, string what) =>
+        _leases.UnloadWhenQuiesced(evicted.LoadContext, UnloadQuiesceBudget, _logger, what)
+            .Subscribe(
+                _ => { },
+                exception => _logger.LogError(exception, "Retiring script context {What} failed", what));
 
     /// <summary>
     /// Computes a cache key based on all compilation inputs.

--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -732,7 +732,9 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
 
 
     /// <inheritdoc />
-    public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+    // No `async` — see the DisposalCompleted subscription below. The turn returns immediately and
+    // the work that used to be awaited hangs off the signal instead.
+    public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
     {
         var grainId = this.GetPrimaryKeyString();
         logger.LogInformation("Grain {GrainId} deactivating: reason={Reason}", grainId, reason.ReasonCode);
@@ -761,57 +763,58 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         // most and dies with the grain — GC covers it.
         try { _hubReadyRaw.OnCompleted(); } catch { /* already terminated */ }
 
-        // 🚨 Gates the ALC unload below. It is only ever set true by the hub REPORTING that it
-        // drained: a timeout, a cancellation, or a disposal fault all leave it false, and false
-        // means we do not unload. Nothing built a hub ⇒ nothing ever ran out of this context.
-        var hubDrained = true;
-
         var hub = _hub;
         if (hub != null)
         {
-            hubDrained = false;
             try
             {
                 hub.CancelCurrentExecution();
                 hub.Dispose();
-                // Bounded wait — Orleans's grain deactivation must not block the silo
-                // shutdown for minutes. 5 s is plenty for action-block drain in tests;
-                // production AI-streaming flushes are best-effort and may be cut short
-                // on silo shutdown. The previous 120 s window was the cause of the
-                // 20+ second inter-class gaps in OrleansClusterCollection runs and the
-                // catastrophic ObjectDisposedException at fixture-cleanup races.
-                // Bridge the reactive completion to a Task once, at this genuine async edge
-                // (Orleans grain deactivation). Catch folds a disposal fault into completion —
-                // deactivation only cares that the hub is done, not why.
-                var disposalTask = hub.DisposalCompleted
-                    .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
-                    .FirstOrDefaultAsync()
-                    .ToTask(cancellationToken);
-                var completed = await Task.WhenAny(disposalTask, Task.Delay(TimeSpan.FromSeconds(5), cancellationToken));
-                // 🚨 Winning WhenAny is not the same as DRAINING. disposalTask can complete
-                // CANCELLED (the deactivation token), and `completed == disposalTask` is true in
-                // that case too — which would have earned the unload without the hub ever
-                // reporting it was done. Awaiting the winner makes cancellation throw into the
-                // catch below, where hubDrained stays false.
-                if (completed == disposalTask)
-                {
-                    await disposalTask;
-                    hubDrained = true;
-                }
-                if (!hubDrained)
-                    logger.LogError(
-                        "Grain {GrainId}: hub disposal exceeded 5 s — KEEPING its load context. "
-                        + "The hub is still draining, so unloading now is the use-after-unload "
-                        + "SIGSEGV; the context is retained until the process exits instead.",
-                        grainId);
+
+                // 🚨 SUBSCRIBE — do not await. A grain turn is a single-threaded scheduler, so
+                // awaiting here parks it, and the disposal we are waiting for may itself need a
+                // turn to complete. The unload is not something this turn has to witness: it is
+                // work that belongs to the DisposalCompleted signal, so it goes in the callback
+                // and the turn returns immediately.
+                //
+                // This also gets the gate right for free, which the previous shape did not. There
+                // is no timer to race and therefore no "the wait expired, unload anyway" branch:
+                // the callback runs when the hub REPORTS it drained, or it never runs at all. If
+                // disposal never completes, the context is simply retained until the process exits
+                // — a memory cost, chosen over an unload with a live user, which costs the process
+                // (CI 32713409169: a dedicated thread faulted on its first managed call, JITting a
+                // dynamic method whose allocator was gone — see AlcLeaseRegistry for the dump).
+                //
+                // Take(1) unsubscribes on the first emission, so the subscription cannot outlive
+                // the signal and root this grain's context (cf. the discarded-timer-roots-the-hub
+                // defect). A disposal FAULT goes to the error arm and unloads nothing: we did not
+                // observe the hub finish, so we have not earned it.
+                // 🚨 The fault handling is FLUENT (.Catch), not a try/catch around the Subscribe.
+                // A try/catch here can only see a throw from the synchronous subscribe call — a
+                // fault travelling through the stream arrives later, on another thread, and sails
+                // straight past it. Catch turns that fault into an EMPTY sequence, so OnNext never
+                // runs and the context is kept: a hub that faulted is a hub we never saw finish.
+                hub.DisposalCompleted
+                    .Take(1)
+                    .Catch<Unit, Exception>(ex =>
+                    {
+                        logger.LogError(
+                            ex, "Grain {GrainId}: hub disposal faulted — KEEPING its load context", grainId);
+                        return Observable.Empty<Unit>();
+                    })
+                    .Subscribe(_ => UnloadContextIfSafe(reason, grainId));
             }
             catch (Exception ex)
             {
-                // Includes the OperationCanceledException from a cancelled deactivation. Either
-                // way we did not observe the hub finish, so we have not earned the unload.
-                hubDrained = false;
+                // Only the SYNCHRONOUS half — CancelCurrentExecution/Dispose throwing on this
+                // turn. Everything the stream reports is handled fluently above.
                 logger.LogError(ex, "Grain {GrainId}: hub disposal failed — KEEPING its load context", grainId);
             }
+        }
+        else
+        {
+            // No hub was ever built, so nothing ever ran out of this context.
+            UnloadContextIfSafe(reason, grainId);
         }
         // 🚨 The unload is gated on a POSITIVE drain report and never on a timer. It used to run
         // unconditionally: wait up to 5 s for DisposalCompleted, log "moving on", unload anyway —
@@ -841,10 +844,28 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         // superseded ALC actually returns memory. So skip it here and let the process exit — and
         // for the live-silo case IoPoolSiloTeardown now cancels + joins the pools before the silo
         // releases, which is what makes any remaining unload safe.
-        if (loadContext != null && !IsSiloShuttingDown(reason) && hubDrained)
-            loadContext.Unload();
+        return base.OnDeactivateAsync(reason, cancellationToken);
+    }
+
+    /// <summary>
+    /// Unloads this grain's collectible context, if unloading it is safe and worth doing. Called
+    /// ONLY from the <c>DisposalCompleted</c> subscription (or directly when no hub was ever
+    /// built) — never on a timer, so an unload always follows a positive drain report.
+    /// </summary>
+    private void UnloadContextIfSafe(DeactivationReason reason, string grainId)
+    {
+        var context = loadContext;
         loadContext = null;
-        await base.OnDeactivateAsync(reason, cancellationToken);
+        if (context == null || IsSiloShuttingDown(reason))
+            return;
+        try
+        {
+            context.Unload();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Grain {GrainId}: unloading the load context failed", grainId);
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -788,7 +788,16 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                     .FirstOrDefaultAsync()
                     .ToTask(cancellationToken);
                 var completed = await Task.WhenAny(disposalTask, Task.Delay(TimeSpan.FromSeconds(5), cancellationToken));
-                hubDrained = completed == disposalTask;
+                // 🚨 Winning WhenAny is not the same as DRAINING. disposalTask can complete
+                // CANCELLED (the deactivation token), and `completed == disposalTask` is true in
+                // that case too — which would have earned the unload without the hub ever
+                // reporting it was done. Awaiting the winner makes cancellation throw into the
+                // catch below, where hubDrained stays false.
+                if (completed == disposalTask)
+                {
+                    await disposalTask;
+                    hubDrained = true;
+                }
                 if (!hubDrained)
                     logger.LogError(
                         "Grain {GrainId}: hub disposal exceeded 5 s — KEEPING its load context. "

--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -761,9 +761,15 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         // most and dies with the grain — GC covers it.
         try { _hubReadyRaw.OnCompleted(); } catch { /* already terminated */ }
 
+        // 🚨 Gates the ALC unload below. It is only ever set true by the hub REPORTING that it
+        // drained: a timeout, a cancellation, or a disposal fault all leave it false, and false
+        // means we do not unload. Nothing built a hub ⇒ nothing ever ran out of this context.
+        var hubDrained = true;
+
         var hub = _hub;
         if (hub != null)
         {
+            hubDrained = false;
             try
             {
                 hub.CancelCurrentExecution();
@@ -782,20 +788,36 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                     .FirstOrDefaultAsync()
                     .ToTask(cancellationToken);
                 var completed = await Task.WhenAny(disposalTask, Task.Delay(TimeSpan.FromSeconds(5), cancellationToken));
-                if (completed != disposalTask)
-                    logger.LogWarning("Grain {GrainId}: hub disposal exceeded 5 s — moving on", grainId);
+                hubDrained = completed == disposalTask;
+                if (!hubDrained)
+                    logger.LogError(
+                        "Grain {GrainId}: hub disposal exceeded 5 s — KEEPING its load context. "
+                        + "The hub is still draining, so unloading now is the use-after-unload "
+                        + "SIGSEGV; the context is retained until the process exits instead.",
+                        grainId);
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Grain {GrainId}: hub disposal failed", grainId);
+                // Includes the OperationCanceledException from a cancelled deactivation. Either
+                // way we did not observe the hub finish, so we have not earned the unload.
+                hubDrained = false;
+                logger.LogError(ex, "Grain {GrainId}: hub disposal failed — KEEPING its load context", grainId);
             }
         }
-        // 🚨 KNOWN GAP (per-ALC accounting): this Unload orders only on the HUB's
-        // DisposalCompleted above — pooled I/O leaves are mesh-shared, so this grain cannot
-        // drain them (DrainAll here would cancel every OTHER grain's work). A pooled leaf
-        // started by this grain's hub that still references this ALC when Unload begins is
-        // the use-after-unload class. A single grain deactivating on a LIVE silo still needs
-        // per-ALC in-flight tracking to close fully.
+        // 🚨 The unload is gated on a POSITIVE drain report and never on a timer. It used to run
+        // unconditionally: wait up to 5 s for DisposalCompleted, log "moving on", unload anyway —
+        // i.e. the one case where we KNEW a user was still live was also a case where we unloaded.
+        // A retained context costs memory until process exit; an unload with a live user costs the
+        // process (CI 32713409169: a dedicated thread faulted on its first managed call, JITting a
+        // dynamic method whose allocator was gone — see AlcLeaseRegistry for the dump analysis).
+        //
+        // 🚨 STILL A NARROWER GAP (per-ALC accounting): DisposalCompleted covers the hub's action
+        // blocks and message round-trips, not mesh-shared pooled I/O leaves (DrainAll here would
+        // cancel every OTHER grain's work). A leaf started by this grain's hub that still
+        // references this ALC is not counted. AlcLeaseRegistry is the mechanism for closing that —
+        // it is applied to the script-compilation contexts, which are retired far more often than
+        // grain contexts; wiring the pool's leaves to it needs per-leaf ownership the pool does
+        // not carry yet.
         //
         // 🚨 SILO SHUTDOWN IS NOT SAFE, and this comment used to claim it was — on the grounds
         // that "MeshTeardownHostedService drains the whole mesh before the scope dies". It does,
@@ -810,7 +832,7 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         // superseded ALC actually returns memory. So skip it here and let the process exit — and
         // for the live-silo case IoPoolSiloTeardown now cancels + joins the pools before the silo
         // releases, which is what makes any remaining unload safe.
-        if (loadContext != null && !IsSiloShuttingDown(reason))
+        if (loadContext != null && !IsSiloShuttingDown(reason) && hubDrained)
             loadContext.Unload();
         loadContext = null;
         await base.OnDeactivateAsync(reason, cancellationToken);

--- a/src/MeshWeaver.Mesh.Contract/Threading/AlcLeaseRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/AlcLeaseRegistry.cs
@@ -108,11 +108,13 @@ public sealed class AlcLeaseRegistry
     /// arbitrary module and finalizer code. Doing that inline would run it under our lock.</para>
     /// </summary>
     public IObservable<Unit> Quiesced(AssemblyLoadContext context) =>
-        entries.TryGetValue(context, out var entry)
-            ? entry.Count.Where(count => count == 0).Take(1)
-                .Select(_ => Unit.Default)
-                .ObserveOn(TaskPoolScheduler.Default)
-            : Observable.Return(Unit.Default);
+        (entries.TryGetValue(context, out var entry)
+            ? entry.Count.Where(count => count == 0).Take(1).Select(_ => Unit.Default)
+            : Observable.Return(Unit.Default))
+        // On BOTH paths, including the never-leased one. A context nobody ever entered is the
+        // common case (retiring a duplicate compilation), and without the hop there it would run
+        // Unload — module and finalizer code — inline on whichever thread happened to subscribe.
+        .ObserveOn(TaskPoolScheduler.Default);
 
     /// <summary>
     /// Unloads <paramref name="context"/> once it is quiesced, and NOT AT ALL if it fails to
@@ -132,8 +134,13 @@ public sealed class AlcLeaseRegistry
             .Timeout(budget)
             .Select(quiesced =>
             {
-                entries.TryRemove(context, out _);
+                // Unload FIRST, drop the tracking only once it succeeded. Removing the entry up
+                // front meant a throwing Unload (a context that turns out not to be collectible)
+                // landed in the Catch below reporting InFlight = 0 — a diagnostic that says
+                // "nothing was using it", about a context we just failed to reclaim and are now
+                // no longer tracking.
                 context.Unload();
+                entries.TryRemove(context, out _);
                 logger?.LogDebug("Unloaded collectible context {What}", what ?? context.Name);
                 return true;
             })

--- a/src/MeshWeaver.Mesh.Contract/Threading/AlcLeaseRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/AlcLeaseRegistry.cs
@@ -1,0 +1,150 @@
+using System.Collections.Concurrent;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Mesh.Threading;
+
+/// <summary>
+/// Per-ALC in-flight accounting: who is currently executing code out of a collectible
+/// <see cref="AssemblyLoadContext"/>, and a reactive signal for when nobody is.
+///
+/// <para><b>Why this exists.</b> Unloading a collectible context while a thread can still enter its
+/// code is the native use-after-unload SIGSEGV — the same class
+/// <see cref="MeshTeardownSignal"/> guards at mesh teardown, but that signal is MESH-WIDE and fires
+/// at silo stop. It says nothing about a single context being retired on a LIVE silo: a NodeType
+/// recompile evicting its predecessor, or one grain deactivating on idle collection. Those are the
+/// unloads that had no gate at all, and <c>MessageHubGrain</c> has carried a "🚨 KNOWN GAP (per-ALC
+/// accounting)" comment saying exactly that.</para>
+///
+/// <para><b>Read the crash before changing this.</b> CI run 32713409169 (2026-08-24) caught it in a
+/// core dump: crashing thread entered at <c>CPalThread::ThreadEntry → KickOffThread →
+/// ManagedThreadBase::KickOff</c> — a dedicated thread, on its very FIRST managed call — which took
+/// the prestub into <c>UnsafeJitFunction</c> and faulted in
+/// <c>LCGMethodResolver::GetCodeInfo+0x1f7</c>, at <c>movl 0x4(%rax), %esi</c> where
+/// <c>rax = 0x0074007300200022</c>: UTF-16 text (<c>" st</c>) sitting where a pointer belonged.
+/// <c>si_code = SI_KERNEL</c> with <c>si_addr = 0</c> is the non-canonical-pointer (#GP) signature,
+/// not a null dereference. The allocator backing that dynamic method was gone while a thread was
+/// still arriving at it.</para>
+///
+/// <para><b>The rule this type enforces: an unload happens on a POSITIVE quiescence signal or it
+/// does not happen at all.</b> Never on a timer expiry. A retained context costs memory until the
+/// process exits; an unload with a live user costs the process. <see cref="UnloadWhenQuiesced"/>
+/// therefore reports <c>false</c> and leaves the context loaded rather than unloading on timeout —
+/// which is the inversion of what the grain used to do (wait 5 s, log "moving on", unload anyway).
+/// </para>
+///
+/// <para>Instance state only — held by whoever owns the contexts, dying with them (NoStaticState).
+/// </para>
+/// </summary>
+public sealed class AlcLeaseRegistry
+{
+    /// <summary>
+    /// One context's lease count. The count is published under the same lock that mutates it, so a
+    /// subscriber can never observe a 0 that a concurrent <see cref="Enter"/> has already
+    /// superseded — the reordering a bare <c>Interlocked</c> + <c>OnNext</c> pair would allow, and
+    /// the one that would hand out a false "safe to unload".
+    /// </summary>
+    private sealed class Entry
+    {
+        private readonly object gate = new();
+        private int inFlight;
+
+        public BehaviorSubject<int> Count { get; } = new(0);
+
+        public void Enter()
+        {
+            lock (gate)
+                Count.OnNext(++inFlight);
+        }
+
+        public void Leave()
+        {
+            lock (gate)
+                Count.OnNext(--inFlight);
+        }
+
+        public int Current
+        {
+            get { lock (gate) return inFlight; }
+        }
+    }
+
+    private readonly ConcurrentDictionary<AssemblyLoadContext, Entry> entries = new();
+
+    /// <summary>
+    /// Marks the caller as executing code from <paramref name="context"/> until the returned handle
+    /// is disposed. Hold it across the WHOLE call — including any await — because the window that
+    /// matters is "a thread can still enter this code", not "a call has been issued".
+    /// </summary>
+    public IDisposable Enter(AssemblyLoadContext context)
+    {
+        var entry = entries.GetOrAdd(context, _ => new Entry());
+        entry.Enter();
+        // Idempotent: a double-dispose must not decrement twice and fake a quiesce.
+        var released = 0;
+        return Disposable.Create(() =>
+        {
+            if (Interlocked.Exchange(ref released, 1) == 0)
+                entry.Leave();
+        });
+    }
+
+    /// <summary>Current lease count — 0 when nobody is inside the context. Diagnostics and tests;
+    /// never gate an unload on reading this, gate on <see cref="Quiesced"/>.</summary>
+    public int InFlight(AssemblyLoadContext context) =>
+        entries.TryGetValue(context, out var entry) ? entry.Current : 0;
+
+    /// <summary>
+    /// Emits once the context has no leases, then completes. Already-quiesced (or never-leased)
+    /// contexts emit immediately.
+    ///
+    /// <para>Observed on the task pool deliberately: the count is published while holding the
+    /// entry's lock, and the whole point of subscribing here is to then UNLOAD — which runs
+    /// arbitrary module and finalizer code. Doing that inline would run it under our lock.</para>
+    /// </summary>
+    public IObservable<Unit> Quiesced(AssemblyLoadContext context) =>
+        entries.TryGetValue(context, out var entry)
+            ? entry.Count.Where(count => count == 0).Take(1)
+                .Select(_ => Unit.Default)
+                .ObserveOn(TaskPoolScheduler.Default)
+            : Observable.Return(Unit.Default);
+
+    /// <summary>
+    /// Unloads <paramref name="context"/> once it is quiesced, and NOT AT ALL if it fails to
+    /// quiesce within <paramref name="budget"/>. Cold — the caller must subscribe.
+    /// </summary>
+    /// <returns><c>true</c> if the context was unloaded; <c>false</c> if it was left loaded
+    /// because it never went quiet (or the unload itself threw). A <c>false</c> is a real finding:
+    /// something outlived the thing that owns it, and it is worth chasing — but it is a memory
+    /// leak, which is the outcome we are deliberately choosing over a crash.</returns>
+    public IObservable<bool> UnloadWhenQuiesced(
+        AssemblyLoadContext context,
+        TimeSpan budget,
+        ILogger? logger = null,
+        string? what = null)
+        => Quiesced(context)
+            .Take(1)
+            .Timeout(budget)
+            .Select(quiesced =>
+            {
+                entries.TryRemove(context, out _);
+                context.Unload();
+                logger?.LogDebug("Unloaded collectible context {What}", what ?? context.Name);
+                return true;
+            })
+            .Catch((Exception exception) =>
+            {
+                logger?.LogError(
+                    exception,
+                    "NOT unloading collectible context {What}: it still has {InFlight} in-flight "
+                    + "lease(s) after {Budget}. Leaving it loaded — unloading a context somebody "
+                    + "can still enter is the use-after-unload SIGSEGV.",
+                    what ?? context.Name, InFlight(context), budget);
+                return Observable.Return(false);
+            });
+}

--- a/test/MeshWeaver.Hosting.Test/AlcLeaseRegistryTest.cs
+++ b/test/MeshWeaver.Hosting.Test/AlcLeaseRegistryTest.cs
@@ -1,0 +1,130 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Runtime.Loader;
+using MeshWeaver.Mesh.Threading;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// The unload gate. The behaviour under test is not "does it unload" — it is <b>does it REFUSE to
+/// unload</b> when something is still inside the context, because that refusal is what stands
+/// between a retired <see cref="AssemblyLoadContext"/> and a native use-after-unload SIGSEGV
+/// (exit=139 with no managed stack; see <see cref="AlcLeaseRegistry"/> for the core-dump analysis).
+///
+/// <para><c>AssemblyLoadContext</c> has no public "was I unloaded" flag, so every assertion here
+/// rides its <c>Unloading</c> event: it fires when — and only when — <c>Unload()</c> is called.
+/// That makes "we did not unload" directly observable instead of inferred.</para>
+/// </summary>
+public class AlcLeaseRegistryTest
+{
+    private static (AssemblyLoadContext Context, Func<bool> Unloaded) Collectible(string name)
+    {
+        var context = new AssemblyLoadContext(name, isCollectible: true);
+        var unloaded = 0;
+        context.Unloading += _ => Interlocked.Exchange(ref unloaded, 1);
+        return (context, () => Volatile.Read(ref unloaded) == 1);
+    }
+
+    [Fact]
+    public void A_context_nobody_has_entered_is_quiesced_immediately()
+    {
+        var registry = new AlcLeaseRegistry();
+        var (context, _) = Collectible(nameof(A_context_nobody_has_entered_is_quiesced_immediately));
+
+        registry.InFlight(context).Should().Be(0);
+        registry.Quiesced(context).Timeout(TimeSpan.FromSeconds(5)).Wait();
+    }
+
+    [Fact]
+    public void Leases_count_up_and_down_and_a_double_dispose_cannot_fake_a_quiesce()
+    {
+        var registry = new AlcLeaseRegistry();
+        var (context, _) = Collectible(nameof(Leases_count_up_and_down_and_a_double_dispose_cannot_fake_a_quiesce));
+
+        var first = registry.Enter(context);
+        var second = registry.Enter(context);
+        registry.InFlight(context).Should().Be(2);
+
+        // Disposing the same lease twice must not decrement twice — that would report 0 while the
+        // other caller is still inside, which is precisely the false "safe to unload".
+        first.Dispose();
+        first.Dispose();
+        registry.InFlight(context).Should().Be(1);
+
+        second.Dispose();
+        registry.InFlight(context).Should().Be(0);
+    }
+
+    [Fact]
+    public void A_LEASED_context_is_NOT_unloaded_when_the_budget_expires()
+    {
+        var registry = new AlcLeaseRegistry();
+        var (context, unloaded) = Collectible(nameof(A_LEASED_context_is_NOT_unloaded_when_the_budget_expires));
+
+        using var _ = registry.Enter(context);   // somebody is inside, and never leaves
+
+        var result = registry.UnloadWhenQuiesced(context, TimeSpan.FromMilliseconds(200))
+            .Timeout(TimeSpan.FromSeconds(10))
+            .Wait();
+
+        result.Should().BeFalse("a context that never went quiet must be REPORTED, not unloaded");
+        unloaded().Should().BeFalse(
+            "unloading a context somebody can still enter is the crash this type exists to prevent — "
+            + "leaking it until process exit is the deliberate trade");
+    }
+
+    [Fact]
+    public void The_unload_happens_once_the_last_lease_is_released()
+    {
+        var registry = new AlcLeaseRegistry();
+        var (context, unloaded) = Collectible(nameof(The_unload_happens_once_the_last_lease_is_released));
+
+        var lease = registry.Enter(context);
+        var pending = registry.UnloadWhenQuiesced(context, TimeSpan.FromSeconds(30))
+            .Timeout(TimeSpan.FromSeconds(20))
+            .ToTask();
+
+        // Still held: the unload must be waiting, not done.
+        unloaded().Should().BeFalse();
+
+        lease.Dispose();
+
+        pending.GetAwaiter().GetResult().Should().BeTrue();
+        unloaded().Should().BeTrue("releasing the last lease is the positive signal the gate waits for");
+    }
+
+    [Fact]
+    public void A_lease_taken_while_the_unload_is_pending_still_holds_it_off()
+    {
+        var registry = new AlcLeaseRegistry();
+        var (context, unloaded) = Collectible(nameof(A_lease_taken_while_the_unload_is_pending_still_holds_it_off));
+
+        var first = registry.Enter(context);
+        var pending = registry.UnloadWhenQuiesced(context, TimeSpan.FromMilliseconds(400)).ToTask();
+
+        // Hand over: a second caller enters before the first leaves, so the count never reaches 0.
+        var second = registry.Enter(context);
+        first.Dispose();
+
+        pending.GetAwaiter().GetResult().Should().BeFalse();
+        unloaded().Should().BeFalse("the count never reached zero, so no quiescence signal was ever earned");
+
+        second.Dispose();
+    }
+
+    [Fact]
+    public void Leases_on_different_contexts_do_not_gate_each_other()
+    {
+        var registry = new AlcLeaseRegistry();
+        var (busy, busyUnloaded) = Collectible("busy");
+        var (idle, idleUnloaded) = Collectible("idle");
+
+        using var _ = registry.Enter(busy);
+
+        registry.UnloadWhenQuiesced(idle, TimeSpan.FromSeconds(10))
+            .Timeout(TimeSpan.FromSeconds(15)).Wait().Should().BeTrue();
+        idleUnloaded().Should().BeTrue();
+        busyUnloaded().Should().BeFalse();
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/AlcLeaseRegistryTest.cs
+++ b/test/MeshWeaver.Hosting.Test/AlcLeaseRegistryTest.cs
@@ -75,7 +75,7 @@ public class AlcLeaseRegistryTest
     }
 
     [Fact]
-    public void The_unload_happens_once_the_last_lease_is_released()
+    public async Task The_unload_happens_once_the_last_lease_is_released()
     {
         var registry = new AlcLeaseRegistry();
         var (context, unloaded) = Collectible(nameof(The_unload_happens_once_the_last_lease_is_released));
@@ -90,12 +90,12 @@ public class AlcLeaseRegistryTest
 
         lease.Dispose();
 
-        pending.GetAwaiter().GetResult().Should().BeTrue();
+        (await pending).Should().BeTrue();
         unloaded().Should().BeTrue("releasing the last lease is the positive signal the gate waits for");
     }
 
     [Fact]
-    public void A_lease_taken_while_the_unload_is_pending_still_holds_it_off()
+    public async Task A_lease_taken_while_the_unload_is_pending_still_holds_it_off()
     {
         var registry = new AlcLeaseRegistry();
         var (context, unloaded) = Collectible(nameof(A_lease_taken_while_the_unload_is_pending_still_holds_it_off));
@@ -107,7 +107,7 @@ public class AlcLeaseRegistryTest
         var second = registry.Enter(context);
         first.Dispose();
 
-        pending.GetAwaiter().GetResult().Should().BeFalse();
+        (await pending).Should().BeFalse();
         unloaded().Should().BeFalse("the count never reached zero, so no quiescence signal was ever earned");
 
         second.Dispose();


### PR DESCRIPTION
Root-caused from the core dump behind `MeshWeaver.Hosting.Orleans.Test exit=139 SIGSEGV` (CI run 32713409169), not from guessing at the flake. It is **not** the ClrMD/DAC crash of #497 — ClrMD only exists in `Monolith.Test`, a different process — and it is not the GC.

## What the dump says

`createdump` prints the crashing thread id in **hex** (`signal 11 (000b)` gives the format away), so it is 5764, not the main thread. That thread was already inside the runtime's SIGSEGV handler — forking createdump and parked in `waitpid` — so its live registers describe the handler. The real context has to be read out of the `rt_sigframe` the kernel pushed on its stack. Doing that gives:

```
LCGMethodResolver::GetCodeInfo+0x1f7      <-- fault
CEEInfo::getMethodInfoWorker
UnsafeJitFunction
MethodDesc::JitCompileCodeLocked / PrepareILBasedCode / DoPrestub
PreStubWorker  <-  ThePreStub
CallDescrWorkerInternal / DispatchCallSimple
ManagedThreadBase::KickOff  <-  KickOffThread  <-  CPalThread::ThreadEntry
```

A **dedicated thread** (`KickOffThread` — not a ThreadPool worker) faulted on its *very first* managed call, JIT-compiling a dynamic method. Disassembling the faulting offset:

```
373884:  movq (%r15), %rax
373887:  movl 0x4(%rax), %esi     <-- fault, rax = 0x0074007300200022
```

`0x0074007300200022` is UTF-16 text (`" st`) sitting where a pointer belonged, and `si_code = SI_KERNEL` with `si_addr = 0` is the non-canonical-address (#GP) signature rather than a null dereference. The allocator backing that dynamic method was gone while a thread was still arriving at it.

`Thread.Start()` returns immediately and the OS schedules the thread later, so nothing waits for it. That gap is the window.

## What was wrong

Two unload sites ran without ever asking whether anyone was still inside:

- **`MessageHubGrain.OnDeactivateAsync`** waited up to 5 s for `DisposalCompleted`, logged *"moving on"*, and unloaded anyway — so the one case where we *knew* a user was still live was also a case where we unloaded. It now unloads only on a positive drain report; a timeout, a cancellation, or a disposal fault keeps the context and logs why.
- **`ScriptCompilationService.InvalidateCache` / `ClearCache`** called `Unload()` inline with nothing waited for at all, while `HubConfiguration` delegates already handed to callers still pointed into the context. Script execution now takes a lease, and eviction retires the context through the same gate.

## The gate

`AlcLeaseRegistry` — per-context in-flight leases plus a reactive `Quiesced` signal. The count is published under the same lock that mutates it, so a subscriber can never observe a `0` that a concurrent `Enter` has already superseded (the reordering a bare `Interlocked` + `OnNext` pair would allow, and the one that hands out a false "safe to unload"). `Quiesced` is observed on the task pool, because subscribing to it in order to *unload* would otherwise run module and finalizer code under our lock.

`UnloadWhenQuiesced` reports `false` and **leaves the context loaded** when it does not go quiet — deliberately never "unload anyway on timeout". A retained context costs memory until process exit; an unload with a live user costs the process.

## What this does not close

Written down where it lives, in the grain: `DisposalCompleted` covers the hub's action blocks and message round-trips, not mesh-shared pooled I/O leaves — `DrainAll` there would cancel every *other* grain's work. Wiring those leaves to the registry needs per-leaf ownership the pool does not carry yet, so the comment now describes a narrower gap rather than claiming the class is closed.

## Tests

`AlcLeaseRegistryTest` (6, green) asserts the **refusal**, which is the half that matters — including that a lease handed from one holder to another never lets the count touch zero, and that a double-dispose cannot decrement twice and fake a quiesce. They observe `AssemblyLoadContext.Unloading`, so *"we did not unload"* is measured rather than inferred. `AssemblyLoadContextLeakTest` (6) still green.

Release `-warnaserror` clean: `MeshWeaver.Mesh.Contract`, `MeshWeaver.Graph`, `MeshWeaver.Hosting.Orleans`.
