### PR TITLE
helm: render OpenRouter__Models — twelve declared keys reached no container

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -269,6 +269,37 @@ data:
   Anthropic__Models__1: "{{ .Values.config.memex_portal.Anthropic__Models__1 }}"
   Anthropic__Models__2: "{{ .Values.config.memex_portal.Anthropic__Models__2 }}"
   AzureFoundry__Endpoint: "{{ .Values.config.memex_portal.AzureFoundry__Endpoint }}"
+  # ── OpenRouter models ────────────────────────────────────────────────────────
+  # 🚨 The FOURTH occurrence of the defect this file already warns about two blocks below
+  # (#1925, and #1778/#1780 before it): every OpenRouter__Models__N was set in both
+  # overlays and rendered by NOTHING, so the keys reached no container and no error was
+  # raised anywhere. The catalog is seeded from these keys by BuiltInLanguageModelProvider
+  # (an IStaticNodeProvider), so the effect was a portal whose model list silently did not
+  # match the reviewed configuration — and, worse, a re-render would have DROPPED the two
+  # models that were live, leaving no OpenRouter models at all.
+  #
+  # Written out INDEX BY INDEX, never a range, per this ConfigMap's contract: it names every
+  # key explicitly so that what reaches a container is reviewable here. Adding a model means
+  # adding a line — that cost is the point.
+  #
+  # An unset index renders "" and is inert: the seeder skips empty entries, so the list may
+  # be shorter than the slots. Extend the range when an environment needs more.
+  OpenRouter__Models__0: "{{ .Values.config.memex_portal.OpenRouter__Models__0 }}"
+  OpenRouter__Models__1: "{{ .Values.config.memex_portal.OpenRouter__Models__1 }}"
+  OpenRouter__Models__2: "{{ .Values.config.memex_portal.OpenRouter__Models__2 }}"
+  OpenRouter__Models__3: "{{ .Values.config.memex_portal.OpenRouter__Models__3 }}"
+  OpenRouter__Models__4: "{{ .Values.config.memex_portal.OpenRouter__Models__4 }}"
+  OpenRouter__Models__5: "{{ .Values.config.memex_portal.OpenRouter__Models__5 }}"
+  OpenRouter__Models__6: "{{ .Values.config.memex_portal.OpenRouter__Models__6 }}"
+  OpenRouter__Models__7: "{{ .Values.config.memex_portal.OpenRouter__Models__7 }}"
+  OpenRouter__Models__8: "{{ .Values.config.memex_portal.OpenRouter__Models__8 }}"
+  OpenRouter__Models__9: "{{ .Values.config.memex_portal.OpenRouter__Models__9 }}"
+  OpenRouter__Models__10: "{{ .Values.config.memex_portal.OpenRouter__Models__10 }}"
+  OpenRouter__Models__11: "{{ .Values.config.memex_portal.OpenRouter__Models__11 }}"
+  OpenRouter__Models__12: "{{ .Values.config.memex_portal.OpenRouter__Models__12 }}"
+  OpenRouter__Models__13: "{{ .Values.config.memex_portal.OpenRouter__Models__13 }}"
+  OpenRouter__Models__14: "{{ .Values.config.memex_portal.OpenRouter__Models__14 }}"
+  OpenRouter__Models__15: "{{ .Values.config.memex_portal.OpenRouter__Models__15 }}"
   AzureFoundry__Models__0: "{{ .Values.config.memex_portal.AzureFoundry__Models__0 }}"
   AzureFoundry__Models__1: "{{ .Values.config.memex_portal.AzureFoundry__Models__1 }}"
   AzureFoundry__Models__2: "{{ .Values.config.memex_portal.AzureFoundry__Models__2 }}"


### PR DESCRIPTION
## The defect
The portal ConfigMap template names **every key explicitly** — there is no catch-all range over `config.memex_portal`. It renders `Anthropic__Models__0..2` and `AzureFoundry__Models__0..3`, and **no `OpenRouter__Models` at all**.

Both overlays declare **twelve**. Every one reached nothing, with no error anywhere.

This is the **fourth occurrence** of the defect this same file warns about two blocks below (#1925, and #1778/#1780 before it):

> *"🚨 A values key this template omits reaches NO container, with no error anywhere."*

## Why it matters more here
The model catalog is seeded from these keys by `BuiltInLanguageModelProvider` — an `IStaticNodeProvider` that owns the `Provider/` namespace and reseeds it on every boot. So the portal's model list **silently did not match the reviewed configuration**: overlays said twelve, instances served two.

## 🚨 A re-render would have been the outage
The two live models are **not** coming from this template — nothing here emits them. So `helm upgrade` would have rendered a ConfigMap with **no** OpenRouter models, the seeder would have created **none**, and **every OpenRouter model would have vanished from both instances**.

That upgrade was queued as the fix for the stale list. It would have caused the failure it was meant to repair.

## The change
Sixteen slots for twelve declared models. An unset index renders `""` and is inert (the seeder skips empty entries), so the list may be shorter than the slots.

Index by index, never a range — per this ConfigMap's own contract: it names every key explicitly so that what reaches a container stays reviewable here. Adding a model means adding a line; **that cost is the point.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)