### PR TITLE
Icons: requested render size beats authored root width/height intrinsics

### DIFF
--- a/clients/react-native/src/rnIcon.tsx
+++ b/clients/react-native/src/rnIcon.tsx
@@ -7,7 +7,7 @@
 // leaf that needs an icon string drawn.
 import { Image, Text, View } from "react-native";
 import { SvgUri, SvgXml } from "react-native-svg";
-import { classifyIcon } from "@meshweaver/react/core";
+import { classifyIcon, sizeInlineSvg } from "@meshweaver/react/core";
 import { resolveAssetUrl } from "./connection";
 import type { ReactNode } from "react";
 
@@ -15,7 +15,9 @@ export function IconGlyph({ icon, size = 20 }: { icon?: string; size?: number })
   const classified = classifyIcon((icon ?? "") as never);
   switch (classified.kind) {
     case "svg":
-      return <SvgXml xml={classified.text} width={size} height={size} />;
+      // sizeInlineSvg: authored root width/height intrinsics would win over the props and
+      // paint e.g. 24px inside a 64px tile — force the requested size on the root tag.
+      return <SvgXml xml={sizeInlineSvg(classified.text, size)} width={size} height={size} />;
     case "url": {
       const url = resolveAssetUrl(classified.text);
       return /\.svg(\?|#|$)/i.test(url)

--- a/clients/react/src/controls/MeshIcon.tsx
+++ b/clients/react/src/controls/MeshIcon.tsx
@@ -12,7 +12,7 @@
 import type { CSSProperties, ReactNode } from "react";
 import type { Json } from "../area/types.js";
 import { resolveIconByName } from "./icon.js";
-import { classifyIcon, sanitizeInlineSvg } from "./iconValue.js";
+import { classifyIcon, sanitizeInlineSvg, sizeInlineSvg } from "./iconValue.js";
 
 export interface MeshIconProps {
   /** The raw icon value: name, `{provider,id,…}` object, inline SVG, URL/path, or emoji. */
@@ -47,7 +47,7 @@ export function MeshIcon({ value, size = 20, fallback = null, style, className, 
           onClick={onClick}
           style={box}
           className={mergeCls("mw-inline-svg", className)}
-          dangerouslySetInnerHTML={{ __html: sanitizeInlineSvg(classified.text) }}
+          dangerouslySetInnerHTML={{ __html: sizeInlineSvg(sanitizeInlineSvg(classified.text), size) }}
         />
       );
     case "url":

--- a/clients/react/src/controls/iconValue.test.ts
+++ b/clients/react/src/controls/iconValue.test.ts
@@ -137,4 +137,9 @@ describe("sizeInlineSvg", () => {
     expect(root).not.toContain('width="24"');
     expect(root).not.toContain("height=24");
   });
+
+  it("preserves the self-closing slash when an unquoted size is the last attribute", () => {
+    const out = sizeInlineSvg(`<svg viewBox="0 0 24 24" width=24/>`, 32);
+    expect(out).toBe(`<svg width="32" height="32" viewBox="0 0 24 24"/>`);
+  });
 });

--- a/clients/react/src/controls/iconValue.test.ts
+++ b/clients/react/src/controls/iconValue.test.ts
@@ -3,7 +3,7 @@
 // ("most SVGs are not showing").
 
 import { describe, expect, it } from "vitest";
-import { backplatePalette, classifyIcon, ensureBackplate, hasBackplate, iconForRendering, isEmojiIcon, isIconUrl } from "./iconValue.js";
+import { backplatePalette, classifyIcon, ensureBackplate, hasBackplate, iconForRendering, isEmojiIcon, isIconUrl, sizeInlineSvg } from "./iconValue.js";
 
 describe("classifyIcon", () => {
   it("classifies inline SVG documents", () => {
@@ -109,5 +109,32 @@ describe("ensureBackplate", () => {
     const out = classifyIcon(monochrome);
     expect(out.kind).toBe("svg");
     expect(out.text).toContain("<rect width='24' height='24' rx='5'");
+  });
+});
+
+describe("sizeInlineSvg", () => {
+  it("strips authored root width/height and injects the requested size first", () => {
+    const out = sizeInlineSvg(`<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'><rect width='24' height='24'/></svg>`, 64);
+    expect(out.startsWith(`<svg width="64" height="64"`)).toBe(true);
+    // the root tag carries no authored size any more…
+    expect(out.slice(0, out.indexOf(">"))).not.toContain("'24'");
+    // …but the CHILD rect keeps its geometry, and the viewBox survives so content scales
+    expect(out).toContain(`<rect width='24' height='24'/>`);
+    expect(out).toContain(`viewBox='0 0 24 24'`);
+  });
+
+  it("sizes a viewBox-only icon the same way", () => {
+    const out = sizeInlineSvg(`<svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z"/></svg>`, 20);
+    expect(out.startsWith(`<svg width="20" height="20"`)).toBe(true);
+    expect(out).toContain(`viewBox="0 0 24 24"`);
+  });
+
+  it("handles double-quoted and unquoted authored sizes", () => {
+    const out = sizeInlineSvg(`<svg width="24" height=24 viewBox="0 0 24 24"/>`, 32);
+    const root = out.slice(0, out.indexOf(">"));
+    expect(root).toContain(`width="32"`);
+    expect(root).toContain(`height="32"`);
+    expect(root).not.toContain('width="24"');
+    expect(root).not.toContain("height=24");
   });
 });

--- a/clients/react/src/controls/iconValue.ts
+++ b/clients/react/src/controls/iconValue.ts
@@ -53,7 +53,9 @@ export function sizeInlineSvg(svg: string, size: number): string {
     const cleaned = attrs
       .replace(/\s(?:width|height)\s*=\s*"[^"]*"/gi, "")
       .replace(/\s(?:width|height)\s*=\s*'[^']*'/gi, "")
-      .replace(/\s(?:width|height)\s*=\s*[^\s>]+/gi, "");
+      // Stop before "/" too: in `<svg … width=24/>` the unquoted value must not swallow the
+      // self-closing slash (that would emit a never-closed root tag — malformed XML).
+      .replace(/\s(?:width|height)\s*=\s*[^\s>/]+/gi, "");
     return `<svg width="${size}" height="${size}"${cleaned}>`;
   });
 }

--- a/clients/react/src/controls/iconValue.ts
+++ b/clients/react/src/controls/iconValue.ts
@@ -39,6 +39,25 @@ export function sanitizeInlineSvg(svg: string): string {
     .replace(/((?:xlink:)?href)\s*=\s*(["'])\s*javascript:[^"']*\2/gi, "");
 }
 
+/** Force the REQUESTED render size onto an inline SVG's ROOT tag. Authored icons can carry
+ *  explicit width/height intrinsics (width="24" height="24"), and both SvgXml (native) and inline
+ *  DOM rendering honor them over the surrounding box — a 24px paint inside a 64px tile, while
+ *  viewBox-only icons fill (the "tiles render tiny" defect; Plugins #620 stripped the authored
+ *  set, this is the structural half so the next fixed-size icon cannot regress it). The root
+ *  tag's own width/height are stripped and the requested size injected FIRST on the tag (a
+ *  duplicate attribute later in a tag is ignored by the parser), so the caller's size always
+ *  wins; viewBox is preserved so content scales; CHILD width/height (<rect width=…>) are
+ *  untouched. */
+export function sizeInlineSvg(svg: string, size: number): string {
+  return svg.replace(/<svg\b([^>]*)>/i, (_m, attrs: string) => {
+    const cleaned = attrs
+      .replace(/\s(?:width|height)\s*=\s*"[^"]*"/gi, "")
+      .replace(/\s(?:width|height)\s*=\s*'[^']*'/gi, "")
+      .replace(/\s(?:width|height)\s*=\s*[^\s>]+/gi, "");
+    return `<svg width="${size}" height="${size}"${cleaned}>`;
+  });
+}
+
 /** An image reference: absolute/rooted URL, data URI, or a path ending in an image extension. */
 export function isIconUrl(value: string): boolean {
   return /^(https?:|data:|blob:|\/)/i.test(value) || /\.(svg|png|jpg|jpeg|gif|webp|ico)(\?|#|$)/i.test(value);

--- a/clients/react/src/core.ts
+++ b/clients/react/src/core.ts
@@ -173,6 +173,7 @@ export {
   isIconUrl,
   isInlineSvg,
   sanitizeInlineSvg,
+  sizeInlineSvg,
   type ClassifiedIcon,
   type IconKind,
 } from "./controls/iconValue.js";

--- a/clients/react/src/index.tsx
+++ b/clients/react/src/index.tsx
@@ -124,6 +124,7 @@ export {
   isIconUrl,
   isInlineSvg,
   sanitizeInlineSvg,
+  sizeInlineSvg,
   type ClassifiedIcon,
   type IconKind,
 } from "./controls/iconValue.js";

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-icon-tiles-render-full-size.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-24-icon-tiles-render-full-size.md
@@ -1,0 +1,13 @@
+---
+Name: App icons fill their tiles
+Category: Fix
+Description: Icons authored with a fixed pixel size no longer render tiny inside larger tiles — the tile size always wins.
+Icon: Sparkle
+Order: -20260824
+---
+
+# App icons fill their tiles
+
+Icons authored with a fixed pixel size used to paint small inside larger surfaces — a 24-pixel
+icon in a 64-pixel app tile. The renderer now always draws an icon at the size the surface asks
+for, on the web and in the native app alike.


### PR DESCRIPTION
## What

Authored inline SVGs carrying explicit `width='24' height='24'` on the **root** tag paint at 24px inside a 64px tile — `SvgXml` (native) and inline DOM rendering honor the intrinsic over the surrounding box, while viewBox-only icons fill (the "tiles render tiny" defect). Plugins #620 stripped the authored icon set; this is the structural half so the next fixed-size icon cannot regress it.

- `sizeInlineSvg(svg, size)` in the shared `iconValue` module: strips the root tag's own width/height, injects the requested size **first** on the tag (a duplicate attribute later in a tag is ignored by the parser), preserves `viewBox` so content scales, leaves child-element geometry untouched.
- Wired in both renderers: web `MeshIcon` (`dangerouslySetInnerHTML`) and RN `IconGlyph` (`SvgXml`).
- Coordinated with Plugins #620 (data half) and the Blazor-side defense (peer session).

## Verification

New tests pin quoted/unquoted root-size replacement, viewBox-only sizing, and child `<rect>` geometry. react 301/301 · RN 177/177 · both typechecks clean. Verified live on the iOS simulator via Metro hot reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)