### PR TITLE
fix: registrations that only fail at runtime — doc images, EA consent, embeddings

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -147,18 +147,34 @@ public static class MemexConfiguration
             .GetSection(EmailOptions.SectionName)
             .Get<EmailOptions>() ?? new EmailOptions();
         services.AddSingleton(emailOptions);
-        if (emailOptions.Enabled)
-        {
-            // Executive Assistant: per-user JUST-IN-TIME delegated Graph access (the user consents to the
-            // EA touching THEIR OWN mailbox only when they first use the tool — no standing app
-            // permission). EaGraphAuth drives the consent/token flow; it is raw OAuth over HTTP, so it
-            // stays HERE with its consent controller — the EA's mailbox TOOLS (which do use the Graph
-            // SDK) ride the MeshWeaver.Mail.MicrosoftGraph module and depend only on this seam.
-            services.AddHttpClient<IEaGraphAuth, Authentication.EaGraphAuth>();
-            // The notification triage runner (escalates in-app notifications to email/Teams per each
-            // recipient's NotificationRules) rides the MeshWeaver.Notifications.Channels module
-            // (Modules:Assemblies); its hosted service self-skips unless Email:Enabled.
-        }
+        // The notification triage runner (escalates in-app notifications to email/Teams per each
+        // recipient's NotificationRules) rides the MeshWeaver.Notifications.Channels module
+        // (Modules:Assemblies); its hosted service self-skips unless Email:Enabled.
+
+        // Executive Assistant: per-user JUST-IN-TIME delegated Graph access (the user consents to the
+        // EA touching THEIR OWN mailbox only when they first use the tool — no standing app
+        // permission). EaGraphAuth drives the consent/token flow; it is raw OAuth over HTTP, so it
+        // stays HERE with its consent controller — the EA's mailbox TOOLS (which do use the Graph
+        // SDK) ride the MeshWeaver.Mail.MicrosoftGraph module and depend only on this seam.
+        //
+        // 🚨 UNCONDITIONAL, and it must stay that way. EaConsentController is registered by
+        // AddControllers().AddApplicationPart(...) below — which discovers controllers by TYPE, with
+        // no idea what any of them needs — so /auth/ea/connect and /auth/ea/callback are routed on
+        // EVERY deployment. Gating this one registration on Email:Enabled therefore did not disable
+        // the endpoint; it left it routed with an unresolvable dependency, and MVC's activator threw
+        // "Unable to resolve service for type 'MeshWeaver.Mesh.IEaGraphAuth' while attempting to
+        // activate 'EaConsentController'" — a deterministic 500 on the consent flow, in memex prod
+        // (issue #2218). A controller and its dependencies are one unit: whatever routes the one
+        // must register the other.
+        //
+        // Nothing is enabled by registering it. The descriptor is inert (a typed HttpClient factory
+        // registration does no work until something resolves it), and IEaGraphAuth carries its own
+        // honest feature probe: EaGraphAuth.IsConfigured reads Authentication:Microsoft
+        // ClientId/ClientSecret — the credentials the DELEGATED flow actually needs, which are not
+        // what Email:Enabled describes (that gates the SYSTEM mailbox's app-permission sender). The
+        // controller checks IsConfigured first and answers 400 "not configured", which is the honest
+        // answer for a deployment that has not set up the EA — instead of a 500 that reads as a bug.
+        services.AddHttpClient<IEaGraphAuth, Authentication.EaGraphAuth>();
 
         // 🚨 TryAdd, deliberately. The Graph sender lives in the MeshWeaver.Mail.MicrosoftGraph
         // module, which registers it with a plain AddSingleton. The pairing is ORDER-INDEPENDENT:

--- a/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
+++ b/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Data;
@@ -251,12 +252,27 @@ public static class ContentFileResolver
 
     /// <summary>
     /// Projects the collection configs out of the owning hub's <c>GetDataResponse</c>. The remote
-    /// form arrives as a <see cref="JsonElement"/>; <see cref="ContentCollectionConfig.IsStatic"/>
-    /// and <see cref="ContentCollectionConfig.Address"/> MUST survive that projection — without the
-    /// first, every legitimately-published remote collection fails a caller's mount check; without
-    /// the second, an inherited collection loses its owner and a child node's file resolves against
-    /// the ancestor's folder. <c>IsStatic</c> is suppressed when false, so an absent property means
-    /// false — the safe value either way.
+    /// form arrives as a <see cref="JsonElement"/>.
+    ///
+    /// <para>🚨 EVERY property of <see cref="ContentCollectionConfig"/> must survive this
+    /// projection, and <c>DocAssetWireProjectionTest.EveryConfigProperty_SurvivesTheWireProjection</c> keeps it true:
+    /// a hand-written projection that reads only the fields its author happened to need is a
+    /// SILENT truncation of the config, and the missing field surfaces far away as a failure that
+    /// names neither this method nor the property it dropped.</para>
+    ///
+    /// <para>Three of them have already cost outages. <see cref="ContentCollectionConfig.IsStatic"/>
+    /// — without it every legitimately-published remote collection fails a caller's mount check.
+    /// <see cref="ContentCollectionConfig.Address"/> — without it an inherited collection loses its
+    /// owner and a child node's file resolves against the ancestor's folder.
+    /// <see cref="ContentCollectionConfig.Settings"/> — the provider-specific payload, and for an
+    /// <c>EmbeddedResource</c> collection the ONLY thing that names the assembly and resource
+    /// prefix its files live in. Dropping it turned every doc-page image into
+    /// <c>ArgumentException: AssemblyName required for EmbeddedResource</c> raised at the far end
+    /// of the pipeline, in <see cref="EmbeddedResourceStreamProviderFactory"/> (issues #2122/#2123):
+    /// the registration DID supply the assembly, the wire read threw it away.</para>
+    ///
+    /// <para><c>IsStatic</c>/<c>IsEditable</c>/<c>ExposeInChildren</c> are suppressed when false, so
+    /// an absent property means false — the safe value for all three.</para>
     /// </summary>
     /// <param name="delivery">The response delivery, or <c>null</c>.</param>
     /// <returns>The configs, or <c>null</c> when the response carried none.</returns>
@@ -265,21 +281,74 @@ public static class ContentFileResolver
         delivery?.Message switch
         {
             GetDataResponse { Data: JsonElement je } => je.EnumerateArray()
-                .Select(e => new ContentCollectionConfig
-                {
-                    Name = e.TryGetProperty("name", out var nameProp) ? nameProp.GetString() ?? "" : "",
-                    SourceType = e.TryGetProperty("sourceType", out var typeProp) ? typeProp.GetString() ?? "" : "",
-                    BasePath = e.TryGetProperty("basePath", out var pathProp) ? pathProp.GetString() : null,
-                    IsStatic = e.TryGetProperty("isStatic", out var staticProp)
-                               && staticProp.ValueKind == JsonValueKind.True,
-                    Address = e.TryGetProperty("address", out var addressProp)
-                        ? ToAddress(addressProp)
-                        : null,
-                })
+                .Select(ToConfig)
                 .ToArray(),
             GetDataResponse { Data: IReadOnlyCollection<ContentCollectionConfig> direct } => direct,
             _ => null
         };
+
+    /// <summary>
+    /// One wire element → one <see cref="ContentCollectionConfig"/>, every property carried across.
+    /// </summary>
+    /// <param name="e">The JSON element for a single config.</param>
+    /// <returns>The reconstructed config.</returns>
+    private static ContentCollectionConfig ToConfig(JsonElement e) =>
+        new()
+        {
+            Name = Text(e, "name") ?? "",
+            SourceType = Text(e, "sourceType") ?? "",
+            DisplayName = Text(e, "displayName"),
+            BasePath = Text(e, "basePath"),
+            Order = e.TryGetProperty("order", out var orderProp)
+                    && orderProp.ValueKind == JsonValueKind.Number
+                    && orderProp.TryGetInt32(out var order)
+                ? order
+                : 0,
+            IsEditable = Flag(e, "isEditable"),
+            IsStatic = Flag(e, "isStatic"),
+            ExposeInChildren = Flag(e, "exposeInChildren"),
+            Address = e.TryGetProperty("address", out var addressProp)
+                ? ToAddress(addressProp)
+                : null,
+            Settings = ToSettings(e),
+        };
+
+    /// <summary>Reads a string property, or <c>null</c> when absent or not a string.</summary>
+    /// <param name="e">The element to read from.</param>
+    /// <param name="name">The camel-cased wire property name.</param>
+    /// <returns>The string value, or <c>null</c>.</returns>
+    private static string? Text(JsonElement e, string name) =>
+        e.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+
+    /// <summary>Reads a boolean property; anything but an explicit <c>true</c> reads as false.</summary>
+    /// <param name="e">The element to read from.</param>
+    /// <param name="name">The camel-cased wire property name.</param>
+    /// <returns>The flag value.</returns>
+    private static bool Flag(JsonElement e, string name) =>
+        e.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.True;
+
+    /// <summary>
+    /// Reads the provider-specific <c>Settings</c> map. Keys are NOT name-policy-converted on the
+    /// wire (only property names are), so <c>AssemblyName</c> comes back exactly as it was
+    /// registered. A non-string value is skipped rather than stringified — the contract is
+    /// <c>IReadOnlyDictionary&lt;string,string&gt;</c>.
+    /// </summary>
+    /// <param name="e">The element to read from.</param>
+    /// <returns>The settings, or <c>null</c> when the config carried none.</returns>
+    private static IReadOnlyDictionary<string, string>? ToSettings(JsonElement e)
+    {
+        if (!e.TryGetProperty("settings", out var settings)
+            || settings.ValueKind != JsonValueKind.Object)
+            return null;
+        var builder = ImmutableDictionary.CreateBuilder<string, string>();
+        foreach (var property in settings.EnumerateObject())
+            if (property.Value.ValueKind == JsonValueKind.String
+                && property.Value.GetString() is { } value)
+                builder[property.Name] = value;
+        return builder.Count == 0 ? null : builder.ToImmutable();
+    }
 
     /// <summary>
     /// Reads a collection config's owning address off the wire. Absent, non-string or empty ⇒

--- a/src/MeshWeaver.ContentCollections/EmbeddedResourceStreamProviderFactory.cs
+++ b/src/MeshWeaver.ContentCollections/EmbeddedResourceStreamProviderFactory.cs
@@ -17,9 +17,9 @@ public class EmbeddedResourceStreamProviderFactory : IStreamProviderFactory
     public IObservable<IStreamProvider> Create(ContentCollectionConfig config)
     {
         var assemblyName = config.Settings?.GetValueOrDefault("AssemblyName")
-            ?? throw new ArgumentException("AssemblyName required for EmbeddedResource");
+            ?? throw Missing(config, "AssemblyName");
         var resourcePrefix = config.Settings?.GetValueOrDefault("ResourcePrefix")
-            ?? throw new ArgumentException("ResourcePrefix required for EmbeddedResource");
+            ?? throw Missing(config, "ResourcePrefix");
 
         var assembly = AppDomain.CurrentDomain.GetAssemblies()
             .FirstOrDefault(a => a.GetName().Name == assemblyName)
@@ -27,4 +27,26 @@ public class EmbeddedResourceStreamProviderFactory : IStreamProviderFactory
 
         return Observable.Return<IStreamProvider>(new EmbeddedResourceStreamProvider(assembly, resourcePrefix));
     }
+
+    /// <summary>
+    /// The guard's exception, naming WHICH collection is missing the setting and where it came
+    /// from — not just which field is absent.
+    ///
+    /// <para>Every registration site supplies both settings
+    /// (<c>AddEmbeddedResourceContentCollection</c>), so a config that reaches here without them
+    /// did not come from a registration: it was rebuilt somewhere in between and lost them. The
+    /// original message named only the field, so triaging issues #2122/#2123 meant walking the
+    /// stack backwards to guess which collection and which hub — the answer was the wire
+    /// projection in <c>ContentFileResolver.ReadCollectionConfigs</c>, three frames up and in
+    /// another assembly. Naming the collection and its address makes the next one a one-line
+    /// read.</para>
+    /// </summary>
+    /// <param name="config">The config that arrived without the setting.</param>
+    /// <param name="setting">The missing setting's key.</param>
+    /// <returns>The exception to throw.</returns>
+    private static ArgumentException Missing(ContentCollectionConfig config, string setting) =>
+        new($"{setting} required for EmbeddedResource collection '{config.Name}'"
+            + (config.Address is null ? "" : $" at '{config.Address}'")
+            + ". Every registration supplies it, so a config without it was rebuilt in transit "
+            + "and lost its Settings.");
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/VectorSearch.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/VectorSearch.md
@@ -151,6 +151,36 @@ The dimension `{dim}` is configured via `PostgreSqlStorageOptions.EmbeddingDimen
 
 When `AddEmbeddings` registers nothing, `PostgreSqlMeshQuery` holds a **null** `IEmbeddingProvider`, so the vector intercept is skipped outright and the query takes the `GenerateTextSearchClause` ILIKE path. The intercept is also skipped when a provider *is* registered but returns `null` for this query (a transient failure) — same fallback, so callers get results instead of an empty page. `NullEmbeddingProvider` is the **write**-side stand-in: `PostgreSqlStorageAdapter` substitutes `NullEmbeddingProvider.Instance` when no provider is injected, and its `GenerateEmbeddingAsync` returns `null`, leaving the `embedding` column NULL. Tests that do not wire an embedding provider get the regular ILIKE behaviour automatically.
 
+### 🚨 The fallback is announced, not silent
+
+Degrading to ILIKE is a supported configuration, not a fault — but a capability that degrades in
+silence is indistinguishable from one that is broken. `TryAddEmbeddingProvider` therefore records
+the decision as a singleton **`EmbeddingCapability`** and registers `EmbeddingCapabilityReporter`,
+which writes exactly **one** `Information` line at host start, in *both* directions:
+
+```
+Semantic (vector) search ENABLED: provider=Ollama, endpoint=…, model=bge-m3, dimensions=1024.
+Semantic (vector) search DISABLED — no Embedding:Endpoint is configured. Free-text queries fall
+back to an ILIKE substring scan and content indexing stays inert; this is a supported
+configuration, not a fault.
+```
+
+A line emitted only when the capability is ON would be no better than the silence, so the disabled
+branch logs too — and names the configuration key that would turn it on (`Embedding:Endpoint`, or
+`Embedding:ApiKey` for the keyed cloud backend). Before this, an operator seeing plainly-lexical
+results could not tell "never configured" from "configured and failing", which is how issue #1642
+came to be triaged from a stack trace.
+
+`EmbeddingCapability.IsEnabled` is taken from whether a provider was *actually* created, never
+re-derived from the options — a second copy of `CreateEmbeddingProvider`'s branch logic could drift
+and then advertise a capability the host does not have.
+
+🚨 **Do not "fix" the null by registering `NullEmbeddingProvider` as a default.** The PRESENCE of an
+`IEmbeddingProvider` registration is the capability signal every consumer reads — both storage
+backends resolve it with `GetService`, and the content-indexing module's resolve-time `enabledWhen`
+gate asks the same question. A Null default answers *yes* on a host that has no embeddings, which
+lights the indexing pipeline up against an embedder that can never embed.
+
 ---
 
 ## Provider backends

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-doc-images-and-ea-consent.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-doc-images-and-ea-consent.md
@@ -1,0 +1,23 @@
+---
+Name: Documentation images and the Microsoft 365 connect link
+Category: Fix
+Description: Fixes broken images on documentation pages and the "Connect Microsoft 365" link, which returned a server error on portals with mail turned off.
+Icon: Sparkle
+Order: -20260825
+---
+
+# Documentation images and the Microsoft 365 connect link
+
+Images and diagrams on documentation pages could fail to load, leaving a broken-image placeholder
+on an otherwise complete page. The page's assets are stored with the page itself, but the portal
+lost track of where they lived when it looked them up, so it could not read them back. It now
+carries that information through, and the images load.
+
+The "Connect Microsoft 365" link that starts the Executive Assistant's consent flow returned a
+server error on any portal that does not have system email enabled. It now works as intended — and
+where the Microsoft credentials have not been set up, it says so plainly instead of failing.
+
+Portal operators get one new line in the startup log stating whether semantic (meaning-based)
+search is switched on, and when it is not, which setting would switch it on. Search results were
+already falling back to plain text matching in that case; nothing said so, which made a working
+portal look broken.

--- a/src/MeshWeaver.Hosting.Embeddings/EmbeddingCapability.cs
+++ b/src/MeshWeaver.Hosting.Embeddings/EmbeddingCapability.cs
@@ -1,0 +1,140 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting.Embeddings;
+
+/// <summary>
+/// The deployment's embedding decision, taken once at composition and reported once at startup.
+///
+/// <para>🚨 Why this exists at all. <see cref="IEmbeddingProvider"/> is genuinely OPTIONAL — with no
+/// <c>Embedding:Endpoint</c> configured there is nothing to register, semantic search degrades to
+/// the ILIKE substring scan and the content-indexing pipeline resolves its inert stand-ins. That is
+/// a legitimate deployment, so a missing provider must NOT fail loudly. But it was also taken
+/// SILENTLY: <c>TryAddEmbeddingProvider</c> returned a bool nobody read, and nothing anywhere said
+/// which way it went. An operator looking at plainly-lexical search results could not tell whether
+/// embeddings were never configured, configured with a key the cloud backend rejected, or
+/// configured against a module that is not landed — three different fixes behind one identical
+/// symptom, which is how issue #1642 was triaged from a stack trace instead of a log line.</para>
+///
+/// <para>A capability that degrades silently is indistinguishable from one that is broken. This
+/// record is the decision made explicit, resolvable from DI, and written to the log exactly once
+/// per process by <see cref="EmbeddingCapabilityReporter"/>.</para>
+/// </summary>
+public sealed record EmbeddingCapability
+{
+    /// <summary>Whether an <see cref="IEmbeddingProvider"/> was registered.</summary>
+    public required bool IsEnabled { get; init; }
+
+    /// <summary>The selected backend (<c>Ollama</c> / <c>OpenAICompatible</c> / <c>AzureFoundry</c>).</summary>
+    public string? Provider { get; init; }
+
+    /// <summary>The configured endpoint, when there is one.</summary>
+    public string? Endpoint { get; init; }
+
+    /// <summary>The embedding model / deployment name.</summary>
+    public string? Model { get; init; }
+
+    /// <summary>The vector dimensionality the storage schema is sized for.</summary>
+    public int Dimensions { get; init; }
+
+    /// <summary>
+    /// Why embeddings are off — naming the exact configuration key to set. <c>null</c> when
+    /// <see cref="IsEnabled"/>.
+    /// </summary>
+    public string? DisabledReason { get; init; }
+
+    /// <summary>The config-section name every reason below refers to.</summary>
+    private const string Section = "Embedding";
+
+    /// <summary>
+    /// Describes what the host did about embeddings.
+    ///
+    /// <para><paramref name="isRegistered"/> — whether
+    /// <see cref="EmbeddingExtensions.CreateEmbeddingProvider"/> actually produced a provider — is
+    /// the AUTHORITY for <see cref="IsEnabled"/>, deliberately. Re-deriving "on or off" from the
+    /// options here would be a second copy of that method's branch logic, free to drift from it and
+    /// then to report a capability the host does not have; the reason below explains a decision
+    /// already taken, it never takes one.</para>
+    /// </summary>
+    /// <param name="options">The bound <c>Embedding</c> configuration section.</param>
+    /// <param name="isRegistered">Whether a provider was actually created and registered.</param>
+    /// <returns>The decision.</returns>
+    public static EmbeddingCapability From(EmbeddingOptions options, bool isRegistered)
+    {
+        var configured = options.Provider?.Trim();
+        var isLocal = configured is not null
+                      && (configured.Equals("ollama", StringComparison.OrdinalIgnoreCase)
+                          || configured.Equals("openaicompatible", StringComparison.OrdinalIgnoreCase));
+        var name = isLocal ? configured! : "AzureFoundry";
+
+        return new EmbeddingCapability
+        {
+            IsEnabled = isRegistered,
+            Provider = name,
+            Endpoint = options.Endpoint,
+            Model = options.Model,
+            Dimensions = options.Dimensions,
+            DisabledReason = isRegistered ? null : Reason(options, name, isLocal),
+        };
+    }
+
+    /// <summary>
+    /// Why no provider was created, naming the configuration key that would create one.
+    /// </summary>
+    /// <param name="options">The bound configuration section.</param>
+    /// <param name="name">The resolved backend name.</param>
+    /// <param name="isLocal">Whether the backend is the keyless on-host one.</param>
+    /// <returns>The reason.</returns>
+    private static string Reason(EmbeddingOptions options, string name, bool isLocal)
+    {
+        if (string.IsNullOrEmpty(options.Endpoint))
+            return $"no {Section}:Endpoint is configured";
+        if (!isLocal && string.IsNullOrEmpty(options.ApiKey))
+            return $"the {name} backend needs {Section}:ApiKey and none is configured "
+                   + $"(set {Section}:Provider=Ollama for a keyless on-host endpoint)";
+        return $"{Section}:Endpoint is set but the {name} backend produced no provider";
+    }
+
+    /// <summary>
+    /// One sentence an operator can act on, in both directions. Never carries
+    /// <see cref="EmbeddingOptions.ApiKey"/> — this goes to the pod log.
+    /// </summary>
+    /// <returns>The human-readable decision.</returns>
+    public string Describe() =>
+        IsEnabled
+            ? $"Semantic (vector) search ENABLED: provider={Provider}, endpoint={Endpoint}, "
+              + $"model={Model}, dimensions={Dimensions}."
+            : $"Semantic (vector) search DISABLED — {DisabledReason}. Free-text queries fall back "
+              + "to an ILIKE substring scan and content indexing stays inert; this is a supported "
+              + "configuration, not a fault.";
+}
+
+/// <summary>
+/// Writes the <see cref="EmbeddingCapability"/> decision to the log once, at host start.
+///
+/// <para>ONE <c>Information</c> line per process — the cost model AGENTS.md describes is about
+/// per-request volume, and a startup capability banner is the cheapest possible way to answer
+/// "is semantic search on here?" without a debugger. It is deliberately logged for BOTH outcomes:
+/// a line that appears only when the capability is on is indistinguishable from a host that never
+/// reached the decision.</para>
+/// </summary>
+/// <param name="capability">The decision taken at composition.</param>
+/// <param name="logger">The logger to report it on.</param>
+public sealed class EmbeddingCapabilityReporter(
+    EmbeddingCapability capability,
+    ILogger<EmbeddingCapabilityReporter> logger) : IHostedService
+{
+    /// <summary>Reports the decision. Pure logging — no I/O, nothing to await.</summary>
+    /// <param name="cancellationToken">Unused; the work is synchronous.</param>
+    /// <returns>A completed task.</returns>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("{EmbeddingCapability}", capability.Describe());
+        return Task.CompletedTask;
+    }
+
+    /// <summary>No-op.</summary>
+    /// <param name="cancellationToken">Unused.</param>
+    /// <returns>A completed task.</returns>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/MeshWeaver.Hosting.Embeddings/EmbeddingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Embeddings/EmbeddingExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Hosting.Embeddings;
@@ -51,11 +53,41 @@ public static class EmbeddingExtensions
     /// Registers the provider selected by <paramref name="options"/> as the singleton
     /// <see cref="IEmbeddingProvider"/>; no-op when <see cref="CreateEmbeddingProvider"/>
     /// yields null. Returns true when a provider was registered.
+    ///
+    /// <para>Either way it records the decision as a singleton
+    /// <see cref="EmbeddingCapability"/> and registers
+    /// <see cref="EmbeddingCapabilityReporter"/>, so the host says once, at startup, whether
+    /// semantic search is on and — when it is not — exactly which configuration key would turn it
+    /// on. The bool this returns is a composition detail only one caller reads; the log line is
+    /// what an operator has.</para>
+    ///
+    /// <para>🚨 It deliberately does NOT fall back to registering
+    /// <see cref="NullEmbeddingProvider"/> when embeddings are off. The PRESENCE of an
+    /// <see cref="IEmbeddingProvider"/> registration is the capability signal every consumer reads
+    /// (<c>sp.GetService&lt;IEmbeddingProvider&gt;()</c> in both storage backends, and the
+    /// content-indexing module's resolve-time <c>enabledWhen</c> gate). A Null default would report
+    /// the capability as PRESENT on a deployment that has none: the query path would survive it
+    /// (a null vector falls through to ILIKE), but the indexing pipeline would activate against an
+    /// embedder that can never embed — re-creating issue #1642 from the other direction.
+    /// <see cref="NullEmbeddingProvider"/> stays what it is: an explicit stand-in a caller opts
+    /// into, not a silent default.</para>
     /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="options">The bound <c>Embedding</c> configuration section.</param>
+    /// <returns><c>true</c> when a provider was registered.</returns>
     public static bool TryAddEmbeddingProvider(
         this IServiceCollection services, EmbeddingOptions options)
     {
         var provider = options.CreateEmbeddingProvider();
+        // Reported from what actually happened, never re-derived — see EmbeddingCapability.From.
+        var capability = EmbeddingCapability.From(options, provider is not null);
+        // Last one wins, matching the provider registration below — a host wires one backend.
+        services.AddSingleton(capability);
+        // TryAddEnumerable dedupes by (ServiceType, ImplementationType), so a host that wires two
+        // storage backends still reports once.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHostedService, EmbeddingCapabilityReporter>());
+
         if (provider is null)
             return false;
         services.AddSingleton(provider);

--- a/src/MeshWeaver.Hosting.Embeddings/MeshWeaver.Hosting.Embeddings.csproj
+++ b/src/MeshWeaver.Hosting.Embeddings/MeshWeaver.Hosting.Embeddings.csproj
@@ -6,6 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <!-- EmbeddingCapabilityReporter: one IHostedService that writes the embeddings
+         on/off decision to the log at startup. Abstractions only — no host. -->
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlExtensions.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlExtensions.cs
@@ -158,19 +158,26 @@ public static class PostgreSqlExtensions
         dataSourceBuilder.UseVector();
         var dataSource = dataSourceBuilder.Build();
 
-        var embeddingProvider = services.BuildServiceProvider().GetService<IEmbeddingProvider>();
-        var storageAdapter = new PostgreSqlStorageAdapter(dataSource, embeddingProvider);
+        // 🚨 The adapter is built from the REAL container, never from a
+        // services.BuildServiceProvider() taken mid-registration. That shortcut builds a SECOND,
+        // throwaway container: IEmbeddingProvider is registered by AddEmbeddings, so whether this
+        // adapter got one came down to whether the host happened to call AddEmbeddings BEFORE this
+        // method — and when it did, the adapter held a DUPLICATE singleton, not the one every other
+        // consumer resolves. Both are invisible: semantic search silently degrades to the ILIKE
+        // substring scan (issue #1642's real user-visible shape).
+        services.AddSingleton(sp =>
+            new PostgreSqlStorageAdapter(dataSource, sp.GetService<IEmbeddingProvider>()));
 
         // Register PostgreSqlMeshQuery BEFORE AddPersistence so TryAddSingleton picks it up.
         // Same instance under IVectorSearchProvider so the search box / MCP find / agent
         // tools route through HNSW cosine similarity when bare-text tokens are present.
         services.AddSingleton<PostgreSqlMeshQuery>(sp =>
             new PostgreSqlMeshQuery(
-                storageAdapter,
+                sp.GetRequiredService<PostgreSqlStorageAdapter>(),
                 sp.GetService<AccessService>(),
                 meshConfiguration: null,
                 excludedNamespaces: null,
-                embeddingProvider: embeddingProvider,
+                embeddingProvider: sp.GetService<IEmbeddingProvider>(),
                 ioPoolRegistry: sp.GetService<IoPoolRegistry>()));
         services.AddSingleton<IMeshQueryProvider>(sp => sp.GetRequiredService<PostgreSqlMeshQuery>());
         services.AddSingleton<IVectorSearchProvider>(sp => sp.GetRequiredService<PostgreSqlMeshQuery>());
@@ -179,7 +186,7 @@ public static class PostgreSqlExtensions
         // NoOpVersionQuery TryAdd (in AddCoreAndWrapperServices) no-ops.
         services.AddSingleton<IVersionQuery>(_ => new PostgreSqlVersionQuery(dataSource, opts.Schema));
 
-        services.AddPersistence(storageAdapter);
+        services.AddPersistence(sp => sp.GetRequiredService<PostgreSqlStorageAdapter>());
 
         // Register access control and activity store
         services.TryAddSingleton(new PostgreSqlAccessControl(dataSource));
@@ -203,20 +210,19 @@ public static class PostgreSqlExtensions
         dataSourceBuilder.UseVector();
         var dataSource = dataSourceBuilder.Build();
 
-        var embeddingProvider = services.BuildServiceProvider().GetService<IEmbeddingProvider>();
-        var storageAdapter = new PostgreSqlStorageAdapter(dataSource, embeddingProvider);
-
-        // Register concrete adapter type for change listener
-        services.AddSingleton(storageAdapter);
+        // Concrete adapter type, built from the REAL container — see the same-shape comment in
+        // AddPostgreSqlPersistence for why this is not services.BuildServiceProvider().
+        services.AddSingleton(sp =>
+            new PostgreSqlStorageAdapter(dataSource, sp.GetService<IEmbeddingProvider>()));
 
         // PostgreSqlMeshQuery + IVectorSearchProvider — same instance.
         services.AddSingleton<PostgreSqlMeshQuery>(sp =>
             new PostgreSqlMeshQuery(
-                storageAdapter,
+                sp.GetRequiredService<PostgreSqlStorageAdapter>(),
                 sp.GetService<AccessService>(),
                 meshConfiguration: null,
                 excludedNamespaces: null,
-                embeddingProvider: embeddingProvider,
+                embeddingProvider: sp.GetService<IEmbeddingProvider>(),
                 ioPoolRegistry: sp.GetService<IoPoolRegistry>()));
         services.AddSingleton<IMeshQueryProvider>(sp => sp.GetRequiredService<PostgreSqlMeshQuery>());
         services.AddSingleton<IVectorSearchProvider>(sp => sp.GetRequiredService<PostgreSqlMeshQuery>());
@@ -226,13 +232,14 @@ public static class PostgreSqlExtensions
         services.AddSingleton<IVersionQuery>(_ => new PostgreSqlVersionQuery(dataSource, opts.Schema));
 
         // Register core persistence services (IStorageAdapter, IStorageService, etc.)
-        services.AddPersistence(storageAdapter);
+        services.AddPersistence(sp => sp.GetRequiredService<PostgreSqlStorageAdapter>());
 
         // Register the Change Listener — feeds the adapter's Changes feed.
         services.AddSingleton(sp =>
         {
             var logger = sp.GetService<ILogger<PostgreSqlChangeListener>>();
-            return new PostgreSqlChangeListener(dataSource, storageAdapter.ChangeObserver, logger);
+            return new PostgreSqlChangeListener(
+                dataSource, sp.GetRequiredService<PostgreSqlStorageAdapter>().ChangeObserver, logger);
         });
 
         // Register access control and activity store

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeExtensions.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeExtensions.cs
@@ -132,26 +132,26 @@ public static class SnowflakeExtensions
         var capabilities = new SnowflakeCapabilityHolder();
         services.AddSingleton(capabilities);
 
-        // Mirrors the PG simple overload's eager-instance shape (incl. its acknowledged
-        // BuildServiceProvider wart) — this overload serves tests/monolith bring-up where
-        // the embedding provider is registered before persistence.
-        var embeddingProvider = services.BuildServiceProvider().GetService<IEmbeddingProvider>();
-        var storageAdapter = new SnowflakeStorageAdapter(
-            source, embeddingProvider, capabilities: capabilities, options: opts);
-        services.AddSingleton(storageAdapter);
+        // Mirrors the PG simple overload — and, like it, resolves the optional IEmbeddingProvider
+        // from the REAL container rather than a services.BuildServiceProvider() taken
+        // mid-registration. The old shape made "does this adapter have embeddings?" depend on
+        // whether the host called AddEmbeddings before or after this method, and gave the adapter a
+        // duplicate singleton when it did — a silent degrade to lexical search either way (#1642).
+        services.AddSingleton(sp => new SnowflakeStorageAdapter(
+            source, sp.GetService<IEmbeddingProvider>(), capabilities: capabilities, options: opts));
 
         services.AddSingleton<SnowflakeMeshQuery>(sp =>
             new SnowflakeMeshQuery(
-                storageAdapter,
+                sp.GetRequiredService<SnowflakeStorageAdapter>(),
                 sp.GetService<AccessService>(),
                 meshConfiguration: null,
                 excludedNamespaces: null,
-                embeddingProvider: embeddingProvider,
+                embeddingProvider: sp.GetService<IEmbeddingProvider>(),
                 ioPoolRegistry: sp.GetService<IoPoolRegistry>()));
         services.AddSingleton<IMeshQueryProvider>(sp => sp.GetRequiredService<SnowflakeMeshQuery>());
         services.AddSingleton<IVectorSearchProvider>(sp => sp.GetRequiredService<SnowflakeMeshQuery>());
 
-        services.AddPersistence(storageAdapter);
+        services.AddPersistence(sp => sp.GetRequiredService<SnowflakeStorageAdapter>());
 
         services.TryAddSingleton(new SnowflakeAccessControl(
             source, schemaName: opts.Schema, centralSchema: opts.Schema,

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -442,6 +442,36 @@ public static class PersistenceExtensions
         return services.AddCoreAndWrapperServices();
     }
 
+    /// <summary>
+    /// Adds a custom storage adapter built LAZILY from the real container, with in-memory
+    /// persistence service.
+    ///
+    /// <para>🚨 Prefer this over the instance overload whenever the adapter needs anything else out
+    /// of DI. The instance overload forces the caller to have the adapter's dependencies in hand at
+    /// REGISTRATION time, and the shortcut that reaches for — <c>services.BuildServiceProvider()</c>
+    /// mid-registration — silently builds a SECOND, throwaway container: anything registered after
+    /// that line is invisible to it, and any singleton it does resolve is a duplicate of the one the
+    /// real container will hand everyone else. Both PostgreSQL simple-persistence lanes and the
+    /// Snowflake one read their optional <c>IEmbeddingProvider</c> that way, so the adapter took a
+    /// null (or a second instance) purely because of registration ORDER.</para>
+    ///
+    /// <para>The version-writing/write-guard decorator chain resolves the last
+    /// <see cref="IStorageAdapter"/> registration whether it is an instance or a factory, so nothing
+    /// downstream can tell the difference.</para>
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="storageAdapterFactory">Builds the adapter from the real service provider.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddPersistence(
+        this IServiceCollection services,
+        Func<IServiceProvider, IStorageAdapter> storageAdapterFactory)
+    {
+        services.AddSingleton(storageAdapterFactory);
+
+        // Register common services and wrapper services
+        return services.AddCoreAndWrapperServices();
+    }
+
     // AddPersistence(IServiceCollection, IStorageService) deleted in the cull —
     // IStorageService is gone. Callers register an IStorageAdapter directly
     // and call AddCoreAndWrapperServices().

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -466,7 +466,13 @@ public static class PersistenceExtensions
         this IServiceCollection services,
         Func<IServiceProvider, IStorageAdapter> storageAdapterFactory)
     {
-        services.AddSingleton(storageAdapterFactory);
+        // 🚨 The service type is EXPLICIT. `AddSingleton(factory)` has two applicable overloads for a
+        // typed `Func<IServiceProvider, IStorageAdapter>` variable — the factory overload
+        // (TService = IStorageAdapter) and the implementation-INSTANCE overload
+        // (TService = Func<IServiceProvider, IStorageAdapter>, i.e. registering the delegate itself
+        // as the service). Both compile. Picking the second would leave IStorageAdapter
+        // unregistered, which is this PR's whole bug class arriving through the fix for it.
+        services.AddSingleton<IStorageAdapter>(storageAdapterFactory);
 
         // Register common services and wrapper services
         return services.AddCoreAndWrapperServices();

--- a/test/Memex.Portal.Shared.Test/EaConsentControllerActivationTest.cs
+++ b/test/Memex.Portal.Shared.Test/EaConsentControllerActivationTest.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Memex.Portal.Shared;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Mesh;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Issue #2218 — every request to <c>/auth/ea/connect</c> answered HTTP 500 in memex prod:
+/// <i>"Unable to resolve service for type 'MeshWeaver.Mesh.IEaGraphAuth' while attempting to
+/// activate 'EaConsentController'"</i>, thrown by MVC's activator before a line of action code ran.
+///
+/// <para><b>Root cause: a routed controller with a feature-flagged dependency.</b>
+/// <c>AddControllers().AddApplicationPart(...)</c> discovers controllers by TYPE — it has no idea
+/// what any of them needs — so the consent endpoints are routed on EVERY deployment.
+/// <c>IEaGraphAuth</c>, meanwhile, was registered only inside <c>if (emailOptions.Enabled)</c>.
+/// Gating it did not disable the endpoint; it left the endpoint routed and unconstructible. And
+/// <c>Email:Enabled</c> was the wrong condition anyway: it gates the SYSTEM mailbox's
+/// app-permission sender, while the EA's delegated flow needs <c>Authentication:Microsoft</c>
+/// credentials — which <c>EaGraphAuth.IsConfigured</c> already reports honestly, letting the
+/// controller answer a 400 that says so instead of a 500 that reads as a bug.</para>
+///
+/// <para><b>Why every existing test passed.</b> <see cref="EaConnectRouteTest"/> asks the routing
+/// table whether the path is served (it is) and deliberately never instantiates a controller;
+/// <see cref="EaConnectReconsentTest"/> and <see cref="EaConnectOpenRedirectTest"/> construct the
+/// controller with a hand-written fake. Nothing put the portal's REAL registrations and the
+/// portal's REAL controllers in the same room — the only place this class of bug is visible.</para>
+/// </summary>
+public class EaConsentControllerActivationTest
+{
+    /// <summary>
+    /// The portal's own service registrations at a given <c>Email:Enabled</c> setting. Nothing is
+    /// started and no host is built — this is the composition, exactly as <c>Program.cs</c> runs it.
+    /// </summary>
+    /// <param name="emailEnabled">The <c>Email:Enabled</c> value to compose with.</param>
+    /// <returns>The configured service collection.</returns>
+    private static IServiceCollection PortalServices(bool emailEnabled)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            ContentRootPath = AppContext.BaseDirectory,
+            EnvironmentName = Environments.Development,
+        });
+        builder.Logging.ClearProviders();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Email:Enabled"] = emailEnabled ? "true" : "false",
+        });
+
+        builder.ConfigureMemexServices();
+        return builder.Services;
+    }
+
+    /// <summary>
+    /// The regression itself: the EA consent seam is registered on a portal with mail OFF — which
+    /// is the DEFAULT, not an exotic configuration.
+    /// </summary>
+    [Fact]
+    public void EaGraphAuth_IsRegistered_EvenWithMailDisabled()
+    {
+        PortalServices(emailEnabled: false).Should()
+            .Contain(d => d.ServiceType == typeof(IEaGraphAuth),
+                "EaConsentController is routed on every deployment, so its seam must resolve on "
+                + "every deployment. Whether the EA is USABLE is IEaGraphAuth.IsConfigured's answer "
+                + "(Authentication:Microsoft credentials) — a 400 the controller already returns, "
+                + "not a 500 from MVC's activator (issue #2218).");
+    }
+
+    /// <summary>
+    /// The general form, and the one that generalises past today's instance: <b>no controller
+    /// dependency may appear or disappear with a deployment flag.</b>
+    ///
+    /// <para>Stated as a DIFFERENCE between two compositions rather than as "everything must be
+    /// registered", because the second question cannot be answered from this collection alone: the
+    /// portal's controllers also take services the MESH contributes (<c>IMeshService</c>,
+    /// <c>IMessageHub</c>, <c>AccessService</c>), which live in the mesh's provider — the one
+    /// <c>MeshHostApplicationBuilder</c> makes the ASP.NET root provider at runtime — and are
+    /// legitimately absent here. Comparing two compositions cancels those out exactly, and leaves
+    /// the property that actually broke: a dependency present under one flag value and missing
+    /// under another is a routed endpoint that 500s on half the deployments.</para>
+    ///
+    /// <para>🚨 <c>Email:Enabled</c> is the flag compared because it is the one that caused #2218.
+    /// It is an EXPLICIT list of one: a new deploy-time toggle that gates a service belongs here
+    /// too, and adding it is a line of config, not a redesign.</para>
+    /// </summary>
+    [Fact]
+    public void NoControllerDependency_DependsOnADeploymentFlag()
+    {
+        var withMail = Registered(PortalServices(emailEnabled: true));
+        var withoutMail = Registered(PortalServices(emailEnabled: false));
+
+        var dependencies = Controllers().SelectMany(Dependencies).Distinct().ToArray();
+        dependencies.Should().NotBeEmpty(
+            "otherwise this test would pass by finding nothing to check — the same vacuity that "
+            + "let the original bug ship");
+
+        var flagged = dependencies
+            .Where(d => withMail.Contains(d) != withoutMail.Contains(d))
+            .Select(d => d.Name)
+            .ToArray();
+
+        flagged.Should().BeEmpty(
+            "a controller is routed by TYPE, with no idea which flags are set, so its dependencies "
+            + "must be registered unconditionally. Flag-dependent: " + string.Join(", ", flagged));
+    }
+
+    /// <summary>Non-vacuity: the controller at the centre of #2218 is actually in the sweep.</summary>
+    [Fact]
+    public void TheSweep_CoversTheConsentController()
+    {
+        Controllers().Should().Contain(typeof(EaConsentController));
+        Dependencies(typeof(EaConsentController)).Should().Contain(typeof(IEaGraphAuth));
+    }
+
+    /// <summary>Every controller the portal's application part contributes.</summary>
+    /// <returns>The controller types.</returns>
+    private static Type[] Controllers() =>
+        [.. typeof(EaConsentController).Assembly.GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false, IsPublic: true }
+                        && typeof(ControllerBase).IsAssignableFrom(t))];
+
+    /// <summary>The constructor parameter types MVC has to resolve for a controller.</summary>
+    /// <param name="controller">The controller type.</param>
+    /// <returns>The dependency types.</returns>
+    private static IEnumerable<Type> Dependencies(Type controller) =>
+        controller.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .OrderByDescending(c => c.GetParameters().Length)
+            .Take(1)
+            .SelectMany(c => c.GetParameters())
+            // Values MVC binds itself rather than resolving from the container.
+            .Where(p => !p.IsOptional
+                        && p.GetCustomAttribute<FromServicesAttribute>() is null
+                        && !p.ParameterType.IsPrimitive
+                        && p.ParameterType != typeof(string))
+            .Select(p => p.ParameterType);
+
+    /// <summary>Folds a composition's registrations into a resolvability question.</summary>
+    /// <param name="services">The composed services.</param>
+    /// <returns>The set to ask about a dependency.</returns>
+    private static ResolvableSet Registered(IServiceCollection services) =>
+        new(services.Select(d => d.ServiceType).ToHashSet());
+
+    /// <summary>The service types a composition can supply, closed generics folded in.</summary>
+    /// <param name="serviceTypes">Every registered service type.</param>
+    private sealed class ResolvableSet(HashSet<Type> serviceTypes)
+    {
+        /// <summary>
+        /// Whether the container could supply <paramref name="dependency"/>. Closed generics count
+        /// when their open form is registered — <c>ILogger&lt;T&gt;</c> is the everyday case.
+        /// </summary>
+        /// <param name="dependency">The dependency type.</param>
+        /// <returns>Whether it resolves.</returns>
+        public bool Contains(Type dependency) =>
+            serviceTypes.Contains(dependency)
+            || (dependency.IsGenericType && serviceTypes.Contains(dependency.GetGenericTypeDefinition()));
+    }
+}

--- a/test/MeshWeaver.Content.Test/DocAssetWireProjectionTest.cs
+++ b/test/MeshWeaver.Content.Test/DocAssetWireProjectionTest.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Data;
+using MeshWeaver.Documentation;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Content.Test;
+
+/// <summary>
+/// Issues #2122 / #2123 — <c>ArgumentException: AssemblyName required for EmbeddedResource</c> on
+/// every doc-tree image, in memex-cloud, on both pods, for days.
+///
+/// <para><b>The defect was not the registration.</b> Every embedded-resource collection is
+/// registered by <c>AddEmbeddedResourceContentCollection</c>, which always writes
+/// <c>Settings["AssemblyName"]</c> and <c>Settings["ResourcePrefix"]</c> — the two things the
+/// provider factory needs to find its bytes. What lost them was the WIRE READ: the content route
+/// asks the owning node hub for its collection configs with a <c>GetDataRequest</c>, the response
+/// arrives as a <see cref="JsonElement"/>, and
+/// <see cref="ContentFileResolver.ReadCollectionConfigs"/> rebuilt each config by hand from five
+/// named properties — <c>Settings</c> not among them. The config that reached
+/// <c>EmbeddedResourceStreamProviderFactory.Create</c> was therefore a TRUNCATED copy of a
+/// perfectly good registration, and the guard three assemblies away threw about a field nobody had
+/// omitted.</para>
+///
+/// <para>That is why this test asserts on BOTH halves and refuses to stop at the projection: it
+/// reads the config off the wire exactly as the route does, and then actually serves the bytes of
+/// two real shipped SVGs — the two paths named in the issues
+/// (<c>Doc/GUI/DataBinding/icon.svg</c>, <c>Doc/AI/images/agenticai.svg</c>). A projection test
+/// alone could pass while the asset stayed unservable for some other reason.</para>
+/// </summary>
+public class DocAssetWireProjectionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static CancellationToken Ct => new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token;
+
+    // Partitioned persistence so the embedded "Doc" partition is actually served (a plain
+    // non-partitioned in-memory adapter leaves the Doc namespace unreachable) — same harness as
+    // DocContentEmbedRenderTest. Only AddDocumentation registers the collections; nothing is
+    // mapped by hand, so what is under test is the shipped wiring.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => builder
+            .UseMonolithMesh()
+            .AddPartitionedInMemoryPersistence()
+            .AddDocumentation()
+            .AddGraph()
+            .ConfigureHub(c => c.WithRequestTimeout(TimeSpan.FromSeconds(60)));
+
+    /// <summary>
+    /// The end-to-end shape of the production failure: read the doc node's <c>content</c> collection
+    /// config the way the content route reads it (over the wire, through
+    /// <see cref="ContentFileResolver.ReadCollectionConfigs"/>), then open that collection and serve
+    /// the file. Before the fix this threw
+    /// <c>ArgumentException: AssemblyName required for EmbeddedResource</c> at the open step.
+    /// </summary>
+    /// <param name="nodePath">The doc node owning the asset.</param>
+    /// <param name="file">The collection-relative file path.</param>
+    [Theory(Timeout = 120000)]
+    [InlineData("Doc/GUI/DataBinding", "icon.svg")]
+    [InlineData("Doc/Architecture", "platform-overview.svg")]
+    [InlineData("Doc/DataMesh", "data-product.svg")]
+    public async Task DocAssetIsServable_AfterTheConfigCrossesTheWire(string nodePath, string file)
+    {
+        var nodeAddress = new Address(nodePath);
+        var client = GetClient(c => c.AddContentCollections());
+
+        // Wake the per-node hub so its collection registrations exist to be reported.
+        await client.Observe(new PingRequest(), o => o.WithTarget(nodeAddress))
+            .Should().Within(60.Seconds()).Emit();
+
+        // The EXACT request ContentFileResolver.Resolve issues for a `{node}/{file…}` reference.
+        var response = await client.Observe(
+                new GetDataRequest(
+                    new ContentCollectionReference([ContentCollectionsExtensions.DefaultCollectionName])),
+                o => o.WithTarget(nodeAddress))
+            .Should().Within(60.Seconds()).Emit();
+
+        var configs = ContentFileResolver.ReadCollectionConfigs(response);
+        configs.Should().NotBeNull("the node reports its content collection");
+
+        var config = configs!.SingleOrDefault(
+            c => c.Name == ContentCollectionsExtensions.DefaultCollectionName);
+        config.Should().NotBeNull($"{nodePath} maps its own Content/ subfolder as 'content'");
+
+        config!.SourceType.Should().Be("EmbeddedResource");
+        config.IsStatic.Should().BeTrue(
+            "the doc assets are published on the content route — this is the property whose loss "
+            + "issue #587 fixed, and it must keep surviving the same projection");
+
+        // 🚨 The regression assertion. Settings is what names the assembly and resource prefix;
+        // without it the factory cannot find a single byte, and the failure surfaces three
+        // assemblies away as a complaint about a field the registration DID supply.
+        config.Settings.Should().NotBeNull(
+            "Settings carries AssemblyName + ResourcePrefix for an EmbeddedResource collection — "
+            + "dropping it on the wire is issues #2122/#2123");
+        config.Settings!.GetValueOrDefault("AssemblyName").Should()
+            .Be(typeof(DocumentationExtensions).Assembly.GetName().Name);
+        config.Settings!.GetValueOrDefault("ResourcePrefix").Should()
+            .StartWith("MeshWeaver.Documentation.Content");
+
+        // …and now actually serve it, exactly as BlazorHostingExtensions.ResolveContentFile does:
+        // register the config under its qualified name on THIS hub's content service, open the
+        // collection, read the bytes.
+        var qualified = config with { Name = $"{nodePath}/{config.Name}", Address = nodeAddress };
+        var contentService = client.ServiceProvider.GetRequiredService<IContentService>();
+        contentService.AddConfiguration(qualified);
+
+        var collection = await contentService.GetCollection(qualified.Name)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).ToTask(Ct);
+        collection.Should().NotBeNull(
+            "a collection whose provider factory threw resolves as null — which is how the route "
+            + "answered 'Content read failed' for every doc image");
+
+        collection!.GetContentType(file).Should().Be("image/svg+xml");
+
+        var bytes = await collection.GetContentBytes(file)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).ToTask(Ct);
+        bytes.Should().NotBeNull($"{nodePath}/{file} ships as an embedded resource");
+        bytes!.Length.Should().BePositive();
+        Encoding.UTF8.GetString(bytes).Should().Contain("<svg",
+            "the served bytes must be the real SVG, not an error page or an empty stream");
+    }
+
+    /// <summary>
+    /// <c>Doc/AI</c> — the OTHER path named in issue #2122
+    /// (<c>Doc/AI/images/agenticai.svg</c>) — separated out because only PART of that path's
+    /// failure is this fix's to own, and pretending otherwise would overstate it.
+    ///
+    /// <para>What this fix does own, and what is asserted here: the config crosses the wire intact
+    /// and the collection OPENS. Before it, <c>EmbeddedResourceStreamProviderFactory.Create</c>
+    /// threw <c>ArgumentException: AssemblyName required for EmbeddedResource</c> and the route
+    /// logged <c>Content read failed</c> at <c>fail:</c> level — the request never got as far as
+    /// looking for a file.</para>
+    ///
+    /// <para>🚨 What it does NOT fix: <c>images/agenticai.svg</c> does not exist under
+    /// <c>Content/AI/</c>. The asset ships at <c>Content/images/agenticai.svg</c> — the partition
+    /// ROOT — while six <c>Doc/AI/*</c> pages declare <c>Thumbnail: "images/agenticai.svg"</c>,
+    /// which resolves against their own folder node. That is a SECOND, independent defect (a
+    /// thumbnail path pointing where the asset is not), it is not confined to this file —
+    /// <c>images/DataMesh.svg</c> and <c>images/notifications.svg</c> are declared as thumbnails and
+    /// ship nowhere either — and it is a doc-content question, not a registration one. After this
+    /// fix that path answers a plain "file not found" instead of a 500, which is the honest answer
+    /// for an asset that genuinely is not there.</para>
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task DocAiCollection_OpensWithACompleteConfig()
+    {
+        const string nodePath = "Doc/AI";
+        var nodeAddress = new Address(nodePath);
+        var client = GetClient(c => c.AddContentCollections());
+
+        await client.Observe(new PingRequest(), o => o.WithTarget(nodeAddress))
+            .Should().Within(60.Seconds()).Emit();
+
+        var response = await client.Observe(
+                new GetDataRequest(
+                    new ContentCollectionReference([ContentCollectionsExtensions.DefaultCollectionName])),
+                o => o.WithTarget(nodeAddress))
+            .Should().Within(60.Seconds()).Emit();
+
+        var config = ContentFileResolver.ReadCollectionConfigs(response)!
+            .Single(c => c.Name == ContentCollectionsExtensions.DefaultCollectionName);
+
+        config.Settings.Should().NotBeNull("this is the payload the wire read used to drop");
+        config.Settings!.GetValueOrDefault("ResourcePrefix").Should()
+            .Be("MeshWeaver.Documentation.Content.AI");
+
+        var qualified = config with { Name = $"{nodePath}/{config.Name}", Address = nodeAddress };
+        var contentService = client.ServiceProvider.GetRequiredService<IContentService>();
+        contentService.AddConfiguration(qualified);
+
+        var collection = await contentService.GetCollection(qualified.Name)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).ToTask(Ct);
+        collection.Should().NotBeNull(
+            "the collection must now be constructible — the ArgumentException from the missing "
+            + "AssemblyName is what made every read of it fail, whatever file was asked for");
+
+        // The collection's OWN asset is servable, which is what proves the config is usable rather
+        // than merely non-throwing.
+        var icon = await collection!.GetContentBytes("icon.svg")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).ToTask(Ct);
+        icon.Should().NotBeNull("Content/AI/icon.svg ships in this collection");
+    }
+
+    /// <summary>
+    /// The completeness guard that keeps the fix from rotting.
+    ///
+    /// <para>A hand-written projection is only ever correct for the properties its author needed.
+    /// <c>ContentCollectionConfig</c> has already lost three this way — <c>IsStatic</c> (every
+    /// published remote collection failed its mount check), <c>Address</c> (an inherited collection
+    /// resolved against the ancestor's folder) and now <c>Settings</c> — each found in production
+    /// rather than here. So this asserts EVERY property survives a real round trip through the hub
+    /// serializer, and pins the property COUNT so that adding a fourth fails this test with a
+    /// message saying what to do instead of shipping the same bug again.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public void EveryConfigProperty_SurvivesTheWireProjection()
+    {
+        var original = new ContentCollectionConfig
+        {
+            Name = "content",
+            SourceType = "EmbeddedResource",
+            DisplayName = "Shipped assets",
+            BasePath = "some/base",
+            Order = 7,
+            IsEditable = true,
+            IsStatic = true,
+            ExposeInChildren = true,
+            Address = new Address("Doc/GUI/DataBinding"),
+            Settings = new Dictionary<string, string>
+            {
+                ["AssemblyName"] = "MeshWeaver.Documentation",
+                ["ResourcePrefix"] = "MeshWeaver.Documentation.Content.GUI.DataBinding",
+            },
+        };
+
+        // Non-vacuity: if a future config type gains a property, this count fails first and says so.
+        typeof(ContentCollectionConfig).GetProperties().Should().HaveCount(10,
+            "every property of ContentCollectionConfig must be carried across "
+            + "ContentFileResolver.ReadCollectionConfigs — add the new one there AND set it above, "
+            + "then bump this count. Silently skipping it is issues #2122/#2123 all over again.");
+
+        var projected = RoundTrip(original);
+
+        projected.Name.Should().Be(original.Name);
+        projected.SourceType.Should().Be(original.SourceType);
+        projected.DisplayName.Should().Be(original.DisplayName);
+        projected.BasePath.Should().Be(original.BasePath);
+        projected.Order.Should().Be(original.Order);
+        projected.IsEditable.Should().BeTrue();
+        projected.IsStatic.Should().BeTrue();
+        projected.ExposeInChildren.Should().BeTrue();
+        projected.Address.Should().NotBeNull();
+        projected.Address!.ToString().Should().Be(original.Address!.ToString());
+        projected.Settings.Should().NotBeNull();
+        projected.Settings!.Count.Should().Be(original.Settings!.Count);
+        foreach (var (key, value) in original.Settings)
+            projected.Settings.GetValueOrDefault(key).Should().Be(value,
+                $"Settings['{key}'] must survive — for an EmbeddedResource collection these two "
+                + "keys ARE the collection");
+    }
+
+    /// <summary>
+    /// A config through the REAL hub serializer and back out of
+    /// <see cref="ContentFileResolver.ReadCollectionConfigs"/> — the same two steps a cross-hub
+    /// <c>GetDataResponse</c> takes.
+    /// </summary>
+    /// <param name="config">The config to round-trip.</param>
+    /// <returns>The config as the reader reconstructs it.</returns>
+    private ContentCollectionConfig RoundTrip(ContentCollectionConfig config)
+    {
+        var wire = JsonSerializer.SerializeToElement(
+            (object)new[] { config }, Mesh.JsonSerializerOptions);
+        wire.ValueKind.Should().Be(JsonValueKind.Array,
+            "the reader enumerates an array — a different shape would make this test vacuous");
+
+        var delivery = new MessageDelivery<GetDataResponse>(
+            new Address("Doc/GUI/DataBinding"),
+            Mesh.Address,
+            new GetDataResponse(wire, 1),
+            Mesh.JsonSerializerOptions);
+
+        var configs = ContentFileResolver.ReadCollectionConfigs(delivery);
+        configs.Should().NotBeNull().And.HaveCount(1);
+        return configs!.Single();
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/EmbeddingCapabilityTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/EmbeddingCapabilityTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Embeddings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Issue #1642 — <c>search_chunks</c> failing with <i>"The requested service
+/// 'MeshWeaver.Hosting.Embeddings.IEmbeddingProvider' has not been registered"</i>.
+///
+/// <para><b>The verdict this pins: <see cref="IEmbeddingProvider"/> is OPTIONAL.</b> A deployment
+/// with no <c>Embedding:Endpoint</c> is a supported deployment — mesh search falls back to an ILIKE
+/// substring scan and the content-indexing pipeline resolves its inert stand-ins
+/// (<c>ContentIndexingOffToolTest</c> pins that half). So the provider must NOT be required, and the
+/// crash the issue reported was correctly fixed by gating the CONSUMER rather than by forcing a
+/// registration.</para>
+///
+/// <para><b>What was still wrong, and is what these tests are for.</b> The decision was taken in
+/// silence. <c>TryAddEmbeddingProvider</c> returned a bool one caller read, and nothing in any log
+/// said which way it went — so "semantic search is off here" and "semantic search is broken here"
+/// produced the same evidence, and #1642 had to be triaged from a stack trace. A capability that
+/// degrades silently is indistinguishable from one that is broken. The decision is now an
+/// <see cref="EmbeddingCapability"/> in DI plus exactly one startup log line, in BOTH directions —
+/// a line that appeared only when the capability was on would be no better than the silence.</para>
+///
+/// <para>Pure unit tests: no container, no fixture.</para>
+/// </summary>
+public class EmbeddingCapabilityTests
+{
+    /// <summary>Runs the real registration and returns what it produced.</summary>
+    /// <param name="options">The embedding options to compose with.</param>
+    /// <returns>The service collection and whether a provider was registered.</returns>
+    private static (IServiceCollection Services, bool Registered) Wire(EmbeddingOptions options)
+    {
+        var services = new ServiceCollection();
+        var registered = services.TryAddEmbeddingProvider(options);
+        return (services, registered);
+    }
+
+    /// <summary>Resolves the reported capability out of the composed container.</summary>
+    /// <param name="services">The composed services.</param>
+    /// <returns>The capability.</returns>
+    private static EmbeddingCapability Capability(IServiceCollection services)
+        => services.BuildServiceProvider().GetRequiredService<EmbeddingCapability>();
+
+    [Fact]
+    public void NoEndpoint_LeavesTheProviderUnregistered_AndSaysSo()
+    {
+        var (services, registered) = Wire(new EmbeddingOptions());
+
+        registered.Should().BeFalse();
+        services.Should().NotContain(d => d.ServiceType == typeof(IEmbeddingProvider),
+            "an unconfigured deployment registers NO provider — the PRESENCE of the registration is "
+            + "the capability signal every consumer reads, so a NullEmbeddingProvider default would "
+            + "report a capability this host does not have and light up the indexing pipeline "
+            + "against an embedder that can never embed");
+
+        var capability = Capability(services);
+        capability.IsEnabled.Should().BeFalse();
+        capability.DisabledReason.Should().Contain("Embedding:Endpoint",
+            "the reason must name the configuration key that would turn it on — 'disabled' alone "
+            + "leaves an operator exactly where #1642 left them");
+        capability.Describe().Should().Contain("DISABLED").And.Contain("ILIKE",
+            "and must state the CONSEQUENCE, so nobody reads a lexical result set as a data bug");
+    }
+
+    [Fact]
+    public void CloudBackendWithoutAKey_IsOff_ForTheRightStatedReason()
+    {
+        var (services, registered) = Wire(new EmbeddingOptions
+        {
+            Endpoint = "https://example-foundry.invalid",
+            // Provider unset ⇒ AzureFoundry, which needs a key.
+        });
+
+        registered.Should().BeFalse();
+        var capability = Capability(services);
+        capability.IsEnabled.Should().BeFalse();
+        capability.DisabledReason.Should().Contain("Embedding:ApiKey",
+            "an endpoint that is set but keyless is a DIFFERENT fix from an endpoint that is "
+            + "absent, and both used to look identical from outside");
+        capability.Provider.Should().Be("AzureFoundry");
+    }
+
+    [Fact]
+    public void ConfiguredLocalBackend_RegistersTheProvider_AndReportsItOn()
+    {
+        var (services, registered) = Wire(new EmbeddingOptions
+        {
+            Provider = "Ollama",
+            Endpoint = "http://localhost:11434",
+            Model = "bge-m3",
+        });
+
+        registered.Should().BeTrue();
+        services.Should().Contain(d => d.ServiceType == typeof(IEmbeddingProvider));
+
+        var capability = Capability(services);
+        capability.IsEnabled.Should().BeTrue();
+        capability.DisabledReason.Should().BeNull();
+        capability.Dimensions.Should().Be(1024, "bge-m3's known dimensionality");
+        capability.Describe().Should().Contain("ENABLED").And.Contain("bge-m3");
+    }
+
+    /// <summary>
+    /// The capability must never claim more than the host actually did. Re-deriving "on or off"
+    /// from the options would be a second copy of <c>CreateEmbeddingProvider</c>'s branch logic,
+    /// free to drift and then to advertise a provider that was never registered.
+    /// </summary>
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData(null, "https://example-foundry.invalid", null)]
+    [InlineData("Ollama", "http://localhost:11434", null)]
+    [InlineData(null, "https://example-foundry.invalid", "key")]
+    public void ReportedState_AlwaysMatchesWhetherAProviderWasActuallyRegistered(
+        string? provider, string? endpoint, string? apiKey)
+    {
+        var (services, registered) = Wire(new EmbeddingOptions
+        {
+            Provider = provider,
+            Endpoint = endpoint,
+            ApiKey = apiKey,
+        });
+
+        Capability(services).IsEnabled.Should().Be(registered);
+        services.Any(d => d.ServiceType == typeof(IEmbeddingProvider)).Should().Be(registered);
+    }
+
+    /// <summary>
+    /// The decision reaches the LOG, not just DI — and in both directions. This runs the real
+    /// hosted service the registration installs and captures what it writes.
+    /// </summary>
+    /// <param name="endpoint">The endpoint to compose with, or null for the unconfigured case.</param>
+    /// <param name="expected">A fragment the emitted line must carry.</param>
+    [Theory]
+    [InlineData(null, "DISABLED")]
+    [InlineData("http://localhost:11434", "ENABLED")]
+    public async Task TheDecisionIsReportedOnce_AtStartup(string? endpoint, string expected)
+    {
+        var (services, _) = Wire(new EmbeddingOptions
+        {
+            Provider = "Ollama",
+            Endpoint = endpoint,
+            Model = "bge-m3",
+        });
+
+        var recorder = new RecordingLoggerProvider();
+        services.AddLogging(b => b.AddProvider(recorder).SetMinimumLevel(LogLevel.Information));
+
+        var provider = services.BuildServiceProvider();
+        var reporters = provider.GetServices<IHostedService>()
+            .OfType<EmbeddingCapabilityReporter>()
+            .ToArray();
+
+        reporters.Should().ContainSingle(
+            "the decision is announced exactly once per process — repeating it per backend would "
+            + "make the banner noise, and omitting it is the silence this fixes");
+
+        await reporters[0].StartAsync(CancellationToken.None);
+
+        recorder.Lines.Should().ContainSingle(line => line.Contains(expected),
+            $"an operator must be able to read '{expected}' out of the pod log without a debugger");
+    }
+
+    /// <summary>Captures emitted log messages so the startup banner can be asserted on.</summary>
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        private readonly List<string> lines = [];
+
+        /// <summary>Everything logged through this provider.</summary>
+        public IReadOnlyList<string> Lines
+        {
+            get
+            {
+                lock (lines) return lines.ToArray();
+            }
+        }
+
+        /// <inheritdoc />
+        public ILogger CreateLogger(string categoryName) => new Recorder(this);
+
+        /// <inheritdoc />
+        public void Dispose() { }
+
+        private void Add(string line)
+        {
+            lock (lines) lines.Add(line);
+        }
+
+        private sealed class Recorder(RecordingLoggerProvider owner) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => owner.Add(formatter(state, exception));
+        }
+    }
+}


### PR DESCRIPTION
Four production issues that share one shape: **the code compiles, every reference resolves, and the
thing that is missing is a *registration*.** None is visible to `dotnet build`, and each surfaces far
from where it was caused.

Closes #2218, #2122, #2123 (#2123 is #2122's other face — same fingerprint `d94a160fc73a60d5`, same
two frames), and #1642.

---

## #2122 / #2123 — doc-tree images: the wire read truncated a perfectly good config

`EmbeddedResourceStreamProviderFactory.Create` threw `ArgumentException: AssemblyName required for
EmbeddedResource` for every image on a doc page, on both memex-cloud pods, over three days.

**The registration was never at fault.** `AddEmbeddedResourceContentCollection` always writes
`Settings["AssemblyName"]` and `Settings["ResourcePrefix"]`. What lost them is the **wire read**: the
content route asks the owning node hub for its collection configs with a `GetDataRequest`, the
response arrives as a `JsonElement`, and `ContentFileResolver.ReadCollectionConfigs` rebuilt each
config **by hand from five named properties** — `Settings` not among them. So the config that reached
the factory was a truncated copy of a correct registration, and a guard three frames and one assembly
away complained about a field nobody had omitted.

- The projection now carries **every** property. `Settings`, `DisplayName`, `Order`, `IsEditable` and
  `ExposeInChildren` were all being dropped.
- `EveryConfigProperty_SurvivesTheWireProjection` pins each one **and the property count**, so adding
  a tenth property to `ContentCollectionConfig` fails there with a message saying what to do.
  `IsStatic` (#587) and `Address` were lost to this same hand-written projection before `Settings`
  was — each found in production, not here.
- The guard's exception now names the collection and its address, not only the field.

## #2218 — `EaConsentController` 500s: a routed controller with a feature-flagged dependency

`AddControllers().AddApplicationPart(...)` discovers controllers by **type**, with no idea what any
of them needs — so `/auth/ea/connect` and `/auth/ea/callback` are routed on every deployment.
`IEaGraphAuth` was registered only inside `if (emailOptions.Enabled)`. Gating it did not disable the
endpoint; it left it routed and unconstructible, and MVC's activator threw before any action code ran.

`Email:Enabled` was the wrong condition anyway: it gates the **system mailbox's app-permission
sender**, while the EA's *delegated* flow needs `Authentication:Microsoft` credentials —
`EaGraphAuth.IsConfigured` already reports that honestly, and the controller already answers **400
"not configured"** on it. The registration is now unconditional (the descriptor is inert; a typed
`HttpClient` registration does no work until something resolves it), so the endpoint returns a
truthful 400 rather than a 500.

Two tests over the portal's **real** composition — which nothing did before (`EaConnectRouteTest`
asks the routing table and deliberately never instantiates a controller; the other two use a
hand-written fake):

- the specific regression, and
- `NoControllerDependency_DependsOnADeploymentFlag`, stated as a **difference** between two
  compositions. A "must all be registered" sweep cannot work here: the controllers also take
  mesh-contributed services (`IMeshService`, `IMessageHub`, `AccessService`) that live in the mesh's
  provider — the one `MeshHostApplicationBuilder` makes the ASP.NET root provider — and are
  legitimately absent from this collection. Comparing two compositions cancels those out exactly and
  leaves the property that actually broke.

## #1642 — `IEmbeddingProvider`: **optional**, and now said out loud

**Verdict: optional.** A deployment with no `Embedding:Endpoint` is supported — search falls back to
an ILIKE substring scan and content indexing resolves inert stand-ins. The crash the issue reported
(`GetRequiredService<IEmbeddingProvider>` inside the vector store's factory) was already root-caused
on main by gating the *consumer*, pinned by `ContentIndexingOffToolTest`. Making it required would be
wrong.

What was still wrong is that the decision was taken **in silence**: `TryAddEmbeddingProvider`
returned a bool one caller read, and nothing said which way it went — so "semantic search is off
here" and "semantic search is broken here" produced identical evidence, which is why #1642 had to be
triaged from a stack trace. The decision is now an `EmbeddingCapability` in DI plus exactly one
`Information` line at startup, **in both directions** (a line that appeared only when the capability
was on would be no better than the silence), naming the config key that would turn it on:

```
Semantic (vector) search DISABLED — no Embedding:Endpoint is configured. Free-text queries fall
back to an ILIKE substring scan and content indexing stays inert; this is a supported
configuration, not a fault.
```

🚨 It deliberately does **not** default to `NullEmbeddingProvider`. The *presence* of the
registration is the capability signal every consumer reads — both storage backends use
`GetService<IEmbeddingProvider>()`, and the content-indexing module's resolve-time `enabledWhen` gate
asks the same question. A Null default answers *yes* on a host that has none, and would light the
indexing pipeline up against an embedder that can never embed — #1642 from the other direction.

`EmbeddingCapability.IsEnabled` is taken from whether a provider was *actually* created, never
re-derived from the options: a second copy of `CreateEmbeddingProvider`'s branch logic could drift
and then advertise a capability the host does not have.

### …and a second, independent defect found while doing it

`PostgreSqlExtensions.cs:161` and `:206` and `SnowflakeExtensions.cs:138` each called
**`services.BuildServiceProvider()` mid-registration** to read the optional `IEmbeddingProvider`.
That builds a *second, throwaway* container: anything registered after that line is invisible to it,
and any singleton it does resolve is a **duplicate** of the one every other consumer gets. So whether
those adapters had embeddings came down to whether the host called `AddEmbeddings` before or after —
and both failure modes are invisible, presenting as the same silent degrade to lexical search. Fixed
by building the adapters from the real container through a new
`AddPersistence(Func<IServiceProvider, IStorageAdapter>)` overload (the decorator chain resolves the
last `IStorageAdapter` registration whether it is an instance or a factory).

Those three lanes currently have **no callers** (the portals use
`AddPartitionedPostgreSqlPersistence`), so the defect was latent — but it would have quietly defeated
the fix above the moment one was used. No `services.BuildServiceProvider()` remains on any
registration path in `src/` or `memex/`.

---

## Verification

**The content tests are red before the fix, by measurement.** Reverse-applied `ContentFileResolver.cs`
alone, rebuilt, re-ran: **5 failed / 0 passed**, each on `Settings` being null —

```
Expected value not to be <null> because Settings carries AssemblyName + ResourcePrefix for an
EmbeddedResource collection — dropping it on the wire is issues #2122/#2123.
```

— then restored the fix: **5 passed**.

| Test | Pins |
|---|---|
| `DocAssetWireProjectionTest` (5) | a real shipped SVG served end-to-end after the config crosses the wire, for three doc nodes at different depths, incl. `image/svg+xml` and `<svg` in the bytes; every config property survives the projection; `Doc/AI`'s collection opens |
| `EaConsentControllerActivationTest` (3) | the seam is registered with mail off; no controller dependency varies with a flag; the sweep is non-vacuous |
| `EmbeddingCapabilityTests` (9) | off / on / keyless-cloud decisions, the reported state always matches what was actually registered, and the startup line is emitted exactly once, in both directions |

`-c Release -warnaserror`, `0 Error(s) / 0 Warning(s)` on each of `MeshWeaver.ContentCollections`,
`MeshWeaver.Hosting`, `MeshWeaver.Hosting.Embeddings`, `MeshWeaver.Hosting.PostgreSql`,
`MeshWeaver.Hosting.Snowflake`, `Memex.Portal.Shared`, and all three touched test projects.

`DocumentationLinkIntegrityTest` re-run green after the `VectorSearch.md` edit, with
`MeshWeaver.Documentation.dll` rebuilt first and its mtime checked against the file's — it ships
`Data/**` as `EmbeddedResource`, so `--no-build` would have tested the old copy.

---

## 🚨 Not fixed here, and deliberately so

One of the two paths #2122 names, `Doc/AI/images/agenticai.svg`, has a **second, independent
defect** this PR does not touch: the asset ships at `Content/images/agenticai.svg` (the partition
root) while six `Doc/AI/*` pages declare `Thumbnail: "images/agenticai.svg"`, which resolves against
their own folder node. It is not confined to that file — `images/DataMesh.svg` and
`images/notifications.svg` are declared as thumbnails and ship nowhere either. That is a doc-content
question, not a registration one, and it wants its own change.

After this PR that path answers a plain "file not found" instead of a 500 — the honest answer for an
asset that genuinely is not there. `DocAiCollection_OpensWithACompleteConfig` pins exactly that much
and says so in its doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
