### PR TITLE
Re-pin Skill/group.md — main is red on the drift guard it just gained

### DIFF
--- a/test/MeshWeaver.AI.Test/TestData/AiContentPackSync.json
+++ b/test/MeshWeaver.AI.Test/TestData/AiContentPackSync.json
@@ -146,7 +146,7 @@
     },
     {
       "file": "Skill/group.md",
-      "core": "4e7238adb03bf6b1da18773e004f29c9b1d3bd451b669edbc104bd17e3ab9564",
+      "core": "c72243ed16ffa6639ad09643befeef35cef9eab20647442bc40d14489195afd9",
       "pack": null,
       "state": "PackAbsent"
     },


### PR DESCRIPTION
## main is RED

`MeshWeaver.AI.Test.AiContentPackDriftTest.EveryFile_StillHashesToItsPinnedReconciliationPoint` fails on `main` (run `32897144937`, head `84af9fad5`). A red main blocks CD, so this is a fix-forward.

## Cause — two parallel cleanups of the same leak

`2fbf6fce7` ("personal data out of the core's shipped content too") edited `content/ai/Skill/group.md`. #2263 landed the drift ledger pinning that file's **previous** hash. Both are correct in isolation; together the ledger is stale by one commit.

**The guard is behaving exactly as designed** — this is precisely the drift it exists to catch, and the content change is the one we want to keep. Only the pin needed updating.

## Two traps on the way, worth recording

1. **The ledger stores a NORMALIZED hash, not a raw sha256 of the file bytes.** Computing one by hand (`sha256sum` / Python `hashlib`) yields `74f8e31c…`, which will *never* match, and pinning it would have left main red while looking fixed. **The test's own reported value is the authority.**
2. **`dotnet test --no-build` reads `TestData/` from `bin/`.** After editing the source JSON the bin copy was 3 minutes stale, so the run kept reporting the old hash — the same class as AGENTS.md's *"`--no-build` after editing a doc / non-`.cs` asset"* trap. Rebuilt, then re-ran.

## Verification

`AiContentPackDriftTest` **15/15 green** after a rebuild; `MeshWeaver.AI.Test` builds `0 Error(s) / 0 Warning(s)` under `-c Release -warnaserror`. One line changed.

## Note for whoever is editing content/ai

The ledger must be re-pinned in the **same commit** as a `content/ai` edit, or main goes red between the two. That is the guard working, not a false positive — but it means content edits and ledger updates cannot be split across PRs.