### PR TITLE
Pin an open-weights model as the deployment default (Auto must not land on proprietary)

### DIFF
--- a/src/MeshWeaver.AI/ModelOrdering.cs
+++ b/src/MeshWeaver.AI/ModelOrdering.cs
@@ -32,8 +32,24 @@ public static class ModelOrdering
     public static readonly ImmutableDictionary<string, int> Defaults =
         new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            // The fast/cheap DeepSeek tier — the platform default. Order -1 = "make this the default".
+            // The fast/cheap DeepSeek tier — Order -1 = "make this the default".
             ["DeepSeek-V4-Flash"] = -1,
+
+            // 🚨 The OPEN-WEIGHTS default. The deployment default is what an UNLABELED tier falls
+            // through to (ChatClientCredentialResolver: "the tier label; null/unknown → the
+            // deployment default"), so it decides what runs whenever no tier carries a model — which
+            // is deliberately most of the time. Pinning an open-weights model here is what makes
+            // "Auto only ever lands on open weights" true by construction rather than by everyone
+            // remembering to label.
+            //
+            // Why it needs a pin at all: the catalog source stamps a UNIFORM Order per provider, so
+            // every OpenRouter model shares one value and "lowest Order" is a tie broken arbitrarily
+            // — a proprietary model could win it. Measured 2026-08-25 on systemorph: glm-5.3 and
+            // eleven siblings all carried Order 6.
+            //
+            // -2, not -1: it must also beat DeepSeek-V4-Flash above, which is proprietary-adjacent
+            // and would otherwise take the default on any deployment carrying both.
+            ["z-ai/glm-5.3"] = -2,
         }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>


### PR DESCRIPTION
## Why
The **deployment default** is what an *unlabeled* tier falls through to:
> *"the tier label; null/unknown → the deployment default"* — `ChatClientCredentialResolver`

Under the open-weights policy, `utility` and `reasoning` are left **unlabeled on purpose**, so the default decides what runs most of the time.

## The defect
That made *"Auto only ever lands on open weights"* depend on an **arbitrary tie**. The catalog source stamps a **uniform Order per provider**, so every OpenRouter model shares one value and "lowest Order" is broken by whatever happens to come first — **a proprietary model can win it.**

Measured on systemorph today: `glm-5.3` and its eleven siblings all carry `Order 6`.

## The fix
Pin `z-ai/glm-5.3` in `ModelOrdering.Defaults`, making the invariant true **by construction** rather than by everyone remembering to mark every proprietary model untiered.

`-2` rather than `-1` so it also beats `DeepSeek-V4-Flash`, which would otherwise take the default on any deployment carrying both.

## 🚨 Why core, not a node patch
The seeder **stamps `Order` onto the node on every boot** (`BuiltInLanguageModelProvider` → `ModelOrdering.For`), so a patched node Order is reverted on the next restart.

**Tier labels *do* survive a reseed** — verified across the 2026-08-24 reseed — which is exactly why tiers stay node data while ordering belongs here. The two look interchangeable and are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)