### PR TITLE
One thread composer (shared mention model + speech), un-shadowed type-node URLs, colorful SVG on native

### DIFF
--- a/clients/grpc-web/src/connection.test.ts
+++ b/clients/grpc-web/src/connection.test.ts
@@ -28,3 +28,28 @@ describe("MeshWebConnection (gRPC-web split, in-memory)", () => {
     mesh.close();
   });
 });
+
+describe("unsolicited typed messages (onMessage)", () => {
+  it("dispatches a server-initiated NavigationRequest to its handler, after pending/stream demux", async () => {
+    const { fakeMeshTransport } = await import("./testTransport");
+    const { MeshWebConnection } = await import("./connection");
+    const conn = await MeshWebConnection.connect("https://portal.example", { transport: fakeMeshTransport() });
+    const seen: string[] = [];
+    const off = conn.onMessage("NavigationRequest", (d) => seen.push(String(d.message["uri"])));
+    // Round-trip an Echo so the fake's stream is live, then hand-feed an unsolicited delivery the
+    // way the server sends one: no RequestId, no streamId — just a typed message to this node.
+    await conn.observe("any", "EchoRequest", { text: "warm" });
+    (conn as unknown as { onFrame(r: string): void }).onFrame(
+      JSON.stringify({ id: "x", sender: "Store", target: conn.address,
+        message: { $type: "NavigationRequest", uri: "Store/Catalog/Catalog?category=Games" }, properties: {} }),
+    );
+    expect(seen).toEqual(["Store/Catalog/Catalog?category=Games"]);
+    off();
+    (conn as unknown as { onFrame(r: string): void }).onFrame(
+      JSON.stringify({ id: "y", sender: "Store", target: conn.address,
+        message: { $type: "NavigationRequest", uri: "Elsewhere" }, properties: {} }),
+    );
+    expect(seen).toEqual(["Store/Catalog/Catalog?category=Games"]); // unsubscribed — not delivered
+    conn.close();
+  });
+});

--- a/clients/grpc-web/src/connection.ts
+++ b/clients/grpc-web/src/connection.ts
@@ -47,6 +47,10 @@ export class MeshWebConnection {
   private connectionId = "";
   private readonly pending = new Map<string, (d: Delivery) => void>();
   private readonly subscriptions = new Map<string, (d: Delivery) => void>();
+  // Handlers for UNSOLICITED typed messages (no RequestId, no streamId) — the server-initiated
+  // channel: a clickable control's ClickedEvent is answered with a NavigationRequest addressed to
+  // this participant, exactly what Blazor's PortalApplication handles with WithHandler<...>.
+  private readonly typedHandlers = new Map<string, Set<(d: Delivery) => void>>();
   // The SubscribeRequest params per live streamId — kept so a dropped Connect stream can be
   // re-opened and every subscription REPLAYED (see open()'s reconnect loop). Without replay, a
   // mid-delivery drop strands the UI on whatever subset of area frames arrived first.
@@ -157,7 +161,26 @@ export class MeshWebConnection {
       return;
     }
     const streamId = (delivery.message["streamId"] ?? delivery.message["StreamId"]) as string | undefined;
-    if (streamId && this.subscriptions.has(streamId)) this.subscriptions.get(streamId)!(delivery);
+    if (streamId && this.subscriptions.has(streamId)) {
+      this.subscriptions.get(streamId)!(delivery);
+      return;
+    }
+    if (delivery.messageType) this.typedHandlers.get(delivery.messageType)?.forEach((h) => h(delivery));
+  }
+
+  /**
+   * Subscribe to unsolicited messages of `messageType` — the client twin of the Blazor portal
+   * hub's `WithHandler<T>` (e.g. `NavigationRequest`: a server click action tells THIS participant
+   * where to go). Returns the unsubscribe.
+   */
+  onMessage(messageType: string, handler: (d: Delivery) => void): () => void {
+    let set = this.typedHandlers.get(messageType);
+    if (!set) this.typedHandlers.set(messageType, (set = new Set()));
+    set.add(handler);
+    return () => {
+      set!.delete(handler);
+      if (set!.size === 0) this.typedHandlers.delete(messageType);
+    };
   }
 
   /** Send `delivery` to the mesh via the unary Deliver, tagged with our connection id. */

--- a/clients/grpc-web/src/mesh.test.ts
+++ b/clients/grpc-web/src/mesh.test.ts
@@ -162,3 +162,22 @@ describe("Mesh ops (gRPC-web, in-memory)", () => {
     mesh.close();
   });
 });
+
+describe("Mesh.autocomplete — the ONE @-mention implementation (was duplicated per shell)", () => {
+  it("targets the viewer's home hub with AutocompleteRequest and returns the items", async () => {
+    const targets: string[] = [];
+    const mesh = await Mesh.connect("https://portal.example", {
+      transport: fakeMeshTransport({ onDeliver: (d) => { targets.push(String(d.target)); } }),
+    });
+    const items = await mesh.autocomplete("rbuergi", "Doc", "rbuergi/Thread/t1");
+    expect(items).toEqual([{ label: "hit:Doc", insertText: "@/Doc", path: "Doc" }]);
+    expect(targets).toContain("rbuergi");
+    mesh.close();
+  });
+
+  it("answers [] with no target — an anonymous composer types on undisturbed", async () => {
+    const mesh = await Mesh.connect("https://portal.example", { transport: fakeMeshTransport() });
+    expect(await mesh.autocomplete("", "Doc")).toEqual([]);
+    mesh.close();
+  });
+});

--- a/clients/grpc-web/src/mesh.ts
+++ b/clients/grpc-web/src/mesh.ts
@@ -116,6 +116,32 @@ export class Mesh {
     return Array.isArray(parsed.results) ? parsed.results : [];
   }
 
+  /**
+   * One-shot @-mention autocomplete — the wire `AutocompleteRequest(Query, Context)` every
+   * data-enabled hub handles (`DataExtensions.HandleAutocompleteRequest`), targeted at the
+   * VIEWER's home hub (`target`), which aggregates all providers. THE one implementation:
+   * portal and portal-next each hand-rolled this observe (the #1497 drift shape — same wire,
+   * two copies, camelCase/PascalCase tolerated differently); both fold into this. Answers []
+   * on any failure — a composer whose suggestions cannot be served types on undisturbed.
+   */
+  async autocomplete(
+    target: string,
+    query: string,
+    contextPath?: string,
+  ): Promise<Record<string, unknown>[]> {
+    if (!target) return [];
+    try {
+      const resp = await this.conn.observe(target, "AutocompleteRequest", {
+        query,
+        context: contextPath ?? null,
+      });
+      const items = (resp.message["items"] ?? resp.message["Items"]) as Record<string, unknown>[] | undefined;
+      return Array.isArray(items) ? items : [];
+    } catch {
+      return [];
+    }
+  }
+
   /** Read a single node's current state (one snapshot off its live stream). */
   async get(path: string): Promise<MeshNode> {
     for await (const node of this.watch(path)) return node;

--- a/clients/grpc-web/src/testTransport.ts
+++ b/clients/grpc-web/src/testTransport.ts
@@ -75,6 +75,14 @@ export function fakeMeshTransport(opts: FakeMeshOptions = {}) {
             case "EchoRequest":
               respond(out, d, { $type: "EchoResponse", text: d.message.text });
               break;
+            case "AutocompleteRequest":
+              // The @-mention surface (DataExtensions.HandleAutocompleteRequest) — echoes a
+              // suggestion derived from the query so tests can assert the round-trip + target.
+              respond(out, d, {
+                $type: "AutocompleteResponse",
+                items: [{ label: `hit:${d.message.query}`, insertText: `@/${d.message.query}`, path: String(d.message.query) }],
+              });
+              break;
             // No QueryRequest responder — the REAL server has no such handler (issue #1473), and
             // faking one here is exactly how Mesh.search shipped posting into the void. Search is
             // REST (`/api/mesh/query-nodes`); tests exercise it via an injected fetch.

--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -23,10 +23,6 @@ import { ensureWebStyles } from "./src/webStyles";
 import { attachInstanceStore, currentInstance, discoverInstances, mergeDiscovered, setConnectStatus, type MeshInstance } from "./src/connection";
 import { type ClientDestination } from "./src/screens";
 import { ThemeProvider, useTheme } from "./src/theme";
-import { ChatComposer } from "./src/chat";
-import { ExpoAvRecorder } from "./src/speech/expoRecorder";
-import { SpeechTranscriptionClient } from "./src/speech/transcription";
-import type { ThreadSubmitter } from "./src/speech/pushToTalk";
 
 // The client connects to the CURRENT mesh instance — "Local" is the mesh that served this app
 // (same origin, anonymous, no CORS); a remote instance is a portal the user added by URL + token
@@ -38,31 +34,14 @@ import type { ThreadSubmitter } from "./src/speech/pushToTalk";
 // against a static file server). connect() only resolves on a real ack, so a non-mesh origin
 // can never swap the sample out for an empty live source.
 
-// The chat composer + CENTRALIZED speech pipeline (distinct from the shell's VoiceScreen, which is
-// the browser's on-device Web Speech API). `namespacePath` anchors new threads (your partition);
-// speech records via expo-av and posts the audio to the portal's `POST /api/speech/transcribe`
-// (the centralized Whisper container — see src/speech/transcription.ts; for a dev container use
-// `speech: { url: "http://localhost:8080", path: "/inference" }`). Set CHAT to null to hide the
-// composer entirely. Submission rides the SAME gRPC-web connection the renderer uses.
-interface ChatOptions {
-  namespacePath: string;
-  speech?: { url?: string; token?: string; path?: string; language?: string } | null;
-}
-// Speech follows the CURRENT mesh instance: with no `speech.url`/`speech.path`, the transcription client
-// POSTs to `{instance}/api/speech/transcribe` — the endpoint every backend now bakes in (the portal AND
-// the local sidecar Memex.LocalMesh), so voice input works in every shell (web, the macOS/Windows desktop
-// apps, and against a remote portal) with no separate container URL. To point at a bare dev Whisper
-// container instead, set `speech: { url: "http://localhost:8080", path: "/inference" }`.
-const CHAT: ChatOptions | null = {
-  namespacePath: "rbuergi",
-  speech: { language: "de" },
-};
-// const CHAT: ChatOptions | null = null;
-
+// The app-level "Message the mesh…" bar is GONE: the composer is the mesh-rendered
+// ThreadChatControl (the user home's Composer band, thread views), whose RN leaf now carries the
+// SAME shared model as the web leaf — @-mention autocomplete included — plus the speech pipeline
+// (ComposerBar). ONE composer, declared by the server, exactly like Blazor.
 // Threads anchor in the viewer's OWN partition: on the native local mesh that is the device user
 // (seeded by the sidecar's DeviceSeed); against a remote portal the configured namespacePath applies.
 const chatNamespace = (inst: MeshInstance): string =>
-  Platform.OS !== "web" && inst.local ? "device-user" : (CHAT?.namespacePath ?? "");
+  Platform.OS !== "web" && inst.local ? "device-user" : "";
 
 // 📱 The native-local landing: the device user's own node, rendered with its DECLARED default
 // area (the User layout declares the activities — the same landing as the MAUI shell) — the app
@@ -105,11 +84,13 @@ function AppInner() {
   // The CURRENT home: local → the device user's node; a signed-in remote → the viewer's OWN node
   // (resolved from the portal via /api/mesh/whoami below); anonymous remote → the docs HOME.
   const [home, setHome] = useState<NavTarget>(() => homeFor(currentInstance()));
+  // The signed-in REMOTE viewer's own partition (whoami) — read lazily by MeshOps (kernel anchor,
+  // autocomplete target), which is built before whoami resolves.
+  const viewerPartition = useRef("");
   const [clientScreen, setClientScreen] = useState<ClientDestination | null>(null);
   const [instanceTick, setInstanceTick] = useState(0);
   const [source, setSource] = useState<AreaSource>(() => new StaticAreaSource(sampleArea));
   const [liveConnected, setLiveConnected] = useState(false);
-  const [submitter, setSubmitter] = useState<ThreadSubmitter | undefined>(undefined);
   // The factory `@@` layout-area embeds (LayoutAreaControl) open their nested area streams through.
   const [embedFactory, setEmbedFactory] = useState<AreaSourceFactory | null>(null);
   // The MeshOps surface (interactive-markdown render + kernel, thread submit, node ops) the tree consumes
@@ -144,6 +125,7 @@ function AppInner() {
   useEffect(() => {
     const inst = currentInstance();
     const base = homeFor(inst);
+    viewerPartition.current = "";
     setHome(base);
     if (inst.local || !inst.token) return;
     let live = true;
@@ -157,6 +139,7 @@ function AppInner() {
         const userId = j?.userId ? String(j.userId).trim() : "";
         if (!live || !userId) return;
         const userHome: NavTarget = { address: userId, area: "" };
+        viewerPartition.current = userId;
         setHome(userHome);
         setNav((n) => (n.address === base.address && n.area === base.area ? userHome : n));
       })
@@ -191,13 +174,11 @@ function AppInner() {
         setSource(l.source);
         setLiveConnected(true);
         setConnectStatus("");
-        // The SAME gRPC-web connection carries thread submissions (Mesh.startThread / Mesh.submitMessage)
-        // AND the nested streams that `@@("area/X")` layout-area embeds open.
-        setSubmitter(Mesh.from(l.connection));
         setEmbedFactory(() => createGrpcEmbeddedFactory(l.connection));
         // The full MeshOps over the same connection — renderMarkdown (server Markdig) + the per-view kernel
-        // anchor the interactive markdown + runnable code cells; the kernel activity lives in CHAT's partition.
-        setMeshOps(buildMeshOps(l.connection, inst.url, chatNamespace(inst), inst.token));
+        // anchor the interactive markdown + runnable code cells; the kernel activity lives in the viewer's partition.
+        setMeshOps(buildMeshOps(l.connection, inst.url,
+          () => chatNamespace(inst) || viewerPartition.current, inst.token));
         // The LOCAL mesh is the instance STORE: hydrate the switcher's mesh list from its
         // MemexInstance nodes. A remote connect detaches (the in-memory cache keeps serving).
         void attachInstanceStore(
@@ -229,24 +210,7 @@ function AppInner() {
     };
   }, [nav.address, nav.area, instanceTick]);
 
-  // Speech seams — the transcription endpoint follows the CURRENT instance (or an explicit
-  // CHAT.speech.url override); the composer hides the mic when speech isn't configured.
-  const speech = useMemo(() => {
-    if (!CHAT?.speech) return null;
-    const inst = currentInstance();
-    const url = CHAT.speech.url ?? inst.url;
-    if (!url) return null; // no portal to transcribe against
-    return {
-      recorder: new ExpoAvRecorder(),
-      transcriber: new SpeechTranscriptionClient({
-        url,
-        token: CHAT.speech.token ?? inst.token,
-        path: CHAT.speech.path,
-        language: CHAT.speech.language,
-      }),
-      language: CHAT.speech.language,
-    };
-  }, [instanceTick]);
+
 
   // Offline (no ack yet): the sample tree's root area is "main"; live nav areas only exist
   // once a mesh is streaming.
@@ -276,15 +240,6 @@ function AppInner() {
         </EmbeddedAreaProvider>
        </MeshOpsProvider>
       </RegistryProvider>
-      {CHAT && (
-        <ChatComposer
-          submitter={submitter}
-          namespacePath={chatNamespace(currentInstance())}
-          recorder={speech?.recorder}
-          transcriber={speech?.transcriber}
-          language={speech?.language}
-        />
-      )}
     </SafeAreaView>
   );
 }

--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -17,7 +17,7 @@ import { rnPack } from "./src/rnPack";
 import { sampleArea } from "./src/sample";
 import { createLiveSource } from "./src/live";
 import { buildMeshOps } from "./src/liveOps";
-import { NavContext, CurrentAddressContext, type NavTarget } from "./src/nav";
+import { NavContext, CurrentAddressContext, resolveNavigationUri, type NavTarget } from "./src/nav";
 import { Shell, HOME } from "./src/Shell";
 import { ensureWebStyles } from "./src/webStyles";
 import { attachInstanceStore, currentInstance, discoverInstances, mergeDiscovered, setConnectStatus, type MeshInstance } from "./src/connection";
@@ -164,7 +164,7 @@ function AppInner() {
     let live: Awaited<ReturnType<typeof createLiveSource>> | null = null;
     let cancelled = false;
     setConnectStatus(`Connecting to ${inst.name}…`);
-    createLiveSource({ url: inst.url, token: inst.token, address: nav.address, area: nav.area })
+    createLiveSource({ url: inst.url, token: inst.token, address: nav.address, area: nav.area, id: nav.id })
       .then((l) => {
         if (cancelled) {
           l.connection.close();
@@ -175,6 +175,14 @@ function AppInner() {
         setLiveConnected(true);
         setConnectStatus("");
         setEmbedFactory(() => createGrpcEmbeddedFactory(l.connection));
+        // Server-initiated navigation (a clickable stack's ClickedEvent is answered with a
+        // NavigationRequest — the Store's category tiles) — the client twin of Blazor's
+        // NavigationService: resolve the uri's node/area split server-side and navigate.
+        l.connection.onMessage("NavigationRequest", (d) => {
+          const uri = String((d.message as { uri?: unknown }).uri ?? "");
+          if (!uri) return;
+          void resolveNavigationUri(uri, inst.url, inst.token || undefined).then(navigate);
+        });
         // The full MeshOps over the same connection — renderMarkdown (server Markdig) + the per-view kernel
         // anchor the interactive markdown + runnable code cells; the kernel activity lives in the viewer's partition.
         setMeshOps(buildMeshOps(l.connection, inst.url,
@@ -208,7 +216,7 @@ function AppInner() {
       cancelled = true;
       live?.connection.close();
     };
-  }, [nav.address, nav.area, instanceTick]);
+  }, [nav.address, nav.area, nav.id, instanceTick]);
 
 
 

--- a/clients/react-native/src/leftMenu.tsx
+++ b/clients/react-native/src/leftMenu.tsx
@@ -9,6 +9,7 @@ import { useState, type ReactNode } from "react";
 import { View, Text, Pressable, ScrollView } from "react-native";
 import type { AreaTree } from "@meshweaver/react/core";
 import { type NavTarget } from "./nav";
+import { IconGlyph } from "./rnIcon";
 import { useStyles, type Palette } from "./theme";
 import { StyleSheet } from "react-native";
 
@@ -116,7 +117,7 @@ export function LeftMenuView<D>({
     if (it.area) onNavigate({ address: nav.address, area: it.area });
   };
 
-  const rowLabel = (it: MenuItem) => `${it.icon ? `${it.icon}  ` : ""}${it.label ?? it.area ?? ""}`;
+  const rowLabel = (it: MenuItem) => it.label ?? it.area ?? "";
 
   const entry = (it: MenuItem, i: number) =>
     it.area === SEPARATOR_AREA ? (
@@ -125,6 +126,7 @@ export function LeftMenuView<D>({
       <NavRow
         key={i}
         label={rowLabel(it)}
+        icon={it.icon}
         active={!clientScreen && nav.area === it.area}
         onPress={() => activate(it)}
         chevron={isSubmenuParent(it)}
@@ -193,6 +195,7 @@ export function LeftMenuView<D>({
  */
 export function NavRow({
   label,
+  icon,
   active,
   onPress,
   chevron,
@@ -200,6 +203,10 @@ export function NavRow({
   opensSubmenu,
 }: {
   label: string;
+  /** Optional icon string — emoji, inline SVG, or a mesh-relative .svg URL. Drawn as a real
+   *  GLYPH (IconGlyph): inlining it into the label rendered the colorful node icons as their
+   *  literal "/static/….svg" paths. */
+  icon?: string;
   active: boolean;
   onPress: () => void;
   chevron?: boolean;
@@ -215,6 +222,7 @@ export function NavRow({
       accessibilityLabel={accessibilityLabel ?? label}
       accessibilityState={opensSubmenu ? { expanded: false } : { selected: active }}
     >
+      {icon ? <View style={styles.navIcon}><IconGlyph icon={icon} size={18} /></View> : null}
       <Text style={[styles.navItemText, active && styles.navItemTextActive]} numberOfLines={1}>{label}</Text>
       {chevron ? <Text style={styles.navChevron}>›</Text> : null}
     </Pressable>
@@ -230,6 +238,7 @@ const makeStyles = (p: Palette) =>
     navItem: { flexDirection: "row", alignItems: "center", minHeight: 44, paddingHorizontal: 16, paddingVertical: 7, marginHorizontal: 8, borderRadius: 6 },
     navItemHover: { backgroundColor: p.navHover },
     navItemActive: { backgroundColor: p.navActiveBg },
+    navIcon: { width: 22, marginRight: 8, alignItems: "center" },
     navItemText: { flexShrink: 1, fontSize: 13.5, color: p.text },
     navItemTextActive: { color: p.navActiveText, fontWeight: "600" },
     navChevron: { marginLeft: "auto", paddingLeft: 8, fontSize: 16, color: p.textMuted },

--- a/clients/react-native/src/liveOps.ts
+++ b/clients/react-native/src/liveOps.ts
@@ -7,6 +7,7 @@
 // parser; the Markdown leaf hydrates its HTML with the shared splitRenderedHtml — no bespoke parser.
 import { Mesh, MeshRest, type MeshWebConnection } from "@meshweaver/client-web";
 import type {
+  AutocompleteSuggestion,
   ContentListing,
   DocumentDownload,
   DocumentExportOptions,
@@ -157,7 +158,15 @@ async function* watchNode(mesh: Mesh, path: string): AsyncIterable<MeshNodeState
  * Build the RN MeshOps from a live connection. `partition` anchors the interactive-markdown kernel
  * activity (the viewer's home partition — CHAT.namespacePath on the anonymous sidecar).
  */
-export function buildMeshOps(connection: MeshWebConnection, baseUrl: string, partition: string, token = ""): MeshOps {
+export function buildMeshOps(
+  connection: MeshWebConnection,
+  baseUrl: string,
+  partition: string | (() => string),
+  token = "",
+): MeshOps {
+  // The viewer's partition may resolve AFTER connect (a signed-in remote's identity arrives via
+  // whoami) — accept a thunk so the kernel anchor and the autocomplete target read it at CALL time.
+  const partitionOf = typeof partition === "function" ? partition : () => partition;
   // The REST reach-back (search + the helpers below) carries the instance's Bearer token; empty
   // = the anonymous sidecar. Without it every REST op 401'd against a remote portal (#1474).
   const mesh = Mesh.from(connection, "mesh/main", { url: baseUrl, token: token || undefined });
@@ -170,7 +179,10 @@ export function buildMeshOps(connection: MeshWebConnection, baseUrl: string, par
   return {
     // The viewer's partition doubles as their mesh id — viewer-scoped reads (the home Apps
     // grid's most-recently-used ordering over {viewer}/_UserActivity) resolve it from here.
-    userId: partition,
+    // A getter: it must track the thunk (a remote's identity resolves after connect).
+    get userId() {
+      return partitionOf();
+    },
     watch: (path: string) => watchNode(mesh, path),
     startThread: (namespacePath: string, userText: string, opts?: ThreadSubmitOptions) =>
       mesh.startThread(namespacePath, userText, opts),
@@ -179,8 +191,13 @@ export function buildMeshOps(connection: MeshWebConnection, baseUrl: string, par
     patch: (path: string, fields: Record<string, unknown>) => mesh.patch(path, fields),
     search: (query: string, basePath?: string, limit?: number) =>
       mesh.search(query, basePath, limit).catch(() => [] as Record<string, unknown>[]),
+    // @-mention autocomplete — the ONE shared implementation (Mesh.autocomplete: the wire
+    // AutocompleteRequest at the viewer's home hub). `partition` IS that hub: the device user on
+    // the local sidecar, the signed-in viewer's own partition against a portal.
+    autocomplete: (query: string, contextPath?: string) =>
+      mesh.autocomplete(partitionOf(), query, contextPath) as Promise<AutocompleteSuggestion[]>,
     renderMarkdown: (markdown: string, nodePath?: string) => rest.renderMarkdown(markdown, nodePath),
-    startMarkdownKernel: (cells: MarkdownCellSubmission[]) => startMarkdownKernel(connection, mesh, partition, cells),
+    startMarkdownKernel: (cells: MarkdownCellSubmission[]) => startMarkdownKernel(connection, mesh, partitionOf(), cells),
     getNode: (path: string) => mesh.get(path).then((n) => n.raw as Record<string, unknown>).catch(() => null),
     createNode: (node: Record<string, unknown>) => mesh.create(node).then(() => undefined),
     // The file-browser and document-export ops. These are plain REST / mesh-request calls with no

--- a/clients/react-native/src/nativeHtml.native.tsx
+++ b/clients/react-native/src/nativeHtml.native.tsx
@@ -3,12 +3,50 @@
 // this .native file, while web/tsc/vitest use nativeHtml.tsx (no render-html dep). Same split as nativeFetch.
 import { useMemo } from "react";
 import RenderHtml from "react-native-render-html";
-import { SvgUri } from "react-native-svg";
+import { SvgUri, SvgXml } from "react-native-svg";
 import { View, Image, useWindowDimensions, Platform, StyleSheet } from "react-native";
 import { resolveAssetUrl } from "./connection";
 
+/** Aspect ratio off an inline svg's viewBox/width/height, for sizing; 4:3 when undeclared. */
+function svgAspect(markup: string): number {
+  const vb = /viewBox\s*=\s*["']\s*[\d.eE+-]+[\s,]+[\d.eE+-]+[\s,]+([\d.eE+-]+)[\s,]+([\d.eE+-]+)/.exec(markup);
+  if (vb) {
+    const w = parseFloat(vb[1]);
+    const h = parseFloat(vb[2]);
+    if (w > 0 && h > 0) return w / h;
+  }
+  return 4 / 3;
+}
+
 export function NativeHtml({ html }: { html: string }) {
   const { width } = useWindowDimensions();
+  // Inline <svg> blocks (the docs' colorful diagrams) render through react-native-svg — the HTML
+  // renderer cannot draw them (they sit in IGNORED_TAGS), which silently DROPPED every diagram on
+  // a device. Split them out and interleave: html chunks through RenderHtml, svg chunks through
+  // SvgXml sized to the content width by their viewBox aspect. The non-greedy match is fine for
+  // doc diagrams (top-level, un-nested); a nested <svg> would simply fall back to being dropped.
+  const contentW = Math.max(240, (width || 360) - 96);
+  const svgSplit = useMemo(() => (html || "").split(/(<svg[\s\S]*?<\/svg>)/gi), [html]);
+  if (svgSplit.length > 1)
+    return (
+      <View style={{ paddingLeft: 2 }}>
+        {svgSplit.map((chunk, i) =>
+          /^<svg/i.test(chunk) ? (
+            <SvgXml key={i} xml={chunk} width={contentW} height={Math.round(contentW / svgAspect(chunk))} />
+          ) : chunk.trim() ? (
+            <NativeHtmlChunk key={i} html={chunk} contentW={contentW} />
+          ) : null,
+        )}
+      </View>
+    );
+  return (
+    <View style={{ paddingLeft: 2 }}>
+      <NativeHtmlChunk html={html} contentW={contentW} />
+    </View>
+  );
+}
+
+function NativeHtmlChunk({ html, contentW }: { html: string; contentW: number }) {
   // Strip the inline style off HEADINGS and DIVS (keep <span> colors). Memoized on `html` — NativeHtml
   // re-renders on width changes/parent renders, and this shouldn't re-run the regex each time.
   //  • headings — `<h1 style="font-size:2rem; line-height:1.15; letter-spacing:-0.02em">` makes render-html
@@ -18,19 +56,18 @@ export function NativeHtml({ html }: { html: string }) {
   //    still reserve a big empty band after the title. Dropping div styles collapses that dead space.
   const cleaned = useMemo(() => (html || "").replace(/(<(?:h[1-6]|div)\b[^>]*?)\sstyle="[^"]*"/gi, "$1"), [html]);
   return (
-    <View style={{ paddingLeft: 2 }}>
       <RenderHtml
         source={{ html: cleaned }}
-        contentWidth={Math.max(240, (width || 360) - 96)}
+        contentWidth={contentW}
         baseStyle={BASE}
         tagsStyles={TAGS}
         systemFonts={SYSTEM_FONTS}
         defaultTextProps={{ selectable: true }}
         renderers={RENDERERS}
-        // Inline <svg>/<picture>/<source> aren't handled; <img> is (see RENDERERS.img).
+        // Standalone inline <svg> blocks are interleaved by NativeHtml above; a NESTED svg (inside
+        // a paragraph) still lands here and is dropped — <picture>/<source> stay unhandled.
         ignoredDomTags={IGNORED_TAGS}
       />
-    </View>
   );
 }
 

--- a/clients/react-native/src/nav.tsx
+++ b/clients/react-native/src/nav.tsx
@@ -5,6 +5,9 @@ import { createContext, useContext } from "react";
 export interface NavTarget {
   address: string;
   area: string;
+  /** Optional area instance id — carries the query string too (LayoutAreaReference.Id parses
+   *  `?name=value` parameters off it, e.g. the Store category filter). */
+  id?: string;
 }
 
 export const NavContext = createContext<(t: NavTarget) => void>(() => {});
@@ -34,4 +37,52 @@ export function parseHref(href: string, currentAddress: string): NavTarget | nul
   // dissolved to nothing is a miss.
   if (parts.length === 0) return href.startsWith("/") ? { address: "", area: "" } : null;
   return { address: parts.join("/"), area: "" };
+}
+
+/**
+ * Resolve a server-sent NavigationRequest uri ("{path}[/{area}[/{id}]][?query]") into a NavTarget —
+ * the client twin of Blazor's NavigationService.NavigateTo(uri) + route resolution. The node/area
+ * split is the SERVER's (`POST /api/mesh/resolve`, the same verb portal-next resolves URLs with):
+ * a node path can span many segments, so the client never guesses the prefix. The query string
+ * rides in the id (LayoutAreaReference.Id parses `?name=value` off it — the Store's
+ * `Catalog?category=Games` shape). Falls back to whole-path + default area when the verb is
+ * missing or fails, matching portal-next's fetchAreaTarget.
+ */
+export async function resolveNavigationUri(
+  uri: string,
+  baseUrl: string,
+  token?: string,
+): Promise<NavTarget> {
+  const qIndex = uri.indexOf("?");
+  const path = (qIndex < 0 ? uri : uri.slice(0, qIndex)).replace(/^\/+|\/+$/g, "");
+  const query = qIndex < 0 ? "" : uri.slice(qIndex);
+  const fallback: NavTarget = { address: path, area: "", id: query || undefined };
+  if (!path) return fallback;
+  try {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/mesh/resolve`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ path }),
+    });
+    if (!resp.ok) return fallback;
+    const text = await resp.text();
+    if (text.startsWith("Error:") || text.startsWith("Not found:")) return fallback;
+    const parsed = JSON.parse(text) as { prefix?: string; remainder?: string | null };
+    const prefix = String(parsed.prefix ?? "");
+    if (!prefix) return fallback;
+    const remainder = String(parsed.remainder ?? "").replace(/^\/+|\/+$/g, "");
+    const slash = remainder.indexOf("/");
+    const area = slash < 0 ? remainder : remainder.slice(0, slash);
+    const idPath = slash < 0 ? "" : remainder.slice(slash + 1);
+    // The query rides in the Id, PREFIXED by a path — the Store contract is Id
+    // "Catalog?category=…" (CategoryHref): with no id segment of its own, the area name is the
+    // Id's path half. A bare "?category=…" reads as a data-collection id server-side and fails
+    // with "Collection ?category=… is not mapped".
+    const id = query ? `${idPath || area}${query}` : idPath;
+    return { address: prefix, area, id: id || undefined };
+  } catch {
+    return fallback;
+  }
 }

--- a/clients/react-native/src/rnComposer.tsx
+++ b/clients/react-native/src/rnComposer.tsx
@@ -1,0 +1,203 @@
+// The RN thread composer bar — the native skin over the SHARED composer model
+// (@meshweaver/react/core useMentionModel): @-mention autocomplete exactly like the web leaf and
+// Blazor's MeshNodeAutocomplete, plus the speech pipeline (tap-dictate / hold-PTT) that used to
+// live on the app-level "Message the mesh…" bar. The app bar is GONE: the mesh renders the
+// composer wherever a thread surface appears (ThreadChatControl — the user home's Composer band,
+// thread views, side panels), so there is ONE composer, declared by the server, same as Blazor.
+import { useMemo, useRef, useState } from "react";
+import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { useLocalize, useMentionModel, type MeshOps } from "@meshweaver/react/core";
+import { currentInstance } from "./connection";
+import { ExpoAvRecorder } from "./speech/expoRecorder";
+import { SpeechTranscriptionClient } from "./speech/transcription";
+import { PushToTalkController, type SpeechFlowState } from "./speech/pushToTalk";
+
+const str = (v: unknown): string => (v == null ? "" : String(v));
+
+export interface ComposerBarProps {
+  ops: MeshOps | null;
+  /** The active thread (submits go here); null starts a new one under `namespacePath`. */
+  threadPath: string | null;
+  /** Namespace a NEW thread anchors under (ThreadChatControl.namespacePath). */
+  namespacePath?: string;
+  /** Context path carried on submissions and anchoring the @-mention autocomplete. */
+  contextPath?: string;
+  /** Fired when a submit created the thread — the leaf pins later sends to it. */
+  onThreadStarted: (path: string) => void;
+}
+
+export function ComposerBar({ ops, threadPath, namespacePath, contextPath, onThreadStarted }: ComposerBarProps) {
+  const t = useLocalize();
+  const [text, setText] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [speechState, setSpeechState] = useState<SpeechFlowState>("idle");
+
+  // ── the SHARED mention model (core) — this leaf only renders the dropdown natively ──────────
+  const mention = useMentionModel(ops, contextPath || threadPath || undefined);
+  const textRef = useRef("");
+  textRef.current = text;
+  const onChange = (value: string) => {
+    setText(value);
+    // RN reports the caret via onSelectionChange; for typing at the end (the overwhelming case)
+    // the end-of-text caret is correct, and a mid-text selection change re-tracks right after.
+    mention.track(value, value.length);
+  };
+  const onSelectionChange = (e: { nativeEvent: { selection: { end: number } } }) =>
+    mention.track(textRef.current, e.nativeEvent.selection.end);
+  const pick = (sIdx: number) => {
+    const next = mention.pick(textRef.current, mention.suggestions[sIdx]);
+    if (next != null) setText(next);
+  };
+
+  // ── send (the leaf's canonical submit surface — Mesh.startThread / Mesh.submitMessage) ──────
+  const send = () => {
+    const body = text.trim();
+    if (!body || !ops || sending) return;
+    setSending(true);
+    setError(null);
+    mention.dismiss();
+    const done = () => {
+      setSending(false);
+      setText("");
+    };
+    const fail = (e: unknown) => {
+      setSending(false);
+      setError(e instanceof Error ? e.message : String(e));
+    };
+    if (threadPath) {
+      ops.submitMessage(threadPath, body, { contextPath: contextPath || undefined }).then(done, fail);
+    } else if (namespacePath) {
+      ops.startThread(namespacePath, body, { contextPath: contextPath || undefined }).then((r) => {
+        onThreadStarted(r.path);
+        done();
+      }, fail);
+    } else {
+      setSending(false);
+      setError(t("chat.noNamespace"));
+    }
+  };
+
+  // ── speech (moved off the deleted app bar): mic tap = dictate → draft; hold = PTT → submit ──
+  const threadRef = useRef<string | null>(null);
+  threadRef.current = threadPath;
+  const controller = useMemo(() => {
+    const inst = currentInstance();
+    if (!inst.url || !ops) return null;
+    return new PushToTalkController({
+      recorder: new ExpoAvRecorder(),
+      transcriber: new SpeechTranscriptionClient({ url: inst.url, token: inst.token || undefined }),
+      submitter: ops,
+      namespacePath: namespacePath ?? "",
+      getActiveThreadPath: () => threadRef.current,
+      onThreadStarted,
+      onTranscript: (transcript) =>
+        setText((d) => (d.trim().length > 0 ? `${d} ${transcript}` : transcript)),
+      onStateChange: (state, err) => {
+        setSpeechState(state);
+        setError(err ?? null);
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ops, namespacePath]);
+  const pttActive = useRef(false);
+
+  return (
+    <View>
+      {mention.open ? (
+        <View style={styles.mentionBox} accessibilityRole="menu">
+          {mention.suggestions.map((sugg, i) => (
+            <Pressable
+              key={`${str(sugg.insertText) || str(sugg.path)}-${i}`}
+              accessibilityRole="menuitem"
+              onPress={() => pick(i)}
+              style={[styles.mentionRow, i === mention.highlight && styles.mentionRowActive]}
+            >
+              <Text style={styles.mentionLabel}>{str(sugg.label) || str(sugg.path)}</Text>
+              {sugg.path || sugg.description ? (
+                <Text style={styles.mentionSub} numberOfLines={1}>
+                  {str(sugg.path) || str(sugg.description)}
+                </Text>
+              ) : null}
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      {speechState !== "idle" ? (
+        <View style={styles.speechRow}>
+          {speechState === "recording" ? <View style={styles.recDot} /> : <ActivityIndicator size="small" />}
+          <Text style={styles.speechText}>
+            {speechState === "recording" ? t("chat.recording") : t("chat.transcribing")}
+          </Text>
+        </View>
+      ) : null}
+      <View style={styles.row}>
+        <TextInput
+          style={styles.input}
+          value={text}
+          onChangeText={onChange}
+          onSelectionChange={onSelectionChange}
+          placeholder={t("chat.composerPlaceholder")}
+          multiline
+          editable={!!ops}
+          onSubmitEditing={send}
+        />
+        {controller ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t("chat.dictate")}
+            style={styles.micButton}
+            onPress={() => {
+              // Tap: start dictation / stop-and-transcribe INTO the draft. A long-press release
+              // also fires onPress — the PTT path owns that gesture (chat-bar semantics, kept).
+              if (pttActive.current) return;
+              if (controller.state === "recording") void controller.stopInto("composer").catch(() => {});
+              else void controller.start().catch(() => {});
+            }}
+            onLongPress={() => {
+              // Hold-to-talk: record while held, release transcribes and SUBMITS directly.
+              if (controller.state !== "idle") return;
+              pttActive.current = true;
+              void controller.start().catch(() => {});
+            }}
+            onPressOut={() => {
+              if (!pttActive.current) return;
+              pttActive.current = false;
+              if (controller.state === "recording") void controller.stopInto("submit").catch(() => {});
+            }}
+          >
+            <Text style={styles.micText}>{speechState === "recording" ? "■" : "🎤"}</Text>
+          </Pressable>
+        ) : null}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t("common.send")}
+          style={[styles.sendButton, (!text.trim() || sending) && styles.sendButtonDisabled]}
+          onPress={send}
+        >
+          <Text style={styles.sendButtonText}>{sending ? "…" : "➤"}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: "row", alignItems: "flex-end", gap: 8 },
+  input: { flex: 1, borderWidth: 1, borderColor: "#d1d1d1", borderRadius: 8, paddingHorizontal: 10, paddingVertical: 8, minHeight: 40, maxHeight: 120, fontSize: 15 },
+  micButton: { width: 40, height: 40, borderRadius: 20, backgroundColor: "#f0f0f0", alignItems: "center", justifyContent: "center" },
+  micText: { fontSize: 18 },
+  sendButton: { backgroundColor: "#0f6cbd", width: 40, height: 40, borderRadius: 20, alignItems: "center", justifyContent: "center" },
+  sendButtonDisabled: { opacity: 0.5 },
+  sendButtonText: { color: "#ffffff", fontSize: 15, fontWeight: "600" },
+  mentionBox: { borderWidth: 1, borderColor: "#e1e1e1", borderRadius: 8, marginBottom: 6, backgroundColor: "#ffffff", overflow: "hidden" },
+  mentionRow: { paddingVertical: 6, paddingHorizontal: 10 },
+  mentionRowActive: { backgroundColor: "#e1ebf7" },
+  mentionLabel: { fontSize: 13, fontWeight: "600", color: "#242424" },
+  mentionSub: { fontSize: 11, color: "#8a8a8a" },
+  error: { color: "#d13438", fontSize: 12, marginBottom: 4 },
+  speechRow: { flexDirection: "row", alignItems: "center", gap: 6, marginBottom: 4 },
+  recDot: { width: 10, height: 10, borderRadius: 5, backgroundColor: "#d13438" },
+  speechText: { fontSize: 12, color: "#616161" },
+});

--- a/clients/react-native/src/rnIcon.tsx
+++ b/clients/react-native/src/rnIcon.tsx
@@ -1,0 +1,36 @@
+// The ONE native icon glyph — the RN twin of the web pack's MeshIcon, over the SAME shared
+// classification (classifyIcon): inline `<svg>` markup and `.svg` URLs render through
+// react-native-svg (RN's Image cannot decode SVG — the reason the colorful node-icon set showed
+// as blanks), raster URLs through Image, emoji as text, a Fluent NAME as a neutral chip (no DOM
+// icon set on native). Relative URLs resolve against the CURRENT instance (resolveAssetUrl) — a
+// device has no origin of its own. Used by the Icon control leaf, the left-menu rows, and any
+// leaf that needs an icon string drawn.
+import { Image, Text, View } from "react-native";
+import { SvgUri, SvgXml } from "react-native-svg";
+import { classifyIcon } from "@meshweaver/react/core";
+import { resolveAssetUrl } from "./connection";
+import type { ReactNode } from "react";
+
+export function IconGlyph({ icon, size = 20 }: { icon?: string; size?: number }): ReactNode {
+  const classified = classifyIcon((icon ?? "") as never);
+  switch (classified.kind) {
+    case "svg":
+      return <SvgXml xml={classified.text} width={size} height={size} />;
+    case "url": {
+      const url = resolveAssetUrl(classified.text);
+      return /\.svg(\?|#|$)/i.test(url)
+        ? <SvgUri uri={url} width={size} height={size} />
+        : <Image source={{ uri: url }} style={{ width: size, height: size, resizeMode: "contain" }} />;
+    }
+    case "emoji":
+      return <Text style={{ fontSize: size * 0.9, lineHeight: size * 1.15 }}>{classified.text}</Text>;
+    case "fluent":
+      return (
+        <View style={{ width: size, height: size, alignItems: "center", justifyContent: "center" }}>
+          <Text style={{ fontSize: size * 0.7, color: "#8a8a8a" }}>▨</Text>
+        </View>
+      );
+    default:
+      return null;
+  }
+}

--- a/clients/react-native/src/rnMeshLive.test.tsx
+++ b/clients/react-native/src/rnMeshLive.test.tsx
@@ -525,3 +525,42 @@ describe("ResultIcon url handling (the icons-not-showing defect)", () => {
     expect(uris).toContain("http://localhost:5250/static/NodeTypeIcons/book.svg");
   });
 });
+
+// ---- the SHARED composer model on the RN leaf (@-mention autocomplete) -----------------------
+
+describe("ThreadChat composer @-mentions (core useMentionModel, native dropdown)", () => {
+  it("typing an @token opens suggestions from ops.autocomplete; picking splices the insertText", async () => {
+    const autocomplete = vi.fn(async () => [
+      { label: "Documentation", insertText: "@/Doc", path: "Doc" },
+    ]);
+    const ops = fakeOps({ autocomplete });
+    let r!: TestRenderer.ReactTestRenderer;
+    await TestRenderer.act(async () => {
+      r = TestRenderer.create(
+        <NavContext.Provider value={() => {}}>
+          <RegistryProvider pack={rnPack}>
+            <MeshOpsProvider ops={ops}>
+              <ScopeProvider
+                source={new StaticAreaSource({ areas: { main: { $type: "ThreadChat", namespacePath: "u1" } as never } })}
+                area="main"
+              >
+                <RenderArea areaKey="main" />
+              </ScopeProvider>
+            </MeshOpsProvider>
+          </RegistryProvider>
+        </NavContext.Provider>,
+      );
+    });
+    const input = r.root.findAll((n) => String(n.type) === "TextInput"
+      && n.props.placeholder === en("chat.composerPlaceholder"))[0];
+    await TestRenderer.act(async () => { input.props.onChangeText("hello @do"); });
+    await TestRenderer.act(async () => { await new Promise((res) => setTimeout(res, 300)); }); // the model's debounce
+    expect(autocomplete).toHaveBeenCalledWith("@do", undefined);
+    const item = r.root.findAll((n) => typeof n.type === "string" && n.props?.accessibilityRole === "menuitem")[0];
+    expect(item).toBeTruthy();
+    await TestRenderer.act(async () => { item.props.onPress(); });
+    const after = r.root.findAll((n) => String(n.type) === "TextInput"
+      && n.props.placeholder === en("chat.composerPlaceholder"))[0];
+    expect(after.props.value).toBe("hello @/Doc ");
+  });
+});

--- a/clients/react-native/src/rnMeshLive.tsx
+++ b/clients/react-native/src/rnMeshLive.tsx
@@ -36,6 +36,7 @@ import {
 } from "@meshweaver/react/core";
 import { useNavigate } from "./nav";
 import { resolveAssetUrl } from "./connection";
+import { ComposerBar } from "./rnComposer";
 import { useTheme } from "./theme";
 
 const s = str;
@@ -226,41 +227,9 @@ const ThreadChat: ControlComponent = ({ control }) => {
       .map((id) => ({ id, msg: pending[id] })),
   ].filter((x): x is { id: string; msg: ThreadMessageJson } => x.msg != null);
 
-  const [text, setText] = useState("");
-  const [sendError, setSendError] = useState<string | null>(null);
-  const [sending, setSending] = useState(false);
-
   // The namespace a NEW thread is created under (ThreadChatControl.namespacePath), resolved with the
   // other bindings — never inside the submit handler.
   const namespacePath = s(useResolve(control.namespacePath ?? control.namespace)) || initialContext;
-
-  const send = () => {
-    const body = text.trim();
-    if (!body || !ops || sending) return;
-    setSending(true);
-    setSendError(null);
-    const done = () => {
-      setSending(false);
-      setText("");
-    };
-    const fail = (e: unknown) => {
-      setSending(false);
-      setSendError(e instanceof Error ? e.message : String(e));
-    };
-    if (threadPath) {
-      ops.submitMessage(threadPath, body, { contextPath: initialContext || undefined }).then(done, fail);
-    } else {
-      if (!namespacePath) {
-        setSending(false);
-        setSendError(t("chat.noNamespace"));
-        return;
-      }
-      ops.startThread(namespacePath, body, { contextPath: initialContext || undefined }).then((r) => {
-        setCreatedPath(r.path);
-        done();
-      }, fail);
-    }
-  };
 
   return (
     <View style={styles.chat}>
@@ -285,28 +254,15 @@ const ThreadChat: ControlComponent = ({ control }) => {
           </View>
         ) : null}
       </ScrollView>
-      {sendError ? <Text style={styles.error}>{sendError}</Text> : null}
-      <View style={styles.composerRow}>
-        <TextInput
-          style={styles.composerInput}
-          value={text}
-          onChangeText={setText}
-          placeholder={t("chat.composerPlaceholder")}
-          multiline
-          editable={!!ops}
-          onSubmitEditing={send}
-        />
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t("common.send")}
-          style={[styles.sendButton, (!text.trim() || sending) && styles.sendButtonDisabled]}
-          onPress={send}
-        >
-          {/* A glyph, not the word — universal, compact on a phone; the localized "Send"
-              survives as the accessibilityLabel above (the i18n icon+tooltip rule). */}
-          <Text style={styles.sendButtonText}>{sending ? "…" : "➤"}</Text>
-        </Pressable>
-      </View>
+      {/* ONE composer everywhere: the shared model (core useMentionModel) + the speech pipeline,
+          rendered by ComposerBar — the same surface the deleted app-level bar used to be. */}
+      <ComposerBar
+        ops={ops}
+        threadPath={threadPath}
+        namespacePath={namespacePath || undefined}
+        contextPath={initialContext || undefined}
+        onThreadStarted={setCreatedPath}
+      />
     </View>
   );
 };

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -65,18 +65,27 @@ function Children({ control }: { control: any }) {
 // ── skins (layout) ──────────────────────────────────────────────────────────
 const stack: SkinComponent = ({ skin, control }) => {
   const horizontal = s(skin.orientation).toLowerCase() === "horizontal";
+  const emit = useEmit();
+  const { area } = useScope();
+  const layout = {
+    flexDirection: horizontal ? ("row" as const) : ("column" as const),
+    // Row: WRAP (a toolbar of node actions overflows a phone otherwise) and size children to their
+    // content height (default `stretch` blew buttons up to fill the row). Column: keep `stretch` so
+    // children fill the width (cards, text, the doc body).
+    flexWrap: horizontal ? ("wrap" as const) : ("nowrap" as const),
+    alignItems: horizontal ? ("flex-start" as const) : ("stretch" as const),
+    gap: (skin.verticalGap ?? skin.horizontalGap ?? 8) as number,
+  };
+  // A CLICKABLE stack posts the ClickedEvent, exactly as Blazor's LayoutStack does — the Store's
+  // category tiles are this shape (isClickable + cursor:pointer) and were inert cards without it.
+  if (control.isClickable)
+    return (
+      <Pressable accessibilityRole="button" style={layout} onPress={() => emit({ kind: "click", area })}>
+        <Children control={control} />
+      </Pressable>
+    );
   return (
-    <View
-      style={{
-        flexDirection: horizontal ? "row" : "column",
-        // Row: WRAP (a toolbar of node actions overflows a phone otherwise) and size children to their
-        // content height (default `stretch` blew buttons up to fill the row). Column: keep `stretch` so
-        // children fill the width (cards, text, the doc body).
-        flexWrap: horizontal ? "wrap" : "nowrap",
-        alignItems: horizontal ? "flex-start" : "stretch",
-        gap: (skin.verticalGap ?? skin.horizontalGap ?? 8) as number,
-      }}
-    >
+    <View style={layout}>
       <Children control={control} />
     </View>
   );

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -7,6 +7,7 @@ import { View, Text, TextInput, Pressable, Switch, ScrollView, ActivityIndicator
 import { SvgXml } from "react-native-svg";
 import { marked } from "marked";
 import { NativeHtml } from "./nativeHtml";
+import { IconGlyph } from "./rnIcon";
 import {
   ControlRenderer,
   RenderArea,
@@ -583,19 +584,9 @@ const Spacer: ControlComponent = () => <View style={{ flex: 1 }} />;
 // native) shows a neutral chip. The DECISION lives in the core; only the leaves are native.
 const Icon: ControlComponent = ({ control }) => {
   const v = useResolve(control.icon ?? control.data);
-  const classified = classifyIcon(v as never);
-  switch (classified.kind) {
-    case "svg":
-      return <SvgXml xml={classified.text} width={20} height={20} />;
-    case "url":
-      return <Image source={{ uri: classified.text }} style={{ width: 20, height: 20, resizeMode: "contain" }} />;
-    case "emoji":
-      return <Text style={styles.body}>{classified.text}</Text>;
-    case "fluent":
-      return <Text style={styles.body}>▨</Text>;
-    default:
-      return null;
-  }
+  // One shared glyph (rnIcon): resolves relative URLs against the instance and routes .svg
+  // through react-native-svg — RN's Image decodes neither, which left the colorful node icons blank.
+  return <IconGlyph icon={s(v)} />;
 };
 
 // ── mesh display controls (native twins of controls/mesh.tsx) ──────────────────────────────────────

--- a/clients/react-native/test/expo-av.mock.tsx
+++ b/clients/react-native/test/expo-av.mock.tsx
@@ -5,3 +5,16 @@ import React from "react";
 export const Video = ({ children, ...props }: any) => React.createElement("Video", props, children);
 
 export const ResizeMode = { CONTAIN: "contain", COVER: "cover", STRETCH: "stretch" } as const;
+
+// The Audio surface expoRecorder reads at MODULE LOAD (RECORDING_OPTIONS): rnComposer — the shared
+// composer bar the ThreadChat leaf mounts — imports it into the pack graph, so headless tests need
+// the enums present (never a real recording).
+export const Audio = {
+  IOSOutputFormat: { LINEARPCM: "lpcm" },
+  IOSAudioQuality: { HIGH: "high" },
+  AndroidOutputFormat: { MPEG_4: 2 },
+  AndroidAudioEncoder: { AAC: 3 },
+  requestPermissionsAsync: async () => ({ granted: true }),
+  setAudioModeAsync: async () => {},
+  Recording: { createAsync: async () => ({ recording: { stopAndUnloadAsync: async () => {}, getURI: () => null } }) },
+} as any;

--- a/clients/react/src/controls/composerModel.ts
+++ b/clients/react/src/controls/composerModel.ts
@@ -1,0 +1,107 @@
+// The thread composer's @-MENTION MODEL — the platform-free half of the composer every shell
+// shares (the same factoring meshSearchModel gave the search surface). The web ThreadChat leaf
+// (Fluent Textarea) and the RN leaf (native TextInput) both consume THIS: token tracking against
+// the caret, the debounced MeshOps.autocomplete fetch (generation-guarded, so a stale response
+// never overwrites a newer token's suggestions), highlight movement, and splice-on-pick. The
+// leaves keep only their platform's rendering and key/gesture wiring.
+//
+// Blazor parity: MeshNodeAutocomplete — an @token opens mesh suggestions; picking one splices the
+// item's insertText (a UCR `@/path`) into the draft. Hosts without ops.autocomplete never open
+// the dropdown, so the model is inert exactly where the capability is absent.
+
+import { useEffect, useRef, useState } from "react";
+import type { AutocompleteSuggestion, MeshOps } from "../live/meshOps.js";
+
+export interface AtTokenState {
+  /** The @token under the caret, including the `@`. */
+  token: string;
+  /** Draft offsets the token spans — what a pick replaces. */
+  start: number;
+  end: number;
+}
+
+export interface MentionModel {
+  /** Call on every draft/caret change; decides whether an @token is active under the caret. */
+  track(value: string, caret: number): void;
+  /** Replace the active token with the suggestion's insert text; returns the new draft (null = no active token). */
+  pick(draft: string, suggestion: AutocompleteSuggestion): string | null;
+  /** Close the dropdown (blur / Escape / after send). */
+  dismiss(): void;
+  /** Move the keyboard highlight by ±1 (wraps). */
+  move(delta: number): void;
+  /** Set the highlight to an absolute index (hover). */
+  highlightAt(index: number): void;
+  suggestions: AutocompleteSuggestion[];
+  highlight: number;
+  /** True while suggestions are open — the leaf renders its dropdown iff this is set. */
+  open: boolean;
+}
+
+const AT_TOKEN = /(^|\s)(@[\w\-./]*)$/;
+const DEBOUNCE_MS = 250;
+const MAX_SUGGESTIONS = 8;
+
+/**
+ * The shared mention model. `context` anchors the server-side autocomplete (the thread the
+ * composer submits into, or its initial context path).
+ */
+export function useMentionModel(ops: MeshOps | null, context?: string): MentionModel {
+  const [atState, setAtState] = useState<AtTokenState | null>(null);
+  const [suggestions, setSuggestions] = useState<AutocompleteSuggestion[]>([]);
+  const [highlight, setHighlight] = useState(0);
+  const generation = useRef(0);
+
+  useEffect(() => {
+    if (!atState || !ops?.autocomplete) return;
+    const gen = ++generation.current;
+    const timer = setTimeout(() => {
+      ops.autocomplete!(atState.token, context || undefined).then(
+        (items) => {
+          if (generation.current !== gen) return;
+          setSuggestions(items.slice(0, MAX_SUGGESTIONS));
+          setHighlight(0);
+        },
+        () => {
+          if (generation.current === gen) setSuggestions([]);
+        },
+      );
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [atState?.token]);
+
+  const dismiss = () => {
+    setAtState(null);
+    setSuggestions([]);
+  };
+
+  return {
+    track: (value, caret) => {
+      const match = AT_TOKEN.exec(value.slice(0, caret));
+      if (!match || !ops?.autocomplete) {
+        dismiss();
+        return;
+      }
+      setAtState({ token: match[2], start: caret - match[2].length, end: caret });
+    },
+    pick: (draft, suggestion) => {
+      if (!atState) return null;
+      const insert =
+        String(suggestion.insertText ?? "") ||
+        (suggestion.path ? `@/${String(suggestion.path)}` : String(suggestion.label ?? ""));
+      const next = draft.slice(0, atState.start) + insert + " " + draft.slice(atState.end);
+      dismiss();
+      return next;
+    },
+    dismiss,
+    move: (delta) =>
+      setHighlight((h) => {
+        const n = suggestions.length;
+        return n === 0 ? 0 : (h + delta + n) % n;
+      }),
+    highlightAt: setHighlight,
+    suggestions,
+    highlight,
+    open: atState != null && suggestions.length > 0,
+  };
+}

--- a/clients/react/src/controls/threadChat.tsx
+++ b/clients/react/src/controls/threadChat.tsx
@@ -36,6 +36,7 @@ import {
 import { useNodeState, watchInto } from "../live/nodeState.js";
 import { controlClass, controlStyle } from "../render/style.js";
 import { str } from "./common.js";
+import { useMentionModel } from "./composerModel.js";
 
 // ---- wire shapes (camelCase — SerializationExtensions serialises with camelCase + string enums) ---
 
@@ -503,65 +504,30 @@ export function ThreadChatView({ control }: { control: UiControl }): ReactNode {
     if (ops && threadPath) ops.patch(threadPath, { content: { requestedStatus: "Cancelled" } });
   };
 
-  // ── @-mention autocomplete (the Blazor MeshNodeAutocomplete parity surface) ──────────────────
-  // Typing an @token opens mesh suggestions from MeshOps.autocomplete (the wire
-  // AutocompleteRequest); picking one splices the item's insertText (a UCR `@/path`) into the
-  // composer. Hosts without the optional ops.autocomplete never open the dropdown.
-  const [atState, setAtState] = useState<{ token: string; start: number; end: number } | null>(null);
-  const [atSuggestions, setAtSuggestions] = useState<AutocompleteSuggestion[]>([]);
-  const [atHighlight, setAtHighlight] = useState(0);
-  const atGeneration = useRef(0);
-
-  const trackAtToken = (value: string, caret: number) => {
-    const before = value.slice(0, caret);
-    const match = /(^|\s)(@[\w\-./]*)$/.exec(before);
-    if (!match || !ops?.autocomplete) {
-      setAtState(null);
-      setAtSuggestions([]);
-      return;
-    }
-    setAtState({ token: match[2], start: caret - match[2].length, end: caret });
-  };
-
-  useEffect(() => {
-    if (!atState || !ops?.autocomplete) return;
-    const gen = ++atGeneration.current;
-    const timer = setTimeout(() => {
-      ops.autocomplete!(atState.token, initialContext || threadPath || undefined).then(
-        (items) => {
-          if (atGeneration.current !== gen) return;
-          setAtSuggestions(items.slice(0, 8));
-          setAtHighlight(0);
-        },
-        () => {
-          if (atGeneration.current === gen) setAtSuggestions([]);
-        },
-      );
-    }, 250);
-    return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [atState?.token]);
+  // ── @-mention autocomplete — the SHARED composer model (composerModel.ts): token tracking,
+  // debounced MeshOps.autocomplete fetch, highlight and splice-on-pick live in core, so this leaf
+  // and the RN one cannot drift. This leaf keeps only the DOM rendering + key handling.
+  const mention = useMentionModel(ops, initialContext || threadPath || undefined);
+  const trackAtToken = mention.track;
+  const atSuggestions = mention.suggestions;
+  const atHighlight = mention.highlight;
+  const atOpen = mention.open;
 
   const pickSuggestion = (s: AutocompleteSuggestion) => {
-    if (!atState) return;
-    const insert = str(s.insertText) || (s.path ? `@/${str(s.path)}` : str(s.label));
-    setText(text.slice(0, atState.start) + insert + " " + text.slice(atState.end));
-    setAtState(null);
-    setAtSuggestions([]);
+    const next = mention.pick(text, s);
+    if (next != null) setText(next);
   };
-
-  const atOpen = atState != null && atSuggestions.length > 0;
 
   const onComposerKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (atOpen) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        setAtHighlight((h) => (h + 1) % atSuggestions.length);
+        mention.move(1);
         return;
       }
       if (e.key === "ArrowUp") {
         e.preventDefault();
-        setAtHighlight((h) => (h <= 0 ? atSuggestions.length - 1 : h - 1));
+        mention.move(-1);
         return;
       }
       if (e.key === "Enter" || e.key === "Tab") {
@@ -570,8 +536,7 @@ export function ThreadChatView({ control }: { control: UiControl }): ReactNode {
         return;
       }
       if (e.key === "Escape") {
-        setAtState(null);
-        setAtSuggestions([]);
+        mention.dismiss();
         return;
       }
     }
@@ -655,7 +620,7 @@ export function ThreadChatView({ control }: { control: UiControl }): ReactNode {
                   e.preventDefault();
                   pickSuggestion(s);
                 }}
-                onMouseEnter={() => setAtHighlight(i)}
+                onMouseEnter={() => mention.highlightAt(i)}
                 style={{
                   display: "flex",
                   flexDirection: "column",

--- a/clients/react/src/core.ts
+++ b/clients/react/src/core.ts
@@ -26,6 +26,8 @@ export {
 } from "./area/meshNodeBinding.js";
 export { NodeBindingContext, type NodeSnapshotStore } from "./area/nodeBindingStore.js";
 export { NodeBindingProvider } from "./live/nodeBinding.js";
+// The shared thread-composer @-mention model — one implementation for the web and RN leaves.
+export { useMentionModel, type MentionModel, type AtTokenState } from "./controls/composerModel.js";
 export {
   GrpcAreaSource,
   MeshAreaRegistry,
@@ -54,6 +56,7 @@ export {
   MeshOpsProvider,
   useMeshOps,
   type MeshOps,
+  type AutocompleteSuggestion,
   type MeshNodeState,
   type ThreadSubmitOptions,
   type MarkdownCellSubmission,

--- a/clients/react/src/i18n/strings.de.json
+++ b/clients/react/src/i18n/strings.de.json
@@ -983,6 +983,8 @@
   "pivot.noAggregates": "Keine Pivot-Aggregate konfiguriert",
   "common.total": "Summe",
   "chat.noNamespace": "Kein Namespace, in dem ein Thread gestartet werden kann.",
+  "chat.recording": "Aufnahme…",
+  "chat.transcribing": "Transkription…",
   "search.meshPlaceholder": "Mesh durchsuchen... (z. B. nodeType:Story status:Open)",
   "analysis.kpi.empty": "Keine Kennzahlen vorhanden.",
   "analysis.tower.empty": "Keine Struktur zum Zeichnen.",

--- a/clients/react/src/i18n/strings.en.json
+++ b/clients/react/src/i18n/strings.en.json
@@ -983,6 +983,8 @@
   "pivot.noAggregates": "No pivot aggregates configured",
   "common.total": "Total",
   "chat.noNamespace": "No namespace to start a thread in.",
+  "chat.recording": "Recording…",
+  "chat.transcribing": "Transcribing…",
   "search.meshPlaceholder": "Search the mesh... (e.g. nodeType:Story status:Open)",
   "analysis.kpi.empty": "No figures to show.",
   "analysis.tower.empty": "No structure to draw.",

--- a/clients/react/src/render/skins.tsx
+++ b/clients/react/src/render/skins.tsx
@@ -49,8 +49,18 @@ export function DefaultStackSkin({ skin, control }: SkinProps): ReactNode {
   // The control's own inline style (WithStyle) wins over the skin defaults — e.g. an overlay stack
   // declared `position: absolute; top; right` (the pinned-card unpin toggle) must escape flow to sit
   // ON the card, not render as a full-width bar below it. Blazor honours the Style the same way.
+  //
+  // A CLICKABLE stack posts the ClickedEvent, exactly as Blazor's LayoutStack does — the Store's
+  // category tiles are precisely this shape (`isClickable: true` + `cursor: pointer`), and without
+  // the handler they render as inert cards in every JS shell.
+  const onClick = useClick(control);
   return (
-    <div className={controlClass(control)} style={{ ...style, ...controlStyle(control) }}>
+    <div
+      className={controlClass(control)}
+      style={{ ...style, ...controlStyle(control) }}
+      onClick={onClick}
+      role={onClick ? "button" : undefined}
+    >
       <Children control={control} />
     </div>
   );

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-one-composer-store-navigation.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-one-composer-store-navigation.md
@@ -1,0 +1,20 @@
+---
+Name: One thread composer everywhere, and Store categories open again
+Category: Fix
+Description: The chat composer is one shared surface with @-mentions on every client, Store category tiles navigate again (they were broken on the web portal too), and the colorful node icons render on mobile.
+Icon: Sparkle
+Order: -20260824
+---
+
+# One thread composer everywhere, and Store categories open again
+
+The chat composer is now one shared surface: @-mentions suggest mesh content as you type on the
+mobile client too, dictation and hold-to-talk moved into the composer itself, and the separate
+message bar at the bottom of the mobile app is gone — you write where the thread is.
+
+Store category tiles open their category again. They had quietly stopped navigating on every
+client, including the web portal: a naming collision made category links land on the wrong page
+with a technical error. Tapping a category now shows its modules everywhere.
+
+The colorful icons also arrived on mobile: menus, app tiles, and the diagrams inside
+documentation pages now draw properly on the phone instead of showing blanks or file paths.

--- a/src/MeshWeaver.Hosting/PathResolutionService.cs
+++ b/src/MeshWeaver.Hosting/PathResolutionService.cs
@@ -244,6 +244,7 @@ internal class PathResolutionService : IPathResolver, IDisposable
         if (forNavigation)
             resolved = resolved
                 .SelectMany(RewriteLegacyUserHome)
+                .SelectMany(r => RewriteTypeNodeShadow(r, routeShapeOnly))
                 // Moved-node redirects are NAVIGATION-ONLY, for the same reason the legacy-home
                 // rewrite above is: a route or a read that silently answers with a DIFFERENT node
                 // than the caller named corrupts callers downstream (the "NO FALLBACK" banner in
@@ -379,6 +380,44 @@ internal class PathResolutionService : IPathResolver, IDisposable
     /// node under <c>User/</c> (transitional data, or a NodeType child) matches deeper,
     /// so Prefix != "User" and this is a no-op — that data still resolves by its own path.</para>
     /// </summary>
+    /// <summary>
+    /// Un-shadows an AREA URL that a same-named <b>NodeType definition node</b> swallowed. A module's
+    /// type node may legitimately live at <c>{parent}/{Name}</c> while the PARENT node renders an
+    /// area of the same name at <c>/{parent}/{Name}[/…]</c> — the Store's catalog type node sits at
+    /// <c>Store/Catalog</c>, the Store node's <c>Catalog</c> area at <c>/Store/Catalog/…</c>. The
+    /// longer prefix match won, so <c>/Store/Catalog/Catalog?category=…</c> resolved onto the TYPE
+    /// node's hub with remainder <c>Catalog?…</c>, where the framework's type-catalog area answered
+    /// "Collection ?category=… is not mapped" — on Blazor and every remote shell alike (they share
+    /// this resolver). When navigation lands on a type-definition node WITH a remainder, re-resolve
+    /// the parent and give it the full remainder back, so the area renders on the node that owns it.
+    /// <para><b>NAVIGATION ONLY</b> (same rule as <see cref="RewriteLegacyUserHome"/>): routing and
+    /// reads of <c>{parent}/{Name}</c> stay literal. Navigating exactly TO the definition node
+    /// (empty remainder) is untouched, so the type node's own pages keep working. If the parent does
+    /// not resolve, the original resolution stands — never a null where something matched.</para>
+    /// <para>The predicate is deliberately the narrow definition-node marker
+    /// (<c>NodeType == "NodeType"</c>): dynamic type definitions all carry it, including the live
+    /// Store case. Once the content-visibility classification lands (#2137 —
+    /// <c>MeshNode.ExcludeFromContext</c> / <c>MeshContexts.Content</c> + the config-node
+    /// registration set), widen to "registration OR declared non-content", minding its per-TYPE
+    /// semantics (marking a definition classifies its instances too).</para>
+    /// </summary>
+    private IObservable<AddressResolution?> RewriteTypeNodeShadow(
+        AddressResolution? resolution, bool routeShapeOnly)
+    {
+        if (resolution is null
+            || string.IsNullOrEmpty(resolution.Remainder)
+            || !string.Equals(resolution.Node?.NodeType, "NodeType", StringComparison.Ordinal)
+            || !resolution.Prefix.Contains('/'))
+            return Observable.Return(resolution);
+        var lastSlash = resolution.Prefix.LastIndexOf('/');
+        var parent = resolution.Prefix[..lastSlash];
+        var shadowed = resolution.Prefix[(lastSlash + 1)..];
+        return ResolveSegments(parent.Split('/'), routeShapeOnly)
+            .Select(parentResolution => parentResolution is null || !string.IsNullOrEmpty(parentResolution.Remainder)
+                ? resolution
+                : parentResolution with { Remainder = $"{shadowed}/{resolution.Remainder}" });
+    }
+
     private IObservable<AddressResolution?> RewriteLegacyUserHome(AddressResolution? resolution)
         => resolution is not null
             && string.Equals(resolution.Prefix, UserNodeType.NodeType, StringComparison.OrdinalIgnoreCase)

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -983,6 +983,8 @@
   "pivot.noAggregates": "Keine Pivot-Aggregate konfiguriert",
   "common.total": "Summe",
   "chat.noNamespace": "Kein Namespace, in dem ein Thread gestartet werden kann.",
+  "chat.recording": "Aufnahme…",
+  "chat.transcribing": "Transkription…",
   "search.meshPlaceholder": "Mesh durchsuchen... (z. B. nodeType:Story status:Open)",
   "analysis.kpi.empty": "Keine Kennzahlen vorhanden.",
   "analysis.tower.empty": "Keine Struktur zum Zeichnen.",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -983,6 +983,8 @@
   "pivot.noAggregates": "No pivot aggregates configured",
   "common.total": "Total",
   "chat.noNamespace": "No namespace to start a thread in.",
+  "chat.recording": "Recording…",
+  "chat.transcribing": "Transcribing…",
   "search.meshPlaceholder": "Search the mesh... (e.g. nodeType:Story status:Open)",
   "analysis.kpi.empty": "No figures to show.",
   "analysis.tower.empty": "No structure to draw.",

--- a/test/MeshWeaver.Hosting.Monolith.Test/TypeNodeShadowResolutionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/TypeNodeShadowResolutionTest.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the type-node UN-SHADOWING on navigation resolution
+/// (<c>PathResolutionService.RewriteTypeNodeShadow</c>). A module's NodeType definition node may
+/// legitimately live at <c>{parent}/{Name}</c> while the PARENT node renders an AREA of the same
+/// name — the live case is the Store: its catalog type node sits at <c>Store/Catalog</c>, and the
+/// Store node's <c>Catalog</c> area renders at <c>/Store/Catalog[/…]</c>. The longer prefix match
+/// won, so <c>/Store/Catalog/Catalog?category=…</c> resolved onto the TYPE node's hub with
+/// remainder <c>Catalog?…</c>, where the framework's type-catalog area answered
+/// "Collection ?category=… is not mapped in Address Store/Catalog" — reproduced on PROD Blazor and
+/// the RN client alike (they share this resolver via <c>ResolveNavigationPath</c> /
+/// <c>POST /api/mesh/resolve</c>).
+/// </summary>
+public class TypeNodeShadowResolutionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private IPathResolver Resolver => Mesh.ServiceProvider.GetRequiredService<IPathResolver>();
+
+    /// <summary>A parent content node plus a NodeType DEFINITION node named like the parent's area.</summary>
+    private async Task SeedShadowPair(string parent, string typeName)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(MeshNode.FromPath(parent) with
+            {
+                Name = parent,
+                NodeType = "Group",
+                State = MeshNodeState.Active,
+            }).Should().Within(30.Seconds()).Emit();
+            await meshService.CreateNode(MeshNode.FromPath($"{parent}/{typeName}") with
+            {
+                Name = typeName,
+                NodeType = "NodeType",
+                State = MeshNodeState.Active,
+            }).Should().Within(30.Seconds()).Emit();
+        }
+    }
+
+    /// <summary>
+    /// THE bug: an area URL under the parent must resolve to the PARENT (which owns the area),
+    /// not to the same-named type node with the area's id as a bogus remainder.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AreaUrlShadowedByTypeNode_ResolvesToParentWithFullRemainder()
+    {
+        await SeedShadowPair("shadowstore", "Catalog");
+
+        var resolution = await Resolver.ResolveNavigationPath("shadowstore/Catalog/Catalog")
+            .Should().Within(20.Seconds()).Emit();
+
+        resolution.Should().NotBeNull();
+        resolution!.Prefix.Should().Be("shadowstore",
+            "the parent owns the Catalog AREA; the same-named type node must not steal the prefix");
+        resolution.Remainder.Should().Be("Catalog/Catalog",
+            "the full remainder (area + id) goes back to the parent's hub");
+    }
+
+    /// <summary>Navigating exactly TO the definition node (no remainder) still resolves to it.</summary>
+    [Fact(Timeout = 30000)]
+    public async Task TypeNodeItself_StillResolvesDirectly()
+    {
+        await SeedShadowPair("shadowstore2", "Catalog");
+
+        var resolution = await Resolver.ResolveNavigationPath("shadowstore2/Catalog")
+            .Should().Within(20.Seconds()).Emit();
+
+        resolution.Should().NotBeNull();
+        resolution!.Prefix.Should().Be("shadowstore2/Catalog",
+            "an exact navigation to the type node is not a shadowing case — its own pages keep working");
+        resolution.Remainder.Should().BeNullOrEmpty();
+    }
+
+    /// <summary>
+    /// The shared read/route resolution stays LITERAL (same scope rule as the legacy-User rewrite):
+    /// only navigation un-shadows.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task SharedResolvePath_DoesNotUnshadow_PreservesReadRouteInvariant()
+    {
+        await SeedShadowPair("shadowstore3", "Catalog");
+
+        var resolution = await Resolver.ResolvePath("shadowstore3/Catalog/Anything")
+            .Should().Within(20.Seconds()).Emit();
+
+        resolution.Should().NotBeNull();
+        resolution!.Prefix.Should().Be("shadowstore3/Catalog",
+            "routing and reads must see the unmodified longest-prefix resolution");
+        resolution.Remainder.Should().Be("Anything");
+    }
+}


### PR DESCRIPTION
Follow-up to #2129, built live with the maintainer driving the app. Three strands:

## 1. ONE thread composer — the core model, everywhere
- `useMentionModel` in `@meshweaver/react` core: the platform-free @-mention half of the composer (caret token tracking, debounced generation-guarded `MeshOps.autocomplete` fetch, highlight, splice-on-pick). The web ThreadChat leaf consumes it (no behavior change); the new RN `ComposerBar` is the native skin — dropdown, mic (tap-dictate + hold-PTT via the existing `PushToTalkController`), glyph send.
- `Mesh.autocomplete` in `@meshweaver/client-web`: THE one `AutocompleteRequest` implementation (portal + portal-next each hand-rolled the same observe — the #1497 drift shape), targeted at the viewer's home hub. RN wires it through a **partition thunk** (a signed-in remote's identity resolves via whoami *after* connect).
- The app-level "Message the mesh…" bar is **removed** — the composer is the mesh-rendered `ThreadChatControl`, same as Blazor. Verified live: typing `@Doc` against prod opens real mesh suggestions.

## 2. Store categories were dead on EVERY client — including prod Blazor
Clickable stacks now post `ClickedEvent` in both JS packs (the tiles are `isClickable` stacks — inert before), `MeshWebConnection.onMessage` delivers the server's unsolicited `NavigationRequest` (the client twin of the Blazor portal hub's `WithHandler`), and the RN app resolves the uri via `POST /api/mesh/resolve` into address/area/id (query rides in the Id, area-prefixed — the `LayoutAreaReference.GetParameterValue` contract).

That exposed the real root cause, **reproduced on prod Blazor** (`/Store/Catalog/Catalog?category=Games` → "Collection ?category=Games is not mapped in Address Store/Catalog"): a NodeType DEFINITION node shadows same-named AREA URLs in `ResolveNavigationPath` — `Store/Catalog` (the type node) steals the prefix of the Store node's `Catalog` area. Fixed with a navigation-only `RewriteTypeNodeShadow` (routing/reads stay literal; exact navigation TO the type node untouched), pinned by `TypeNodeShadowResolutionTest` ×3; adjacent nav regressions re-run green ×15. Coordinated with #2137 (content-visibility): predicate stays the narrow `NodeType=="NodeType"` for now; the comment names the agreed widening path.

## 3. Colorful SVG on native
One `IconGlyph` (shared `classifyIcon` → `SvgXml`/`SvgUri`/`Image`/emoji, instance-resolved URLs) for the Icon leaf and the left-menu rows (which inlined `/static/….svg` into the *label*); doc pages interleave standalone inline `<svg>` diagrams through `SvgXml` (previously in `ignoredDomTags` — every diagram silently dropped on a device).

i18n: `chat.recording`/`chat.transcribing` in en+de, server catalogs + react mirror (drift guard ✓, `LocalizationTest` 56 ✓).

**Verification**: grpc-web 82 ✓ · react 293 ✓ · RN 164 ✓ · RN Playwright e2e ✓ · Hosting + Messaging.Hub Release `-warnaserror` clean · Store category click verified end-to-end against prod (web) · home/composer/mic verified on the iOS simulator against the sidecar.

What's New entry included (Category: Fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)