### PR TITLE
Convergence opt-in: auto-recycle instances onto a newly published build

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-auto-recycle-on-stale-build.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-auto-recycle-on-stale-build.md
@@ -1,0 +1,24 @@
+---
+Name: Production converges onto new builds by itself
+Category: Fix
+Description: A deployment can now opt in (Modules:AutoRecycleOnStaleBuild) to have every page automatically pick up a freshly compiled module build — no more "a newer build is available" banners lingering on production while pages serve the previous code.
+Icon: ArrowSync
+Order: -20260825
+---
+
+# Production converges onto new builds by itself
+
+When a module updates on a live mesh, its types recompile green — but until now every page that
+was already running kept executing the **previous** build behind a *"a newer build of this type is
+available — Recycle"* banner, until someone clicked. On a production portal that inversion is an
+outage in waiting: after this morning's Store update, the store page served a mixture of old and
+new code until each hub was recycled by hand.
+
+Deployments can now opt into **convergence**: with `Modules:AutoRecycleOnStaleBuild: true`, an
+instance whose type published a genuinely different build recycles itself — once, only after the
+publish burst has settled, and never for node writes that carry the same assembly. The banner
+remains the default everywhere else (authoring and local meshes keep the choice per page), and the
+guards that once forced the banner-only design — one recycle per binding, the settle window, the
+assembly-path gate — bound the opted-in behaviour too.
+
+Production portals should set the flag in their configuration; nothing changes until they do.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1570,7 +1570,11 @@ internal static class NodeTypeEnrichmentHelpers
                         instanceHub.RegisterForDisposal(ArmStaleAssemblySelfHeal(
                             meshHub.GetWorkspace().GetMeshNodeStream(nodeType),
                             instanceHub, nodeType, boundAssemblyPath, logger,
-                            guards: NodeTypeCompilationHelpers.GuardsOf(meshHub)));
+                            guards: NodeTypeCompilationHelpers.GuardsOf(meshHub),
+                            // Deployment policy, resolved off the MESH hub's configuration: a
+                            // production portal opts into convergence (auto-recycle), everything
+                            // else keeps the offer. See AutoRecycleConfigKey.
+                            autoRecycle: AutoRecycleOnStaleBuild(meshHub)));
                     }
                     catch (Exception ex)
                     {
@@ -1584,10 +1588,12 @@ internal static class NodeTypeEnrichmentHelpers
 
     /// <summary>
     /// Watcher core of <see cref="WithStaleAssemblySelfHeal"/>, split out so the firing contract is
-    /// unit-testable without building a hub (<c>StaleAssemblySelfHealWatcherTest</c>). Posts exactly
-    /// ONE self-<see cref="DisposeRequest"/> (<c>Take(1)</c>) when the NodeType publishes a USABLE
-    /// build whose <see cref="NodeTypeDefinition.LatestAssemblyPath"/> differs from
-    /// <paramref name="boundAssemblyPath"/>.
+    /// unit-testable without building a hub (<c>StaleAssemblySelfHealWatcherTest</c>). Fires exactly
+    /// ONCE (<c>Take(1)</c>) when the NodeType publishes a USABLE build whose
+    /// <see cref="NodeTypeDefinition.LatestAssemblyPath"/> differs from
+    /// <paramref name="boundAssemblyPath"/> — publishing the <see cref="StaleBuildOffer"/> banner
+    /// by default, or posting the self-<see cref="DisposeRequest"/> when the deployment opted into
+    /// convergence (<paramref name="autoRecycle"/>, from <see cref="AutoRecycleConfigKey"/>).
     ///
     /// <para>Unsettled states, non-<see cref="NodeTypeDefinition"/> content, and republications of
     /// the SAME assembly are ignored — the last of those is what keeps an unrelated node write from
@@ -1601,7 +1607,8 @@ internal static class NodeTypeEnrichmentHelpers
         string boundAssemblyPath,
         ILogger? logger,
         IScheduler? scheduler = null,
-        NodeTypeCompilationHelpers.BuildGuards? guards = null)
+        NodeTypeCompilationHelpers.BuildGuards? guards = null,
+        bool autoRecycle = false)
         // 🚨 ContentAs, never `is NodeTypeDefinition` (#1669): the type node reaches this stream
         // in UN-MATERIALIZED JSON shape whenever the publication just crossed a sync stream — the
         // normal shape for exactly the emission this watcher exists to catch. A CLR type test is
@@ -1628,17 +1635,39 @@ internal static class NodeTypeEnrichmentHelpers
                 x =>
                 {
                     var published = x.Def?.LatestAssemblyPath;
+                    // 🚨 The DEPLOYMENT decides between the two terminal behaviours
+                    // (AutoRecycleConfigKey):
+                    //
+                    // CONVERGE (production portals): post the self-DisposeRequest, so the update
+                    // that published this build ENDS with every instance serving it. This is the
+                    // pre-banner behaviour, re-admitted only behind the guards that did not exist
+                    // when it was removed — the assembly-path gate, the settle-window throttle,
+                    // and Take(1) — so a publish burst costs each instance at most ONE recycle,
+                    // and an unrelated node write costs nothing. Without it, prod after a package
+                    // update is a mixture of old and new assemblies for as long as viewers do not
+                    // click (the 2026-08-25 Store outage).
+                    if (autoRecycle)
+                    {
+                        logger?.LogInformation(
+                            "Stale-build convergence: NodeType '{NodeType}' published a new build ('{Published}' supersedes '{Bound}') — auto-recycling instance '{InstancePath}' ({ConfigKey}=true)",
+                            nodeType, published, boundAssemblyPath, instanceHub.Address,
+                            AutoRecycleConfigKey);
+                        instanceHub.Post(new DisposeRequest(), o => o.WithTarget(instanceHub.Address));
+                        return;
+                    }
+
                     logger?.LogInformation(
                         "Stale-build offer: NodeType '{NodeType}' published a new build ('{Published}' supersedes '{Bound}') — offering instance '{InstancePath}' a recycle",
                         nodeType, published, boundAssemblyPath, instanceHub.Address);
-                    // 🚨 OFFER, never an automatic restart. This used to post a self-DisposeRequest
-                    // here, so every live instance of the type recycled on every publish —
-                    // publication frequency became restart frequency, and a user mid-edit lost
-                    // their hub without asking. Publishing the offer instead puts a banner above
-                    // the instance's (still working) content and lets the user choose. Stated
+                    // 🚨 OFFER as the DEFAULT. The unconditional self-DisposeRequest that once
+                    // lived here recycled every live instance on every publish — publication
+                    // frequency became restart frequency, and a user mid-edit lost their hub
+                    // without asking. Publishing the offer instead puts a banner above the
+                    // instance's (still working) content and lets the user choose. Stated
                     // consequence: an instance whose viewer never clicks keeps serving the OLDER
                     // assembly indefinitely — safe, since that build worked, but "published" no
-                    // longer implies "every instance is running it".
+                    // longer implies "every instance is running it"; a deployment whose invariant
+                    // is convergence opts into the branch above instead.
                     instanceHub.Get<BehaviorSubject<StaleBuildOffer?>>()
                         ?.OnNext(new StaleBuildOffer(nodeType, published, boundAssemblyPath));
                 },
@@ -2008,6 +2037,40 @@ internal static class NodeTypeEnrichmentHelpers
     /// case this whole watcher exists for is unaffected in substance.</para>
     /// </summary>
     private static readonly TimeSpan AssemblySettleWindow = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Deployment opt-in that turns the stale-build OFFER into an automatic self-recycle: when a
+    /// NodeType publishes a new usable build, instances converge onto it by themselves instead of
+    /// waiting for a viewer to click the banner (<see cref="StaleBuildBanner"/>).
+    ///
+    /// <para>🚨 <b>Default OFF — the banner stays the default.</b> The auto-recycle this key
+    /// re-enables was removed once because it fired per PUBLICATION: every instance of a type
+    /// restarted on every publish, and a user mid-edit lost their hub. The guards that exist now
+    /// make the opted-in behaviour a different animal: the gate is the published ASSEMBLY PATH
+    /// (an unrelated node write cannot fire it), the <see cref="AssemblySettleWindow"/> collapses
+    /// an install's publish burst into one recycle, and <c>Take(1)</c> bounds the cost at one
+    /// recycle per bound assembly. A PRODUCTION portal sets this to <c>true</c> because its
+    /// invariant is "after an update, everything serves the new build" (the 2026-08-25 Store
+    /// outage: green recompiles, every instance banner-stale, the store page wedged until a manual
+    /// recycle); an authoring/dev mesh keeps the default and decides per page.</para>
+    /// </summary>
+    public const string AutoRecycleConfigKey = "Modules:AutoRecycleOnStaleBuild";
+
+    /// <summary>Reads <see cref="AutoRecycleConfigKey"/> off the hub's configuration — absent or
+    /// unparseable means OFF, the banner default. Never throws.</summary>
+    internal static bool AutoRecycleOnStaleBuild(IMessageHub hub)
+    {
+        try
+        {
+            var value = hub.ServiceProvider
+                .GetService<Microsoft.Extensions.Configuration.IConfiguration>()?[AutoRecycleConfigKey];
+            return bool.TryParse(value, out var parsed) && parsed;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     /// <param name="activityPath">
     /// The NodeType's <see cref="NodeTypeDefinition.LastCompilationActivityPath"/>, when

--- a/src/MeshWeaver.Graph/Configuration/StaleBuildBanner.cs
+++ b/src/MeshWeaver.Graph/Configuration/StaleBuildBanner.cs
@@ -26,13 +26,19 @@ public sealed record StaleBuildOffer(
 /// Renders "a newer build of this type is available — recycle to pick it up" as an ADORNMENT above
 /// every layout area of an instance whose NodeType has since published a different assembly.
 ///
-/// <para>🚨 <b>An offer, never an automatic restart.</b> This REPLACES an auto-recycle: the
-/// stale-assembly watcher used to post a self-<c>DisposeRequest</c> the moment a type published,
-/// so every live instance of that type restarted on every publish — publication frequency became
-/// restart frequency, and a user mid-edit lost their hub without asking for it. The user now
-/// decides. The stated consequence: an instance whose viewer never clicks keeps serving the OLDER
-/// assembly indefinitely. That is deliberate and safe — the old build is a build that worked — but
-/// it does mean "published" no longer implies "every instance is running it".</para>
+/// <para>🚨 <b>An offer by default, convergence by deployment choice.</b> This REPLACED an
+/// unguarded auto-recycle: the stale-assembly watcher used to post a self-<c>DisposeRequest</c>
+/// the moment a type published, so every live instance of that type restarted on every publish —
+/// publication frequency became restart frequency, and a user mid-edit lost their hub without
+/// asking for it. The user now decides. The stated consequence: an instance whose viewer never
+/// clicks keeps serving the OLDER assembly indefinitely. That is deliberate and safe — the old
+/// build is a build that worked — but it does mean "published" no longer implies "every instance
+/// is running it", and on a production portal that inversion IS the outage (memex 2026-08-25: a
+/// package update recompiled the Store green while every serving instance stayed on the previous
+/// assembly behind this banner). A deployment whose invariant is convergence therefore opts back
+/// into the automatic recycle — now bounded by the assembly-path gate, the settle window and
+/// <c>Take(1)</c> — via <see cref="NodeTypeEnrichmentHelpers.AutoRecycleConfigKey"/>; the banner
+/// remains the default everywhere else.</para>
 ///
 /// <para>🚨 <b>Adornment, not replacement.</b> The compilation-error overlay
 /// (<c>NodeTypeEnrichmentHelpers.WithCompilationErrorOverlay</c>) SWAPS the hub's

--- a/test/MeshWeaver.Graph.Test/StaleAssemblySelfHealWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaleAssemblySelfHealWatcherTest.cs
@@ -308,4 +308,91 @@ public class StaleAssemblySelfHealWatcherTest
 
         AssertNoOffer(offers);
     }
+
+    // ───────────────────────────── the convergence opt-in (Modules:AutoRecycleOnStaleBuild)
+
+    /// <summary>
+    /// The instance hub with its Post spec pinned, for the auto-recycle branch.
+    /// <c>Configure()</c> records the spec WITHOUT NSubstitute's auto-value provider —
+    /// <c>IMessageDelivery</c> carries an internal member, so auto-substituting Post's return
+    /// type throws at proxy generation (the OverlaySelfHealWatcherTest idiom).
+    /// </summary>
+    private static IMessageHub BuildAutoRecycleHub(
+        out List<StaleBuildOffer?> offers, out Func<Func<PostOptions, PostOptions>?> capturedOptions)
+    {
+        var hub = BuildInstanceHub(out offers);
+        Func<PostOptions, PostOptions>? captured = null;
+        hub.Configure()
+            .Post(Arg.Any<DisposeRequest>(),
+                Arg.Do<Func<PostOptions, PostOptions>>(f => captured = f))
+            .Returns((IMessageDelivery<DisposeRequest>?)null);
+        capturedOptions = () => captured;
+        return hub;
+    }
+
+    /// <summary>
+    /// 🚨 The convergence contract (memex 2026-08-25: a package update recompiled the Store green
+    /// while every serving instance stayed on the previous assembly behind the banner, and the
+    /// store page stayed wedged until a manual recycle). A deployment that opted in
+    /// (<c>Modules:AutoRecycleOnStaleBuild</c>) must converge WITHOUT a viewer's click: exactly one
+    /// self-<see cref="DisposeRequest"/>, addressed to the instance itself, no banner offer —
+    /// and the same guards as the offer path (settle window, Take(1)) still bound it.
+    /// </summary>
+    [Fact]
+    public void AutoRecycle_PostsExactlyOneSelfDispose_AndNoOffer()
+    {
+        var hub = BuildAutoRecycleHub(out var offers, out var capturedOptions);
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler,
+            autoRecycle: true);
+
+        typeStream.OnNext(TypeNode(version: 12, assemblyPath: "TestData_StaleAssemblyType/v12-abc-222222222222.dll"));
+        // Inside the settle window nothing may be disposed — an install's publish burst must not
+        // put DisposeRequests through hubs mid-read (the #1343 regression, same guard as the offer).
+        hub.DidNotReceive().Post(Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+
+        Settle(scheduler);
+        hub.Received(1).Post(Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+        AssertNoOffer(offers);
+
+        // The dispose must target the instance ITSELF — the RecycleLayoutArea idiom. Derive
+        // expected from the SAME base options so the auto-generated MessageId doesn't perturb
+        // record equality (the OverlaySelfHealWatcherTest idiom).
+        var options = capturedOptions();
+        options.Should().NotBeNull("the post must carry explicit options targeting the instance");
+        var baseOptions = new PostOptions(new Address("TestData/sender"));
+        options!(baseOptions).Should().Be(baseOptions.WithTarget(new Address(InstancePath)),
+            "the convergence recycle must target the instance hub's own address");
+
+        // Take(1): a later build does not recycle again off this binding — the recycled instance
+        // re-enriches against the new path, which arms the NEXT watcher with the new baseline.
+        typeStream.OnNext(TypeNode(version: 13, assemblyPath: "TestData_StaleAssemblyType/v13-abc-333333333333.dll"));
+        Settle(scheduler);
+        hub.Received(1).Post(Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+    }
+
+    /// <summary>
+    /// The anti-bounce half holds under convergence too: republishing the SAME assembly — the
+    /// release-request stamp / release-notes / pin-edit writes — must not recycle anything, or the
+    /// opt-in reintroduces exactly the restart storm that got the unguarded auto-recycle removed.
+    /// </summary>
+    [Fact]
+    public void AutoRecycle_RepublishingTheSameAssembly_DoesNotRecycle()
+    {
+        var hub = BuildAutoRecycleHub(out var offers, out _);
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler,
+            autoRecycle: true);
+
+        for (var version = 11; version <= 14; version++)
+            typeStream.OnNext(TypeNode(version, assemblyPath: BoundAssembly));
+        Settle(scheduler);
+
+        hub.DidNotReceive().Post(Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+        AssertNoOffer(offers);
+    }
 }


### PR DESCRIPTION
## What changed

`Modules:AutoRecycleOnStaleBuild` (default **off**) turns the stale-build *offer* into an automatic self-recycle: when a NodeType publishes a usable build whose assembly path differs from the one an instance bound, the instance posts its own `DisposeRequest` instead of hanging the *"a newer build of this type is available — Recycle"* banner and waiting for a viewer's click. The banner remains the default everywhere that does not opt in.

## Why

memex 2026-08-25: a Store package update recompiled every type green while **all serving instances stayed on the previous assembly** behind the banner — mixed old/new assemblies (`$type` registration mismatches in the logs), and the store page wedged until type and instance hubs were recycled by hand. A production portal's invariant is "after an update, everything serves the new build"; this key states that policy per deployment.

The unguarded auto-recycle that once lived at this exact seam was removed because it fired per publication. The opted-in branch sits behind the guards that did not exist then — the assembly-path gate (unrelated node writes cost nothing), the settle-window throttle (a publish burst collapses to one recycle, the #1343 regression guard), and `Take(1)` per binding — so "publication frequency = restart frequency" cannot recur.

## How tested

- `StaleAssemblySelfHealWatcherTest`: two new pinned contracts — opted-in fires exactly one self-`DisposeRequest` targeting the instance's own address with **no** banner offer (and not before the settle window); same-assembly republication recycles nothing even as versions advance. All 21 self-heal watcher tests green.
- `dotnet build -c Release -p:CIRun=true -warnaserror` clean on MeshWeaver.Graph.

## Rollout

No behaviour change until a deployment sets the key. Production portals (memex-cloud, systemorph) should set `Modules:AutoRecycleOnStaleBuild: true` — flagged to the maintainer as a config/Helm change, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)