### PR TITLE
Existence of a specific path is not a query question

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -743,8 +743,19 @@ workspace.GetMeshNodeStream(path)
     .Take(1).Timeout(TimeSpan.FromSeconds(10));
 ```
 
-**Valid query uses:** listing children (`path/*`), searching by predicate, existence checks, autocomplete.  
-**Wrong:** reading content by exact path, reading state before a write, polling for job completion.
+**Valid query uses:** listing children (`path/*`), searching by predicate, autocomplete — anywhere a
+stale negative is harmless.  
+🚨 **Existence of a SPECIFIC path is NOT one of them** — use `GetMeshNodeStream(path)` / a direct read.
+A query's negative can be minutes old, so a caller that reads it as "absent" redoes work that already
+happened. This line used to sanction existence checks, and that was wrong in a way that shipped: on
+2026-08-25 a `search` reported two just-minted tiles missing while a direct `get` returned both
+(#2229), and a create whose reply was lost plus a query that then answered "absent" gave one caller
+two independent reasons to conclude nothing had happened — two mesh-wide sweeps were armed 40 seconds
+apart on that basis. Existence-by-query is safe only where the write it guards is path-deterministic
+and idempotent (the redundant write lands on the same path); where the target id is minted per
+attempt, a stale negative produces DUPLICATE DATA, not merely duplicated work.  
+**Wrong:** reading content by exact path, reading state before a write, polling for job completion,
+deciding create-or-skip for a known path.
 
 `GetMeshNodeStream(path)` + `Where(...).Take(1)` is also the right primitive for **waiting for work to finish**.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
@@ -156,7 +156,7 @@ mesh.Query<MeshNode>(
 
 | Question | `select:` clause |
 |---|---|
-| "Does it exist?" | `select:path` |
+| "Does anything MATCH?" (a set — never one known path) | `select:path` |
 | "Is anything stale?" | `select:path,version` |
 | "Render a tree / list / picker" | `select:path,name,nodeType,icon` |
 | "Show last-modified column" | `select:path,name,lastModified` |
@@ -735,7 +735,8 @@ return request.Processed();   // handler returns immediately
 | Intent | Primitive |
 |---|---|
 | List nodes under X (paths / metadata only) | `mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(...))` — project to `Path` / `Name` / etc. **never read `.Content`** |
-| Does node X exist? | `Query` + check `Items.Count` |
+| Does **anything match** a predicate? | `Query` + check `Items.Count` |
+| Does node X (a KNOWN path) exist? | `workspace.GetMeshNodeStream(X)` — a query's negative can be minutes stale, and a caller that writes on it redoes finished work ([why](#-never-query-to-ask-does-this-path-exist--a-stale-negative-redoes-finished-work)). Creating it anyway? `CreateOrUpdateNodeRequest` — no check needed |
 | Give me node X's MeshNode (live) | `workspace.GetMeshNodeStream(X)` — the **only** non-stale read path |
 | Give me node X's MeshNode (once) | `workspace.GetMeshNodeStream(X).Where(n => n is not null).Take(1).Timeout(...)` |
 | Keep me updated on node X's MeshNode | `workspace.GetMeshNodeStream(X)` — stay subscribed (no `.Take(1)`) |

--- a/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
@@ -209,6 +209,31 @@ module will also mint.
 
 The recompile design that this rule supports is described in [NodeTypeCompilation](/Doc/Architecture/NodeTypeCompilation) — the NodeType keeps a `{sourcePath → version}` snapshot from the synced query, and a divergent emission triggers re-fetch and recompile. Nothing in the catalog row's `Content` is consulted.
 
+### 🚨 Never query to ask "does this path exist?" — a stale negative redoes finished work
+
+Same shape as staleness below, and it bites harder because the answer is acted on by *writers*. The
+query index trails the durable store by design, so a `search`/`path:` probe can answer "absent" for a
+node that exists — measured 2026-08-25 (#2229): a `search` reported two just-minted `_App` tiles
+missing while a direct read returned both, minutes after they landed.
+
+| Question | Read it with |
+|---|---|
+| "Does `{partition}/_App/{id}` exist?" | `GetMeshNodeStream(path)` / a direct path read |
+| "Should I create it, or is it already there?" | Neither — use [`CreateOrUpdateNodeRequest`](#upserts-createorupdatenoderequest--single-verb-no-delete-then-create), which reads persistence itself |
+| "Which children does this parent have?" | A query — a stale negative in a listing is harmless |
+
+**Severity depends on the write the check guards**, and it is worth knowing which case you are in:
+
+- The write target is **path-deterministic and idempotent** (`{viewer}/_App/{packageId}`, an install
+  whose copy plan skips by path): a stale negative costs a **redundant write or a repeated sweep** —
+  expensive and confusing, never corrupting. Both audited plugin-side guards are this shape.
+- The write mints a **new id per attempt**: a stale negative produces **duplicate DATA**. Treat any
+  such guard as a defect.
+
+The compounding case to watch for: a write whose *reply* was lost looks identical to a write that
+never happened, and a query that then answers "absent" appears to confirm it. On 2026-08-25 that pair
+armed two mesh-wide sweeps forty seconds apart. Check existence by path before retrying anything.
+
 ### 🚨 Staleness lives on the owner — never query to check "is this stale?"
 
 A query is for finding **sets** of things. "Is *this specific thing* up to date?" is a question about one thing, and the answer belongs **on that thing** as a property — never re-derived by querying.


### PR DESCRIPTION
Found while investigating #2229. AGENTS.md listed **"existence checks"** among valid query uses — but the query index trails the durable store by design, and callers act on that answer by *writing*.

Measured 2026-08-25: a `search` reported two just-minted `_App` tiles missing while a direct read returned both. The compounding case is worse — a create whose *reply* was lost looks identical to one that never happened, and a query that then answers "absent" appears to confirm it; two mesh-wide sweeps were armed forty seconds apart on that pair.

The replacement keeps the severity honest rather than issuing a blanket ban, because the two cases differ:

- **path-deterministic + idempotent** write (`{viewer}/_App/{packageId}`, an install whose copy plan skips by path) → a stale negative costs a redundant write or a repeated sweep. Both audited plugin-side guards are this shape, so nobody needs to hunt for corrupted records.
- **id minted per attempt** → a stale negative produces genuine **duplicate data**. That shape is a defect wherever it exists.

`CqrsAndContentAccess.md` gains the matching section beside the staleness rule it mirrors, and points at `CreateOrUpdateNodeRequest`, which reads persistence itself and removes the need to check at all.

Verified: Documentation.Test 42/42 including link integrity. Docs-only, no What's New entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
