### PR TITLE
Plugin pack: reference MeshWeaver.Maps, or three galleries hold back every package

### DIFF
--- a/src/MeshWeaver.Plugin.Build/CompilationEnvironment.cs
+++ b/src/MeshWeaver.Plugin.Build/CompilationEnvironment.cs
@@ -75,6 +75,12 @@ public static class CompilationEnvironment
         "MeshWeaver.AI",
         "MeshWeaver.ContentCollections.Indexing",
         "MeshWeaver.Graph",
+        // MapControl and its provider-neutral surface. The three map view packs' example
+        // galleries (AppleMaps, GoogleMaps, OpenStreetMap) `using MeshWeaver.Maps`, which the
+        // portal has loaded and this list did not carry — so they compiled in the mesh and failed
+        // to PACK with CS0234, and because a failed unit pushes NOTHING, one missing reference
+        // held back every package in the repo.
+        "MeshWeaver.Maps",
         "MeshWeaver.PluginCatalog",
     ];
 }


### PR DESCRIPTION
## The failure

`Publish Plugin Packages` is **red on `main`** ([run 32855666164](https://github.com/Systemorph/MeshWeaver/actions)), and has been since the map galleries landed:

```
AppleMaps/Gallery/Source/AppleMapsGallery.cs(12,18): error CS0234:
  The type or namespace name 'Maps' does not exist in the namespace 'MeshWeaver'
…
::error::packing failed for: AppleMaps GoogleMaps OpenStreetMap — nothing was pushed
```

## Why it is not a three-gallery problem

**A failed unit pushes nothing** — so one missing reference held back *every* package in MeshWeaver.Plugins. The visible symptom was somewhere else entirely: on memex the app-declared package roots (`Import`, `Northwind`, `DefaultViews`, `EntityViews`, `GraphViews`) sat days behind `main` with their `app: true` flags absent, so their home tiles could not mint — while the plugins repo was green on every gate a PR runs. The galleries compile fine *in the mesh*, because there the portal's whole loaded assembly set is available; only the pack's csproj is narrower.

## The change

Add `MeshWeaver.Maps` to `CompilationEnvironment.PackageIds`. The list's own doc comment states the rule this restores: *"deliberately broader than any single plugin needs: an unused reference costs a restore entry, a missing one costs a false compile error that looks like broken plugin code."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)