### PR TITLE
Arm the observer BEFORE the trigger — a hot emission missed has no second chance

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -243,6 +243,34 @@
              Properties="MeshModulesAppDir=$([System.IO.Path]::GetFullPath('$(OutDir)', '$(MSBuildProjectDirectory)'));Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=false;MeshModulesClosureSubset=$([MSBuild]::Escape('$(MeshModulesClosureSubset)'))" />
   </Target>
 
+  <!--
+    The ONE place @(MeshModuleClosure) is restored, shared by every host's lane (#2127).
+
+    🚨 The property set here is the whole point, and it is why this cannot be folded back into
+    LayoutMeshModuleClosures. That target is parameterised per host — MeshModulesAppDir,
+    MeshModulesGuardAppRoot, MeshModulesClosureSubset — so each host gets its own build
+    configuration of this file and its own restore. This one is invoked with those REMOVED, so all
+    of them resolve to the same configuration and MSBuild runs it exactly once per build.
+
+    🚨 It restores the FULL inventory, not the caller's subset. MeshModulesClosureSubset is removed
+    above precisely so the subset lane (Memex.Portal.Shared.Test: Cosmos + Snowflake) converges with
+    the full lanes instead of forking a second configuration — a superset restore is free, since the
+    other modules are restored by the other lanes in the same build anyway. Narrowing happens in
+    LayoutMeshModuleClosures, which is where it affects what gets LAID OUT.
+  -->
+  <Target Name="RestoreMeshModuleClosures">
+    <MSBuild Projects="@(MeshModuleClosure)"
+             Targets="Restore"
+             BuildInParallel="false"
+             Properties="Configuration=$(Configuration)"
+             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
+    <!-- Says ONCE per build, however many lanes are open — which is the whole assertion this target
+         makes, and the cheapest way to notice if a property leak ever forks the configuration again
+         (two of these lines in one log means the dedupe is gone and #2127 is live). -->
+    <Message Importance="high"
+             Text="RestoreMeshModuleClosures: restored @(MeshModuleClosure->Count()) closure module(s) — one shared lane for every host (#2127)." />
+  </Target>
+
   <!-- The closure-lane worker. Runs against THIS file as its own project (see the callers for
        why), parameterized by MeshModulesAppDir — so it must receive Configuration,
        MeshModulesTargetFramework and NetCoreTargetingPackRoot from the caller: evaluated
@@ -285,9 +313,28 @@
          Restore explicitly: post-flip the module is OUTSIDE the host's project graph, so the
          host's implicit restore never touches it and a clean machine has no assets file. A
          separate invocation (different global properties than the build below) also sidesteps
-         MSBuild's evaluation reuse between a Restore and the build that needs its outputs. -->
-    <MSBuild Projects="@(MeshModuleClosure)"
-             Targets="Restore"
+         MSBuild's evaluation reuse between a Restore and the build that needs its outputs.
+
+         🚨 And it is hoisted into RestoreMeshModuleClosures above rather than run here — #2127.
+         Every host that imports this file opens its own lane, so three lanes were live within ~7 s
+         of each other in one CI run. `BuildInParallel="false"` serialises the modules WITHIN a lane
+         and nothing serialised the lanes, so `Social:Restore` from one lane and
+         `Hosting.Cosmos:Restore` from another overlapped — two NuGet RestoreTasks whose closures
+         both contain src/MeshWeaver.AI, racing the write of its shared obj/project.assets.json.
+         The loser's atomic temp-file move found the destination already present:
+
+             error : The file '.../src/MeshWeaver.AI/obj/project.assets.json' already exists.
+                     [.../MeshWeaver.Social.csproj]
+             MSB4181: The "MSBuild" task returned false but did not log an error.  (x2)
+
+         and `Build solution (once)` failed for a PR whose diff was one markdown file. MSBuild
+         cannot dedupe those on its own: the entry projects differ, so they are distinct build
+         requests however much their restore graphs overlap. Routing every lane through ONE
+         self-invocation with a host-INDEPENDENT property set gives them a single shared build
+         configuration instead, which MSBuild does dedupe — the first lane runs it, the rest block
+         and take the cached result. -->
+    <MSBuild Projects="$(MSBuildThisFileFullPath)"
+             Targets="RestoreMeshModuleClosures"
              BuildInParallel="false"
              Properties="Configuration=$(Configuration)"
              RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />

--- a/src/MeshWeaver.Blazor/Infrastructure/UserIdentityCache.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/UserIdentityCache.cs
@@ -75,12 +75,26 @@ public readonly record struct UserIdentityLookup(MeshNode? Node, string? Unavail
     /// (<see cref="UserIdentityCache.IndexChanged"/>) and re-asks the same
     /// <see cref="Classify"/> question. Same chain, one extra lap.</para>
     ///
-    /// <para><b>The <c>StartWith</c> closes the sample-then-subscribe race.</b> A caller reaches
-    /// here BECAUSE its own <see cref="UserIdentityCache.Lookup"/> came back unavailable; between
-    /// that call and this subscription the snapshot may already have landed, and its emission would
-    /// be gone. Re-asking at subscribe time (inside
-    /// <see cref="Observable.Defer{TResult}(Func{IObservable{TResult}})"/>, so it is
-    /// per-subscription and not captured once) means the window cannot swallow the answer.</para>
+    /// <para><b>🚨 Listen FIRST, then take the reading — never the other way round.</b> A caller
+    /// reaches here BECAUSE its own <see cref="UserIdentityCache.Lookup"/> came back unavailable;
+    /// between that call and this subscription the snapshot may already have landed, and
+    /// <see cref="UserIdentityCache.IndexChanged"/> is a HOT, non-replaying stream, so that emission
+    /// is simply gone. Re-asking at subscribe time is what covers that window — but only if the
+    /// change feed is already subscribed when the re-ask happens.</para>
+    /// <para>This used to be <c>indexChanged.Select(_ =&gt; lookup()).StartWith(lookup())</c>, which
+    /// gets that order exactly backwards: <c>StartWith</c>'s argument is evaluated while the chain is
+    /// being BUILT, and <c>Concat</c> only subscribes to the change feed after the prepended value has
+    /// been delivered. So the window was never closed, merely moved — from "before the caller's own
+    /// lookup" to "between the re-ask and the subscribe", a handful of instructions that one
+    /// preemption on a loaded machine is enough to stretch across. Lose that emission and there is no
+    /// second chance: the index fires once per applied snapshot, and a mesh that has finished writing
+    /// never fires again. The observable then never emits — which is a 60 s
+    /// <see cref="TimeoutException"/> at the caller and NOT a wrong answer, exactly the shape of
+    /// #2031 / #2185 (full-assembly only, green in isolation).</para>
+    /// <para>Hence <see cref="Observable.Create{TResult}(Func{IObserver{TResult}, IDisposable})"/>
+    /// with the order spelled out rather than implied by an operator's argument-evaluation order:
+    /// subscribe, then read. <c>Observer.Synchronize</c> serialises the two producers, since the
+    /// index applies its snapshot on the query's thread while the reading is taken on this one.</para>
     ///
     /// <para><b><c>Take(1)</c> is sanctioned here</b> and is not the live-view mistake: this
     /// restores a ONE-SHOT resolution that the success path also performs exactly once. It is not
@@ -108,7 +122,16 @@ public readonly record struct UserIdentityLookup(MeshNode? Node, string? Unavail
         ArgumentNullException.ThrowIfNull(indexChanged);
         ArgumentNullException.ThrowIfNull(lookup);
         return Observable
-            .Defer(() => indexChanged.Select(_ => lookup()).StartWith(lookup()))
+            .Create<UserIdentityLookup>(observer =>
+            {
+                // 🚨 The order of these two statements IS the fix — see the remarks. The change
+                // feed is hot and fires once per applied snapshot, so an emission that lands
+                // before the subscription exists is unrecoverable.
+                var serialized = Observer.Synchronize(observer);
+                var changes = indexChanged.Select(_ => lookup()).Subscribe(serialized);
+                serialized.OnNext(lookup());
+                return changes;
+            })
             .Where(l => !l.IsUnavailable)
             .Take(1);
     }

--- a/src/MeshWeaver.Blazor/Infrastructure/UserIdentityCache.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/UserIdentityCache.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Mesh;
@@ -129,7 +130,23 @@ public readonly record struct UserIdentityLookup(MeshNode? Node, string? Unavail
                 // before the subscription exists is unrecoverable.
                 var serialized = Observer.Synchronize(observer);
                 var changes = indexChanged.Select(_ => lookup()).Subscribe(serialized);
-                serialized.OnNext(lookup());
+                try
+                {
+                    serialized.OnNext(lookup());
+                }
+                catch (Exception ex)
+                {
+                    // Subscribing FIRST means the feed subscription already exists when the reading
+                    // is taken, so a throwing lookup must not simply propagate out of this factory:
+                    // `changes` would never be returned, and a live subscription to a hot,
+                    // process-wide stream that nobody holds re-invokes `lookup()` for the life of
+                    // the cache. Tear it down and report the fault as the sequence's own OnError,
+                    // which is what the old Defer/StartWith shape got for free by not having
+                    // subscribed yet.
+                    changes.Dispose();
+                    serialized.OnError(ex);
+                    return Disposable.Empty;
+                }
                 return changes;
             })
             .Where(l => !l.IsUnavailable)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-identity-repair-no-longer-misses-the-snapshot.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-identity-repair-no-longer-misses-the-snapshot.md
@@ -1,0 +1,30 @@
+---
+Name: Signing in moments after a restart no longer strands you on UTC and English
+Category: Fix
+Description: The wait that repairs your identity while the portal's user directory is still filling could miss the very moment it filled, and then wait a full minute for an event that was never coming again.
+Icon: Globe
+Order: -20260825
+---
+
+# Signing in moments after a restart no longer strands you on UTC and English
+
+When the portal has just started — a deploy, a restart, a scale-up — its directory of users is still
+filling. A sign-in that arrives in that window cannot be answered yet: "I have no record of this
+email" and "I have not finished reading the records" look identical from the outside, and the portal
+deliberately refuses to guess between them, because the first is what drives onboarding. So it waits
+for the directory to finish, and then answers.
+
+The wait had a gap in it. It took its reading of the directory *before* it started listening for the
+directory to change — a handful of instructions apart, but the announcement fires exactly once, when
+the first full snapshot lands, and it is not repeated. If the snapshot landed inside that gap the
+announcement went to nobody, and nothing would ever fire again: a mesh that has finished writing has
+nothing left to announce. The wait then ran out its full minute and gave up.
+
+What you saw when it happened: your profile did not reach your session. The portal kept the details
+that came with the sign-in itself, which carry no time zone and no language — so every timestamp
+rendered in UTC and every string in English, regardless of what your profile says, until you
+reloaded. Nothing was logged, and nothing on screen suggested anything had gone wrong.
+
+The wait now subscribes first and reads second, so a snapshot that lands while it is taking its
+reading is still seen. Ordinary sign-ins — the overwhelming majority, where the directory has been
+ready for hours — are unchanged: they are answered from the first reading and never wait at all.

--- a/src/MeshWeaver.Reactive.Assertions/ObservableAssertions.cs
+++ b/src/MeshWeaver.Reactive.Assertions/ObservableAssertions.cs
@@ -1,4 +1,3 @@
-using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 
@@ -42,22 +41,37 @@ public static class ObservableAssertionExtensions
 /// Fluent assertions over a reactive stream. Each terminal method subscribes, waits (up to the
 /// timeout) for the relevant emission, and asserts — so test bodies stay declarative.
 /// <para>
-/// The wait is the sanctioned test-edge Rx→Task bridge: the source is <c>SubscribeOn</c>'d onto the
-/// thread pool, filtered, <c>Take(1)</c>'d, bounded with <c>Timeout</c>, and bridged via <c>.ToTask()</c> —
+/// The wait is the sanctioned test-edge Rx→Task bridge: the source is subscribed synchronously off the
+/// ambient sync-context, filtered, <c>Take(1)</c>'d, bounded with <c>Timeout</c>, and bridged via <c>.ToTask()</c> —
 /// never a thread-blocking <see cref="System.Threading.ManualResetEventSlim"/> + <c>Wait</c>. Each terminal
 /// assertion returns a <see cref="System.Threading.Tasks.Task"/> the test body <c>await</c>s; the bridge
 /// lives in the assertion, never the test body. <c>Within(...)</c> stays synchronous — it only configures
 /// the timeout for the rest of the chain.
 /// </para>
 /// <para>
-/// 🚨 The <see cref="System.Reactive.Concurrency.TaskPoolScheduler"/> <c>SubscribeOn</c> is load-bearing,
-/// not cosmetic. xUnit runs <c>async Task</c> tests under a single-threaded <c>MaxConcurrencySyncContext</c>
-/// (<c>maxParallelThreads: 1</c>). If a cold mesh observable is subscribed directly on that thread, the
-/// mesh's async continuations get funnelled back onto the one sync-context thread and serialise/starve —
-/// a path that profiled at 8 s versus 3 ms when the same subscribe ran off the context
-/// (AddressResolutionTest, 2026-06-15). Subscribing on the pool keeps every mesh round-trip on the thread
-/// pool where it belongs; only the final awaited result hops back to the test. Do NOT remove the
-/// <c>SubscribeOn</c>.
+/// 🚨 The subscribe happens SYNCHRONOUSLY, on the calling thread, before the returned
+/// <see cref="System.Threading.Tasks.Task"/> is handed back — see
+/// <c>SubscribeHereOffSyncContext</c> below. A test that arms an assertion and then makes the thing
+/// happen is the normal shape, and half of what it observes is a HOT source (a bare
+/// <c>Subject&lt;T&gt;</c> such as <c>MessageStormBreaker.AggregateSheds</c>) whose emission is simply
+/// GONE if no observer is attached yet. This used to be <c>SubscribeOn(TaskPoolScheduler.Default)</c>,
+/// which deferred the subscribe to the thread pool: the test thread raced ahead, the source emitted into
+/// a subject with no observer, and the assertion then waited out its full timeout against a stream that
+/// would never emit again (#2243 — <c>ManyDistinctMissingSubscribes_DoNotWedge</c>, intermittently, only
+/// under full-suite ThreadPool pressure).
+/// </para>
+/// <para>
+/// 🚨 What the pool hop was actually FOR is preserved, and preserved is the operative word. xUnit runs
+/// <c>async Task</c> tests under a single-threaded <c>MaxConcurrencySyncContext</c>
+/// (<c>maxParallelThreads: 1</c>). If a cold mesh observable is subscribed with that context ambient, the
+/// mesh's async continuations get captured and funnelled back onto the one sync-context thread, where they
+/// serialise and starve — a path that profiled at 8 s versus 3 ms when the same subscribe ran off the
+/// context (AddressResolutionTest, 2026-06-15). It was never the pool THREAD that fixed that; it was the
+/// absence of the ambient context on it. So the subscribe now runs here with
+/// <see cref="System.Threading.SynchronizationContext"/> suppressed and restored around it: continuations
+/// created during the subscribe capture <c>null</c> and land on the pool exactly as before, while the
+/// observer is attached in time to see a synchronous emission. Do NOT reintroduce <c>SubscribeOn</c>, and
+/// do NOT drop the suppression.
 /// </para>
 /// </summary>
 /// <typeparam name="T">The element type of the observed stream.</typeparam>
@@ -114,7 +128,7 @@ public class ObservableAssertions<T>
         {
             // Same sentinel discipline as WaitForFirst: only the WAIT's own timeout maps
             // to "did not"; a source-thrown TimeoutException surfaces via "errored:".
-            await _subject.SubscribeOn(TaskPoolScheduler.Default)
+            await SubscribeHereOffSyncContext(_subject)
                 .IgnoreElements()
                 .Timeout(_timeout, Observable.Defer(() =>
                     Observable.Throw<T>(new AssertionWaitTimeoutException())))
@@ -148,7 +162,7 @@ public class ObservableAssertions<T>
             // failure; if the window elapses with nothing (Timeout), the source completes empty,
             // or the source errors before emitting, the assertion holds — mirroring the original
             // "no positive signal => pass" semantics.
-            observed = await _subject.SubscribeOn(TaskPoolScheduler.Default)
+            observed = await SubscribeHereOffSyncContext(_subject)
                 .Take(1).Timeout(within).ToTask();
             emitted = true;
         }
@@ -198,7 +212,7 @@ public class ObservableAssertions<T>
             // run 31407254207: an Interval-based poll "completed" — Interval never completes).
             // ToList reports empty completion as DATA (an empty list), so the only exceptions
             // left in flight are the sentinel and genuine source errors.
-            matched = await source.SubscribeOn(TaskPoolScheduler.Default)
+            matched = await SubscribeHereOffSyncContext(source)
                 .Take(1)
                 .ToList()
                 .Timeout(_timeout, Observable.Defer(() =>
@@ -220,6 +234,38 @@ public class ObservableAssertions<T>
                 $"Expected the observable to {expectation} within {Describe(_timeout)}{Reason(because)}, but it completed without one. {seen.Describe(predicate is not null)}");
         return matched[0];
     }
+
+    /// <summary>
+    /// Subscribes to <paramref name="source"/> on the CALLING thread — synchronously, so the observer
+    /// is attached before the terminal assertion returns its <see cref="System.Threading.Tasks.Task"/> — with the ambient
+    /// <see cref="SynchronizationContext"/> suppressed for the duration of the subscribe.
+    /// <para>
+    /// Both halves are load-bearing and neither can be dropped for the other; see the class remarks.
+    /// Synchronous attach is what makes an assertion armed BEFORE the trigger able to observe a hot,
+    /// non-replaying <c>Subject&lt;T&gt;</c> (#2243). Suppressing the context is what keeps a cold mesh
+    /// observable's async continuations off xUnit's single-threaded <c>MaxConcurrencySyncContext</c>,
+    /// which is the property the old <c>SubscribeOn(TaskPoolScheduler.Default)</c> was really buying
+    /// (AddressResolutionTest, 2026-06-15). The context is restored in a <c>finally</c>, so a throwing
+    /// subscribe cannot leave the test thread contextless.
+    /// </para>
+    /// </summary>
+    private static IObservable<TSource> SubscribeHereOffSyncContext<TSource>(IObservable<TSource> source)
+        => Observable.Create<TSource>(observer =>
+        {
+            var ambient = SynchronizationContext.Current;
+            if (ambient is null)
+                return source.Subscribe(observer);
+
+            SynchronizationContext.SetSynchronizationContext(null);
+            try
+            {
+                return source.Subscribe(observer);
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(ambient);
+            }
+        });
 
     /// <summary>
     /// Private sentinel thrown by the assertion's own <c>Timeout</c> operator so a

--- a/test/BlockingBridgeSites.allow
+++ b/test/BlockingBridgeSites.allow
@@ -1,0 +1,77 @@
+# BlockingBridgeSites.allow — the blocking-bridge ratchet (#2013).
+#
+# Each line is a test file that still bridges an observable (or a task) to a BLOCKING call:
+#
+#     source.ToEnumerable()          source.Wait()          x.GetAwaiter().GetResult()
+#
+# All three park the calling thread on a semaphore until the source produces. When the source
+# schedules onto that SAME thread — a hub action block, a grain turn, xUnit's single-threaded
+# MaxConcurrencySyncContext — it self-deadlocks. Which thread it lands on depends on the scheduler
+# an operator picks, so it is intermittent: in #1991 one local run passed with the offending test
+# present and two later runs wedged for 31 and 15 minutes at ~0% CPU.
+#
+# 🚨 xUnit's methodTimeout CANNOT abort a thread parked in a native wait, so this costs the WHOLE
+# SHARD and lies about why: `exit=124 TIMEOUT`, no failing test named, and a marker that guesses
+# "likely fixture/init hang". Treat any exit=124 with no named test as this, first.
+#
+# TO FIX A SITE:  await the stream — `await source.Should().Emit()` / `.Match(...)`, or
+#                 `.FirstAsync().ToTask(ct)`. Awaiting SUSPENDS the test instead of parking its
+#                 thread, so it cannot self-deadlock. Where the assertion must stay synchronous,
+#                 subscribe and collect on ImmediateScheduler (PresentationScreenTest documents it).
+#                 For a test class that needs cleanup after the mesh: override
+#                 `public override async ValueTask DisposeAsync()` — never implement IDisposable and
+#                 block on base.DisposeAsync().
+#
+# WHAT THE 2026-08-25 RE-TRIAGE FOUND. #2013 counted 37 `.Wait()` sites and asked for per-site
+# judgement rather than a blanket rewrite. Re-measured across all three markers:
+#
+#   * `.ToEnumerable()` is at ZERO — the #1991 instance stayed fixed.
+#   * THREE sites were the real thing and are GONE in the change that added this file:
+#     CodeEditRecompileTest, CompileSourceSnapshotWedgeTest and SourceDiscoveryUnavailableTest each
+#     implemented IDisposable and blocked on `base.DisposeAsync()` — parking the disposing thread on
+#     MESH TEARDOWN, the one operation in this suite with a documented history of not completing
+#     (#613, the teardown-straggler cluster), and doing it OUTSIDE methodTimeout. They now override
+#     `DisposeAsync` and await it.
+#   * Every remaining `.Wait()` was inspected and is over a source that has ALREADY COMPLETED before
+#     the wait begins (Observable.Return, Scheduler.Immediate, an NSubstitute stub, an in-memory
+#     fake store, a configuration reader) or is bounded by an upstream `.Timeout(...)`, whose timer
+#     runs on the default scheduler and therefore always unblocks the parked thread — a named
+#     TimeoutException, not a wedge.
+#
+# 🚨 NOT individually cleared, and the first place to look if an exit=124 recurs: the
+# `StartAsync(default).GetAwaiter().GetResult()` helpers (ScheduledPostWatcherTest,
+# OrleansScheduledPostTest, OrleansEventSubscriptionTimerTest) and the
+# `persistence.SaveNode(...).FirstAsync().ToTask().GetAwaiter().GetResult()` setup helpers
+# (CreatableTypesIntegrationTest, MeshNodeVisibilityTests, DataContextIntegrationTest,
+# MeshNodeVersionSyncTest). They are called from synchronous setup with the xUnit sync context
+# ambient, so they are safe only while the awaited work completes synchronously — a property of the
+# implementation today, not a guarantee. These are the lines to lower first.
+#
+# 🚨 THIS LIST MAY ONLY SHRINK. Fixing a site means LOWERING or DELETING its line. A new file or a
+# raised count fails BlockingBridgeInTestRatchetGuard — adding a line is not a fix.
+#
+# Scope: test/ only. src/ is governed by the harder rule AGENTS.md already states for product code.
+#
+# format: relative/path.cs<TAB>count
+test/MeshWeaver.Content.Test/ThreadMessageToolTest.cs	1
+test/MeshWeaver.ContentCollections.Indexing.Graph.Test/ContentChunkAutocompleteProviderTest.cs	2
+test/MeshWeaver.ContentCollections.Indexing.Test/ChunkNavigationStoreTest.cs	2
+test/MeshWeaver.ContentCollections.Indexing.Test/ContentChunkSearchTest.cs	6
+test/MeshWeaver.ContentCollections.Indexing.Test/ContentSearchHitContractTest.cs	2
+test/MeshWeaver.ContentCollections.Test/ObservableCollectionSurfaceTest.cs	2
+test/MeshWeaver.Graph.Test/NodeTypeAdoptionRegistryTest.cs	3
+test/MeshWeaver.Graph.Test/NodeTypeBakeStatusTest.cs	2
+test/MeshWeaver.Graph.Test/OverlayReEvaluationReadTest.cs	3
+test/MeshWeaver.Hosting.Monolith.Test/CreatableTypesIntegrationTest.cs	8
+test/MeshWeaver.Hosting.Monolith.Test/MeshNodeVisibilityTests.cs	1
+test/MeshWeaver.Hosting.Monolith.Test/ScheduledPostWatcherTest.cs	1
+test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs	1
+test/MeshWeaver.Hosting.Orleans.Test/OrleansEventSubscriptionTimerTest.cs	1
+test/MeshWeaver.Hosting.Orleans.Test/OrleansScheduledPostTest.cs	2
+test/MeshWeaver.Hosting.PostgreSql.Test/PostgreSqlTransientRetryTest.cs	4
+test/MeshWeaver.Hosting.Test/AlcLeaseRegistryTest.cs	3
+test/MeshWeaver.Messaging.Hub.Test/SystemScopeDoesNotEscapeTest.cs	3
+test/MeshWeaver.Persistence.Test/DataContextIntegrationTest.cs	4
+test/MeshWeaver.Persistence.Test/MeshNodeVersionSyncTest.cs	1
+test/MeshWeaver.PluginCatalog.Test/FeatureFlagReaderTest.cs	7
+test/MeshWeaver.PluginCatalog.Test/PackageParameterResolutionTest.cs	1

--- a/test/MeshWeaver.Documentation.Test/BlockingBridgeInTestRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/BlockingBridgeInTestRatchetGuard.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance ratchet for the blocking-bridge defect class (#2013): a test that bridges an
+/// observable — or a task — to a BLOCKING call may not appear at a new site.
+///
+/// <para><b>Why this is a defect and not a style preference.</b> <c>.ToEnumerable()</c>, Rx's
+/// <c>IObservable&lt;T&gt;.Wait()</c>, <c>.Result</c> and <c>.GetAwaiter().GetResult()</c> all park the
+/// calling thread on a semaphore until the source produces. When the source schedules onto that same
+/// thread — a hub action block, a grain turn, xUnit's single-threaded
+/// <c>MaxConcurrencySyncContext</c> — it self-deadlocks. Which thread it lands on depends on the
+/// scheduler an operator picks, so it is INTERMITTENT: one local run passes with the offending test
+/// present and the next two wedge for 31 and 15 minutes at ~0% CPU (#1991).</para>
+///
+/// <para><b>And it costs a whole shard, not one test.</b> 🚨 xUnit's <c>methodTimeout</c> cannot abort
+/// a thread parked in a native wait. So instead of a 30 s test failure you get an unbounded host
+/// wedge that CI reports as <c>exit=124 TIMEOUT</c> with NO failing test named and a marker whose own
+/// guess ("likely fixture/init hang") points away from the cause. That signature was misattributed
+/// twice in one day. Product code that deadlocks fails one request; a test that deadlocks takes the
+/// shard's remaining tests with it and lies about why.</para>
+///
+/// <para><b>The fix at a site</b> is the sanctioned test-edge bridge: <c>await</c> the stream
+/// (<c>await source.Should().Emit()</c> / <c>.Match(...)</c>, or <c>.FirstAsync().ToTask(ct)</c>),
+/// which suspends the test rather than parking its thread and therefore CANNOT self-deadlock. Where
+/// the assertion must stay synchronous, subscribe and collect on <c>ImmediateScheduler</c> — the
+/// pattern <c>PresentationScreenTest</c> moved to and documents.</para>
+///
+/// <para><b>Why the file is seeded rather than empty, and what the seeding measured.</b> #2013 counted
+/// 37 <c>.Wait()</c> sites and asked for per-site judgement rather than a blanket rewrite. The
+/// 2026-08-25 re-triage across all three markers found <c>.ToEnumerable()</c> at ZERO and THREE sites
+/// that were the real thing — <c>CodeEditRecompileTest</c>, <c>CompileSourceSnapshotWedgeTest</c> and
+/// <c>SourceDiscoveryUnavailableTest</c> each implemented <see cref="IDisposable"/> and blocked on
+/// <c>base.DisposeAsync()</c>, parking the disposing thread on MESH TEARDOWN, outside
+/// <c>methodTimeout</c>. Those are fixed in the same change that added this guard. Every remaining
+/// <c>.Wait()</c> is over a source that has already completed before the wait begins
+/// (<c>Observable.Return</c>, <c>Scheduler.Immediate</c>, an NSubstitute stub, a fake store) or is
+/// bounded by an upstream <c>.Timeout(...)</c>, whose timer runs on the default scheduler and
+/// therefore always unblocks the parked thread — a named failure, not a wedge. The
+/// <c>GetAwaiter().GetResult()</c> setup helpers are NOT individually cleared; the allow file names
+/// them and says why they are the lines to lower first.</para>
+///
+/// <para><b>The ratchet may only SHRINK.</b> A new file, a raised count, or a raised TOTAL is a
+/// failure. A line that has become stale (its site was fixed) is reported, not failed: two PRs
+/// closing sites concurrently would otherwise red <c>main</c> on whichever merged second, and a gate
+/// that punishes the direction it is asking for teaches people to stop shrinking. Delete the stale
+/// line and lower <see cref="TotalBudget"/> in the same change.</para>
+/// </summary>
+public class BlockingBridgeInTestRatchetGuard(ITestOutputHelper output)
+{
+    /// <summary>
+    /// The seeded inventory's size. Per-file entries stop a new site in a file that already carries
+    /// the shape; this stops the list as a WHOLE from growing — including by the trick of adding a
+    /// new file's line. Lower it whenever you delete or lower an entry.
+    /// </summary>
+    private const int TotalBudget = 60;
+
+    /// <summary>
+    /// <c>test/</c> only. <c>src/</c> is governed by the harder rule AGENTS.md already states for
+    /// product code (nothing async, ever) and by the reviews that enforce it; this guard exists
+    /// because tests were treated as exempt from it, and the consequence there is WORSE, not milder.
+    /// </summary>
+    private static readonly string[] ScannedRoots = ["test"];
+
+    /// <summary>
+    /// The bridges, as they appear in source.
+    ///
+    /// <para>🚨 <c>.Result</c> is deliberately NOT here. It is overwhelmingly a domain property in
+    /// this repo — <c>ToolCall.Result</c>, <c>PatchResult.Result</c> — and a marker that matches a
+    /// hundred innocent reads to catch one bridge would be ignored, which is how a ratchet dies. The
+    /// <c>.GetAwaiter().GetResult()</c> spelling below IS unambiguous and is matched.</para>
+    /// </summary>
+    private static readonly string[] Markers =
+        [".ToEnumerable()", ".Wait()", ".GetAwaiter().GetResult()"];
+
+    private const string AllowFileName = "BlockingBridgeSites.allow";
+
+    [Fact]
+    public void NoNewTestBridgesAnObservableToABlockingWait()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var allowed = SourceScan.ReadAllowFile(Path.Combine(root, "test", AllowFileName), AllowFileName);
+        var found = Scan(root);
+
+        var failures = new List<string>();
+
+        foreach (var (file, count) in found.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            if (!allowed.TryGetValue(file, out var budget))
+                failures.Add(
+                    $"  NEW SITE   {file} ({count}) — await the stream instead "
+                    + "(`await source.Should().Emit()` / `.FirstAsync().ToTask(ct)`), or subscribe and "
+                    + "collect on ImmediateScheduler. Do NOT add a line to " + AllowFileName + ".");
+            else if (count > budget)
+                failures.Add(
+                    $"  MORE       {file} ({count} > {budget} allowed) — a bridge was ADDED to a file "
+                    + "that already carries the shape.");
+        }
+
+        var total = allowed.Values.Sum();
+        if (total > TotalBudget)
+            failures.Add(
+                $"  TOTAL      {total} allowances > {TotalBudget} budgeted — the inventory GREW. "
+                + "Adding a line to " + AllowFileName + " is not a fix.");
+
+        foreach (var (file, budget) in allowed.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            var count = found.GetValueOrDefault(file, 0);
+            if (count < budget)
+                output.WriteLine(
+                    $"STALE (please tidy): {file} — {count} found, {budget} allowed. "
+                    + $"{(count == 0 ? "Delete the line" : $"Lower it to {count}")} and lower "
+                    + $"TotalBudget by {budget - count}.");
+        }
+
+        Assert.True(failures.Count == 0,
+            "A blocking bridge in a test parks the calling thread in a native wait that xUnit's "
+            + "methodTimeout CANNOT abort, so a self-deadlock costs the whole shard and reports "
+            + "`exit=124 TIMEOUT` with no test named (#2013). Await the stream instead.\n"
+            + string.Join("\n", failures));
+    }
+
+    /// <summary>
+    /// Non-vacuity, pinned in the same run: the scanner must actually SEE the shape. The seeded allow
+    /// file is non-empty, so a scanner that silently matched nothing — a renamed marker, a masking bug
+    /// that blanked every file — would report every entry as STALE rather than pass; this states the
+    /// expectation directly so the failure names the scanner instead of the tree.
+    /// </summary>
+    [Fact]
+    public void TheScannerFindsTheShapeItIsRatcheting()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var found = Scan(root);
+
+        Assert.True(found.Count > 0,
+            "The scanner found no blocking bridge anywhere under " + string.Join(", ", ScannedRoots)
+            + ". Either every site was migrated — in which case empty " + AllowFileName
+            + " and delete this assertion — or the scanner is broken, which would make the ratchet "
+            + "above pass on no evidence.");
+
+        // Several tests EXPLAIN in a comment why they no longer use a bridge, quoting the shape
+        // verbatim (PresentationScreenTest, SyncedQueryPgTest, ThreadStreamingIdentityTest). A
+        // scanner that counted those would ratchet against prose, so prove the masking works.
+        var explained = Path.Combine(root, "test", "MeshWeaver.Graph.Test", "PresentationScreenTest.cs");
+        Assert.True(File.Exists(explained), "the quoting file must exist for this check to mean anything");
+        Assert.Contains(".ToEnumerable()", File.ReadAllText(explained), StringComparison.Ordinal);
+        Assert.False(found.ContainsKey("test/MeshWeaver.Graph.Test/PresentationScreenTest.cs"),
+            "the scanner counted a COMMENT as a call site — comment masking is broken, and every "
+            + "count in the allow file is therefore unreliable.");
+    }
+
+    private static Dictionary<string, int> Scan(string root) =>
+        SourceScan.SourceFiles(root, ScannedRoots)
+            .Select(f => (Relative: SourceScan.Relative(root, f), Count: CountSites(f)))
+            .Where(x => x.Count > 0)
+            .ToDictionary(x => x.Relative, x => x.Count, StringComparer.Ordinal);
+
+    /// <summary>Occurrences of any <see cref="Markers"/> entry, with comments and string literals
+    /// masked first.</summary>
+    private static int CountSites(string path)
+    {
+        string text;
+        try { text = File.ReadAllText(path); }
+        catch (IOException) { return 0; } // a file a concurrent build is writing is not evidence
+
+        if (!Markers.Any(m => text.Contains(m, StringComparison.Ordinal))) return 0;
+
+        var code = SourceScan.MaskCommentsAndStrings(text);
+        var count = 0;
+        foreach (var marker in Markers)
+        {
+            var at = 0;
+            while ((at = code.IndexOf(marker, at, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                at += marker.Length;
+            }
+        }
+
+        // `.GetAwaiter().GetResult()` also contains no other marker, but `.Wait()` never overlaps
+        // either — so no double counting to correct for.
+        return count;
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Xunit;
 
 namespace MeshWeaver.Documentation.Test;
@@ -65,14 +64,11 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
 
     private const string AllowFileName = "ImpersonationScopeSites.allow";
 
-    private static readonly string[] ExcludedSegments =
-        ["bin", "obj", "node_modules", "TestResults", ".git", ".vs", "dist"];
-
     [Fact]
     public void NoNewSiteOpensAnImpersonationScopeInsideObservableUsing()
     {
-        var root = FindRepoRoot();
-        var allowed = ReadAllowFile(Path.Combine(root, "test", AllowFileName));
+        var root = SourceScan.FindRepoRoot();
+        var allowed = SourceScan.ReadAllowFile(Path.Combine(root, "test", AllowFileName), AllowFileName);
         var found = Scan(root);
 
         var failures = new List<string>();
@@ -125,7 +121,7 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
     [Fact]
     public void TheScannerFindsTheShapeItIsRatcheting()
     {
-        var root = FindRepoRoot();
+        var root = SourceScan.FindRepoRoot();
         var found = Scan(root);
 
         Assert.True(found.Count > 0,
@@ -148,13 +144,8 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
     }
 
     private static Dictionary<string, int> Scan(string root) =>
-        ScannedRoots
-            .Select(r => Path.Combine(root, r))
-            .Where(Directory.Exists)
-            .SelectMany(dir => Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
-            .Where(f => Path.GetExtension(f) is ".cs" or ".razor")
-            .Where(f => !IsExcluded(root, f))
-            .Select(f => (Relative: Relative(root, f), Count: CountSites(f)))
+        SourceScan.SourceFiles(root, ScannedRoots)
+            .Select(f => (Relative: SourceScan.Relative(root, f), Count: CountSites(f)))
             .Where(x => x.Count > 0)
             .ToDictionary(x => x.Relative, x => x.Count, StringComparer.Ordinal);
 
@@ -171,7 +162,7 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
 
         if (!text.Contains(Marker, StringComparison.Ordinal)) return 0;
 
-        var code = MaskCommentsAndStrings(text);
+        var code = SourceScan.MaskCommentsAndStrings(text);
         var count = 0;
         var at = 0;
         while ((at = code.IndexOf(Marker, at, StringComparison.Ordinal)) >= 0)
@@ -179,167 +170,11 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
             var open = code.IndexOf('(', at + Marker.Length);
             at += Marker.Length;
             if (open < 0) continue;
-            var firstArg = FirstArgument(code, open);
+            var firstArg = SourceScan.FirstArgument(code, open);
             if (ScopeFactories.Any(f => firstArg.Contains(f, StringComparison.Ordinal)))
                 count++;
         }
 
         return count;
-    }
-
-    /// <summary>The text between <paramref name="openParen"/> and the first comma at its own nesting
-    /// depth (or the matching close paren) — i.e. the call's first argument.</summary>
-    private static string FirstArgument(string code, int openParen)
-    {
-        var depth = 0;
-        for (var i = openParen; i < code.Length; i++)
-        {
-            switch (code[i])
-            {
-                case '(' or '[' or '{':
-                    depth++;
-                    break;
-                case ')' or ']' or '}':
-                    if (--depth == 0) return code[(openParen + 1)..i];
-                    break;
-                case ',' when depth == 1:
-                    return code[(openParen + 1)..i];
-            }
-        }
-
-        return code[(openParen + 1)..];
-    }
-
-    /// <summary>
-    /// Blanks comment and string-literal characters, preserving offsets and newlines, so the scan
-    /// sees code only. Handles line/block comments, ordinary, verbatim and raw string literals, and
-    /// character literals — enough that a doc comment containing <c>Plugins/*</c> does not swallow
-    /// the next thousand lines (which is exactly what a naive scanner did).
-    /// </summary>
-    private static string MaskCommentsAndStrings(string text)
-    {
-        var masked = new StringBuilder(text);
-        var i = 0;
-        var n = text.Length;
-
-        void Blank(int from, int to)
-        {
-            for (var k = from; k < to && k < n; k++)
-                if (text[k] != '\n')
-                    masked[k] = ' ';
-        }
-
-        while (i < n)
-        {
-            var c = text[i];
-            var next = i + 1 < n ? text[i + 1] : '\0';
-
-            if (c == '/' && next == '/')
-            {
-                var end = text.IndexOf('\n', i);
-                end = end < 0 ? n : end;
-                Blank(i, end);
-                i = end;
-            }
-            else if (c == '/' && next == '*')
-            {
-                var end = text.IndexOf("*/", i + 2, StringComparison.Ordinal);
-                end = end < 0 ? n : end + 2;
-                Blank(i, end);
-                i = end;
-            }
-            else if (c == '"' && i + 2 < n && text[i + 1] == '"' && text[i + 2] == '"')
-            {
-                var end = text.IndexOf("\"\"\"", i + 3, StringComparison.Ordinal);
-                end = end < 0 ? n : end + 3;
-                Blank(i, end);
-                i = end;
-            }
-            else if (c == '@' && next == '"')
-            {
-                i = MaskVerbatim(text, masked, i + 1, Blank);
-            }
-            else if (c == '$' && next == '@' && i + 2 < n && text[i + 2] == '"')
-            {
-                Blank(i, i + 2);
-                i = MaskVerbatim(text, masked, i + 2, Blank);
-            }
-            else if (c is '"' or '\'')
-            {
-                var quote = c;
-                Blank(i, i + 1);
-                i++;
-                while (i < n && text[i] != quote && text[i] != '\n')
-                {
-                    var step = text[i] == '\\' ? 2 : 1;
-                    Blank(i, i + step);
-                    i += step;
-                }
-
-                if (i < n && text[i] == quote) { Blank(i, i + 1); i++; }
-            }
-            else
-            {
-                i++;
-            }
-        }
-
-        return masked.ToString();
-    }
-
-    /// <summary>Masks a verbatim string starting at its opening quote; <c>""</c> is an escaped quote.</summary>
-    private static int MaskVerbatim(string text, StringBuilder masked, int quote, Action<int, int> blank)
-    {
-        var n = text.Length;
-        blank(quote, quote + 1);
-        var i = quote + 1;
-        while (i < n)
-        {
-            if (text[i] == '"')
-            {
-                if (i + 1 < n && text[i + 1] == '"') { blank(i, i + 2); i += 2; continue; }
-                blank(i, i + 1);
-                return i + 1;
-            }
-
-            blank(i, i + 1);
-            i++;
-        }
-
-        return n;
-    }
-
-    /// <summary>
-    /// <c>relative/path.cs&lt;TAB&gt;count</c>, one per line; <c>#</c> starts a comment.
-    /// </summary>
-    private static Dictionary<string, int> ReadAllowFile(string path)
-    {
-        Assert.True(File.Exists(path),
-            $"{AllowFileName} is missing — without it this guard cannot tell a pre-existing site "
-            + "from a new one and would report every occurrence as a failure. Restore it from git "
-            + "rather than regenerating it: a regenerated file would silently bless whatever is in "
-            + "the tree, which is the one thing a ratchet must never do.");
-
-        return File.ReadAllLines(path)
-            .Select(l => l.Trim())
-            .Where(l => l.Length > 0 && !l.StartsWith('#'))
-            .Select(l => l.Split('\t', StringSplitOptions.TrimEntries))
-            .ToDictionary(parts => parts[0], parts => int.Parse(parts[1]), StringComparer.Ordinal);
-    }
-
-    private static string Relative(string root, string path) =>
-        Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/');
-
-    private static bool IsExcluded(string root, string path) =>
-        Relative(root, path).Split('/').Any(s => ExcludedSegments.Contains(s, StringComparer.OrdinalIgnoreCase));
-
-    private static string FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
-            dir = dir.Parent;
-        return dir?.FullName
-               ?? throw new InvalidOperationException(
-                   "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
     }
 }

--- a/test/MeshWeaver.Documentation.Test/SourceScan.cs
+++ b/test/MeshWeaver.Documentation.Test/SourceScan.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// The scanning half of a governance ratchet: locate the repo, enumerate its source files, blank out
+/// anything that is prose rather than code, and read the seeded allow file.
+///
+/// <para>Extracted so a second ratchet does not have to reimplement it. That is not tidiness — the
+/// masker is the part that decides whether a guard is measuring code or its own documentation, and
+/// this repo's remarks quote the exact shapes being ratcheted (the impersonation seam quotes
+/// <c>Observable.Using(access.ImpersonateAsSystem</c>; half the blocking-bridge sites are named in
+/// comments explaining why they were removed). A second, subtly different copy would give a second,
+/// subtly wrong inventory — and a ratchet whose counts are wrong is worse than none, because it reads
+/// as evidence.</para>
+/// </summary>
+internal static class SourceScan
+{
+    private static readonly string[] ExcludedSegments =
+        ["bin", "obj", "node_modules", "TestResults", ".git", ".vs", "dist"];
+
+    /// <summary>The repo root, found by walking up from the test binary until <c>MeshWeaver.slnx</c>.</summary>
+    public static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+               ?? throw new InvalidOperationException(
+                   "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
+    }
+
+    /// <summary>Repo-relative, forward-slashed — the key form every allow file uses.</summary>
+    public static string Relative(string root, string path) =>
+        Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/');
+
+    public static bool IsExcluded(string root, string path) =>
+        Relative(root, path).Split('/').Any(s => ExcludedSegments.Contains(s, StringComparer.OrdinalIgnoreCase));
+
+    /// <summary>Every C#/Razor source file under the named roots, build output excluded.</summary>
+    public static IEnumerable<string> SourceFiles(string root, IEnumerable<string> scannedRoots) =>
+        scannedRoots
+            .Select(r => Path.Combine(root, r))
+            .Where(Directory.Exists)
+            .SelectMany(dir => Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
+            .Where(f => Path.GetExtension(f) is ".cs" or ".razor")
+            .Where(f => !IsExcluded(root, f));
+
+    /// <summary>
+    /// Blanks comment and string-literal characters, preserving offsets and newlines, so the scan
+    /// sees code only. Handles line/block comments, ordinary, verbatim and raw string literals, and
+    /// character literals — enough that a doc comment containing <c>Plugins/*</c> does not swallow
+    /// the next thousand lines (which is exactly what a naive scanner did).
+    /// </summary>
+    public static string MaskCommentsAndStrings(string text)
+    {
+        var masked = new StringBuilder(text);
+        var i = 0;
+        var n = text.Length;
+
+        void Blank(int from, int to)
+        {
+            for (var k = from; k < to && k < n; k++)
+                if (text[k] != '\n')
+                    masked[k] = ' ';
+        }
+
+        while (i < n)
+        {
+            var c = text[i];
+            var next = i + 1 < n ? text[i + 1] : '\0';
+
+            if (c == '/' && next == '/')
+            {
+                var end = text.IndexOf('\n', i);
+                end = end < 0 ? n : end;
+                Blank(i, end);
+                i = end;
+            }
+            else if (c == '/' && next == '*')
+            {
+                var end = text.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                end = end < 0 ? n : end + 2;
+                Blank(i, end);
+                i = end;
+            }
+            else if (c == '"' && i + 2 < n && text[i + 1] == '"' && text[i + 2] == '"')
+            {
+                var end = text.IndexOf("\"\"\"", i + 3, StringComparison.Ordinal);
+                end = end < 0 ? n : end + 3;
+                Blank(i, end);
+                i = end;
+            }
+            else if (c == '@' && next == '"')
+            {
+                i = MaskVerbatim(text, masked, i + 1, Blank);
+            }
+            else if (c == '$' && next == '@' && i + 2 < n && text[i + 2] == '"')
+            {
+                Blank(i, i + 2);
+                i = MaskVerbatim(text, masked, i + 2, Blank);
+            }
+            else if (c is '"' or '\'')
+            {
+                var quote = c;
+                Blank(i, i + 1);
+                i++;
+                while (i < n && text[i] != quote && text[i] != '\n')
+                {
+                    var step = text[i] == '\\' ? 2 : 1;
+                    Blank(i, i + step);
+                    i += step;
+                }
+
+                if (i < n && text[i] == quote) { Blank(i, i + 1); i++; }
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        return masked.ToString();
+    }
+
+    /// <summary>Masks a verbatim string starting at its opening quote; <c>""</c> is an escaped quote.</summary>
+    private static int MaskVerbatim(string text, StringBuilder masked, int quote, Action<int, int> blank)
+    {
+        var n = text.Length;
+        blank(quote, quote + 1);
+        var i = quote + 1;
+        while (i < n)
+        {
+            if (text[i] == '"')
+            {
+                if (i + 1 < n && text[i + 1] == '"') { blank(i, i + 2); i += 2; continue; }
+                blank(i, i + 1);
+                return i + 1;
+            }
+
+            blank(i, i + 1);
+            i++;
+        }
+
+        return n;
+    }
+
+    /// <summary>The text between <paramref name="openParen"/> and the first comma at its own nesting
+    /// depth (or the matching close paren) — i.e. the call's first argument.</summary>
+    public static string FirstArgument(string code, int openParen)
+    {
+        var depth = 0;
+        for (var i = openParen; i < code.Length; i++)
+        {
+            switch (code[i])
+            {
+                case '(' or '[' or '{':
+                    depth++;
+                    break;
+                case ')' or ']' or '}':
+                    if (--depth == 0) return code[(openParen + 1)..i];
+                    break;
+                case ',' when depth == 1:
+                    return code[(openParen + 1)..i];
+            }
+        }
+
+        return code[(openParen + 1)..];
+    }
+
+    /// <summary>
+    /// <c>relative/path.cs&lt;TAB&gt;count</c>, one per line; <c>#</c> starts a comment.
+    /// </summary>
+    public static Dictionary<string, int> ReadAllowFile(string path, string allowFileName)
+    {
+        Assert.True(File.Exists(path),
+            $"{allowFileName} is missing — without it this guard cannot tell a pre-existing site "
+            + "from a new one and would report every occurrence as a failure. Restore it from git "
+            + "rather than regenerating it: a regenerated file would silently bless whatever is in "
+            + "the tree, which is the one thing a ratchet must never do.");
+
+        return File.ReadAllLines(path)
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0 && !l.StartsWith('#'))
+            .Select(l => l.Split('\t', StringSplitOptions.TrimEntries))
+            .ToDictionary(parts => parts[0], parts => int.Parse(parts[1]), StringComparer.Ordinal);
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/UserIdentityLookupClassifierTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/UserIdentityLookupClassifierTest.cs
@@ -174,4 +174,28 @@ public class UserIdentityLookupClassifierTest
 
         Assert.Same(node, determined.Node);
     }
+
+    /// <summary>
+    /// Subscribing to the change feed BEFORE taking the first reading has a cost the old
+    /// <c>Defer</c>/<c>StartWith</c> shape did not: the subscription already exists when the reading
+    /// runs. If that reading throws and the exception is simply allowed to propagate out of the
+    /// subscribe factory, the handle is never returned to anyone — leaving a live subscription to a
+    /// hot, process-wide stream that keeps re-invoking the reading for the life of the cache, with no
+    /// way to dispose it. So a throwing reading must tear the feed down and surface as the sequence's
+    /// own <c>OnError</c>. (Copilot review, #2259.)
+    /// </summary>
+    [Fact]
+    public async Task UntilDetermined_AThrowingReading_FaultsTheSequence_AndLeavesNoSubscriptionBehind()
+    {
+        var indexChanged = new Subject<Unit>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await UserIdentityLookup
+                .UntilDetermined(indexChanged, () => throw new InvalidOperationException("index read failed"))
+                .Timeout(TimeSpan.FromSeconds(10))
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken));
+
+        Assert.False(indexChanged.HasObservers);
+    }
 }

--- a/test/MeshWeaver.Hosting.Blazor.Test/UserIdentityLookupClassifierTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/UserIdentityLookupClassifierTest.cs
@@ -1,3 +1,7 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
 using MeshWeaver.Blazor.Infrastructure;
 using MeshWeaver.Mesh;
 using Xunit;
@@ -100,5 +104,74 @@ public class UserIdentityLookupClassifierTest
         Assert.False(lookup.IsUnavailable);
         Assert.Null(lookup.Node);
         Assert.Null(lookup.UnavailableReason);
+    }
+
+    // ---- THE WAIT: UntilDetermined must be LISTENING before it takes its first reading ----
+
+    /// <summary>
+    /// 🚨 #2031 / #2185. <see cref="UserIdentityLookup.UntilDetermined"/> exists to cover the window
+    /// between a caller's own unavailable lookup and this subscription — and it used to be written
+    /// <c>indexChanged.Select(_ =&gt; lookup()).StartWith(lookup())</c>, which gets the order exactly
+    /// backwards. <c>StartWith</c>'s argument is evaluated while the chain is being BUILT, and
+    /// <c>Concat</c> subscribes to the change feed only after the prepended value is delivered, so the
+    /// window was moved rather than closed.
+    ///
+    /// <para><b>Why that is fatal rather than merely unlucky.</b> The index is a hot, non-replaying
+    /// stream that fires once per APPLIED snapshot. A mesh that has finished writing never fires
+    /// again, so a lost emission has no second chance: the observable never emits at all, and the
+    /// caller reports a 60 s <c>TimeoutException</c> — not a wrong answer, which is precisely the
+    /// signature of both open issues (full-assembly only, green in isolation, because in isolation
+    /// the snapshot lands long after the subscribe and cannot fall in the window).</para>
+    ///
+    /// <para><b>Why this is deterministic and not a timing test.</b> Firing the index change from
+    /// INSIDE the first reading reproduces the exact interleaving a preemption on a loaded shard
+    /// produces — the snapshot landing between "take the reading" and "start listening" — with no
+    /// sleeps, no scheduler and no load. Under the old order the emission has no observer and is
+    /// dropped; under the fixed order the subscription is already live and sees it.</para>
+    /// </summary>
+    [Fact]
+    public async Task UntilDetermined_SeesAnIndexChangeThatLandsWhileTheFirstReadingIsBeingTaken()
+    {
+        var indexChanged = new Subject<Unit>();   // hot + non-replaying, exactly like IndexChanged
+        var node = User("rbuergi");
+        var hydrated = false;
+
+        UserIdentityLookup Lookup()
+        {
+            if (hydrated)
+                return UserIdentityLookup.Classify(node, hydrated: true, subscriptionFailure: null);
+
+            // The snapshot lands DURING the first reading: applied first (so a re-ask would now
+            // succeed), then announced — the same order UserIdentityCache.Apply uses.
+            hydrated = true;
+            indexChanged.OnNext(Unit.Default);
+            return UserIdentityLookup.Classify(hit: null, hydrated: false, subscriptionFailure: null);
+        }
+
+        var determined = await UserIdentityLookup.UntilDetermined(indexChanged, Lookup)
+            .Timeout(TimeSpan.FromSeconds(10))
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        Assert.False(determined.IsUnavailable);
+        Assert.Same(node, determined.Node);
+    }
+
+    /// <summary>
+    /// The ordinary path stays ordinary: an index that is already determinate at subscribe time is
+    /// answered from the first reading, without waiting for any change at all.
+    /// </summary>
+    [Fact]
+    public async Task UntilDetermined_AnswersFromTheFirstReading_WhenTheIndexIsAlreadyDeterminate()
+    {
+        var node = User("rbuergi");
+        var determined = await UserIdentityLookup
+            .UntilDetermined(Observable.Never<Unit>(),
+                () => UserIdentityLookup.Classify(node, hydrated: true, subscriptionFailure: null))
+            .Timeout(TimeSpan.FromSeconds(10))
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        Assert.Same(node, determined.Node);
     }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
@@ -28,7 +28,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// The automatic MeshChangeFeed → TryTriggerRecompile path has been removed.
 /// All compilation is now triggered explicitly via CreateReleaseRequest.
 /// </summary>
-public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestBase(output), IDisposable
+public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     private readonly string _cacheDir = Path.Combine(
         Path.GetTempPath(), $"MeshWeaverCodeEditTest-{Guid.NewGuid():N}");
@@ -46,9 +46,20 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
                 }));
     }
 
-    public new void Dispose()
+    /// <summary>
+    /// 🚨 Overrides <see cref="MonolithMeshTestBase.DisposeAsync"/> — it does NOT implement
+    /// <see cref="IDisposable"/> and block on it. This used to read
+    /// <c>base.DisposeAsync().AsTask().GetAwaiter().GetResult()</c>, which parks the disposing thread
+    /// in a native wait on MESH TEARDOWN — the one operation in this suite with a documented history
+    /// of not completing. xUnit's <c>methodTimeout</c> cannot abort a thread in that state, and
+    /// teardown runs outside it anyway, so a stall there is not a failed test: it is the whole shard
+    /// hanging to its wall-clock cap and reporting <c>exit=124 TIMEOUT</c> with no test named
+    /// (#2013). Awaiting suspends instead of parking, so the same stall surfaces as a bounded,
+    /// attributable teardown.
+    /// </summary>
+    public override async ValueTask DisposeAsync()
     {
-        base.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        await base.DisposeAsync();
         if (Directory.Exists(_cacheDir))
             try { Directory.Delete(_cacheDir, recursive: true); } catch { }
     }

--- a/test/MeshWeaver.Hosting.Monolith.Test/CompileSourceSnapshotWedgeTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CompileSourceSnapshotWedgeTest.cs
@@ -50,7 +50,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// compile SETTLES, terminally, naming the dead query, and a fresh trigger recovers.</para>
 /// </summary>
 public class CompileSourceSnapshotWedgeTest(ITestOutputHelper output)
-    : MonolithMeshTestBase(output), IDisposable
+    : MonolithMeshTestBase(output)
 {
     private readonly string _cacheDir = Path.Combine(
         Path.GetTempPath(), $"MeshWeaverSnapshotWedgeTest-{Guid.NewGuid():N}");
@@ -76,9 +76,20 @@ public class CompileSourceSnapshotWedgeTest(ITestOutputHelper output)
                 }));
     }
 
-    public new void Dispose()
+    /// <summary>
+    /// 🚨 Overrides <see cref="MonolithMeshTestBase.DisposeAsync"/> — it does NOT implement
+    /// <see cref="IDisposable"/> and block on it. This used to read
+    /// <c>base.DisposeAsync().AsTask().GetAwaiter().GetResult()</c>, which parks the disposing thread
+    /// in a native wait on MESH TEARDOWN — the one operation in this suite with a documented history
+    /// of not completing. xUnit's <c>methodTimeout</c> cannot abort a thread in that state, and
+    /// teardown runs outside it anyway, so a stall there is not a failed test: it is the whole shard
+    /// hanging to its wall-clock cap and reporting <c>exit=124 TIMEOUT</c> with no test named
+    /// (#2013). Awaiting suspends instead of parking, so the same stall surfaces as a bounded,
+    /// attributable teardown.
+    /// </summary>
+    public override async ValueTask DisposeAsync()
     {
-        base.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        await base.DisposeAsync();
         if (Directory.Exists(_cacheDir))
             try { Directory.Delete(_cacheDir, recursive: true); } catch { }
     }

--- a/test/MeshWeaver.Hosting.Monolith.Test/SourceDiscoveryUnavailableTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SourceDiscoveryUnavailableTest.cs
@@ -57,7 +57,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// </list></para>
 /// </summary>
 public class SourceDiscoveryUnavailableTest(ITestOutputHelper output)
-    : MonolithMeshTestBase(output), IDisposable
+    : MonolithMeshTestBase(output)
 {
     private readonly string _cacheDir = Path.Combine(
         Path.GetTempPath(), $"MeshWeaverSourceUnavailableTest-{Guid.NewGuid():N}");
@@ -83,9 +83,20 @@ public class SourceDiscoveryUnavailableTest(ITestOutputHelper output)
                 }));
     }
 
-    public new void Dispose()
+    /// <summary>
+    /// 🚨 Overrides <see cref="MonolithMeshTestBase.DisposeAsync"/> — it does NOT implement
+    /// <see cref="IDisposable"/> and block on it. This used to read
+    /// <c>base.DisposeAsync().AsTask().GetAwaiter().GetResult()</c>, which parks the disposing thread
+    /// in a native wait on MESH TEARDOWN — the one operation in this suite with a documented history
+    /// of not completing. xUnit's <c>methodTimeout</c> cannot abort a thread in that state, and
+    /// teardown runs outside it anyway, so a stall there is not a failed test: it is the whole shard
+    /// hanging to its wall-clock cap and reporting <c>exit=124 TIMEOUT</c> with no test named
+    /// (#2013). Awaiting suspends instead of parking, so the same stall surfaces as a bounded,
+    /// attributable teardown.
+    /// </summary>
+    public override async ValueTask DisposeAsync()
     {
-        base.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        await base.DisposeAsync();
         if (Directory.Exists(_cacheDir))
             try { Directory.Delete(_cacheDir, recursive: true); } catch { }
     }

--- a/test/MeshWeaver.Reactive.Assertions.Test/AssertionTests.cs
+++ b/test/MeshWeaver.Reactive.Assertions.Test/AssertionTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Reactive.Assertions;
 using Xunit;
@@ -286,5 +288,90 @@ public class AssertionTests
         Assert.Contains("Edit, Create, Resume synchronization", ex.Message);
         Assert.Contains("3 item(s)", ex.Message);
         Assert.DoesNotContain("System.Collections.Generic.List", ex.Message);
+    }
+
+    /// <summary>
+    /// 🚨 #2243. The terminal assertions must attach their observer SYNCHRONOUSLY, on the calling
+    /// thread, before handing back the Task. "Arm the wait, then make the thing happen" is the normal
+    /// test shape, and half of what gets observed is a hot, non-replaying <c>Subject&lt;T&gt;</c> — an
+    /// emission with no observer attached is simply gone, and the assertion then waits out its ENTIRE
+    /// timeout for a second emission that is never coming. That is what
+    /// <c>MessageHubTest.ManyDistinctMissingSubscribes_DoNotWedge</c> was failing on intermittently:
+    /// the old <c>SubscribeOn(TaskPoolScheduler.Default)</c> deferred the subscribe to the thread pool,
+    /// and under full-suite pool pressure the test thread's flood — and the shed it provoked —
+    /// completed first.
+    /// <para>
+    /// The assertion is on the THREAD, not on timing, so it is deterministic: with a pool hop the
+    /// subscribe can never run on the calling thread, however lucky the scheduling.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task Emit_SubscribesSynchronouslyOnTheCallingThread_SoAHotSourceCannotOutrunTheObserver()
+    {
+        var callingThread = Environment.CurrentManagedThreadId;
+        var subscribeThread = 0;
+        var hot = new Subject<int>();
+        var source = Observable.Create<int>(observer =>
+        {
+            subscribeThread = Environment.CurrentManagedThreadId;
+            return hot.Subscribe(observer);
+        });
+
+        var wait = source.Should().Within(10.Seconds()).Emit();
+
+        Assert.Equal(callingThread, subscribeThread);
+        hot.OnNext(7);                       // hot + non-replaying: lost unless the observer is already on
+        Assert.Equal(7, await wait);
+    }
+
+    /// <summary>
+    /// The other half of the same contract, and the reason the pool hop existed at all: xUnit runs
+    /// <c>async Task</c> tests under a single-threaded <c>MaxConcurrencySyncContext</c>, and a cold mesh
+    /// observable subscribed with that context ambient funnels every async continuation back onto the
+    /// one context thread (8 s versus 3 ms — AddressResolutionTest, 2026-06-15). Subscribing here would
+    /// reintroduce exactly that unless the context is suppressed for the duration of the subscribe — so
+    /// this pins BOTH the suppression and its restoration.
+    /// </summary>
+    [Fact]
+    public async Task Emit_SuppressesTheAmbientSyncContextForTheSubscribe_ThenRestoresIt()
+    {
+        var previous = SynchronizationContext.Current;
+        var probe = new SynchronizationContext();
+        SynchronizationContext.SetSynchronizationContext(probe);
+        try
+        {
+            SynchronizationContext? duringSubscribe = probe;   // sentinel — must be overwritten
+            var source = Observable.Create<int>(observer =>
+            {
+                duringSubscribe = SynchronizationContext.Current;
+                observer.OnNext(3);
+                observer.OnCompleted();
+                return Disposable.Empty;
+            });
+
+            var wait = source.Should().Within(10.Seconds()).Emit();
+
+            Assert.Null(duringSubscribe);
+            Assert.Same(probe, SynchronizationContext.Current);
+            Assert.Equal(3, await wait);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previous);
+        }
+    }
+
+    /// <summary>
+    /// <c>NotEmit</c> is the window assertion, so a deferred subscribe would make it pass on a source
+    /// that emitted at the very start of the window — a false green in a negative test, which is the
+    /// worst kind. It must observe from the first instant too.
+    /// </summary>
+    [Fact]
+    public async Task NotEmit_ObservesFromTheFirstInstantOfTheWindow()
+    {
+        var hot = new Subject<int>();
+        var wait = hot.Should().NotEmit(2.Seconds());
+        hot.OnNext(1);
+        await Assert.ThrowsAnyAsync<AssertionException>(async () => await wait);
     }
 }


### PR DESCRIPTION
Four items from the flake population (#1384). Three of them are the same defect,
seen in three places: **something subscribes AFTER the event it is waiting for, to
a source that announces exactly once and never repeats itself.**

---

## 1. The production one — `UntilDetermined` misses the snapshot it is waiting for (#2031, #2185)

`UserIdentityLookup.UntilDetermined` is the portal's answer to "the user directory
is still filling, so I cannot yet tell 'no such user' from 'not read yet'". Its own
remarks said the `StartWith` closed the sample-then-subscribe race. It did not:

```csharp
indexChanged.Select(_ => lookup()).StartWith(lookup())
```

`StartWith`'s argument is evaluated while the chain is being **built**, and `Concat`
subscribes to the change feed only **after** the prepended value has been delivered.
The window was not closed — it was moved, from "before the caller's own lookup" to
"between the re-ask and the subscribe". A handful of instructions, which one
preemption on a loaded machine is enough to stretch across.

**Why that is fatal rather than merely unlucky.** `IndexChanged` is a hot,
non-replaying stream that fires **once per applied snapshot**, and a mesh that has
finished writing never fires again. Lose that emission and the observable never
emits at all — a 60 s `TimeoutException` at the caller, *not* a wrong answer.

That is the signature of both open issues, verbatim, and it explains their shape:

| observation in #2031 / #2185 | explained by |
|---|---|
| `System.TimeoutException`, never a failed assertion | the wait never emits; it does not emit something wrong |
| green in isolation, fails under the full assembly | alone, the snapshot lands long after the subscribe and cannot fall in the window |
| exactly one chance | `UserDirectoryCompletenessTests` seeds every user **before** constructing the cache, so there is exactly one announcement to lose |
| same signature in a different assembly, on in-memory persistence | nothing here is Postgres-specific — which is what ruled out #2031's own leading hypothesis |

Now `Observable.Create` with the order spelled out — **subscribe, then read** — rather
than implied by an operator's argument-evaluation order, plus `Observer.Synchronize`
because the index applies its snapshot on the query's thread while the reading is
taken on this one.

**RED before / GREEN after, deterministically and with no timing.** The new test fires
the index change from *inside* the first reading, which is exactly the interleaving a
loaded shard produces by preemption. Against the old implementation it fails with

```
System.TimeoutException : The operation has timed out.
```

— the production text, in 10 s instead of 60.

**In production** the same gap left a sign-in that arrived during hydration on the
claims seed, which carries no time zone and no locale: UTC timestamps and English
strings for that session, nothing logged. Hence the What's New entry.

## 2. The test-infrastructure one — `ObservableAssertions` (#2243)

Every terminal assertion subscribed through `SubscribeOn(TaskPoolScheduler.Default)`,
so `stream.Should().Emit()` handed back its Task **before the observer was attached**.
"Arm the wait, then make the thing happen" is the normal test shape, and half of what
gets observed is a bare `Subject<T>` — `MessageStormBreaker.AggregateSheds` in the
reported case. Under full-suite ThreadPool pressure the flood, the shed and the
emission all completed 15 ms in, before the scheduled subscribe ran, and the assertion
then waited out its whole 10 s for a repeat that was never coming.

**What the pool hop was actually for is preserved — that is the point.** xUnit runs
`async Task` tests under a single-threaded `MaxConcurrencySyncContext`, and subscribing
a cold mesh observable with that context ambient funnels every continuation back onto
the one thread (8 s versus 3 ms, AddressResolutionTest, 2026-06-15). It was never the
pool *thread* that fixed that; it was the **absence of the ambient context on it**. So
the subscribe now happens on the calling thread, synchronously, with
`SynchronizationContext` suppressed and restored around it.

**Why this cannot reintroduce a blocking subscribe.** The source's own subscribe now runs on the test
thread, so a source whose subscribe BLOCKS would park it. That shape is already forbidden in `src/`:
`Observable.FromAsync` may appear only inside `IoPool`, and `IIoPool.Invoke` does its own
`SubscribeOn(TaskPoolScheduler.Default)` (ControlledIoPooling.md), so every pooled leaf still moves
its own subscribe off the caller. Empirically: 1844 tests across the two heaviest users of this
library are green, and a blocking subscribe would show as timeouts, not as passes.

Both halves are pinned, and both fail against the old implementation:

| test | pre-fix |
|---|---|
| `Emit_SubscribesSynchronouslyOnTheCallingThread_…` | `Assert.Equal() Failure: Expected 4, Actual 0` — the subscribe had not run **anywhere** yet |
| `Emit_SuppressesTheAmbientSyncContextForTheSubscribe_ThenRestoresIt` | `Assert.Null() Failure: Value is not null` |

The assertion is on the **thread**, not on timing, so it is deterministic: with a pool
hop the subscribe can never run on the calling thread, however lucky the scheduling.

## 3. The build one — concurrent closure restores clobber a shared assets file (#2127)

Every host importing `MeshModulesPublish.targets` opens its own closure lane;
three were live within ~7 s of each other in the reported run. `BuildInParallel="false"`
serialises the modules **within** a lane and nothing serialised the lanes, so two NuGet
`RestoreTask`s whose closures both contain `src/MeshWeaver.AI` raced the write of its
shared `obj/project.assets.json` — `already exists`, `MSB4181` twice, and a failed
`Build solution (once)` for a PR whose diff was one markdown file.

MSBuild cannot dedupe those on its own: the entry projects differ, so they are distinct
build requests however much their restore graphs overlap. The restore is hoisted into
one `RestoreMeshModuleClosures` target, self-invoked with a **host-independent** property
set, so every lane converges on a single build configuration — which MSBuild *does*
dedupe. It restores the full inventory rather than the caller's subset, so the subset
lane (`Memex.Portal.Shared.Test`: Cosmos + Snowflake) converges too instead of forking a
second configuration; narrowing still happens where it affects what gets laid **out**.

The target logs one line per build, so a property leak that ever forks the configuration
again shows up as two of them rather than as a rare red on someone else's PR.

**The dedupe is measured, not argued.** A build with TWO closure lanes open logs
`LayoutMeshModuleClosures` **twice** (5 modules for the full lane, 2 for the subset lane) and
`RestoreMeshModuleClosures` **exactly once** — so the two lanes really do share one restore
rather than running their own.

🚨 **Honest limit**: the race itself is rare (main was green 8/8 around the report) and I did
**not** reproduce the failure locally. What is verified is that the overlapping-restore mechanism
is gone and that both lanes still lay out what they should.

## 4. #2013 — re-triaged, three sites eliminated, the rest ratcheted

`.ToEnumerable()` is at **zero**. Of the blocking bridges left, **three were the real
thing**: `CodeEditRecompileTest`, `CompileSourceSnapshotWedgeTest` and
`SourceDiscoveryUnavailableTest` each implemented `IDisposable` and blocked on
`base.DisposeAsync()` — parking the disposing thread on **mesh teardown**, the one
operation in this suite with a documented history of not completing, and doing it
**outside `methodTimeout`**. That is precisely how one test costs a whole shard and
reports `exit=124` with no test named. They now override `DisposeAsync` and await it.

Every remaining `.Wait()` was inspected: each is over a source that has already
completed before the wait begins (`Observable.Return`, `Scheduler.Immediate`, an
NSubstitute stub, a fake store, a configuration reader) or is bounded by an upstream
`.Timeout(...)`, whose timer runs on the default scheduler and therefore always
unblocks the parked thread — a named failure, not a wedge.

`BlockingBridgeInTestRatchetGuard` + `BlockingBridgeSites.allow` seed that inventory so
the next one fails at review instead of as a wedged shard. The allow file explicitly
names what is **not** individually cleared — the `StartAsync(…).GetAwaiter().GetResult()`
and `SaveNode(…).GetAwaiter().GetResult()` setup helpers, safe only while the awaited
work completes synchronously — and says those are the lines to lower first.

The scanner is extracted into `SourceScan` and shared with the impersonation ratchet
rather than copied: the comment/string masker is what decides whether a guard measures
code or its own documentation, and a second subtly different copy would produce a
second subtly wrong inventory.

---

## Does #2245 subsume #2031 / #2185?

**No** — and its own author already declined to claim it. That PR removes the
`As<User> for User: value is NodeTypeDefinition` line from the directory query, which is
real and worth having, but a row that fails conversion is simply skipped by
`TryGetEmail`; `_hydrated` still flips on the `Initial` snapshot and the wait still
completes. It cannot produce the 60 s timeout. This PR's fix can, and does.

## Verification

All `-c Release -warnaserror`, `0 Error(s)` / `0 Warning(s)`:

| suite | result |
|---|---|
| `MeshWeaver.Reactive.Assertions.Test` | 21/21 |
| `MeshWeaver.Messaging.Hub.Test` (full assembly — contains #2243's test) | 265/265 |
| `MeshWeaver.Graph.Test` (full assembly — heaviest user of the assertions) | 1579/1579 |
| `MeshWeaver.Documentation.Test` (full — both ratchets, link integrity, What's New) | 44/44 |
| `MeshWeaver.Hosting.Blazor.Test` — `UserIdentityLookupClassifierTest` | 8/8 |
| `MeshWeaver.Hosting.Monolith.Test` (full assembly — carries the `DisposeAsync` edits) | see the comment below |
| `Memex.Portal.Monolith` / `Memex.Portal.Shared.Test` builds | 5 / 2 closure modules laid out |

## Still open, deliberately

`#2155` (PandasExplorer — the assertion *did* see 3 emissions, so the subscribe race is
not it), `#2025`, `#2008`, `#1843` — not investigated here and not reproduced. `#1810`
(mocked `IMessageHub`, now 10 files) is untouched. `#1384` stays open with a comment.

Closes #2243, closes #2127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
