### PR TITLE
Credential encryption is platform, not AI (#2276 step A2)

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
@@ -1,12 +1,11 @@
+using MeshWeaver.Mesh.Security;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text.Json;
-using MeshWeaver.AI;                        // IProviderKeyProtector
 using MeshWeaver.Blazor.Infrastructure;     // PortalApplication
 using MeshWeaver.Data;                       // IWorkspace.GetMeshNodeStream
 using MeshWeaver.Graph.Configuration;        // EaCredentialNodeType
 using MeshWeaver.Mesh;                        // EaCredential, MeshNode
-using MeshWeaver.Mesh.Security;               // ImpersonateAsSystem
 using MeshWeaver.Mesh.Services;               // IMeshService
 using MeshWeaver.Messaging;                   // AccessService
 using Microsoft.Extensions.Configuration;

--- a/memex/Memex.Portal.Shared/Models/ModelProviderService.cs
+++ b/memex/Memex.Portal.Shared/Models/ModelProviderService.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Mesh.Security;
 using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Linq;

--- a/src/MeshWeaver.AI/LanguageModelNodeType.cs
+++ b/src/MeshWeaver.AI/LanguageModelNodeType.cs
@@ -96,13 +96,9 @@ public static class LanguageModelNodeType
         {
             services.TryAddSingleton<LanguageModelCatalogOptions>();
             services.TryAddSingleton<BuiltInLanguageModelProvider>();
-            // Encryption-at-rest for ModelProvider.ApiKey. Default master key
-            // comes from config (Ai:KeyProtection:MasterKey); swap in a
-            // KMS/Key Vault IMasterKeyProvider for hardened deployments. With
-            // no key configured both are pure passthrough (plaintext), so this
-            // is safe to register unconditionally.
-            services.TryAddSingleton<IMasterKeyProvider, ConfigMasterKeyProvider>();
-            services.TryAddSingleton<IProviderKeyProtector, ProviderKeyProtector>();
+            // Encryption-at-rest for ModelProvider.ApiKey is registered by AddGraph() — the
+            // protector is platform (GitHub PATs, the EA credential and the plugin catalog's
+            // signing key ride it too), so it must exist on a deployment with no AI at all.
             // 🧊 The mesh's SHARED resolver is warmed by whoever builds it — here. Reads are pure
             // (they never open the catalog subscription), so warming is an owner's decision rather
             // than a side effect of the first lookup. Every consumer resolves the resolver from DI,

--- a/src/MeshWeaver.AI/ModelProviderLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ModelProviderLayoutAreas.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Mesh.Security;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;

--- a/src/MeshWeaver.AI/ModelStaticRepoSource.cs
+++ b/src/MeshWeaver.AI/ModelStaticRepoSource.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1420,7 +1420,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     /// <item><c>/login gateway &lt;base-url&gt; &lt;token&gt;</c> — a gateway/proxy (ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL).</item>
     /// <item><c>/logout</c> — forget the stored credential.</item>
     /// </list>
-    /// The credential is encrypted at rest (<see cref="MeshWeaver.AI.IProviderKeyProtector"/>) and stored as
+    /// The credential is encrypted at rest (<see cref="MeshWeaver.Mesh.Security.IProviderKeyProtector"/>) and stored as
     /// the harness's <c>ModelProvider</c> node at <c>{user}/_Memex/{harnessId}</c> — the SAME path
     /// <c>ChatClientCredentialResolver.ResolveConnectCredential</c> reads, so writer and reader agree.
     /// </summary>
@@ -1698,7 +1698,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             return;
         }
         var providerPath = $"{MeshWeaver.AI.ModelProviderNodeType.UserNamespacePath(owner)}/{harness.Id}";
-        var protector = Hub.ServiceProvider.GetService<MeshWeaver.AI.IProviderKeyProtector>();
+        var protector = Hub.ServiceProvider.GetService<MeshWeaver.Mesh.Security.IProviderKeyProtector>();
         var stored = protector is null ? credential : protector.Protect(credential);
         var node = MeshWeaver.Mesh.MeshNode.FromPath(providerPath) with
         {

--- a/src/MeshWeaver.GitSync/GitHubCredential.cs
+++ b/src/MeshWeaver.GitSync/GitHubCredential.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Mesh.Security;
 using System.ComponentModel;
 
 namespace MeshWeaver.GitSync;
@@ -6,7 +7,7 @@ namespace MeshWeaver.GitSync;
 /// A per-user GitHub OAuth credential, stored as a MeshNode at
 /// <c>{userId}/_Provider/GitHub</c> on the user's own partition. The
 /// <see cref="AccessToken"/> (and optional <see cref="RefreshToken"/>) are
-/// encrypted at rest via <see cref="MeshWeaver.AI.IProviderKeyProtector"/>
+/// encrypted at rest via <see cref="MeshWeaver.Mesh.Security.IProviderKeyProtector"/>
 /// (AES-256-GCM, <c>enc:v1:…</c>) — the same protector that guards LLM provider
 /// keys. The token is the <b>committing user's</b>: every push authenticates as
 /// this user and the commit is authored as them.

--- a/src/MeshWeaver.GitSync/GitHubCredentialService.cs
+++ b/src/MeshWeaver.GitSync/GitHubCredentialService.cs
@@ -4,6 +4,7 @@ using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -96,6 +96,24 @@ public static class GraphConfigurationExtensions
             // set (empty when no modules) — stamped by compile write-backs as CompiledModulesHash.
             builder.ConfigureServices(s => s.AddSingleton<InstalledModulesFingerprint>());
 
+            // Encryption-at-rest for stored credentials: a model provider's ApiKey, a GitHub PAT,
+            // the Entra EA credential, the plugin catalog's sync-token signing key. Registered
+            // HERE rather than with any one of those, because every one of them is optional and
+            // the protector is not — it rode AddModelProviderType(), i.e. AddAI(). That held only
+            // while AI shipped in every image; the moment the engine leaves for a module (#2276) a
+            // deployment without it would resolve NO protector, and every consumer's optional
+            // GetService() null-check would then store its secret in PLAINTEXT without a word.
+            //
+            // With no master key configured (Ai:KeyProtection:MasterKey) both are pure
+            // passthrough, so registering unconditionally changes nothing for a deployment that
+            // has not set one. Swap in a KMS/Key Vault IMasterKeyProvider to harden.
+            builder.ConfigureServices(s =>
+            {
+                s.TryAddSingleton<IMasterKeyProvider, ConfigMasterKeyProvider>();
+                s.TryAddSingleton<IProviderKeyProtector, ProviderKeyProtector>();
+                return s;
+            });
+
             // The static-repo importer runs its bulk create/upsert traffic on a DEDICATED
             // hub (import/{meshHubId}) so it never floods the root mesh hub's action block —
             // the router must stay free (prod 2026-06-11 wedge). Declare its address-type as

--- a/src/MeshWeaver.Mesh.Contract/Security/ConfigMasterKeyProvider.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/ConfigMasterKeyProvider.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace MeshWeaver.AI;
+namespace MeshWeaver.Mesh.Security;
 
 /// <summary>
 /// Default <see cref="IMasterKeyProvider"/> — reads a base64 master key from

--- a/src/MeshWeaver.Mesh.Contract/Security/IMasterKeyProvider.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/IMasterKeyProvider.cs
@@ -1,4 +1,4 @@
-namespace MeshWeaver.AI;
+namespace MeshWeaver.Mesh.Security;
 
 /// <summary>
 /// Supplies the symmetric master key used by <see cref="IProviderKeyProtector"/>

--- a/src/MeshWeaver.Mesh.Contract/Security/IProviderKeyProtector.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/IProviderKeyProtector.cs
@@ -1,11 +1,14 @@
-namespace MeshWeaver.AI;
+namespace MeshWeaver.Mesh.Security;
 
 /// <summary>
-/// Encrypts / decrypts the literal credential stored on a
-/// <see cref="ModelProviderConfiguration.ApiKey"/> before it is persisted to
-/// (and read back from) the mesh — i.e. Postgres. Answers "is it safe to keep
-/// LLM keys in PG": with a master key configured the value at rest is AES-256-GCM
-/// ciphertext, so a DB / backup leak alone yields no usable key.
+/// Encrypts / decrypts a literal credential before it is persisted to (and read back from) the
+/// mesh — i.e. Postgres. Answers "is it safe to keep secrets in PG": with a master key configured
+/// the value at rest is AES-256-GCM ciphertext, so a DB / backup leak alone yields no usable key.
+///
+/// <para>Callers today: a model provider's <c>ApiKey</c>, a GitHub PAT
+/// (<c>GitHubCredential</c>), the Entra EA credential, and the plugin catalog's sync-token
+/// signing key. It lives in the platform rather than with any one of them precisely because it
+/// is none of their concern — see Systemorph/MeshWeaver#2276.</para>
 ///
 /// <para>Backward compatible: <see cref="Protect"/> is idempotent and
 /// <see cref="Unprotect"/> passes through any value not carrying the

--- a/src/MeshWeaver.Mesh.Contract/Security/ProviderKeyProtector.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/ProviderKeyProtector.cs
@@ -2,7 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
-namespace MeshWeaver.AI;
+namespace MeshWeaver.Mesh.Security;
 
 /// <summary>
 /// AES-256-GCM <see cref="IProviderKeyProtector"/>. Stored form is

--- a/test/MeshWeaver.AI.Test/ProviderCredentialSeedDecisionTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderCredentialSeedDecisionTest.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using MeshWeaver.Mesh.Security;
 using Xunit;
 
 namespace MeshWeaver.AI.Test;

--- a/test/MeshWeaver.AI.Test/ProviderCredentialSeedTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderCredentialSeedTest.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using MeshWeaver.Mesh.Security;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/test/MeshWeaver.AI.Test/ProviderKeyEncryptionTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderKeyEncryptionTest.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using MeshWeaver.Mesh.Security;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/test/MeshWeaver.AI.Test/ProviderKeyProtectorTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderKeyProtectorTest.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using MeshWeaver.Mesh.Security;
 using System.Security.Cryptography;
 using MeshWeaver.AI;
 using Xunit;

--- a/test/MeshWeaver.GitSync.Test/GitHubSyncTestBase.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubSyncTestBase.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Mesh.Security;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.AI;

--- a/test/MeshWeaver.Graph.Test/ProviderKeyProtectorRegistrationTest.cs
+++ b/test/MeshWeaver.Graph.Test/ProviderKeyProtectorRegistrationTest.cs
@@ -1,0 +1,43 @@
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh.Security;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The credential protector must exist on a mesh built from the PLATFORM alone.
+///
+/// <para>It used to be registered by <c>AddModelProviderType()</c>, i.e. by <c>AddAI()</c>. That was
+/// invisible while the AI engine shipped in every image — but four unrelated subsystems resolve it
+/// OPTIONALLY (<c>GetService</c>, null ⇒ store the secret verbatim): a model provider's ApiKey, a
+/// GitHub PAT, the Entra EA credential, and the plugin catalog's sync-token signing key. So the
+/// day the engine leaves for a module (#2276), a deployment without it would have written all four
+/// in PLAINTEXT and said nothing — no exception, no warning, and a stored secret that still
+/// "works" because Unprotect passes untagged values through.</para>
+///
+/// <para>The registration now lives in <c>AddGraph()</c> and this is the ratchet: exactly ONE
+/// registration exists in the tree, so resolving it here proves the platform path carries it.</para>
+/// </summary>
+public class ProviderKeyProtectorRegistrationTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 30000)]
+    public void AddGraph_RegistersTheCredentialProtector()
+    {
+        var protector = Mesh.ServiceProvider.GetService<IProviderKeyProtector>();
+        var masterKey = Mesh.ServiceProvider.GetService<IMasterKeyProvider>();
+
+        protector.Should().NotBeNull(
+            "every consumer resolves this optionally and falls back to storing the secret VERBATIM — "
+            + "an absent registration is silent plaintext at rest, not an error");
+        masterKey.Should().BeOfType<ConfigMasterKeyProvider>(
+            "the default reads Ai:KeyProtection:MasterKey from configuration; a deployment swaps in "
+            + "a KMS-backed provider by registering its own before AddGraph runs");
+
+        // Round-trips whether or not this host configures a master key: with one, through
+        // AES-256-GCM; without, both directions are passthrough.
+        protector!.Unprotect(protector.Protect("ghp_the_committing_users_token"))
+            .Should().Be("ghp_the_committing_users_token");
+    }
+}


### PR DESCRIPTION
Step A2 of #2276 (*all AI deleted from core, deployed and green*). Independent of #2283 — different files.

`IProviderKeyProtector` / `IMasterKeyProvider` / `ProviderKeyProtector` / `ConfigMasterKeyProvider` move from `MeshWeaver.AI` into `MeshWeaver.Mesh.Contract` (`MeshWeaver.Mesh.Security`).

They were never AI. Four unrelated subsystems already encrypt with them:

| Consumer | Secret |
|---|---|
| `ModelProviderService` | a model provider's `ApiKey` |
| `GitSync/GitHubCredential` | the committing user's GitHub PAT |
| `Memex.Portal.Shared/Authentication/EaGraphAuth` | the Entra EA credential |
| `PluginCatalog/SyncTokenSigningKeyService` | the sync-token signing key |

The last two reach the type only through `GitSync`'s transitive reference to the AI engine.

### The registration is the load-bearing half

It sat in `AddModelProviderType()` — behind `AddAI()`. Every consumer resolves the protector **optionally** (`GetService`, and on null stores the secret verbatim), so the day the engine leaves for a module a deployment without it would have written all four credentials **in plaintext and said nothing**: no exception, no warning, and the values still "work" afterwards because `Unprotect` passes untagged input straight through. `AddGraph()` registers it now, so it exists on any mesh built from the platform.

`ProviderKeyProtectorRegistrationTest` is the ratchet — and it was verified to FAIL with the two lines removed (`Expected value not to be <null>`), which also proves nothing else in the tree registers them.

### The config key does NOT get tidied

It stays `Ai:KeyProtection:MasterKey`. It is live in Key Vault and in the CSI `SecretProviderClass` mapping of every deployment, and `DeploymentOptions.md` records that deploying a *different* master key makes every stored `enc:` value undecryptable — including the live `Systemorph/Provider/AzureFoundry` key. Renaming it here would be a silent deletion of a running secret.

### Verification

- Full solution build under CI's flags (`MW_ALLOW_SOLUTION_BUILD=1 … -c Release -p:CIRun=true -warnaserror`) → `0 Error(s)`. That is what surfaced the three doc `cref`s and a fully-qualified `MeshWeaver.AI.IProviderKeyProtector` in `ThreadChatView`.
- 23 provider-key tests pass (`ProviderKeyProtectorTest`, `ProviderKeyEncryptionTest`, `ProviderCredentialSeedTest`, `ProviderCredentialSeedDecisionTest`) + the new ratchet.

### Follow-up, deliberately not in this PR

All four consumers still `GetService` + fall back to plaintext. With the registration now unconditional that fallback is unreachable in a real host — which makes it exactly the kind of fail-open worth deleting on its own, with its own reasoning about bespoke hosts. Tracked on #2276.

**No What's New entry**: pure-internal refactor, no user-visible effect.

Refs #2276

🤖 Generated with [Claude Code](https://claude.com/claude-code)