### PR TITLE
Read an optional node with a listing AND a stream, not one or the other

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -783,7 +783,17 @@ hub.GetQuery(id, $"path:{parent} scope:children nodeType:X select:path")   // EX
 The index **trails** the store, so "the index has seen it" implies "the store has it" — the point read
 opened on that signal can never be early, and never NotFounds. The same lag that disqualifies a query
 for CONTENT is what makes it a safe gate. Creating the node anyway? Skip the check entirely and use
-`CreateOrUpdateNodeRequest`. Full pattern: [CqrsAndContentAccess.md](src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md) → "An OPTIONAL node".
+`CreateOrUpdateNodeRequest`.
+
+🚨 **This is about ONE known path whose value you are GATING on — not about node counts.** The
+worked counter-example is `src/MeshWeaver.Blazor.Portal/Chat/ThreadTokenChip.razor.cs:106`: it reads
+`content` out of the very same `{thread}/_Usage scope:children` query, **and it is correct** — it
+sums a SET to paint a total, and a briefly-stale total is cosmetic. Converting it to N point reads
+would mean N per-node hub activations per render, and on a legitimately EMPTY set (a thread with no
+rounds yet) every one is an absent-node read tripping the breaker **on the render path**. So: stale
+answer merely looks wrong on screen → query, `content` and all. Stale answer DECIDES whether
+something proceeds, passes, or is written → the owner's stream. Full pattern:
+[CqrsAndContentAccess.md](src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md) → "An OPTIONAL node".
 
 **Free-floating words → vector search.** When a query contains bare text tokens (`laptop nodeType:Story`) AND PG is the backend AND an `IEmbeddingProvider` is registered, `PostgreSqlMeshQuery.QueryAsync` automatically routes through the HNSW cosine index instead of ILIKE substring scan. Structured-only queries (`nodeType:Story namespace:ACME`) stay on the regular SQL path. Full reference: [VectorSearch.md](src/MeshWeaver.Documentation/Data/Architecture/VectorSearch.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -757,7 +757,33 @@ attempt, a stale negative produces DUPLICATE DATA, not merely duplicated work.
 **Wrong:** reading content by exact path, reading state before a write, polling for job completion,
 deciding create-or-skip for a known path.
 
-`GetMeshNodeStream(path)` + `Where(...).Take(1)` is also the right primitive for **waiting for work to finish**.
+`GetMeshNodeStream(path)` + `Where(...).Take(1)` is also the right primitive for **waiting for work to finish** — for a node that **exists**.
+
+🚨 **A node that may NOT EXIST YET is the one case where neither half is enough on its own, and each
+half alone is a defect that has shipped.** Do not pick a horn:
+
+- **A point read of an ABSENT node is forbidden by the framework**, not merely slow: the owner
+  answers an authoritative routing NotFound which **terminates the stream with an error** (it cannot
+  wait for the node to appear), and that NotFound opens `MeshNodeStreamCache`'s **storm-breaker**
+  window on the path — and the breaker **fast-fails WRITES too**, so the read suppresses the write it
+  is waiting for. The breaker says so itself: *"A point node-access to a node that does not exist is
+  a defect — read optional nodes via GetQuery (empty-on-absent), not GetMeshNodeStream(exactPath)."*
+- **Reading that node's CONTENT out of a query is forbidden above** — unbounded lag.
+
+**The composition, and it is the canonical pattern — listing for EXISTENCE, stream for CONTENT:**
+
+```csharp
+hub.GetQuery(id, $"path:{parent} scope:children nodeType:X select:path")   // EXISTENCE — empty-on-absent
+    .Where(nodes => nodes.Any(n => string.Equals(n.Path, target, StringComparison.OrdinalIgnoreCase)))
+    .Take(1)
+    .SelectMany(_ => workspace.GetMeshNodeStream(target))                  // CONTENT — authoritative, live
+    .Select(node => node.ContentAs<X>(hub.JsonSerializerOptions));
+```
+
+The index **trails** the store, so "the index has seen it" implies "the store has it" — the point read
+opened on that signal can never be early, and never NotFounds. The same lag that disqualifies a query
+for CONTENT is what makes it a safe gate. Creating the node anyway? Skip the check entirely and use
+`CreateOrUpdateNodeRequest`. Full pattern: [CqrsAndContentAccess.md](src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md) → "An OPTIONAL node".
 
 **Free-floating words → vector search.** When a query contains bare text tokens (`laptop nodeType:Story`) AND PG is the backend AND an `IEmbeddingProvider` is registered, `PostgreSqlMeshQuery.QueryAsync` automatically routes through the HNSW cosine index instead of ILIKE substring scan. Structured-only queries (`nodeType:Story namespace:ACME`) stay on the regular SQL path. Full reference: [VectorSearch.md](src/MeshWeaver.Documentation/Data/Architecture/VectorSearch.md).
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
@@ -533,6 +533,28 @@ failed at 20 s — widening a wait is not a repair for an unbounded lag.
 [`CreateOrUpdateNodeRequest`](#upserts-createorupdatenoderequest--single-verb-no-delete-then-create),
 which reads persistence itself.
 
+🚨 **Do not over-apply this to a genuine SET — the worked counter-example is
+`src/MeshWeaver.Blazor.Portal/Chat/ThreadTokenChip.razor.cs:106`.** That chip reads `content` out of
+the very same `{thread}/_Usage scope:children` query this section just told you not to read a value
+from, **and it is correct.** It is summing a SET — every `_Usage/{model}` child — to paint a total.
+A briefly-stale total is a cosmetic artefact on screen; nothing decides anything on it.
+
+"Fixing" it into N point reads would be strictly worse in two ways: N per-node hub activations on
+every chat render, and — on a set that is legitimately EMPTY, i.e. a thread with no rounds yet —
+every one of those is an **absent-node point read**, which is the storm breaker in the first row
+above, now firing on the render path.
+
+So the rule is not about how many nodes you read. **It is about whether a stale answer DECIDES
+anything:**
+
+| The value… | Read it from |
+|---|---|
+| is displayed, and a stale one merely looks briefly wrong | the query, `content` and all |
+| **gates** something — a wait passes, a branch is taken, a write happens | the OWNER's `GetMeshNodeStream` |
+
+`ThreadTokenUsageTest` was in the second row and using the first row's primitive. The chip is in the
+first row and using it correctly. Same query, opposite verdicts.
+
 ---
 
 ## Live updates — stay subscribed on `GetMeshNodeStream`

--- a/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
@@ -481,7 +481,57 @@ workspace.GetMeshNodeStream(path)
         ex => logger.LogWarning(ex, "read failed for {Path}", path));
 ```
 
-No `Query`, no `await`, no `FromAsync` bridge, no separate request type. The owning hub activates on subscribe, the first emission is its authoritative current state, and `Take(1)` completes the subscription. (For an optional node that may not exist, don't point an exact-path stream at it — read via a query, which is empty-on-absent; an exact-path subscribe to a missing node NotFound-storms the owner.)
+No `Query`, no `await`, no `FromAsync` bridge, no separate request type. The owning hub activates on subscribe, the first emission is its authoritative current state, and `Take(1)` completes the subscription.
+
+That is the read for a node that **exists**. A node that may not exist yet is a different problem, and it has its own pattern — the next section.
+
+---
+
+### 🚨 An OPTIONAL node: listing for EXISTENCE, stream for CONTENT
+
+Two rules on this page pull in opposite directions the moment the node might not be there yet, and
+**each one, followed alone, is a real defect that has shipped**:
+
+| If you… | …you hit |
+|---|---|
+| point `GetMeshNodeStream(exactPath)` at an **absent** node | The owner answers an authoritative routing **NotFound**, which **terminates the stream with an error** — it cannot wait for the node to appear. Worse, that NotFound opens `MeshNodeStreamCache`'s **storm-breaker** window on that path, and the breaker **fast-fails WRITES too** — so the read suppresses the very write it is waiting for. |
+| read a known path's **`Content`** out of a query | The index is eventually consistent; a query's answer for one path can be **minutes** old. Waiting on a VALUE through it is waiting on an unbounded lag. |
+
+So do not pick a horn. **Compose them** — the listing answers *whether it is there*, the owner's
+stream answers *what it says*:
+
+```csharp
+// EXISTENCE — a children LISTING. Empty-on-absent, so the watcher may be in place long before
+// the node is written, and a stale negative only means waiting a beat longer. select:path —
+// nothing here reads Content.
+hub.GetQuery($"usage:{parentPath}", $"path:{parentPath}/_Usage scope:children nodeType:TokenUsage select:path")
+    .Where(nodes => nodes.Any(n => string.Equals(n.Path, target, StringComparison.OrdinalIgnoreCase)))
+    .Take(1)
+    // CONTENT — the OWNER's authoritative stream, opened only now that the node demonstrably
+    // exists, so it can neither NotFound nor trip the storm breaker. Live (no Take): later
+    // writes to the same node keep arriving.
+    .SelectMany(_ => workspace.GetMeshNodeStream(target))
+    .Select(node => node.ContentAs<TokenUsage>(hub.JsonSerializerOptions))
+    .Where(u => u is not null)
+    .Subscribe(u => { /* … */ }, ex => logger.LogWarning(ex, "usage read failed for {Path}", target));
+```
+
+Why the ordering is sound rather than merely convenient: the listing is served by the index, which
+**trails** the durable store. So "the index has seen it" implies "the store has it" — the point read
+opened on that signal cannot be early. The lag that makes a query useless for CONTENT is exactly
+what makes it safe as a gate for the point read.
+
+**This is not hypothetical, and it has cost real time in both directions.** `ThreadTokenUsageTest`
+used a point read, hit `No node found at …/_Usage/…` under load — an error, not a timeout, so no
+budget could save it (#1040) — and was moved wholesale onto the query. It then became a repeat CI
+offender on the *other* horn: #1812, #2001, and run `32876073965` are all "the observable emitted
+nothing at all" on a **usage** wait, never on the thread/cell waits carrying the identical budget in
+the same test methods. #2001's fix widened every budget from 10 s to 20 s and the same assertion
+failed at 20 s — widening a wait is not a repair for an unbounded lag.
+
+**Creating it anyway?** Then you need no existence check at all — use
+[`CreateOrUpdateNodeRequest`](#upserts-createorupdatenoderequest--single-verb-no-delete-then-create),
+which reads persistence itself.
 
 ---
 
@@ -738,6 +788,7 @@ return request.Processed();   // handler returns immediately
 | Does **anything match** a predicate? | `Query` + check `Items.Count` |
 | Does node X (a KNOWN path) exist? | `workspace.GetMeshNodeStream(X)` — a query's negative can be minutes stale, and a caller that writes on it redoes finished work ([why](#-never-query-to-ask-does-this-path-exist--a-stale-negative-redoes-finished-work)). Creating it anyway? `CreateOrUpdateNodeRequest` — no check needed |
 | Give me node X's MeshNode (live) | `workspace.GetMeshNodeStream(X)` — the **only** non-stale read path |
+| Give me node X, which **may not exist yet** | Children LISTING (`select:path`) for existence, then `GetMeshNodeStream(X)` for content ([pattern](#-an-optional-node-listing-for-existence-stream-for-content)). Neither half alone: a point read of an absent node NotFounds AND storm-breaks the writer; a query's `Content` for one path can be minutes stale |
 | Give me node X's MeshNode (once) | `workspace.GetMeshNodeStream(X).Where(n => n is not null).Take(1).Timeout(...)` |
 | Keep me updated on node X's MeshNode | `workspace.GetMeshNodeStream(X)` — stay subscribed (no `.Take(1)`) |
 | Patch node X | `workspace.GetMeshNodeStream(X).Update(node => updated).Subscribe(...)` |

--- a/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelSubstitutionTest.cs
@@ -300,29 +300,28 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
     /// Watches the per-model <see cref="TokenUsage"/> satellite at
     /// <c>{threadPath}/_Usage/{modelKey}</c> until it matches <paramref name="predicate"/>.
     ///
-    /// <para>🚨 Through the LIVE CHILDREN QUERY of <c>{threadPath}/_Usage</c> — byte for byte the
-    /// primitive <c>ThreadTokenChip</c> binds to in the portal, and the same helper
-    /// <c>ThreadTokenUsageTest</c> and <c>DelegationSubThreadUsageTest</c> already use — never a
-    /// point <c>GetMeshNodeStream({threadPath}/_Usage/{modelKey})</c> read. A point read of an
-    /// ABSENT node answers with an authoritative routing NotFound and TERMINATES the stream with an
-    /// error; it cannot wait for a node to appear. The children query starts from the (possibly
-    /// empty) collection and re-emits when the node lands, which is the only shape that serves this
-    /// ordering — and <c>TokenUsageNodeType.RecordUsage</c> is subscribed as an INDEPENDENT side
-    /// effect, deliberately NOT chained before the round's terminal status write, so "the round
-    /// finished" never implies "the satellite exists".</para>
-    ///
-    /// <para>This class was the last straggler on the point read. It cost a red shard on an
-    /// unrelated PR (#1703, 2026-08-17): the round lost the race and the read errored inside a
-    /// second with <c>No node found at …/_Usage/…</c> — an error, not a timeout, so no amount of
-    /// waiting could have saved it. Same defect #1040 fixed in <c>ThreadTokenUsageTest</c>.</para>
-    ///
-    /// <para>🚨 <b>Do not switch this to the node stream</b> (#1812). That issue proposed it, on the
-    /// theory that an all-zero <c>TokenUsage</c> CI once timed out on was a stale CQRS projection.
-    /// Measured, it is not: this query and <c>GetMeshNodeStream(usagePath)</c> resolve within ±13 ms
-    /// of each other, and the point stream is the SLOWER of the two once its cold per-node hub
-    /// activation is counted. The zeros were the node's authoritative value — <c>RecordUsage</c>'s
-    /// phase 1 wrote them — so an authoritative read returned the same zeros. Fixed on the write
-    /// side; pinned by <c>ThreadTokenUsageTest.UsageSatelliteIsNeverObservableWithZeroTokens</c>.</para>
+    /// <para><b>EXISTENCE from the children listing, CONTENT from the owner</b> — the same two-leg
+    /// composition <c>ThreadTokenUsageTest.ObserveUsage</c> documents in full, and for the same
+    /// reason: reading an optional node has two rules pulling opposite ways and neither may be
+    /// bent.</para>
+    /// <list type="bullet">
+    ///   <item>A point <c>GetMeshNodeStream({usagePath})</c> on an ABSENT node answers with an
+    ///     authoritative routing NotFound, TERMINATES the stream, and opens
+    ///     <c>MeshNodeStreamCache</c>'s storm-breaker window on the very path <c>RecordUsage</c> is
+    ///     about to write — fast-failing the WRITE too. This class was the last straggler on that
+    ///     read and it cost a red shard on an unrelated PR (#1703, 2026-08-17): the round lost the
+    ///     race and the read errored inside a second with <c>No node found at …/_Usage/…</c>, an
+    ///     error rather than a timeout, so no budget could have saved it. <c>RecordUsage</c> is
+    ///     subscribed as an INDEPENDENT side effect, NOT chained before the round's terminal status
+    ///     write, so "the round finished" never implies "the satellite exists".</item>
+    ///   <item>A query cannot answer for a known path's CONTENT — the index is eventually
+    ///     consistent (AGENTS.md → "Never Query for a Single Node's Content"), so waiting on a VALUE
+    ///     through it is waiting on an unbounded lag. That is the #1812 / #2001 / run 32876073965
+    ///     failure shape.</item>
+    /// </list>
+    /// <para>So the listing answers only "is it there yet" (empty-on-absent; a stale negative merely
+    /// waits a beat longer), and the value comes off the owner's stream once the node demonstrably
+    /// exists — which is also when the point read is safe.</para>
     /// </summary>
     private async Task<TokenUsage> WaitForUsage(string threadPath, string modelKey, Func<TokenUsage, bool> predicate, int timeoutMs)
     {
@@ -330,10 +329,12 @@ public class ModelSubstitutionTest(ITestOutputHelper output) : AITestBase(output
         return (await Mesh.GetQuery(
                 $"usage:{threadPath}",
                 $"path:{threadPath}/{TokenUsageNodeType.SatelliteSegment} scope:children "
-                + $"nodeType:{TokenUsageNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
-            .Select(nodes => nodes
-                .FirstOrDefault(n => string.Equals(n.Path, usagePath, StringComparison.OrdinalIgnoreCase))
-                .ContentAs<TokenUsage>(Mesh.JsonSerializerOptions))
+                + $"nodeType:{TokenUsageNodeType.NodeType} select:path")
+            .Where(nodes => nodes.Any(n =>
+                string.Equals(n.Path, usagePath, StringComparison.OrdinalIgnoreCase)))
+            .Take(1)
+            .SelectMany(_ => Mesh.GetWorkspace().GetMeshNodeStream(usagePath))
+            .Select(n => n.ContentAs<TokenUsage>(Mesh.JsonSerializerOptions))
             .Where(u => u is not null)
             .Should().Within(TimeSpan.FromMilliseconds(timeoutMs))
             .Match(u => predicate(u!)))!;

--- a/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
@@ -200,6 +200,15 @@ public class ThreadTokenUsageTest : AITestBase
     /// <para>The watcher is opened BEFORE the round so it is live across every write the satellite
     /// receives: the underlying query re-runs on each change with no debounce, so a durable zero
     /// state cannot slip past it. Pre-fix this failed on the first emission, every run.</para>
+    ///
+    /// <para>🚨 The zero-watch deliberately reads through
+    /// <see cref="ObserveUsageAsThePortalChipDoes"/> — the query-shaped reader — because the claim
+    /// is about what a query-bound GUI reader can OBSERVE, and pointing it at
+    /// <see cref="ObserveUsage"/> would quietly gut it: that helper's point-read leg opens only once
+    /// the index has already seen the node, so a regressed zero window could land and be overwritten
+    /// before the leg ever subscribes, and this test would pass having watched nothing. The SETTLE,
+    /// by contrast, runs on <see cref="ObserveUsage"/>, so the test's pass does not hang on the
+    /// query index's lag — the assertion keeps its subject, without inheriting its flakiness.</para>
     /// </summary>
     [Fact]
     public async Task UsageSatelliteIsNeverObservableWithZeroTokens()
@@ -212,13 +221,15 @@ public class ThreadTokenUsageTest : AITestBase
 
         // Live from before the round — see the summary: this must see every state the node passes
         // through, not just the one it settles on.
-        var settled = ObserveUsage(threadPath, "usage_model")
-            .Do(u =>
+        using var zeroWatch = ObserveUsageAsThePortalChipDoes(threadPath, "usage_model")
+            .Subscribe(u =>
             {
                 if (u.InputTokens == 0 && u.OutputTokens == 0
                     && u.CacheReadTokens == 0 && u.CacheWriteTokens == 0)
                     lock (gate) zeroSnapshots.Add(u);
-            })
+            });
+
+        var settled = ObserveUsage(threadPath, "usage_model")
             .Should().Within(TimeSpan.FromSeconds(20))
             .Match(u => u.InputTokens == InTokens && u.OutputTokens == OutTokens);
 
@@ -480,49 +491,89 @@ public class ThreadTokenUsageTest : AITestBase
     /// The live per-model <see cref="TokenUsage"/> satellite at <c>{threadPath}/_Usage/{modelKey}</c>,
     /// as every emission the reader can observe (nulls — "not there yet" — filtered out).
     ///
-    /// <para>🚨 Through the LIVE CHILDREN QUERY of <c>{threadPath}/_Usage</c> — byte for byte the
-    /// primitive <c>ThreadTokenChip</c> binds to in the portal — and never a point
-    /// <c>GetMeshNodeStream({threadPath}/_Usage/{modelKey})</c> read. The satellite is written by
-    /// <c>TokenUsageNodeType.RecordUsage</c>, which is subscribed as an INDEPENDENT side effect and
-    /// deliberately NOT chained before the round's terminal status write; a watcher can therefore be
-    /// in place before the node exists. A point read of an absent node answers with an authoritative
-    /// routing NotFound and TERMINATES the stream with an error — it cannot wait for a node to
-    /// appear, and worse, that NotFound opens MeshNodeStreamCache's storm-breaker window on the very
-    /// path RecordUsage is about to write, which fast-fails the WRITE too. The children query starts
-    /// from the (possibly empty) collection and re-emits when the node lands, which is the only shape
-    /// that serves this ordering. Listing children is exactly the use AGENTS.md sanctions for a
-    /// query.</para>
+    /// <para><b>Two legs, and the split is the whole point: EXISTENCE from a listing, CONTENT from
+    /// the owner.</b> Reading an optional node has two rules pulling opposite ways, and every
+    /// previous version of this helper picked one horn and was bitten by the other:</para>
+    /// <list type="bullet">
+    ///   <item><b>A point read cannot wait for a node to appear.</b>
+    ///     <c>GetMeshNodeStream({usagePath})</c> on an ABSENT node answers with an authoritative
+    ///     routing NotFound and TERMINATES the stream with an error — and that NotFound opens
+    ///     <c>MeshNodeStreamCache</c>'s storm-breaker window on the very path
+    ///     <c>RecordUsage</c> is about to write, which fast-fails the WRITE too. That is #1040's
+    ///     <c>No node found at …/_Usage/…</c>, an error rather than a timeout, and it is why
+    ///     <c>02b851fd6</c> moved this helper onto a query at all. <c>RecordUsage</c> is subscribed
+    ///     as an INDEPENDENT side effect, deliberately NOT chained before the round's terminal
+    ///     status write, so "the round reached a terminal state" never implies "the satellite
+    ///     exists" — a reader genuinely has to cope with the node not being there yet.</item>
+    ///   <item><b>A query cannot answer for a known path's CONTENT.</b> The query index is
+    ///     eventually consistent; AGENTS.md → "Never Query for a Single Node's Content" forbids
+    ///     exactly this, and the 2026-08-25 tightening of
+    ///     <c>Doc/Architecture/CqrsAndContentAccess</c> (#2229) put a number on it: a query's answer
+    ///     for one path can be minutes old. Waiting on a VALUE through that index is waiting on an
+    ///     unbounded lag, which is what turned this class into a repeat CI offender — #1812, #2001
+    ///     and run 32876073965 are all the same shape, "the observable emitted nothing at all" on a
+    ///     <c>WaitForUsage</c>, never on <c>WaitForThread</c>/<c>WaitForCell</c> despite identical
+    ///     budgets in the same test methods.</item>
+    /// </list>
     ///
-    /// <para>That mismatch was #1040's largest blocker: at
-    /// <c>DOTNET_PROCESSOR_COUNT=4 -parallel collections</c> three of this class's tests failed
-    /// inside a second with <c>No node found at …/_Usage/…</c> — not a timeout, an error. Serial
-    /// scheduling merely let the create win the race.
-    /// <see cref="UsageWatchedFromBeforeTheRound_ArrivesWhenTheSatelliteIsCreated"/> pins the losing
-    /// ordering deterministically.</para>
+    /// <para>So: the children LISTING answers only "is it there yet" — the one query use AGENTS.md
+    /// still sanctions, empty-on-absent, where a stale negative merely makes us wait a beat longer —
+    /// and the moment it says yes, CONTENT comes off the OWNER's authoritative
+    /// <c>GetMeshNodeStream(usagePath)</c>, which is never stale and stays live so accumulation
+    /// across rounds is observed. The point read only ever opens on a node the index has already
+    /// seen, so it cannot NotFound and cannot poison the writer. Both horns satisfied; neither rule
+    /// bent. <see cref="UsageWatchedFromBeforeTheRound_ArrivesWhenTheSatelliteIsCreated"/> pins the
+    /// watcher-first ordering deterministically.</para>
     ///
-    /// <para>🚨 <b>Do NOT "fix" a slow usage read by switching this to the node stream</b> (#1812).
-    /// That issue proposed it, on the theory that the all-zero <c>TokenUsage</c> CI once timed out on
-    /// was a stale CQRS projection. Measured, it is not: with both readers racing the same round,
-    /// this query and <c>GetMeshNodeStream(usagePath)</c> resolve within ±13 ms of each other, and
-    /// the point stream is the SLOWER of the two once its cold per-node hub activation is counted.
-    /// The zeros were not a lagged view of a written value — they WERE the node's authoritative
-    /// value, because <c>RecordUsage</c>'s phase 1 wrote them. An authoritative read would have
-    /// returned the same zeros. The defect was on the write side and is fixed there; see
-    /// <see cref="UsageSatelliteIsNeverObservableWithZeroTokens"/>, which pins it.</para>
+    /// <para>🚨 Do not "simplify" this back to either half. Switching wholesale to the node stream
+    /// re-opens #1040 (NotFound + storm breaker); reading <c>content</c> out of the query re-opens
+    /// the unbounded-lag wait. Note also that widening the wait is not a repair: #2001's fix
+    /// (<c>3fcf79f8f</c>) replaced every 10 s budget with 20 s, and the same assertion then failed
+    /// at 20 s.</para>
     /// </summary>
     private IObservable<TokenUsage> ObserveUsage(string threadPath, string modelKey)
     {
         var usagePath = $"{threadPath}/{TokenUsageNodeType.SatelliteSegment}/{modelKey}";
-        return Mesh.GetQuery(
-                $"usage:{threadPath}",
-                $"path:{threadPath}/{TokenUsageNodeType.SatelliteSegment} scope:children "
-                + $"nodeType:{TokenUsageNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
+        // Leg 1 — EXISTENCE, via the children listing. select:path only: nothing here reads Content.
+        return ObserveUsageNamespace(threadPath, "select:path")
+            .Where(nodes => nodes.Any(n =>
+                string.Equals(n.Path, usagePath, StringComparison.OrdinalIgnoreCase)))
+            .Take(1)
+            // Leg 2 — CONTENT, from the owner. Live (no Take): rounds 2+ accumulate onto the same node.
+            .SelectMany(_ => Mesh.GetWorkspace().GetMeshNodeStream(usagePath))
+            .Select(n => n.ContentAs<TokenUsage>(Mesh.JsonSerializerOptions))
+            .Where(u => u is not null)
+            .Select(u => u!);
+    }
+
+    /// <summary>
+    /// The satellite as the PORTAL's <c>ThreadTokenChip</c> sees it — the raw children query,
+    /// content and all. This is deliberately the shape <see cref="ObserveUsage"/> refuses to use for
+    /// a value wait, and it exists for exactly one job: letting
+    /// <see cref="UsageSatelliteIsNeverObservableWithZeroTokens"/> assert what a query-bound GUI
+    /// reader can observe, without also making the test's PASS depend on that reader's lag.
+    /// </summary>
+    private IObservable<TokenUsage> ObserveUsageAsThePortalChipDoes(string threadPath, string modelKey)
+    {
+        var usagePath = $"{threadPath}/{TokenUsageNodeType.SatelliteSegment}/{modelKey}";
+        return ObserveUsageNamespace(threadPath, "select:path,id,namespace,name,nodeType,content")
             .Select(nodes => nodes
                 .FirstOrDefault(n => string.Equals(n.Path, usagePath, StringComparison.OrdinalIgnoreCase))
                 .ContentAs<TokenUsage>(Mesh.JsonSerializerOptions))
             .Where(u => u is not null)
             .Select(u => u!);
     }
+
+    /// <summary>
+    /// The live children listing of <c>{threadPath}/_Usage</c>. Distinct cache ids per projection —
+    /// the query set is part of the cache key (#1311), and giving the two projections separate ids
+    /// keeps that explicit rather than relying on it.
+    /// </summary>
+    private IObservable<IEnumerable<MeshNode>> ObserveUsageNamespace(string threadPath, string select)
+        => Mesh.GetQuery(
+            $"usage:{threadPath}:{select}",
+            $"path:{threadPath}/{TokenUsageNodeType.SatelliteSegment} scope:children "
+            + $"nodeType:{TokenUsageNodeType.NodeType} {select}");
 
     /// <summary>
     /// Watches <see cref="ObserveUsage"/> until it matches <paramref name="predicate"/>.

--- a/test/MeshWeaver.Threading.Test/DelegationSubThreadUsageTest.cs
+++ b/test/MeshWeaver.Threading.Test/DelegationSubThreadUsageTest.cs
@@ -144,21 +144,26 @@ public class DelegationSubThreadUsageTest(ITestOutputHelper output) : MonolithMe
         //    unsound, since Thread.IsExecuting is false for the INITIAL Idle state as well as for a
         //    finished round (the same defect fixed in OrleansSubThreadAutoResumeTest).
         //
-        //    🚨 Do NOT switch this to the node stream (#1812). That issue proposed it, on the theory
-        //    that an all-zero TokenUsage CI once timed out on was a stale CQRS projection. Measured,
-        //    it is not: this query and GetMeshNodeStream(usagePath) resolve within ±13 ms of each
-        //    other, and the point stream is the SLOWER of the two once its cold per-node hub
-        //    activation is counted. The zeros were the node's authoritative value — RecordUsage's
-        //    phase 1 wrote them — so an authoritative read returned the same zeros. Fixed on the
-        //    write side; pinned by ThreadTokenUsageTest.UsageSatelliteIsNeverObservableWithZeroTokens.
+        //    🚨 But the listing answers EXISTENCE ONLY — never the value. The query index is
+        //    eventually consistent, so waiting on CONTENT through it is waiting on an unbounded lag
+        //    (AGENTS.md → "Never Query for a Single Node's Content"; the 2026-08-25 tightening of
+        //    Doc/Architecture/CqrsAndContentAccess puts a number on it — a query's answer for one
+        //    path can be minutes old). That is the OTHER horn, and it is the one that made
+        //    ThreadTokenUsageTest a repeat CI offender (#1812, #2001, run 32876073965: "the
+        //    observable emitted nothing at all", always on a usage wait, never on a thread/cell wait
+        //    with the identical budget). So: listing for existence, then the OWNER's authoritative
+        //    GetMeshNodeStream for the value — a point read that can no longer NotFound, because by
+        //    then the node demonstrably exists. Both horns satisfied, neither rule bent.
         var usagePath = $"{subThreadPath}/{TokenUsageNodeType.SatelliteSegment}/{UsageModelKey}";
         var usage = (await Mesh.GetQuery(
                 $"usage:{subThreadPath}",
                 $"path:{subThreadPath}/{TokenUsageNodeType.SatelliteSegment} scope:children "
-                + $"nodeType:{TokenUsageNodeType.NodeType} select:path,id,namespace,name,nodeType,content")
-            .Select(nodes => nodes
-                .FirstOrDefault(n => string.Equals(n.Path, usagePath, StringComparison.OrdinalIgnoreCase))
-                .ContentAs<TokenUsage>(Mesh.JsonSerializerOptions))
+                + $"nodeType:{TokenUsageNodeType.NodeType} select:path")
+            .Where(nodes => nodes.Any(n =>
+                string.Equals(n.Path, usagePath, StringComparison.OrdinalIgnoreCase)))
+            .Take(1)
+            .SelectMany(_ => Mesh.GetWorkspace().GetMeshNodeStream(usagePath))
+            .Select(n => n.ContentAs<TokenUsage>(Mesh.JsonSerializerOptions))
             .Should().Within(60.Seconds())
             .Match(u => u is not null
                         && u.InputTokens == SubInTokens


### PR DESCRIPTION
## The one-line finding

`ThreadTokenUsageTest` has been declared fixed three times and failed a fourth (run [32876073965](https://github.com/Systemorph/MeshWeaver/actions/runs/32876073965) turned **main** red at `dcba079ce`). **Every failure across #1040, #1812, #2001 and today is a `WaitForUsage` — never the `WaitForThread` or `WaitForCell` sitting in the same test methods on the identical budget.** That asymmetry rules out generic runner starvation and points at the one thing the usage read does differently: it reads **one known node's CONTENT through an eventually-consistent query**.

## Why the previous fixes could not hold

Reading a node that **may not exist yet** has two rules pulling opposite ways, and each earlier fix picked one horn and got bitten by the other:

| Do this | And you hit |
|---|---|
| point `GetMeshNodeStream(exactPath)` at an **absent** node | The owner answers an authoritative routing **NotFound**, which **terminates the stream with an error** — it cannot wait for the node to appear. Worse, that NotFound opens `MeshNodeStreamCache`'s **storm-breaker** window on the path, and the breaker **fast-fails WRITES too** — so the read suppresses the write it is waiting for. This is #1040's `No node found at …/_Usage/…`: an *error*, not a timeout, so no budget could have saved it. It is why `02b851fd6` moved these tests onto a query. |
| read a known path's **`Content`** out of a query | The index is eventually consistent. The `CqrsAndContentAccess` tightening that landed hours before this failure (#2229 → #2232) puts a number on it: a query's answer for one path can be **minutes** old. Waiting on a VALUE through it is waiting on an unbounded lag. |

The irony is worth stating plainly: **the doc-only commit that turned main red is the one that tightened AGENTS.md to say a query's answer for a known path can be minutes stale — describing exactly the read shape of the test that then failed on that run.**

## The fix — stop picking a horn, compose them

```csharp
GetQuery(id, "path:{parent} scope:children nodeType:X select:path")   // EXISTENCE — empty-on-absent
    .Where(nodes => nodes.Any(n => n.Path == target))
    .Take(1)
    .SelectMany(_ => workspace.GetMeshNodeStream(target))             // CONTENT — authoritative, live
    .Select(node => node.ContentAs<X>(hub.JsonSerializerOptions));
```

The listing answers only *is it there yet* — the one query use AGENTS.md still sanctions, empty-on-absent, where a stale negative merely waits a beat longer. The value comes off the **owner's** stream, opened only once the node demonstrably exists, and left live so rounds 2+ accumulate onto the same node.

The ordering is sound rather than merely convenient: **the index TRAILS the store**, so "the index has seen it" implies "the store has it". The point read opened on that signal can never be early and can never NotFound. The same lag that disqualifies a query for CONTENT is what makes it a safe gate for the point read.

Applied to **all three** copies of the shape — `ThreadTokenUsageTest`, `ModelSubstitutionTest`, `DelegationSubThreadUsageTest`. Leaving stragglers is how this came back three times carrying three mutually contradictory "🚨 do NOT switch this to X" comments.

## `UsageSatelliteIsNeverObservableWithZeroTokens` keeps its subject

A naive port would have gutted that test **silently**. Its claim is about what a *query-bound GUI reader* can observe; the new composition's point-read leg opens only after the index has seen the node, so a regressed zero window could land and be overwritten unseen and the test would pass having watched nothing.

It now does both: collects zero-snapshots from a deliberately query-shaped reader (byte for byte what `ThreadTokenChip` binds to) while **settling** on the authoritative composition. Strictly stronger than before — the assertion keeps its subject, and the test's pass no longer hangs on that reader's lag.

## AGENTS.md is amended, because it is the artefact that made this hard

Its CQRS section states *"Never Query for a Single Node's Content"* **unqualified**, with a ❌/✅ pair that says to use the exact-path stream. The absent-node horn existed only as a parenthetical **484 lines into** `CqrsAndContentAccess.md`. An agent following AGENTS.md literally writes the point read and storm-breaks the writer — which is what happened. Both documents now carry the composition as a named pattern, and the primitives table gains a row for it.

## Also worth recording: #2001's fix was a band-aid

`3fcf79f8f` ("One wait budget in ThreadTokenUsageTest, and it is a hang-stopper") did exactly one thing: replaced every `10_000` with a `20_000` constant. Its commit message argues at length that this is *"NOT the widening AGENTS.md forbids"* — while #2001's own issue body had already written:

> **Not** raising 10 000 to 20 000. That is the band-aid `AGENTS.md` forbids.

The same assertion then failed at 20 s. Recorded so the next person does not spend the cycle re-deriving it.

## What is NOT claimed

**No local repro.** Under the documented lever (`DOTNET_PROCESSOR_COUNT=4`) over repeated full-assembly runs, the failure did not reproduce. A first attempt using four concurrent loops *did* produce failures — `AgentToolCancellationTest`, `MeshPluginTest` — but at load average 217 those are starvation artefacts, neither has ever appeared in CI, and I am not reporting them as members of #1384's population. So this rests on the read shape being wrong **by the repo's own rules**, not on catching it in the act.

**One writer-side hypothesis remains open and unproven**, and it is the inconvenient one: a cancelled round whose `RecordUsage` no-ops on zero tokens (Debug level) or whose create chain **completes without emitting** — silent, because an empty completion passes straight through the 15 s `Timeout` without tripping its deliberately-loud fail-open warning. That would mean **cancelled-round tokens go unbilled in production**. The CI log for the failing run shows no `[TokenUsage]` warning at all, which is consistent with both. It is written up on #1384 rather than guessed at here, and it is a separate product question from this test's read shape.

## Verification

- `dotnet build -c Release -warnaserror`: `MeshWeaver.AI.Test`, `MeshWeaver.Threading.Test`, `MeshWeaver.Documentation.Test` — **0 Warning(s), 0 Error(s)** each.
- `MeshWeaver.Documentation.Test` — 42/42 (covers `DocumentationLinkIntegrityTest` for the doc edits; `src/MeshWeaver.Documentation/Data/**` is `<EmbeddedResource>`, so the project was rebuilt first).
- `ThreadTokenUsageTest` + `ModelSubstitutionTest` — 12/12.
- `DelegationSubThreadUsageTest` — 1/1.
- Full `MeshWeaver.AI.Test` assembly under `DOTNET_PROCESSOR_COUNT=4`, repeated.

**No What's New entry**: tests and internal docs only, no user-visible change (per the `pullrequest` skill's pure-internal exemption — noted here deliberately).

Refs #1384, #1040, #1812, #2001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
