### PR TITLE
Modules:RequirePrebuilt — a missing prebuilt build fails early, never compiles (#2193 §A)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-require-prebuilt-modules.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-require-prebuilt-modules.md
@@ -1,0 +1,25 @@
+---
+Name: A missing module build now fails loudly instead of compiling quietly
+Category: Fix
+Description: Production meshes can require prebuilt module assemblies (Modules:RequirePrebuilt) — a missing or hollow bundle fails the install immediately, naming the package, registry, framework lane and the fix, instead of silently falling back to an on-mesh compile.
+Icon: ShieldError
+Order: -20260825
+---
+
+# A missing module build now fails loudly instead of compiling quietly
+
+Until now, when a module's prebuilt assemblies could not be fetched — the registry did not
+advertise the package for this framework build, served no bytes for the lane, or shipped a bundle
+with nothing in it — the mesh logged a line and **compiled the module locally**. On a production
+portal that fallback hides a distribution failure: the install "succeeds", slowly, and the real
+problem (no bundle was ever baked for that lane) surfaces days later as something else entirely.
+
+Deployments can now set `Modules:RequirePrebuilt: true`. On such a mesh, every one of those misses
+**fails the install immediately** with one clear message naming the package, the registry, the
+framework identity and architecture the bundle is missing for, and the fix — publish or rebake the
+bundle for that lane. Nothing compiles. The adoption ledger still records every miss, and an empty
+bundle found at boot is reported as an error naming the same fix.
+
+The default is unchanged: meshes that do not opt in — local and dev meshes, CI's disposable
+meshes, the bake itself — keep the compile fallback, which remains correct wherever bundles are
+not expected to exist.

--- a/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
@@ -20,6 +20,40 @@ namespace MeshWeaver.Graph.Configuration;
 public static class PrebuiltAssemblySeeder
 {
     /// <summary>
+    /// Deployment opt-in that turns the compile FALLBACK into a NAMED, early error: a mesh that
+    /// sets <c>Modules:RequirePrebuilt</c> to <c>true</c> refuses to Roslyn-compile module content
+    /// whose prebuilt assemblies are missing — the miss fails the install/update immediately,
+    /// naming the package, the registry, the framework identity/architecture and the fix
+    /// (publish or rebake the bundle for this lane) instead of quietly compiling.
+    ///
+    /// <para>🚨 <b>Default OFF.</b> Compiling stays the correct fallback wherever the bake lanes do
+    /// not yet cover the mesh's identity (local/dev meshes, CI's disposable meshes, the bake mesh
+    /// itself — those are the places compiling remains legal). A PRODUCTION portal opts in because
+    /// its invariant is "the runtime artifact of a module is a baked DLL": a silent compile there
+    /// is a distribution failure being papered over — the 2026-08-25 Store incident's
+    /// "carried no assemblies — compiling instead" family. Design of record:
+    /// Systemorph/MeshWeaver#2193 §A. Sibling policy key:
+    /// <c>NodeTypeEnrichmentHelpers.AutoRecycleConfigKey</c> (convergence after a publish).</para>
+    /// </summary>
+    public const string RequirePrebuiltConfigKey = "Modules:RequirePrebuilt";
+
+    /// <summary>Reads <see cref="RequirePrebuiltConfigKey"/> — absent or unparseable means OFF,
+    /// the compile-fallback default. Never throws.</summary>
+    public static bool RequirePrebuilt(IServiceProvider? services)
+    {
+        try
+        {
+            var value = services?
+                .GetService<Microsoft.Extensions.Configuration.IConfiguration>()?[RequirePrebuiltConfigKey];
+            return bool.TryParse(value, out var parsed) && parsed;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Why a prebuilt assembly may NOT be adopted, or null when it may.
     ///
     /// <para>🚨 This is the whole safety argument, kept as one pure function so it can be tested

--- a/src/MeshWeaver.Graph/Configuration/PrebuiltRequiredException.cs
+++ b/src/MeshWeaver.Graph/Configuration/PrebuiltRequiredException.cs
@@ -1,0 +1,12 @@
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The NAMED refusal behind <see cref="PrebuiltAssemblySeeder.RequirePrebuiltConfigKey"/>: this
+/// mesh requires prebuilt module assemblies, none could be resolved for the lane, and compiling is
+/// not a fallback here. The message always says WHAT was missing (package, registry, framework
+/// identity/architecture, the miss kind) and WHAT fixes it (publish or rebake the bundle for this
+/// lane) — a distribution failure must read as a distribution failure, never as a build one four
+/// causal steps later (the 2026-08-25 incident shape; design of record Systemorph/MeshWeaver#2193
+/// §A).
+/// </summary>
+public sealed class PrebuiltRequiredException(string message) : InvalidOperationException(message);

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -400,9 +400,26 @@ public static class ShippedPrebuiltBundles
                 }
                 if (manifest!.Assemblies is not { Count: > 0 } assemblies)
                 {
-                    logger?.LogWarning(
-                        "ShippedPrebuiltBundles: bundle {Bundle} carries no assemblies (or no "
-                        + "readable manifest) — nothing to adopt", Path.GetFileName(bundlePath));
+                    // 🚨 On a require-prebuilt mesh an empty bundle is an ERROR, loudly named: the
+                    // types it should have covered will not compile here (that is the flag's whole
+                    // point), so "nothing to adopt" is not a degraded-but-fine state — it is the
+                    // distribution lane shipping a hollow artifact, and the fix is a rebake of the
+                    // bundle for this identity, never anything on this mesh. The sweep itself
+                    // continues either way: one hollow bundle must not stop the good ones from
+                    // seeding (#2193 §A).
+                    if (PrebuiltAssemblySeeder.RequirePrebuilt(mesh.ServiceProvider))
+                        logger?.LogError(
+                            "ShippedPrebuiltBundles: bundle {Bundle} carries no assemblies (or no "
+                            + "readable manifest) and this mesh sets {Key} — the types it should "
+                            + "cover on framework {Identity} will NOT compile here. Fix: rebake and "
+                            + "republish the bundle for this framework identity (MeshWeaver#2193).",
+                            Path.GetFileName(bundlePath),
+                            PrebuiltAssemblySeeder.RequirePrebuiltConfigKey,
+                            PrebuiltAssemblySeeder.LiveFrameworkMvid);
+                    else
+                        logger?.LogWarning(
+                            "ShippedPrebuiltBundles: bundle {Bundle} carries no assemblies (or no "
+                            + "readable manifest) — nothing to adopt", Path.GetFileName(bundlePath));
                     return Observable.Return(default(SeedTally));
                 }
 

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text.Json;
 using MeshWeaver.AI;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Features;
@@ -1139,20 +1140,35 @@ public sealed class InstanceAutoRegistrationService(
         if (bundles is null)
             return Observable.Return(0);
 
-        return bundles.Adopt(package.Id)
-            .Catch((Exception exception) =>
-            {
-                logger.LogInformation(exception,
-                    "[DefaultInstall] {Id}: no prebuilt assemblies adopted — compiling instead",
-                    package.Id);
-                return Observable.Return(0);
-            });
+        return AbsorbUnlessPrebuiltRequired(bundles.Adopt(package.Id), logger, package.Id);
         // A package's compiled MODULE (#1664) is deliberately NOT adopted here: the module branch
         // lives inside CatalogLayoutAreas.InstallOrUpdate — the one orchestrator this lane (and the
         // manual click, and the content auto-update) already funnels through — riding the
         // RegistryPackageSource's own Bundles handle. A second call here would land drift the
         // update policy is supposed to gate (the reconciler's module pass owns drift).
     }
+
+    /// <summary>
+    /// The absorb policy on the adoption lane: any ordinary failure is logged and stepped over —
+    /// compiling is the correct, always-available fallback on a default mesh — EXCEPT the named
+    /// <see cref="PrebuiltRequiredException"/>, which only exists on a mesh that opted into
+    /// <see cref="PrebuiltAssemblySeeder.RequirePrebuiltConfigKey"/> and must therefore PROPAGATE:
+    /// swallowing it here would restore the exact silent compile the flag forbids, one call site
+    /// above where it was refused (#2193 §A). The failure surfaces in this lane's install summary,
+    /// naming the package. Internal for the DefaultInstallPrebuiltPolicyTest pin
+    /// (InternalsVisibleTo).
+    /// </summary>
+    internal static IObservable<int> AbsorbUnlessPrebuiltRequired(
+        IObservable<int> adoption, ILogger? logger, string packageId) =>
+        adoption.Catch((Exception exception) =>
+        {
+            if (exception is PrebuiltRequiredException)
+                return Observable.Throw<int>(exception);
+            logger?.LogInformation(exception,
+                "[DefaultInstall] {Id}: no prebuilt assemblies adopted — compiling instead",
+                packageId);
+            return Observable.Return(0);
+        });
 
     /// <summary>One package the default install should carry, and the source it came from.</summary>
     /// <param name="Source">The source the package was listed from.</param>

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -161,11 +161,11 @@ public sealed class PluginBundleClient
                     // exactly why the arm64 lane went unnoticed. Naming both architectures makes the
                     // miss diagnosable from one log line.
                     _logger?.LogInformation(
-                        "Prebuilt assemblies at {Registry} are not adoptable: {Reason} — compiling. "
+                        "Prebuilt assemblies at {Registry} are not adoptable: {Reason} — {Consequence}. "
                         + "The registry bakes {RegistryArchitecture}; this instance is "
                         + "{LiveArchitecture}. Adoption needs a bake published for THIS lane; "
                         + "re-publishing another lane's bytes under this identity is never the fix.",
-                        _registryUrl, reason,
+                        _registryUrl, reason, MissConsequence("compiling"),
                         index.Architecture ?? "(an architecture it does not state)",
                         ReleaseArchitecture.Live);
                     return Miss(pluginId, BundleAdoptionKind.FrameworkDeclined, reason);
@@ -185,12 +185,13 @@ public sealed class PluginBundleClient
                     // log worth reading.
                     _logger?.LogWarning(
                         "Bundle for {Plugin}: {Registry} does not advertise it on framework "
-                        + "{Identity}/{Architecture} — it will be COMPILED here. Either that "
+                        + "{Identity}/{Architecture} — {Consequence}. Either that "
                         + "registry has no install record and no published module for it, or its "
                         + "index is filtered by this instance's grant. {Advertised} package(s) are "
                         + "advertised to this instance.",
                         pluginId, _registryUrl, PrebuiltAssemblySeeder.LiveFrameworkMvid,
-                        ReleaseArchitecture.Live, index.Bundles?.Count ?? 0);
+                        ReleaseArchitecture.Live, MissConsequence("it will be COMPILED here"),
+                        index.Bundles?.Count ?? 0);
                     return Miss(pluginId, BundleAdoptionKind.NotAdvertised,
                         $"{_registryUrl} advertises {index.Bundles?.Count ?? 0} package(s) to this "
                         + "instance, and this is not one of them");
@@ -223,6 +224,13 @@ public sealed class PluginBundleClient
                 pluginId, kind.ToString(), reason)));
         return Observable.Return(0);
     }
+
+    /// <summary>The consequence half of a miss LOG LINE, truthful per mode: a default mesh
+    /// compiles, a require-prebuilt mesh fails the adoption right after the line (#2198 review).</summary>
+    private string MissConsequence(string defaultConsequence) =>
+        _requirePrebuilt
+            ? "the adoption FAILS here (" + PrebuiltAssemblySeeder.RequirePrebuiltConfigKey + ")"
+            : defaultConsequence;
 
     /// <summary>The one message shape for every <see cref="PrebuiltAssemblySeeder.RequirePrebuiltConfigKey"/>
     /// refusal on this lane — package, registry, identity/architecture, miss kind, fix. Pure.</summary>
@@ -414,8 +422,8 @@ public sealed class PluginBundleClient
             if (resp.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 _logger?.LogInformation(
-                    "No prebuilt bundle for {Plugin}@{Version} at {Registry} — will compile",
-                    pluginId, version, _registryUrl);
+                    "No prebuilt bundle for {Plugin}@{Version} at {Registry} — {Consequence}",
+                    pluginId, version, _registryUrl, MissConsequence("will compile"));
                 return new FetchResult(null, BundleAdoptionKind.NotServed,
                     $"the registry advertises {pluginId}@{version} but serves no bytes for "
                     + $"{PrebuiltAssemblySeeder.LiveFrameworkMvid}/{ReleaseArchitecture.Live}");
@@ -428,8 +436,8 @@ public sealed class PluginBundleClient
                 // it always works; turning a distribution hiccup into an install failure trades a
                 // slow success for a hard error.
                 _logger?.LogWarning(
-                    "Bundle fetch for {Plugin}@{Version} failed ({Status}) — will compile",
-                    pluginId, version, (int)resp.StatusCode);
+                    "Bundle fetch for {Plugin}@{Version} failed ({Status}) — {Consequence}",
+                    pluginId, version, (int)resp.StatusCode, MissConsequence("will compile"));
                 return new FetchResult(null, BundleAdoptionKind.FetchFailed,
                     $"HTTP {(int)resp.StatusCode} from {_registryUrl}");
             }
@@ -455,8 +463,8 @@ public sealed class PluginBundleClient
                 if (PrebuiltAssemblySeeder.DeclineReason(manifest?.FrameworkMvid) is { } reason)
                 {
                     _logger?.LogInformation(
-                        "Bundle for {Plugin} DECLINED whole: {Reason} — compiling instead",
-                        pluginId, reason);
+                        "Bundle for {Plugin} DECLINED whole: {Reason} — {Consequence}",
+                        pluginId, reason, MissConsequence("compiling instead"));
                     return Miss(pluginId, BundleAdoptionKind.BundleDeclined, reason);
                 }
 
@@ -467,12 +475,16 @@ public sealed class PluginBundleClient
                 // normal behaviour rather than a regression in the distribution lane.
                 if (manifest?.Misses is { Count: > 0 } misses)
                 {
+                    // The consequence half of the line must tell the truth PER MODE: on a default
+                    // mesh the unresolved types compile here; on a require-prebuilt mesh the very
+                    // next statement fails the adoption instead (Copilot on #2198).
                     _logger?.LogWarning(
                         "Bundle for {Plugin}: the registry could resolve NO artifact for {Missed} "
-                        + "NodeType(s) on framework {Identity}/{Architecture} — they will be "
-                        + "compiled here: {Misses}",
+                        + "NodeType(s) on framework {Identity}/{Architecture} — {Consequence}: {Misses}",
                         pluginId, misses.Count, PrebuiltAssemblySeeder.LiveFrameworkMvid,
-                        ReleaseArchitecture.Live, string.Join(" | ", misses));
+                        ReleaseArchitecture.Live,
+                        MissConsequence("they will be compiled here"),
+                        string.Join(" | ", misses));
                     // 🚨 PARTIAL coverage fails a require-prebuilt mesh just like a whole-bundle
                     // miss, and it fails BEFORE any of the resolved assemblies are seeded: the
                     // unresolved types would otherwise compile at first access — the exact silent
@@ -487,7 +499,8 @@ public sealed class PluginBundleClient
                 if (assemblies.Count == 0)
                 {
                     _logger?.LogInformation(
-                        "Bundle for {Plugin} carried no assemblies — compiling instead", pluginId);
+                        "Bundle for {Plugin} carried no assemblies — {Consequence}", pluginId,
+                        MissConsequence("compiling instead"));
                     return Miss(pluginId, BundleAdoptionKind.NoAssemblies,
                         "the bundle carried no assemblies");
                 }

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -53,6 +53,7 @@ public sealed class PluginBundleClient
     // The count that proves the lane works (#1782 gap 4). Optional: a host that registers no
     // ledger loses the counting, never the fetching.
     private readonly BundleAdoptionLedger? _ledger;
+    private readonly bool _requirePrebuilt;
 
     // ONE index read per client, shared by every package the install pass covers. PromiseSlot, not
     // a plain cached field: concurrent first callers share the single run, and a fault EVICTS so
@@ -78,6 +79,9 @@ public sealed class PluginBundleClient
         _logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger<PluginBundleClient>();
         _ledger = hub.ServiceProvider.GetService<BundleAdoptionLedger>();
+        // Deployment policy, resolved once: a require-prebuilt mesh turns every miss below into a
+        // named early failure instead of a compile fallback. See RequirePrebuiltConfigKey.
+        _requirePrebuilt = PrebuiltAssemblySeeder.RequirePrebuilt(hub.ServiceProvider);
     }
 
     /// <summary>What the registry advertises: the framework its assemblies were built against, and
@@ -199,18 +203,36 @@ public sealed class PluginBundleClient
             });
 
     /// <summary>
-    /// Records a miss and reports it as the zero every caller already handles.
+    /// Records a miss and reports it as the zero every caller already handles — or, on a mesh that
+    /// opted into <see cref="PrebuiltAssemblySeeder.RequirePrebuiltConfigKey"/>, FAILS with the
+    /// named <see cref="PrebuiltRequiredException"/> instead: such a mesh does not compile, so a
+    /// miss is not a slow success, it is the distribution lane being dark, and it must fail the
+    /// install EARLY, naming what is missing and what fixes it (#2193 §A).
     ///
-    /// <para>The integer return is deliberately unchanged: adoption must never fail an install, and
-    /// widening the contract would ripple through five call sites for no gain. What changes is that
-    /// the zero is no longer the ONLY thing that happened — the reason is named in the log and
-    /// counted in the ledger, so "the lane is dark" is answerable after the fact.</para>
+    /// <para>On the default path the integer return is deliberately unchanged: adoption must never
+    /// fail an install there, and widening the contract would ripple through five call sites for
+    /// no gain. What changed first (#1782) is that the zero is no longer the ONLY thing that
+    /// happened — the reason is named in the log and counted in the ledger; the ledger records the
+    /// miss in BOTH modes, so the flag never trades observability for strictness.</para>
     /// </summary>
     private IObservable<int> Miss(string pluginId, BundleAdoptionKind kind, string? reason)
     {
         _ledger?.Record(new BundleAdoptionOutcome(pluginId, kind, _registryUrl, Reason: reason));
+        if (_requirePrebuilt)
+            return Observable.Throw<int>(new PrebuiltRequiredException(RequiredMessage(
+                pluginId, kind.ToString(), reason)));
         return Observable.Return(0);
     }
+
+    /// <summary>The one message shape for every <see cref="PrebuiltAssemblySeeder.RequirePrebuiltConfigKey"/>
+    /// refusal on this lane — package, registry, identity/architecture, miss kind, fix. Pure.</summary>
+    private string RequiredMessage(string pluginId, string kind, string? reason) =>
+        $"{PrebuiltAssemblySeeder.RequirePrebuiltConfigKey}: no prebuilt assemblies for "
+        + $"'{pluginId}' from {_registryUrl} on framework "
+        + $"{PrebuiltAssemblySeeder.LiveFrameworkMvid}/{ReleaseArchitecture.Live} "
+        + $"({kind}{(string.IsNullOrWhiteSpace(reason) ? "" : $": {reason}")}). "
+        + "This mesh does not compile module content — publish or rebake the bundle for this "
+        + "framework identity and architecture, then retry the install (MeshWeaver#2193 §A).";
 
     /// <summary>
     /// Fetches <paramref name="pluginId"/>'s bundle and LANDS the compiled module it carries into
@@ -444,12 +466,23 @@ public sealed class PluginBundleClient
                 // like a package that has no NodeTypes, and the compile that follows looks like
                 // normal behaviour rather than a regression in the distribution lane.
                 if (manifest?.Misses is { Count: > 0 } misses)
+                {
                     _logger?.LogWarning(
                         "Bundle for {Plugin}: the registry could resolve NO artifact for {Missed} "
                         + "NodeType(s) on framework {Identity}/{Architecture} — they will be "
                         + "compiled here: {Misses}",
                         pluginId, misses.Count, PrebuiltAssemblySeeder.LiveFrameworkMvid,
                         ReleaseArchitecture.Live, string.Join(" | ", misses));
+                    // 🚨 PARTIAL coverage fails a require-prebuilt mesh just like a whole-bundle
+                    // miss, and it fails BEFORE any of the resolved assemblies are seeded: the
+                    // unresolved types would otherwise compile at first access — the exact silent
+                    // fallback the flag forbids — and a half-seeded package would make the retry
+                    // after the rebake harder to reason about, not easier.
+                    if (_requirePrebuilt)
+                        return Miss(pluginId, BundleAdoptionKind.NoAssemblies,
+                            $"the registry resolved no artifact for {misses.Count} NodeType(s): "
+                            + string.Join(" | ", misses));
+                }
 
                 if (assemblies.Count == 0)
                 {

--- a/test/MeshWeaver.PluginCatalog.Test/RequirePrebuiltAdoptionTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RequirePrebuiltAdoptionTest.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+#pragma warning disable CS1591
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// 🚨 <b>The compile fallback is a POLICY, and a require-prebuilt mesh refuses it EARLY and by
+/// NAME</b> (MeshWeaver#2193 §A — the 2026-08-25 incident: distribution misses surfaced as
+/// "carried no assemblies — compiling instead" and the failure was only diagnosable four causal
+/// steps later).
+///
+/// <para>With <c>Modules:RequirePrebuilt=true</c>, every adoption miss —
+/// not advertised, not served for this lane, the registry down — FAILS the adoption with a
+/// <see cref="PrebuiltRequiredException"/> whose message names the package, the registry, the
+/// framework identity/architecture, the miss kind and the fix (publish/rebake the bundle for this
+/// lane). Nothing compiles. The ledger still records every miss, so the flag never trades
+/// observability for strictness.</para>
+///
+/// <para>The flag-OFF contract is pinned byte-for-byte by the existing
+/// <see cref="BundleAdoptionMissTest"/> suite, which runs unchanged: same stub registry, same miss
+/// shapes, bare zeros.</para>
+/// </summary>
+public class RequirePrebuiltAdoptionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string RegistryUrl = "http://registry.test";
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private sealed class StubRegistry : HttpMessageHandler
+    {
+        public string? IndexJson { get; set; }
+        public HttpStatusCode DownloadStatus { get; set; } = HttpStatusCode.NotFound;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path.EndsWith("/index.json", StringComparison.Ordinal))
+                return Task.FromResult(IndexJson is null
+                    ? new HttpResponseMessage(HttpStatusCode.NotFound)
+                    : new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(IndexJson, Encoding.UTF8, "application/json"),
+                    });
+            return Task.FromResult(new HttpResponseMessage(DownloadStatus)
+            {
+                Content = new StringContent(string.Empty),
+            });
+        }
+    }
+
+    private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private readonly StubRegistry registry = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        base.ConfigureMesh(builder).AddGraph().AddPluginCatalog()
+            .ConfigureServices(services => services
+                .AddSingleton<IHttpClientFactory>(new StubFactory(registry))
+                // The deployment opt-in under test — the same registration idiom the Content tests
+                // use for in-memory configuration.
+                .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [PrebuiltAssemblySeeder.RequirePrebuiltConfigKey] = "true",
+                    })
+                    .Build()));
+
+    private BundleAdoptionLedger Ledger =>
+        Mesh.ServiceProvider.GetRequiredService<BundleAdoptionLedger>();
+
+    private static string Index(string identity, params (string Plugin, string Version)[] bundles) =>
+        JsonSerializer.Serialize(new
+        {
+            frameworkMvid = identity,
+            architecture = ReleaseArchitecture.Live,
+            bundles = bundles.Select(b => new
+            {
+                plugin = b.Plugin,
+                version = b.Version,
+                url = $"{RegistryUrl}/api/plugins/bundles/{b.Plugin}/{b.Version}",
+            }).ToArray(),
+        }, Json);
+
+    private static async Task<PrebuiltRequiredException> ShouldRefuse(IObservable<int> adoption)
+    {
+        var act = () => adoption.FirstAsync().ToTask();
+        return (await act.Should().ThrowAsync<PrebuiltRequiredException>()).Which;
+    }
+
+    /// <summary>A package the registry does not advertise fails EARLY, with every fact an operator
+    /// needs in one message — and the miss is still ledgered.</summary>
+    [Fact(Timeout = 120_000)]
+    public async Task NotAdvertised_FailsEarly_NamingPackageRegistryIdentityAndFix()
+    {
+        registry.IndexJson = Index(PrebuiltAssemblySeeder.LiveFrameworkMvid, ("Other", "1.0.0"));
+
+        var refusal = await ShouldRefuse(new PluginBundleClient(Mesh, RegistryUrl).Adopt("Store"));
+
+        refusal.Message.Should().Contain(PrebuiltAssemblySeeder.RequirePrebuiltConfigKey,
+            "the message must say WHICH policy refused");
+        refusal.Message.Should().Contain("'Store'").And.Contain(RegistryUrl);
+        refusal.Message.Should().Contain(PrebuiltAssemblySeeder.LiveFrameworkMvid,
+            "…and WHICH lane the bundle is missing for");
+        refusal.Message.Should().Contain("rebake",
+            "…and WHAT fixes it — the fix is on the distribution side, never this mesh");
+
+        Ledger.Misses.Should().ContainSingle()
+            .Which.Kind.Should().Be(BundleAdoptionKind.NotAdvertised);
+    }
+
+    /// <summary>Advertised but not served for this lane — the incident's own shape — fails early
+    /// instead of compiling.</summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AdvertisedButNotServed_FailsEarly()
+    {
+        registry.IndexJson = Index(PrebuiltAssemblySeeder.LiveFrameworkMvid, ("Store", "1.0.0"));
+        registry.DownloadStatus = HttpStatusCode.NotFound;
+
+        var refusal = await ShouldRefuse(new PluginBundleClient(Mesh, RegistryUrl).Adopt("Store"));
+
+        refusal.Message.Should().Contain("NotServed");
+        Ledger.Misses.Should().ContainSingle()
+            .Which.Kind.Should().Be(BundleAdoptionKind.NotServed);
+    }
+
+    /// <summary>A registry outage is ALSO a refusal here: "never start compiling" tolerates a
+    /// failed install (retryable) but not a silent local build.</summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ARegistryOutage_FailsEarly_NotCompile()
+    {
+        registry.IndexJson = Index(PrebuiltAssemblySeeder.LiveFrameworkMvid, ("Store", "1.0.0"));
+        registry.DownloadStatus = HttpStatusCode.ServiceUnavailable;
+
+        var refusal = await ShouldRefuse(new PluginBundleClient(Mesh, RegistryUrl).Adopt("Store"));
+
+        refusal.Message.Should().Contain("FetchFailed");
+        Ledger.Misses.Should().ContainSingle()
+            .Which.Kind.Should().Be(BundleAdoptionKind.FetchFailed);
+    }
+
+    // ── the default-install absorb policy (pure — no mesh) ─────────────────────────────────────
+
+    /// <summary>Ordinary adoption failures stay absorbed (compiling is the default fallback), but
+    /// the named refusal must PROPAGATE — swallowing it one call site above where it was refused
+    /// would restore the silent compile the flag forbids.</summary>
+    [Fact]
+    public void AbsorbPolicy_SwallowsOrdinaryFailures_ButPropagatesTheNamedRefusal()
+    {
+        var ordinary = new Subject<int>();
+        var absorbed = new List<int>();
+        using (InstanceAutoRegistrationService
+                   .AbsorbUnlessPrebuiltRequired(ordinary, logger: null, "Pack")
+                   .Subscribe(absorbed.Add))
+        {
+            ordinary.OnError(new InvalidOperationException("registry hiccup"));
+        }
+        absorbed.Should().Equal([0], "an ordinary failure degrades to the compile fallback");
+
+        var required = new Subject<int>();
+        Exception? propagated = null;
+        using (InstanceAutoRegistrationService
+                   .AbsorbUnlessPrebuiltRequired(required, logger: null, "Pack")
+                   .Subscribe(_ => { }, ex => propagated = ex))
+        {
+            required.OnError(new PrebuiltRequiredException("Modules:RequirePrebuilt: no bundle"));
+        }
+        propagated.Should().BeOfType<PrebuiltRequiredException>(
+            "the named refusal must fail the install, visibly");
+    }
+}


### PR DESCRIPTION
Implements MeshWeaver#2193 §A under the standing directive: **error early when a pre-built DLL is missing — never fall back to compiling.**

## What changed

New deployment flag `Modules:RequirePrebuilt` (default **off**). When on, the three seams that turned a distribution miss into a silent local compile refuse instead — loudly and by name:

- **`PluginBundleClient`** — every miss kind (not advertised, framework-declined, not served for this lane, registry outage, empty bundle, per-type misses) throws `PrebuiltRequiredException`; the message names the package, registry, framework identity/architecture, miss kind and the fix (*publish or rebake the bundle for this lane*). Partial coverage fails **before** any assembly is seeded. The adoption ledger still records every miss in both modes.
- **`InstanceAutoRegistrationService`** — the default-install absorb policy is extracted (`AbsorbUnlessPrebuiltRequired`): ordinary failures still degrade to the compile fallback; the named refusal propagates and surfaces in the lane's install summary.
- **`ShippedPrebuiltBundles`** — an empty bundle at boot logs as an **error** naming the bundle, identity and rebake fix; the sweep continues (one hollow bundle never blocks the good ones).

Config key + rationale documented beside `PrebuiltAssemblySeeder`; sibling of #2192's `Modules:AutoRecycleOnStaleBuild`.

## Contract pinned

- `RequirePrebuiltAdoptionTest` (new): three named refusals against the stubbed registry — message asserts the policy key, the package, the registry, the lane identity and the fix; ledger still counts each miss. Plus the absorb-policy pin (ordinary failure → 0, named refusal → propagates).
- Flag-off = today's behavior byte-for-byte: the existing `BundleAdoptionMissTest` suite runs **unchanged** (bare zeros, ledgered misses). 11/11 green together; `ShippedPrebuiltBundlesTest` 9/9 green.
- `dotnet build -c Release -p:CIRun=true -warnaserror` clean on Graph, PluginCatalog, Hosting.

## Rollout

No behavior change until a deployment opts in. Production portals should enable it **only after** the bundle lanes cover their identities (tracked in MeshWeaver.Plugins#641); dev/CI/bake meshes stay off by design.

Refs #2193. Merge is yours, Roland.

🤖 Generated with [Claude Code](https://claude.com/claude-code)