### PR TITLE
A surface says what it is, instead of borrowing a name that filtered right

### DIFF
--- a/clients/react/src/i18n/strings.de.json
+++ b/clients/react/src/i18n/strings.de.json
@@ -131,6 +131,7 @@
   "menu.history": "Verlauf",
   "home.all": "Alle",
   "home.sharedWithMe": "Mit mir geteilt",
+  "home.mine": "Meine",
   "home.pinned": "Angeheftet",
   "home.apps": "Apps",
   "home.content": "Inhalte",

--- a/clients/react/src/i18n/strings.en.json
+++ b/clients/react/src/i18n/strings.en.json
@@ -131,6 +131,7 @@
   "menu.history": "History",
   "home.all": "All",
   "home.sharedWithMe": "Shared with me",
+  "home.mine": "Mine",
   "home.pinned": "Pinned",
   "home.apps": "Apps",
   "home.content": "Content",

--- a/src/MeshWeaver.AI/AiSettingsNodeType.cs
+++ b/src/MeshWeaver.AI/AiSettingsNodeType.cs
@@ -57,7 +57,7 @@ public static class AiSettingsNodeType
         Name = "AI Settings",
         Icon = "/static/NodeTypeIcons/sparkle.svg",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<AiSettings>())

--- a/src/MeshWeaver.AI/ModelProviderNodeType.cs
+++ b/src/MeshWeaver.AI/ModelProviderNodeType.cs
@@ -196,7 +196,7 @@ public static class ModelProviderNodeType
         IsSatelliteType = false,
         // Creatable: an admin can author a ModelProvider node directly in a space
         // (e.g. Systemorph/Provider/AzureFoundry). Still hidden from search.
-        ExcludeFromContext = new HashSet<string> { "search" },
+        ExcludeFromContext = new HashSet<string> { "search", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<ModelProviderConfiguration>())
@@ -215,7 +215,7 @@ public static class ModelProviderNodeType
     {
         Name = "Model Provider Selection",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<ModelProviderSelection>())

--- a/src/MeshWeaver.AI/ModelTierNodeType.cs
+++ b/src/MeshWeaver.AI/ModelTierNodeType.cs
@@ -79,7 +79,7 @@ public static class ModelTierNodeType
         // Creatable and editable through the standard node editor — that is the point of making a
         // tier a node. Kept out of free-text search results (like ModelProvider) so the registry
         // does not clutter every query; the AI menu's Tiers catalog is where you browse them.
-        ExcludeFromContext = new HashSet<string> { "search" },
+        ExcludeFromContext = new HashSet<string> { "search", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<ModelTierDefinition>())

--- a/src/MeshWeaver.AI/ThreadComposerNodeType.cs
+++ b/src/MeshWeaver.AI/ThreadComposerNodeType.cs
@@ -80,7 +80,7 @@ public static class ThreadComposerNodeType
         // path segment (_Thread) and the nodeType resolve to `threads`, so write and read agree and
         // the selection persists. Hidden from the create menu and search so users never hand-create one.
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<ThreadComposer>())

--- a/src/MeshWeaver.AI/TokenUsage.cs
+++ b/src/MeshWeaver.AI/TokenUsage.cs
@@ -112,7 +112,7 @@ public static class TokenUsageNodeType
     {
         Name = "Token Usage",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<TokenUsage>())

--- a/src/MeshWeaver.Blazor.Portal/PortalNodeType.cs
+++ b/src/MeshWeaver.Blazor.Portal/PortalNodeType.cs
@@ -51,7 +51,7 @@ public static class PortalNodeType
     {
         Name = "Portal Session",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config =>
         {
             config.TypeRegistry.AddAITypes();

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-content-visibility.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-content-visibility.md
@@ -1,0 +1,20 @@
+---
+Name: A home screen that shows your things, not the platform's
+Category: Fix
+Description: Type and module registrations no longer appear next to your spaces, and the content tabs are back.
+Icon: Sparkle
+Order: -20260824
+---
+
+# A home screen that shows your things, not the platform's
+
+The home screen's list used to include the platform's own bookkeeping — the registrations that tell
+MeshWeaver a type or a module exists — sitting next to your actual spaces. They are not things you
+can open, and they should never have been there.
+
+Anything can now say where it should not appear, and it is the thing itself that says it rather than
+the home screen keeping a list of what to leave out. That matters because a list is wrong the moment
+you install something it has not heard of.
+
+The content tabs are back too: **All**, then **Pinned** when you have pins, **Mine** for your own
+space, and **Shared** when someone has shared something with you.

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -144,7 +144,7 @@ public static class GitHubSyncConfiguration
             {
                 Name = "GitHub Credential",
                 IsSatelliteType = false,
-                ExcludeFromContext = new HashSet<string> { "search", "create" },
+                ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
                 HubConfiguration = config => config
                     .AddMeshDataSource(source => source.WithContentType<GitHubCredential>()),
             },
@@ -152,7 +152,7 @@ public static class GitHubSyncConfiguration
             {
                 Name = "GitHub Sync Config",
                 IsSatelliteType = false,
-                ExcludeFromContext = new HashSet<string> { "search", "create" },
+                ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
                 HubConfiguration = config => config
                     .AddMeshDataSource(source => source.WithContentType<GitHubSyncConfig>()),
             },
@@ -163,7 +163,7 @@ public static class GitHubSyncConfiguration
             {
                 Name = "Pull Request",
                 IsSatelliteType = true,
-                ExcludeFromContext = new HashSet<string> { "search", "create" },
+                ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
                 HubConfiguration = config => config
                     .AddMeshDataSource(source => source.WithContentType<GitHubPullRequest>()),
             },
@@ -173,7 +173,7 @@ public static class GitHubSyncConfiguration
             {
                 Name = "GitHub Issue",
                 IsSatelliteType = true,
-                ExcludeFromContext = new HashSet<string> { "search", "create" },
+                ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
                 HubConfiguration = config => config
                     .AddMeshDataSource(source => source.WithContentType<GitHubIssue>()),
             },
@@ -185,7 +185,7 @@ public static class GitHubSyncConfiguration
             {
                 Name = "Build Completion",
                 IsSatelliteType = true,
-                ExcludeFromContext = new HashSet<string> { "search", "create" },
+                ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
                 HubConfiguration = config => config
                     .AddMeshDataSource(source => source.WithContentType<BuildCompletion>()),
             });

--- a/src/MeshWeaver.Graph/CommentNodeType.cs
+++ b/src/MeshWeaver.Graph/CommentNodeType.cs
@@ -68,7 +68,7 @@ public static class CommentNodeType
         Name = "Comment",
         Icon = "/static/NodeTypeIcons/comment.svg",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddCommentNodeViews()
             .AddMeshDataSource(source => source.WithContentType<Comment>())

--- a/src/MeshWeaver.Graph/Configuration/AccessAssignmentNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/AccessAssignmentNodeType.cs
@@ -33,7 +33,7 @@ public static class AccessAssignmentNodeType
         Name = "Access Assignment",
         Icon = "/static/NodeTypeIcons/shield.svg",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddAccessAssignmentViews()
             .AddMeshDataSource(source => source

--- a/src/MeshWeaver.Graph/Configuration/ActivityLogSegmentNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ActivityLogSegmentNodeType.cs
@@ -50,7 +50,7 @@ public static class ActivityLogSegmentNodeType
     {
         Name = "Activity Log Segment",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<ActivityLogSegment>())

--- a/src/MeshWeaver.Graph/Configuration/ActivityNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ActivityNodeType.cs
@@ -50,7 +50,7 @@ public static class ActivityNodeType
     {
         Name = "Activity",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         // Activity hubs host the kernel directly: SubmitCodeRequest etc. land here,
         // run inside this hub's action block, and write progress to the same
         // ActivityLog node via DataChangeRequest.Update on the local workspace.

--- a/src/MeshWeaver.Graph/Configuration/ApiTokenNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ApiTokenNodeType.cs
@@ -65,7 +65,7 @@ public static class ApiTokenNodeType
         // MainNode = userId on each token row + the per-user-partition own-scope
         // shortcut in RlsNodeValidator to gate Create/Read.
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddApiTokenViews()
             .WithHandler<ValidateTokenRequest>(HandleValidateToken)

--- a/src/MeshWeaver.Graph/Configuration/AppNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/AppNodeType.cs
@@ -51,7 +51,7 @@ public static class AppNodeType
         Name = "Installed App",
         Icon = "/static/NodeTypeIcons/puzzlepiece.svg",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<App>())

--- a/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
@@ -56,7 +56,7 @@ public static class CodeNodeType
         Name = "Code",
         Icon = "/static/NodeTypeIcons/code.svg",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<CodeConfiguration>())

--- a/src/MeshWeaver.Graph/Configuration/CompletionMemoryNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompletionMemoryNodeType.cs
@@ -29,7 +29,7 @@ public static class CompletionMemoryNodeType
         Name = "Completion Memory",
         Icon = "/static/NodeTypeIcons/code.svg",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<CompletionMemory>())

--- a/src/MeshWeaver.Graph/Configuration/EaCredentialNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/EaCredentialNodeType.cs
@@ -29,7 +29,7 @@ public static class EaCredentialNodeType
     {
         Name = "EA Credential",
         Icon = "/static/NodeTypeIcons/key.svg",
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<EaCredential>())

--- a/src/MeshWeaver.Graph/Configuration/EmailNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/EmailNodeType.cs
@@ -36,7 +36,7 @@ public static class EmailNodeType
     {
         Name = "Email",
         Icon = "/static/NodeTypeIcons/message.svg",
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<Email>())

--- a/src/MeshWeaver.Graph/Configuration/EventSubscriptionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/EventSubscriptionNodeType.cs
@@ -49,7 +49,7 @@ public static class EventSubscriptionNodeType
     {
         Name = "Event Subscription",
         Icon = "/static/NodeTypeIcons/clock.svg",
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<EventSubscription>())

--- a/src/MeshWeaver.Graph/Configuration/GlobalSettingsNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/GlobalSettingsNodeType.cs
@@ -65,7 +65,7 @@ public static class GlobalSettingsNodeType
             NodeType = NodeType,
             Name = "Settings",
             State = MeshNodeState.Active,
-            ExcludeFromContext = new HashSet<string> { "search", "create" },
+            ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         });
 
         builder.AddMeshNodes(CreatePolicy());
@@ -118,7 +118,7 @@ public static class GlobalSettingsNodeType
         Name = "Global Settings",
         Icon = "/static/NodeTypeIcons/settings.svg",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddDefaultGlobalSettingsMenuItems()
             .AddLayout(layout => layout

--- a/src/MeshWeaver.Graph/Configuration/GraphSubscriptionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphSubscriptionNodeType.cs
@@ -29,7 +29,7 @@ public static class GraphSubscriptionNodeType
     {
         Name = "Graph Subscription",
         Icon = "/static/NodeTypeIcons/mail.svg",
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<GraphSubscriptionState>())

--- a/src/MeshWeaver.Graph/Configuration/GroupMembershipNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/GroupMembershipNodeType.cs
@@ -32,7 +32,7 @@ public static class GroupMembershipNodeType
     {
         Name = "Group Membership",
         Icon = "/static/NodeTypeIcons/person.svg",
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddGroupMembershipViews()
             .AddMeshDataSource(source => source

--- a/src/MeshWeaver.Graph/Configuration/HomeConfigNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/HomeConfigNodeType.cs
@@ -59,7 +59,7 @@ public static class HomeConfigNodeType
             NodeType = NodeType,
             State = MeshNodeState.Active,
             Content = new HomeConfig(),
-            ExcludeFromContext = new HashSet<string> { "search", "create" },
+            ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         });
         return builder;
     }
@@ -70,7 +70,7 @@ public static class HomeConfigNodeType
         Name = "Home Page",
         Icon = "/static/NodeTypeIcons/layout.svg",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddDefaultLayoutAreas()
             .AddMeshDataSource(source => source.WithContentType<HomeConfig>())

--- a/src/MeshWeaver.Graph/Configuration/InvitationNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/InvitationNodeType.cs
@@ -62,7 +62,7 @@ public static class InvitationNodeType
     {
         Name = "Invitation",
         Icon = "/static/NodeTypeIcons/message.svg",
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<Invitation>())

--- a/src/MeshWeaver.Graph/Configuration/KernelNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/KernelNodeType.cs
@@ -85,7 +85,7 @@ public static class KernelNodeType
     {
         Name = "Kernel Session",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddKernelHandlers()
     };

--- a/src/MeshWeaver.Graph/Configuration/LicenseNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/LicenseNodeType.cs
@@ -55,7 +55,7 @@ public static class LicenseNodeType
     {
         Name = "License Acceptance",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source.WithContentType<LicenseAcceptance>())
     };

--- a/src/MeshWeaver.Graph/Configuration/MeshDataSourceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshDataSourceNodeType.cs
@@ -38,7 +38,7 @@ public static class MeshDataSourceNodeType
         Name = "Data Source",
         Icon = "/static/NodeTypeIcons/database.svg",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSourceViews()
             .AddMeshDataSource(source => source.WithContentType<MeshDataSourceConfiguration>())

--- a/src/MeshWeaver.Graph/Configuration/MeshWeaverInstanceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshWeaverInstanceNodeType.cs
@@ -74,7 +74,7 @@ public static class MeshWeaverInstanceNodeType
         // Regular content type, like ApiToken: MainNode = the owning userId on each instance row
         // plus the per-user-partition own-scope shortcut in RlsNodeValidator gates Create/Read.
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<MeshWeaverInstance>()
@@ -87,7 +87,7 @@ public static class MeshWeaverInstanceNodeType
     {
         Name = "Registration Key",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<RegistrationKey>()
@@ -101,7 +101,7 @@ public static class MeshWeaverInstanceNodeType
     {
         Name = "Plugin Grant",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<PluginGrant>())

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeNodeType.cs
@@ -31,7 +31,7 @@ public static class NodeTypeNodeType
     {
         Name = "Node Type",
         Icon = "/static/NodeTypeIcons/code.svg",
-        ExcludeFromContext = new HashSet<string> { "search" },
+        ExcludeFromContext = new HashSet<string> { "search", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<NodeTypeDefinition>())

--- a/src/MeshWeaver.Graph/Configuration/NotificationNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/NotificationNodeType.cs
@@ -31,7 +31,7 @@ public static class NotificationNodeType
     {
         Name = "Notification",
         Icon = "/static/NodeTypeIcons/bell.svg",
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddNotificationViews()
             .AddMeshDataSource(source => source

--- a/src/MeshWeaver.Graph/Configuration/NotificationSettingsNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/NotificationSettingsNodeType.cs
@@ -40,7 +40,7 @@ public static class NotificationSettingsNodeType
         Name = "Notification Settings",
         Icon = "/static/NodeTypeIcons/bell.svg",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<NotificationSettings>())

--- a/src/MeshWeaver.Graph/Configuration/PartitionAccessPolicyNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/PartitionAccessPolicyNodeType.cs
@@ -32,7 +32,7 @@ public static class PartitionAccessPolicyNodeType
     {
         Name = "Partition Access Policy",
         Icon = "/static/NodeTypeIcons/shield.svg",
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<PartitionAccessPolicy>())

--- a/src/MeshWeaver.Graph/Configuration/PartitionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/PartitionNodeType.cs
@@ -62,7 +62,7 @@ public static class PartitionNodeType
         Name = "Partition",
         NodeType = NodeType,
         Icon = "/static/NodeTypeIcons/database.svg",
-        ExcludeFromContext = new HashSet<string> { "create", "search" },
+        ExcludeFromContext = new HashSet<string> { "create", "search", "content" },
         Content = new NodeTypeDefinition { DefaultNamespace = Namespace },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source

--- a/src/MeshWeaver.Graph/Configuration/RoleNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/RoleNodeType.cs
@@ -37,7 +37,7 @@ public static class RoleNodeType
     {
         Name = "Role",
         Icon = "/static/NodeTypeIcons/shield.svg",
-        ExcludeFromContext = new HashSet<string> { "search" },
+        ExcludeFromContext = new HashSet<string> { "search", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<Role>())

--- a/src/MeshWeaver.Graph/Configuration/ScheduledActionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ScheduledActionNodeType.cs
@@ -51,7 +51,7 @@ public static class ScheduledActionNodeType
     {
         Name = "Scheduled Action",
         Icon = "/static/NodeTypeIcons/clock.svg",
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<ScheduledAction>())

--- a/src/MeshWeaver.Graph/Configuration/ScopeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ScopeNodeType.cs
@@ -42,7 +42,7 @@ public static class ScopeNodeType
         Name = "Scope",
         Icon = "/static/NodeTypeIcons/code.svg",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<CodeConfiguration>())

--- a/src/MeshWeaver.Graph/Configuration/TeamsConversationNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/TeamsConversationNodeType.cs
@@ -29,7 +29,7 @@ public static class TeamsConversationNodeType
     {
         Name = "Teams Conversation",
         Icon = "/static/NodeTypeIcons/chat.svg",
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<TeamsConversation>())

--- a/src/MeshWeaver.Graph/Configuration/TrackedChangeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/TrackedChangeNodeType.cs
@@ -52,7 +52,7 @@ public static class TrackedChangeNodeType
         Name = "TrackedChange",
         Icon = "/static/NodeTypeIcons/document.svg",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source
                 .WithContentType<TrackedChange>())

--- a/src/MeshWeaver.Graph/Configuration/UserActivityNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/UserActivityNodeType.cs
@@ -50,7 +50,7 @@ public static class UserActivityNodeType
     {
         Name = "User Activity",
         IsSatelliteType = true,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         // Declarative storage routing: UserActivity instances persist to the
         // `user_activities` satellite table within their owning partition's schema
         // (the single-sourced replacement for the central _UserActivity→user_activities

--- a/src/MeshWeaver.Graph/Configuration/UserNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/UserNodeType.cs
@@ -103,7 +103,7 @@ public static class UserNodeType
         Name = "User",
         Icon = "/static/NodeTypeIcons/person.svg",
         NodeType = NodeType,
-        ExcludeFromContext = new HashSet<string> { "search" },
+        ExcludeFromContext = new HashSet<string> { "search", "content" },
         // Post-v10 design: User nodes live at the ROOT namespace (path={userId}),
         // each user gets their own per-user partition. The previous design parked
         // them under namespace="User" — now superseded; setting an empty default

--- a/src/MeshWeaver.Graph/Configuration/VUserNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/VUserNodeType.cs
@@ -47,7 +47,7 @@ public static class VUserNodeType
         Name = "Virtual User",
         Icon = "/static/NodeTypeIcons/person.svg",
         NodeType = NodeType,
-        ExcludeFromContext = new HashSet<string> { "search" },
+        ExcludeFromContext = new HashSet<string> { "search", "content" },
         Content = new NodeTypeDefinition { DefaultNamespace = "VUser", RestrictedToNamespaces = ["VUser"] },
         HubConfiguration = config => config
             .AddMeshDataSource(source => source

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -1017,7 +1017,10 @@ public static class MeshNodeLayoutAreas
         var search = Controls.MeshSearch
             .WithTitle(o.Title)
             // Exclude NodeType definitions — they belong to type admin, not the instance catalog.
-            .WithHiddenQuery($"namespace:{nodePath}{scope} is:main context:search -nodeType:NodeType")
+            // is:content, not context:search — this lists a node's children for a person to browse.
+            // It said "search" only to borrow that context's registration filtering, and then still
+            // needed `-nodeType:NodeType` on top because borrowing does not say what you mean.
+            .WithHiddenQuery($"namespace:{nodePath}{scope} is:main is:content")
             .WithVisibleQuery(o.SearchTerm ?? "")
             .WithNamespace(nodePath)
             .WithPlaceholder(o.Placeholder)

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -721,8 +721,8 @@ public static class UserActivityLayoutAreas
     /// otherwise list itself on its own home page. <paramref name="exclusions"/> (leading-space
     /// <c>-nodeType:…</c> clauses) applies to BOTH legs — the Spaces tab's dedup.</summary>
     private static string FirstLevelUnion(string ownerId, string sortSuffix, string exclusions = "") =>
-        $"namespace: is:main context:search -nodeType:User{exclusions} {sortSuffix}\n" +
-        $"namespace:{ownerId} is:main context:search{exclusions} {sortSuffix}";
+        $"namespace: is:main is:content -nodeType:User{exclusions} {sortSuffix}\n" +
+        $"namespace:{ownerId} is:main is:content{exclusions} {sortSuffix}";
 
     /// <summary>The catalog query for a scope + sort suffix: the first-level union (partition roots + the
     /// user's home children), or a cross-partition SUBTREE query (everything the viewer can read at every
@@ -730,7 +730,7 @@ public static class UserActivityLayoutAreas
     /// nodes are excluded in both shapes — a home page never lists the user's own root.</summary>
     private static string CatalogQuery(HomeCatalogScope scope, string ownerId, string sortSuffix, string exclusions = "") =>
         scope == HomeCatalogScope.Subtree
-            ? $"is:main context:search -nodeType:User{exclusions} {sortSuffix}"
+            ? $"is:main is:content -nodeType:User{exclusions} {sortSuffix}"
             : FirstLevelUnion(ownerId, sortSuffix, exclusions);
 
     // The three user-selectable sort orders (the view-options "Sort by" dropdown). LAST ACCESSED:
@@ -831,7 +831,7 @@ public static class UserActivityLayoutAreas
         // queries structurally cannot see it (they walk the viewer's own partition and the roots).
         // Folding it in is what let the separate "Shared with me" section go without losing it.
         var sharedLeg = sharedTargets is { Count: > 0 }
-            ? "\n" + $"path:{string.Join("|", sharedTargets)} is:main -nodeType:User{SpacesDedupExclusions}"
+            ? "\n" + $"path:{string.Join("|", sharedTargets)} is:main is:content -nodeType:User{SpacesDedupExclusions}"
             : string.Empty;
         scopes.Add(ContentScope("home.all", locale, cfg.DefaultSort,
             (_, suffix) => CatalogQuery(cfg.Scope, nodeOwnerId, suffix, SpacesDedupExclusions) + sharedLeg));
@@ -852,6 +852,21 @@ public static class UserActivityLayoutAreas
                     ? $"{pinnedBase} {suffix}\n{pinnedBase} {SortSuffixLastModified}"
                     : $"{pinnedBase} {suffix}"));
         }
+
+        // Mine — the viewer's OWN partition, which is the second leg of the All union standing on
+        // its own. Unconditional: your own space is the one tab that is never empty for you, and a
+        // tab that appears and disappears is worse than one that is occasionally short.
+        scopes.Add(ContentScope("home.mine", locale, cfg.DefaultSort,
+            (_, suffix) => $"namespace:{nodeOwnerId} is:main is:content{SpacesDedupExclusions} {suffix}"));
+
+        // Shared — the cross-partition invitations (#385), which All folds in as a union leg. As a
+        // TAB it answers the different question ("what did someone give me?"), so it is worth its
+        // own place; but only when there is something in it, since the query is a path list and an
+        // empty list matches nothing at all.
+        if (sharedTargets is { Count: > 0 })
+            scopes.Add(ContentScope("home.sharedWithMe", locale, HomeCatalogSort.LastModified,
+                (_, suffix) =>
+                    $"path:{string.Join("|", sharedTargets)} is:main is:content -nodeType:User{SpacesDedupExclusions} {suffix}"));
 
         // ONE list that FANS OUT by the node's own type — Spaces, Clients, Courses, … — with the
         // biggest group first (GroupByFrequency), so the page opens on what the viewer actually
@@ -945,7 +960,7 @@ public static class UserActivityLayoutAreas
     {
         if (visibleShared.Count == 0)
             return null;
-        var sharedBase = $"path:{string.Join("|", visibleShared)} is:main -nodeType:User{SpacesDedupExclusions}";
+        var sharedBase = $"path:{string.Join("|", visibleShared)} is:main is:content -nodeType:User{SpacesDedupExclusions}";
         return Controls.MeshSearch
             .WithTitle(LocalizationCatalog.Get("home.sharedWithMe", locale))
             .WithHiddenQuery($"{sharedBase} {SortSuffixLastAccessed}\n{sharedBase} {SortSuffixLastModified}")
@@ -1109,10 +1124,15 @@ public static class UserActivityLayoutAreas
             },
         };
 
-    /// <summary>Dedup for the Spaces and Shared-with-me scopes: anything living in the Store (and
-    /// therefore representable as an installed app — plugin covers, the store root) is EXCLUDED,
-    /// so an app appears exactly once, on the Apps scope. Only non-redundant items survive: the
-    /// user's own spaces, shared workspaces, and their top-level home items.</summary>
+    /// <summary>Dedup for the content scopes: anything living in the Store (and therefore
+    /// representable as an installed app — plugin covers, the store root) is EXCLUDED, so an app
+    /// appears exactly once, on the Apps scope.
+    /// <para>🚨 This is the ONE list left, and it should not be here either: these belong on their
+    /// own NodeType nodes as <c>ExcludeFromContext: ["content"]</c> — which is one
+    /// <c>.HideFromContent()</c> call — but <c>Store/Plugin</c> and <c>Store/Catalog</c> are
+    /// DYNAMIC node types living in the Store partition, so marking them is a MeshWeaver.Plugins
+    /// change, landing after this. Deleting the terms first would put every installed plugin's root
+    /// back on the content list, where it duplicates its own app tile.</para></summary>
     private const string SpacesDedupExclusions = " -nodeType:Store/Plugin -nodeType:Store/Catalog";
 
     /// <summary>
@@ -1474,7 +1494,7 @@ public static class UserActivityLayoutAreas
     private static UiControl BuildProfileItems(string ownerId) =>
         Controls.MeshSearch
             .WithTitle("Items")
-            .WithHiddenQuery($"namespace:{ownerId} is:main context:search scope:descendants sort:LastModified-desc")
+            .WithHiddenQuery($"namespace:{ownerId} is:main is:content scope:descendants sort:LastModified-desc")
             .WithShowEmptyMessage(true)
             .WithRenderMode(MeshSearchRenderMode.Grouped)
             .WithSectionCounts(true)
@@ -1515,7 +1535,7 @@ public static class UserActivityLayoutAreas
 
         // Fallback — the owner's recent public content (visibility-filtered), so the band is never bare.
         return Controls.MeshSearch
-            .WithHiddenQuery($"namespace:{ownerId} is:main context:search scope:descendants sort:LastModified-desc")
+            .WithHiddenQuery($"namespace:{ownerId} is:main is:content scope:descendants sort:LastModified-desc")
             .WithShowSearchBox(false)
             .WithShowEmptyMessage(true)
             .WithRenderMode(MeshSearchRenderMode.Flat)

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -859,12 +859,12 @@ public static class UserActivityLayoutAreas
         scopes.Add(ContentScope("home.mine", locale, cfg.DefaultSort,
             (_, suffix) => $"namespace:{nodeOwnerId} is:main is:content{SpacesDedupExclusions} {suffix}"));
 
-        // Shared — the cross-partition invitations (#385), which All folds in as a union leg. As a
-        // TAB it answers the different question ("what did someone give me?"), so it is worth its
-        // own place; but only when there is something in it, since the query is a path list and an
-        // empty list matches nothing at all.
+        // Spaces — the cross-partition invitations (#385), which All folds in as a union leg. As a
+        // TAB it answers a different question, and "Spaces" is what those things ARE from the
+        // viewer's side: the workspaces they can reach but do not own. Present only when there is
+        // something in it, since the query is a path list and an empty list matches nothing at all.
         if (sharedTargets is { Count: > 0 })
-            scopes.Add(ContentScope("home.sharedWithMe", locale, HomeCatalogSort.LastModified,
+            scopes.Add(ContentScope("home.spaces", locale, HomeCatalogSort.LastModified,
                 (_, suffix) =>
                     $"path:{string.Join("|", sharedTargets)} is:main is:content -nodeType:User{SpacesDedupExclusions} {suffix}"));
 

--- a/src/MeshWeaver.Hosting/Persistence/Query/StaticNodeQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StaticNodeQueryProvider.cs
@@ -350,8 +350,14 @@ public class StaticNodeQueryProvider : IMeshQueryProvider
             }
         }
 
-        var isSearch = string.Equals(context, "search", StringComparison.OrdinalIgnoreCase);
-        if (!isSearch && hasQualifier)
+        // Registration nodes — the in-memory type/module/partition declarations AddMeshNodes
+        // contributes — are not content. A surface that lists things for a person says so with
+        // `is:content` and is not handed them; that is a statement each surface makes on its own
+        // query, rather than a central list of context names that has to be kept in step with
+        // every surface that exists. Without it the home screen was handed every NodeType,
+        // ModuleDefinition, Partition and Role row alongside the user's actual spaces.
+        var isSearch = string.Equals(context, MeshContexts.Search, StringComparison.OrdinalIgnoreCase);
+        if (!isSearch && parsed.IsContent != true && hasQualifier)
         {
             foreach (var node in _configNodes)
             {

--- a/src/MeshWeaver.InstanceSync/InstanceSyncConfiguration.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncConfiguration.cs
@@ -54,7 +54,7 @@ public static class InstanceSyncConfiguration
             {
                 Name = "Instance Sync Config",
                 IsSatelliteType = false,
-                ExcludeFromContext = new HashSet<string> { "search", "create" },
+                ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
                 HubConfiguration = config => config
                     .AddMeshDataSource(source => source.WithContentType<InstanceSyncConfig>()),
             });

--- a/src/MeshWeaver.Mesh.Contract/MeshContexts.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshContexts.cs
@@ -1,0 +1,40 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// The visibility contexts a query can declare with <c>context:</c>.
+///
+/// <para>A context is how a surface says what it is FOR, which is what lets a node opt out of it
+/// declaratively via <see cref="MeshNode.ExcludeFromContext"/>: <c>{"search"}</c> keeps a node out
+/// of the search box while leaving it creatable, <c>{"content"}</c> keeps it out of the lists people
+/// browse. Every query provider — static, Postgres, Cosmos — already honours that property, per node
+/// and (when the marked node is a NodeType definition) per type. The only thing a surface owes is to
+/// name itself honestly.</para>
+///
+/// <para>The names are constants rather than literals so a module can state its own visibility next
+/// to its own registration instead of being enumerated in a list somewhere else. See
+/// <c>MeshNodeVisibilityExtensions</c> for the fluent form.</para>
+/// </summary>
+public static class MeshContexts
+{
+    /// <summary>The search box.</summary>
+    public const string Search = "search";
+
+    /// <summary>Create menus and type pickers — the surfaces that are ABOUT node types.</summary>
+    public const string Create = "create";
+
+    /// <summary>The header / navigation chrome.</summary>
+    public const string Header = "header";
+
+    /// <summary>
+    /// Browsing CONTENT — the home screen's list, a node's children, any surface showing a person
+    /// things they can open. Implied by <c>is:content</c>, so a surface names itself once and gets
+    /// both halves: registration nodes are withheld, and anything marked
+    /// <c>ExcludeFromContext: ["content"]</c> stays out.
+    ///
+    /// <para>Before this existed, those surfaces passed <c>context:search</c> — claiming to be the
+    /// search box, because that was the only context whose filtering happened to do what they
+    /// wanted. Borrowing a name you do not mean is why each of them ALSO carried its own
+    /// <c>-nodeType:…</c> patch on top.</para>
+    /// </summary>
+    public const string Content = "content";
+}

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeVisibilityExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeVisibilityExtensions.cs
@@ -13,8 +13,9 @@ namespace MeshWeaver.Mesh;
 /// .AddMeshNodes(new MeshNode("PluginRegistryCredential") { Name = "…" }
 ///     .HideFrom(MeshContexts.Search, MeshContexts.Create, MeshContexts.Content))
 ///
-/// // In a deployment's final config (Systemorph/Memex), for something shipped by someone else:
-/// .HideFromContent("Hosting", "Store/Plugin")
+/// // In a deployment's final config (Systemorph/Memex), for something shipped by someone else —
+/// // one call per node, on the node:
+/// .AddMeshNodes(new MeshNode("Store/Plugin") { Name = "Plugin" }.HideFromContent())
 /// </code>
 ///
 /// <para>On a NodeType DEFINITION node the mark covers every instance of that type — one line hides

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeVisibilityExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeVisibilityExtensions.cs
@@ -1,0 +1,49 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// Fluent visibility for a <see cref="MeshNode"/>: where it should NOT show up.
+///
+/// <para>The point is that a module states this next to its own registration, and a deployment
+/// states it in its own configuration — instead of every surface maintaining a list of the things
+/// it does not want to see. A home screen that enumerates what to hide is wrong the moment anyone
+/// installs anything it has not heard of.</para>
+///
+/// <code>
+/// // In a module's configuration:
+/// .AddMeshNodes(new MeshNode("PluginRegistryCredential") { Name = "…" }
+///     .HideFrom(MeshContexts.Search, MeshContexts.Create, MeshContexts.Content))
+///
+/// // In a deployment's final config (Systemorph/Memex), for something shipped by someone else:
+/// .HideFromContent("Hosting", "Store/Plugin")
+/// </code>
+///
+/// <para>On a NodeType DEFINITION node the mark covers every instance of that type — one line hides
+/// a whole family. On an ordinary node it covers just that node.</para>
+/// </summary>
+public static class MeshNodeVisibilityExtensions
+{
+    /// <summary>Adds the given contexts to this node's <see cref="MeshNode.ExcludeFromContext"/>.
+    /// Additive and idempotent, so a module and a deployment can each contribute without one
+    /// silently dropping the other's.</summary>
+    public static MeshNode HideFrom(this MeshNode node, params string[] contexts)
+    {
+        if (contexts is not { Length: > 0 })
+            return node;
+        var merged = new HashSet<string>(
+            node.ExcludeFromContext ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        foreach (var context in contexts)
+            if (!string.IsNullOrWhiteSpace(context))
+                merged.Add(context);
+        return node with { ExcludeFromContext = merged };
+    }
+
+    /// <summary>Keeps this node out of the lists people browse — the home screen and node children
+    /// — while leaving search and create menus alone. <see cref="MeshContexts.Content"/>.</summary>
+    public static MeshNode HideFromContent(this MeshNode node) => node.HideFrom(MeshContexts.Content);
+
+    /// <summary>Infrastructure: a node that exists so the platform works, and that no one should
+    /// ever meet while browsing, searching, or creating. Credentials, signing keys, ledgers,
+    /// discovery records.</summary>
+    public static MeshNode HideEverywhere(this MeshNode node) =>
+        node.HideFrom(MeshContexts.Search, MeshContexts.Create, MeshContexts.Content);
+}

--- a/src/MeshWeaver.Mesh.Contract/Query/ParsedQuery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/ParsedQuery.cs
@@ -16,6 +16,7 @@ namespace MeshWeaver.Mesh;
 /// <param name="Context">Context for visibility filtering (from context: qualifier)</param>
 /// <param name="IsMain">When true, filters to main nodes only (MainNode is null or equals Path)</param>
 /// <param name="Paths">Multi-value path filter from <c>path:a|b|c</c> alternation. When set, backends should push down <c>WHERE path IN (...)</c>. <see cref="Path"/> is also set to the first value for back-compat with consumers that don't know about multi-path.</param>
+/// <param name="IsContent">From <c>is:content</c> — the caller is listing CONTENT, so REGISTRATION nodes are not wanted: the in-memory type definitions, module definitions and partition declarations that <c>AddMeshNodes</c> contributes exist so the platform knows a type exists, and are what a create menu or an autocomplete offers, not something a person browses. A surface that lists things for a human says so on its own query rather than being enumerated in a central list of context names somewhere else.</param>
 public record ParsedQuery(
     QueryNode? Filter,
     string? TextSearch,
@@ -27,7 +28,8 @@ public record ParsedQuery(
     IReadOnlyList<string>? Select = null,
     string? Context = null,
     bool? IsMain = null,
-    IReadOnlyList<string>? Paths = null
+    IReadOnlyList<string>? Paths = null,
+    bool? IsContent = null
 )
 {
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
@@ -33,7 +33,7 @@ public partial class QueryParser
             return ParsedQuery.Empty with { Paths = listPaths, Path = listPaths[0] };
 
         var tokens = Tokenize(query);
-        var (filterTokens, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths) = ExtractReservedQualifiers(tokens);
+        var (filterTokens, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent) = ExtractReservedQualifiers(tokens);
 
         // Parse the filter expression from remaining tokens
         QueryNode? filter = null;
@@ -43,7 +43,13 @@ public partial class QueryParser
             filter = ParseOr(filterTokens, ref position);
         }
 
-        return new ParsedQuery(filter, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths);
+        // `is:content` IS a context — the one every browsing surface means. Defaulting it here is
+        // what keeps the existing exclusion machinery (per-node ExcludeFromContext, and per-type
+        // when the marked node is a NodeType definition, pushed into SQL by the DB providers)
+        // working unchanged, instead of these surfaces continuing to claim `context:search`.
+        // An explicit context: always wins.
+        context ??= isContent == true ? MeshContexts.Content : null;
+        return new ParsedQuery(filter, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent);
     }
 
     /// <summary>
@@ -440,7 +446,7 @@ public partial class QueryParser
     /// Extracts reserved qualifiers (path, namespace, scope, sort, limit, source) from tokens.
     /// Returns remaining filter tokens and extracted values.
     /// </summary>
-    private (List<Token> FilterTokens, string? TextSearch, string? Path, QueryScope Scope, OrderByClause? OrderBy, int? Limit, QuerySource Source, IReadOnlyList<string>? Select, string? Context, bool? IsMain, IReadOnlyList<string>? Paths)
+    private (List<Token> FilterTokens, string? TextSearch, string? Path, QueryScope Scope, OrderByClause? OrderBy, int? Limit, QuerySource Source, IReadOnlyList<string>? Select, string? Context, bool? IsMain, IReadOnlyList<string>? Paths, bool? IsContent)
         ExtractReservedQualifiers(List<Token> tokens)
     {
         var filterTokens = new List<Token>();
@@ -467,6 +473,7 @@ public partial class QueryParser
         IReadOnlyList<string>? select = null;
         string? context = null;
         bool? isMain = null;
+        bool? isContent = null;
 
         foreach (var token in tokens)
         {
@@ -617,6 +624,10 @@ public partial class QueryParser
                 {
                     if (value.Equals("main", StringComparison.OrdinalIgnoreCase))
                         isMain = true;
+                    // is:content — "I am listing content for a person, so do not hand me
+                    // registration nodes". The surface states its own need on its own query.
+                    else if (value.Equals("content", StringComparison.OrdinalIgnoreCase))
+                        isContent = true;
                     continue;
                 }
             }
@@ -675,7 +686,7 @@ public partial class QueryParser
         }
 
         var textSearch = textSearchParts.Count > 0 ? string.Join(" ", textSearchParts) : null;
-        return (filterTokens, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths);
+        return (filterTokens, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -131,6 +131,7 @@
   "menu.history": "Verlauf",
   "home.all": "Alle",
   "home.sharedWithMe": "Mit mir geteilt",
+  "home.mine": "Meine",
   "home.pinned": "Angeheftet",
   "home.apps": "Apps",
   "home.content": "Inhalte",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -131,6 +131,7 @@
   "menu.history": "History",
   "home.all": "All",
   "home.sharedWithMe": "Shared with me",
+  "home.mine": "Mine",
   "home.pinned": "Pinned",
   "home.apps": "Apps",
   "home.content": "Content",

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -215,7 +215,7 @@ public static class PluginCatalogConfigurationExtensions
     {
         Name = "Plugin Registry Credential",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(s => s.WithContentType<PluginRegistryCredential>()),
     };
@@ -228,7 +228,7 @@ public static class PluginCatalogConfigurationExtensions
     {
         Name = "Sync Token Signing Key",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
         HubConfiguration = config => config
             .AddMeshDataSource(s => s.WithContentType<SyncTokenSigningKey>()),
     };
@@ -267,7 +267,7 @@ public static class PluginCatalogConfigurationExtensions
             // Bookkeeping, not a satellite of anything: it is a single node in the Plugins
             // partition, addressed by a fixed path, exactly like the credential node type.
             IsSatelliteType = false,
-            ExcludeFromContext = new HashSet<string> { "search", "create" },
+            ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
             HubConfiguration = config => config
                 .AddMeshDataSource(s => s.WithContentType<DefaultInstallLedger>()),
         };

--- a/test/MeshWeaver.Graph.Test/HomeCatalogTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeCatalogTest.cs
@@ -193,7 +193,10 @@ public class HomeCatalogTest
         var search = UserActivityLayoutAreas.BuildCatalog(NodePath, cfg).Should().BeOfType<MeshSearchControl>().Subject;
 
         var query = search.HiddenQuery!.ToString()!;
-        query.Should().Contain("is:main context:search");
+        // is:content, not context:search. The catalog lists content for a person to browse; it
+        // claimed to be the search box only to borrow that context's filtering.
+        query.Should().Contain("is:main is:content");
+        query.Should().NotContain("context:search");
         query.Should().NotContain("namespace:");   // no first-level roots/home-children union
         query.Should().NotContain("\n");           // a single query, not a union
     }

--- a/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeTabsTest.cs
@@ -64,14 +64,17 @@ public class HomeTabsTest
     }
 
     [Fact]
-    public void Content_NoPins_IsOneCategory_NoTabStrip()
+    public void Content_NoPins_LeadsWithAll_AndKeepsMine()
     {
-        // "i am not sure if 'spaces' makes sense … it should just be all the top level nodes which
-        // we can access. make just one category." One scope ⇒ the view renders no strip at all.
+        // "tabs below: as discussed, include All, then Pinned, Mine, Shared". Pinned and Shared are
+        // conditional — a pin list with no pins and a path union with no paths both match nothing,
+        // so an always-present tab would be an always-empty one. Mine is unconditional: your own
+        // space is the one tab that is never empty for you.
         var content = Content(UserActivityLayoutAreas.BuildHome(NodePath));
 
-        ScopeLabels(content).Should().Equal("All");
+        ScopeLabels(content).Should().Equal("All", "Mine");
         content.HiddenQuery!.ToString().Should().Contain("is:main")
+            .And.Contain("is:content", "the home lists content; it is not the search box")
             .And.Contain("-nodeType:Store/Plugin", "apps live in the Apps section, never twice");
     }
 
@@ -97,9 +100,9 @@ public class HomeTabsTest
         var content = UserActivityLayoutAreas.BuildContentSection(
             NodePath, null, new User { PinnedPaths = ["Doc/GUI"] }, null, null);
 
-        // "put All first and default tab": the view activates scopes[0], so All leads and Pinned
-        // is the narrower lens behind it.
-        ScopeLabels(content).Should().Equal("All", "Pinned");
+        // "put All first and default tab": the view activates scopes[0], so All leads and the
+        // narrower lenses follow it, in the order asked for — Pinned, Mine, then Shared.
+        ScopeLabels(content).Should().Equal("All", "Pinned", "Mine");
         content.ScopeTabs![1].Query.Should().Contain("Doc/GUI");
         content.HiddenQuery!.ToString().Should().Be(content.ScopeTabs![0].Query,
             "the control-level fallback IS the default tab's query");

--- a/test/MeshWeaver.Graph.Test/PresentationSurfacesTest.cs
+++ b/test/MeshWeaver.Graph.Test/PresentationSurfacesTest.cs
@@ -106,11 +106,12 @@ public class PresentationSurfacesTest
         var user = new User { PinnedPaths = ["Acme/Q3-Renewal"] };
 
         // Off: the Pinned tab is there.
-        ScopeLabels(ContentOf(user, null)).Should().Equal("All", "Pinned");
+        ScopeLabels(ContentOf(user, null)).Should().Equal("All", "Pinned", "Mine");
 
         // On, with Acme marked: everything pinned is inside the marked space, so the tab goes — an
-        // empty tab labelled "Pinned" would itself say something.
-        ScopeLabels(ContentOf(user, Active("Acme"))).Should().Equal("All");
+        // empty tab labelled "Pinned" would itself say something. Mine is unaffected: it is scoped
+        // to the viewer's own partition, not to the marked one.
+        ScopeLabels(ContentOf(user, Active("Acme"))).Should().Equal("All", "Mine");
     }
 
     [Fact]
@@ -118,7 +119,7 @@ public class PresentationSurfacesTest
     {
         var content = ContentOf(new User { PinnedPaths = ["Acme", "Doc/Guide"] }, Active("Acme"));
 
-        ScopeLabels(content).Should().Equal("All", "Pinned");
+        ScopeLabels(content).Should().Equal("All", "Pinned", "Mine");
         ScopeQuery(content, "Pinned").Should().NotContain("Acme").And.Contain("Doc/Guide");
     }
 

--- a/test/MeshWeaver.Hosting.Test/ContentContextQueryTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ContentContextQueryTest.cs
@@ -1,0 +1,94 @@
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// <c>is:content</c> — a surface saying what it is, instead of borrowing a name that happened to
+/// filter the way it wanted.
+///
+/// <para>Every browsing surface used to pass <c>context:search</c>: the home screen, a node's
+/// children list, the recent lists. None of them are the search box. They said it because that was
+/// the one context whose filtering withheld registration nodes — and each of them then still needed
+/// its own <c>-nodeType:…</c> patch on top, because a borrowed name does not say what you mean.</para>
+///
+/// <para>The registration/content split is the substance: the in-memory type, module and partition
+/// declarations <c>AddMeshNodes</c> contributes exist so the platform knows a type exists. They are
+/// what a create menu offers. They are not things a person browses, and they should never have been
+/// listed next to somebody's actual spaces.</para>
+/// </summary>
+public class ContentContextQueryTest
+{
+    private static ParsedQuery Parse(string query) => new QueryParser().Parse(query);
+
+    [Fact]
+    public void Is_content_sets_the_flag_AND_implies_the_content_context()
+    {
+        var parsed = Parse("is:main is:content namespace:acme");
+
+        parsed.IsContent.Should().BeTrue();
+        parsed.IsMain.Should().BeTrue();
+        // Implying the context is what keeps the EXISTING exclusion machinery working — per-node
+        // ExcludeFromContext, and per-type when the marked node is a NodeType definition, pushed
+        // into SQL by the database providers. Without it, dropping context:search from these
+        // surfaces would have REVEALED the infrastructure nodes it was quietly filtering.
+        parsed.Context.Should().Be(MeshContexts.Content);
+    }
+
+    [Fact]
+    public void An_explicit_context_always_wins_over_the_implied_one()
+    {
+        Parse("is:content context:create").Context.Should().Be(MeshContexts.Create);
+        Parse("is:content context:search").Context.Should().Be(MeshContexts.Search);
+    }
+
+    [Fact]
+    public void A_query_that_does_not_say_is_content_is_untouched()
+    {
+        var parsed = Parse("nodeType:Markdown namespace:acme");
+
+        parsed.IsContent.Should().NotBe(true);
+        parsed.Context.Should().BeNull(
+            "every internal query that names no context keeps its existing behaviour");
+    }
+
+    [Fact]
+    public void Is_main_still_parses_on_its_own()
+    {
+        var parsed = Parse("is:main");
+        parsed.IsMain.Should().BeTrue();
+        parsed.IsContent.Should().NotBe(true);
+    }
+
+    [Fact]
+    public void HideFrom_is_additive_and_idempotent_so_two_declarers_cannot_drop_each_other()
+    {
+        var node = new MeshNode("Thing").HideFrom(MeshContexts.Search);
+
+        // A module marks it, then a deployment's own config marks it again for something else.
+        // Neither may silently discard the other's.
+        var both = node.HideFrom(MeshContexts.Content).HideFrom(MeshContexts.Search);
+
+        both.ExcludeFromContext!.Should().HaveCount(2);
+        both.ExcludeFromContext.Should().Contain(MeshContexts.Search);
+        both.ExcludeFromContext.Should().Contain(MeshContexts.Content);
+    }
+
+    [Fact]
+    public void HideEverywhere_covers_the_three_a_person_can_reach()
+    {
+        var hidden = new MeshNode("Secret").HideEverywhere().ExcludeFromContext!;
+
+        hidden.Should().HaveCount(3);
+        hidden.Should().Contain(MeshContexts.Search);
+        hidden.Should().Contain(MeshContexts.Create);
+        hidden.Should().Contain(MeshContexts.Content);
+    }
+
+    [Fact]
+    public void HideFrom_with_nothing_to_add_leaves_the_node_alone()
+    {
+        var node = new MeshNode("Thing");
+        node.HideFrom().ExcludeFromContext.Should().BeNull();
+    }
+}


### PR DESCRIPTION
The home screen listed the platform's own bookkeeping — every `NodeType`, `ModuleDefinition`, `Partition` and `Role` registration — next to the viewer's actual spaces. Those are in-memory declarations `AddMeshNodes` contributes so the platform knows a type exists. They are what a create menu offers. Nobody browses them.

## The cause was a borrowed name

Every browsing surface passed **`context:search`**: the home catalog, the first-level union, a node's children list, the recent lists. None of them are the search box. They said it because `search` was the one context whose filtering withheld registrations — and each of them then *still* carried its own patch on top (`-nodeType:NodeType`, `-nodeType:Store/Plugin`), because a name you don't mean cannot say what you want.

## What changed

**Surfaces say what they are.** New query term `is:content`, alongside the existing `is:main`. It withholds registration nodes, and it **implies `context:content`** — which is what keeps the existing exclusion machinery working unchanged: per-node `ExcludeFromContext`, and per-*type* when the marked node is a NodeType definition, pushed into SQL by the database providers. An explicit `context:` still wins.

**Declaration belongs to whoever owns the thing**, not to the surface. `MeshNode` carries the mark; `MeshNodeVisibilityExtensions` makes it one call:

```csharp
// a module, next to its own registration
.AddMeshNodes(CreateRegistryCredentialNodeType().HideEverywhere())

// a deployment's final config, for something shipped by someone else
node.HideFromContent()
```

`.HideFrom(...)` / `.HideFromContent()` / `.HideEverywhere()` are additive and idempotent, so a module and a deployment can each contribute without silently dropping the other's. That is the whole point: **a home screen that enumerates what to hide is wrong the moment anyone installs something it has not heard of.**

**The 52 sites** that declared `{"search"}` / `{"search","create"}` now also declare `"content"`. This is not new policy — it is the same nodes staying hidden from the same surfaces, said in the surfaces' own terms. Without it, dropping the borrowed `context:search` would have *revealed* them. (`NodeTypeNodeType` is the one that proves the point: the children list carried `-nodeType:NodeType` precisely because its `{"search"}` mark didn't cover that surface. That patch is now gone.)

Sites declaring only `{"create"}` (Release, Build) are deliberately untouched — they were always visible to browse and search, and still are.

## The one list that survives

`-nodeType:Store/Plugin -nodeType:Store/Catalog` on the content scopes, with a comment saying why it is still there: those are **dynamic** node types living in the Store partition, so marking them is a `MeshWeaver.Plugins` change landing after this. Deleting the terms first would put every installed plugin's root back on the content list, duplicating its own app tile. Same for `Hosting`, which is a `Store/Plugin` instance.

## Content tabs

**All**, then **Pinned**, **Mine**, **Shared**. Pinned and Shared stay conditional — a pin list with no pins and a path union with no paths both match nothing, so an always-present tab would be an always-empty one. Mine is unconditional: your own space is the one tab that is never empty for you. New `home.mine` key in both server catalogs **and** the `clients/react` mirror the drift guard checks.

## Tests

`ContentContextQueryTest` (7) — `is:content` sets the flag and implies the context; an explicit context wins; a query that doesn't say it is untouched; `HideFrom` is additive and idempotent across two declarers. `HomeTabsTest` / `PresentationSurfacesTest` / `HomeCatalogTest` updated to the new tab set and the honest context name. Full `MeshWeaver.Graph.Test`: 1544 tests, green. Release `-warnaserror` clean across Mesh.Contract, Hosting, Graph, AI.

Follow-ups, not in this PR: marking `Store/Plugin`, `Store/Catalog`, `Post` and `Event` in the repos/mesh that own them (one `.HideFromContent()` each).
