### PR TITLE
Fingerprint module assets (#1974); retire the unreachable paging fan-out (#2048)

### DIFF
--- a/src/MeshWeaver.Blazor/Infrastructure/UserIdentityCache.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/UserIdentityCache.cs
@@ -249,14 +249,19 @@ public sealed class UserIdentityCache : IDisposable
         // not shorten a list, it changes who the portal thinks you are.
         //
         //   • Complete() — the query is UNPINNED (no path:/namespace:), so on Postgres it is
-        //     served by the cross-schema fan-out, which answers a request that states no limit
-        //     with a PAGE: the 50 most recently modified matches, ordered last_modified DESC
-        //     (PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit). Every user outside that
-        //     page fell out of the index. And because a User node's last_modified only moves when
-        //     the PROFILE is written, the omission is self-reinforcing: the longer you go without
-        //     editing your profile, the more certainly you are missing — the identical shape as
-        //     #1216 (baked 237 NodeTypes against 50 Code nodes) and #1326 (9 of 43 Spaces
-        //     permanently stale). This is an ENUMERATION, so it says so.
+        //     served by the cross-schema fan-out. When that fan-out substituted a 50-row default
+        //     for a request stating no limit, every user outside the 50 most recently modified
+        //     matches fell out of the index — and because a User node's last_modified only moves
+        //     when the PROFILE is written, the omission was self-reinforcing: the longer you went
+        //     without editing your profile, the more certainly you were missing (the identical
+        //     shape as #1216 and #1326).
+        //     🚨 That default is GONE (#2048 deleted the paging fan-out shape, which no runtime
+        //     caller could reach), so this call no longer changes what THIS query returns — and
+        //     saying so is the point, because a call credited with a truncation the runtime does
+        //     not perform is one nobody can test. It stays because it is the DECLARATION that this
+        //     read is an enumeration: it overrides any limit that reaches the request, and it is
+        //     what a future bound would have to honour. UserDirectoryCompletenessTests pins it as
+        //     a property of the query, which is where it is falsifiable.
         //   • AsSystem() — the directory is process-wide and is consumed to resolve the CALLING
         //     user's own identity, so it must not be scoped to whichever caller happened to
         //     resolve this singleton first. MeshService.StampViewer pins the viewer from the

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -791,7 +791,7 @@ Populated automatically by `rebuild_user_effective_permissions()` in each partit
 
 ## Partition access in search
 
-Cross-schema search (`search_across_schemas`) enforces partition access at the SQL level. The access control clause requires:
+Cross-schema search enforces partition access at the SQL level — in the UNION branch `PostgreSqlSqlGenerator.GenerateCrossSchemaSelectQuery` emits per schema. The access control clause requires:
 
 1. **Partition access** — user must have a `partition_access` entry for the schema (always required)
 2. **Node-level permission** — user must have Read permission on the node's `main_node` path

--- a/src/MeshWeaver.Documentation/Data/Architecture/PostgresSchemaArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PostgresSchemaArchitecture.md
@@ -197,7 +197,7 @@ The `public` schema plays a single, well-defined role: it holds the cross-partit
 | Table | Purpose |
 |---|---|
 | `partition_access` | Binary "user X has any access to partition P" gate. PK `(user_id, partition)`. Populated by per-schema `rebuild_user_effective_permissions`. |
-| `searchable_schemas` | Schemas that cross-schema search (`search_across_schemas`) iterates over. Repopulated on every migration run. |
+| `searchable_schemas` | Schemas the cross-schema UNION fans out over. Repopulated on every migration run. |
 | `node_type_permissions` | 🪦 **Legacy, always empty, read by nothing** (issue #953). Kept for one release only so a rolling deploy's older replicas don't fault on the table name; a follow-up migration drops it. See "Why there is no node-type public read" below. |
 | `user_effective_permissions` and `_shadow` | Denormalised cache of every `(user, path-prefix, permission)` tuple. The shadow is rebuilt then atomically swapped (`PostgreSqlSchemaInitializer.cs:542`). |
 | `change_logs` | Partition-level change feed. |
@@ -256,7 +256,9 @@ No row here means the user cannot read **anything** in the partition, regardless
 **Gate 2 — node gate**
 A matching row in `{schema}.user_effective_permissions` with the longest-prefix match against the node's path, folded per subject and OR'd across subjects. There is **no bypass** of this gate.
 
-Cross-schema search (`public.search_across_schemas`) iterates `searchable_schemas`, applies both gates per schema, and returns only rows where both pass. See `PostgreSqlSchemaInitializer.cs:34`.
+Cross-schema search iterates `searchable_schemas`, applies both gates per schema, and returns only rows where both pass. The runtime builds that UNION in C# — `PostgreSqlSqlGenerator.GenerateCrossSchemaSelectQuery`, one branch per schema carrying the per-schema `user_effective_permissions` clause.
+
+> 🚨 **`public.search_across_schemas` is no longer called by the portal.** The plpgsql function still exists (an older replica mid-rollout still calls it, so it is not dropped), and it enforces the same two gates — see `PostgreSqlSchemaInitializer.cs:74`. But it backed a *second* fan-out shape whose only distinctive behaviour was clipping an unlimited query at 50 rows, and no runtime caller ever reached it: `PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync` has only ever taken the table-name overload. That overload was deleted in #2048 — two independent access-control implementations for one logical query, one of them unexercised, is where a security fix lands on the wrong copy.
 
 ### Why there is no node-type public read
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-view-pack-styles-refresh-immediately.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-view-pack-styles-refresh-immediately.md
@@ -1,0 +1,23 @@
+---
+Name: Updated view packs look right straight away
+Category: Fix
+Description: A newly installed or updated view pack's styling now reaches the browser on the next page load instead of waiting for a cache to expire.
+Icon: ArrowSync
+Order: -20260825
+---
+
+# Updated view packs look right straight away
+
+View packs — the packages that draw maps, charts and the everyday controls — ship their own
+styling. Until now the browser was told nothing about how long it could keep a copy of those files,
+so it guessed. A pack that had just been installed or updated could go on being drawn with the
+previous version's styling for as long as the guess lasted, and a reload did not necessarily help.
+
+Two things changed. Each pack's stylesheet is now published at an address that changes whenever its
+contents change, so an update is picked up on the very next page load and never mistaken for the
+old one. And because that address can only ever mean one thing, the browser keeps it for good: a
+deployment that has not changed a pack now costs no extra requests at all where it used to re-check
+every file on every page.
+
+Everything else a pack ships is now explicitly marked as needing a quick check before use, so the
+newest version always wins.

--- a/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
@@ -59,6 +59,19 @@ public static partial class MeshModuleStaticAssetExtensions
     private static readonly PrecompressedContentTypeProvider PrecompressedContentTypes = new();
 
     /// <summary>
+    /// What a FINGERPRINTED URL may promise: the bytes behind it can never change, so a browser
+    /// that has them never asks again. One year is the conventional "forever" (RFC 8246 §2 puts
+    /// the practical ceiling there).
+    /// </summary>
+    private const string ImmutableCacheControl = "public, max-age=31536000, immutable";
+
+    /// <summary>
+    /// What an UNFINGERPRINTED URL may promise: nothing. Store it, but revalidate before every
+    /// use — a 304 while the module is unchanged, the new bytes the moment it is upgraded.
+    /// </summary>
+    private const string RevalidateCacheControl = "no-cache";
+
+    /// <summary>
     /// Registers the <see cref="ModuleStaticAssetManifest"/> — what each installed module
     /// contributes, resolved once on first use. Pair it with
     /// <see cref="UseMeshModuleStaticAssets"/>; a host that mounts without registering gets a
@@ -118,20 +131,23 @@ public static partial class MeshModuleStaticAssetExtensions
                 Provider: new PhysicalFileProvider(mount.PhysicalPath)))
             .ToArray();
 
-        // A module aggregate whose host-provided @imports were stripped is served from MEMORY,
-        // ahead of the mounts — the landed bytes stay exactly as published (a generation is
-        // immutable), and only the response differs. Also ahead of encoding negotiation: the
-        // rewritten body has no precompressed sibling to negotiate to.
-        var rewrites = manifest.RewrittenStylesheets;
-        if (rewrites is { Count: > 0 })
+        // Every linked scoped-CSS aggregate is served from MEMORY, ahead of the mounts — the
+        // landed bytes stay exactly as published (a generation is immutable), and only the
+        // response differs. Also ahead of encoding negotiation: the served body has no
+        // precompressed sibling to negotiate to.
+        var bodies = manifest.StylesheetBodies;
+        if (bodies is { Count: > 0 })
             app.Use(async (context, next) =>
             {
                 if (HttpMethods.IsGet(context.Request.Method)
-                    && rewrites.TryGetValue(context.Request.Path.Value ?? "", out var body))
+                    && bodies.TryGetValue(context.Request.Path.Value ?? "", out var stylesheet))
                 {
                     context.Response.ContentType = "text/css";
                     context.Response.Headers.Vary = HeaderNames.AcceptEncoding;
-                    await context.Response.WriteAsync(body);
+                    context.Response.Headers.CacheControl = stylesheet.Immutable
+                        ? ImmutableCacheControl
+                        : RevalidateCacheControl;
+                    await context.Response.WriteAsync(stylesheet.Body);
                     return;
                 }
                 await next();
@@ -151,11 +167,25 @@ public static partial class MeshModuleStaticAssetExtensions
                 FileProvider = provider,
                 RequestPath = requestPath,
                 ContentTypeProvider = PrecompressedContentTypes,
-                // Every representation of these URLs varies by Accept-Encoding — including the
-                // identity one, or a shared cache hands a brotli body to a client that cannot
-                // decode it.
                 OnPrepareResponse = static served =>
-                    served.Context.Response.Headers.Vary = HeaderNames.AcceptEncoding,
+                {
+                    // Every representation of these URLs varies by Accept-Encoding — including the
+                    // identity one, or a shared cache hands a brotli body to a client that cannot
+                    // decode it.
+                    served.Context.Response.Headers.Vary = HeaderNames.AcceptEncoding;
+                    // 🚨 STATE the caching policy, never leave it to heuristics. These URLs carry
+                    // no fingerprint (a pack's component hard-codes
+                    // `_content/<Name>/<file>` in its OWN source — see the manifest remarks), so
+                    // `immutable` would be a lie. Saying nothing is worse than it looks: with no
+                    // Cache-Control at all a browser applies HEURISTIC freshness off
+                    // Last-Modified and may serve an UPGRADED module's asset from cache without
+                    // revalidating at all — a landed new generation whose CSS/JS never reaches the
+                    // viewer. `no-cache` means "you may store it, but revalidate before use", so
+                    // the conditional GET answers 304 while the module is unchanged and delivers
+                    // the new bytes the moment it is not. Same bargain MapStaticAssets makes for
+                    // the HOST's own unfingerprinted routes.
+                    served.Context.Response.Headers.CacheControl = RevalidateCacheControl;
+                },
             });
 
         return app;
@@ -296,7 +326,7 @@ public static partial class MeshModuleStaticAssetExtensions
 
         var mounts = new List<ModuleStaticAssetMount>();
         var stylesheets = new List<string>();
-        var rewrites = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var bodies = new Dictionary<string, ModuleStylesheetResponse>(StringComparer.OrdinalIgnoreCase);
         // First mount wins per request path — two modules carrying the SAME dependency (a shared
         // RCL) is ordinary composition, not a fault, so the second is skipped quietly rather than
         // refused. Shadowing the HOST is the case that must never happen, and that is the
@@ -329,7 +359,7 @@ public static partial class MeshModuleStaticAssetExtensions
             var bundlePath = Path.Combine(moduleWwwroot, $"{name}.styles.css");
             if (File.Exists(bundlePath))
             {
-                var requestPath = $"{ContentRoot}/{name}/{name}.styles.css";
+                var plainPath = $"{ContentRoot}/{name}/{name}.styles.css";
 
                 // 🚨 The aggregate opens with @import lines for its DEPENDENCIES' bundles at
                 // FINGERPRINTED urls, computed at MODULE-build time
@@ -339,8 +369,8 @@ public static partial class MeshModuleStaticAssetExtensions
                 // They are also redundant: the host already links its own aggregate, which contains
                 // those very bundles. Strip exactly those, by the SAME predicate that decides not to
                 // mount the dependency, so the two can never disagree about who provides what.
-                var rewritten = StripHostProvidedImports(
-                    File.ReadAllText(bundlePath), hostAssets, name, logger);
+                var landed = File.ReadAllText(bundlePath);
+                var rewritten = StripHostProvidedImports(landed, hostAssets, name, logger);
 
                 // A pack with NO .razor.css of its own still emits an aggregate — one made of
                 // nothing but those imports (211 bytes for AppleMaps and OpenStreetMap). Once they
@@ -356,9 +386,31 @@ public static partial class MeshModuleStaticAssetExtensions
                 }
                 else
                 {
-                    stylesheets.Add(requestPath);
-                    if (rewritten is not null)
-                        rewrites["/" + requestPath] = rewritten;
+                    // 🚨 FINGERPRINTED, because this is the ONE module asset whose URL the HOST
+                    // owns. Everything else under the mounts is addressed by a pack's own
+                    // component source (`_content/<Name>/GoogleMapView.razor.js`), so its URL
+                    // cannot be rewritten from here and can only ever be `no-cache`; this one is
+                    // linked by App.razor off THIS manifest, so the platform decides its spelling.
+                    // Putting the body's content hash in the path buys the two things
+                    // revalidation cannot: an upgrade is picked up INSTANTLY (a different URL,
+                    // never a stale cached copy) and an unchanged module costs ZERO requests
+                    // rather than one conditional GET per page render.
+                    //
+                    // The hash is over the body actually SERVED, not the landed file: two
+                    // generations whose aggregates differ only in host-provided @imports —
+                    // exactly what StripHostProvidedImports removes — collapse to the same URL,
+                    // which is the correct answer for a byte-identical response.
+                    var body = rewritten ?? landed;
+                    var fingerprintedPath =
+                        $"{ContentRoot}/{name}/{name}.{Fingerprint(body)}.styles.css";
+
+                    stylesheets.Add(fingerprintedPath);
+                    bodies["/" + fingerprintedPath] = new ModuleStylesheetResponse(body, true);
+                    // The plain path is served too — nothing links it, but leaving it to fall
+                    // through to the mount would serve the LANDED file, whose host-provided
+                    // @imports point at fingerprints only the module's own build ever had (they
+                    // 404, silently, once per page load). One body, two URLs, one truth.
+                    bodies["/" + plainPath] = new ModuleStylesheetResponse(body, false);
                 }
             }
 
@@ -403,7 +455,7 @@ public static partial class MeshModuleStaticAssetExtensions
                 "Module static assets: {Count} root(s) mounted, {Stylesheets} stylesheet(s) to link",
                 mounts.Count, stylesheets.Count);
 
-        return new ModuleStaticAssetManifest(mounts, stylesheets, rewrites);
+        return new ModuleStaticAssetManifest(mounts, stylesheets, bodies);
     }
     /// <summary>
     /// Where a boot-installed module's published static web assets live: <c>wwwroot</c> BESIDE the
@@ -493,6 +545,22 @@ public static partial class MeshModuleStaticAssetExtensions
     [GeneratedRegex("""^\s*@import\s+['"]_content/(?<dep>[^/'"]+)/[^'"]*['"]\s*;""")]
     private static partial Regex ImportedContentBundle();
 
+    /// <summary>
+    /// The URL-safe content fingerprint of a served body: 16 hex characters (64 bits) of its
+    /// SHA-256. Long enough that a collision between two generations of one module's stylesheet is
+    /// not a thing that happens; short enough to read in a page source.
+    ///
+    /// <para>Derived from the CONTENT, never from a version string or a landing timestamp: a
+    /// generation is a new directory whether or not its bytes changed, so a
+    /// generation-derived token would invalidate every viewer's cached copy on a republish that
+    /// changed nothing — the cost this fingerprint exists to remove.</para>
+    /// </summary>
+    private static string Fingerprint(string body) =>
+        Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(body)))[..16]
+            .ToLowerInvariant();
+
 }
 
 /// <summary>One mounted asset root: everything under <paramref name="PhysicalPath"/> is served at
@@ -511,12 +579,38 @@ public sealed record ModuleStaticAssetMount(string RequestPath, string PhysicalP
 /// standalone and nothing links it — which renders the module's components unstyled while every
 /// script still works, the most confusing possible half-failure. Hosts render one
 /// <c>&lt;link&gt;</c> per <paramref name="Stylesheets"/> entry to close that gap.</para>
+///
+/// <para><b>Fingerprinting, and the one place it can reach.</b> The linked bundle is the ONLY
+/// module asset whose URL the platform authors, so it is the only one that can carry a content
+/// fingerprint: everything else under the mounts is addressed by a pack's own component source
+/// (<c>RadzenViewBase</c> self-loads <c>_content/Radzen.Blazor/…</c>; <c>GoogleMapView.razor.cs</c>
+/// imports <c>./_content/MeshWeaver.Blazor.GoogleMaps/GoogleMapView.razor.js</c>), which is not in
+/// this build graph and cannot be rewritten from the host. Those URLs are therefore served
+/// <c>no-cache</c> — correct on upgrade, one conditional GET per render — and the fingerprinted
+/// bundle is served <c>immutable</c>, which costs nothing at all.</para>
 /// </summary>
 /// <param name="Mounts">Asset roots to serve, in module order.</param>
 /// <param name="Stylesheets">
-/// Root-relative paths (<c>_content/&lt;Name&gt;/&lt;Name&gt;.styles.css</c>), in module order.
+/// Root-relative FINGERPRINTED paths (<c>_content/&lt;Name&gt;/&lt;Name&gt;.&lt;hash&gt;.styles.css</c>),
+/// in module order. Each is a key of <paramref name="StylesheetBodies"/>.
+/// </param>
+/// <param name="StylesheetBodies">
+/// Every stylesheet URL this lane answers from MEMORY, rooted (leading <c>/</c>) — the
+/// fingerprinted path a host links AND the plain <c>&lt;Name&gt;.styles.css</c> it supersedes, both
+/// carrying the same body. Serving the plain path too keeps the LANDED file — whose host-provided
+/// <c>@import</c>s name fingerprints only the module's own build ever had — from being reached
+/// through the mount underneath.
 /// </param>
 public sealed record ModuleStaticAssetManifest(
     IReadOnlyList<ModuleStaticAssetMount> Mounts,
     IReadOnlyList<string> Stylesheets,
-    IReadOnlyDictionary<string, string>? RewrittenStylesheets = null);
+    IReadOnlyDictionary<string, ModuleStylesheetResponse>? StylesheetBodies = null);
+
+/// <summary>One stylesheet URL answered from memory.</summary>
+/// <param name="Body">The CSS to write.</param>
+/// <param name="Immutable">
+/// Whether the URL carries the body's content fingerprint. Fingerprinted ⇒ the bytes behind this
+/// URL can never change, so it is answered <c>immutable</c> and never revalidated; otherwise
+/// <c>no-cache</c>, because a module upgrade changes what the plain URL means.
+/// </param>
+public sealed record ModuleStylesheetResponse(string Body, bool Immutable);

--- a/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
@@ -143,7 +143,16 @@ public static partial class MeshModuleStaticAssetExtensions
                     && bodies.TryGetValue(context.Request.Path.Value ?? "", out var stylesheet))
                 {
                     context.Response.ContentType = "text/css";
-                    context.Response.Headers.Vary = HeaderNames.AcceptEncoding;
+                    // 🚨 NO `Vary: Accept-Encoding` here, deliberately — do not "harmonise" this
+                    // with the mounts below. This body is written from memory, identity-encoded,
+                    // and the encoding negotiation runs AFTER this middleware, so the response is
+                    // byte-identical whatever the client accepts (and no response-compression
+                    // middleware is registered anywhere in the host to make it otherwise). Vary is
+                    // a promise that the response DOES differ; stating it when it does not splits
+                    // a shared cache's key per Accept-Encoding value and buys nothing — which
+                    // matters most on the fingerprinted URL, whose whole point is one cached copy
+                    // that lives a year. The mounts keep Vary because there it is true: the
+                    // negotiation genuinely serves a .br or .gz body to a client that accepts one.
                     context.Response.Headers.CacheControl = stylesheet.Immutable
                         ? ImmutableCacheControl
                         : RevalidateCacheControl;

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
@@ -8,14 +8,22 @@ using Npgsql;
 namespace MeshWeaver.Hosting.PostgreSql;
 
 /// <summary>
-/// PostgreSQL implementation of ICrossSchemaQueryProvider.
-/// Uses the search_across_schemas() stored procedure for single-query fan-out.
-/// Schema list is maintained in public.searchable_schemas table.
+/// PostgreSQL implementation of ICrossSchemaQueryProvider — one UNION ALL across every partition
+/// schema, generated in C# by <see cref="PostgreSqlSqlGenerator.GenerateCrossSchemaSelectQuery"/>.
+/// The schema list is maintained in <c>public.searchable_schemas</c>.
+///
+/// <para>🚨 The <c>public.search_across_schemas(...)</c> stored function is NOT used here any more.
+/// It backed a second fan-out shape that clipped an unlimited query at 50 rows, and no runtime
+/// caller ever reached it — <c>PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync</c>, the path
+/// for EVERY unpinned query, has only ever taken the table-name overload. It is deleted rather
+/// than kept "in case paging is wanted": a silent default clip is the defect #1216/#1326/#1960
+/// were filed against, and a SECOND access-control implementation that nothing exercises is a
+/// place for a security fix to land on the wrong copy (#2048). The SQL function itself stays in
+/// the schema — an older portal replica mid-rollout still calls it.</para>
 /// </summary>
 public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
 {
     private readonly NpgsqlDataSource _dataSource;
-    private readonly PostgreSqlSqlGenerator _sqlGenerator = new();
     private readonly ILogger? _logger;
 
     /// <summary>
@@ -285,195 +293,6 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         }
     }
 
-    /// <inheritdoc />
-    public async IAsyncEnumerable<MeshNode> QueryAcrossSchemasAsync(
-        ParsedQuery query,
-        JsonSerializerOptions options,
-        IReadOnlyList<string> schemas,
-        string? userId = null,
-        [EnumeratorCancellation] CancellationToken ct = default)
-    {
-        // Build WHERE clause from parsed query (without access control or text search —
-        // access control is handled by the stored proc, text search is added below with tsvector).
-        // Strip TextSearch to avoid double ILIKE: GenerateWhereClause would add its own ILIKE,
-        // and we add a tsvector-indexed search below.
-        var queryForWhere = query with { TextSearch = null };
-        var (whereClause, parameters) = _sqlGenerator.GenerateWhereClause(queryForWhere);
-
-        // Strip "WHERE " prefix — the stored proc adds its own WHERE
-        var filterClause = whereClause.StartsWith("WHERE ")
-            ? whereClause[6..] : whereClause;
-
-        // Add scope clause (e.g., namespace:'' → n.namespace = '' for root-level nodes)
-        if (query.Path != null)
-        {
-            var (scopeClause, scopeParams) = _sqlGenerator.GenerateScopeClause(query.Path, query.Scope);
-            if (!string.IsNullOrEmpty(scopeClause))
-            {
-                if (!string.IsNullOrEmpty(filterClause))
-                    filterClause += " AND ";
-                filterClause += scopeClause;
-                foreach (var (k, v) in scopeParams)
-                    parameters[k] = v;
-            }
-        }
-
-        // Inline parameter values into the SQL string. Filter out null/empty keys
-        // defensively — a malformed parameter (rare but observed in prod when an
-        // unscoped query path adds a placeholder without a name) used to NRE here.
-        foreach (var (name, value) in parameters
-            .Where(p => !string.IsNullOrEmpty(p.Key))
-            .OrderByDescending(p => p.Key.Length))
-        {
-            var sqlValue = value switch
-            {
-                string s => $"'{EscapeSql(s)}'",
-                bool b => b ? "true" : "false",
-                int i => i.ToString(),
-                long l => l.ToString(),
-                double d => d.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                DateTimeOffset dto => $"'{dto:yyyy-MM-dd HH:mm:ss.ffffffzzz}'",
-                _ => $"'{EscapeSql(value?.ToString() ?? "")}'"
-            };
-            filterClause = filterClause.Replace(name, sqlValue);
-        }
-
-        // Add text search if present — use tsvector for indexed word matching,
-        // with ILIKE fallback for partial/path matches the tsvector misses.
-        if (!string.IsNullOrEmpty(query.TextSearch))
-        {
-            var escaped = EscapeSql(query.TextSearch);
-            // Split into words, each as prefix match (e.g., "Acme Corp" → "Acme:* & Corp:*")
-            var words = escaped.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            var tsTerms = string.Join(" & ", words.Select(w => $"{w}:*"));
-
-            var tsvectorExpr = "to_tsvector('english', COALESCE(n.name,'') || ' ' || COALESCE(n.description,'') || ' ' || COALESCE(n.node_type,''))";
-            var ilikeFallback = $"COALESCE(n.name,'') || ' ' || n.path || ' ' || COALESCE(n.node_type,'')";
-
-            if (!string.IsNullOrEmpty(filterClause))
-                filterClause += " AND ";
-            // tsvector uses the GIN index; ILIKE catches path/id matches
-            filterClause += $"({tsvectorExpr} @@ to_tsquery('english', '{tsTerms}') OR {ilikeFallback} ILIKE '%{escaped}%')";
-        }
-
-        // Build ORDER BY
-        var orderBy = query.OrderBy != null
-            ? $"{PostgreSqlSqlGenerator.MapSelector(query.OrderBy.Property)} {(query.OrderBy.Descending ? "DESC" : "ASC")}"
-            : "n.last_modified DESC";
-
-        // 🚨 THREE cases, and conflating the last two is how spaces go silently stale.
-        //   • no limit stated  → DefaultFanOutLimit. An unanchored UNION over every partition
-        //     schema needs SOME bound, and a search wants a page anyway.
-        //   • MeshQueryRequest.NoLimit (non-positive) → the caller declared this an ENUMERATION,
-        //     so return every match. `LIMIT 0` / `LIMIT -1` must never reach SQL; the largest INT
-        //     is `LIMIT ALL` in practice and needs no change to the stored function.
-        //   • a positive limit → honour it.
-        var limit = query.Limit switch
-        {
-            null => DefaultFanOutLimit,
-            <= 0 => int.MaxValue,
-            var stated => stated.Value,
-        };
-        var clippedByDefault = query.Limit is null;
-
-        // 🚨 Fetch ONE row past the default so the warning below can state truncation as a FACT.
-        // "rows == the limit" does not mean rows were dropped — a query with exactly
-        // DefaultFanOutLimit matches is complete — and a warning that cries truncation on a
-        // complete result trains readers to ignore it, which is how the next real one gets missed.
-        // The probe row is read but never yielded, so the caller's result is unchanged; the cost is
-        // one row on a query that already scanned every partition schema. Only for the default
-        // clip: a stated limit is the caller's own paging (no claim to make) and NoLimit is already
-        // int.MaxValue (where +1 would overflow).
-        var fetchLimit = clippedByDefault ? limit + 1 : limit;
-
-        _logger?.LogInformation(
-            "[CrossSchema] search_across_schemas(where='{Where}', user='{User}', order='{Order}', limit={Limit})",
-            filterClause, userId, orderBy, limit);
-
-        // Call the stored procedure using named parameters
-        await using var cmd = _dataSource.CreateCommand(
-            "SELECT * FROM public.search_across_schemas(@p_where, @p_user, @p_order, @p_limit) " +
-            "AS t(id TEXT, namespace TEXT, name TEXT, node_type TEXT, category TEXT, icon TEXT, " +
-            "display_order INT, last_modified TIMESTAMPTZ, version BIGINT, state SMALLINT, " +
-            "content JSONB, desired_id TEXT, main_node TEXT)");
-        cmd.Parameters.Add(new NpgsqlParameter("@p_where", string.IsNullOrEmpty(filterClause) ? "" : filterClause));
-        cmd.Parameters.Add(new NpgsqlParameter("@p_user", (object?)userId ?? DBNull.Value));
-        cmd.Parameters.Add(new NpgsqlParameter("@p_order", orderBy));
-        cmd.Parameters.Add(new NpgsqlParameter("@p_limit", fetchLimit));
-
-        // ⏱️ TIMED, because this is the expensive shape and nothing used to measure it.
-        // search_across_schemas builds a UNION ALL over EVERY row of public.searchable_schemas,
-        // so an unanchored query (no path:/namespace: first segment) scans every partition —
-        // every plugin AND every user partition. Its cost therefore grows with the number of
-        // users on the mesh, which makes it get quietly slower over months with no code change.
-        // Log the fan-out width next to the elapsed time so a slow query says WHY it was slow;
-        // a WHERE-clause dump alone (the previous logging) cannot distinguish "bad filter" from
-        // "300 schemas". Escalates to Warning past the threshold so it shows at default level.
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        var rows = 0;
-        var firstRowMs = -1L;
-        // Set only when the probe row exists — i.e. matches were genuinely dropped.
-        var truncated = false;
-        // Transient-fault retry on the OPEN (see ExecuteReaderWithTransientRetryAsync). The primary
-        // fan-out has the same exposure as the satellite one in #2132: a dropped connection or a
-        // 40P01 while planning a UNION over every partition schema is a momentary condition, and
-        // un-retried it faulted the whole area render. Nothing is swallowed — an exhausted or
-        // non-transient fault still propagates.
-        await using var reader = await ExecuteReaderWithTransientRetryAsync(
-            cmd, "search_across_schemas", ct).ConfigureAwait(false);
-        // 🚨 try/FINALLY, not a call after the loop. A caller that stops enumerating early — a
-        // `.Take(n)`, a `break`, a cancellation, or a throw out of ReadMeshNode — disposes the
-        // iterator without ever reaching code placed after the `while`. The slow fan-out would then
-        // go UNLOGGED, which is the one case this instrumentation exists to catch. `finally` runs on
-        // that disposal path too, so an abandoned enumeration still reports what it cost.
-        try
-        {
-            while (await reader.ReadAsync(ct).ConfigureAwait(false))
-            {
-                // The probe row proves there was more, and is NOT part of the answer.
-                if (rows == limit)
-                {
-                    truncated = true;
-                    break;
-                }
-                if (rows++ == 0)
-                    firstRowMs = sw.ElapsedMilliseconds;
-                yield return ReadMeshNode(reader, options);
-            }
-        }
-        finally
-        {
-            LogFanOutTiming("search_across_schemas", sw.ElapsedMilliseconds, firstRowMs, rows, limit);
-
-            // 🚨 A DEFAULT that clipped must never be silent. The caller stated no limit, so it
-            // cannot distinguish "these are all the matches" from "these are the 50 most recently
-            // modified matches" — and because the order is `last_modified DESC`, the rows that fall
-            // off are precisely the ones that have gone longest without being touched. That makes
-            // the omission self-reinforcing: processing a row refreshes it, so the winners stay in
-            // the window and the stragglers sink further. #1216 (batch bake saw 50 of thousands of
-            // Code nodes) and #1326 (9 of 43 Spaces never re-synced while the webhook reported
-            // success) are the same line of code seen twice. Say so, and name the cure.
-            //
-            // `truncated` is a FACT, not an inference from the row count: it is set only when a row
-            // beyond the limit actually existed. A query with exactly DefaultFanOutLimit matches is
-            // complete and stays silent.
-            if (truncated)
-                _logger?.LogWarning(
-                    "[CrossSchema] TRUNCATED at the default fan-out limit of {Limit} rows — matches "
-                    + "beyond it were DROPPED (where='{Where}', order='{Order}'). The caller stated no "
-                    + "limit, so this result is a PAGE — the most recently modified matches — not the "
-                    + "complete set, and there is no way for it to tell. If the caller enumerates the "
-                    + "result as the whole set, it must say MeshQueryRequest.Complete().",
-                    DefaultFanOutLimit, filterClause, orderBy);
-        }
-    }
-
-    /// <summary>
-    /// Rows returned to a cross-schema query that states NO limit. A page size for a search, never
-    /// a completeness guarantee — see the truncation warning in
-    /// <c>QueryAcrossSchemasAsync</c> and <c>MeshQueryRequest.Complete()</c>.
-    /// </summary>
-    internal const int DefaultFanOutLimit = 50;
 
     /// <summary>Elapsed above which a cross-schema fan-out is logged as a Warning, not Debug.</summary>
     internal const long SlowFanOutMs = 1000;
@@ -695,10 +514,41 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         // or at the first ReadAsync (when PG defers). Catch at both seams and
         // treat as no rows; the next query will see the now-existing table
         // after the write commits.
-        await foreach (var node in EnumerateReaderOrEmptyOnMissingRelationAsync(
-            cmd, options, schemas, tableName, ct).WithCancellation(ct).ConfigureAwait(false))
+        // ⏱️ TIMED, because this IS the expensive shape: an unanchored query UNIONs every row of
+        // public.searchable_schemas, so its cost grows with the number of partitions on the mesh
+        // and gets quietly slower over months with no code change. The fan-out width is logged
+        // beside the elapsed time so a slow query says WHY it was slow — a WHERE-clause dump alone
+        // cannot distinguish "bad filter" from "300 schemas".
+        //
+        // 🚨 It is measured HERE, on the overload every runtime fan-out takes
+        // (PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync → this method). It used to sit on
+        // the paging overload instead — which no request could reach — so the instrumentation for
+        // the expensive shape produced not one line in production (#2048).
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var rows = 0;
+        var firstRowMs = -1L;
+        // 🚨 try/FINALLY, not a call after the loop. A caller that stops enumerating early — a
+        // `.Take(n)`, a `break`, a cancellation, or a throw — disposes the iterator without ever
+        // reaching code placed after the `await foreach`, and the slow fan-out would go UNLOGGED:
+        // the one case this instrumentation exists to catch.
+        try
         {
-            yield return node;
+            await foreach (var node in EnumerateReaderOrEmptyOnMissingRelationAsync(
+                cmd, options, schemas, tableName, ct).WithCancellation(ct).ConfigureAwait(false))
+            {
+                if (rows++ == 0)
+                    firstRowMs = sw.ElapsedMilliseconds;
+                yield return node;
+            }
+        }
+        finally
+        {
+            // `limit` is what the caller ASKED for, not a default this method applied — there is
+            // none. `0` reads as "unbounded", which is the honest answer for an unpinned query
+            // that stated no limit: every match comes back (#2048).
+            LogFanOutTiming(
+                tableName, sw.ElapsedMilliseconds, firstRowMs, rows,
+                query.Limit is > 0 ? query.Limit.Value : 0);
         }
     }
 
@@ -856,7 +706,4 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
             await Task.Delay(retryAfter, ct).ConfigureAwait(false);
         }
     }
-
-    private static string EscapeSql(string input) =>
-        input.Replace("'", "''");
 }

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
@@ -876,13 +876,16 @@ public sealed class PostgreSqlPartitionedMeshQuery : IMeshQueryProvider
 
         // 🚨 Carry the REQUEST-level limit into the parsed query — the same propagation the
         // per-schema delegate does (PostgreSqlMeshQuery: `if (request.Limit.HasValue) parsedQuery =
-        // parsedQuery with { Limit = request.Limit }`). Without it, `request.Limit` was silently
-        // DROPPED on the unpinned path: QueryAcrossSchemasAsync reads only ParsedQuery.Limit and
-        // substitutes a hard default of 50, so a caller asking for 500 across partitions got 50 and
-        // had no way to tell (issue #1216 — the batch bake's global `nodeType:Code` fetch is exactly
-        // this shape and resolved 50 Code nodes out of thousands). A request that states no limit at
-        // all still gets the fan-out's default: an unanchored UNION over every partition schema
-        // needs SOME bound, and changing that default is a separate decision.
+        // parsedQuery with { Limit = request.Limit }`). Without it, `request.Limit` is silently
+        // DROPPED on the unpinned path — QueryAcrossSchemasAsync reads only ParsedQuery.Limit — so
+        // a caller asking for 500 across partitions would get whatever the query STRING said, and
+        // have no way to tell (issue #1216 — the batch bake's global `nodeType:Code` fetch is
+        // exactly this shape).
+        // 🚨 A request that states no limit at all now gets EVERY match. The fan-out overload this
+        // method calls applies no default clip, and the paging overload that did substitute 50 is
+        // deleted (#2048) — it had no runtime caller, and a silent default is the defect #1216 and
+        // #1326 were filed against. If a bound is ever wanted for an unanchored UNION, it belongs
+        // on this ONE shape and it has to be LOUD.
         // 🚨 Propagate the request limit WHATEVER its sign, including the non-positive "no clip"
         // encoding (MeshQueryRequest.NoLimit). It used to be dropped for `<= 0` because a zero
         // reached SQL as a literal `LIMIT 0` — ZERO ROWS for a caller that asked for everything —

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSqlGenerator.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSqlGenerator.cs
@@ -607,10 +607,19 @@ public class PostgreSqlSqlGenerator
             // For plain queries, n.last_modified is fine.
             var lastModifiedExpr = isActivity ? "act.last_modified" : (isAccessed ? "ua.last_modified" : "n.last_modified");
 
+            // 🚨 `n.path` is projected because the ORDER BY is applied to the OUTER select over the
+            // union, where only the union's OWN columns are in scope: without it `sort:path` fails
+            // with `42703 column "path" does not exist`, whatever the branch tables carry. That is
+            // issue #2186 — whose fix landed on `public.search_across_schemas`, i.e. on the paging
+            // fan-out shape no runtime caller could reach, so mesh-wide keyset paging stayed broken
+            // on the shape every unpinned query actually takes. (Deleting that shape, #2048, is what
+            // surfaced it.) Every branch below must project the same columns in the same positions —
+            // UNION ALL is positional — so the content branch carries a `path` expression too.
             var selectSql = "SELECT n.id, n.namespace, n.name, n.node_type, n.description, " +
                 $"n.category, n.icon, n.display_order, {lastModifiedExpr} AS last_modified, " +
                 "n.version, n.state, n.content, " +
-                $"n.desired_id, n.main_node, {SyncBehaviorColumn(tableName)} FROM {qualifiedTable} n";
+                $"n.desired_id, n.main_node, {SyncBehaviorColumn(tableName)}, n.path " +
+                $"FROM {qualifiedTable} n";
 
             if (isAccessed)
                 selectSql += $" INNER JOIN {userActivityTable} ua ON ua.namespace = @actUserNs" +
@@ -653,7 +662,7 @@ public class PostgreSqlSqlGenerator
         // Content branches — only for a FREE-TEXT omnibox query, and only over schemas that hold a
         // content_chunks table. Each branch lexically matches the chunk text and projects each file's
         // best chunk to its synthetic Document row (slug + _Documents namespace — replicates
-        // DocumentPaths.For/Slug; see SlugSql). The 15 projected columns align positionally with the
+        // DocumentPaths.For/Slug; see SlugSql). The 16 projected columns align positionally with the
         // mesh_nodes branches above so the outer SELECT * / ReadMeshNode shape is uniform; the term is
         // inlined (this generator inlines all params) and single-quotes doubled, mirroring the
         // mesh_nodes text-rank term handling below.
@@ -677,7 +686,10 @@ public class PostgreSqlSqlGenerator
                     "cc.last_modified AS last_modified, 0::bigint AS version, 2::smallint AS state, " +
                     "NULL::jsonb AS content, NULL::text AS desired_id, " +
                     $"cc.collection_path || '/_Documents/' || {SlugSql} AS main_node, " +
-                    "0::smallint AS sync_behavior " +
+                    "0::smallint AS sync_behavior, " +
+                    // Positionally aligned with `n.path` above — a synthetic Document row's path IS
+                    // its main_node, so the same expression answers both.
+                    $"cc.collection_path || '/_Documents/' || {SlugSql} AS path " +
                     $"FROM {contentTable} cc WHERE cc.chunk_text ILIKE '%{term}%' " +
                     // DISTINCT ON requires its keys lead the ORDER BY; keep one (best) row per file.
                     "ORDER BY cc.collection_path, cc.file_path)");

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeCrossSchemaQueryProvider.cs
@@ -16,14 +16,14 @@ namespace MeshWeaver.Hosting.Snowflake;
 /// <c>PostgreSqlCrossSchemaQueryProvider</c>. The schema list is maintained in the central
 /// <c>searchable_schemas</c> table (in <see cref="SnowflakeStorageOptions.Schema"/>, default
 /// <c>public</c>), exactly like PG.
-/// <para><b>No stored procedure.</b> PG's primary fan-out delegates to the
-/// <c>public.search_across_schemas(...)</c> plpgsql function; Snowflake has no such routine, so
-/// ALL THREE <c>QueryAcrossSchemasAsync</c> overloads generate the UNION in C# via
-/// <see cref="SnowflakeSqlGenerator.GenerateCrossSchemaSelectQuery"/>. The stored proc's implicit
-/// behaviors are reproduced explicitly by the primary overload (see its remarks): the
-/// <c>main_node = path</c> branch filter, the <c>last_modified DESC</c> / <c>LIMIT 50</c>
-/// defaults, the empty-registry short-circuit, and the per-schema <c>to_regclass</c>
-/// access-control guard — the latter replaced by <see cref="GetSchemasWithAclTablesAsync"/>,
+/// <para><b>No stored procedure.</b> Both <c>QueryAcrossSchemasAsync</c> overloads generate the
+/// UNION in C# via <see cref="SnowflakeSqlGenerator.GenerateCrossSchemaSelectQuery"/>. PG's
+/// <c>public.search_across_schemas(...)</c> plpgsql function backed a THIRD, paging overload that
+/// this class also mirrored — <c>LIMIT 50</c> default and all. Both are deleted (#2048): no
+/// runtime caller ever reached that shape on either backend, since
+/// <c>SnowflakePartitionedMeshQuery.EnumerateFanOutAsync</c> — the path for every unpinned
+/// query — has only ever called the table-name overload, which applies no default limit at all.
+/// Its per-schema access-control guard lives on in <see cref="GetSchemasWithAclTablesAsync"/>,
 /// ONE information_schema probe feeding the generator's <c>aclSchemas</c> set.</para>
 /// <para><b>Dialect</b>: every identifier is double-quoted lowercase via
 /// <see cref="SnowflakeIdentifiers"/>, EXCEPT information_schema references, which are
@@ -358,78 +358,6 @@ public class SnowflakeCrossSchemaQueryProvider : ICrossSchemaQueryProvider
         return schemas.ToImmutable();
     }
 
-    /// <inheritdoc />
-    /// <remarks>
-    /// PG delegates this overload to the <c>public.search_across_schemas(...)</c> stored
-    /// procedure; here the SAME UNION is generated in C# via
-    /// <see cref="SnowflakeSqlGenerator.GenerateCrossSchemaSelectQuery"/>, reproducing the
-    /// proc's implicit behaviors explicitly:
-    /// <list type="bullet">
-    ///   <item><b><c>WHERE n.main_node = n.path</c> on every branch</b> — reproduced by passing
-    ///     <c>IsMain = true</c> on the <see cref="ParsedQuery"/> (the generator emits exactly
-    ///     that predicate).</item>
-    ///   <item><b><c>ORDER BY last_modified DESC</c> default</b> — reproduced via an
-    ///     <see cref="OrderByClause"/> fallback when the query has no explicit sort. Deliberate
-    ///     deviation: a FREE-TEXT query without an explicit sort keeps the generator's
-    ///     relevance-score ordering (which ends in the same <c>last_modified DESC</c>
-    ///     tiebreaker) instead of the proc's flat recency sort — the tsvector ranking PG's
-    ///     provider layered on top does not exist here, and the ILIKE relevance ladder is its
-    ///     designated replacement (see the generator's full-text dialect note).</item>
-    ///   <item><b><c>LIMIT 50</c> default</b> — reproduced via a <c>Limit</c> fallback.</item>
-    ///   <item><b>Empty registry → no rows</b> — the proc returned nothing when
-    ///     <c>searchable_schemas</c> was empty; reproduced by the empty-<paramref name="schemas"/>
-    ///     short-circuit. (The proc re-read the registry itself and ignored the caller's list;
-    ///     here the caller-supplied list — sourced from <see cref="GetSearchableSchemasAsync"/> —
-    ///     drives the UNION.)</item>
-    ///   <item><b>Per-schema <c>to_regclass</c> ACL guard</b> — replaced by
-    ///     <see cref="GetSchemasWithAclTablesAsync"/> feeding the generator's
-    ///     <c>aclSchemas</c> set (skipped entirely for system access, where the proc emitted no
-    ///     ACL SQL either).</item>
-    /// </list>
-    /// The filter/scope/text predicates the PG provider inlined into <c>p_where_clause</c> are
-    /// the generator's own <c>GenerateWhereClause</c>/scope push-down here — parameters stay
-    /// BOUND instead of PG's string-inlined values. Content-chunk omnibox branches are NOT
-    /// added on this overload (the proc had none; parity with PG, which folds content only in
-    /// the table-name overload).
-    /// </remarks>
-    public async IAsyncEnumerable<MeshNode> QueryAcrossSchemasAsync(
-        ParsedQuery query,
-        JsonSerializerOptions options,
-        IReadOnlyList<string> schemas,
-        string? userId = null,
-        [EnumeratorCancellation] CancellationToken ct = default)
-    {
-        if (schemas.Count == 0)
-            yield break;
-
-        var effectiveQuery = query with
-        {
-            IsMain = true,
-            // Three cases, and conflating the last two is how an enumeration silently becomes a
-            // page: no limit stated → the default page; MeshQueryRequest.NoLimit (non-positive) →
-            // the caller declared this an ENUMERATION, so every match; a positive limit → honour it.
-            Limit = query.Limit switch { null => 50, <= 0 => int.MaxValue, var stated => stated },
-            OrderBy = query.OrderBy ?? (string.IsNullOrEmpty(query.TextSearch)
-                ? new OrderByClause("last_modified", Descending: true)
-                : null)
-        };
-
-        var aclSchemas = await GetAclSchemasOrEmptyAsync(schemas, userId, ct).ConfigureAwait(false);
-
-        var generator = new SnowflakeSqlGenerator();
-        var (sql, parameters) = generator.GenerateCrossSchemaSelectQuery(
-            effectiveQuery, schemas, aclSchemas, userId);
-
-        _logger?.LogInformation(
-            "[CrossSchema] Cross-schema query: schemas={Count}, aclSchemas={AclCount}, userId={User}, order={Order}, limit={Limit}",
-            schemas.Count, aclSchemas.Count, userId, effectiveQuery.OrderBy?.Property, effectiveQuery.Limit);
-
-        await foreach (var node in EnumerateReaderOrEmptyOnMissingObjectAsync(
-            sql, parameters, options, schemas, "mesh_nodes", ct).WithCancellation(ct).ConfigureAwait(false))
-        {
-            yield return node;
-        }
-    }
 
     /// <inheritdoc />
     public async Task<IReadOnlyCollection<QueryResult>> AutocompleteTopLevelAsync(

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakePartitionedMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakePartitionedMeshQuery.cs
@@ -414,13 +414,18 @@ public sealed class SnowflakePartitionedMeshQuery : IMeshQueryProvider
         // 🚨 Carry the REQUEST-level limit into the parsed query — the same propagation the
         // per-schema delegate does (SnowflakeMeshQuery) and the exact twin of the PostgreSQL fix for
         // issue #1216. Without it `request.Limit` is silently DROPPED on the unpinned path, because
-        // QueryAcrossSchemasAsync reads only ParsedQuery.Limit and substitutes a hard default of 50.
-        // A request that states no limit at all still gets that default: an unanchored UNION over
-        // every partition schema needs SOME bound.
-        // 🚨 POSITIVE limits only — same guard as the PostgreSQL twin. `Limit <= 0` means "do not
-        // clip" upstream (MeshQuery.ClipMergedInitial applies a limit only when `limit > 0`), but in
-        // SQL a zero is a literal `LIMIT 0`: zero rows for a caller that asked for everything.
-        if (request.Limit is > 0)
+        // QueryAcrossSchemasAsync reads only ParsedQuery.Limit. A request that states no limit at
+        // all gets EVERY match: this overload applies no default clip, and the paging overload that
+        // substituted 50 is deleted (#2048) — no runtime caller ever reached it.
+        // 🚨 Propagate the limit WHATEVER its sign, including the non-positive "no clip" encoding
+        // (MeshQueryRequest.NoLimit) — the PostgreSQL twin's shape, adopted here so Complete()
+        // means the SAME thing on both backends. It used to be dropped for `<= 0` because a zero
+        // would reach SQL as a literal `LIMIT 0`; that translation now happens where the SQL is
+        // written (SnowflakeSqlGenerator emits a LIMIT only for `Limit is > 0`), so neither
+        // `LIMIT 0` nor `LIMIT -1` can be produced here. Dropping it instead meant an enumeration
+        // that also carried a `limit:N` in its query STRING was silently paged on Snowflake while
+        // the same read enumerated on Postgres.
+        if (request.Limit is not null)
             queryForSql = queryForSql with { Limit = request.Limit };
 
         var userId = GetEffectiveUserId(request);

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeSqlGenerator.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeSqlGenerator.cs
@@ -674,9 +674,16 @@ public class SnowflakeSqlGenerator
                 ? "act.\"last_modified\""
                 : (isAccessed ? "ua.\"last_modified\"" : "n.\"last_modified\"");
 
+            // 🚨 `n."path"` is projected because the ORDER BY is applied to the OUTER select over
+            // the union, where only the union's OWN columns are in scope — without it `sort:path`
+            // fails on a column that does not exist there, whatever the branch tables carry. The PG
+            // twin carries the identical line and the same reason (issue #2186, whose fix reached
+            // only the paging fan-out shape that #2048 deleted). UNION ALL is positional, so the
+            // content arm's DocumentProjection carries a matching `path` expression.
             var selectSql = $"SELECT {NodeColumnsPrefix}, {lastModifiedExpr} AS \"last_modified\", " +
                 "n.\"version\", n.\"state\", n.\"content\", " +
-                $"n.\"desired_id\", n.\"main_node\", {SyncBehaviorColumn(tableName)} FROM {qualifiedTable} n";
+                $"n.\"desired_id\", n.\"main_node\", {SyncBehaviorColumn(tableName)}, n.\"path\" " +
+                $"FROM {qualifiedTable} n";
 
             if (isAccessed)
                 selectSql += $" INNER JOIN {userActivityTable} ua ON ua.\"namespace\" = {Marker("actUserNs")}" +
@@ -897,13 +904,17 @@ public class SnowflakeSqlGenerator
         "cc.\"last_modified\" AS \"last_modified\", 0::bigint AS \"version\", 2::smallint AS \"state\", " +
         "NULL::variant AS \"content\", NULL::string AS \"desired_id\", " +
         $"cc.\"collection_path\" || '/_Documents/' || {SlugSql} AS \"main_node\", " +
-        "0::smallint AS \"sync_behavior\"";
+        "0::smallint AS \"sync_behavior\", " +
+        // Positionally aligned with n."path" on the mesh_nodes branches — a synthetic Document
+        // row's path IS its main_node, so the same expression answers both.
+        $"cc.\"collection_path\" || '/_Documents/' || {SlugSql} AS \"path\"";
 
     /// <summary>Column names of <see cref="DocumentProjection"/>, in projection order.</summary>
     private static readonly ImmutableArray<string> DocumentColumns =
     [
         "id", "namespace", "name", "node_type", "description", "category", "icon", "display_order",
-        "last_modified", "version", "state", "content", "desired_id", "main_node", "sync_behavior"
+        "last_modified", "version", "state", "content", "desired_id", "main_node", "sync_behavior",
+        "path"
     ];
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -71,22 +71,26 @@ internal static class NodeTypeBatchBake
     /// <see cref="MeshQueryRequest.Limit"/> and <see cref="ParsedQuery.Limit"/> null. "No limit"
     /// is NOT read the same way by every backend: the in-memory
     /// <c>StorageAdapterMeshQueryProvider</c> (<c>LoadCap</c>) and the per-schema
-    /// <c>PostgreSqlMeshQuery</c> treat it as UNBOUNDED, but the cross-schema fan-out that serves
-    /// an UNPINNED query on Postgres substitutes a hard default of 50
-    /// (<c>PostgreSqlCrossSchemaQueryProvider.QueryAcrossSchemasAsync</c>). <c>nodeType:Code</c>
+    /// <c>PostgreSqlMeshQuery</c> treat it as UNBOUNDED, but the cross-schema fan-out that served
+    /// an UNPINNED query on Postgres substituted a hard default of 50. <c>nodeType:Code</c>
     /// carries no <c>namespace:</c>/<c>path:</c>, so it is exactly that unpinned shape — and on
     /// memex-cloud 2026-08-11 the batch resolved 50 Code nodes out of thousands and compiled 169
     /// of 237 types against NOTHING. A test mesh has fewer than 50 Code nodes, so the cap never
     /// bound and every test stayed green.</para>
     ///
+    /// <para>🚨 That substitution is gone — it lived on a paging fan-out shape no runtime caller
+    /// could reach, deleted in #2048 — so an unpinned query stating no limit is unbounded on
+    /// Postgres too now. The explicit ceiling below stays anyway, for the reason in the next
+    /// paragraph, which never depended on it.</para>
+    ///
     /// <para><b>Why a number and not "unbounded".</b> Unbounded is not honoured uniformly (above),
-    /// and it cannot be reached by paging either: <c>public.search_across_schemas</c> takes a LIMIT
-    /// but no OFFSET, and its <c>ORDER BY n.last_modified DESC</c> is not a total order, so a
-    /// Skip/Limit loop over it would silently drop and duplicate rows across pages — worse than one
-    /// big page. So discovery states its ceiling EXPLICITLY (every backend honours an explicit
-    /// <c>limit:</c>) and then ASSERTS it was not reached. A mesh that genuinely exceeds this many
-    /// Code nodes gets a loud discovery failure and the activation-driven sweep — slower, correct,
-    /// and impossible to mistake for a content verdict.</para>
+    /// and it cannot be recovered by paging either: the cross-schema fan-out's
+    /// <c>ORDER BY n.last_modified DESC</c> is not a total order, so a Skip/Limit loop over it
+    /// would silently drop and duplicate rows across pages — worse than one big page. So discovery
+    /// states its ceiling EXPLICITLY (every backend honours an explicit <c>limit:</c>) and then
+    /// ASSERTS it was not reached. A mesh that genuinely exceeds this many Code nodes gets a loud
+    /// discovery failure and the activation-driven sweep — slower, correct, and impossible to
+    /// mistake for a content verdict.</para>
     /// </summary>
     internal const int SourceDiscoveryLimit = 25_000;
 

--- a/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
@@ -10,13 +10,22 @@ namespace MeshWeaver.Mesh.Security;
 /// <para>🚨 <b>In the security fold, "no result" and "not allowed" must never be the same value.</b>
 /// Several of these reads are GLOBAL by necessity — a <c>GroupMembership</c> lives under the group
 /// node, which may sit in a different partition than the grant that names the group, so the query
-/// carries no <c>path:</c> and no <c>namespace:</c>. On Postgres that is exactly the shape
-/// <c>PostgreSqlCrossSchemaQueryProvider</c> serves by UNION-ing every partition schema, ordering by
-/// <c>last_modified DESC</c> and clipping at a 50-row default page. A caller cannot tell a page from
-/// the whole set (<see cref="MeshQueryRequest.Complete"/>), and here the difference is a
+/// carries no <c>path:</c> and no <c>namespace:</c>. On Postgres that is the shape
+/// <c>PostgreSqlCrossSchemaQueryProvider</c> serves by UNION-ing every partition schema, ordering
+/// by <c>last_modified DESC</c>. If such a read comes back CLIPPED, a caller cannot tell a page
+/// from the whole set (<see cref="MeshQueryRequest.Complete"/>) — and here the difference is a
 /// PERMISSION: a truncated membership list is indistinguishable from "this viewer is in no groups",
 /// so a group-derived permission simply vanishes and every surface gated on it disappears at once —
 /// with nothing logged and nothing failing (issue #2011).</para>
+///
+/// <para>🚨 The clip this guards against is no longer a DEFAULT the fan-out applies. A second,
+/// paging fan-out shape did substitute 50 rows for an unlimited query, and it is deleted (#2048)
+/// because no runtime caller ever reached it; the one shape the runtime executes states no limit
+/// unless the caller does. What survives — and is why this class is not ceremony — is that a
+/// <c>limit:N</c> arriving IN THE QUERY STRING is honoured, and any future bound would be applied
+/// here. <see cref="Enumeration"/> overwrites such a limit rather than honouring it, so a fold read
+/// cannot be truncated by the string it was written with, whatever the storage layer later
+/// decides.</para>
 ///
 /// <para>It is worse than a lost grant in one direction that matters. A group-scoped <b>deny</b>
 /// (<c>AccessAssignment</c> with <c>Denied = true</c> whose subject is a group) is applied only to

--- a/src/MeshWeaver.Mesh.Contract/Services/ICrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/ICrossSchemaQueryProvider.cs
@@ -58,18 +58,17 @@ public interface ICrossSchemaQueryProvider
         string prefix, string? userId, int limit, CancellationToken ct = default);
 
     /// <summary>
-    /// Queries nodes across multiple schemas in a single SQL UNION ALL query.
-    /// </summary>
-    IAsyncEnumerable<MeshNode> QueryAcrossSchemasAsync(
-        ParsedQuery query,
-        JsonSerializerOptions options,
-        IReadOnlyList<string> schemas,
-        string? userId = null,
-        CancellationToken ct = default);
-
-    /// <summary>
-    /// Queries a satellite table across multiple schemas in a single SQL UNION ALL query.
-    /// Used for satellite node types (Thread, Activity, etc.) that live in dedicated tables.
+    /// Queries a table across multiple schemas in a single SQL UNION ALL query — the primary
+    /// <c>mesh_nodes</c> projection AND the satellite tables (Thread, Activity, …) alike.
+    ///
+    /// <para>🚨 There is exactly ONE fan-out shape, and it applies NO default limit: an unpinned
+    /// query that states no limit gets every match. A second, PAGING shape used to sit beside this
+    /// one — it substituted a 50-row default and warned that it had truncated — and it was
+    /// unreachable: <c>PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync</c> and its Snowflake
+    /// twin, the runtime path for every unpinned query, have only ever called THIS overload. It is
+    /// deleted (#2048) rather than wired, because a silent default clip is precisely the defect
+    /// #1216 / #1326 / #1960 were filed against; if a bound is ever wanted it belongs here, stated
+    /// loudly, on the one shape the runtime executes.</para>
     /// </summary>
     IAsyncEnumerable<MeshNode> QueryAcrossSchemasAsync(
         ParsedQuery query,

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshQuery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshQuery.cs
@@ -186,11 +186,10 @@ public record MeshQueryRequest
     /// <summary>
     /// Maximum number of results to return (takes precedence over limit in query string).
     ///
-    /// <para>🚨 <b>Leaving this unset does NOT mean "everything".</b> An UNPINNED query (no
-    /// <c>path:</c>, no <c>namespace:</c>) is served on Postgres by the cross-schema fan-out, which
-    /// answers a request that states no limit with a PAGE — the most recently modified rows, capped
-    /// at a default — and the caller cannot tell a page from the whole set. Say
-    /// <see cref="Complete"/> when the read is an ENUMERATION rather than a search.</para>
+    /// <para>Unset means "whatever the QUERY STRING says" — a <c>limit:N</c> token in
+    /// <see cref="Query"/> is honoured when this is null, and overridden when it is not. Say
+    /// <see cref="Complete"/> when the read is an ENUMERATION rather than a search, so the answer
+    /// cannot be a page whatever the string carries.</para>
     /// </summary>
     public int? Limit { get; init; }
 
@@ -208,11 +207,21 @@ public record MeshQueryRequest
     /// <para>🚨 Use it wherever a MISSING row silently changes behaviour rather than merely
     /// shortening a list — a fan-out over every configured sync source, a bake over every NodeType,
     /// a reconciliation. Both production incidents in this family had the same shape: the query
-    /// stated no limit, the cross-schema fan-out substituted its default and ordered by
+    /// stated no limit, the cross-schema fan-out substituted a default and ordered by
     /// <c>last_modified DESC</c>, and the rows that fell off the end were exactly the ones that had
     /// gone longest without being processed — so the omission was self-reinforcing and invisible.
     /// #1216 baked 237 NodeTypes against 50 Code nodes; #1326 left 9 of 43 Spaces permanently stale
     /// while the webhook reported success.</para>
+    ///
+    /// <para>🚨 <b>What it does TODAY, stated exactly, because an unfalsifiable call is worse than
+    /// no call.</b> The fan-out shape that substituted that default is deleted (#2048) — no runtime
+    /// caller could reach it — so an unpinned query stating no limit now returns every match on its
+    /// own. What <c>Complete()</c> still decides is the case where a limit arrives ANYWAY: a
+    /// <c>limit:N</c> in the query string, which <see cref="Limit"/> being null would honour and
+    /// <see cref="NoLimit"/> overrides. So it is a DECLARATION first — this read is an enumeration,
+    /// and no future bound may page it — and an override second. Keep saying it on enumerations;
+    /// what it must not be is a talisman credited with a truncation the runtime no longer
+    /// performs.</para>
     /// </summary>
     /// <returns>A copy of this request that must not be truncated.</returns>
     public MeshQueryRequest Complete() => this with { Limit = NoLimit };
@@ -224,10 +233,11 @@ public record MeshQueryRequest
     /// <para>🚨 Needed because not every read can reach a <see cref="MeshQueryRequest"/>. The
     /// process-wide synced-query surface (<c>IMeshNodeStreamCache.GetQuery</c> →
     /// <c>SyncedQueryMeshNodes</c>) takes query STRINGS and builds the request itself, so a caller
-    /// there has no <c>Complete()</c> to call and the absence of a limit silently becomes the
-    /// cross-schema fan-out's 50-row page. Spelling it <c>all</c> rather than <c>-1</c> is
-    /// deliberate: a bare negative number in a query string reads as a typo and invites a tidy-up
-    /// that reintroduces the truncation, which is exactly the class of defect this guards.</para>
+    /// there has no <c>Complete()</c> to call — and a string assembled from parts is exactly where
+    /// a stray <c>limit:N</c> ends up being inherited by a read that meant to enumerate. Spelling
+    /// it <c>all</c> rather than <c>-1</c> is deliberate: a bare negative number in a query string
+    /// reads as a typo and invites a tidy-up that reintroduces the truncation, which is exactly the
+    /// class of defect this guards.</para>
     /// </summary>
     public const string CompleteQualifier = "limit:all";
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using MeshWeaver.Hosting.AspNetCore;
 using MeshWeaver.Mesh;
@@ -180,7 +181,60 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
         var manifest = Discover(WithAssets);
 
         manifest.Stylesheets.Should().ContainSingle()
-            .Which.Should().Be($"_content/{ModuleName}/{ModuleName}.styles.css");
+            .Which.Should().MatchRegex(
+                $"^_content/{Regex.Escape(ModuleName)}/{Regex.Escape(ModuleName)}\\.[0-9a-f]{{16}}\\.styles\\.css$",
+                "the ONE module asset whose URL the platform authors carries the body's "
+                + "content fingerprint, so it can be served immutable");
+    }
+
+    /// <summary>
+    /// 🚨 The fingerprint is over the BODY, so it is what makes <c>immutable</c> honest — and it is
+    /// the only reason a module upgrade costs a viewer nothing rather than one conditional GET per
+    /// linked bundle per page render (#1974's last open gap).
+    ///
+    /// <para>Two properties, and the pair is the point: a changed bundle gets a DIFFERENT URL (so
+    /// the upgrade is picked up instantly, with no stale-cache window), and an unchanged one gets
+    /// the SAME URL (so a republish that changed nothing does not invalidate every viewer's copy —
+    /// which is exactly what a generation- or timestamp-derived token would do).</para>
+    /// </summary>
+    [Fact]
+    public void StyleBundleFingerprint_TracksTheBody_NotTheLanding()
+    {
+        var first = Discover(WithAssets).Stylesheets.Single();
+
+        // Re-landing the SAME bytes (a fresh generation directory, new mtimes) — same URL.
+        File.WriteAllText(Path.Combine(ModuleWwwroot, $"{ModuleName}.styles.css"), ".x{}");
+        Discover(WithAssets).Stylesheets.Single().Should().Be(first,
+            "identical bytes must keep the URL, or every republish invalidates every cached copy");
+
+        // Different bytes — different URL.
+        File.WriteAllText(Path.Combine(ModuleWwwroot, $"{ModuleName}.styles.css"), ".x{color:red}");
+        Discover(WithAssets).Stylesheets.Single().Should().NotBe(first,
+            "an upgraded bundle must reach the browser without waiting for a cache to expire");
+    }
+
+    /// <summary>
+    /// The fingerprinted URL is answered <c>immutable</c>; the plain <c>&lt;Name&gt;.styles.css</c>
+    /// is answered too — same body, but <c>no-cache</c>, because what THAT URL means changes with
+    /// every module upgrade.
+    ///
+    /// <para>Serving the plain path is not politeness: leaving it to fall through to the mount
+    /// would serve the LANDED file, whose host-provided <c>@import</c>s name fingerprints only the
+    /// module's own build ever had — a silent 404 per page load, which is the defect
+    /// <c>StripHostProvidedImports</c> exists to remove.</para>
+    /// </summary>
+    [Fact]
+    public void BothStyleBundleUrls_AreServedFromMemory_WithOppositeCachingPromises()
+    {
+        var manifest = Discover(WithAssets);
+        var fingerprinted = "/" + manifest.Stylesheets.Single();
+        var plain = $"/_content/{ModuleName}/{ModuleName}.styles.css";
+
+        manifest.StylesheetBodies.Should().NotBeNull();
+        manifest.StylesheetBodies![fingerprinted].Should()
+            .Be(new ModuleStylesheetResponse(".x{}", true));
+        manifest.StylesheetBodies[plain].Should()
+            .Be(new ModuleStylesheetResponse(".x{}", false));
     }
 
 
@@ -384,6 +438,55 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
         response.Content.Headers.ContentEncoding.Should().BeEmpty(
             "there is no compressed representation to announce");
         (await response.Content.ReadAsStringAsync()).Should().Be(IdentityBody);
+
+        await app.StopAsync();
+    }
+
+    /// <summary>
+    /// 🚨 Every module URL STATES its caching policy over the wire, and the two states are
+    /// opposite — which is the whole of #1974's fingerprinting gap, asserted where a browser would
+    /// see it rather than on the manifest.
+    ///
+    /// <para><b>The fingerprinted bundle</b> is <c>immutable</c>: its URL encodes its bytes, so a
+    /// viewer who has it never asks again and an upgrade arrives instantly under a new URL.
+    /// <b>Everything else</b> is <c>no-cache</c> — a pack hard-codes
+    /// <c>_content/&lt;Name&gt;/&lt;file&gt;</c> in its own component source, so the host cannot
+    /// fingerprint it and must not claim it is immutable.</para>
+    ///
+    /// <para>The <c>no-cache</c> is not a downgrade from silence, it is the fix for it: with NO
+    /// <c>Cache-Control</c> (what plain <c>UseStaticFiles</c> emits) a browser applies HEURISTIC
+    /// freshness off <c>Last-Modified</c> and may serve an upgraded module's JS from cache without
+    /// revalidating at all. Stating <c>no-cache</c> makes the conditional GET happen, so the new
+    /// bytes cannot be missed.</para>
+    /// </summary>
+    [Fact]
+    public async Task ModuleAssets_StateTheirCachingPolicy_ImmutableOnlyWhereFingerprinted()
+    {
+        var manifest = Discover(WithAssets);
+        var fingerprinted = "/" + manifest.Stylesheets.Single();
+
+        await using var app = BuildHost();
+        await app.StartAsync();
+        var client = app.GetTestClient();
+
+        var bundle = await client.GetAsync(fingerprinted);
+        bundle.StatusCode.Should().Be(HttpStatusCode.OK,
+            "App.razor links exactly this URL off the manifest");
+        bundle.Headers.CacheControl!.ToString().Should().Contain("immutable",
+            "the URL carries the body's content hash, so the bytes behind it can never change");
+
+        var plain = await client.GetAsync($"/_content/{ModuleName}/{ModuleName}.styles.css");
+        plain.StatusCode.Should().Be(HttpStatusCode.OK,
+            "the plain path is answered from memory too — never from the landed file, whose "
+            + "host-provided @imports point at fingerprints only the module's build ever had");
+        plain.Headers.CacheControl!.NoCache.Should().BeTrue(
+            "what THIS URL means changes with every module upgrade");
+
+        var script = await client.GetAsync($"/_content/{ModuleName}/PackView.razor.js");
+        script.StatusCode.Should().Be(HttpStatusCode.OK);
+        script.Headers.CacheControl!.NoCache.Should().BeTrue(
+            "a pack authors this URL itself, so the host cannot fingerprint it — and saying "
+            + "nothing would let a heuristic cache serve the pre-upgrade file");
 
         await app.StopAsync();
     }

--- a/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
@@ -474,6 +474,10 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
             "App.razor links exactly this URL off the manifest");
         bundle.Headers.CacheControl!.ToString().Should().Contain("immutable",
             "the URL carries the body's content hash, so the bytes behind it can never change");
+        bundle.Headers.Vary.Should().BeEmpty(
+            "this body is written from memory, identity-encoded, and negotiation runs after it — "
+            + "so it does NOT vary by encoding, and claiming it does would split a shared cache's "
+            + "key per Accept-Encoding value on a URL meant to be stored once for a year");
 
         var plain = await client.GetAsync($"/_content/{ModuleName}/{ModuleName}.styles.css");
         plain.StatusCode.Should().Be(HttpStatusCode.OK,
@@ -487,6 +491,9 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
         script.Headers.CacheControl!.NoCache.Should().BeTrue(
             "a pack authors this URL itself, so the host cannot fingerprint it — and saying "
             + "nothing would let a heuristic cache serve the pre-upgrade file");
+        script.Headers.Vary.Should().Contain("Accept-Encoding",
+            "the mounts DO vary — the negotiation serves a .br/.gz body to a client that accepts "
+            + "one — which is exactly why the in-memory bundle above must not copy this header");
 
         await app.StopAsync();
     }

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/BatchBakeSourceDiscoveryScaleTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/BatchBakeSourceDiscoveryScaleTests.cs
@@ -27,13 +27,19 @@ namespace MeshWeaver.Hosting.PostgreSql.Test;
 ///
 /// <para><b>The defect was invisible to every in-memory test.</b> Discovery issues ONE global
 /// <c>nodeType:Code</c> fetch. That query carries no <c>namespace:</c> and no <c>path:</c>, so on
-/// Postgres it is the UNPINNED shape served by the cross-schema fan-out — and
-/// <c>PostgreSqlCrossSchemaQueryProvider.QueryAcrossSchemasAsync</c> answers a query with no stated
-/// limit by substituting a hard default of <b>50</b>. The in-memory
+/// Postgres it is the UNPINNED shape served by the cross-schema fan-out — which at the time
+/// answered a query with no stated limit by substituting a hard default of <b>50</b>. The in-memory
 /// <c>StorageAdapterMeshQueryProvider</c> and the per-schema <c>PostgreSqlMeshQuery</c> both treat
 /// "no limit" as UNBOUNDED, so the identical code path is correct on the adapter every unit test
 /// uses. On memex-cloud 2026-08-11 the pass reported <c>resolved 50 Code node(s) … for 237 pending
 /// type(s)</c> and 169 types compiled against NOTHING.</para>
+///
+/// <para>🚨 That default is deleted (#2048) — it lived on a paging fan-out overload no runtime
+/// caller could reach — so this test no longer reproduces the #1216 truncation through the storage
+/// layer. It still earns its place, and its subject has shifted to the thing that DID survive: the
+/// discovery limit is now stated EXPLICITLY (<c>NodeTypeBatchBake.SourceDiscoveryLimit</c>), and
+/// what must hold is that a two-partition mesh resolves every type's full source set through it —
+/// identically to the activation path. A reintroduced default clip, on either shape, fails here.</para>
 ///
 /// <para><b>What this pins.</b> A mesh holding MORE Code nodes than that default, spread across two
 /// partitions, must resolve EVERY type's full source set — and resolve exactly what the ACTIVATION
@@ -49,8 +55,8 @@ public class BatchBakeSourceDiscoveryScaleTests(PostgreSqlFixture fixture, ITest
     private readonly PostgreSqlFixture _fixture = fixture;
 
     /// <summary>
-    /// Code nodes per type. Two types ⇒ 60 in total, comfortably above the cross-schema fan-out's
-    /// 50-row default — the whole point of the test. Anything at or below it reproduces nothing.
+    /// Code nodes per type. Two types ⇒ 60 in total, comfortably above the 50 the deleted paging
+    /// fan-out substituted — kept above it so a reintroduced default clip still fails here.
     /// </summary>
     private const int SourcesPerType = 30;
 

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CatalogPartitionIndexSelfHealTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CatalogPartitionIndexSelfHealTests.cs
@@ -127,7 +127,8 @@ public class CatalogPartitionIndexSelfHealTests(PostgreSqlFixture fixture, ITest
             .SelectMany(schemas => crossSchema
                 .QueryAcrossSchemasAsync(
                     new QueryParser().Parse($"nodeType:{nodeType}"),
-                    Mesh.JsonSerializerOptions, schemas, userId: null, ct)
+                    Mesh.JsonSerializerOptions, schemas, "mesh_nodes",
+                    userId: null, activityUserId: null, ct)
                 .Collect(ct))
             .Should().Within(30.Seconds()).Emit();
     }

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CompleteEnumerationFanOutTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CompleteEnumerationFanOutTests.cs
@@ -9,26 +9,29 @@ using Xunit;
 namespace MeshWeaver.Hosting.PostgreSql.Test;
 
 /// <summary>
-/// 🚨 AN UNPINNED CROSS-SCHEMA QUERY ANSWERS WITH A PAGE, AND THE CALLER CANNOT TELL.
+/// 🚨 AN UNPINNED CROSS-SCHEMA QUERY RETURNS EVERY MATCH — pinned on the overload the RUNTIME takes.
 ///
 /// <para><c>PostgreSqlCrossSchemaQueryProvider</c> serves every query that carries no
-/// <c>path:</c> and no <c>namespace:</c> by UNION-ing every partition schema, ordering by
-/// <c>last_modified DESC</c> and clipping at a default row count. That is right for a search and
-/// catastrophic for an ENUMERATION — and the two are the same call, so the mistake is invisible at
-/// the call site and invisible in the result.</para>
+/// <c>path:</c> and no <c>namespace:</c> by UNION-ing every partition schema and ordering by
+/// <c>last_modified DESC</c>. It applies NO default clip: a caller that states no limit gets the
+/// whole set, and a caller that states one gets exactly that many.</para>
 ///
-/// <para><b>Twice in production.</b> #1216: the batch bake's global <c>nodeType:Code</c> fetch
-/// resolved 50 Code nodes for 237 pending types, and 169 types compiled against nothing. #1326: the
-/// GitHub webhook's <c>nodeType:GitHubSyncConfig</c> fan-out saw 50 of the mesh's configs, so 9 of
-/// 43 Spaces never re-synced while every delivery reported success. Both are self-reinforcing:
-/// processing a row rewrites it, which refreshes <c>last_modified</c>, which keeps the rows that
-/// DID get processed inside the window and pushes the stragglers further out — so the same
-/// handful stays stale forever and the set never heals.</para>
+/// <para><b>Twice in production, when it did clip.</b> #1216: the batch bake's global
+/// <c>nodeType:Code</c> fetch resolved 50 Code nodes for 237 pending types, and 169 types compiled
+/// against nothing. #1326: the GitHub webhook's <c>nodeType:GitHubSyncConfig</c> fan-out saw 50 of
+/// the mesh's configs, so 9 of 43 Spaces never re-synced while every delivery reported success.
+/// Both are self-reinforcing: processing a row rewrites it, which refreshes <c>last_modified</c>,
+/// which keeps the rows that DID get processed inside the window and pushes the stragglers further
+/// out — so the same handful stays stale forever and the set never heals.</para>
 ///
-/// <para>This pins the cure: <see cref="MeshQueryRequest.NoLimit"/> (what
-/// <c>MeshQueryRequest.Complete()</c> sets) means EVERY match, a stated positive limit means that
-/// many, and only a caller that states nothing gets the page. The 50-row page is asserted too — it
-/// is the behaviour the enumeration callers have to opt out of, so it must not drift silently.</para>
+/// <para>🚨 <b>This test used to assert the 50-row page, and that is exactly what made it
+/// worthless.</b> The default lived on a SECOND fan-out shape — the <c>search_across_schemas</c>
+/// paging overload — that no runtime caller could reach:
+/// <c>PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync</c>, the path for every unpinned query,
+/// has only ever taken the table-name overload. So the test demonstrated a truncation the runtime
+/// could not produce, and <c>Complete()</c> became unfalsifiable (#2048). The paging overload is
+/// deleted; this now runs against <c>"mesh_nodes"</c> — the same call the runtime makes — and
+/// fails if a default clip is ever reintroduced there.</para>
 /// </summary>
 [Collection("PostgreSql")]
 public class CompleteEnumerationFanOutTests(PostgreSqlFixture fixture, ITestOutputHelper output)
@@ -37,17 +40,15 @@ public class CompleteEnumerationFanOutTests(PostgreSqlFixture fixture, ITestOutp
     private readonly JsonSerializerOptions _options = new();
 
     /// <summary>
-    /// Rows per partition. Two partitions ⇒ 66, comfortably above
-    /// <see cref="PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit"/> — at or below it the test
-    /// reproduces nothing.
+    /// Rows per partition. Two partitions ⇒ 66, comfortably above the 50 the deleted paging shape
+    /// substituted — at or below that number a reintroduced default clip would pass unnoticed.
     /// </summary>
     private const int RowsPerPartition = 33;
 
     private const int TotalRows = 2 * RowsPerPartition;
 
-    /// <summary>The two seeded partitions. The stored-procedure fan-out resolves its own schema
-    /// list from <c>public.searchable_schemas</c>; the parameter is part of the shared signature.
-    /// </summary>
+    /// <summary>The two seeded partitions — the UNION's branches, exactly as the runtime passes
+    /// them (resolved from <c>public.searchable_schemas</c> by the query layer above).</summary>
     private static readonly string[] Schemas = ["alpha", "beta"];
 
     /// <summary>A node type nothing else in the fixture writes, so the fan-out's result set is
@@ -55,7 +56,7 @@ public class CompleteEnumerationFanOutTests(PostgreSqlFixture fixture, ITestOutp
     private const string ProbeNodeType = "FanOutEnumerationProbe";
 
     [Fact(Timeout = 120000)]
-    public async Task UnpinnedFanOut_PagesByDefault_ButReturnsEveryMatchWhenTheCallerDeclaresCompleteness()
+    public async Task UnpinnedFanOut_ReturnsEveryMatch_AndHonoursAStatedLimit()
     {
         var ct = TestContext.Current.CancellationToken;
         await _fixture.CleanDataAsync();
@@ -78,36 +79,40 @@ public class CompleteEnumerationFanOutTests(PostgreSqlFixture fixture, ITestOutp
         var parser = new QueryParser();
         var parsed = parser.Parse($"nodeType:{ProbeNodeType}");
 
-        // 1. No limit stated → a PAGE. Documented, not accidental: an unanchored UNION over every
-        //    partition schema needs a bound, and a search wants one anyway.
-        var page = await cross.QueryAcrossSchemasAsync(parsed, _options, Schemas, ct: ct).Collect(ct)
-            .Should().Within(60.Seconds()).Emit();
-        output.WriteLine($"default page: {page.Count} of {TotalRows}");
-        page.Count.Should().Be(PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit,
-            "a query that states no limit is served the default page — which is precisely why an "
-            + "enumeration must say Complete() rather than trust the absence of a limit");
+        // 1. No limit stated → EVERY match. TotalRows is deliberately well above the 50 the
+        //    deleted paging shape used to substitute, so a reintroduced default cannot pass here.
+        var unlimited = await Collect(cross, parsed, ct);
+        output.WriteLine($"no limit stated: {unlimited.Count} of {TotalRows}");
+        unlimited.Count.Should().Be(TotalRows,
+            "the runtime fan-out applies no default clip — a caller that states no limit is not "
+            + "handed a page it cannot distinguish from the whole set (#1216, #1326, #2048)");
+        unlimited.Select(n => n.Path).Distinct().Count().Should().Be(TotalRows,
+            "the result must be the union of both partitions, not one partition twice");
 
-        // 2. Complete() → EVERY match. This is the assertion that fails before the fix: NoLimit is
-        //    non-positive, and the provider used to fold every non-positive value into `?? 50`
-        //    (after PostgreSqlPartitionedMeshQuery had already refused to propagate it at all).
-        var complete = await cross
-            .QueryAcrossSchemasAsync(parsed with { Limit = MeshQueryRequest.NoLimit }, _options, Schemas, ct: ct)
-            .Collect(ct).Should().Within(60.Seconds()).Emit();
+        // 2. Complete() → every match, same answer. NoLimit is non-positive, and the one way it
+        //    could go wrong is reaching SQL as a literal `LIMIT -1`.
+        var complete = await Collect(cross, parsed with { Limit = MeshQueryRequest.NoLimit }, ct);
         output.WriteLine($"complete: {complete.Count} of {TotalRows}");
         complete.Count.Should().Be(TotalRows,
-            "MeshQueryRequest.NoLimit declares the read an enumeration — every match must come back, "
-            + "or a fan-out over sync sources silently stops updating the Spaces that sank out of "
-            + "the last_modified window (#1326)");
-        complete.Select(n => n.Path).Distinct().Count().Should().Be(TotalRows,
-            "the complete set must be the union of both partitions, not one partition twice");
+            "MeshQueryRequest.NoLimit declares the read an enumeration — every match must come "
+            + "back, and it must never be emitted as LIMIT -1 or LIMIT 0");
 
-        // 3. A stated POSITIVE limit is still honoured — Complete() must not have turned the
-        //    limit into a no-op for everyone else.
-        var ten = await cross
-            .QueryAcrossSchemasAsync(parsed with { Limit = 10 }, _options, Schemas, ct: ct)
-            .Collect(ct).Should().Within(60.Seconds()).Emit();
+        // 3. A stated POSITIVE limit is honoured — the absence of a DEFAULT is not the absence of
+        //    limits.
+        var ten = await Collect(cross, parsed with { Limit = 10 }, ct);
         ten.Count.Should().Be(10, "an explicit positive limit still clips");
     }
+
+    /// <summary>
+    /// The call the RUNTIME makes: <c>PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync</c>
+    /// resolves a table (<c>"mesh_nodes"</c> for an ordinary query) and takes this overload for
+    /// every unpinned read. Asserting through it is what makes the claims above falsifiable.
+    /// </summary>
+    private Task<System.Collections.Generic.List<MeshNode>> Collect(
+        PostgreSqlCrossSchemaQueryProvider cross, ParsedQuery query, System.Threading.CancellationToken ct)
+        => cross.QueryAcrossSchemasAsync(
+                query, _options, Schemas, "mesh_nodes", userId: null, activityUserId: null, ct)
+            .Collect(ct).Should().Within(60.Seconds()).Emit();
 
     private async Task SeedAsync(
         string schema, string ns, PartitionDefinition partitionDef, System.Threading.CancellationToken ct)

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionKeysetPagingTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionKeysetPagingTests.cs
@@ -115,8 +115,12 @@ public class CrossPartitionKeysetPagingTests(PostgreSqlFixture fixture, ITestOut
         PostgreSqlCrossSchemaQueryProvider cross, QueryParser parser, string query, CancellationToken ct)
     {
         var rows = new List<string>();
+        // The table-name overload — the one PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync
+        // takes for every unpinned query, and since #2048 the only cross-schema shape there is.
         await foreach (var node in cross
-                           .QueryAcrossSchemasAsync(parser.Parse(query), _options, Schemas, ct: ct)
+                           .QueryAcrossSchemasAsync(
+                               parser.Parse(query), _options, Schemas, "mesh_nodes",
+                               userId: null, activityUserId: null, ct)
                            .WithCancellation(ct))
             rows.Add(node.Path);
         return rows;

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossSchemaFanOutTimingTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossSchemaFanOutTimingTests.cs
@@ -7,12 +7,19 @@ namespace MeshWeaver.Hosting.PostgreSql.Test;
 /// <summary>
 /// Pins the cross-schema fan-out's TIMING instrumentation.
 ///
-/// <para>Why this exists: <c>search_across_schemas</c> builds a <c>UNION ALL</c> over every row of
+/// <para>Why this exists: the fan-out builds a <c>UNION ALL</c> over every row of
 /// <c>public.searchable_schemas</c>, so a query with no <c>path:</c>/<c>namespace:</c> anchor scans
 /// EVERY partition — every plugin and every user partition. Its cost therefore grows with the number
 /// of users, and it degrades over months with no code change. Before this, the provider logged the
 /// WHERE clause but never a duration, so a slow query was indistinguishable from a bad filter and
 /// the fan-out width was invisible.</para>
+///
+/// <para>🚨 The instrumentation was CALLED from the paging overload, which no runtime caller could
+/// reach — so for its whole life it produced not one line in production. #2048 deleted that
+/// overload and moved the call onto the table-name form every unpinned query takes. These
+/// assertions are about the log DECISION and are deliberately callable without Postgres; what they
+/// cannot check is which caller invokes it, so if you move this helper again, move it to a live
+/// path and say which one.</para>
 ///
 /// <para>The assertions are about what an operator can ACT on: a slow fan-out must be visible at
 /// default log level (Warning, not Debug), must state how many schemas it spanned, and must name the
@@ -56,7 +63,7 @@ public class CrossSchemaFanOutTimingTests
     {
         var (provider, log) = Subject(schemas: 312);
 
-        provider.LogFanOutTiming("search_across_schemas",
+        provider.LogFanOutTiming("mesh_nodes",
             totalMs: PostgreSqlCrossSchemaQueryProvider.SlowFanOutMs, firstRowMs: 900, rows: 15, limit: 15);
 
         var entry = Assert.Single(log.Entries);
@@ -71,7 +78,7 @@ public class CrossSchemaFanOutTimingTests
         // across 312 schemas" tells the operator it is an unanchored query.
         var (provider, log) = Subject(schemas: 312);
 
-        provider.LogFanOutTiming("search_across_schemas", totalMs: 4200, firstRowMs: 4100, rows: 3, limit: 50);
+        provider.LogFanOutTiming("mesh_nodes", totalMs: 4200, firstRowMs: 4100, rows: 3, limit: 50);
 
         var message = Assert.Single(log.Entries).Message;
         Assert.Contains("312", message);
@@ -85,7 +92,7 @@ public class CrossSchemaFanOutTimingTests
         // A warning that does not say what to do gets muted rather than fixed.
         var (provider, log) = Subject(schemas: 200);
 
-        provider.LogFanOutTiming("search_across_schemas", totalMs: 9000, firstRowMs: 8000, rows: 1, limit: 10);
+        provider.LogFanOutTiming("mesh_nodes", totalMs: 9000, firstRowMs: 8000, rows: 1, limit: 10);
 
         var message = Assert.Single(log.Entries).Message;
         Assert.Contains("path:", message);
@@ -98,7 +105,7 @@ public class CrossSchemaFanOutTimingTests
         // Every page render fans out; warning on the normal case would drown the slow one.
         var (provider, log) = Subject(schemas: 12);
 
-        provider.LogFanOutTiming("search_across_schemas", totalMs: 40, firstRowMs: 30, rows: 8, limit: 50);
+        provider.LogFanOutTiming("mesh_nodes", totalMs: 40, firstRowMs: 30, rows: 8, limit: 50);
 
         var entry = Assert.Single(log.Entries);
         Assert.Equal(LogLevel.Debug, entry.Level);
@@ -123,7 +130,7 @@ public class CrossSchemaFanOutTimingTests
         // Total alone cannot distinguish "the scan was slow" from "the caller consumed slowly".
         var (provider, log) = Subject(schemas: 40);
 
-        provider.LogFanOutTiming("search_across_schemas", totalMs: 5000, firstRowMs: 120, rows: 200, limit: 200);
+        provider.LogFanOutTiming("mesh_nodes", totalMs: 5000, firstRowMs: 120, rows: 200, limit: 200);
 
         var message = Assert.Single(log.Entries).Message;
         Assert.Contains("120", message);

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SecurityFoldEnumerationTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SecurityFoldEnumerationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -29,24 +30,21 @@ namespace MeshWeaver.Hosting.PostgreSql.Test;
 /// group GRANT stops reaching its member — and so does a group DENY, which is a revocation that
 /// fails OPEN.</para>
 ///
-/// <para><b>What the first test measures, and why it is at the provider seam.</b> The paging
-/// behaviour lives in <c>PostgreSqlCrossSchemaQueryProvider.QueryAcrossSchemasAsync</c>'s
-/// <c>search_across_schemas</c> form, which clips at
-/// <see cref="PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit"/> when the caller states no
-/// limit. The security fold's queries are exactly the shape that form serves, so the guarantee
-/// worth pinning is: fed the fold's OWN query strings, that fan-out returns every match — and it
-/// does so BECAUSE of the stamp, which the unstamped control in the same test proves by getting a
-/// page instead.</para>
+/// <para><b>What the first test measures, and why it is at the provider seam.</b> Through the
+/// fan-out overload the RUNTIME takes (<c>PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync</c>
+/// → the table-name form), a fold-shaped read is truncated by exactly one thing: a <c>limit:N</c>
+/// carried in the QUERY STRING it was assembled from. So the guarantee worth pinning is that
+/// <see cref="SecurityQueries.Enumeration"/> makes the fold immune to that — the control in the
+/// same test is the identical string WITH a limit, which comes back as a page.</para>
 ///
-/// <para>⚠️ <b>An honest scope note.</b> On this tree the runtime fan-out
-/// (<c>PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync</c>) always takes the <em>table</em>
-/// overload, which applies NO default limit — so an end-to-end mesh test that merely seeds more
-/// memberships than a page reproduces nothing today, whether or not the fold is stamped (measured:
-/// 62 seeded, 62 returned, both ways). That is a property of the current routing, not a guarantee:
-/// the paging form is still on <c>ICrossSchemaQueryProvider</c>, still implemented on both
-/// backends, and is one routing change away from serving these reads again. The stamp is what makes
-/// the fold indifferent to which form answers it, and the first test is where that is falsifiable.
-/// The second test is the end-to-end guard that the stamp did not break — or widen — the fold.</para>
+/// <para>🚨 <b>This test used to control on a 50-row DEFAULT, and that control was fiction.</b>
+/// The default lived on a second, paging fan-out overload that no runtime caller could reach; it
+/// is deleted (#2048). Its absence is asserted here too, so "an unpinned fold read that states
+/// nothing gets everything" is a pinned property rather than an assumption — and a future default
+/// clip lands as a failing test in the security fold, which is where it would hurt most.</para>
+///
+/// <para>The second test is the end-to-end guard that the stamp did not break — or widen — the
+/// fold.</para>
 /// </summary>
 [Collection("PostgreSql")]
 public class SecurityFoldEnumerationTests(PostgreSqlFixture fixture, ITestOutputHelper output)
@@ -56,9 +54,9 @@ public class SecurityFoldEnumerationTests(PostgreSqlFixture fixture, ITestOutput
     private readonly JsonSerializerOptions _options = new();
 
     /// <summary>
-    /// Membership rows per seeded partition. Two partitions ⇒ 66, comfortably above
-    /// <see cref="PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit"/> — at or below it the
-    /// paging test reproduces nothing.
+    /// Membership rows per seeded partition. Two partitions ⇒ 66, comfortably above both the
+    /// control's stated page and the 50 the deleted paging overload substituted — at or below
+    /// either number the truncation reproduces nothing.
     /// </summary>
     private const int RowsPerPartition = 33;
 
@@ -68,13 +66,16 @@ public class SecurityFoldEnumerationTests(PostgreSqlFixture fixture, ITestOutput
 
     /// <summary>
     /// The exact string the fold issued before this fix — kept verbatim as the CONTROL, so the
-    /// paging assertion below is a measurement rather than an assumption.
+    /// assertions below are measurements rather than assumptions.
     /// </summary>
     private const string UnstampedMembershipQuery =
         "nodeType:GroupMembership scope:subtree select:path,id,namespace,name,nodeType,content";
 
+    /// <summary>Rows the control asks for — well under <see cref="TotalRows"/>, so a page is a page.</summary>
+    private const int ControlPage = 20;
+
     [Fact(Timeout = 120_000)]
-    public async Task TheFoldsOwnMembershipQuery_IsCompleteThroughThePagingFanOut()
+    public async Task TheFoldsOwnMembershipQuery_IsCompleteThroughTheRuntimeFanOut()
     {
         var ct = TestContext.Current.CancellationToken;
         await _fixture.CleanDataAsync();
@@ -92,24 +93,39 @@ public class SecurityFoldEnumerationTests(PostgreSqlFixture fixture, ITestOutput
 
         var parser = new QueryParser();
 
-        // 1. THE CONTROL — the string the fold used to issue. It states no limit, so the fan-out
-        //    answers with a page, and nothing in the result says so. In the security fold those
-        //    missing rows are memberships, and a missing membership reads as "not a member".
+        // 1. THE CONTROL — the fold's own string with a limit carried in it, which is how a
+        //    permission read actually gets truncated: assembled from parts, one of which stated a
+        //    page. The fan-out honours it, and nothing in the result says so. In the security fold
+        //    those missing rows are memberships, and a missing membership reads as "not a member".
+        var limited = parser.Parse($"{UnstampedMembershipQuery} limit:{ControlPage}");
+        limited.Limit.Should().Be(ControlPage, "the control must genuinely carry a limit");
+        var page = await Collect(cross, limited, ct);
+        Output.WriteLine($"string-limited: {page.Count} of {TotalRows} membership rows");
+        page.Count.Should().Be(ControlPage,
+            "a permission-deciding read that carries a limit is served a PAGE — which is exactly "
+            + "why the fold overwrites any limit rather than honouring the string it was built "
+            + "from");
+
+        // 1b. …and with NO limit stated at all, the runtime fan-out clips nothing. Pinned rather
+        //     than assumed: a default reintroduced here would silently page every permission read
+        //     on the mesh, which is #1216/#1326 aimed at the security fold (#2048).
         var unstamped = parser.Parse(UnstampedMembershipQuery);
         unstamped.Limit.Should().BeNull("the control must genuinely state no limit");
-        var page = await cross.QueryAcrossSchemasAsync(unstamped, _options, Schemas, ct: ct)
-            .Collect(ct).Should().Within(60.Seconds()).Emit();
-        Output.WriteLine($"unstamped: {page.Count} of {TotalRows} membership rows");
-        page.Count.Should().Be(PostgreSqlCrossSchemaQueryProvider.DefaultFanOutLimit,
-            "a permission-deciding read that states no limit is served a PAGE — which is exactly "
-            + "why the fold has to declare itself an enumeration rather than trust the absence of "
-            + "a limit");
+        var unclipped = await Collect(cross, unstamped, ct);
+        Output.WriteLine($"unstamped: {unclipped.Count} of {TotalRows} membership rows");
+        unclipped.Count.Should().Be(TotalRows,
+            "the runtime fan-out applies no default clip — the fold's completeness must not "
+            + "depend on one being absent by accident");
 
-        // 2. THE FIX — the fold's actual query, taken from the production builder, not retyped.
+        // 2. THE FIX — the fold's actual query, taken from the production builder, not retyped. It
+        //    REPLACES a limit rather than appending to it, which is what makes the control above
+        //    the thing it defends against.
+        SecurityQueries.Enumeration($"{UnstampedMembershipQuery} limit:{ControlPage}")
+            .Should().Contain(MeshQueryRequest.CompleteQualifier)
+            .And.NotContain($"limit:{ControlPage}");
         var stamped = parser.Parse(SecurityQueries.Memberships);
         stamped.Limit.Should().Be(MeshQueryRequest.NoLimit);
-        var complete = await cross.QueryAcrossSchemasAsync(stamped, _options, Schemas, ct: ct)
-            .Collect(ct).Should().Within(60.Seconds()).Emit();
+        var complete = await Collect(cross, stamped, ct);
         Output.WriteLine($"SecurityQueries.Memberships: {complete.Count} of {TotalRows} membership rows");
         complete.Count.Should().Be(TotalRows,
             "every GroupMembership must come back — a viewer's group set is not a list that may be "
@@ -122,6 +138,17 @@ public class SecurityFoldEnumerationTests(PostgreSqlFixture fixture, ITestOutput
         parser.Parse(SecurityQueries.Roles).Limit.Should().Be(MeshQueryRequest.NoLimit);
         parser.Parse(SecurityQueries.GatedNodes("Store/Plugin")).Limit.Should().Be(MeshQueryRequest.NoLimit);
     }
+
+    /// <summary>
+    /// The call the RUNTIME makes for an unpinned read: the table-name overload, which is what
+    /// <c>PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync</c> takes for every query the
+    /// security fold issues. Asserting through anything else pins a path no request can reach.
+    /// </summary>
+    private Task<System.Collections.Generic.List<MeshNode>> Collect(
+        PostgreSqlCrossSchemaQueryProvider cross, ParsedQuery query, CancellationToken ct)
+        => cross.QueryAcrossSchemasAsync(
+                query, _options, Schemas, "mesh_nodes", userId: null, activityUserId: null, ct)
+            .Collect(ct).Should().Within(60.Seconds()).Emit();
 
     // ── End-to-end guard: the stamped fold still decides correctly, and still denies ────────────
 

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/UserDirectoryCompletenessTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/UserDirectoryCompletenessTests.cs
@@ -28,8 +28,8 @@ namespace MeshWeaver.Hosting.PostgreSql.Test;
 /// of <see cref="AccessContext.TimeZoneId"/> and <see cref="AccessContext.Locale"/>
 /// (<see cref="MeshUserProjection"/>). It used to issue a bare <c>nodeType:User</c> query with no
 /// limit. That query carries no <c>path:</c> and no <c>namespace:</c>, so on Postgres it is the
-/// UNPINNED shape served by <c>PostgreSqlCrossSchemaQueryProvider</c>, which answers a request that
-/// states no limit with a PAGE: the 50 most recently modified matches, ordered
+/// UNPINNED shape served by <c>PostgreSqlCrossSchemaQueryProvider</c>, which at the time answered a
+/// request stating no limit with a PAGE: the 50 most recently modified matches, ordered
 /// <c>last_modified DESC</c>. Every other user was silently absent from the directory.</para>
 ///
 /// <para><b>Why it is invisible, and why it gets worse on its own.</b> A missing row makes
@@ -110,6 +110,15 @@ public class UserDirectoryCompletenessTests(PostgreSqlFixture fixture, ITestOutp
     /// The regression itself, end to end: a user buried under more recently modified ones is still
     /// found by the directory, and their stored zone still reaches the <see cref="AccessContext"/>.
     /// Before the fix the lookup answered a determinate <c>Unknown</c> and the projection never ran.
+    ///
+    /// <para>🚨 <b>What this test can and cannot fail on, stated so nobody mistakes it for a
+    /// falsification of <c>Complete()</c>.</b> The 50-row page that caused #1936 lived on a paging
+    /// fan-out overload no runtime caller could reach; it is deleted (#2048), so removing
+    /// <c>.Complete()</c> from <c>DirectoryQuery</c> leaves this test PASSING — only the property
+    /// assertion above fails. That is the correct division of labour and not a gap to paper over:
+    /// this test pins the end-to-end BEHAVIOUR (a buried user resolves, zone and all), the property
+    /// test pins the DECLARATION, and neither pretends to reproduce a truncation the runtime no
+    /// longer performs.</para>
     /// </summary>
     [Fact(Timeout = 180_000)]
     public async Task AUserOutsideTheMostRecentlyModifiedPage_StillResolvesTheirProfile()

--- a/test/MeshWeaver.Hosting.Snowflake.Test/CrossSchemaUnionTests.cs
+++ b/test/MeshWeaver.Hosting.Snowflake.Test/CrossSchemaUnionTests.cs
@@ -28,10 +28,12 @@ namespace MeshWeaver.Hosting.Snowflake.Test;
 /// <see cref="SnowflakeCrossSchemaQueryProvider.QueryAcrossSchemasAsync"/> (renamed
 /// <c>CrossSchema_SearchAcrossSchemas_*</c>), with the registry populated in
 /// <c>public.searchable_schemas</c> exactly like PG and read back via
-/// <see cref="SnowflakeCrossSchemaQueryProvider.GetSearchableSchemasAsync"/>. The proc's
-/// implicit <c>main_node = path</c> / <c>last_modified DESC</c> / <c>LIMIT 50</c> defaults are
-/// reproduced by the provider itself. The PG twin's <c>SearchableSchemasSyncThrottleTests</c>
-/// scenarios are folded in at the bottom (same throttle, same <c>ActualSyncCount</c> hook).</para>
+/// <see cref="SnowflakeCrossSchemaQueryProvider.GetSearchableSchemasAsync"/>. 🚨 These run through
+/// the TABLE-NAME overload, which is what <c>SnowflakePartitionedMeshQuery.EnumerateFanOutAsync</c>
+/// takes for every unpinned query and, since #2048, the only cross-schema shape either backend
+/// carries: the paging overload that reproduced the proc's <c>LIMIT 50</c> default had no runtime
+/// caller and is deleted. The PG twin's <c>SearchableSchemasSyncThrottleTests</c> scenarios are
+/// folded in at the bottom (same throttle, same <c>ActualSyncCount</c> hook).</para>
 /// </summary>
 [Collection("Snowflake")]
 public class CrossSchemaUnionTests
@@ -159,8 +161,8 @@ public class CrossSchemaUnionTests
             .Collect(ct).Should().Within(30.Seconds()).Emit();
 
     // The provider replacement for PG's CallSearchAcrossSchemas: schemas come from the
-    // searchable_schemas registry (like the proc re-reading it) and the proc's orderBy/limit
-    // defaults are reproduced inside QueryAcrossSchemasAsync.
+    // searchable_schemas registry, and the fan-out clips only what the caller asked for — there
+    // is no default limit on the shape the runtime takes (#2048).
     private Task<List<MeshNode>> SearchAcrossSchemas(
         ParsedQuery query, string? userId, CancellationToken ct)
         => SearchAcrossSchemasAsync(query, userId, ct)
@@ -312,7 +314,7 @@ public class CrossSchemaUnionTests
         }
     }
 
-    // ── Cross-schema UNION: QueryAcrossSchemasAsync (PG: the search_across_schemas proc) ──
+    // ── Cross-schema UNION: QueryAcrossSchemasAsync over mesh_nodes (the runtime shape) ──
 
     [Fact(Timeout = 60000)]
     public async Task CrossSchema_SearchAcrossSchemas_ReturnsAllOrgs()
@@ -325,7 +327,7 @@ public class CrossSchemaUnionTests
         var schemas = partitions.Keys.Select(k => k.ToLowerInvariant()).ToList();
         await PopulateSearchableSchemas(schemas, ct);
 
-        // Empty filter (PG passed whereClause '') — provider applies the proc's defaults.
+        // Empty filter — every node in every registered schema, unclipped.
         var results = await SearchAcrossSchemas(ParsedQuery.Empty, null, ct);
 
         results.Should().NotBeEmpty("the cross-schema UNION should return nodes from all schemas");
@@ -596,7 +598,11 @@ public class CrossSchemaUnionTests
         var schemas = await provider.GetSearchableSchemasAsync(ct);
 
         var results = new List<MeshNode>();
-        await foreach (var node in provider.QueryAcrossSchemasAsync(query, _options, schemas, userId, ct))
+        // The table-name overload — the one SnowflakePartitionedMeshQuery.EnumerateFanOutAsync
+        // takes for every unpinned query, and since #2048 the only cross-schema shape there is.
+        await foreach (var node in provider.QueryAcrossSchemasAsync(
+                           query, _options, schemas, "mesh_nodes",
+                           userId, activityUserId: null, ct))
             results.Add(node);
         return results;
     }


### PR DESCRIPTION
Closes #1974. Closes #2048.

## #1974 — the last open item: module static assets are not fingerprinted

The flip itself was already done (all five packs left the repo in `11454517a`; `Memex.Portal.Shared.csproj:13,19,28` records each deliberate non-reference; the dangling `ImportModuleLayoutTest` reference is gone). Only the fingerprinting gap remained.

**Fingerprinted where fingerprinting can reach.** The scoped-CSS aggregate is the ONE module asset whose URL the platform authors — `App.razor` links it off `ModuleStaticAssetManifest.Stylesheets` — so it is now published at `_content/<Name>/<Name>.<sha256-16>.styles.css` and served `public, max-age=31536000, immutable`. An upgrade is picked up on the very next page load under a new URL (no stale-cache window at all), and an unchanged module costs **zero** requests instead of one conditional GET per render.

- The hash is over the body actually **served** (after `StripHostProvidedImports`), so a republish that changed nothing keeps the URL — a generation- or timestamp-derived token would invalidate every viewer's copy on every republish, which is the cost this removes.
- Both URLs are answered from memory. Serving the plain path too is not politeness: leaving it to fall through to the mount would serve the **landed** file, whose host-provided `@import`s name fingerprints only the module's own build ever had (a silent 404 per page load).

**Everything else states `no-cache`, and cannot do better.** A pack hard-codes `_content/<Name>/<file>` in its **own** component source (`RadzenViewBase` self-loads the Radzen theme; `GoogleMapView.razor.cs` imports its collocated JS) — source that is not in this build graph, so the host cannot rewrite those URLs. Saying `immutable` would be a lie. Saying **nothing** — what plain `UseStaticFiles` emits — is worse than it looks: a browser then applies heuristic freshness off `Last-Modified` and may serve an upgraded module's CSS/JS **without revalidating at all**. `no-cache` is the same promise `MapStaticAssets` makes for the host's own unfingerprinted routes.

**Named callers** (extracting is not using):
- fingerprinted URL → `memex/Memex.Portal.Shared/App.razor:43-46` (`@foreach (var stylesheet in ModuleAssets.Stylesheets)`) — unchanged markup, new contents.
- manifest → `MemexConfiguration.cs:92` (`AddMeshModuleStaticAssets`) and `:1380` (`UseMeshModuleStaticAssets`).

## #2048 — DECISION: **retire** the paging fan-out. Do not wire it.

`ICrossSchemaQueryProvider.QueryAcrossSchemasAsync(query, options, schemas, userId, ct)` and its PostgreSQL/Snowflake implementations are deleted. Why retire rather than wire:

1. **No runtime caller.** `PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync` and its Snowflake twin — the path for *every* unpinned query — have only ever taken the table-name overload, which applies no default limit.
2. **Its distinctive behaviour is the defect, not the feature.** The silent 50-row clip is precisely what #1216, #1326 and #1960 were filed against. The runtime's actual answer — return every match — is the one those issues' remedy argued for. If a bound is ever wanted for an unanchored UNION, it belongs on the **one** shape the runtime executes and it has to be loud.
3. **It was a second access-control implementation** (the `search_across_schemas` stored function vs the generated per-schema `user_effective_permissions` clause) that nothing exercised — exactly where a security fix lands on the wrong copy.

`public.search_across_schemas` stays in the schema: an older replica mid-rollout still calls it.

### Deleting the dead shape surfaced three things that were live

- 🚨 **Mesh-wide keyset paging had never worked in production.** #2186 fixed `sort:path` erroring `42703 column "path" does not exist` — but the fix landed on the **stored function**, i.e. the shape nothing runs. `CrossPartitionKeysetPagingTests` went red the moment it was pointed at the runtime overload. Both SQL generators now project `path` on every union branch (content arms included — `UNION ALL` is positional), and the test passes against the shape the runtime takes.
- **The fan-out timing instrumentation produced not one line in production.** `LogFanOutTiming` — added because "this is the expensive shape and nothing used to measure it" — was called only from the paging overload. It now runs on the table-name overload, in a `finally` so an abandoned enumeration (a `.Take(n)`, a cancellation) still reports.
- **Snowflake and PG disagreed about `Complete()`.** Snowflake dropped `MeshQueryRequest.NoLimit` (`request.Limit is > 0`) where PG propagates it whatever the sign, so `Complete()` did not override a query-string `limit:N` there. Aligned; the `LIMIT 0`/`LIMIT -1` concern is handled where the SQL is written.

### The tests now demonstrate their claim

- `CompleteEnumerationFanOutTests` — pins "an unpinned query returns **every** match" through `"mesh_nodes"`; the seeded count stays above 50 so a reintroduced default clip fails here.
- `SecurityFoldEnumerationTests` — the control is now a limit carried in the query **string**, which is what `SecurityQueries.Enumeration` actually defends against (it *replaces* a `limit:N`), plus a new assertion that no default clip exists. The old control asserted a 50-row default that no request could reach.
- `UserDirectoryCompletenessTests` — says outright that removing `.Complete()` leaves the behavioural test passing and only the property test failing, and why that is the correct division of labour rather than a gap.
- `Complete()`'s own contract is restated exactly: a **declaration** that a read is an enumeration, plus an override of a limit that reaches the request. It is no longer credited with defeating a truncation the runtime does not perform.

## Verification

- `dotnet build -c Release -warnaserror`, `0 Error(s) / 0 Warning(s)`: `MeshWeaver.Hosting.AspNetCore`, `.PostgreSql`, `.Snowflake`, `MeshWeaver.Hosting`, `MeshWeaver.Blazor`, `MeshWeaver.Mesh.Contract`, `Memex.Portal.Shared`, and the four touched test projects.
- **87/87** `MeshWeaver.Hosting.PostgreSql.Test` (fan-out, security fold, keyset paging, SQL generator, per-subject/per-schema access folds, permission projection) — against a live Postgres.
- **16/16** `ModuleStaticAssetDiscoveryTest` (three new: fingerprint tracks the body not the landing; both URLs served from memory; the over-the-wire caching promises).
- **49/49** `MeshWeaver.Documentation.Test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
