### PR TITLE
content/ai gets a drift guard against its published master, and a leak guard (#1627)

### DIFF
--- a/content/ai/Skill/og-card.md
+++ b/content/ai/Skill/og-card.md
@@ -16,8 +16,8 @@ order: 40
 ### 1. Target on THIS mesh ⇒ use the mesh-node form, never the URL form
 
 ```
-@@("area:OgCard/PartnerRe/EslProposalQA")                                   ✅ mesh node
-@@("area:OgCard?url=https://this-portal/PartnerRe/EslProposalQA")           ❌ same page, via HTTP
+@@("area:OgCard/Acme/AIConsulting/FinalReport")                            ✅ mesh node
+@@("area:OgCard?url=https://this-portal/Acme/AIConsulting/FinalReport")    ❌ same page, via HTTP
 ```
 
 They look interchangeable and are not. The mesh-node form reads the node **off its stream**: no HTTP, no anonymous access, no cache, and it works for **private** nodes. The `?url=` form sends the portal out to fetch its own page **anonymously** — which returns the generic shell for every node that is not public, so the card is permanently empty and no amount of retrying changes it.

--- a/memex/aspire/Memex.Database.Migration/Migrations/V53_RetypeBuiltinSlideDeckToPublish.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V53_RetypeBuiltinSlideDeckToPublish.cs
@@ -11,10 +11,10 @@ namespace Memex.Database.Migration.Migrations;
 /// July, and <c>Publish/Deck</c> (Publish v1.0.8) ships the deck Overview/Present areas compiled
 /// in-mesh from the pack's shared slide source. The platform's built-in registrations are slated
 /// for deletion — but live meshes hold core-typed nodes created directly on the mesh, outside any
-/// git repo (AgenticPension on atioz; PartnerRe / PG3 presentations on systemorph). Deleting the
-/// built-ins with those rows in place would strip the views from production content, so every
-/// install must retype first — this migration is that retype, and the deletion lands only a
-/// release AFTER it has run everywhere.</para>
+/// git repo (deck and slide nodes authored directly on the atioz and systemorph portals).
+/// Deleting the built-ins with those rows in place would strip the views from production
+/// content, so every install must retype first — this migration is that retype, and the
+/// deletion lands only a release AFTER it has run everywhere.</para>
 ///
 /// <para><b>Fix.</b> Across every partition schema, retype <c>node_type = 'Slide'</c> rows to
 /// <c>'Publish/Slide'</c> and <c>node_type = 'Deck'</c> rows to <c>'Publish/Deck'</c>. The content

--- a/test/MeshWeaver.AI.Test/AiContentPackDriftTest.cs
+++ b/test/MeshWeaver.AI.Test/AiContentPackDriftTest.cs
@@ -1,0 +1,410 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MeshWeaver.AI;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// 🚨 <b>content/ai IS A MIRROR, AND THE MIRROR MUST NOT DRIFT SILENTLY</b> — issue #1627.
+///
+/// <para>The <b>served</b> master for the built-in agents and skills is the
+/// <c>Systemorph/MeshWeaver.Plugins</c> pack (<c>Agent/</c>, <c>Skill/</c>);
+/// <c>src/MeshWeaver.AI/MeshWeaver.AI.csproj</c> says so in as many words. This repo's
+/// <c>content/ai</c> is the in-memory fixture the framework's delegation / picker / tool-wiring
+/// suites run against. Two copies of the same text, edited by different people at different times,
+/// with <b>nothing comparing them</b> — so drift accumulated in BOTH directions and was found only
+/// by measuring by hand.</para>
+///
+/// <para><b>Why this is a guard and not a sync.</b> The pack repo is <b>private</b> and this repo is
+/// <b>public</b>. A "just copy the master over" job would have published a real customer's node path
+/// into a public repository — that difference is a deliberate <b>sanitisation</b>, not drift, and it
+/// is the one divergence that must be preserved forever. So the guard does two things a diff cannot:
+/// it pins the reconciliation point (<c>TestData/AiContentPackSync.json</c>) so a core edit has to
+/// state what it did about the master, and it refuses any content carrying an identifier that must
+/// never appear in public.</para>
+///
+/// <para><b>The forbidden identifiers are stored as HASHES</b>, and a hit is reported by
+/// <c>file:line</c> only — never by echoing the token. A deny-list that spells the name out, or a
+/// failure message that prints it, would publish in this repository (and in its public CI log)
+/// exactly what it exists to keep out.</para>
+/// </summary>
+public class AiContentPackDriftTest
+{
+    // ── The pinned ledger ──────────────────────────────────────────────────────
+
+    private sealed record PackAttestation(string? Repo, string? Commit, string? Observed);
+
+    private sealed record ForbiddenIdentifier(string Sha256, string Reason);
+
+    private sealed record LedgerEntry(
+        string File,
+        string Core,
+        string? Pack,
+        string State,
+        string? Note,
+        string? SanitisedToken);
+
+    private sealed record PackSyncLedger(
+        PackAttestation? Pack,
+        IReadOnlyList<ForbiddenIdentifier>? ForbiddenIdentifiers,
+        IReadOnlyList<LedgerEntry>? Files);
+
+    /// <summary>The states an entry may declare. <c>SanitisedOnly</c> is load-bearing: it is the
+    /// record that a file differs from the master ONLY by a placeholder, and must stay that way.</summary>
+    private static readonly string[] KnownStates =
+        ["InSync", "CoreAhead", "PackAhead", "SanitisedOnly", "PackAbsent"];
+
+    private const string LedgerFileName = "AiContentPackSync.json";
+
+    private static readonly JsonSerializerOptions LedgerJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString,
+    };
+
+    private static PackSyncLedger Ledger()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "TestData", LedgerFileName);
+        System.IO.File.Exists(path).Should().BeTrue(
+            "the pack-sync ledger must ship beside the test at {0} — without it this guard checks "
+            + "nothing, and a guard that cannot find its input must be RED, never green", path);
+
+        var ledger = JsonSerializer.Deserialize<PackSyncLedger>(
+            System.IO.File.ReadAllText(path), LedgerJson);
+        ledger.Should().NotBeNull("the ledger must parse");
+        ledger!.Files.Should().NotBeEmpty("the ledger must pin at least one file");
+        return ledger;
+    }
+
+    // ── The content section ────────────────────────────────────────────────────
+
+    /// <summary>Every authored file in the AI content section, as <c>Section/File.md</c> → text.</summary>
+    private static IReadOnlyDictionary<string, string> Section()
+    {
+        var root = AiContentLocator.SectionRoot();
+        root.Should().NotBeNull(
+            "the AI content section (content/ai, or the AiContent copy beside the assembly) must be "
+            + "resolvable from the test run — this guard has no meaningful 'skip'");
+
+        var files = Directory
+            .EnumerateFiles(root!, "*.md", SearchOption.AllDirectories)
+            .ToDictionary(
+                f => Path.GetRelativePath(root!, f).Replace('\\', '/'),
+                System.IO.File.ReadAllText,
+                StringComparer.Ordinal);
+
+        files.Should().NotBeEmpty("the section must ship authored files");
+        return files;
+    }
+
+    /// <summary>
+    /// The hash the ledger pins. Text, not bytes: a BOM, a CRLF checkout or a trailing blank line is
+    /// not drift, and a guard that fired on those would be turned off within a week.
+    /// </summary>
+    internal static string ContentHash(string text)
+    {
+        var normalized = text.Replace("\r\n", "\n").Replace("\r", "\n").TrimEnd('\n');
+        if (normalized.StartsWith('\uFEFF'))
+            normalized = normalized[1..];
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)));
+    }
+
+    private static string TokenHash(string token)
+        => Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
+
+    // ── 1. The roster ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Adding or deleting an agent/skill file is exactly the moment someone has to decide what
+    /// happens to the master, so the roster is pinned rather than discovered. A file that appears
+    /// here and never in the pack is how the two copies started diverging in the first place.
+    /// </summary>
+    [Fact]
+    public void TheRoster_MatchesTheLedger()
+    {
+        var onDisk = Section().Keys.OrderBy(f => f, StringComparer.Ordinal).ToArray();
+        var pinned = Ledger().Files!.Select(f => f.File)
+            .OrderBy(f => f, StringComparer.Ordinal).ToArray();
+
+        onDisk.Should().Equal(pinned,
+            "every file under content/ai must have a ledger entry and vice versa. Added: [{0}]. "
+            + "Removed: [{1}]. Add or delete the entry in test/MeshWeaver.AI.Test/TestData/{2} and "
+            + "state in it what you did about the MeshWeaver.Plugins master.",
+            string.Join(", ", onDisk.Except(pinned, StringComparer.Ordinal)),
+            string.Join(", ", pinned.Except(onDisk, StringComparer.Ordinal)),
+            LedgerFileName);
+    }
+
+    // ── 2. Divergence from the pinned reconciliation point ─────────────────────
+
+    /// <summary>
+    /// 🚨 THE DRIFT DETECTOR. The pack half cannot be read from this repo's CI — it is private and
+    /// this repo holds no credential for it — so what is enforceable from here is that a core file
+    /// never moves away from the recorded reconciliation point <i>unnoticed</i>. Edit an agent's
+    /// instructions and this test goes red, printing the new hash: updating the entry is where you
+    /// record whether the master was updated too, or why it deliberately was not.
+    /// </summary>
+    [Fact]
+    public void EveryFile_StillHashesToItsPinnedReconciliationPoint()
+    {
+        var section = Section();
+        var drifted = Ledger().Files!
+            .Where(e => section.TryGetValue(e.File, out var text) && ContentHash(text) != e.Core)
+            .Select(e => $"{e.File}: pinned {e.Core[..12]}… → now {ContentHash(section[e.File])[..12]}…")
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+        drifted.Should().BeEmpty(
+            "content/ai mirrors the Systemorph/MeshWeaver.Plugins pack, which is what actually SERVES "
+            + "— so an edit here that is not carried over to the master is a change production never "
+            + "sees, and an edit there that is not carried here is one the framework tests never see. "
+            + "Re-pin the entry in test/MeshWeaver.AI.Test/TestData/{0} (paste the new hash, set the "
+            + "state, say what you did about the master). Drifted: {1}",
+            LedgerFileName, string.Join(" | ", drifted));
+    }
+
+    /// <summary>Every entry must declare a known state, and the state must agree with the
+    /// attestation: a pack hash is absent exactly when there is nothing to compare against.</summary>
+    [Fact]
+    public void EveryEntry_DeclaresACoherentState()
+    {
+        var incoherent = Ledger().Files!
+            .Select(e => (e.File, Problem: StateProblem(e)))
+            .Where(x => x.Problem is not null)
+            .Select(x => $"{x.File}: {x.Problem}")
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+        incoherent.Should().BeEmpty(
+            "a ledger entry whose state contradicts its own hashes documents nothing. Problems: {0}",
+            string.Join(" | ", incoherent));
+    }
+
+    private static string? StateProblem(LedgerEntry e)
+    {
+        if (!KnownStates.Contains(e.State, StringComparer.Ordinal))
+            return $"unknown state '{e.State}' (expected one of {string.Join("/", KnownStates)})";
+        if (e.State == "PackAbsent")
+            return e.Pack is null ? null : "PackAbsent but a pack hash is recorded";
+        if (e.Pack is null)
+            return $"{e.State} but no pack hash is recorded";
+        if (e.State == "InSync")
+            return e.Pack == e.Core ? null : "InSync but the two hashes differ";
+        if (e.Pack == e.Core)
+            return $"{e.State} but the two hashes are identical";
+        return e.Note is null ? $"{e.State} without a note saying what diverged" : null;
+    }
+
+    // ── 3. Sanitisation — the divergence that must NEVER be reconciled ─────────
+
+    /// <summary>
+    /// 🚨 The public/private asymmetry, pinned. A file the ledger marks as sanitised must still carry
+    /// its placeholder, and must still be recorded as diverging from the master — because the day it
+    /// reads <c>InSync</c> is the day someone pasted the master's text back in, customer name and all.
+    /// </summary>
+    [Fact]
+    public void SanitisedFiles_KeepTheirPlaceholder_AndStayDivergedOnPurpose()
+    {
+        var section = Section();
+        var sanitised = Ledger().Files!.Where(e => e.SanitisedToken is not null).ToArray();
+
+        sanitised.Should().NotBeEmpty(
+            "at least one file is sanitised on purpose (the example namespace in the commenting "
+            + "reference) — if this list empties, the rule below stopped being checked");
+
+        foreach (var entry in sanitised)
+        {
+            section.TryGetValue(entry.File, out var text).Should().BeTrue(
+                "{0} is pinned as sanitised but is not in the section", entry.File);
+            text.Should().Contain(entry.SanitisedToken!,
+                "{0} must keep its sanitised placeholder '{1}' — this repo is PUBLIC and the pack "
+                + "master is PRIVATE, so this divergence is permanent, never something to reconcile",
+                entry.File, entry.SanitisedToken!);
+            entry.State.Should().Be("SanitisedOnly",
+                "{0} differs from the master only by the placeholder; recording it as anything else "
+                + "invites a future sync to 'fix' it", entry.File);
+        }
+    }
+
+    // ── 4. Nothing in the public repo may name a customer ─────────────────────
+
+    /// <summary>
+    /// 🚨 THE LEAK GUARD. Reported as <c>file:line</c> and nothing else — echoing the token would
+    /// publish it in the CI log of a public repository, which is the thing being prevented.
+    /// </summary>
+    [Fact]
+    public void NoForbiddenIdentifier_AppearsInTheContentSection()
+    {
+        var ledger = Ledger();
+        var hashes = ForbiddenHashes(ledger);
+
+        hashes.Should().NotBeEmpty(
+            "an empty deny-list makes the scan below vacuous — it would pass over any content at all");
+
+        var hits = Section()
+            .SelectMany(kv => Hits(kv.Value, hashes).Select(line => $"{kv.Key}:{line}"))
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+        hits.Should().BeEmpty(
+            "Systemorph/MeshWeaver.Plugins is PRIVATE and this repository is PUBLIC. A customer or "
+            + "engagement identifier reaching content/ai — most easily by copying the pack master's "
+            + "text over — publishes it. Replace it with the placeholder the rest of the section "
+            + "uses. (The token is deliberately not printed. Sites: {0})",
+            string.Join(", ", hits));
+    }
+
+    private static IReadOnlySet<string> ForbiddenHashes(PackSyncLedger ledger)
+        => (ledger.ForbiddenIdentifiers ?? [])
+            .Select(f => f.Sha256.ToLowerInvariant())
+            .ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The 1-based line numbers on which some hashed identifier appears. Candidates are built so the
+    /// same name is caught however it is written: as one word (<c>AcmeCorp</c>), spaced
+    /// (<c>Acme Corp</c>), slashed in a path (<c>@/AcmeCorp/Docs</c>) or embedded in a longer
+    /// camel-cased identifier (<c>MyAcmeCorpReport</c>). It is a word-level scan, not a substring
+    /// scan: a name glued into a lowercase run (<c>myacmecorpreport</c>) is not caught.
+    /// </summary>
+    internal static IReadOnlyList<int> Hits(string text, params string[] forbiddenHashes)
+        => Hits(text, forbiddenHashes.ToHashSet(StringComparer.Ordinal));
+
+    /// <inheritdoc cref="Hits(string, string[])"/>
+    internal static IReadOnlyList<int> Hits(string text, IReadOnlySet<string> forbiddenHashes)
+    {
+        if (forbiddenHashes.Count == 0)
+            return [];
+
+        var lines = text.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n');
+        var hits = new List<int>();
+        for (var i = 0; i < lines.Length; i++)
+            if (Candidates(lines[i]).Any(c => forbiddenHashes.Contains(TokenHash(c))))
+                hits.Add(i + 1);
+        return hits;
+    }
+
+    /// <summary>How many adjacent atoms a candidate may span. A name longer than this many words
+    /// would not be caught; six covers every company-name shape seen so far and keeps the scan at
+    /// tens of milliseconds over the whole section.</summary>
+    private const int MaxAtomSpan = 6;
+
+    /// <summary>
+    /// Every contiguous run of up to <see cref="MaxAtomSpan"/> atoms, glued together and lowercased.
+    /// Atoms are word-parts: an alphanumeric run split at its camel-case boundaries. Gluing across
+    /// atoms is what makes <c>AcmeCorp</c>, <c>Acme Corp</c>, <c>acme-corp</c>, <c>@/AcmeCorp/Docs</c>
+    /// and <c>MyAcmeCorpReport</c> all produce the same candidate.
+    /// </summary>
+    private static IEnumerable<string> Candidates(string line)
+    {
+        var atoms = Atoms(line);
+        for (var start = 0; start < atoms.Count; start++)
+        {
+            var builder = new StringBuilder();
+            var last = Math.Min(atoms.Count - 1, start + MaxAtomSpan - 1);
+            for (var end = start; end <= last; end++)
+            {
+                builder.Append(atoms[end]);
+                yield return builder.ToString();
+            }
+        }
+    }
+
+    /// <summary>The line's word-parts, in order: alphanumeric runs split at camel-case boundaries,
+    /// lowercased. Everything else (punctuation, slashes, whitespace) is a separator and is dropped
+    /// — which is exactly why a name reads the same however it was punctuated.</summary>
+    private static List<string> Atoms(string line)
+    {
+        var atoms = new List<string>();
+        var current = new StringBuilder();
+
+        void Flush()
+        {
+            if (current.Length == 0)
+                return;
+            atoms.Add(current.ToString().ToLowerInvariant());
+            current.Clear();
+        }
+
+        foreach (var ch in line)
+        {
+            if (!char.IsLetterOrDigit(ch))
+            {
+                Flush();
+                continue;
+            }
+            if (char.IsUpper(ch))
+                Flush();
+            current.Append(ch);
+        }
+        Flush();
+        return atoms;
+    }
+
+    // ── 5. THE CONTROLS ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The leak guard passes trivially on clean content, so on its own it is not evidence that it
+    /// works. This drives the SAME scanner over the exact shape that caused #1627 — the pack master's
+    /// example path with a company name in the namespace — and requires a hit, in every spelling.
+    /// The name used here is invented, for the same reason the real list is hashed.
+    /// </summary>
+    [Theory]
+    [InlineData("- Pass the canonical node path (`@/GlobalReinsuranceAg/AIConsulting/FinalReport`).")]
+    [InlineData("@@(\"area:OgCard/GlobalReinsuranceAg/EslProposalQa\")")]
+    [InlineData("const string nested = \"https://portal.example.org/GlobalReinsuranceAg/Proposal\";")]
+    [InlineData("Mirrors the **Global Reinsurance Ag** space into the repository.")]
+    [InlineData("the report prepared for Global-Reinsurance-Ag last quarter")]
+    [InlineData("a MyGlobalReinsuranceAgReport node under the customer partition")]
+    public void TheLeakGuard_FiresOnACustomerName(string line)
+    {
+        Hits(line, TokenHash("globalreinsuranceag")).Should().Equal([1],
+            "the scanner must catch the identifier however it is spelled — one word, spaced, "
+            + "hyphenated, inside a path segment or embedded in a longer camel-cased name. Line: {0}",
+            line);
+    }
+
+    /// <summary>The other direction: the scanner must not fire on the placeholder the section
+    /// actually uses, or on ordinary prose. A guard that cries wolf gets deleted.</summary>
+    [Theory]
+    [InlineData("- Pass the canonical node path (`@/Acme/AIConsulting/FinalReport`).")]
+    [InlineData("Global reinsurance is a market, not a customer.")]
+    [InlineData("")]
+    public void TheLeakGuard_StaysQuietOnPlaceholdersAndProse(string line)
+        => Hits(line, TokenHash("globalreinsuranceag")).Should().BeEmpty(
+            "false positives are how a leak guard gets switched off. Line: {0}", line);
+
+    /// <summary>
+    /// 🚨 The sanitisation control. Re-syncing the sanitised file from the private master is the
+    /// exact accident #1627 warns about; this proves BOTH pins catch it — the hash stops matching
+    /// AND the placeholder disappears — so it cannot slip through by updating one of them.
+    /// </summary>
+    [Fact]
+    public void ReSyncingASanitisedFileFromTheMaster_TripsBothPins()
+    {
+        var entry = Ledger().Files!.Single(f => f.SanitisedToken is not null);
+        var live = Section()[entry.File];
+
+        ContentHash(live).Should().Be(entry.Core, "the live file is at its pinned point to begin with");
+        live.Should().Contain(entry.SanitisedToken!);
+
+        // What "copy the master over" would produce: the placeholder replaced by a company name.
+        var resynced = live.Replace(entry.SanitisedToken!, "GlobalReinsuranceAg", StringComparison.Ordinal);
+
+        ContentHash(resynced).Should().NotBe(entry.Core,
+            "the pinned hash must stop matching, so the drift detector fires");
+        resynced.Contains(entry.SanitisedToken!, StringComparison.Ordinal).Should().BeFalse(
+            "the placeholder is gone, so the sanitisation pin fires too");
+        Hits(resynced, TokenHash("globalreinsuranceag")).Should().NotBeEmpty(
+            "and the leak guard names the line");
+    }
+}

--- a/test/MeshWeaver.AI.Test/AiContentPackDriftTest.cs
+++ b/test/MeshWeaver.AI.Test/AiContentPackDriftTest.cs
@@ -160,7 +160,10 @@ public class AiContentPackDriftTest
         var section = Section();
         var drifted = Ledger().Files!
             .Where(e => section.TryGetValue(e.File, out var text) && ContentHash(text) != e.Core)
-            .Select(e => $"{e.File}: pinned {e.Core[..12]}… → now {ContentHash(section[e.File])[..12]}…")
+            // The NEW hash is printed in FULL, because re-pinning the entry means pasting it. A
+            // truncated hash would turn a one-paste fix into "go and compute it yourself".
+            .Select(e => $"{e.File}: pinned {e.Core[..12]}… → re-pin \"core\" to "
+                + $"\"{ContentHash(section[e.File])}\"")
             .OrderBy(x => x, StringComparer.Ordinal)
             .ToArray();
 

--- a/test/MeshWeaver.AI.Test/AiContentPackDriftTest.cs
+++ b/test/MeshWeaver.AI.Test/AiContentPackDriftTest.cs
@@ -29,8 +29,9 @@ namespace MeshWeaver.AI.Test;
 /// into a public repository — that difference is a deliberate <b>sanitisation</b>, not drift, and it
 /// is the one divergence that must be preserved forever. So the guard does two things a diff cannot:
 /// it pins the reconciliation point (<c>TestData/AiContentPackSync.json</c>) so a core edit has to
-/// state what it did about the master, and it refuses any content carrying an identifier that must
-/// never appear in public.</para>
+/// state what it did about the master, and it refuses any file <b>in this section</b> carrying an
+/// identifier that must never appear in public. Everything below is scoped to
+/// <c>content/ai/**</c> — this is a mirror guard, not a repository-wide secret scan.</para>
 ///
 /// <para><b>The forbidden identifiers are stored as HASHES</b>, and a hit is reported by
 /// <c>file:line</c> only — never by echoing the token. A deny-list that spells the name out, or a
@@ -239,11 +240,17 @@ public class AiContentPackDriftTest
         }
     }
 
-    // ── 4. Nothing in the public repo may name a customer ─────────────────────
+    // ── 4. Nothing in the mirrored content section may name a customer ────────
 
     /// <summary>
     /// 🚨 THE LEAK GUARD. Reported as <c>file:line</c> and nothing else — echoing the token would
     /// publish it in the CI log of a public repository, which is the thing being prevented.
+    ///
+    /// <para><b>Scope, stated precisely because the gap matters:</b> this scans
+    /// <c>content/ai/**</c> and nothing else. That is the surface this guard is about — the tree
+    /// that MIRRORS the private pack, where a copy-the-master-over is the way a customer name
+    /// gets in. It is NOT a repository-wide secret scan, and must not be read as one; a name
+    /// pasted into a `.cs` file elsewhere is not covered here.</para>
     /// </summary>
     [Fact]
     public void NoForbiddenIdentifier_AppearsInTheContentSection()

--- a/test/MeshWeaver.AI.Test/TestData/AiContentPackSync.json
+++ b/test/MeshWeaver.AI.Test/TestData/AiContentPackSync.json
@@ -1,0 +1,250 @@
+{
+  "$comment": [
+    "PACK SYNC LEDGER for content/ai — the drift guard's pinned reconciliation point (#1627).",
+    "content/ai is a MIRROR: the served master is Systemorph/MeshWeaver.Plugins (Agent/, Skill/),",
+    "and drift runs in BOTH directions. Nothing compares the two automatically, because that repo",
+    "is PRIVATE and this one is PUBLIC — so this file records the reconciliation point instead,",
+    "and AiContentPackDriftTest fails the build when a core file moves away from it.",
+    "REGENERATE: edit the file, run the test, and paste the 'core' hash it prints into this entry",
+    "together with the state/note that says what you did about the pack master."
+  ],
+  "hash": "sha256 of the file's text as UTF-8, BOM stripped, CRLF/CR folded to LF, trailing newlines trimmed",
+  "pack": {
+    "repo": "Systemorph/MeshWeaver.Plugins",
+    "commit": "c29a0de",
+    "observed": "2026-08-25",
+    "note": "The pack half cannot be checked from this repo's CI — it is private and this repo holds no credential for it. The 'pack' hashes are an ATTESTATION of what was measured at the commit above, not something the test verifies."
+  },
+  "notes": [
+    "Skill/*.md entries have pack:null because the pack master still stores its skills as typed .json nodes (Skill/*.json), not the .md-with-front-matter format this repo uses. A byte comparison is therefore impossible for skills; only the roster and the sanitisation rules apply to them."
+  ],
+  "forbiddenIdentifiers": [
+    {
+      "sha256": "eaf8859353effdd6182703ab92af8cd88360df4d3452bd3ab27d763947ff97e5",
+      "reason": "A customer / engagement identifier that must never appear in this PUBLIC repository. Stored as a hash so listing it does not itself publish the name (#1627)."
+    }
+  ],
+  "files": [
+    {
+      "file": "Agent/Assistant.md",
+      "core": "9386bc34d4f5e60430a9f035f929c907642ddc29f6db69f6424a53e88934e6e3",
+      "pack": "4a9cb965ee065983446a9c97d275fd1d1ae6f046edcca6971898e7b76212d0b3",
+      "state": "PackAhead",
+      "note": "The pack master carries one extra skill row the core fixture does not. Reconciling it is a change to agent INSTRUCTIONS and needs its own review (#1627)."
+    },
+    {
+      "file": "Agent/CommentingReference.md",
+      "core": "8ca83e8185749880750607b29c671ea4b293d144b4b63cf5fa5b1cae67e479e6",
+      "pack": "d7db39e2185ea89e624ff01b3763b297294b31bf368d6c257bb91fef459ef175",
+      "state": "SanitisedOnly",
+      "note": "Byte-identical to the pack master EXCEPT the example namespace, which is sanitised here. This divergence is PERMANENT and must never be reconciled: the pack repo is private, this one is public.",
+      "sanitisedToken": "Acme"
+    },
+    {
+      "file": "Agent/DescriptionWriter.md",
+      "core": "28bad6b71e891f57d04d49df76119dee22328a8bccfe74a0f28579406f4befa1",
+      "pack": "28bad6b71e891f57d04d49df76119dee22328a8bccfe74a0f28579406f4befa1",
+      "state": "InSync"
+    },
+    {
+      "file": "Agent/EmailRouter.md",
+      "core": "00c014318f7a029ff9b6773bdcf5329556ec14fc361f0cf1f84d5dcecfd6afd9",
+      "pack": "00c014318f7a029ff9b6773bdcf5329556ec14fc361f0cf1f84d5dcecfd6afd9",
+      "state": "InSync"
+    },
+    {
+      "file": "Agent/ExecutiveAssistant.md",
+      "core": "3985e92e165e859ba83a8a92fba35ddb3beb2ded67d561ce5008c56e5407b9ca",
+      "pack": "3985e92e165e859ba83a8a92fba35ddb3beb2ded67d561ce5008c56e5407b9ca",
+      "state": "InSync"
+    },
+    {
+      "file": "Agent/LogTriage.md",
+      "core": "49a7468dc8910259f8ed066fdd9a2aae3f8b56133675a603a534e280dd65ef82",
+      "pack": "99769e78e6497b33b093205ec3692a81f4d21566878571c0e281fda9687e50f9",
+      "state": "CoreAhead",
+      "note": "Core documents the current incident shape (normalizedDetail / variants); the pack master still describes the earlier single-field shape. The pack is what SERVES, so production runs the older text (#1627)."
+    },
+    {
+      "file": "Agent/NodeInitializer.md",
+      "core": "4852779220d127d30d8f577cc314ec5903ec4329c0774d8c61162ad6ef06d987",
+      "pack": "4852779220d127d30d8f577cc314ec5903ec4329c0774d8c61162ad6ef06d987",
+      "state": "InSync"
+    },
+    {
+      "file": "Agent/NotificationTriage.md",
+      "core": "4787815823cff81136848cb9fa86ff6e83f55908ac15304426f4d67c67d0dc25",
+      "pack": "4787815823cff81136848cb9fa86ff6e83f55908ac15304426f4d67c67d0dc25",
+      "state": "InSync"
+    },
+    {
+      "file": "Agent/PullRequestWriter.md",
+      "core": "57ec31e3d007de116ef526e51be31a9c1d6653cd71afef866091d7152593bc24",
+      "pack": "57ec31e3d007de116ef526e51be31a9c1d6653cd71afef866091d7152593bc24",
+      "state": "InSync"
+    },
+    {
+      "file": "Agent/Researcher.md",
+      "core": "8f93b1d3644730c9340000b3bb12b5ea06ed6e656fbd0e8ad202c01c09a5bf56",
+      "pack": "8f93b1d3644730c9340000b3bb12b5ea06ed6e656fbd0e8ad202c01c09a5bf56",
+      "state": "InSync"
+    },
+    {
+      "file": "Agent/ToolsReference.md",
+      "core": "3dcd15ddf71d7bd826aa6cd054603e69902caf694d1610f12ac70805ba560b4c",
+      "pack": "3dcd15ddf71d7bd826aa6cd054603e69902caf694d1610f12ac70805ba560b4c",
+      "state": "InSync"
+    },
+    {
+      "file": "Agent/TrainingSim.md",
+      "core": "dfe6749a31fd7baf70456e904999f802021175829cf640ed1609929b14d3db98",
+      "pack": "dfe6749a31fd7baf70456e904999f802021175829cf640ed1609929b14d3db98",
+      "state": "InSync"
+    },
+    {
+      "file": "Agent/Tutor.md",
+      "core": "4112c94f27b91a6e5971358faddf5d17fc3f25b5f609f9770fe45b19b04d11df",
+      "pack": "0a66bfbb4c14c8945683295c0959fd2fe53d2a217995783d83ada935d56475e3",
+      "state": "CoreAhead",
+      "note": "Core describes the node-native course model (Edu/Module, Edu/Lesson, Edu/Exercise); the pack master still describes the retired Course/Module/ExerciseAttempt model. The pack is what SERVES (#1627)."
+    },
+    {
+      "file": "Agent/Worker.md",
+      "core": "b881490b3ca767ca11a44c6d596615ebd053ff4277e4bccc9bc613ddd05ba5a9",
+      "pack": "b881490b3ca767ca11a44c6d596615ebd053ff4277e4bccc9bc613ddd05ba5a9",
+      "state": "InSync"
+    },
+    {
+      "file": "Skill/access.md",
+      "core": "59a03986de2d1db19ded4344e2977f0f9ff21bb280abcac4c71d126b6f8a15ba",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/activity.md",
+      "core": "bf7f57e84cb72a04156978f2e51df86094526d5103e6336d7b5ebdddcd3905ac",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/agent.md",
+      "core": "01e2413079c68a57a4029ddb0973d15693238e616b76df6f0bc2352d9fe1bd86",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/clear.md",
+      "core": "2a90ffb9042d3516242ab40a21a8d4bfdfea516d03c0692dee21510ce0ec331e",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/code.md",
+      "core": "efab48644f6735f250d60f695371f797263ef5d1f22085d230c215d7c8f11aba",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/group.md",
+      "core": "4e7238adb03bf6b1da18773e004f29c9b1d3bd451b669edbc104bd17e3ab9564",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/harness.md",
+      "core": "302051632d744a8e3ba1cb42832aabc2211a349c2ff37227dd0984698cbc0673",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/layout-area.md",
+      "core": "36f028e569e6c5f4676349403fd337441bbc77cbc44b5deaa4ca18b0be5f8b33",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/logon-action.md",
+      "core": "fe1278b5dd8876ade6cb06e160a29d44a655fa429d690dc44b82925e4bf7a550",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/markdown.md",
+      "core": "13f81f157d0a470420d7a0276fde03ac7af7f75c3539701c7ab8e47926dbc61b",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/maui.md",
+      "core": "efe405ee0a85674daa6a117f37a61dcde4b1c901e58d1f1200810bfd345d9f99",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/model.md",
+      "core": "7ca80c6958650abec9c659e7e9455cb621352bd635d439a0adcde11004144419",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/navigate.md",
+      "core": "061abc720fdc83cff3988df322e4771d3c6e62bb3ed5a9af80f31de543368d9f",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/og-card.md",
+      "core": "a2bbc0f8ab50221f73dcd7c6e456c208c5ab191cc2ef38483c959a0597ff5e24",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/presentation.md",
+      "core": "394db08b881f6455b2b9b4561bb94ad2c00db167a89ca78413dd5be32a1d0087",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/provider-keys.md",
+      "core": "612cc0475a99ec42b2ab96ba7bed355621c7f33ff63da935a5e2267099942193",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/pull-request.md",
+      "core": "35cf06fbdd45511d3bbbd5768be5eff8ef11c72eda5847886b6e9a9bca868c31",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/share-email.md",
+      "core": "1c00fbaba9830c03605d6ee13b2173173ddc2f7c01d8c292e87f8b0da5d9c759",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/slide.md",
+      "core": "489660b1757ae81c5b93cc052de55394830bd7b5b062762b161a449da5d917f7",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/space.md",
+      "core": "4545ec6020c5b2a8054a54730075a307a288261f73903285f8eab6189cda62b8",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/thread.md",
+      "core": "ba0e046a185f456b4b58b6df3410aebc47064a753cfc7cd18359164e1137134b",
+      "pack": null,
+      "state": "PackAbsent"
+    },
+    {
+      "file": "Skill/ui-extensibility.md",
+      "core": "3e4174807ed58abbd22546ae0e494f906adc5d6ff6eb8a8e14b12352505ecbd1",
+      "pack": null,
+      "state": "PackAbsent"
+    }
+  ]
+}

--- a/test/MeshWeaver.Graph.Test/OpenGraphHtmlParserTest.cs
+++ b/test/MeshWeaver.Graph.Test/OpenGraphHtmlParserTest.cs
@@ -97,14 +97,14 @@ public class OpenGraphHtmlParserTest
     /// <summary>
     /// 🚨 The exact head a MeshWeaver (Blazor) portal serves: <c>&lt;base href="/"&gt;</c> plus a
     /// RELATIVE <c>href="favicon.ico"</c>. Resolved against the PAGE URL this would yield
-    /// <c>/PartnerRe/favicon.ico</c> — which a catch-all-routed SPA answers with 200 text/html,
+    /// <c>/Acme/AIConsulting/favicon.ico</c> — which a catch-all-routed SPA answers with 200 text/html,
     /// not a 404, i.e. a silently broken image. The base tag is what makes it resolve to the real
     /// origin-root icon.
     /// </summary>
     [Fact]
     public void Parse_RelativeIcon_ResolvesAgainstBaseHref_NotThePagePath()
     {
-        const string nested = "https://portal.example.org/PartnerRe/EslProposalQA";
+        const string nested = "https://portal.example.org/Acme/AIConsulting/FinalReport";
         const string html = """
             <html><head><base href="/">
             <link rel="icon" type="image/png" href="favicon.ico">


### PR DESCRIPTION
Closes the guard half of #1627.

## The problem

`content/ai` is a **mirror**. The **served** master for the built-in agents and skills is the private `Systemorph/MeshWeaver.Plugins` pack (`MeshWeaver.AI.csproj` says so in as many words); this repo's copy is the in-memory fixture the framework's delegation / picker / tool-wiring suites run against. **Nothing compared the two**, so drift accumulated in *both* directions and was only ever found by measuring by hand.

Measured on this branch's base (core `d6c198c0f`, pack `c29a0de`), normalizing line endings — this **supersedes the issue's own table**:

| file | state | what diverges |
|---|---|---|
| `Agent/ToolsReference.md` | **InSync** | the issue lists this as diverged; it has since been reconciled and now hashes identically |
| `Agent/Assistant.md` | PackAhead | the master carries one extra skill row |
| `Agent/LogTriage.md` | CoreAhead | core documents the current incident shape; **the master, which serves, has the older text** |
| `Agent/Tutor.md` | CoreAhead | core has the node-native course model; **the master still describes the retired one** |
| `Agent/CommentingReference.md` | **SanitisedOnly** | the **only** difference is a sanitised example namespace |
| the other 9 | InSync | — |

## Why a guard and not a sync

This repo is **PUBLIC**; the pack repo is **PRIVATE**. "Copy the master over" would publish a customer's node path here — that divergence is deliberate and **permanent**. So the guard pins the *reconciliation point* rather than demanding equality:

- **`TestData/AiContentPackSync.json`** records per file: the normalized hash of this repo's copy, the attested hash of the master, a state (`InSync` / `CoreAhead` / `PackAhead` / `SanitisedOnly` / `PackAbsent`) and a note. **A core edit that does not re-pin its entry fails the build** — which is the moment someone has to say what they did about the master.
- The sanitised entry must keep its placeholder **and** stay recorded as diverged, so a future sync cannot quietly "fix" it back.
- The pack half genuinely cannot be checked from this repo's CI (private, no credential here). The ledger says so, and records the pack hashes as an **attestation**, not something the test verifies — rather than pretending to a check it cannot make.

## 🚨 The leak guard reports WHERE, never WHAT — please keep it that way

The deny-list is stored as **hashes**, and a hit is reported as **`file:line` only**. A list that spelled the name out, or a failure message that echoed the token, would publish in this public repo — and in its **public CI log** — exactly what the guard exists to keep out. Please do not "helpfully" add the value to the error message later; the author already knows what is on the line.

## It found three live instances, all fixed here

All in example text, none a credential — a company name used where a placeholder belongs:

- `content/ai/Skill/og-card.md` — the `/og-card` skill's example path
- `test/MeshWeaver.Graph.Test/OpenGraphHtmlParserTest.cs` — a fixture URL (assertions do not depend on the segment)
- one migration doc comment

All three now use the `Acme/AIConsulting/FinalReport` placeholder the rest of the section uses.

**Proof the guard fires** — restoring the pre-fix `og-card.md` and running only the leak guard:

```
Expected collection to be empty because Systemorph/MeshWeaver.Plugins is PRIVATE and this
repository is PUBLIC. … (The token is deliberately not printed.
Sites: Skill/og-card.md:19, Skill/og-card.md:20), but found 2 item(s).
```

Two sites, named precisely, token withheld. Six in-suite controls drive the same scanner over an **invented** company name in every spelling it could take (one word, spaced, hyphenated, inside a path segment, embedded in a longer camel-cased identifier) and require a hit; three more require it to stay quiet on the real placeholder and on ordinary prose.

## Scope — deliberately not in this PR

- **The content reconciliation itself.** Changing agent instructions is a behaviour change needing its own review. The four diverged files are recorded, with which side is ahead, and left open for the maintainer.
- **Skills are roster- and leak-checked only, not hash-compared.** The master still stores its skills as typed `Skill/*.json` nodes, so there is no byte comparison to make against this repo's `.md`-with-front-matter files. Recorded in the ledger's notes.

## What's New

Skipped deliberately: this is a test guard plus example-text sanitisation, with no user-visible behaviour change.

## Verification

- `dotnet build -c Release -warnaserror` — `0 Error(s)` for `MeshWeaver.AI.Test`, `MeshWeaver.Graph.Test`, `Memex.Database.Migration`
- `AiContentPackDriftTest` — 15/15 pass (section scan ~70 ms)
- `AiContent*` / `BuiltInSkillCatalog` / `SkillMarkdownRoundTrip` / `SkillNodeType` — 50/50 pass
- `OpenGraphHtmlParserTest` — 18/18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
