### PR TITLE
fix: red logs report real faults, not routine teardown (#2152 #2153 #2182 #2222 #2138 #2139)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
@@ -42,6 +42,43 @@ answers again. Nothing is lost — delivery is just delayed.
 The portal owns everything *after* detection, because that is where the mesh, the agents and the
 GitHub App credential already live.
 
+## Line → burst: reconstruction is PER POD, and a bodyless burst is never a fault
+
+A .NET console error is several *lines* — the `fail:` header, the message, then the stack trace —
+and the CRI log format stamps **each line** with its own timestamp. The query is deliberately
+namespace-wide (a line filter would return headers without their stack traces, `LokiQuery`), so what
+comes back is every replica's output **merged by timestamp**. A burst whose header and trace fall in
+different milliseconds therefore has any other pod's line from in between sorted right into the
+middle of it.
+
+🚨 **So the burst grouper reconstructs per pod, never over the merged sequence.** It used to end a
+burst at the first line that came from somewhere else, and that is how production filed two
+unactionable tickets in a week:
+
+| Where the cut landed | What the incident carried | Filed as |
+|---|---|---|
+| after the header | nothing at all | #2222 — "an Error with no message, exception, or stack" |
+| after the message | message, no exception, no frame | #2153 — "logs a bare Unexpected error with no exception attached" |
+
+#2153 is worth reading twice: the call site *does* pass its exception to `LogError(ex, …)` and
+always did. The exception was lost in the READER. `RedLogBurstReconstructionTest` pins both shapes on
+the incidents' own lines.
+
+**A burst that arrives bodyless anyway is not fingerprinted.** With no message, no exception and no
+frame, its only possible identity is `(category, event id)` — a token that names a component and no
+defect, into which every later bodyless capture from that site would fold. `BurstAggregator` keeps
+those out of the reports and surfaces them on `BurstAggregation.HeaderOnly` instead, and the watcher:
+
+- **recovers the recoverable ones** — a burst still open at the window's edge (`AtWindowEdge`) has
+  its body on the other side of `end`, where the grouper has no header to attach it to. The cursor
+  resumes **at that header** so the next poll reads the burst whole. Terminating by construction: the
+  rewind lands the cursor *on* the header, so a burst that is still bodyless next time is genuinely
+  bodyless and falls through;
+- **reports the rest once per namespace**, naming the categories
+  (`LogPipelineGap.HeaderOnlyReport`) — the same pattern as the truncated-window and lost-window
+  findings. Nothing is dropped silently; what changes is that the finding is about the capture, which
+  is what it actually is.
+
 ## One fault, one ticket
 
 The fingerprint (`StructuralLogIncidentIdentity.Compute`) identifies **the fault, not the reporter**.
@@ -344,6 +381,37 @@ az aks command invoke -g <aks-resource-group> -n <aks-cluster> --command \
 
 Then browse `Admin/_LogIncident` in the portal — every incident links to the ticket it opened and
 to the triage thread that wrote it.
+
+## What belongs at `fail:` — a cancellation and a disconnect do not
+
+Everything red becomes a ticket, so **the level a call site chooses is a ticketing decision**, not a
+verbosity knob (AGENTS.md: never edit a level to dial a debugging session up or down; fix it
+permanently, with the reason, or leave it). Two outcomes are routinely mistaken for faults, and both
+produced steady ticket streams:
+
+| Outcome | Why it is not a fault | Where |
+|---|---|---|
+| **Cooperative cancellation** — the caller went away, a partition cleanup cascaded, the host is shutting down, the I/O pool drained | Nothing failed and nothing was written. `MeshWeaver.Mesh.CreateNode` logged 491 of these in three days (#2152); `MeshWeaver.Mesh.MeshNode` logged `[DeleteNode] unexpected … partial-deleted=0` (#2182) — a counter that says the node was never touched. | `CancellationClassifier.IsCooperativeCancellation` |
+| **A client that disconnected mid-stream** | gRPC finalises the request and answers the next write with `InvalidOperationException("Can't write the message because the request is complete.")`; the client is already gone (#2138 / #2139). | `MeshGrpcService.WritePumpAsync` |
+
+🚨 **The rule is narrow on purpose, and the exceptions to it are the point:**
+
+- **`catch (OperationCanceledException)` is NOT the rule.** A **timeout** raised on a token is the
+  same CLR type and IS a fault. .NET marks it by hanging a `TimeoutException` off the cancellation
+  (an `HttpClient` timeout is verbatim `TaskCanceledException(…, new TimeoutException())`), and
+  `CancellationClassifier` refuses to call that benign. Classifying by the CONDITION rather than the
+  type is what keeps "cancellation is benign" from silently becoming "storage timeouts are benign".
+- **A cancellation that arrives AFTER work landed stays LOUD.** A delete cancelled with
+  `partial-deleted > 0` really did leave the subtree torn — that is the case the old wording was
+  borrowing its urgency from, and it keeps `Error` plus the count.
+- **The caller is still answered, and answered accurately.** Both handlers reply with the
+  `Unavailable` rejection reason ("not evaluated; retrying is meaningful"), never `Unknown`, and an
+  error string that says *cancelled* rather than *unexpected error*. Downgrading a level is never
+  licence to swallow an outcome.
+- **The exception still rides along.** The benign line is `LogDebug(ex, …)`, and it states the token
+  state that made it benign rather than asserting it (`CancellationClassifier.Describe`).
+
+`CancellationIsNotAFaultTest` pins both directions, including the timeout impostor.
 
 ## What this is not
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-red-logs-report-real-faults.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-red-logs-report-real-faults.md
@@ -1,0 +1,35 @@
+---
+Name: Error logs now report real faults, not routine teardown
+Category: Fix
+Description: Cancelled creates and deletes, client disconnects, and truncated log captures were all filed as errors — burying the failures that actually needed attention.
+Icon: Bug
+Order: -20260825
+---
+
+# Error logs now report real faults, not routine teardown
+
+Four different situations were being reported as errors when nothing had gone wrong, and between
+them they produced most of the entries in the platform's error log — and most of the tickets its
+automatic triage opened. The genuine failures were still there, indistinguishable from the noise.
+
+- **A cancelled create or delete is no longer an error.** When a create or delete is cut short —
+  the caller navigated away, a workspace cleanup cascaded, the service was shutting down — nothing
+  failed and nothing was written. It is now recorded as what it is, and the answer you get back
+  says "cancelled" and that retrying is meaningful, instead of "unexpected error".
+- **A client that disconnects mid-stream no longer looks like a broken request.** A browser or
+  device closing a live connection at the wrong instant surfaced as a failed service call, with a
+  stack trace pointing into the platform.
+- **Error reports carry their diagnosis again.** The log reader rebuilt each error from the lines a
+  server writes, but merged the output of every replica first — so another replica writing at the
+  same moment could cut an error in half and throw away its exception and stack trace. Errors are
+  now rebuilt per server, so what you read is the whole thing.
+- **An error with no content is never filed as one.** A capture that arrived with no message, no
+  exception and no stack could only be identified by which component logged it, so every later
+  content-free capture from that component piled onto the same ticket. Those are now reported as
+  what they are — a capture problem, naming the component — and the ticket you get for a real
+  failure stays about that failure.
+
+A cancellation that happens *after* a delete has already removed something is still reported loudly:
+that one leaves work half-done, and it is exactly the case the old wording was borrowing its urgency
+from. A timeout is likewise still a failure, even though the platform reports timeouts using the
+same mechanism as cancellations.

--- a/src/MeshWeaver.Hosting.Grpc/MeshGrpcService.cs
+++ b/src/MeshWeaver.Hosting.Grpc/MeshGrpcService.cs
@@ -7,6 +7,7 @@ using MeshWeaver.Hosting.Grpc.Protocol;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace MeshWeaver.Hosting.Grpc;
@@ -25,7 +26,11 @@ namespace MeshWeaver.Hosting.Grpc;
 /// outbound frame — the connect ack AND mesh deliveries — funnels through one pump draining the
 /// connection's <see cref="Channel{T}"/>.</para>
 /// </summary>
-public sealed class MeshGrpcService(IMessageHub hub, GrpcConnectionRegistry registry, IOptions<GrpcOptions>? options = null)
+public sealed class MeshGrpcService(
+    IMessageHub hub,
+    GrpcConnectionRegistry registry,
+    IOptions<GrpcOptions>? options = null,
+    ILogger<MeshGrpcService>? logger = null)
     : Protocol.Mesh.MeshBase
 {
     /// <summary>The fully-qualified gRPC service name the endpoint is mapped at.</summary>
@@ -94,7 +99,7 @@ public sealed class MeshGrpcService(IMessageHub hub, GrpcConnectionRegistry regi
 
         // ONE writer owns the response stream (gRPC forbids concurrent writes). It drains every
         // outbound frame — connect ack + mesh deliveries the registry enqueues — to the wire.
-        var pump = WritePumpAsync(outbound.Reader, responseStream);
+        var pump = WritePumpAsync(outbound.Reader, responseStream, context.CancellationToken, logger);
         try
         {
             // Boundary bridge: validate the Bearer token (gRPC call metadata) once per connection.
@@ -147,7 +152,7 @@ public sealed class MeshGrpcService(IMessageHub hub, GrpcConnectionRegistry regi
         var outbound = Channel.CreateUnbounded<ServerFrame>(new UnboundedChannelOptions { SingleReader = true });
         registry.Begin(connectionId, outbound.Writer);
 
-        var pump = WritePumpAsync(outbound.Reader, responseStream);
+        var pump = WritePumpAsync(outbound.Reader, responseStream, context.CancellationToken, logger);
         try
         {
             await AuthenticateOrAbortRetryable(connectionId, context);
@@ -187,18 +192,72 @@ public sealed class MeshGrpcService(IMessageHub hub, GrpcConnectionRegistry regi
         return Task.FromResult(new DeliverAck());
     }
 
-    private static async Task WritePumpAsync(ChannelReader<ServerFrame> reader, IServerStreamWriter<ServerFrame> responseStream)
+    /// <summary>
+    /// Drains the connection's outbound channel to the response stream. ONE writer owns that stream
+    /// (gRPC forbids concurrent writes), so every outbound frame funnels through here.
+    ///
+    /// <para>🚨 <b>A client that went away is not a service-method failure</b> (#2138, #2139). The
+    /// pump used to write without observing the call at all, so when the client dropped mid-stream
+    /// gRPC answered the next write with
+    /// <c>InvalidOperationException("Can't write the message because the request is complete.")</c>,
+    /// the exception escaped through <c>Connect</c>'s <c>await pump</c> in its <c>finally</c>, and
+    /// <c>Grpc.AspNetCore.Server.ServerCallHandler</c> logged <c>fail: Error when executing service
+    /// method 'Connect'</c> for a routine browser disconnect.</para>
+    ///
+    /// <para>The fix is in two halves, and the first is the real one: the pump now <b>observes the
+    /// call's cancellation token</b>, so a disconnect ENDS the drain instead of racing it. The second
+    /// half exists because the race is inherent and cannot be closed by checking a flag — the request
+    /// can complete between the token check and the write, and gRPC's only signal for that state is
+    /// the exception itself. So a write that fails <i>because the call is over</i> ends the pump
+    /// quietly, with the reason on a Debug line; <b>any other</b> <see cref="InvalidOperationException"/>
+    /// (notably "Only one write can be pending at a time", which would mean two writers got hold of
+    /// this stream) still propagates and is still a fault.</para>
+    /// </summary>
+    /// <param name="reader">The connection's outbound channel.</param>
+    /// <param name="responseStream">The gRPC response stream.</param>
+    /// <param name="callCancelled">The call's cancellation token — cancelled when the client goes away.</param>
+    /// <param name="logger">Optional logger for the benign teardown lines.</param>
+    private static async Task WritePumpAsync(
+        ChannelReader<ServerFrame> reader,
+        IServerStreamWriter<ServerFrame> responseStream,
+        CancellationToken callCancelled,
+        ILogger? logger)
     {
         try
         {
-            await foreach (var frame in reader.ReadAllAsync())
+            await foreach (var frame in reader.ReadAllAsync(callCancelled))
                 await responseStream.WriteAsync(frame);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (callCancelled.IsCancellationRequested)
         {
-            // Response stream torn down (client gone) — stop pumping.
+            // The call ended while the pump was waiting — normal teardown, nothing to write to.
+            logger?.LogDebug(
+                "gRPC write pump stopped: the call was cancelled (the client disconnected).");
+        }
+        catch (InvalidOperationException ex) when (IsWriteAfterCallEnded(ex, callCancelled))
+        {
+            logger?.LogDebug(ex,
+                "gRPC write pump raced the end of the call: the request was already complete when the "
+                + "next frame was written, so the frame had nowhere to go. The client is gone; the "
+                + "connection is torn down on the Disconnect path either way.");
         }
     }
+
+    /// <summary>
+    /// True when a failed write means <b>the call is already over</b> rather than that something is
+    /// wrong with this server.
+    ///
+    /// <para>The token carries the decision wherever it can: a client that disconnects aborts the
+    /// request, which is what cancels it. The message check covers the one case the token cannot —
+    /// the call was completed by the SERVER (an <see cref="RpcException"/> thrown out of
+    /// <c>Connect</c> finalises the response while frames are still queued) — and it is deliberately
+    /// narrow: gRPC raises this sentence from <c>HttpContextStreamWriter.WriteCoreAsync</c> and
+    /// nowhere else, so anything that stops matching it becomes a propagated fault, which is the
+    /// safe direction to fail.</para>
+    /// </summary>
+    private static bool IsWriteAfterCallEnded(InvalidOperationException ex, CancellationToken callCancelled) =>
+        callCancelled.IsCancellationRequested
+        || ex.Message.Contains("request is complete", StringComparison.OrdinalIgnoreCase);
 
     // gRPC metadata keys are lower-cased. The participant sends the API token as
     // "authorization: Bearer <token>"; accept that single shape.

--- a/src/MeshWeaver.Mesh.Contract/CancellationClassifier.cs
+++ b/src/MeshWeaver.Mesh.Contract/CancellationClassifier.cs
@@ -1,0 +1,67 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// Tells a <b>cancellation</b> apart from a <b>fault</b> — the one distinction a node-operation
+/// handler's catch-all cannot make on its own, and the reason routine teardown used to be logged and
+/// ticketed as if a write had failed.
+///
+/// <para>🚨 <b>Why this is not a log-level preference</b> (#2152, #2182). A cooperative cancellation
+/// is a control-flow signal: the caller went away, the hub is tearing down, the host is shutting
+/// down, the I/O pool was drained. Nothing failed, nothing is inconsistent, and there is nothing to
+/// investigate — but `fail:` on that outcome is indistinguishable from a real storage outage on the
+/// same path, so on-call reads 491 cancellations and the one genuine failure looks exactly like
+/// them. Naming the condition is what makes the remaining `fail:` lines mean something again.</para>
+///
+/// <para>🚨 <b>It is NOT "catch OperationCanceledException".</b> A timeout implemented on a token
+/// throws the same type and IS a fault — an availability failure someone must look at. .NET marks
+/// that case by hanging a <see cref="TimeoutException"/> off the cancellation (an
+/// <c>HttpClient</c> timeout is verbatim
+/// <c>TaskCanceledException("… the configured HttpClient.Timeout of 100 s elapsed", new TimeoutException())</c>),
+/// which is exactly what this refuses to call benign.</para>
+/// </summary>
+public static class CancellationClassifier
+{
+    /// <summary>
+    /// True when <paramref name="exception"/> is a token firing because someone cancelled it —
+    /// never a timeout, never a wrapped fault.
+    /// </summary>
+    /// <param name="exception">The exception a handler's error branch received.</param>
+    /// <returns>True for cooperative cancellation; false for everything else, including a
+    /// cancellation raised to express a timeout.</returns>
+    public static bool IsCooperativeCancellation(Exception? exception) =>
+        Unwrap(exception) is OperationCanceledException cancelled && !HasTimeoutCause(cancelled);
+
+    /// <summary>
+    /// The evidence line for a benign cancellation — what token state the exception actually
+    /// carried, so the Debug line says WHY it was judged benign instead of asserting it.
+    /// </summary>
+    /// <param name="exception">The exception a handler's error branch received.</param>
+    /// <returns>A short, log-safe description.</returns>
+    public static string Describe(Exception? exception) =>
+        Unwrap(exception) is OperationCanceledException cancelled
+            ? $"{cancelled.GetType().Name} (token cancelled: "
+              + $"{cancelled.CancellationToken.IsCancellationRequested.ToString().ToLowerInvariant()})"
+            : exception?.GetType().Name ?? "(none)";
+
+    /// <summary>
+    /// Reactive operators surface the original exception, but a bridged <c>Task</c> can still hand
+    /// over a single-inner <see cref="AggregateException"/>. Look through exactly that one wrapper —
+    /// a multi-inner aggregate is genuinely several faults and stays one.
+    /// </summary>
+    private static Exception? Unwrap(Exception? exception) =>
+        exception is AggregateException { InnerExceptions.Count: 1 } aggregate
+            ? aggregate.InnerExceptions[0]
+            : exception;
+
+    /// <summary>
+    /// True when the cancellation was raised to express a timeout — the impostor this classifier
+    /// exists to keep out. Walks the inner chain because a transport may wrap it once more.
+    /// </summary>
+    private static bool HasTimeoutCause(Exception exception)
+    {
+        for (var inner = exception.InnerException; inner is not null; inner = inner.InnerException)
+            if (inner is TimeoutException)
+                return true;
+        return false;
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -961,9 +961,41 @@ public static class MeshExtensions
                         logger.LogWarning(ex, "Node creation failed for path {Path}", node.Path);
                         Respond(CreateNodeResponse.Fail(ex.Message, NodeCreationRejectionReason.ValidationFailed));
                     }
+                    else if (CancellationClassifier.IsCooperativeCancellation(ex))
+                    {
+                        // 🚨 A CANCELLATION IS NOT A FAULT (#2152). The token the create composed
+                        // under fired — the caller went away, the hub is tearing down, the host is
+                        // shutting down, the I/O pool was drained. Nothing failed, no row was
+                        // written, and there is nothing to investigate; reporting it at fail: level
+                        // put 491 lines of routine teardown in front of on-call in three days and
+                        // made a real storage failure on the same path look identical to them.
+                        //
+                        // It is judged by the CONDITION, not by the type: a timeout raised on a
+                        // token carries a TimeoutException cause and stays a fault on the branch
+                        // below, with its exception and its Error level (see CancellationClassifier).
+                        //
+                        // The caller is still ANSWERED, and answered accurately — Unavailable says
+                        // "not evaluated, retry is meaningful", which is exactly true of a create
+                        // that was cut short. Never a swallow.
+                        logger.LogDebug(ex,
+                            "[CreateNode] cancelled path={Path} — {Cancellation}. The create was cut "
+                            + "short before it completed; nothing was written and nothing failed.",
+                            node.Path, CancellationClassifier.Describe(ex));
+                        Respond(CreateNodeResponse.Fail(
+                            $"Node creation at '{node.Path}' was cancelled before it completed.",
+                            NodeCreationRejectionReason.Unavailable));
+                    }
                     else
                     {
-                        logger.LogError(ex, "Unexpected error during node creation at {Path}", node.Path);
+                        // 🚨 The exception type and its own words are IN THE MESSAGE, not only on
+                        // the attached exception (#2153). `LogError(ex, …)` does print the exception
+                        // — that half of the ticket's premise was wrong — but a capture that loses
+                        // the burst's trailing lines keeps the message and drops the exception, and
+                        // the incident then carries no fault at all. Naming the fault in the first
+                        // line makes it survive; the parser reads the type back out of it.
+                        logger.LogError(ex,
+                            "Unexpected error during node creation at {Path}: {ExceptionType}: {ExceptionMessage}",
+                            node.Path, ex.GetType().Name, ex.Message);
                         Respond(CreateNodeResponse.Fail($"Unexpected error: {ex.Message}",
                             NodeCreationRejectionReason.Unknown));
                     }
@@ -2647,6 +2679,16 @@ public static class MeshExtensions
                     // longer happen (the commit now runs under the system identity after
                     // up-front authorization, so this leg is a canary, not a code path).
                     var isUnauthorized = dfxReason == NodeDeletionRejectionReason.Unauthorized;
+                    // 🚨 A CANCELLATION IS NOT A FAULT — and with nothing deleted it is not even an
+                    // inconsistency (#2182). The delete pipeline composes under tokens that fire on
+                    // ordinary teardown (a cleaned-up parent partition cascading into its `_Access`
+                    // satellites, grain/hub deactivation, host shutdown), and `[DeleteNode]
+                    // unexpected … partial-deleted=0` said "unexpected" about a state that is
+                    // neither unexpected nor a state: the node was never touched. The word that has
+                    // to stay LOUD is a torn subtree, and that is the branch below — a delete that
+                    // was cancelled AFTER removing nodes really did leave the tree half-gone.
+                    // A timeout is a different condition and keeps its own branch and its Error.
+                    var isCancelled = !isTimeout && CancellationClassifier.IsCooperativeCancellation(ex);
                     if (isUnauthorized && partial.Count > 0)
                         logger.LogError(ex,
                             "[DeleteNode] permission-denied MID-COMMIT path={Path} — {Partial} node(s) were "
@@ -2669,12 +2711,35 @@ public static class MeshExtensions
                                 ? "-"
                                 : string.Join(", ", unanswered.Take(20))
                                   + (unanswered.Count > 20 ? $" (+{unanswered.Count - 20} more)" : ""));
+                    else if (isCancelled && partial.Count > 0)
+                        // Cancelled MID-COMMIT: nodes are already gone and the rest never will be.
+                        // That IS an inconsistency and stays a loud error, naming what was removed.
+                        logger.LogError(ex,
+                            "[DeleteNode] CANCELLED MID-COMMIT path={Path} — {Partial} node(s) were already "
+                            + "deleted before the cancellation; the subtree is left partially deleted",
+                            path, partial.Count);
+                    else if (isCancelled)
+                        logger.LogDebug(ex,
+                            "[DeleteNode] cancelled path={Path} — {Cancellation}, partial-deleted=0. The "
+                            + "operation was aborted before any node was removed, so nothing is inconsistent.",
+                            path, CancellationClassifier.Describe(ex));
                     else
                         logger.LogError(ex, "[DeleteNode] {Kind} path={Path} partial-deleted={Partial}",
                             isNotFound ? "not-found" : "unexpected", path, partial.Count);
+                    // Say "cancelled", never "Unexpected error" — this string is what a user, an
+                    // agent or a test reads, and retrying a cancelled delete is meaningful in a way
+                    // retrying an "unexpected error" is not. One local so the ACTIVITY LOG and the
+                    // response carry the same sentence; "A task was canceled." is no more readable
+                    // in the activity a user opens than it was in the pod log (#2182).
+                    var cancelledMessage = partial.Count > 0
+                        ? $"Delete of '{path}' was cancelled after removing {partial.Count} node(s) — "
+                          + "the subtree is left partially deleted."
+                        : $"Delete of '{path}' was cancelled before any node was removed.";
                     var failMsgs = collectedMessages.ToImmutable()
                         .Add(new LogMessage(
-                            isNotFound ? $"Node not found at path '{path}'" : ex.Message,
+                            isNotFound
+                                ? $"Node not found at path '{path}'"
+                                : (isCancelled ? cancelledMessage : ex.Message),
                             LogLevel.Error));
                     PostFailed(
                         isTimeout
@@ -2683,19 +2748,21 @@ public static class MeshExtensions
                             // exactly as unreadable there as it was in the log.
                             ? $"Delete of '{path}' exceeded {budget.TotalSeconds:0}s timeout "
                               + $"in stage '{stage}': {ex.Message}"
-                            : (isNotFound
-                                ? $"Node not found at path '{path}'"
-                                : (isUnauthorized
-                                    // Already legible ("Access denied: user 'x' lacks Delete
-                                    // permission on 'y'") — no "Unexpected error:" prefix.
-                                    ? ex.Message
-                                    : $"Unexpected error: {ex.Message}")),
-                        isTimeout
+                            : (isCancelled
+                                ? cancelledMessage
+                                : (isNotFound
+                                    ? $"Node not found at path '{path}'"
+                                    : (isUnauthorized
+                                        // Already legible ("Access denied: user 'x' lacks Delete
+                                        // permission on 'y'") — no "Unexpected error:" prefix.
+                                        ? ex.Message
+                                        : $"Unexpected error: {ex.Message}"))),
+                        isTimeout || isCancelled
                             // 🚨 A stage that ran out of time DECIDED nothing — it is an
                             // availability failure, and Unknown said neither that nor anything
                             // else (#1198). Same vocabulary as NodeRejectionReason.Unavailable and
                             // CompilationStatus.Unavailable: fail-closed, but stop implying the
-                            // content was judged.
+                            // content was judged. A cancellation decided nothing either (#2182).
                             ? NodeDeletionRejectionReason.Unavailable
                             : (dfxReason
                                 ?? (isNotFound

--- a/src/MeshWeaver.Observability.Contract/BurstAggregator.cs
+++ b/src/MeshWeaver.Observability.Contract/BurstAggregator.cs
@@ -23,11 +23,41 @@ public record LogLine(DateTimeOffset Timestamp, string? Namespace, string? Pod, 
 /// <param name="TotalLines">Every line the query returned, red or not.</param>
 /// <param name="FoldedSites">How many log sites exceeded the per-site variant budget and were
 /// collapsed onto a single site-level incident.</param>
+/// <param name="HeaderOnly">The red bursts that arrived as a console header and NOTHING else. They
+/// are deliberately NOT in <paramref name="Reports"/> — a burst with no message, no exception and no
+/// frame can only fingerprint on its category and event id, which is a token that names a component
+/// and no defect (#2222). They are surfaced here instead so the caller can recover the ones that are
+/// recoverable and REPORT the ones that are not, rather than either fabricating an incident or
+/// dropping them in silence.</param>
 public record BurstAggregation(
     ImmutableList<LogIncidentReport> Reports,
     int RedBursts,
     int TotalLines,
-    int FoldedSites);
+    int FoldedSites,
+    ImmutableList<HeaderOnlyBurst>? HeaderOnly = null)
+{
+    /// <summary>The bodyless bursts this window saw; never null.</summary>
+    public ImmutableList<HeaderOnlyBurst> HeaderOnly { get; init; } =
+        HeaderOnly ?? ImmutableList<HeaderOnlyBurst>.Empty;
+}
+
+/// <summary>
+/// A red burst whose console header was all that reached the aggregator.
+/// </summary>
+/// <param name="Timestamp">The header line's timestamp.</param>
+/// <param name="Pod">The pod that emitted it.</param>
+/// <param name="Category">The log category from the header.</param>
+/// <param name="AtWindowEdge">
+/// True when this was the LAST burst its pod produced in the window — i.e. the body may simply not
+/// have been read yet, because the window ended between the header and the lines that follow it. A
+/// caller holding a cursor can recover that burst whole by resuming at <paramref name="Timestamp"/>
+/// instead of at the window's end; anything else here genuinely had no body.
+/// </param>
+public record HeaderOnlyBurst(
+    DateTimeOffset Timestamp,
+    string? Pod,
+    string Category,
+    bool AtWindowEdge);
 
 /// <summary>
 /// Turns a flat batch of log lines into one <see cref="LogIncidentReport"/> per distinct
@@ -71,7 +101,18 @@ public record BurstAggregation(
 public static class BurstAggregator
 {
     /// <summary>A header line plus the continuation lines that belong to it.</summary>
-    private record RawBurst(DateTimeOffset Timestamp, string? Namespace, string? Pod, ImmutableList<string> Lines);
+    /// <param name="Timestamp">The header line's timestamp.</param>
+    /// <param name="Namespace">The namespace label.</param>
+    /// <param name="Pod">The pod label.</param>
+    /// <param name="Lines">The header line and its continuation lines.</param>
+    /// <param name="LastForPod">True when no further burst from this pod followed in the window —
+    /// so a body that is missing here may simply be on the other side of the window's edge.</param>
+    private record RawBurst(
+        DateTimeOffset Timestamp,
+        string? Namespace,
+        string? Pod,
+        ImmutableList<string> Lines,
+        bool LastForPod = false);
 
     /// <summary>One parsed burst, with both identities it could be filed under.</summary>
     private record KeyedBurst(RawBurst Raw, LogLineParser.ParsedBurst Parsed, string Fingerprint, string SiteFold);
@@ -97,6 +138,7 @@ public static class BurstAggregator
         ArgumentNullException.ThrowIfNull(entries);
 
         var keyed = new List<KeyedBurst>();
+        var headerOnly = ImmutableList.CreateBuilder<HeaderOnlyBurst>();
         foreach (var raw in SplitBursts(entries))
         {
             if (LogLineParser.Parse(raw.Lines) is not { } parsed)
@@ -104,6 +146,17 @@ public static class BurstAggregator
             if (ignoreCategories?.Any(prefix =>
                     parsed.Category.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) == true)
                 continue;
+
+            // 🚨 A burst that is nothing but its console header carries no diagnostic at all, and
+            // hashing it would key an incident on the category and event id alone — the degenerate
+            // fingerprint of #2222, into which every later bodyless capture from that site would
+            // fold. It is reported as what it is (a capture with no body) rather than as a fault.
+            if (parsed.IsHeaderOnly)
+            {
+                headerOnly.Add(new HeaderOnlyBurst(
+                    raw.Timestamp, raw.Pod, parsed.Category, raw.LastForPod));
+                continue;
+            }
 
             var burst = LogLineParser.ToBurst(parsed);
             keyed.Add(new KeyedBurst(raw, parsed,
@@ -164,9 +217,12 @@ public static class BurstAggregator
 
         return new BurstAggregation(
             reports.Values.OrderBy(r => r.FirstSeen).ToImmutableList(),
-            keyed.Count,
+            // Bodyless bursts WERE red bursts — they are counted here even though they open no
+            // incident, so "N fingerprints from M red bursts" stays an honest ratio.
+            keyed.Count + headerOnly.Count,
             entries.Count,
-            folded.Count);
+            folded.Count,
+            headerOnly.ToImmutable());
     }
 
     /// <summary>The log sites whose distinct-fingerprint count exceeds the budget.</summary>
@@ -180,16 +236,39 @@ public static class BurstAggregator
                 .ToImmutableHashSet(StringComparer.Ordinal);
 
     /// <summary>
-    /// Re-attaches each red header to the continuation lines that followed it. A line starts a new
-    /// burst when it is itself a red header, or when it carries any other console level prefix
-    /// (<c>info:</c>, <c>warn:</c>, …) — that prefix means the previous burst has ended, and the
-    /// line is dropped because it is not red.
+    /// Re-attaches each red header to the continuation lines that followed it — <b>per pod</b>.
+    ///
+    /// <para>🚨 <b>The query is namespace-wide, so the lines of one burst are NOT adjacent</b>
+    /// (#2153, #2222). Every replica writes to its own stream, the CRI log format stamps each LINE
+    /// with its own timestamp, and the collector merges those streams by timestamp — so a burst
+    /// whose header and stack trace fall in different milliseconds has any other pod's line from the
+    /// millisecond in between sorted right into the middle of it. Reconstructing over the merged
+    /// sequence therefore CUT bursts at an arbitrary point and threw the rest away: the header alone
+    /// ("no message, no exception, no stack" — #2222), or the header plus the message with the
+    /// exception line lost ("a bare Unexpected error with no exception attached" — #2153, whose call
+    /// site does pass its exception to <c>LogError</c> and always did). Both filed as incidents that
+    /// named a component and no defect.</para>
+    ///
+    /// <para>A pod's own lines ARE in order within its stream, so grouping by pod first makes the
+    /// reconstruction immune to whatever else the namespace was writing at the same moment. Bursts
+    /// come back ordered by their header timestamp, as the callers downstream expect.</para>
+    ///
+    /// <para>Within one pod a line still starts a new burst when it is itself a red header, or when
+    /// it carries any other console level prefix (<c>info:</c>, <c>warn:</c>, …) — that prefix means
+    /// the previous burst has ended, and the line is dropped because it is not red.</para>
     /// </summary>
-    private static IEnumerable<RawBurst> SplitBursts(IReadOnlyList<LogLine> entries)
+    private static IEnumerable<RawBurst> SplitBursts(IReadOnlyList<LogLine> entries) =>
+        entries
+            .GroupBy(entry => entry.Pod ?? string.Empty, StringComparer.Ordinal)
+            .SelectMany(SplitPodBursts)
+            .OrderBy(burst => burst.Timestamp);
+
+    /// <summary>Reconstructs the bursts of ONE pod, whose lines are already in emission order.</summary>
+    private static IEnumerable<RawBurst> SplitPodBursts(IEnumerable<LogLine> podEntries)
     {
         RawBurst? current = null;
 
-        foreach (var entry in entries)
+        foreach (var entry in podEntries)
         {
             var line = entry.Line.TrimEnd('\r', '\n');
 
@@ -205,8 +284,8 @@ public static class BurstAggregator
             if (current is null)
                 continue;
 
-            // A different pod's line, or a non-red level header, ends the burst.
-            if (!string.Equals(current.Pod, entry.Pod, StringComparison.Ordinal) || IsLevelHeader(line))
+            // A non-red level header from this pod ends the burst.
+            if (IsLevelHeader(line))
             {
                 yield return current;
                 current = null;
@@ -216,8 +295,10 @@ public static class BurstAggregator
             current = current with { Lines = current.Lines.Add(line) };
         }
 
+        // The last burst this pod opened in the window: its body may simply be on the other side of
+        // the window's edge, which is what LastForPod tells the caller.
         if (current is not null)
-            yield return current;
+            yield return current with { LastForPod = true };
     }
 
     /// <summary>True for any <c>xxxx: </c> console level prefix — the marker that a new log event began.</summary>

--- a/src/MeshWeaver.Observability.Contract/BurstAggregator.cs
+++ b/src/MeshWeaver.Observability.Contract/BurstAggregator.cs
@@ -34,12 +34,7 @@ public record BurstAggregation(
     int RedBursts,
     int TotalLines,
     int FoldedSites,
-    ImmutableList<HeaderOnlyBurst>? HeaderOnly = null)
-{
-    /// <summary>The bodyless bursts this window saw; never null.</summary>
-    public ImmutableList<HeaderOnlyBurst> HeaderOnly { get; init; } =
-        HeaderOnly ?? ImmutableList<HeaderOnlyBurst>.Empty;
-}
+    ImmutableList<HeaderOnlyBurst> HeaderOnly);
 
 /// <summary>
 /// A red burst whose console header was all that reached the aggregator.

--- a/src/MeshWeaver.Observability.Contract/LogLineParser.cs
+++ b/src/MeshWeaver.Observability.Contract/LogLineParser.cs
@@ -61,7 +61,28 @@ public static partial class LogLineParser
         string? ExceptionType,
         string? TopFrame,
         string? ExceptionMessage = null,
-        string NormalizedDetail = "");
+        string NormalizedDetail = "")
+    {
+        /// <summary>
+        /// True when the burst arrived as its console HEADER and nothing else — no message, no
+        /// exception, no stack frame.
+        ///
+        /// <para>🚨 <b>This is not a fault report and must never be fingerprinted</b> (#2222). The
+        /// identity of a bodyless burst can only be its category and event id, so every future
+        /// bodyless capture from that site collapses onto the same token — a fingerprint that names
+        /// a component and no defect, and a ticket nobody can act on. It used to look substantive
+        /// because the parser fabricated a message out of the header line itself; it no longer
+        /// does, so "there was nothing in the body" is now a state a caller can see and refuse.</para>
+        ///
+        /// <para>The body goes missing for exactly two reasons, and both are about the CAPTURE, not
+        /// the code: the burst's continuation lines were separated from their header before it got
+        /// here (see <c>BurstAggregator.SplitBursts</c>, which reconstructs per pod for that
+        /// reason), or the call site really did log an empty message with no exception — which is a
+        /// defect at that call site, not an incident to triage.</para>
+        /// </summary>
+        public bool IsHeaderOnly =>
+            Message.Length == 0 && ExceptionType is null && TopFrame is null;
+    }
 
     /// <summary>
     /// True when <paramref name="line"/> opens a red burst (<c>fail:</c> / <c>crit:</c>), with the
@@ -105,10 +126,16 @@ public static partial class LogLineParser
 
         // The message is everything before the exception line (the logged text); a burst that is
         // nothing but an exception falls back to the exception line itself.
+        //
+        // 🚨 A burst with NO body at all keeps an EMPTY message (#2222). It used to fall back to the
+        // console header — "MeshWeaver.Layout.Composition.LayoutAreaHost[0]" — which made a capture
+        // that carried no diagnostic whatsoever look like a burst with a message, and produced a
+        // fingerprint keyed on nothing but the category and the event id. Saying "there was nothing
+        // here" is what lets the aggregator refuse to ticket it; see <see cref="ParsedBurst.IsHeaderOnly"/>.
         var message = string.Join(' ', exceptionIndex < 0 ? body.Take(1) : body.Take(exceptionIndex))
             .Trim();
-        if (message.Length == 0)
-            message = exceptionIndex >= 0 ? body[exceptionIndex] : header;
+        if (message.Length == 0 && exceptionIndex >= 0)
+            message = body[exceptionIndex];
 
         // 🚨 A call site that interpolates the exception INTO its message — `LogError("… after {Ms}ms:
         // {Exception}", …)` — leaves no own-line exception header, so the rule above finds nothing,

--- a/test/MeshWeaver.Graph.Test/RedLogBurstReconstructionTest.cs
+++ b/test/MeshWeaver.Graph.Test/RedLogBurstReconstructionTest.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using MeshWeaver.Observability;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>A red-log incident must carry a defect, not just a component</b> — issues #2153 and #2222.
+///
+/// <para><b>What production filed.</b> Two tickets, minutes of triage each, both unactionable and
+/// both about the SAME thing. #2222: an Error from
+/// <c>MeshWeaver.Layout.Composition.LayoutAreaHost</c> with "no message body, no exception, and no
+/// stack frame" — nothing on the wire but the console header. #2153: an Error from
+/// <c>MeshWeaver.Mesh.CreateNode</c> whose message was intact but whose exception was gone, filed
+/// with the conclusion that the call site "does not pass the caught exception to the logger". It
+/// does, and always did (<c>logger.LogError(ex, …)</c>).</para>
+///
+/// <para><b>The actual defect was in the READER.</b> The watcher's Loki query is namespace-wide
+/// (deliberately — a line filter returns headers without their stack traces), every replica writes
+/// to its own stream, the CRI log format stamps each LINE with its own timestamp, and the collector
+/// merges those streams by timestamp. So a burst whose header and stack trace fall in different
+/// milliseconds has any other pod's line from in between sorted into the middle of it — and the
+/// grouper, which reconstructed over the merged sequence, ENDED the burst there and dropped
+/// everything after. Cut after the header ⇒ #2222. Cut after the message ⇒ #2153. Both then
+/// fingerprinted on whatever survived, and the bodyless one could only key on category + event id:
+/// a token that names a component and no defect, into which every later truncated burst from that
+/// site would fold.</para>
+///
+/// <para>These tests pin both halves of the fix: reconstruction is per POD, so interleaving cannot
+/// truncate a burst; and a burst that arrives bodyless anyway is never fingerprinted — it is
+/// surfaced as what it is, a capture with no body.</para>
+/// </summary>
+public class RedLogBurstReconstructionTest
+{
+    private const string Pod = "memex-portal-deployment-867dc45877-wtcks";
+    private const string OtherPod = "memex-portal-deployment-867dc45877-xqs4p";
+    private const string Namespace = "memex-cloud";
+
+    private static readonly DateTimeOffset T0 =
+        DateTimeOffset.Parse("2026-08-24T14:21:24Z", System.Globalization.CultureInfo.InvariantCulture);
+
+    private static LogLine Line(int millis, string pod, string text) =>
+        new(T0.AddMilliseconds(millis), Namespace, pod, text);
+
+    /// <summary>
+    /// #2153 verbatim: the CreateNode burst, with another pod's line landing between its message and
+    /// its exception. <b>Fail-without:</b> the burst ended at the interleaved line, the exception was
+    /// discarded, and the incident carried <c>exceptionType</c>, <c>topFrame</c> and
+    /// <c>normalizedDetail</c> all empty — which is exactly what the ticket reported.
+    /// </summary>
+    [Fact]
+    public void Another_pods_line_in_the_middle_does_not_truncate_a_burst()
+    {
+        var entries = ImmutableList.Create(
+            Line(0, Pod, "fail: MeshWeaver.Mesh.CreateNode[0]"),
+            Line(0, Pod, "      Unexpected error during node creation at Pricing/Program/Release/20260824140324-Jb5MOj-p"),
+            // Another replica writes in the millisecond between the message and the exception. The
+            // merged, namespace-wide stream puts it right here; nothing about it belongs to the burst.
+            Line(1, OtherPod, "info: MeshWeaver.Mesh.Services.IMeshCatalog[0]"),
+            Line(1, OtherPod, "      catalog refreshed"),
+            Line(2, Pod, "      System.Threading.Tasks.TaskCanceledException: A task was canceled."),
+            Line(2, Pod, "         at MeshWeaver.Mesh.MeshExtensions.HandleCreateNodeRequest(IMessageHub hub) in /src/MeshExtensions.cs:line 966"));
+
+        var aggregation = BurstAggregator.Aggregate(entries, maxSamples: 10, maxSampleLength: 4000);
+
+        var create = aggregation.Reports
+            .Should().ContainSingle(r => r.Category == "MeshWeaver.Mesh.CreateNode").Which;
+        create.ExceptionType.Should().Be("System.Threading.Tasks.TaskCanceledException",
+            "the exception line belongs to this burst however many other pods wrote in between");
+        create.TopFrame.Should().Contain("HandleCreateNodeRequest",
+            "the stack trace belongs to this burst too — it is what locates the fault");
+        create.NormalizedDetail.Should().Contain("task was canceled",
+            "the detail — the exception's OWN words — is what tells two faults at one site apart");
+        aggregation.HeaderOnly.Should().BeEmpty("nothing here was bodyless");
+    }
+
+    /// <summary>
+    /// #2222 verbatim: another pod's RED header lands immediately after this one's. The
+    /// interleaved header used to steal the following continuation lines AND leave the first burst
+    /// with nothing but its header — one truncated incident plus one degenerate one, from two
+    /// perfectly well-formed log events.
+    /// </summary>
+    [Fact]
+    public void An_interleaved_red_header_from_another_pod_steals_nothing()
+    {
+        var entries = ImmutableList.Create(
+            Line(0, Pod, "fail: MeshWeaver.Layout.Composition.LayoutAreaHost[0]"),
+            Line(1, OtherPod, "fail: MeshWeaver.Mesh.MeshNode[0]"),
+            Line(1, OtherPod, "      [DeleteNode] not-found path=Chess/Play partial-deleted=0"),
+            Line(2, Pod, "      Rendering failed for area Overview"),
+            Line(2, Pod, "      System.InvalidOperationException: Sequence contains no elements"),
+            Line(2, Pod, "         at MeshWeaver.Layout.Composition.LayoutAreaHost.RenderArea(RenderingContext context)"));
+
+        var aggregation = BurstAggregator.Aggregate(entries, maxSamples: 10, maxSampleLength: 4000);
+
+        aggregation.HeaderOnly.Should().BeEmpty(
+            "neither burst is bodyless — the LayoutAreaHost one only looked that way because the "
+            + "other pod's header cut it off");
+
+        var layout = aggregation.Reports
+            .Should().ContainSingle(r => r.Category == "MeshWeaver.Layout.Composition.LayoutAreaHost").Which;
+        layout.ExceptionType.Should().Be("System.InvalidOperationException");
+        layout.TopFrame.Should().Contain("LayoutAreaHost.RenderArea");
+
+        var delete = aggregation.Reports
+            .Should().ContainSingle(r => r.Category == "MeshWeaver.Mesh.MeshNode").Which;
+        delete.NormalizedMessage.Should().Contain("DeleteNode",
+            "the other pod's burst keeps its own message and gains none of this one's lines");
+    }
+
+    /// <summary>
+    /// The guarantee behind the fix: a burst that really is nothing but a header opens NO incident.
+    /// Its only possible identity is category + event id — a fingerprint that names a component and
+    /// no defect, which then swallows every later bodyless capture from the same site. It is
+    /// reported as a capture with no body instead, which names the same category and says something
+    /// true about it.
+    /// </summary>
+    [Fact]
+    public void A_bodyless_burst_is_reported_but_never_fingerprinted()
+    {
+        var entries = ImmutableList.Create(
+            Line(0, Pod, "fail: MeshWeaver.Layout.Composition.LayoutAreaHost[0]"),
+            // A following level header from the SAME pod proves the body is not merely unread:
+            // the next log event has already begun, so there was nothing after that header.
+            Line(1, Pod, "info: MeshWeaver.Hosting.MeshNodeStreamCache[0]"),
+            Line(1, Pod, "      handle opened"));
+
+        var aggregation = BurstAggregator.Aggregate(entries, maxSamples: 10, maxSampleLength: 4000);
+
+        aggregation.Reports.Should().BeEmpty(
+            "a red line with no message, no exception and no frame carries no defect to ticket");
+        aggregation.RedBursts.Should().Be(1, "it WAS a red burst — it is counted, never hidden");
+        var bodyless = aggregation.HeaderOnly.Should().ContainSingle().Which;
+        bodyless.Category.Should().Be("MeshWeaver.Layout.Composition.LayoutAreaHost",
+            "the category is the actionable part and must survive");
+        bodyless.AtWindowEdge.Should().BeFalse(
+            "another event from this pod followed, so the body was not merely on the other side of "
+            + "the window's edge");
+    }
+
+    /// <summary>
+    /// The recoverable case, and why the two are told apart: the header is the LAST thing this pod
+    /// produced in the window, so its body is on the other side of the edge. Marking it lets the
+    /// watcher hold its cursor at the header and read the burst whole next poll, instead of filing
+    /// a bodyless incident for it and dropping the body when it arrives headerless.
+    /// </summary>
+    [Fact]
+    public void A_burst_still_open_at_the_window_edge_is_marked_recoverable()
+    {
+        var entries = ImmutableList.Create(
+            Line(0, OtherPod, "fail: MeshWeaver.Mesh.MeshNode[0]"),
+            Line(0, OtherPod, "      [DeleteNode] not-found path=Chess/Play partial-deleted=0"),
+            Line(5, Pod, "fail: MeshWeaver.Mesh.CreateNode[0]"));
+
+        var aggregation = BurstAggregator.Aggregate(entries, maxSamples: 10, maxSampleLength: 4000);
+
+        var open = aggregation.HeaderOnly.Should().ContainSingle().Which;
+        open.AtWindowEdge.Should().BeTrue("no further line from this pod followed it in the window");
+        open.Timestamp.Should().Be(T0.AddMilliseconds(5),
+            "the cursor must resume AT the header so the next poll reads the burst whole");
+        aggregation.Reports.Should().ContainSingle(r => r.Category == "MeshWeaver.Mesh.MeshNode",
+            "the complete burst from the other pod is unaffected");
+    }
+
+    /// <summary>
+    /// The masking / dedup contract still holds across the per-pod grouping: the same fault on two
+    /// replicas is ONE incident with both pods on it, not one incident per replica.
+    /// </summary>
+    [Fact]
+    public void The_same_fault_on_two_pods_is_still_one_incident()
+    {
+        var entries = ImmutableList.Create(
+            Line(0, Pod, "fail: MeshWeaver.Mesh.CreateNode[0]"),
+            Line(0, Pod, "      Unexpected error during node creation at Pricing/Program/Release/aaa"),
+            Line(0, Pod, "      System.Threading.Tasks.TaskCanceledException: A task was canceled."),
+            Line(1, OtherPod, "fail: MeshWeaver.Mesh.CreateNode[0]"),
+            Line(1, OtherPod, "      Unexpected error during node creation at Reinsurance/Acceptance/Release/bbb"),
+            Line(1, OtherPod, "      System.Threading.Tasks.TaskCanceledException: A task was canceled."));
+
+        var aggregation = BurstAggregator.Aggregate(entries, maxSamples: 10, maxSampleLength: 4000);
+
+        var report = aggregation.Reports.Should().ContainSingle().Which;
+        report.Occurrences.Should().Be(2);
+        report.Pods.Should().Contain(Pod).And.Contain(OtherPod);
+    }
+
+    /// <summary>
+    /// Bursts come back in emission order even though they are reconstructed per pod — the reports'
+    /// FirstSeen and the evidence samples depend on it.
+    /// </summary>
+    [Fact]
+    public void Bursts_are_returned_in_timestamp_order_across_pods()
+    {
+        var entries = ImmutableList.Create(
+            Line(10, Pod, "fail: MeshWeaver.Mesh.CreateNode[0]"),
+            Line(10, Pod, "      later burst"),
+            Line(0, OtherPod, "fail: MeshWeaver.Mesh.MeshNode[0]"),
+            Line(0, OtherPod, "      earlier burst"));
+
+        var aggregation = BurstAggregator.Aggregate(
+            entries.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp)),
+            maxSamples: 10, maxSampleLength: 4000);
+
+        aggregation.Reports.Select(r => r.Category).Should().Equal(
+            "MeshWeaver.Mesh.MeshNode", "MeshWeaver.Mesh.CreateNode");
+    }
+}

--- a/test/MeshWeaver.Hosting.Grpc.Test/MeshGrpcTransportTest.cs
+++ b/test/MeshWeaver.Hosting.Grpc.Test/MeshGrpcTransportTest.cs
@@ -420,6 +420,96 @@ public class MeshGrpcTransportTest(ITestOutputHelper output) : MonolithMeshTestB
         await connectB;
     }
 
+    /// <summary>
+    /// 🚨 <b>A client that went away is not a service-method failure</b> — issues #2138 / #2139.
+    ///
+    /// <para>The server-streaming <c>Connect</c> holds the call open while a background pump drains
+    /// the connection's channel to the response stream. When the client drops mid-stream, gRPC
+    /// finalises the HTTP request and answers the pump's next write with
+    /// <c>InvalidOperationException("Can't write the message because the request is complete.")</c>.
+    /// The pump had no guard, so that exception escaped through <c>Connect</c>'s <c>await pump</c>
+    /// and <c>Grpc.AspNetCore.Server.ServerCallHandler</c> logged
+    /// <c>fail: Error when executing service method 'Connect'</c> — a routine browser disconnect
+    /// filed as a service fault, with a stack trace pointing at our own frames.</para>
+    ///
+    /// <para><b>Fail-without:</b> this test's <c>await connect</c> throws that
+    /// InvalidOperationException. The client is already gone; there is nothing to fail.</para>
+    /// </summary>
+    [Fact]
+    public async Task Connect_survives_the_client_disconnect_race_on_the_write_pump()
+    {
+        var hub = Mesh;
+        var registry = hub.ServiceProvider.GetRequiredService<GrpcConnectionRegistry>();
+        var service = new MeshGrpcService(hub, registry);
+        var participant = new Address(GrpcHostingExtensions.NodeAddressType, Guid.NewGuid().ToString("N"));
+
+        // The response stream of a call whose request the client already completed: every write
+        // raises gRPC's own sentinel, exactly as HttpContextStreamWriter.WriteCoreAsync does.
+        var gone = new ThrowingStreamWriter<ServerFrame>(
+            () => new InvalidOperationException("Can't write the message because the request is complete."));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var connect = service.Connect(
+            new ConnectRequest { Address = JsonSerializer.Serialize(participant, hub.JsonSerializerOptions) },
+            gone,
+            new FakeServerCallContext(new Metadata(), cts.Token));
+
+        // The connect ack is the frame that races the disconnect — wait until the pump has tried it.
+        await gone.Attempted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        cts.Cancel();
+
+        await connect; // must COMPLETE, not throw: the call is over, and that is not an error.
+    }
+
+    /// <summary>
+    /// The bound on the fix: only a write that failed BECAUSE THE CALL IS OVER is benign. gRPC
+    /// raises <see cref="InvalidOperationException"/> for one other reason — two writes pending on
+    /// one response stream — and that would mean a second writer got hold of a stream this service
+    /// guarantees has exactly one. It must still fault the call.
+    /// </summary>
+    [Fact]
+    public async Task A_write_failure_that_is_not_the_disconnect_race_still_faults_the_call()
+    {
+        var hub = Mesh;
+        var registry = hub.ServiceProvider.GetRequiredService<GrpcConnectionRegistry>();
+        var service = new MeshGrpcService(hub, registry);
+        var participant = new Address(GrpcHostingExtensions.PythonAddressType, Guid.NewGuid().ToString("N"));
+
+        var broken = new ThrowingStreamWriter<ServerFrame>(
+            () => new InvalidOperationException("Only one write can be pending at a time."));
+        var inbound = Channel.CreateUnbounded<ClientFrame>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var open = service.Open(new ChannelStreamReader<ClientFrame>(inbound.Reader), broken,
+            new FakeServerCallContext(new Metadata(), cts.Token));
+        await inbound.Writer.WriteAsync(new ClientFrame
+        {
+            Connect = JsonSerializer.Serialize(participant, hub.JsonSerializerOptions)
+        }, cts.Token);
+
+        await broken.Attempted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        // End the call NORMALLY (the client half-closes; the token never fires), so the only reason
+        // the pump could have failed is the fault itself.
+        inbound.Writer.Complete();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => open);
+    }
+
+    /// <summary>A response stream that refuses every write with a chosen exception.</summary>
+    private sealed class ThrowingStreamWriter<T>(Func<Exception> failure) : IServerStreamWriter<T>
+    {
+        /// <summary>Completes on the first write attempt — the moment the race is live.</summary>
+        public TaskCompletionSource Attempted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public WriteOptions? WriteOptions { get; set; }
+
+        public Task WriteAsync(T message)
+        {
+            Attempted.TrySetResult();
+            throw failure();
+        }
+    }
+
     // Read the next outbound frame, failing fast with a clear locus instead of hanging to the watchdog.
     private static async Task<ServerFrame> NextFrame(CapturingStreamWriter<ServerFrame> writer, string step, TimeSpan timeout)
     {

--- a/test/MeshWeaver.NodeOperations.Test/CancellationIsNotAFaultTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/CancellationIsNotAFaultTest.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.NodeOperations.Test;
+
+/// <summary>
+/// 🚨 <b>A cancellation is not a fault</b> — issues #2152 and #2182.
+///
+/// <para><b>What production reported.</b> <c>MeshWeaver.Mesh.CreateNode</c> logged
+/// <c>fail: Unexpected error during node creation at …</c> for a bare
+/// <c>TaskCanceledException</c> — 491 times in three days, across ten pods and several deployment
+/// revisions, on paths as mundane as <c>Home</c> and <c>Admin</c>. <c>MeshWeaver.Mesh.MeshNode</c>
+/// logged <c>fail: [DeleteNode] unexpected path=… partial-deleted=0</c> for the same shape: that
+/// counter says the node was never touched, so there was no "unexpected" state to report at all.
+/// Both are cooperative cancellation — the caller went away, a partition cleanup cascaded into its
+/// <c>_Access</c> satellites, the hub tore down. Nothing failed.</para>
+///
+/// <para><b>Why it mattered.</b> Not volume: <i>signal</i>. A genuine storage failure on the very
+/// same path printed identically to a client disconnect, so the one red line worth reading was
+/// indistinguishable from 491 that were not — and both sites automatically opened tickets.</para>
+///
+/// <para><b>The bound these tests hold.</b> The rule is NOT "catch OperationCanceledException" —
+/// that would swallow the one impostor that matters. A timeout raised on a token is the same CLR
+/// type and IS a fault; .NET marks it by hanging a <see cref="TimeoutException"/> off the
+/// cancellation. <see cref="Timeout_dressed_as_a_cancellation_stays_a_fault"/> is what makes the
+/// distinction load-bearing rather than decorative, and
+/// <see cref="A_genuine_fault_still_logs_Error_with_its_exception"/> pins that the fault path keeps
+/// its level, its exception, and now also names the fault in its message (#2153).</para>
+/// </summary>
+public class CancellationIsNotAFaultTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string CreateCategory = "MeshWeaver.Mesh.CreateNode";
+    private const string DeleteCategory = "MeshWeaver.Mesh.MeshNode";
+
+    /// <summary>Node ids the scripted validator reacts to. Everything else it passes.</summary>
+    private const string CancelOnCreate = "cancelled-create";
+    private const string TimeoutOnCreate = "timeout-create";
+    private const string FaultOnCreate = "faulted-create";
+    private const string CancelOnDelete = "cancelled-delete";
+
+    private readonly CapturingLoggerProvider logs = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services
+                .AddSingleton<INodeValidator, ScriptedOutcomeValidator>()
+                .AddSingleton<ILoggerProvider>(logs)
+                // Debug for the two categories under test ONLY, and only on THIS provider — the
+                // benign branch logs at Debug, and a test that cannot see it could only assert an
+                // absence. Nothing in src/ or its appsettings is touched (AGENTS.md: log levels in
+                // code are a production cost decision, not a debugging knob).
+                .AddLogging(b => b
+                    .AddFilter<CapturingLoggerProvider>(CreateCategory, LogLevel.Debug)
+                    .AddFilter<CapturingLoggerProvider>(DeleteCategory, LogLevel.Debug)));
+
+    /// <summary>
+    /// #2152. A cancelled create logs at Debug — never <c>fail:</c> — and still answers the caller,
+    /// with the reason that is actually true of it: <c>Unavailable</c> ("not evaluated; retrying is
+    /// meaningful"), never <c>Unknown</c>.
+    /// </summary>
+    [Fact]
+    public async Task A_cancelled_create_is_not_logged_as_a_fault()
+    {
+        var response = await CreateAt(CancelOnCreate);
+
+        response.Success.Should().BeFalse("the node was not created — the caller must know");
+        response.Error.Should().Contain("cancelled",
+            "the caller reads this string, and 'Unexpected error' says the opposite of what happened");
+        response.RejectionReason.Should().Be(NodeCreationRejectionReason.Unavailable,
+            "a cancelled create DECIDED nothing about the node — Unknown implies it was judged");
+
+        logs.Red(CreateCategory, CancelOnCreate).Should().BeEmpty(
+            "a cancellation is routine teardown; at fail: level it is indistinguishable from the "
+            + "storage outage on the same path that on-call actually needs to see");
+        var benign = logs.Entries(CreateCategory, CancelOnCreate)
+            .Should().ContainSingle(e => e.Message.Contains("[CreateNode] cancelled path=")).Which;
+        benign.Level.Should().Be(LogLevel.Debug);
+        benign.Exception.Should().BeOfType<TaskCanceledException>(
+            "downgrading the level must not throw the evidence away — the exception still rides along");
+    }
+
+    /// <summary>
+    /// The impostor. <c>HttpClient</c> (and friends) express a TIMEOUT as a
+    /// <see cref="TaskCanceledException"/> carrying a <see cref="TimeoutException"/> cause. That is
+    /// an availability fault someone must look at, and it must survive the #2152 fix with its Error
+    /// level and its exception intact — otherwise "cancellation is benign" would quietly have become
+    /// "storage timeouts are benign".
+    /// </summary>
+    [Fact]
+    public async Task Timeout_dressed_as_a_cancellation_stays_a_fault()
+    {
+        var response = await CreateAt(TimeoutOnCreate);
+
+        response.Success.Should().BeFalse();
+        var red = logs.Red(CreateCategory, TimeoutOnCreate).Should().ContainSingle(
+            "a timeout is a fault however it is spelled").Which;
+        red.Exception.Should().BeOfType<TaskCanceledException>();
+        red.Exception!.InnerException.Should().BeOfType<TimeoutException>(
+            "that inner cause is the exact signal separating the two, so the test must exercise it");
+    }
+
+    /// <summary>
+    /// The fault direction, and #2153's ask: an unexpected failure keeps <c>Error</c>, keeps its
+    /// exception, and now also NAMES the fault inside the message — so an incident whose capture
+    /// lost the trailing exception line still says what went wrong.
+    /// </summary>
+    [Fact]
+    public async Task A_genuine_fault_still_logs_Error_with_its_exception()
+    {
+        var response = await CreateAt(FaultOnCreate);
+
+        response.Success.Should().BeFalse();
+        response.RejectionReason.Should().Be(NodeCreationRejectionReason.Unknown);
+
+        var red = logs.Red(CreateCategory, FaultOnCreate).Should().ContainSingle().Which;
+        red.Exception.Should().BeOfType<NotSupportedException>(
+            "the catch-all must forward the exception it caught — that half of #2153 was already true");
+        red.Message.Should().Contain(nameof(NotSupportedException),
+            "and the type must ALSO be in the message: a burst that loses its trailing exception "
+            + "line still has to name the fault (#2153)");
+        red.Message.Should().Contain("the fixture's genuine fault",
+            "the exception's own words belong in the message for the same reason");
+    }
+
+    /// <summary>
+    /// #2182. A delete cancelled before it removed anything logs at Debug and says so —
+    /// <c>partial-deleted=0</c> means there is no torn subtree to report. "unexpected" is reserved
+    /// for the case that IS one.
+    /// </summary>
+    [Fact]
+    public async Task A_delete_cancelled_before_it_touched_anything_is_not_logged_as_a_fault()
+    {
+        // Create the victim first — the validator only cancels this path's DELETE.
+        var node = new MeshNode(CancelOnDelete, TestPartition)
+        {
+            Name = "Doomed", NodeType = "Markdown", Content = "victim",
+        };
+        var created = await AwaitResponseAsync<CreateNodeResponse>(
+            new CreateNodeRequest(node), o => o.WithTarget(Mesh.Address));
+        created.Message.Success.Should().BeTrue("the fixture needs a node to delete");
+
+        var deleted = await AwaitResponseAsync<DeleteNodeResponse>(
+            new DeleteNodeRequest(node.Path), o => o.WithTarget(Mesh.Address));
+
+        deleted.Message.Success.Should().BeFalse("the delete did not happen");
+        deleted.Message.Error.Should().Contain("cancelled",
+            "'unexpected' described a state the node was never in");
+        deleted.Message.RejectionReason.Should().Be(NodeDeletionRejectionReason.Unavailable,
+            "a cancelled delete decided nothing — retrying it is meaningful");
+
+        logs.Red(DeleteCategory, CancelOnDelete).Should().BeEmpty(
+            "nothing was removed, so there is no inconsistency for a fail: line to be about");
+        logs.Entries(DeleteCategory, CancelOnDelete)
+            .Should().Contain(
+                e => e.Level == LogLevel.Debug && e.Message.Contains("partial-deleted=0"),
+                "the benign line still records what happened, including the counter that makes it benign");
+    }
+
+    /// <summary>
+    /// The classifier itself, on the exact shapes production produces. It is the ONE place the
+    /// benign/fault judgement is made, so it is worth pinning directly and not only through the
+    /// handlers.
+    /// </summary>
+    [Fact]
+    public void The_classifier_separates_cancellation_from_every_impostor()
+    {
+        CancellationClassifier.IsCooperativeCancellation(Cancellation()).Should().BeTrue(
+            "the production shape: TaskCanceledException, 'A task was canceled.', no inner");
+        CancellationClassifier.IsCooperativeCancellation(new OperationCanceledException()).Should().BeTrue();
+        CancellationClassifier.IsCooperativeCancellation(new AggregateException(Cancellation()))
+            .Should().BeTrue("a Task bridge can hand over a single-inner aggregate");
+
+        CancellationClassifier.IsCooperativeCancellation(TimeoutDressedAsCancellation()).Should().BeFalse(
+            "an HttpClient/Npgsql timeout wears this exact costume and IS a fault");
+        CancellationClassifier.IsCooperativeCancellation(new TimeoutException()).Should().BeFalse();
+        CancellationClassifier.IsCooperativeCancellation(new InvalidOperationException()).Should().BeFalse();
+        CancellationClassifier.IsCooperativeCancellation(null).Should().BeFalse();
+        CancellationClassifier.IsCooperativeCancellation(
+                new AggregateException(Cancellation(), new InvalidOperationException("also this")))
+            .Should().BeFalse("a multi-inner aggregate is genuinely several faults");
+
+        CancellationClassifier.Describe(Cancellation()).Should()
+            .Contain("TaskCanceledException").And.Contain("token cancelled: true",
+                "the log line must say WHY it judged the outcome benign, not merely assert it");
+    }
+
+    private async Task<CreateNodeResponse> CreateAt(string id)
+    {
+        var node = new MeshNode(id, TestPartition)
+        {
+            Name = id, NodeType = "Markdown", Content = "fixture",
+        };
+        var response = await AwaitResponseAsync<CreateNodeResponse>(
+            new CreateNodeRequest(node), o => o.WithTarget(Mesh.Address));
+        return response.Message;
+    }
+
+    /// <summary>The production exception verbatim: a token someone cancelled, nothing else.</summary>
+    private static TaskCanceledException Cancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        return new TaskCanceledException("A task was canceled.", null, cts.Token);
+    }
+
+    /// <summary>A TIMEOUT wearing the cancellation costume — how .NET reports one raised on a token.</summary>
+    private static TaskCanceledException TimeoutDressedAsCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        return new TaskCanceledException(
+            "The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.",
+            new TimeoutException("A connection could not be established within the time limit."),
+            cts.Token);
+    }
+
+    /// <summary>
+    /// A real <see cref="INodeValidator"/> — the framework's own extension point, not a stand-in for
+    /// one — that ends the operation in a chosen way for a chosen node id and passes everything else
+    /// untouched. This is how the handler's error branch is reached without reaching into it.
+    /// </summary>
+    private sealed class ScriptedOutcomeValidator : INodeValidator
+    {
+        public IReadOnlyCollection<NodeOperation> SupportedOperations { get; } =
+            [NodeOperation.Create, NodeOperation.Delete];
+
+        public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
+        {
+            var id = context.Node.Path.Split('/')[^1];
+            return (context.Operation, id) switch
+            {
+                (NodeOperation.Create, CancelOnCreate) =>
+                    Observable.Throw<NodeValidationResult>(Cancellation()),
+                (NodeOperation.Create, TimeoutOnCreate) =>
+                    Observable.Throw<NodeValidationResult>(TimeoutDressedAsCancellation()),
+                (NodeOperation.Create, FaultOnCreate) =>
+                    Observable.Throw<NodeValidationResult>(
+                        new NotSupportedException("the fixture's genuine fault")),
+                (NodeOperation.Delete, CancelOnDelete) =>
+                    Observable.Throw<NodeValidationResult>(Cancellation()),
+                _ => Observable.Return(NodeValidationResult.Valid()),
+            };
+        }
+    }
+
+    /// <summary>One captured log entry.</summary>
+    private sealed record Entry(string Category, LogLevel Level, string Message, Exception? Exception);
+
+    /// <summary>
+    /// Captures what the handlers actually logged. An INSTANCE owned by the test class (AGENTS.md:
+    /// no static state) — it dies with the mesh, and every read is filtered by the node id under
+    /// test, so no per-test reset is needed or wanted.
+    /// </summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<Entry> entries = new();
+
+        public ILogger CreateLogger(string categoryName) => new Capturing(categoryName, entries);
+
+        /// <summary>What this category logged about one node.</summary>
+        public IReadOnlyList<Entry> Entries(string category, string nodeId) =>
+            entries
+                .Where(e => e.Category == category && e.Message.Contains(nodeId, StringComparison.Ordinal))
+                .ToImmutableList();
+
+        /// <summary>The fail:/crit: lines — what the red-log watcher turns into tickets.</summary>
+        public IReadOnlyList<Entry> Red(string category, string nodeId) =>
+            Entries(category, nodeId).Where(e => e.Level >= LogLevel.Error).ToImmutableList();
+
+        public void Dispose() { }
+
+        private sealed class Capturing(string category, ConcurrentQueue<Entry> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter) =>
+                sink.Enqueue(new Entry(category, logLevel, formatter(state, exception), exception));
+        }
+    }
+}

--- a/tools/MeshWeaver.LogWatcher/LogPipelineGap.cs
+++ b/tools/MeshWeaver.LogWatcher/LogPipelineGap.cs
@@ -137,6 +137,56 @@ public static class LogPipelineGap
         };
 
     /// <summary>
+    /// The incident for red bursts that reached the watcher as a console HEADER and nothing else.
+    ///
+    /// <para>🚨 <b>This exists so a bodyless capture is REPORTED rather than fingerprinted</b>
+    /// (#2222). A burst with no message, no exception and no stack frame can only key on its
+    /// category and event id, and an incident keyed on that names a component and no defect — into
+    /// which every later bodyless capture from that site then folds. So the aggregator refuses to
+    /// open one, and the fact travels here instead: ONE finding per namespace, naming the categories
+    /// it happened to, which is strictly more actionable than the degenerate ticket it replaces.</para>
+    ///
+    /// <para>Bursts still open at the window's edge are NOT counted here — the watcher holds its
+    /// cursor at their header and reads them whole on the next poll. What reaches this report is a
+    /// header whose body genuinely was not in the log: a call site that logged an empty message with
+    /// no exception, or a line the collector dropped. Both are fixable at the named category.</para>
+    /// </summary>
+    /// <param name="ns">The namespace the headers came from.</param>
+    /// <param name="count">How many bodyless bursts the window saw.</param>
+    /// <param name="categories">The distinct log categories they came from.</param>
+    /// <param name="start">The window's start.</param>
+    /// <param name="end">The window's end.</param>
+    /// <returns>The report to queue.</returns>
+    public static LogIncidentReport HeaderOnlyReport(
+        string ns, int count, IReadOnlyCollection<string> categories,
+        DateTimeOffset start, DateTimeOffset end) =>
+        new()
+        {
+            Fingerprint = $"log-burst-header-only-{ns}",
+            Category = "MeshWeaver.LogWatcher.Pipeline",
+            Severity = LogSeverity.Error,
+            NormalizedMessage =
+                $"Red log line(s) in namespace '{ns}' arrived with NO body: a 'fail:'/'crit:' header "
+                + "and no message, no exception and no stack frame. They are deliberately not "
+                + "fingerprinted — an incident keyed on category+event id alone names a component and "
+                + "no defect, and swallows every later bodyless capture from the same site. Fix it at "
+                + "the category named below: either the call site logs an empty message with no "
+                + "exception (pass the exception, or give the message a template), or its lines are "
+                + "being dropped between the pod and the log store.",
+            NormalizedDetail = "A red console header reached the watcher with no body.",
+            Namespace = ns,
+            Occurrences = count,
+            FirstSeen = start,
+            LastSeen = end,
+            Samples = ImmutableList.Create(new LogSample(
+                end,
+                null,
+                $"{count} bodyless red burst(s) in [{start:u}, {end:u}) — categories: "
+                + string.Join(", ", categories.Take(10))
+                + (categories.Count > 10 ? $" (+{categories.Count - 10} more)" : ""))),
+        };
+
+    /// <summary>
     /// The incident for a window the watcher will never read: a cursor older than
     /// <see cref="LogWatcherOptions.MaxCatchUp"/> is dragged forward, and everything between the old
     /// cursor and the new floor is skipped for good.

--- a/tools/MeshWeaver.LogWatcher/LogWatchWorker.cs
+++ b/tools/MeshWeaver.LogWatcher/LogWatchWorker.cs
@@ -150,6 +150,52 @@ public sealed class LogWatchWorker(
                     LogPipelineGap.TruncatedReport(ns, start, end, resumeAt, options.QueryLimit));
             }
 
+            // 🚨 A burst still OPEN at the window's edge must not be judged from its header alone
+            // (#2222). Its message and stack are on the other side of `end`, where the grouper has no
+            // header to re-attach them to and drops them — so the header would file as an incident
+            // that names a component and no defect, and the body would be lost outright. Hold the
+            // cursor at the header instead and read the burst whole on the next poll.
+            //
+            // Terminating by construction: the rewind lands the cursor ON that header, so if the same
+            // burst is STILL bodyless next time (a call site that really logged nothing), `> start`
+            // is false, no rewind happens and it is reported as bodyless below.
+            var openAtEdge = aggregation.HeaderOnly.Where(b => b.AtWindowEdge).ToImmutableList();
+            var rewindTo = openAtEdge.IsEmpty
+                ? (DateTimeOffset?)null
+                : openAtEdge.Min(b => b.Timestamp);
+            // Deferred, not lost: the cursor ends at or before these headers, so the next poll reads
+            // each burst whole. `> start` is the fixed point that makes this terminate — a burst that
+            // is STILL bodyless when the cursor already sits on its header genuinely has no body, and
+            // falls through to the report below instead of pinning the cursor forever.
+            var deferring = rewindTo is { } candidate && candidate > start;
+            if (deferring && rewindTo!.Value < resumeAt)
+            {
+                logger?.LogDebug(
+                    "{Namespace}: {Count} red burst(s) were still open at the window edge — resuming at "
+                    + "{Cursor:u} instead of {End:u} so their body is read with them.",
+                    ns, openAtEdge.Count, rewindTo.Value.UtcDateTime, resumeAt.UtcDateTime);
+                resumeAt = rewindTo.Value;
+            }
+
+            // Whatever is left had no body to read: report it ONCE per namespace, naming the
+            // categories, instead of opening a degenerate per-category incident for each.
+            var bodyless = deferring
+                ? aggregation.HeaderOnly.Where(b => !b.AtWindowEdge).ToImmutableList()
+                : aggregation.HeaderOnly;
+            if (!bodyless.IsEmpty)
+            {
+                var categories = bodyless
+                    .Select(b => b.Category)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToImmutableList();
+                logger?.LogWarning(
+                    "{Namespace}: {Count} red log line(s) carried NO body (categories: {Categories}) — "
+                    + "not fingerprinted, reported as a pipeline finding instead.",
+                    ns, bodyless.Count, string.Join(", ", categories));
+                reports = reports.Add(
+                    LogPipelineGap.HeaderOnlyReport(ns, bodyless.Count, categories, start, end));
+            }
+
             if (reports.Count > 0)
                 logger?.LogInformation(
                     "{Namespace}: {Fingerprints} distinct fingerprint(s) from {Bursts} red burst(s) "

--- a/tools/MeshWeaver.LogWatcher/LokiClient.cs
+++ b/tools/MeshWeaver.LogWatcher/LokiClient.cs
@@ -71,8 +71,13 @@ public sealed class LokiClient(HttpClient http, IIoPool pool, ILogger<LokiClient
     private static string? Label(LokiStream stream, string name) =>
         stream.Stream is not null && stream.Stream.TryGetValue(name, out var value) ? value : null;
 
+    // 🚨 Full precision on the WINDOW BOUNDS too, for the same reason FromNanos keeps it. This used
+    // to truncate to milliseconds while the cursor it is formatting carries 100ns ticks, so every
+    // poll re-read up to a millisecond of lines it had already processed — harmless (the fingerprint
+    // dedups) but it quietly contradicted the guarantee the cursor is supposed to give. Ticks × 100
+    // stays inside Int64 until the year 2262, the same bound Unix-nanosecond timestamps have.
     private static string Nanos(DateTimeOffset value) =>
-        (value.ToUnixTimeMilliseconds() * 1_000_000L).ToString(CultureInfo.InvariantCulture);
+        ((value - DateTimeOffset.UnixEpoch).Ticks * 100L).ToString(CultureInfo.InvariantCulture);
 
     // 🚨 100ns ticks, NOT milliseconds. Loki stamps every line to the nanosecond and the merge below
     // sorts on this value; truncating to a millisecond threw away the ordering between lines written

--- a/tools/MeshWeaver.LogWatcher/LokiClient.cs
+++ b/tools/MeshWeaver.LogWatcher/LokiClient.cs
@@ -74,9 +74,14 @@ public sealed class LokiClient(HttpClient http, IIoPool pool, ILogger<LokiClient
     private static string Nanos(DateTimeOffset value) =>
         (value.ToUnixTimeMilliseconds() * 1_000_000L).ToString(CultureInfo.InvariantCulture);
 
+    // 🚨 100ns ticks, NOT milliseconds. Loki stamps every line to the nanosecond and the merge below
+    // sorts on this value; truncating to a millisecond threw away the ordering between lines written
+    // inside the same millisecond, which is most of a stack trace. The burst grouper reconstructs per
+    // pod so it no longer depends on the cross-stream order, but a cursor advanced to a truncated
+    // timestamp also silently re-reads part of the window — keep the precision the store gave us.
     private static DateTimeOffset FromNanos(string value) =>
         long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var nanos)
-            ? DateTimeOffset.FromUnixTimeMilliseconds(nanos / 1_000_000L)
+            ? DateTimeOffset.UnixEpoch.AddTicks(nanos / 100L)
             : DateTimeOffset.UtcNow;
 
     // ── Loki's wire shape ────────────────────────────────────────────────────


### PR DESCRIPTION
Six automatically-filed tickets, four root causes, all the same failure of judgement: something benign was reported as a fault, or a fault was reported with nothing to act on.

Closes #2152, #2153, #2182, #2222, #2138, #2139.

## A cancellation is not a fault — #2152, #2182

`MeshWeaver.Mesh.CreateNode` logged a bare `TaskCanceledException` as `fail: Unexpected error during node creation at …` — **491 times in three days**, across ten pods and several deployment revisions, on paths as mundane as `Home` and `Admin`. `MeshWeaver.Mesh.MeshNode` logged `[DeleteNode] unexpected path=… partial-deleted=0` for the same shape, where that counter says the node was never touched.

Both are cooperative cancellation: the caller went away, a partition cleanup cascaded into its `_Access` satellites, the hub tore down. The cost was **signal, not volume** — a genuine storage failure on the same path printed identically to a client disconnect.

`CancellationClassifier` makes the judgement by **condition, never by type**:

- a **timeout** raised on a token is the same CLR type and IS a fault — .NET marks it with a `TimeoutException` cause (`HttpClient` timeout is verbatim `TaskCanceledException(…, new TimeoutException())`), and it keeps `Error` plus its exception;
- a cancellation arriving **after nodes were already deleted** stays LOUD — that subtree really is torn, and that is the case the old wording was borrowing its urgency from;
- the caller is still **answered**: `Unavailable` ("not evaluated; retrying is meaningful") instead of `Unknown`, and an error string that says *cancelled* rather than *unexpected error*. Downgrading a level is not licence to swallow an outcome.

## A client that disconnected is not a service-method failure — #2138, #2139

`MeshGrpcService.WritePumpAsync` wrote without observing the call, so a browser dropping mid-stream made gRPC refuse the next write and the exception escaped `Connect`'s `await pump` into `ServerCallHandler` as `fail: Error when executing service method 'Connect'`.

The pump now observes the call's cancellation token, so a disconnect **ends** the drain instead of racing it. The residual race is inherent — the request can complete between the token check and the write, and gRPC's only signal for that state is the exception — so a write that fails *because the call is over* ends the pump on Debug. **Any other** `InvalidOperationException` (notably "Only one write can be pending at a time", which would mean two writers got hold of a stream this service guarantees has one) still faults the call.

## The exception was lost in the READER, not the writer — #2153, #2222

The watcher's Loki query is namespace-wide (a line filter returns headers without their stack traces) and the CRI log format stamps **each line**, so what comes back is every replica's output **merged by timestamp** — and a burst whose header and trace fall in different milliseconds has another pod's line sorted right into the middle of it. The grouper ended the burst there and dropped the rest:

| Where the cut landed | What the incident carried | Filed as |
|---|---|---|
| after the header | nothing at all | #2222 |
| after the message | message, no exception, no frame | #2153 |

#2153 was filed against a call site that *does* pass its exception to `LogError(ex, …)` and always did. Reconstruction is now **per pod**, so interleaving cannot truncate a burst. The `CreateNode` catch-all also names the fault inside its message, so a capture that loses trailing lines still says what went wrong.

**A bodyless burst is never fingerprinted.** With no message, exception or frame its only possible identity is `(category, event id)` — a token naming a component and no defect, into which every later bodyless capture from that site folds. Those are excluded from reports and surfaced on `BurstAggregation.HeaderOnly`; the watcher holds its cursor at a burst still open at the window edge so the next poll reads it whole (terminating by construction — the rewind lands the cursor *on* the header), and reports the rest once per namespace naming the categories. Nothing is dropped in silence.

## Tests

- `RedLogBurstReconstructionTest` — built from the two incidents' own log lines; the two root-cause facts **fail against the pre-fix grouper** (verified by reverting it).
- `CancellationIsNotAFaultTest` — both directions through a real `INodeValidator` on a `MonolithMeshTestBase` mesh, with a capturing logger provider: benign ⇒ Debug with the exception attached and no `fail:`; genuine fault ⇒ `Error` with its exception AND the type in the message; **timeout impostor ⇒ still a fault**. The benign facts fail with the classifier neutralised (verified).
- Two `MeshGrpcTransportTest` facts: the disconnect race completes the call; a non-disconnect write failure still faults it. The first fails without the guard (verified).

Local, with CI's flags (`-c Release -warnaserror`, `0 Error(s)` per touched project and dependents incl. `Memex.Portal.Distributed`): NodeOperations 98/98 · Graph 1585/1585 · Hosting.Grpc 11/11 · Documentation 42/42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
