### PR TITLE
One incompatible module must not abort the pod — record it, report it, keep serving

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -437,8 +437,11 @@ builder.Services.AddHealthChecks()
     // 🚨 Unhealthy when a declared-required module is missing, so a rollout that would silently
     // drop a feature STALLS and the pods that still have it keep serving. Inert unless the
     // deployment declares Modules:Required.
-    .AddCheck("required_modules",
-        new Memex.Portal.Distributed.RequiredModulesHealthCheck(builder.Configuration))
+    // Resolved from DI rather than hand-constructed: it now also needs the modules that loaded but
+    // could NOT register (#2234), which MeshBuilder.InstallAssemblies registers as enumerable
+    // singletons on this very container. Constructing it by hand would silently pass an empty set —
+    // the check would go on reporting "every required module is present" for a replica missing one.
+    .AddCheck<Memex.Portal.Distributed.RequiredModulesHealthCheck>("required_modules")
     .AddCheck<Memex.Portal.Distributed.BundleAdoptionHealthCheck>("bundle_adoption")
     // 🚨 The other half of the same blindness (#1782 gap 2). Adoption's miss is invisible because
     // a lazy compile absorbs it; an entitlement answer's degradation is invisible because every

--- a/memex/aspire/Memex.Portal.Distributed/RequiredModulesHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.Distributed/RequiredModulesHealthCheck.cs
@@ -42,7 +42,9 @@ namespace Memex.Portal.Distributed;
 /// <para>It reports only what the deployment ITSELF declared required, so it is inert by default:
 /// no <c>Modules:Required</c> means nothing to report.</para>
 /// </summary>
-public sealed class RequiredModulesHealthCheck(IConfiguration configuration) : IHealthCheck
+public sealed class RequiredModulesHealthCheck(
+    IConfiguration configuration,
+    IEnumerable<IncompatibleModule> incompatibleModules) : IHealthCheck
 {
     /// <inheritdoc />
     public Task<HealthCheckResult> CheckHealthAsync(
@@ -65,10 +67,12 @@ public sealed class RequiredModulesHealthCheck(IConfiguration configuration) : I
             entry => File.Exists(MeshBuilder.ResolveModulePath(entry)),
             activation,
             entry => ModuleActivationBoot.LandedModuleDllExists(moduleRoot, entry),
-            ModulePlatformFloor.DeclineReason);
+            ModulePlatformFloor.DeclineReason,
+            [.. incompatibleModules]);
 
         var absent = RequiredModuleStatus.Absent(verdicts);
         var expected = RequiredModuleStatus.ExpectedLater(verdicts);
+        var incompatible = RequiredModuleStatus.Incompatible(verdicts);
 
         // 🚨 Both lists ship in the payload whatever the verdict, so an operator reading /health
         // never has to infer which bucket a module fell into from the status alone.
@@ -76,9 +80,22 @@ public sealed class RequiredModulesHealthCheck(IConfiguration configuration) : I
         {
             ["missing"] = absent.Select(v => v.Entry).ToArray(),
             ["expected"] = expected.Select(v => v.Entry).ToArray(),
+            ["incompatible"] = incompatible.Select(v => v.Entry).ToArray(),
             ["detail"] = verdicts.Select(v => $"{v.Name} [{v.State}]: {v.Reason}").ToArray(),
             ["unreadableActivationRecords"] = unreadable.ToArray(),
         };
+
+        // 🚨 BEFORE the absent/expected buckets, and Unhealthy on purpose. Without this the verdict
+        // falls through to "every required module is present" — the assembly IS on the deployment,
+        // so nothing above it is false — and a replica whose feature is entirely missing reports
+        // Healthy. Stalling here preserves the previous generation, which still has the module
+        // working, and this is a fault the deployment can actually fix by moving both halves.
+        if (incompatible.Count > 0)
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                $"{incompatible.Count} required module(s) are present but did not install against "
+                + "this platform build, so their features are absent: "
+                + RequiredModuleStatus.Describe(incompatible),
+                data: data));
 
         if (absent.Count > 0)
             return Task.FromResult(HealthCheckResult.Unhealthy(

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-one-module-cannot-take-the-portal-down.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-one-module-cannot-take-the-portal-down.md
@@ -1,0 +1,21 @@
+---
+Name: A single incompatible add-on can no longer take the portal down
+Category: Fix
+Description: One add-on that does not match the running version is now skipped and reported, instead of stopping the whole portal from starting.
+Icon: Sparkle
+Order: -20260825
+---
+
+# A single incompatible add-on can no longer take the portal down
+
+When an installed add-on was built against a different version of the platform than the one your
+portal is running, the portal could fail to start at all — and because this happened before logging
+began, there was nothing in the logs to explain why.
+
+Now the portal starts anyway. The add-on that does not match is skipped, and it is reported clearly
+rather than quietly ignored: it is named at startup, and it shows up as a problem on the portal's
+health status instead of the portal claiming everything is fine. That matters because a silently
+missing add-on looks exactly like one that is working — the feature is simply gone.
+
+The remedy is unchanged and is now stated in the message itself: an add-on and the platform have to
+move together, never one on its own.

--- a/src/MeshWeaver.Mesh.Contract/IncompatibleModule.cs
+++ b/src/MeshWeaver.Mesh.Contract/IncompatibleModule.cs
@@ -1,0 +1,72 @@
+using System.Text.RegularExpressions;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// One module this deployment CARRIES and tried to install, whose registration threw against THIS
+/// platform build — so it contributes nothing, and this replica is degraded until the two halves
+/// agree again. Registered as an enumerable DI singleton, the same way
+/// <see cref="InstalledModuleAssembly"/> records the ones that succeeded.
+///
+/// <para>🚨 <b>This exists so a version-skewed module cannot take the pod with it (#2234).</b> A
+/// landed <c>MeshWeaver.AI.AzureFoundry</c> built against a 9-parameter record ctor met an image
+/// carrying the 8-parameter one; its provider attribute called the ctor that did not exist, the
+/// <see cref="MissingMethodException"/> escaped <c>MeshBuilder.InstallAssemblies</c>, and the
+/// process aborted ~2 s into boot — <c>exit 139</c>, a 178 MB core dump per attempt, and no
+/// application logging at all, because the logging pipeline is not up yet at that point. memex-cloud
+/// could not start a replacement pod for ~90 minutes and survived only on two pods that had booted
+/// before the module landed.</para>
+///
+/// <para><b>The blast radius was the defect, separately from the binary break.</b> One module's
+/// incompatibility is a reason to lose THAT module's contribution, never every other module, the
+/// portal, and the ability to roll at all. A deployment whose two halves are consistently old is
+/// serving; the same deployment mid-move is a crashloop — which is what strands an install that can
+/// move neither half alone.</para>
+///
+/// <para>🚨 <b>Skipping is NOT quietly tolerating.</b> A skip nobody can see is the shape that
+/// forges correct-looking bugs: the portal serves, the feature is simply gone, and nobody files
+/// anything because it looks like it works. So every skip is reported three ways — written to
+/// stderr at boot (the ONLY channel that exists before logging is configured, and the answer to
+/// "the container log contained only the createdump DSO listing"), registered here for any host to
+/// surface, and classified <c>RequiredModuleState.Incompatible</c> (PluginCatalog, which
+/// depends on this assembly rather than the other way round) so a module
+/// declared under <c>Modules:Required</c> is named on <c>/health</c> rather than silently absent.
+/// It never reports <c>Present</c>: the assembly did load, so a check that asked only "is it
+/// loaded?" would call this healthy, which is the lie this record exists to prevent.</para>
+/// </summary>
+/// <param name="Entry">The raw <c>Modules:Assemblies</c> entry or resolved path that was installed.</param>
+/// <param name="Name">Its assembly simple name — what <c>Modules:Required</c> is matched on.</param>
+/// <param name="Error">The exception's type and message, kept whole: for the skew case the message
+/// names the exact signature that was missing, which is the sentence an operator acts on.</param>
+/// <param name="MissingMember">The member the module wanted and this build does not have, when the
+/// exception names one. Null when the failure is of another kind.</param>
+public sealed record IncompatibleModule(string Entry, string Name, string Error, string? MissingMember)
+{
+    // MissingMethodException / MissingFieldException render as: Method not found: 'Void Ns.T..ctor(...)'.
+    // TypeLoadException names the type instead. Both put the thing that is missing in quotes, which is
+    // the one detail that turns "a module failed" into "this build lacks this signature".
+    private static readonly Regex QuotedMember = new("'([^']+)'", RegexOptions.Compiled);
+
+    /// <summary>Builds the record from a failed install, extracting the missing member when named.</summary>
+    public static IncompatibleModule From(string entry, Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        var name = Path.GetFileNameWithoutExtension(entry) ?? entry;
+        var error = $"{exception.GetType().Name}: {exception.Message}";
+        var match = QuotedMember.Match(exception.Message ?? string.Empty);
+        return new IncompatibleModule(entry, name, error, match.Success ? match.Groups[1].Value : null);
+    }
+
+    /// <summary>
+    /// The operator-facing sentence: which module, what it wanted, and what to do about it. Used
+    /// for the boot-time stderr line and by any host surfacing this on a health endpoint.
+    /// </summary>
+    public string Report() =>
+        $"Module '{Name}' did not install against this platform build and is CONTRIBUTING NOTHING. "
+        + (MissingMember is null
+            ? $"{Error}. "
+            : $"It requires '{MissingMember}', which this build does not have. ")
+        + "This replica is degraded, not healthy: the module's features are absent. Its build and "
+        + "the platform's disagree — move BOTH halves together (the module set and the image), "
+        + $"never one alone. Entry: {Entry}";
+}

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -87,9 +87,43 @@ public record MeshBuilder
         // consults the module's deps.json, so nothing probes modules/<Name>/runtimes/<rid>/native/.
         // Subscribed here — before anything from a module folder is loaded — and idempotent.
         ModuleNativeAssets.EnsureRegistered();
-        var assemblies = assemblyLocations
-            .Select(Assembly.LoadFrom)
-            .ToArray();
+
+        // 🚨 Per-module isolation (#2234). One module that cannot install against THIS build must
+        // cost that module's contribution and nothing else. It used to cost the process: a landed
+        // AzureFoundry built against a 9-parameter record ctor met an image carrying the
+        // 8-parameter one, the MissingMethodException escaped this method, and every replacement
+        // pod aborted ~2 s into boot with no application logging (the pipeline is not up yet) —
+        // memex-cloud could not start a pod for ~90 minutes.
+        //
+        // Everything an attribute can THROW from is materialised here, before any builder state is
+        // mutated, so a module that fails leaves no half-applied configuration behind. The lambdas
+        // are the hazard: `a.Nodes` is what constructs the objects whose ctor may have moved.
+        var pending = new List<PendingModuleInstall>();
+        var incompatible = new List<IncompatibleModule>();
+        foreach (var location in assemblyLocations)
+        {
+            try
+            {
+                var assembly = Assembly.LoadFrom(location);
+                var moduleAttributes = assembly.GetCustomAttributes<MeshNodeProviderAttribute>().ToArray();
+                pending.Add(new PendingModuleInstall(
+                    assembly,
+                    moduleAttributes.SelectMany(a => a.Nodes).ToArray(),
+                    moduleAttributes.SelectMany(a => a.AddressTypes).ToArray(),
+                    moduleAttributes.SelectMany(a => a.HubConfigurations).ToArray(),
+                    moduleAttributes.SelectMany(a => a.DefaultNodeHubConfigurations).ToArray(),
+                    moduleAttributes.SelectMany(a => a.BuilderConfigurations).ToArray()));
+            }
+            catch (Exception exception)
+            {
+                incompatible.Add(ReportIncompatible(location, exception));
+            }
+        }
+
+        // Only the modules that actually installed are recorded as installed. A skewed one is
+        // deliberately NOT in this list: it contributes no nodes, and letting it into the in-mesh
+        // compile reference set would hand every dynamic NodeType the same broken signatures.
+        var assemblies = pending.Select(p => p.Assembly).ToArray();
         // Record every installed module for the runtime surfaces that must SEE modules the way
         // they see the platform: the in-mesh compile reference set (a module leaving the publish
         // closure leaves TRUSTED_PLATFORM_ASSEMBLIES, so compilation composes TPA + these) and
@@ -102,13 +136,23 @@ public record MeshBuilder
                 services.AddSingleton(new InstalledModuleAssembly(assembly));
             return services;
         });
-        var attributes = assemblies
-            .SelectMany(a => a.GetCustomAttributes<MeshNodeProviderAttribute>())
-            .ToArray();
-        MeshNodes.AddRange(attributes.SelectMany(a => InstallServices(a.Nodes)));
+        // Every incompatible module is visible to any host that wants to surface it, alongside the
+        // stderr line already written and the Modules:Required verdict computed from it. A skip
+        // nobody can see is the shape that forges correct-looking bugs.
+        if (incompatible.Count > 0)
+        {
+            ConfigureServices(services =>
+            {
+                foreach (var module in incompatible)
+                    services.AddSingleton(module);
+                return services;
+            });
+        }
+
+        MeshNodes.AddRange(pending.SelectMany(p => InstallServices(p.Nodes)));
 
         // Register address types from attributes
-        var addressTypes = attributes.SelectMany(a => a.AddressTypes).ToArray();
+        var addressTypes = pending.SelectMany(p => p.AddressTypes).ToArray();
         if (addressTypes.Length > 0)
         {
             ConfigureHub(config =>
@@ -121,18 +165,59 @@ public record MeshBuilder
         // Attribute-carried hub configuration — the surfaces a boot-loaded pack needs beyond
         // root DI: the mesh hub's own configuration and the every-per-node-hub chain
         // (Courses/Observability-shaped packs register types + default areas there).
-        foreach (var hubConfiguration in attributes.SelectMany(a => a.HubConfigurations))
+        foreach (var hubConfiguration in pending.SelectMany(p => p.HubConfigurations))
             ConfigureHub(hubConfiguration);
-        foreach (var nodeHubConfiguration in attributes.SelectMany(a => a.DefaultNodeHubConfigurations))
+        foreach (var nodeHubConfiguration in pending.SelectMany(p => p.DefaultNodeHubConfigurations))
             ConfigureDefaultNodeHub(nodeHubConfiguration);
 
         // Attribute-carried BUILDER configuration — the full-surface hook. Applied last so a
         // builder-level hook observes the attribute's own nodes/services, mirroring the order a
         // compiled-in caller would get from `builder.InstallAssemblies(...).AddX()`. MeshBuilder
         // methods mutate this instance and return it, so the fold cannot lose configuration.
-        return attributes
-            .SelectMany(a => a.BuilderConfigurations)
-            .Aggregate(this, (builder, configure) => configure(builder));
+        //
+        // Folded per MODULE rather than over one flat list: these run arbitrary module code, so a
+        // throw here is the same hazard as the materialisation above and must cost only its own
+        // module. The fold keeps the builder from the last SUCCESSFUL configuration, so a module
+        // that throws midway cannot strand the chain.
+        var result = this;
+        foreach (var module in pending)
+        {
+            try
+            {
+                result = module.BuilderConfigurations.Aggregate(result, (builder, configure) => configure(builder));
+            }
+            catch (Exception exception)
+            {
+                ReportIncompatible(module.Assembly.Location, exception);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// One module's contributions, materialised before any builder state is touched.
+    /// </summary>
+    private sealed record PendingModuleInstall(
+        Assembly Assembly,
+        IReadOnlyCollection<MeshNode> Nodes,
+        IReadOnlyCollection<KeyValuePair<string, Type>> AddressTypes,
+        IReadOnlyCollection<Func<MessageHubConfiguration, MessageHubConfiguration>> HubConfigurations,
+        IReadOnlyCollection<Func<MessageHubConfiguration, MessageHubConfiguration>> DefaultNodeHubConfigurations,
+        IReadOnlyCollection<Func<MeshBuilder, MeshBuilder>> BuilderConfigurations);
+
+    /// <summary>
+    /// Records a module that could not install, and writes it to stderr.
+    ///
+    /// <para>🚨 stderr, not a logger: this runs BEFORE the logging pipeline exists, which is
+    /// exactly why #2234's crash left a container log containing only the createdump DSO listing
+    /// and cost most of a day to diagnose. The one channel that works at this point is the one the
+    /// container captures.</para>
+    /// </summary>
+    private static IncompatibleModule ReportIncompatible(string entry, Exception exception)
+    {
+        var module = IncompatibleModule.From(entry, exception);
+        Console.Error.WriteLine($"[MeshWeaver.Mesh.IncompatibleModule] {module.Report()}");
+        return module;
     }
 
     private IEnumerable<MeshNode> InstallServices(IEnumerable<MeshNode> nodes)

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -136,19 +136,6 @@ public record MeshBuilder
                 services.AddSingleton(new InstalledModuleAssembly(assembly));
             return services;
         });
-        // Every incompatible module is visible to any host that wants to surface it, alongside the
-        // stderr line already written and the Modules:Required verdict computed from it. A skip
-        // nobody can see is the shape that forges correct-looking bugs.
-        if (incompatible.Count > 0)
-        {
-            ConfigureServices(services =>
-            {
-                foreach (var module in incompatible)
-                    services.AddSingleton(module);
-                return services;
-            });
-        }
-
         MeshNodes.AddRange(pending.SelectMany(p => InstallServices(p.Nodes)));
 
         // Register address types from attributes
@@ -188,8 +175,24 @@ public record MeshBuilder
             }
             catch (Exception exception)
             {
-                ReportIncompatible(module.Assembly.Location, exception);
+                incompatible.Add(ReportIncompatible(module.Assembly.Location, exception));
             }
+        }
+
+        // 🚨 Registered AFTER the fold, not before it. A module can fail in either half — while its
+        // contributions are materialised, or while its BuilderConfigurations run — and registering
+        // early captured only the first. The second would have been written to stderr and then
+        // dropped, so /health and RequiredModuleStatus would report a replica missing that module's
+        // features as healthy: the exact invisible-skip this record exists to prevent, reintroduced
+        // one code path over.
+        if (incompatible.Count > 0)
+        {
+            result.ConfigureServices(services =>
+            {
+                foreach (var module in incompatible)
+                    services.AddSingleton(module);
+                return services;
+            });
         }
         return result;
     }

--- a/src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs
+++ b/src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs
@@ -21,6 +21,13 @@ public enum RequiredModuleState
     /// there. Nothing on this deployment can produce it, and the pods of the previous generation
     /// still have it — so the rollout must STALL.</summary>
     Absent,
+
+    /// <summary>It is HERE and it loaded, and its registration threw against this platform build
+    /// (#2234), so it contributes nothing. Never <see cref="Present"/>: the assembly did load, so a
+    /// check asking only "is it loaded?" would call a replica missing the feature healthy. The two
+    /// halves disagree and must move together — which is the one thing a rollout CAN fix, unlike
+    /// <see cref="ExpectedLater"/>.</summary>
+    Incompatible,
 }
 
 /// <summary>One required module's verdict, with the sentence an operator acts on.</summary>
@@ -94,7 +101,33 @@ public static class RequiredModuleStatus
         ModuleActivationList? activation,
         Func<ModuleActivationEntry, bool> landedDllExists,
         Func<string?, string?> platformGate)
+        => Classify(requiredEntries, baselineEntries, loadedAssemblyNames, resolvesFromDeployment,
+            activation, landedDllExists, platformGate, []);
+
+    /// <summary>
+    /// As the seven-argument overload, plus the modules that loaded but could not REGISTER against
+    /// this build (<see cref="Mesh.IncompatibleModule"/>, #2234).
+    ///
+    /// <para>🚨 <b>An overload, deliberately, not an optional parameter on the existing method.</b>
+    /// Adding an optional parameter is source-compatible and BINARY-breaking — the signature is
+    /// replaced, so a caller compiled against the old one gets MissingMethodException at runtime.
+    /// That is precisely the change that aborted every memex-cloud pod for ~90 minutes and the
+    /// reason this overload exists at all; making the fix in the shape of the bug would be a poor
+    /// joke. The seven-argument form stays, forwarding an empty set, so a host compiled against the
+    /// previous platform keeps working.</para>
+    /// </summary>
+    /// <param name="incompatibleModules">Modules whose registration threw at boot, by simple name.</param>
+    public static ImmutableList<RequiredModuleVerdict> Classify(
+        IEnumerable<string?>? requiredEntries,
+        IEnumerable<string?>? baselineEntries,
+        IReadOnlySet<string> loadedAssemblyNames,
+        Func<string, bool> resolvesFromDeployment,
+        ModuleActivationList? activation,
+        Func<ModuleActivationEntry, bool> landedDllExists,
+        Func<string?, string?> platformGate,
+        IReadOnlyCollection<Mesh.IncompatibleModule> incompatibleModules)
     {
+        ArgumentNullException.ThrowIfNull(incompatibleModules);
         ArgumentNullException.ThrowIfNull(loadedAssemblyNames);
         ArgumentNullException.ThrowIfNull(resolvesFromDeployment);
         ArgumentNullException.ThrowIfNull(landedDllExists);
@@ -116,6 +149,18 @@ public static class RequiredModuleStatus
             if (string.IsNullOrWhiteSpace(entry))
                 continue;
             var name = Path.GetFileNameWithoutExtension(entry!);
+
+            // 🚨 BEFORE the loaded check, which an incompatible module would otherwise satisfy:
+            // its assembly IS loaded, it simply registered nothing. Asked in the other order this
+            // reports Present and the operator learns nothing until a user reports a missing feature.
+            var broken = incompatibleModules.FirstOrDefault(
+                module => string.Equals(module.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (broken is not null)
+            {
+                verdicts.Add(new RequiredModuleVerdict(
+                    entry!, name, RequiredModuleState.Incompatible, broken.Report()));
+                continue;
+            }
 
             if (loadedAssemblyNames.Contains(name))
             {
@@ -180,6 +225,17 @@ public static class RequiredModuleStatus
     public static ImmutableList<RequiredModuleVerdict> ExpectedLater(
         IEnumerable<RequiredModuleVerdict> verdicts) =>
         [.. (verdicts ?? []).Where(v => v.State == RequiredModuleState.ExpectedLater)];
+
+    /// <summary>
+    /// Those that ARE here and could not register against this build (#2234). A rollout stalls on
+    /// these, for the same reason it stalls on <see cref="Absent"/> and NOT on
+    /// <see cref="ExpectedLater"/>: the previous generation is serving the feature, and unlike a
+    /// store-delivered module this deployment CAN fix it — by moving the module set and the image
+    /// together instead of one alone.
+    /// </summary>
+    public static ImmutableList<RequiredModuleVerdict> Incompatible(
+        IEnumerable<RequiredModuleVerdict> verdicts) =>
+        [.. (verdicts ?? []).Where(v => v.State == RequiredModuleState.Incompatible)];
 
     /// <summary>One line per module, so the probe payload and the boot log read identically.</summary>
     public static string Describe(IEnumerable<RequiredModuleVerdict> verdicts) =>

--- a/test/Memex.Portal.Shared.Test/RequiredModulesHealthCheckTest.cs
+++ b/test/Memex.Portal.Shared.Test/RequiredModulesHealthCheckTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Memex.Portal.Distributed;
+using MeshWeaver.Mesh;
 using MeshWeaver.PluginCatalog;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -43,7 +44,8 @@ public class RequiredModulesHealthCheckTest : IDisposable
         catch { /* temp cleanup is the OS's problem, never a test failure */ }
     }
 
-    private Task<HealthCheckResult> Check(string[] required, string[] baseline)
+    private Task<HealthCheckResult> Check(
+        string[] required, string[] baseline, params IncompatibleModule[] incompatible)
     {
         var settings = new Dictionary<string, string?> { [ModuleRoot.ConfigKey] = root };
         for (var i = 0; i < required.Length; i++)
@@ -52,8 +54,49 @@ public class RequiredModulesHealthCheckTest : IDisposable
             settings[$"Modules:Assemblies:{i}"] = baseline[i];
 
         return new RequiredModulesHealthCheck(
-                new ConfigurationBuilder().AddInMemoryCollection(settings).Build())
+                new ConfigurationBuilder().AddInMemoryCollection(settings).Build(),
+                incompatible)
             .CheckHealthAsync(new HealthCheckContext());
+    }
+
+    /// <summary>
+    /// A module that IS on the deployment and loaded, whose registration threw against this build
+    /// (#2234). Without a bucket of its own this fell through every check above it — the assembly
+    /// is present, so "absent" is false and "expected later" is false — and landed on
+    /// "every required module is present", i.e. Healthy for a replica whose feature is entirely
+    /// gone. That fall-through is the regression this pins.
+    /// </summary>
+    [Fact]
+    public async Task AnIncompatibleModule_IsUnhealthy_NotHealthy()
+    {
+        var broken = IncompatibleModule.From(
+            "MeshWeaver.AI.AzureFoundry.dll",
+            new MissingMethodException("Method not found: 'Void Ns.T..ctor(String)'."));
+
+        var result = await Check(
+            ["MeshWeaver.AI.AzureFoundry.dll"], ["MeshWeaver.AI.AzureFoundry.dll"], broken);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.NotEqual(HealthStatus.Healthy, result.Status);
+        Assert.Contains("did not install against this platform build", result.Description);
+        Assert.Contains("incompatible", result.Data.Keys);
+    }
+
+    /// <summary>
+    /// The partner: the same declaration with nothing broken stays Healthy, so the bucket above
+    /// discriminates rather than failing every deployment that declares a required module.
+    /// </summary>
+    [Fact]
+    public async Task NothingIncompatible_StaysHealthy()
+    {
+        // A module genuinely loaded in THIS process, so it classifies Present on the same evidence
+        // production uses (ModuleActivationStatus.LoadedAssemblyNames). Declaring a name that is
+        // merely recorded would classify Absent and fail here for a reason unrelated to the bucket
+        // under test — which is exactly how this assertion misled me the first time.
+        var result = await Check(
+            ["MeshWeaver.PluginCatalog.dll"], ["MeshWeaver.PluginCatalog.dll"]);
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
     }
 
     /// <summary>Lands an activation record, with or without the bytes it points at.</summary>

--- a/test/MeshWeaver.AI.Test/ProviderModulePackBootTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderModulePackBootTest.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -67,6 +68,70 @@ public class ProviderModulePackBootTest
             (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
 
         AssertFactoryAndCatalogSourceLanded(services);
+    }
+
+    /// <summary>
+    /// The partner to the fold above, and the property that would have kept memex-cloud serving on
+    /// 2026-08-25 (#2234): a module this build CANNOT install must cost its own contribution and
+    /// nothing else. It used to cost the process — a landed AzureFoundry built against a
+    /// 9-parameter record ctor met the 8-parameter image, the MissingMethodException escaped
+    /// InstallAssemblies, and every replacement pod aborted ~2 s into boot with no application
+    /// logging, for ~90 minutes.
+    ///
+    /// <para>🚨 The assertion that matters is not "it did not throw" — it is that the GOOD pack
+    /// beside it still landed. A fix that swallowed the failure and also dropped the healthy
+    /// module would pass a no-throw test while leaving the portal just as broken.</para>
+    /// </summary>
+    [Fact]
+    public void InstallAssemblies_WithAModuleItCannotLoad_KeepsTheGoodOne_AndDoesNotAbort()
+    {
+        var configurations = new List<Func<IServiceCollection, IServiceCollection>>();
+        var builder = new MeshBuilder(configure => configurations.Add(configure),
+            AddressExtensions.CreateMeshAddress());
+
+        var unloadable = Path.Combine(AppContext.BaseDirectory, "MeshWeaver.ThisModuleCannotLoad.dll");
+
+        var exception = Record.Exception(() => builder.InstallAssemblies(
+            unloadable,
+            typeof(ProbeProviderPackAttribute).Assembly.Location));
+
+        Assert.Null(exception);
+
+        var services = configurations.Aggregate(
+            (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+
+        // The healthy pack is unaffected by its neighbour's failure.
+        AssertFactoryAndCatalogSourceLanded(services);
+
+        // And the failure is RECORDED rather than swallowed — a skip nobody can see is the shape
+        // that forges correct-looking bugs, so the host must be able to surface it.
+        var recorded = services
+            .Where(d => d.ServiceType == typeof(IncompatibleModule))
+            .Select(d => d.ImplementationInstance)
+            .OfType<IncompatibleModule>()
+            .ToList();
+        var broken = Assert.Single(recorded);
+        Assert.Equal("MeshWeaver.ThisModuleCannotLoad", broken.Name);
+        Assert.Contains("CONTRIBUTING NOTHING", broken.Report());
+    }
+
+    /// <summary>
+    /// The other direction: with every module loadable, nothing is reported as incompatible. A
+    /// recorder that always fired would make the assertion above meaningless.
+    /// </summary>
+    [Fact]
+    public void InstallAssemblies_WithEveryModuleLoadable_RecordsNoIncompatibility()
+    {
+        var configurations = new List<Func<IServiceCollection, IServiceCollection>>();
+        var builder = new MeshBuilder(configure => configurations.Add(configure),
+            AddressExtensions.CreateMeshAddress());
+
+        builder.InstallAssemblies(typeof(ProbeProviderPackAttribute).Assembly.Location);
+
+        var services = configurations.Aggregate(
+            (IServiceCollection)new ServiceCollection(), (collection, configure) => configure(collection));
+
+        Assert.DoesNotContain(services, d => d.ServiceType == typeof(IncompatibleModule));
     }
 
     [Fact]

--- a/test/MeshWeaver.PluginCatalog.Test/RequiredModuleStatusTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RequiredModuleStatusTest.cs
@@ -40,6 +40,110 @@ public class RequiredModuleStatusTest
             required, baseline, loaded ?? Loaded(), resolves ?? (_ => false),
             activation, bytes ?? BytesPresent, floor ?? FloorSatisfied);
 
+    private static ImmutableList<RequiredModuleVerdict> ClassifyWithBroken(
+        string[] required,
+        string[] baseline,
+        IReadOnlySet<string> loaded,
+        params Mesh.IncompatibleModule[] broken) =>
+        RequiredModuleStatus.Classify(
+            required, baseline, loaded, _ => false, null, BytesPresent, FloorSatisfied, broken);
+
+    private static Mesh.IncompatibleModule Skewed(string name) =>
+        Mesh.IncompatibleModule.From(
+            $"{name}.dll",
+            new MissingMethodException(
+                "Method not found: 'Void MeshWeaver.AI.LanguageModelCatalogSource..ctor(String, String, Int32)'."));
+
+    // ── a module that LOADED but could not register (#2234) ──────────────────────────────────────
+
+    /// <summary>
+    /// The lie this state exists to prevent. The assembly IS loaded — so the "is it loaded?"
+    /// question answers yes — but its registration threw and it contributes nothing. Reporting
+    /// Present here is how a replica missing an entire feature passes as healthy, and nobody finds
+    /// out until a user reports the feature gone.
+    /// </summary>
+    [Fact]
+    public void LoadedButUnregistered_IsIncompatible_NotPresent()
+    {
+        var verdicts = ClassifyWithBroken(
+            ["MeshWeaver.AI.AzureFoundry.dll"],
+            ["MeshWeaver.AI.AzureFoundry.dll"],
+            Loaded("MeshWeaver.AI.AzureFoundry"),
+            Skewed("MeshWeaver.AI.AzureFoundry"));
+
+        var verdict = Assert.Single(verdicts);
+        Assert.Equal(RequiredModuleState.Incompatible, verdict.State);
+        Assert.NotEqual(RequiredModuleState.Present, verdict.State);
+        // The remedy has to be in the sentence: the two halves must move together.
+        Assert.Contains("CONTRIBUTING NOTHING", verdict.Reason);
+        Assert.Contains("move BOTH halves together", verdict.Reason);
+    }
+
+    /// <summary>
+    /// The partner. Same shape, nothing broken — a loaded module is still Present, so the check
+    /// above is discriminating rather than answering Incompatible for everything.
+    /// </summary>
+    [Fact]
+    public void Loaded_AndNothingBroken_IsStillPresent()
+    {
+        var verdicts = ClassifyWithBroken(
+            ["MeshWeaver.AI.AzureFoundry.dll"],
+            ["MeshWeaver.AI.AzureFoundry.dll"],
+            Loaded("MeshWeaver.AI.AzureFoundry"));
+
+        Assert.Equal(RequiredModuleState.Present, Assert.Single(verdicts).State);
+    }
+
+    /// <summary>
+    /// One skewed module must not change the verdict for a healthy sibling — the same blast-radius
+    /// property at the reporting layer that the boot path now has at the loading layer.
+    /// </summary>
+    [Fact]
+    public void OneIncompatibleModule_DoesNotTaintTheOthers()
+    {
+        var verdicts = ClassifyWithBroken(
+            ["MeshWeaver.AI.AzureFoundry.dll", "MeshWeaver.Speech.dll"],
+            ["MeshWeaver.AI.AzureFoundry.dll", "MeshWeaver.Speech.dll"],
+            Loaded("MeshWeaver.AI.AzureFoundry", "MeshWeaver.Speech"),
+            Skewed("MeshWeaver.AI.AzureFoundry"));
+
+        Assert.Equal(
+            RequiredModuleState.Incompatible,
+            verdicts.Single(v => v.Name == "MeshWeaver.AI.AzureFoundry").State);
+        Assert.Equal(
+            RequiredModuleState.Present,
+            verdicts.Single(v => v.Name == "MeshWeaver.Speech").State);
+    }
+
+    /// <summary>
+    /// The missing signature is the sentence an operator acts on — #2234 was diagnosed by reading
+    /// exactly this string out of a previous container's log. Losing it costs a day.
+    /// </summary>
+    [Fact]
+    public void TheReportNamesTheMissingSignature()
+    {
+        var module = Skewed("MeshWeaver.AI.AzureFoundry");
+        Assert.Equal(
+            "Void MeshWeaver.AI.LanguageModelCatalogSource..ctor(String, String, Int32)",
+            module.MissingMember);
+        Assert.Contains(module.MissingMember!, module.Report());
+    }
+
+    /// <summary>
+    /// The seven-argument overload still compiles and behaves — a host built against the previous
+    /// platform must keep working, which is the whole point of not having added an optional
+    /// parameter to the existing signature.
+    /// </summary>
+    [Fact]
+    public void TheOriginalOverloadStillAnswers()
+    {
+        var verdicts = RequiredModuleStatus.Classify(
+            ["MeshWeaver.Speech.dll"], ["MeshWeaver.Speech.dll"],
+            Loaded("MeshWeaver.Speech"), _ => false, null, BytesPresent, FloorSatisfied);
+
+        Assert.Equal(RequiredModuleState.Present, Assert.Single(verdicts).State);
+    }
+
     // ── the hard gate keeps its teeth ────────────────────────────────────────────────────────────
 
     /// <summary>


### PR DESCRIPTION
Addresses the **blast-radius half** of #2234. The prevention half (a `minMeshVersion` floor rising on
a binary break) stays open.

## What happened

memex-cloud could not start a replacement portal pod for ~90 minutes on 2026-08-25. A landed
`MeshWeaver.AI.AzureFoundry` built against a 9-parameter record ctor met an image carrying the
8-parameter one; its provider attribute called the ctor that did not exist, the
`MissingMethodException` escaped `MeshBuilder.InstallAssemblies`, and every pod died ~2 s into boot
(`exit 139`, a 178 MB core dump each). The container log held only the createdump DSO listing,
because the logging pipeline is not up at that point.

**The binary break is one defect; the blast radius is a separate one.** One module's incompatibility
is a reason to lose *that module's* contribution — never every other module, the portal, and the
ability to roll at all. That is exactly what strands a deployment which can move neither half alone:
consistently-old halves serve, and any move crashloops.

## The change

- **`InstallAssemblies` isolates each module.** Everything an attribute can throw from is
  materialised *before* any builder state is mutated, so a module that cannot register leaves
  nothing half-applied. Only modules that actually installed are recorded as installed — a skewed
  one deliberately stays out of the in-mesh compile reference set, or every dynamic NodeType would
  inherit the same broken signatures.
- **🚨 Skipping is not quiet tolerance.** A skip nobody can see is the shape that forges
  correct-looking bugs. Every skip is reported three ways: stderr at boot (the only channel that
  exists before logging — the answer to "the log contained only the createdump listing"), an
  enumerable DI singleton, and a new `RequiredModuleState.Incompatible`.
- **The verdict is checked BEFORE "is it loaded?"** The assembly *is* loaded; it simply registered
  nothing. Asked in the other order it reports `Present`, and nobody learns anything until a user
  notices a missing feature.
- **The health check had that exact fall-through.** Bucketing only on absent/expected sent an
  `Incompatible` verdict to `Healthy("every required module is present")` — true about the file,
  a lie about the replica. Now `Unhealthy`, which stalls the rollout and preserves the previous
  generation that still has the module working. It also resolves from DI rather than being
  hand-constructed with an empty set, which would have silently defeated the whole check.

## 🚨 An overload, not an optional parameter

Adding an optional parameter to `Classify` would be source-compatible and **binary-breaking** — the
signature is replaced, so a caller compiled against the old one gets `MissingMethodException` at
runtime. That is precisely the change that caused this outage, and the caller lives in a project
that compiles against a pinned platform. Making the fix in the shape of the bug would be a poor
joke, so the seven-argument form stays and forwards an empty set.

## Tests

Nine, each with a partner asserting the opposite verdict, so a classifier that always answers one
way fails:

- the **good module beside a broken one still lands** — the property that would have kept
  memex-cloud serving, and the one a no-throw test would miss
- loaded-but-unregistered is `Incompatible`, not `Present`; a healthy one is still `Present`
- one skewed module does not taint its siblings
- the report names the missing signature (#2234 was diagnosed by reading exactly that string)
- the old overload still answers
- the health check is `Unhealthy` for an incompatible module and `Healthy` when nothing is broken

All green locally with fresh `.trx` files.