### PR TITLE
A member that never JOINED is not Alive (#2076), and Build stops constructing hubs (#1868)

### DIFF
--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -127,12 +127,73 @@ internal static class ThreadExecution
                 MeshWeaver.AI.Delegation.DelegationHandlers.HandleHeartbeatTick)
             .WithHandler<MeshWeaver.AI.Delegation.CancelDelegationSubThread>(
                 MeshWeaver.AI.Delegation.DelegationHandlers.HandleCancelDelegationSubThread)
-            .WithInitialization(SetThreadHubIdentity)
-            .WithInitialization(InitializeThreadLifecycle)
-            .WithInitialization(InstallCancellationWatcher)
-            .WithInitialization(InstallExecutionHub)
-            .WithInitialization(InstallSubmissionWatcher)
-            .WithInitialization(InstallHeartbeatTicker);
+            // 🚨 The OBSERVABLE overload throughout, deliberately (#1868). Every one of these six
+            // reaches hub construction on the SYNCHRONOUS overload, which runs inside
+            // MessageHubConfiguration.Build, before StartMessageProcessing:
+            // InstallExecutionHub calls GetHostedHub(…/_Exec, HostedHubCreation.Always) outright,
+            // and SetThreadHubIdentity / InitializeThreadLifecycle / InstallCancellationWatcher each
+            // resolve workspace.GetMeshNodeStream(), whose SynchronizationStream ctor ALWAYS calls
+            // GetHostedHub(sync/{clientId}, Always). So every thread hub in the product built four
+            // child hubs — and four more Autofac containers — from inside its own Build, and a
+            // disposal racing the thread hub's creation raced a TREE of constructions rather than
+            // one frame: the shape behind the whole shutdown-race family (#645/#715/#967/#1573).
+            // Threads are the hottest per-node hub in the product, so this was the biggest remaining
+            // source of that nesting.
+            //
+            // ALL SIX move together, keeping the registration ORDER intact — BuildupActions are
+            // Concat-ed on the InitializeHubRequest turn, so the owner identity is still stamped
+            // first, _Exec still exists before the submission watcher can claim a round (the
+            // eager-creation requirement documented on InstallExecutionHub), and the heartbeat
+            // ticker still comes last. The init turn runs after Build has returned and still BEFORE
+            // the Initialize gate opens, so no message can overtake them and nothing observable to
+            // a message changes. It also runs after the workspace's own data sources have been
+            // started (DataExtensions.StartDataSourcesAndOpenGate, moved by #2045), which is
+            // strictly better than subscribing a stream on a workspace that has not started its
+            // sources yet. Same shape #774 applied to MeshDataSource.SubscribeToOwnDeletion.
+            .WithInitialization(SetThreadHubIdentityInit)
+            .WithInitialization(InitializeThreadLifecycleInit)
+            .WithInitialization(InstallCancellationWatcherInit)
+            .WithInitialization(InstallExecutionHubInit)
+            .WithInitialization(InstallSubmissionWatcherInit)
+            .WithInitialization(InstallHeartbeatTickerInit);
+
+    /// <summary>Init-turn wrapper for <see cref="SetThreadHubIdentity"/> — see the registration (#1868).</summary>
+    /// <param name="hub">The thread hub being initialized.</param>
+    /// <returns>An observable that completes once the owner observation is established.</returns>
+    private static IObservable<System.Reactive.Unit> SetThreadHubIdentityInit(IMessageHub hub) =>
+        Observable.Defer(() => { SetThreadHubIdentity(hub); return Observable.Return(System.Reactive.Unit.Default); });
+
+    /// <summary>Init-turn wrapper for <see cref="InitializeThreadLifecycle"/> — see the registration (#1868).</summary>
+    /// <param name="hub">The thread hub being initialized.</param>
+    /// <returns>An observable that completes once the lifecycle observation is established.</returns>
+    private static IObservable<System.Reactive.Unit> InitializeThreadLifecycleInit(IMessageHub hub) =>
+        Observable.Defer(() => { InitializeThreadLifecycle(hub); return Observable.Return(System.Reactive.Unit.Default); });
+
+    /// <summary>Init-turn wrapper for <see cref="InstallCancellationWatcher"/> — see the registration (#1868).</summary>
+    /// <param name="hub">The thread hub being initialized.</param>
+    /// <returns>An observable that completes once the cancellation watcher is installed.</returns>
+    private static IObservable<System.Reactive.Unit> InstallCancellationWatcherInit(IMessageHub hub) =>
+        Observable.Defer(() => { InstallCancellationWatcher(hub); return Observable.Return(System.Reactive.Unit.Default); });
+
+    /// <summary>Init-turn wrapper for <see cref="InstallExecutionHub"/> — see the registration (#1868).</summary>
+    /// <param name="hub">The thread hub being initialized.</param>
+    /// <returns>An observable that completes once the <c>_Exec</c> hub exists.</returns>
+    private static IObservable<System.Reactive.Unit> InstallExecutionHubInit(IMessageHub hub) =>
+        // Defer so the work happens at SUBSCRIBE time (the init turn), not when the observable is
+        // constructed — HandleInitialize builds the whole Concat chain up front.
+        Observable.Defer(() => { InstallExecutionHub(hub); return Observable.Return(System.Reactive.Unit.Default); });
+
+    /// <summary>Init-turn wrapper for <see cref="InstallSubmissionWatcher"/> — see the registration (#1868).</summary>
+    /// <param name="hub">The thread hub being initialized.</param>
+    /// <returns>An observable that completes once the watcher is installed.</returns>
+    private static IObservable<System.Reactive.Unit> InstallSubmissionWatcherInit(IMessageHub hub) =>
+        Observable.Defer(() => { InstallSubmissionWatcher(hub); return Observable.Return(System.Reactive.Unit.Default); });
+
+    /// <summary>Init-turn wrapper for <see cref="InstallHeartbeatTicker"/> — see the registration (#1868).</summary>
+    /// <param name="hub">The thread hub being initialized.</param>
+    /// <returns>An observable that completes once the ticker is installed.</returns>
+    private static IObservable<System.Reactive.Unit> InstallHeartbeatTickerInit(IMessageHub hub) =>
+        Observable.Defer(() => { InstallHeartbeatTicker(hub); return Observable.Return(System.Reactive.Unit.Default); });
 
     /// <summary>
     /// Eagerly creates the <c>_Exec</c> hosted hub at thread hub init time and

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
@@ -191,6 +191,26 @@ snapshot and resolves to `Gone`. One that is missing entirely usually means our 
 hydrated yet — and reading that as death on a freshly-started silo would evict a live builder, which
 is the one failure this rule exists to make impossible.
 
+🚨 **…and the mirror image: PRESENCE in the snapshot is not `Alive` either (#2076).** `Alive` is read
+above as *permission-denied-forever* — it is the one verdict that skips the clock entirely — so it
+must mean "the cluster positively recorded this member as RUNNING", not "a row exists for it". Only
+`Active`, `ShuttingDown` and `Stopping` qualify. A silo still `Created`/`Joining` is `Unknown`,
+because **Orleans only probes ACTIVE silos**: a process that dies before finishing its join leaves a
+row no failure detector will ever move to `Dead`. Mapping those to `Alive` made the `ClaimStaleAfter`
+fallback structurally unreachable for exactly the case it exists to cover, and on 2026-08-22 a pod
+deleted MID-BOOT held the claim on memex-cloud while every other pod sat in `FollowGo` for 25+
+minutes — with `PreWarm:GateReadiness=true` that holds the whole rollout. Note this is NOT an
+immediate steal: `Unknown` hands the decision to the heartbeat clock, so a holder that really is
+mid-join and working keeps its claim through the beat it writes.
+
+🚨 **The holder's heartbeat starts with the build, not after its planning phase.** `BakeAsMaster`
+wraps the WHOLE master path in `Observable.Using(StartHeartbeat, …)`, chunk opening included.
+`OpenChunk` waits up to `GrantWindow` per chunk for its own grant, so with dozens of chunks the root
+claim could otherwise go minutes without a beat — and `Observable.Interval` does not fire until one
+full `HeartbeatInterval` after subscribe. Across clusters the holder is `Unknown` **by construction**
+(see above), so the peer's arbiter judges it on `ClaimStaleAfter` alone: a builder working perfectly
+well could age past that budget before its first beat and license a second builder.
+
 The heartbeat needs no defending here: it is a field on the Build node written through
 `stream.Update`, so it is durable mesh state rather than a file's last-write metadata. The
 predecessor lease kept its instant in an SMB timestamp, where Azure Files' metadata caching could

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-rollouts-no-longer-wait-on-a-pod-that-never-started.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-rollouts-no-longer-wait-on-a-pod-that-never-started.md
@@ -1,0 +1,24 @@
+---
+Name: Rollouts no longer wait on a pod that never started
+Category: Fix
+Description: Fixes a rollout that could stall for tens of minutes when a server was deleted while still booting — the other servers now take over its startup compilation instead of waiting for it forever.
+Icon: Sparkle
+Order: -20260825
+---
+
+# Rollouts no longer wait on a pod that never started
+
+When a server is deleted while it is still starting up, the cluster keeps a record of it that no
+health check ever revisits — nothing is watching a member that never finished joining. Startup
+compilation reads that record to decide whether the server currently responsible for the build is
+still working, and it read "still starting" as "still running". So if the responsible server
+disappeared mid-boot, every other server waited for a build that would never happen: a rollout could
+sit for 25 minutes or more, with no error anywhere to explain it.
+
+This is fixed. A member that never finished joining is now treated as "no information" rather than
+"running", which hands the decision back to the liveness stamp the build already writes — so the
+work is picked up by the next server as soon as that stamp goes stale, and the rollout completes.
+A server that is genuinely mid-start and working keeps its build, exactly as before.
+
+The same change also starts the liveness stamp earlier, at the beginning of the build rather than
+after its planning phase, so a long build can no longer look abandoned while it is running.

--- a/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
@@ -143,8 +143,33 @@ public static class BuildNodeType
             .AddMeshDataSource(source => source
                 .WithContentType<BuildState>())
             .AddDefaultLayoutAreas()
-            .WithInitialization(hub => hub.RegisterForDisposal(InstallClaimArbiter(hub)))
+            // 🚨 The OBSERVABLE overload, deliberately (#1868). InstallClaimArbiter resolves the
+            // hub's own node stream (workspace.GetMeshNodeStream() → SynchronizationStream..ctor →
+            // GetHostedHub(sync/{clientId}, HostedHubCreation.Always)), so on the SYNCHRONOUS
+            // overload it constructed a hub — and a second container — from inside
+            // MessageHubConfiguration.Build, before StartMessageProcessing and before the
+            // workspace's own data sources had been started on the init turn. The observable
+            // overload runs on the InitializeHubRequest turn, after Build returns and still before
+            // the Initialize gate opens, so the arbiter's triggers are wired against a workspace
+            // that is actually running.
+            .WithInitialization(StartClaimArbiter)
     };
+
+    /// <summary>
+    /// Installs the claim arbiter on the hub's INIT TURN and couples it to the hub's lifetime.
+    /// A static method group, so <c>WithInitialization</c>'s delegate-identity idempotency still
+    /// collapses repeat registrations from composed configurators.
+    /// </summary>
+    /// <param name="hub">The Build node's own hub.</param>
+    /// <returns>An observable that completes once the arbiter is installed.</returns>
+    private static IObservable<Unit> StartClaimArbiter(IMessageHub hub) =>
+        // Defer so the work happens at SUBSCRIBE time (the init turn), not when the observable is
+        // constructed — HandleInitialize builds the whole Concat chain up front.
+        Observable.Defer(() =>
+        {
+            hub.RegisterForDisposal(InstallClaimArbiter(hub));
+            return Observable.Return(Unit.Default);
+        });
 
     /// <summary>
     /// The claim arbiter — runs on each Build node's OWN hub.

--- a/src/MeshWeaver.Hosting.Orleans/OrleansClusterMembership.cs
+++ b/src/MeshWeaver.Hosting.Orleans/OrleansClusterMembership.cs
@@ -21,6 +21,10 @@ namespace MeshWeaver.Hosting.Orleans;
 /// or — the case that matters — our snapshot is not hydrated yet, and reading that as "gone" on a
 /// freshly-started silo would license taking over from a peer that is perfectly alive. Unknown falls
 /// back to whatever the caller's fallback is, which is always the safe direction.</para>
+///
+/// <para>🚨 <b>…and the mirror-image rule: a row that is merely PRESENT is not
+/// <see cref="ClusterMemberState.Alive"/> either</b> — see <see cref="Classify"/> for why
+/// <see cref="SiloStatus.Created"/> / <see cref="SiloStatus.Joining"/> report Unknown (#2076).</para>
 /// </summary>
 public sealed class OrleansClusterMembership(
     IClusterMembershipService membership,
@@ -65,15 +69,45 @@ public sealed class OrleansClusterMembership(
             return ClusterMemberState.Unknown;
         }
 
-        return status switch
-        {
-            // Still executing — including while it drains. Anything it holds, it still holds.
-            SiloStatus.Created or SiloStatus.Joining or SiloStatus.Active
-                or SiloStatus.ShuttingDown or SiloStatus.Stopping => ClusterMemberState.Alive,
-            // The ONE positive departure verdict.
-            SiloStatus.Dead => ClusterMemberState.Gone,
-            // SiloStatus.None — not in this snapshot. See the class remarks: absence is not death.
-            _ => ClusterMemberState.Unknown
-        };
+        return Classify(status);
     }
+
+    /// <summary>
+    /// The <see cref="SiloStatus"/> → <see cref="ClusterMemberState"/> mapping, pure so the rule can
+    /// be pinned without standing up a cluster.
+    ///
+    /// <para>🚨 <b><see cref="SiloStatus.Created"/> and <see cref="SiloStatus.Joining"/> are NOT
+    /// <see cref="ClusterMemberState.Alive"/></b> (#2076). <c>Alive</c> is not "a row exists" — it is
+    /// a POSITIVE verdict that the member is running, and its consumers treat it as
+    /// permission-denied-forever: <c>BuildNodeType.HolderStillHoldsIt</c> reads Alive as <i>"never
+    /// take over, however old the heartbeat looks"</i>, deliberately skipping the
+    /// <c>ClaimStaleAfter</c> clock. Orleans only probes ACTIVE silos, so a process that died before
+    /// finishing its join leaves a <c>Created</c>/<c>Joining</c> row that no failure detector will
+    /// ever move to <c>Dead</c>. Mapping those to Alive therefore made the clock fallback
+    /// STRUCTURALLY UNREACHABLE for the one case it exists to cover — and that is exactly what
+    /// happened on memex-cloud (2026-08-22): a pod deleted MID-BOOT held the build claim, every
+    /// other pod sat in <c>FollowGo</c> for 25+ minutes, and with <c>PreWarm:GateReadiness=true</c>
+    /// that held the whole rollout.</para>
+    ///
+    /// <para>Reporting them as <see cref="ClusterMemberState.Unknown"/> is the honest answer — the
+    /// cluster genuinely has no opinion about a member that never joined — and it hands the decision
+    /// to the caller's fallback rather than to a takeover. It does NOT license an immediate steal: a
+    /// holder that IS mid-join and working keeps its claim through the heartbeat it writes, and only
+    /// a holder that has been silent for the full staleness budget is displaced. The states that
+    /// mean "this process reached Active and is still executing" — including while it drains — stay
+    /// Alive, which is what the original rule was actually reaching for.</para>
+    /// </summary>
+    /// <param name="status">The membership status read from the snapshot.</param>
+    /// <returns>What this cluster knows about that member.</returns>
+    internal static ClusterMemberState Classify(SiloStatus status) => status switch
+    {
+        // Reached Active and still executing — including while it drains. Anything it holds, it
+        // still holds, and Orleans' failure detector is watching it.
+        SiloStatus.Active or SiloStatus.ShuttingDown or SiloStatus.Stopping => ClusterMemberState.Alive,
+        // The ONE positive departure verdict.
+        SiloStatus.Dead => ClusterMemberState.Gone,
+        // SiloStatus.Created / Joining — never became a probed member, so nothing will ever move it
+        // to Dead (see above). SiloStatus.None — not in this snapshot; absence is not death.
+        _ => ClusterMemberState.Unknown
+    };
 }

--- a/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
+++ b/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
@@ -161,21 +161,32 @@ public static class BuildProtocolDriver
                 _ => { },
                 ex => logger?.LogWarning(ex, "BuildProtocol: heartbeat failed for {Holder}", holder));
 
-        return mesh
-            // Record the plan on the root, then materialize + claim + open an activity per chunk.
-            .UpdateBuildAsHolder(holder, s => s with
-            {
-                Status = BuildStatus.Building,
-                Chunks = chunks.Keys.OrderBy(k => k, StringComparer.Ordinal).ToImmutableList(),
-            })
-            .SelectMany(_ => chunks
-                .OrderBy(c => c.Key, StringComparer.Ordinal)
-                .Select(c => OpenChunk(mesh, holder, fingerprint, c.Key, c.Value, logger))
-                .Concat())
-            .ToList()
-            .SelectMany(openedChunks => Observable.Using(
-                StartHeartbeat,
-                _ => bake()
+        // 🚨 The heartbeat covers the WHOLE master path, chunk opening included (#2076). It used to
+        // start only after `.ToList()` — i.e. after every chunk had been materialised, claimed and
+        // given an activity — and `OpenChunk` waits up to `GrantWindow` for each chunk's own grant.
+        // With 37 chunks that is minutes of silence on a claim whose only liveness stamp is the
+        // grant instant, and `Observable.Interval` does not beat until one full
+        // `HeartbeatInterval` after it is subscribed. Across clusters the holder's identity is
+        // Unknown BY CONSTRUCTION (Orleans membership is per-cluster), so the peer's arbiter judges
+        // it on `ClaimStaleAfter` alone — and a builder that is working perfectly well can age past
+        // that budget before its first beat, licensing a second builder. Starting the beat first
+        // makes the stamp track the work rather than trail it; the Using still disposes it with the
+        // sweep, so a released claim stops beating exactly as before.
+        return Observable.Using(
+            StartHeartbeat,
+            _ => mesh
+                // Record the plan on the root, then materialize + claim + open an activity per chunk.
+                .UpdateBuildAsHolder(holder, s => s with
+                {
+                    Status = BuildStatus.Building,
+                    Chunks = chunks.Keys.OrderBy(k => k, StringComparer.Ordinal).ToImmutableList(),
+                })
+                .SelectMany(_ => chunks
+                    .OrderBy(c => c.Key, StringComparer.Ordinal)
+                    .Select(c => OpenChunk(mesh, holder, fingerprint, c.Key, c.Value, logger))
+                    .Concat())
+                .ToList()
+                .SelectMany(openedChunks => bake()
                     .Do(outcomes.Add)
                     .Concat(Observable.Defer(() =>
                         CloseOut(mesh, holder, fingerprint, chunks, openedChunks.ToList(), outcomes, logger)

--- a/src/MeshWeaver.Mesh.Contract/Services/IClusterMembership.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IClusterMembership.cs
@@ -4,8 +4,17 @@ namespace MeshWeaver.Mesh.Services;
 public enum ClusterMemberState
 {
     /// <summary>
-    /// The member is running — joining, active, or shutting down. Deliberately includes the
-    /// shutting-down states: that process is still executing, so anything it holds is still held.
+    /// The cluster has POSITIVELY recorded this member as running — it became a full member and is
+    /// still executing. Deliberately includes the shutting-down states: that process is still
+    /// executing, so anything it holds is still held.
+    ///
+    /// <para>🚨 <b>Not "a row exists for it".</b> Consumers read Alive as permission-denied-forever
+    /// — <c>BuildNodeType.HolderStillHoldsIt</c> takes it to mean <i>"never take over, however old
+    /// the heartbeat looks"</i> and skips the staleness clock entirely. So a member that has NOT yet
+    /// become a full member (an Orleans silo still <c>Created</c>/<c>Joining</c>) must report
+    /// <see cref="Unknown"/>, not Alive: nothing probes such a member, so nothing will ever move it
+    /// to <see cref="Gone"/>, and calling it Alive makes every clock fallback unreachable for a
+    /// process that died mid-boot (#2076).</para>
     /// </summary>
     Alive,
 

--- a/test/MeshWeaver.AI.Test/ThreadHubBuildsNoHubTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadHubBuildsNoHubTest.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.ShortGuid;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// 🚨 <b>#1868 — <c>Build</c> must not construct another hub.</b> This is the AI half of the
+/// adoption, and the last framework site that still violated it.
+///
+/// <para><b>The fact.</b> <c>MessageHubConfiguration.Build</c> runs <c>SyncBuildupActions</c> inline,
+/// before <c>StartMessageProcessing()</c>. <c>ThreadExecution.AddThreadExecution</c> registered
+/// <c>InstallExecutionHub</c> — which calls <c>GetHostedHub(…/_Exec,
+/// HostedHubCreation.Always)</c> — on the SYNCHRONOUS overload, so EVERY thread hub in the product
+/// built a child hub, and a second Autofac container, from inside its own <c>Build</c>. #2045
+/// adopted the workspace and kernel sites (<c>DataExtensions</c>, <c>KernelContainer</c>) and its
+/// pin, <c>MeshWeaver.Data.Test.BuildMustNotConstructHubsTest</c>, covers a data-enabled hub — it
+/// cannot see this one, which needs the AI stack.</para>
+///
+/// <para><b>Why it matters</b> — and explicitly NOT as a crash claim, which #1867 withdrew: <i>a
+/// disposal that races a construction races a TREE of constructions, not one frame.</i> That is the
+/// shape behind the whole shutdown-race family (#645, #715, #967, #1573), each of which had to widen
+/// its guard to cover work started by a construction that had itself been started by a construction.
+/// <c>HostedHubsCollection</c>'s in-flight counter tracks the OUTER creation; the inner one it spawns
+/// is a second entry, on the same thread, whose refusal/finish semantics are only correct because the
+/// guards were extended by hand, one incident at a time. Threads are the hottest per-node hub in the
+/// product, so this site was paying that tax on every round.</para>
+///
+/// <para><b>What the fix does NOT change.</b> <c>_Exec</c> is still created EAGERLY, and still before
+/// the submission watcher — it just happens on the <c>InitializeHubRequest</c> turn instead of inside
+/// <c>Build</c>. <c>BuildupActions</c> are <c>Concat</c>-ed in registration order and the Initialize
+/// gate opens only after they complete, so no message can overtake them; the eager-creation
+/// requirement documented on <c>InstallExecutionHub</c> ("if _Exec isn't running yet, the
+/// StartingExecution emission has no subscriber and the round stalls") still holds. The rest of the
+/// class's thread tests are what prove that end to end.</para>
+/// </summary>
+public class ThreadHubBuildsNoHubTest(ITestOutputHelper output) : AITestBase(output)
+{
+    /// <summary>
+    /// Activating a thread hub must construct no hub of its own.
+    ///
+    /// <para><b>Non-vacuity is asserted, not assumed.</b> The test first requires that the thread hub
+    /// really did come up AND that its <c>_Exec</c> child really was created — otherwise "constructed
+    /// nothing during Build" would also be satisfied by a hub that constructed nothing at all. On
+    /// <c>origin/main</c> that same <c>_Exec</c> address is what the violation list names, and this
+    /// fails with it in the message.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ActivatingAThreadHub_BuildsNoHubOfItsOwn()
+    {
+        var threadId = Guid.NewGuid().AsString();
+        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
+        {
+            Name = $"Nesting probe {threadId}",
+            NodeType = ThreadNodeType.NodeType,
+            MainNode = MonolithMeshTestBase.TestPartition,
+            Content = new Thread { CreatedBy = "rbuergi@systemorph.com" }
+        }).Should().Emit();
+
+        // Reading the node through its stream is what routes a message to the per-node hub and so
+        // activates it — the same path the GUI takes.
+        (await ReadNode(threadPath).Should().Emit()).Should().NotBeNull();
+
+        var hubs = Walk(Mesh).ToArray();
+        foreach (var h in hubs.Where(h => h.Address.ToString().StartsWith(threadPath, StringComparison.Ordinal)))
+            Output.WriteLine($"hub: {h.Address}");
+
+        var threadHub = hubs.SingleOrDefault(h =>
+            string.Equals(h.Address.ToString(), threadPath, StringComparison.Ordinal));
+        threadHub.Should().NotBeNull(
+            $"the thread hub {threadPath} must have been activated, or this test proves nothing");
+
+        hubs.Select(h => h.Address.ToString())
+            .Should().Contain($"{threadPath}/_Exec",
+                "InstallExecutionHub must still create _Exec EAGERLY — moving it to the observable "
+                + "WithInitialization overload changes WHEN, never WHETHER");
+
+        var violations = hubs
+            .Where(h => h.Address.ToString().StartsWith(threadPath, StringComparison.Ordinal))
+            .OfType<MessageHub>()
+            .SelectMany(h => h.HubsConstructedDuringBuild.Select(a => $"{h.Address} → {a}"))
+            .ToArray();
+
+        violations.Should().BeEmpty(
+            "a SyncBuildupAction reached hub construction: Build runs those inline, before "
+            + "StartMessageProcessing, so a disposal racing this hub's creation races a TREE of "
+            + "constructions rather than one frame (#1868). The initialization belongs on the "
+            + "OBSERVABLE WithInitialization overload, which runs on InitializeHubRequest after "
+            + "Build has returned. Constructed during Build: " + string.Join(", ", violations));
+    }
+
+    /// <summary>
+    /// Every hub in the hosted-hub tree rooted at <paramref name="root"/>, deduplicated by
+    /// collection identity — a hub that shares its parent's collection must not be walked twice
+    /// (the double-count trap <c>ProbeHubCostTest.HubCreationCounter</c> documents).
+    /// </summary>
+    private static IEnumerable<IMessageHub> Walk(IMessageHub root)
+    {
+        var seen = new HashSet<HostedHubsCollection>();
+        var stack = new Stack<IMessageHub>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var hub = stack.Pop();
+            yield return hub;
+            var collection = hub.ServiceProvider.GetService<HostedHubsCollection>();
+            if (collection is null || !seen.Add(collection))
+                continue;
+            foreach (var child in collection.Hubs.ToArray())
+                stack.Push(child);
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/BuildNodeHubBuildsNoHubTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/BuildNodeHubBuildsNoHubTest.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 <b>#1868 — <c>Build</c> must not construct another hub</b>, for the Build node's own hub.
+///
+/// <para><c>BuildNodeType.CreateMeshNode</c> registered <c>InstallClaimArbiter</c> on the
+/// SYNCHRONOUS <c>WithInitialization</c> overload. That runs inside
+/// <c>MessageHubConfiguration.Build</c>, before <c>StartMessageProcessing()</c> — and the arbiter
+/// resolves the hub's own node stream (<c>workspace.GetMeshNodeStream()</c> →
+/// <c>SynchronizationStream..ctor</c> → <c>GetHostedHub(sync/{clientId},
+/// HostedHubCreation.Always)</c>), so the Build node built a child hub, and a second Autofac
+/// container, from inside its own construction.</para>
+///
+/// <para>Two things are wrong with that, and only the first is #1868's general one. <b>(a)</b> A
+/// disposal racing this hub's creation races a TREE of constructions rather than one frame — the
+/// shape behind the whole shutdown-race family (#645/#715/#967/#1573). <b>(b)</b> Specific to this
+/// site: the arbiter's triggers were wired against a workspace whose data sources had not been
+/// started yet, because <c>DataExtensions</c> moved exactly that work
+/// (<c>StartDataSourcesAndOpenGate</c>) onto the init turn in #2045. The arbiter is what re-grants a
+/// claim whose holder has gone away — the recovery #2076 needed and never got — so wiring it
+/// against a half-built workspace is not a tidiness question.</para>
+///
+/// <para>The observable overload runs on the <c>InitializeHubRequest</c> turn, after <c>Build</c>
+/// has returned and still before the Initialize gate opens, so nothing observable to a message
+/// changes; <c>BuildCoordinationTest</c> is what proves the arbiter still arbitrates.</para>
+/// </summary>
+public class BuildNodeHubBuildsNoHubTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// Activating the Build root's hub must construct no hub of its own.
+    ///
+    /// <para><b>Non-vacuity.</b> The test asserts first that the Build hub is up AND that it opened a
+    /// <c>sync/</c> stream — without that there would be nothing that COULD have nested. On
+    /// <c>origin/main</c> that same <c>sync/</c> address is what the violation list names.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ActivatingTheBuildNodeHub_BuildsNoHubOfItsOwn()
+    {
+        // Materialise the root, then READ it through its own node stream — the read is what routes
+        // a message to the per-node hub and therefore activates it (the same path the GUI takes;
+        // the create alone goes through the mesh router and activates nothing).
+        (await Mesh.EnsureBuildNode().Take(1).Timeout(TimeSpan.FromSeconds(30)).ToTask())
+            .Should().NotBeNull();
+        (await ReadNode(BuildNodeType.RootPath).Should().Emit()).Should().NotBeNull();
+
+        var hubs = Walk(Mesh).ToArray();
+        var buildHub = hubs.SingleOrDefault(h =>
+            string.Equals(h.Address.ToString(), BuildNodeType.RootPath, StringComparison.Ordinal));
+        buildHub.Should().NotBeNull(
+            $"the Build node's hub {BuildNodeType.RootPath} must have been activated, or this test "
+            + "proves nothing");
+
+        // 🚨 The subtree is walked from the hub, not filtered by address prefix: a sync sub-hub's
+        // address is a bare `sync/{clientId}`, so a prefix filter would silently miss the very
+        // hub whose creation this test is about.
+        var subtree = Walk(buildHub!).ToArray();
+        foreach (var h in subtree)
+            Output.WriteLine($"hub: {h.Address}");
+
+        subtree.Select(h => h.Address.ToString())
+            .Should().Contain(a => a.StartsWith("sync/", StringComparison.Ordinal),
+                "the arbiter must still open the hub's own node stream (which always creates a "
+                + "sync/{clientId} sub-hub) — moving it to the observable WithInitialization "
+                + "overload changes WHEN, never WHETHER");
+
+        var violations = subtree
+            .OfType<MessageHub>()
+            .SelectMany(h => h.HubsConstructedDuringBuild.Select(a => $"{h.Address} → {a}"))
+            .ToArray();
+
+        violations.Should().BeEmpty(
+            "a SyncBuildupAction reached hub construction: Build runs those inline, before "
+            + "StartMessageProcessing, so a disposal racing this hub's creation races a TREE of "
+            + "constructions rather than one frame (#1868) — and here it also wired the claim "
+            + "arbiter against a workspace whose data sources had not been started yet. Constructed "
+            + "during Build: " + string.Join(", ", violations));
+    }
+
+    /// <summary>
+    /// Every hub in the hosted-hub tree rooted at <paramref name="root"/>, deduplicated by
+    /// collection identity — a hub that shares its parent's collection must not be walked twice
+    /// (the double-count trap <c>ProbeHubCostTest.HubCreationCounter</c> documents).
+    /// </summary>
+    private static IEnumerable<IMessageHub> Walk(IMessageHub root)
+    {
+        var seen = new HashSet<HostedHubsCollection>();
+        var stack = new Stack<IMessageHub>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var hub = stack.Pop();
+            yield return hub;
+            var collection = hub.ServiceProvider.GetService<HostedHubsCollection>();
+            if (collection is null || !seen.Add(collection))
+                continue;
+            foreach (var child in collection.Hubs.ToArray())
+                stack.Push(child);
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/NeverActiveHolderIsNotAliveTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/NeverActiveHolderIsNotAliveTest.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Immutable;
+using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Orleans.Runtime;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 <b>#2076 — a follower waited forever on a claim whose holder was gone.</b>
+///
+/// <para><b>What happened</b> (memex-cloud, 2026-08-22, reproduced twice). A portal pod resolved its
+/// identity, logged <i>"BuildProtocol: claim held elsewhere — … follows the build"</i> and never
+/// proceeded. A cluster-wide scan over both namespaces and every pod found NO pod holding the grant
+/// and none publishing GO: the durable claim's holder was a pod that had been <b>deleted
+/// mid-boot</b>. The follower sat in <c>FollowGo</c> for 25+ minutes and, with
+/// <c>PreWarm:GateReadiness=true</c>, held its readiness — and therefore the whole rollout.</para>
+///
+/// <para><b>Why the existing recovery could not fire.</b> The protocol already has everything it
+/// needs: the claim arbiter re-runs on a periodic tick, and <c>BuildNodeType.HolderStillHoldsIt</c>
+/// ages a holder out after <see cref="BuildNodeType.ClaimStaleAfter"/> when membership has no
+/// opinion. But that clock is consulted <i>only</i> for <see cref="ClusterMemberState.Unknown"/> —
+/// an <see cref="ClusterMemberState.Alive"/> verdict means <i>"never take over, however old the
+/// heartbeat looks"</i>, which is correct and deliberate (#1355: a stopped heartbeat on a running
+/// process means busy or starved, and evicting it puts two builders on one compile).
+/// <see cref="OrleansClusterMembership"/> mapped <see cref="SiloStatus.Created"/> and
+/// <see cref="SiloStatus.Joining"/> to Alive. Orleans only probes ACTIVE silos, so a process that
+/// died before finishing its join leaves a Created/Joining row that no failure detector will ever
+/// move to <see cref="SiloStatus.Dead"/> — the holder reads Alive forever, and the clock fallback is
+/// STRUCTURALLY UNREACHABLE for precisely the case it exists to cover.</para>
+///
+/// <para><b>The fix is a classification, not a bound.</b> No timer is added, no budget widened, no
+/// retry introduced — <c>Alive</c> is narrowed back to what its contract says: a member the cluster
+/// has POSITIVELY recorded as running. A member that never became one is <c>Unknown</c>, which hands
+/// the decision to the heartbeat clock that was there all along. That is observing the holder's
+/// silence, not guessing at it: a holder that is genuinely mid-join and working keeps its claim
+/// through the heartbeat it writes, and only one silent for the full staleness budget is displaced.</para>
+/// </summary>
+public class NeverActiveHolderIsNotAliveTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+    private static readonly DateTime T0 = new(2026, 8, 22, 13, 20, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// The mapping itself. <see cref="SiloStatus.Created"/>/<see cref="SiloStatus.Joining"/> are the
+    /// two that changed; the rest are pinned so the narrowing cannot quietly grow.
+    /// </summary>
+    [Theory]
+    // The regression under test: a silo that never became a full member. Nothing probes it, so
+    // nothing will ever move it to Dead — calling it Alive is a verdict the cluster cannot support.
+    [InlineData(SiloStatus.Created, ClusterMemberState.Unknown)]
+    [InlineData(SiloStatus.Joining, ClusterMemberState.Unknown)]
+    // Reached Active and still executing — including while it drains. Anything it holds, it holds.
+    [InlineData(SiloStatus.Active, ClusterMemberState.Alive)]
+    [InlineData(SiloStatus.ShuttingDown, ClusterMemberState.Alive)]
+    [InlineData(SiloStatus.Stopping, ClusterMemberState.Alive)]
+    // The ONE positive departure verdict.
+    [InlineData(SiloStatus.Dead, ClusterMemberState.Gone)]
+    // Absence is not death (see the class remarks on OrleansClusterMembership).
+    [InlineData(SiloStatus.None, ClusterMemberState.Unknown)]
+    public void SiloStatus_MapsToTheStateItsConsumersCanActOn(
+        SiloStatus status, ClusterMemberState expected)
+        => OrleansClusterMembership.Classify(status).Should().Be(expected,
+            "Alive is read as permission-denied-forever by every takeover rule, so it must mean "
+            + "'the cluster positively recorded this member as running' — never merely 'a row "
+            + "exists for it' (#2076)");
+
+    /// <summary>
+    /// The consequence, expressed on the decision procedure the outage actually stalled: a build
+    /// claim held by a silo that never reached Active is handed to the waiting candidate once the
+    /// staleness budget has elapsed.
+    ///
+    /// <para><b>Non-vacuity.</b> On <c>origin/main</c> <c>Classify(Joining)</c> is <c>Alive</c>, so
+    /// <c>HolderStillHoldsIt</c> short-circuits before ever reading the clock and
+    /// <c>Arbitrate</c> returns the node unchanged — this assertion fails with
+    /// <c>ClaimedBy == "boot-casualty"</c>, which is the 25-minute hang in one line.</para>
+    /// </summary>
+    [Fact]
+    public void AClaimHeldByASiloThatNeverJoined_IsTakenOverOnceTheHeartbeatHasAgedOut()
+    {
+        var node = ClaimHeldBy("boot-casualty", "silo-deleted-mid-boot", T0);
+
+        var result = BuildNodeType.Arbitrate(
+                node, Options,
+                T0 + BuildNodeType.ClaimStaleAfter + TimeSpan.FromSeconds(1),
+                new StatusCluster("silo-live", ("silo-deleted-mid-boot", SiloStatus.Joining)))
+            .ContentAs<BuildState>(Options)!;
+
+        result.ClaimedBy.Should().Be("follower",
+            "a holder that never became a cluster member cannot defend its claim forever — nothing "
+            + "will ever probe it Dead, so the staleness clock has to govern it (#2076)");
+        result.FrameworkVersion.Should().Be("fp-next");
+    }
+
+    /// <summary>
+    /// The guard on the other side, so the narrowing above cannot be read as "aging out is now
+    /// allowed for anyone": a holder still mid-join whose heartbeat is FRESH keeps its claim. The
+    /// clock governs it — that is the whole point — and the clock says it is alive.
+    /// </summary>
+    [Fact]
+    public void AJoiningHolderWithAFreshHeartbeat_KeepsItsClaim()
+    {
+        var node = ClaimHeldBy("still-booting", "silo-joining", T0);
+
+        BuildNodeType.Arbitrate(
+                node, Options,
+                T0 + BuildNodeType.ClaimStaleAfter - TimeSpan.FromMinutes(1),
+                new StatusCluster("silo-live", ("silo-joining", SiloStatus.Joining)))
+            .Should().BeSameAs(node,
+                "Unknown means 'ask the clock', not 'take it' — a redundant arbitration pass over a "
+                + "claim whose heartbeat is still inside the budget must write nothing");
+    }
+
+    /// <summary>
+    /// An ACTIVE holder is still untouchable however ancient its heartbeat looks — #1355's rule,
+    /// re-pinned here because this change edits the very mapping that rule reads.
+    /// </summary>
+    [Fact]
+    public void AnActiveHolder_IsStillNeverTakenOver()
+    {
+        var node = ClaimHeldBy("slow-builder", "silo-active", T0);
+
+        BuildNodeType.Arbitrate(
+                node, Options,
+                T0 + BuildNodeType.ClaimStaleAfter + TimeSpan.FromHours(1),
+                new StatusCluster("silo-live", ("silo-active", SiloStatus.Active)))
+            .Should().BeSameAs(node,
+                "a stopped heartbeat on a process the cluster sees running means busy or starved, "
+                + "never dead — evicting it puts two builders on one compile (#1355)");
+    }
+
+    private static MeshNode ClaimHeldBy(string holder, string identity, DateTime beat) =>
+        new("Build", "Admin")
+        {
+            NodeType = BuildNodeType.NodeType,
+            Content = new BuildState
+            {
+                ClaimedBy = holder,
+                ClaimedByIdentity = identity,
+                ClaimedAt = beat,
+                HeartbeatAt = beat,
+                Status = BuildStatus.Building,
+                RequestedClaims = ImmutableDictionary<string, BuildClaimRequest>.Empty
+                    .Add("follower", new BuildClaimRequest("fp-next", beat.AddMinutes(1), "silo-live")),
+            }
+        };
+
+    /// <summary>
+    /// One pod's view of the cluster expressed in the SAME currency Orleans speaks — a
+    /// <see cref="SiloStatus"/> per identity, routed through the production classifier. Deliberately
+    /// not a hand-written Alive/Gone/Unknown double: the defect lived in the status→state mapping,
+    /// so a double that skipped it would assert nothing about the code that broke.
+    /// </summary>
+    private sealed class StatusCluster(string localIdentity, params (string Identity, SiloStatus Status)[] members)
+        : IClusterMembership
+    {
+        private readonly ImmutableDictionary<string, SiloStatus> members =
+            members.ToImmutableDictionary(m => m.Identity, m => m.Status);
+
+        public string LocalIdentity { get; } = localIdentity;
+
+        public ClusterMemberState StateOf(string identity) =>
+            identity == LocalIdentity
+                ? ClusterMemberState.Alive
+                : OrleansClusterMembership.Classify(
+                    members.TryGetValue(identity, out var status) ? status : SiloStatus.None);
+    }
+}


### PR DESCRIPTION
Fixes #2076. Fixes #1868.

Two defects in one family: **a participant commits to waiting on something that has already gone, and nothing can tell it.**

## #2076 — the follower waited forever on a claim whose holder was gone

`ClusterMemberState.Alive` is read by `BuildNodeType.HolderStillHoldsIt` as *"never take over, however old the heartbeat looks"* — the ONE verdict that skips the `ClaimStaleAfter` clock entirely, and correctly so (#1355: a stopped heartbeat on a *running* process means busy, not dead).

`OrleansClusterMembership` mapped `SiloStatus.Created` and `SiloStatus.Joining` to **Alive**. Orleans only probes ACTIVE silos, so a process deleted before it finishes joining leaves a `Created`/`Joining` row that **no failure detector will ever move to `Dead`**. The holder therefore reads Alive *forever*, and the clock fallback is **structurally unreachable for exactly the case it exists to cover**.

That is the 2026-08-22 memex-cloud incident verbatim: a pod deleted **mid-boot** held the build claim; a cluster-wide scan found no pod granted and none publishing GO; the followers sat in `FollowGo` for 25+ minutes; with `PreWarm:GateReadiness=true` that held the whole rollout.

**The fix is a classification, not a bound.** No timer added, no budget widened, no retry introduced. `Alive` is narrowed to what its own contract says — a member the cluster has POSITIVELY recorded as running (`Active`, `ShuttingDown`, `Stopping`). A member that never became one is `Unknown`, which hands the decision back to the heartbeat clock and the arbiter's existing periodic pass. That is *observing* the holder's silence rather than guessing at it: a holder that IS mid-join and working keeps its claim through the beat it writes, and only one silent for the full staleness budget is displaced.

**Also found on the same path:** `BakeAsMaster` started its heartbeat only *after* every chunk had been opened, and `OpenChunk` waits up to `GrantWindow` per chunk. With dozens of chunks a working builder could go minutes without a beat before `Observable.Interval`'s first tick — and across clusters the holder is `Unknown` **by construction**, so the peer judges it on `ClaimStaleAfter` alone and could license a second builder. The heartbeat now wraps the whole master path. This is the mirror image of the bug above and would have been its next incident.

## #1868 — `Build` must not construct another hub

#2045 adopted the invariant for the workspace and kernel sites. **Two framework sites still violated it**, and one of them is the arbiter above:

- **`ThreadExecution.AddThreadExecution`** registered all six initializers on the SYNCHRONOUS `WithInitialization` overload, which runs inside `MessageHubConfiguration.Build`. `InstallExecutionHub` calls `GetHostedHub(…/_Exec, Always)` outright; `SetThreadHubIdentity`, `InitializeThreadLifecycle` and `InstallCancellationWatcher` each resolve `workspace.GetMeshNodeStream()`, whose `SynchronizationStream` ctor always creates a `sync/{clientId}` sub-hub. So **every thread hub in the product built four child hubs — and four more Autofac containers — inside its own `Build`**. Threads are the hottest per-node hub there is.
- **`BuildNodeType.CreateMeshNode`** registered `InstallClaimArbiter` the same way, so the claim arbiter's triggers were wired against a workspace whose data sources had not been started yet (#2045 moved that onto the init turn).

All move to the OBSERVABLE overload: the `InitializeHubRequest` turn, after `Build` returns, still before the Initialize gate opens, and after the workspace's sources are up. `BuildupActions` are `Concat`-ed in registration order, so `_Exec` still exists eagerly before the submission watcher can claim a round — nothing observable to a message changes.

## Pins — every one verified RED before the fix

| Test | Red on main with |
|---|---|
| `NeverActiveHolderIsNotAliveTest` (new) | 3 of 10 fail; the consequence test reports `found "boot-casualty"` — the 25-minute hang in one line |
| `ThreadHubBuildsNoHubTest` (new) | `…/_Exec` + three `sync/…` hubs constructed during Build |
| `BuildNodeHubBuildsNoHubTest` (new) | three `sync/…` hubs constructed during Build |

Each was proven by reverting the specific fix, rebuilding, and re-running — not by reasoning. Both new hub tests also assert **non-vacuity** (the hub really activated, and the child hub really was created) so "constructed nothing" cannot be satisfied by a hub that did nothing.

## Verification

- BuildCoordination + CrossClusterBuildClaim + the two new hub tests: **18/18**
- AI thread suites (`ThreadSubmissionIntegration`, `CancellationAck`, `ThreadComposerFlow`, new test): **19/19**
- `RenderAreaOperationTest`: **9/9** · `BuildMustNotConstructHubs` + `RemoteStreamDisposeCancelsSubscribe`: **3/3**
- Documentation link integrity + What's-New integrity: **2/2**
- Release `-warnaserror`: clean on `MeshWeaver.Mesh.Contract`, `.Hosting`, `.Hosting.Orleans`, `.Graph`, `.AI`, `.Documentation` and all three touched test projects.

What's New entry included (`Category: Fix`), and `BuildCoordination.md` documents both new rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
