### PR TITLE
Fix two unbounded GetHashCode recursions that StackOverflow the pod

### DIFF
--- a/src/MeshWeaver.Data.Contract/EntityStore.cs
+++ b/src/MeshWeaver.Data.Contract/EntityStore.cs
@@ -111,12 +111,34 @@ public record EntityStore
                                              && value.Equals(x.Value));
     }
 
-    /// <summary>Returns a hash code derived from the contained collections.</summary>
-    /// <returns>The hash code.</returns>
+    /// <summary>
+    /// Hash derived from the collection NAMES and their sizes — deliberately NOT from the
+    /// contained instances.
+    /// <para>
+    /// 🚨 The previous version aggregated <c>InstanceCollection.GetHashCode()</c>, which walked
+    /// every stored instance; because a stored instance can transitively hold this very store
+    /// (<c>EntityStore → ChangeItem → InstanceCollection → EntityStore</c>), that recursion was
+    /// unbounded and killed pods with an uncatchable StackOverflowException (#2170/#2171).
+    /// </para>
+    /// <para>
+    /// It also threw <see cref="InvalidOperationException"/> ("Sequence contains no elements") for
+    /// an EMPTY store: <c>Aggregate</c> was called without a seed. An empty store now hashes
+    /// normally.
+    /// </para>
+    /// <para>
+    /// Contract-consistent with <see cref="Equals(EntityStore)"/>: equal stores hold the same
+    /// collection names, and equal <see cref="InstanceCollection"/>s hold the same number of
+    /// instances, so equal stores hash equal. The XOR is order-independent.
+    /// </para>
+    /// </summary>
+    /// <returns>A bounded, cycle-free hash code.</returns>
     public override int GetHashCode()
-        => Collections.Values
-            .Select(x => x.GetHashCode())
-            .Aggregate((x, y) => x ^ y);
+    {
+        var hash = 0;
+        foreach (var kvp in Collections)
+            hash ^= HashCode.Combine(kvp.Key, kvp.Value.Instances.Count);
+        return HashCode.Combine(hash, Collections.Count);
+    }
 
 
     internal IEnumerable<EntityUpdate> ComputeChanges(string collection, InstanceCollection updated)

--- a/src/MeshWeaver.Data.Contract/InstanceCollection.cs
+++ b/src/MeshWeaver.Data.Contract/InstanceCollection.cs
@@ -167,8 +167,35 @@ public record InstanceCollection
                );
     }
 
-    /// <summary>Returns a hash code derived from the contained instances.</summary>
-    /// <returns>The hash code.</returns>
-    public override int GetHashCode() =>
-        Instances.Values.Select(x => x.GetHashCode()).Aggregate(0, (x, y) => x ^ y);
+    /// <summary>
+    /// Hash derived from the instance KEYS and the count — deliberately NOT from the instance
+    /// VALUES.
+    /// <para>
+    /// 🚨 <see cref="Instances"/> holds ARBITRARY user objects, and in a running mesh those
+    /// objects reach back into the store that contains this collection
+    /// (<c>InstanceCollection → EntityStore → ChangeItem → InstanceCollection</c>). Hashing the
+    /// values therefore walked an unbounded object graph and died on an uncatchable
+    /// StackOverflowException, terminating the pod (#2170/#2171). It was also O(entire graph) on
+    /// a routing hot path.
+    /// </para>
+    /// <para>
+    /// Keys are safe by construction — <see cref="Instances"/> already hashed every one of them to
+    /// store it — and they satisfy the hash/equals contract against the value-based
+    /// <see cref="Equals(InstanceCollection)"/>: equal collections hold the same keys in the same
+    /// number, hence the same hash. The XOR is order-independent, so it does not depend on
+    /// <see cref="ImmutableDictionary{TKey,TValue}"/> enumeration order. Note
+    /// <see cref="CollectionName"/> is excluded because <c>Equals</c> ignores it — including it
+    /// would break the contract.
+    /// </para>
+    /// </summary>
+    /// <returns>A bounded, cycle-free hash code.</returns>
+    public override int GetHashCode()
+    {
+        // foreach over the struct enumerator: no LINQ delegate/iterator allocation, unlike the
+        // Select+Aggregate this replaced.
+        var keyHash = 0;
+        foreach (var kvp in Instances)
+            keyHash ^= kvp.Key.GetHashCode();
+        return HashCode.Combine(keyHash, Instances.Count);
+    }
 }

--- a/src/MeshWeaver.Data/ChangeItem.cs
+++ b/src/MeshWeaver.Data/ChangeItem.cs
@@ -61,4 +61,25 @@ public record ChangeItem<TStream>(
         : this(Value, null, StreamId, ChangeType.Full, Version, null)
     { }
 
+    /// <summary>
+    /// Hash derived from the change's own identity fields — deliberately NOT from
+    /// <see cref="Value"/>.
+    /// <para>
+    /// 🚨 <see cref="Value"/> is the whole synchronized state (typically an
+    /// <see cref="EntityStore"/>, or the stream state of an arbitrary <typeparamref name="TStream"/>).
+    /// The record-synthesized hash walked it, which made <c>ChangeItem</c> the third layer of the
+    /// unbounded <c>InstanceCollection → EntityStore → ChangeItem → InstanceCollection</c> hash
+    /// recursion that killed pods with an uncatchable StackOverflowException (#2170/#2171), and
+    /// made a single hash O(the entire object graph) on a hot path.
+    /// </para>
+    /// <para>
+    /// The four fields used are all part of the synthesized <c>Equals</c>, so the hash/equals
+    /// contract holds: equal change items agree on them and therefore hash equal. Value-based
+    /// <c>Equals</c> is intentionally left untouched — the <c>SetCurrent</c> dedup that suppresses
+    /// re-emission of an identical re-synced store depends on it.
+    /// </para>
+    /// </summary>
+    /// <returns>A bounded, cycle-free hash code.</returns>
+    public override int GetHashCode() =>
+        HashCode.Combine(StreamId, ChangedBy, ChangeType, Version);
 }

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -3,6 +3,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using MeshWeaver.Messaging;
@@ -1611,6 +1612,37 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
 
     internal StreamConfiguration<TStream> Configuration { get; }
 
+    /// <summary>
+    /// 🚨 REFERENCE identity — deliberately NOT the record-synthesized structural equality.
+    /// <para>
+    /// A stream is a LIVE object, not a value: it owns a <see cref="ReplaySubject{T}"/>, mutable
+    /// <c>current</c> state, a hosted hub, subscriptions and disposal state. Two distinct stream
+    /// instances are never "the same stream", so reference identity IS the correct semantics
+    /// (the synthesized version already behaved this way in practice — each instance carries its
+    /// own <see cref="Store"/> subject, compared by reference).
+    /// </para>
+    /// <para>
+    /// It is also the only SAFE semantics. The synthesized <c>GetHashCode</c>/<c>Equals</c> walk
+    /// every instance field, including <see cref="Configuration"/> — and
+    /// <see cref="StreamConfiguration{TStream}.Stream"/> points straight back here. That closed a
+    /// cycle <c>SynchronizationStream.GetHashCode → StreamConfiguration.GetHashCode →
+    /// EqualityComparer&lt;ISynchronizationStream&lt;TStream&gt;&gt;.Default.GetHashCode(Stream) →
+    /// …</c> with no base case, so ANY hash of a stream instance (a dictionary key, a log scope,
+    /// a HashSet) recursed until the process died on an uncatchable StackOverflowException
+    /// (#2163/#2164/#2172/#2173/#2174/#2175 — repeated pod kills in prod).
+    /// </para>
+    /// </summary>
+    /// <param name="other">The stream to compare against.</param>
+    /// <returns>True only when <paramref name="other"/> is this very instance.</returns>
+    public virtual bool Equals(SynchronizationStream<TStream>? other) => ReferenceEquals(this, other);
+
+    /// <summary>
+    /// Reference-identity hash — see <see cref="Equals(SynchronizationStream{TStream})"/> for why
+    /// structural hashing of a stream is both wrong and fatal.
+    /// </summary>
+    /// <returns>The runtime identity hash of this instance.</returns>
+    public override int GetHashCode() => RuntimeHelpers.GetHashCode(this);
+
 
     /// <summary>
     /// Disposes the stream: completes the underlying store and tears down the hosted hub.
@@ -1873,4 +1905,50 @@ public record StreamConfiguration<TStream>(ISynchronizationStream<TStream> Strea
     public StreamConfiguration<TStream> WithDeferredInitialization(
         string gateName, Predicate<IMessageDelivery> allowDuringInit)
         => this with { DeferredInitialization = true, DeferredGateName = gateName, DeferredGatePredicate = allowDuringInit };
+
+    /// <summary>
+    /// 🚨 Compares this configuration's OWN values; the <see cref="Stream"/> back-pointer
+    /// participates BY REFERENCE and is never traversed structurally.
+    /// <para>
+    /// <see cref="Stream"/> points back at the stream that OWNS this configuration
+    /// (<c>new StreamConfiguration&lt;TStream&gt;(this)</c>), so letting the record-synthesized
+    /// members walk it closes an unbounded cycle through
+    /// <see cref="SynchronizationStream{TStream}"/> — the StackOverflow that killed portal pods
+    /// (#2163/#2164/#2172/#2173/#2174/#2175). The owning stream is part of this configuration's
+    /// IDENTITY, not of its value, which is exactly what reference comparison expresses.
+    /// </para>
+    /// </summary>
+    /// <param name="other">The configuration to compare against.</param>
+    /// <returns>True if both configurations belong to the same stream and carry the same settings.</returns>
+    public virtual bool Equals(StreamConfiguration<TStream>? other) =>
+        other is not null
+        && (ReferenceEquals(this, other)
+            || (ReferenceEquals(Stream, other.Stream)
+                && ClientId == other.ClientId
+                && Equals(Subscriber, other.Subscriber)
+                && NullReturn == other.NullReturn
+                && RunsAsInfrastructure == other.RunsAsInfrastructure
+                && DeferredInitialization == other.DeferredInitialization
+                && DeferredGateName == other.DeferredGateName
+                && Equals(Initialization, other.Initialization)
+                && Equals(ObservableInitialization, other.ObservableInitialization)
+                && Equals(ExceptionCallback, other.ExceptionCallback)
+                && Equals(DeferredGatePredicate, other.DeferredGatePredicate)));
+
+    /// <summary>
+    /// Hash over this configuration's own settings plus the owning stream's REFERENCE identity —
+    /// never a structural walk of <see cref="Stream"/>. See
+    /// <see cref="Equals(StreamConfiguration{TStream})"/>. The delegate-valued settings are
+    /// deliberately omitted (equal configurations still hash equal, which is all the contract asks).
+    /// </summary>
+    /// <returns>A bounded, cycle-free hash code.</returns>
+    public override int GetHashCode() =>
+        HashCode.Combine(
+            RuntimeHelpers.GetHashCode(Stream),
+            ClientId,
+            Subscriber,
+            NullReturn,
+            RunsAsInfrastructure,
+            DeferredInitialization,
+            DeferredGateName);
 }

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -439,15 +439,16 @@ public class Workspace : IWorkspace
     // workspace disposal would leak the stream's heartbeat for the process lifetime).
     // Keyed set (value unused) rather than a bag so a per-identity release can remove
     // matching entries without the drain-and-re-add race a ConcurrentBag would force.
-    // 🚨 MUST hash by REFERENCE: SynchronizationStream is a record whose generated
-    // GetHashCode recurses into StreamConfiguration (which holds the stream back) —
-    // value-hashing a stream instance stack-overflows the process. Stream identity
-    // here IS the instance, so reference semantics is also the correct semantics.
+    // Hashes by REFERENCE: stream identity here IS the instance. SynchronizationStream now
+    // declares reference identity itself (the generated structural GetHashCode recursed into
+    // StreamConfiguration, which holds the stream back — an uncatchable StackOverflow, #2163…),
+    // so this comparer is no longer load-bearing for that; it is kept because ISynchronizationStream
+    // is an interface and reference semantics must hold for ANY implementation put in this set.
     private readonly ConcurrentDictionary<ISynchronizationStream, byte> _evictedRemoteStreams =
         new(StreamReferenceComparer.Instance);
 
     /// <summary>Reference-identity comparer for stream instances — see the
-    /// <see cref="_evictedRemoteStreams"/> field note (record GetHashCode recursion).</summary>
+    /// <see cref="_evictedRemoteStreams"/> field note.</summary>
     private sealed class StreamReferenceComparer : IEqualityComparer<ISynchronizationStream>
     {
         public static readonly StreamReferenceComparer Instance = new();

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-hash-recursion-pod-crash.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-hash-recursion-pod-crash.md
@@ -1,0 +1,22 @@
+---
+Name: Portal no longer crashes on a self-referencing data graph
+Category: Fix
+Description: Fixed an unbounded hash-code recursion that could kill a portal instance outright, dropping every open page on it.
+Icon: Sparkle
+Order: -20260825
+---
+
+# Portal no longer crashes on a self-referencing data graph
+
+Two places in the data layer computed an object's hash code by walking everything it
+contained. When the data pointed back at itself — which happens routinely once a
+synchronization stream or an entity store is involved — that walk never finished and the
+portal process died on the spot, taking every page open on that instance with it.
+
+Streams and their configuration now compare and hash by identity, which is what they always
+meant: two live streams are two different streams, never two copies of the same value. Stores
+and collections hash from their keys and sizes instead of from the arbitrary objects they
+carry, so the cost no longer grows with the size of your workspace either.
+
+A related crash is fixed at the same time: an empty store used to throw when something asked
+for its hash code.

--- a/test/MeshWeaver.Data.Test/HashRecursionTest.cs
+++ b/test/MeshWeaver.Data.Test/HashRecursionTest.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using MeshWeaver.Data.Serialization;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Pins the two unbounded <c>GetHashCode</c> cycles that killed portal pods with an uncatchable
+/// <c>StackOverflowException</c> (#2163/#2164/#2172/#2173/#2174/#2175 and #2170/#2171).
+///
+/// <para><b>Cycle 1 — record-synthesized structural hashing over a back-reference.</b>
+/// <c>SynchronizationStream&lt;T&gt;</c> is a <c>record</c>, so the compiler synthesized a
+/// <c>GetHashCode</c> walking every instance field — including <c>Configuration</c>.
+/// <c>StreamConfiguration&lt;T&gt;</c>'s primary-ctor property <c>Stream</c> is a back-pointer to
+/// the owning stream (<c>new StreamConfiguration&lt;T&gt;(this)</c>), so hashing a stream ran
+/// <c>SynchronizationStream.GetHashCode → StreamConfiguration.GetHashCode →
+/// EqualityComparer&lt;ISynchronizationStream&lt;T&gt;&gt;.Default.GetHashCode(Stream) → …</c>
+/// forever — exactly the captured production stack.</para>
+///
+/// <para><b>Cycle 2 — hand-written structural hashing over an arbitrary object graph.</b>
+/// <c>InstanceCollection.GetHashCode</c> aggregated the hashes of its VALUES (arbitrary user
+/// objects), <c>EntityStore.GetHashCode</c> aggregated its collections, and
+/// <c>ChangeItem&lt;T&gt;</c>'s synthesized hash walked its <c>Value</c> — so a value that
+/// transitively holds the store closed the loop
+/// <c>InstanceCollection → EntityStore → ChangeItem → InstanceCollection</c>.</para>
+///
+/// <para><b>The fix is semantic, not a depth guard.</b> A stream is a live identity object, so it
+/// hashes by reference; a configuration hashes its own values and treats its owner as a reference;
+/// stores and collections hash their KEYS and counts, never the instance values they carry.</para>
+///
+/// <para>A <c>StackOverflowException</c> cannot be caught in .NET, so these tests never let the
+/// recursion run free: <see cref="ReentrancyProbe"/> is the cycle-closing value and it THROWS once
+/// it has been re-entered, turning a pre-fix regression into a clean red test instead of a dead
+/// test host. The assertion is stronger than "it terminated" — it is that the instance value was
+/// never traversed at all.</para>
+/// </summary>
+public class HashRecursionTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const int ReentrancyBudget = 8;
+
+    /// <summary>
+    /// A value stored inside an <see cref="InstanceCollection"/> that points back at the graph
+    /// containing it — the shape a running mesh actually produces. Hashing it re-enters the graph,
+    /// so it counts its own invocations and refuses to recurse past
+    /// <see cref="ReentrancyBudget"/>: pre-fix this surfaces as a deterministic exception naming
+    /// the defect, instead of a StackOverflow that takes the test host down with it.
+    /// </summary>
+    private sealed class ReentrancyProbe
+    {
+        /// <summary>The back-pointer that closes the cycle (a ChangeItem holding the store).</summary>
+        public object? Back { get; set; }
+
+        /// <summary>How many times structural hashing has reached this instance value.</summary>
+        public int HashCalls { get; private set; }
+
+        /// <summary>Reference identity — this probe measures hashing, not equality.</summary>
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            HashCalls++;
+            if (HashCalls > ReentrancyBudget)
+                throw new InvalidOperationException(
+                    $"Instance-value hashing re-entered {HashCalls} times: the store/collection "
+                    + "hash is walking its VALUES again and would StackOverflow in production "
+                    + "(#2170/#2171).");
+            return Back?.GetHashCode() ?? 0;
+        }
+    }
+
+    /// <summary>
+    /// Builds the exact production cycle: an <see cref="EntityStore"/> whose
+    /// <see cref="InstanceCollection"/> holds a value that points back at a
+    /// <see cref="ChangeItem{TStream}"/> carrying that same store.
+    /// </summary>
+    private static (EntityStore Store, InstanceCollection Collection, ChangeItem<EntityStore> Change, ReentrancyProbe Probe)
+        BuildCyclicGraph()
+    {
+        var probe = new ReentrancyProbe();
+        var collection = new InstanceCollection(
+            new Dictionary<object, object> { ["id-1"] = probe, ["id-2"] = "a plain value" });
+        var store = new EntityStore(
+            new Dictionary<string, InstanceCollection> { ["Probes"] = collection });
+        var change = new ChangeItem<EntityStore>(store, "stream-1", 1);
+        probe.Back = change;   // ← closes the loop
+        return (store, collection, change, probe);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Cycle 2 — InstanceCollection / EntityStore / ChangeItem
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Hashing anywhere on the cyclic store graph terminates, and does so because the instance
+    /// VALUES are never traversed — the property that makes it bounded for ANY object graph, not
+    /// just this one.
+    /// </summary>
+    [HubFact]
+    public void CyclicStoreGraph_HashesWithoutTraversingInstanceValues()
+    {
+        var (store, collection, change, probe) = BuildCyclicGraph();
+
+        // Each of these was an entry point into the unbounded walk in production.
+        _ = collection.GetHashCode();
+        _ = store.GetHashCode();
+        _ = change.GetHashCode();
+
+        probe.HashCalls.Should().Be(0,
+            "InstanceCollection/EntityStore/ChangeItem must hash their KEYS and counts, never the "
+            + "arbitrary instance values — a value that reaches back into the store is exactly how "
+            + "the production StackOverflow (#2170/#2171) was reached");
+    }
+
+    /// <summary>
+    /// The hash must be stable, not merely terminating — a hash that varies between calls silently
+    /// corrupts every dictionary it is used in.
+    /// </summary>
+    [HubFact]
+    public void CyclicStoreGraph_HashIsStableAcrossCalls()
+    {
+        var (store, collection, change, _) = BuildCyclicGraph();
+
+        collection.GetHashCode().Should().Be(collection.GetHashCode());
+        store.GetHashCode().Should().Be(store.GetHashCode());
+        change.GetHashCode().Should().Be(change.GetHashCode());
+    }
+
+    /// <summary>
+    /// The seedless <c>Aggregate((x, y) =&gt; x ^ y)</c> in <c>EntityStore.GetHashCode</c> threw
+    /// <see cref="InvalidOperationException"/> ("Sequence contains no elements") for a store with
+    /// no collections — a latent crash on the emptiest possible input.
+    /// </summary>
+    [HubFact]
+    public void EmptyEntityStore_Hashes_WithoutThrowing()
+    {
+        Action hashEmptyStore = () => { _ = new EntityStore().GetHashCode(); };
+        hashEmptyStore.Should().NotThrow(
+            "an empty store is a legal store; the hash used Aggregate with no seed");
+
+        Action hashEmptyCollection = () => { _ = new InstanceCollection().GetHashCode(); };
+        hashEmptyCollection.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// The hash/equals contract: equal objects hash equal. The hashes got WEAKER (keys and counts
+    /// rather than values) — weaker is fine, inconsistent is not.
+    /// </summary>
+    [HubFact]
+    public void EqualStoresAndCollections_HashEqual()
+    {
+        InstanceCollection Collection() => new(
+            new Dictionary<object, object> { ["a"] = "one", ["b"] = "two" });
+        EntityStore Store() => new(
+            new Dictionary<string, InstanceCollection> { ["C"] = Collection() });
+
+        var c1 = Collection();
+        var c2 = Collection();
+        c1.Equals(c2).Should().BeTrue();
+        c1.GetHashCode().Should().Be(c2.GetHashCode());
+
+        var s1 = Store();
+        var s2 = Store();
+        s1.Equals(s2).Should().BeTrue();
+        s1.GetHashCode().Should().Be(s2.GetHashCode());
+
+        var ch1 = new ChangeItem<EntityStore>(s1, "stream-1", 7);
+        var ch2 = new ChangeItem<EntityStore>(s2, "stream-1", 7);
+        ch1.Equals(ch2).Should().BeTrue(
+            "value equality drives the SetCurrent dedup and is deliberately unchanged");
+        ch1.GetHashCode().Should().Be(ch2.GetHashCode());
+    }
+
+    /// <summary>
+    /// The weakened hash still has to discriminate on the things it claims to hash — otherwise it
+    /// degenerates every dictionary into a linked list.
+    /// </summary>
+    [HubFact]
+    public void DifferentKeysOrSizes_HashDifferently()
+    {
+        var a = new InstanceCollection(new Dictionary<object, object> { ["a"] = "x" });
+        var b = new InstanceCollection(new Dictionary<object, object> { ["b"] = "x" });
+        var ab = new InstanceCollection(
+            new Dictionary<object, object> { ["a"] = "x", ["b"] = "x" });
+
+        a.GetHashCode().Should().NotBe(b.GetHashCode(), "different keys");
+        a.GetHashCode().Should().NotBe(ab.GetHashCode(), "different size");
+
+        var s1 = new EntityStore(new Dictionary<string, InstanceCollection> { ["One"] = a });
+        var s2 = new EntityStore(new Dictionary<string, InstanceCollection> { ["Two"] = a });
+        s1.GetHashCode().Should().NotBe(s2.GetHashCode(), "different collection names");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Cycle 1 — SynchronizationStream / StreamConfiguration
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A stream and its configuration hash without recursing through the configuration's
+    /// back-pointer to the stream — and the stream compares by REFERENCE, because two distinct
+    /// live streams (each owning its own ReplaySubject, hub and disposal state) are never the same
+    /// stream.
+    /// </summary>
+    [HubFact]
+    public void Stream_And_ItsConfiguration_HashByIdentity_NotStructurally()
+    {
+        var host = GetHost();
+        using var stream = new SynchronizationStream<EntityStore>(
+            new StreamIdentity(host.Address, null),
+            host,
+            new EntityReference("Probes", "id-1"),
+            new ReduceManager<EntityStore>(host),
+            null);
+
+        // Pre-fix each of these entered the unbounded stream ↔ configuration cycle
+        // and never returned.
+        var streamHash = stream.GetHashCode();
+        var configHash = stream.Configuration.GetHashCode();
+
+        streamHash.Should().Be(stream.GetHashCode(), "an identity hash must be stable");
+        configHash.Should().Be(stream.Configuration.GetHashCode());
+
+        // A configuration constructed independently over the same stream also terminates —
+        // the back-pointer is never traversed structurally, whoever holds it.
+        _ = new StreamConfiguration<EntityStore>(stream).GetHashCode();
+
+        stream.Equals(stream).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Reference identity is the SEMANTICS, not just the mechanism: two streams built with the
+    /// same identity, host and reference are still two different live streams.
+    /// </summary>
+    [HubFact]
+    public void TwoDistinctStreams_AreNeverEqual()
+    {
+        var host = GetHost();
+        using var a = new SynchronizationStream<EntityStore>(
+            new StreamIdentity(host.Address, null), host,
+            new EntityReference("Probes", "id-1"), new ReduceManager<EntityStore>(host), null);
+        using var b = new SynchronizationStream<EntityStore>(
+            new StreamIdentity(host.Address, null), host,
+            new EntityReference("Probes", "id-1"), new ReduceManager<EntityStore>(host), null);
+
+        a.Equals(b).Should().BeFalse(
+            "a stream owns a ReplaySubject, mutable current state, a hosted hub and disposal state "
+            + "— distinct instances are distinct streams");
+        (a == b).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <c>StreamConfiguration</c> keeps value semantics over its OWN settings (it is used as a
+    /// <c>with</c>-based builder throughout: WithClientId / WithSubscriber / AsInfrastructure / …),
+    /// while its owning stream participates by reference only.
+    /// </summary>
+    [HubFact]
+    public void StreamConfiguration_KeepsValueSemantics_OverItsOwnSettings()
+    {
+        var host = GetHost();
+        using var stream = new SynchronizationStream<EntityStore>(
+            new StreamIdentity(host.Address, null), host,
+            new EntityReference("Probes", "id-1"), new ReduceManager<EntityStore>(host), null);
+
+        // Derive both from the same base so the delegate-valued settings are literally shared —
+        // the difference under test is the client id, nothing else.
+        var baseConfig = new StreamConfiguration<EntityStore>(stream);
+        var sameA = baseConfig.WithClientId("client-a");
+        var sameB = baseConfig.WithClientId("client-a");
+        var other = baseConfig.WithClientId("client-b");
+
+        sameA.Equals(sameB).Should().BeTrue(
+            "the settings are identical and the owner is the same stream");
+        sameA.GetHashCode().Should().Be(sameB.GetHashCode());
+        sameA.Equals(other).Should().BeFalse("the client id differs");
+        sameA.GetHashCode().Should().NotBe(other.GetHashCode());
+
+        baseConfig.AsInfrastructure().Equals(baseConfig).Should().BeFalse();
+        baseConfig.ReturnNullWhenNotPresent().Equals(baseConfig).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Closes #2163, #2164, #2170, #2171, #2172, #2173, #2174, #2175 — eight incident issues, four
fingerprints, two root causes, one change.

## The two cycles

Both are **semantic** defects — structural hashing applied to something that was never a value —
so both are fixed by giving the type the equality semantics it actually has. No depth limits, no
visited-sets, no guards (AGENTS.md: no band-aids).

**Cycle 1 — record-synthesized structural hashing over a back-reference**
(#2163/#2164/#2172/#2173/#2174/#2175, fingerprints `6e643370636ed34a` / `52c67215dc2ff138` /
`e089a7d2379666fb`)

`SynchronizationStream<T>` is a `record`, so the compiler synthesized a `GetHashCode`/`Equals`
walking every instance field — including `internal StreamConfiguration<T> Configuration`.
`StreamConfiguration<T>`'s primary-ctor property `Stream` is a back-pointer to the owning stream
(`new StreamConfiguration<TStream>(this)`, SynchronizationStream.cs:1042). So hashing a stream ran:

```
SynchronizationStream.GetHashCode
  → StreamConfiguration.GetHashCode
    → EqualityComparer<ISynchronizationStream<T>>.Default.GetHashCode(Stream)
      → SynchronizationStream.GetHashCode → …
```

with no base case — exactly the captured production stack. Any hash of a stream instance (a
dictionary key, a log scope, a `HashSet`) killed the process.

**Cycle 2 — hand-written structural hashing over an arbitrary object graph** (#2170/#2171,
fingerprint `786f05aa5de0c166`)

`InstanceCollection.GetHashCode` aggregated the hashes of its **values** — an
`ImmutableDictionary<object, object>` of arbitrary user instances — `EntityStore.GetHashCode`
aggregated its collections, and `ChangeItem<T>`'s synthesized hash walked its `Value`. A stored
instance that reaches back into the store closes the loop
`InstanceCollection → EntityStore → ChangeItem → InstanceCollection`, which is the recorded stack.
It was also O(the entire object graph) on a routing hot path.

## Why reference identity on the stream is the ROOT fix, not half of one

The two cycles are not independent: **cycle 1 fed cycle 2.** `SynchronizationStream`'s
record-synthesized `GetHashCode` walks every instance field, including its private
`ChangeItem<TStream>? current` — so hashing a stream descended
`SynchronizationStream → ChangeItem → EntityStore → InstanceCollection` and, from there, into
whatever arbitrary instances the store happened to hold. **Both recorded production stacks were
entered by hashing a STREAM**, whether via the `_evictedRemoteStreams` dictionary (before its
hand-rolled reference-comparer workaround) or a log scope.

That is why giving the stream reference identity is the root fix rather than a partial one: it
removes the entry point. The container fixes below then close the same hole for any other caller
that reaches those types directly — belt and braces, deliberately, because
`ISynchronizationStream` is an interface and a future implementation must not be able to
reintroduce the descent.

## The fix

- **`SynchronizationStream<T>`** — reference identity (`ReferenceEquals` / `RuntimeHelpers.GetHashCode`).
  A stream is a live object: it owns a `ReplaySubject`, mutable `current` state, a hosted hub, and
  disposal state. Two distinct streams are never the same stream. This is not a behaviour change:
  the synthesized `Equals` already compared the per-instance `Store` subject by reference, so
  distinct instances were never equal — it just could not compute a hash without dying.
- **`StreamConfiguration<T>`** — compares/hashes its own settings; the `Stream` back-pointer
  participates **by reference** and is never traversed. Still a `record`; the `with`-based builder
  API (`WithClientId` / `WithSubscriber` / `AsInfrastructure` / `WithInitialization` / …) is untouched.
- **`InstanceCollection` / `EntityStore` / `ChangeItem<T>`** — hash from keys, collection names,
  and counts. Bounded, cycle-free, allocation-free (`foreach` over the struct enumerator rather than
  `Select` + `Aggregate`), and no longer proportional to the workspace size.

**Bonus latent crash, fixed here too:** `EntityStore.GetHashCode` called `.Aggregate((x, y) => x ^ y)`
with **no seed**, so an EMPTY store threw `InvalidOperationException("Sequence contains no elements")`.

## Every value-based `Equals` is deliberately left intact

The `SetCurrent` dedup that suppresses re-emission of an identical re-synced store depends on
value equality (`MeshNodeContentEqualityTest.EntityStoreChain_WithJsonElementNodes_DedupesViaValueEquality`
— its comment calls re-emission "the amplifier"). Weakening it to match the weakened hash would be
a real regression, and it is not needed: the hash/equals contract only requires that **equal objects
hash equal**, which each new hash satisfies (equal collections hold the same keys in the same
number; equal stores hold the same collection names with the same sizes; equal change items agree
on `StreamId`/`ChangedBy`/`ChangeType`/`Version`).

One caveat worth recording rather than papering over: `InstanceCollection.Equals` *can* itself
recurse on a cyclic graph, because it compares arbitrary values. It needs **two distinct** parallel
cyclic graphs to do so (record `Equals` short-circuits on `ReferenceEquals`, so a graph compared
with itself terminates), it has never appeared in any production trace, and every captured stack is
`GetHashCode`. Fixing it would mean breaking the dedup contract above, so it is left as-is and noted.

## Verification — the tests are red before the fix, by measurement

`test/MeshWeaver.Data.Test/HashRecursionTest.cs` (8 tests) builds the *real* cyclic graphs. A
`StackOverflowException` cannot be caught in .NET, so the cycle-closing value is a probe that throws
once re-entered — a pre-fix regression is a clean red test, not a dead test host — and the assertion
is stronger than "it terminated": the instance values are never traversed at all.

Reverse-applied the fix and re-ran to confirm the tests actually fail without it:

| test | without the fix |
|---|---|
| `CyclicStoreGraph_HashesWithoutTraversingInstanceValues` | `InvalidOperationException: Instance-value hashing re-entered 9 times…` |
| `EmptyEntityStore_Hashes_WithoutThrowing` | `InvalidOperationException: Sequence contains no elements` |
| `Stream_And_ItsConfiguration_HashByIdentity_NotStructurally` | **test host crashed, exit code 134 (SIGABRT)** — the StackOverflow itself |

All 8 pass with the fix.

Independent corroboration that the diagnosis is right: `Workspace.cs` already carried a
hand-rolled `StreamReferenceComparer` whose comment reads *"value-hashing a stream instance
stack-overflows the process"* — a previous session hit this and worked around it locally. That
comment is updated (the comparer is kept, since `ISynchronizationStream` is an interface and
reference semantics must hold for any implementation put in that set).

## Builds and tests

`-c Release -warnaserror`, `0 Error(s) / 0 Warning(s)` on each: `MeshWeaver.Data.Contract`,
`MeshWeaver.Data`, `MeshWeaver.Mesh.Contract`, `MeshWeaver.Graph`, `MeshWeaver.Blazor`,
`MeshWeaver.Hosting.Orleans`, `MeshWeaver.AI`, `MeshWeaver.Data.Test`, `MeshWeaver.Layout.Test`,
`MeshWeaver.Hosting.Monolith.Test`, `MeshWeaver.Documentation.Test`.

- `MeshWeaver.Data.Test` — **385/385 pass**
- `MeshWeaver.Layout.Test` — **474/474 pass** (equality/hash tests included)
- `MeshWeaver.Documentation.Test` `WhatsNewEntryIntegrityTest` — pass

No production code derives change detection from these hashes (swept every `GetHashCode()` call
site in `src/`); the only consumers are hash containers, where a weaker-but-consistent hash costs
distribution, never correctness.

What's New entry: `Category: Fix` — a crash a user notices as the page dropping under them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## CI note: the first run's two reds, diagnosed

The first run of this PR went red on two jobs. Both were investigated to a cause before the failed
jobs were re-run; recording it here so the next person who meets either does not repeat the work.

### 1. `Run tests (shard 3)` — `MeshGrpcTrustedKestrelTest` — **environmental, proven**

From the shard-3 `.trx` artifact:

```
=== TEST FAILED: Failed to bind to address http://127.0.0.1:39933: address already in use.
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketConnectionListener.Bind()
   at MeshGrpcTrustedKestrelTest…(MeshGrpcTrustedKestrelTest.cs:line 79)
```

A port collision on the runner — it threw at `Bind()` before doing any work, which is why it took
0 s. Shard 3 ran **2264 tests with exactly this 1 failure**. Passes locally 1/1 both with and
without this diff.

### 2. `Plugins compile against this PR` — `Store/Catalog` — **no mechanism found; considered and excluded**

`❌ StoreCatalogTests timed out waiting for: the recovered read lands` — a *timeout* on a 20 ms-poll
`WaitUntil`, not an assertion mismatch. Three hypotheses were raised and each was **disproved by
measurement**, not by argument:

- **"A weakened hash broke change detection."** That pipeline's dedup is
  `.DistinctUntilChanged(RegistryPackages.CatalogKey)` (`StoreManifestSource.cs:298`), and
  `CatalogKey` (`RegistryPackages.cs:229`) is a pure **string** — `id@version`, ordered. Across the
  transition under test the keys are `"Hosting@"` → `"Chess@|Hosting@"`: different strings, so
  `DistinctUntilChanged` must emit. No hash, no container type, on that path. Sweeps for a
  hash-based consumer came back empty in all three trees: `MeshWeaver.Plugins` (one hit, an
  unrelated `entity.GetHashCode()` in `ImportManager`), `content` + `samples/*/Data` (zero), and
  `src/` (zero).
- **"The plugins tree moved underneath this run."** It did not: this gate and the sibling PR's gate
  both checked out plugins **`a886396c`**, and the sibling reported
  `ok Store/Catalog: compile=Ok render=ok tests=ok`.
- **"The hash got much cheaper, and a large timing change can flip a latent race."** The sharpest of
  the three, and the reason this section exists — a change that alters only *cost* can still flip a
  race, so "it only affects performance" is never automatically safe. But it has no reachable call
  site here: nothing anywhere is **keyed** by `EntityStore` / `InstanceCollection` / `ChangeItem`
  (zero hits in key position across `src/` and `test/`), and the reactive hot path uses the
  parameterless `DistinctUntilChanged()`, which resolves through `EqualityComparer<T>.Default.Equals`
  and never calls `GetHashCode`. **Equals is deliberately unchanged by this PR**, so the per-emission
  cost of that pipeline is exactly what it was.

  Note also which direction this fix moves the cost: the production stacks were entered by hashing a
  **stream** — `SynchronizationStream`'s synthesized hash walks its private `ChangeItem<TStream>
  current`, so cycle 1 was the entry point into cycle 2. With streams now hashing by reference, those
  container hashes run *less* often than before, not more.

No allow-list entry was added: the gate's `0 stale allow entr(ies)` ratchet is working as designed
and must not be papered over.
