### PR TITLE
The render-error placeholder is readable in dark mode

### DIFF
--- a/src/MeshWeaver.Blazor/Components/DispatchView.razor
+++ b/src/MeshWeaver.Blazor/Components/DispatchView.razor
@@ -56,10 +56,9 @@ else if(ViewDescriptor != null)
                 }))
             </ChildContent>
             <ErrorContent Context="renderError">
-                <div class="meshweaver-render-error"
-                     style="padding:0.75rem;border:1px solid var(--error,#d13438);border-radius:4px;background:rgba(209,52,56,0.08);color:var(--error,#d13438);font-size:0.875rem">
+                <div class="meshweaver-render-error">
                     <strong>@Access.Localize("error.viewFailed")</strong>
-                    <div style="margin-top:0.25rem;white-space:pre-wrap;font-family:monospace">@renderError.Message</div>
+                    <div class="meshweaver-render-error-detail">@renderError.Message</div>
                 </div>
             </ErrorContent>
         </ErrorBoundary>

--- a/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor
+++ b/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor
@@ -65,10 +65,9 @@
                 <NamedAreaView Stream="@AreaStream" ViewModel="@NamedArea" Area="@NamedArea.GetArea()" Top="@Top" />
             </ChildContent>
             <ErrorContent Context="areaError">
-                <div class="meshweaver-render-error"
-                     style="padding:0.75rem;border:1px solid var(--error,#d13438);border-radius:4px;background:rgba(209,52,56,0.08);color:var(--error,#d13438);font-size:0.875rem">
+                <div class="meshweaver-render-error">
                     <strong>@Access.Localize("error.areaFailed")</strong>
-                    <div style="margin-top:0.25rem;white-space:pre-wrap;font-family:monospace">@areaError.Message</div>
+                    <div class="meshweaver-render-error-detail">@areaError.Message</div>
                 </div>
             </ErrorContent>
         </ErrorBoundary>
@@ -86,10 +85,9 @@
             <DialogView ViewModel="@currentDialog" Area="@DialogControl.DialogArea" Stream="@AreaStream" />
         </ChildContent>
         <ErrorContent Context="dialogError">
-            <div class="meshweaver-render-error"
-                 style="padding:0.75rem;border:1px solid var(--error,#d13438);border-radius:4px;background:rgba(209,52,56,0.08);color:var(--error,#d13438);font-size:0.875rem">
+            <div class="meshweaver-render-error">
                 <strong>@Access.Localize("error.dialogFailed")</strong>
-                <div style="margin-top:0.25rem;white-space:pre-wrap;font-family:monospace">@dialogError.Message</div>
+                <div class="meshweaver-render-error-detail">@dialogError.Message</div>
             </div>
         </ErrorContent>
     </ErrorBoundary>

--- a/src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css
+++ b/src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css
@@ -573,3 +573,56 @@ fluent-header,
         }
 
 }
+
+/* ── The render-error placeholder ───────────────────────────────────────────────────────────────
+   Shown by every ErrorBoundary that wraps a view, an area or a dialog. It used to be styled inline
+   as `color: var(--error, #d13438)` over `rgba(209,52,56,0.08)`, which is a mid-dark red on a
+   near-transparent ground: legible on white, and dark-red-on-black in dark mode — exactly when a
+   reader most needs to read it, because the message IS the diagnosis.
+
+   Fluent's `--error` is a single value that does not flip with the theme, so the fix is not a
+   better token but a theme-aware rule. The foreground lightens in dark mode while the tinted
+   background and the border carry the "this is an error" signal in both. */
+.meshweaver-render-error {
+    padding: 0.75rem;
+    border: 1px solid rgba(209, 52, 56, 0.55);
+    border-radius: 4px;
+    background: rgba(209, 52, 56, 0.08);
+    color: #b3261e;
+    font-size: 0.875rem;
+}
+
+/* The message itself is a stack trace or an import failure — monospace, and allowed to wrap rather
+   than pushing the page sideways on a phone. */
+.meshweaver-render-error .meshweaver-render-error-detail {
+    margin-top: 0.25rem;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+    .meshweaver-render-error {
+        border-color: rgba(255, 138, 128, 0.45);
+        background: rgba(209, 52, 56, 0.14);
+        color: #ff9a91;
+    }
+}
+
+/* An explicit theme choice wins over the OS preference, in both directions — the portal stamps the
+   root, and a rule that only answers `prefers-color-scheme` is wrong for exactly the readers who
+   went and set the toggle. */
+:root[data-theme="dark"] .meshweaver-render-error,
+body[data-theme="dark"] .meshweaver-render-error,
+.dark .meshweaver-render-error {
+    border-color: rgba(255, 138, 128, 0.45);
+    background: rgba(209, 52, 56, 0.14);
+    color: #ff9a91;
+}
+
+:root[data-theme="light"] .meshweaver-render-error,
+body[data-theme="light"] .meshweaver-render-error {
+    border-color: rgba(209, 52, 56, 0.55);
+    background: rgba(209, 52, 56, 0.08);
+    color: #b3261e;
+}


### PR DESCRIPTION
Reported from `memex.systemorph.com`: a view failed with *"Importing a module script failed"* — and **the error box itself was dark red on black**, so the message you most need to read was the least legible thing on the page.

## The defect

The placeholder was styled **inline at three sites** — the view boundary (`DispatchView`), the area boundary and the dialog boundary (`LayoutAreaView`) — identically:

```razor
style="…border:1px solid var(--error,#d13438);background:rgba(209,52,56,0.08);color:var(--error,#d13438)…"
```

`#d13438` is a mid-dark red and the background is near-transparent, so on a dark ground it renders dark-red-on-black. Fluent's `--error` is a single value that does not flip with the theme, so there was no better token to reach for — the fix has to be a theme-aware rule.

## The fix

One `.meshweaver-render-error` class replacing the three inline copies. The foreground lightens in dark mode while the tinted background and border carry the "this is an error" signal in both themes.

It answers **both** `prefers-color-scheme` *and* an explicit `data-theme` stamp, in both directions — a rule that only reads the OS preference is wrong for exactly the readers who went and set the toggle.

The detail line also gains `overflow-wrap: anywhere`: it carries stack traces and import URLs, which have no spaces to break on, so on a phone it used to push the page sideways.

## Why this is worth a PR rather than a tweak

When a view fails, **the message is the diagnosis**. Making it hard to read costs exactly the person who is already having a bad time — and in this case it was hiding a real production signal (missing module assets on that portal).

Build: `MeshWeaver.Blazor` Release, 0 warnings, 0 errors.