### PR TITLE
Module delivery lane: one activation record per module, and readiness that tells required-absent from expected-later

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -9,6 +9,51 @@ name: node-repo module pack
 # `content.minMeshVersion` — the ONE declaration `NodeRepoPackageSource` reads. The job asserts
 # that `content.module` names the module it is packing, so the two halves of a mixed package
 # cannot drift apart silently.
+#
+# ─────────────────────────────── Caller contract ───────────────────────────────
+# 🚨 THE MODULE LANE MUST FOLLOW THE RELEASE, exactly as the bundle bake does (#2088). A module is
+# built against a platform PIN. When the platform releases, the pin moves and the module must be
+# rebuilt AND republished, or every portal reads `FrameworkDeclined (built against <old>, live
+# <new>)` and adopts nothing — which is what both prod portals said after ci.5050. The rebuild
+# already happened there: the repo's release-follow schedule ran it. What threw it away was the
+# caller passing `publish: ${{ github.event_name == 'push' }}`, so a scheduled run packed, versioned
+# and inspected the bundles and handed them to nobody. Module adoption then stayed broken until an
+# unrelated push to the plugin repo republished by accident.
+#
+# So `publish` is TRUNK-ONLY, not PUSH-ONLY. A caller wires it exactly like node-repo-publish-bake:
+#
+#   on:
+#     push: { branches: [main] }
+#     pull_request:
+#     repository_dispatch:
+#       types: [meshweaver-framework-released]
+#     # 🚨 REQUIRED, not optional — the dispatch above has never been armed and the cross-repo PAT
+#     # it needed was removed on purpose (2026-08-21), so THIS POLL is how a satellite learns a
+#     # release happened. Stagger the minute per repo.
+#     schedule:
+#       - cron: "17,47 * * * *"
+#
+#   # Share the dispatch's concurrency lane: a scheduled run carries the DEFAULT BRANCH ref, so in
+#   # a plain `github.ref` group a poll can cancel a main run mid-publish.
+#   concurrency:
+#     group: ${{ github.workflow }}-${{ (github.event_name == 'repository_dispatch' || github.event_name == 'schedule') && 'framework-release' || github.ref }}
+#     cancel-in-progress: true
+#
+#   module-pack:
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-pack.yml@<40-char platform sha>
+#     with:
+#       publish: >-
+#         ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main')
+#             || github.event_name == 'repository_dispatch'
+#             || github.event_name == 'schedule' }}
+#     secrets: { publish-token: ${{ secrets.PLUGIN_REGISTRY_PUBLISH_TOKEN }} }
+#
+# Republishing is SAFE to repeat, which is why the schedule may simply publish rather than
+# first proving something changed: the registry is keyed by `{package}@{version}` from
+# `manifest.lock`, so a rebuild of an unchanged version overwrites the same slot with equivalent
+# bytes. There is no `_complete` sentinel to shrink here — unlike the prebuilt-bundle bake, this
+# lane uploads one independent bundle per module and never seals a listing, so a partial run costs
+# only the modules it did not reach, never the ones it did.
 
 on:
   workflow_call:
@@ -25,7 +70,11 @@ on:
         required: true
         type: string
       publish:
-        description: Hand the packed bundles to the registry. Trunk only — a PR packs and inspects, never publishes.
+        description: >
+          Hand the packed bundles to the registry. TRUNK-ONLY, not push-only — a PR packs and
+          inspects and never publishes, but a release-follow schedule or repository_dispatch run
+          MUST publish or the rebuild it just did is discarded and every portal stays on
+          FrameworkDeclined (#2088). See the caller contract at the top of this file.
         type: boolean
         default: false
       registry-source:

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -441,6 +441,53 @@ public static class MemexConfiguration
     }
 
     /// <summary>
+    /// Says out loud, once at startup, which ACTIVATED modules did not host-load here (#2093).
+    ///
+    /// <para>🚨 <b>Why this cannot be left to the module's own code.</b> A module that does not load
+    /// runs nothing — including anything that would have complained. <c>MapMeshModuleEndpoints</c>
+    /// scans only LOADED assemblies, so an activated endpoint provider that never made it into the
+    /// process contributes no routes and its whole HTTP surface answers 404 for the pod's lifetime,
+    /// with no exception, no warning and nothing to grep. On memex.systemorph that was <c>/mcp</c>,
+    /// dead through two clean rolling restarts while <c>/health</c> and <c>/readyz</c> were 200 and
+    /// the activation record cheerfully listed the module as installed. Absence of evidence read as
+    /// evidence of absence, again.</para>
+    ///
+    /// <para>The two cases are reported differently because the remedies are: a module whose bytes
+    /// are on the volume is one restart from working, while a module whose landed assembly is GONE
+    /// is a half-completed landing that no restart repairs — that one is an ERROR naming the
+    /// re-install. Same reader, same wording, as the <c>pending_module_activation</c> health check,
+    /// so the pod log and the probe can never disagree.</para>
+    /// </summary>
+    private static void ReportUnloadedActivatedModules(WebApplication app)
+    {
+        var logger = app.Services.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("MeshWeaver.PluginCatalog.ModuleActivation");
+        var report = app.Services.GetRequiredService<PendingModuleActivations>().Read();
+
+        if (report.IsUndetermined)
+        {
+            logger.LogError(
+                "Module endpoint contributions mapped, but this pod cannot say whether an "
+                + "activated module failed to load: {Reason}", report.Describe());
+            return;
+        }
+
+        if (report.HasUnresolvable)
+            logger.LogError(
+                "🚨 {Count} ACTIVATED module(s) are not loaded in this process and NO RESTART will "
+                + "load them — any HTTP endpoint, view or provider they contribute is silently "
+                + "absent (a 404 with no error) until the package is re-installed: {Detail}",
+                report.Unresolvable.Count,
+                ModuleActivationStatus.DescribeUnresolvable(report.Unresolvable));
+
+        if (report.HasPending)
+            logger.LogWarning(
+                "{Count} activated module(s) are landed but not loaded in this process — whatever "
+                + "they contribute (endpoints included) is absent until a restart: {Detail}",
+                report.Pending.Count, ModuleActivationStatus.Describe(report.Pending));
+    }
+
+    /// <summary>
     /// Fails fast on the content-storage configuration that GUARANTEES silent data loss (issue #435):
     /// a DEPLOYED (non-development) <c>FileSystem</c> content store whose <c>BasePath</c> is empty or
     /// relative. Such a path resolves against the container's ephemeral working directory (<c>/app</c>),
@@ -456,6 +503,7 @@ public static class MemexConfiguration
     /// <exception cref="InvalidOperationException">
     /// Thrown when a non-development FileSystem content store has an empty or relative <c>BasePath</c>.
     /// </exception>
+
     public static void ValidateContentStorageDurability(
         ContentCollectionConfig? contentStorageConfig, bool isDevelopment)
     {
@@ -623,11 +671,15 @@ public static class MemexConfiguration
             // Restart-as-activation: this boot IS the restart the sidecar was waiting for —
             // consume the pending flag so the step-10 signal reads current. Best-effort: on a
             // read-only app filesystem the flag simply stays set (cosmetic), and boot proceeds.
+            // 🚨 Clears the MARKER, never rewrites the activation record (#2090). Rewriting the
+            // whole list here meant every replica's boot read-modify-wrote a file the other
+            // replicas were reading — on a rolling restart that is several writers and several
+            // readers on one SMB file at once, which is how a boot read came back
+            // FileNotFoundException and the pod started with NONE of its store modules (#2189).
             if (persistedActivation.PendingRestart)
                 try
                 {
-                    ModuleActivationSidecar.Write(moduleRoot,
-                        persistedActivation with { PendingRestart = false });
+                    ModuleActivationSidecar.SetPendingRestart(moduleRoot, false);
                 }
                 catch (Exception ex)
                 {
@@ -1375,6 +1427,14 @@ public static class MemexConfiguration
         // MeshEndpointProviderAttribute maps its routes here — authenticated by default, loud
         // startup failure on route collisions. Delisting a module removes its routes wholesale.
         app.MapMeshModuleEndpoints();
+        // 🚨 …and SAY SO when an activated module contributed nothing because it never host-loaded
+        // (#2093). MapMeshModuleEndpoints can only scan assemblies that ARE loaded, so a module the
+        // activation record says is ON but whose bytes never reached this process contributes zero
+        // routes — and its whole HTTP surface 404s for the pod's entire lifetime with no error
+        // anywhere. That is exactly how /mcp went dark on memex.systemorph while the portal was
+        // otherwise healthy and two clean restarts changed nothing. The report is the same one the
+        // health check renders, so the pod log and /health never tell different stories.
+        ReportUnloadedActivatedModules(app);
 
         // First-startup auto-registration — POST /api/instances/register. A new deployment presents
         // an admin-minted bootstrap key (mwr_) and receives its own instance key (mwi_) once;

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -462,7 +462,15 @@ public static class MemexConfiguration
     {
         var logger = app.Services.GetRequiredService<ILoggerFactory>()
             .CreateLogger("MeshWeaver.PluginCatalog.ModuleActivation");
-        var report = app.Services.GetRequiredService<PendingModuleActivations>().Read();
+        // 🚨 CONSTRUCTED, not resolved — deliberately. PendingModuleActivations is registered in
+        // the MESH container (AddPluginCatalog), which is why every other caller reaches it through
+        // `hub.ServiceProvider` and guards with GetService. Asking `app.Services` for it would
+        // throw at startup on any host where the two containers differ — a diagnostic that CRASHES
+        // the portal it exists to inform is worse than the silence it replaces. Constructing costs
+        // nothing and cannot differ: the reader is a stateless file reader that starts nothing and
+        // writes nothing, and the registration is this same one-liner over the same resolved
+        // module root.
+        var report = new PendingModuleActivations(app.Configuration).Read();
 
         if (report.IsUndetermined)
         {

--- a/memex/aspire/Memex.Portal.Distributed/PendingModuleActivationHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.Distributed/PendingModuleActivationHealthCheck.cs
@@ -60,8 +60,12 @@ public sealed class PendingModuleActivationHealthCheck(PendingModuleActivations 
         if (report.IsUndetermined)
             return Task.FromResult(HealthCheckResult.Degraded(report.Describe()));
 
-        return Task.FromResult(report.HasPending
-            ? HealthCheckResult.Degraded(report.Describe())
-            : HealthCheckResult.Healthy(report.Describe()));
+        // 🚨 An ACTIVATED module whose landed assembly is GONE degrades too, and says so in its own
+        // words (#2093). It is not "pending": no restart loads it, so folding it into the pending
+        // line would print a restart prompt that can never come true — the exact false promise that
+        // let /mcp 404 for a pod's whole lifetime while every surface read "restart required".
+        return report.HasPending || report.HasUnresolvable
+            ? Task.FromResult(HealthCheckResult.Degraded(report.Describe()))
+            : Task.FromResult(HealthCheckResult.Healthy(report.Describe()));
     }
 }

--- a/memex/aspire/Memex.Portal.Distributed/RequiredModulesHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.Distributed/RequiredModulesHealthCheck.cs
@@ -1,16 +1,18 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Mesh;
+using MeshWeaver.PluginCatalog;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Memex.Portal.Distributed;
 
 /// <summary>
-/// Fails readiness when a module this deployment declares under <c>Modules:Required</c> is not
-/// present in the image.
+/// Reports what this deployment can and cannot serve of the modules it declares under
+/// <c>Modules:Required</c> — and, crucially, tells the two apart (#2089).
 ///
 /// <para><b>The hole this closes.</b> A listed-but-absent module is SKIPPED at boot, deliberately —
 /// a host that will not start is worse than one missing a feature, and that rule is what stopped the
@@ -19,15 +21,26 @@ namespace Memex.Portal.Distributed;
 /// carries a pack, land it where the package was never installed, and charts go blank, maps go
 /// blank, voice goes mute — behind one stderr line and a green rollout.</para>
 ///
-/// <para>🚨 <b>Unhealthy, not Degraded — and that difference IS the gate.</b> Readiness failing on
-/// the new pods means Kubernetes holds the old ReplicaSet in service: the rollout stalls instead of
+/// <para>🚨 <b>Unhealthy for a LOST PACK — and that difference IS the gate.</b> When the image's own
+/// <c>Modules:Assemblies</c> names a required module the image does not actually carry, readiness
+/// fails: Kubernetes holds the old ReplicaSet in service, so the rollout stalls instead of
 /// completing into a portal that cannot do what it did yesterday. Degraded would be visible and
-/// useless — the bad build would take over while a dashboard turned amber. This is the one case
-/// where refusing traffic is the kinder answer, because the pods that still have the module are
-/// right there, already serving.</para>
+/// useless there — the bad build would take over while a dashboard turned amber. This is the one
+/// case where refusing traffic is the kinder answer, because the pods that still have the module
+/// are right there, already serving.</para>
+///
+/// <para>🚨 <b>Degraded for a STORE-DELIVERED one — and that is not leniency.</b> A module the
+/// image never claimed to ship cannot be produced by holding the rollout: the registry that must
+/// serve it is itself a portal downstream of this very deploy. Reporting it Unhealthy wedged both
+/// prod rollouts on 2026-08-23 with no remedy but blanking <c>Modules__Required__0..4</c> on the
+/// live deployment. So it is Degraded — which is NOT Healthy: the module is named in the payload
+/// and in the message together with which of the four states it is in (never installed / landed and
+/// awaiting a restart / landing incomplete / held above the platform floor) and what to do about
+/// it. An operator can always separate "required, and nothing here can produce it" from "expected,
+/// and here is exactly what it waits on".</para>
 ///
 /// <para>It reports only what the deployment ITSELF declared required, so it is inert by default:
-/// no <c>Modules:Required</c> means nothing to fail on, and today's behaviour is unchanged.</para>
+/// no <c>Modules:Required</c> means nothing to report.</para>
 /// </summary>
 public sealed class RequiredModulesHealthCheck(IConfiguration configuration) : IHealthCheck
 {
@@ -35,19 +48,51 @@ public sealed class RequiredModulesHealthCheck(IConfiguration configuration) : I
     public Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        // The SAME pure rule the boot path used, asked the same way — a probe that answered
-        // differently from the log line that preceded it would be worse than no probe.
-        var missing = MeshBuilderModuleActivation.MissingRequired(
-            configuration, MeshBuilder.ResolveModulePath, File.Exists);
+        var moduleRoot = ModuleRoot.Resolve(configuration);
+        var activation = ModuleActivationSidecar.Read(moduleRoot);
 
-        if (missing.Length == 0)
-            return Task.FromResult(HealthCheckResult.Healthy("every required module is present"));
+        // The SAME resolution and the SAME gates the boot path used, asked the same way — a probe
+        // that answered differently from the log line that preceded it would be worse than no probe.
+        var verdicts = RequiredModuleStatus.Classify(
+            Values(MeshBuilderModuleActivation.RequiredKey),
+            Values(MeshBuilderModuleActivation.AssembliesKey),
+            ModuleActivationStatus.LoadedAssemblyNames(),
+            entry => File.Exists(MeshBuilder.ResolveModulePath(entry)),
+            activation,
+            entry => ModuleActivationBoot.LandedModuleDllExists(moduleRoot, entry),
+            ModulePlatformFloor.DeclineReason);
 
-        var data = new Dictionary<string, object> { ["missing"] = missing };
-        return Task.FromResult(HealthCheckResult.Unhealthy(
-            $"{missing.Length} required module(s) absent: {string.Join(", ", missing)}. "
-            + "This image does not ship them and no install landed them — the features they provide "
-            + "are gone. Install the packages, or delist them from Modules:Required.",
-            data: data));
+        var absent = RequiredModuleStatus.Absent(verdicts);
+        var expected = RequiredModuleStatus.ExpectedLater(verdicts);
+
+        // 🚨 Both lists ship in the payload whatever the verdict, so an operator reading /health
+        // never has to infer which bucket a module fell into from the status alone.
+        var data = new Dictionary<string, object>
+        {
+            ["missing"] = absent.Select(v => v.Entry).ToArray(),
+            ["expected"] = expected.Select(v => v.Entry).ToArray(),
+            ["detail"] = verdicts.Select(v => $"{v.Name} [{v.State}]: {v.Reason}").ToArray(),
+        };
+
+        if (absent.Count > 0)
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                $"{absent.Count} required module(s) the image is supposed to ship are absent: "
+                + RequiredModuleStatus.Describe(absent)
+                + (expected.Count > 0
+                    ? $". Also awaiting the store lane: {RequiredModuleStatus.Describe(expected)}"
+                    : string.Empty),
+                data: data));
+
+        if (expected.Count > 0)
+            return Task.FromResult(HealthCheckResult.Degraded(
+                $"{expected.Count} required module(s) are store-delivered and not here yet — the "
+                + "features they provide are missing until the module lane catches up: "
+                + RequiredModuleStatus.Describe(expected),
+                data: data));
+
+        return Task.FromResult(HealthCheckResult.Healthy("every required module is present", data));
+
+        IEnumerable<string?> Values(string key) =>
+            configuration.GetSection(key).GetChildren().Select(child => child.Value);
     }
 }

--- a/memex/aspire/Memex.Portal.Distributed/RequiredModulesHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.Distributed/RequiredModulesHealthCheck.cs
@@ -49,7 +49,12 @@ public sealed class RequiredModulesHealthCheck(IConfiguration configuration) : I
         HealthCheckContext context, CancellationToken cancellationToken = default)
     {
         var moduleRoot = ModuleRoot.Resolve(configuration);
-        var activation = ModuleActivationSidecar.Read(moduleRoot);
+        // 🚨 A gate must not read its own input silently. An unreadable activation record cannot
+        // make this probe pass — a required store module would classify as "not installed", which
+        // is still Degraded and still named — but it WOULD give the wrong reason, and "I could not
+        // read the record" is the one an operator can act on. So it rides in the payload.
+        var unreadable = new List<string>();
+        var activation = ModuleActivationSidecar.Read(moduleRoot, unreadable.Add);
 
         // The SAME resolution and the SAME gates the boot path used, asked the same way — a probe
         // that answered differently from the log line that preceded it would be worse than no probe.
@@ -72,6 +77,7 @@ public sealed class RequiredModulesHealthCheck(IConfiguration configuration) : I
             ["missing"] = absent.Select(v => v.Entry).ToArray(),
             ["expected"] = expected.Select(v => v.Entry).ToArray(),
             ["detail"] = verdicts.Select(v => $"{v.Name} [{v.State}]: {v.Reason}").ToArray(),
+            ["unreadableActivationRecords"] = unreadable.ToArray(),
         };
 
         if (absent.Count > 0)
@@ -90,7 +96,14 @@ public sealed class RequiredModulesHealthCheck(IConfiguration configuration) : I
                 + RequiredModuleStatus.Describe(expected),
                 data: data));
 
-        return Task.FromResult(HealthCheckResult.Healthy("every required module is present", data));
+        // Every required module IS accounted for, so nothing is missing — but if a record could
+        // not be read, say so rather than let the reassuring answer stand on partial evidence.
+        return Task.FromResult(unreadable.Count > 0
+            ? HealthCheckResult.Degraded(
+                "every required module is present, but "
+                + $"{unreadable.Count} activation record(s) could not be read: "
+                + string.Join("; ", unreadable), data: data)
+            : HealthCheckResult.Healthy("every required module is present", data));
 
         IEnumerable<string?> Values(string key) =>
             configuration.GetSection(key).GetChildren().Select(child => child.Value);

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -89,10 +89,27 @@ container builds) and fed to `MeshBuilder.InstallAssemblies` as one list:
 1. **The `Modules:Assemblies` appsettings baseline** — the DLLs the image ships with; the list is
    the operator's on/off switch for first-party packs, exactly as before. A baseline entry that
    fails to load fails loudly at startup, never silently.
-2. **The persisted activation list** — `modules/activation.json`, a sidecar file beside the module
-   folders, written by the runtime landing service (`ModuleLandingService`) when a compiled module
-   is installed from the Store. Each entry records the module name, its source, the install
-   record's mesh path, and the framework MVID the landed assemblies were built against.
+2. **The persisted activation record** — one file per module under `modules/activation.d/`, written
+   by the runtime landing service (`ModuleLandingService`) when a compiled module is installed from
+   the Store. Each entry records the module name, its source, the install record's mesh path, its
+   generation directory, its declared platform floor, and the framework MVID the landed assemblies
+   were built against. The legacy aggregate `modules/activation.json` is still READ (deployments
+   already carry one) and a per-module file wins over it by name; nothing writes it any more.
+
+   > 🚨 **Why one file per module and not one index.** Every portal replica mounts the same RWX
+   > `/data`, and a republish after a release pushes 30+ modules concurrently. A single mutable
+   > index that each landing read, appended to and renamed over has two failure modes no retry
+   > fixes: concurrent landings of *different* modules **lose each other's entries** (last writer
+   > wins the whole list), and the rename **contends for the file's SMB lease** with every other
+   > reader and writer of that one path — `Access to the path '/data/modules/activation.json' is
+   > denied` on the write side (HTTP 409), and a `FileNotFoundException` on the read side from
+   > opening into the replace window, which the reader then reported as a corrupt sidecar and
+   > **booted the pod with no store modules at all**. Sharding by module removes the shared cell:
+   > two writers of different modules share no path, so neither outcome is possible. The
+   > restart-required flag is a marker FILE (`activation.d/.pending-restart`) for the same reason —
+   > setting it is a create and clearing it is a delete, never a read-modify-write. And a record
+   > that cannot be read now costs exactly that one module, reported by name, instead of collapsing
+   > the whole answer to the empty list.
 
 The union dedupes by module name (a store install of an already-baseline module contributes
 nothing). **Activation is restart-based**: landing a module writes its assemblies into

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGates.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGates.md
@@ -444,16 +444,52 @@ package `preInstalled` is what puts that guarantee back — it is what makes the
 `{source}/_DefaultInstallLedger`, and that ledger's entries are exactly the packages carrying the
 flag.
 
-Ship only the first half and the readiness gate reports, correctly:
+Ship only the first half and the readiness gate reports it — but **which status it reports is the
+whole design**, because the two situations `Modules:Required` used to conflate have opposite
+remedies:
 
-```
-required_modules Unhealthy: 4 required module(s) absent … This image does not
-ship them and no install landed them.
-```
+| what happened | verdict | `required_modules` | effect |
+|---|---|---|---|
+| The module is loaded, or resolves from this deployment | `Present` | Healthy | — |
+| `Modules:Assemblies` **claims** the pack and the image does not carry it | `Absent` | **Unhealthy** | Readiness fails → the rollout STALLS and the old pods keep serving |
+| Required but the image never claimed it — i.e. store-delivered | `ExpectedLater` | **Degraded**, named | The rollout completes; the missing feature is reported, per module, with its exact sub-state |
+
+🚨 **Degraded here is not leniency, and Unhealthy is not a bigger hammer.** The gate exists to stop a
+build that silently dropped a feature, and stalling only helps when the PREVIOUS pods have what the
+new ones lack — which is true for a pack the image was supposed to ship, and false for a
+store-delivered module. Reporting the second as Unhealthy wedged both prod rollouts on 2026-08-23:
+the module can only arrive from the registry, the registry is itself a portal downstream of the same
+rollout, and the only remedy anyone found was blanking `Modules__Required__0..4` on the live
+deployment. A gate whose one escape hatch is deleting its own declaration is the skip-trapdoor with
+its polarity flipped — it fails on no evidence instead of passing on it.
+
+The evidence that separates them was already on disk: **`Modules:Assemblies` is the image's own
+claim about what it carries.** `RequiredModuleStatus.Classify` asks that question, and an
+`ExpectedLater` module always names which of four states it is in, so an operator never has to
+guess: not installed (install the package), landed and awaiting the restart, landing incomplete
+(re-install — no restart will fix it), or held above the platform floor (the platform update that
+satisfies it is itself the restart that loads it). Both buckets ship in the probe's `data` payload
+(`missing`, `expected`, `detail`) whatever the status, so a fleet sweep can enumerate them without
+parsing prose.
 
 ⚠️ **Provisioning a package is NOT installing its module.** Provisioning creates the node partition;
 landing the DLL is a separate step that the catalog performs for pre-installed packages. Confusing
 the two costs a deploy.
+
+### An activated module that never host-loaded is a SILENT 404
+
+`MapMeshModuleEndpoints` can only scan assemblies that are actually loaded. So a module the
+activation record says is ON, whose bytes never reached the process, contributes no routes — and its
+whole HTTP surface answers 404 for the pod's entire lifetime with no exception and nothing to grep.
+That is how `/mcp` went dark on memex.systemorph while the portal was otherwise healthy and two
+clean rolling restarts changed nothing.
+
+Startup now reports it, and `pending_module_activation` distinguishes the two cases rather than
+promising a restart that cannot help:
+
+- **landed, not loaded** → "a restart activates them" — true, and the rollout performs it;
+- **activated, bytes ABSENT** → "re-install the package" — a restart will NOT load them, and saying
+  otherwise is a prompt no restart can ever clear.
 
 ### Breaking the deadlock by hand
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-store-modules-load-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-store-modules-load-again.md
@@ -1,0 +1,42 @@
+---
+Name: Store-installed modules load again, and a missing one says why
+Category: Fix
+Description: Modules installed from the Store no longer disappear when several are published at once or when a pod restarts, and a module that is missing now says which of "waiting for a restart", "re-install it" or "never installed" it is — instead of stalling a release or silently 404ing.
+Icon: PuzzlePiece
+Order: -20260825
+---
+
+# Store-installed modules load again, and a missing one says why
+
+Modules installed from the Store — charts, maps, analysis views, voice, the MCP tool surface —
+could go missing in three different ways, each of which looked like nothing had gone wrong.
+
+**Publishing several modules at once could lose some of them.** Every portal replica shares one
+volume, and the list of installed modules was a single file that each install rewrote from end to
+end. Two installs landing at the same moment overwrote each other's entries, and a restart could
+erase a module a sibling replica had just installed. Installing a module now writes only that
+module's own record, so two installs can never collide and nothing can be lost.
+
+**A brief hiccup reading that file demoted a whole portal.** If the file could not be read for even
+a moment — which is exactly what happens while another replica is replacing it — the portal started
+with *none* of its Store modules and stayed that way until someone restarted it. One unreadable
+record now costs only its own module, reported by name, and everything else loads normally.
+
+**A module that could not load said nothing at all.** A module whose files had gone missing still
+showed as installed, so anything it provided — including whole web endpoints — simply answered "not
+found" for as long as the portal ran. That state is now reported at startup and on the health page,
+and it is clearly separated from the ordinary "installed, restarts on the next update" case: one
+says a restart activates it, the other says to re-install it.
+
+## Releases no longer stall waiting for a module the release itself delivers
+
+A portal can declare modules it must not run without. That check used to treat every absence the
+same way and hold the release — including for modules that only ever arrive from the Store, which
+no held release could deliver. Two production updates stalled that way with no way out but editing
+live configuration.
+
+The check now tells the two apart. A feature the build itself was supposed to include and lost
+still stops the release, exactly as before — the previous version keeps serving, which is the point.
+A Store-delivered module that has not arrived yet is reported clearly, named, with what it is
+waiting for, and the release proceeds. Nothing is hidden: the health page lists both kinds
+separately, so an operator can always see the difference.

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilderModuleActivation.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilderModuleActivation.cs
@@ -69,10 +69,13 @@ public static class MeshBuilderModuleActivation
         // The loud half. Absent-and-required is reported at boot as well as by the health check, so
         // it is in the pod log the operator already has open — not only behind a probe endpoint.
         foreach (var missing in MissingRequired(configuration, MeshBuilder.ResolveModulePath, File.Exists))
-            report($"REQUIRED module '{missing}' is NOT present. This deployment declares it under "
-                + $"{RequiredKey}, so whatever it provides is missing and that is a fault, not a "
-                + "choice. The host is starting anyway — a host that will not start is worse — but a "
-                + "readiness probe wired to RequiredModulesAbsent will hold the rollout.");
+            report($"REQUIRED module '{missing}' does NOT resolve from this image. This deployment "
+                + $"declares it under {RequiredKey}, so whatever it provides is missing. The host is "
+                + "starting anyway — a host that will not start is worse. The readiness probe then "
+                + "separates the two cases the boot path cannot: a pack this image claims under "
+                + $"{AssembliesKey} and lost HOLDS the rollout, while a store-delivered module the "
+                + "registry has not landed yet is reported degraded and named (it is not something "
+                + "a held rollout could deliver).");
 
         return resolved.Length == 0 ? builder : builder.InstallAssemblies(resolved);
     }

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -325,11 +325,17 @@ public static class ModuleActivationSidecar
     private static ModuleActivationList ReadLegacy(string baseDirectory, Action<string>? onCorrupt)
     {
         var path = SidecarPath(baseDirectory);
-        var text = TryReadAllText(path);
-        if (text is null)
-            return new ModuleActivationList();
         try
         {
+            // 🚨 The READ is inside the try, not before it. Only genuine ABSENCE is silent
+            // (TryReadAllText); every other failure — an SMB sharing violation or lease conflict
+            // arriving as IOException/UnauthorizedAccessException just as much as a parse error —
+            // must be REPORTED and skipped, never allowed to escape. Boot calls this un-wrapped, so
+            // an escaping exception would take the portal down over a transient volume blip: worse
+            // than the silence this whole change exists to remove.
+            var text = TryReadAllText(path);
+            if (text is null)
+                return new ModuleActivationList();
             return JsonSerializer.Deserialize<ModuleActivationList>(text, Json)
                    ?? new ModuleActivationList();
         }
@@ -366,17 +372,24 @@ public static class ModuleActivationSidecar
 
         foreach (var file in files)
         {
-            var text = TryReadAllText(file);
-            if (text is null)
-                // Vanished between the listing and the read — another replica re-landing that very
-                // module. Its next read sees the new file; nothing else is affected, which is the
-                // whole point of one file per module.
-                continue;
             ModuleActivationEntry? entry;
             try
             {
+                var text = TryReadAllText(file);
+                if (text is null)
+                    // Vanished between the listing and the read — another replica re-landing that
+                    // very module. Its next read sees the new file; nothing else is affected, which
+                    // is the whole point of one file per module.
+                    continue;
                 entry = JsonSerializer.Deserialize<ModuleActivationEntry>(text, Json);
             }
+            // 🚨 EVERY failure, not only a parse error. An SMB sharing violation or lease conflict
+            // arrives as IOException/UnauthorizedAccessException, and letting it escape would fail
+            // the WHOLE activation read — restoring the exact all-or-nothing behaviour this change
+            // removes, and crashing boot, which calls Read un-wrapped. It costs the one module it
+            // names, loudly. Deliberately NOT retried: the contended window is now a single
+            // module's own record being replaced, and a retry loop here would be a band-aid over a
+            // condition the next boot resolves on its own.
             catch (Exception ex)
             {
                 onCorrupt?.Invoke(

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -91,8 +91,7 @@ public sealed record ModuleActivationList
 }
 
 /// <summary>
-/// Plain-file persistence of the module-activation list: <c>modules/activation.json</c>, beside
-/// the module folders it describes.
+/// Plain-file persistence of the module-activation list, beside the module folders it describes.
 ///
 /// <para><b>Why a sidecar file and not a mesh node:</b> the list is consumed at BOOT, in
 /// <c>ConfigureMemexMesh</c>, BEFORE the DI container exists — before any storage provider is
@@ -102,14 +101,55 @@ public sealed record ModuleActivationList
 /// the landing service writes both in the same operation onto the same volume, so a
 /// restore/copy of the deployment's file tree carries both or neither.</para>
 ///
+/// <para>🚨 <b>ONE FILE PER MODULE — never one shared mutable index (#2090, #2189).</b> The
+/// activation record used to be a single <c>modules/activation.json</c> that every writer
+/// read-modify-wrote. On the RWX <c>/data</c> volume every portal replica shares, that single
+/// mutable cell has two defects no retry can fix:</para>
+/// <list type="number">
+///   <item><b>Lost updates.</b> Replica A reads [Y], adds X, writes [Y,X]; replica B concurrently
+///     reads [Y], adds Z, writes [Y,Z] — and X is gone, silently. A busy republish (30+ modules
+///     after a release) is exactly this shape.</item>
+///   <item><b>Replace-in-place races every reader.</b> The write is a rename over the live file.
+///     On SMB the server refuses a rename whose target another client holds open
+///     (<c>SHARING_VIOLATION</c> → <c>Access to the path '…/activation.json' is denied</c>, the
+///     409s of #2090), and a reader whose <c>File.Exists</c> hit the CIFS attribute cache opens
+///     into the replace window and gets <c>ENOENT</c> — reported as a CORRUPT sidecar, which
+///     collapsed the whole list to empty and booted the pod with NO store modules at all
+///     (#2189).</item>
+/// </list>
+/// <para>So the contended cell is removed rather than guarded: each module owns
+/// <c>modules/activation.d/&lt;Name&gt;.json</c> and a writer touches ONLY its own file. Two
+/// landings of DIFFERENT modules now share no path at all — no contention, and lost updates are
+/// structurally impossible. Two landings of the SAME module are inherently ordered work whose
+/// last-writer-wins is the correct answer, and can no longer cost any OTHER module its entry.
+/// A per-entry file that cannot be read costs exactly that one entry, reported loudly, instead of
+/// the whole deployment's module set.</para>
+///
+/// <para><b>The legacy aggregate file is still READ, never written by the runtime lane.</b>
+/// <c>modules/activation.json</c> is what deployments already on disk carry, so
+/// <see cref="Read"/> unions it under the per-module files (a per-module file WINS by name — an
+/// uninstall recorded there must beat a stale enabled row in the aggregate). Nothing on the
+/// landing path writes it any more, which is what takes the contention to zero.</para>
+///
 /// <para>All IO here is plain and synchronous by design — boot-time (pre-DI, pre-IoPool) callers
 /// use it directly; runtime callers go through <see cref="ModuleLandingService"/>, which runs
 /// these on its bounded IO pool.</para>
 /// </summary>
 public static class ModuleActivationSidecar
 {
-    /// <summary>The sidecar's file name inside the <c>modules/</c> folder.</summary>
+    /// <summary>The legacy aggregate file's name inside the <c>modules/</c> folder. Read for
+    /// deployments that already carry one; never written by the landing lane.</summary>
     public const string FileName = "activation.json";
+
+    /// <summary>The per-module entry directory inside <c>modules/</c>. One file per module,
+    /// so concurrent writers of different modules never share a path.</summary>
+    public const string EntriesDirectoryName = "activation.d";
+
+    /// <summary>The restart-required marker's file name inside <see cref="EntriesDirectoryName"/>.
+    /// A marker rather than a field, for the same reason the entries are split: setting it is a
+    /// create and clearing it is a delete, and neither is a read-modify-write of a file some other
+    /// replica is reading.</summary>
+    public const string PendingRestartMarkerName = ".pending-restart";
 
     private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
     {
@@ -117,48 +157,250 @@ public static class ModuleActivationSidecar
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
-    /// <summary>The sidecar's full path for a deployment rooted at
+    /// <summary>The legacy aggregate file's full path for a deployment rooted at
     /// <paramref name="baseDirectory"/> (normally <c>AppContext.BaseDirectory</c>).</summary>
     public static string SidecarPath(string baseDirectory) =>
         Path.Combine(baseDirectory, "modules", FileName);
 
+    /// <summary>The per-module entry directory for a deployment rooted at
+    /// <paramref name="baseDirectory"/>.</summary>
+    public static string EntriesDirectory(string baseDirectory) =>
+        Path.Combine(baseDirectory, "modules", EntriesDirectoryName);
+
+    /// <summary>The file one module's activation entry lives in — the ONLY path a landing of that
+    /// module writes.</summary>
+    public static string EntryPath(string baseDirectory, string moduleName) =>
+        Path.Combine(EntriesDirectory(baseDirectory), moduleName + ".json");
+
+    /// <summary>The restart-required marker's full path.</summary>
+    public static string PendingRestartMarkerPath(string baseDirectory) =>
+        Path.Combine(EntriesDirectory(baseDirectory), PendingRestartMarkerName);
+
     /// <summary>
-    /// Reads the activation list. A missing file is the normal fresh-deployment state and reads
-    /// as the empty list; a CORRUPT file reads as the empty list too — the deployment must boot
-    /// (baseline modules unaffected) — but reports through <paramref name="onCorrupt"/> so the
-    /// skip is loud, never silent.
+    /// Reads the activation list: the legacy aggregate file unioned with every per-module entry
+    /// file, the per-module file winning by name.
+    ///
+    /// <para>An ABSENT file — either kind — is the normal fresh-deployment state and contributes
+    /// nothing, silently. An UNREADABLE one is reported through <paramref name="onCorrupt"/> and
+    /// contributes nothing, so the skip is loud rather than silent — but 🚨 it no longer costs the
+    /// OTHER entries: one bad file used to collapse the entire answer to the empty list, which is
+    /// how a transient SMB read fault booted a pod with none of its store modules (#2189). The
+    /// caller still gets everything that WAS readable, plus one report per file that was not.</para>
     /// </summary>
     public static ModuleActivationList Read(string baseDirectory, Action<string>? onCorrupt = null)
     {
+        var legacy = ReadLegacy(baseDirectory, onCorrupt);
+        var byName = new Dictionary<string, ModuleActivationEntry>(StringComparer.OrdinalIgnoreCase);
+        var order = new List<string>();
+
+        void Accept(ModuleActivationEntry entry)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Name))
+                return;
+            if (!byName.ContainsKey(entry.Name))
+                order.Add(entry.Name);
+            byName[entry.Name] = entry;
+        }
+
+        foreach (var entry in legacy.Entries)
+            Accept(entry);
+        // Per-module files last: a record written by the landing lane WINS over whatever the
+        // frozen aggregate still says about that name (an uninstall must beat a stale enabled row).
+        // Sorted so the union is deterministic regardless of directory-enumeration order.
+        foreach (var entry in ReadEntryFiles(baseDirectory, onCorrupt))
+            Accept(entry);
+
+        return new ModuleActivationList
+        {
+            Entries = [.. order.Select(name => byName[name])],
+            // The marker is authoritative; the legacy flag is honoured once, for a deployment
+            // upgrading with the flag still set. Boot clears both.
+            PendingRestart = File.Exists(PendingRestartMarkerPath(baseDirectory)) || legacy.PendingRestart,
+        };
+    }
+
+    /// <summary>
+    /// Records ONE module's activation entry — the only write the landing lane performs, and the
+    /// reason concurrent landings of different modules cannot contend or lose each other's work.
+    /// Atomic: serialized to a temp file in the same directory, then renamed into place.
+    /// </summary>
+    public static void WriteEntry(string baseDirectory, ModuleActivationEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        if (string.IsNullOrWhiteSpace(entry.Name))
+            throw new ArgumentException("An activation entry must name its module.", nameof(entry));
+        WriteAtomic(EntryPath(baseDirectory, entry.Name), JsonSerializer.Serialize(entry, Json));
+    }
+
+    /// <summary>
+    /// Raises or clears the deployment's restart-required marker. A create and a delete — never a
+    /// read-modify-write — so it adds no contention of its own. Clearing a marker that is already
+    /// gone is a no-op, which is what makes several replicas booting at once benign.
+    /// </summary>
+    public static void SetPendingRestart(string baseDirectory, bool pending)
+    {
+        var marker = PendingRestartMarkerPath(baseDirectory);
+        if (pending)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(marker)!);
+            // Create-if-absent. Never a rewrite: a second replica raising the same marker must not
+            // rename over a file the first is holding.
+            if (!File.Exists(marker))
+                File.Open(marker, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite).Dispose();
+            return;
+        }
+
+        try
+        {
+            File.Delete(marker);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Another replica is clearing the same marker, or the volume is momentarily read-only.
+            // The flag is a hint; activation itself never depends on it.
+        }
+
+        // One-time carry-over: a deployment upgrading with the flag still set in the frozen
+        // aggregate would otherwise read PendingRestart forever. Rewritten only while it is
+        // actually set, so this converges after the first boot and never becomes a hot write.
+        var legacyPath = SidecarPath(baseDirectory);
+        if (!File.Exists(legacyPath))
+            return;
+        var legacy = ReadLegacy(baseDirectory, null);
+        if (!legacy.PendingRestart)
+            return;
+        try
+        {
+            WriteAtomic(legacyPath, JsonSerializer.Serialize(legacy with { PendingRestart = false }, Json));
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Best effort, exactly as before: on a read-only /app the flag simply stays set.
+        }
+    }
+
+    /// <summary>
+    /// Writes the WHOLE list — the administrative/bulk form, used to seed or rewrite a
+    /// deployment's activation state wholesale (and by tests to arrange one).
+    ///
+    /// <para>🚨 Not the landing lane's write: this rewrites every module's record, which is
+    /// precisely the read-modify-write of shared state that #2090 was. Runtime callers use
+    /// <see cref="WriteEntry"/>. Bulk means bulk — the per-module directory is made to match the
+    /// list exactly, so an entry dropped from the list is dropped from disk.</para>
+    /// </summary>
+    public static void Write(string baseDirectory, ModuleActivationList list)
+    {
+        ArgumentNullException.ThrowIfNull(list);
+        var entries = EntriesDirectory(baseDirectory);
+        Directory.CreateDirectory(entries);
+
+        var keep = list.Entries
+            .Where(e => !string.IsNullOrWhiteSpace(e.Name))
+            .ToDictionary(e => e.Name, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in Directory.EnumerateFiles(entries, "*.json").ToArray())
+            if (!keep.ContainsKey(Path.GetFileNameWithoutExtension(file)))
+                File.Delete(file);
+
+        foreach (var entry in keep.Values)
+            WriteEntry(baseDirectory, entry);
+
+        // The aggregate is superseded by what was just written per module. Leaving a stale copy
+        // behind would resurrect entries this call removed.
+        var legacyPath = SidecarPath(baseDirectory);
+        if (File.Exists(legacyPath))
+            File.Delete(legacyPath);
+
+        SetPendingRestart(baseDirectory, list.PendingRestart);
+    }
+
+    private static ModuleActivationList ReadLegacy(string baseDirectory, Action<string>? onCorrupt)
+    {
         var path = SidecarPath(baseDirectory);
-        if (!File.Exists(path))
+        var text = TryReadAllText(path);
+        if (text is null)
             return new ModuleActivationList();
         try
         {
-            return JsonSerializer.Deserialize<ModuleActivationList>(File.ReadAllText(path), Json)
+            return JsonSerializer.Deserialize<ModuleActivationList>(text, Json)
                    ?? new ModuleActivationList();
         }
         catch (Exception ex)
         {
             onCorrupt?.Invoke(
                 $"Module activation sidecar '{path}' could not be read ({ex.GetType().Name}: "
-                + $"{ex.Message}) — booting with the appsettings baseline only. Store-installed "
-                + "modules will NOT load until the sidecar is repaired or the modules are "
+                + $"{ex.Message}) — the entries it holds are skipped. Store-installed modules "
+                + "recorded there will NOT load until the file is repaired or the modules are "
                 + "re-installed.");
             return new ModuleActivationList();
         }
     }
 
-    /// <summary>
-    /// Writes the activation list atomically: serialize to a temp file in the same directory,
-    /// then rename over the target — a crash mid-write can never leave a half-written sidecar.
-    /// </summary>
-    public static void Write(string baseDirectory, ModuleActivationList list)
+    private static IEnumerable<ModuleActivationEntry> ReadEntryFiles(
+        string baseDirectory, Action<string>? onCorrupt)
     {
-        var path = SidecarPath(baseDirectory);
+        var directory = EntriesDirectory(baseDirectory);
+        string[] files;
+        try
+        {
+            files = Directory.Exists(directory)
+                ? [.. Directory.EnumerateFiles(directory, "*.json").OrderBy(f => f, StringComparer.Ordinal)]
+                : [];
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            onCorrupt?.Invoke(
+                $"Module activation entries under '{directory}' could not be listed "
+                + $"({ex.GetType().Name}: {ex.Message}) — store-installed modules will NOT load "
+                + "until the volume is readable again.");
+            yield break;
+        }
+
+        foreach (var file in files)
+        {
+            var text = TryReadAllText(file);
+            if (text is null)
+                // Vanished between the listing and the read — another replica re-landing that very
+                // module. Its next read sees the new file; nothing else is affected, which is the
+                // whole point of one file per module.
+                continue;
+            ModuleActivationEntry? entry;
+            try
+            {
+                entry = JsonSerializer.Deserialize<ModuleActivationEntry>(text, Json);
+            }
+            catch (Exception ex)
+            {
+                onCorrupt?.Invoke(
+                    $"Module activation entry '{file}' could not be read ({ex.GetType().Name}: "
+                    + $"{ex.Message}) — that ONE module is skipped; re-install it to repair the "
+                    + "entry. Every other activation entry is unaffected.");
+                continue;
+            }
+            if (entry is not null && !string.IsNullOrWhiteSpace(entry.Name))
+                yield return entry;
+        }
+    }
+
+    /// <summary>Reads a file, answering null for "not there" — including the ENOENT a concurrent
+    /// rename produces on SMB, which is genuinely absence and never corruption.</summary>
+    private static string? TryReadAllText(string path)
+    {
+        try
+        {
+            return File.ReadAllText(path);
+        }
+        catch (Exception e) when (e is FileNotFoundException or DirectoryNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    private static void WriteAtomic(string path, string content)
+    {
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var temp = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
-        File.WriteAllText(temp, JsonSerializer.Serialize(list, Json));
+        File.WriteAllText(temp, content);
         File.Move(temp, path, overwrite: true);
     }
 }

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -227,8 +227,16 @@ public static class ModuleActivationSidecar
     public static void WriteEntry(string baseDirectory, ModuleActivationEntry entry)
     {
         ArgumentNullException.ThrowIfNull(entry);
-        if (string.IsNullOrWhiteSpace(entry.Name))
-            throw new ArgumentException("An activation entry must name its module.", nameof(entry));
+        // 🚨 The name BECOMES a path here, so it is validated here — not only in the landing
+        // service that happens to be today's caller. A record file is derived from the module
+        // name, and a name carrying a separator or '..' would write wherever it points.
+        if (string.IsNullOrWhiteSpace(entry.Name)
+            || entry.Name is "." or ".."
+            || entry.Name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || entry.Name.Contains('/') || entry.Name.Contains('\\'))
+            throw new ArgumentException(
+                $"'{entry.Name}' is not a valid module name — an activation record is a file named "
+                + "after its module.", nameof(entry));
         WriteAtomic(EntryPath(baseDirectory, entry.Name), JsonSerializer.Serialize(entry, Json));
     }
 

--- a/src/MeshWeaver.PluginCatalog/ModuleActivationStatus.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivationStatus.cs
@@ -51,12 +51,66 @@ public static class ModuleActivationStatus
     /// leaves this question entirely). The gate is a parameter for the same reason boot's is:
     /// production passes <see cref="ModulePlatformFloor.DeclineReason(string?)"/>, and there is
     /// never a second notion of the module platform requirement.</para>
+    ///
+    /// <para>🚨 And an entry whose LANDED BYTES ARE GONE is not pending either — it is
+    /// <see cref="Unresolvable"/> (#2093). Same reason, sharper: "pending" promises that a restart
+    /// activates this, and boot skips an entry whose DLL is missing exactly as loudly as a held
+    /// one. Reporting it as pending is a promise every restart breaks and none of them clears —
+    /// and it is the state that took <c>/mcp</c> down for a pod's whole lifetime while every
+    /// surface said "restart required". The two must render differently because the ACTIONS
+    /// differ: wait for the restart, versus re-install the package.</para>
     /// </summary>
     /// <param name="activation">The persisted activation list.</param>
     /// <param name="loadedAssemblyNames">Assembly SIMPLE names loaded in this process.</param>
     /// <param name="platformGate">Returns WHY a recorded platform FLOOR is not satisfied by the
     /// running platform, or null when it is (an absent floor is always satisfied).</param>
+    /// <param name="landedDllExists">Whether the entry's landed DLL is actually on the volume —
+    /// production passes <see cref="ModuleActivationBoot.LandedModuleDllExists"/>, the SAME check
+    /// boot gates on, so this report can never promise a restart boot would not honour.</param>
     public static ImmutableList<PendingModuleActivation> NotYetLoaded(
+        ModuleActivationList activation,
+        IReadOnlySet<string> loadedAssemblyNames,
+        Func<string?, string?> platformGate,
+        Func<ModuleActivationEntry, bool> landedDllExists)
+    {
+        ArgumentNullException.ThrowIfNull(landedDllExists);
+        return AwaitingLoad(activation, loadedAssemblyNames, platformGate)
+            .Where(landedDllExists)
+            .Select(Describe)
+            .ToImmutableList();
+    }
+
+    /// <summary>
+    /// The enabled, floor-satisfied entries that are not loaded here AND whose landed DLL is not on
+    /// the volume — activated modules a restart will NOT bring up (#2093).
+    ///
+    /// <para>This is the state behind an endpoint module that 404s for a pod's whole lifetime: the
+    /// activation record says the module is on, so every NodeType-facing surface treats it as
+    /// installed, while its assembly was never host-loaded and so contributed no routes. It has
+    /// exactly one remedy — re-install the package — and the whole defect was that nothing
+    /// anywhere said so.</para>
+    /// </summary>
+    /// <param name="activation">The persisted activation list.</param>
+    /// <param name="loadedAssemblyNames">Assembly SIMPLE names loaded in this process.</param>
+    /// <param name="platformGate">The one platform floor gate.</param>
+    /// <param name="landedDllExists">Whether the entry's landed DLL is on the volume.</param>
+    public static ImmutableList<PendingModuleActivation> Unresolvable(
+        ModuleActivationList activation,
+        IReadOnlySet<string> loadedAssemblyNames,
+        Func<string?, string?> platformGate,
+        Func<ModuleActivationEntry, bool> landedDllExists)
+    {
+        ArgumentNullException.ThrowIfNull(landedDllExists);
+        return AwaitingLoad(activation, loadedAssemblyNames, platformGate)
+            .Where(entry => !landedDllExists(entry))
+            .Select(Describe)
+            .ToImmutableList();
+    }
+
+    private static PendingModuleActivation Describe(ModuleActivationEntry entry) =>
+        new(entry.Name, entry.PackagePath, entry.Version);
+
+    private static IEnumerable<ModuleActivationEntry> AwaitingLoad(
         ModuleActivationList activation,
         IReadOnlySet<string> loadedAssemblyNames,
         Func<string?, string?> platformGate)
@@ -69,9 +123,7 @@ public static class ModuleActivationStatus
             .Where(entry => entry.Enabled
                 && !string.IsNullOrWhiteSpace(entry.Name)
                 && !loadedAssemblyNames.Contains(entry.Name)
-                && platformGate(entry.MinMeshVersion) is null)
-            .Select(entry => new PendingModuleActivation(entry.Name, entry.PackagePath, entry.Version))
-            .ToImmutableList();
+                && platformGate(entry.MinMeshVersion) is null);
     }
 
     /// <summary>
@@ -125,7 +177,34 @@ public static class ModuleActivationStatus
 
         return $"{names.Length} module(s) are landed but not yet loaded in this process — "
             + "a restart activates them: "
-            + string.Join(", ", names.Take(Math.Max(1, maxNamed)))
-            + (names.Length > maxNamed ? $", …(+{names.Length - maxNamed})" : string.Empty);
+            + Name(names, maxNamed);
     }
+
+    /// <summary>
+    /// One human-readable line naming the ACTIVATED modules a restart will not fix — the other
+    /// half of the report, kept separate because the remedy is different (#2093).
+    /// </summary>
+    /// <param name="unresolvable">The activated entries whose landed bytes are absent.</param>
+    /// <param name="maxNamed">How many are named before the line truncates.</param>
+    public static string DescribeUnresolvable(
+        IReadOnlyCollection<PendingModuleActivation> unresolvable, int maxNamed = 10)
+    {
+        ArgumentNullException.ThrowIfNull(unresolvable);
+        if (unresolvable.Count == 0)
+            return "no module activation is unresolvable";
+
+        var names = unresolvable
+            .Select(p => p.Name)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return $"{names.Length} module(s) are ACTIVATED but their landed assemblies are absent — "
+            + "a restart will NOT load them and anything they contribute (endpoints included) "
+            + "stays missing; re-install the package: "
+            + Name(names, maxNamed);
+    }
+
+    private static string Name(string[] names, int maxNamed) =>
+        string.Join(", ", names.Take(Math.Max(1, maxNamed)))
+        + (names.Length > maxNamed ? $", …(+{names.Length - maxNamed})" : string.Empty);
 }

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -46,9 +46,15 @@ namespace MeshWeaver.PluginCatalog;
 ///
 /// <para><b>Reactive surface, pooled IO.</b> Both operations return cold
 /// <see cref="IObservable{T}"/>s whose file IO runs on this service's own cap-1
-/// <see cref="IoPool"/> — the one sanctioned bounded-IO primitive — so concurrent landings (and
-/// their sidecar read-modify-writes) serialize without a hand-rolled gate, and nothing blocks a
-/// hub scheduler. Mesh-scoped singleton: the pool dies with the mesh.</para>
+/// <see cref="IoPool"/> — the one sanctioned bounded-IO primitive — so concurrent landings
+/// serialize without a hand-rolled gate, and nothing blocks a hub scheduler. Mesh-scoped
+/// singleton: the pool dies with the mesh.</para>
+///
+/// <para><b>Cross-REPLICA safety is structural, not a gate (#2090).</b> The pool bounds one
+/// process; <c>/data</c> is shared by every portal replica. So the activation record is one file
+/// PER MODULE (<see cref="ModuleActivationSidecar"/>) and a landing writes only its own — two
+/// replicas landing different modules share no path, cannot lose each other's entry, and never
+/// contend for one file's SMB lease.</para>
 /// </summary>
 public sealed class ModuleLandingService : IDisposable
 {
@@ -107,9 +113,11 @@ public sealed class ModuleLandingService : IDisposable
         return removed;
     }
 
-    // Cap 1 deliberately: LandModule/RemoveModule each read-modify-write the shared
-    // activation.json sidecar, and the cap IS the serialization — no lock, no semaphore
-    // outside the sealed IoPool primitive. Landing is rare and short; 1 costs nothing.
+    // Cap 1 deliberately: landing writes files and the cap IS the in-process serialization — no
+    // lock, no semaphore outside the sealed IoPool primitive. Landing is rare and short; 1 costs
+    // nothing. 🚨 It is NOT what makes the activation record safe: this pool bounds ONE process,
+    // and /data is shared by every replica. Cross-process safety comes from the record's SHAPE —
+    // one file per module (ModuleActivationSidecar), so concurrent writers never share a path.
     private readonly IoPool pool = new(1);
     private readonly string baseDirectory;
     private readonly ILogger<ModuleLandingService>? logger;
@@ -356,8 +364,6 @@ public sealed class ModuleLandingService : IDisposable
             throw;
         }
 
-        var list = ModuleActivationSidecar.Read(baseDirectory,
-            msg => logger?.LogError("{Message}", msg));
         var entry = new ModuleActivationEntry
         {
             Name = name,
@@ -369,17 +375,21 @@ public sealed class ModuleLandingService : IDisposable
             Enabled = true,
             Directory = generation,
         };
-        ModuleActivationSidecar.Write(baseDirectory, list with
-        {
-            Entries = list.Entries
-                .RemoveAll(e => string.Equals(e.Name, name, StringComparison.OrdinalIgnoreCase))
-                .Add(entry),
-            // A HELD landing does not raise the restart signal: a restart cannot activate it (the
-            // boot gate skips the entry until the platform satisfies its floor), so "restart
-            // required" would be a prompt no restart can clear. The platform update that DOES
-            // satisfy the floor is itself a restart, which activates the entry with no flag.
-            PendingRestart = held is null || list.PendingRestart,
-        });
+        // 🚨 THIS MODULE'S OWN FILE, and nothing else (#2090). The landing used to read the whole
+        // shared activation index, append to it and rename the result over the live file — a
+        // read-modify-write of state every replica shares on the RWX /data volume. Two concurrent
+        // landings of DIFFERENT modules therefore raced: the later write silently dropped the
+        // earlier module's entry, and the rename itself contended for the SMB lease on the one hot
+        // file ('Access to the path …/activation.json is denied' → HTTP 409). Writing only
+        // activation.d/<Name>.json removes the shared cell instead of guarding it — different
+        // modules no longer share a path at all.
+        ModuleActivationSidecar.WriteEntry(baseDirectory, entry);
+        // A HELD landing does not raise the restart signal: a restart cannot activate it (the boot
+        // gate skips the entry until the platform satisfies its floor), so "restart required"
+        // would be a prompt no restart can clear. The platform update that DOES satisfy the floor
+        // is itself a restart, which activates the entry with no flag.
+        if (held is null)
+            ModuleActivationSidecar.SetPendingRestart(baseDirectory, true);
 
         if (held is null)
             logger?.LogInformation(
@@ -413,13 +423,12 @@ public sealed class ModuleLandingService : IDisposable
                 + "publish-laid-out module folders are managed by the deployment, not uninstall.");
 
         // The generation pointer is CLEARED on uninstall — a disabled entry must not keep its
-        // directory 'referenced', or boot GC could never reclaim it.
-        ModuleActivationSidecar.Write(baseDirectory, list with
-        {
-            Entries = list.Entries.Replace(existing,
-                existing with { Enabled = false, Directory = null }),
-            PendingRestart = true,
-        });
+        // directory 'referenced', or boot GC could never reclaim it. Written to THIS module's own
+        // file, never through the shared index (#2090): an uninstall racing another module's
+        // landing used to drop whichever entry lost.
+        ModuleActivationSidecar.WriteEntry(baseDirectory,
+            existing with { Enabled = false, Directory = null });
+        ModuleActivationSidecar.SetPendingRestart(baseDirectory, true);
 
         // Best-effort immediate delete: on a shared volume the files of a LOADED module refuse
         // deletion (SMB keeps them open) — that is fine, the cleared pointer above makes the

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -12,24 +12,41 @@ namespace MeshWeaver.PluginCatalog;
 /// the second as the first is exactly the gate that cannot run but looks like a gate that
 /// passed.</para>
 /// </summary>
-/// <param name="Pending">The modules landed on the volume but not loaded in this process.</param>
+/// <param name="Pending">The modules landed on the volume but not loaded in this process — a
+/// restart activates them.</param>
 /// <param name="UndeterminedReason">Why the answer is unknown, or <c>null</c> when it is known.
 /// When set, <paramref name="Pending"/> is empty and means nothing.</param>
+/// <param name="Unresolvable">🚨 The modules the activation record says are ON but whose landed
+/// assemblies are ABSENT (#2093). A restart will NOT load them — boot skips them — so they are
+/// deliberately NOT folded into <paramref name="Pending"/>: a "restart required" no restart can
+/// clear is the same lie as a green tick over a gate that never ran, and the remedy is different
+/// (re-install, not wait).</param>
 public sealed record ModuleActivationReport(
     ImmutableList<PendingModuleActivation> Pending,
-    string? UndeterminedReason = null)
+    string? UndeterminedReason = null,
+    ImmutableList<PendingModuleActivation>? Unresolvable = null)
 {
+    /// <summary>The activated modules whose bytes are gone. Never null.</summary>
+    public ImmutableList<PendingModuleActivation> Unresolvable { get; init; } = Unresolvable ?? [];
+
     /// <summary>True when this process could not establish the activation state at all.</summary>
     public bool IsUndetermined => UndeterminedReason is not null;
 
     /// <summary>True when the state is KNOWN and something is waiting on a restart.</summary>
     public bool HasPending => !IsUndetermined && !Pending.IsEmpty;
 
+    /// <summary>True when the state is KNOWN and an activated module can never load as it stands.
+    /// The FAULT half of the report — a restart does not clear it.</summary>
+    public bool HasUnresolvable => !IsUndetermined && !Unresolvable.IsEmpty;
+
     /// <summary>The one line every surface renders, so nobody is told two different stories.</summary>
     public string Describe() =>
         UndeterminedReason is { } reason
             ? "module activation state could not be determined — " + reason
-            : ModuleActivationStatus.Describe(Pending);
+            : HasUnresolvable
+                ? ModuleActivationStatus.DescribeUnresolvable(Unresolvable)
+                    + (HasPending ? "; " + ModuleActivationStatus.Describe(Pending) : string.Empty)
+                : ModuleActivationStatus.Describe(Pending);
 }
 
 /// <summary>
@@ -83,12 +100,21 @@ public sealed class PendingModuleActivations(string moduleRoot)
         if (corrupt is not null)
             return new ModuleActivationReport([], corrupt);
 
+        // 🚨 The SAME two gates boot applies, threaded here for the same reason: this report
+        // PROMISES that a restart activates what it calls pending, and only the gates boot itself
+        // uses can keep that promise. The platform floor (a HELD entry — the registry shelf,
+        // 2026-08-22) and the landed DLL's existence (#2093) each mean boot would skip the entry.
+        // The second is reported SEPARATELY rather than dropped: an activated module whose bytes
+        // are gone is a fault an operator must act on, not a quiet nothing.
+        bool LandedDllExists(ModuleActivationEntry entry) =>
+            ModuleActivationBoot.LandedModuleDllExists(ModuleRootPath, entry);
+
         return new ModuleActivationReport(
-            // The ONE platform gate (ModulePlatformFloor), threaded here as boot threads it: a
-            // HELD entry (floor above this platform — the registry shelf, 2026-08-22) must not read
-            // as "restart required", because the boot this report promises would skip it.
             ModuleActivationStatus.NotYetLoaded(
-                activation, loadedAssemblyNames, ModulePlatformFloor.DeclineReason));
+                activation, loadedAssemblyNames, ModulePlatformFloor.DeclineReason, LandedDllExists),
+            UndeterminedReason: null,
+            ModuleActivationStatus.Unresolvable(
+                activation, loadedAssemblyNames, ModulePlatformFloor.DeclineReason, LandedDllExists));
     }
 
     /// <summary>

--- a/src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs
+++ b/src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs
@@ -1,0 +1,187 @@
+using System.Collections.Immutable;
+using System.IO;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// What a deployment can honestly say about ONE module it declared under <c>Modules:Required</c>.
+/// </summary>
+public enum RequiredModuleState
+{
+    /// <summary>Loaded in this process, or resolvable from what this deployment carries. Nothing
+    /// to report.</summary>
+    Present,
+
+    /// <summary>Not here YET, and the lane that delivers it is the store — a restart, a landing or
+    /// a platform update brings it. Visible and named, never a rollout blocker: holding the
+    /// rollout cannot make the registry deliver it.</summary>
+    ExpectedLater,
+
+    /// <summary>The IMAGE claims to ship it (<c>Modules:Assemblies</c> names it) and it is not
+    /// there. Nothing on this deployment can produce it, and the pods of the previous generation
+    /// still have it — so the rollout must STALL.</summary>
+    Absent,
+}
+
+/// <summary>One required module's verdict, with the sentence an operator acts on.</summary>
+/// <param name="Entry">The raw <c>Modules:Required</c> value (e.g. <c>MeshWeaver.Speech.dll</c>).</param>
+/// <param name="Name">Its assembly simple name.</param>
+/// <param name="State">The verdict.</param>
+/// <param name="Reason">Why — naming the lane and the remedy, never just "missing".</param>
+public sealed record RequiredModuleVerdict(
+    string Entry, string Name, RequiredModuleState State, string Reason);
+
+/// <summary>
+/// The readiness contract for <c>Modules:Required</c> (#2089): which declared-required modules are
+/// here, which are on their way, and which are a FAULT that must hold a rollout.
+///
+/// <para>🚨 <b>Why the old one-bit answer was wrong in both directions.</b>
+/// <c>MeshBuilderModuleActivation.MissingRequired</c> asks a single question — does the file
+/// resolve from the image? — and reports Unhealthy for every "no". That was right while every
+/// module shipped in the image. Once modules started LEAVING for the registry it became a gate
+/// asserting something it cannot know: a required module that is not in the image is either a
+/// pack the build dropped (a real fault; the previous pods still have it, so stalling preserves
+/// the feature) or a store-delivered module the lane has not landed yet (stalling delivers
+/// nothing — the registry that must serve it is itself a portal downstream of this very
+/// rollout). Reported identically, the second wedged both prod rollouts on 2026-08-23, and the
+/// only remedy anyone had was blanking <c>Modules__Required__0..4</c> on the live deployment as
+/// standing revert-debt — a "gate" whose one escape hatch is deleting the declaration is the
+/// skip-trapdoor with its polarity flipped: it fails on no evidence instead of passing on it.</para>
+///
+/// <para><b>The missing evidence was already on disk: <c>Modules:Assemblies</c>.</b> That list is
+/// the IMAGE's own claim about what it carries. A module named under BOTH keys is the image's
+/// responsibility — absent means the build lost it, and that stays <see cref="RequiredModuleState.Absent"/>
+/// → Unhealthy → the rollout stalls, which is the case the gate was built for (3.0.0-rc5). A
+/// module named under <c>Required</c> but NOT under <c>Assemblies</c> is by construction
+/// store-delivered: the deployment is saying "I need this feature", never "my image ships it". Its
+/// absence is <see cref="RequiredModuleState.ExpectedLater"/> — reported, named, with the exact
+/// sub-reason and remedy, and NOT Healthy — but it does not hold a rollout that cannot fix it.</para>
+///
+/// <para>🚨 <b>Degraded is not lenient.</b> Every ExpectedLater module is named on <c>/health</c>,
+/// in the payload and in the boot log, with which of the four sub-states it is in (never installed
+/// / landed-awaiting-restart / landing incomplete / held above the platform floor) and what to do.
+/// An operator can always tell "required and nothing here can produce it" from "expected, and here
+/// is precisely what it is waiting for". What is gone is only the one behaviour that never helped:
+/// stalling a rollout on a lane the rollout is upstream of.</para>
+///
+/// <para>Pure and total — the caller supplies configuration, the loaded set, the activation record
+/// and both gates — so the whole contract is testable with no filesystem and no host.</para>
+/// </summary>
+public static class RequiredModuleStatus
+{
+    /// <summary>
+    /// Classifies every declared-required module.
+    /// </summary>
+    /// <param name="requiredEntries">The raw <c>Modules:Required</c> values.</param>
+    /// <param name="baselineEntries">The raw <c>Modules:Assemblies</c> values — the IMAGE's claim
+    /// about what it carries, and the evidence that separates a lost pack from a store-delivered
+    /// one.</param>
+    /// <param name="loadedAssemblyNames">Assembly SIMPLE names loaded in this process.</param>
+    /// <param name="resolvesFromDeployment">Whether the raw entry resolves to a file that exists —
+    /// production passes <c>MeshBuilder.ResolveModulePath</c> + <c>File.Exists</c>, the same
+    /// resolution the boot loader used, so a verdict can never disagree with the line that
+    /// preceded it.</param>
+    /// <param name="activation">The persisted activation record.</param>
+    /// <param name="landedDllExists">Whether a store entry's landed DLL is on the volume —
+    /// production passes <see cref="ModuleActivationBoot.LandedModuleDllExists"/>.</param>
+    /// <param name="platformGate">The ONE platform floor gate
+    /// (<see cref="ModulePlatformFloor.DeclineReason(string?)"/>).</param>
+    public static ImmutableList<RequiredModuleVerdict> Classify(
+        IEnumerable<string?>? requiredEntries,
+        IEnumerable<string?>? baselineEntries,
+        IReadOnlySet<string> loadedAssemblyNames,
+        Func<string, bool> resolvesFromDeployment,
+        ModuleActivationList? activation,
+        Func<ModuleActivationEntry, bool> landedDllExists,
+        Func<string?, string?> platformGate)
+    {
+        ArgumentNullException.ThrowIfNull(loadedAssemblyNames);
+        ArgumentNullException.ThrowIfNull(resolvesFromDeployment);
+        ArgumentNullException.ThrowIfNull(landedDllExists);
+        ArgumentNullException.ThrowIfNull(platformGate);
+
+        var imageShips = (baselineEntries ?? [])
+            .Where(entry => !string.IsNullOrWhiteSpace(entry))
+            .Select(entry => Path.GetFileNameWithoutExtension(entry!))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var landed = (activation?.Entries ?? [])
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.Name))
+            .GroupBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Last(), StringComparer.OrdinalIgnoreCase);
+
+        var verdicts = ImmutableList.CreateBuilder<RequiredModuleVerdict>();
+        foreach (var entry in requiredEntries ?? [])
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+                continue;
+            var name = Path.GetFileNameWithoutExtension(entry!);
+
+            if (loadedAssemblyNames.Contains(name))
+            {
+                verdicts.Add(new RequiredModuleVerdict(
+                    entry!, name, RequiredModuleState.Present, "loaded in this process"));
+                continue;
+            }
+
+            if (resolvesFromDeployment(entry!))
+            {
+                verdicts.Add(new RequiredModuleVerdict(
+                    entry!, name, RequiredModuleState.Present,
+                    "present on this deployment; it loads at the next restart"));
+                continue;
+            }
+
+            // 🚨 The one question the old gate never asked. The image's OWN list is what says
+            // whether stalling the rollout can preserve anything: a pack the build was supposed to
+            // carry is a fault the previous generation does not share, while a store-delivered
+            // module is not something a held rollout can conjure.
+            if (imageShips.Contains(name))
+            {
+                verdicts.Add(new RequiredModuleVerdict(
+                    entry!, name, RequiredModuleState.Absent,
+                    "this image lists it under Modules:Assemblies but does not ship it — the build "
+                    + "lost the pack. The previous pods still have it, so this rollout must not "
+                    + "complete. Fix the build, or delist it from Modules:Required."));
+                continue;
+            }
+
+            verdicts.Add(new RequiredModuleVerdict(
+                entry!, name, RequiredModuleState.ExpectedLater, StoreReason(name)));
+        }
+
+        return verdicts.ToImmutable();
+
+        string StoreReason(string name)
+        {
+            if (!landed.TryGetValue(name, out var record) || !record.Enabled)
+                return "store-delivered and NOT installed on this instance — install the package "
+                    + "from the registry, or delist it from Modules:Required if this deployment "
+                    + "does not want the feature. The image never shipped it, so no rollout can "
+                    + "deliver it.";
+            if (platformGate(record.MinMeshVersion) is { } held)
+                return $"store-delivered, landed, and HELD above this platform: {held}. A platform "
+                    + "update satisfies the floor and that boot loads it.";
+            if (!landedDllExists(record))
+                return "store-delivered and recorded as installed, but its landed assembly is "
+                    + "ABSENT — the landing did not complete, and no restart will fix it. "
+                    + "Re-install the package.";
+            return "store-delivered and landed on the volume, not yet loaded in this process — "
+                + "a restart activates it.";
+        }
+    }
+
+    /// <summary>Those a rollout must stall on — the image's own lost packs.</summary>
+    public static ImmutableList<RequiredModuleVerdict> Absent(
+        IEnumerable<RequiredModuleVerdict> verdicts) =>
+        [.. (verdicts ?? []).Where(v => v.State == RequiredModuleState.Absent)];
+
+    /// <summary>Those the store lane still owes — reported and named, never a rollout blocker.</summary>
+    public static ImmutableList<RequiredModuleVerdict> ExpectedLater(
+        IEnumerable<RequiredModuleVerdict> verdicts) =>
+        [.. (verdicts ?? []).Where(v => v.State == RequiredModuleState.ExpectedLater)];
+
+    /// <summary>One line per module, so the probe payload and the boot log read identically.</summary>
+    public static string Describe(IEnumerable<RequiredModuleVerdict> verdicts) =>
+        string.Join("; ", (verdicts ?? []).Select(v => $"{v.Name}: {v.Reason}"));
+}

--- a/test/Memex.Portal.Shared.Test/PendingModuleActivationHealthCheckTest.cs
+++ b/test/Memex.Portal.Shared.Test/PendingModuleActivationHealthCheckTest.cs
@@ -147,6 +147,49 @@ public class PendingModuleActivationHealthCheckTest : IDisposable
         Assert.Equal(HealthStatus.Healthy, result.Status);
     }
 
+    /// <summary>
+    /// 🚨 #2093. An ACTIVATED module whose landed assembly is gone is Degraded like a pending one —
+    /// but it must say something DIFFERENT, because the remedy is different. The old surface told
+    /// an operator "a restart activates them" about a module no restart could ever load, which is
+    /// how <c>/mcp</c> stayed 404 through two clean rolling restarts while every probe was green.
+    /// </summary>
+    [Fact]
+    public async Task AnActivatedModuleWhoseBytesAreGone_SaysReinstall_NotRestart()
+    {
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Mcp", Enabled = true }],
+        });
+        // Deliberately no modules/MeshWeaver.Mcp/MeshWeaver.Mcp.dll.
+
+        var result = await Check();
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("MeshWeaver.Mcp", result.Description);
+        Assert.Contains("re-install", result.Description);
+        Assert.DoesNotContain("a restart activates them", result.Description);
+    }
+
+    /// <summary>The partner direction: the SAME record, with its bytes on the volume, is the
+    /// ordinary pending restart and says so. The two must never render the same.</summary>
+    [Fact]
+    public async Task ThatSameModule_WithItsBytesOnTheVolume_SaysARestartActivatesIt()
+    {
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Mcp", Enabled = true }],
+        });
+        Directory.CreateDirectory(Path.Combine(root, "modules", "MeshWeaver.Mcp"));
+        File.WriteAllBytes(
+            Path.Combine(root, "modules", "MeshWeaver.Mcp", "MeshWeaver.Mcp.dll"), [1]);
+
+        var result = await Check();
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("a restart activates them", result.Description);
+        Assert.DoesNotContain("re-install", result.Description);
+    }
+
     [Fact]
     public async Task ALandingSetsIt_AndTheSurfaceSeesIt_WithoutAnInMemoryHandoff()
     {

--- a/test/Memex.Portal.Shared.Test/RequiredModulesHealthCheckTest.cs
+++ b/test/Memex.Portal.Shared.Test/RequiredModulesHealthCheckTest.cs
@@ -1,0 +1,179 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Memex.Portal.Distributed;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The <c>required_modules</c> probe, over the real configuration and the real activation record
+/// (#2089) — and specifically the fact that it now gives DIFFERENT answers to two situations it
+/// used to conflate.
+///
+/// <para><b>Why this probe matters more than most.</b> The chart points the STARTUP probe at
+/// <c>/health</c>, and ASP.NET maps Unhealthy to 503. So Unhealthy here does not merely colour a
+/// dashboard: it fails the startup probe, Kubernetes never marks the new pods ready, and the
+/// rollout stalls with the old ReplicaSet still serving. That is exactly right for a build that
+/// dropped a pack it claims to ship. It was exactly wrong for a store-delivered module — the
+/// registry that must serve it is a portal downstream of the same rollout, so the stall could
+/// never end, and the only remedy anyone found was blanking <c>Modules__Required__0..4</c> on the
+/// live deployment as standing revert-debt.</para>
+///
+/// <para>🚨 Every test here has a partner asserting the OPPOSITE status from a neighbouring input.
+/// A probe that always passed would be the skip-trapdoor this repo forbids; a probe that always
+/// failed is the wedge being fixed. Both must be impossible.</para>
+/// </summary>
+public class RequiredModulesHealthCheckTest : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-required-" + Guid.NewGuid().ToString("N"));
+
+    public RequiredModulesHealthCheckTest() => Directory.CreateDirectory(Path.Combine(root, "modules"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+    }
+
+    private Task<HealthCheckResult> Check(string[] required, string[] baseline)
+    {
+        var settings = new Dictionary<string, string?> { [ModuleRoot.ConfigKey] = root };
+        for (var i = 0; i < required.Length; i++)
+            settings[$"Modules:Required:{i}"] = required[i];
+        for (var i = 0; i < baseline.Length; i++)
+            settings[$"Modules:Assemblies:{i}"] = baseline[i];
+
+        return new RequiredModulesHealthCheck(
+                new ConfigurationBuilder().AddInMemoryCollection(settings).Build())
+            .CheckHealthAsync(new HealthCheckContext());
+    }
+
+    /// <summary>Lands an activation record, with or without the bytes it points at.</summary>
+    private void Record(string name, bool withBytes, string? minMeshVersion = null)
+    {
+        var directory = name + "@gen";
+        ModuleActivationSidecar.WriteEntry(root, new ModuleActivationEntry
+        {
+            Name = name, Directory = directory, MinMeshVersion = minMeshVersion,
+        });
+        if (!withBytes)
+            return;
+        var dir = Path.Combine(root, "modules", directory);
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, name + ".dll"), [1]);
+    }
+
+    [Fact]
+    public async Task DeclaringNothingRequired_IsHealthy()
+    {
+        // Inert by default — a probe that fired on deployments declaring nothing would fail every
+        // portal on the first boot after it shipped.
+        Assert.Equal(HealthStatus.Healthy, (await Check([], ["MeshWeaver.Social.dll"])).Status);
+    }
+
+    /// <summary>
+    /// 🚨 THE TEETH. The image's own <c>Modules:Assemblies</c> claims the pack and the image does
+    /// not carry it. Nothing on this deployment can produce it and the previous pods still have it,
+    /// so readiness must FAIL and hold the rollout.
+    /// </summary>
+    [Fact]
+    public async Task APackTheImageClaimsAndLost_IsUNHEALTHY_SoTheRolloutStalls()
+    {
+        var result = await Check(
+            required: ["MeshWeaver.Blazor.Views.dll"],
+            baseline: ["MeshWeaver.Blazor.Views.dll"]);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("MeshWeaver.Blazor.Views", result.Description);
+    }
+
+    /// <summary>
+    /// 🚨 THE WEDGE, gone. The same declaration for a module the image never claimed to ship is
+    /// store-delivered by construction. It is reported — Degraded, named, with the reason — but it
+    /// does not fail readiness, because holding the rollout cannot deliver it.
+    /// </summary>
+    [Fact]
+    public async Task AStoreDeliveredModuleNotYetLanded_IsDEGRADED_AndNamed()
+    {
+        var result = await Check(
+            required: ["MeshWeaver.Speech.dll"],
+            baseline: ["MeshWeaver.Social.dll"]);
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("MeshWeaver.Speech", result.Description);
+        Assert.Contains("install the package", result.Description);
+        // 🚨 Degraded is NOT silence: the operator surface must be able to enumerate it without
+        // parsing prose, so both buckets ship in the payload whatever the status.
+        Assert.Contains("MeshWeaver.Speech.dll", Assert.IsType<string[]>(result.Data["expected"]));
+        Assert.Empty(Assert.IsType<string[]>(result.Data["missing"]));
+    }
+
+    /// <summary>The partner direction — the SAME declaration, once the module has landed and
+    /// loaded, is simply Healthy. A probe stuck on Degraded would fail here.</summary>
+    [Fact]
+    public async Task AStoreModuleThisProcessHasLoaded_IsHEALTHY()
+    {
+        var loaded = typeof(ModuleActivationList).Assembly.GetName().Name!;
+
+        var result = await Check(required: [loaded + ".dll"], baseline: []);
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    /// <summary>Landed on the volume, awaiting the restart the rollout itself performs: Degraded,
+    /// and the reason says a restart is what it waits on.</summary>
+    [Fact]
+    public async Task AStoreModuleLandedButNotLoaded_IsDEGRADED_AndSaysARestartActivatesIt()
+    {
+        Record("MeshWeaver.Speech", withBytes: true);
+
+        var result = await Check(required: ["MeshWeaver.Speech.dll"], baseline: []);
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("a restart activates it", result.Description);
+    }
+
+    /// <summary>
+    /// The half-completed landing (#2093): the record says installed, the assembly is not there. A
+    /// restart will not fix it, so the reason must say RE-INSTALL — never "a restart activates it",
+    /// which is the false promise that left <c>/mcp</c> 404ing for a pod's whole lifetime.
+    /// </summary>
+    [Fact]
+    public async Task AStoreModuleRecordedWithoutBytes_SaysReinstall_NotRestart()
+    {
+        Record("MeshWeaver.Mcp", withBytes: false);
+
+        var result = await Check(required: ["MeshWeaver.Mcp.dll"], baseline: []);
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("Re-install", result.Description);
+        Assert.DoesNotContain("a restart activates it", result.Description);
+    }
+
+    /// <summary>
+    /// Both at once — the state that actually shipped. Unhealthy wins the STATUS (a lost pack must
+    /// still stall the rollout) but the store-lane half is still named, so fixing the build does
+    /// not leave the second problem undiscovered.
+    /// </summary>
+    [Fact]
+    public async Task ALostPackAndAnOwedModule_AreBothReported_AndTheLostPackDecidesTheStatus()
+    {
+        var result = await Check(
+            required: ["MeshWeaver.Blazor.Views.dll", "MeshWeaver.Speech.dll"],
+            baseline: ["MeshWeaver.Blazor.Views.dll"]);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("MeshWeaver.Blazor.Views", result.Description);
+        Assert.Contains("MeshWeaver.Speech", result.Description);
+        Assert.Contains("MeshWeaver.Blazor.Views.dll", Assert.IsType<string[]>(result.Data["missing"]));
+        Assert.Contains("MeshWeaver.Speech.dll", Assert.IsType<string[]>(result.Data["expected"]));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/RequiredModulesHealthCheckTest.cs
+++ b/test/Memex.Portal.Shared.Test/RequiredModulesHealthCheckTest.cs
@@ -80,6 +80,24 @@ public class RequiredModulesHealthCheckTest : IDisposable
     }
 
     /// <summary>
+    /// 🚨 A gate must not read its own input silently. Everything declared is accounted for, so the
+    /// verdicts alone would read Healthy — but a record that could not be read means the evidence
+    /// behind that answer is partial, and the reassuring answer must not stand on partial evidence.
+    /// </summary>
+    [Fact]
+    public async Task AnUnreadableActivationRecord_IsDEGRADED_EvenWhenNothingLooksMissing()
+    {
+        Directory.CreateDirectory(ModuleActivationSidecar.EntriesDirectory(root));
+        File.WriteAllText(ModuleActivationSidecar.EntryPath(root, "MeshWeaver.Broken"), "{ not json");
+
+        var result = await Check(required: [], baseline: []);
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("could not be read", result.Description);
+        Assert.NotEmpty(Assert.IsType<string[]>(result.Data["unreadableActivationRecords"]));
+    }
+
+    /// <summary>
     /// 🚨 THE TEETH. The image's own <c>Modules:Assemblies</c> claims the pack and the image does
     /// not carry it. Nothing on this deployment can produce it and the previous pods still have it,
     /// so readiness must FAIL and hold the rollout.

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationContentionTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationContentionTest.cs
@@ -1,0 +1,254 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The activation record under CONCURRENT WRITERS (#2090, #2189) — the case the whole module lane
+/// actually runs in, and the one the old shape could not survive.
+///
+/// <para><b>What production does.</b> Every portal replica mounts the same RWX <c>/data</c>, and a
+/// republish after a release pushes 30+ modules at once, landing on whichever replica the load
+/// balancer picked. The old record was ONE <c>modules/activation.json</c> that each landing read,
+/// appended to, and renamed over. That has two failure modes and neither is fixable by retrying:
+/// concurrent landings of DIFFERENT modules LOSE each other's entries (last writer wins the whole
+/// list), and the rename contends for the file's SMB lease against every reader and writer of the
+/// same path — the 409 <c>Access to the path '/data/modules/activation.json' is denied</c> of
+/// #2090, and the <c>FileNotFoundException</c> a reader gets from opening into the replace window,
+/// which booted pods with NO store modules at all (#2189).</para>
+///
+/// <para><b>What these pin.</b> Not "the race is now unlikely" — that would be untestable and
+/// untrue. They pin the STRUCTURAL property that makes the race impossible: a landing writes only
+/// its own module's file, so two writers of different modules never touch a shared path. Every
+/// test below fails against the single-shared-file design.</para>
+/// </summary>
+public class ModuleActivationContentionTest : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-contention-" + Guid.NewGuid().ToString("N"));
+
+    public ModuleActivationContentionTest() => Directory.CreateDirectory(root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+    }
+
+    private Task Land(ModuleLandingService service, string name) =>
+        service.LandModule(name, [(name + ".dll", [1, 2, 3])]).FirstAsync().ToTask();
+
+    /// <summary>Every file under the deployment root, by relative path and content hash.</summary>
+    private Dictionary<string, string> Snapshot() =>
+        Directory.Exists(root)
+            ? Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories)
+                .ToDictionary(
+                    file => Path.GetRelativePath(root, file).Replace('\\', '/'),
+                    file => Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(file))))
+            : [];
+
+    /// <summary>
+    /// 🚨 THE REPRO. Landing one module must not touch any byte belonging to another — that
+    /// property, and only that property, is what makes two replicas landing at once safe.
+    ///
+    /// <para>Against the old single-file record this FAILS at the first assertion: Beta's landing
+    /// rewrites <c>modules/activation.json</c>, which is where Alpha's record lives. That one
+    /// rewrite is both defects at once — the lost update (Beta's writer had to re-serialize
+    /// Alpha's entry, so a stale read drops it) and the lease contention (both replicas rename
+    /// over the same path).</para>
+    /// </summary>
+    [Fact]
+    public async Task LandingOneModule_TouchesNoFileBelongingToAnother()
+    {
+        using var replicaA = new ModuleLandingService(baseDirectory: root);
+        using var replicaB = new ModuleLandingService(baseDirectory: root);
+
+        await Land(replicaA, "MeshWeaver.Alpha");
+        var before = Snapshot();
+        before.Keys.Should().Contain(key => key.Contains("MeshWeaver.Alpha"),
+            "the arrangement is only meaningful if Alpha's record is on disk");
+
+        await Land(replicaB, "MeshWeaver.Beta");
+        var after = Snapshot();
+
+        var written = after
+            .Where(entry => !before.TryGetValue(entry.Key, out var hash) || hash != entry.Value)
+            .Select(entry => entry.Key)
+            .ToArray();
+
+        written.Should().NotBeEmpty("the landing must have written something");
+        written.Should().OnlyContain(path => path.Contains("MeshWeaver.Beta"),
+            "a landing that rewrites a path holding ANOTHER module's record is exactly the shared "
+            + "mutable cell two replicas lose each other's entries on, and contend for the SMB "
+            + "lease of");
+        before.Keys.Where(key => key.Contains("MeshWeaver.Alpha"))
+            .Should().OnlyContain(path => after[path] == before[path],
+                "Alpha's bytes are not Beta's landing's business");
+    }
+
+    /// <summary>
+    /// 🚨 THE LOST UPDATE, in the exact sequence production runs it. Boot reads the record, does
+    /// its work, then consumes the restart flag — and the OLD code consumed it by writing the
+    /// whole list BACK from the snapshot it read at the start. Any module another replica landed
+    /// in between was silently erased by a pod that was merely starting up. On a rolling restart
+    /// that is several pods doing it at once, which is why #2189's pods came up with none of
+    /// their store modules.
+    ///
+    /// <para>Fails against the old shape: the boot write is <c>Write(root, snapshot with
+    /// { PendingRestart = false })</c> and Zulu is not in <c>snapshot</c>.</para>
+    /// </summary>
+    [Fact]
+    public async Task ConsumingTheRestartFlag_CannotErase_AModuleLandedMeanwhile()
+    {
+        using var replica = new ModuleLandingService(baseDirectory: root);
+        await Land(replica, "MeshWeaver.Yankee");
+
+        // A booting pod reads the record it is about to apply.
+        var bootSnapshot = ModuleActivationSidecar.Read(root);
+        bootSnapshot.Entries.Should().ContainSingle();
+        bootSnapshot.PendingRestart.Should().BeTrue();
+
+        // Another replica lands a module while this one is still booting.
+        await Land(replica, "MeshWeaver.Zulu");
+
+        // The booting pod now consumes the flag — the ONE thing it may write.
+        ModuleActivationSidecar.SetPendingRestart(root, false);
+
+        var after = ModuleActivationSidecar.Read(root);
+        after.PendingRestart.Should().BeFalse("this boot IS the restart the flag was waiting for");
+        after.Entries.Select(entry => entry.Name).Order(StringComparer.Ordinal)
+            .Should().Equal(["MeshWeaver.Yankee", "MeshWeaver.Zulu"],
+                "a pod starting up must never delete a module another replica just landed");
+    }
+
+    /// <summary>
+    /// 🚨 The hazard the two tests above exist to exclude, demonstrated — so nobody "simplifies"
+    /// the landing lane back onto the whole-list write.
+    ///
+    /// <para><see cref="ModuleActivationSidecar.Write"/> is the ADMINISTRATIVE form and rewrites
+    /// every module's record from the caller's list. Called with a snapshot taken before someone
+    /// else's landing, it erases that landing — silently, with no error and no retry that could
+    /// help. That is precisely what the landing service and the boot path used to do on EVERY
+    /// install and EVERY startup. The remedy is not a lock: it is that those two paths now write
+    /// <see cref="ModuleActivationSidecar.WriteEntry"/> and
+    /// <see cref="ModuleActivationSidecar.SetPendingRestart"/>, which touch one module and one
+    /// marker.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheWholeListWrite_STILL_ClobbersAStaleSnapshot_WhichIsWhyTheLanesDoNotUseIt()
+    {
+        using var replica = new ModuleLandingService(baseDirectory: root);
+        await Land(replica, "MeshWeaver.Yankee");
+        var staleSnapshot = ModuleActivationSidecar.Read(root);
+
+        await Land(replica, "MeshWeaver.Zulu");
+
+        ModuleActivationSidecar.Write(root, staleSnapshot with { PendingRestart = false });
+
+        ModuleActivationSidecar.Read(root).Entries.Select(entry => entry.Name)
+            .Should().Equal(["MeshWeaver.Yankee"],
+                "the bulk form means BULK — it is the shape that lost modules, and the reason no "
+                + "runtime path may call it");
+    }
+
+    /// <summary>
+    /// The same property under genuine concurrency: two replicas, each with its OWN in-process IO
+    /// pool (the cap-1 pool bounds one process and cannot serialize across pods), landing a batch
+    /// at the same time. Every entry survives. The assertion is deterministic even though the
+    /// interleaving is not — which is the point of removing the shared cell rather than timing it.
+    /// </summary>
+    [Fact]
+    public async Task TwoReplicasLandingAtOnce_LoseNothing()
+    {
+        using var replicaA = new ModuleLandingService(baseDirectory: root);
+        using var replicaB = new ModuleLandingService(baseDirectory: root);
+
+        var expected = Enumerable.Range(0, 12).Select(i => $"MeshWeaver.Mod{i:00}").ToArray();
+        await Task.WhenAll(expected.Select((name, i) =>
+            Land(i % 2 == 0 ? replicaA : replicaB, name)));
+
+        ModuleActivationSidecar.Read(root).Entries.Select(entry => entry.Name)
+            .Order(StringComparer.Ordinal).Should().Equal(expected);
+    }
+
+    /// <summary>
+    /// 🚨 #2189's severity, pinned. One unreadable record must cost exactly that ONE module.
+    ///
+    /// <para>The old reader collapsed ANY failure — a transient SMB <c>ENOENT</c> from opening into
+    /// another replica's rename, just as much as real corruption — into the empty list, and then
+    /// logged that store modules "will NOT load". So one blip during boot demoted a pod to the
+    /// appsettings baseline for its entire lifetime, silently, with every other module's record
+    /// perfectly intact on disk.</para>
+    /// </summary>
+    [Fact]
+    public async Task AnUnreadableRecord_CostsOnlyItsOwnModule_AndIsReportedLoudly()
+    {
+        using var replica = new ModuleLandingService(baseDirectory: root);
+        await Land(replica, "MeshWeaver.Good");
+        await Land(replica, "MeshWeaver.Bad");
+
+        File.WriteAllText(ModuleActivationSidecar.EntryPath(root, "MeshWeaver.Bad"), "{ not json");
+
+        var reported = new List<string>();
+        var list = ModuleActivationSidecar.Read(root, reported.Add);
+
+        list.Entries.Select(entry => entry.Name).Should().Equal(["MeshWeaver.Good"],
+            "the readable records must survive their neighbour's corruption");
+        reported.Should().ContainSingle().Which.Should().Contain("MeshWeaver.Bad",
+            "the skip has to be loud AND name what was skipped — an unreadable record that reads "
+            + "as 'nothing pending' is the absence of evidence dressed as evidence");
+    }
+
+    /// <summary>
+    /// Deployments already on disk carry the legacy aggregate file, so it stays READABLE — and a
+    /// per-module record WINS over it by name, because an uninstall written by the landing lane
+    /// must beat a stale enabled row the frozen aggregate still holds.
+    /// </summary>
+    [Fact]
+    public void TheLegacyAggregateIsStillRead_AndAPerModuleRecordOverridesIt()
+    {
+        Directory.CreateDirectory(Path.Combine(root, "modules"));
+        File.WriteAllText(ModuleActivationSidecar.SidecarPath(root), """
+            {
+              "entries": [
+                { "name": "MeshWeaver.Legacy", "enabled": true },
+                { "name": "MeshWeaver.Uninstalled", "enabled": true }
+              ],
+              "pendingRestart": false
+            }
+            """);
+        ModuleActivationSidecar.WriteEntry(root,
+            new ModuleActivationEntry { Name = "MeshWeaver.Uninstalled", Enabled = false });
+
+        var list = ModuleActivationSidecar.Read(root);
+
+        list.Entries.Should().HaveCount(2);
+        list.Entries.Single(entry => entry.Name == "MeshWeaver.Legacy").Enabled.Should().BeTrue(
+            "an existing deployment's records must not vanish on upgrade");
+        list.Entries.Single(entry => entry.Name == "MeshWeaver.Uninstalled").Enabled.Should().BeFalse(
+            "the record the landing lane wrote is the current one");
+    }
+
+    /// <summary>An absent record is the fresh-deployment state: empty, and SILENT. It must never
+    /// be reported as unreadable — that is the noise that made #2189's real signal unreadable.</summary>
+    [Fact]
+    public void AnAbsentRecord_IsAQuietEmptyAnswer()
+    {
+        var reported = new List<string>();
+
+        var list = ModuleActivationSidecar.Read(Path.Combine(root, "never-deployed"), reported.Add);
+
+        list.Entries.Should().BeEmpty();
+        list.PendingRestart.Should().BeFalse();
+        reported.Should().BeEmpty();
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationContentionTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationContentionTest.cs
@@ -239,6 +239,54 @@ public class ModuleActivationContentionTest : IDisposable
     }
 
     /// <summary>
+    /// 🚨 An IO failure is not a parse failure, and the read must survive BOTH the same way.
+    ///
+    /// <para>An SMB sharing violation or lease conflict surfaces as <c>IOException</c> /
+    /// <c>UnauthorizedAccessException</c>, not as bad JSON — and boot calls
+    /// <see cref="ModuleActivationSidecar.Read"/> UN-WRAPPED, so an escaping exception takes the
+    /// portal down over a transient volume blip. A symlink LOOP reproduces exactly that class
+    /// (<c>ELOOP</c> → <c>IOException</c>) deterministically and without depending on the uid the
+    /// test happens to run as — a permission-based arrangement would silently do nothing as root,
+    /// which CI containers often are. Both halves are asserted: the neighbour still loads, and the
+    /// failure is reported by name.</para>
+    /// </summary>
+    [Fact]
+    public async Task AnIOFailureOnOneRecord_IsReportedAndSkipped_NeverThrown()
+    {
+        using var replica = new ModuleLandingService(baseDirectory: root);
+        await Land(replica, "MeshWeaver.Good");
+
+        var looped = ModuleActivationSidecar.EntryPath(root, "MeshWeaver.Looped");
+        var partner = ModuleActivationSidecar.EntryPath(root, "MeshWeaver.Partner");
+        File.CreateSymbolicLink(looped, partner);
+        File.CreateSymbolicLink(partner, looped);
+
+        var reported = new List<string>();
+        var list = ModuleActivationSidecar.Read(root, reported.Add);
+
+        list.Entries.Select(entry => entry.Name).Should().Equal(["MeshWeaver.Good"],
+            "one unreadable record costs its own module and nothing else");
+        reported.Should().HaveCount(2, "each unreadable record reports itself, by name");
+        reported.Should().OnlyContain(line => line.Contains("MeshWeaver.Looped")
+            || line.Contains("MeshWeaver.Partner"));
+    }
+
+    /// <summary>The legacy aggregate gets the same treatment: an IO failure there is reported and
+    /// skipped, never thrown, because boot reads it before anything can catch.</summary>
+    [Fact]
+    public void AnIOFailureOnTheLegacyAggregate_IsReportedAndSkipped_NeverThrown()
+    {
+        Directory.CreateDirectory(ModuleActivationSidecar.SidecarPath(root));
+        ModuleActivationSidecar.WriteEntry(root, new ModuleActivationEntry { Name = "MeshWeaver.Good" });
+
+        var reported = new List<string>();
+        var list = ModuleActivationSidecar.Read(root, reported.Add);
+
+        list.Entries.Select(entry => entry.Name).Should().Equal(["MeshWeaver.Good"]);
+        reported.Should().ContainSingle().Which.Should().Contain("activation.json");
+    }
+
+    /// <summary>
     /// 🚨 The module name BECOMES a path, so it is refused at the writer rather than trusted from
     /// whichever caller got there. A record file named after its module is a path-traversal surface
     /// the moment a name can carry a separator.

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationContentionTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationContentionTest.cs
@@ -238,6 +238,22 @@ public class ModuleActivationContentionTest : IDisposable
             "the record the landing lane wrote is the current one");
     }
 
+    /// <summary>
+    /// 🚨 The module name BECOMES a path, so it is refused at the writer rather than trusted from
+    /// whichever caller got there. A record file named after its module is a path-traversal surface
+    /// the moment a name can carry a separator.
+    /// </summary>
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("dir/child")]
+    [InlineData("..")]
+    [InlineData("  ")]
+    public void AModuleNameThatIsNotAFileName_IsRefused(string name)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            ModuleActivationSidecar.WriteEntry(root, new ModuleActivationEntry { Name = name }));
+    }
+
     /// <summary>An absent record is the fresh-deployment state: empty, and SILENT. It must never
     /// be reported as unreadable — that is the noise that made #2189's real signal unreadable.</summary>
     [Fact]

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleActivationStatusTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleActivationStatusTest.cs
@@ -39,6 +39,14 @@ public class ModuleActivationStatusTest : IDisposable
     /// module, and only the floor gate can keep that promise honest (2026-08-22).</summary>
     private static readonly Func<string?, string?> FloorSatisfied = _ => null;
 
+    /// <summary>The bytes-are-there half of the same promise (#2093): pending means a restart
+    /// LOADS it, which is false when the landed assembly is gone. Explicit here for the same
+    /// reason the floor gate is — production passes boot's own existence check.</summary>
+    private static readonly Func<ModuleActivationEntry, bool> BytesPresent = _ => true;
+
+    /// <summary>The opposite: the activation record says the module is on, the volume disagrees.</summary>
+    private static readonly Func<ModuleActivationEntry, bool> BytesGone = _ => false;
+
     // ── the pure derivation ─────────────────────────────────────────────────────────────────────
 
     [Fact]
@@ -54,7 +62,7 @@ public class ModuleActivationStatusTest : IDisposable
                 ],
             },
             Loaded("MeshWeaver.Loaded"),
-            FloorSatisfied);
+            FloorSatisfied, BytesPresent);
 
         pending.Should().ContainSingle();
         pending[0].Name.Should().Be("MeshWeaver.Acme");
@@ -76,7 +84,7 @@ public class ModuleActivationStatusTest : IDisposable
                 Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Acme" }],
             },
             Loaded("MeshWeaver.Something.Else"),
-            FloorSatisfied);
+            FloorSatisfied, BytesPresent);
 
         pending.Should().ContainSingle();
     }
@@ -92,7 +100,7 @@ public class ModuleActivationStatusTest : IDisposable
                     Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Acme" }],
                 },
                 Loaded("MeshWeaver.Acme"),
-                FloorSatisfied)
+                FloorSatisfied, BytesPresent)
             .Should().BeEmpty();
     }
 
@@ -106,7 +114,7 @@ public class ModuleActivationStatusTest : IDisposable
                     Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Removed", Enabled = false }],
                 },
                 Loaded(),
-                FloorSatisfied)
+                FloorSatisfied, BytesPresent)
             .Should().BeEmpty();
     }
 
@@ -129,16 +137,70 @@ public class ModuleActivationStatusTest : IDisposable
         };
 
         ModuleActivationStatus.NotYetLoaded(list, Loaded(),
-                floor => ModulePlatformFloor.DeclineReason(floor, "3.0.0-rc6"))
+                floor => ModulePlatformFloor.DeclineReason(floor, "3.0.0-rc6"), BytesPresent)
             .Should().BeEmpty(
                 "a restart cannot activate a held module — reporting it would be a permanent "
                 + "restart prompt no restart can clear");
 
         ModuleActivationStatus.NotYetLoaded(list, Loaded(),
-                floor => ModulePlatformFloor.DeclineReason(floor, "3.0.0-rc7"))
+                floor => ModulePlatformFloor.DeclineReason(floor, "3.0.0-rc7"), BytesPresent)
             .Should().ContainSingle(
                 "once the platform satisfies the floor, the restart promise is honest again")
             .Subject.Name.Should().Be("MeshWeaver.Speech");
+    }
+
+    /// <summary>
+    /// 🚨 #2093, pure. The same entry lands in EXACTLY ONE of the two buckets, decided by whether
+    /// its bytes are on the volume — and the buckets must not overlap, because the remedies are
+    /// opposite: wait for the restart, versus re-install the package. Asserted in BOTH directions,
+    /// so a derivation that always answered "pending" (today's bug) or always answered
+    /// "unresolvable" would fail.
+    /// </summary>
+    [Fact]
+    public void AnEntryIsPENDING_OrUNRESOLVABLE_ByWhetherItsBytesAreThere()
+    {
+        var list = new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Mcp", PackagePath = "Plugins/mcp" }],
+        };
+
+        ModuleActivationStatus.NotYetLoaded(list, Loaded(), FloorSatisfied, BytesPresent)
+            .Should().ContainSingle("bytes on the volume — a restart genuinely loads it");
+        ModuleActivationStatus.Unresolvable(list, Loaded(), FloorSatisfied, BytesPresent)
+            .Should().BeEmpty();
+
+        ModuleActivationStatus.NotYetLoaded(list, Loaded(), FloorSatisfied, BytesGone)
+            .Should().BeEmpty("no restart loads an assembly that is not on the volume");
+        ModuleActivationStatus.Unresolvable(list, Loaded(), FloorSatisfied, BytesGone)
+            .Should().ContainSingle().Subject.Name.Should().Be("MeshWeaver.Mcp");
+    }
+
+    /// <summary>A HELD entry is neither: the platform, not the bytes, is what it waits on, and the
+    /// platform update that satisfies the floor is itself the restart that loads it.</summary>
+    [Fact]
+    public void AHeldEntry_IsNeitherPendingNorUnresolvable()
+    {
+        var list = new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Speech", MinMeshVersion = "9.9.9" }],
+        };
+        Func<string?, string?> floorRefused = _ => "platform 1.0.0 is below the declared floor 9.9.9";
+
+        ModuleActivationStatus.NotYetLoaded(list, Loaded(), floorRefused, BytesGone).Should().BeEmpty();
+        ModuleActivationStatus.Unresolvable(list, Loaded(), floorRefused, BytesGone).Should().BeEmpty();
+    }
+
+    /// <summary>An unresolvable module must not put a restart prompt on a buyer's package card:
+    /// the card's question is "will a restart finish this install", and the answer is no.</summary>
+    [Fact]
+    public void AnUnresolvableModule_IsNotAPendingRestartForItsPackage()
+    {
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Mcp", PackagePath = "Plugins/mcp" }],
+        });
+
+        new PendingModuleActivations(root).IsPendingForPackage("Plugins/mcp").Should().BeFalse();
     }
 
     [Fact]
@@ -147,7 +209,7 @@ public class ModuleActivationStatusTest : IDisposable
         ModuleActivationStatus.NotYetLoaded(
                 new ModuleActivationList { Entries = [new ModuleActivationEntry { Name = "MeshWeaver.ACME" }] },
                 Loaded("meshweaver.acme"),
-                FloorSatisfied)
+                FloorSatisfied, BytesPresent)
             .Should().BeEmpty();
     }
 
@@ -192,6 +254,15 @@ public class ModuleActivationStatusTest : IDisposable
 
     // ── the reader, over the durable state ──────────────────────────────────────────────────────
 
+    /// <summary>Puts an entry's landed DLL where boot looks for it, so the entry is genuinely one
+    /// restart from loading rather than a record pointing at nothing.</summary>
+    private void LandBytesFor(string name, string? directory = null)
+    {
+        var dir = Path.Combine(root, "modules", directory ?? name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, name + ".dll"), [1]);
+    }
+
     [Fact]
     public void TheReader_ReportsWhatTheSidecarSays_AgainstThisProcess()
     {
@@ -199,13 +270,60 @@ public class ModuleActivationStatusTest : IDisposable
         {
             Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Acme", PackagePath = "Plugins/acme" }],
         });
+        LandBytesFor("MeshWeaver.Acme");
 
         var report = new PendingModuleActivations(root).Read(Loaded());
 
         report.IsUndetermined.Should().BeFalse();
         report.HasPending.Should().BeTrue();
+        report.HasUnresolvable.Should().BeFalse();
         report.Describe().Should().Contain("MeshWeaver.Acme");
         new PendingModuleActivations(root).IsPendingForPackage("Plugins/acme").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 🚨 #2093, over the durable state. The record says the module is ON; the volume says its
+    /// assembly is not there. That is NOT "pending": no restart loads it, and boot skips it. It
+    /// must land in the OTHER bucket, or the surface makes a promise every restart breaks — which
+    /// is what let <c>/mcp</c> 404 for a whole pod lifetime while everything read "installed".
+    /// </summary>
+    [Fact]
+    public void AnActivatedEntryWhoseBytesAreGone_IsUnresolvable_NotPending()
+    {
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Mcp", PackagePath = "Plugins/mcp" }],
+        });
+        // Deliberately no bytes on the volume — the half-completed landing.
+
+        var report = new PendingModuleActivations(root).Read(Loaded());
+
+        report.IsUndetermined.Should().BeFalse();
+        report.HasPending.Should().BeFalse("a restart cannot load an assembly that is not there");
+        report.HasUnresolvable.Should().BeTrue();
+        report.Unresolvable.Should().ContainSingle().Subject.Name.Should().Be("MeshWeaver.Mcp");
+        report.Describe().Should().Contain("re-install");
+        report.Describe().Should().NotContain("a restart activates them");
+    }
+
+    /// <summary>The generation directory is the ONE resolution — an entry whose bytes live in its
+    /// generation folder is pending, exactly as boot would find it.</summary>
+    [Fact]
+    public void BytesInTheEntrysGenerationDirectory_CountAsLanded()
+    {
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            Entries =
+            [
+                new ModuleActivationEntry { Name = "MeshWeaver.Acme", Directory = "MeshWeaver.Acme@abc123" },
+            ],
+        });
+        LandBytesFor("MeshWeaver.Acme", "MeshWeaver.Acme@abc123");
+
+        var report = new PendingModuleActivations(root).Read(Loaded());
+
+        report.HasPending.Should().BeTrue();
+        report.HasUnresolvable.Should().BeFalse();
     }
 
     [Fact]

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleLandingServiceTest.cs
@@ -34,6 +34,12 @@ public class ModuleLandingServiceTest : IDisposable
 
     public ModuleLandingServiceTest() => Directory.CreateDirectory(baseDirectory);
 
+    /// <summary>The module GENERATION folders under <c>modules/</c> — everything except the
+    /// activation record's own directory, which is bookkeeping and never a landed module.</summary>
+    private string[] GenerationDirectories() =>
+        [.. Directory.GetDirectories(Path.Combine(baseDirectory, "modules"))
+            .Where(dir => Path.GetFileName(dir) != ModuleActivationSidecar.EntriesDirectoryName)];
+
     public void Dispose()
     {
         if (Directory.Exists(baseDirectory))
@@ -94,7 +100,7 @@ public class ModuleLandingServiceTest : IDisposable
         var dir = ModuleLandingService.ModuleDirectoryFor(baseDirectory, "Acme.Widgets", entry);
         File.ReadAllBytes(Path.Combine(dir, "Acme.Widgets.dll"))
             .Should().Equal([9, 9], "the pointer moves to the fresh generation");
-        Directory.GetDirectories(Path.Combine(baseDirectory, "modules"))
+        GenerationDirectories()
             .Should().HaveCount(2,
                 "the superseded generation SURVIVES the landing path — a running pod may hold "
                 + "it open; boot GC reclaims it once nothing references it");
@@ -268,7 +274,7 @@ public class ModuleLandingServiceTest : IDisposable
 
         await service.RemoveModule("Acme.Widgets").FirstAsync().ToTask();
 
-        Directory.GetDirectories(Path.Combine(baseDirectory, "modules"))
+        GenerationDirectories()
             .Should().BeEmpty("uninstall deletes the landed generation (best-effort here; on a "
                 + "shared volume a loaded copy survives to boot GC)");
         var list = ModuleActivationSidecar.Read(baseDirectory);

--- a/test/MeshWeaver.PluginCatalog.Test/RequiredModuleStatusTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RequiredModuleStatusTest.cs
@@ -1,0 +1,225 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The readiness contract for <c>Modules:Required</c> (#2089): required-and-nothing-can-produce-it
+/// versus expected-from-the-store-lane, told apart.
+///
+/// <para>🚨 <b>These assert BOTH directions on purpose.</b> The defect being fixed is a probe that
+/// answered the same way for two situations with opposite remedies — and the obvious "fix" is a
+/// probe that answers Degraded for everything, which is the skip-trapdoor: a gate that passes on no
+/// evidence. So every test below has a partner asserting the OTHER verdict from the same shape of
+/// input. A classifier that always said Absent (today's wedge) and one that always said
+/// ExpectedLater (the lenient non-fix) each fail here.</para>
+/// </summary>
+public class RequiredModuleStatusTest
+{
+    private static IReadOnlySet<string> Loaded(params string[] names) =>
+        names.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly Func<string?, string?> FloorSatisfied = _ => null;
+    private static readonly Func<ModuleActivationEntry, bool> BytesPresent = _ => true;
+    private static readonly Func<ModuleActivationEntry, bool> BytesGone = _ => false;
+
+    private static ImmutableList<RequiredModuleVerdict> Classify(
+        string[] required,
+        string[] baseline,
+        IReadOnlySet<string>? loaded = null,
+        Func<string, bool>? resolves = null,
+        ModuleActivationList? activation = null,
+        Func<ModuleActivationEntry, bool>? bytes = null,
+        Func<string?, string?>? floor = null) =>
+        RequiredModuleStatus.Classify(
+            required, baseline, loaded ?? Loaded(), resolves ?? (_ => false),
+            activation, bytes ?? BytesPresent, floor ?? FloorSatisfied);
+
+    // ── the hard gate keeps its teeth ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The case the gate exists for: the image's OWN list claims the pack and the image does not
+    /// carry it. Nothing here can produce it and the previous pods still have it, so the rollout
+    /// must stall. This is 3.0.0-rc5's shape.
+    /// </summary>
+    [Fact]
+    public void APackTheImageClaimsToShip_AndDoesNot_IsABSENT()
+    {
+        var verdict = Classify(
+            required: ["MeshWeaver.Blazor.Views.dll"],
+            baseline: ["MeshWeaver.Blazor.Views.dll"]).Single();
+
+        verdict.State.Should().Be(RequiredModuleState.Absent);
+        verdict.Reason.Should().Contain("Modules:Assemblies");
+    }
+
+    /// <summary>The partner direction — the very same declaration, resolvable, is simply fine. A
+    /// classifier that always reported Absent would fail here.</summary>
+    [Fact]
+    public void ThatSamePack_WhenTheImageActuallyCarriesIt_IsPRESENT()
+    {
+        Classify(
+                required: ["MeshWeaver.Blazor.Views.dll"],
+                baseline: ["MeshWeaver.Blazor.Views.dll"],
+                resolves: _ => true)
+            .Single().State.Should().Be(RequiredModuleState.Present);
+    }
+
+    // ── the store lane is expected, never a wedge ────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 #2089 itself. MeshWeaver.Speech moved OUT of the image into the store, so the image
+    /// requires it while never claiming to ship it. Reporting that as Absent stalled both prod
+    /// rollouts with no remedy but blanking the config on the live deployment — and stalling could
+    /// never have delivered it, because the registry that serves it is a portal downstream of this
+    /// very rollout.
+    /// </summary>
+    [Fact]
+    public void AStoreDeliveredModuleTheImageNeverClaimed_IsEXPECTEDLATER_NotAbsent()
+    {
+        var verdict = Classify(
+            required: ["MeshWeaver.Speech.dll"],
+            baseline: ["MeshWeaver.Social.dll"]).Single();
+
+        verdict.State.Should().Be(RequiredModuleState.ExpectedLater);
+        verdict.Reason.Should().Contain("install the package");
+    }
+
+    /// <summary>The partner direction — expected-later is NOT "always degraded". Once it is loaded
+    /// here, it is Present and nothing is reported at all.</summary>
+    [Fact]
+    public void ThatSameStoreModule_OnceLoaded_IsPRESENT()
+    {
+        Classify(
+                required: ["MeshWeaver.Speech.dll"],
+                baseline: ["MeshWeaver.Social.dll"],
+                loaded: Loaded("MeshWeaver.Speech"))
+            .Single().State.Should().Be(RequiredModuleState.Present);
+    }
+
+    /// <summary>Landed on the volume and awaiting the restart — still expected, and the reason says
+    /// which of the four store states it is in, so an operator is never left guessing.</summary>
+    [Fact]
+    public void AStoreModuleLandedButNotLoaded_SaysARestartActivatesIt()
+    {
+        var verdict = Classify(
+            required: ["MeshWeaver.Speech.dll"],
+            baseline: [],
+            activation: new ModuleActivationList
+            {
+                Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Speech" }],
+            }).Single();
+
+        verdict.State.Should().Be(RequiredModuleState.ExpectedLater);
+        verdict.Reason.Should().Contain("a restart activates it");
+    }
+
+    /// <summary>A landing that did not complete is still expected-later — but it says so, and it
+    /// says the remedy is a re-install, not a restart (#2093's promise, kept honest).</summary>
+    [Fact]
+    public void AStoreModuleRecordedButWithoutBytes_SaysReinstall_NotRestart()
+    {
+        var verdict = Classify(
+            required: ["MeshWeaver.Mcp.dll"],
+            baseline: [],
+            activation: new ModuleActivationList
+            {
+                Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Mcp" }],
+            },
+            bytes: BytesGone).Single();
+
+        verdict.State.Should().Be(RequiredModuleState.ExpectedLater);
+        verdict.Reason.Should().Contain("Re-install");
+        verdict.Reason.Should().NotContain("a restart activates it");
+    }
+
+    /// <summary>
+    /// The near-circular case (#2089's registry shelf): the module is landed but HELD above this
+    /// platform's version. The platform update that satisfies the floor is itself the restart that
+    /// loads it — so holding the rollout is precisely the wrong move, and the reason names the
+    /// floor rather than saying "missing".
+    /// </summary>
+    [Fact]
+    public void AStoreModuleHeldAboveThePlatformFloor_NamesTheFloor()
+    {
+        var verdict = Classify(
+            required: ["MeshWeaver.Speech.dll"],
+            baseline: [],
+            activation: new ModuleActivationList
+            {
+                Entries = [new ModuleActivationEntry
+                {
+                    Name = "MeshWeaver.Speech", MinMeshVersion = "3.0.0-rc7",
+                }],
+            },
+            floor: _ => "the running platform 3.0.0-rc6 is below the declared floor 3.0.0-rc7").Single();
+
+        verdict.State.Should().Be(RequiredModuleState.ExpectedLater);
+        verdict.Reason.Should().Contain("3.0.0-rc7");
+    }
+
+    /// <summary>A DISABLED record is an uninstall, not an install in flight — the module is simply
+    /// not installed, and the remedy is to install it (or delist it).</summary>
+    [Fact]
+    public void ADisabledRecord_ReadsAsNotInstalled()
+    {
+        Classify(
+                required: ["MeshWeaver.Speech.dll"],
+                baseline: [],
+                activation: new ModuleActivationList
+                {
+                    Entries = [new ModuleActivationEntry { Name = "MeshWeaver.Speech", Enabled = false }],
+                })
+            .Single().Reason.Should().Contain("NOT installed");
+    }
+
+    // ── the buckets never blur ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The two verdicts in ONE deployment, which is the state that actually shipped: the image
+    /// lost a pack it claims AND the store lane owes another. Both must be reported, separately —
+    /// an aggregate that reduced to one number would hide whichever half the operator needed.
+    /// </summary>
+    [Fact]
+    public void ALostPackAndAnOwedModule_AreReportedSeparately()
+    {
+        var verdicts = Classify(
+            required: ["MeshWeaver.Blazor.Views.dll", "MeshWeaver.Speech.dll"],
+            baseline: ["MeshWeaver.Blazor.Views.dll"]);
+
+        RequiredModuleStatus.Absent(verdicts).Select(v => v.Name)
+            .Should().Equal(["MeshWeaver.Blazor.Views"]);
+        RequiredModuleStatus.ExpectedLater(verdicts).Select(v => v.Name)
+            .Should().Equal(["MeshWeaver.Speech"]);
+    }
+
+    [Fact]
+    public void DeclaringNothingRequired_IsInert()
+    {
+        // Today's deployments that declare none must behave exactly as they do now.
+        Classify(required: [], baseline: ["MeshWeaver.Social.dll"]).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BlankEntries_AreIgnored_NotReportedAsFaults()
+    {
+        RequiredModuleStatus.Classify(
+                ["", "   ", null], null, Loaded(), _ => false, null, BytesPresent, FloorSatisfied)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MatchingIsCaseInsensitive_LikeAssemblyNames()
+    {
+        Classify(
+                required: ["MeshWeaver.SPEECH.dll"],
+                baseline: [],
+                loaded: Loaded("meshweaver.speech"))
+            .Single().State.Should().Be(RequiredModuleState.Present);
+    }
+}


### PR DESCRIPTION
Closes #2090, #2189, #2190, #2089, #2093. Platform half of #2088.

A module is only delivered if it is **built → published → uploaded → activated → host-loaded**. Five open issues are five different links of that one chain, and every one of them fails the same way: a surface that cannot tell *"I have no evidence"* from *"the evidence says fine"*.

## One activation record per module (#2090, #2189/#2190)

Every portal replica mounts the same RWX `/data`, and the activation record was ONE `modules/activation.json` that each landing read, appended to, and renamed over. Two defects, neither fixable by retrying:

1. **Lost updates.** Concurrent landings of *different* modules overwrite each other's entries — last writer wins the whole list. Worse, boot's `PendingRestart` reset wrote the whole list back **from a snapshot taken before it started**, so a pod merely *starting up* erased whatever another replica had landed meanwhile. On a rolling restart that is several pods doing it at once.
2. **Replace-in-place races every reader.** On SMB the rename is refused while another client holds the target open — `Access to the path '/data/modules/activation.json' is denied`, the 409s of #2090 — and a reader that opens into the replace window gets `ENOENT`. The reader reported that as a **corrupt sidecar**, collapsed the answer to the empty list, and **booted the pod with no store modules at all** for its whole lifetime. That is #2189's `FileNotFoundException` on a file the reader had just seen exist.

**The contended cell is removed rather than guarded.** Each module owns `modules/activation.d/<Name>.json`; a landing writes only its own. Two writers of different modules share no path at all, so lost updates are structurally impossible and there is no single hot lease. `PendingRestart` becomes a marker **file** — a create and a delete, never a read-modify-write. The legacy aggregate is still **read** (deployments already carry one), with a per-module record winning by name; nothing writes it any more. And an unreadable record now costs exactly **that one module**, reported by name, instead of the deployment's whole module set — with `ENOENT` classified as *absent* (which it is) rather than as corruption.

> The in-process cap-1 `IoPool` was never the safety here and could not be: it bounds one process, and `/data` is shared by every replica. Cross-replica safety had to come from the record's **shape**.

## Readiness tells required-absent from expected-later (#2089)

`Modules:Required` reported **Unhealthy** for every absence, which asserts something it cannot know. A required module missing from the image is either:

- a pack the build **dropped** — the previous pods still have it, so stalling the rollout preserves the feature; or
- a **store-delivered** module the lane has not landed — stalling delivers nothing, because the registry that must serve it is a portal *downstream of the same rollout*.

Conflated, the second wedged both prod rollouts on 2026-08-23, and the only remedy anyone found was blanking `Modules__Required__0..4` on the live deployment as standing revert-debt. **A gate whose one escape hatch is deleting its own declaration is the skip-trapdoor with its polarity flipped** — it fails on no evidence instead of passing on it.

The missing evidence was already on disk: **`Modules:Assemblies` is the image's own claim about what it carries.**

| situation | verdict | `required_modules` | effect |
|---|---|---|---|
| loaded here, or resolvable from this deployment | `Present` | Healthy | — |
| named under `Modules:Assemblies` and absent | `Absent` | **Unhealthy** | readiness fails → rollout **stalls**, old pods keep serving |
| required but never claimed by the image (store-delivered) | `ExpectedLater` | **Degraded**, named | rollout completes; the gap is reported per module |

🚨 **Degraded is not leniency.** Every `ExpectedLater` module is named with *which of four states* it is in — not installed (install the package) / landed and awaiting the restart / landing incomplete (re-install; no restart helps) / held above the platform floor (the platform update that satisfies it *is* the restart that loads it). Both buckets ship in the probe payload (`missing`, `expected`, `detail`) whatever the status, so an operator never has to infer the bucket from the colour. The hard gate keeps its teeth exactly where stalling can preserve something.

## An activated module that never host-loaded is a silent 404 (#2093, and #1979's remaining lie)

`MapMeshModuleEndpoints` can only scan assemblies that are **loaded**. A module the activation record says is ON, whose bytes never reached the process, contributes no routes — and its whole HTTP surface 404s for the pod's entire lifetime with no exception and nothing to grep. That is `/mcp` on memex.systemorph, dead through two clean rolling restarts while `/health` was 200.

Startup now reports it, and the report distinguishes what the old one could not:

- **landed, not loaded** → *"a restart activates them"* — true, and the rollout performs it;
- **activated, bytes ABSENT** → *"re-install the package"* — a restart will **not** load them.

#1979 (surfacing `PendingRestart`) had already shipped; what remained was that its surface made a promise every restart broke and none could clear. That is closed here — `#1979` itself stays open only if its author wants more than the health check + startup report already give.

## Module-bundle publish follows the release (#2088 — platform half)

`node-repo-module-pack`'s `publish` input said *"Trunk only"*, which is what taught every caller to write `publish: ${{ github.event_name == 'push' }}`. So a release-follow **schedule** run packed, versioned and inspected the bundles and handed them to **nobody**, and module adoption stayed `FrameworkDeclined` until an unrelated push republished by accident. The input is redocumented as **trunk-only, not push-only**, and the file gains the caller-contract block every sibling reusable workflow carries (modelled on `node-repo-publish-bake`): the three-way `if:`, the release-follow cron, and the shared `framework-release` concurrency lane.

The `publish:` expression itself lives in `Systemorph/MeshWeaver.Plugins` `ci.yml` — that repo already has the `schedule` + `repository_dispatch` triggers and the shared concurrency lane, so it is a one-line change, filed as the follow-up half.

## Tests

`ModuleActivationContentionTest` is the deterministic repro, not a timing test:

- **landing one module must touch no file belonging to another** — fails against the single-file record, where Beta's landing rewrites the file holding Alpha's entry;
- **consuming the restart flag cannot erase a module landed meanwhile** — the exact production sequence, deterministic;
- a companion test **demonstrates that the bulk whole-list write still clobbers a stale snapshot**, which is precisely why no runtime path may call it;
- **one unreadable record costs only its own module**, and is reported by name.

`RequiredModuleStatusTest` and `RequiredModulesHealthCheckTest` assert **both directions** on every input shape, so neither an always-`Absent` classifier (today's wedge) nor an always-`Degraded` one (the lenient non-fix) can pass.

Local, Release + `-warnaserror`, all `0 Error(s)`:
`MeshWeaver.PluginCatalog.Test` **627/627**, `Memex.Portal.Shared.Test` **411/411**, `MeshWeaver.Documentation.Test` **42/42**, `MeshWeaver.Graph.Test --filter ConfiguredModuleActivation` **8/8**.

## Not done here

- **No chart or overlay change.** The `Modules__Required__0..4` blanking in `values.local.defaults.yaml` and the prod overlays is now *unnecessary* — those requirements would report Degraded rather than 503 — but retiring standing revert-debt on a live deployment is an operator decision, and chart edits need a render-and-diff pass (#2210).
- Nothing rolls a portal; delivery is CD's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
