### PR TITLE
Skill catalog: port the write-into-your-own-home preamble to the canonical /presentation + /slide seeds

### DIFF
--- a/content/ai/Skill/presentation.md
+++ b/content/ai/Skill/presentation.md
@@ -7,6 +7,36 @@ category: Skills
 order: 17
 ---
 
+# 🚨 WRITE INTO THE USER'S OWN HOME — never into the space you are reading
+
+The chat you are running in is almost always opened **from a page**, so your context is that page's
+node — a course lesson, a doc, someone else's space. On any of those the signed-in reader typically
+holds **Read only**: a course is gated (entitlement = the `Viewer` role), a plugin/doc space is
+GitSynced and writable by `system-security` alone.
+
+Create your output there and the write fails with
+
+> ⚠️ Access denied: Create permission required for node '{Space}/…'
+
+which is what the person sees **instead of the thing they asked for**. It is not a permissions bug to
+report, not something for them to "get access" to, and not a reason to stop: it is the wrong target.
+
+**Everything you CREATE belongs under the user's own home — `{userId}/…`** (e.g.
+`felice.buergi/DiceGame`, `felice.buergi/Skill/…`). That covers the program, the deck, the document,
+the poster, the data node, the scratch node you needed on the way — and the **thread / activity**
+that produces them.
+
+- **Resolve the user id from the signed-in identity**, never from the page you happen to be on.
+  Being *on* `AgenticPrimerDe/02-CodeWunsch` says what the request is ABOUT, not where it goes.
+- **Read from anywhere; write only there.** Reading the lesson to understand the ask is right;
+  writing next to it is not.
+- If the user explicitly names a target they own, use it. Otherwise **default to their home** — do
+  not ask them where to put it; they mostly do not know the mesh has places.
+- If a write is denied anyway, **do not retry against the same space and do not escalate to the
+  user**: re-target their home, finish the job, and tell them one line about where it landed.
+- Say where it went when you are done ("I put it in your space at `…`"), with a link — a thing
+  created somewhere the user cannot find is a thing you did not create.
+
 Build a **presentation** by authoring it as data — you never write a layout area or a nav. A presentation is a **Deck** (`NodeType = "Deck"`) whose ordered manifest points at **Slide** pages (`NodeType = "Slide"`). Both ship from the platform (`AddGraph()`), and their views already render the stage, the presenter bar, a hidable side-nav, and Present. This skill is the end-to-end workflow; for the full authoring reference see the **[/slide](@/Skill/slide)** skill and [Slides & Decks](/Doc/GUI/SlidesAndDecks).
 
 # The workflow

--- a/content/ai/Skill/slide.md
+++ b/content/ai/Skill/slide.md
@@ -7,6 +7,36 @@ category: Skills
 order: 16
 ---
 
+# 🚨 WRITE INTO THE USER'S OWN HOME — never into the space you are reading
+
+The chat you are running in is almost always opened **from a page**, so your context is that page's
+node — a course lesson, a doc, someone else's space. On any of those the signed-in reader typically
+holds **Read only**: a course is gated (entitlement = the `Viewer` role), a plugin/doc space is
+GitSynced and writable by `system-security` alone.
+
+Create your output there and the write fails with
+
+> ⚠️ Access denied: Create permission required for node '{Space}/…'
+
+which is what the person sees **instead of the thing they asked for**. It is not a permissions bug to
+report, not something for them to "get access" to, and not a reason to stop: it is the wrong target.
+
+**Everything you CREATE belongs under the user's own home — `{userId}/…`** (e.g.
+`felice.buergi/DiceGame`, `felice.buergi/Skill/…`). That covers the program, the deck, the document,
+the poster, the data node, the scratch node you needed on the way — and the **thread / activity**
+that produces them.
+
+- **Resolve the user id from the signed-in identity**, never from the page you happen to be on.
+  Being *on* `AgenticPrimerDe/02-CodeWunsch` says what the request is ABOUT, not where it goes.
+- **Read from anywhere; write only there.** Reading the lesson to understand the ask is right;
+  writing next to it is not.
+- If the user explicitly names a target they own, use it. Otherwise **default to their home** — do
+  not ask them where to put it; they mostly do not know the mesh has places.
+- If a write is denied anyway, **do not retry against the same space and do not escalate to the
+  user**: re-target their home, finish the job, and tell them one line about where it landed.
+- Say where it went when you are done ("I put it in your space at `…`"), with a link — a thing
+  created somewhere the user cannot find is a thing you did not create.
+
 A **Slide** is one page of a presentation. A **Deck** is the ordered set of slides — and the deck owns the order, declared EXTERNALLY in the deck node, not on each slide. Both ship from the platform (`AddGraph()`), so you author them as data: create nodes, set content, list the order. You never write a layout area for a deck — the Slide and Deck views already render the stage, the presenter bar, the hidable side-nav, and Present.
 
 Before authoring, skim [Slides & Decks](/Doc/GUI/SlidesAndDecks).


### PR DESCRIPTION
## What

The 2026-08-03 enrichment (MeshWeaver.Plugins `d873cc9` — "Skills: create in the user's own home, never in the space being read") was applied to the Skill **package's** copies of `/presentation` and `/slide` but never to these canonical `content/ai/Skill/*.md` seeds. Two consequences:

1. Every portal reseed serves the un-enriched text — the fix never actually reached installs' built-in skills.
2. The catalog's two copies diverged, and under current main the static-seed vs durable-install race became a real value fight: MeshWeaver.Plugins#634's platform-pin bump tripped the idempotence gate on exactly these two nodes (`MonotonicWriteGuard` dropping `Category/Order/Content.instructions`; reinstall of the unchanged snapshot rewrote both).

Porting the package's exact instruction text restores byte-identity (race value-neutral again) and ships the enrichment everywhere. Bodies now equal the package's `content.instructions`; front matter untouched.

## Verification

Skill loader + id-list tests 69/69 (`MeshWeaver.AI.Test` Skill filter). Unblocks Plugins#634 → the ci.5280+ bake → the portals' roll onto #2183/#2184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)