### PR TITLE
Modules:ImportSourceNodes — imports can skip persisting compile inputs as nodes (#2193 §B, step 1)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-import-source-nodes-mode.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-import-source-nodes-mode.md
@@ -1,0 +1,24 @@
+---
+Name: Module source can stay out of the mesh database
+Category: Feature
+Description: Adopt-only meshes can set Modules:ImportSourceNodes to false — package installs and GitSync imports then skip persisting Source/ and Test/ files as nodes; the compiled form arrives in the prebuilt bundle and the text stays in the repo.
+Icon: DatabaseArrowUp
+Order: -20260825
+---
+
+# Module source can stay out of the mesh database
+
+On a mesh that runs modules from prebuilt bundles, the C# under every type's `Source/` and `Test/`
+folders has no runtime job — the compiled assembly is the artifact — yet every import kept writing
+those files into the database as nodes, where they cost storage, sync traffic, and a second copy
+of the truth that lives in the repo.
+
+Deployments can now set `Modules:ImportSourceNodes: false`. Package installs and GitSync imports then
+skip compile-input files entirely: they are not parsed, not persisted, and reported once per
+import as a counted policy line — never as per-file noise. The default is unchanged (sources are
+imported), and the mode is designed to be enabled together with `Modules:RequirePrebuilt`: a mesh
+that still compiles on a miss but no longer holds the sources would fail its recompiles, so that
+combination is honoured but loudly warned about.
+
+This is the first sequenced step of moving module source out of the mesh database entirely —
+imports must stop re-creating source before any existing source nodes can be retired.

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -580,8 +580,39 @@ public sealed class GitHubSyncService
         var contentSyncs = ContentAssetMapper.ToContentSyncs(
             spaceId, classified.Where(c => c.Asset is not null).Select(c => c.Asset!));
 
-        return classified
-            .Where(c => c.Asset is null)
+        // The adopt-only import mode (Modules:ImportSourceNodes=false, MeshWeaver#2193 §B):
+        // compile inputs (Source/, Test/) are not persisted as nodes — their compiled form is the
+        // prebuilt bundle, and the text stays browsable in the repo. Reported ONCE, with the
+        // count, on the activity (never per file — the O(n²) progress-write rule above); and the
+        // sources-skipped-but-still-compiling misconfiguration is warned about, never silent.
+        var importSourceNodes = Graph.Configuration.PrebuiltAssemblySeeder
+            .ImportSourceNodes(hub.ServiceProvider);
+        var nodeCandidates = classified.Where(c => c.Asset is null).ToArray();
+        if (!importSourceNodes)
+        {
+            var sources = nodeCandidates
+                .Where(c => NodeFileMapper.IsCompileInputPath(
+                    NodeFileMapper.RelativePath(c.File.Path, spaceId)))
+                .ToArray();
+            if (sources.Length > 0)
+            {
+                progress?.Invoke(
+                    $"{sources.Length} compile-input file(s) (Source/, Test/) were not persisted "
+                    + $"as nodes ({Graph.Configuration.PrebuiltAssemblySeeder.ImportSourceNodesConfigKey}=false) "
+                    + "— their compiled form arrives in the prebuilt bundle.",
+                    LogLevel.Information);
+                if (!Graph.Configuration.PrebuiltAssemblySeeder.RequirePrebuilt(hub.ServiceProvider))
+                    progress?.Invoke(
+                        $"{Graph.Configuration.PrebuiltAssemblySeeder.ImportSourceNodesConfigKey}=false while "
+                        + $"{Graph.Configuration.PrebuiltAssemblySeeder.RequirePrebuiltConfigKey} is not set: "
+                        + "this mesh still compiles on a miss, and a recompile of any affected type "
+                        + "will fail for lack of sources. Set both keys together (adopt-only), or neither.",
+                        LogLevel.Warning);
+                nodeCandidates = nodeCandidates.Except(sources).ToArray();
+            }
+        }
+
+        return nodeCandidates
             .Select(c => ParseFile(c.File, spaceId))
             .Merge(8)
             .ToList()

--- a/src/MeshWeaver.GitSync/NodeFileMapper.cs
+++ b/src/MeshWeaver.GitSync/NodeFileMapper.cs
@@ -83,4 +83,24 @@ public static class NodeFileMapper
         var dot = p.LastIndexOf('.');
         return dot > lastSlash ? p[..dot] : p;
     }
+
+    /// <summary>
+    /// Whether a repo file is a COMPILE INPUT by the node-repo layout — it lives under a
+    /// <c>Source/</c> or <c>Test/</c> DIRECTORY (a type's own, or a partition-shared one). These
+    /// are the files a mesh that adopts prebuilt assemblies never needs as nodes
+    /// (<c>Modules:ImportSourceNodes=false</c>, MeshWeaver#2193 §B): their compiled form arrives
+    /// in the bundle, and persisting the text only re-creates the source-in-DB surface the
+    /// adopt-only design removes.
+    ///
+    /// <para>The match is the DIRECTORY segment, exact and case-sensitive — the same
+    /// <c>/Source/</c>, <c>/Test/</c> convention the compile-input resolution and the installer's
+    /// owning-type derivation use. A FILE named <c>Test.json</c> (the node backing a
+    /// <c>Test/</c> folder) is not a compile input, and neither is a folder merely containing the
+    /// words (<c>Sources/</c>, <c>Testing/</c>). Pure.</para>
+    /// </summary>
+    public static bool IsCompileInputPath(string relativePath) =>
+        relativePath.Contains("/Source/", StringComparison.Ordinal)
+        || relativePath.Contains("/Test/", StringComparison.Ordinal)
+        || relativePath.StartsWith("Source/", StringComparison.Ordinal)
+        || relativePath.StartsWith("Test/", StringComparison.Ordinal);
 }

--- a/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
@@ -54,6 +54,37 @@ public static class PrebuiltAssemblySeeder
     }
 
     /// <summary>
+    /// The import half of the adopt-only mode (MeshWeaver#2193 §B, sequenced FIRST — a purge that
+    /// runs before imports stop re-creating source is undone by the next sync): with
+    /// <c>Modules:ImportSourceNodes</c> set to <c>false</c>, package installs and GitSync imports
+    /// SKIP persisting compile-input files (<c>Source/</c>, <c>Test/</c> —
+    /// <c>NodeFileMapper.IsCompileInputPath</c>) as mesh nodes. Their compiled form arrives in the
+    /// prebuilt bundle; the text stays in the repo, browsed through GitHub (§C), not the DB.
+    ///
+    /// <para>🚨 <b>Default ON (sources ARE imported)</b> — and only sane to turn off TOGETHER with
+    /// <see cref="RequirePrebuiltConfigKey"/>: a mesh that still compiles but no longer holds the
+    /// sources would fail every recompile. The import lanes log a loud warning on that
+    /// combination rather than guessing an intent.</para>
+    /// </summary>
+    public const string ImportSourceNodesConfigKey = "Modules:ImportSourceNodes";
+
+    /// <summary>Reads <see cref="ImportSourceNodesConfigKey"/> — absent or unparseable means ON
+    /// (sources are imported), the long-standing default. Never throws.</summary>
+    public static bool ImportSourceNodes(IServiceProvider? services)
+    {
+        try
+        {
+            var value = services?
+                .GetService<Microsoft.Extensions.Configuration.IConfiguration>()?[ImportSourceNodesConfigKey];
+            return !bool.TryParse(value, out var parsed) || parsed;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Why a prebuilt assembly may NOT be adopted, or null when it may.
     ///
     /// <para>🚨 This is the whole safety argument, kept as one pure function so it can be tested

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1997,13 +1997,14 @@ public static class PackageInstaller
     {
         _ = batchSize; // node-repo installs are ordered (bucketed bulk saves + Concat), not fanned out
         var parsers = new FileFormatParserRegistry(hub.JsonSerializerOptions, hub.ServiceProvider.GetServices<IFileFormatParser>());
+        var importSourceNodes = ImportSourceNodesFor(hub, logger);
         // The CI manifest sidecar (when the package ships one) becomes the install record's diff
         // baseline — the next update touches only what its manifest diff names.
         var moduleManifest = files
             .Where(f => ModuleManifest.IsManifestPath(f.RelativePath))
             .Select(f => ModuleManifest.TryParse(f.Content, logger))
             .FirstOrDefault(m => m is not null);
-        var nodes = ParseAll(parsers, files, manifest.Id, logger);
+        var nodes = ParseAll(parsers, files, manifest.Id, logger, importSourceNodes);
 
         if (nodes.Length == 0)
             return Observable.Throw<InstallResult>(new InvalidOperationException(
@@ -2559,7 +2560,7 @@ public static class PackageInstaller
     {
 
         var parsers = new FileFormatParserRegistry(hub.JsonSerializerOptions, hub.ServiceProvider.GetServices<IFileFormatParser>());
-        var nodes = ParseAll(parsers, changedFiles, manifest.Id, logger);
+        var nodes = ParseAll(parsers, changedFiles, manifest.Id, logger, ImportSourceNodesFor(hub, logger));
 
         if (RefuseIfStaticShadowed(hub, manifest, nodes, logger) is { } shadowed)
             return shadowed;
@@ -2730,23 +2731,67 @@ public static class PackageInstaller
     /// nodes by design (README, manifest, `content/**` assets) are not skips and are not counted.
     /// </para>
     /// </summary>
-    private static MeshNode[] ParseAll(
-        FileFormatParserRegistry parsers, IReadOnlyList<PackageFile> files, string packageId, ILogger? logger)
+    // Internal for the ImportSourceNodesTest pin (InternalsVisibleTo).
+    internal static MeshNode[] ParseAll(
+        FileFormatParserRegistry parsers, IReadOnlyList<PackageFile> files, string packageId,
+        ILogger? logger, bool importSourceNodes = true)
     {
         var unparsed = new List<string>();
         var nodes = files
-            .Select(f => ParseCanonical(parsers, f, logger, unparsed))
+            .Select(f => ParseCanonical(parsers, f, logger, unparsed, importSourceNodes))
             .Where(n => n is not null).Select(n => n!)
             .ToArray();
+
+        // The adopt-only import mode (Modules:ImportSourceNodes=false, MeshWeaver#2193 §B):
+        // compile inputs are deliberately NOT persisted as nodes — say so ONCE, with the count,
+        // so "the sources are not on the mesh" reads as the configured policy and never as loss.
+        if (!importSourceNodes)
+        {
+            var sourceFiles = files.Count(f =>
+                !IsNotANodeFile(f.RelativePath)
+                && GitSync.NodeFileMapper.IsCompileInputPath(f.RelativePath));
+            if (sourceFiles > 0)
+                logger?.LogInformation(
+                    "Package '{Package}': {SourceFiles} compile-input file(s) (Source/, Test/) "
+                    + "were NOT persisted as nodes ({Key}=false) — their compiled form arrives in "
+                    + "the prebuilt bundle.",
+                    packageId, sourceFiles,
+                    Graph.Configuration.PrebuiltAssemblySeeder.ImportSourceNodesConfigKey);
+        }
 
         if (unparsed.Count > 0)
             logger?.LogWarning(
                 "Package '{Package}': {Skipped} of {Candidates} candidate files had no parser and "
                 + "were skipped; {Installed} nodes installed. First skipped: {Sample}.",
-                packageId, unparsed.Count, files.Count(f => !IsNotANodeFile(f.RelativePath)),
+                packageId, unparsed.Count,
+                files.Count(f => !IsNotANodeFile(f.RelativePath)
+                    && (importSourceNodes
+                        || !GitSync.NodeFileMapper.IsCompileInputPath(f.RelativePath))),
                 nodes.Length, string.Join(", ", unparsed.Take(5)));
 
         return nodes;
+    }
+
+    /// <summary>
+    /// The import-mode policy for one install run, with its one sanity warning: skipping the
+    /// sources while the mesh still COMPILES (no <see cref="Graph.Configuration.PrebuiltAssemblySeeder.RequirePrebuiltConfigKey"/>)
+    /// would fail every recompile with "no sources" — so the combination is honoured (the operator
+    /// asked) but never silent (MeshWeaver#2193 §B).
+    /// </summary>
+    private static bool ImportSourceNodesFor(IMessageHub hub, ILogger? logger)
+    {
+        var importSourceNodes =
+            Graph.Configuration.PrebuiltAssemblySeeder.ImportSourceNodes(hub.ServiceProvider);
+        if (!importSourceNodes
+            && !Graph.Configuration.PrebuiltAssemblySeeder.RequirePrebuilt(hub.ServiceProvider))
+            logger?.LogWarning(
+                "{ImportKey}=false while {RequireKey} is not set: compile inputs will not be "
+                + "persisted, but this mesh still compiles on a miss — a recompile of any affected "
+                + "type will fail for lack of sources. Set both keys together (adopt-only), or "
+                + "neither.",
+                Graph.Configuration.PrebuiltAssemblySeeder.ImportSourceNodesConfigKey,
+                Graph.Configuration.PrebuiltAssemblySeeder.RequirePrebuiltConfigKey);
+        return importSourceNodes;
     }
 
     /// <summary>
@@ -2773,9 +2818,15 @@ public static class PackageInstaller
         || ContentAssetMapper.IsContentPath(relativePath);
 
     private static MeshNode? ParseCanonical(
-        FileFormatParserRegistry parsers, PackageFile file, ILogger? logger, List<string>? unparsed = null)
+        FileFormatParserRegistry parsers, PackageFile file, ILogger? logger,
+        List<string>? unparsed = null, bool importSourceNodes = true)
     {
         if (IsNotANodeFile(file.RelativePath))
+            return null;
+        // Adopt-only import mode: a compile input is not a node candidate here at all — not
+        // parsed, not warned, not counted as a skip (ParseAll reports the policy once, with the
+        // count). See PrebuiltAssemblySeeder.ImportSourceNodesConfigKey.
+        if (!importSourceNodes && GitSync.NodeFileMapper.IsCompileInputPath(file.RelativePath))
             return null;
         var ext = System.IO.Path.GetExtension(file.RelativePath);
         var parsed = parsers.TryParse(ext, file.RelativePath, file.Content, file.RelativePath);

--- a/test/MeshWeaver.GitSync.Test/NodeFileMapperTest.cs
+++ b/test/MeshWeaver.GitSync.Test/NodeFileMapperTest.cs
@@ -76,4 +76,28 @@ public class NodeFileMapperTest
         Assert.Equal(("Docs", ""), (docsId, docsNs));
         Assert.Equal(("Intro", "Docs"), (introId, introNs));
     }
+
+    /// <summary>
+    /// The compile-input predicate behind <c>Modules:ImportSourceNodes=false</c> (MeshWeaver#2193
+    /// §B): only DIRECTORY segments named exactly <c>Source</c>/<c>Test</c> match — a node FILE
+    /// backing a Test/ folder is a node, and folders that merely contain the words are content.
+    /// </summary>
+    [Fact]
+    public void CompileInputPaths_AreTheSourceAndTestDirectories_Exactly()
+    {
+        // A type's own compile inputs, and a partition-shared root.
+        Assert.True(NodeFileMapper.IsCompileInputPath("Store/Plugin/Source/PluginContent.cs"));
+        Assert.True(NodeFileMapper.IsCompileInputPath("Store/Plugin/Test/PluginCoverTests.cs"));
+        Assert.True(NodeFileMapper.IsCompileInputPath("Source/Shared.cs"));
+        Assert.True(NodeFileMapper.IsCompileInputPath("Test/SharedTests.cs"));
+
+        // The node FILE backing a Test/ folder is a node, not an input.
+        Assert.False(NodeFileMapper.IsCompileInputPath("Store/Plugin/Test.json"));
+        Assert.False(NodeFileMapper.IsCompileInputPath("Store/Source.json"));
+        // Names that merely contain the words are content.
+        Assert.False(NodeFileMapper.IsCompileInputPath("Edu/Sources/Reading.md"));
+        Assert.False(NodeFileMapper.IsCompileInputPath("Edu/Testing/Intro.md"));
+        // …and the match is case-sensitive, like the layout convention itself.
+        Assert.False(NodeFileMapper.IsCompileInputPath("Edu/source/x.cs"));
+    }
 }

--- a/test/MeshWeaver.PluginCatalog.Test/ImportSourceNodesTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ImportSourceNodesTest.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using MeshWeaver.Hosting.Persistence.Parsers;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+#pragma warning disable CS1591
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The adopt-only import mode on the install parse lane (MeshWeaver#2193 §B): with
+/// <c>Modules:ImportSourceNodes=false</c>, compile-input files (<c>Source/</c>, <c>Test/</c>) are
+/// not node candidates AT ALL — not parsed, not persisted, and not counted as parse-failure skips
+/// (the policy is reported once, as information with a count, never as warning noise). With the
+/// flag on — the default — behaviour is unchanged: the built-in C# parser turns compile inputs
+/// into Code nodes at their canonical paths, exactly as today.
+/// </summary>
+public class ImportSourceNodesTest
+{
+    // The registry with its BUILT-IN parsers only (no extras injected) — .cs files parse into
+    // Code nodes by default, which is exactly what the flag-off mode must prevent.
+    private static readonly FileFormatParserRegistry Parsers =
+        new(new JsonSerializerOptions(JsonSerializerDefaults.Web), []);
+
+    private static readonly IReadOnlyList<PackageFile> Files =
+    [
+        new("README.md", "# display file — never a node"),
+        new("Store/Plugin/Source/PluginContent.cs", "// compile input"),
+        new("Store/Plugin/Test/PluginCoverTests.cs", "// compile input"),
+    ];
+
+    /// <summary>Records every log entry, so the two modes are distinguishable by what they SAY.</summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    [Fact]
+    public void FlagOff_CompileInputsAreNotCandidates_ReportedAsPolicyNotAsSkips()
+    {
+        var log = new RecordingLogger();
+        var nodes = PackageInstaller.ParseAll(
+            Parsers, Files, "Store", log, importSourceNodes: false);
+
+        Assert.Empty(nodes);
+        // The policy is one INFORMATION line with the count…
+        var info = Assert.Single(log.Entries, e => e.Level == LogLevel.Information);
+        Assert.Contains("2 compile-input file(s)", info.Message);
+        Assert.Contains("Modules:ImportSourceNodes", info.Message);
+        // …and nothing reached the parser, so there is no "had no parser" warning at all.
+        Assert.DoesNotContain(log.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void FlagOn_TheDefault_CompileInputsBecomeCodeNodes_ExactlyAsToday()
+    {
+        var log = new RecordingLogger();
+        var nodes = PackageInstaller.ParseAll(Parsers, Files, "Store", log);
+
+        // Same files, default mode: the registry's built-in C# parser turns both compile inputs
+        // into Code nodes at their canonical paths — today's behaviour, byte for byte. The pin is
+        // the CONTRAST with the flag-off case above: same inputs, different candidacy.
+        Assert.Equal(2, nodes.Length);
+        Assert.All(nodes, n => Assert.Equal("Code", n.NodeType));
+        Assert.Contains(nodes, n => n.Path == "Store/Plugin/Source/PluginContent");
+        Assert.Contains(nodes, n => n.Path == "Store/Plugin/Test/PluginCoverTests");
+        Assert.Empty(log.Entries);
+    }
+}


### PR DESCRIPTION
Stacked on #2198 (base retargets to `main` automatically when it merges). Implements the first sequenced step of MeshWeaver#2193 §B — **imports must stop re-creating source before any existing source nodes can be retired**; a purge before this lands is undone by the next sync.

## What changed

New deployment flag `Modules:ImportSourceNodes` (default **on** — sources are imported, unchanged). When set to `false`:

- **Both import lanes skip compile inputs**: package installs (`PackageInstaller.ParseAll`) and GitSync imports (`GitHubSyncService.ParseSnapshot`) neither parse nor persist files under `Source/` / `Test/` directories. The skip is reported once per import as a counted policy line — never per-file noise (the O(n²) progress-write rule holds).
- **The predicate is `NodeFileMapper.IsCompileInputPath`** — directory segments exactly `Source`/`Test`, the same convention the compile-input resolution and the installer's owning-type derivation use. A node file named `Test.json` and folders merely containing the words (`Sources/`, `Testing/`) stay nodes/content.
- **The unsafe combination is loud**: skipping sources while `Modules:RequirePrebuilt` is off (the mesh still compiles on a miss) would fail every recompile for lack of sources — both lanes warn explicitly instead of guessing; the operator's setting is honoured.

## Contract pinned

- `NodeFileMapperTest.CompileInputPaths_AreTheSourceAndTestDirectories_Exactly` — the predicate's exact-directory, case-sensitive contract (18/18 suite green).
- `ImportSourceNodesTest` — flag off: zero nodes from Source/Test files, one counted Info line, no warnings; flag on (default): the built-in C# parser produces the same `Code` nodes as today, byte for byte.
- `dotnet build -c Release -p:CIRun=true -warnaserror` clean on GitSync, PluginCatalog, Graph.

## Rollout

No behavior change until a deployment opts in; intended to be enabled together with `Modules:RequirePrebuilt` on adopt-only meshes. The purge of EXISTING source nodes remains strictly later and human-gated (#2193 §B step c).

Refs #2193. Merge is yours, Roland.

🤖 Generated with [Claude Code](https://claude.com/claude-code)