### PR TITLE
fix(ai): one agent slug is one picker row — collapse the registry layers

### DIFF
--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -373,7 +373,7 @@ public static class AgentPickerProjection
                 $"{AgentsQueryId}|u={userPath ?? ""}|s={spacePath ?? ""}|q={Fingerprint(queries)}",
                 queries))
             .Switch()
-            .Select(snapshot => ProjectAgents(snapshot, hub.JsonSerializerOptions, locale));
+            .Select(snapshot => ProjectAgents(snapshot, hub.JsonSerializerOptions, locale, userPath, spacePath));
     }
 
     /// <summary>Deterministic short fingerprint of a resolved query set, for cache-keying the
@@ -643,10 +643,32 @@ public static class AgentPickerProjection
     /// 🌍 The viewer's language, resolved ONCE on the render turn and passed down — see
     /// <see cref="ToAgentDisplayInfo"/> for why it is an argument and not an ambient read.
     /// </param>
+    /// <param name="userPath">The viewer's home partition — its <c>{user}/Agent</c> layer wins a
+    /// slug collision (see the layer note above). Null for the programmatic generators.</param>
+    /// <param name="spacePath">The context/space path — its layer wins over any other package's.</param>
     public static IReadOnlyList<AgentDisplayInfo> ProjectAgents(
-        IEnumerable<MeshNode> snapshot, JsonSerializerOptions jsonOptions, string? locale = null)
+        IEnumerable<MeshNode> snapshot, JsonSerializerOptions jsonOptions, string? locale = null,
+        string? userPath = null, string? spacePath = null)
     {
-        var byPath = new Dictionary<string, AgentDisplayInfo>(StringComparer.Ordinal);
+        // 🚨 Collapse the registry LAYERS: one agent SLUG is one row.
+        //
+        // The registry is deliberately layered — the same agent exists as a platform default
+        // (`Agent/Tutor`), as a package's shipped copy (`Essentials/Agent/Tutor`) and as the copy
+        // plugin install rebases into the viewer's home (`{user}/Agent/Tutor`). Keying this dict by
+        // node.Path (as it was until 2026-08-25) made every layer its own dropdown row: users saw
+        // ToolsReference twice and most platform agents three times.
+        //
+        // De-duplicating by PATH was not merely untidy, it offered a choice the execution side
+        // cannot honour: an agent is ADDRESSED by its slug (handoffs, /agent, the chat chip,
+        // SetSelectedAgent), and AgentChatClient.CreateAgentsSync keys its dict on exactly that
+        // (`createdAgents.SetItem(agentConfig.Id, agent)`). Three rows sharing one slug already
+        // collapsed to ONE executable agent — whichever won a last-write-wins race.
+        //
+        // So: group by slug, and keep the MOST SPECIFIC layer (LayerRank). Ties inside one layer
+        // resolve by ordinal path, because a synced-query snapshot carries no ordering guarantee
+        // and the surviving row must not depend on arrival order.
+        var bySlug = new Dictionary<string, (AgentDisplayInfo Info, int Rank, string Path)>(
+            StringComparer.OrdinalIgnoreCase);
         foreach (var node in snapshot)
         {
             if (node.Path == null) continue;
@@ -654,8 +676,18 @@ public static class AgentPickerProjection
                 continue;
 
             var info = ToAgentDisplayInfo(node, jsonOptions, locale);
-            if (info != null)
-                byPath[node.Path] = info;
+            if (info == null) continue;
+
+            // A node whose configuration carries no slug is not addressable by one — key it by its
+            // own path so it stays a row of its own instead of collapsing with every other such node.
+            var slug = string.IsNullOrWhiteSpace(info.AgentConfiguration?.Id)
+                ? node.Path
+                : info.AgentConfiguration!.Id;
+            var rank = LayerRank(node, userPath, spacePath);
+            if (!bySlug.TryGetValue(slug, out var winner)
+                || rank < winner.Rank
+                || (rank == winner.Rank && string.CompareOrdinal(node.Path, winner.Path) < 0))
+                bySlug[slug] = (info, rank, node.Path);
         }
 
         // Group by harness (GroupName) so the picker shows major categories —
@@ -663,11 +695,33 @@ public static class AgentPickerProjection
         // contiguous (SimpleDropdown renders a header when the group key changes).
         // Alphabetical group order happens to give Claude Code, GitHub Copilot,
         // MeshWeaver; within a group, Order then Name (Assistant's order:-1 leads MeshWeaver).
-        return byPath.Values
+        return bySlug.Values
+            .Select(winner => winner.Info)
             .OrderBy(a => a.GroupName ?? Harnesses.MeshWeaver, StringComparer.OrdinalIgnoreCase)
             .ThenBy(a => a.Order)
             .ThenBy(a => a.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    /// <summary>
+    /// How SPECIFIC an agent node's layer is — the tie-break when one slug is shipped by several
+    /// layers. Lower wins: the viewer's own copy, then the space being chatted in, then any other
+    /// package, and last the bare platform default. Pure.
+    /// </summary>
+    private static int LayerRank(MeshNode node, string? userPath, string? spacePath)
+    {
+        var ns = node.Namespace;
+        if (!string.IsNullOrEmpty(userPath)
+            && string.Equals(ns, $"{userPath}/{AgentSubNamespace}", StringComparison.OrdinalIgnoreCase))
+            return 0;
+        if (PartitionOf(spacePath) is { Length: > 0 } space
+            && string.Equals(ns, $"{space}/{AgentSubNamespace}", StringComparison.OrdinalIgnoreCase))
+            return 1;
+        // The bare platform namespace is the LEAST specific: anything a package or a user ships
+        // under the same slug is a deliberate override of it.
+        if (string.Equals(ns, AgentRootNamespace, StringComparison.OrdinalIgnoreCase))
+            return 3;
+        return 2;
     }
 
     /// <summary>The utility model tier marks a programmatic generator agent (ThreadNamer,

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-agent-picker-duplicates.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-agent-picker-duplicates.md
@@ -1,0 +1,15 @@
+---
+Name: Each AI agent appears once in the chat picker
+Category: Fix
+Description: Agents shipped by more than one layer — the platform, a package and your own copy — were listed two or three times in the chat agent dropdown.
+Icon: Bot
+Order: -20260825
+---
+
+# Each AI agent appears once in the chat picker
+
+The agent dropdown in AI chat listed some agents twice or three times — the Tools Reference agent
+appeared twice, and most built-in agents once for the platform, once for the package that ships them
+and once for the copy installed into your own space. Each agent is now listed a single time, and the
+entry you get is the most specific one available: your own copy if you have it, otherwise the one
+from the space you are working in, otherwise the package's, otherwise the platform default.

--- a/test/MeshWeaver.AI.Test/AgentPickerDeduplicationTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentPickerDeduplicationTest.cs
@@ -1,0 +1,181 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the fix for the DUPLICATED agent rows in the chat picker (reported 2026-08-25: the
+/// ToolsReference agent listed twice, most platform agents three times).
+///
+/// <para><b>Why it happened.</b> The registry is deliberately LAYERED — the same agent legitimately
+/// exists as a platform default (<c>Agent/Tutor</c>), as a package's shipped copy
+/// (<c>Essentials/Agent/Tutor</c>) and as the copy plugin install rebases into the viewer's own home
+/// (<c>{user}/Agent/Tutor</c>). <see cref="AgentPickerProjection.ProjectAgents"/> de-duplicated by
+/// <c>node.Path</c>, which is DISTINCT for every layer, so each layer reached the dropdown as its own
+/// row.</para>
+///
+/// <para><b>Why de-duplicating by path was wrong rather than merely untidy.</b> The identity an agent
+/// is ADDRESSED by is its slug (<c>AgentConfiguration.Id</c>) — handoffs, <c>/agent</c>, the chat chip
+/// and <c>SetSelectedAgent</c> all use it, and <c>AgentChatClient.CreateAgentsSync</c> keys its dict
+/// on exactly that (<c>createdAgents.SetItem(agentConfig.Id, agent)</c>). Three rows sharing one slug
+/// therefore already collapsed to ONE executable agent — whichever won a last-write-wins race. The
+/// picker offered a choice the execution side could not honour.</para>
+///
+/// <para>So the projection collapses by slug, and the layer that survives is the MOST SPECIFIC one:
+/// the viewer's own copy (the one they can edit) beats a package's, which beats the platform
+/// default.</para>
+/// </summary>
+public class AgentPickerDeduplicationTest
+{
+    private static readonly JsonSerializerOptions Json = new();
+
+    private const string User = "sglauser";
+    private const string Space = "Manufacturing";
+
+    /// <param name="ns">The agent's namespace — the LAYER: <c>Agent</c> (platform),
+    /// <c>Essentials/Agent</c> (a package), <c>{user}/Agent</c> (the viewer's own).</param>
+    private static MeshNode AgentNode(string slug, string ns, string? name = null) =>
+        new(slug, ns)
+        {
+            NodeType = AgentNodeType.NodeType,
+            Name = name ?? slug,
+            Content = new AgentConfiguration { Id = slug },
+        };
+
+    [Fact]
+    public void TheReportedCase_ToolsReferenceIsListedOnce()
+    {
+        // Exactly what the local mesh held: the package's copy and the viewer's installed copy.
+        var snapshot = new[]
+        {
+            AgentNode("ToolsReference", "Essentials/Agent"),
+            AgentNode("ToolsReference", $"{User}/Agent"),
+        };
+
+        var projected = AgentPickerProjection.ProjectAgents(snapshot, Json, userPath: User);
+
+        projected.Should().ContainSingle("one agent slug is one row, however many layers ship it")
+            .Which.Path.Should().Be($"{User}/Agent/ToolsReference");
+    }
+
+    [Fact]
+    public void ThreeLayers_CollapseToTheViewersOwnCopy()
+    {
+        var snapshot = new[]
+        {
+            AgentNode("Tutor", AgentPickerProjection.AgentRootNamespace),
+            AgentNode("Tutor", "Essentials/Agent"),
+            AgentNode("Tutor", $"{User}/Agent"),
+        };
+
+        var projected = AgentPickerProjection.ProjectAgents(snapshot, Json, userPath: User);
+
+        projected.Should().ContainSingle().Which.Path.Should().Be($"{User}/Agent/Tutor",
+            "the copy in the viewer's own home is the one they can edit — most specific wins");
+    }
+
+    [Fact]
+    public void WithoutTheViewersCopy_ThePackageBeatsThePlatformDefault()
+    {
+        var snapshot = new[]
+        {
+            AgentNode("Worker", AgentPickerProjection.AgentRootNamespace),
+            AgentNode("Worker", "Essentials/Agent"),
+        };
+
+        var projected = AgentPickerProjection.ProjectAgents(snapshot, Json, userPath: User);
+
+        projected.Should().ContainSingle().Which.Path.Should().Be("Essentials/Agent/Worker",
+            "a package that ships the agent is more specific than the bare platform default");
+    }
+
+    [Fact]
+    public void TheContextSpacesCopy_BeatsAnUnrelatedPackage()
+    {
+        var snapshot = new[]
+        {
+            AgentNode("Assistant", "Essentials/Agent"),
+            AgentNode("Assistant", $"{Space}/Agent"),
+        };
+
+        var projected = AgentPickerProjection.ProjectAgents(
+            snapshot, Json, userPath: User, spacePath: Space);
+
+        projected.Should().ContainSingle().Which.Path.Should().Be($"{Space}/Agent/Assistant",
+            "the space being chatted in is more specific than a package that merely ships the slug");
+    }
+
+    [Fact]
+    public void DistinctSlugs_AreNeverCollapsed()
+    {
+        var snapshot = new[]
+        {
+            AgentNode("Tutor", $"{User}/Agent"),
+            AgentNode("Worker", $"{User}/Agent"),
+            AgentNode("ToolsReference", "Essentials/Agent"),
+        };
+
+        var projected = AgentPickerProjection.ProjectAgents(snapshot, Json, userPath: User);
+
+        // De-duplication must collapse the LAYERS of one agent, never distinct agents.
+        projected.Select(a => a.Name).OrderBy(n => n, StringComparer.Ordinal)
+            .Should().Equal("ToolsReference", "Tutor", "Worker");
+    }
+
+    [Fact]
+    public void TheWinnerDoesNotDependOnSnapshotOrder()
+    {
+        // A synced-query snapshot carries no ordering guarantee; the surviving layer must be
+        // decided by specificity, never by which row happened to arrive last.
+        var platform = AgentNode("Researcher", AgentPickerProjection.AgentRootNamespace);
+        var package = AgentNode("Researcher", "Essentials/Agent");
+        var mine = AgentNode("Researcher", $"{User}/Agent");
+
+        foreach (var order in new[]
+                 {
+                     new[] { platform, package, mine },
+                     new[] { mine, package, platform },
+                     new[] { package, mine, platform },
+                 })
+        {
+            AgentPickerProjection.ProjectAgents(order, Json, userPath: User)
+                .Should().ContainSingle().Which.Path.Should().Be($"{User}/Agent/Researcher");
+        }
+    }
+
+    [Fact]
+    public void SlugMatchingIsCaseInsensitive_LikeTheResolutionSideIs()
+    {
+        var snapshot = new[]
+        {
+            AgentNode("toolsreference", "Essentials/Agent"),
+            AgentNode("ToolsReference", $"{User}/Agent"),
+        };
+
+        var projected = AgentPickerProjection.ProjectAgents(snapshot, Json, userPath: User);
+
+        projected.Should().ContainSingle(
+            "the execution-side dict resolves slugs case-insensitively, so the picker must collapse them too");
+    }
+
+    [Fact]
+    public void WithNoViewerContext_TheProjectionStillCollapsesDeterministically()
+    {
+        // The generators (IconGenerator, DescriptionGenerator) project without a user or space.
+        var snapshot = new[]
+        {
+            AgentNode("NodeInitializer", "Essentials/Agent"),
+            AgentNode("NodeInitializer", AgentPickerProjection.AgentRootNamespace),
+        };
+
+        var projected = AgentPickerProjection.ProjectAgents(snapshot, Json);
+
+        projected.Should().ContainSingle().Which.Path.Should().Be("Essentials/Agent/NodeInitializer",
+            "without a viewer, a package copy is still more specific than the platform default");
+    }
+}


### PR DESCRIPTION
## The bug

The chat agent dropdown listed ToolsReference **twice** and most built-in agents **three times** (reported by @sglauser, 2026-08-25; confirmed on a local mesh holding 54 Agent nodes).

The registry is deliberately layered — the same agent legitimately exists as the platform package's (`Agent/Tutor`), a shipping package's (`Essentials/Agent/Tutor`) and the copy plugin install rebases into the viewer's home (`{user}/Agent/Tutor`). `ProjectAgents` de-duplicated by `node.Path`, which is distinct for every layer, so each layer reached the dropdown as its own row.

## Why this was more than cosmetic

An agent is **addressed by its slug** (`AgentConfiguration.Id`) — handoffs, `/agent`, the chat chip and `SetSelectedAgent` all use it — and `AgentChatClient.CreateAgentsSync` keys its dict on exactly that (`createdAgents.SetItem(agentConfig.Id, agent)`). Three rows sharing one slug therefore **already collapsed to one executable agent**, whichever won a last-write-wins race. The picker offered a choice the execution side could not honour, and which configuration you got was not deterministic.

## The change

Group by slug, keep the **most specific layer**: the viewer's own copy → the space being chatted in → any other package → the bare platform default. Ties inside a layer resolve by ordinal path, because a synced-query snapshot carries no ordering guarantee and the surviving row must not depend on arrival order. A node whose configuration carries no slug keys on its own path, so it stays a row of its own rather than collapsing with every other such node.

`ObserveAgents` passes the `userPath`/`spacePath` it already resolves; `ProjectAgents` keeps working without them (the programmatic generators project with no viewer context).

## Tests — written first

Eight cases in `AgentPickerDeduplicationTest`, red before the implementation (the precedence parameters did not exist; the no-context case returned two rows): the reported ToolsReference case, three-layer collapse, each precedence step, order-independence, case-insensitive slugs, distinct agents never merged, and the no-viewer path.

- Agent-picker tests: **52/52**.
- Full `MeshWeaver.AI.Test`: **1254 passed, 0 failed, 3 skipped**.
- Mutation check: reverting to path-keying fails **7 of the 8** — the tests pin the defect rather than the implementation.
- `-c Release -warnaserror` clean for `MeshWeaver.AI` and the test project.

What's New entry included (`Category: Fix`).

## Out of scope, filed separately

The underlying data redundancy is a packaging matter, not a picker one — Essentials ships copies of the Agents package's agents, those copies go stale (this mesh's `Agent/Assistant` is 13 394 chars against the user's 12 744), and `ToolsReference`/`CommentingReference` are `nodeType: Markdown` in one package and `nodeType: Agent` in the other. Also unaddressed here: `AgentView.Catalog` runs an unscoped `nodeType:Agent` query, and `ThreadComposer.AgentName` queries only `namespace:Agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
