### PR TITLE
A NodeType declaration declares itself a NodeType, never the type it declares

### DIFF
--- a/src/MeshWeaver.AI/AiSourcesInstallHook.cs
+++ b/src/MeshWeaver.AI/AiSourcesInstallHook.cs
@@ -80,14 +80,14 @@ public sealed class AiSourcesInstallHook(IMessageHub hub) : IPartitionInstallHoo
             .Select(nodes => (IReadOnlyList<string>)nodes
                 .Select(n => n.Id)
                 .Where(id => !string.IsNullOrEmpty(id))
-                // 🚨 Drop the NodeType DECLARATION node. `User` is self-typed — the node that
-                // DEFINES the type carries `nodeType: User` too — so a pathless `nodeType:User`
-                // query returns it alongside the real accounts. Treated as a user it resolves to a
-                // partition literally named "User", which no instance provisions, and every install
-                // logged `42P01: relation "user.mesh_nodes" does not exist` once per package. The
-                // per-user Catch swallowed it, so the only visible trace was the noise — and a
-                // stray `vuser` partition on any instance where the same query shape ran for VUser.
-                .Where(id => !string.Equals(id, UserNodeType, StringComparison.OrdinalIgnoreCase))
+                // The hand-rolled `id != "User"` filter that used to sit here is GONE with its
+                // cause: the `User` declaration node carried `nodeType: User`, so a pathless
+                // `nodeType:User` query returned it alongside the real accounts and every install
+                // logged `42P01: relation "user.mesh_nodes" does not exist` for a partition
+                // literally named "User". Declarations now declare themselves
+                // (`NodeType = MeshNode.NodeTypePath`, UserNodeType.CreateMeshNode), so this query
+                // returns accounts only — and NodeTypeDeclarationSelfTypingTest keeps it that way
+                // for every built-in type, not just the two this filter happened to name.
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList());
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-node-type-declarations-stop-posing-as-instances.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-node-type-declarations-stop-posing-as-instances.md
@@ -1,0 +1,34 @@
+---
+Name: Node type declarations stop posing as their own instances
+Category: Fix
+Description: The built-in User, Virtual User and Partition declarations no longer show up as results in their own nodeType queries — so the portal's user directory returns people, and a node type whose path is taken now says so instead of quietly binding to the wrong thing.
+Icon: PersonQuestionMark
+Order: -20260825
+---
+
+# Node type declarations stop posing as their own instances
+
+Every kind of thing in the mesh is described by a **declaration** node — the page you land on at
+`/User` describes what a user *is*. Three of those declarations were filed under the very type they
+describe: the `User` declaration claimed to be a user, `Virtual User` claimed to be a virtual user,
+and `Partition` claimed to be a partition.
+
+That made them indistinguishable from the real thing. Anything asking the mesh "give me all the
+users" got the declaration back alongside the actual accounts — and then tried to read a person's
+email off a page that describes what a person is. The portal's user directory did this on every
+refresh, several hundred thousand times over.
+
+Now a declaration declares itself a declaration, the way the `Space`, `Release` and `Build` ones
+already did. Listing users returns people. Installing a package no longer tries to write into a
+storage area named after the *word* "User".
+
+## When two things want the same name
+
+A related case, from the same family: a package installed at a short name — say `Feedback` — while
+the node type it ships lives one level deeper. A page pointing at just `Feedback` used to attach
+itself to the package's own page and serve the wrong thing, leaving nothing behind but one
+inscrutable line in the log.
+
+The mesh now checks whether what sits at that name is actually a node type declaration. When it is
+not, the page says exactly that — naming both the name it wanted and what it found there instead —
+so the fix is obvious: point it at the declaration's real path, or move whatever is in the way.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -152,31 +152,61 @@ internal static class NodeTypeEnrichmentHelpers
                 .Where(c => c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
                 .Take(1)
                 .Timeout(NodeTypeProbeTimeout)
-                .Select(probe => probe.Items.Count > 0 ? ProbeOutcome.Registered : ProbeOutcome.Missing)
+                // 🚨 The probe's question is "is a NodeType REGISTERED at that path", not "does
+                // ANY node live there" — and those diverge the moment two things want the same
+                // name. A Store plugin installs its root at the bare path `Feedback` while its
+                // NodeType is `Feedback/Feedback`, so an instance that named the bare `Feedback`
+                // passed this gate on the PLUGIN ROOT and then bound to the plugin's own hub
+                // configuration, leaving only a lone
+                // `As<NodeTypeDefinition> for Feedback: value is PluginContent` line behind
+                // (Systemorph/MeshWeaver#2230/#2231). Counting the occupant as a registration is
+                // the defect; see ProbeCollision for why the test is deliberately one-sided.
+                .Select(probe =>
+                {
+                    var collision = ProbeCollision(probe.Items, meshHub.JsonSerializerOptions);
+                    return (
+                        Outcome: probe.Items.Count == 0 || collision is not null
+                            ? ProbeOutcome.Missing
+                            : ProbeOutcome.Registered,
+                        Collision: collision);
+                })
                 // 🚨 A FAULTED probe is NOT the same answer as an EMPTY one. Folding
                 // both into "missing" made a ~3s lookup timeout (busy mesh hub, slow
                 // storage, restart in progress) render the genuine-compile-failure
                 // overlay — "There was a compilation error… Please correct the code" —
                 // for a type whose source was never even read (#641). Keep the two
                 // apart and say which one happened.
-                .Catch<ProbeOutcome, Exception>(ex =>
+                .Catch<(ProbeOutcome Outcome, string? Collision), Exception>(ex =>
                 {
                     logger?.LogWarning(ex,
                         "EnrichWithNodeType probe for NodeType '{NodeType}' faulted ({ExceptionType}) — registration is INDETERMINATE, not missing",
                         nodeType, ex.GetType().Name);
-                    return Observable.Return(ProbeOutcome.Indeterminate);
+                    return Observable.Return((ProbeOutcome.Indeterminate, (string?)null));
                 })
-                .SelectMany(outcome =>
+                .SelectMany(result =>
                 {
+                    var (outcome, collision) = result;
                     if (outcome == ProbeOutcome.Missing)
                     {
-                        var msg =
-                            $"NodeType '{nodeType}' is not registered (referenced by instance '{node.Path}'). " +
-                            $"Either register the type via AddXxxType() in your mesh builder, or fix " +
-                            $"the instance's NodeType field. Activation cannot proceed.";
-                        logger?.LogWarning(
-                            "EnrichWithNodeType: NodeType '{NodeType}' has no static registration and no persisted node at that path — applying error overlay to '{InstancePath}'",
-                            nodeType, node.Path);
+                        var msg = collision is null
+                            ? $"NodeType '{nodeType}' is not registered (referenced by instance '{node.Path}'). " +
+                              $"Either register the type via AddXxxType() in your mesh builder, or fix " +
+                              $"the instance's NodeType field. Activation cannot proceed."
+                            : $"NodeType '{nodeType}' is not registered: {collision} (referenced by " +
+                              $"instance '{node.Path}'). Point the instance's NodeType field at the " +
+                              $"declaration's real path, or move whatever occupies '{nodeType}' out of " +
+                              $"the way. Activation cannot proceed.";
+                        if (collision is null)
+                            logger?.LogWarning(
+                                "EnrichWithNodeType: NodeType '{NodeType}' has no static registration and no persisted node at that path — applying error overlay to '{InstancePath}'",
+                                nodeType, node.Path);
+                        else
+                            // Error, not Warning: a name COLLISION is a misconfiguration someone
+                            // has to resolve, and it names both sides so it is actionable without
+                            // a second incident.
+                            logger?.LogError(
+                                "EnrichWithNodeType: path '{NodeType}' is occupied by a node that is not a NodeType declaration ({Collision}) — instance '{InstancePath}' has no type to bind to; applying error overlay",
+                                nodeType, collision, node.Path);
                         // Self-heal with a NULL version gate — there is no type
                         // node at all yet; the first usable state (the type gets
                         // registered/imported and compiled later) recycles this
@@ -262,6 +292,49 @@ internal static class NodeTypeEnrichmentHelpers
 
         /// <summary>The probe timed out or faulted — registration is UNKNOWN, not absent.</summary>
         Indeterminate
+    }
+
+    /// <summary>
+    /// Describes the node squatting on a NodeType's path when it is PROVABLY not a NodeType
+    /// declaration — otherwise <c>null</c>. This is the difference between "a node exists there"
+    /// and "a NodeType is registered there", which only diverge when two things claim one name:
+    /// a Store plugin root at <c>Feedback</c> versus the NodeType at <c>Feedback/Feedback</c>
+    /// (Systemorph/MeshWeaver#2230/#2231).
+    ///
+    /// <para>🚨 <b>The test is deliberately one-sided</b>: it may only ever say "definitely not a
+    /// declaration", never "definitely is one". A false positive fails an activation that would
+    /// have worked, so every uncertain shape has to fall through to the existing chain —
+    /// which is why BOTH of these must hold, for EVERY returned candidate:</para>
+    /// <list type="bullet">
+    ///   <item>the node DECLARES a NodeType that is not <see cref="MeshNode.NodeTypePath"/> — a
+    ///     null/empty <c>NodeType</c> proves nothing (several built-in declarations, e.g. Role and
+    ///     Group, leave it unset), and one that says <c>NodeType</c> is a declaration by
+    ///     construction;</item>
+    ///   <item>and its content does not convert to a <see cref="NodeTypeDefinition"/>. Untyped
+    ///     JSON deserialises into one happily, so this branch is only reached by content typed as
+    ///     something else entirely — <c>PluginContent</c> in the incident.</item>
+    /// </list>
+    ///
+    /// <para>No logger is passed to <c>ContentAs</c> on purpose: a non-convertible candidate is
+    /// this method's normal input, and the caller logs the collision once with both sides. The
+    /// unexplained <c>As&lt;NodeTypeDefinition&gt; for Feedback: value is PluginContent</c> line
+    /// that WAS the only evidence is exactly what this replaces.</para>
+    /// </summary>
+    private static string? ProbeCollision(
+        IReadOnlyCollection<MeshNode> candidates,
+        System.Text.Json.JsonSerializerOptions options)
+    {
+        if (candidates.Count == 0)
+            return null;
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrEmpty(candidate.NodeType)
+                || string.Equals(candidate.NodeType, MeshNode.NodeTypePath, StringComparison.OrdinalIgnoreCase)
+                || candidate.ContentAs<NodeTypeDefinition>(options) is not null)
+                return null;
+        }
+        var occupant = candidates.First();
+        return $"'{occupant.Path}' is a '{occupant.NodeType}' node";
     }
 
     /// <param name="afterIndeterminateProbe">

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -145,10 +145,17 @@ internal static class NodeTypeEnrichmentHelpers
             {
                 UserId = WellKnownUsers.System,
             };
-            return Observable.Using(
-                    () => (meshHub.ServiceProvider.GetService<AccessService>()?.ImpersonateAsSystem())
-                          ?? System.Reactive.Disposables.Disposable.Empty,
-                    _ => queryCore.Query<MeshNode>(probeRequest, meshHub.JsonSerializerOptions))
+            // 🚨 RunAsSystem, never `Observable.Using(access.ImpersonateAsSystem, …)` (#1790).
+            // Impersonation is an AsyncLocal store/restore pair, and Rx runs the resource factory
+            // on the SUBSCRIBING thread while disposing it when the inner observable TERMINATES —
+            // the owning hub's response thread for a cross-hub query. The subscriber was therefore
+            // left latched as `system-security`, and this probe is subscribed from an activation
+            // that continues doing work afterwards. RunAsSystem seals both ends inside the one
+            // Subscribe, and delivers every notification under the subscriber's OWN identity.
+            // This was the last site on ImpersonationScopeSites.allow for this file — the line is
+            // deleted rather than lowered, which is the only direction that ratchet may move.
+            return meshHub.ServiceProvider.GetService<AccessService>()
+                .RunAsSystem(() => queryCore.Query<MeshNode>(probeRequest, meshHub.JsonSerializerOptions))
                 .Where(c => c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
                 .Take(1)
                 .Timeout(NodeTypeProbeTimeout)

--- a/src/MeshWeaver.Graph/Configuration/PartitionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/PartitionNodeType.cs
@@ -60,7 +60,12 @@ public static class PartitionNodeType
     public static MeshNode CreateMeshNode() => new(NodeType)
     {
         Name = "Partition",
-        NodeType = NodeType,
+        // A declaration declares itself a NodeType, never the type it declares — see the note on
+        // UserNodeType.CreateMeshNode for what self-typing cost in production. The partition
+        // enumerations happen to pin a namespace (`namespace:Admin/Partition nodeType:Partition`,
+        // which this root-level node never matched), so this one was latent rather than live —
+        // but any pathless `nodeType:Partition` read would have hit the same collision.
+        NodeType = MeshNode.NodeTypePath,
         Icon = "/static/NodeTypeIcons/database.svg",
         ExcludeFromContext = new HashSet<string> { "create", "search", "content" },
         Content = new NodeTypeDefinition { DefaultNamespace = Namespace },

--- a/src/MeshWeaver.Graph/Configuration/UserNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/UserNodeType.cs
@@ -102,7 +102,19 @@ public static class UserNodeType
     {
         Name = "User",
         Icon = "/static/NodeTypeIcons/person.svg",
-        NodeType = NodeType,
+        // 🚨 A NodeType DECLARATION declares itself a NodeType — never the type it declares.
+        // This node used to carry `NodeType = "User"`, i.e. it claimed to BE a user, and every
+        // `nodeType:User` query in the mesh therefore returned it alongside the real accounts.
+        // It has no email, so the portal's user DIRECTORY (UserIdentityCache, whose whole job is
+        // email → mesh user) tried to read it as a `User` and logged
+        // `As<User> for User: value is NodeTypeDefinition` on EVERY index snapshot — 355k+
+        // occurrences in production (Systemorph/MeshWeaver#2160/#2161/#2162). The same collision
+        // made AI-source installs resolve a partition literally named "User" (`42P01: relation
+        // "user.mesh_nodes" does not exist`) and, for the VUser twin, left a stray `vuser`
+        // partition behind. Declaration nodes are identified mesh-wide by
+        // `NodeType == MeshNode.NodeTypePath` (CreatableTypesProvider, MeshNodeLayoutAreas'
+        // `-nodeType:NodeType` exclusions) — say so, exactly as Space/Release/Build do.
+        NodeType = MeshNode.NodeTypePath,
         ExcludeFromContext = new HashSet<string> { "search", "content" },
         // Post-v10 design: User nodes live at the ROOT namespace (path={userId}),
         // each user gets their own per-user partition. The previous design parked

--- a/src/MeshWeaver.Graph/Configuration/VUserNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/VUserNodeType.cs
@@ -46,7 +46,9 @@ public static class VUserNodeType
     {
         Name = "Virtual User",
         Icon = "/static/NodeTypeIcons/person.svg",
-        NodeType = NodeType,
+        // A declaration declares itself a NodeType, never the type it declares — see the note on
+        // UserNodeType.CreateMeshNode for what `NodeType = "VUser"` here cost in production.
+        NodeType = MeshNode.NodeTypePath,
         ExcludeFromContext = new HashSet<string> { "search", "content" },
         Content = new NodeTypeDefinition { DefaultNamespace = "VUser", RestrictedToNamespaces = ["VUser"] },
         HubConfiguration = config => config

--- a/test/ImpersonationScopeSites.allow
+++ b/test/ImpersonationScopeSites.allow
@@ -56,7 +56,6 @@ src/MeshWeaver.Graph/Configuration/NodeTypeCompilationActivity.cs	2
 src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs	3
 src/MeshWeaver.Graph/Configuration/NodeTypeCompileState.cs	1
 src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs	1
-src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs	1
 src/MeshWeaver.Graph/Configuration/PartitionDropPostDeletionHandler.cs	1
 src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs	1
 src/MeshWeaver.Graph/Configuration/WebhookEventNodeType.cs	1

--- a/test/MeshWeaver.Hosting.Monolith.Test/AiSourcesInstallHookTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/AiSourcesInstallHookTest.cs
@@ -17,13 +17,13 @@ using Xunit;
 namespace MeshWeaver.Hosting.Monolith.Test;
 
 /// <summary>
-/// 🚨 #1127: pins <see cref="AiSourcesInstallHook"/>'s user enumeration against the SELF-TYPED
-/// <c>User</c> NodeType declaration node.
+/// 🚨 #1127: pins <see cref="AiSourcesInstallHook"/>'s user enumeration against the <c>User</c>
+/// NodeType DECLARATION node ever being reconciled as an account.
 ///
-/// <para><c>User</c> is deliberately self-typed (<see cref="UserNodeType.CreateMeshNode"/> sets
-/// <c>NodeType = "User"</c> on the declaration at path <c>User</c>), so the hook's pathless
-/// <c>nodeType:User</c> enumeration returns the DECLARATION alongside the real accounts. Pre-fix,
-/// the declaration's Id (<c>"User"</c>) was treated as an account id, and every install / boot
+/// <para><c>User</c> used to be SELF-TYPED — <see cref="UserNodeType.CreateMeshNode"/> set
+/// <c>NodeType = "User"</c> on the declaration at path <c>User</c> — so the hook's pathless
+/// <c>nodeType:User</c> enumeration returned the DECLARATION alongside the real accounts. The
+/// declaration's Id (<c>"User"</c>) was then treated as an account id, and every install / boot
 /// repair pass tried to write <c>User/_Memex/AiSettings</c> — a partition literally named
 /// <c>User</c> that no instance provisions. On PostgreSQL that failed each time with
 /// <c>42P01: relation "user.mesh_nodes" does not exist</c> (27× on memex-cloud: 3 pod boots ×
@@ -31,10 +31,15 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// partition schemas it silently created a phantom node. The failing writes carried nothing a
 /// real user ever entered — no user data was lost — but the noise re-fired on every boot.</para>
 ///
-/// <para>The fix is in the enumeration (<c>AiSourcesInstallHook.Users()</c>): the declaration id
-/// is dropped before reconciliation. This test seeds real accounts, runs the hook end-to-end on
-/// the monolith mesh (where the phantom write would SUCCEED and leave evidence), and asserts the
-/// package sources land on real users while <c>User/_Memex/AiSettings</c> is never created.</para>
+/// <para><b>The first fix was a hand-rolled <c>id != "User"</c> filter in the enumeration; the
+/// root fix replaced it</b> (Systemorph/MeshWeaver#2160/#2161/#2162): a declaration now declares
+/// itself a NodeType, so <c>nodeType:User</c> returns accounts and nothing else — for every type,
+/// not the two the filter happened to name. <c>NodeTypeDeclarationSelfTypingTest</c> pins that
+/// invariant; THIS test stays exactly as it was, because it pins the OUTCOME (the phantom is never
+/// written) rather than the mechanism, and is the one that would catch a regression arriving by
+/// some other route. It seeds real accounts, runs the hook end-to-end on the monolith mesh (where
+/// the phantom write would SUCCEED and leave evidence), and asserts the package sources land on
+/// real users while <c>User/_Memex/AiSettings</c> is never created.</para>
 /// </summary>
 public class AiSourcesInstallHookTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeDeclarationSelfTypingTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeDeclarationSelfTypingTest.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Blazor.Infrastructure;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 A NodeType DECLARATION declares itself a NodeType — never the type it declares.
+///
+/// <para><c>UserNodeType.CreateMeshNode()</c> shipped the <c>User</c> declaration with
+/// <c>NodeType = "User"</c>, i.e. the node that DEFINES the type also claimed to BE one. There is
+/// no way to tell it apart from a real account after that: it is returned by every
+/// <c>nodeType:User</c> query in the mesh, and it carries a <see cref="NodeTypeDefinition"/> where
+/// each consumer expects a <see cref="User"/>. The portal's user DIRECTORY
+/// (<see cref="UserIdentityCache"/> — email → mesh user) is the loudest victim: it read the
+/// declaration on EVERY index snapshot and logged
+/// <c>As&lt;User&gt; for User: value is NodeTypeDefinition</c> each time, 355k+ occurrences in
+/// production (Systemorph/MeshWeaver#2160/#2161/#2162). The same collision made AI-source installs
+/// resolve a partition literally named "User" (<c>42P01: relation "user.mesh_nodes" does not
+/// exist</c>) and left a stray <c>vuser</c> partition behind — which is why
+/// <c>AiSourcesInstallHook</c> carried a hand-rolled <c>id != "User"</c> filter until this landed.
+/// A filter names two types; the invariant covers all of them, which is what this class pins.</para>
+/// </summary>
+public class NodeTypeDeclarationSelfTypingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    /// <summary>
+    /// The ratchet. Every statically-registered declaration — anything whose content IS a
+    /// <see cref="NodeTypeDefinition"/> — must say so in its <see cref="MeshNode.NodeType"/>:
+    /// either unset, or the literal <see cref="MeshNode.NodeTypePath"/>. A declaration that names
+    /// the type it declares is the defect, and it is invisible to every other gate — the node
+    /// builds, activates, and renders; it just quietly joins its own instances in every query.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void NoDeclaration_ClaimsToBeAnInstanceOfTheTypeItDeclares()
+    {
+        var offenders = Mesh.ServiceProvider.EnumerateStaticNodes()
+            .Where(n => n.Content is NodeTypeDefinition)
+            .Where(n => !string.IsNullOrEmpty(n.NodeType)
+                && !string.Equals(n.NodeType, MeshNode.NodeTypePath, StringComparison.OrdinalIgnoreCase))
+            .Select(n => $"{n.Path} (nodeType:{n.NodeType})")
+            .Distinct()
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToList();
+
+        foreach (var offender in offenders)
+            Output.WriteLine($"self-typed declaration: {offender}");
+
+        offenders.Should().BeEmpty(
+            "a NodeType declaration must carry NodeType = \"{0}\" (or leave it unset), never the "
+            + "name of the type it declares — otherwise it is returned by every nodeType:<Type> "
+            + "query alongside the real instances, carrying NodeTypeDefinition content where the "
+            + "caller expects the instance type",
+            MeshNode.NodeTypePath);
+    }
+
+    /// <summary>
+    /// The call site the incident was reported from, end to end: the portal's user directory query
+    /// (<see cref="UserIdentityCache.DirectoryQuery"/> — verbatim, so a change to it re-aims this
+    /// test automatically) must return USERS. Every row it hands back is read as a
+    /// <see cref="User"/> by <c>UserIdentityCache.TryGetEmail</c>, so a row that is not one is not
+    /// a longer list — it is an error line per row per snapshot, forever.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheUserDirectory_ReturnsUsers_NotTheUserDeclaration()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        using (access.ImpersonateAsSystem())
+        {
+            await MeshService.CreateNode(MeshNode.FromPath("directoryprobe") with
+            {
+                Name = "Directory Probe",
+                NodeType = UserNodeType.NodeType,
+                State = MeshNodeState.Active,
+                Content = new User { Email = "directoryprobe@meshweaver.io" }
+            }).Should().Within(60.Seconds()).Emit();
+        }
+
+        var rows = await MeshService.Query<MeshNode>(UserIdentityCache.DirectoryQuery)
+            .Where(c => c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+            .Select(c => c.Items)
+            .Where(items => items.Any(n => n.Path == "directoryprobe"))
+            .FirstAsync()
+            .Timeout(60.Seconds())
+            .ToTask(ct);
+
+        var notUsers = new List<string>();
+        foreach (var row in rows)
+        {
+            var actual = row.Content?.GetType().Name ?? "(null)";
+            Output.WriteLine($"directory row: {row.Path} nodeType={row.NodeType} content={actual}");
+            // ContentAs, not `is User` — content legitimately arrives typed, as a JsonElement or as
+            // the as-written DOM, and only the first would satisfy a CLR type test
+            // (UserDirectoryContentShapeTest pins all three). A row that cannot be read as a User
+            // is the failure this test is about.
+            if (row.ContentAs<User>(Mesh.JsonSerializerOptions) is null)
+                notUsers.Add($"{row.Path} (nodeType:{row.NodeType}, content:{actual})");
+        }
+
+        notUsers.Should().BeEmpty(
+            "every row of the portal's user directory is read as a User by UserIdentityCache — the "
+            + "`User` NodeType declaration used to be in here because it declared itself "
+            + "nodeType:User, and it produced one `As<User> for User: value is NodeTypeDefinition` "
+            + "error per row per index snapshot");
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypePathCollisionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypePathCollisionTest.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 A node existing at a NodeType's path is not the same thing as a NodeType being REGISTERED
+/// there — and the two diverge the moment something else claims the name.
+///
+/// <para>On memex-cloud a Store plugin installed its root at the bare path <c>Feedback</c>
+/// (content <c>PluginContent</c>, nodeType <c>Store/Plugin</c>) while the plugin's actual NodeType
+/// lived at <c>Feedback/Feedback</c>. An instance naming the bare <c>Feedback</c> passed
+/// <c>EnrichWithNodeType</c>'s existence probe on the PLUGIN ROOT — the probe only counted rows —
+/// and then spent the whole 60 s slow-path budget waiting for a <c>PluginContent</c> node to look
+/// like a <see cref="NodeTypeDefinition"/>, ending on the "there was a compilation error, please
+/// correct the code" overlay for source that is perfectly fine. The only evidence was one
+/// unexplained <c>As&lt;NodeTypeDefinition&gt; for Feedback: value is PluginContent</c> line
+/// (Systemorph/MeshWeaver#2230/#2231).</para>
+///
+/// <para>The fix is not a filter that silently skips the occupant: the probe now answers the
+/// question it is actually asking, and a collision is reported by NAME — both sides of it — fast
+/// enough that nobody waits a minute to be told the wrong thing.</para>
+/// </summary>
+public class NodeTypePathCollisionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The NodeType of the node that SQUATS on the path — the Store/Plugin analogue.</summary>
+    private const string SquatterType = "Squatter";
+
+    /// <summary>The bare path both the squatter and the (absent) NodeType want.</summary>
+    private const string ContestedPath = "Contested";
+
+    /// <summary>Content of the squatting node — a typed record that is NOT a NodeTypeDefinition.</summary>
+    public record SquatterContent
+    {
+        /// <summary>Arbitrary payload, so the record is not empty.</summary>
+        public string? Label { get; init; }
+    }
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMeshNodes(new MeshNode(SquatterType)
+            {
+                Name = "Squatter",
+                NodeType = MeshNode.NodeTypePath,
+                Content = new NodeTypeDefinition(),
+                HubConfiguration = config => config
+                    .AddMeshDataSource(source => source.WithContentType<SquatterContent>())
+            })
+            // The mesh hub must resolve the squatter's `$type` for itself, or the probe reads the
+            // occupant's content as untyped JSON — which deserialises into a NodeTypeDefinition
+            // quite happily and would make this test pass for the wrong reason.
+            .ConfigureHub(config => config.WithType<SquatterContent>(nameof(SquatterContent)));
+
+    /// <summary>
+    /// 🚨 A FRESH mesh per [Fact]: the assertion is about a cold enrichment of one node, and a
+    /// hub bound by a previous test would short-circuit on its existing HubConfiguration.
+    /// </summary>
+    protected override bool ShareMeshAcrossTests => false;
+
+    /// <summary>
+    /// An instance whose NodeType names a path occupied by something that is NOT a declaration
+    /// must be told exactly that — naming the occupant — and must be told it inside the probe's
+    /// budget, not the 60 s slow-path one.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AnOccupiedNodeTypePath_IsReportedAsACollision_NotWaitedOutForAMinute()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        using (access.ImpersonateAsSystem())
+        {
+            // The squatter: a real node, at the bare path, that is not a NodeType declaration.
+            await meshService.CreateNode(MeshNode.FromPath(ContestedPath) with
+            {
+                Name = "Contested",
+                NodeType = SquatterType,
+                State = MeshNodeState.Active,
+                Content = new SquatterContent { Label = "plugin root analogue" }
+            }).Should().Within(60.Seconds()).Emit();
+        }
+
+        var instance = MeshNode.FromPath($"{TestPartition}/collides") with
+        {
+            Name = "Collides",
+            NodeType = ContestedPath,
+            State = MeshNodeState.Active,
+        };
+
+        var factory = Mesh.ServiceProvider.GetRequiredService<IMeshNodeHubFactory>();
+
+        // 🚨 30 s is under EnrichWithNodeType's 60 s SlowPathTimeout ON PURPOSE. Before the fix
+        // the probe accepted the squatter as a registration and the chain waited that whole budget
+        // out; a passing run here is itself part of the assertion.
+        var enriched = await factory.ResolveHubConfiguration(instance)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask(ct);
+
+        enriched.HubConfiguration.Should().NotBeNull(
+            "an unresolvable NodeType still yields the overlay configuration, never a null hub");
+
+        var configuration = enriched.HubConfiguration!(
+            new MessageHubConfiguration(Mesh.ServiceProvider, new Address("test", "collision")));
+        var nack = configuration.Get<UnhandledMessageNack>();
+
+        Output.WriteLine($"nack: {nack?.Reason ?? "(none)"}");
+
+        nack.Should().NotBeNull(
+            "the overlay sets an UnhandledMessageNack so typed requests to the instance fail fast "
+            + "with the cause instead of parking");
+        nack!.Reason.Should().Contain(ContestedPath);
+        nack.Reason.Should().Contain(SquatterType,
+            "the collision must name what actually occupies the path — the whole defect was that "
+            + "the only trace was a bare `As<NodeTypeDefinition>` line with no second side to it");
+        nack.Reason.Should().NotContain("compilation error",
+            "nothing failed to compile — telling the author to correct their code sends them after "
+            + "a defect that is not there");
+    }
+}


### PR DESCRIPTION
## The colliding key

**A NodeType DECLARATION was filed under the very type it declares.**
`UserNodeType`, `VUserNodeType` and `PartitionNodeType` each set
`NodeType = <their own name>` on the node whose `Content` **is** a `NodeTypeDefinition`.
A declaration is then indistinguishable from an instance: it matches every
`nodeType:<Type>` query in the mesh and hands the caller `NodeTypeDefinition` content
where the instance type is expected.

Both reported call sites are the same collision class — *a bare name resolved against a
namespace that something else already occupies* — seen from two directions.

## Half 1 — the user directory (#2160 / #2161 / #2162, #2229 item D)

`UserIdentityCache`'s `nodeType:User` query is the portal's user directory. It returned
the `User` **declaration** alongside the real accounts, and `TryGetEmail` read it as a
`User` on every index emission:

```
fail: MeshWeaver.Blazor.Infrastructure.UserIdentityCache[0]
      As<User> for User: value is MeshWeaver.Graph.Configuration.NodeTypeDefinition (MeshWeaver.Graph), not convertible
```

**Mechanism, precisely** — because #2229 item D asks whether the failure path re-populates
the cache and makes the loop self-sustaining: **it does not.** `UserIdentityCache` is a DI
**singleton** with exactly one query subscription, and `TryGetEmail` returns `false` for the
declaration, so nothing wrong is ever stored in `_byEmail`. The row is re-encountered because
**the collision lives in the QUERY RESULT, not in the cache's storage** — `Apply` re-reads the
whole result set on each emission of a live `nodeType:User` query, and under request-shaped load
the auth-mirror change feed emits ~2/s (which is a live directory doing its job, and is unchanged
by this PR; the pod with zero occurrences was simply serving no requests). Removing the row from
the result set makes the line **impossible at any emission rate** — 355k+ occurrences to zero.

The same collision made every AI-source install resolve a partition literally named `"User"`
(`42P01: relation "user.mesh_nodes" does not exist`, once per package per boot) and leave a stray
`vuser` partition behind. `AiSourcesInstallHook` carried a hand-rolled `id != "User"` filter for
that; **it goes with its cause.** A filter names two types — the invariant covers all of them.

Declarations now say `NodeType = MeshNode.NodeTypePath`, exactly as `Space`, `Release`, `Build`,
`WebhookEvent` and `ApiCredential` already did.

## Half 2 — the hub factory (#2230 / #2231)

`EnrichWithNodeType`'s existence probe asked *"does ANY node live at that path"* when the question
is *"is a NodeType REGISTERED there"*. A Store plugin installs its root at the bare path `Feedback`
while its NodeType is `Feedback/Feedback`, so an instance naming the bare `Feedback` **passed the
gate on the plugin root and bound to the plugin's own hub configuration** — leaving behind one
unexplained line and nothing else:

```
As<NodeTypeDefinition> for Feedback: value is PluginContent (DynamicNode_Store_Plugin)
```

The probe now recognises an occupant that is **provably** not a declaration and reports the
collision **by name — both sides of it** — instead of binding to it.

**Not a silent skip.** The collision is logged at `Error` naming the requested path, the occupant
and the instance, and the instance's overlay says what to do rather than "correct the code" for
source that is fine. `ProbeCollision`'s test is deliberately **one-sided** — it may only ever say
"definitely not a declaration": a null/empty `NodeType` proves nothing (Role and Group leave it
unset) and untyped JSON deserialises into a `NodeTypeDefinition` happily, so every uncertain shape
falls through to the existing chain. Only content typed as something else entirely trips it.

## Tests — both halves fail before the fix

| test | pre-fix |
|---|---|
| `NodeTypeDeclarationSelfTypingTest.NoDeclaration_ClaimsToBeAnInstanceOfTheTypeItDeclares` | 3 offenders: `Partition`, `User`, `VUser` |
| `…TheUserDirectory_ReturnsUsers_NotTheUserDeclaration` | `directory row: User nodeType=User content=NodeTypeDefinition` — the production row, verbatim |
| `NodeTypePathCollisionTest.AnOccupiedNodeTypePath_IsReportedAsACollision_NotWaitedOutForAMinute` | emits the exact `As<NodeTypeDefinition> for …` line, then binds to the squatter with **no** nack at all |

The first is a **ratchet** over every statically-registered declaration, present and future — so
this cannot come back by a route no filter anticipated. `AiSourcesInstallHookTest` is unchanged in
substance (it pins the *outcome*, not the mechanism) and still passes with the filter removed.

### The line itself, measured A/B under FULL-ASSEMBLY conditions

The synthetic repro is not the only evidence. Counting the production line across a full
`MeshWeaver.Hosting.Monolith.Test` assembly run, same host, same load:

| | occurrences of `As<User> for User: value is …NodeTypeDefinition…` |
|---|---|
| clean `main` (9494b1219) | **3** |
| this branch | **0** |

and on `main` they are logged **inside `UserDirectoryContentShapeTest`** (2 of the 3 shapes) —
which is the test family of the open full-assembly timeouts **#2031** and **#2185**. Those two are
`TimeoutException` on the same `UserIdentityCache.WhenDetermined(...).Timeout(60s)` call, and this
line is what their failing runs log at test-class INIT. **The condition is provably gone; the
timeout itself did not reproduce on this host in either arm, so I am NOT claiming #2031/#2185 are
resolved** — only that the contributing condition they log is eliminated. They are deliberately
left open.

Verified locally with CI's flags (`-c Release -warnaserror`, `0 Error(s)` on Graph, AI,
Documentation and the test project):

- Graph.Test **1579/1579**, Query.Test **396/396**, Documentation.Test What's New + link
  integrity **2/2**
- **PostgreSql.Test full assembly 758/759 pass, 0 fail** — including
  `UserDirectoryCompletenessTests` (#2031's own test) under full-assembly conditions, with **0**
  occurrences of the line
- Monolith.Test full assembly: **760 pass / 1 fail**
  (`BuildCoordinationTest.Follower_StandsDown`). **Clean `main` under the identical run fails
  exactly one test too — a different one** (`WorkspaceCacheEvictionTest.NewSubscriber_AfterRecreate`,
  757/1). Eight concurrent `dotnet test` processes were on this host; both failures are
  load-induced timeouts in `Admin/Build` claim arbitration and workspace-cache eviction, neither of
  which this diff reaches. `BuildCoordinationTest` passes 16/16 in isolation on main **and** passes
  in main's full run.

## Note for the reviewer

Because these three declarations now correctly answer `nodeType:NodeType`, they also become
discoverable as declarations — which is the point. `CreatableTypesProvider` does not apply
`context:create` to its own queries, so a type that opts out of creation via `ExcludeFromContext`
(today: `Release`, `Notification`) is already offered there; `Partition` now joins that
pre-existing gap. That is a separate defect in `CreatableTypesProvider`, not introduced here, and
deliberately not widened into. `CreateLayoutArea`'s picker is unaffected — it filters Items on
`ExcludeFromContext("create")` and already listed `User` deliberately (see its own comment at the
namespace field).

Closes #2160, closes #2161, closes #2162, closes #2230, closes #2231.
Kills **item D of #2229** (that issue is multi-part and owned elsewhere — deliberately not closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
