### PR TITLE
Fix #2260: an automatic re-drive must never un-park a NodeType

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-parked-type-stays-parked.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-parked-type-stays-parked.md
@@ -1,0 +1,20 @@
+---
+Name: A parked type stays parked
+Category: Fix
+Description: A type whose build was refused can no longer briefly un-park itself while the framework retries it.
+Icon: Sparkle
+Order: -20260825
+---
+
+# A parked type stays parked
+
+When a type cannot be built, the portal parks it: the failure is recorded once, shown once, and
+nothing retries it until you ask for a build. That containment had a gap. The framework's automatic
+"the build inputs changed, take one more attempt" retry used to clear the park first and only
+re-apply it after the attempt failed again — so for a moment the broken type looked healthy, and any
+trigger arriving in that moment was let through.
+
+The retry no longer clears the park. It asks to be let through once, the park stays in place the
+whole time, and everything else still meets it. In practice this means a type refused for a missing
+prebuilt assembly reports its refusal consistently instead of flickering, and a broken type can no
+longer be woken by a stray trigger that happened to land at the wrong instant.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -258,11 +258,30 @@ internal static class NodeTypeCompilationHelpers
 
                     if (parkRegistry?.IsParked(hubPath) == true)
                     {
-                        logger?.LogDebug(
-                            "Compile watcher: {HubPath} is PARKED (terminal compile failure) — " +
-                            "skipping recompile, serving cached error", hubPath);
-                        SettleAsError(parkRegistry.GetParkedError(hubPath));
-                        return;
+                        // 🅿️ …unless THIS Pending flip is the one sanctioned automatic retry
+                        // (#2260). The failed-verdict re-drive used to un-park so its flip would
+                        // not be swallowed here — which left the type un-parked for the whole
+                        // round-trip until a second failure re-parked it, and un-parked FOREVER
+                        // whenever the re-drive's own re-check then declined to flip. It now asks
+                        // for a one-shot ADMISSION instead, so the park never moves and the
+                        // containment guarantee ("parked ⇒ no later trigger can storm") holds at
+                        // every instant. Consuming the admission is what lets this single flip
+                        // through; every other trigger still takes the short-circuit below.
+                        if (parkRegistry.TryConsumeRetryAdmission(hubPath))
+                        {
+                            logger?.LogDebug(
+                                "Compile watcher: {HubPath} is PARKED but this Pending flip carries the "
+                                + "sanctioned one-shot retry admission — letting it through WITHOUT "
+                                + "un-parking (the park holds for every other trigger).", hubPath);
+                        }
+                        else
+                        {
+                            logger?.LogDebug(
+                                "Compile watcher: {HubPath} is PARKED (terminal compile failure) — " +
+                                "skipping recompile, serving cached error", hubPath);
+                            SettleAsError(parkRegistry.GetParkedError(hubPath));
+                            return;
+                        }
                     }
 
                     // 🚨 THE ADOPT-ONLY GATE (Modules:RequirePrebuilt, MeshWeaver#2193 §A). On a
@@ -711,43 +730,16 @@ internal static class NodeTypeCompilationHelpers
                         liveInputs, total, NodeTypeCompileParkRegistry.MaxAutomaticFailureRedrives,
                         def.CompilationError ?? "(none recorded)");
 
-                    // 🅿️ Un-park FIRST (in-memory + synchronous, so it happens-before the Pending
-                    // emission the compile watcher observes), exactly as the sources watcher's
-                    // parked auto-retry does — otherwise the parked short-circuit would swallow the
-                    // flip and re-settle it to Error. This does not weaken the park: the predicate
-                    // above is false for a type parked in THIS process under THESE inputs, so a
-                    // broken type whose inputs have not moved is never woken.
-                    parkRegistry?.Unpark(hubPath);
                     var redriveAccess = hub.ServiceProvider.GetService<AccessService>();
                     using var systemScope = redriveAccess?.ImpersonateAsSystem();
-                    workspace.GetMeshNodeStream().Update(curr =>
-                    {
-                        if (curr?.Content is not NodeTypeDefinition d) return curr!;
-                        // Never clobber an in-flight compile (a concurrent release request or
-                        // enrichment self-heal may already have flipped Pending/Compiling).
-                        if (d.CompilationStatus is CompilationStatus.Pending
-                                                or CompilationStatus.Compiling)
-                            return curr;
-                        // Re-check inside the lambda — a genuine compile may have settled between
-                        // the outer Where and this write.
-                        if (!HasStaleFailureVerdict(d, guards.ModulesHash)) return curr;
-                        return curr with
-                        {
-                            Content = d with
-                            {
-                                // 🚨 The bookkeeping and the flip land TOGETHER. Stamping the live
-                                // inputs here — not only in ApplyCompileFailure — is what makes the
-                                // re-drive unable to schedule another pass even if the compile
-                                // never writes back at all (process death mid-compile, the parked
-                                // re-settle, a poisoned content read).
-                                FailedBuildInputs = BuildInputsToken(
-                                    guards.ModulesHash, d.CurrentSourceVersions),
-                                CompilationStatus = CompilationStatus.Pending
-                            }
-                        };
-                    }).Subscribe(_ => { },
-                        ex => logger?.LogWarning(ex,
-                            "Failed-verdict re-drive: Update failed for {HubPath}", hubPath));
+                    // 🅿️ The park is NOT lifted here (#2260). Admission and flip are one decision
+                    // and they commit together, inside the lambda — see ApplyFailedVerdictRedrive.
+                    workspace.GetMeshNodeStream()
+                        .Update(curr => ApplyFailedVerdictRedrive(
+                            curr, hubPath, guards.ModulesHash, parkRegistry))
+                        .Subscribe(_ => { },
+                            ex => logger?.LogWarning(ex,
+                                "Failed-verdict re-drive: Update failed for {HubPath}", hubPath));
                 },
                 ex => logger?.LogWarning(ex,
                     "Failed-verdict re-drive: own-stream subscription faulted for {HubPath} — a "
@@ -1724,6 +1716,71 @@ internal static class NodeTypeCompilationHelpers
             def.FailedBuildInputs,
             BuildInputsToken(modulesHash, def.CurrentSourceVersions),
             StringComparison.Ordinal);
+
+    /// <summary>
+    /// 🅿️ THE failed-verdict re-drive's COMMIT step (#2260) — the whole decision, including the
+    /// retry ADMISSION, as one function of the node state it commits against. Passed as the
+    /// <c>Update</c> lambda so it runs on the data source's action block, exactly once, immediately
+    /// before the write it produces.
+    ///
+    /// <para><b>Two defects this shape closes, both in the old
+    /// <c>parkRegistry.Unpark(hubPath); …Update(…)</c> pair.</b></para>
+    ///
+    /// <para>(1) <b>An un-park decided from a SNAPSHOT.</b> The subscriber's emission is a snapshot;
+    /// by the time the body ran, a terminal failure could have parked the type again
+    /// (<c>NodeTypeCompileParkRegistry.ParkAndNotify</c> is the only writer of that entry). The
+    /// un-park removed a park the decision never observed — and, when the lambda's own re-checks
+    /// then declined to flip, NOTHING re-parked afterwards. The type ended up neither parked nor
+    /// re-driven: exactly the state the park exists to make impossible. Here every early return
+    /// leaves the registry untouched, so the registry is only ever touched by a re-drive that is,
+    /// in the same committed state, genuinely flipping the type back to Pending.</para>
+    ///
+    /// <para>(2) <b>Un-parking at all.</b> Even a perfectly-validated un-park leaves the type
+    /// un-parked for the whole Pending → refusal → re-park round-trip, and any trigger arriving in
+    /// that window is admitted. Under <c>Modules:RequirePrebuilt</c> that window opened on EVERY
+    /// refusal. The re-drive never needed the failure cleared — only its one flip let through — so
+    /// it asks for a one-shot <c>AdmitOneRetry</c> and <see cref="NodeTypeCompileParkRegistry.IsParked"/>
+    /// stays true at every instant. The admission still happens-before the Pending emission the
+    /// compile watcher observes (this lambda runs ahead of the commit), which is what the old
+    /// hoisted-out un-park was buying.</para>
+    /// </summary>
+    /// <param name="curr">The node state this write is committing against (authoritative).</param>
+    /// <param name="hubPath">The NodeType's path.</param>
+    /// <param name="modulesHash">The installed-module fingerprint half of the compile inputs.</param>
+    /// <param name="parkRegistry">The park registry, or <c>null</c> on a host that has none.</param>
+    /// <returns><paramref name="curr"/> unchanged when the re-drive declines; otherwise the node
+    /// flipped to <see cref="CompilationStatus.Pending"/> with the live inputs stamped.</returns>
+    internal static MeshNode ApplyFailedVerdictRedrive(
+        MeshNode curr, string hubPath, string? modulesHash,
+        NodeTypeCompileParkRegistry? parkRegistry)
+    {
+        if (curr?.Content is not NodeTypeDefinition d) return curr!;
+        // Never clobber an in-flight compile (a concurrent release request or
+        // enrichment self-heal may already have flipped Pending/Compiling).
+        if (d.CompilationStatus is CompilationStatus.Pending
+                                or CompilationStatus.Compiling)
+            return curr;
+        // Re-check against the state being committed — a genuine compile may have settled, or a
+        // fresh terminal failure may have re-parked, between the outer Where and this write.
+        if (!HasStaleFailureVerdict(d, modulesHash)) return curr;
+        // 🅿️ Committing the flip — and ONLY now — claim the one-shot admission, so the compile
+        // watcher's parked short-circuit lets this Pending emission through. The park itself is
+        // never touched.
+        parkRegistry?.AdmitOneRetry(hubPath);
+        return curr with
+        {
+            Content = d with
+            {
+                // 🚨 The bookkeeping and the flip land TOGETHER. Stamping the live
+                // inputs here — not only in ApplyCompileFailure — is what makes the
+                // re-drive unable to schedule another pass even if the compile
+                // never writes back at all (process death mid-compile, the parked
+                // re-settle, a poisoned content read).
+                FailedBuildInputs = BuildInputsToken(modulesHash, d.CurrentSourceVersions),
+                CompilationStatus = CompilationStatus.Pending
+            }
+        };
+    }
 
     /// <summary>
     /// THE terminal stamp of a SUCCESSFUL compile — the exact field set

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -1766,7 +1766,18 @@ internal static class NodeTypeCompilationHelpers
         // 🅿️ Committing the flip — and ONLY now — claim the one-shot admission, so the compile
         // watcher's parked short-circuit lets this Pending emission through. The park itself is
         // never touched.
-        parkRegistry?.AdmitOneRetry(hubPath);
+        //
+        // 🚨 …and ONLY while the type is actually PARKED. An admission for an un-parked type is
+        // never consumed — the short-circuit it exists to pass is not taken — so it would sit in
+        // the registry until some LATER park, where a stray Pending flip could spend it and get
+        // through the very containment this restores. That case is the common one, not a corner:
+        // a failure that predates this PROCESS is not in the (in-memory) registry at all. Gating
+        // here makes the leak impossible rather than merely unlikely, because it establishes
+        // "an admission implies a standing park" — and every path that REMOVES a park (Unpark,
+        // OnCompileSucceeded) clears admissions with it, so no admission can outlive the park it
+        // was granted against.
+        if (parkRegistry?.IsParked(hubPath) == true)
+            parkRegistry.AdmitOneRetry(hubPath);
         return curr with
         {
             Content = d with

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompileParkRegistry.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompileParkRegistry.cs
@@ -187,6 +187,13 @@ public sealed class NodeTypeCompileParkRegistry
     /// widens nothing: exactly one Pending flip gets through, every later stray trigger still
     /// short-circuits on the park that never moved. A DELIBERATE retry keeps using
     /// <see cref="Unpark"/> — a human asking for a build really is clearing the failure.</para>
+    ///
+    /// <para>🚨 <b>Grant this ONLY while <see cref="IsParked"/> is true.</b> An admission for an
+    /// un-parked type is never consumed (the short-circuit it exists to pass is not taken) and
+    /// would linger until some LATER park, where a stray trigger could spend it. Callers gate on
+    /// the park, which establishes "an admission implies a standing park"; both paths that remove
+    /// a park (<see cref="Unpark"/>, <see cref="OnCompileSucceeded"/>) clear admissions with it,
+    /// so an admission can never outlive the park it was granted against.</para>
     /// </summary>
     public void AdmitOneRetry(string nodeTypePath) => _retryAdmissions[nodeTypePath] = 0;
 

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompileParkRegistry.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompileParkRegistry.cs
@@ -39,6 +39,13 @@ namespace MeshWeaver.Graph.Configuration;
 /// only if the sources changed" path). The registry is mesh-scoped and held in
 /// memory, so a process restart also clears it — a redeployed fix recompiles fresh.</para>
 ///
+/// <para>🅿️ <b>An AUTOMATIC re-drive does NOT un-park (#2260).</b> The failed-verdict kickoff
+/// (#1793) takes its one fresh attempt through <see cref="AdmitOneRetry"/> instead: the park entry
+/// stays, so <see cref="IsParked"/> is true at every instant and there is no window in which a
+/// broken type reads as un-parked and a stray trigger is admitted. Lifting the park is reserved
+/// for the two events that genuinely END the failure — a human-requested build and a successful
+/// compile.</para>
+///
 /// <para>Mesh-scoped singleton (registered in <c>AddGraph</c>): one instance shared by
 /// every per-NodeType hub, with instance maps only — NO static state.</para>
 /// </summary>
@@ -59,6 +66,11 @@ public sealed class NodeTypeCompileParkRegistry
     // (diagnostic). Proves boundedness: a parked type holds at its small attempt count
     // instead of climbing on every access.
     private readonly ConcurrentDictionary<string, int> _attempts = new();
+
+    // 🅿️ #2260 — ONE-SHOT RETRY ADMISSIONS. An AUTOMATIC re-drive needs its single fresh attempt
+    // to reach the compile watcher without being swallowed by the parked short-circuit; it does
+    // NOT need — and must not have — the park itself lifted. See AdmitOneRetry.
+    private readonly ConcurrentDictionary<string, byte> _retryAdmissions = new();
 
     /// <summary>Record that a real Roslyn compile was kicked off for the NodeType.</summary>
     public void RecordAttempt(string nodeTypePath) =>
@@ -156,11 +168,42 @@ public sealed class NodeTypeCompileParkRegistry
         return true;
     }
 
+    /// <summary>
+    /// 🅿️ #2260 — admit ONE sanctioned automatic retry through the compile watcher's parked
+    /// short-circuit, WITHOUT un-parking.
+    ///
+    /// <para><b>Why this exists.</b> The automatic re-drives (the failed-verdict kickoff) used to
+    /// call <see cref="Unpark"/> so their <c>CompilationStatus = Pending</c> flip would not be
+    /// swallowed by the short-circuit. That conflates two different things — "this terminal
+    /// failure is cleared" and "let this one flip through" — and it costs the guarantee the park
+    /// exists for: between the un-park and the re-park that follows a second refusal, the type is
+    /// NOT parked, so every reader (<c>IsParked</c>, the framework-stale kickoff's guard, the
+    /// adopt-only refusal's own test) can observe an un-parked broken type, and any trigger
+    /// arriving in that window is admitted. On a mesh that sets <c>Modules:RequirePrebuilt</c> the
+    /// window opens on EVERY refusal, because the refusal's settle records no verdict inputs and
+    /// therefore always reads as "never attempted".</para>
+    ///
+    /// <para>An admission is one-shot (<see cref="TryConsumeRetryAdmission"/> removes it), so it
+    /// widens nothing: exactly one Pending flip gets through, every later stray trigger still
+    /// short-circuits on the park that never moved. A DELIBERATE retry keeps using
+    /// <see cref="Unpark"/> — a human asking for a build really is clearing the failure.</para>
+    /// </summary>
+    public void AdmitOneRetry(string nodeTypePath) => _retryAdmissions[nodeTypePath] = 0;
+
+    /// <summary>
+    /// Consume a pending one-shot admission (see <see cref="AdmitOneRetry"/>). <c>true</c> when
+    /// this Pending flip IS the sanctioned automatic retry and must be let through the parked
+    /// short-circuit; <c>false</c> for every other trigger.
+    /// </summary>
+    public bool TryConsumeRetryAdmission(string nodeTypePath) =>
+        _retryAdmissions.TryRemove(nodeTypePath, out _);
+
     /// <summary>A compile succeeded — clear any parked failure / retry budget for the type.</summary>
     public void OnCompileSucceeded(string nodeTypePath)
     {
         _parked.TryRemove(nodeTypePath, out _);
         _failureCounts.TryRemove(nodeTypePath, out _);
+        _retryAdmissions.TryRemove(nodeTypePath, out _);
         // The automatic re-drive CONVERGED, so its budget is spent and returned: a type that
         // breaks again later gets a fresh set of attempts rather than inheriting a used-up one.
         ClearFailureRedrives(nodeTypePath);
@@ -186,6 +229,9 @@ public sealed class NodeTypeCompileParkRegistry
         if (_parked.TryRemove(nodeTypePath, out _))
             _attempts.TryRemove(nodeTypePath, out _);
         _failureCounts.TryRemove(nodeTypePath, out _);
+        // An un-parked type needs no admission — and a leftover one would let a later stray
+        // trigger through the short-circuit if the type parks again.
+        _retryAdmissions.TryRemove(nodeTypePath, out _);
     }
 
     /// <summary>
@@ -239,7 +285,20 @@ public sealed class NodeTypeCompileParkRegistry
         IReadOnlyDictionary<string, long>? sources, string? recipientUserId, ILogger? logger)
     {
         if (!_parked.TryAdd(nodeTypePath, new ParkedCompileFailure(error, DateTimeOffset.UtcNow, sources)))
-            return; // already parked — do not re-notify
+        {
+            // 🅿️ Already parked — an ADMITTED automatic retry (AdmitOneRetry) re-failed, which is
+            // now the normal shape: the park is never lifted for one, so the second refusal lands
+            // here rather than adding a fresh entry. REFRESH the record in place so the cached
+            // error and — decisively — the source snapshot describe the LATEST verdict:
+            // ShouldRetryForSourceChange compares that snapshot against the live one, and a stale
+            // snapshot would keep re-arming the source-change retry against a source set nothing
+            // has actually changed. Compare-and-replace, never a blind write: a concurrent Unpark
+            // (a human pressing Compile) must not be resurrected by this refresh.
+            if (_parked.TryGetValue(nodeTypePath, out var standing))
+                _parked.TryUpdate(
+                    nodeTypePath, standing with { Error = error, Sources = sources }, standing);
+            return; // …and never re-notify: a broken type yields exactly one notification.
+        }
 
         logger?.LogError(
             "NodeType '{NodeTypePath}' PARKED after compile failure — further activations serve the " +

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
@@ -497,6 +497,37 @@ public class NodeTypeCompileParkTest(ITestOutputHelper output) : MonolithMeshTes
     }
 
     /// <summary>
+    /// 🚨 The leak the admission could otherwise cause, pinned: on a type that is NOT parked — the
+    /// COMMON case, since a failure predating this process is not in the in-memory registry at
+    /// all — the re-drive must flip and leave NOTHING behind.
+    ///
+    /// <para>An admission granted here would never be consumed (the parked short-circuit it exists
+    /// to pass is not taken), so it would sit in the registry until some LATER park, where a stray
+    /// Pending flip could spend it and get through the very containment this PR restores. Gating
+    /// the grant on <c>IsParked</c> establishes "an admission implies a standing park", and both
+    /// park-removal paths clear admissions — so none can outlive its park.</para>
+    /// </summary>
+    [Fact]
+    public void RedriveCommit_OnATypeThatIsNotParked_FlipsAndLeavesNoAdmissionBehind()
+    {
+        var sources = ImmutableDictionary<string, long>.Empty;
+        // Never parked: exactly the "failure predates this PROCESS" shape.
+        var registry = new NodeTypeCompileParkRegistry();
+        registry.IsParked(RedrivePath).Should().BeFalse("the fixture must start un-parked");
+        var curr = SettledFailure(failedBuildInputs: null, sources);
+
+        var result = NodeTypeCompilationHelpers.ApplyFailedVerdictRedrive(
+            curr, RedrivePath, modulesHash: null, registry);
+
+        result.Content.Should().BeOfType<NodeTypeDefinition>().Subject
+            .CompilationStatus.Should().Be(CompilationStatus.Pending,
+                "an un-parked stale verdict still earns its attempt — nothing is short-circuiting it");
+        registry.TryConsumeRetryAdmission(RedrivePath).Should().BeFalse(
+            "an admission is meaningful ONLY for a parked type; one granted here would never be "
+            + "consumed and would wait for a LATER park, where a stray trigger could spend it");
+    }
+
+    /// <summary>
     /// A compile already in flight (a concurrent release request, an enrichment self-heal) —
     /// the re-drive must write nothing, admit nothing, and leave the park exactly as it found it.
     /// </summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
@@ -390,6 +392,129 @@ public class NodeTypeCompileParkTest(ITestOutputHelper output) : MonolithMeshTes
             .IsParked(typePath).Should().BeTrue(
                 "a deterministic compile error must park the type");
         Output.WriteLine($"{typePath} settled at Error and is parked.");
+    }
+
+    // ── 🅿️ #2260 — the park is never lifted by an AUTOMATIC re-drive ────────────────────────
+    //
+    // RequirePrebuiltParkTest catches the defect only by CONSEQUENCE (it happened to read
+    // IsParked inside the un-park → re-park window). These three pin the invariant itself,
+    // directly on the re-drive's commit step, with a real registry and no timing at all.
+
+    private const string RedrivePath = $"{Partition}/RedriveCommit";
+
+    private static MeshNode SettledFailure(
+        string? failedBuildInputs, IReadOnlyDictionary<string, long>? sources,
+        CompilationStatus status = CompilationStatus.Error) =>
+        new("RedriveCommit", Partition)
+        {
+            Name = "Re-drive commit",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = "config => config",
+                CompilationStatus = status,
+                CompilationError = "the recorded verdict",
+                CurrentSourceVersions = sources,
+                FailedBuildInputs = failedBuildInputs,
+            }
+        };
+
+    /// <summary>Parks <see cref="RedrivePath"/> on a FRESH registry instance (never the mesh's —
+    /// no shared state to bleed) using the real, deterministic park path.</summary>
+    private NodeTypeCompileParkRegistry ParkedRegistry(IReadOnlyDictionary<string, long>? sources)
+    {
+        var registry = new NodeTypeCompileParkRegistry();
+        registry.OnCompileFailed(
+            Mesh, RedrivePath, "the recorded verdict", deterministic: true,
+            recipientUserId: null, sources: sources, logger: null);
+        registry.IsParked(RedrivePath).Should().BeTrue("the fixture must start from a real park");
+        return registry;
+    }
+
+    /// <summary>
+    /// 🚨 THE invariant, stated directly: <b>a park, once placed, is never removed by a re-drive
+    /// that did not observe it.</b>
+    ///
+    /// <para>The re-drive fires from a SNAPSHOT. By the time its write commits, a fresh terminal
+    /// failure may have parked the type again — which is exactly what the adopt-only gate
+    /// (<c>Modules:RequirePrebuilt</c>) does on every refused Pending flip. Committing against
+    /// that state, the re-drive declines to flip; before the fix it had ALREADY un-parked
+    /// unconditionally, so nothing re-parked afterwards and the type was left neither parked nor
+    /// re-driven — the one state the park exists to make impossible.</para>
+    /// </summary>
+    [Fact]
+    public void RedriveCommit_AgainstAVerdictFormedUnderTheLiveInputs_LeavesTheParkUntouched()
+    {
+        var sources = ImmutableDictionary<string, long>.Empty;
+        var registry = ParkedRegistry(sources);
+        // The state the re-drive is committing against: the verdict now records EXACTLY the live
+        // compile inputs, i.e. this type has already had its attempt on this deployment.
+        var curr = SettledFailure(
+            NodeTypeCompilationHelpers.BuildInputsToken(modulesHash: null, sources), sources);
+
+        var result = NodeTypeCompilationHelpers.ApplyFailedVerdictRedrive(
+            curr, RedrivePath, modulesHash: null, registry);
+
+        result.Should().BeSameAs(curr, "a declined re-drive must write nothing");
+        registry.IsParked(RedrivePath).Should().BeTrue(
+            "a re-drive that does not flip the type must not remove the park it never observed — "
+            + "nothing would re-park it, and 'parked ⇒ no later trigger can storm' would be false");
+        registry.TryConsumeRetryAdmission(RedrivePath).Should().BeFalse(
+            "…and it must not leave a retry admission behind either, which a later stray Pending "
+            + "flip would consume to get through the parked short-circuit");
+    }
+
+    /// <summary>
+    /// The positive half, and the reason the fix is an ADMISSION rather than a validated un-park:
+    /// a genuinely stale verdict still gets its one fresh attempt, and the park STILL never
+    /// moves — so <c>IsParked</c> is true at every instant, including the whole
+    /// Pending → refusal → re-park round-trip that used to run un-parked.
+    /// </summary>
+    [Fact]
+    public void RedriveCommit_AgainstAGenuinelyStaleVerdict_AdmitsOneRetry_WithoutUnparking()
+    {
+        var sources = ImmutableDictionary<string, long>.Empty;
+        var registry = ParkedRegistry(sources);
+        // "never stamped" — the verdict records nothing about the inputs it was formed under.
+        var curr = SettledFailure(failedBuildInputs: null, sources);
+
+        var result = NodeTypeCompilationHelpers.ApplyFailedVerdictRedrive(
+            curr, RedrivePath, modulesHash: null, registry);
+
+        var flipped = result.Content.Should().BeOfType<NodeTypeDefinition>().Subject;
+        flipped.CompilationStatus.Should().Be(CompilationStatus.Pending,
+            "a stale verdict earns exactly one fresh attempt");
+        flipped.FailedBuildInputs.Should().Be(
+            NodeTypeCompilationHelpers.BuildInputsToken(modulesHash: null, sources),
+            "the bookkeeping and the flip land TOGETHER, so the trigger is false the instant it fires");
+
+        registry.IsParked(RedrivePath).Should().BeTrue(
+            "the automatic re-drive never lifts the park — it only asks to be let through");
+        registry.TryConsumeRetryAdmission(RedrivePath).Should().BeTrue(
+            "the compile watcher's parked short-circuit consumes this admission to let the flip through");
+        registry.TryConsumeRetryAdmission(RedrivePath).Should().BeFalse(
+            "…and it is ONE-SHOT: every later trigger still meets the park");
+    }
+
+    /// <summary>
+    /// A compile already in flight (a concurrent release request, an enrichment self-heal) —
+    /// the re-drive must write nothing, admit nothing, and leave the park exactly as it found it.
+    /// </summary>
+    [Fact]
+    public void RedriveCommit_WhileACompileIsInFlight_LeavesTheParkAndTheNodeUntouched()
+    {
+        var sources = ImmutableDictionary<string, long>.Empty;
+        var registry = ParkedRegistry(sources);
+        var curr = SettledFailure(
+            failedBuildInputs: null, sources, status: CompilationStatus.Compiling);
+
+        var result = NodeTypeCompilationHelpers.ApplyFailedVerdictRedrive(
+            curr, RedrivePath, modulesHash: null, registry);
+
+        result.Should().BeSameAs(curr, "an in-flight compile must never be clobbered");
+        registry.IsParked(RedrivePath).Should().BeTrue("…and the park must survive it");
+        registry.TryConsumeRetryAdmission(RedrivePath).Should().BeFalse(
+            "no flip, no admission");
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #2260. **Unblocks #2238**, whose required check is red on `RequirePrebuiltParkTest` — the failure is this defect on `main`, not that diff.

## The test was right: a parked type really was being un-parked

Measured with the registry instrumented (instance id on every entry, plus a stack trace on every entry actually *removed*, so nothing is inferred):

```
ISPARKED  => False          the compile watcher checks, not parked yet
PARK-ADDED   sources=null   the adopt-only gate refuses -> parks
ISPARKED  => False   <----- the TEST reads HERE, inside the window
UNPARK-REMOVED              the failed-verdict re-drive un-parks  (the only removal in the run)
PARK-ADDED   sources=0      the gate refuses again -> re-parks
```

A passing run has the same first five lines and a sixth, `ISPARKED => True`. So the assertion is not
racy in the "test is wrong" sense — it reads a moment in which the type genuinely is **not parked**.

## Root cause

The failed-verdict re-drive (#1793) called `parkRegistry.Unpark(hubPath)` before its `Update`, so its
`CompilationStatus = Pending` flip would not be swallowed by the compile watcher's parked
short-circuit. Two defects:

1. **The un-park was decided from a SNAPSHOT and never re-validated.** The `Update` lambda re-checks
   current state and can decline to flip — and the park is already gone by then, with nothing to
   re-park it. The type ends up *neither parked nor re-driven*: the one state the park exists to make
   impossible. The file's own comment (*"correctness is the re-check inside the Update lambda, not
   this"*) held for the Pending flip and not for the un-park.
2. **Un-parking at all.** Even a perfectly validated un-park leaves the type un-parked for the whole
   `Pending -> refusal -> re-park` round-trip, and any trigger arriving in that window is admitted.
   Under `Modules:RequirePrebuilt` that window opens on **every** refusal.

Fixing only (1) would not have closed the window — this was verified against the measured trace
before choosing the shape.

## The fix: the re-drive asks to be let through, it does not clear the failure

The automatic re-drive never needed the terminal failure *cleared* — only its one flip *let through*.
Conflating those two is the defect.

- `AdmitOneRetry` / `TryConsumeRetryAdmission` — a one-shot admission. The park entry is never
  touched, so `IsParked` is **true at every instant**, and every other trigger still meets the park.
- The admission is claimed **inside** the `Update` lambda (`ApplyFailedVerdictRedrive`), so the
  decision and its effect commit against one observed state — every early return leaves the registry
  untouched.
- Lifting a park stays reserved for the two events that genuinely END the failure: a human-requested
  build (`Unpark`, unchanged) and a successful compile (`OnCompileSucceeded`).
- `ParkAndNotify` now **refreshes** the standing record when an admitted retry re-fails
  (compare-and-replace, never a blind write) instead of returning blind: `ShouldRetryForSourceChange`
  reads that source snapshot, and a stale one would keep re-arming the source-change retry. It still
  never re-notifies — one notification per broken type.

No retry, no delay, no watchdog, no widened bound, and `RequirePrebuiltParkTest` is untouched.

## Verification

`RequirePrebuiltParkTest`, same amplifier both arms (`--logger "console;verbosity=detailed"`,
`DOTNET_PROCESSOR_COUNT=4`), same machine:

| arm | result |
|---|---|
| `origin/main`, plain amplifier | 12 / 15 pass |
| `origin/main`, + registry instrumentation (more I/O widens the window) | **2 / 10 pass** |
| **this branch** | **15 / 15 pass**, and 20 / 20 on the final tree |

Post-fix the log shows exactly **one** `PARKED after compile failure` and **one** notification (it was
two of each while the park was being dropped and re-added), and the second refusal still reaches the
gate — i.e. the admission let the flip through without the park moving.

Regression suites, all green: `NodeTypeCompileParkTest` (9), `NeverCompiledFailureRedriveTest` (11),
`RedriveObservationReplayTest`, `CodeEditRecompileTest`, `OverlaySelfHealInstanceRecycleTest`,
`RequirePrebuilt*`, `MeshWeaver.Graph.Test/FailedVerdictRedriveTest`.

`dotnet build -c Release -warnaserror` clean (0 warnings, 0 errors) for `MeshWeaver.Graph`
(`--no-incremental`) and `MeshWeaver.Hosting.Monolith.Test`.

## New tests

`RequirePrebuiltParkTest` catches this only by *consequence*. Three new pins in
`NodeTypeCompileParkTest` assert the invariant itself, on the re-drive's commit step, with a real
registry and no timing at all:

- **a park is never removed by a re-drive that did not observe it** (the durable assertion);
- a genuinely stale verdict still earns its one attempt — *without* un-parking, and the admission is
  one-shot;
- an in-flight compile is never clobbered, and leaves no admission behind.

## Follow-up (not in this PR)

`SettleAsError` never stamps `FailedBuildInputs`, so the adopt-only gate's refusal reads as "never
attempted" and burns one automatic re-drive per refused type. That is the *trigger* that made this
race reachable, but it is not the race, and removing it would not have closed the window (the first
refusal settles before `CurrentSourceVersions` is established, so the token moves anyway). Worth its
own issue — see the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
