### PR TITLE
Registry publish: land a module's static web assets, not just its assemblies

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -201,7 +201,20 @@ public static class PluginBundleEndpoints
 
                 var (accepted, decline) = ModulePublish.Validate(
                     plugin, manifest, files, http.Request.Query["version"],
-                    http.Request.Query["packagePath"]);
+                    http.Request.Query["packagePath"],
+                    // 🚨 THE SHELF MUST CARRY THE ASSETS TOO. A consumer never reads this upload's
+                    // archive — it fetches what the shelf holds — so an asset dropped at the
+                    // warehouse door is unreachable for every instance downstream, however complete
+                    // the packed bundle was. Both halves of this were already built (Validate takes
+                    // them, Accepted carries them, ShelveModule lands them); only these two
+                    // arguments were missing, and that is why every landed view pack held
+                    // assemblies and no wwwroot: DefaultViews' bundle declares 254 static assets
+                    // and its landed generation had 11 files with no wwwroot, EntityViews' scoped
+                    // CSS 404'd in production from #2188 on, and the Views/Graph image copies were
+                    // the only reason a portal was styled at all (#2221). Same read the consumer's
+                    // own landing does (PluginBundleClient.LandFromBundle), so shelf and adopt
+                    // place byte-identical content.
+                    BundleReader.ReadModuleAssets(bytes));
                 if (accepted is null)
                 {
                     logger?.LogWarning("Module publish for {Plugin} REFUSED: {Reason}", plugin, decline);
@@ -225,7 +238,8 @@ public static class PluginBundleEndpoints
                         frameworkMvid: accepted.FrameworkMvid,
                         packagePath: accepted.PackagePath,
                         version: accepted.Version,
-                        minMeshVersion: accepted.MinMeshVersion)
+                        minMeshVersion: accepted.MinMeshVersion,
+                        staticAssets: accepted.StaticAssets)
                         .FirstAsync().ToTask(ct);
                 }
                 catch (Exception exception)

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -188,9 +188,15 @@ public static class PluginBundleEndpoints
 
                 BundleReader.Manifest? manifest;
                 IReadOnlyList<BundleReader.ModuleFile> files;
+                IReadOnlyList<BundleReader.ModuleAsset> assets;
                 try
                 {
                     (manifest, files) = BundleReader.ReadModule(bytes);
+                    // Inside the SAME guard: a bundle whose assemblies read cleanly can still carry
+                    // a corrupt asset entry, and reading that outside here would throw out of the
+                    // handler as a 500 — telling the publisher "the server broke" for what is
+                    // simply an unreadable upload, the case this catch already classifies.
+                    assets = BundleReader.ReadModuleAssets(bytes);
                 }
                 catch (Exception exception)
                 {
@@ -214,7 +220,7 @@ public static class PluginBundleEndpoints
                     // the only reason a portal was styled at all (#2221). Same read the consumer's
                     // own landing does (PluginBundleClient.LandFromBundle), so shelf and adopt
                     // place byte-identical content.
-                    BundleReader.ReadModuleAssets(bytes));
+                    assets);
                 if (accepted is null)
                 {
                     logger?.LogWarning("Module publish for {Plugin} REFUSED: {Reason}", plugin, decline);
@@ -881,8 +887,9 @@ public static class PluginBundleEndpoints
                         string.Join(" | ", misses.Take(MissesReported)));
 
                 return assemblies.SelectMany(found => ModuleFiles(rootHub, package)
-                    .Select(moduleFiles =>
-                        BuildResult(package, found, moduleFiles, identity, architecture, misses)));
+                    .Select(module =>
+                        BuildResult(package, found, module.Files, module.Assets,
+                            identity, architecture, misses)));
             });
     }
 
@@ -961,12 +968,14 @@ public static class PluginBundleEndpoints
     /// serve — the bundle then simply has no module section, which a consumer reads as "nothing
     /// to land".
     /// </summary>
-    private static IObservable<IReadOnlyList<string>> ModuleFiles(
+    private static IObservable<(IReadOnlyList<string> Files,
+        IReadOnlyList<(string RelativePath, string FullPath)> Assets)> ModuleFiles(
         IMessageHub rootHub, BundleEntry package)
     {
         var landing = rootHub.ServiceProvider.GetService<ModuleLandingService>();
         if (landing is null || string.IsNullOrWhiteSpace(package.Module))
-            return Observable.Return<IReadOnlyList<string>>([]);
+            return Observable.Return<(IReadOnlyList<string> Files,
+                IReadOnlyList<(string RelativePath, string FullPath)> Assets)>(([], []));
 
         var logger = rootHub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger(typeof(PluginBundleEndpoints));
@@ -974,13 +983,13 @@ public static class PluginBundleEndpoints
         return landing.GetActivation().Take(1)
             .Select(activation =>
             {
-                var (files, decline) = ModuleBundleSource.Collect(
+                var (files, assets, decline) = ModuleBundleSource.Collect(
                     landing.BaseDirectory, package.Module!, activation);
                 if (decline is not null)
                     logger?.LogInformation(
                         "Plugin bundles: {Plugin} declares module '{Module}' but it is not served: {Reason}",
                         package.PluginId, package.Module, decline);
-                return files;
+                return (Files: files, Assets: assets);
             });
     }
 
@@ -1008,6 +1017,7 @@ public static class PluginBundleEndpoints
         BundleEntry package,
         IReadOnlyList<(string NodePath, string? Path, IReadOnlyDictionary<string, string>? Dependencies)> assemblies,
         IReadOnlyList<string> moduleFiles,
+        IReadOnlyList<(string RelativePath, string FullPath)> moduleAssets,
         string identity,
         string architecture,
         IReadOnlyList<string> misses)
@@ -1036,6 +1046,19 @@ public static class PluginBundleEndpoints
             var local = moduleFile;
             entries.Add(new NuGetPackageWriter.Entry(
                 NuGetPackageWriter.ModuleEntryPathFor(Path.GetFileName(local)),
+                () => File.OpenRead(local)));
+        }
+
+        // The module's STATIC WEB ASSETS ride under their own folder, keeping the relative path a
+        // component's _content/<pack>/… URL asks for. Without this the serve path re-creates the
+        // defect the publish path was just fixed for (#2221): the shelf would hold a complete pack
+        // and hand consumers an assemblies-only bundle, so every downstream portal renders
+        // unstyled while the registry's own copy looks fine.
+        foreach (var (relativePath, fullPath) in moduleAssets)
+        {
+            var local = fullPath;
+            entries.Add(new NuGetPackageWriter.Entry(
+                NuGetPackageWriter.ModuleAssetEntryPathFor(relativePath),
                 () => File.OpenRead(local)));
         }
 
@@ -1074,6 +1097,12 @@ public static class PluginBundleEndpoints
                         assemblyName = package.Module,
                         assemblies = moduleFiles.Select(Path.GetFileName).ToArray(),
                         minMeshVersion = package.MinMeshVersion,
+                        // Declared, never inferred from the archive — BundleReader.ReadModuleAssets
+                        // reads THIS list and treats a declared-but-absent entry as an incomplete
+                        // bundle, the same all-or-nothing rule the assemblies follow.
+                        staticAssets = moduleAssets.Count == 0
+                            ? null
+                            : moduleAssets.Select(a => a.RelativePath).ToArray(),
                     },
             },
             new JsonSerializerOptions

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-installed-packs-keep-their-styles.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-installed-packs-keep-their-styles.md
@@ -1,0 +1,17 @@
+---
+Name: Installed view packs keep their styles
+Category: Fix
+Description: A view pack installed from the store now arrives with its stylesheets and scripts, not just its code.
+Icon: Sparkle
+Order: -20260825
+---
+
+# Installed view packs keep their styles
+
+A package installed from the store arrives as a set of compiled files plus the stylesheets and
+scripts its screens need. The registry was handing on only the code half, so a pack that no longer
+travels inside the portal image could render without its own styling — form fields and other
+components inherited whatever the page around them looked like instead of their intended design.
+
+Packages published from now on carry their styles and scripts all the way through to the portals
+that install them. Packages published earlier need to be published once more to pick this up.

--- a/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
@@ -38,8 +38,11 @@ public static class ModuleBundleSource
     /// <param name="moduleName">The module's entry-assembly name without extension.</param>
     /// <param name="activation">The deployment's activation sidecar list (empty for a module that
     /// ships with the image — image modules have no sidecar entry).</param>
-    /// <returns>Absolute file paths (entry DLL first) or the decline reason.</returns>
-    public static (IReadOnlyList<string> Files, string? DeclineReason) Collect(
+    /// <returns>Absolute closure paths (entry DLL first), the module's STATIC WEB ASSETS as
+    /// (module-relative path, absolute path) pairs, or the decline reason.</returns>
+    public static (IReadOnlyList<string> Files,
+        IReadOnlyList<(string RelativePath, string FullPath)> Assets,
+        string? DeclineReason) Collect(
         string baseDirectory,
         string moduleName,
         ModuleActivationList activation)
@@ -48,12 +51,12 @@ public static class ModuleBundleSource
             || moduleName is "." or ".."
             || moduleName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
             || moduleName.Contains('/') || moduleName.Contains('\\'))
-            return ([], $"'{moduleName}' is not a valid module name");
+            return ([], [], $"'{moduleName}' is not a valid module name");
 
         var entry = activation.Entries.FirstOrDefault(e =>
             string.Equals(e.Name, moduleName, StringComparison.OrdinalIgnoreCase));
         if (entry is { Enabled: false })
-            return ([], $"module '{moduleName}' is uninstalled on this instance");
+            return ([], [], $"module '{moduleName}' is uninstalled on this instance");
         // 🚨 Deliberately NO floor check on the entry here — a HELD landing (floor above this
         // instance's platform, ShelveModule) and a landing the platform rolled back below are
         // both SERVED: their recorded floor rides the index and the manifest, and the consumer's
@@ -70,17 +73,36 @@ public static class ModuleBundleSource
             // Covers the missing folder, the transitional publish state (a module still riding the
             // app closure prunes its modules/ folder empty), and a lost volume alike: no entry DLL,
             // no module bundle — the package still serves its content and NodeType assemblies.
-            return ([], $"{Path.GetFileName(folder)}/{moduleName}.dll does not exist on this instance");
+            return ([], [], $"{Path.GetFileName(folder)}/{moduleName}.dll does not exist on this instance");
 
-        // Entry DLL first, the rest of the closure (dlls + symbols) in stable order. Top level
-        // only — a module directory is flat by construction (ModuleLandingService writes file
-        // names, and the publish target lays closures out flat).
+        // Entry DLL first, the rest of the CLOSURE (dlls + symbols) in stable order. Top level
+        // only — a module's assemblies are flat by construction (ModuleLandingService writes file
+        // names, and the publish target lays closures out flat). 🚨 That flatness is why the
+        // assets below need their own walk: they are the one part of a landed module that is NOT
+        // flat, and a top-level-only listing silently omits every one of them.
         var files = new List<string> { entryDll };
         files.AddRange(Directory.EnumerateFiles(folder)
             .Where(f => Path.GetExtension(f).ToLowerInvariant() is ".dll" or ".pdb")
             .Where(f => !string.Equals(f, entryDll, StringComparison.OrdinalIgnoreCase))
             .OrderBy(Path.GetFileName, StringComparer.OrdinalIgnoreCase));
 
-        return (files, null);
+        // 🚨 THE ASSETS MUST ROUND-TRIP, or the registry re-creates the very defect it was just
+        // fixed for. A consumer lands what this bundle carries and nothing else, so a pack whose
+        // wwwroot the SERVE path drops renders unstyled downstream even though the shelf holds it
+        // — the publish-side fix (#2221) only makes the registry's own copy complete. Assets keep
+        // their RELATIVE path: a component asks for _content/<pack>/Components/x.razor.js, so a
+        // flattened asset 404s exactly like a missing one.
+        var assetRoot = Path.Combine(folder, "wwwroot");
+        var assets = Directory.Exists(assetRoot)
+            ? Directory.EnumerateFiles(assetRoot, "*", SearchOption.AllDirectories)
+                .Select(f => (
+                    RelativePath: "wwwroot/" + Path.GetRelativePath(assetRoot, f)
+                        .Replace(Path.DirectorySeparatorChar, '/'),
+                    FullPath: f))
+                .OrderBy(a => a.RelativePath, StringComparer.Ordinal)
+                .ToList()
+            : [];
+
+        return (files, assets, null);
     }
 }

--- a/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
@@ -143,7 +143,7 @@ public class ModulePublishShelfTest : IDisposable
 
         // …and the SERVE side lists exactly this held landing for consumers — the same Collect
         // the index and the download route resolve through, against the state the route wrote.
-        var (files, decline) = ModuleBundleSource.Collect(root, "MeshWeaver.Speech", list);
+        var (files, _, decline) = ModuleBundleSource.Collect(root, "MeshWeaver.Speech", list);
         Assert.Null(decline);
         Assert.Single(files);
     }

--- a/test/Memex.Portal.Shared.Test/PluginBundlePublishAssetsTest.cs
+++ b/test/Memex.Portal.Shared.Test/PluginBundlePublishAssetsTest.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Api;
+using MeshWeaver.Plugin.Packaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// A module PUBLISHED to the registry must reach the shelf with its STATIC WEB ASSETS, not just
+/// its assemblies.
+///
+/// <para>🚨 Why this needs a test of its own: nothing else fails when the assets are dropped. The
+/// publish returns 200, the shelf entry is recorded, the module lands, it loads, and every page
+/// still renders — only unstyled, and only for the packs whose image copy has been retired. That
+/// is exactly how it shipped: <c>Validate</c> already took the assets and <c>Accepted</c> already
+/// carried them to <c>ShelveModule</c>, but the endpoint passed neither argument, so every module
+/// ever published landed with assemblies alone. Measured in production 2026-08-25 (#2221):
+/// DefaultViews' bundle declares 254 static assets while its landed generation held 11 files and
+/// no <c>wwwroot</c> at all; <c>MeshWeaver.Blazor.EntityViews.styles.css</c> had been 404 since
+/// #2188 retired that pack's image copy, and the portal was styled only because Views' and Graph's
+/// image copies were still there.</para>
+///
+/// <para>So the assertion is deliberately about BYTES ON DISK under the landed module directory,
+/// not about a status code or a log line: the consumer's stylesheet request is a file lookup, and
+/// only a file satisfies it.</para>
+/// </summary>
+public class PluginBundlePublishAssetsTest : IDisposable
+{
+    private const string Token = "publish-token-for-this-test";
+    private const string Module = "MeshWeaver.Test.ViewPack";
+    private const string Plugin = "TestViewPack";
+    private const string AssetPath = "wwwroot/MeshWeaver.Test.ViewPack.styles.css";
+    private static readonly byte[] AssetBytes = Encoding.UTF8.GetBytes(".mw-test{color:#bada55}");
+
+    // 🚨 A SECOND asset, and a NESTED one deliberately: one file landing is not evidence that the
+    // set landed, so a partial drop has to fail here too — and a pack's collocated JS is requested
+    // at its relative path (_content/<pack>/Components/…), so flattening it would 404 exactly like
+    // dropping it. Both are asserted byte-exact below.
+    private const string NestedAssetPath = "wwwroot/Components/TestView.razor.js";
+    private static readonly byte[] NestedAssetBytes =
+        Encoding.UTF8.GetBytes("export function init(){ return 'mw-test'; }");
+
+    private readonly string root = Path.Combine(
+        Path.GetTempPath(), "mw-publish-assets-" + Guid.NewGuid().ToString("N"));
+
+    /// <summary>
+    /// The publish endpoint lands the bundle's assets beside its assemblies — the file a browser
+    /// would request exists, with the bytes the producer packed.
+    /// </summary>
+    [Fact]
+    public async Task PublishedModule_LandsItsStaticAssets()
+    {
+        var response = await Publish(BuildBundle(withAssets: true));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        foreach (var (relative, expected) in new[]
+                 {
+                     (AssetPath, AssetBytes),
+                     (NestedAssetPath, NestedAssetBytes),
+                 })
+        {
+            var landed = LandedFile(relative);
+            Assert.True(landed is not null,
+                $"the published bundle declared '{relative}' but no landed module directory under "
+                + $"'{root}' carries it — the shelf dropped part or all of the pack's static web "
+                + "assets, so consumers of this module render unstyled or 404 its collocated JS "
+                + "(#2221)");
+            Assert.Equal(expected, File.ReadAllBytes(landed!));
+        }
+    }
+
+    /// <summary>
+    /// The entry assembly still lands — the assertion above must be evidence about ASSETS, not
+    /// about a publish path that happens to write everything or nothing.
+    /// </summary>
+    [Fact]
+    public async Task PublishedModule_LandsItsEntryAssembly()
+    {
+        var response = await Publish(BuildBundle(withAssets: true));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(LandedFile(Module + ".dll") is not null,
+            "the entry assembly did not land — this test's own premise is broken, so its asset "
+            + "assertion would prove nothing");
+    }
+
+    /// <summary>
+    /// A bundle that declares NO assets lands its assembly and writes no <c>wwwroot</c> — the
+    /// asset path is driven by what the producer packed, never fabricated by the shelf.
+    /// </summary>
+    [Fact]
+    public async Task PublishedModuleWithoutAssets_LandsNoWwwroot()
+    {
+        var response = await Publish(BuildBundle(withAssets: false));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(LandedFile(Module + ".dll") is not null, "the entry assembly did not land");
+        Assert.Null(LandedFile(AssetPath));
+        Assert.Null(LandedFile(NestedAssetPath));
+    }
+
+    /// <summary>The landed path of one module-relative file, or null when no generation carries it.</summary>
+    private string? LandedFile(string relativePath)
+    {
+        var modules = Path.Combine(root, "modules");
+        if (!Directory.Exists(modules))
+            return null;
+        foreach (var directory in Directory.EnumerateDirectories(modules))
+        {
+            var candidate = Path.Combine(directory, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            if (File.Exists(candidate))
+                return candidate;
+        }
+        return null;
+    }
+
+    private async Task<HttpResponseMessage> Publish(byte[] bundle)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Configuration[ModulePublish.TokenConfigKey] = Token;
+        // The landing seam: a real service writing under this test's own root, so the assertion
+        // reads the bytes the production path would have written.
+        builder.Services.AddSingleton(_ => new ModuleLandingService(null, root));
+
+        var app = builder.Build();
+        app.MapPluginBundles();
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var content = new ByteArrayContent(bundle);
+        var request = new HttpRequestMessage(
+            HttpMethod.Post, $"{PluginBundleEndpoints.RoutePrefix}/{Plugin}")
+        {
+            Content = content,
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        var response = await client.SendAsync(request);
+        await app.StopAsync();
+        return response;
+    }
+
+    /// <summary>
+    /// A minimal but REAL module bundle: the same writer the packer uses, so the manifest shape and
+    /// the entry paths are the production ones rather than this test's idea of them.
+    /// </summary>
+    private static byte[] BuildBundle(bool withAssets)
+    {
+        var assembly = Encoding.UTF8.GetBytes("not-a-real-assembly-but-real-bytes");
+        var entries = new List<NuGetPackageWriter.Entry>
+        {
+            new(NuGetPackageWriter.ModuleEntryPathFor(Module + ".dll"),
+                () => new MemoryStream(assembly)),
+        };
+        if (withAssets)
+        {
+            entries.Add(new NuGetPackageWriter.Entry(
+                NuGetPackageWriter.ModuleAssetEntryPathFor(AssetPath),
+                () => new MemoryStream(AssetBytes)));
+            entries.Add(new NuGetPackageWriter.Entry(
+                NuGetPackageWriter.ModuleAssetEntryPathFor(NestedAssetPath),
+                () => new MemoryStream(NestedAssetBytes)));
+        }
+
+        var manifest = new BundleReader.Manifest(
+            Plugin,
+            "1.0.0",
+            FrameworkMvid: "00000000000000000000000000000000",
+            Assemblies: null,
+            Module: new BundleReader.ModuleRef(
+                Module,
+                [Module + ".dll"],
+                MinMeshVersion: null,
+                StaticAssets: withAssets ? [AssetPath, NestedAssetPath] : null));
+
+        using var stream = new MemoryStream();
+        NuGetPackageWriter.Write(
+            stream,
+            new MeshWeaver.Plugin.Packaging.PluginManifest(
+                Plugin,
+                MeshWeaver.Plugin.Packaging.PluginManifest.IdPrefix + Plugin,
+                "1.0.0",
+                "a view pack for the publish-assets guard",
+                MinMeshVersion: null,
+                Requires: ImmutableArray<string>.Empty),
+            frameworkVersion: "3.0.0",
+            entries,
+            JsonSerializer.Serialize(manifest, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            }));
+        return stream.ToArray();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+            Directory.Delete(root, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleBundleSourceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleBundleSourceTest.cs
@@ -39,8 +39,65 @@ public class ModuleBundleSourceTest : IDisposable
             File.WriteAllBytes(Path.Combine(folder, file), [2]);
     }
 
+    /// <summary>Writes one static web asset at its module-relative path, directories and all —
+    /// the shape <c>ModuleLandingService</c> materializes from a bundle.</summary>
+    private void LayOutAsset(string name, string relativePath)
+    {
+        var target = Path.Combine(
+            baseDirectory, "modules", name,
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+        File.WriteAllBytes(target, [3]);
+    }
+
     private static ModuleActivationList Activation(params ModuleActivationEntry[] entries) =>
         new() { Entries = [.. entries] };
+
+    /// <summary>
+    /// A landed pack's STATIC WEB ASSETS are served with it, each keeping its module-relative
+    /// path.
+    ///
+    /// <para>🚨 The serve half of #2221. The publish fix alone leaves the registry holding a
+    /// complete pack while handing consumers an assemblies-only bundle — every downstream portal
+    /// then renders unstyled while the registry's own copy looks fine, which is the harder version
+    /// of the same bug to notice. The relative path is asserted, not just the count: a component
+    /// requests <c>_content/&lt;pack&gt;/Components/x.razor.js</c>, so a flattened asset 404s
+    /// exactly like a dropped one.</para>
+    /// </summary>
+    [Fact]
+    public void ALandedModulesStaticAssets_AreServedWithTheirRelativePaths()
+    {
+        LayOut("MeshWeaver.Social");
+        LayOutAsset("MeshWeaver.Social", "wwwroot/MeshWeaver.Social.styles.css");
+        LayOutAsset("MeshWeaver.Social", "wwwroot/Components/Feed.razor.js");
+
+        var (files, assets, decline) = ModuleBundleSource.Collect(
+            baseDirectory, "MeshWeaver.Social", Activation());
+
+        Assert.Null(decline);
+        Assert.Equal(
+            new[] { "wwwroot/Components/Feed.razor.js", "wwwroot/MeshWeaver.Social.styles.css" },
+            assets.Select(a => a.RelativePath).ToArray());
+        Assert.All(assets, a => Assert.True(File.Exists(a.FullPath)));
+        // The asset walk must not leak into the assembly closure: a bundle that seeded CSS as a
+        // module assembly would fail only at load.
+        Assert.DoesNotContain(files, f => f.Contains("wwwroot", StringComparison.Ordinal));
+    }
+
+    /// <summary>A pack with no <c>wwwroot</c> serves none — the serve side reports what landed and
+    /// never fabricates an asset set.</summary>
+    [Fact]
+    public void AModuleWithoutAssets_ServesNone()
+    {
+        LayOut("MeshWeaver.Social", "Aux.dll");
+
+        var (files, assets, decline) = ModuleBundleSource.Collect(
+            baseDirectory, "MeshWeaver.Social", Activation());
+
+        Assert.Null(decline);
+        Assert.NotEmpty(files);
+        Assert.Empty(assets);
+    }
 
     [Fact]
     public void AnImageLaidOutModule_IsServed_EntryDllFirst()
@@ -49,7 +106,7 @@ public class ModuleBundleSourceTest : IDisposable
         // the image, so they match the running framework by construction.
         LayOut("MeshWeaver.Social", "MeshWeaver.Social.pdb", "Aux.dll", "readme.txt");
 
-        var (files, decline) = ModuleBundleSource.Collect(
+        var (files, _, decline) = ModuleBundleSource.Collect(
             baseDirectory, "MeshWeaver.Social", Activation());
 
         Assert.Null(decline);
@@ -65,7 +122,7 @@ public class ModuleBundleSourceTest : IDisposable
     {
         LayOut("MeshWeaver.Social");
 
-        var (files, decline) = ModuleBundleSource.Collect(
+        var (files, _, decline) = ModuleBundleSource.Collect(
             baseDirectory, "MeshWeaver.Social",
             Activation(new ModuleActivationEntry
             {
@@ -85,7 +142,7 @@ public class ModuleBundleSourceTest : IDisposable
         // image roll, which is precisely the bake semantics the module lane rejects.
         LayOut("MeshWeaver.Social");
 
-        var (files, decline) = ModuleBundleSource.Collect(
+        var (files, _, decline) = ModuleBundleSource.Collect(
             baseDirectory, "MeshWeaver.Social",
             Activation(new ModuleActivationEntry
             {
@@ -110,7 +167,7 @@ public class ModuleBundleSourceTest : IDisposable
         // platform off the index/manifest — never the warehouse's.
         LayOut("MeshWeaver.Social");
 
-        var (files, decline) = ModuleBundleSource.Collect(
+        var (files, _, decline) = ModuleBundleSource.Collect(
             baseDirectory, "MeshWeaver.Social",
             Activation(new ModuleActivationEntry
             {
@@ -126,7 +183,7 @@ public class ModuleBundleSourceTest : IDisposable
     {
         LayOut("MeshWeaver.Social");
 
-        var (files, decline) = ModuleBundleSource.Collect(
+        var (files, _, decline) = ModuleBundleSource.Collect(
             baseDirectory, "MeshWeaver.Social",
             Activation(new ModuleActivationEntry
             {
@@ -145,7 +202,7 @@ public class ModuleBundleSourceTest : IDisposable
         // closure.
         Directory.CreateDirectory(Path.Combine(baseDirectory, "modules", "MeshWeaver.Social"));
 
-        var (files, decline) = ModuleBundleSource.Collect(
+        var (files, _, decline) = ModuleBundleSource.Collect(
             baseDirectory, "MeshWeaver.Social", Activation());
 
         Assert.Empty(files);
@@ -159,7 +216,7 @@ public class ModuleBundleSourceTest : IDisposable
     [InlineData("..")]
     public void AnInvalidModuleName_IsRefused(string name)
     {
-        var (files, decline) = ModuleBundleSource.Collect(baseDirectory, name, Activation());
+        var (files, _, decline) = ModuleBundleSource.Collect(baseDirectory, name, Activation());
 
         Assert.Empty(files);
         Assert.NotNull(decline);

--- a/test/MeshWeaver.PluginCatalog.Test/PendingLandingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PendingLandingTest.cs
@@ -99,7 +99,7 @@ public class PendingLandingTest : IDisposable
             }],
         };
 
-        var (files, decline) = ModuleBundleSource.Collect(
+        var (files, _, decline) = ModuleBundleSource.Collect(
             root, "MeshWeaver.Widget", activation);
 
         Assert.Null(decline);
@@ -113,7 +113,7 @@ public class PendingLandingTest : IDisposable
     {
         Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "CURRENT");
 
-        var (files, decline) = ModuleBundleSource.Collect(
+        var (files, _, decline) = ModuleBundleSource.Collect(
             root, "MeshWeaver.Widget", new ModuleActivationList());
 
         Assert.Null(decline);


### PR DESCRIPTION
Fixes #2221.

`PluginBundleEndpoints.MapPublish` passed neither the bundle's assets to `ModulePublish.Validate` nor `accepted.StaticAssets` to `ShelveModule`, so the registry dropped every published module's `wwwroot`. A consumer never reads the producer's archive — it fetches what the shelf holds — so no instance could receive a pack's CSS or collocated JS no matter how complete the bundle was. Everything else was already wired for it (`Validate` takes them, `Accepted` carries them, `ShelveModule` lands them, `LandCore` materializes them, and the consumer's own landing passes them); only these two arguments were missing.

**Production evidence:** DefaultViews' bundle declares **254** static assets while its landed generation holds 11 files and no `wwwroot` — same for Graph, EntityViews, Radzen, GoogleMaps, Analysis (all `wwwroot=0`). `MeshWeaver.Blazor.EntityViews.styles.css` has been **404** since #2188 retired that pack's image copy, and the portal is styled only because Views' and Graph's image copies still ship — which is precisely what blocks retiring them (#2169 Phase B2).

**Producer side re-proven, not assumed:** running the workflow's exact sequence locally (`dotnet build` → `dotnet publish --no-build` → `module-pack --deps-closure`) on `MeshWeaver.Blazor.Views` yields a publish `wwwroot/` with the scoped-CSS bundle and JS initializers, and a manifest declaring 254 `staticAssets`.

**Test:** `PluginBundlePublishAssetsTest` publishes a real bundle (production `NuGetPackageWriter`) through the endpoint against a `ModuleLandingService` rooted in a temp dir, asserting **two** declared assets materialize as files with byte-exact content — one at the pack root, one nested under `Components/` so a partial drop fails and the relative path `_content/<pack>/…` URLs depend on is pinned — plus an entry-assembly control and a declares-no-assets case. A test is needed because nothing else fails when assets are dropped: 200, entry recorded, module loads, pages render, just unstyled.

**Negative control:** reverting the `ShelveModule` argument turns the asset test red (1 failed / 2 passed); with the fix, 3/3 green. Release + `-warnaserror`: 0 warnings, 0 errors.

🚨 **Republish required after this merges** — the fix does not retro-fill the shelf. Sequence for the flip: merge → image on the registry → republish the Blazor packs → EntityViews 404→200 (the unambiguous check, it has no image copy to mask it) → only then retire the Views/Graph image copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)