### PR TITLE
A sign-in event core can raise without knowing who cares

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/LogonActionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/LogonActionNodeType.cs
@@ -60,7 +60,41 @@ public static class LogonActionNodeType
             // Mesh-scoped singleton: its lifetime IS the mesh's, so nothing survives disposal and
             // nothing bleeds between tests (Doc/Architecture/NoStaticState).
             .AddSingleton<LogonActionRunner>()
+            .AddSingleton<SignInNotificationTargets>()
+            .AddSingleton<ILogonAction, AnnounceSignInLogonAction>()
             .AddSingleton<ILogonAction, AppIconAdoptionLogonAction>());
+        return builder;
+    }
+
+    /// <summary>
+    /// Asks to be told when a user signs in: <paramref name="address"/> receives a
+    /// <see cref="UserSignedIn"/> event, fire-and-forget, once per sign-in.
+    ///
+    /// <para>Register this from the SUBSCRIBER's own configuration, not from core's. That is the
+    /// whole point of the seam: core owns "a user signed in" and nothing else, and does not know
+    /// which partitions exist or what they would do about it. A subscriber that is absent on a given
+    /// deployment simply never registers, so there is nothing to probe and no NotFound to
+    /// tolerate.</para>
+    ///
+    /// <para>The handler runs on the subscriber's own hub under the delivery's identity, so it acts
+    /// as the signing-in user. Nothing is expected back — an event with a response would put the
+    /// subscriber's availability on the user's sign-in path.</para>
+    /// </summary>
+    /// <param name="builder">The mesh builder.</param>
+    /// <param name="address">The hub address to notify.</param>
+    public static TBuilder AddSignInNotificationTarget<TBuilder>(this TBuilder builder, Address address)
+        where TBuilder : MeshBuilder
+    {
+        builder.ConfigureServices(services =>
+        {
+            services.AddSingleton<SignInNotificationTargets>();
+            return services;
+        });
+        builder.ConfigureHub(config => config.WithInitialization(hub =>
+        {
+            hub.ServiceProvider.GetService<SignInNotificationTargets>()?.Add(address);
+            return System.Reactive.Linq.Observable.Return(System.Reactive.Unit.Default);
+        }));
         return builder;
     }
 

--- a/src/MeshWeaver.Graph/Configuration/LogonActionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/LogonActionNodeType.cs
@@ -70,11 +70,23 @@ public static class LogonActionNodeType
     /// Asks to be told when a user signs in: <paramref name="address"/> receives a
     /// <see cref="UserSignedIn"/> event, fire-and-forget, once per sign-in.
     ///
-    /// <para>Register this from the SUBSCRIBER's own configuration, not from core's. That is the
-    /// whole point of the seam: core owns "a user signed in" and nothing else, and does not know
-    /// which partitions exist or what they would do about it. A subscriber that is absent on a given
-    /// deployment simply never registers, so there is nothing to probe and no NotFound to
-    /// tolerate.</para>
+    /// <para>Core owns "a user signed in" and nothing else — it does not know which partitions exist
+    /// or what they would do about it. A deployment that carries no subscriber registers none, so
+    /// there is nothing to probe and no NotFound to tolerate.</para>
+    ///
+    /// <para>🚨 <b>This belongs in DEPLOYMENT configuration</b> (where the mesh is built — e.g.
+    /// <c>MemexConfiguration</c>), NOT in a module's own <c>HubConfiguration</c>, and the reason is
+    /// process topology rather than API surface. This registry is a mesh-scoped singleton, so it is
+    /// per-PROCESS; the announcement is posted by whichever process handles the sign-in. A module's
+    /// per-type hub configuration runs only when that node's hub ACTIVATES — on one silo, at some
+    /// point, possibly never — so a module registering itself there would populate the registry in a
+    /// process that may not be the one announcing, and the event would silently go nowhere. It would
+    /// look self-contained and work on a monolith, which is the worst combination.</para>
+    ///
+    /// <para>The one line per subscriber in deployment configuration is therefore not a compromise
+    /// on module self-containment; it is the only placement that runs in every process. If a module
+    /// genuinely must declare its own subscription, that wants to be DATA (a node the announcer
+    /// reads) rather than a call — same reason logon ACTIONS are data.</para>
     ///
     /// <para>The handler runs on the subscriber's own hub under the delivery's identity, so it acts
     /// as the signing-in user. Nothing is expected back — an event with a response would put the

--- a/src/MeshWeaver.Graph/Logon/AnnounceSignInLogonAction.cs
+++ b/src/MeshWeaver.Graph/Logon/AnnounceSignInLogonAction.cs
@@ -1,0 +1,65 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Logon;
+
+/// <summary>
+/// Announces <see cref="UserSignedIn"/> to every registered
+/// <see cref="SignInNotificationTargets">subscriber</see>, once per sign-in.
+///
+/// <para><b>Fire-and-forget, and that is the design.</b> Each address gets a <c>Post</c>; nothing is
+/// observed, no response type exists, and a subscriber that is absent, slow or throwing costs the
+/// signing-in user nothing. Sign-in is on the critical path — the moment it can be held up by
+/// another partition's health, a Store outage becomes a login outage.</para>
+///
+/// <para><b>EveryLogon.</b> A run-once announcement is a contradiction: subscribers exist to react
+/// to each sign-in, and a ledger entry would silence every one after the first. There is nothing to
+/// make idempotent here because core writes nothing — what a subscriber does with the event is its
+/// own business, including deciding it has already done it.</para>
+/// </summary>
+public sealed class AnnounceSignInLogonAction : ILogonAction
+{
+    /// <inheritdoc />
+    public string Id => "announce-sign-in";
+
+    /// <inheritdoc />
+    public LogonActionMode Mode => LogonActionMode.EveryLogon;
+
+    /// <summary>Last. Core's own per-user work (seeding, icon repair) settles first, so a
+    /// subscriber reacting to the announcement sees a coherent set of records rather than one
+    /// mid-repair. Not a correctness requirement — the event carries no state — but it removes an
+    /// ordering question a subscriber would otherwise have to think about.</summary>
+    public int Order => int.MaxValue;
+
+    /// <inheritdoc />
+    public IObservable<LogonActionOutcome> Run(LogonActionContext context)
+    {
+        var registry = context.Hub.ServiceProvider.GetService<SignInNotificationTargets>();
+        var logger = context.Hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Graph.Logon.AnnounceSignIn");
+        var targets = registry?.Targets;
+        if (targets is not { Count: > 0 })
+            return Observable.Return(LogonActionOutcome.Nothing);
+
+        var announcement = new UserSignedIn(context.UserPath);
+        foreach (var target in targets)
+        {
+            try
+            {
+                context.Hub.Post(announcement, o => o.WithTarget(target));
+            }
+            catch (Exception exception)
+            {
+                // A throw from Post is a routing problem, not the user's problem. Debug, not
+                // Warning: on a portal where a subscriber's partition is simply absent this would
+                // otherwise be a line on every single sign-in.
+                logger?.LogDebug(exception, "Announcing sign-in to {Target} failed", target);
+            }
+        }
+
+        return Observable.Return(LogonActionOutcome.Nothing);
+    }
+}

--- a/src/MeshWeaver.Graph/Logon/SignInNotificationTargets.cs
+++ b/src/MeshWeaver.Graph/Logon/SignInNotificationTargets.cs
@@ -1,0 +1,41 @@
+using System.Collections.Immutable;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Graph.Logon;
+
+/// <summary>
+/// Who has asked to hear <see cref="MeshWeaver.Mesh.UserSignedIn"/>. Empty by default — core
+/// notifies nobody until something opts in.
+///
+/// <para>🚨 <b>Opt-in, rather than core posting to a known address.</b> The obvious shape was for
+/// core to post straight to the Store's root hub and tolerate a NotFound when the Store is absent.
+/// That works, and it quietly puts "the Store exists, and this is where it lives" into core — the
+/// same knowledge core deliberately does not hold anywhere else about apps (which is why
+/// <c>AppRecordSpecs</c> covers the platform defaults only and nothing else). A subscriber
+/// registering itself keeps the direction of knowledge right: the Store knows about core, core does
+/// not know about the Store.</para>
+///
+/// <para>It also generalises for free. The second thing that wants a sign-in hook — and there will
+/// be one — adds a line at its own registration instead of another address hard-coded here.</para>
+///
+/// <para>Instance state on a mesh-scoped singleton, never static: it dies with the mesh, so nothing
+/// leaks between tests (NoStaticState).</para>
+/// </summary>
+public sealed class SignInNotificationTargets
+{
+    private ImmutableList<Address> targets = [];
+
+    /// <summary>The registered addresses, in registration order.</summary>
+    public IReadOnlyList<Address> Targets => targets;
+
+    /// <summary>Adds an address to notify. Idempotent — registering the same address twice does not
+    /// double-post, which matters because a plugin's configuration can run more than once.</summary>
+    public SignInNotificationTargets Add(Address address)
+    {
+        if (address is null)
+            return this;
+        if (!targets.Contains(address))
+            targets = targets.Add(address);
+        return this;
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/UserSignedIn.cs
+++ b/src/MeshWeaver.Mesh.Contract/UserSignedIn.cs
@@ -1,0 +1,26 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// A user signed in. Posted once per sign-in to each address that asked to hear about it
+/// (<c>AddSignInNotificationTarget</c>), fire-and-forget.
+///
+/// <para><b>This is an EVENT, not a request.</b> Nothing is expected back, no response type exists,
+/// and the sender ignores every outcome including a failure to deliver. That is deliberate: sign-in
+/// is on the user's critical path and must not acquire a dependency on whether some other partition
+/// is present, healthy, or fast. A subscriber that is missing, slow, or broken costs the user
+/// nothing.</para>
+///
+/// <para><b>Why core does not simply call the interested party.</b> The work a subscriber does with
+/// this — converging a viewer's app tiles to their packages' current artwork, running standard-pack
+/// onboarding — needs knowledge core does not have and should not acquire: what a package's current
+/// icon is, what "stale" means for an install, what a viewer's escape hatch from convergence is.
+/// Core owns exactly one fact, "a user signed in", and says it out loud. Whoever cares subscribes
+/// and keeps their own semantics. Handing core an interface to call instead would put that
+/// knowledge back in core wearing a different shape.</para>
+///
+/// <para>🚨 It carries a user PATH, not a session or a token. A subscriber acts on the user's own
+/// nodes under the identity the delivery already carries; there is nothing here to authenticate
+/// with and nothing worth replaying.</para>
+/// </summary>
+/// <param name="UserPath">The signing-in user's node path — the partition their own nodes live in.</param>
+public record UserSignedIn(string UserPath);

--- a/test/MeshWeaver.Graph.Test/SignInAnnouncementTest.cs
+++ b/test/MeshWeaver.Graph.Test/SignInAnnouncementTest.cs
@@ -1,0 +1,79 @@
+using MeshWeaver.Graph.Logon;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The sign-in seam: core says "a user signed in" and knows nothing else.
+///
+/// <para>The design question this settles is where knowledge lives. Convergence of a viewer's app
+/// tiles onto their packages' current artwork needs to know what a package's icon is, what "stale"
+/// means for an install, and what a viewer's escape hatch is — Store knowledge. Core holding an
+/// interface to call, or posting to the Store's address and tolerating a NotFound, both put that
+/// knowledge back into core wearing a different shape. A subscriber registering ITSELF keeps the
+/// direction right: the Store knows about core, core does not know about the Store.</para>
+/// </summary>
+public class SignInAnnouncementTest
+{
+    private static readonly Address First = new Address("app", "store");
+    private static readonly Address Second = new Address("app", "other");
+
+    [Fact]
+    public void Nobody_is_notified_until_somebody_asks()
+    {
+        // The default is silence. A portal where nothing subscribes posts nothing at sign-in —
+        // no address to probe, no NotFound to tolerate, no latency to explain.
+        new SignInNotificationTargets().Targets.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Registering_twice_does_not_double_post()
+    {
+        // A plugin's configuration can run more than once. Two posts per sign-in would make a
+        // subscriber's own idempotence load-bearing for core's bug.
+        var targets = new SignInNotificationTargets().Add(First).Add(First);
+
+        targets.Targets.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Subscribers_are_notified_in_registration_order()
+    {
+        var targets = new SignInNotificationTargets().Add(First).Add(Second);
+
+        targets.Targets.Should().Equal(First, Second);
+    }
+
+    [Fact]
+    public void The_announcement_carries_the_user_path_and_nothing_else()
+    {
+        // 🚨 A path, not a session or a token. The subscriber acts under the identity the delivery
+        // already carries; there is nothing here to authenticate with and nothing worth replaying.
+        var announcement = new UserSignedIn("alice");
+
+        announcement.UserPath.Should().Be("alice");
+        typeof(UserSignedIn).GetProperties().Should().ContainSingle(
+            "an event that grows fields grows coupling — subscribers should read the mesh, not the message");
+    }
+
+    [Fact]
+    public void It_announces_on_every_sign_in()
+    {
+        // Run-once would be a contradiction: subscribers exist to react to EACH sign-in, and a
+        // ledger entry would silence every one after the first.
+        new AnnounceSignInLogonAction().Mode.Should().Be(LogonActionMode.EveryLogon);
+    }
+
+    [Fact]
+    public void It_announces_after_cores_own_per_user_work()
+    {
+        // So a subscriber reacting to the announcement sees a settled set of records rather than
+        // one mid-repair. Not correctness — the event carries no state — but it removes an ordering
+        // question the subscriber would otherwise have to reason about.
+        var announce = new AnnounceSignInLogonAction();
+
+        announce.Order.Should().BeGreaterThan(new AppIconAdoptionLogonAction().Order);
+    }
+}


### PR DESCRIPTION
The Store wants per-user tile convergence at sign-in (MeshWeaver.Plugins#624) and the "user never visits /Store" gap is real. This is core's half: the trigger, and nothing else.

## The addressing is inverted from what was proposed

The suggested shape was for core to post `UserSignedIn` to the Store's root hub, probe-and-delegate, tolerating a NotFound where the Store is absent. That works — and it puts *"the Store exists, and this is where it lives"* into core, which is exactly the knowledge core deliberately does not hold anywhere else about apps. (`AppRecordSpecs` covers the platform defaults only for the same reason.)

So subscribers register themselves:

```csharp
builder.AddSignInNotificationTarget(storeAddress);
```

Empty by default. A portal where nothing subscribes posts nothing — no address to probe, no NotFound to tolerate, no latency to explain. And it generalises for free: the second thing that wants a sign-in hook adds a line at its own registration rather than another address hard-coded in core.

## The contract

`UserSignedIn(string UserPath)` — a path, not a session or a token. The handler runs on the subscriber's hub under the delivery's identity, so it acts as the signing-in user. A test asserts the record stays single-field: an event that grows fields grows coupling, and a subscriber should read the mesh rather than the message.

**Fire-and-forget, deliberately.** Each target gets a `Post`; nothing is observed and no response type exists. Sign-in is on the user's critical path — the moment it can be held up by another partition's health, a Store outage becomes a login outage. A throw from `Post` logs at Debug rather than Warning, because on a portal whose subscriber partition is absent, Warning would be a line on every single sign-in.

**EveryLogon.** Run-once would be a contradiction: subscribers exist to react to *each* sign-in, and a ledger entry would silence every one after the first. Nothing here needs to be idempotent because core writes nothing.

**Ordered last**, so a subscriber sees core's own per-user work settled rather than mid-repair. Not a correctness requirement — the event carries no state — it just removes an ordering question the subscriber would otherwise have to reason about.

## Why an event and not an interface

Convergence needs to know a package's current artwork, what "stale" means for an install, and what a viewer's escape hatch from convergence is. That is Store knowledge. Core holding an interface to call would put it back in core wearing a different shape; core owns exactly one fact — *a user signed in* — and says it out loud.

Full `MeshWeaver.Graph.Test`: 1577/1577. Release `-warnaserror` clean.

Companion: the Store-side handler lands in MeshWeaver.Plugins.