### PR TITLE
Node catalogs hide governance satellites by default (?hidden=true reveals)

### DIFF
--- a/src/MeshWeaver.Blazor.Views/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor.Views/Components/MeshSearchView.razor.cs
@@ -188,6 +188,30 @@ public partial class MeshSearchView
         }
     }
     private bool BoundExcludeBasePath => ViewModel?.ExcludeBasePath is bool exclude ? exclude : true;
+    private bool BoundIncludeHidden => ViewModel?.IncludeHidden is bool include && include;
+
+    /// <summary>
+    /// Whether <paramref name="path"/> sits under an underscore-prefixed SATELLITE segment
+    /// relative to <paramref name="anchor"/> (the catalog's namespace root) — the rule behind the
+    /// catalog's default hiding of governance bookkeeping (<c>_Entitlements</c>, <c>_Access</c>,
+    /// <c>_Policy</c>, …). The anchor itself and its own leading segments are never tested, so an
+    /// anchored catalog INSIDE a satellite (e.g. drilling into <c>X/_App</c> explicitly) still
+    /// lists its children. Pure.
+    /// </summary>
+    public static bool HasSatelliteSegmentUnder(string? path, string? anchor)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        var trimmed = path.Trim('/');
+        var root = (anchor ?? "").Trim('/');
+        var rel = root.Length > 0 && trimmed.StartsWith(root + "/", StringComparison.OrdinalIgnoreCase)
+            ? trimmed[(root.Length + 1)..]
+            : trimmed;
+        foreach (var segment in rel.Split('/'))
+            if (segment.StartsWith('_'))
+                return true;
+        return false;
+    }
     private bool BoundLiveSearch => ViewModel?.LiveSearch is bool live ? live : true;
     private bool BoundReactiveMode
     {
@@ -973,6 +997,15 @@ public partial class MeshSearchView
             var basePath = BoundNamespace.Trim('/');
             visible = visible.Where(n => n.Path != basePath);
         }
+        // Governance satellites (_Entitlements, _Access, _Policy, …) are bookkeeping, not
+        // content: a namespace-ANCHORED catalog hides them by default (?hidden=true /
+        // WithIncludeHidden reveals). Unanchored searches are untouched — thread/agent results
+        // legitimately live under satellite segments.
+        if (!BoundIncludeHidden && !string.IsNullOrEmpty(BoundNamespace))
+        {
+            var anchor = BoundNamespace.Trim('/');
+            visible = visible.Where(n => !HasSatelliteSegmentUnder(n.Path, anchor));
+        }
 
         // The presentation screen (#1803): display-only, per-viewer, and applied to what is
         // PAINTED — the query, the permissions and the nodes themselves are untouched, and this is
@@ -1633,6 +1666,15 @@ public partial class MeshSearchView
             .Subscribe(
                 change =>
                 {
+                    // Same default as the flat results: governance satellites stay out of the
+                    // namespace tree unless the control opts in.
+                    if (!BoundIncludeHidden)
+                        change = change with
+                        {
+                            Items = change.Items
+                                .Where(n => !HasSatelliteSegmentUnder(n.Path, TreeRootNamespace))
+                                .ToList()
+                        };
                     switch (change.ChangeType)
                     {
                         case QueryChangeType.Initial:

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -960,6 +960,9 @@ public static class MeshNodeLayoutAreas
         public int MaxColumns { get; init; } = 3;
         /// <summary><c>?collapsible=false</c> keeps every section expanded.</summary>
         public bool Collapsible { get; init; } = true;
+        /// <summary><c>?hidden=true</c> reveals underscore-prefixed satellite namespaces
+        /// (<c>_Entitlements</c>, <c>_Access</c>, …) that the catalog hides by default.</summary>
+        public bool IncludeHidden { get; init; }
         /// <summary><c>?reactive=false</c> disables live updates on data change.</summary>
         public bool Reactive { get; init; } = true;
         /// <summary><c>?title=</c> — the section title.</summary>
@@ -987,6 +990,7 @@ public static class MeshNodeLayoutAreas
             MaxRows = ReadInt(host, "maxRows", 3),
             MaxColumns = ReadInt(host, "maxColumns", 3),
             Collapsible = ReadBool(host, "collapsible", true),
+            IncludeHidden = ReadBool(host, "hidden", false),
             Reactive = ReadBool(host, "reactive", true),
             Title = host.GetQueryStringParamValue("title")?.Trim() is { Length: > 0 } t ? t : "Catalog",
             Placeholder = host.GetQueryStringParamValue("placeholder")?.Trim() is { Length: > 0 } p
@@ -1037,6 +1041,9 @@ public static class MeshNodeLayoutAreas
             // Each card/folder gets a secondary "Drill down" link to /{path}/Search,
             // so users keep browsing INTO a namespace; the primary click still opens
             // the node's default page /{path} (empty area, never a hardcoded "Overview").
+            // Governance satellites stay out of a browsing catalog by default — ?hidden=true
+            // reveals them (MeshSearchView.HasSatelliteSegmentUnder is the rule).
+            .WithIncludeHidden(o.IncludeHidden)
             .WithDrillDownArea(SearchArea)
             .WithCreateHref($"/{nodePath}/{CreateNodeArea}?namespace={Uri.EscapeDataString(nodePath)}");
         return string.IsNullOrEmpty(o.GroupByProperty) ? search : search.WithGroupBy(o.GroupByProperty);

--- a/src/MeshWeaver.Layout/MeshSearchControl.cs
+++ b/src/MeshWeaver.Layout/MeshSearchControl.cs
@@ -241,6 +241,17 @@ public record MeshSearchControl()
     public object? ExcludeBasePath { get; init; }
 
     /// <summary>
+    /// Whether nodes under an underscore-prefixed segment RELATIVE to <see cref="Namespace"/>
+    /// (<c>_Entitlements</c>, <c>_Access</c>, <c>_Policy</c>, …) are shown. Default FALSE — those
+    /// satellites are governance bookkeeping, not content, and a node's Contents catalog listing
+    /// them reads as clutter at best and as leaked internals at worst. The filter is
+    /// namespace-RELATIVE and only active when <see cref="Namespace"/> anchors the control, so an
+    /// unanchored search (the global /search page, the top-bar Thread/Agent searches — whose
+    /// results legitimately LIVE under satellites) is untouched.
+    /// </summary>
+    public object? IncludeHidden { get; init; }
+
+    /// <summary>
     /// Whether results should update live as user types (default true).
     /// When false, search only triggers on Enter.
     /// </summary>
@@ -375,6 +386,9 @@ public record MeshSearchControl()
     /// <summary>Returns a copy with base-path exclusion set to <paramref name="exclude"/>.</summary>
     /// <param name="exclude"><c>true</c> removes the namespace root node from results.</param>
     public MeshSearchControl WithExcludeBasePath(bool exclude) => this with { ExcludeBasePath = exclude };
+
+    /// <summary>Show nodes under underscore-prefixed satellite segments (see <see cref="IncludeHidden"/>).</summary>
+    public MeshSearchControl WithIncludeHidden(bool include) => this with { IncludeHidden = include };
     /// <summary>Returns a copy with live-search set to <paramref name="live"/>.</summary>
     /// <param name="live"><c>false</c> restricts search to trigger only on Enter.</param>
     public MeshSearchControl WithLiveSearch(bool live) => this with { LiveSearch = live };

--- a/test/MeshWeaver.Hosting.Blazor.Test/CatalogSatelliteFilterTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/CatalogSatelliteFilterTest.cs
@@ -1,0 +1,40 @@
+using MeshWeaver.Blazor.Components;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// The catalog's default hiding of governance satellites — the rule behind
+/// "<c>_Entitlements</c> showing at the bottom of a plugin page" (memex, 2026-08-25).
+/// <see cref="MeshSearchView.HasSatelliteSegmentUnder"/> is namespace-RELATIVE: only segments
+/// BELOW the catalog's anchor are tested, so a catalog anchored INSIDE a satellite still lists
+/// its children, and an unanchored search (whose thread/agent results legitimately live under
+/// satellites) never engages the rule at all (the view gates on a non-empty anchor).
+/// </summary>
+public class CatalogSatelliteFilterTest
+{
+    [Theory]
+    // The incident shape: satellites directly under the anchored plugin root are hidden.
+    [InlineData("AgenticEngineering/_Entitlements/rbuergi", "AgenticEngineering", true)]
+    [InlineData("Chess/_Policy", "Chess", true)]
+    [InlineData("Chess/_Access/Public_Access", "Chess", true)]
+    // …including deeper satellites under an ordinary child.
+    [InlineData("Edu/Course/_Comment/c1", "Edu", true)]
+    // Ordinary content stays visible.
+    [InlineData("AgenticEngineering/Module1", "AgenticEngineering", false)]
+    [InlineData("Edu/Course/Lesson", "Edu", false)]
+    // The anchor's OWN leading segments are never tested: a catalog deliberately anchored
+    // inside a satellite still lists that satellite's children.
+    [InlineData("rbuergi/_App/Chess", "rbuergi/_App", false)]
+    [InlineData("rbuergi/_App/Chess/_Access/x", "rbuergi/_App", true)]
+    // A path outside the anchor falls back to testing all of its own segments.
+    [InlineData("Other/_Policy", "Chess", true)]
+    [InlineData("Other/Doc", "Chess", false)]
+    // Degenerate inputs.
+    [InlineData(null, "Chess", false)]
+    [InlineData("", "Chess", false)]
+    [InlineData("Chess/_Policy", null, true)]
+    public void SatelliteSegments_AreHiddenRelativeToTheAnchor(
+        string? path, string? anchor, bool hidden)
+        => Assert.Equal(hidden, MeshSearchView.HasSatelliteSegmentUnder(path, anchor));
+}


### PR DESCRIPTION
"At the bottom of the screen we see `_Entitlements`" — a plugin page's Contents section listed the partition's governance bookkeeping (`_Entitlements`, `_Access`, `_Policy`, …) alongside its content.

- `MeshSearchControl.IncludeHidden` (default false) + `WithIncludeHidden`.
- A namespace-ANCHORED `MeshSearchView` drops flat results AND namespace-tree entries under an underscore-prefixed segment RELATIVE to the anchor (`HasSatelliteSegmentUnder`, pure, pinned in `CatalogSatelliteFilterTest` — 13 cases).
- Two deliberate edges: a catalog anchored INSIDE a satellite (`rbuergi/_App`) still lists its children; an UNANCHORED search (global /search, top-bar Thread/Agent queries — whose results legitimately live under satellites) never engages the rule.
- The Search/Children catalog (`MeshNodeLayoutAreas`) exposes `?hidden=true` to reveal.

RN twin follows in MeshWeaver.Plugins (app/react-native mesh-live pack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)