### PR TITLE
GitSync stops depending on the AI engine (#2276 step B2)

### DIFF
--- a/src/MeshWeaver.AI/AIExtensions.cs
+++ b/src/MeshWeaver.AI/AIExtensions.cs
@@ -2,6 +2,7 @@
 using MeshWeaver.AI.Persistence;
 using MeshWeaver.AI.Plugins;
 using MeshWeaver.Data;
+using MeshWeaver.GitSync;
 using MeshWeaver.Hosting.Persistence.Parsers;
 using MeshWeaver.Domain;
 using MeshWeaver.Layout;
@@ -63,7 +64,17 @@ public static class AIExtensions
                         // node. Registering it here — rather than hard-coding it in the registry —
                         // is what let MeshWeaver.Hosting drop its ProjectReference to this
                         // assembly, so the platform builds and runs with no AI at all.
-                        .AddSingleton<IFileFormatParser, AgentFileParser>())
+                        .AddSingleton<IFileFormatParser, AgentFileParser>()
+                        // Writes the live Agent + Skill partitions back to the repo's content/ai
+                        // section — the inverse of the built-in providers that READ it. Dev-time
+                        // (source checkout) only, and AI content by definition, so it rides AI
+                        // rather than GitSync (#2276).
+                        .AddSingleton<AiContentDiskWriter>()
+                        // The real PR drafter, delegating to the PullRequestWriter agent through
+                        // the existing chat surface. A plain AddSingleton against GitSync's
+                        // TryAddSingleton fallback: this one wins in EITHER configure order, and a
+                        // deployment without AI still opens PRs with the placeholder draft.
+                        .AddSingleton<IPullRequestDraftService, PullRequestDraftService>())
                     // Register AI types on the MESH hub (for MeshQuery deserialization of Thread content)
                     .ConfigureHub(config =>
                     {
@@ -74,7 +85,17 @@ public static class AIExtensions
                     {
                         config.TypeRegistry.AddAITypes();
                         return config
-                            .WithHandler<Plugins.SaveContentRequest>(HandleSaveContent);
+                            .WithHandler<Plugins.SaveContentRequest>(HandleSaveContent)
+                            // "Sync to repo" on Agent/Skill nodes + the area its item navigates to.
+                            // Self-gates to a source checkout and a platform admin, so it is inert
+                            // on a deployment that has neither.
+                            .WithServices(s =>
+                            {
+                                s.TryAddEnumerable(ServiceDescriptor.Scoped<INodeMenuProvider, AiContentSyncMenuProvider>());
+                                return s;
+                            })
+                            .AddLayout(layout => layout
+                                .WithView(AiContentSyncArea.AreaName, AiContentSyncArea.Render));
                     })
                 ;
         }

--- a/src/MeshWeaver.AI/AiContentDiskWriter.cs
+++ b/src/MeshWeaver.AI/AiContentDiskWriter.cs
@@ -1,6 +1,6 @@
 using System.Reactive.Linq;
 using System.Text.Json;
-using MeshWeaver.AI;
+using MeshWeaver.GitSync;
 using MeshWeaver.AI.Persistence;
 using MeshWeaver.Data;
 using MeshWeaver.Hosting.Persistence.Parsers;
@@ -10,7 +10,7 @@ using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Logging;
 
-namespace MeshWeaver.GitSync;
+namespace MeshWeaver.AI;
 
 /// <summary>Outcome of an AI-content sync-back: how many Agent/Skill files were written, repo-relative.</summary>
 public sealed record AiContentSyncResult(int AgentsWritten, int SkillsWritten, IReadOnlyList<string> Files)

--- a/src/MeshWeaver.AI/AiContentSyncArea.cs
+++ b/src/MeshWeaver.AI/AiContentSyncArea.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Text;
-using MeshWeaver.AI;
+using MeshWeaver.GitSync;
 using MeshWeaver.Application.Styles;
 using MeshWeaver.Graph;
 using MeshWeaver.Layout;
@@ -11,7 +11,7 @@ using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace MeshWeaver.GitSync;
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// The action layout area the "Sync to repo" AI-content menu item navigates to — writes the live

--- a/src/MeshWeaver.AI/AiContentSyncMenuProvider.cs
+++ b/src/MeshWeaver.AI/AiContentSyncMenuProvider.cs
@@ -1,12 +1,12 @@
 using System.Reactive.Linq;
-using MeshWeaver.AI;
+using MeshWeaver.GitSync;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 
-namespace MeshWeaver.GitSync;
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// DI-registered <see cref="INodeMenuProvider"/> that contributes the "Sync to repo" entry to the NODE

--- a/src/MeshWeaver.AI/HubAiContentSyncExtensions.cs
+++ b/src/MeshWeaver.AI/HubAiContentSyncExtensions.cs
@@ -1,10 +1,10 @@
 using System.Reactive.Linq;
-using MeshWeaver.AI;
+using MeshWeaver.GitSync;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace MeshWeaver.GitSync;
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// The hub-extension surface for the AI-content sync-back: write the agents &amp; skills edited in the

--- a/src/MeshWeaver.AI/MeshWeaver.AI.csproj
+++ b/src/MeshWeaver.AI/MeshWeaver.AI.csproj
@@ -47,6 +47,7 @@
       <ProjectReference Include="..\MeshWeaver.Data.Contract\MeshWeaver.Data.Contract.csproj" />
       <ProjectReference Include="..\MeshWeaver.Data\MeshWeaver.Data.csproj" />
       <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+      <ProjectReference Include="..\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
     <ProjectReference Include="..\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
       <ProjectReference Include="..\MeshWeaver.Markdown\MeshWeaver.Markdown.csproj" />
       <ProjectReference Include="..\MeshWeaver.Markdown.Collaboration\MeshWeaver.Markdown.Collaboration.csproj" />

--- a/src/MeshWeaver.AI/PullRequestDraftService.cs
+++ b/src/MeshWeaver.AI/PullRequestDraftService.cs
@@ -1,33 +1,12 @@
-using System.Reactive.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using MeshWeaver.AI;
+using MeshWeaver.GitSync;
 using MeshWeaver.Reactive;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using System.Reactive.Linq;
+using System.Text.RegularExpressions;
+using System.Text;
 
-namespace MeshWeaver.GitSync;
-
-/// <summary>The AI-suggested draft for a pull request — a title and a markdown body.</summary>
-public record PullRequestDraft(string Title, string Body);
-
-/// <summary>
-/// Drafts a pull-request title + body from the change context (the Space name/summary,
-/// the head vs base branch). Implementations delegate to the existing AI agent surface —
-/// never a hand-rolled LLM HTTP call. Reactive: emits exactly once on success, OnError on
-/// failure (no model configured, empty response, network error).
-/// </summary>
-public interface IPullRequestDraftService
-{
-    /// <summary>
-    /// Produces a suggested PR title + body. <paramref name="spaceName"/> /
-    /// <paramref name="spaceSummary"/> describe what changed; <paramref name="headBranch"/> /
-    /// <paramref name="baseBranch"/> are the PR's branches.
-    /// </summary>
-    IObservable<PullRequestDraft> DraftAsync(
-        string spaceName, string? spaceSummary, string headBranch, string baseBranch,
-        CancellationToken ct = default);
-}
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// Default <see cref="IPullRequestDraftService"/> — spins up a fresh <see cref="AgentChatClient"/>

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -114,12 +114,11 @@ public static class GitHubSyncConfiguration
                     o.KeepCommitsPerRepo = keep;
             });
         services.AddSingleton<GitModuleReplica>();
-        // Writes the live Agent + Skill partitions back to the repo's content/ai section — the inverse
-        // of the built-in providers that READ that section. Dev-time (source checkout) only.
-        services.AddSingleton<AiContentDiskWriter>();
-        // AI-drafted PR title/body. Default delegates to the PullRequestWriter agent via the
-        // existing chat surface (mirrors DescriptionGenerator); tests override with a stub.
-        services.AddSingleton<IPullRequestDraftService, PullRequestDraftService>();
+        // The PR title/body drafter. This is the FALLBACK — a deterministic title and a body that
+        // asks the human to edit it — registered with TryAdd so the AI module's real drafter wins
+        // whichever configures first (AddAI uses a plain AddSingleton). PR creation therefore never
+        // depends on AI being installed; tests override with a stub. See #2276.
+        services.TryAddSingleton<IPullRequestDraftService, PlaceholderPullRequestDraftService>();
         // Factory so the optional HttpClient param is explicitly defaulted (the service
         // creates its own) — no bare-HttpClient registration required in the container.
         services.AddSingleton(sp => new GitHubOAuthService(
@@ -209,13 +208,12 @@ public static class GitHubSyncConfiguration
             .WithServices(s =>
             {
                 s.TryAddEnumerable(ServiceDescriptor.Scoped<INodeMenuProvider, GitHubSyncMenuProvider>());
-                // "Sync to repo" on Agent/Skill nodes — self-gates to a source checkout + platform admin.
-                s.TryAddEnumerable(ServiceDescriptor.Scoped<INodeMenuProvider, AiContentSyncMenuProvider>());
+                // "Sync to repo" on Agent/Skill nodes rides AddAI() — it is an AI-content feature
+                // that happens to write through this repo client, not a GitHub feature (#2276).
                 return s;
             })
             .AddLayout(layout => layout
-                .WithView(GitHubActionArea.AreaName, GitHubActionArea.Render)
-                .WithView(AiContentSyncArea.AreaName, AiContentSyncArea.Render)));
+                .WithView(GitHubActionArea.AreaName, GitHubActionArea.Render)));
         return builder;
     }
 }

--- a/src/MeshWeaver.GitSync/MeshWeaver.GitSync.csproj
+++ b/src/MeshWeaver.GitSync/MeshWeaver.GitSync.csproj
@@ -23,7 +23,6 @@
     <ProjectReference Include="..\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
     <ProjectReference Include="..\MeshWeaver.Application.Styles\MeshWeaver.Application.Styles.csproj" />
     <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
-    <ProjectReference Include="..\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <ProjectReference Include="..\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
   </ItemGroup>
 

--- a/src/MeshWeaver.GitSync/PullRequestDraftContract.cs
+++ b/src/MeshWeaver.GitSync/PullRequestDraftContract.cs
@@ -1,0 +1,44 @@
+namespace MeshWeaver.GitSync;
+
+/// <summary>The AI-suggested draft for a pull request — a title and a markdown body.</summary>
+public record PullRequestDraft(string Title, string Body);
+
+/// <summary>
+/// Drafts a pull-request title + body from the change context (the Space name/summary,
+/// the head vs base branch). Implementations delegate to the existing AI agent surface —
+/// never a hand-rolled LLM HTTP call. Reactive: emits exactly once on success, OnError on
+/// failure (no model configured, empty response, network error).
+/// </summary>
+public interface IPullRequestDraftService
+{
+    /// <summary>
+    /// Produces a suggested PR title + body. <paramref name="spaceName"/> /
+    /// <paramref name="spaceSummary"/> describe what changed; <paramref name="headBranch"/> /
+    /// <paramref name="baseBranch"/> are the PR's branches.
+    /// </summary>
+    IObservable<PullRequestDraft> DraftAsync(
+        string spaceName, string? spaceSummary, string headBranch, string baseBranch,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// The draft used when no better drafter is registered: a deterministic title and a body that says
+/// what the PR mirrors and asks the human to edit it.
+///
+/// <para>🚨 This exists so PR creation does not DEPEND on AI. The real drafter lives in
+/// <c>MeshWeaver.AI</c> and registers with a plain <c>AddSingleton</c> while this one registers
+/// with <c>TryAddSingleton</c> — which makes the override order-independent: whichever configures
+/// first, the AI implementation is the one resolved, and a deployment without the AI module gets
+/// this instead of a DI resolution failure (issue #2276, the LogIncidentEndpoints shape).</para>
+/// </summary>
+public sealed class PlaceholderPullRequestDraftService : IPullRequestDraftService
+{
+    /// <inheritdoc />
+    public IObservable<PullRequestDraft> DraftAsync(
+        string spaceName, string? spaceSummary, string headBranch, string baseBranch,
+        CancellationToken ct = default)
+        => System.Reactive.Linq.Observable.Return(new PullRequestDraft(
+            $"Sync {spaceName} ({headBranch} → {baseBranch})",
+            $"Mirrors the **{spaceName}** Space from MeshWeaver into `{headBranch}`.\n\n"
+            + "_(No AI drafter is installed — edit this body before submitting.)_"));
+}

--- a/test/MeshWeaver.GitSync.Test/AiContentSyncBackTest.cs
+++ b/test/MeshWeaver.GitSync.Test/AiContentSyncBackTest.cs
@@ -21,9 +21,14 @@ public class AiContentSyncBackTest(ITestOutputHelper output) : MonolithMeshTestB
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder)
             .AddSkillType()   // serves the built-in skills (Skill/*), the enumeration target
+            // AddAI registers the disk writer: writing the Agent/Skill partitions back to a
+            // content/ai section is an AI-content feature that happens to target a git checkout,
+            // so it rides AI rather than GitSync (#2276). GitSync still supplies the repo client
+            // the writer resolves the section root from.
+            .AddAI()
             .ConfigureServices(s =>
             {
-                s.AddGitHubSyncServices();   // registers AiContentDiskWriter
+                s.AddGitHubSyncServices();
                 return s;
             });
 

--- a/test/MeshWeaver.PluginCatalog.Test/MeshWeaver.PluginCatalog.Test.csproj
+++ b/test/MeshWeaver.PluginCatalog.Test/MeshWeaver.PluginCatalog.Test.csproj
@@ -5,5 +5,6 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Step B2 of #2276. **Stacked on #2287** (A2) — base retargets to `main` automatically once that merges.

A module cannot be injected into a platform that compiles against it. `MeshWeaver.GitSync` referenced `MeshWeaver.AI`, and through it so did `MeshWeaver.PluginCatalog` — **transitively**, which is why no grep of direct `ProjectReference`s ever showed that edge. This inverts it.

### What moves

`AiContentDiskWriter`, `AiContentSyncArea`, `AiContentSyncMenuProvider`, `HubAiContentSyncExtensions` and the agent-backed PR drafter → `MeshWeaver.AI`. **None of them imported a GitSync namespace**: they were AI features filed under the wrong project. `MeshWeaver.AI` now references `MeshWeaver.GitSync` for the repo client, which is the allowed direction (a module may reference the platform, never the reverse).

Their registrations move with them — the disk writer, the "Sync to repo" node-menu provider and its area now ride `AddAI()`.

### The drafter splits at an interface, and PR creation stops depending on AI

`IPullRequestDraftService` + the `PullRequestDraft` record stay in GitSync; the agent implementation goes to AI.

| | registration | result |
|---|---|---|
| GitSync | `TryAddSingleton<…, PlaceholderPullRequestDraftService>` | deterministic title + "edit this before submitting" body |
| `AddAI()` | `AddSingleton<…, PullRequestDraftService>` | the agent-drafted title/body |

Order-independent — the module wins whichever configures first (the `IEmailSender` shape). Without AI you now get the placeholder rather than a DI resolution failure, which is what the call site's `.Catch` already produced when no model was configured.

### Two consumers gain an explicit reference, and that is the point

- `MeshWeaver.PluginCatalog.Test` installs Agent/Skill packages and asserts on the pickers — a real AI dependency that had been arriving through GitSync.
- `AiContentSyncBackTest` gains `.AddAI()`. **It failed without it** (`AiContentDiskWriter has not been registered`), which is the proof the seam is real rather than nominal.

### Verification

- Full solution build under CI's flags (`-c Release -p:CIRun=true -warnaserror`) → `0 Error(s)`.
- `MeshWeaver.GitSync.Test`: 182 tests, 0 failed.

After this and #2287, `MeshWeaver.GitSync`'s dependency on the AI engine is **zero**.

**No What's New entry**: internal refactor. The one behaviour change — a PR drafted without AI gets a placeholder instead of failing — is strictly an improvement to a path that previously required a configured model.

Refs #2276

🤖 Generated with [Claude Code](https://claude.com/claude-code)