### PR TITLE
Orleans membership lives in the mesh database, in its own schema

### DIFF
--- a/deploy/helm/templates/memex-migration/secrets.yaml
+++ b/deploy/helm/templates/memex-migration/secrets.yaml
@@ -19,9 +19,14 @@ stringData:
   # the migration's OrleansClusteringSetup creates the DB + tables when this is
   # set. Emitted only for AdoNet (HA) deployments — mirrors the portal gate.
   {{- if eq ((.Values.config.memex_portal).Deployment__Orleans__Clustering | default "Localhost") "AdoNet" }}
-  {{- if and (not .Values.secrets.memex_migration.ConnectionStrings__orleans) .Values.secrets.memex_migration.ConnectionStrings__memex }}
-  {{- fail "AdoNet Orleans clustering with an EXTERNAL mesh database: set secrets.memex_migration.ConnectionStrings__orleans too, or the migration creates the membership tables on the in-cluster memex-postgres-service instead of the server the portal actually joins." }}
+  {{- $orleans := .Values.secrets.memex_migration.ConnectionStrings__orleans }}
+  {{- if and (not $orleans) .Values.secrets.memex_migration.ConnectionStrings__memex }}
+  {{- /* Derived EXACTLY as the portal's is (see memex-portal/secrets.yaml): same server, same
+         database, `Search Path=orleans`. These two strings must agree or the migration creates the
+         tables somewhere the silo never looks — which is why both are derived by the same rule
+         from the same input rather than typed twice. */}}
+  {{- $orleans = printf "%s;Search Path=orleans" (trimSuffix ";" .Values.secrets.memex_migration.ConnectionStrings__memex) }}
   {{- end }}
-  ConnectionStrings__orleans: {{ .Values.secrets.memex_migration.ConnectionStrings__orleans | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=orleans" .Values.secrets.memex_migration.memex_postgres_password) | quote }}
+  ConnectionStrings__orleans: {{ $orleans | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=orleans" .Values.secrets.memex_migration.memex_postgres_password) | quote }}
   {{- end }}
 type: "Opaque"

--- a/deploy/helm/templates/memex-migration/secrets.yaml
+++ b/deploy/helm/templates/memex-migration/secrets.yaml
@@ -15,9 +15,11 @@ stringData:
   ConnectionStrings__memex: {{ .Values.secrets.memex_migration.ConnectionStrings__memex | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=memex" .Values.secrets.memex_migration.memex_postgres_password) | quote }}
   MEMEX_PASSWORD: "{{ .Values.secrets.memex_migration.memex_postgres_password }}"
   MEMEX_URI: {{ .Values.secrets.memex_migration.MEMEX_URI | default (printf "postgresql://postgres:%s@memex-postgres-service:5432/memex" .Values.secrets.memex_migration.memex_postgres_password) | quote }}
-  # Orleans membership tables live in a dedicated `orleans` DB on the same server;
-  # the migration's OrleansClusteringSetup creates the DB + tables when this is
-  # set. Emitted only for AdoNet (HA) deployments — mirrors the portal gate.
+  # Orleans membership tables live either in a dedicated `orleans` database (explicit
+  # ConnectionStrings__orleans) or — the default for an external mesh database — in the MESH
+  # database's own `orleans` SCHEMA, derived below. OrleansClusteringSetup creates whichever
+  # it is pointed at (database, schema and tables) when this is set. Emitted only for AdoNet
+  # (HA) deployments — mirrors the portal gate, and must resolve to the SAME store.
   {{- if eq ((.Values.config.memex_portal).Deployment__Orleans__Clustering | default "Localhost") "AdoNet" }}
   {{- $orleans := .Values.secrets.memex_migration.ConnectionStrings__orleans }}
   {{- if and (not $orleans) .Values.secrets.memex_migration.ConnectionStrings__memex }}

--- a/deploy/helm/templates/memex-portal/secrets.yaml
+++ b/deploy/helm/templates/memex-portal/secrets.yaml
@@ -34,10 +34,27 @@ stringData:
   # OrleansClusteringSetup creates + seeds with the membership tables. Emitted
   # ONLY for AdoNet; Localhost single-replica deployments omit it (no unused DB).
   {{- if eq ((.Values.config.memex_portal).Deployment__Orleans__Clustering | default "Localhost") "AdoNet" }}
-  {{- if and (not .Values.secrets.memex_portal.ConnectionStrings__orleans) .Values.secrets.memex_portal.ConnectionStrings__memex }}
-  {{- fail "AdoNet Orleans clustering with an EXTERNAL mesh database: set secrets.memex_portal.ConnectionStrings__orleans too. Silo membership would otherwise be pointed at the in-cluster memex-postgres-service, which an external-Postgres deployment does not run — the silo throws at startup and the namespace has no portal. Use the same server as ConnectionStrings__memex with Database=orleans (the migration's OrleansClusteringSetup creates it)." }}
+  {{- $orleans := .Values.secrets.memex_portal.ConnectionStrings__orleans }}
+  {{- if and (not $orleans) .Values.secrets.memex_portal.ConnectionStrings__memex }}
+  {{- /*
+       EXTERNAL mesh database, no explicit orleans string: DERIVE one from the mesh connection by
+       adding `Search Path=orleans`. Same server, same DATABASE as the mesh/graph data, isolated in
+       its own SCHEMA — the migration's OrleansClusteringSetup creates that schema and the tables.
+
+       This used to `fail` at template time, which was right about the danger and wrong about the
+       remedy: it demanded a second secret nobody had, so every external-Postgres deployment stayed
+       on Localhost clustering. That is not a safe default — it is single-process membership, so a
+       multi-pod deployment silently becomes N one-silo clusters, each running every singleton and
+       none able to reach the others' grains (memex-cloud + systemorph, measured 2026-08-25).
+
+       Deriving is safe on the one axis that matters: ClusterId is the fixed constant "Memex", so
+       isolation has to come from the STORE. Each instance's mesh database is already its own, so a
+       schema inside it can never merge two deployments into one cluster — which a shared `orleans`
+       database on a shared server could.
+  */}}
+  {{- $orleans = printf "%s;Search Path=orleans" (trimSuffix ";" .Values.secrets.memex_portal.ConnectionStrings__memex) }}
   {{- end }}
-  ConnectionStrings__orleans: {{ .Values.secrets.memex_portal.ConnectionStrings__orleans | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=orleans" .Values.secrets.memex_portal.memex_postgres_password) | quote }}
+  ConnectionStrings__orleans: {{ $orleans | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=orleans" .Values.secrets.memex_portal.memex_postgres_password) | quote }}
   {{- end }}
   # ---- AI provider keys (secret) -------------------------------------------
   # Conditionally emitted: a key is set ONLY when its value is non-empty, so the chart never

--- a/deploy/helm/templates/memex-portal/secrets.yaml
+++ b/deploy/helm/templates/memex-portal/secrets.yaml
@@ -30,9 +30,13 @@ stringData:
   # ---- Orleans AdoNet clustering (HA / multi-replica) ----------------------
   # The silo THROWS at startup when Deployment:Orleans:Clustering=AdoNet but
   # ConnectionStrings:orleans is unset — so this MUST accompany the AdoNet flag.
-  # Same Postgres server, a dedicated `orleans` database that the migration's
-  # OrleansClusteringSetup creates + seeds with the membership tables. Emitted
-  # ONLY for AdoNet; Localhost single-replica deployments omit it (no unused DB).
+  # TWO supported shapes, both seeded by the migration's OrleansClusteringSetup:
+  #   * explicit — whatever ConnectionStrings__orleans says (e.g. a dedicated `orleans`
+  #     database on the same server); it always wins;
+  #   * derived  — the mesh connection plus `Search Path=orleans`: the SAME database as the
+  #     mesh/graph data, isolated in its own schema. This is the default for an external
+  #     mesh database, so a multi-pod deployment is never left on Localhost membership.
+  # Emitted ONLY for AdoNet; Localhost single-replica deployments omit it entirely.
   {{- if eq ((.Values.config.memex_portal).Deployment__Orleans__Clustering | default "Localhost") "AdoNet" }}
   {{- $orleans := .Values.secrets.memex_portal.ConnectionStrings__orleans }}
   {{- if and (not $orleans) .Values.secrets.memex_portal.ConnectionStrings__memex }}

--- a/memex/aspire/Memex.Database.Migration/Migrations/OrleansClusteringSetup.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/OrleansClusteringSetup.cs
@@ -48,6 +48,16 @@ public static class OrleansClusteringSetup
         await using var conn = new NpgsqlConnection(orleansConnectionString);
         await conn.OpenAsync();
 
+        // 🚨 The SCHEMA must exist before anything else, because every gate below asks
+        // `current_schema()` — which resolves through the connection's Search Path. Point the
+        // connection at a schema that does not exist and current_schema() falls back to public:
+        // the gates then read PUBLIC's tables, conclude "already present", and the Orleans tables
+        // are silently created in (or read from) the wrong schema. This is what makes
+        // "Orleans lives in the MESH database, in its own schema" a safe shape — one database per
+        // instance, so two deployments sharing a server can never merge into one cluster even
+        // though ClusterId is a fixed constant.
+        await EnsureSchemaExistsAsync(conn, orleansConnectionString, logger);
+
         // Phase 1 — membership (OrleansQuery + the membership tables). Must run first: the
         // persistence script INSERTs its query texts INTO OrleansQuery.
         if (await TableExistsAsync(conn, "orleansquery"))
@@ -257,6 +267,32 @@ public static class OrleansClusteringSetup
             + "WHERE table_name = @t AND table_schema = current_schema())", conn);
         check.Parameters.AddWithValue("t", tableName);
         return (bool)(await check.ExecuteScalarAsync())!;
+    }
+
+    /// <summary>
+    /// Creates the schema named by the connection string's <c>Search Path</c>, when it names one
+    /// other than <c>public</c>. Orleans' own scripts are verbatim Microsoft SQL with unqualified
+    /// table names, so the SEARCH PATH is the only seam that can place them — and Postgres will
+    /// not create a schema on demand. Idempotent (<c>CREATE SCHEMA IF NOT EXISTS</c>), and a no-op
+    /// for the dedicated-database shape that names no search path.
+    /// </summary>
+    private static async Task EnsureSchemaExistsAsync(
+        NpgsqlConnection conn, string connectionString, ILogger logger)
+    {
+        var schema = new NpgsqlConnectionStringBuilder(connectionString).SearchPath;
+        if (string.IsNullOrWhiteSpace(schema))
+            return;
+        // Search Path may list several schemas; the FIRST is where unqualified CREATEs land, and
+        // it is therefore the only one this step owns.
+        schema = schema.Split(',')[0].Trim().Trim('"');
+        if (schema.Length == 0 || string.Equals(schema, "public", StringComparison.OrdinalIgnoreCase))
+            return;
+        await using var create = new NpgsqlCommand(
+            $"CREATE SCHEMA IF NOT EXISTS \"{schema.Replace("\"", "\"\"")}\"", conn);
+        await create.ExecuteNonQueryAsync();
+        logger.LogInformation(
+            "[OrleansClustering] Schema '{Schema}' ensured — Orleans tables live beside the mesh "
+            + "data in this database, isolated by schema.", schema);
     }
 
     /// <summary>

--- a/memex/aspire/Memex.Database.Migration/Migrations/OrleansClusteringSetup.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/OrleansClusteringSetup.cs
@@ -284,8 +284,19 @@ public static class OrleansClusteringSetup
             return;
         // Search Path may list several schemas; the FIRST is where unqualified CREATEs land, and
         // it is therefore the only one this step owns.
-        schema = schema.Split(',')[0].Trim().Trim('"');
-        if (schema.Length == 0 || string.Equals(schema, "public", StringComparison.OrdinalIgnoreCase))
+        var raw = schema.Split(',')[0].Trim();
+        if (raw.Length == 0)
+            return;
+        // 🚨 Match Postgres's OWN folding, or this creates a schema the silo cannot see. An
+        // UNQUOTED identifier is folded to lower case when the connection applies its search
+        // path, so `Search Path=Orleans` resolves to `orleans`; creating a quoted "Orleans"
+        // would make a SECOND, differently-cased schema and leave the resolved one empty. A
+        // quoted entry means the case is deliberate and is preserved verbatim.
+        var quoted = raw.Length >= 2 && raw[0] == '"' && raw[^1] == '"';
+        schema = quoted
+            ? raw[1..^1].Replace("\"\"", "\"")
+            : raw.ToLowerInvariant();
+        if (schema.Length == 0 || string.Equals(schema, "public", StringComparison.Ordinal))
             return;
         await using var create = new NpgsqlCommand(
             $"CREATE SCHEMA IF NOT EXISTS \"{schema.Replace("\"", "\"\"")}\"", conn);


### PR DESCRIPTION
Multi-pod deployments were stuck on `Localhost` clustering because the chart **failed at template time** when AdoNet met an external mesh database without a separate `ConnectionStrings__orleans` — a remedy nobody had, so every external-Postgres deployment kept the safe-looking default. It is not safe: measured on 2026-08-25, memex-cloud and systemorph each ran 2 pods where **every pod was its own one-silo cluster** — silo advertising `S127.0.0.1:11111`, membership heartbeats 1d8h stale, every singleton running once per pod, and cross-pod grain calls failing with `no silo in this cluster is currently serving that hub`.

**Change:** both the portal and migration secrets now DERIVE the orleans connection from the mesh one by appending `Search Path=orleans` — same server, same database as the mesh/graph data, isolated in its own schema. One rule, one input, both templates (a migration that seeds tables where the silo never looks is exactly the failure being replaced). An explicit `ConnectionStrings__orleans` still wins, so the existing dedicated-database deployments are untouched.

Isolation holds on the axis that matters: `ClusterId` is the fixed constant `"Memex"`, so two deployments must never share a membership store — and each instance's mesh database is already its own, which a shared `orleans` database on a shared server is not.

`OrleansClusteringSetup` creates the schema before anything else, because every gate in it asks `current_schema()`: pointed at a schema that does not exist, `current_schema()` silently falls back to `public` and the gates read the wrong tables.

Verified: `helm template` renders both strings identically (`Host=…;Database=memex;…;Search Path=orleans`); `check-chart-invariants.sh` passes all three combinations; the migration builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)