### PR TITLE
RN deployment manifests compose plugin client modules (plugin: specifiers, build-time vendoring)

### DIFF
--- a/clients/react-native/.gitignore
+++ b/clients/react-native/.gitignore
@@ -7,3 +7,4 @@ ios/
 android/
 test-results/
 playwright-report/
+src/deployment.vendor/

--- a/clients/react-native/deployment/deployment.schema.json
+++ b/clients/react-native/deployment/deployment.schema.json
@@ -4,24 +4,45 @@
   "description": "What ONE deployment's app bundle is composed of. The JS bundle is static (Hermes loads no code at runtime), so this manifest is consumed at BUILD time: scripts/gen-deployment.mjs turns it into static imports (src/deployment.generated.ts) that Metro bundles. Select a manifest with MEMEX_DEPLOYMENT=<name|path> (default: deployment/default.json).",
   "type": "object",
   "additionalProperties": false,
-  "required": ["name"],
+  "required": [
+    "name"
+  ],
   "properties": {
-    "$schema": { "type": "string" },
-    "name": { "type": "string", "description": "Deployment name (diagnostics, app display fallback)." },
-    "portalUrl": { "type": "string", "description": "The mesh a NATIVE build dials by default (web is same-origin). MEMEX_PORTAL_URL still overrides at build time." },
+    "$schema": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string",
+      "description": "Deployment name (diagnostics, app display fallback)."
+    },
+    "portalUrl": {
+      "type": "string",
+      "description": "The mesh a NATIVE build dials by default (web is same-origin). MEMEX_PORTAL_URL still overrides at build time."
+    },
     "branding": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "displayName": { "type": "string", "description": "The name in the top bar (desktop widths)." },
-        "accent": { "type": "string", "description": "Light-mode accent (hex)." },
-        "accentDark": { "type": "string", "description": "Dark-mode accent (hex); falls back to accent." }
+        "displayName": {
+          "type": "string",
+          "description": "The name in the top bar (desktop widths)."
+        },
+        "accent": {
+          "type": "string",
+          "description": "Light-mode accent (hex)."
+        },
+        "accentDark": {
+          "type": "string",
+          "description": "Dark-mode accent (hex); falls back to accent."
+        }
       }
     },
     "modules": {
       "type": "array",
-      "description": "Client modules composed into the bundle — anything of interest a deployment needs: each entry is a Metro-resolvable import specifier (a package name, or a path relative to the app root) whose module default-exports a DeploymentModule ({ name?, pack?: { controls, skins, fallback, defaultContainer } } — @meshweaver/react/core). Later modules win on collisions.",
-      "items": { "type": "string" }
+      "description": "Client modules composed into the bundle \u2014 anything of interest a deployment needs: each entry is (a) a Metro-resolvable import specifier (a package name, or a path relative to the app root), or (b) a PLUGIN module reference \"plugin:<RepoName>/<path-in-repo>\" (no extension), resolved against the colon-separated repo checkouts in MEMEX_PLUGIN_REPOS (basename = repo name, the memex-local convention) and VENDORED into src/deployment.vendor/ at generation time \u2014 Metro never resolves across repos, so the module's directory is copied into the app and imported from there. Every entry's module default-exports a DeploymentModule ({ name?, pack?: { controls, skins, fallback, defaultContainer } } \u2014 @meshweaver/react/core). Later modules win on collisions.",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/clients/react-native/deployment/examples/chess.json
+++ b/clients/react-native/deployment/examples/chess.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../deployment.schema.json",
+  "name": "Chess",
+  "branding": {
+    "displayName": "MeshWeaver Chess",
+    "accent": "#b08a5a",
+    "accentDark": "#eed8b0"
+  },
+  "modules": [
+    "./src/modules/threads",
+    "./src/modules/meshBrowse",
+    "./src/modules/nodeEditing",
+    "./src/modules/data",
+    "./src/modules/documents",
+    "./src/modules/analysis",
+    "./src/modules/media",
+    "plugin:MeshWeaver.Plugins/Chess/gui/rn/chess"
+  ]
+}

--- a/clients/react-native/scripts/gen-deployment.mjs
+++ b/clients/react-native/scripts/gen-deployment.mjs
@@ -59,15 +59,27 @@ const vendorPlugin = (spec) => {
     process.exit(1);
   }
   const modulePath = rest.join("/");
-  const entry = ["", ".tsx", ".ts"].map((ext) => path.join(repo, modulePath + ext)).find((p) => fs.existsSync(p) && fs.statSync(p).isFile());
+  // Containment: the specifier is manifest data — a ".." segment must never let it resolve
+  // outside the plugin checkout (or vendor outside the vendor tree below).
+  const inside = (child, parent) => {
+    const rel = path.relative(parent, child);
+    return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+  };
+  const entry = ["", ".tsx", ".ts"]
+    .map((ext) => path.resolve(repo, modulePath + ext))
+    .find((p) => inside(p, repo) && fs.existsSync(p) && fs.statSync(p).isFile());
   if (!entry) {
-    console.error(`gen-deployment: plugin module '${modulePath}(.tsx|.ts)' not found under ${repo}`);
+    console.error(`gen-deployment: plugin module '${modulePath}(.tsx|.ts)' not found under ${repo} (paths must stay inside the repo)`);
     process.exit(1);
   }
   // Copy the module's DIRECTORY (a module may span several files) into the vendor tree at the
   // same repo-relative location, so intra-module relative imports keep working.
   const moduleDir = path.dirname(entry);
-  const destDir = path.join(vendorRoot, repoName, path.relative(repo, moduleDir));
+  const destDir = path.resolve(vendorRoot, repoName, path.relative(repo, moduleDir));
+  if (!inside(destDir, vendorRoot)) {
+    console.error(`gen-deployment: refusing to vendor '${spec}' outside ${vendorRoot}`);
+    process.exit(1);
+  }
   fs.cpSync(moduleDir, destDir, { recursive: true });
   const destEntry = path.join(destDir, path.basename(entry).replace(/\.(tsx|ts)$/, ""));
   return "./" + path.relative(srcDir, destEntry).split(path.sep).join("/");

--- a/clients/react-native/scripts/gen-deployment.mjs
+++ b/clients/react-native/scripts/gen-deployment.mjs
@@ -31,10 +31,53 @@ const name = String(manifest.name ?? sel);
 // in the manifest (author-friendly) and rewritten relative to src/ here, where the generated file
 // lives — Metro and tsc both resolve the emitted import from that directory.
 const srcDir = path.join(root, "src");
+// PLUGIN modules ("plugin:<RepoName>/<path>") are VENDORED: Metro never resolves across repos
+// (watchFolders would pin absolute developer paths into the build), so the module's whole
+// directory is copied from the plugin checkout into src/deployment.vendor/<RepoName>/<dir>/ and
+// imported from there. Deterministic from the checkout's content; the vendor dir is regenerated
+// (wiped) on every run and gitignored — the DEFAULT manifest must never reference a plugin, or a
+// fresh clone could not build without the plugin checkout.
+const vendorRoot = path.join(srcDir, "deployment.vendor");
+fs.rmSync(vendorRoot, { recursive: true, force: true });
+const pluginRepos = (process.env.MEMEX_PLUGIN_REPOS ?? "")
+  .split(":")
+  .filter(Boolean)
+  .map((p) => path.resolve(p));
+const vendorPlugin = (spec) => {
+  const ref = spec.slice("plugin:".length);
+  const [repoName, ...rest] = ref.split("/");
+  if (!repoName || rest.length === 0) {
+    console.error(`gen-deployment: malformed plugin specifier '${spec}' — expected plugin:<RepoName>/<path-in-repo>`);
+    process.exit(1);
+  }
+  const repo = pluginRepos.find((p) => path.basename(p) === repoName);
+  if (!repo) {
+    console.error(
+      `gen-deployment: plugin repo '${repoName}' (for '${spec}') is not in MEMEX_PLUGIN_REPOS — `
+      + `set it to colon-separated checkout paths whose basename names the repo (the memex-local convention). `
+      + `Currently: ${pluginRepos.join(":") || "(unset)"}`);
+    process.exit(1);
+  }
+  const modulePath = rest.join("/");
+  const entry = ["", ".tsx", ".ts"].map((ext) => path.join(repo, modulePath + ext)).find((p) => fs.existsSync(p) && fs.statSync(p).isFile());
+  if (!entry) {
+    console.error(`gen-deployment: plugin module '${modulePath}(.tsx|.ts)' not found under ${repo}`);
+    process.exit(1);
+  }
+  // Copy the module's DIRECTORY (a module may span several files) into the vendor tree at the
+  // same repo-relative location, so intra-module relative imports keep working.
+  const moduleDir = path.dirname(entry);
+  const destDir = path.join(vendorRoot, repoName, path.relative(repo, moduleDir));
+  fs.cpSync(moduleDir, destDir, { recursive: true });
+  const destEntry = path.join(destDir, path.basename(entry).replace(/\.(tsx|ts)$/, ""));
+  return "./" + path.relative(srcDir, destEntry).split(path.sep).join("/");
+};
 const rewrite = (spec) =>
-  spec.startsWith("./") || spec.startsWith("../")
-    ? "./" + path.relative(srcDir, path.resolve(root, spec)).split(path.sep).join("/").replace(/^(?!\.)/, "")
-    : spec;
+  spec.startsWith("plugin:")
+    ? vendorPlugin(spec)
+    : spec.startsWith("./") || spec.startsWith("../")
+      ? "./" + path.relative(srcDir, path.resolve(root, spec)).split(path.sep).join("/").replace(/^(?!\.)/, "")
+      : spec;
 const modules = (Array.isArray(manifest.modules) ? manifest.modules.map(String) : []).map(rewrite);
 const branding = manifest.branding ?? {};
 

--- a/clients/react-native/src/genDeployment.test.ts
+++ b/clients/react-native/src/genDeployment.test.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+// The PLUGIN half of deployment composition (gen-deployment.mjs): a manifest entry
+// "plugin:<RepoName>/<path>" is resolved against MEMEX_PLUGIN_REPOS and the module's directory is
+// VENDORED into src/deployment.vendor/ — Metro never resolves across repos, so the copy IS the
+// mechanism. Exercised here against a synthetic plugin checkout so the test is self-contained
+// (the real consumer is MeshWeaver.Plugins/Chess/gui/rn/chess — see deployment/examples/chess.json).
+
+const appRoot = resolve(__dirname, "..");
+const script = join(appRoot, "scripts", "gen-deployment.mjs");
+const generated = join(appRoot, "src", "deployment.generated.ts");
+const vendorRoot = join(appRoot, "src", "deployment.vendor");
+
+let tmp: string | undefined;
+
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+  tmp = undefined;
+  rmSync(vendorRoot, { recursive: true, force: true });
+  // Restore the checked-in default output for whoever builds next.
+  execFileSync(process.execPath, [script], { env: { ...process.env, MEMEX_DEPLOYMENT: undefined, MEMEX_PLUGIN_REPOS: undefined } });
+});
+
+function makePluginRepo(): { repo: string; manifest: string } {
+  tmp = mkdtempSync(join(tmpdir(), "mw-plugmod-"));
+  const repo = join(tmp, "FixturePlugins");
+  mkdirSync(join(repo, "Widget", "gui", "rn"), { recursive: true });
+  writeFileSync(
+    join(repo, "Widget", "gui", "rn", "widget.tsx"),
+    `import type { DeploymentModule } from "@meshweaver/react/core";\n` +
+      `const widget: DeploymentModule = { name: "widget", pack: { controls: {} } };\n` +
+      `export default widget;\n`,
+  );
+  // A sibling file proves the whole DIRECTORY vendors (intra-module imports keep working).
+  writeFileSync(join(repo, "Widget", "gui", "rn", "helper.ts"), `export const answer = 42;\n`);
+  const manifest = join(tmp, "deployment.json");
+  writeFileSync(
+    manifest,
+    JSON.stringify({ name: "Fixture", modules: ["plugin:FixturePlugins/Widget/gui/rn/widget"] }),
+  );
+  return { repo, manifest };
+}
+
+describe("gen-deployment plugin modules", () => {
+  it("vendors a plugin module directory and imports it from the vendor tree", () => {
+    const { repo, manifest } = makePluginRepo();
+    execFileSync(process.execPath, [script], {
+      env: { ...process.env, MEMEX_DEPLOYMENT: manifest, MEMEX_PLUGIN_REPOS: repo },
+    });
+    const out = readFileSync(generated, "utf8");
+    expect(out).toContain(`"./deployment.vendor/FixturePlugins/Widget/gui/rn/widget"`);
+    expect(existsSync(join(vendorRoot, "FixturePlugins", "Widget", "gui", "rn", "widget.tsx"))).toBe(true);
+    expect(existsSync(join(vendorRoot, "FixturePlugins", "Widget", "gui", "rn", "helper.ts"))).toBe(true);
+  });
+
+  it("fails loudly when the plugin repo is not in MEMEX_PLUGIN_REPOS", () => {
+    const { manifest } = makePluginRepo();
+    expect(() =>
+      execFileSync(process.execPath, [script], {
+        env: { ...process.env, MEMEX_DEPLOYMENT: manifest, MEMEX_PLUGIN_REPOS: "" },
+        stdio: "pipe",
+      }),
+    ).toThrow(/MEMEX_PLUGIN_REPOS/);
+  });
+
+  it("fails loudly when the module path does not exist in the repo", () => {
+    const { repo } = makePluginRepo();
+    const bad = join(tmp!, "bad.json");
+    writeFileSync(bad, JSON.stringify({ name: "Bad", modules: ["plugin:FixturePlugins/Widget/gui/rn/missing"] }));
+    expect(() =>
+      execFileSync(process.execPath, [script], {
+        env: { ...process.env, MEMEX_DEPLOYMENT: bad, MEMEX_PLUGIN_REPOS: repo },
+        stdio: "pipe",
+      }),
+    ).toThrow(/not found/);
+  });
+});

--- a/clients/react-native/src/genDeployment.test.ts
+++ b/clients/react-native/src/genDeployment.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 // The PLUGIN half of deployment composition (gen-deployment.mjs): a manifest entry
@@ -10,7 +11,8 @@ import { afterEach, describe, expect, it } from "vitest";
 // mechanism. Exercised here against a synthetic plugin checkout so the test is self-contained
 // (the real consumer is MeshWeaver.Plugins/Chess/gui/rn/chess — see deployment/examples/chess.json).
 
-const appRoot = resolve(__dirname, "..");
+// import.meta.url, not __dirname: vitest runs this file as ESM (module: "ESNext").
+const appRoot = fileURLToPath(new URL("..", import.meta.url));
 const script = join(appRoot, "scripts", "gen-deployment.mjs");
 const generated = join(appRoot, "src", "deployment.generated.ts");
 const vendorRoot = join(appRoot, "src", "deployment.vendor");
@@ -77,5 +79,21 @@ describe("gen-deployment plugin modules", () => {
         stdio: "pipe",
       }),
     ).toThrow(/not found/);
+  });
+});
+
+describe("gen-deployment plugin path containment", () => {
+  it("refuses a plugin path that escapes the repo with ..", () => {
+    const { repo } = makePluginRepo();
+    // A real file OUTSIDE the repo that a traversal would otherwise reach.
+    writeFileSync(join(tmp!, "outside.ts"), "export default {};\n");
+    const evil = join(tmp!, "evil.json");
+    writeFileSync(evil, JSON.stringify({ name: "Evil", modules: ["plugin:FixturePlugins/../outside"] }));
+    expect(() =>
+      execFileSync(process.execPath, [script], {
+        env: { ...process.env, MEMEX_DEPLOYMENT: evil, MEMEX_PLUGIN_REPOS: repo },
+        stdio: "pipe",
+      }),
+    ).toThrow(/not found|inside the repo/);
   });
 });


### PR DESCRIPTION
## What

The "module JS colocated with its GUI pack" lane, platform half. A deployment manifest module entry `plugin:<RepoName>/<path-in-repo>` resolves against `MEMEX_PLUGIN_REPOS` (colon-separated checkouts, basename = repo name — the memex-local convention) and **vendors** the module's directory into `src/deployment.vendor/` at generation time, importing from there. Metro never resolves across repos — the copy IS the mechanism: deterministic from the checkout content, no `watchFolders`, no absolute paths in the build. The vendor tree is wiped per run and gitignored; the default manifest carries no plugin references, so a fresh clone builds untouched.

Resolution fails LOUD (unknown repo → names `MEMEX_PLUGIN_REPOS` + convention; missing path → names what was probed).

## Pilot consumer

MeshWeaver.Plugins PR (same change set, dependency order platform-first): the Chess plugin gains a typed `ChessBoardControl` ($type `ChessBoard`, MapControl pattern per Doc/GUI/ReactCustomControls) emitted by a new `NativeBoard` layout area, and carries its own native leaf at `Chess/gui/rn/chess.tsx`. `deployment/examples/chess.json` composes it.

## Verification

- `genDeployment.test.ts` (committed): vendoring + both loud-failure paths against a synthetic plugin checkout — self-contained, no cross-repo dependency in CI.
- Real-module proof (local, needs the Plugins checkout): the Chess module vendors, typechecks in the app, and a render test showed the composed pack drawing a 32-piece board from the control's FEN.
- RN suite 176/176; default generated outputs byte-identical.

No What's New: builder-facing deployment tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)