### PR TITLE
fix(search): the view-options bar overflowed the header instead of giving way

### DIFF
--- a/src/MeshWeaver.Blazor.Views/Components/MeshSearchView.razor.css
+++ b/src/MeshWeaver.Blazor.Views/Components/MeshSearchView.razor.css
@@ -48,7 +48,10 @@
 }
 
 .mesh-search-header .mesh-search-viewbar {
-    flex: 0 0 auto;
+    /* 0 1 auto, not 0 0 auto: the search box keeps its 320px basis, so a bar that may not shrink
+       simply runs off the end of the row. */
+    flex: 0 1 auto;
+    min-width: 0;
     margin-left: auto;
     margin-bottom: 12px;
 }
@@ -217,6 +220,11 @@
     gap: 8px;
     margin-bottom: 12px;
     min-height: 28px;
+    /* Give way instead of overflowing (#2216). Every piece of this bar is a flex container, and a
+       flex item's default `min-width: auto` refuses to shrink below its content — so without these
+       the bar could neither wrap nor narrow, and drew its selects over the search input with the
+       captions cut mid-word. `flex-wrap` here, `min-width: 0` on each nested container below. */
+    flex-wrap: wrap;
 }
 
 .mesh-search-viewbar-spacer {
@@ -227,6 +235,7 @@
     display: flex;
     align-items: center;
     gap: 6px;
+    min-width: 0;
 }
 
 .mesh-search-viewbar-label {
@@ -236,6 +245,7 @@
 
 .mesh-search-groupby,
 .mesh-search-sortby {
+    min-width: 0;
     font-size: 13px;
     padding: 3px 24px 3px 8px;
     height: 28px;

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-view-options-bar-gives-way.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-view-options-bar-gives-way.md
@@ -1,0 +1,27 @@
+---
+Name: The sort and group controls stop overlapping the search box
+Category: Fix
+Description: On a home or search page, the Group by / Sort by controls beside the search box drew on top of it and cut their own captions mid-word — worst inside a narrow panel. The bar now wraps onto its own line instead of running off the end of the row.
+Icon: Options
+Order: -20260825
+---
+
+# The sort and group controls stop overlapping the search box
+
+The view-options bar — *Group by ▾ · Sort by ▾ · ⚙* — shares one row with the search box. When that
+row ran out of width the bar did not wrap and did not shrink: it **overflowed**, painting its
+dropdowns across the search input and past the edge of the page, with captions cut mid-word. A
+narrow container made it worse, so it was most visible in a side panel, but it was already wrong at
+full width.
+
+The cause is a flexbox default that catches everyone once. A flex item's `min-width` is `auto`,
+which means "never shrink below your content" — so a row of them cannot give way when space runs
+short. Nothing was constraining the bar to the space it had; each piece simply kept its natural
+width and drew wherever that landed.
+
+The bar now wraps, and every container inside it may narrow. When the row is wide, nothing changes.
+When it is not, the controls drop onto their own line and stay whole and legible, which is what the
+layout intended all along.
+
+A guard test pins the four declarations that make this work, checked against the stylesheet itself —
+remove any one of them and it fails, naming which.

--- a/test/MeshWeaver.Hosting.Blazor.Test/SearchViewBarWrapTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/SearchViewBarWrapTest.cs
@@ -81,12 +81,21 @@ public class SearchViewBarWrapTest
         Assert.Matches(@"min-width:\s*0", body);
     }
 
-    [Fact]
-    public void ViewBarSelects_CanShrink()
+    /// <summary>
+    /// The selects carry the longest content ("Last accessed"). They must be allowed to narrow;
+    /// otherwise the field shrinks to nothing and the select still overflows it.
+    ///
+    /// <para>BOTH are named, not just one. They share a grouped rule today, so asserting either
+    /// covers both — but the day someone splits the group, an assertion on one selector keeps
+    /// passing while the other regresses (Copilot review, #2219). The guard has to say what it
+    /// means: every select in this bar can shrink.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(".mesh-search-groupby")]
+    [InlineData(".mesh-search-sortby")]
+    public void ViewBarSelects_CanShrink(string selector)
     {
-        // The selects carry the longest content ("Last accessed"). They must be allowed to narrow;
-        // otherwise the field shrinks to nothing and the select still overflows it.
-        var body = RuleBody(Stylesheet(), ".mesh-search-sortby");
+        var body = RuleBody(Stylesheet(), selector);
         Assert.Matches(@"min-width:\s*0", body);
     }
 }

--- a/test/MeshWeaver.Hosting.Blazor.Test/SearchViewBarWrapTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/SearchViewBarWrapTest.cs
@@ -1,0 +1,92 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// 🚨 <b>The view-options bar must be able to WRAP, and its fields must be able to SHRINK.</b>
+///
+/// <para>The bar (<c>Group by ▾ · Sort by ▾ · ⚙</c>) shares one header row with the search box on
+/// desktop. Every piece of it is a flex container, and a flex item's default <c>min-width: auto</c>
+/// refuses to shrink below its content — so with no <c>flex-wrap</c> and no <c>min-width: 0</c> the
+/// bar cannot give way when the row runs out of space. It does not clip and it does not wrap: it
+/// OVERFLOWS, drawing its selects on top of the search input and past the container's edge, with the
+/// labels cut mid-word (#2216: "Type" rendered as "pe", an empty select overlapping "Last accessed").
+/// It was wrong at full width and worse in a narrow pane.</para>
+///
+/// <para>This asserts the four rules that let the row give way, against the stylesheet itself. A
+/// rendering test would need a browser and a viewport; the defect, however, is entirely in these
+/// declarations — remove any one of them and the overflow returns.</para>
+/// </summary>
+public class SearchViewBarWrapTest
+{
+    private static string Stylesheet()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        var path = Path.Combine(dir!.FullName,
+            "src", "MeshWeaver.Blazor.Views", "Components", "MeshSearchView.razor.css");
+        Assert.True(File.Exists(path), $"stylesheet not found at {path}");
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>
+    /// The declarations of one CSS rule, by EXACT selector — the rule's own block only.
+    ///
+    /// <para>Anchored at the start of a line, because <c>.mesh-search-viewbar</c> is also the tail
+    /// of <c>.mesh-search-header .mesh-search-viewbar</c>: an unanchored match reads the descendant
+    /// rule's body and answers a question about the wrong rule. Caught by this test failing after
+    /// the fix had already landed in the rule it was meant to check.</para>
+    /// </summary>
+    private static string RuleBody(string css, string selector)
+    {
+        var match = Regex.Match(
+            css,
+            $@"^{Regex.Escape(selector)}\s*(,[^{{]*)?\{{(?<body>[^}}]*)\}}",
+            RegexOptions.Multiline);
+        Assert.True(match.Success, $"no rule found for '{selector}'");
+        return match.Groups["body"].Value;
+    }
+
+    [Fact]
+    public void ViewBar_Wraps_RatherThanOverflowing()
+    {
+        var body = RuleBody(Stylesheet(), ".mesh-search-viewbar");
+        Assert.Matches(@"flex-wrap:\s*wrap", body);
+    }
+
+    [Fact]
+    public void ViewBar_CanShrink_WithinTheHeaderRow()
+    {
+        // In the header the bar sat at `flex: 0 0 auto` — it could neither shrink nor wrap, so the
+        // search box kept its 320px basis and the bar ran off the end.
+        var body = RuleBody(Stylesheet(), ".mesh-search-header .mesh-search-viewbar");
+        Assert.Matches(@"flex:\s*0\s+1\s+auto", body);
+        Assert.Matches(@"min-width:\s*0", body);
+    }
+
+    [Fact]
+    public void ViewBarField_CanShrinkBelowItsContent()
+    {
+        // Each `label` is itself a flex container holding a caption and a select. Without
+        // `min-width: 0` its default `min-width: auto` keeps it at content width, and the caption
+        // is what gets painted over.
+        var body = RuleBody(Stylesheet(), ".mesh-search-viewbar-field");
+        Assert.Matches(@"min-width:\s*0", body);
+    }
+
+    [Fact]
+    public void ViewBarSelects_CanShrink()
+    {
+        // The selects carry the longest content ("Last accessed"). They must be allowed to narrow;
+        // otherwise the field shrinks to nothing and the select still overflows it.
+        var body = RuleBody(Stylesheet(), ".mesh-search-sortby");
+        Assert.Matches(@"min-width:\s*0", body);
+    }
+}


### PR DESCRIPTION
Closes #2216.

## The defect

The view-options bar — *Group by ▾ · Sort by ▾ · ⚙* — shares one row with the search box. When the
row ran out of width it neither wrapped nor shrank: it **overflowed**, painting its selects over the
search input and past the container's edge, with captions cut mid-word ("Type" rendered as `pe`, an
empty select drawn across "Last accessed"). Worst inside a narrow panel, but already wrong at full
width.

## Root cause

Every piece of the bar is a flex container, and a flex item's `min-width` defaults to `auto` —
*never shrink below your content*. With no `flex-wrap` on the bar and `flex: 0 0 auto` on it inside
the header, nothing could give way: the search box kept its `320px` basis and the bar simply ran off
the end, each nested container holding its natural width and drawing wherever that landed.

Four declarations, one per level that has to yield:

| Selector | Added |
|---|---|
| `.mesh-search-viewbar` | `flex-wrap: wrap` |
| `.mesh-search-header .mesh-search-viewbar` | `flex: 0 1 auto` + `min-width: 0` |
| `.mesh-search-viewbar-field` | `min-width: 0` |
| `.mesh-search-groupby` / `.mesh-search-sortby` | `min-width: 0` |

Wide rows are unchanged; a tight row drops the controls onto their own line, whole and legible.

## Test first, and it can fail

`SearchViewBarWrapTest` reads the stylesheet and pins those four declarations:

| | |
|---|---|
| written **before** the fix | **4 failed, 0 passed** |
| after the fix | **4 passed** |
| each declaration removed again | its own assertion fails, naming which |

A browser test would need a viewport; the defect is entirely in these declarations, and removing any
one returns the overflow.

## Two mistakes the red run caught

Recorded rather than quietly fixed, because both are the same family as the bug:

- **The test's rule matcher was unanchored**, so `.mesh-search-viewbar` matched the *tail* of
  `.mesh-search-header .mesh-search-viewbar` and answered about the wrong rule — it went red after
  the fix had already landed in the rule it was meant to check. Now anchored, with the reason in the
  code.
- **My first negative control was wrong, not the test.** It stripped `flex-wrap` from
  `.mesh-search-header`, which carries that declaration too, and so appeared to prove an assertion
  vacuous that is not. Re-targeted at the correct rule, it fails as it should.

## Gates

```
Release -warnaserror, 3 touched projects   0 Warning(s), 0 Error(s)
MeshWeaver.Hosting.Blazor.Test             480 / 480
MeshWeaver.Documentation.Test               42 /  42   (incl. the What's New integrity check)
```

Ships with a `Category: Fix` What's New entry, as this is a change a user can notice.
