### PR TITLE
Pandas Explorer wait FOLLOWS the overlay's redirect instead of dying on it (#2155)

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/PandasExplorerLayoutAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/PandasExplorerLayoutAreaTest.cs
@@ -203,5 +203,11 @@ public class PandasExplorerLayoutAreaTest : MonolithMeshTestBase
                             + $"({hopsLeft - 1} hop(s) left)");
                         return Rendered(areaPath, client: null, hopsLeft - 1);
                     })
-                    : Observable.Empty<UiControl?>());
+                    // Hops exhausted: pass the redirect THROUGH rather than completing empty. It
+                    // never matches a caller's predicate, so the wait still fails on its budget —
+                    // but the failure keeps naming what was actually last seen ("Last of N
+                    // emission(s) was: RedirectControl … Href = …"), which is the line that made
+                    // #2155 diagnosable in the first place. An empty completion would report only
+                    // that nothing arrived.
+                    : Observable.Return(c));
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/PandasExplorerLayoutAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/PandasExplorerLayoutAreaTest.cs
@@ -36,6 +36,9 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <para>Every assertion runs under a hard wall-clock budget: if the grid sub-area hung instead of
 /// degrading, the <c>Within(...)</c> bound trips and the test FAILS loudly rather than blocking CI —
 /// which is the exact production hazard being guarded.</para>
+///
+/// <para>🚨 <b>Every wait goes through <see cref="Rendered"/>, which FOLLOWS the redirect</b> — see
+/// its remarks. A wait that merely sat on one subscription was #2155.</para>
 /// </summary>
 public class PandasExplorerLayoutAreaTest : MonolithMeshTestBase
 {
@@ -51,6 +54,14 @@ public class PandasExplorerLayoutAreaTest : MonolithMeshTestBase
     /// yet still a HARD ceiling, so a genuine hang (the regression this guards) fails the test.
     /// </summary>
     private static readonly TimeSpan RenderBudget = TimeSpan.FromSeconds(50);
+
+    /// <summary>
+    /// How many overlay redirects one wait will follow before giving up. One is the expected
+    /// maximum (the overlay heals once per compile); the extra hops cover a sweep in which the
+    /// type is recompiled again while we are re-subscribing. Bounded on purpose — an instance
+    /// stuck in an overlay↔heal loop must fail this test, not spin in it.
+    /// </summary>
+    private const int MaxRedirectHops = 3;
 
     private readonly string _cacheDirectory;
 
@@ -86,14 +97,8 @@ public class PandasExplorerLayoutAreaTest : MonolithMeshTestBase
     [Fact(Timeout = 120000)]
     public async Task Explorer_NoPythonNode_RendersToolbarAndDegradesGridWithoutHanging()
     {
-        var client = GetClient(c => c.AddData(data => data));
-        var address = new Address(LiveFramePath);
-
         // No ping: subscribing to the layout area activates the per-node hub AND triggers the cold
         // Roslyn compile of the Pandas NodeType Source. The budget below covers that.
-        var stream = client.GetWorkspace()
-            .GetRemoteStream<JsonElement, LayoutAreaReference>(
-                address, new LayoutAreaReference(ExplorerArea));
 
         // 1. The Explorer area renders a Stack composing title + intro + toolbar + grid sub-areas.
         //    The composition is INCREMENTAL: the root Stack can emit with only the first children
@@ -101,8 +106,7 @@ public class PandasExplorerLayoutAreaTest : MonolithMeshTestBase
         //    runner sampled exactly that 3-child intermediate frame (PR #1970's run). So the wait
         //    matches the COMPLETE composition, never the first Stack-shaped emission; the Within
         //    budget still guards the hang this test exists for.
-        var root = await stream.GetControlStream(ExplorerArea)
-            .Where(c => c is not null)
+        var root = await Rendered(ExplorerArea)
             .Should().Within(RenderBudget).Match(c => c is StackControl s && s.Areas.Count >= 4);
 
         Output.WriteLine($"Explorer root control: {root!.GetType().Name}");
@@ -117,8 +121,7 @@ public class PandasExplorerLayoutAreaTest : MonolithMeshTestBase
 
         // 2. The toolbar resolves to a horizontal Stack whose named sub-areas are the real buttons —
         //    the point of the sample is genuine framework controls, not an HTML string.
-        var toolbar = await stream.GetControlStream($"{ExplorerArea}/toolbar")
-            .Where(c => c is not null)
+        var toolbar = await Rendered($"{ExplorerArea}/toolbar")
             .Should().Within(RenderBudget).Match(c => c is StackControl);
 
         var toolbarStack = toolbar!.Should().BeOfType<StackControl>().Subject;
@@ -128,8 +131,7 @@ public class PandasExplorerLayoutAreaTest : MonolithMeshTestBase
             buttonAreas.Should().Contain(expected, $"the toolbar exposes the '{expected}' button");
 
         // Each named button area resolves to a real ButtonControl carrying its label.
-        var loadButton = await stream.GetControlStream($"{ExplorerArea}/toolbar/load")
-            .Where(c => c is not null)
+        var loadButton = await Rendered($"{ExplorerArea}/toolbar/load")
             .Should().Within(RenderBudget).Match(c => c is ButtonControl);
         loadButton.Should().BeOfType<ButtonControl>()
             .Which.Data!.ToString().Should().Contain("Load", "the primary action loads the sales CSV");
@@ -137,7 +139,7 @@ public class PandasExplorerLayoutAreaTest : MonolithMeshTestBase
         // 3. THE POINT: with no py/pandas participant attached, the grid MUST degrade to the
         //    "No Python pandas node attached" notice WITHIN the budget — not hang, not raw error.
         //    The grid area resolves to a NoNode() stack whose 'status' markdown carries the notice.
-        var gridStatus = await stream.GetControlStream($"{ExplorerArea}/grid/status")
+        var gridStatus = await Rendered($"{ExplorerArea}/grid/status")
             .Where(c => c is MarkdownControl)
             .Should().Within(RenderBudget).Match(c =>
                 ((MarkdownControl)c!).Markdown?.ToString()?
@@ -148,4 +150,58 @@ public class PandasExplorerLayoutAreaTest : MonolithMeshTestBase
         notice.Markdown!.ToString().Should().Contain("No Python pandas node attached",
             "with no participant the grid degrades to the informative no-node notice — it must never hang");
     }
+
+    /// <summary>
+    /// The Explorer area's control stream for <paramref name="areaPath"/>, <b>following the
+    /// compilation-in-progress overlay's redirect the way a GUI client does</b>.
+    ///
+    /// <para>🚨 <b>Why a plain subscription is not enough (#2155).</b> When the Pandas NodeType's
+    /// cold Roslyn compile outlives <c>NodeTypeEnrichmentHelpers.InFlightOverlayGrace</c> (5 s — a
+    /// loaded CI runner routinely does), the LiveFrame instance activates against the
+    /// compilation-in-progress overlay, which serves <c>NodeTypeLayoutAreas.CompileProgressView</c>
+    /// on EVERY area. When the build lands <c>Ok</c> that view emits a
+    /// <see cref="RedirectControl"/> — and the SAME event recycles the instance hub
+    /// (<c>WithOverlaySelfHeal</c> posts a <c>DisposeRequest</c> to it) so the next access
+    /// re-enriches against the now-usable type. A subscriber that just keeps waiting is therefore
+    /// attached to a hub that has gone away: the redirect is the LAST thing it ever sees. That is
+    /// exactly what #2155 recorded — "Last of 3 emission(s) was: RedirectControl … Href =
+    /// /Doc/DataMesh/PythonPandasNode/PandasExplorer/LiveFrame/Explorer" after 50 s.</para>
+    ///
+    /// <para>Following it is what a real client does — the Blazor <c>DispatchView</c> answers a
+    /// <see cref="RedirectControl"/> with <c>NavigationManager.NavigateTo(href)</c>, i.e. a fresh
+    /// area subscription. A fresh <see cref="HubTestBase.GetClient"/> is this test's navigation: it
+    /// is a brand-new client hub, so its workspace opens a brand-new remote stream rather than
+    /// handing back the orphaned one out of <c>Workspace._remoteStreamCache</c> (which is keyed on
+    /// owner + reference + identity, and would otherwise return the same dead stream).</para>
+    ///
+    /// <para>No timer, no retry, no widened bound: the redirect IS the event, and each hop is
+    /// driven by receiving one. <see cref="MaxRedirectHops"/> bounds it so an instance stuck in an
+    /// overlay↔heal loop still fails inside <see cref="RenderBudget"/>.</para>
+    /// </summary>
+    /// <param name="areaPath">Area (or sub-area) path to observe, e.g. <c>Explorer/toolbar</c>.</param>
+    /// <param name="client">Client hub to subscribe from; a fresh one is created per hop.</param>
+    /// <param name="hopsLeft">Remaining redirects this wait may follow.</param>
+    private IObservable<UiControl?> Rendered(
+        string areaPath, IMessageHub? client = null, int hopsLeft = MaxRedirectHops) =>
+        Observable.Defer(() =>
+                (client ?? GetClient(c => c.AddData(data => data)))
+                .GetWorkspace()
+                .GetRemoteStream<JsonElement, LayoutAreaReference>(
+                    new Address(LiveFramePath), new LayoutAreaReference(ExplorerArea))
+                .GetControlStream(areaPath))
+            .Where(c => c is not null)
+            .SelectMany(c => c is not RedirectControl
+                ? Observable.Return(c)
+                : hopsLeft > 0
+                    // Navigate: a fresh client ⇒ a fresh subscription ⇒ a fresh activation of the
+                    // instance hub, which re-enriches against the now-compiled NodeType.
+                    ? Observable.Defer(() =>
+                    {
+                        Output.WriteLine(
+                            $"[{areaPath}] compile-progress overlay redirected to "
+                            + $"{(c as RedirectControl)!.Href} — re-subscribing "
+                            + $"({hopsLeft - 1} hop(s) left)");
+                        return Rendered(areaPath, client: null, hopsLeft - 1);
+                    })
+                    : Observable.Empty<UiControl?>());
 }


### PR DESCRIPTION
Closes #2155.

`PandasExplorerLayoutAreaTest.Explorer_NoPythonNode_RendersToolbarAndDegradesGridWithoutHanging`
spends its whole 50 s budget on a `RedirectControl` and fails. Three occurrences in the last 300
`MeshWeaver Build and Test` runs (2026-08-24 14:18, 2026-08-25 09:43, 2026-08-25 18:32), each on a
branch whose diff cannot reach the Doc sample's layout composition.

## What actually happens — and it is not a slow render

When the cold Roslyn compile of the Pandas NodeType outlives
`NodeTypeEnrichmentHelpers.InFlightOverlayGrace` (5 s — a loaded CI runner routinely does), the
`LiveFrame` instance activates against the **compilation-in-progress overlay**, which serves
`NodeTypeLayoutAreas.CompileProgressView` on EVERY area. When the build lands `Ok` that view emits
a `RedirectControl` — and **the same event recycles the instance hub**: `WithOverlaySelfHeal` posts
a `DisposeRequest` to it so the next access re-enriches against the now-usable type.

A subscriber that merely keeps waiting is therefore attached to a hub that has gone away. The
redirect is the last thing it ever sees, and the remaining ~45 s of the budget are spent on a dead
stream — exactly what the issue recorded:

```
Last of 3 emission(s) was: RedirectControl { …, Href = /Doc/DataMesh/PythonPandasNode/PandasExplorer/LiveFrame/Explorer }
```

Per no-band-aids: the bound is the detector, so this does not widen it. What was missing is that
**the test never did what a client does with a redirect.**

## The fix — follow it, the way the client does

Blazor's `DispatchView` answers a `RedirectControl` with `NavigationManager.NavigateTo(href)`, i.e.
a fresh area subscription. Every wait now goes through a `Rendered(...)` helper that, on a
`RedirectControl`, re-subscribes from a **fresh client hub**. A new client is this test's
navigation: its workspace opens a brand-new remote stream rather than handing back the orphaned one
out of `Workspace._remoteStreamCache` (keyed on owner + reference + identity, so re-asking the same
client would return the same dead stream).

No timer, no retry, no widened bound — the redirect IS the event, and each hop is driven by
receiving one. `MaxRedirectHops` bounds it so an instance stuck in an overlay↔heal loop still fails
inside the 50 s budget instead of spinning.

## RED before / GREEN after — deterministic, no timing

`InFlightOverlayGrace` was temporarily set to 1 ms locally, which forces the overlay path CI only
reaches under load:

| tree | grace | outcome |
|---|---|---|
| `main` | 1 ms | **FAIL at 50 s** — `Last of 6 emission(s) was: RedirectControl … Href = /Doc/.../LiveFrame/Explorer` (the issue's text, verbatim) |
| this PR | 1 ms | **PASS in 2 s**, logging `[Explorer] compile-progress overlay redirected to … — re-subscribing (2 hop(s) left)` |
| this PR | 5 s (shipped) | **PASS in 2 s** — the fast path is untouched |

The grace change was only a probe; it is not in this diff (`git diff origin/main...HEAD --stat` is
one file, the test).

## Noted while investigating, NOT fixed here

The same shape is worth a look in production and is filed as a comment on #2155 rather than smuggled
in: the overlay's redirect href is the URL the user is **already on**, and `LayoutAreaView` is keyed
on the stream identity `(Address, Reference)` — which the redirect does not change — so
`NavigateTo(sameUrl)` need not remount it, and `Workspace._remoteStreamCache` would hand the
remounted view the same orphaned stream. That is a separate question from this flake and needs a
browser to settle.

## What's New

Skipped: test-only change, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
