### PR TITLE
Source browsing via the registry: the shell reads module source from the repo, not the DB (#2193 §C)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-source-browsing-via-registry.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-source-browsing-via-registry.md
@@ -1,0 +1,24 @@
+---
+Name: Module source stays browsable when it leaves the database
+Category: Feature
+Description: On an adopt-only mesh the NodeType shell's Sources and Tests trees and its code view now read a module's source from the module's repository through the registry — no source nodes on the mesh, no GitHub credential on the consumer.
+Icon: Code
+Order: -20260825
+---
+
+# Module source stays browsable when it leaves the database
+
+`Modules:ImportSourceNodes: false` stops a mesh from persisting a module's `Source/` and `Test/`
+files as nodes — which would have left the NodeType shell's Sources and Tests trees empty, reading
+like a module with no code at all.
+
+They are not empty. On such a mesh the shell lists a type's compile inputs from the package's
+manifest as served by the **registry** this mesh installs from, and opening a file reads its text
+through the same registry, read-only, at exactly the URL the imported node would have answered.
+The credential is the registry's — the same GitHub App that serves the package — so a private
+repository is browsable exactly as far as the registry grants the package, and the consumer never
+holds a GitHub credential. A mesh with no registry access says so in place of the tree instead of
+showing nothing.
+
+This is what makes retiring the existing source nodes safe later: browsing no longer depends on
+them. Meshes that keep importing source (the default) are unchanged.

--- a/src/MeshWeaver.Graph/Configuration/IModuleSourceBrowser.cs
+++ b/src/MeshWeaver.Graph/Configuration/IModuleSourceBrowser.cs
@@ -1,0 +1,80 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>One compile-input file of a module, as the source browser lists it.</summary>
+/// <param name="NodePath">The mesh path the file WOULD have as a node (<c>{Package}/{Type}/Source/{Name}</c>)
+/// — the address the NodeType shell's Code area navigates by, so a browsed file and an imported
+/// one share one URL shape.</param>
+/// <param name="RelativePath">The repo-relative file path (<c>{Package}/{Type}/Source/{Name}.cs</c>).</param>
+/// <param name="FileName">The display name (the file name).</param>
+public sealed record ModuleSourceFile(string NodePath, string RelativePath, string FileName);
+
+/// <summary>
+/// Browses a module's SOURCE from its repository, through the registry — the read seam of
+/// MeshWeaver#2193 §C. On an adopt-only mesh (<see cref="PrebuiltAssemblySeeder.ImportSourceNodesConfigKey"/>
+/// off) the <c>Source/</c>/<c>Test/</c> files are no longer persisted as nodes; their text lives
+/// in the package repo, and this seam serves it: the NodeType shell's Sources/Tests trees list
+/// through <see cref="ListSources"/> and the Code area reads through <see cref="FetchSource"/>.
+///
+/// <para>🚨 The credential is the REGISTRY's, never the consumer's. The consumer asks the
+/// registry it already installs from, with the instance key it already holds; the registry
+/// resolves the package from its curated catalog and reads the file with its own GitHub App
+/// credential — the same encapsulation that serves the packages themselves. A private repo is
+/// browsable exactly as far as the registry grants the package, and a consumer never holds a
+/// GitHub credential for it.</para>
+///
+/// <para>Registered by the plugin catalog (<c>RegistrySourceBrowser</c>). A mesh with no
+/// registry access simply has no browser registered — the shell then says so
+/// (<see cref="ModuleSourceBrowsing.NeedsRegistryMarkdown"/>) rather than rendering an empty tree
+/// that reads like a module with no code.</para>
+/// </summary>
+public interface IModuleSourceBrowser
+{
+    /// <summary>The compile-input files of <paramref name="packageId"/>, from the registry's
+    /// package manifest. Empty when the registry does not serve the package.</summary>
+    IObservable<IReadOnlyList<ModuleSourceFile>> ListSources(string packageId);
+
+    /// <summary>The text of the file that would be the node at <paramref name="nodePath"/>, or
+    /// null when the registry does not serve it.</summary>
+    IObservable<string?> FetchSource(string packageId, string nodePath);
+}
+
+/// <summary>Pure helpers shared by the shell and the browsers.</summary>
+public static class ModuleSourceBrowsing
+{
+    /// <summary>What the shell renders when sources are not on the mesh and no registry can
+    /// serve them.</summary>
+    public const string NeedsRegistryMarkdown =
+        "*Source browsing needs the registry.* This mesh runs modules from prebuilt assemblies "
+        + "and keeps no source nodes; the source is read from the module's repository through "
+        + "the registry this mesh installs from — and no registry is configured or reachable here.";
+
+    /// <summary>What the shell renders for a file the registry does not serve.</summary>
+    public static string NotServedMarkdown(string nodePath) =>
+        $"*The registry does not serve a source file for `{nodePath}`.* Either the package no "
+        + "longer ships it, or this mesh's registry grant does not cover the package.";
+
+    /// <summary>The package a mesh path belongs to — its partition root. Pure.</summary>
+    public static string PackageOf(string path)
+    {
+        var slash = path.IndexOf('/');
+        return slash > 0 ? path[..slash] : path;
+    }
+
+    /// <summary>Whether this mesh browses source REMOTELY: it does not persist source nodes
+    /// (<see cref="PrebuiltAssemblySeeder.ImportSourceNodesConfigKey"/> off). Pure over config.</summary>
+    public static bool BrowsesRemotely(IServiceProvider? services) =>
+        !PrebuiltAssemblySeeder.ImportSourceNodes(services);
+
+    /// <summary>A stand-in node for a browsed file, so the shell's existing code tree — which
+    /// walks nodes — renders the registry's listing unchanged: same path, same label, the Code
+    /// node type, no content. Pure.</summary>
+    public static MeshNode Synthesize(ModuleSourceFile file) =>
+        MeshNode.FromPath(file.NodePath) with
+        {
+            Name = file.FileName,
+            NodeType = "Code",
+        };
+}

--- a/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
@@ -513,6 +513,22 @@ public static class NodeTypeLayoutAreas
                         node.Path, CodeQueryResolver.DefaultSourceGroupName);
                 if (groups.Count == 0)
                     return Observable.Return<IReadOnlyList<(CodeQueryGroup, IReadOnlyList<MeshNode>)>>([]);
+                // 🚨 The adopt-only mesh (#2193 §C): source nodes are not persisted here, so the
+                // groups' node queries would resolve to nothing and the tree would read like a
+                // module with no code. Instead each group lists through the registry-backed
+                // source browser — the same tree, walked over stand-in nodes whose paths are
+                // exactly the paths the imported nodes would have had.
+                if (ModuleSourceBrowsing.BrowsesRemotely(host.Hub.ServiceProvider))
+                {
+                    var browser = host.Hub.ServiceProvider.GetService<IModuleSourceBrowser>();
+                    if (browser is null)
+                        return Observable.Return<IReadOnlyList<(CodeQueryGroup, IReadOnlyList<MeshNode>)>>(
+                            groups.Select(g => (g, (IReadOnlyList<MeshNode>)[])).ToList());
+                    var remote = groups.Select(g => BrowseGroup(browser, g, node.Path)
+                        .Select(nodes => (Group: g, Nodes: nodes)));
+                    return Observable.CombineLatest(remote)
+                        .Select(list => (IReadOnlyList<(CodeQueryGroup, IReadOnlyList<MeshNode>)>)list.ToList());
+                }
                 var streams = groups.Select(g =>
                     RunQueries(host, g.ExpandedQueries).Select(nodes => (Group: g, Nodes: nodes)));
                 return Observable.CombineLatest(streams)
@@ -749,9 +765,68 @@ public static class NodeTypeLayoutAreas
                     "*No source file selected — pick one from the Sources or Tests tree.*")
                 .WithStyle("padding: 24px;"));
 
+        // The adopt-only mesh (#2193 §C): there is no Code node to embed — the file is read from
+        // the module's repo through the registry and rendered read-only, at the same URL an
+        // imported node would answer. No browser → the shell says why, never a blank page.
+        if (ModuleSourceBrowsing.BrowsesRemotely(host.Hub.ServiceProvider))
+        {
+            var browser = host.Hub.ServiceProvider.GetService<IModuleSourceBrowser>();
+            if (browser is null)
+                return Observable.Return<UiControl?>(
+                    Controls.Markdown(ModuleSourceBrowsing.NeedsRegistryMarkdown).WithStyle("padding: 24px;"));
+            return browser.FetchSource(ModuleSourceBrowsing.PackageOf(codePath!), codePath!)
+                .Take(1)
+                .Select(text => text is null
+                    ? Controls.Markdown(ModuleSourceBrowsing.NotServedMarkdown(codePath!))
+                        .WithStyle("padding: 24px;")
+                    : (UiControl?)BrowsedSourceView(codePath!, text))
+                .Catch<UiControl?, Exception>(ex => Observable.Return<UiControl?>(
+                    Controls.Markdown($"*Could not read `{codePath}` through the registry:* {ex.Message}")
+                        .WithStyle("padding: 24px;")));
+        }
+
         return Observable.Return<UiControl?>(
             new LayoutAreaControl(new Address(codePath!), new LayoutAreaReference(CodeLayoutAreas.ContentArea))
                 .WithStyle("width: 100%;"));
+    }
+
+    /// <summary>A browsed (registry-served) source file: its path as the heading, the text in a
+    /// read-only editor. Pure — pinned in ModuleSourceBrowsingTest.</summary>
+    internal static UiControl BrowsedSourceView(string nodePath, string text) =>
+        Controls.Stack
+            .WithStyle("width: 100%; gap: 8px;")
+            .WithView(Controls.Markdown($"##### `{nodePath}` — read from the module's repository")
+                .WithStyle("margin: 8px 0 0 0;"))
+            .WithView(BrowsedSourceEditor(text));
+
+    /// <summary>The editor a browsed file renders in: read-only always — the repository is the
+    /// truth, and there is no node here to write back to. Pure.</summary>
+    internal static CodeEditorControl BrowsedSourceEditor(string text) =>
+        new CodeEditorControl()
+            .WithValue(text)
+            .WithLanguage("csharp")
+            .WithReadonly(true)
+            .WithLineNumbers(true)
+            .WithMinimap(false)
+            .WithHeight("70vh");
+
+    /// <summary>One source/test group, listed through the browser: the package's files whose
+    /// node paths fall under the group's namespace root (a type's own <c>Source/</c>, or a
+    /// <c>shared=@Pkg/…</c> root in another package), as stand-in nodes. A group with no
+    /// resolvable root lists nothing. Pure over the browser's answer.</summary>
+    internal static IObservable<IReadOnlyList<MeshNode>> BrowseGroup(
+        IModuleSourceBrowser browser, CodeQueryGroup group, string nodeTypePath)
+    {
+        var root = group.BaseNamespace;
+        if (string.IsNullOrEmpty(root))
+            return Observable.Return<IReadOnlyList<MeshNode>>([]);
+        return browser.ListSources(ModuleSourceBrowsing.PackageOf(root!))
+            .Take(1)
+            .Select(files => (IReadOnlyList<MeshNode>)files
+                .Where(f => f.NodePath.StartsWith(root! + "/", StringComparison.Ordinal))
+                .Select(ModuleSourceBrowsing.Synthesize)
+                .ToList())
+            .Catch<IReadOnlyList<MeshNode>, Exception>(_ => Observable.Return<IReadOnlyList<MeshNode>>([]));
     }
 
     /// <summary>

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Domain;
 using Microsoft.Extensions.DependencyInjection;
 using MeshWeaver.Graph;
@@ -96,6 +97,11 @@ public static class PluginCatalogConfigurationExtensions
                 // Resolves the effective registry token: configured token, else the stored
                 // auto-registration credential (decrypted), else empty.
                 .AddSingleton<RegistryTokenResolver>()
+                // The source-browsing seam (#2193 §C): a mesh that keeps no source nodes reads a
+                // module's source from its repo THROUGH the registry it installs from. Registered
+                // wherever the catalog is; a mesh with no registry configured resolves the
+                // browser but lists nothing, and the shell says so.
+                .AddSingleton<IModuleSourceBrowser, RegistrySourceBrowser>()
                 // Re-runs the install hooks for ALREADY-installed packages once at startup. Packages
                 // installed before hooks existed never registered their agent/skill sources, so on a
                 // live instance every user's picker is missing them — and nothing else would fix it

--- a/src/MeshWeaver.PluginCatalog/RegistrySourceBrowser.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistrySourceBrowser.cs
@@ -1,0 +1,123 @@
+using System.Reactive.Linq;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The registry-backed <see cref="IModuleSourceBrowser"/> (MeshWeaver#2193 §C): lists a module's
+/// compile inputs from the package's <c>manifest.lock</c> as the registry serves it, and reads a
+/// file's text through the registry's authenticated <c>/api/plugins/files</c> route with a
+/// one-path filter — the very lane installs already use, so nothing new is exposed and nothing
+/// a consumer could not already fetch is served. The registry resolves the package from its
+/// curated catalog and reads with ITS credential; this mesh presents only the instance key it
+/// already holds.
+///
+/// <para>Registries are the ones this mesh installs from (<see cref="PluginCatalogOptions"/>,
+/// legacy single entry folded in exactly as the default install does). A package is looked up
+/// across them in configured order; the first registry advertising it serves it. Reactive
+/// end-to-end; cold; every call is its own read — the browse surface is rare and small, and a
+/// cache here would only hide a registry that stopped serving.</para>
+/// </summary>
+public sealed class RegistrySourceBrowser(
+    IMessageHub hub,
+    RegistryTokenResolver tokens,
+    IOptions<PluginCatalogOptions> options,
+    ILogger<RegistrySourceBrowser>? logger = null) : IModuleSourceBrowser
+{
+    private sealed record Hit(RegistryPackageSource Source, string GitRef, PackageManifest Package);
+
+    public IObservable<IReadOnlyList<ModuleSourceFile>> ListSources(string packageId) =>
+        Find(packageId).SelectMany(hit => hit is null
+            ? Observable.Return<IReadOnlyList<ModuleSourceFile>>([])
+            : hit.Source.FetchPackageFiles(hit.Package, hit.GitRef, [ManifestPath(packageId)])
+                .Take(1)
+                .Select(files => SourcesOf(files
+                    .FirstOrDefault(f => ModuleManifest.IsManifestPath(f.RelativePath))?.Content, logger)));
+
+    public IObservable<string?> FetchSource(string packageId, string nodePath) =>
+        Find(packageId).SelectMany(hit => hit is null
+            ? Observable.Return<string?>(null)
+            : hit.Source.FetchPackageFiles(hit.Package, hit.GitRef, [ManifestPath(packageId)])
+                .Take(1)
+                .SelectMany(files =>
+                {
+                    var file = SourcesOf(files
+                            .FirstOrDefault(f => ModuleManifest.IsManifestPath(f.RelativePath))?.Content, logger)
+                        .FirstOrDefault(f => string.Equals(f.NodePath, nodePath, StringComparison.Ordinal));
+                    return file is null
+                        ? Observable.Return<string?>(null)
+                        : hit.Source.FetchPackageFiles(hit.Package, hit.GitRef, [file.RelativePath])
+                            .Take(1)
+                            .Select(list => list.FirstOrDefault()?.Content);
+                }));
+
+    // ─────────────────────────────────────────────────────────────────── pure
+
+    /// <summary>The package's manifest path inside its files — the same path the installer's
+    /// incremental update fetches.</summary>
+    public static string ManifestPath(string packageId) => $"{packageId}/{ModuleManifest.FileName}";
+
+    /// <summary>The compile inputs a manifest lists, as browsable files: every entry under a
+    /// <c>Source/</c>/<c>Test/</c> directory (<see cref="NodeFileMapper.IsCompileInputPath"/>),
+    /// keyed by the node path it would have had. No manifest, or an unparseable one, lists
+    /// nothing. Pure.</summary>
+    public static IReadOnlyList<ModuleSourceFile> SourcesOf(string? manifestJson, ILogger? logger = null)
+    {
+        if (string.IsNullOrWhiteSpace(manifestJson))
+            return [];
+        var manifest = ModuleManifest.TryParse(manifestJson!, logger);
+        if (manifest is null)
+            return [];
+        return manifest.Files.Keys
+            .Where(NodeFileMapper.IsCompileInputPath)
+            .Select(ToSourceFile)
+            .OrderBy(f => f.NodePath, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>A repo file → the node it would have been: the installer's own path mapping
+    /// (<see cref="NodeFileMapper.FromRelativePath"/>), so a browsed file and an imported node
+    /// share one address. Pure.</summary>
+    public static ModuleSourceFile ToSourceFile(string relativePath)
+    {
+        var (id, ns) = NodeFileMapper.FromRelativePath(relativePath);
+        var nodePath = string.IsNullOrEmpty(ns) ? id : $"{ns}/{id}";
+        var slash = relativePath.LastIndexOf('/');
+        return new ModuleSourceFile(nodePath, relativePath, slash < 0 ? relativePath : relativePath[(slash + 1)..]);
+    }
+
+    // The first configured registry advertising the package, with the source to fetch it from.
+    private IObservable<Hit?> Find(string packageId)
+    {
+        var registries = RegistryTokenResolver.WithLegacyTokens(options.Value, options.Value.EffectiveRegistries);
+        if (registries.Count == 0)
+            return Observable.Return<Hit?>(null);
+        return registries
+            .Select(registry => tokens.ResolveToken(registry).Take(1)
+                .SelectMany(token =>
+                {
+                    var gitRef = string.IsNullOrWhiteSpace(registry.Ref) ? "HEAD" : registry.Ref;
+                    var source = new RegistryPackageSource(hub, registry.Url, token);
+                    return source.ListPackages(gitRef).Take(1)
+                        .Select(packages => packages
+                            .Where(p => string.Equals(p.Id, packageId, StringComparison.OrdinalIgnoreCase))
+                            .Select(p => (Hit?)new Hit(source, gitRef, p))
+                            .FirstOrDefault())
+                        .Catch<Hit?, Exception>(ex =>
+                        {
+                            logger?.LogWarning(ex,
+                                "Source browsing: listing {Registry} for '{Package}' failed — trying the next registry",
+                                registry.Url, packageId);
+                            return Observable.Return<Hit?>(null);
+                        });
+                }))
+            .ToObservable()
+            .Concat()
+            .FirstOrDefaultAsync(hit => hit is not null)
+            .Select(hit => hit);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ModuleSourceBrowsingTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModuleSourceBrowsingTest.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Compiler;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The shell side of source browsing (MeshWeaver#2193 §C): on a mesh that keeps no source nodes,
+/// the Sources/Tests trees list through the browser as stand-in nodes at the imported nodes'
+/// exact paths, a group filters to its own namespace root, and the Code area renders a browsed
+/// file read-only — or says plainly why it cannot.
+/// </summary>
+public class ModuleSourceBrowsingTest
+{
+    private sealed class FakeBrowser(IReadOnlyList<ModuleSourceFile> files) : IModuleSourceBrowser
+    {
+        public IObservable<IReadOnlyList<ModuleSourceFile>> ListSources(string packageId) =>
+            Observable.Return<IReadOnlyList<ModuleSourceFile>>(
+                files.Where(f => ModuleSourceBrowsing.PackageOf(f.NodePath) == packageId).ToList());
+
+        public IObservable<string?> FetchSource(string packageId, string nodePath) =>
+            Observable.Return<string?>(files.Any(f => f.NodePath == nodePath) ? "// text" : null);
+    }
+
+    private static readonly IReadOnlyList<ModuleSourceFile> Files =
+    [
+        new("Store/Plugin/Source/PluginContent", "Store/Plugin/Source/PluginContent.cs", "PluginContent.cs"),
+        new("Store/Plugin/Test/PluginCoverTests", "Store/Plugin/Test/PluginCoverTests.cs", "PluginCoverTests.cs"),
+        new("Store/Core/Source/MeshQueries", "Store/Core/Source/MeshQueries.cs", "MeshQueries.cs"),
+        new("Edu/Module/Source/CourseAppTile", "Edu/Module/Source/CourseAppTile.cs", "CourseAppTile.cs"),
+    ];
+
+    [Fact]
+    public void Synthesize_StandsInForTheImportedNode_AtTheSamePath()
+    {
+        var node = ModuleSourceBrowsing.Synthesize(Files[0]);
+        node.Path.Should().Be("Store/Plugin/Source/PluginContent", "same address as the imported node");
+        node.Name.Should().Be("PluginContent.cs");
+        node.NodeType.Should().Be("Code");
+        node.Content.Should().BeNull("a stand-in carries no content — the text is fetched on open");
+        ModuleSourceBrowsing.PackageOf("Store/Plugin/Source/PluginContent").Should().Be("Store");
+    }
+
+    [Fact]
+    public void BrowseGroup_ListsOnlyTheGroupsOwnRoot_AndSharedRootsFromTheirPackage()
+    {
+        var browser = new FakeBrowser(Files);
+        var own = new CodeQueryGroup("src", [], [], "Store/Plugin/Source");
+        var ownNodes = NodeTypeLayoutAreas.BrowseGroup(browser, own, "Store/Plugin").Wait();
+        // The type's own Source/ root lists its files and nothing from Test/ or other types.
+        ownNodes.Select(n => n.Path).Should().Equal(new[] { "Store/Plugin/Source/PluginContent" });
+
+        var shared = new CodeQueryGroup("shared", [], [], "Store/Core/Source");
+        // A shared=@Store/Core/Source root lists from ITS package, whoever compiles it.
+        NodeTypeLayoutAreas.BrowseGroup(browser, shared, "Edu/Module").Wait()
+            .Select(n => n.Path).Should().Equal(new[] { "Store/Core/Source/MeshQueries" });
+
+        var rootless = new CodeQueryGroup("raw", ["nodeType:Code"], ["nodeType:Code"], null);
+        NodeTypeLayoutAreas.BrowseGroup(browser, rootless, "Store/Plugin").Wait()
+            .Should().BeEmpty("a group with no resolvable root cannot be browsed and lists nothing");
+    }
+
+    [Fact]
+    public void BrowsedSourceView_IsReadOnly_AndNamesTheFile()
+    {
+        var view = NodeTypeLayoutAreas.BrowsedSourceView("Store/Plugin/Source/PluginContent", "// text");
+        view.Should().BeOfType<StackControl>("the heading and the editor stack vertically");
+        var editor = NodeTypeLayoutAreas.BrowsedSourceEditor("// text");
+        editor.Readonly.Should().Be(true, "a browsed file is never editable here — the repo is the truth");
+        editor.Value.Should().Be("// text");
+        editor.Language.Should().Be("csharp");
+    }
+
+    [Fact]
+    public void TheShellSaysWhyWhenItCannotBrowse()
+    {
+        ModuleSourceBrowsing.NeedsRegistryMarkdown.Should().Contain("registry");
+        ModuleSourceBrowsing.NotServedMarkdown("Edu/Module/Source/Gone").Should().Contain("Edu/Module/Source/Gone");
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/RegistrySourceBrowserTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RegistrySourceBrowserTest.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+#pragma warning disable CS1591
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The pure half of the registry source browser (MeshWeaver#2193 §C): a package manifest lists
+/// exactly its compile inputs, keyed by the node paths the imported files would have had — so a
+/// browsed file and an imported node share one address — and a file the manifest does not carry
+/// is simply not a source.
+/// </summary>
+public class RegistrySourceBrowserTest
+{
+    private static string Manifest(params string[] files) =>
+        JsonSerializer.Serialize(new
+        {
+            module = "Store",
+            moduleVersion = "abc",
+            files = files.ToDictionary(f => f, _ => "sha"),
+        }, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+    [Fact]
+    public void SourcesOf_ListsCompileInputsOnly_KeyedByNodePath()
+    {
+        var sources = RegistrySourceBrowser.SourcesOf(Manifest(
+            "Store/index.json",
+            "Store/Plugin.json",
+            "Store/Plugin/Source/PluginContent.cs",
+            "Store/Plugin/Test/PluginCoverTests.cs",
+            "Store/Source/Shared.cs",
+            "Store/Guide.md"));
+
+        sources.Should().HaveCount(3, "only files under Source/ or Test/ directories are compile inputs");
+        sources.Select(s => s.NodePath).Should().Equal(
+            "Store/Plugin/Source/PluginContent",
+            "Store/Plugin/Test/PluginCoverTests",
+            "Store/Source/Shared");
+        sources[0].RelativePath.Should().Be("Store/Plugin/Source/PluginContent.cs");
+        sources[0].FileName.Should().Be("PluginContent.cs");
+    }
+
+    [Fact]
+    public void SourcesOf_NoOrBrokenManifest_ListsNothing()
+    {
+        RegistrySourceBrowser.SourcesOf(null).Should().BeEmpty();
+        RegistrySourceBrowser.SourcesOf("").Should().BeEmpty();
+        RegistrySourceBrowser.SourcesOf("{ not json").Should().BeEmpty("a broken manifest is an empty listing, never a throw");
+    }
+
+    [Fact]
+    public void ToSourceFile_UsesTheInstallersPathMapping()
+    {
+        var file = RegistrySourceBrowser.ToSourceFile("Edu/Module/Source/CourseAppTile.cs");
+        file.NodePath.Should().Be("Edu/Module/Source/CourseAppTile",
+            "the node path is the file path without its extension — the installer's mapping");
+        file.FileName.Should().Be("CourseAppTile.cs");
+        RegistrySourceBrowser.ManifestPath("Edu").Should().Be("Edu/manifest.lock");
+    }
+}


### PR DESCRIPTION
Stacked on #2200 (retargets to `main` when it merges). Implements MeshWeaver#2193 §C — the piece that makes §B(c)'s purge safe to run later: browsing no longer depends on source nodes.

## What changed

- **Seam** (`MeshWeaver.Graph`): `IModuleSourceBrowser` (`ListSources`, `FetchSource`) + `ModuleSourceBrowsing`. On a mesh with `Modules:ImportSourceNodes=false` the NodeType shell lists each Sources/Tests group through the browser as stand-in nodes at **exactly the paths the imported nodes would have had** (own `Source/` root; `shared=@Pkg/…` roots listed from *their* package), and the Code area renders a browsed file read-only at the same URL.
- **Implementation** (`MeshWeaver.PluginCatalog`): `RegistrySourceBrowser` — compile inputs from the package's `manifest.lock` as the registry serves it; file text through the registry's existing authenticated `/api/plugins/files` route with a one-path filter. **No new endpoint, nothing newly exposed**: the registry resolves the package from its curated catalog and reads with its own GitHub App credential; the consumer presents only its instance key. Registries = the ones the mesh installs from, in order.
- **Honest failure modes**: no browser → *source browsing needs the registry*; a file the registry does not serve → named; a registry that fails to list → next one, logged.
- Meshes that keep importing source (default) are unchanged — the fallback keys on the same policy flag that removed the nodes.

## Contract pinned

`ModuleSourceBrowsingTest` (Graph, 4): stand-in paths; per-root filtering (own root, shared root from its package, rootless lists nothing); read-only editor; messages. `RegistrySourceBrowserTest` (PluginCatalog, 3): manifest → compile inputs only, keyed by node path via the installer's own mapping; absent/broken manifest lists nothing. Graph + PluginCatalog build Release `-warnaserror`.

Refs #2193. Merge is yours, Roland.

🤖 Generated with [Claude Code](https://claude.com/claude-code)