### PR TITLE
RCA #2194: stale-build retention docs + fleet-wide Modules:AutoRecycleOnStaleBuild opt-in

### DIFF
--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -415,6 +415,25 @@ kubectl get deploy memex-portal-deployment -n <env> \
 volume silently misaligns an environment and a cluster can run an older volume set while the chart
 in git looks right. Diff live mounts against the chart after every deploy.
 
+### Degraded-but-Ready replica — intermittent hangs, `kubectl top` divergence
+
+Symptom: some requests hang or serve garbled state while most succeed, typically after a burst of
+content syncs or a scheduled bake. Cause class (2026-08-25, MeshWeaver#2194): each NodeType
+publication mints a new AssemblyLoadContext and serving instances stay on the OLD build behind the
+Recycle banner, so every superseded ALC stays rooted — the type-hosting silos climb to tens of GB
+and go GC-bound while still answering `/alive` (both post-startup probes), so Kubernetes never
+pulls them from rotation.
+
+```bash
+az aks command invoke -g <rg> -n <cluster> --command "kubectl top pods -n <ns> --no-headers"
+```
+
+One or two pods far above their siblings in BOTH memory and CPU = this. Remedy: `kubectl delete
+pod` the outliers (grace-drain; the Deployment replaces them). Prevention: enable
+`Modules:AutoRecycleOnStaleBuild` (MeshWeaver#2192) so instances converge onto each newly
+published build and old ALCs collect — mechanism in
+`src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md`.
+
 ## Known gaps / follow-ups
 - **Dump mount not applied to the live clusters** (2026-07-28): all three namespaces carry the dump
   env vars while no pod mounts `/data/dumps`, so every production `exit=139` so far produced no

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -286,6 +286,13 @@ config:
     # newest image immediately (the startup pass), and `gh workflow run
     # main-cd.yml --ref main` bypasses the batch window.
     SelfUpdate__MinRollInterval: "01:00:00"
+    # Converge instances onto every newly published NodeType build (MeshWeaver#2192).
+    # A prod portal's invariant is "after an update, everything serves the new build" —
+    # leaving the banner default meant every publication wave stacked one more rooted
+    # assembly generation on the type-hosting silos until they went GC-bound at 17-20 GB
+    # while still Ready (2026-08-25, MeshWeaver#2194). Applies fleet-wide: every AKS
+    # portal self-updates its catalog, so every one needs the convergence policy.
+    Modules__AutoRecycleOnStaleBuild: "true"
     Mcp__BaseUrl: "http://memex-portal-service:8080"
     # ---- AI model providers (templated by the chart) ------------------------
     # These seed the system model catalog on deploy (BuiltInLanguageModelProvider

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -319,6 +319,15 @@ data:
   {{- if hasKey .Values.config.memex_portal "Modules__Required__4" }}
   Modules__Required__4: "{{ .Values.config.memex_portal.Modules__Required__4 }}"
   {{- end }}
+  # Convergence policy (MeshWeaver#2192): when a NodeType publishes a usable build, instances
+  # self-recycle onto it instead of waiting behind the "Recycle" banner. Off = the image default
+  # (banner). A self-updating portal that leaves this off chooses unbounded in-memory assembly
+  # generations on its type-hosting silos — the 2026-08-25 degradation (MeshWeaver#2194):
+  # superseded AssemblyLoadContexts stay rooted by serving instances, 17-20 GB + GC-bound while
+  # still Ready. Emitted only when a deployment sets it, like the Required list above.
+  {{- if hasKey .Values.config.memex_portal "Modules__AutoRecycleOnStaleBuild" }}
+  Modules__AutoRecycleOnStaleBuild: "{{ .Values.config.memex_portal.Modules__AutoRecycleOnStaleBuild }}"
+  {{- end }}
   # ---- OpenAI-compatible provider (self-hosted / local: Ollama, vLLM, LM Studio, …) ----
   # Generic OpenAI-wire endpoint. Set Endpoint + Models (+ ApiKey in secrets) to seed a
   # provider + LanguageModel nodes pointing at any OpenAI-compatible gateway. Empty = inert.

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -241,6 +241,13 @@ spec:
             # because the STARTUP probe below already holds readiness on /health until the mesh is up
             # (so no 502 to a booting pod); once up, /alive keeps a serving pod in rotation and never
             # flaps it out. (Fixed live 2026-07-21; it regressed because the fix wasn't in this chart.)
+            # ⚠️ The trade's blind spot (2026-08-25, MeshWeaver#2194): a pod that degrades AFTER
+            # startup — e.g. GC-bound at 20 GB from superseded-NodeType-build (ALC) accumulation —
+            # still answers /alive, so it stays in rotation serving hung requests until a human
+            # reads `kubectl top`. Accepted here: the fix is convergence
+            # (Modules:AutoRecycleOnStaleBuild, MeshWeaver#2192), not a heavier probe; a cheap
+            # progress-aware check is an open design item on #2194. Do NOT "fix" this by pointing
+            # readiness back at /health — that re-creates the death-spiral above.
             httpGet: { path: /alive, port: 8080 }
             periodSeconds: 10
             timeoutSeconds: 5

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -318,6 +318,14 @@ Note the tension with §2: because the chart's migration is a Job created per He
 ## Diagnostics (private cluster)
 
 - Logs: `az aks command invoke … --command "kubectl -n <NS> logs deployment/memex-portal-deployment --tail=120"`. Note: the Azure CLI can crash on non-ASCII (`→`) in log output on Windows (cp1252) — pipe through `tr -cd '\11\12\15\40-\176'` **inside** the `--command` so az only receives printable text.
+- **Intermittent hangs while most requests succeed** (portal recently synced or baked): suspect a
+  degraded-but-Ready replica, not a global wedge — after startup, readiness and liveness both watch
+  the light `/alive`, so a GC-bound pod never leaves rotation on its own. Run
+  `az aks command invoke … --command "kubectl top pods -n <NS> --no-headers"`; one or two pods far
+  above their siblings in BOTH memory and CPU is the superseded-NodeType-build (ALC) accumulation of
+  issue #2194 — `kubectl delete pod` the outliers (grace-drain; the Deployment replaces them).
+  Mechanism and the convergence key that prevents it:
+  [NodeTypeCompilation](/Doc/Architecture/NodeTypeCompilation).
 - A `MESHWEAVER_MSG_TRACE=1` env var on the portal Deployment turns on the message-flow trace (`/tmp/meshweaver-msg-trace.log` in the pod). Toggling it restarts the pod; remove it (`kubectl set env … MESHWEAVER_MSG_TRACE-`) when done — it writes per-message and adds lock/IO overhead.
 
 ---

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -647,6 +647,44 @@ wired by `AddAssemblyCacheRetention` (`src/MeshWeaver.Hosting/AssemblyCacheReten
 `BlobAssemblyStore` is unaffected: it keys `v{version}` with no framework tag, so a new image
 overwrites rather than accrues.
 
+### 🚨 In-MEMORY generations accumulate the same way — a superseded build stays ROOTED while any instance serves it
+
+The store section above is about disk; the same generation arithmetic plays out inside every
+process that hosts instance hubs, and there the unit is an **AssemblyLoadContext**. Every publish
+of a usable build mints a new collectible ALC; *collectible* only means "may unload once nothing
+roots it" — and a serving instance hub roots the build it bound. The stale-build banner ("a newer
+build of this type is available — Recycle") deliberately leaves every instance on its old build
+until a human clicks, so in a sync-heavy window each publication wave stacks one more full
+assembly generation — types × Roslyn artifacts — onto the silo hosting the type hubs. The
+eviction fix on the compile path (#605) cannot free any of it: eviction drops the store's
+reference, not the instance's.
+
+Measured, 2026-08-25 (issue #2194): two memex-cloud silos flat at 2.7–4.5 GB for five hours, then
+a hard inflection the moment the first scheduled bake tick after a framework-pin bump published a
+full-catalog rebake, followed by five content merges — six publication waves in four hours. The
+two type-hosting silos climbed ~2.5 GB/h to 17–20 GB and four cores of GC; every other replica
+stayed ≤3.6 GB. Nothing intervened: no OOMKill (the pod limit was never reached), no probe
+failure (after startup, readiness and liveness both watch `/alive`, a process-up check a
+thrashing pod still answers), no alert — the pods served hung requests as Ready for 3½ hours
+until a human read `kubectl top`. The same stranded instances also produced the visible half:
+old and new assemblies serving side by side (`$type` registration mismatches), pages wedged until
+the type and instance hubs were recycled by hand.
+
+The missing piece is **convergence**, and it is policy, not plumbing:
+`Modules:AutoRecycleOnStaleBuild` (#2192, default **off**) turns the banner's offer into an
+automatic self-recycle — when a NodeType publishes a usable build whose assembly differs from the
+one an instance bound, the instance posts its own `DisposeRequest`, re-activates on the new
+build, and the superseded ALC unroots and collects. Anywhere the catalog updates itself — every
+self-updating portal — leaving the key off means choosing the accumulation above; #2194 tracks
+the prod enablement. The structural end state is stronger still: DLL-only module adoption
+("never ship uncompiled state") removes in-portal recompilation altogether, so a publication
+wave costs an assembly load instead of a Roslyn generation.
+
+**Triage fingerprint** — intermittent hangs while most requests succeed, on a portal that
+recently synced or baked: suspect a degraded-but-Ready replica, not a global wedge. One or two
+pods far above their siblings in BOTH memory and CPU in `kubectl top pods` is this incident;
+`kubectl delete pod` them (grace-drain — the Deployment replaces them) and read #2194.
+
 ---
 
 ## 🚨 That recompile can FAIL — and nothing upstream can warn you


### PR DESCRIPTION
Closes the docs + chart-policy lanes of #2194 (2026-08-25 memex-cloud degradation).

**Docs** — the retention mechanism (every publish mints a collectible ALC; serving instances root the previous one; the Recycle banner makes staying the default), the measured incident (flat 5 h → inflection at the first post-pin-bump bake tick → ~2.5 GB/h over six publication waves → 17–20 GB GC-bound on exactly the type-hosting silos, Ready throughout), and the triage fingerprint (`kubectl top` divergence → delete the outliers) land in NodeTypeCompilation.md, DeploymentAKS.md and DEPLOY-RUNBOOK.md. The chart's readiness comment now names the deliberate blind spot so nobody "fixes" it back into the 2026-07-21 death-spiral.

**Chart policy** — `Modules__AutoRecycleOnStaleBuild: "true"` in `values.aks.yaml` (fleet-wide: every AKS portal self-updates its catalog) with a `hasKey` passthrough in the portal ConfigMap template, same shape as `Modules__Required`. The key is #2192's (merged); it is inert on any pod still running a pre-#2192 image, so ordering is safe. Live clusters get the matching ConfigMap patch + rolling restart after this merges (no `helm upgrade` — it reverts live patches).

Verified: `MeshWeaver.Documentation.Test` DocumentationLinkIntegrity + PlatformBakeLaneGuard 10/10 (Release, fresh .trx), `check-chart-invariants.sh` self-consistent for all 3 values combinations, helm render emits the key exactly once under the AKS values.

No What's New entry: docs/ops-only — the user-visible behaviour change shipped with #2192, which carries the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)