### PR TITLE
Optional GUI shells: Blazor-only, Next-only, or both — with a per-browser switch and next-only e2e

### DIFF
--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -39,6 +39,8 @@ name: Clients
 #   src/MeshWeaver.Data.Contract/Messages.cs              must turn the client red, because the hub
 #   src/MeshWeaver.Data.Contract/PatchDataRequest.cs      DROPS an unmatched member silently)
 #   memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs   → clients/grpc-web/src/restContract.test.ts
+#   memex/Memex.Portal.Monolith/**                        → clients/portal-next/e2e (the next-only
+#                                                            e2e boots this host as its backend)
 #   memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs        (BOTH backends must serve every /api/mesh
 #                                                         verb the client SDK posts to — an unmapped
 #                                                         one answers the SPA fallback with a 200)
@@ -72,6 +74,7 @@ on:
       - "src/MeshWeaver.Data.Contract/PatchDataRequest.cs"
       - "memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs"
       - "memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs"
+      - "memex/Memex.Portal.Monolith/**"
   push:
     branches: [main]
     paths:
@@ -88,6 +91,7 @@ on:
       - "src/MeshWeaver.Data.Contract/PatchDataRequest.cs"
       - "memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs"
       - "memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs"
+      - "memex/Memex.Portal.Monolith/**"
 
 jobs:
   react:

--- a/clients/portal-next/.gitignore
+++ b/clients/portal-next/.gitignore
@@ -3,3 +3,7 @@ node_modules
 .next/
 next-env.d.ts
 *.tsbuildinfo
+
+# Playwright artifacts
+/test-results
+/playwright-report

--- a/clients/portal-next/e2e/next-only.spec.ts
+++ b/clients/portal-next/e2e/next-only.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "@playwright/test";
+
+// NEXT-ONLY portal mode, end to end: the mesh backend runs with Features__Gui__Blazor=false — no
+// Razor-components pipeline, no circuit, no Blazor view registry — and the Next.js app is the
+// entire GUI (dev server with PORTAL_ORIGIN rewrites, exactly the DEPLOY.md local topology). The
+// two servers are booted by playwright.config's webServer entries.
+//
+// What this proves, in order: the backend genuinely serves NO Blazor; the mesh surfaces the JS
+// shell consumes still work — auth policies included; and the Next frontend renders real mesh
+// content through them for a signed-in visitor.
+
+const portal = "http://localhost:5022";
+const next = "http://localhost:3300";
+
+test("the portal serves NO Blazor: circuit endpoints are absent", async ({ request }) => {
+  // The circuit's negotiate endpoint is the Blazor tell — mapped by MapRazorComponents/
+  // MapBlazorHub, absent in next-only mode.
+  const negotiate = await request.post(`${portal}/_blazor/negotiate?negotiateVersion=1`, { failOnStatusCode: false });
+  expect(negotiate.status()).toBe(404);
+  // The framework asset prefix 404s too — the static-asset manifest still lists blazor.web.js
+  // (the assemblies stay referenced), and without the gate its dev endpoint 500s.
+  const framework = await request.get(`${portal}/_framework/blazor.web.js`, { failOnStatusCode: false });
+  expect(framework.status()).toBe(404);
+});
+
+test("a browser navigation on the portal origin lands on the Next shell", async ({ request }) => {
+  const r = await request.get(`${portal}/Doc/Architecture`, {
+    maxRedirects: 0,
+    failOnStatusCode: false,
+    headers: { accept: "text/html,application/xhtml+xml" },
+  });
+  expect(r.status()).toBe(302);
+  expect(r.headers()["location"]).toBe("/next/Doc/Architecture");
+});
+
+test("the mesh surfaces the JS shells consume still work without Blazor", async ({ request }) => {
+  // whoami is cookie-OR-bearer gated (ReadPolicy) — anonymous is 401 BY DESIGN, with or
+  // without Blazor. The auth pipeline holding is part of what this asserts.
+  const anonymous = await request.post(`${portal}/api/mesh/whoami`, { data: {}, failOnStatusCode: false });
+  expect(anonymous.status()).toBe(401);
+  // Sign in through DevLogin (Monolith, Authentication:EnableDevLogin) — the cookie lands in
+  // this request context's jar and authenticates the reads below.
+  // maxRedirects 0: the 302 lands on `/`, which in next-only mode 302s again to /next — a path
+  // the PORTAL origin deliberately answers 404 (it belongs to the Next server). Following the
+  // chain would report that terminal 404 and hide the successful sign-in.
+  const login = await request.post(`${portal}/dev/signin`, {
+    form: { personId: "rbuergi" },
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  });
+  expect(login.status()).toBe(302);
+  const who = await request.post(`${portal}/api/mesh/whoami`, { data: {} });
+  expect(who.status()).toBe(200);
+  // The resolve verb (navigation resolution — portal-next's SSR depends on it).
+  const resolve = await request.post(`${portal}/api/mesh/resolve`, { data: { path: "Doc" } });
+  expect(resolve.status()).toBe(200);
+  // Static assets (node icons) still serve — they are shell-independent.
+  const icon = await request.get(`${portal}/static/NodeTypeIcons/book.svg`);
+  expect(icon.status()).toBe(200);
+  expect(icon.headers()["content-type"]).toContain("svg");
+});
+
+test("the Next frontend renders real mesh content", async ({ page }) => {
+  // Watch for anything Blazor-shaped from the very first request — a listener attached after
+  // goto would miss the load itself.
+  const blazorRequests: string[] = [];
+  page.on("request", (r) => {
+    if (r.url().includes("_blazor") || r.url().includes("blazor.web.js")) blazorRequests.push(r.url());
+  });
+  // Sign in via DevLogin: page.request shares the browser context's cookie jar, and localhost
+  // cookies ignore the port, so the cookie minted against :5022 rides to the :3300 page (whose
+  // dev server forwards it to the portal via the PORTAL_ORIGIN rewrites).
+  const login = await page.request.post(`${portal}/dev/signin`, {
+    form: { personId: "rbuergi" },
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  });
+  expect(login.status()).toBe(302);
+  await page.goto(`${next}/next/Doc`, { waitUntil: "domcontentloaded" });
+  // Real mesh content appears (a fresh Monolith renders the Doc space's home — the page title is
+  // the space name), under the SIGNED-IN chrome (the user-profile button only renders for a
+  // resolved identity)…
+  await expect(page.getByRole("heading", { name: "Doc" })).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: "User profile" })).toBeVisible({ timeout: 30_000 });
+  // …with the LIVE connection up: this banner appears when the live-source token mint fails,
+  // which is exactly what a Blazor-shell dependency left in the API path caused before the fix.
+  await expect(page.getByText("No live mesh connection")).toHaveCount(0);
+  expect(blazorRequests).toEqual([]);
+});

--- a/clients/portal-next/e2e/playwright.next-only.config.ts
+++ b/clients/portal-next/e2e/playwright.next-only.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// The NEXT-ONLY portal e2e: mesh backend WITHOUT Blazor + the Next.js frontend, booted together.
+//
+//   npm run e2e:next-only        (from clients/portal-next)
+//
+// webServer[0] — the Monolith with the Blazor shell OFF (Features__Gui__Blazor=false). Its /alive
+//   comes up only when the mesh is served, so the wait is a real readiness signal.
+// webServer[1] — `next dev` with PORTAL_ORIGIN rewrites (the DEPLOY.md local topology): /api/*,
+//   the gRPC-web service and /static/* proxy to the portal, exactly like behind the shared ingress.
+//
+// The Monolith boot builds nothing (dotnet run compiles on demand) — first run takes minutes;
+// keep reuseExistingServer for local iteration.
+export default defineConfig({
+  testDir: ".",
+  testMatch: "next-only.spec.ts",
+  timeout: 90_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  reporter: [["list"]],
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: [
+    {
+      command:
+        "dotnet run --project ../../../memex/Memex.Portal.Monolith --no-launch-profile",
+      cwd: ".",
+      url: "http://localhost:5022/healthz",
+      reuseExistingServer: !process.env.CI,
+      timeout: 600_000,
+      stdout: "pipe",
+      env: {
+        ASPNETCORE_URLS: "http://localhost:5022",
+        // --no-launch-profile defaults the environment to Production; DevLogin (the suite's
+        // sign-in) and the dev static-asset pipeline are Development behaviours.
+        ASPNETCORE_ENVIRONMENT: "Development",
+        Features__Gui__Blazor: "false",
+      },
+    },
+    {
+      command: "npm run dev",
+      cwd: "..",
+      url: "http://localhost:3300/next",
+      reuseExistingServer: !process.env.CI,
+      timeout: 300_000,
+      stdout: "pipe",
+      env: {
+        PORTAL_ORIGIN: "http://localhost:5022",
+        PORT: "3300",
+      },
+    },
+  ],
+});

--- a/clients/portal-next/package-lock.json
+++ b/clients/portal-next/package-lock.json
@@ -24,6 +24,7 @@
         "server-only": "^0.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^26.2.0",
@@ -2719,6 +2720,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6580,6 +6597,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/points-on-curve": {

--- a/clients/portal-next/package.json
+++ b/clients/portal-next/package.json
@@ -8,7 +8,8 @@
     "build": "next build --webpack",
     "start": "next start -p 3300",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "e2e:next-only": "playwright test -c e2e/playwright.next-only.config.ts"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.14.0",
@@ -27,6 +28,7 @@
     "server-only": "^0.0.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.2.0",

--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -190,8 +190,12 @@ public static class MeshApiEndpoints
     /// </summary>
     private static IResult HandleWhoAmI(HttpContext http)
     {
-        var caller = http.RequestServices.GetRequiredService<PortalApplication>()
-            .Hub.ServiceProvider.GetRequiredService<AccessService>().Context;
+        // Portal hub when the Blazor shell registered one; the mesh root hub on a next-only
+        // portal (Features:Gui:Blazor=false). AccessService is the mesh-wide singleton either
+        // way — see UserContextMiddleware, which stamps the identity this reads.
+        var caller = (http.RequestServices.GetService<PortalApplication>()?.Hub
+                      ?? http.RequestServices.GetRequiredService<IMessageHub>())
+            .ServiceProvider.GetRequiredService<AccessService>().Context;
 
         var userId = caller?.ObjectId;
         var resolved = !string.IsNullOrEmpty(userId)

--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenController.cs
@@ -38,8 +38,12 @@ public class ApiTokenController(IServiceProvider serviceProvider) : ControllerBa
     /// </para>
     /// </summary>
     private AccessContext? CurrentUser =>
-        serviceProvider.GetRequiredService<PortalApplication>()
-            .Hub.ServiceProvider.GetRequiredService<AccessService>()
+        // Portal hub when the Blazor shell registered one; the mesh root hub on a next-only
+        // portal (Features:Gui:Blazor=false). AccessService is the mesh-wide singleton either
+        // way — see UserContextMiddleware, which stamps the identity this reads.
+        (serviceProvider.GetService<PortalApplication>()?.Hub
+         ?? serviceProvider.GetRequiredService<IMessageHub>())
+            .ServiceProvider.GetRequiredService<AccessService>()
             .Context;
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
@@ -143,7 +143,9 @@ public sealed class EaGraphAuth(
     private async Task StoreAsync(string userObjectId, string refreshToken, CancellationToken ct)
     {
         using var scope = rootServices.CreateScope();
-        var hub = scope.ServiceProvider.GetRequiredService<PortalApplication>().Hub;
+        // Portal hub when the Blazor shell registered one; the mesh root hub otherwise.
+        var hub = scope.ServiceProvider.GetService<PortalApplication>()?.Hub
+                  ?? scope.ServiceProvider.GetRequiredService<IMessageHub>();
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         var access = hub.ServiceProvider.GetRequiredService<AccessService>();
 
@@ -175,7 +177,9 @@ public sealed class EaGraphAuth(
             if (hub is null)
             {
                 owned = rootServices.CreateScope();
-                hub = owned.ServiceProvider.GetRequiredService<PortalApplication>().Hub;
+                // Portal hub when the Blazor shell registered one; the mesh root hub otherwise.
+                hub = owned.ServiceProvider.GetService<PortalApplication>()?.Hub
+                      ?? owned.ServiceProvider.GetRequiredService<IMessageHub>();
             }
             var ws = hub.GetWorkspace();
             var access = hub.ServiceProvider.GetRequiredService<AccessService>();

--- a/memex/Memex.Portal.Shared/Email/InvitationEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/InvitationEmailSender.cs
@@ -72,7 +72,9 @@ public sealed class InvitationEmailSender(
         try
         {
             scope = rootServices.CreateScope();
-            var hub = scope.ServiceProvider.GetRequiredService<PortalApplication>().Hub;
+            // Portal hub when the Blazor shell registered one; the mesh root hub otherwise.
+            var hub = scope.ServiceProvider.GetService<PortalApplication>()?.Hub
+                      ?? scope.ServiceProvider.GetRequiredService<IMessageHub>();
             var sp = hub.ServiceProvider;
             var query = sp.GetRequiredService<IMeshQueryCore>();
             var meshService = sp.GetRequiredService<IMeshService>();

--- a/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
@@ -85,7 +85,9 @@ public sealed class OutboundEmailSender(
             // Resolve a fresh PortalApplication in its own scope now that the mesh is up — the
             // instance DI built at host-construction time may have captured a not-yet-ready hub.
             scope = rootServices.CreateScope();
-            var hub = scope.ServiceProvider.GetRequiredService<PortalApplication>().Hub;
+            // Portal hub when the Blazor shell registered one; the mesh root hub otherwise.
+            var hub = scope.ServiceProvider.GetService<PortalApplication>()?.Hub
+                      ?? scope.ServiceProvider.GetRequiredService<IMessageHub>();
             var sp = hub.ServiceProvider;
             var query = sp.GetRequiredService<IMeshQueryCore>();
             var meshService = sp.GetRequiredService<IMeshService>();

--- a/memex/Memex.Portal.Shared/GuiShellSwitch.cs
+++ b/memex/Memex.Portal.Shared/GuiShellSwitch.cs
@@ -94,6 +94,9 @@ public static class GuiShellSwitch
                     MaxAge = TimeSpan.FromDays(365),
                     HttpOnly = false,     // the shells may read it to render their switch affordance
                     SameSite = SameSiteMode.Lax,
+                    // Same policy as the frontend-selection cookie: Secure whenever the request
+                    // itself is HTTPS, so the preference never rides plain HTTP on a TLS site.
+                    Secure = context.Request.IsHttps,
                 });
             if (redirect is not null)
             {

--- a/memex/Memex.Portal.Shared/GuiShellSwitch.cs
+++ b/memex/Memex.Portal.Shared/GuiShellSwitch.cs
@@ -1,0 +1,109 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Memex.Portal.Shared;
+
+/// <summary>
+/// The per-browser GUI-shell switch for a deployment serving BOTH shells (<see cref="GuiFeatureOptions"/>):
+/// Blazor owns <c>/</c>, Next lives under <c>/next</c> on the same host. A plain browser navigation
+/// lands on <see cref="GuiFeatureOptions.Default"/>; <c>?gui=next</c> / <c>?gui=blazor</c> on any
+/// page switches — the choice is remembered in a cookie and applied by a REDIRECT (never a proxy:
+/// the ingress owns the actual routing to the Next service, exactly as today).
+///
+/// <para>Only NAVIGATIONS switch: GET, an <c>Accept</c> that wants <c>text/html</c>, and a path
+/// outside every non-page surface (APIs, the circuit, static assets, auth). Everything else — the
+/// mesh surfaces both shells consume — is untouched, so a Next viewer's same-host REST/gRPC-web
+/// calls flow exactly as before.</para>
+/// </summary>
+public static class GuiShellSwitch
+{
+    /// <summary>The preference cookie. Values: "next" | "blazor".</summary>
+    public const string CookieName = "memex-gui";
+
+    /// <summary>The query parameter that sets (and re-sets) the preference.</summary>
+    public const string QueryParam = "gui";
+
+    /// <summary>The Next shell's base path on the shared host (its build bakes <c>basePath: "/next"</c>).</summary>
+    public const string NextBasePath = "/next";
+
+    // Non-page surfaces a navigation redirect must never touch. Prefix match on the raw path.
+    private static readonly string[] ExcludedPrefixes =
+    [
+        NextBasePath,
+        "/api", "/mcp", "/signalr", "/meshweaver.v1.Mesh",
+        "/_blazor", "/_framework", "/_content",
+        "/static", "/content", "/images", "/favicon", "/robots.txt", "/manifest",
+        "/login", "/logout", "/signin-oidc", "/signout", "/authorize", "/token", "/register",
+        "/.well-known", "/healthz", "/alive", "/webhooks",
+    ];
+
+    /// <summary>
+    /// The pure decision: where should this request land, and should the cookie be (re)written?
+    /// Exposed for unit tests — the middleware below is just this plus HttpContext plumbing.
+    /// </summary>
+    /// <returns><c>redirect</c> null = pass through; otherwise the location to 302 to.
+    /// <c>setCookie</c> null = leave the cookie alone; otherwise write this value.</returns>
+    public static (string? Redirect, string? SetCookie) Decide(
+        string method, PathString path, string? acceptHeader, string? queryGui, string? cookieGui,
+        string defaultShell)
+    {
+        // An explicit ?gui= always records the choice, even on excluded paths (the redirect below
+        // still only applies to navigations).
+        var setCookie = queryGui?.ToLowerInvariant() switch
+        {
+            "next" => "next",
+            "blazor" => "blazor",
+            _ => null,
+        };
+
+        if (!HttpMethods.IsGet(method))
+            return (null, setCookie);
+        if (acceptHeader is null || !acceptHeader.Contains("text/html", StringComparison.OrdinalIgnoreCase))
+            return (null, setCookie);
+        var raw = path.HasValue ? path.Value! : "/";
+        foreach (var prefix in ExcludedPrefixes)
+            if (raw.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return (null, setCookie);
+
+        var effective = setCookie
+            ?? cookieGui?.ToLowerInvariant()
+            ?? (string.Equals(defaultShell, "Next", StringComparison.OrdinalIgnoreCase) ? "next" : "blazor");
+        if (effective != "next")
+            return (null, setCookie);
+
+        // Send the navigation to the same path under /next (Next is built with that basePath).
+        var target = NextBasePath + (raw == "/" ? "" : raw);
+        return (target, setCookie);
+    }
+
+    /// <summary>Mounts the switch. Call only when BOTH shells are enabled.</summary>
+    public static IApplicationBuilder UseGuiShellSwitch(this IApplicationBuilder app, GuiFeatureOptions gui)
+        => app.Use(async (context, nextMiddleware) =>
+        {
+            var (redirect, setCookie) = Decide(
+                context.Request.Method,
+                context.Request.Path,
+                context.Request.Headers.Accept,
+                context.Request.Query[QueryParam],
+                context.Request.Cookies[CookieName],
+                gui.Default);
+            if (setCookie is not null)
+                context.Response.Cookies.Append(CookieName, setCookie, new CookieOptions
+                {
+                    Path = "/",
+                    MaxAge = TimeSpan.FromDays(365),
+                    HttpOnly = false,     // the shells may read it to render their switch affordance
+                    SameSite = SameSiteMode.Lax,
+                });
+            if (redirect is not null)
+            {
+                // Preserve the query, minus the gui parameter itself (it has done its job).
+                var query = QueryString.Create(
+                    context.Request.Query.Where(kv => !string.Equals(kv.Key, QueryParam, StringComparison.OrdinalIgnoreCase))
+                        .SelectMany(kv => kv.Value, (kv, v) => new KeyValuePair<string, string?>(kv.Key, v)));
+                context.Response.Redirect(redirect + query, permanent: false);
+                return;
+            }
+            await nextMiddleware();
+        });
+}

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1457,6 +1457,9 @@ public static class MemexConfiguration
             // base path. In k8s the ingress usually routes /next to the Next service before this
             // fires; locally (PORTAL_ORIGIN dev / e2e) this is what makes the portal origin usable
             // in a browser at all. APIs and assets are mapped ABOVE and never hit this fallback.
+            // Gated on the Next shell being ON: with BOTH shells off (a headless mesh API
+            // deployment) there is nothing to redirect to, and unmatched paths 404 naturally.
+            if (guiShells.Next)
             app.MapFallback("/{**path}", (HttpContext http) =>
             {
                 var accept = http.Request.Headers.Accept.ToString();

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -92,13 +92,22 @@ public static class MemexConfiguration
         // standalone rather than folded into the host's <App>.styles.css aggregate.
         services.AddMeshModuleStaticAssets();
 
-        services.AddRazorComponents()
-            .AddInteractiveServerComponents()
-            .AddHubOptions(opt =>
-            {
-                opt.DisableImplicitFromServicesParameters = true;
-            })
-            .AddBlazorPortalServices();
+        // ── GUI shells (Features:Gui) — the Blazor pipeline is OPTIONAL per deployment ─────────
+        // A next-only portal (Features__Gui__Blazor=false) serves every mesh surface (REST,
+        // gRPC-web, SignalR, MCP, auth, static assets) and NO Razor components: no circuit, no
+        // Blazor view registry, no per-circuit portal hubs. Both shells default ON — an absent
+        // section preserves today's behaviour.
+        var guiShells = (builder.Configuration
+            .GetSection(MemexFeatureOptions.SectionName)
+            .Get<MemexFeatureOptions>() ?? new MemexFeatureOptions()).Gui;
+        if (guiShells.Blazor)
+            services.AddRazorComponents()
+                .AddInteractiveServerComponents()
+                .AddHubOptions(opt =>
+                {
+                    opt.DisableImplicitFromServicesParameters = true;
+                })
+                .AddBlazorPortalServices();
 
         // Onboarding service — pulls the three-row dual-write out of
         // Onboarding.razor so it's unit-testable end-to-end.
@@ -1032,6 +1041,12 @@ public static class MemexConfiguration
         {
             var features = configuration.GetSection(MemexFeatureOptions.SectionName)
                 .Get<MemexFeatureOptions>() ?? new MemexFeatureOptions();
+            // Without the Blazor shell there are no circuits, hence no per-circuit portal hubs —
+            // the whole portal-hub configuration (view packs + AddBlazor's registry/data wiring)
+            // is circuit-side and must not be built. The JS shells reach the mesh through the
+            // session hubs (REST/gRPC-web), configured elsewhere.
+            if (!features.Gui.Blazor)
+                return (TBuilder)builder;
             return (TBuilder)builder
             .ConfigureHub(mesh => mesh
                 .AddMeshTypes()
@@ -1225,6 +1240,36 @@ public static class MemexConfiguration
 
         app.UseRouting();
 
+        // ── GUI shells (Features:Gui) — middleware placement is load-bearing ────────────────────
+        // Both the per-browser shell switch and the next-only Blazor-prefix gate MUST sit here,
+        // directly after UseRouting: this app's empirical rule (see the UserContextMiddleware
+        // ordering comment below) is that middleware registered after a Map* call never sees a
+        // request that call's endpoint matched, and the raw-wwwroot UseStaticFiles below would
+        // likewise answer /_framework files before a later gate. Registered at the bottom of this
+        // method (2026-08-24, first cut) the 404 gate never ran: the static-asset endpoint for
+        // blazor.web.js executed first and 500'd in dev on the missing file.
+        var guiShells = (app.Configuration
+            .GetSection(MemexFeatureOptions.SectionName)
+            .Get<MemexFeatureOptions>() ?? new MemexFeatureOptions()).Gui;
+        if (guiShells is { Blazor: true, Next: true })
+            // Both shells on one host: the per-browser switch (?gui=next|blazor + cookie).
+            app.UseGuiShellSwitch(guiShells);
+        if (!guiShells.Blazor)
+            // NEXT-ONLY: this portal HAS no Blazor surface, so Blazor's two URL prefixes answer
+            // 404 outright. Without this gate they answer worse: the static-asset manifest still
+            // lists /_framework/blazor.web.js (the assemblies stay referenced), and with
+            // MapRazorComponents absent its endpoint 500s in dev on the missing file.
+            app.Use((http, nextMiddleware) =>
+            {
+                if (http.Request.Path.StartsWithSegments("/_blazor")
+                    || http.Request.Path.StartsWithSegments("/_framework"))
+                {
+                    http.Response.StatusCode = StatusCodes.Status404NotFound;
+                    return Task.CompletedTask;
+                }
+                return nextMiddleware(http);
+            });
+
         // 🚨 The static-file middleware runs AFTER UseRouting, and that ordering is the whole
         // point: StaticFileMiddleware skips a request whose ENDPOINT has already been selected, so
         // everything in the build-time static-asset manifest is answered by MapStaticAssets below
@@ -1400,9 +1445,30 @@ public static class MemexConfiguration
         );
         app.MapStaticAssets();
         app.MapControllers();
-        app.MapRazorComponents<TApp>()
-            .AddMeshViews()
-            .AddInteractiveServerRenderMode();
+        // The shell-switch and next-only middleware live directly after UseRouting above — a
+        // gate registered down here never sees a request an earlier Map* already matched.
+        if (guiShells.Blazor)
+            app.MapRazorComponents<TApp>()
+                .AddMeshViews()
+                .AddInteractiveServerRenderMode();
+        else
+        {
+            // The host serves no pages of its own — send browser navigations to the Next shell's
+            // base path. In k8s the ingress usually routes /next to the Next service before this
+            // fires; locally (PORTAL_ORIGIN dev / e2e) this is what makes the portal origin usable
+            // in a browser at all. APIs and assets are mapped ABOVE and never hit this fallback.
+            app.MapFallback("/{**path}", (HttpContext http) =>
+            {
+                var accept = http.Request.Headers.Accept.ToString();
+                if (!HttpMethods.IsGet(http.Request.Method)
+                    || !accept.Contains("text/html", StringComparison.OrdinalIgnoreCase))
+                    return Results.NotFound();
+                var path = http.Request.Path.HasValue ? http.Request.Path.Value! : "/";
+                if (path.StartsWith(GuiShellSwitch.NextBasePath, StringComparison.OrdinalIgnoreCase))
+                    return Results.NotFound(); // /next is the Next service's — never loop
+                return Results.Redirect(GuiShellSwitch.NextBasePath + (path == "/" ? "" : path));
+            });
+        }
 
         // Deploy-timing lifecycle markers, measurable in Loki (grep "PortalReady" /
         // "PortalShutdown"). A dedicated Information-level category (the same surfaced-channel

--- a/memex/Memex.Portal.Shared/MemexFeatureOptions.cs
+++ b/memex/Memex.Portal.Shared/MemexFeatureOptions.cs
@@ -20,6 +20,9 @@ public sealed record MemexFeatureOptions
 
     public AiFeatureOptions Ai { get; init; } = new();
 
+    /// <summary>Which GUI shells this deployment serves — see <see cref="GuiFeatureOptions"/>.</summary>
+    public GuiFeatureOptions Gui { get; init; } = new();
+
     /// <summary>Static-repo → DB sync: which partitions are materialized into and served from the DB.</summary>
     public StaticRepoSyncFeatureOptions StaticRepoSync { get; init; } = new();
 
@@ -185,4 +188,28 @@ public sealed record AiCliFeatureOptions
     public bool Copilot { get; init; } = true;
 
     public bool HasAny => ClaudeCode || Copilot;
+}
+
+/// <summary>
+/// The GUI SHELLS a deployment serves, and which one owns the front door. Both default ON so an
+/// absent section preserves today's behaviour; a deployment composes its portal by turning shells
+/// off (<c>Features__Gui__Blazor=false</c> → a NEXT-ONLY portal: the host serves the mesh surfaces
+/// — REST, gRPC-web, SignalR, MCP, auth, static assets — and NO Razor-components pipeline, no
+/// circuit, no Blazor view registry; the Next.js app is the whole GUI).
+/// <para>When BOTH are on, <see cref="Default"/> picks the shell a plain browser navigation lands
+/// on, and the viewer can switch per-browser with <c>?gui=next</c> / <c>?gui=blazor</c> (a cookie
+/// remembers the choice — see <c>GuiShellSwitch</c>). Next is served under <c>/next</c> on the
+/// same host (ingress-routed in k8s; <c>PORTAL_ORIGIN</c> rewrites in local dev), so the switch is
+/// a redirect, never a proxy.</para>
+/// </summary>
+public sealed record GuiFeatureOptions
+{
+    /// <summary>Serve the Blazor shell (Razor components + circuit + Blazor view registry).</summary>
+    public bool Blazor { get; init; } = true;
+
+    /// <summary>The Next.js shell participates (under <c>/next</c>); enables the shell switch.</summary>
+    public bool Next { get; init; } = true;
+
+    /// <summary>The shell a plain navigation lands on when both are enabled: "Blazor" or "Next".</summary>
+    public string Default { get; init; } = "Blazor";
 }

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -20,7 +20,10 @@ using Orleans.Hosting;
 using MeshWeaver.Compiler;
 var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
-builder.Services.AddServerSideBlazor().AddCircuitOptions(o => o.DetailedErrors = true);
+// Blazor is a per-deployment SHELL (Features:Gui) — a next-only portal registers none of it.
+if ((builder.Configuration.GetSection(Memex.Portal.Shared.MemexFeatureOptions.SectionName)
+        .Get<Memex.Portal.Shared.MemexFeatureOptions>() ?? new Memex.Portal.Shared.MemexFeatureOptions()).Gui.Blazor)
+    builder.Services.AddServerSideBlazor().AddCircuitOptions(o => o.DetailedErrors = true);
 // Give Orleans time to drain grain activations during a rolling update.
 // ACA termination grace period is set to 120 s in Memex.AppHost; this
 // keeps the .NET host alive for 90 s (leaves 30 s headroom before SIGKILL).

--- a/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
@@ -57,7 +57,14 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
             return;
         }
 
-        var hub = context.RequestServices.GetRequiredService<PortalApplication>().Hub;
+        // The Blazor shell's per-circuit portal hub when it is registered; the mesh root hub on a
+        // portal running without the Blazor shell (Features:Gui:Blazor=false). Identity resolution
+        // is an HTTP concern, not a circuit concern: AccessService is the MESH-wide singleton
+        // either way (a hosted hub only registers its own when the parent has none), so both paths
+        // stamp the same service — the portal hub is merely preferred so SSR scopes reuse their
+        // circuit hub. Same shape as ResolveContentCaller in BlazorHostingExtensions.
+        var hub = context.RequestServices.GetService<PortalApplication>()?.Hub
+                  ?? context.RequestServices.GetRequiredService<IMessageHub>();
         var userService = hub.ServiceProvider.GetRequiredService<AccessService>();
 
         // 🚨 THE ONLY THING WE KNOW about an ANONYMOUS visitor's language. Everything downstream

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-optional-blazor-gui-shells.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-optional-blazor-gui-shells.md
@@ -1,0 +1,18 @@
+---
+Name: Choose your portal: Blazor, the new Next shell, or both
+Category: Feature
+Description: A deployment now composes its GUI shells — Blazor-only, Next-only, or both — and on a portal serving both, ?gui=next / ?gui=blazor switches your browser between them.
+Icon: Sparkle
+Order: -20260824
+---
+
+# Choose your portal: Blazor, the new Next shell, or both
+
+Which GUI a portal serves is now deployment configuration. A deployment can run the classic
+Blazor portal, the new Next-based portal, or both side by side — and a Next-only portal carries no
+Blazor at all: no circuit, no server-side rendering pipeline, just the mesh services the modern
+shell talks to.
+
+On a portal serving both — like meshweaver.cloud — add `?gui=next` to any page to switch your
+browser to the new shell, and `?gui=blazor` to switch back. The choice sticks per browser; every
+page keeps its address across the switch.

--- a/test/Memex.Portal.Shared.Test/GuiShellSwitchTest.cs
+++ b/test/Memex.Portal.Shared.Test/GuiShellSwitchTest.cs
@@ -1,0 +1,82 @@
+using Memex.Portal.Shared;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the per-browser GUI-shell switch decision (<see cref="GuiShellSwitch.Decide"/>) — the pure
+/// half of the both-shells middleware. The contract: only NAVIGATIONS switch (GET + text/html +
+/// a page path), <c>?gui=</c> records the choice, the cookie replays it, and the deployment's
+/// <c>Features:Gui:Default</c> decides where a fresh browser lands.
+/// </summary>
+public class GuiShellSwitchTest
+{
+    private const string Html = "text/html,application/xhtml+xml";
+
+    [Fact]
+    public void FreshBrowser_DefaultBlazor_PassesThrough()
+    {
+        var (redirect, setCookie) = GuiShellSwitch.Decide("GET", "/Doc/Architecture", Html, null, null, "Blazor");
+        Assert.Null(redirect);
+        Assert.Null(setCookie);
+    }
+
+    [Fact]
+    public void FreshBrowser_DefaultNext_LandsOnNext_SamePath()
+    {
+        var (redirect, _) = GuiShellSwitch.Decide("GET", "/Doc/Architecture", Html, null, null, "Next");
+        Assert.Equal("/next/Doc/Architecture", redirect);
+    }
+
+    [Fact]
+    public void QueryGuiNext_SetsCookie_AndRedirects()
+    {
+        var (redirect, setCookie) = GuiShellSwitch.Decide("GET", "/", Html, "next", null, "Blazor");
+        Assert.Equal("next", setCookie);
+        Assert.Equal("/next", redirect);
+    }
+
+    [Fact]
+    public void QueryGuiBlazor_OverridesNextCookie_AndStays()
+    {
+        var (redirect, setCookie) = GuiShellSwitch.Decide("GET", "/rbuergi", Html, "blazor", "next", "Blazor");
+        Assert.Equal("blazor", setCookie);
+        Assert.Null(redirect);
+    }
+
+    [Fact]
+    public void NextCookie_RedirectsEveryNavigation()
+    {
+        var (redirect, _) = GuiShellSwitch.Decide("GET", "/Store", Html, null, "next", "Blazor");
+        Assert.Equal("/next/Store", redirect);
+    }
+
+    [Theory]
+    [InlineData("/api/mesh/whoami")]
+    [InlineData("/meshweaver.v1.Mesh/Connect")]
+    [InlineData("/_blazor/negotiate")]
+    [InlineData("/static/NodeTypeIcons/book.svg")]
+    [InlineData("/login")]
+    [InlineData("/next/Doc")]
+    [InlineData("/mcp")]
+    public void NonPageSurfaces_NeverRedirect(string path)
+    {
+        var (redirect, _) = GuiShellSwitch.Decide("GET", path, Html, null, "next", "Blazor");
+        Assert.Null(redirect);
+    }
+
+    [Fact]
+    public void NonHtmlAccept_NeverRedirects_TheMeshSurfacesFlowUntouched()
+    {
+        var (redirect, _) = GuiShellSwitch.Decide("GET", "/Doc", "application/json", null, "next", "Blazor");
+        Assert.Null(redirect);
+    }
+
+    [Fact]
+    public void Post_NeverRedirects_ButStillRecordsAnExplicitChoice()
+    {
+        var (redirect, setCookie) = GuiShellSwitch.Decide("POST", "/Doc", Html, "next", null, "Blazor");
+        Assert.Null(redirect);
+        Assert.Equal("next", setCookie);
+    }
+}


### PR DESCRIPTION
## What

`Features:Gui` makes the GUI shells deployment configuration:

| Setting | Effect |
|---|---|
| `Features:Gui:Blazor` (default `true`) | The classic Blazor portal — Razor components, circuits, portal-hub config |
| `Features:Gui:Next` (default `true`) | The Next shell served at `/next` |
| `Features:Gui:Default` (default `Blazor`) | Which shell a bare browser navigation lands on |

- **Next-only** (`Features__Gui__Blazor=false`): no Razor/circuit services, no per-circuit portal-hub configuration, `/_blazor` + `/_framework` answer 404, and browser navigations 302 to `/next{path}`. The mesh surfaces (REST, gRPC-web, MCP, SignalR, auth, static assets) are untouched.
- **Both shells** (meshweaver.cloud's shape): `?gui=next` / `?gui=blazor` switches the browser per the `memex-gui` cookie (365d, Lax); every page keeps its path across the switch.
- **Identity decoupled from the Blazor shell**: `UserContextMiddleware`, `whoami`, `ApiTokenController`, `EaGraphAuth`, and the email senders prefer the circuit's `PortalApplication` hub and fall back to the mesh root hub — `AccessService` is the mesh-wide singleton either way (the shape `ResolveContentCaller` already used). Previously every page request and the live-source token mint 500'd without Blazor.
- **Middleware placement is load-bearing**: the switch and the next-only 404 gate sit directly after `UseRouting` — middleware registered after a `Map*` call never sees a request that endpoint matched (this repo's documented trap; the first cut of the gate never ran).

## Verification

- `clients/portal-next`: **`npm run e2e:next-only`** — 4/4 green. Boots the Monolith with `Features__Gui__Blazor=false` + the Next dev server and proves: no Blazor endpoints; portal navigations land on `/next`; anonymous `whoami` still 401s (ReadPolicy holds); DevLogin-authenticated `whoami`/`resolve`/static assets work; the signed-in Next shell renders **live** mesh content with zero Blazor-shaped requests.
- `GuiShellSwitchTest` (new): 14/14 on the pure `Decide()` logic.
- `Memex.Portal.Shared.Test` 399/399 · `MeshWeaver.Hosting.Blazor.Test` 452/452 (Blazor-on default unregressed).
- Monolith + Distributed build clean with `-c Release -warnaserror`.

Known gap (documented): interactive `/login` UI is Blazor-side — next-only auth rides the OIDC controller endpoints (prod's flow) and DevLogin; the e2e uses DevLogin.

Follow-ups (separate PRs): factor the default Blazor view implementations into a view-pack module; set `Features:Gui` on meshweaver.cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)