### PR TITLE
The last leaf disposed the gate, then released it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-iopool-release-order.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-iopool-release-order.md
@@ -1,0 +1,18 @@
+---
+Name: Pages stop failing to load while a portal shuts down
+Category: Fix
+Description: A part of the page could show an error instead of its content when a portal was restarting.
+Icon: Sparkle
+Order: -20260824
+---
+
+# Pages stop failing to load while a portal shuts down
+
+If a portal was shutting down or restarting at the exact moment a part of your page was still
+loading, that part could give up and show an error instead of its content — the comments section
+was where it showed up.
+
+The cause was an ordering mistake in how the platform tidies up: the last piece of work to finish
+was releasing a resource that the tidy-up had, a moment earlier, already thrown away. Nothing was
+lost and nothing was corrupted; the page section simply reported a failure it had no business
+reporting. It now finishes cleanly.

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
@@ -135,11 +135,35 @@ public sealed class IoPool : IIoPool, IDisposable
             }
             finally
             {
-                Interlocked.Decrement(ref _inFlight);
-                TryFinishDisposal();
-                _gate.Release();
+                // 🚨 RELEASE THE PERMIT FIRST. TryFinishDisposal disposes _gate the moment the
+                // last leaf's decrement takes _inFlight to zero — so with the decrement first,
+                // THIS leaf disposed the gate and then called Release() on it, throwing
+                // ObjectDisposedException out of its own finally. Not a cross-thread race: the
+                // last leaf to unwind during a dispose does it to itself, every time (issue
+                // #2135, seen in prod as a failed `Comments` area render on memex-cloud).
+                //
+                // Releasing first is safe for the drain guarantee: Drain joins by re-acquiring
+                // every permit, and once Release has run the only work left in this finally is
+                // two interlocked ops — no user code, no ALC code — so "no pool thread is still
+                // running the leaf" remains true at the moment Drain observes the permit.
+                ReleaseGateThenFinish();
             }
         }).SubscribeOn(TaskPoolScheduler.Default);
+
+    /// <summary>
+    /// The exit path every gated leaf shares: hand the permit back while the gate is still alive,
+    /// then account for the leaf and let disposal complete if it was the last one.
+    ///
+    /// <para>Extracted so the ordering exists in ONE place. It was duplicated at three call sites
+    /// and wrong at all three, which is what made <see cref="Dispose"/>'s careful "release the
+    /// resources on the last leaf's way out" design throw on that very last leaf.</para>
+    /// </summary>
+    private void ReleaseGateThenFinish()
+    {
+        _gate.Release();
+        Interlocked.Decrement(ref _inFlight);
+        TryFinishDisposal();
+    }
 
     /// <summary>
     /// Streams an async-enumerable I/O leaf off the calling scheduler under the pool's concurrency gate.
@@ -165,9 +189,7 @@ public sealed class IoPool : IIoPool, IDisposable
             }
             finally
             {
-                Interlocked.Decrement(ref _inFlight);
-                TryFinishDisposal();
-                _gate.Release();
+                ReleaseGateThenFinish();
             }
         }).SubscribeOn(TaskPoolScheduler.Default);
 
@@ -270,9 +292,7 @@ public sealed class IoPool : IIoPool, IDisposable
                     }
                     finally
                     {
-                        Interlocked.Decrement(ref _inFlight);
-                TryFinishDisposal();
-                        _gate.Release();
+                        ReleaseGateThenFinish();
                     }
                     return System.Reactive.Unit.Default;
                 })

--- a/test/MeshWeaver.Hosting.Test/IoPoolDisposeReleaseOrderTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolDisposeReleaseOrderTest.cs
@@ -1,0 +1,93 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Mesh.Threading;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Issue #2135: the LAST leaf to unwind during a dispose threw
+/// <see cref="ObjectDisposedException"/> out of its own <c>finally</c>.
+///
+/// <para>Not a cross-thread race — self-inflicted and deterministic. The exit path read
+/// <c>Decrement(_inFlight); TryFinishDisposal(); _gate.Release();</c>, and
+/// <c>TryFinishDisposal</c> disposes the gate the instant that decrement takes the count to zero.
+/// So the leaf disposed the semaphore and then released it. In production it surfaced as a failed
+/// <c>Comments</c> area render on memex-cloud, reported by <c>LayoutAreaHost</c> — which is the
+/// reporter, not the defect.</para>
+///
+/// <para>These tests need no timing: the leaf parks on a TCS the test controls, so "dispose while a
+/// leaf is in flight" is a sequence, not a race. That matters because the bug is invisible to a
+/// pool that is idle at dispose — which is every pool in a test that does not deliberately hold a
+/// leaf open.</para>
+/// </summary>
+public class IoPoolDisposeReleaseOrderTest
+{
+    [Fact]
+    public async Task Disposing_while_a_leaf_is_in_flight_does_not_fault_the_subscriber()
+    {
+        var pool = new IoPool(maxConcurrency: 1);
+        var leafEntered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+
+        var run = pool.Invoke(async ct =>
+        {
+            leafEntered.TrySetResult();
+            await release.Task;
+            return 42;
+        }).ToTask();
+
+        await leafEntered.Task;      // the permit is taken and _inFlight is 1
+
+        pool.Dispose();              // cancels; the gate must survive until the leaf is out
+        release.TrySetResult();      // the leaf now runs its finally — the moment of the defect
+
+        // The leaf was cancelled by Dispose, so a cancellation is a legitimate outcome. An
+        // ObjectDisposedException is NOT: it means the pool tore its own gate out from under the
+        // leaf that was still holding a permit.
+        var fault = await Record.ExceptionAsync(() => run);
+        fault.Should().NotBeOfType<ObjectDisposedException>(
+            "the last leaf disposed the gate and then released it");
+    }
+
+    [Fact]
+    public async Task Disposal_still_completes_after_the_last_leaf_leaves()
+    {
+        var pool = new IoPool(maxConcurrency: 1);
+        var leafEntered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+
+        var disposed = pool.Disposed.FirstAsync().ToTask();
+        var run = pool.Invoke(async ct =>
+        {
+            leafEntered.TrySetResult();
+            await release.Task;
+            return 1;
+        }).ToTask();
+
+        await leafEntered.Task;
+        pool.Dispose();
+
+        // Reordering the exit path must not cost the guarantee the ordering existed for: the
+        // resources are released on the last leaf's way OUT, and Disposed reports it.
+        release.TrySetResult();
+        await Record.ExceptionAsync(() => run);
+
+        var leaked = await disposed.WaitAsync(TimeSpan.FromSeconds(20));
+        leaked.Should().Be(0, "the leaf unwound, so nothing survived teardown");
+        pool.CurrentInFlight.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task An_idle_pool_still_disposes_immediately()
+    {
+        // The path that always worked, kept honest: with nothing in flight, Dispose completes on
+        // the spot rather than waiting for a leaf that will never come.
+        var pool = new IoPool(maxConcurrency: 2);
+        var disposed = pool.Disposed.FirstAsync().ToTask();
+
+        pool.Dispose();
+
+        (await disposed.WaitAsync(TimeSpan.FromSeconds(10))).Should().Be(0);
+    }
+}


### PR DESCRIPTION
Fixes #2135 (and #2134, which is the same issue filed twice).

## The issue's diagnosis was wrong, and the truth is simpler

The report proposed that `Dispose()` races outstanding leaves, or that `DrainAll()` is not being called. Neither. It is **not a race at all** — it is self-inflicted and deterministic.

Every gated leaf's exit path read:

```csharp
Interlocked.Decrement(ref _inFlight);
TryFinishDisposal();     // disposes _gate the moment this hits zero
_gate.Release();         // ...on the semaphore this same thread just disposed
```

`TryFinishDisposal` exists to release the pool's resources "on the last leaf's way out". So during a dispose, the last leaf to unwind takes the count to zero, disposes the gate, and then releases it. Every time. The careful design in `Dispose()` was throwing on exactly the leaf it was written to accommodate.

That is why prod saw it as a one-off: it needs a dispose to coincide with a leaf still in flight. When it does, it is certain, not probable.

## The fix

Release the permit **first**, while the gate is provably alive, then account for the leaf and let disposal finish.

Safe for the drain guarantee: `Drain()` joins by re-acquiring every permit, and once `Release` has run the only work left in the finally is two interlocked ops — no user code, no ALC code. So *"no pool thread is still running the leaf"* still holds at the moment `Drain` observes the permit, which is the property the whole teardown contract rests on.

The ordering was duplicated at all three call sites (`Invoke`, `InvokeStream`, and the subscribe-gated path) and wrong at all three — one of them mis-indented, from an earlier hurried edit. It now exists once, in `ReleaseGateThenFinish`.

## What I deliberately did not do

The issue's first suggestion was to guard `Release` against a disposed gate. That swallows the symptom and leaves the pool disposing itself out from under live leaves — the exact defect, minus the evidence.

## Tests

`IoPoolDisposeReleaseOrderTest`, deterministic by construction: the leaf parks on a `TaskCompletionSource` the test controls, so "dispose while a leaf is in flight" is a *sequence*, not a timing hope. That matters because the bug is invisible to a pool that happens to be idle at dispose — which is every pool in every test that does not deliberately hold a leaf open, and is why this survived a well-tested file.

Three cases: the subscriber is not faulted with `ObjectDisposedException` (cancellation is a legitimate outcome and is allowed); disposal still completes and reports `0` leaked once the last leaf leaves — the guarantee the ordering existed for; and an idle pool still disposes immediately.

**Verified the repro is real** by reverting the order: `Disposing_while_a_leaf_is_in_flight_does_not_fault_the_subscriber` fails on the old order, passes on the new. All 24 `IoPool` tests green. Release `-warnaserror` clean.

## Note on the issue tracker

`#2134`/`#2135` are duplicates of each other, as are `#2138`/`#2139`, `#2132`/`#2133` and `#2130`/`#2131` — four pairs filed within the same window. Whatever files these is emitting each finding twice; worth looking at separately, since it doubles the triage load on every future report.
