### PR TITLE
Postgres resilience: retry the genuinely-transient, never present it as empty

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-postgres-blips-no-longer-break-pages.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-postgres-blips-no-longer-break-pages.md
@@ -1,0 +1,34 @@
+---
+Name: A momentary database blip no longer blanks a page, fails a delete, or drops a package
+Category: Fix
+Description: Transient Postgres conditions — a dropped connection, a read timeout, a deadlock, a concurrent schema creation — are now retried where they occur instead of surfacing as an error panel on a dashboard area, a delete that refuses with no explanation, or a package that silently never installs.
+Icon: Bug
+Order: -20260825
+---
+
+# A momentary database blip no longer blanks a page, fails a delete, or drops a package
+
+Some database conditions are momentary by design. PostgreSQL picks a "victim" when two operations
+deadlock, rolls it back cleanly, and expects it to be tried again; a connection can drop mid-read
+during a failover; two servers creating the same thing at the same instant means one of them simply
+arrives second. None of these are faults — but three places in the platform treated them as if they
+were, and each one showed up as something a user could see.
+
+**Dashboard areas no longer fail on a blip.** A cross-partition search that hit a dropped
+connection, a read timeout, or a deadlock used to fault the whole area — Timeline, Comments,
+Preview and Catalog all put an error panel where their content should be. Those conditions are now
+retried briefly before anything is reported. A genuine failure still surfaces as one: the area says
+so rather than quietly rendering as if there were no comments, no timeline entries, and nothing in
+the catalog.
+
+**Deleting a page or folder no longer loses a race.** Working out everything inside a subtree runs
+alongside whatever else is writing to it, so it can be chosen as the deadlock victim. That aborted
+the delete with nothing removed and no hint that simply trying again would have worked. It is now
+retried, so the delete just happens.
+
+**Packages install even when several start at once.** When a server started up and installed
+several packages together, two of them creating their storage at the same moment could collide, and
+the loser was skipped — the server came up looking healthy while quietly missing that package until
+the next restart or a manual install. Different servers in the same deployment could end up with
+different sets of packages. That collision is now recognised for what it is and retried, so every
+package finishes installing.

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
@@ -414,7 +414,13 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         var firstRowMs = -1L;
         // Set only when the probe row exists — i.e. matches were genuinely dropped.
         var truncated = false;
-        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        // Transient-fault retry on the OPEN (see ExecuteReaderWithTransientRetryAsync). The primary
+        // fan-out has the same exposure as the satellite one in #2132: a dropped connection or a
+        // 40P01 while planning a UNION over every partition schema is a momentary condition, and
+        // un-retried it faulted the whole area render. Nothing is swallowed — an exhausted or
+        // non-transient fault still propagates.
+        await using var reader = await ExecuteReaderWithTransientRetryAsync(
+            cmd, "search_across_schemas", ct).ConfigureAwait(false);
         // 🚨 try/FINALLY, not a call after the loop. A caller that stops enumerating early — a
         // `.Take(n)`, a `break`, a cancellation, or a throw out of ReadMeshNode — disposes the
         // iterator without ever reaching code placed after the `while`. The slow fan-out would then
@@ -696,6 +702,47 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         }
     }
 
+    /// <summary>
+    /// Bounded retry budget for a TRANSIENT fan-out fault — matches the storage adapter's read
+    /// retry (<c>PostgreSqlStorageAdapter.MaxTransientReadRetries</c>), and for the same reason:
+    /// short enough that four attempts stay well inside a render's budget.
+    /// </summary>
+    private const int MaxTransientQueryRetries = 3;
+
+    /// <summary>
+    /// Runs the command and streams its rows, distinguishing THREE outcomes that used to be two
+    /// (issue #2132).
+    ///
+    /// <list type="number">
+    ///   <item><b><c>42P01</c> undefined_table → empty, and that is AUTHORITATIVE.</b> The
+    ///     satellite table genuinely does not exist in one of the targeted schemas, so there are
+    ///     genuinely no rows. Unchanged.</item>
+    ///   <item><b>A TRANSIENT fault → retry, bounded.</b> An <c>NpgsqlException</c> wrapping
+    ///     <c>EndOfStreamException</c> ("Attempted to read past the end of the stream" — the
+    ///     connection dropped mid-read) or <c>TimeoutException</c>, and <c>PostgresException</c>
+    ///     <c>40P01</c>/<c>40001</c>, are momentary conditions that a re-run resolves. These were
+    ///     the 171 occurrences across every memex-portal replica that put an error panel on
+    ///     Timeline / Comments / Preview / Catalog.</item>
+    ///   <item><b>Anything else, and an exhausted transient → PROPAGATE.</b></item>
+    /// </list>
+    ///
+    /// <para>🚨 Widening the <c>42P01</c> catch to swallow a transient as "no rows" — the obvious
+    /// way to stop the area failing — is the ONE thing this must not do. It would hand the view a
+    /// well-formed EMPTY result that is indistinguishable from an authoritative one, so a
+    /// momentary connection blip would silently render "no comments", "no timeline entries", "the
+    /// catalog is empty" as fact. A failure the user can see (LayoutAreaHost already renders an
+    /// error control into the failed area) is strictly better than a lie; the cure for the blip is
+    /// the retry above, not the swallow.</para>
+    ///
+    /// <para>The retry is only ever taken BEFORE the first row is yielded. Once a row has left this
+    /// method a re-execution would duplicate it, so a mid-stream fault past that point propagates
+    /// even when it is transient.</para>
+    ///
+    /// <para>🚨 ONE <c>attempts</c> counter spans BOTH legs (open and stream), rather than a budget
+    /// per leg. Nested budgets MULTIPLY — 4 opens × 4 reads — which is how a "bounded" retry quietly
+    /// becomes a 16-attempt, multi-second stall inside a render. The bound here is exactly
+    /// <see cref="MaxTransientQueryRetries"/> retries in total, however they are distributed.</para>
+    /// </summary>
     private async IAsyncEnumerable<MeshNode> EnumerateReaderOrEmptyOnMissingRelationAsync(
         Npgsql.NpgsqlCommand cmd,
         JsonSerializerOptions options,
@@ -703,43 +750,110 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         string tableName,
         [EnumeratorCancellation] CancellationToken ct)
     {
-        Npgsql.NpgsqlDataReader reader;
-        try { reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false); }
-        catch (Npgsql.PostgresException ex) when (ex.SqlState == "42P01")
-        {
-            _logger?.LogDebug(
-                "[CrossSchema] Skipping satellite query — {Schemas} schemas missing {Table}: {Error}",
-                schemas.Count, tableName, ex.Message);
-            yield break;
-        }
-
-        await using var _disposeReader = reader;
+        var yieldedAny = false;
+        var attempts = 0;
         while (true)
         {
-            bool hasNext;
-            try { hasNext = await reader.ReadAsync(ct).ConfigureAwait(false); }
+            Npgsql.NpgsqlDataReader? reader = null;
+            var retryAfter = TimeSpan.Zero;
+            try { reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false); }
             catch (Npgsql.PostgresException ex) when (ex.SqlState == "42P01")
             {
                 _logger?.LogDebug(
-                    "[CrossSchema] Skipping satellite query mid-stream — {Table} missing in some schema: {Error}",
-                    tableName, ex.Message);
+                    "[CrossSchema] Skipping satellite query — {Schemas} schemas missing {Table}: {Error}",
+                    schemas.Count, tableName, ex.Message);
                 yield break;
             }
-            if (!hasNext) break;
-
-            MeshNode? node;
-            try { node = ReadMeshNode(reader, options); }
-            catch (Exception ex)
+            catch (Exception ex) when (PostgreSqlStorageAdapter.IsTransientConnectionFault(ex)
+                                       && attempts < MaxTransientQueryRetries)
             {
-                // Per-row defence: a malformed reader value (corrupt vector,
-                // unparseable timestamp, etc.) must not take down the entire
-                // UNION. Log + skip.
-                _logger?.LogWarning(ex,
-                    "[CrossSchema] Skipping unreadable row in {Table}: {Error}",
-                    tableName, ex.Message);
+                retryAfter = PostgreSqlStorageAdapter.TransientReadBackoff(attempts);
+                LogTransientRetry(ex, tableName, attempts++, retryAfter);
+            }
+
+            if (reader is null)
+            {
+                await Task.Delay(retryAfter, ct).ConfigureAwait(false);
                 continue;
             }
-            yield return node;
+
+            // Streaming leg. `restart` is set only by a transient fault that arrived before any row
+            // was yielded — the one case a re-execution cannot duplicate anything.
+            var restart = false;
+            await using (reader)
+            {
+                while (true)
+                {
+                    bool hasNext;
+                    try { hasNext = await reader.ReadAsync(ct).ConfigureAwait(false); }
+                    catch (Npgsql.PostgresException ex) when (ex.SqlState == "42P01")
+                    {
+                        _logger?.LogDebug(
+                            "[CrossSchema] Skipping satellite query mid-stream — {Table} missing in some schema: {Error}",
+                            tableName, ex.Message);
+                        yield break;
+                    }
+                    catch (Exception ex) when (!yieldedAny
+                                               && PostgreSqlStorageAdapter.IsTransientConnectionFault(ex)
+                                               && attempts < MaxTransientQueryRetries)
+                    {
+                        retryAfter = PostgreSqlStorageAdapter.TransientReadBackoff(attempts);
+                        LogTransientRetry(ex, tableName, attempts++, retryAfter);
+                        restart = true;
+                        break;
+                    }
+                    if (!hasNext) break;
+
+                    MeshNode? node;
+                    try { node = ReadMeshNode(reader, options); }
+                    catch (Exception ex)
+                    {
+                        // Per-row defence: a malformed reader value (corrupt vector,
+                        // unparseable timestamp, etc.) must not take down the entire
+                        // UNION. Log + skip.
+                        _logger?.LogWarning(ex,
+                            "[CrossSchema] Skipping unreadable row in {Table}: {Error}",
+                            tableName, ex.Message);
+                        continue;
+                    }
+                    yieldedAny = true;
+                    yield return node;
+                }
+            }
+
+            if (!restart) yield break;
+            await Task.Delay(retryAfter, ct).ConfigureAwait(false);
+        }
+    }
+
+    private void LogTransientRetry(Exception ex, string what, int attempt, TimeSpan delay) =>
+        _logger?.LogWarning(ex,
+            "[CrossSchema] transient DB fault on {What} fan-out, attempt {Attempt}/{Max}, retrying in {Delay}ms",
+            what, attempt + 1, MaxTransientQueryRetries, delay.TotalMilliseconds);
+
+    /// <summary>
+    /// Opens the command's reader, retrying ONLY on
+    /// <see cref="PostgreSqlStorageAdapter.IsTransientConnectionFault"/> (dropped connection,
+    /// read timeout, <c>40P01</c>/<c>40001</c>) up to <see cref="MaxTransientQueryRetries"/> times
+    /// with the same jittered backoff the storage adapter's reads use. Every other error —
+    /// <c>42P01</c> included — propagates untouched to the caller's own handling, so this can
+    /// never turn a real fault into an empty result. Safe by construction: no row has been read
+    /// yet, so a re-execution cannot duplicate anything.
+    /// </summary>
+    private async Task<Npgsql.NpgsqlDataReader> ExecuteReaderWithTransientRetryAsync(
+        Npgsql.NpgsqlCommand cmd, string what, CancellationToken ct)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            TimeSpan retryAfter;
+            try { return await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false); }
+            catch (Exception ex) when (PostgreSqlStorageAdapter.IsTransientConnectionFault(ex)
+                                       && attempt < MaxTransientQueryRetries)
+            {
+                retryAfter = PostgreSqlStorageAdapter.TransientReadBackoff(attempt);
+                LogTransientRetry(ex, what, attempt, retryAfter);
+            }
+            await Task.Delay(retryAfter, ct).ConfigureAwait(false);
         }
     }
 

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionStorageProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionStorageProvider.cs
@@ -304,17 +304,73 @@ public sealed class PostgreSqlPartitionStorageProvider : IPartitionStorageProvid
                 logger?.LogDebug(ex,
                     "PostgreSqlPartitionStorageProvider: transient concurrent-DDL error ({SqlState}: {Message}) on attempt {Attempt}/{Max}; retrying",
                     ex.SqlState, ex.MessageText, attempt, maxAttempts);
-                await Task.Delay(TimeSpan.FromMilliseconds(50 * attempt), ct).ConfigureAwait(false);
+                await Task.Delay(DdlRaceBackoff(attempt), ct).ConfigureAwait(false);
             }
         }
     }
 
+    /// <summary>
+    /// Backoff between concurrent-DDL retries: 50 ms × attempt, JITTERED by up to ±40%.
+    ///
+    /// <para>🚨 The jitter is load-bearing, not decoration. The losers of a catalog race are, by
+    /// construction, two sessions that issued the same statement at the same instant; a
+    /// deterministic delay re-synchronises them and they collide again on every attempt until the
+    /// bound is exhausted. Spreading the wake-ups is what makes a bounded retry actually converge.</para>
+    /// </summary>
+    private static TimeSpan DdlRaceBackoff(int attempt) =>
+        TimeSpan.FromMilliseconds(50 * attempt * (0.6 + Random.Shared.NextDouble() * 0.8));
+
     /// <summary>Postgres errors meaning "another session is concurrently running the same idempotent
-    /// DDL" — transient and safe to retry (the retry observes the committed result).</summary>
-    private static bool IsTransientDdlRace(PostgresException ex) =>
+    /// DDL" — transient and safe to retry (the retry observes the committed result).
+    ///
+    /// <para>🚨 <c>IF NOT EXISTS</c> is NOT race-free, and that is the whole of issue #2130.
+    /// Postgres checks for the object and inserts the catalog row in two separate steps under no
+    /// common lock, so two sessions running the same <c>CREATE SCHEMA IF NOT EXISTS</c> can both
+    /// pass the check and the loser's insert then violates a SYSTEM-CATALOG unique index —
+    /// <c>23505 duplicate key value violates unique constraint "pg_namespace_nspname_index"</c>
+    /// (the exact error that silently dropped AppleMaps/ICloud/GoogleMaps/Agent package installs).
+    /// The same race on a table/index/type/trigger surfaces either as 23505 on its own catalog
+    /// index or as the corresponding <c>duplicate_*</c> state. All of them mean "the winner
+    /// committed the object"; re-running this provisioning DDL then finds it present and
+    /// succeeds.</para>
+    ///
+    /// <para>🚨 The 23505 arm is scoped to a SYSTEM CATALOG constraint (<c>pg_*</c>) precisely so it
+    /// can never swallow an application-level unique violation — a duplicate mesh-node primary key
+    /// stays a hard error, as <c>PostgreSqlStorageAdapter.IsTransientConnectionFault</c> also
+    /// insists.</para></summary>
+    internal static bool IsTransientDdlRace(PostgresException ex) =>
         ex.MessageText.Contains("tuple concurrently updated", StringComparison.OrdinalIgnoreCase)
         || ex.SqlState == PostgresErrorCodes.DeadlockDetected
-        || ex.SqlState == PostgresErrorCodes.SerializationFailure;
+        || ex.SqlState == PostgresErrorCodes.SerializationFailure
+        || IsCatalogUniqueViolation(ex)
+        || IsDuplicateObject(ex);
+
+    /// <summary>
+    /// A <c>23505</c> whose violated constraint is a SYSTEM CATALOG index (<c>pg_namespace_nspname_index</c>,
+    /// <c>pg_type_typname_nsp_index</c>, <c>pg_class_relname_nsp_index</c>, <c>pg_extension_name_index</c>, …)
+    /// — i.e. another session committed the same catalog object between our existence check and our
+    /// insert. Never an application constraint: those keep propagating as the real errors they are.
+    /// The constraint name is read from the structured field, with a message fallback because a
+    /// server configured with <c>Include Error Detail=false</c> redacts DETAIL but not the message.
+    /// </summary>
+    private static bool IsCatalogUniqueViolation(PostgresException ex)
+    {
+        if (ex.SqlState != PostgresErrorCodes.UniqueViolation) return false;
+        if (!string.IsNullOrEmpty(ex.ConstraintName))
+            return ex.ConstraintName.StartsWith("pg_", StringComparison.OrdinalIgnoreCase);
+        return ex.MessageText.Contains("\"pg_", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The "already exists" states an idempotent <c>CREATE … IF NOT EXISTS</c> can only produce by
+    /// losing a race — every statement this provider issues carries the guard, so a duplicate here
+    /// is never a genuine authoring error.
+    /// </summary>
+    private static bool IsDuplicateObject(PostgresException ex) =>
+        ex.SqlState is PostgresErrorCodes.DuplicateSchema
+            or PostgresErrorCodes.DuplicateTable
+            or PostgresErrorCodes.DuplicateObject
+            or PostgresErrorCodes.DuplicateFunction;
 
     private async Task<PartitionDefinition> EnsureSchemaAsync(
         PartitionDefinition def, CancellationToken ct)
@@ -387,8 +443,13 @@ public sealed class PostgreSqlPartitionStorageProvider : IPartitionStorageProvid
                 VectorDimensions = _options.VectorDimensions,
                 Schema = schema
             };
-            await PostgreSqlSchemaInitializer.CreateSatelliteTablesAsync(
-                ddlDs, schemaOptions, extraTables, ct).ConfigureAwait(false);
+            // Same concurrent-DDL exposure as the proc above (CREATE TABLE IF NOT EXISTS races a
+            // concurrent creator on pg_type_typname_nsp_index / pg_class_relname_nsp_index), so it
+            // gets the same bounded, jittered retry rather than faulting the whole provisioning.
+            await ExecuteDdlWithRetryAsync(attemptCt =>
+                    PostgreSqlSchemaInitializer.CreateSatelliteTablesAsync(
+                        ddlDs, schemaOptions, extraTables, attemptCt),
+                ct, _logger).ConfigureAwait(false);
         }
 
         // 🚨 Register the brand-new partition in the CENTRAL registry (public.searchable_schemas)

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -310,8 +310,21 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     }
 
     /// <summary>Bounded exponential backoff for the transient-read retry: 200ms, 400ms, 800ms (capped).</summary>
-    internal static TimeSpan TransientReadBackoff(int attempt)
+    internal static TimeSpan TransientReadBackoffBase(int attempt)
         => TimeSpan.FromMilliseconds(Math.Min(200 * Math.Pow(2, attempt), 800));
+
+    /// <summary>
+    /// <see cref="TransientReadBackoffBase"/> JITTERED by up to ±40% — the delay actually used.
+    ///
+    /// <para>🚨 The jitter earns its place on the DEADLOCK arm of the classifier (<c>40P01</c>,
+    /// <c>40001</c>). Postgres picks a deadlock victim precisely because two transactions took
+    /// overlapping locks in opposite orders at the same moment; waking both after an identical
+    /// 200 ms re-creates that same moment, and they deadlock again on every attempt until the
+    /// bound is spent. Spreading the wake-ups is what turns a bounded retry into one that
+    /// converges. (Harmless for the connectivity arm — a dropped connection does not care.)</para>
+    /// </summary>
+    internal static TimeSpan TransientReadBackoff(int attempt)
+        => TransientReadBackoffBase(attempt) * (0.6 + Random.Shared.NextDouble() * 0.8);
 
     /// <summary>
     /// Wraps a cold read observable with a bounded exponential-backoff retry that fires ONLY on
@@ -923,7 +936,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     // connection-pool size, NOT the cap-1 write pool (which would serialise it behind writes).
     /// <inheritdoc />
     public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)> ListChildPaths(string? parentPath)
-        => _readPool.Invoke(ct => ListChildPathsAsyncCore(parentPath, ct))
+        => WithTransientRetry(() => _readPool.Invoke(ct => ListChildPathsAsyncCore(parentPath, ct)), "ListChildPaths")
             .Catch<(IEnumerable<string>, IEnumerable<string>), Exception>(ex => IsUndefinedTable(ex)
                 ? Observable.Return<(IEnumerable<string>, IEnumerable<string>)>(([], []))
                 : Observable.Throw<(IEnumerable<string>, IEnumerable<string>)>(ex));
@@ -964,9 +977,18 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     /// node-less intermediate segments (<c>{path}/_Thread/{id}</c>,
     /// <c>{nodeType}/Release/{version}</c>) — exactly the rows that survived (issue #839).
     /// An absent (never-provisioned) schema means nothing to enumerate → empty.
+    ///
+    /// <para>🚨 Wrapped in <see cref="WithTransientRetry{T}"/> like every other read, and issue
+    /// #2158 is what happens when it is not. This UNION spans the partition's primary table and
+    /// every satellite, and it runs as the planning step of a recursive DELETE — so it is one of
+    /// the likeliest reads in the system to be chosen as a Postgres deadlock victim
+    /// (<c>40P01</c>) by a concurrent writer on an overlapping subtree. A deadlock is not a
+    /// failure, it is Postgres electing a loser and rolling it back atomically precisely SO THAT
+    /// the loser can retry; un-retried it aborted the whole user-facing delete with
+    /// <c>partial-deleted=0</c> and no hint that trying again would work.</para>
     /// </summary>
     public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
-        => _readPool.Invoke(ct => ListDescendantPathsAsyncCore(rootPath, ct))
+        => WithTransientRetry(() => _readPool.Invoke(ct => ListDescendantPathsAsyncCore(rootPath, ct)), "ListDescendantPaths")
             .Catch<IReadOnlyCollection<string>, Exception>(ex => IsUndefinedTable(ex)
                 ? Observable.Return<IReadOnlyCollection<string>>([])
                 : Observable.Throw<IReadOnlyCollection<string>>(ex));

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ConcurrentPartitionProvisioningRaceTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ConcurrentPartitionProvisioningRaceTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Issue #2130 — two sessions provisioning the SAME partition at the same time must both end up
+/// with a fully provisioned partition. Neither may lose its install.
+///
+/// <para><b>The defect.</b> All per-partition DDL funnels through
+/// <c>public.ensure_partition_schema</c>, whose first statement is
+/// <c>CREATE SCHEMA IF NOT EXISTS</c>. That guard is <b>not</b> race-free: PostgreSQL performs the
+/// existence check and the <c>pg_namespace</c> insert as two separate steps under no common lock,
+/// so a second session can pass the check while a first session's insert is still uncommitted, then
+/// block on the catalog's unique index and — the moment the first commits — fail with
+/// <c>23505: duplicate key value violates unique constraint "pg_namespace_nspname_index"</c>.
+/// <c>ExecuteDdlWithRetryAsync</c> retried <c>40P01</c>/<c>40001</c>/"tuple concurrently updated"
+/// but NOT that, so the loser's provisioning faulted, <c>InstanceAutoRegistrationService</c>'s
+/// <c>[DefaultInstall]</c> logged it and moved on, and the pod came up healthy while silently
+/// MISSING whichever package lost the race (observed in prod: AppleMaps, ICloud, GoogleMaps,
+/// Agent). Different replicas of one deployment ended up with different package sets.</para>
+///
+/// <para><b>How the race is induced — deterministically, and with no mocking.</b> An ordinary
+/// second connection opens a transaction and runs a bare <c>CREATE SCHEMA</c> for the partition,
+/// leaving the catalog row written but uncommitted. Provisioning is then started on the provider
+/// and <i>observed to block</i> on that row (a real <c>pg_stat_activity</c> lock wait — this is the
+/// anti-vacuous guard: without it a mistimed commit would let provisioning sail through and the
+/// test would pass having raced nothing). Committing the blocker then hands the provider the exact
+/// 23505 production saw.</para>
+///
+/// <para><b>Fail-before / pass-after.</b> Before the fix the provisioning observable faults with
+/// that <c>PostgresException</c> and the partition is left as a bare schema with no tables — the
+/// dropped install. After it, the bounded jittered retry re-runs the idempotent proc, which now
+/// observes the winner's committed schema, creates every table, and the partition takes writes.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class ConcurrentPartitionProvisioningRaceTests(PostgreSqlFixture fixture)
+{
+    /// <summary>Captures the provider's retry diagnostics — the proof the race was REAL.</summary>
+    private sealed class CapturingLogger : ILogger<PostgreSqlPartitionStorageProvider>
+    {
+        private readonly List<string> lines = [];
+
+        public IReadOnlyList<string> Lines
+        {
+            get { lock (lines) return lines.ToArray(); }
+        }
+
+        IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var line = formatter(state, exception) + " " + (exception?.ToString() ?? string.Empty);
+            lock (lines) lines.Add(line);
+        }
+    }
+
+    private IObservable<long> SchemaCount(string schema, CancellationToken ct) =>
+        fixture.DataSource.ScalarLong(
+            "SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = @s",
+            [("s", (object)schema)], ct);
+
+    /// <summary>
+    /// Backends parked on a lock. A catalog unique-index conflict against an uncommitted tuple
+    /// waits on the inserter's transaction id, which surfaces here as
+    /// <c>wait_event_type = 'Lock'</c>.
+    /// </summary>
+    private IObservable<long> BlockedBackends(CancellationToken ct) =>
+        fixture.DataSource.ScalarLong(
+            """
+            SELECT COUNT(*) FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND state = 'active'
+              AND wait_event_type = 'Lock'
+            """, ct);
+
+    [Fact(Timeout = 120000)]
+    public async Task AConcurrentSchemaCreator_DoesNotDropTheLosersProvisioning()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var logger = new CapturingLogger();
+        var provider = new PostgreSqlPartitionStorageProvider(
+            fixture.DataSource, fixture.ConnectionString, fixture.Options, logger: logger);
+
+        // Lowercase by construction — the router lowercases a namespace to reach its schema, so the
+        // blocker below must create exactly the name provisioning will resolve to.
+        var part = $"race{Guid.NewGuid():N}"[..12];
+
+        await using var blocker = await fixture.DataSource.OpenConnectionAsync(ct);
+        var uncommitted = await blocker.BeginTransactionAsync(ct);
+        var committed = false;
+        try
+        {
+            // ── The winner: a catalog row written and held uncommitted. ──────────────────────
+            await using (var create = new NpgsqlCommand($"CREATE SCHEMA \"{part}\"", blocker, uncommitted))
+                await create.ExecuteNonQueryAsync(ct);
+
+            // ── The loser: provisioning starts, passes IF NOT EXISTS, and parks on the index. ─
+            var provisioning = provider.EnsurePartitionProvisioned(part)
+                .Timeout(TimeSpan.FromSeconds(60))
+                .FirstAsync()
+                .ToTask(ct);
+
+            // 🚨 The anti-vacuous guard. Commit before the loser is actually waiting and it simply
+            // observes a committed schema — no 23505, nothing retried, and a green test that
+            // exercised none of this. Wait for the real lock wait instead of guessing with a delay.
+            await Observable.Interval(TimeSpan.FromMilliseconds(50))
+                .StartWith(0L)
+                .SelectMany(_ => BlockedBackends(ct))
+                .Where(blocked => blocked > 0)
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(ct);
+
+            // ── The winner commits. The loser's insert now conflicts: 23505 on a pg_* index. ──
+            await uncommitted.CommitAsync(ct);
+            committed = true;
+
+            // 🚨 THE REGRESSION: this used to fault with the unique violation, leaving a bare
+            // schema and a package that never installed.
+            await provisioning;
+
+            // The race was genuinely run and genuinely recovered — not avoided.
+            Assert.Contains(logger.Lines, l =>
+                l.Contains("transient concurrent-DDL error", StringComparison.OrdinalIgnoreCase));
+
+            // Exactly one schema: the retry re-observed the winner's, it did not create a second.
+            await SchemaCount(part, ct).Should().Within(30.Seconds()).Be(1L);
+
+            // …and the consequence that actually hurt: nothing was dropped — the partition is
+            // fully provisioned (the proc's tables exist) and takes writes.
+            var node = new MeshNode("Installed", part) { Name = "Installed", NodeType = "Markdown" };
+            await provider.Adapter.Write(node, JsonSerializerOptions.Default)
+                .Should().Within(30.Seconds()).Emit();
+            await fixture.DataSource.ScalarLong($"SELECT COUNT(*) FROM \"{part}\".mesh_nodes", ct)
+                .Should().Within(30.Seconds()).Be(1L);
+        }
+        finally
+        {
+            if (!committed)
+                await uncommitted.RollbackAsync(ct);
+            await uncommitted.DisposeAsync();
+            await fixture.DataSource.ExecuteNonQuery($"DROP SCHEMA IF EXISTS \"{part}\" CASCADE", ct)
+                .Should().Within(30.Seconds()).Emit();
+            await fixture.DataSource.ExecuteNonQuery(
+                    $"DELETE FROM public.searchable_schemas WHERE schema_name = '{part}'", ct)
+                .Should().Within(30.Seconds()).Emit();
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PostgreSqlTransientRetryTest.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PostgreSqlTransientRetryTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net.Sockets;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
@@ -84,7 +85,113 @@ public class PostgreSqlTransientRetryTest
     [InlineData(3, 800)] // capped
     [InlineData(5, 800)] // capped
     public void Backoff_IsBoundedExponential(int attempt, int expectedMs) =>
-        Assert.Equal(expectedMs, (int)PostgreSqlStorageAdapter.TransientReadBackoff(attempt).TotalMilliseconds);
+        Assert.Equal(expectedMs, (int)PostgreSqlStorageAdapter.TransientReadBackoffBase(attempt).TotalMilliseconds);
+
+    /// <summary>
+    /// The delay actually used is the base JITTERED by ±40%, and the jitter is load-bearing for the
+    /// deadlock arm (40P01/40001): two transactions that deadlocked did so because they collided at
+    /// the same instant, so waking both after an identical delay re-creates the collision on every
+    /// attempt. Pinned as a BAND, and as "successive draws are not all identical" — an
+    /// implementation that quietly dropped the jitter would satisfy the band but not the spread.
+    /// </summary>
+    [Theory]
+    [InlineData(0, 200)]
+    [InlineData(1, 400)]
+    [InlineData(2, 800)]
+    public void Backoff_IsJitteredWithinBand(int attempt, int baseMs)
+    {
+        var draws = Enumerable.Range(0, 50)
+            .Select(_ => PostgreSqlStorageAdapter.TransientReadBackoff(attempt).TotalMilliseconds)
+            .ToArray();
+
+        Assert.All(draws, ms =>
+        {
+            Assert.InRange(ms, baseMs * 0.6, baseMs * 1.4);
+        });
+        Assert.True(draws.Distinct().Count() > 1, "the backoff must actually vary, or it is not jitter");
+    }
+
+    // ---- Concurrent-DDL race classifier (issue #2130) ----
+    //
+    // `CREATE SCHEMA IF NOT EXISTS` is NOT atomic against a concurrent creator: the existence check
+    // and the pg_namespace insert are separate steps under no common lock, so the loser's insert
+    // violates the SYSTEM CATALOG unique index. Production evidence is verbatim
+    // `23505: duplicate key value violates unique constraint "pg_namespace_nspname_index"`, which
+    // silently dropped four package installs. It must classify as the retryable race it is.
+
+    private static PostgresException PgWithConstraint(string sqlState, string constraint, string message) =>
+        new(message, "ERROR", "ERROR", sqlState, constraintName: constraint);
+
+    [Theory]
+    [InlineData("pg_namespace_nspname_index")]   // CREATE SCHEMA IF NOT EXISTS — the observed one
+    [InlineData("pg_type_typname_nsp_index")]    // CREATE TABLE IF NOT EXISTS
+    [InlineData("pg_class_relname_nsp_index")]   // CREATE INDEX IF NOT EXISTS
+    [InlineData("pg_extension_name_index")]      // CREATE EXTENSION IF NOT EXISTS
+    public void CatalogUniqueViolation_IsATransientDdlRace(string constraint) =>
+        Assert.True(PostgreSqlPartitionStorageProvider.IsTransientDdlRace(
+            PgWithConstraint("23505", constraint,
+                $"duplicate key value violates unique constraint \"{constraint}\"")));
+
+    /// <summary>
+    /// A server with <c>Include Error Detail=false</c> redacts DETAIL — the prod shape — but the
+    /// constraint still names itself in the message, so the fallback path must recognise it.
+    /// </summary>
+    [Fact]
+    public void CatalogUniqueViolation_IsRecognisedFromTheMessage_WhenConstraintFieldIsAbsent() =>
+        Assert.True(PostgreSqlPartitionStorageProvider.IsTransientDdlRace(
+            new PostgresException(
+                "duplicate key value violates unique constraint \"pg_namespace_nspname_index\"",
+                "ERROR", "ERROR", "23505")));
+
+    /// <summary>
+    /// 🚨 The scoping that keeps this from being a blanket retry: an APPLICATION unique violation is
+    /// a real error and must propagate. Only a `pg_*` system-catalog constraint means "another
+    /// session concurrently created the same catalog object".
+    /// </summary>
+    [Theory]
+    [InlineData("mesh_nodes_pkey")]
+    [InlineData("searchable_schemas_pkey")]
+    [InlineData("uq_user_email")]
+    public void ApplicationUniqueViolation_IsNotATransientDdlRace(string constraint) =>
+        Assert.False(PostgreSqlPartitionStorageProvider.IsTransientDdlRace(
+            PgWithConstraint("23505", constraint,
+                $"duplicate key value violates unique constraint \"{constraint}\"")));
+
+    [Theory]
+    [InlineData("42P06")] // duplicate_schema
+    [InlineData("42P07")] // duplicate_table
+    [InlineData("42710")] // duplicate_object
+    [InlineData("42723")] // duplicate_function
+    [InlineData("40P01")] // deadlock_detected
+    [InlineData("40001")] // serialization_failure
+    public void DuplicateObjectStates_AreTransientDdlRaces(string sqlState) =>
+        Assert.True(PostgreSqlPartitionStorageProvider.IsTransientDdlRace(Pg(sqlState)));
+
+    [Theory]
+    [InlineData("42883")] // undefined_function — the proc is missing; a REAL failure (#1369's inducer)
+    [InlineData("42P01")] // undefined_table
+    [InlineData("42501")] // insufficient_privilege
+    [InlineData("42601")] // syntax_error
+    public void RealDdlErrors_AreNotTransientDdlRaces(string sqlState) =>
+        Assert.False(PostgreSqlPartitionStorageProvider.IsTransientDdlRace(Pg(sqlState)));
+
+    /// <summary>
+    /// The #2132 shape: Npgsql wraps a mid-read connection drop as <c>NpgsqlException</c> around
+    /// <c>EndOfStreamException</c> ("Attempted to read past the end of the stream"). It is NOT a
+    /// <see cref="PostgresException"/>, so no SqlState filter can see it — the cross-schema fan-out
+    /// must still classify it as transient and retry rather than fault the area render.
+    /// </summary>
+    [Fact]
+    public void NpgsqlExceptionWrappingEndOfStream_IsTransient() =>
+        Assert.True(PostgreSqlStorageAdapter.IsTransientConnectionFault(
+            new NpgsqlException("Exception while reading from stream",
+                new System.IO.EndOfStreamException("Attempted to read past the end of the stream."))));
+
+    [Fact]
+    public void NpgsqlExceptionWrappingTimeout_IsTransient() =>
+        Assert.True(PostgreSqlStorageAdapter.IsTransientConnectionFault(
+            new NpgsqlException("Exception while reading from stream",
+                new TimeoutException("Timeout during reading attempt"))));
 
     // ---- Retry policy behaviour (deterministic: immediate scheduler + zero backoff) ----
 


### PR DESCRIPTION
Fixes #2130, #2131, #2132, #2133, #2158, #2159.

Three Postgres call sites treated a **genuinely transient** condition as a hard failure. Each one surfaced as something a user could see. The framing throughout: a transient gets a *bounded, scoped* retry; a real fault still **propagates** — nothing is swallowed, and no failure is ever presented as an empty result.

## #2130 / #2131 — `CREATE SCHEMA IF NOT EXISTS` is not race-free

**Root cause.** PostgreSQL performs the existence check and the `pg_namespace` insert as two separate steps under no common lock. Two sessions provisioning at the same moment both pass the check, and the loser's insert violates a **system-catalog** unique index: `23505 duplicate key value violates unique constraint "pg_namespace_nspname_index"`. `ExecuteDdlWithRetryAsync` retried `40P01` / `40001` / "tuple concurrently updated" but *not* that, so `InstanceAutoRegistrationService` logged the failure and continued — the pod came up healthy while silently **missing** whichever package lost the race (prod: AppleMaps, ICloud, GoogleMaps, Agent), and different replicas of one deployment ended up with different package sets.

**Fix.** `IsTransientDdlRace` now also classifies:
- a `23505` whose violated constraint is a **`pg_*` catalog index** — scoped exactly so an *application* unique violation (a duplicate mesh-node key) still propagates as the hard error it is;
- the `duplicate_schema` / `duplicate_table` / `duplicate_object` / `duplicate_function` states, which an idempotent `CREATE … IF NOT EXISTS` can only reach by losing a race.

The extra-satellite DDL leg gets the same retry, and the backoff is **jittered** — two racers woken after an identical delay collide again on every attempt.

Not touched, because it is already correct: the `PromiseCache` fault-eviction from #1369 (`_provisioned` is already a `PromiseCache`, not a bare `ConcurrentDictionary`), and the schema-name lowercasing, which is consistent between `EnsurePartitionProvisioned` and the router (`seg.ToLowerInvariant()`).

## #2158 / #2159 — the delete planner was the one read without the retry

**Root cause.** `ListDescendantPaths` and `ListChildPaths` were the only reads on `PostgreSqlStorageAdapter` not wrapped in the existing `WithTransientRetry`. `ListDescendantPaths` is the *planning step of a recursive delete* — a UNION over the partition's primary table and every satellite, running alongside whatever else writes to that subtree — so it is one of the likeliest reads in the system to be chosen as a `40P01` deadlock victim. A deadlock is not a failure: Postgres elects a loser and rolls it back atomically **so that** the loser can retry. Un-retried it aborted the whole user-facing delete with `partial-deleted=0` and no hint that trying again would work.

**Fix.** Both now use `WithTransientRetry`, whose classifier already covers `40P01`/`40001` and connection faults with a bounded 3-retry backoff. `TransientReadBackoff` gains jitter for the same reason as above (its deterministic form is kept as `TransientReadBackoffBase` and still pinned by the existing test).

The `[DeleteNode] unexpected … partial-deleted=` log level is deliberately left alone: with the retry in place a first deadlock never reaches it, and an *exhausted* retry is a real failure that has earned `Error`.

## #2132 / #2133 — a blip must not become an error panel, and must not become "no data"

**Root cause.** The cross-schema fan-out caught only `42P01`. An `NpgsqlException` wrapping `EndOfStreamException` ("Attempted to read past the end of the stream") or `TimeoutException` — neither of which is a `PostgresException`, so no SqlState filter can see them — and `PostgresException 40P01`, all propagated and faulted the area render. 171 occurrences across every `memex-portal` replica, putting an error panel on Timeline / Comments / Preview / Catalog.

**Fix.** Both fan-out paths (`search_across_schemas` and the satellite UNION) retry a transient, bounded, **only before the first row is yielded** — a re-execution after a row has left the iterator would duplicate it. One `attempts` counter spans the open and the stream leg, because nested per-leg budgets *multiply* (4 × 4) and quietly turn a "bounded" retry into a multi-second stall inside a render.

🚨 **Deliberately NOT the remediation the issue proposes.** Widening the `42P01` catch to return `Enumerable.Empty<T>()` on a transient would hand the view a well-formed empty result **indistinguishable from an authoritative one** — a momentary connection blip would silently render "no comments", "no timeline entries", "the catalog is empty" as fact. `42P01` keeps returning empty because there it genuinely *is* the answer; everything else propagates. `LayoutAreaHost` already carries a per-area error boundary (`CreateRenderErrorControl`), so a real failure is surfaced visibly rather than blanked — the issue's suggestion to add one is already satisfied.

## Tests

- **`ConcurrentPartitionProvisioningRaceTests`** (new) — induces the `23505` **deterministically** against a real Postgres, no mocking: a second connection holds an uncommitted `CREATE SCHEMA`, provisioning is then *observed to block on it* via `pg_stat_activity` (the anti-vacuous guard — commit too early and the test would pass having raced nothing), and the blocker commits. Asserts the retry actually fired, exactly one schema exists, and a write to the partition lands.
- **Verified fail-before**: with only the `23505` arm disabled, that test fails with the issue's exact stack frame (`ExecuteNonQuery` inside `EnsureSchemaAsync`).
- **`PostgreSqlTransientRetryTest`** — the classifier is pinned in both directions: `pg_*` catalog constraints and the `duplicate_*` states are races; `mesh_nodes_pkey` and friends are **not**; `42883`/`42P01`/`42501`/`42601` are **not**; the `NpgsqlException`-wrapping-`EndOfStream`/`Timeout` shapes from #2132 are transient. Plus the jitter band and spread.
- Fault-eviction (#1369) was already pinned by `PromiseCacheFaultEvictionTest` + `PartitionProvisioningFaultRecoveryTests`; unchanged and still green.

## Verification

- `dotnet build … -c Release -warnaserror` clean (`0 Error(s)`) for `MeshWeaver.Hosting.PostgreSql`, its test project, `MeshWeaver.Documentation.Test`, and `Memex.Portal.Monolith` as a broad dependent.
- Full `MeshWeaver.Hosting.PostgreSql.Test`: **782 passed, 0 failed**, 1 skipped.
- `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` green.

## Not fixed

- **The underlying infrastructure question in #2132** — `EndOfStream`/`Timeout` bursts on *every* pod simultaneously point at a shared cause (pool exhaustion, a proxy idle-timeout, a server restart) that the issue itself flags for DB-side correlation. This change makes the portal *tolerate* those blips; it does not explain why they are happening. Worth a separate look at the Postgres side.
- **Lock-order auditing in the subtree delete path** (#2158's stated follow-up) — the caller must tolerate deadlocks regardless, which is what this does; closing the deadlock window at the SQL level is a separate change.
- **Snowflake's `ListDescendantPaths`** has the same shape but different transient semantics and no equivalent classifier; out of scope for these Postgres issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
