### PR TITLE
The LISTEN readiness signal is the LISTEN statement, not the connection (#2281)

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlChangeListener.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlChangeListener.cs
@@ -20,6 +20,35 @@ public class PostgreSqlChangeListener : IAsyncDisposable
     private CancellationTokenSource? _cts;
     private Task? _listenTask;
 
+    // Completed the instant `LISTEN mesh_node_changes` has actually executed — see Listening.
+    // AsyncSubject: it replays its completion to every later subscriber, so a consumer that asks
+    // after registration already happened is answered immediately rather than waiting for an
+    // announcement that has been and gone.
+    private readonly System.Reactive.Subjects.AsyncSubject<System.Reactive.Unit> _listening = new();
+
+    /// <summary>
+    /// Completes once <c>LISTEN mesh_node_changes</c> has been REGISTERED on the dedicated
+    /// connection — i.e. from this point on a <c>NOTIFY</c> is actually delivered here.
+    ///
+    /// <para>🚨 <b>Why this is not the same as "StartAsync returned", and why nothing else can
+    /// stand in for it.</b> <see cref="StartAsync"/> deliberately returns as soon as the loop is
+    /// launched (a hosted service must not block host startup on a database being reachable), and
+    /// the loop then opens a connection FIRST and issues <c>LISTEN</c> second. In that window the
+    /// process is connected but not subscribed — and <b>Postgres never replays a
+    /// <c>NOTIFY</c></b>, so every notification fired in it is lost with no recovery path.</para>
+    ///
+    /// <para>The connection is therefore NOT a proxy for the subscription: a backend appears in
+    /// <c>pg_stat_activity</c> the moment it opens, which is exactly why the readiness probe that
+    /// counted rows there could go green before <c>LISTEN</c> had run and let a writer race it
+    /// (Systemorph/MeshWeaver#2281). Anything that must not miss the first notification waits on
+    /// THIS, which is signalled by the <c>LISTEN</c> statement itself completing.</para>
+    ///
+    /// <para>Completes on the FIRST successful registration only. A later reconnect re-issues
+    /// <c>LISTEN</c> but does not re-signal — this answers "has this listener ever come up", not
+    /// "is the connection healthy right now".</para>
+    /// </summary>
+    public IObservable<System.Reactive.Unit> Listening => _listening;
+
     /// <summary>
     /// Initializes the change listener.
     /// </summary>
@@ -71,6 +100,12 @@ public class PostgreSqlChangeListener : IAsyncDisposable
 
     /// <summary>
     /// Starts the background listener loop.
+    ///
+    /// <para>🚨 Returns as soon as the loop is LAUNCHED — deliberately, because this runs from an
+    /// <c>IHostedService</c> and a portal must not fail to start because the database is briefly
+    /// unreachable (the loop reconnects on its own). So "StartAsync completed" does NOT mean
+    /// "listening": wait on <see cref="Listening"/> for that, and read its remarks for why the
+    /// difference is a real, silent data-loss window rather than a technicality.</para>
     /// </summary>
     public Task StartAsync(CancellationToken ct = default)
     {
@@ -118,6 +153,11 @@ public class PostgreSqlChangeListener : IAsyncDisposable
                 }
 
                 _logger?.LogInformation("PostgreSQL LISTEN started on mesh_node_changes");
+                // The subscription now exists on the server, so from here a NOTIFY reaches us.
+                // Signalled AFTER ExecuteNonQueryAsync, never after OpenConnectionAsync — the
+                // whole point of Listening is that those two are not the same instant.
+                _listening.OnNext(System.Reactive.Unit.Default);
+                _listening.OnCompleted();
 
                 // WaitAsync will block until a notification arrives or cancellation is requested
                 while (!ct.IsCancellationRequested)

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlChangeListener.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlChangeListener.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Mesh.Services;
 using Microsoft.Extensions.Logging;
@@ -47,7 +48,11 @@ public class PostgreSqlChangeListener : IAsyncDisposable
     /// <c>LISTEN</c> but does not re-signal — this answers "has this listener ever come up", not
     /// "is the connection healthy right now".</para>
     /// </summary>
-    public IObservable<System.Reactive.Unit> Listening => _listening;
+    /// <remarks><c>AsObservable()</c>, not the subject: the runtime type would otherwise still be
+    /// <c>AsyncSubject&lt;Unit&gt;</c>, so a caller could downcast and SIGNAL readiness itself —
+    /// the one thing a readiness signal must never let anyone but its source do. Same guard as
+    /// <c>OrleansStreamingReadiness</c>.</remarks>
+    public IObservable<System.Reactive.Unit> Listening => _listening.AsObservable();
 
     /// <summary>
     /// Initializes the change listener.

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossProcessNotifyPgTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossProcessNotifyPgTests.cs
@@ -66,10 +66,19 @@ public class CrossProcessNotifyPgTests(IsolatedPostgreSqlFixture fixture) : IAsy
         _listener = PostgreSqlChangeListener.OwningDataSource(
             _processB.CreateChangeListenerDataSource(), _router);
         await _listener.StartAsync(TestContext.Current.CancellationToken);
-        // The LISTEN session has to be OPEN before the write, or the NOTIFY has no subscriber —
-        // Postgres does not replay. Poll pg_stat_activity for the named session rather than sleep:
-        // a fixed delay is either flaky or slow, and this one is neither.
-        await WaitForListenSession();
+        // 🚨 The LISTEN has to be REGISTERED before the write, or the NOTIFY has no subscriber and
+        // Postgres never replays it — the write then lands, nothing arrives, and this test times
+        // out 30 s later with no clue why (#2281: two CI failures on diffs that cannot reach PG).
+        //
+        // This waits on the listener's OWN signal, raised by the `LISTEN mesh_node_changes`
+        // statement completing. It replaced a poll of pg_stat_activity for the named session,
+        // which could not detect the hazard its own comment named: a backend appears there the
+        // moment the CONNECTION opens, and the loop opens the connection FIRST and issues LISTEN
+        // SECOND — so the gate went green inside exactly the window it existed to close.
+        await _listener.Listening
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
     }
 
     public async ValueTask DisposeAsync()
@@ -146,20 +155,4 @@ public class CrossProcessNotifyPgTests(IsolatedPostgreSqlFixture fixture) : IAsy
             .ToTask(TestContext.Current.CancellationToken);
     }
 
-    /// <summary>
-    /// Waits until the listener's named session is visible in <c>pg_stat_activity</c> — the positive
-    /// "the LISTEN is open" signal. Bounded: no session inside the budget fails the test rather than
-    /// letting every assertion below time out on a missing subscription.
-    /// </summary>
-    private Task WaitForListenSession()
-        => Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
-            .SelectMany(_ => fixture.DataSource.ScalarLong(
-                "SELECT count(*) FROM pg_stat_activity "
-                + "WHERE application_name = 'meshweaver-change-listener'",
-                TestContext.Current.CancellationToken))
-            .Where(count => count > 0)
-            .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(30))
-            .Select(_ => System.Reactive.Unit.Default)
-            .ToTask(TestContext.Current.CancellationToken);
 }


### PR DESCRIPTION
Closes #2281.

`CrossProcessNotifyPgTests.AWriteByAnotherProcess_ArrivesOnThisProcessesPartitionFeed` times out at
**30 s** — no notification arrives at all. Two occurrences in three days, both on diffs that cannot
reach PostgreSQL notify: run [32718680912](https://github.com/Systemorph/MeshWeaver/actions/runs/32718680912)
(branch `fix/rn-remote-navigation`) and PR #2250 (bake gate + an allow-list). It had no issue until
today; it is a **sibling of #2008** by area (the cross-process change feed) and a different failure
mode.

## The gate could not detect the hazard it was named after

`PostgreSqlChangeListener.StartAsync` launches its loop and returns immediately — correctly, because
it runs from an `IHostedService` and a portal must not fail to start because the database is briefly
unreachable. The loop then opens the connection **first** and issues `LISTEN mesh_node_changes`
**second**. In that window the process is connected but not subscribed, and **Postgres never replays
a `NOTIFY`**, so anything fired there is lost with no recovery path.

The test knew this and guarded it — with a probe that goes green inside exactly that window:

```csharp
"SELECT count(*) FROM pg_stat_activity WHERE application_name = 'meshweaver-change-listener'"
```

A backend appears in `pg_stat_activity` the moment the **connection** opens. So the gate passes, the
test writes, the `NOTIFY` reaches nobody, and the wait burns its full 30 s. Its own comment reads
*"The LISTEN session has to be OPEN before the write, or the NOTIFY has no subscriber — Postgres does
not replay"* — and then measures the connection instead of the subscription.

Same defect class as #2259 (*a subscriber attaching after a once-only announcement*), one layer down,
in Postgres — and the same "green signal measuring the wrong thing" shape.

## The fix

`PostgreSqlChangeListener` exposes **`Listening`**: an `AsyncSubject` completed by the `LISTEN`
statement itself, i.e. the moment a `NOTIFY` actually reaches this process. It replays, so a consumer
that asks after registration already happened is answered immediately rather than waiting for an
announcement that has been and gone.

- `StartAsync` is **unchanged** — no production behaviour change, no blocking of host startup. Its
  remarks now say that "started" is not "listening", and point at the signal that is.
- The test waits on `Listening`, and `WaitForListenSession` is **deleted** rather than made cleverer:
  with a truthful signal there is nothing left to poll for.

## RED before / GREEN after — deterministic, no timing

The window was widened with a temporary 3 s delay between `OpenConnectionAsync` and the `LISTEN`
statement (a probe only; not in this diff):

| gate | window | outcome |
|---|---|---|
| `pg_stat_activity` poll (main) | +3 s | **FAIL** — `System.TimeoutException` at `[30 s]`, the CI signature verbatim |
| `listener.Listening` (this PR) | +3 s | **PASS** in 3 s — the wait absorbs the whole window |
| `listener.Listening` | shipped (no delay) | **PASS** in 153 ms |

Both tests in the class pass; run against a real Postgres via testcontainers, `-c Release`.

## Left standing, deliberately

The **production** window is narrowed in visibility, not closed: a `NOTIFY` fired between a pod's
`StartAsync` and its `LISTEN` is still lost. Closing it would mean either blocking host startup on
the database (rejected above) or treating the feed as non-authoritative until `Listening` — a design
call for whoever owns the change feed, now that the signal to make it on exists. Recorded in #2281
rather than smuggled in here.

## What's New

Skipped: no user-visible effect (an additive readiness signal plus a test gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
