### PR TITLE
Recycle's exits land on the node's default page, never the raw Overview

### DIFF
--- a/src/MeshWeaver.Graph/RecycleLayoutArea.cs
+++ b/src/MeshWeaver.Graph/RecycleLayoutArea.cs
@@ -18,6 +18,15 @@ namespace MeshWeaver.Graph;
 public static class RecycleLayoutArea
 {
     /// <summary>
+    /// Where BOTH buttons land: the node's DEFAULT page (<c>/{path}</c>, empty area) — the same
+    /// rule the breadcrumbs follow, and never a hardcoded <c>Overview</c>. For a plugin node the
+    /// default page is its COVER; the Overview area is the generic raw-body dump, and sending a
+    /// user there after Cancel read as a broken page (memex, 2026-08-25: Cancel on
+    /// OpenStreetMap/Recycle landed on the un-rendered cover HTML). Pure.
+    /// </summary>
+    public static string LandingHref(string nodePath) => $"/{(nodePath ?? "").Trim('/')}";
+
+    /// <summary>
     /// Returns the Recycle menu item if the user has Update permission.
     /// Sort order 90 places it just above Delete (100).
     /// </summary>
@@ -53,7 +62,7 @@ public static class RecycleLayoutArea
     {
         var nodePath = host.Hub.Address.Path;
         var targetAddress = host.Hub.Address;
-        var overviewHref = MeshNodeLayoutAreas.BuildUrl(nodePath, MeshNodeLayoutAreas.OverviewArea);
+        var landingHref = LandingHref(nodePath);
 
         var card = Controls.Stack
             .WithStyle("padding: 24px; max-width: 640px;")
@@ -64,7 +73,7 @@ public static class RecycleLayoutArea
                 .WithHorizontalGap(12)
                 .WithView(Controls.Button(host.Localize("common.cancel"))
                     .WithAppearance(Appearance.Neutral)
-                    .WithNavigateToHref(overviewHref))
+                    .WithNavigateToHref(landingHref))
                 .WithView(Controls.Button(host.Localize("menu.recycle"))
                     .WithAppearance(Appearance.Accent)
                     .WithIconStart(FluentIcons.BinRecycle())
@@ -73,7 +82,7 @@ public static class RecycleLayoutArea
                         // Redirect FIRST — see the remarks above. This emission is on the wire
                         // before the dispose below is dequeued, so the client never depends on a
                         // hub that is shutting down.
-                        ctx.Host.UpdateArea(ctx.Area, new RedirectControl(overviewHref));
+                        ctx.Host.UpdateArea(ctx.Area, new RedirectControl(landingHref));
                         ctx.Host.Hub.Post(new DisposeRequest(), o => o.WithTarget(targetAddress));
                         return Task.CompletedTask;
                     })));

--- a/test/MeshWeaver.Hosting.Blazor.Test/RecycleLandingTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/RecycleLandingTest.cs
@@ -1,0 +1,24 @@
+using MeshWeaver.Graph;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// Recycle's two exits land on the node's DEFAULT page — the same rule the breadcrumbs follow —
+/// never the hardcoded Overview area. For a plugin node the default page is its rendered COVER;
+/// Overview is the generic raw-body dump, and Cancel sending a user there read as a broken page
+/// (memex, 2026-08-25: Cancel on OpenStreetMap/Recycle landed on the un-rendered cover HTML).
+/// </summary>
+public class RecycleLandingTest
+{
+    [Theory]
+    [InlineData("OpenStreetMap", "/OpenStreetMap")]
+    [InlineData("Edu/Course", "/Edu/Course")]
+    [InlineData("/Chess/", "/Chess")]
+    public void BothExits_LandOnTheDefaultPage_NeverOverview(string nodePath, string expected)
+    {
+        var href = RecycleLayoutArea.LandingHref(nodePath);
+        Assert.Equal(expected, href);
+        Assert.DoesNotContain("Overview", href);
+    }
+}


### PR DESCRIPTION
Live on memex (2026-08-25, maintainer report): Cancel on `OpenStreetMap/Recycle` dumped the user on the generic Overview area — the un-rendered raw cover HTML — which reads as a broken page.

Both exits (Cancel and the post-recycle redirect) now target `LandingHref` — the node's DEFAULT page (`/{path}`, empty area), the same rule the breadcrumbs follow; for a plugin node that is its rendered cover. Pinned in `RecycleLandingTest`.

The dead blue button and the per-area refresh mosaic after a recycle are the deeper defect — the confirmation runs ON the hub it kills, so the redirect races its own dispose and the landing page's areas each die separately. Filed with the design in the follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)