### PR TITLE
fix(AI): price qwen3.6-35b-a3b (the chat tier)

### DIFF
--- a/src/MeshWeaver.AI/ModelPricing.cs
+++ b/src/MeshWeaver.AI/ModelPricing.cs
@@ -128,6 +128,7 @@ public static class ModelPricing
             ["deepseek/deepseek-v4-pro"] = new(0.5262m, 1.0524m, Usd),
             ["x-ai/grok-4.6"] = new(2.0m, 6.0m, Usd),
             ["qwen/qwen3-max"] = new(0.78m, 3.9m, Usd),
+            ["qwen/qwen3.6-35b-a3b"] = new(0.14m, 1.0m, Usd),  // the chat tier — fast MoE (~3B active)
         }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>


### PR DESCRIPTION
The chat-tier model `qwen/qwen3.6-35b-a3b` was chosen after #2113, so it had no `ModelPricing.Default` entry — its cost surfaces would show $0. Adds the OpenRouter published rate (0.14/1.0 USD per 1M). Node price still wins via ModelPriceCatalog; this is the built-in backstop.