### PR TITLE
Two more mutation paths that write storage without announcing it (#2087)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-newly-created-nodes-are-reachable-immediately.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-newly-created-nodes-are-reachable-immediately.md
@@ -1,0 +1,23 @@
+---
+Name: Newly created nodes are reachable immediately
+Category: Fix
+Description: Fixes nodes that existed in the database but could not be opened — a freshly imported space or a newly created node could stay "not found" until the server restarted.
+Icon: Sparkle
+Order: -20260825
+---
+
+# Newly created nodes are reachable immediately
+
+Some nodes were saved correctly and then stayed invisible to the running server. Opening them
+reported that the page could not be found, even though the content was in the database the whole
+time, and only restarting the server made them appear. It showed up most often right after importing
+a new space or installing new content: one item — sometimes the space's own home page — would simply
+refuse to open, while everything imported alongside it worked.
+
+The cause was an internal announcement that two save paths were skipping. When a node is created,
+the rest of the server has to be told, or the earlier answer — "there is nothing at this address" —
+stays remembered. Both paths now announce their creations like every other save, so a node is
+openable the moment it is written.
+
+If you hit this before, the affected content was never lost; it is reachable again without any
+action on your part.

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -673,7 +673,11 @@ internal static class NodeTypeBatchBake
             // the compare-and-set below reads as "insert only if absent". Carried explicitly rather
             // than derived from stampedNode.Version - 1, which would silently rot if the mint
             // changed.
-            .Select(stored => (Expected: stored?.Version ?? 0, Fresh: stored ?? typeNode))
+            // 🚨 `IsInsert` is carried from `stored is null`, NOT inferred from `Expected == 0`
+            // (#2087). The two coincide today only because versions start at 1; deriving the
+            // announcement KIND from a version number is exactly the kind of silent rot the
+            // Expected note below warns about, and getting it wrong strands a path permanently.
+            .Select(stored => (Expected: stored?.Version ?? 0, IsInsert: stored is null, Fresh: stored ?? typeNode))
             .Select(read =>
             {
                 var fresh = read.Fresh;
@@ -683,7 +687,7 @@ internal static class NodeTypeBatchBake
                     logger?.LogWarning(
                         "BatchBake: {TypePath} content could not be read as NodeTypeDefinition — "
                         + "stamp skipped", typeNode.Path);
-                    return (Expected: read.Expected, Stamped: (MeshNode?)null);
+                    return (Expected: read.Expected, read.IsInsert, Stamped: (MeshNode?)null);
                 }
                 var stamped = (ok
                         // currentNodeVersion = typeNode.Version — the version the compiler's
@@ -700,7 +704,7 @@ internal static class NodeTypeBatchBake
                     // there). Written here so a per-type duration is derivable FROM THE MESH on both
                     // drivers, not just from a log line — issue #1439.
                     with { LastCompileStartedAt = startedAt };
-                return (Expected: read.Expected, Stamped: (MeshNode?)(fresh with
+                return (Expected: read.Expected, read.IsInsert, Stamped: (MeshNode?)(fresh with
                 {
                     Content = stamped,
                     Version = MeshNode.NextVersion(fresh.Version)
@@ -743,10 +747,27 @@ internal static class NodeTypeBatchBake
                                 typeNode.Path, stampedNode.Version, stamp.Expected);
                             return;
                         }
-                        // Post-commit announce, exactly as WriteAndPublishUpdated did — the
-                        // mesh-change feed is what invalidates the resolution / stream caches.
+                        // Post-commit announce — the mesh-change feed is what invalidates the
+                        // resolution / stream caches.
+                        //
+                        // 🚨 Created vs Updated is NOT cosmetic here (#2087). `WriteIfVersion` with
+                        // an expected version of 0 is an INSERT — "write only if absent" — so on a
+                        // fresh or freshly-imported partition this line lands the NodeType's very
+                        // first durable row, and it announced that CREATE as an UPDATE.
+                        // `PathResolutionService` only STALE-MARKS on Updated and keeps serving the
+                        // cached route shape (deliberately — removing on Updated was the #1172
+                        // routing/compile feedback loop); only Created/Deleted REMOVE the entry. So
+                        // a path probed while the type was still absent — which is precisely what
+                        // an installer's overlay watchers do — kept its cached miss for the life of
+                        // the process: the row is in Postgres, no hub is ever woken, the type never
+                        // comes live, and every instance typed on it wears the missing-type overlay.
+                        // That is the #817/#824 announce-loss shape reaching the mesh through a
+                        // primitive (#1424's compare-and-set) that was added without an announcement
+                        // partner.
                         if (applied is true)
-                            changeFeed?.Publish(MeshChangeEvent.Updated(stampedNode));
+                            changeFeed?.Publish(stamp.IsInsert
+                                ? MeshChangeEvent.Created(stampedNode)
+                                : MeshChangeEvent.Updated(stampedNode));
                     })
                     .Select(_ => Unit.Default))
             .Catch<Unit, Exception>(ex =>

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -3400,6 +3400,10 @@ public static class MeshExtensions
             return Observable.Empty<System.Reactive.Unit>();
 
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
+        // 🚨 The announcement channel for the additional nodes below (#2087). A bulk/raw storage
+        // write that skips it lands a node that EXISTS in Postgres and does not exist to the
+        // running mesh — see WriteAndPublishCreated for the full mechanism.
+        var changeFeed = hub.ServiceProvider.GetService<IMeshChangeFeed>();
         var handlers = hub.ServiceProvider.GetServices<INodePostCreationHandler>()
             .Where(h => h.NodeType.Equals(node.NodeType, StringComparison.OrdinalIgnoreCase))
             .ToList();
@@ -3447,7 +3451,21 @@ public static class MeshExtensions
                     return handleObs;
 
                 var saveExtras = additional
-                    .Select(extra => persistence.Write(extra with { State = MeshNodeState.Active }, hub.JsonSerializerOptions)
+                    // 🚨 …AndPublishCreated, never a bare Write (#2087). These are BRAND-NEW nodes
+                    // — a Space's creator-Admin grant, an Admin/Partition definition, onboarding
+                    // seeds — written straight to storage on the create path of every node whose
+                    // type has a post-creation handler, i.e. on essentially every imported root.
+                    // Without the announcement the row is in Postgres and does not exist to the
+                    // running mesh: PathResolutionService's cached miss for that path is never
+                    // evicted, MeshNodeStreamCache and the Orleans path-cache invalidator are never
+                    // told, and routing answers "No node found at '…'" for the life of the process.
+                    // The DataChangeRequest.Update posted below is NOT a substitute — it targets the
+                    // new node's own address (which is what has to become reachable in the first
+                    // place) and feeds synced queries, not the resolution caches. This is the
+                    // #817/#824 announce-loss shape on a mutation path that never adopted the
+                    // helpers.
+                    .Select(extra => persistence.WriteAndPublishCreated(
+                            extra with { State = MeshNodeState.Active }, hub.JsonSerializerOptions, changeFeed)
                         .Where(saved => saved is not null)
                         .Select(saved => saved!)
                         .Do(saved =>

--- a/test/MeshWeaver.Hosting.Monolith.Test/PostCreationNodeIsAnnouncedTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/PostCreationNodeIsAnnouncedTest.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 <b>#2087 / the #817–#824 announce-loss class — a node a post-creation handler writes must be
+/// ANNOUNCED, or it is invisible to the mesh that wrote it.</b>
+///
+/// <para><b>The invariant</b> (#824): the <see cref="IMeshChangeFeed"/> is what invalidates the
+/// caches that decide whether a node is REACHABLE — <c>PathResolutionService</c>'s resolution cache,
+/// <c>MeshNodeStreamCache</c>, the Orleans path-cache invalidator. A write that skips it leaves a
+/// node that EXISTS in storage and does not exist to the running mesh: a path probed while it was
+/// still absent resolves to its ancestor with a remainder — a perfectly cacheable value — and
+/// nothing ever evicts it, so routing answers <c>No node found at '…'</c> for the life of the
+/// process. #824 closed that for the installer's bulk path and warned: <i>"if this shape recurs,
+/// look for a NEW mutation path that writes storage without going through those helpers."</i></para>
+///
+/// <para><b>The recurrence.</b> <c>MeshExtensions.RunPostCreationHandlersObs</c> persists the
+/// additional nodes an <see cref="INodePostCreationHandler"/> returns with a bare
+/// <c>IStorageAdapter.Write</c> — no announcement of any kind. Those are brand-new nodes (a Space's
+/// creator-Admin grant, an <c>Admin/Partition</c> definition, onboarding seeds) written on the
+/// create path of every node whose type has a handler, i.e. on essentially every imported root. The
+/// <c>DataChangeRequest.Update</c> it posts instead is not a substitute: it targets the new node's
+/// OWN address — the thing that has to become reachable in the first place — and feeds synced
+/// queries, not the resolution caches.</para>
+/// </summary>
+public class PostCreationNodeIsAnnouncedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string ProbeType = "AnnounceProbe";
+    private const string ExtraPath = $"{TestPartition}/announce-probe-extra";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMeshNodes(new MeshNode(ProbeType) { Name = "Announce Probe" })
+            .ConfigureServices(services => services
+                .AddSingleton<INodePostCreationHandler, ExtraNodeHandler>());
+
+    /// <summary>
+    /// The invariant, asserted directly on the feed: the additional node the handler returns carries
+    /// a <see cref="MeshChangeKind.Created"/> event, exactly as any other create does.
+    ///
+    /// <para><b>Non-vacuity.</b> The parent's own <c>Created</c> is required first, so a feed that
+    /// published nothing at all (a mis-wired subscription) cannot pass this by being empty.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ANodeWrittenByAPostCreationHandler_IsAnnouncedOnTheMeshChangeFeed()
+    {
+        var seen = new ConcurrentQueue<MeshChangeEvent>();
+        var feed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        using var _ = feed.Subscribe(seen.Enqueue);
+
+        var parentPath = $"{TestPartition}/announce-probe-parent";
+        await NodeFactory.CreateNode(MeshNode.FromPath(parentPath) with
+        {
+            Name = "Announce probe parent",
+            NodeType = ProbeType,
+        }).Should().Emit();
+
+        // The handler's write is chained off the create, so the event has landed by the time the
+        // additional node is readable. Wait on the CONDITION, never a delay.
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .Select(_ => seen.ToArray())
+            .Where(events => events.Any(e => e.Path == ExtraPath))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(20)).ToTask();
+
+        var events = seen.ToArray();
+        foreach (var e in events)
+            Output.WriteLine($"{e.Kind} {e.Path}");
+
+        events.Should().Contain(e => e.Path == parentPath && e.Kind == MeshChangeKind.Created,
+            "the parent's own create announces normally — if this is missing the feed is mis-wired "
+            + "and the assertion below would prove nothing");
+
+        events.Should().Contain(e => e.Path == ExtraPath && e.Kind == MeshChangeKind.Created,
+            "a node written by a post-creation handler is a CREATE like any other, and the "
+            + "mesh-change feed is what makes it reachable — without it the row is in storage and "
+            + "does not exist to the running mesh (#2087, the #817/#824 class)");
+    }
+
+    /// <summary>
+    /// The outage in miniature, deterministic and in-process: probe the path while it is genuinely
+    /// absent (which caches the miss), then create the parent whose handler writes it, then require
+    /// the node reachable with nothing restarted. This is the same shape #824 pinned for the bulk
+    /// installer path, on the mutation path that had not adopted the helpers.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task APathProbedBeforeItExisted_IsReachableRightAfterTheHandlerWritesIt()
+    {
+        // PROBE the absent node — the poisoning step. It must not find anything (that is the
+        // point), and whatever the resolver caches here is what the create has to invalidate.
+        var beforeCreate = await Mesh.GetWorkspace().GetMeshNodeStream(ExtraPath)
+            .Take(1).Timeout(TimeSpan.FromSeconds(5))
+            .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))
+            .FirstAsync().ToTask();
+        beforeCreate.Should().BeNull("the additional node is genuinely absent at this point");
+
+        var parentPath = $"{TestPartition}/announce-probe-reach";
+        await NodeFactory.CreateNode(MeshNode.FromPath(parentPath) with
+        {
+            Name = "Announce probe reach",
+            NodeType = ProbeType,
+        }).Should().Emit();
+
+        var afterCreate = await Mesh.GetWorkspace().GetMeshNodeStream(ExtraPath)
+            .Where(n => n is not null).Select(n => n!)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(20)).ToTask();
+
+        afterCreate.Path.Should().Be(ExtraPath,
+            "a node written by a post-creation handler that was probed while absent must not stay "
+            + "unreachable — that is the fresh-import outage this pins (#2087)");
+    }
+
+    /// <summary>
+    /// Writes exactly one additional node at a fixed path, so the test can probe that path before
+    /// the create. <c>Handle</c> itself does nothing — the defect is entirely in how
+    /// <c>GetAdditionalNodes</c>' result is persisted.
+    /// </summary>
+    private sealed class ExtraNodeHandler : INodePostCreationHandler
+    {
+        public string NodeType => ProbeType;
+
+        public IObservable<Unit> Handle(MeshNode createdNode, string? createdBy)
+            => Observable.Return(Unit.Default);
+
+        public IEnumerable<MeshNode> GetAdditionalNodes(MeshNode createdNode)
+            => [MeshNode.FromPath(ExtraPath) with { Name = "Announce probe extra", NodeType = ProbeType }];
+    }
+}

--- a/test/MeshWeaver.PathResolution.Test/PathResolutionCacheTest.cs
+++ b/test/MeshWeaver.PathResolution.Test/PathResolutionCacheTest.cs
@@ -6,6 +6,7 @@ using MeshWeaver.Graph;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.PathResolution.Test;
@@ -178,5 +179,60 @@ public class PathResolutionCacheTest(ITestOutputHelper output) : MonolithMeshTes
             r => string.Equals(r?.Node?.Name, "After", StringComparison.Ordinal));
         fresh.Should().NotBeNull(
             "the update's change-feed event must evict the cached resolution so a fresh query sees the new Name");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The announcement KIND decides whether a cached MISS is ever evicted</b> — the mechanism
+    /// behind the #817/#824/#2087 announce-loss class, made executable.
+    ///
+    /// <para>A path probed while its node is absent resolves to <c>prefix = ancestor</c> with a
+    /// non-empty <c>Remainder</c>. That is a perfectly cacheable POSITIVE value, so it is cached —
+    /// and from then on only the change feed can dislodge it. <c>Created</c>/<c>Deleted</c> REMOVE
+    /// matching entries; <c>Updated</c> deliberately only STALE-MARKS them and keeps serving the
+    /// route shape, because removing on Updated was the #1172 routing/compile feedback loop (every
+    /// activity-log write invalidated the entry the next routed message needed).</para>
+    ///
+    /// <para>So a genuine CREATE announced as an UPDATE leaves the miss in place for the life of the
+    /// process: the row is in storage, routing keeps answering <i>"No node found at '…'"</i>, no hub
+    /// is ever woken. This test states both halves as facts so no future change can invert them
+    /// silently — and so the reason <c>NodeTypeBatchBake</c>'s insert must publish <c>Created</c>
+    /// (its <c>WriteIfVersion(node, 0)</c> is "write only if absent") is not just prose.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ACachedMiss_IsEvictedByCreated_ButNotByUpdated()
+    {
+        var space = await SeedSpace();
+        var absent = $"{space}/never-created";
+        var feed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+
+        // Cache the MISS: the ancestor resolves, the last segment does not.
+        var miss = await PollResolution(absent,
+            r => r is not null && string.Equals(r.Prefix, space, StringComparison.Ordinal));
+        miss!.Remainder.Should().Be("never-created", "this is the cached-miss shape the class doc names");
+
+        // An UPDATED event for that path must NOT change the route shape — it stale-marks only.
+        // Asserted as the STABLE state after the event has been given every chance to land: an
+        // Updated that arrived and did the right thing is indistinguishable from one still in
+        // flight, so the point is that the shape never changes, not that it changes slowly.
+        var placeholder = MeshNode.FromPath(absent) with { Name = "Phantom", NodeType = "Markdown" };
+        feed.Publish(MeshChangeEvent.Updated(placeholder));
+        var afterUpdated = await Observable.Interval(TimeSpan.FromMilliseconds(100))
+            .StartWith(0L).Take(5)
+            .SelectMany(_ => PathResolver.ResolvePath(absent))
+            .ToArray().ToTask();
+        afterUpdated.Should().OnlyContain(
+            r => r != null && r.Prefix == space && r.Remainder == "never-created",
+            "Updated only STALE-MARKS the entry and keeps serving the route shape (#1172) — which "
+            + "is exactly why announcing a CREATE as an Updated strands the path forever");
+
+        // A CREATED event for the same path REMOVES the entry, so the next resolution re-queries.
+        // The node genuinely exists by then, so the re-query resolves it fully.
+        await SeedChild(absent);
+        feed.Publish(MeshChangeEvent.Created(placeholder));
+        var afterCreated = await PollResolution(absent,
+            r => r is not null && string.Equals(r.Prefix, absent, StringComparison.Ordinal));
+        afterCreated!.Remainder.Should().BeNull(
+            "Created REMOVES the cached miss, so the path resolves in full without a restart — "
+            + "this is the half the announce-loss class keeps losing");
     }
 }


### PR DESCRIPTION
Contributes to #2087 (deliberately **not** auto-closing it — see "Honest scope").

#824 established the invariant and warned exactly where to look next: *"if this shape recurs, look for a NEW mutation path that writes storage without going through those helpers."* **It has recurred, twice.**

A write that skips the `IMeshChangeFeed` leaves a node that EXISTS in Postgres and does not exist to the running mesh: a path probed while it was still absent resolves to its ancestor with a remainder — a perfectly cacheable POSITIVE value — and nothing ever evicts it. Routing answers `No node found at '…'` for the life of the process.

## 1. Post-creation handlers wrote their additional nodes silently

`MeshExtensions.RunPostCreationHandlersObs` persisted every node an `INodePostCreationHandler` returns with a bare `IStorageAdapter.Write` — **no announcement of any kind**. Those are brand-new nodes (a Space's creator-Admin grant, an `Admin/Partition` definition, onboarding seeds), written on the create path of every node whose type has a handler — i.e. essentially every imported root.

The `DataChangeRequest.Update` it posts instead is not a substitute: it targets the new node's **own address** — the thing that has to become reachable in the first place — and feeds synced queries, not the resolution caches.

→ now `WriteAndPublishCreated`, like every other create.

## 2. The batch bake announced an INSERT as an UPDATE

`NodeTypeBatchBake` stamps compile state with `WriteIfVersion(node, expected)` where `expected = stored?.Version ?? 0` — and **expected 0 means "write only if absent", i.e. an INSERT**. On a fresh or freshly-imported partition that lands the NodeType's very first durable row, and it published `MeshChangeEvent.Updated`.

That distinction is not cosmetic:

- `PathResolutionService` **REMOVES** matching entries on `Created`/`Deleted`;
- it deliberately only **STALE-MARKS** on `Updated`, and a stale-marked entry still answers `ResolveRoute` — removing on Updated was the #1172 routing/compile feedback loop.

So a create announced as an update leaves the cached miss in place: the row is in Postgres, no hub is ever woken, **the type never comes live**, and every instance typed on it wears the missing-type overlay. That is #2087's reported symptom (`NodeType 'Store/Plugin' never came live`), and it exists because #1424's compare-and-set primitive was added **without an announcement partner** — there is still no `WriteIfVersionAndPublish*`.

The kind is now carried as `IsInsert` from `stored is null`, **not** inferred from `Expected == 0`: those coincide only because versions start at 1, and deriving an announcement kind from a version number is exactly the silent rot the surrounding note already warns about.

## Pins

| Test | Status |
|---|---|
| `PostCreationNodeIsAnnouncedTest` (new, 2 tests) | **Failing-first proven.** The invariant on the feed (a handler-written node carries `Created`, with the parent's own `Created` required first so an empty feed cannot pass), and the outage in miniature — probe the path while absent, create, require it reachable with nothing restarted. Reverting the one call site reds BOTH with a `TimeoutException`. |
| `PathResolutionCacheTest.ACachedMiss_IsEvictedByCreated_ButNotByUpdated` (new) | Mechanism pin: states **both** halves as executable facts — Updated keeps serving the cached miss (#1172's rule), Created removes it. |

## 🚨 Honest scope

Pin 1 is a genuine failing-first repro of defect 1. **Defect 2 has no repro of its own** — the bake path needs a full Roslyn bake harness — so it ships on the argument above plus the mechanism pin. It is a one-line kind selection whose worst case if wrong is one extra cache eviction per NodeType per fresh mesh; the worst case of leaving it is an unreachable type for the life of the process.

I am **not** closing #2087: I have no access to the education CI mesh and cannot prove the reported flake is gone. The full audit — including six further unannounced paths I did **not** change blind, and three decorators that make a caller's announcement *wrong* in the other direction — is posted on the issue.

## Verification

- `PostCreationNodeIsAnnouncedTest` 2/2 · `PathResolutionCacheTest` 5/5
- `CreateNodesRequestTest` + `BuildCoordinationTest` + the new test: 25/25
- Documentation link integrity + What's-New integrity: 2/2
- Release `-warnaserror` clean on `MeshWeaver.Mesh.Contract`, `MeshWeaver.Hosting`, `MeshWeaver.Documentation` and the touched test projects.

What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
