### PR TITLE
AI sources: one resolution seam — named, described, placeholder-expanded, anchored

### DIFF
--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -410,7 +410,7 @@ public static class AgentPickerProjection
     /// (agent / model / harness) the default is the node with the LOWEST <c>Order</c> (the <c>Order = -1</c>
     /// convention: "to make something the default, set its order to -1"). No hardcoded agent name, model
     /// id, or harness; nothing is invented when a registry is empty (the field stays null). Reactive +
-    /// testable like <see cref="ObserveAgents"/> / <see cref="ObserveModels"/>; the chat view subscribes
+    /// testable like <see cref="ObserveAgents"/> / <see cref="ObserveModels(IWorkspace, IMessageHub, string?, string?, IReadOnlyList{string}?, string?)"/>; the chat view subscribes
     /// to this to seed a new composer.
     /// <para>Utility (generator) agents are excluded — the default is never a background generator.</para>
     /// </summary>
@@ -565,13 +565,36 @@ public static class AgentPickerProjection
     /// varying only namespace + scope (the synced-collection all-Initial gating constraint). The
     /// per-partition flat <c>/Model</c> registry is the next increment; credentials live in <c>Provider</c>.
     /// </summary>
+    /// <summary>The node types every model-registry query reads — models, their providers and the tiers.</summary>
+    public const string ModelRegistryTypes =
+        $"{LanguageModelNodeType.NodeType}|{ModelProviderNodeType.NodeType}|{ModelTierNodeType.NodeType}";
+
+    /// <summary>
+    /// The SETTINGS-AWARE model pipeline: the user's resolved model sources
+    /// (<see cref="AiSettingsNodeType.ObserveModelQueries"/>) drive the registry snapshot, so the
+    /// picker lists exactly what the user's AI Settings say — and re-resolves when they change.
+    /// Prefer this over the raw-context overload in every user-facing surface.
+    /// </summary>
+    public static IObservable<IReadOnlyList<ModelInfo>> ObserveModels(
+        IWorkspace workspace, IMessageHub hub, IServiceProvider services, string? user,
+        string? currentPath = null, string? nodeTypePath = null,
+        IReadOnlyList<string>? selectedProviderPaths = null)
+        => AiSettingsNodeType
+            .ObserveModelQueries(workspace, hub, services, user, currentPath, nodeTypePath, selectedProviderPaths)
+            .Select(queries => ObserveSnapshot(workspace, hub,
+                    BuildModelQueryId(ModelsQueryId, currentPath, nodeTypePath, selectedProviderPaths, user)
+                    + "|q=" + string.Join(";", queries),
+                    queries)
+                .Select(snapshot => ProjectModels(snapshot, hub.JsonSerializerOptions)))
+            .Switch();
+
     public static string[] BuildModelQueries(
         string? currentPath = null,
         string? nodeTypePath = null,
         IEnumerable<string>? selectedProviderPaths = null,
         string? userPath = null)
     {
-        var typeFilter = $"{LanguageModelNodeType.NodeType}|{ModelProviderNodeType.NodeType}|{ModelTierNodeType.NodeType}";
+        var typeFilter = ModelRegistryTypes;
         var queries = new List<string>
         {
             $"namespace:{ModelProviderNodeType.RootNamespace} nodeType:{typeFilter} scope:descendants{RegistryProjection}",

--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -573,9 +573,11 @@ public static class AgentPickerProjection
     /// The SETTINGS-AWARE model pipeline: the user's resolved model sources
     /// (<see cref="AiSettingsNodeType.ObserveModelQueries"/>) drive the registry snapshot, so the
     /// picker lists exactly what the user's AI Settings say — and re-resolves when they change.
-    /// Prefer this over the raw-context overload in every user-facing surface.
+    /// Prefer this over <see cref="ObserveModels"/> in every user-facing surface. Deliberately NOT
+    /// an overload of that name: landed plugin sources cref <c>ObserveModels</c> unqualified, and
+    /// overloading it turns their docs into CS0419 under warnings-as-errors.
     /// </summary>
-    public static IObservable<IReadOnlyList<ModelInfo>> ObserveModels(
+    public static IObservable<IReadOnlyList<ModelInfo>> ObserveResolvedModels(
         IWorkspace workspace, IMessageHub hub, IServiceProvider services, string? user,
         string? currentPath = null, string? nodeTypePath = null,
         IReadOnlyList<string>? selectedProviderPaths = null)

--- a/src/MeshWeaver.AI/AgentView.cs
+++ b/src/MeshWeaver.AI/AgentView.cs
@@ -63,11 +63,20 @@ public static class AgentView
             .WithView(
                 (h, c) =>
                 {
-                    var meshQuery = host.Hub.ServiceProvider.GetService<IMeshService>();
+                    var services = host.Hub.ServiceProvider;
+                    var meshQuery = services.GetService<IMeshService>();
                     if (meshQuery == null)
                         return Observable.Return(RenderError("Query service not available."));
 
-                    return meshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery("nodeType:Agent"))
+                    // The agents the VIEWER resolves — their AI Settings agent sources for this
+                    // context, through the one seam — never an unanchored nodeType:Agent sweep
+                    // (which UNIONs every partition schema, MeshWeaver #2186).
+                    var user = AgentPickerProjection.ResolveUserHome(services.GetService<AccessService>());
+                    return AiSettingsNodeType
+                        .ObserveAgentQueries(host.Hub.GetWorkspace(), host.Hub, services, user,
+                            host.Hub.Address.ToString())
+                        .Select(queries => meshQuery.Query<MeshNode>(new MeshQueryRequest { Queries = queries }))
+                        .Switch()
                         .Select(change => BuildCatalogContent(change.Items.ToList()))
                         .Catch<UiControl, Exception>(_ => Observable.Return(BuildCatalogContent([])));
                 },

--- a/src/MeshWeaver.AI/AiCatalogLayoutAreas.cs
+++ b/src/MeshWeaver.AI/AiCatalogLayoutAreas.cs
@@ -1,3 +1,5 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Layout.Domain;
@@ -50,19 +52,51 @@ public static class AiCatalogLayoutAreas
     public static MessageHubConfiguration AddAiCatalogLayoutAreas(this MessageHubConfiguration configuration)
         => configuration.AddLayout(layout => layout.AddAiCatalogLayoutAreas());
 
-    private static UiControl AgentsCatalog(LayoutAreaHost host, RenderingContext _)
-        => BuildScopeCatalog(host, "agents", AgentNodeType.NodeType, globalNamespace: "Agent");
+    private static IObservable<UiControl> AgentsCatalog(LayoutAreaHost host, RenderingContext _)
+        => BuildSourceCatalog(host, "agents", AiSourceKinds.Agent, AgentNodeType.NodeType);
 
-    private static UiControl SkillsCatalog(LayoutAreaHost host, RenderingContext _)
-        => BuildScopeCatalog(host, "skills", SkillNodeType.NodeType, globalNamespace: SkillNodeType.RootNamespace);
+    private static IObservable<UiControl> SkillsCatalog(LayoutAreaHost host, RenderingContext _)
+        => BuildSourceCatalog(host, "skills", AiSourceKinds.Skill, SkillNodeType.NodeType);
+
+    /// <summary>
+    /// A catalog whose tabs ARE the viewer's resolved sources — one tab per active
+    /// <see cref="AiSourceEntry"/> of <paramref name="kind"/> (its name as the label, its expanded
+    /// query as the search), so what the catalog lists is exactly what the platform resolves for
+    /// this viewer here, and editing AI Settings changes both. Live: re-renders when the settings
+    /// node changes. Signed out ⇒ the defaults.
+    /// </summary>
+    private static IObservable<UiControl> BuildSourceCatalog(
+        LayoutAreaHost host, string catalog, string kind, string nodeType)
+    {
+        var contextPath = host.Hub.Address.ToString();
+        var viewerHome = ResolveViewerHome(host);
+        var services = host.Hub.ServiceProvider;
+        var settings = string.IsNullOrEmpty(viewerHome)
+            ? Observable.Return<AiSettings?>(null)
+            : AiSettingsNodeType.Observe(host.Hub.GetWorkspace(), host.Hub, services, viewerHome!)
+                .Select(s => (AiSettings?)s);
+        return settings.Select(s =>
+        {
+            var context = AiSourceCatalog.Context(viewerHome, contextPath, null);
+            var tabs = Controls.Tabs.WithSkin(sk => sk.WithWidth("100%"));
+            foreach (var source in AiSourceCatalog.Resolve(kind, s, context).Where(r => r.IsActive))
+                tabs = tabs.WithMeshSearch(source.Entry.Name,
+                    query: AiSourceCatalog.ForSearch(source.Query!, nodeType),
+                    createNodeType: nodeType,
+                    createNamespace: AiSourceCatalog.AnchorNamespace(source.Query),
+                    placeholder: string.IsNullOrWhiteSpace(source.Entry.Description)
+                        ? host.Localize(SearchKey(catalog, "global"))
+                        : source.Entry.Description,
+                    configure: ScopeSearch);
+            return (UiControl)tabs;
+        });
+    }
 
     private static UiControl ProvidersCatalog(LayoutAreaHost host, RenderingContext _)
         => BuildScopeCatalog(host, "providers", ModelProviderNodeType.NodeType, globalNamespace: ModelProviderNodeType.RootNamespace);
 
-    private static UiControl ModelsCatalog(LayoutAreaHost host, RenderingContext _)
-        // Models live UNDER the "Provider" partition (LanguageModelNodeType remark), so the global
-        // scope roots at ModelProviderNodeType.RootNamespace ("Provider"), not "Model".
-        => BuildScopeCatalog(host, "models", LanguageModelNodeType.NodeType, globalNamespace: ModelProviderNodeType.RootNamespace);
+    private static IObservable<UiControl> ModelsCatalog(LayoutAreaHost host, RenderingContext _)
+        => BuildSourceCatalog(host, "models", AiSourceKinds.Model, LanguageModelNodeType.NodeType);
 
     private static UiControl TiersCatalog(LayoutAreaHost host, RenderingContext _)
         // Tiers are a PLATFORM registry, not a per-space one — deliberately the ONE catalog here

--- a/src/MeshWeaver.AI/AiSettings.cs
+++ b/src/MeshWeaver.AI/AiSettings.cs
@@ -46,4 +46,22 @@ public record AiSettings
     /// seeding the defaults first so adding a package never silently drops the standard sources.
     /// </summary>
     public ImmutableArray<string> SkillQueries { get; init; } = ImmutableArray<string>.Empty;
+
+    /// <summary>
+    /// The user's NAMED skill sources — the editable form of <see cref="SkillQueries"/>: each row
+    /// carries a name and a description beside its query template, so the AI Settings app can say
+    /// what every source finds and why. When non-empty these WIN over <see cref="SkillQueries"/>
+    /// (which stays for older nodes and for callers that only carry a template);
+    /// <see cref="AiSourceCatalog.EffectiveEntries"/> is the one rule. Empty ⇒ the legacy list, else
+    /// <see cref="AiSourceCatalog.SkillDefaults"/>.
+    /// </summary>
+    public ImmutableArray<AiSourceEntry> SkillSources { get; init; } = ImmutableArray<AiSourceEntry>.Empty;
+
+    /// <summary>The user's NAMED agent sources — same rule as <see cref="SkillSources"/>.</summary>
+    public ImmutableArray<AiSourceEntry> AgentSources { get; init; } = ImmutableArray<AiSourceEntry>.Empty;
+
+    /// <summary>The user's NAMED model sources — same rule as <see cref="SkillSources"/>. Selecting
+    /// a visible model in AI Settings adds an anchored entry here (its own path); the platform path
+    /// "MeshWeaver OpenRouter" is a default entry, removable like any other.</summary>
+    public ImmutableArray<AiSourceEntry> ModelSources { get; init; } = ImmutableArray<AiSourceEntry>.Empty;
 }

--- a/src/MeshWeaver.AI/AiSettingsNodeType.cs
+++ b/src/MeshWeaver.AI/AiSettingsNodeType.cs
@@ -128,14 +128,10 @@ public static class AiSettingsNodeType
     public static string[] ResolveSkillQueries(
         AiSettings? settings, string? contextPath, string? nodeTypePath, string? userPath)
     {
-        var templates = settings is { SkillQueries.IsDefaultOrEmpty: false }
-            ? settings.SkillQueries.AsEnumerable()
-            : DefaultSkillQueryTemplates;
-        string? Partition(string? path)
-            => AgentPickerProjection.IsReservedPartition(path) ? null : AgentPickerProjection.PartitionOf(path);
-        var resolved = ResolveQueries(templates, Partition(contextPath), Partition(nodeTypePath), userPath)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+        // THE seam: named entries → legacy templates → defaults, expanded and anchored by
+        // AiSourceCatalog (the one algorithm every skill/agent/model consumer shares).
+        var resolved = AiSourceCatalog.Queries(AiSourceCatalog.Resolve(
+            AiSourceKinds.Skill, settings, AiSourceCatalog.Context(userPath, contextPath, nodeTypePath)));
         return resolved.Length > 0
             ? resolved
             : SkillNodeType.SkillQueries(contextPath, userPath, nodeTypePath);
@@ -150,14 +146,30 @@ public static class AiSettingsNodeType
     /// </summary>
     public static AiSettings MergeSkillSource(AiSettings settings, string sourceNamespace)
     {
+        var query = $"namespace:{sourceNamespace} nodeType:{SkillNodeType.NodeType}";
+        // A user who maintains NAMED sources gets the package as a named row beside them; the
+        // legacy template list is only extended while it is still the list in force.
+        if (!settings.SkillSources.IsDefaultOrEmpty)
+            return settings.SkillSources.Any(e => string.Equals(e.Query, query, StringComparison.OrdinalIgnoreCase))
+                ? settings
+                : settings with { SkillSources = settings.SkillSources.Add(PackageEntry(AiSourceKinds.Skill, sourceNamespace, query)) };
         var rows = settings.SkillQueries.IsDefaultOrEmpty
             ? DefaultSkillQueryTemplates
             : settings.SkillQueries;
-        var query = $"namespace:{sourceNamespace} nodeType:{SkillNodeType.NodeType}";
         return rows.Contains(query, StringComparer.OrdinalIgnoreCase)
             ? settings with { SkillQueries = rows }
             : settings with { SkillQueries = rows.Add(query) };
     }
+
+    /// <summary>The named row an installed package contributes — its partition as the name, the
+    /// source query as the how. Pure.</summary>
+    public static AiSourceEntry PackageEntry(string kind, string sourceNamespace, string query) => new()
+    {
+        Kind = kind,
+        Name = $"{AgentPickerProjection.PartitionOf(sourceNamespace) ?? sourceNamespace} package",
+        Description = $"Installed package source: {sourceNamespace}.",
+        Query = query,
+    };
 
     /// <summary>
     /// The default AGENT sources, as tokenized templates — the same set
@@ -178,11 +190,15 @@ public static class AiSettingsNodeType
     /// </summary>
     public static AiSettings MergeAgentSource(AiSettings settings, string sourceNamespace)
     {
+        var query = $"namespace:{sourceNamespace}/{AgentPickerProjection.AgentSubNamespace} "
+                    + $"nodeType:{AgentNodeType.NodeType}{AgentPickerProjection.RegistryProjection}";
+        if (!settings.AgentSources.IsDefaultOrEmpty)
+            return settings.AgentSources.Any(e => string.Equals(e.Query, query, StringComparison.OrdinalIgnoreCase))
+                ? settings
+                : settings with { AgentSources = settings.AgentSources.Add(PackageEntry(AiSourceKinds.Agent, sourceNamespace, query)) };
         var rows = settings.AgentQueries.IsDefaultOrEmpty
             ? DefaultAgentQueryTemplates
             : settings.AgentQueries;
-        var query = $"namespace:{sourceNamespace}/{AgentPickerProjection.AgentSubNamespace} "
-                    + $"nodeType:{AgentNodeType.NodeType}{AgentPickerProjection.RegistryProjection}";
         return rows.Contains(query, StringComparer.OrdinalIgnoreCase)
             ? settings with { AgentQueries = rows }
             : settings with { AgentQueries = rows.Add(query) };
@@ -215,18 +231,53 @@ public static class AiSettingsNodeType
     public static string[] ResolveAgentQueries(
         AiSettings? settings, string? contextPath, string? userPath)
     {
-        string? Partition(string? path)
-            => AgentPickerProjection.IsReservedPartition(path) ? null : AgentPickerProjection.PartitionOf(path);
-        var spacePartition = Partition(contextPath);
-        var baseQuery = AgentPickerProjection.BuildAgentQuery(userPath, spacePartition);
-        var templates = settings is { AgentQueries.IsDefaultOrEmpty: false }
-            ? settings.AgentQueries.AsEnumerable()
-            : DefaultAgentQueryTemplates;
+        var context = AiSourceCatalog.Context(userPath, contextPath, null);
+        var baseQuery = AgentPickerProjection.BuildAgentQuery(userPath, context.ObjectPartition);
         return new[] { baseQuery }
-            .Concat(ResolveQueries(templates, spacePartition, null, userPath))
+            .Concat(AiSourceCatalog.Queries(AiSourceCatalog.Resolve(AiSourceKinds.Agent, settings, context)))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
     }
+
+    /// <summary>
+    /// Resolves the user's MODEL sources for a context — the model-picker counterpart of
+    /// <see cref="ResolveAgentQueries"/>: the user's named entries (else legacy templates, else the
+    /// <see cref="AiSourceCatalog.ModelDefaults"/>, which are exactly
+    /// <see cref="AgentPickerProjection.BuildModelQueries"/>'s rows), expanded and anchored by the
+    /// seam, plus a <c>selfAndDescendants</c> row per explicitly selected provider subtree. Falls back
+    /// to the canonical builder if everything resolves away, so the picker is never empty by
+    /// construction.
+    /// </summary>
+    public static string[] ResolveModelQueries(
+        AiSettings? settings, string? contextPath, string? nodeTypePath, string? userPath,
+        IEnumerable<string>? selectedProviderPaths = null)
+    {
+        var context = AiSourceCatalog.Context(userPath, contextPath, nodeTypePath);
+        var resolved = AiSourceCatalog.Queries(AiSourceCatalog.Resolve(AiSourceKinds.Model, settings, context));
+        var selected = (selectedProviderPaths ?? Array.Empty<string>())
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Select(p => $"namespace:{p} nodeType:{AgentPickerProjection.ModelRegistryTypes} "
+                         + $"scope:selfAndDescendants{AgentPickerProjection.RegistryProjection}");
+        var all = resolved.Concat(selected).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        return all.Length > 0
+            ? all
+            : AgentPickerProjection.BuildModelQueries(contextPath, nodeTypePath, selectedProviderPaths, userPath);
+    }
+
+    /// <summary>
+    /// The LIVE resolved model queries for a user + context — mirrors
+    /// <see cref="ObserveAgentQueries"/>: observes the user's <see cref="AiSettings"/> (defaults when
+    /// signed out) and re-resolves on change.
+    /// </summary>
+    public static IObservable<string[]> ObserveModelQueries(
+        IWorkspace workspace, IMessageHub hub, IServiceProvider services,
+        string? user, string? contextPath, string? nodeTypePath,
+        IReadOnlyList<string>? selectedProviderPaths = null)
+        => string.IsNullOrEmpty(user)
+            ? Observable.Return(ResolveModelQueries(null, contextPath, nodeTypePath, user, selectedProviderPaths))
+            : Observe(workspace, hub, services, user!)
+                .Select(settings => ResolveModelQueries(settings, contextPath, nodeTypePath, user, selectedProviderPaths))
+                .DistinctUntilChanged(qs => string.Join("\n", qs));
 
     /// <summary>
     /// The LIVE resolved agent queries for a user + context — the reactive form

--- a/src/MeshWeaver.AI/AiSourceCatalog.cs
+++ b/src/MeshWeaver.AI/AiSourceCatalog.cs
@@ -1,0 +1,388 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// THE resolution seam for AI sources — the one algorithm that turns a user's
+/// <see cref="AiSettings"/> plus a context into the queries the platform runs for skills, agents
+/// and models. Every consumer that lists or resolves one of those kinds goes through here (pinned by
+/// <c>AiResolutionSeamAuditTest</c>); nothing else builds a resolution query from a literal.
+///
+/// <para><b>What the user controls.</b> Each kind has a list of NAMED, DESCRIBED
+/// <see cref="AiSourceEntry"/> rows — "My skills", "Skills of the current space",
+/// "MeshWeaver OpenRouter" — whose <see cref="AiSourceEntry.Query"/> is a template. The defaults
+/// (<see cref="Defaults"/>) reproduce exactly the queries the platform has always run — the same
+/// strings <see cref="AiSettingsNodeType.DefaultSkillQueryTemplates"/>,
+/// <see cref="AiSettingsNodeType.DefaultAgentQueryTemplates"/> and
+/// <see cref="AgentPickerProjection.BuildModelQueries"/> define — so a user who never opens AI
+/// Settings sees no change; a user who edits their list gets exactly what they listed.</para>
+///
+/// <para><b>Placeholders.</b> <c>{user}</c> (the viewer's home partition),
+/// <c>{objectPartition}</c> (the top-level partition of the node in view), <c>{objectPath}</c> (its
+/// full path), <c>{nodeTypePartition}</c> (the partition that defines the node's type) and
+/// <c>{nodeTypePath}</c> (the type's full path). The legacy spellings <c>{userPath}</c> /
+/// <c>{currentPath}</c> keep working: <c>{currentPath}</c> means the partition for skill and agent
+/// sources and the full path for model sources — exactly what each builder substituted before this
+/// seam existed, so no stored template changes meaning.</para>
+///
+/// <para><b>Two rules, enforced here and nowhere else.</b> A template whose placeholder has no value
+/// in the context is DROPPED with a reason — never emitted half-expanded. And an expanded query that
+/// is not partition-anchored (<c>namespace:</c> or <c>path:</c>) is never executed: an unanchored
+/// <c>nodeType:</c> read UNIONs every partition schema and wedges the mesh (MeshWeaver #2186).</para>
+/// </summary>
+public static class AiSourceCatalog
+{
+    // ————————————————————————————————————————————————————————— placeholders
+
+    /// <summary>The viewer's home partition.</summary>
+    public const string UserToken = "{user}";
+    /// <summary>The top-level partition of the node in view.</summary>
+    public const string ObjectPartitionToken = "{objectPartition}";
+    /// <summary>The full path of the node in view.</summary>
+    public const string ObjectPathToken = "{objectPath}";
+    /// <summary>The partition that defines the current node's type.</summary>
+    public const string NodeTypePartitionToken = "{nodeTypePartition}";
+    /// <summary>The full path of the current node's type.</summary>
+    public const string NodeTypePathToken = "{nodeTypePath}";
+
+    /// <summary>Legacy spelling of <see cref="UserToken"/>.</summary>
+    public const string LegacyUserPathToken = "{userPath}";
+    /// <summary>Legacy context token — the partition for skills/agents, the full path for models.</summary>
+    public const string LegacyCurrentPathToken = "{currentPath}";
+
+    /// <summary>Every placeholder a template may carry, with what each expands to.</summary>
+    public static readonly ImmutableArray<(string Token, string Meaning)> Placeholders = ImmutableArray.Create(
+        (UserToken, "your home partition (your user id)"),
+        (ObjectPartitionToken, "the top-level partition of the node you are on"),
+        (ObjectPathToken, "the full path of the node you are on"),
+        (NodeTypePartitionToken, "the partition that defines the current node's type"),
+        (NodeTypePathToken, "the full path of the current node's type"),
+        (LegacyUserPathToken, "same as {user}"),
+        (LegacyCurrentPathToken, "the partition (skills, agents) or the full path (models) of the node you are on"));
+
+    // ————————————————————————————————————————————————————————— the platform model path
+
+    /// <summary>The label of the model path the platform supplies.</summary>
+    public const string MeshWeaverOpenRouterLabel = "MeshWeaver OpenRouter";
+
+    /// <summary>OpenRouter's terms — verified to resolve 2026-08-25.</summary>
+    public const string OpenRouterTermsUrl = "https://openrouter.ai/terms";
+
+    /// <summary>
+    /// The disclosure every surface that offers the platform model path renders — seeded onto the
+    /// <c>Provider/OpenRouter</c> node's description (<see cref="BuiltInLanguageModelProvider"/>), and
+    /// used verbatim wherever that node is not readable. ONE text, ONE place.
+    /// </summary>
+    public const string OpenRouterDisclosure =
+        "Models served through OpenRouter under MeshWeaver's account — OpenRouter's terms apply "
+        + "(" + OpenRouterTermsUrl + "). The credit included in your plan applies here.";
+
+    // ————————————————————————————————————————————————————————— defaults
+
+    /// <summary>The default sources for <paramref name="kind"/> — named and described.</summary>
+    public static ImmutableArray<AiSourceEntry> Defaults(string kind) =>
+        AiSourceKinds.Canonical(kind) switch
+        {
+            AiSourceKinds.Skill => SkillDefaults,
+            AiSourceKinds.Agent => AgentDefaults,
+            AiSourceKinds.Model => ModelDefaults,
+            _ => ImmutableArray<AiSourceEntry>.Empty,
+        };
+
+    /// <summary>
+    /// The skill defaults — the same four templates as
+    /// <see cref="AiSettingsNodeType.DefaultSkillQueryTemplates"/>, in the same order (the platform
+    /// row stays first: it is the only one guaranteed to resolve).
+    /// </summary>
+    public static readonly ImmutableArray<AiSourceEntry> SkillDefaults = ImmutableArray.Create(
+        Entry(AiSourceKinds.Skill, "Platform skills",
+            "The platform's own skill catalog (Skill/…) — always searched, always first.",
+            AiSettingsNodeType.DefaultSkillQueryTemplates[0]),
+        Entry(AiSourceKinds.Skill, "My skills",
+            "Skills in your own space ({user}/Skill).",
+            AiSettingsNodeType.DefaultSkillQueryTemplates[1]),
+        Entry(AiSourceKinds.Skill, "Skills of the current space",
+            "Every skill anywhere in the partition of the node you are on — a space or plugin can file a "
+            + "skill next to the content it describes.",
+            AiSettingsNodeType.DefaultSkillQueryTemplates[2]),
+        Entry(AiSourceKinds.Skill, "Skills shipped with the node type",
+            "Every skill in the partition that defines the current node's type — what a plugin ships "
+            + "beside its types.",
+            AiSettingsNodeType.DefaultSkillQueryTemplates[3]));
+
+    /// <summary>The agent default — the one canonical registry query (platform + space + yours).</summary>
+    public static readonly ImmutableArray<AiSourceEntry> AgentDefaults = ImmutableArray.Create(
+        Entry(AiSourceKinds.Agent, "Platform, space and my agents",
+            "The platform's Agent registry, the current space's /Agent and your own /Agent — one "
+            + "exact-membership query.",
+            AiSettingsNodeType.DefaultAgentQueryTemplates[0]));
+
+    /// <summary>
+    /// The model defaults — the same rows <see cref="AgentPickerProjection.BuildModelQueries"/>
+    /// produces for a tokenized context, in the same order. The platform row is the path WE supply
+    /// and is labeled <see cref="MeshWeaverOpenRouterLabel"/>, with the disclosure as its description.
+    /// </summary>
+    public static readonly ImmutableArray<AiSourceEntry> ModelDefaults = BuildModelDefaults();
+
+    private static ImmutableArray<AiSourceEntry> BuildModelDefaults()
+    {
+        var templates = AgentPickerProjection.BuildModelQueries(
+            ObjectPathToken, NodeTypePathToken, null, UserToken);
+        var names = new[]
+        {
+            (MeshWeaverOpenRouterLabel, OpenRouterDisclosure),
+            ("Models of the current space",
+                "Models and providers configured in the space you are on ({objectPath}/Provider)."),
+            ("Models shipped with the node type",
+                "Models a plugin ships beside the current node's type ({nodeTypePath}/Provider)."),
+            ("My models", "Providers and models you installed in your own space."),
+        };
+        var entries = ImmutableArray.CreateBuilder<AiSourceEntry>(templates.Length);
+        for (var i = 0; i < templates.Length; i++)
+        {
+            var (name, description) = i < names.Length ? names[i] : ($"Model source {i + 1}", "");
+            entries.Add(Entry(AiSourceKinds.Model, name, description, templates[i]));
+        }
+        return entries.ToImmutable();
+    }
+
+    private static AiSourceEntry Entry(string kind, string name, string description, string query) =>
+        new() { Kind = kind, Name = name, Description = description, Query = query };
+
+    // ————————————————————————————————————————————————————————— context
+
+    /// <summary>
+    /// Builds the expansion context from the raw paths a caller has — the viewer's home, the node in
+    /// view and its type — nulling reserved/rogue route partitions (login, welcome, settings, …) so a
+    /// poisoned context can never put a policy-less partition into a query. Pure.
+    /// </summary>
+    public static AiSourceContext Context(string? userPath, string? contextPath, string? nodeTypePath)
+    {
+        static (string? Path, string? Partition) Usable(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || AgentPickerProjection.IsReservedPartition(path))
+                return (null, null);
+            var trimmed = path!.Trim('/');
+            return (trimmed, AgentPickerProjection.PartitionOf(trimmed));
+        }
+        var (objectPath, objectPartition) = Usable(contextPath);
+        var (typePath, typePartition) = Usable(nodeTypePath);
+        return new AiSourceContext
+        {
+            User = string.IsNullOrWhiteSpace(userPath) ? null : userPath!.Trim('/'),
+            ObjectPath = objectPath,
+            ObjectPartition = objectPartition,
+            NodeTypePath = typePath,
+            NodeTypePartition = typePartition,
+        };
+    }
+
+    // ————————————————————————————————————————————————————————— effective entries
+
+    /// <summary>
+    /// The entries in force for <paramref name="kind"/>: the user's named entries when they have
+    /// any; else their legacy bare-string templates (each annotated — a default's template gets the
+    /// default's name and description, anything else reads as a custom source); else the defaults.
+    /// Pure.
+    /// </summary>
+    public static ImmutableArray<AiSourceEntry> EffectiveEntries(string kind, AiSettings? settings)
+    {
+        var canonical = AiSourceKinds.Canonical(kind);
+        if (canonical is null)
+            return ImmutableArray<AiSourceEntry>.Empty;
+        var entries = canonical switch
+        {
+            AiSourceKinds.Skill => settings?.SkillSources ?? default,
+            AiSourceKinds.Agent => settings?.AgentSources ?? default,
+            _ => settings?.ModelSources ?? default,
+        };
+        if (!entries.IsDefaultOrEmpty)
+            return entries.Where(e => AiSourceKinds.Canonical(e.Kind) == canonical || string.IsNullOrEmpty(e.Kind))
+                .Select(e => e with { Kind = canonical })
+                .ToImmutableArray();
+
+        var legacy = canonical switch
+        {
+            AiSourceKinds.Skill => settings?.SkillQueries ?? default,
+            AiSourceKinds.Agent => settings?.AgentQueries ?? default,
+            _ => settings?.ModelQueries ?? default,
+        };
+        if (!legacy.IsDefaultOrEmpty)
+            return legacy.Select(template => Annotate(canonical, template)).ToImmutableArray();
+
+        return Defaults(canonical);
+    }
+
+    /// <summary>A bare template as an entry — the default's identity when it IS a default, else a
+    /// custom source. Pure.</summary>
+    public static AiSourceEntry Annotate(string kind, string template) =>
+        Defaults(kind).FirstOrDefault(d => string.Equals(d.Query, template, StringComparison.OrdinalIgnoreCase))
+        ?? new AiSourceEntry
+        {
+            Kind = AiSourceKinds.Canonical(kind) ?? kind,
+            Name = "Custom source",
+            Description = "Added to your settings.",
+            Query = template,
+        };
+
+    /// <summary>True when the entry's template is one of the kind's defaults. Pure.</summary>
+    public static bool IsDefault(AiSourceEntry entry) =>
+        Defaults(entry.Kind).Any(d => string.Equals(d.Query, entry.Query, StringComparison.OrdinalIgnoreCase));
+
+    // ————————————————————————————————————————————————————————— resolution
+
+    /// <summary>
+    /// Resolves every effective entry for <paramref name="kind"/> against <paramref name="context"/>:
+    /// each becomes the query the platform runs, or carries the reason it was dropped. Pure.
+    /// </summary>
+    public static ImmutableArray<AiResolvedSource> Resolve(
+        string kind, AiSettings? settings, AiSourceContext context) =>
+        EffectiveEntries(kind, settings)
+            .Select(entry =>
+            {
+                var query = Expand(entry.Kind, entry.Query, context, out var reason);
+                return new AiResolvedSource(entry, query, IsDefault(entry), reason);
+            })
+            .ToImmutableArray();
+
+    /// <summary>The runnable queries of a resolution — active entries only, deduplicated, in order. Pure.</summary>
+    public static string[] Queries(IEnumerable<AiResolvedSource> resolved) =>
+        resolved.Where(r => r.IsActive)
+            .Select(r => r.Query!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    /// <summary>
+    /// Expands one template. Returns the query, or null with <paramref name="reason"/> set when a
+    /// placeholder has no value in this context, the template carries an unknown placeholder, or the
+    /// expanded query is not partition-anchored. Pure.
+    /// </summary>
+    public static string? Expand(string kind, string template, AiSourceContext context, out string? reason)
+    {
+        reason = null;
+        if (string.IsNullOrWhiteSpace(template))
+        {
+            reason = "The query is empty.";
+            return null;
+        }
+        var isModel = AiSourceKinds.Canonical(kind) == AiSourceKinds.Model;
+        var substitutions = new (string Token, string? Value)[]
+        {
+            (UserToken, context.User),
+            (LegacyUserPathToken, context.User),
+            (ObjectPartitionToken, context.ObjectPartition),
+            (ObjectPathToken, context.ObjectPath),
+            (NodeTypePartitionToken, context.NodeTypePartition),
+            // {nodeTypePath} always meant the partition for skills/agents and the full path for models.
+            (NodeTypePathToken, isModel ? context.NodeTypePath : context.NodeTypePartition),
+            (LegacyCurrentPathToken, isModel ? context.ObjectPath : context.ObjectPartition),
+        };
+
+        var query = template.Trim();
+        foreach (var (token, value) in substitutions)
+        {
+            if (!query.Contains(token, StringComparison.Ordinal))
+                continue;
+            if (string.IsNullOrEmpty(value))
+            {
+                reason = $"{token} has no value here.";
+                return null;
+            }
+            query = query.Replace(token, value, StringComparison.Ordinal);
+        }
+        if (UnknownPlaceholder(query) is { } unknown)
+        {
+            reason = $"Unknown placeholder {unknown}.";
+            return null;
+        }
+        if (!IsAnchored(query))
+        {
+            reason = "Not anchored to a partition (needs namespace: or path:) — an unanchored read would scan every partition.";
+            return null;
+        }
+        return query;
+    }
+
+    /// <summary>
+    /// The namespace a catalog tab CREATES into for an expanded query — the first alternative of
+    /// its <c>namespace:</c> (or <c>path:</c>) clause. Null when the clause is absent. Pure.
+    /// </summary>
+    public static string? AnchorNamespace(string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return null;
+        foreach (var token in query.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separator = token.IndexOf(':');
+            if (separator <= 0)
+                continue;
+            var key = token[..separator];
+            if (!key.Equals("namespace", StringComparison.OrdinalIgnoreCase)
+                && !key.Equals("path", StringComparison.OrdinalIgnoreCase))
+                continue;
+            var value = token[(separator + 1)..];
+            var pipe = value.IndexOf('|');
+            value = pipe >= 0 ? value[..pipe] : value;
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// The query as a SEARCH control runs it: the registry <c>select:</c> projection stripped (a
+    /// picker's content read, meaningless to a card search) and, when <paramref name="nodeType"/>
+    /// is given, the <c>nodeType:</c> clause narrowed to it — the models catalog shows models, not
+    /// the providers and tiers the picker query also reads. Pure.
+    /// </summary>
+    public static string ForSearch(string query, string? nodeType = null)
+    {
+        var tokens = query.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(t => !t.StartsWith("select:", StringComparison.OrdinalIgnoreCase))
+            .Select(t => nodeType is not null && t.StartsWith("nodeType:", StringComparison.OrdinalIgnoreCase)
+                ? $"nodeType:{nodeType}"
+                : t);
+        return string.Join(" ", tokens);
+    }
+
+    /// <summary>True when the query names a partition — <c>namespace:</c> or <c>path:</c>. Pure.</summary>
+    public static bool IsAnchored(string? query) =>
+        !string.IsNullOrWhiteSpace(query)
+        && (query.Contains("namespace:", StringComparison.OrdinalIgnoreCase)
+            || query.Contains("path:", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The first <c>{…}</c> placeholder left in a query that this seam does not know, or null. Pure.</summary>
+    public static string? UnknownPlaceholder(string query)
+    {
+        var open = query.IndexOf('{');
+        while (open >= 0)
+        {
+            var close = query.IndexOf('}', open + 1);
+            if (close < 0)
+                return query[open..];
+            return query[open..(close + 1)];
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Validates a user-authored entry before it is saved: a known kind, a name, a template that
+    /// carries only known placeholders and is partition-anchored in every context it can expand in.
+    /// Returns the problem, or null when the entry is fine. Pure.
+    /// </summary>
+    public static string? Validate(AiSourceEntry entry)
+    {
+        if (!AiSourceKinds.IsKnown(entry.Kind))
+            return $"Unknown kind '{entry.Kind}' — use skill, agent or model.";
+        if (string.IsNullOrWhiteSpace(entry.Name))
+            return "Give the source a name.";
+        if (string.IsNullOrWhiteSpace(entry.Query))
+            return "Give the source a query.";
+        // Expand against a fully populated probe context: what survives must be anchored and known.
+        var probe = new AiSourceContext
+        {
+            User = "user", ObjectPath = "space/node", ObjectPartition = "space",
+            NodeTypePath = "pkg/Type", NodeTypePartition = "pkg",
+        };
+        return Expand(entry.Kind, entry.Query, probe, out var reason) is null ? reason : null;
+    }
+}

--- a/src/MeshWeaver.AI/AiSourceEntry.cs
+++ b/src/MeshWeaver.AI/AiSourceEntry.cs
@@ -1,0 +1,82 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.AI;
+
+/// <summary>The three kinds of AI source a user resolves through their settings.</summary>
+public static class AiSourceKinds
+{
+    /// <summary>Skill sources (<c>nodeType:Skill</c>).</summary>
+    public const string Skill = "skill";
+    /// <summary>Agent sources (<c>nodeType:Agent</c>).</summary>
+    public const string Agent = "agent";
+    /// <summary>Language-model sources (<c>nodeType:LanguageModel|ModelProvider|ModelTier</c>).</summary>
+    public const string Model = "model";
+
+    /// <summary>Every kind, in display order.</summary>
+    public static readonly ImmutableArray<string> All = ImmutableArray.Create(Skill, Agent, Model);
+
+    /// <summary>True for a known kind (case-insensitive).</summary>
+    public static bool IsKnown(string? kind) =>
+        kind is not null && All.Contains(kind, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The canonical (lower-case) spelling of a known kind, or null.</summary>
+    public static string? Canonical(string? kind) =>
+        All.FirstOrDefault(k => string.Equals(k, kind, StringComparison.OrdinalIgnoreCase));
+}
+
+/// <summary>
+/// One NAMED, DESCRIBED resolution source in a user's <see cref="AiSettings"/> — "where do my
+/// skills / agents / models come from, and why". The <see cref="Query"/> is a TEMPLATE carrying
+/// placeholders (<see cref="AiSourceCatalog"/> lists them: <c>{user}</c>, <c>{objectPartition}</c>,
+/// <c>{objectPath}</c>, <c>{nodeTypePartition}</c>, <c>{nodeTypePath}</c>, plus the legacy
+/// <c>{userPath}</c> / <c>{currentPath}</c> / <c>{nodeTypePath}</c> spellings) that the seam expands
+/// per context. A template whose placeholder has no value in the current context is DROPPED — never
+/// emitted half-expanded — and a template that is not partition-anchored is never executed.
+/// </summary>
+public record AiSourceEntry
+{
+    /// <summary>One of <see cref="AiSourceKinds"/>.</summary>
+    public string Kind { get; init; } = AiSourceKinds.Skill;
+
+    /// <summary>The label a user sees — "My skills", "Skills of the current space", "MeshWeaver OpenRouter".</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>What this source finds and why it is there — rendered beside the name everywhere the
+    /// entry shows.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>The query TEMPLATE (placeholders unexpanded). Must be partition-anchored
+    /// (<c>namespace:</c> or <c>path:</c>) once expanded.</summary>
+    public string Query { get; init; } = "";
+}
+
+/// <summary>
+/// The context a source template is expanded against: the viewer's home partition, the node in
+/// view (full path + its partition) and that node's TYPE (full path + its partition). Built through
+/// <see cref="AiSourceCatalog.Context"/>, which nulls reserved/rogue route partitions so a poisoned
+/// context can never fail a query.
+/// </summary>
+public sealed record AiSourceContext
+{
+    /// <summary>The viewer's home partition (their user id), or null when signed out.</summary>
+    public string? User { get; init; }
+    /// <summary>The full path of the node in view, or null.</summary>
+    public string? ObjectPath { get; init; }
+    /// <summary>The top-level partition of the node in view, or null.</summary>
+    public string? ObjectPartition { get; init; }
+    /// <summary>The full path of the node type of the node in view, or null.</summary>
+    public string? NodeTypePath { get; init; }
+    /// <summary>The top-level partition of that node type, or null.</summary>
+    public string? NodeTypePartition { get; init; }
+}
+
+/// <summary>One entry after expansion: the query the platform will run for it, or why it was dropped.</summary>
+public sealed record AiResolvedSource(
+    AiSourceEntry Entry,
+    string? Query,
+    bool IsDefault,
+    string? DroppedReason)
+{
+    /// <summary>True when the entry produced a runnable query.</summary>
+    public bool IsActive => Query is not null;
+}

--- a/src/MeshWeaver.AI/BuiltInLanguageModelProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInLanguageModelProvider.cs
@@ -40,6 +40,21 @@ public class BuiltInLanguageModelProvider : IStaticNodeProvider
     private readonly LanguageModelCatalogOptions options;
     private readonly ILogger<BuiltInLanguageModelProvider>? logger;
 
+    /// <summary>The wire name of the platform's OpenRouter provider (<c>Provider/OpenRouter</c>).</summary>
+    public const string OpenRouterProviderName = "OpenRouter";
+
+    /// <summary>
+    /// The description a provider node is seeded with: what the source declares, else — for the
+    /// platform's OpenRouter path only — the ONE disclosure text with OpenRouter's terms link
+    /// (<see cref="AiSourceCatalog.OpenRouterDisclosure"/>). Every surface that offers the provider
+    /// renders this description; none repeats the link. Pure.
+    /// </summary>
+    public static string? ProviderDescription(string providerName, string? declared) =>
+        !string.IsNullOrWhiteSpace(declared) ? declared
+        : string.Equals(providerName, OpenRouterProviderName, StringComparison.OrdinalIgnoreCase)
+            ? AiSourceCatalog.OpenRouterDisclosure
+            : null;
+
     /// <summary>
     /// Constructs the provider from the configuration root (where each catalog source reads
     /// its endpoint/key/models) and the registered catalog options.
@@ -156,6 +171,10 @@ public class BuiltInLanguageModelProvider : IStaticNodeProvider
                 // its group title, so ProviderName here published "AzureFoundry" as a user-facing
                 // heading while the source had declared "Azure Foundry" all along.
                 Label = source.EffectiveLabel,
+                // The provider's disclosure — what a user should know before using it — rendered as
+                // the node's description on every surface that offers the provider. The platform's
+                // OpenRouter path carries its terms link HERE and nowhere else.
+                Description = ProviderDescription(source.ProviderName, source.Description),
                 // 🚨 DETERMINISTIC seed timestamp — NEVER DateTimeOffset.UtcNow. The static-repo
                 // importer fingerprints this node's CONTENT (Versioned=false → contentHash). A
                 // per-enumeration UtcNow changed the content — and thus the fingerprint — on EVERY
@@ -174,6 +193,7 @@ public class BuiltInLanguageModelProvider : IStaticNodeProvider
             {
                 NodeType = ModelProviderNodeType.NodeType,
                 Name = source.EffectiveLabel,
+                Description = providerConfig.Description,
                 Category = "Providers",
                 // Brand logo when the provider name resolves to a known maker; the
                 // generic key SVG otherwise. Fall back to the self-contained SVG URL
@@ -456,7 +476,8 @@ public record LanguageModelCatalogSource(
     string? DefaultEndpoint = null,
     ImmutableArray<string> DefaultModelIds = default,
     bool RequiresApiKey = true,
-    ProviderKind Kind = ProviderKind.Api)
+    ProviderKind Kind = ProviderKind.Api,
+    string? Description = null)
 {
     /// <summary>Effective display label — falls back to <see cref="ProviderName"/> when not supplied.</summary>
     public string EffectiveLabel => DisplayLabel ?? ProviderName;

--- a/src/MeshWeaver.AI/ModelProviderConfiguration.cs
+++ b/src/MeshWeaver.AI/ModelProviderConfiguration.cs
@@ -97,6 +97,14 @@ public record ModelProviderConfiguration
     /// <summary>Human-readable display name (e.g. "Roland's personal key").</summary>
     public string? Label { get; init; }
 
+    /// <summary>
+    /// What a user should know before using this provider — rendered as the provider node's
+    /// description everywhere the provider is offered (AI Settings, the catalogs, plan cards). ONE
+    /// source: the platform's OpenRouter path carries its disclosure and terms link here
+    /// (<see cref="AiSourceCatalog.OpenRouterDisclosure"/>), and no other surface repeats it.
+    /// </summary>
+    public string? Description { get; init; }
+
     /// <summary>UTC timestamp when this provider configuration node was first created.</summary>
     public DateTimeOffset CreatedAt { get; init; }
 

--- a/src/MeshWeaver.AI/Navigation/NavigationResolver.cs
+++ b/src/MeshWeaver.AI/Navigation/NavigationResolver.cs
@@ -51,7 +51,7 @@ public sealed class NavigationResolver
             case NavigationInputKind.DirectPath:
                 return ResolveDirect(row!.Trim(), contextPath);
             default:
-                return ResolvePhrase(row!.Trim());
+                return ResolvePhrase(row!.Trim(), contextPath);
         }
     }
 
@@ -121,10 +121,16 @@ public sealed class NavigationResolver
             .Timeout(TimeSpan.FromSeconds(ExistsTimeoutSeconds))
             .Catch((Exception _) => Observable.Return((MeshNode?)null));
 
-    private IObservable<NavigationResolution> ResolvePhrase(string phrase)
+    private IObservable<NavigationResolution> ResolvePhrase(string phrase, string? contextPath)
     {
         // 1) Prefer a SKILL — a skill can do more than a route change ("change my model" → /model).
-        return SearchNodes("nodeType:Skill", 100)
+        // The skills considered are the ones the USER resolves — their AI Settings sources for this
+        // context, through the one seam (AiSourceCatalog) — never an unanchored nodeType sweep.
+        var user = AgentPickerProjection.ResolveUserHome(hub.ServiceProvider.GetService<AccessService>());
+        return AiSettingsNodeType
+            .ObserveSkillQueries(hub.GetWorkspace(), hub, hub.ServiceProvider, user, contextPath, nodeTypePath: null)
+            .Take(1)
+            .SelectMany(queries => SearchNodes(queries, 100))
             .SelectMany(skills =>
             {
                 var skill = NavigationTargetResolver.PickBestSkill(phrase, skills);
@@ -166,6 +172,19 @@ public sealed class NavigationResolver
         nodes.Where(n => !string.IsNullOrEmpty(n.Path)
                     && !string.Equals(n.Path, exclude, StringComparison.OrdinalIgnoreCase))
             .Select(n => n.Path!).Distinct().Take(take).ToList();
+
+    private IObservable<IReadOnlyList<MeshNode>> SearchNodes(IReadOnlyList<string> queries, int limit) =>
+        queries.Count == 0
+            ? Observable.Return((IReadOnlyList<MeshNode>)[])
+            : mesh.Query<MeshNode>(new MeshQueryRequest { Queries = queries, Limit = limit })
+                .Take(1)
+                .Select(change => (IReadOnlyList<MeshNode>)change.Items.ToList())
+                .Timeout(TimeSpan.FromSeconds(SearchTimeoutSeconds))
+                .Catch((Exception ex) =>
+                {
+                    logger.LogWarning(ex, "Navigation search failed for queries {Queries}", string.Join(" | ", queries));
+                    return Observable.Return((IReadOnlyList<MeshNode>)[]);
+                });
 
     private IObservable<IReadOnlyList<MeshNode>> SearchNodes(string query, int limit) =>
         mesh.Query<MeshNode>(new MeshQueryRequest { Query = query, Limit = limit })

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -974,7 +974,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     }
 
     /// <summary>
-    /// READ-ONLY subscription to the live model catalog — the SAME <see cref="AgentPickerProjection.ObserveModels"/>
+    /// READ-ONLY subscription to the live model catalog — the SAME <see cref="AgentPickerProjection.ObserveModels(IWorkspace, IMessageHub, IServiceProvider, string?, string?, string?, IReadOnlyList{string}?)"/>
     /// pipeline the /model picker binds to. Drives Send-gating (empty catalog → disable + message) and
     /// submit-time model resolution. NEVER writes a node (a prior write-from-callback NotFound-stormed the
     /// hub). A load error is logged, not surfaced, and leaves <c>_modelsLoaded</c> false so Send isn't
@@ -988,7 +988,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             return;
         var picker = AgentPickerProjection.DerivePickerContext(_currentNavContext, initialContext);
         modelsSubscription = AgentPickerProjection
-            .ObserveModels(workspace, Hub, picker.ContextPath, picker.NodeTypePath, userPath: _userHome)
+            .ObserveModels(workspace, Hub, Hub.ServiceProvider, _userHome, picker.ContextPath, picker.NodeTypePath)
             .Subscribe(
                 models => InvokeAsync(() =>
                 {

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -974,7 +974,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     }
 
     /// <summary>
-    /// READ-ONLY subscription to the live model catalog — the SAME <see cref="AgentPickerProjection.ObserveModels(IWorkspace, IMessageHub, IServiceProvider, string?, string?, string?, IReadOnlyList{string}?)"/>
+    /// READ-ONLY subscription to the live model catalog — the SAME <see cref="AgentPickerProjection.ObserveResolvedModels"/>
     /// pipeline the /model picker binds to. Drives Send-gating (empty catalog → disable + message) and
     /// submit-time model resolution. NEVER writes a node (a prior write-from-callback NotFound-stormed the
     /// hub). A load error is logged, not surfaced, and leaves <c>_modelsLoaded</c> false so Send isn't
@@ -988,7 +988,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             return;
         var picker = AgentPickerProjection.DerivePickerContext(_currentNavContext, initialContext);
         modelsSubscription = AgentPickerProjection
-            .ObserveModels(workspace, Hub, Hub.ServiceProvider, _userHome, picker.ContextPath, picker.NodeTypePath)
+            .ObserveResolvedModels(workspace, Hub, Hub.ServiceProvider, _userHome, picker.ContextPath, picker.NodeTypePath)
             .Subscribe(
                 models => InvokeAsync(() =>
                 {

--- a/test/MeshWeaver.AI.Test/AiResolutionSeamAuditTest.cs
+++ b/test/MeshWeaver.AI.Test/AiResolutionSeamAuditTest.cs
@@ -1,0 +1,148 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Architecture audit: every place that RESOLVES skills, agents or models goes through the one
+/// seam (<see cref="AiSourceCatalog"/> via <see cref="AiSettingsNodeType"/>), and no hard-coded
+/// resolution query creeps back in outside it. Two halves:
+/// <list type="number">
+///   <item>the known entry points must reference the seam (a refactor that reverts one to a literal
+///     fails here, not in production as an unanchored sweep);</item>
+///   <item>a source scan over the platform's AI-facing projects fails on any NEW file that builds a
+///     <c>nodeType:Skill|Agent|LanguageModel|ModelProvider</c> query from a literal — the allow-list
+///     names the seam itself and the files whose literals are NOT resolution (attribute metadata,
+///     prompt text, per-partition credential lookup), each with the reason.</item>
+/// </list>
+/// The scan runs against the repo checkout the test assembly was built from; it is skipped when no
+/// checkout is reachable (a packaged test run), never silently green.
+/// </summary>
+public class AiResolutionSeamAuditTest
+{
+    // Files where a resolution-shaped literal is LEGITIMATE — with why. Anything else that builds a
+    // resolution query from a literal must go through AiSourceCatalog.
+    private static readonly IReadOnlyDictionary<string, string> Allowed = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["src/MeshWeaver.AI/AiSourceCatalog.cs"] = "THE seam — defines the defaults.",
+        ["src/MeshWeaver.AI/AgentPickerProjection.cs"] = "The canonical query BUILDERS the seam's defaults are derived from.",
+        ["src/MeshWeaver.AI/AiSettingsNodeType.cs"] = "The default templates + resolvers that delegate to the seam.",
+        ["src/MeshWeaver.AI/SkillNodeType.cs"] = "SkillQueries — the builder-backed fallback the seam degrades to.",
+        ["src/MeshWeaver.AI/ThreadComposer.cs"] = "[MeshNode] attribute metadata for the composer's editor fields — static picker defaults; the live picker resolves through the seam (ObserveAgents/ObserveModels).",
+        ["src/MeshWeaver.AI/AgentChatClient.cs"] = "Prompt text telling the model how to create a skill — not a resolution.",
+        ["src/MeshWeaver.AI/Plugins/SkillTool.cs"] = "Tool descriptions/help text — not a resolution.",
+        ["src/MeshWeaver.AI/MeshPlugin.cs"] = "Tool parameter description text — not a resolution.",
+        ["src/MeshWeaver.AI/ChatClientCredentialResolver.cs"] = "Credential lookup by the MODEL's own partition set — a security seam keyed on the selected model, not a user-facing resolution.",
+        ["src/MeshWeaver.AI/Stores/MeshAgentSkillsSource.cs"] = "Consumes AiSettingsNodeType.ObserveSkillQueries; its literal is documentation.",
+        ["src/MeshWeaver.AI/Completion/SkillAutocompleteProvider.cs"] = "Consumes ObserveSkillQueries; literal is documentation.",
+        ["src/MeshWeaver.AI/AiSourcesInstallHook.cs"] = "Registers package sources INTO the settings — the write side of the seam.",
+        ["src/MeshWeaver.AI/BuiltInSkillProvider.cs"] = "Static-repo import source (writes the platform Skill partition) — not a resolution.",
+        ["src/MeshWeaver.AI/BuiltInAgentProvider.cs"] = "Static-repo import source for the offline Agent partition — not a resolution.",
+        ["src/MeshWeaver.AI/AgentNodeType.cs"] = "Type registration + comments naming the namespace — not a resolution.",
+        ["src/MeshWeaver.AI/LanguageModelNodeType.cs"] = "Type registration — not a resolution.",
+        ["src/MeshWeaver.AI/ModelProviderNodeType.cs"] = "Type registration — not a resolution.",
+        ["src/MeshWeaver.AI/ModelTierNodeType.cs"] = "Type registration — not a resolution.",
+        ["src/MeshWeaver.AI/Navigation/NavigationResolver.cs"] = "Consumes ObserveSkillQueries; any literal left is documentation.",
+        ["src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs"] = "Lists the agents a NODE TYPE's partition ships — a per-type listing anchored on that hub, not the viewer's resolution.",
+        ["src/MeshWeaver.Cli/Program.cs"] = "CLI help text example.",
+    };
+
+    // The consumers that MUST go through the seam, and the seam symbol each must reference.
+    private static readonly (string File, string Symbol)[] EntryPoints =
+    {
+        ("src/MeshWeaver.AI/AgentView.cs", "ObserveAgentQueries("),
+        ("src/MeshWeaver.AI/Navigation/NavigationResolver.cs", "ObserveSkillQueries("),
+        ("src/MeshWeaver.AI/AiCatalogLayoutAreas.cs", "AiSourceCatalog.Resolve("),
+        ("src/MeshWeaver.AI/Stores/MeshAgentSkillsSource.cs", "ObserveSkillQueries("),
+        ("src/MeshWeaver.AI/Completion/SkillAutocompleteProvider.cs", "SkillQueries("),
+        ("src/MeshWeaver.AI/AgentPickerProjection.cs", "ObserveModelQueries("),
+        ("src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs", "ObserveModels(workspace, Hub, Hub.ServiceProvider"),
+        ("src/MeshWeaver.AI/AiSettingsNodeType.cs", "AiSourceCatalog.Resolve("),
+    };
+
+    private static readonly Regex ResolutionLiteral = new(
+        @"nodeType:(Skill|Agent|LanguageModel|ModelProvider)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly string[] ScannedRoots = { "src/MeshWeaver.AI", "src/MeshWeaver.Graph", "src/MeshWeaver.Blazor.Portal" };
+
+    // The checkout root: the first ancestor of the test assembly that holds the platform's
+    // src/MeshWeaver.AI project — works from a worktree, a clone, or bin/ of either.
+    private static string? RepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+            if (File.Exists(Path.Combine(dir.FullName, "src", "MeshWeaver.AI", "MeshWeaver.AI.csproj")))
+                return dir.FullName;
+        return null;
+    }
+
+    [Fact]
+    public void EveryResolutionEntryPoint_GoesThroughTheSeam()
+    {
+        var root = RepoRoot();
+        Assert.SkipWhen(root is null, "No repo checkout reachable from the test assembly — the audit needs the sources.");
+        foreach (var (file, symbol) in EntryPoints)
+        {
+            var path = Path.Combine(root!, file);
+            Assert.True(File.Exists(path), $"Entry point moved or vanished: {file} — update the audit.");
+            var source = File.ReadAllText(path);
+            Assert.True(source.Contains(symbol, StringComparison.Ordinal),
+                $"{file} no longer resolves through the seam ({symbol} not referenced) — direct node access crept back.");
+        }
+    }
+
+    [Fact]
+    public void NoResolutionLiteral_OutsideTheAllowList()
+    {
+        var root = RepoRoot();
+        Assert.SkipWhen(root is null, "No repo checkout reachable from the test assembly — the audit needs the sources.");
+        var offenders = new List<string>();
+        foreach (var scanned in ScannedRoots)
+        {
+            var dir = Path.Combine(root!, scanned);
+            if (!Directory.Exists(dir))
+                continue;
+            foreach (var file in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+            {
+                if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                    || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+                    continue;
+                var relative = Path.GetRelativePath(root!, file).Replace('\\', '/');
+                if (Allowed.ContainsKey(relative))
+                    continue;
+                var lines = File.ReadAllLines(file);
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    var line = lines[i].TrimStart();
+                    // Comments and XML docs may NAME a query; only code that builds one counts.
+                    if (line.StartsWith("//", StringComparison.Ordinal))
+                        continue;
+                    if (ResolutionLiteral.IsMatch(line))
+                        offenders.Add($"{relative}:{i + 1}: {line.Trim()}");
+                }
+            }
+        }
+        Assert.True(offenders.Count == 0,
+            "Resolution query literals outside the seam — route them through AiSourceCatalog "
+            + "(or allow-list the file WITH a reason in AiResolutionSeamAuditTest):\n"
+            + string.Join("\n", offenders));
+    }
+
+    [Fact]
+    public void AllowList_NamesOnlyFilesThatExist_WithAReason()
+    {
+        var root = RepoRoot();
+        Assert.SkipWhen(root is null, "No repo checkout reachable from the test assembly.");
+        foreach (var (file, reason) in Allowed)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(reason), $"{file}: an allow-list entry needs its reason.");
+            Assert.True(File.Exists(Path.Combine(root!, file)), $"Stale allow-list entry: {file} no longer exists.");
+        }
+    }
+}

--- a/test/MeshWeaver.AI.Test/AiResolutionSeamAuditTest.cs
+++ b/test/MeshWeaver.AI.Test/AiResolutionSeamAuditTest.cs
@@ -62,7 +62,7 @@ public class AiResolutionSeamAuditTest
         ("src/MeshWeaver.AI/Stores/MeshAgentSkillsSource.cs", "ObserveSkillQueries("),
         ("src/MeshWeaver.AI/Completion/SkillAutocompleteProvider.cs", "SkillQueries("),
         ("src/MeshWeaver.AI/AgentPickerProjection.cs", "ObserveModelQueries("),
-        ("src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs", "ObserveModels(workspace, Hub, Hub.ServiceProvider"),
+        ("src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs", "ObserveResolvedModels("),
         ("src/MeshWeaver.AI/AiSettingsNodeType.cs", "AiSourceCatalog.Resolve("),
     };
 

--- a/test/MeshWeaver.AI.Test/AiSourceCatalogTest.cs
+++ b/test/MeshWeaver.AI.Test/AiSourceCatalogTest.cs
@@ -1,0 +1,248 @@
+#pragma warning disable CS1591
+
+using System.Collections.Immutable;
+using System.Linq;
+using MeshWeaver.AI;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the ONE resolution seam (<see cref="AiSourceCatalog"/>): the named/described defaults
+/// reproduce the platform's historical queries exactly, placeholders expand (legacy spellings
+/// included), a template whose placeholder has no value is DROPPED — never emitted half-expanded —
+/// an unanchored query is never emitted, user entries override defaults, legacy bare templates are
+/// still honored, and the platform model path carries its disclosure and terms link.
+/// </summary>
+public class AiSourceCatalogTest
+{
+    private static readonly AiSourceContext Full = AiSourceCatalog.Context(
+        userPath: "alice", contextPath: "ACME/Project/Todo", nodeTypePath: "Office/Slide");
+
+    [Fact]
+    public void Defaults_AreNamedAndDescribed_ForEveryKind()
+    {
+        foreach (var kind in AiSourceKinds.All)
+        {
+            var defaults = AiSourceCatalog.Defaults(kind);
+            Assert.NotEmpty(defaults);
+            Assert.All(defaults, d =>
+            {
+                Assert.Equal(kind, d.Kind);
+                Assert.False(string.IsNullOrWhiteSpace(d.Name), $"{kind} default without a name: {d.Query}");
+                Assert.False(string.IsNullOrWhiteSpace(d.Description), $"{kind} default without a description: {d.Name}");
+                Assert.False(string.IsNullOrWhiteSpace(d.Query));
+            });
+        }
+    }
+
+    [Fact]
+    public void Defaults_ReproduceTheHistoricalQueries_Exactly()
+    {
+        // Skills: the four rows AiSettingsNodeType has always resolved, in order.
+        Assert.Equal(
+            AiSettingsNodeType.DefaultSkillQueryTemplates,
+            AiSourceCatalog.SkillDefaults.Select(d => d.Query).ToImmutableArray());
+        // Agents: the one canonical registry template.
+        Assert.Equal(
+            AiSettingsNodeType.DefaultAgentQueryTemplates,
+            AiSourceCatalog.AgentDefaults.Select(d => d.Query).ToImmutableArray());
+        // Models: BuildModelQueries' rows for the tokenized context.
+        Assert.Equal(
+            AgentPickerProjection.BuildModelQueries(
+                AiSourceCatalog.ObjectPathToken, AiSourceCatalog.NodeTypePathToken, null, AiSourceCatalog.UserToken),
+            AiSourceCatalog.ModelDefaults.Select(d => d.Query).ToArray());
+    }
+
+    [Fact]
+    public void ResolvedSkillDefaults_EqualTheCanonicalBuilder_InEveryContextShape()
+    {
+        // Full context, no user, no type, nothing — the seam must equal what SkillNodeType.SkillQueries
+        // produced before it existed (this is the "nothing regresses" guarantee).
+        foreach (var (user, ctx, type) in new (string?, string?, string?)[]
+                 {
+                     ("alice", "ACME/Project", "Office/Slide"),
+                     (null, "ACME/Project", null),
+                     ("alice", null, null),
+                     ("alice", "login/whatever", "settings/x"), // reserved partitions drop
+                 })
+        {
+            var expected = SkillNodeType.SkillQueries(ctx, user, type);
+            var actual = AiSettingsNodeType.ResolveSkillQueries(null, ctx, type, user);
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void ResolvedModelDefaults_EqualTheCanonicalBuilder()
+    {
+        foreach (var (user, ctx, type) in new (string?, string?, string?)[]
+                 {
+                     ("alice", "ACME/Project", "Office/Slide"),
+                     (null, null, null),
+                     ("alice", "welcome/x", null),
+                 })
+        {
+            var expected = AgentPickerProjection.BuildModelQueries(
+                AgentPickerProjection.IsReservedPartition(ctx) ? null : ctx, type, null, user);
+            var actual = AiSettingsNodeType.ResolveModelQueries(null, ctx, type, user);
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void Expand_SubstitutesNewAndLegacyPlaceholders()
+    {
+        Assert.Equal("namespace:alice/Skill nodeType:Skill",
+            AiSourceCatalog.Expand(AiSourceKinds.Skill, "namespace:{user}/Skill nodeType:Skill", Full, out _));
+        Assert.Equal("namespace:alice/Skill nodeType:Skill",
+            AiSourceCatalog.Expand(AiSourceKinds.Skill, "namespace:{userPath}/Skill nodeType:Skill", Full, out _));
+        Assert.Equal("path:ACME scope:descendants nodeType:Skill",
+            AiSourceCatalog.Expand(AiSourceKinds.Skill, "path:{objectPartition} scope:descendants nodeType:Skill", Full, out _));
+        Assert.Equal("path:ACME/Project/Todo nodeType:Skill",
+            AiSourceCatalog.Expand(AiSourceKinds.Skill, "path:{objectPath} nodeType:Skill", Full, out _));
+        Assert.Equal("path:Office scope:descendants nodeType:Skill",
+            AiSourceCatalog.Expand(AiSourceKinds.Skill, "path:{nodeTypePartition} scope:descendants nodeType:Skill", Full, out _));
+        // Legacy {currentPath}: the partition for skills/agents, the full path for models — exactly
+        // what each builder substituted before the seam existed.
+        Assert.Equal("path:ACME scope:descendants nodeType:Skill",
+            AiSourceCatalog.Expand(AiSourceKinds.Skill, "path:{currentPath} scope:descendants nodeType:Skill", Full, out _));
+        Assert.Equal("namespace:ACME/Project/Todo/Provider nodeType:LanguageModel",
+            AiSourceCatalog.Expand(AiSourceKinds.Model, "namespace:{currentPath}/Provider nodeType:LanguageModel", Full, out _));
+    }
+
+    [Fact]
+    public void Expand_DropsWhenAPlaceholderHasNoValue_NeverHalfExpanded()
+    {
+        var noType = AiSourceCatalog.Context("alice", "ACME/Project", null);
+        var query = AiSourceCatalog.Expand(AiSourceKinds.Skill,
+            "path:{nodeTypePartition} scope:descendants nodeType:Skill", noType, out var reason);
+        Assert.Null(query);
+        Assert.Contains("{nodeTypePartition}", reason);
+
+        var signedOut = AiSourceCatalog.Context(null, "ACME", null);
+        Assert.Null(AiSourceCatalog.Expand(AiSourceKinds.Skill, "namespace:{user}/Skill nodeType:Skill", signedOut, out _));
+    }
+
+    [Fact]
+    public void Expand_RefusesUnanchoredAndUnknownPlaceholders()
+    {
+        Assert.Null(AiSourceCatalog.Expand(AiSourceKinds.Skill, "nodeType:Skill", Full, out var reason));
+        Assert.Contains("anchored", reason);
+        Assert.Null(AiSourceCatalog.Expand(AiSourceKinds.Skill, "namespace:{space}/Skill nodeType:Skill", Full, out reason));
+        Assert.Contains("{space}", reason);
+        Assert.Null(AiSourceCatalog.Expand(AiSourceKinds.Skill, "   ", Full, out reason));
+        Assert.NotNull(reason);
+    }
+
+    [Fact]
+    public void Resolve_UserEntriesWinOverDefaults_LegacyTemplatesStillHonored()
+    {
+        var named = new AiSettings
+        {
+            SkillSources = ImmutableArray.Create(new AiSourceEntry
+            {
+                Kind = AiSourceKinds.Skill, Name = "Team skills",
+                Description = "Our shared team skills.", Query = "namespace:Team/Skill nodeType:Skill",
+            }),
+            SkillQueries = ImmutableArray.Create("namespace:Legacy/Skill nodeType:Skill"),
+        };
+        var resolved = AiSourceCatalog.Resolve(AiSourceKinds.Skill, named, Full);
+        Assert.Single(resolved);
+        Assert.Equal("Team skills", resolved[0].Entry.Name);
+        Assert.Equal("namespace:Team/Skill nodeType:Skill", resolved[0].Query);
+        Assert.False(resolved[0].IsDefault);
+
+        var legacy = new AiSettings
+        {
+            SkillQueries = ImmutableArray.Create(
+                AiSettingsNodeType.DefaultSkillQueryTemplates[0],
+                "namespace:Legacy/Skill nodeType:Skill"),
+        };
+        var annotated = AiSourceCatalog.Resolve(AiSourceKinds.Skill, legacy, Full);
+        Assert.Equal(2, annotated.Length);
+        Assert.Equal("Platform skills", annotated[0].Entry.Name);   // a default's template keeps its identity
+        Assert.True(annotated[0].IsDefault);
+        Assert.Equal("Custom source", annotated[1].Entry.Name);
+        Assert.False(annotated[1].IsDefault);
+
+        var none = AiSourceCatalog.Resolve(AiSourceKinds.Skill, new AiSettings(), Full);
+        Assert.Equal(AiSourceCatalog.SkillDefaults.Length, none.Length);
+        Assert.All(none, r => Assert.True(r.IsDefault));
+    }
+
+    [Fact]
+    public void Queries_KeepOnlyActiveEntries_Deduplicated()
+    {
+        var settings = new AiSettings
+        {
+            SkillSources = ImmutableArray.Create(
+                new AiSourceEntry { Kind = AiSourceKinds.Skill, Name = "A", Query = "namespace:X/Skill nodeType:Skill" },
+                new AiSourceEntry { Kind = AiSourceKinds.Skill, Name = "B", Query = "namespace:x/skill nodeType:Skill" },
+                new AiSourceEntry { Kind = AiSourceKinds.Skill, Name = "C", Query = "nodeType:Skill" },
+                new AiSourceEntry { Kind = AiSourceKinds.Skill, Name = "D", Query = "namespace:{nodeTypePartition}/Skill nodeType:Skill" }),
+        };
+        var queries = AiSourceCatalog.Queries(AiSourceCatalog.Resolve(
+            AiSourceKinds.Skill, settings, AiSourceCatalog.Context("alice", "ACME", null)));
+        Assert.Equal(new[] { "namespace:X/Skill nodeType:Skill" }, queries);
+    }
+
+    [Fact]
+    public void Validate_RejectsWhatTheSeamWouldDrop()
+    {
+        Assert.Null(AiSourceCatalog.Validate(new AiSourceEntry
+        { Kind = "skill", Name = "ok", Query = "namespace:{user}/Skill nodeType:Skill" }));
+        Assert.NotNull(AiSourceCatalog.Validate(new AiSourceEntry { Kind = "skill", Name = "", Query = "namespace:X nodeType:Skill" }));
+        Assert.NotNull(AiSourceCatalog.Validate(new AiSourceEntry { Kind = "thing", Name = "x", Query = "namespace:X nodeType:Skill" }));
+        Assert.Contains("anchored", AiSourceCatalog.Validate(new AiSourceEntry { Kind = "model", Name = "x", Query = "nodeType:LanguageModel" }));
+        Assert.Contains("{typo}", AiSourceCatalog.Validate(new AiSourceEntry { Kind = "agent", Name = "x", Query = "namespace:{typo}/Agent nodeType:Agent" }));
+    }
+
+    [Fact]
+    public void PlatformModelPath_IsLabeledMeshWeaverOpenRouter_WithTheDisclosureAndTermsLink()
+    {
+        var platform = AiSourceCatalog.ModelDefaults[0];
+        Assert.Equal(AiSourceCatalog.MeshWeaverOpenRouterLabel, platform.Name);
+        Assert.Equal(AiSourceCatalog.OpenRouterDisclosure, platform.Description);
+        Assert.Contains(AiSourceCatalog.OpenRouterTermsUrl, platform.Description);
+        Assert.Contains("OpenRouter", platform.Description);
+        Assert.StartsWith($"namespace:{ModelProviderNodeType.RootNamespace} ", platform.Query);
+        // The disclosure is seeded onto the provider node — one text, one place.
+        Assert.Equal(AiSourceCatalog.OpenRouterDisclosure,
+            BuiltInLanguageModelProvider.ProviderDescription("OpenRouter", null));
+        Assert.Equal("custom", BuiltInLanguageModelProvider.ProviderDescription("OpenRouter", "custom"));
+        Assert.Null(BuiltInLanguageModelProvider.ProviderDescription("Anthropic", null));
+    }
+
+    [Fact]
+    public void MergePackageSources_AppendNamedRows_WhenTheUserMaintainsNamedSources()
+    {
+        var named = new AiSettings
+        {
+            SkillSources = AiSourceCatalog.SkillDefaults,
+            AgentSources = AiSourceCatalog.AgentDefaults,
+        };
+        var merged = AiSettingsNodeType.MergePackageSources(named, "Office");
+        Assert.Equal(AiSourceCatalog.SkillDefaults.Length + 1, merged.SkillSources.Length);
+        Assert.Equal(AiSourceCatalog.AgentDefaults.Length + 1, merged.AgentSources.Length);
+        Assert.Equal("Office package", merged.SkillSources[^1].Name);
+        Assert.Equal("namespace:Office/Skill nodeType:Skill", merged.SkillSources[^1].Query);
+        // Idempotent.
+        Assert.Equal(merged, AiSettingsNodeType.MergePackageSources(merged, "Office"));
+        // A user on legacy templates keeps the legacy behavior byte for byte.
+        var legacy = AiSettingsNodeType.MergePackageSources(new AiSettings(), "Office");
+        Assert.True(legacy.SkillSources.IsDefaultOrEmpty);
+        Assert.Contains("namespace:Office/Skill nodeType:Skill", legacy.SkillQueries);
+    }
+
+    [Fact]
+    public void SearchHelpers_AnchorAndNarrow()
+    {
+        Assert.Equal("ACME", AiSourceCatalog.AnchorNamespace("namespace:ACME/Skill|Skill nodeType:Skill".Replace("ACME/Skill", "ACME")));
+        Assert.Equal("Office", AiSourceCatalog.AnchorNamespace("path:Office scope:descendants nodeType:Skill"));
+        Assert.Null(AiSourceCatalog.AnchorNamespace("nodeType:Skill"));
+        Assert.Equal("namespace:Provider nodeType:LanguageModel scope:descendants",
+            AiSourceCatalog.ForSearch("namespace:Provider nodeType:LanguageModel|ModelProvider scope:descendants select:path,id,content",
+                LanguageModelNodeType.NodeType));
+    }
+}


### PR DESCRIPTION
## What changed

**`AiSourceCatalog`** — THE resolution seam: user `AiSettings` + context → the queries the platform runs for skills, agents and models.
- `AiSourceEntry` rows (kind, **name**, **description**, query template) on `AiSettings` (`SkillSources` / `AgentSources` / `ModelSources`) beside the legacy template lists; entries win when present, legacy templates are annotated (a default's template keeps its identity), defaults otherwise.
- The defaults are named and described — "Platform skills", "My skills", "Skills of the current space", "Skills shipped with the node type", "Platform, space and my agents", "**MeshWeaver OpenRouter**", … — and reproduce the historical queries byte for byte (pinned against `DefaultSkillQueryTemplates`, `DefaultAgentQueryTemplates`, `BuildModelQueries`, and `SkillNodeType.SkillQueries` in every context shape).
- Placeholders `{user}`, `{objectPartition}`, `{objectPath}`, `{nodeTypePartition}`, `{nodeTypePath}`; legacy `{userPath}`/`{currentPath}` keep their per-kind meanings. A row whose placeholder has no value is **dropped with a reason**, never half-expanded; an **unanchored** query is never emitted (the #2186 union wedge).
- `ResolveModelQueries` / `ObserveModelQueries` and a settings-aware `ObserveModels` overload — the chat's model picker now resolves through the user's settings.
- **Direct-access sites migrated**: `AgentView` catalog (was an unanchored `nodeType:Agent` sweep), `NavigationResolver` skill match (unanchored `nodeType:Skill`), the AI catalog areas (tabs are now the viewer's resolved sources — name as label — instead of fixed This-space/User/Global scopes). Install-time `MergeSkillSource`/`MergeAgentSource` append named rows when the user maintains named sources.
- `Provider/OpenRouter` is seeded with the MeshWeaver OpenRouter disclosure + OpenRouter's terms link as its **description** (`ModelProviderConfiguration.Description`, `LanguageModelCatalogSource.Description`, `BuiltInLanguageModelProvider.ProviderDescription`) — the one place the link lives; surfaces render the node's description.

**Tests** (`MeshWeaver.AI.Test`): `AiSourceCatalogTest` (12 cases) and `AiResolutionSeamAuditTest` — the known entry points must reference the seam, and a **source scan over MeshWeaver.AI / Graph / Blazor.Portal fails any new `nodeType:Skill|Agent|LanguageModel|ModelProvider` literal outside the allow-list** (every entry carries its reason: attribute metadata, prompt text, the credential resolver's model-partition lookup). 16/16 green; Release `-warnaserror` builds of MeshWeaver.AI.Test and MeshWeaver.Blazor.Portal clean.

Companion: Systemorph/MeshWeaver.Plugins — the AI Settings app that edits these rows (writes both shapes, so it works before and after this lands). Design issue follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)