### PR TITLE
Chat history: read prior cells with ContentAs, not the `Content is` trap-door (#2290)

### DIFF
--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -3728,26 +3728,38 @@ internal static class ThreadExecution
                 var cellLookups = cellIds
                     .Select(id =>
                         hub.GetMeshNodeStream($"{threadPath}/{id}")
-                            .Where(n => n.Content is ThreadMessage m && !string.IsNullOrEmpty(m.Text))
+                            // 🚨 #2290 — ContentAs, NOT `n.Content is ThreadMessage`. The cast is the
+                            // trap-door: it matches only when the value ALREADY is that CLR type, and
+                            // misses silently for a degraded JsonElement (an unresolvable `$type` is
+                            // DEGRADED, not thrown), for the as-written JsonObject DOM, and for a
+                            // same-short-named record from another collectible build. A miss here is
+                            // not "one lost message": the predicate never matches → Take(1) never
+                            // fires → the per-cell Timeout trips → the cell is dropped as
+                            // HISTORY_CELL_DROP → and once EVERY cell degrades (a cold start: pod
+                            // restart, grains not activated, cells not yet re-typed) the zero-loaded
+                            // guard below throws and HARD-ERRORS the user's round. ContentAs
+                            // deserializes the degraded forms and LOGS when it genuinely cannot —
+                            // exactly what the thread node two reads above already does.
+                            .Select(n => n.ContentAs<ThreadMessage>(hub.JsonSerializerOptions, logger))
+                            .Where(m => m is not null && !string.IsNullOrEmpty(m.Text))
                             .Take(1)
                             .Timeout(perCellTimeout)
-                            .Select(n => (MeshNode?)n)
-                            .Catch<MeshNode?, Exception>(ex =>
+                            .Catch<ThreadMessage?, Exception>(ex =>
                             {
                                 logger.LogWarning(ex,
                                     "[ThreadExec] HISTORY_CELL_DROP threadPath={ThreadPath} cellId={CellId} — cell unreadable within budget; will be omitted",
                                     threadPath, id);
-                                return Observable.Return<MeshNode?>(null);
+                                return Observable.Return<ThreadMessage?>(null);
                             }))
                     .ToList();
 
                 return Observable.CombineLatest(cellLookups)
                     .Take(1)
-                    .Select(nodes =>
+                    .Select(cells =>
                     {
-                        var messages = nodes
-                            .Where(n => n is not null)
-                            .Select(n => (ThreadMessage)n!.Content!)
+                        var messages = cells
+                            // OfType drops the per-cell null sentinels AND re-types in one step.
+                            .OfType<ThreadMessage>()
                             .OrderBy(m => m.Timestamp)
                             .Select(m =>
                             {

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-chat-history-survives-a-cold-start.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-25-chat-history-survives-a-cold-start.md
@@ -1,0 +1,25 @@
+---
+Name: Chat history survives a cold start
+Category: Fix
+Description: Sending a message in an existing conversation shortly after the portal restarts no longer fails with an error — the earlier turns are read back correctly instead of being treated as unreadable.
+Icon: Sparkle
+Order: -20260825
+---
+
+# Chat history survives a cold start
+
+Sending a message in a conversation that already had earlier turns could fail outright if the
+portal had only just restarted. The round ended in an error rather than an answer, and trying
+again a moment later often worked — which made it look like an intermittent glitch rather than
+something reproducible.
+
+It was not a glitch. When a conversation is read for the first time after a restart, its earlier
+messages briefly arrive in a raw, not-yet-typed form. The step that rebuilds the conversation for
+the assistant only recognised the fully-typed form, so it quietly treated every earlier message as
+unreadable, waited out its own time limit on each one, and then — correctly refusing to answer
+with no history at all — failed the round.
+
+Earlier messages are now read in whichever form they arrive, so the assistant sees the whole
+conversation and the round proceeds normally. A message that is genuinely unreadable is still
+skipped and still recorded as such, and a conversation with no earlier turns still starts cleanly
+rather than erroring.

--- a/test/MeshWeaver.Threading.Test/LoadConversationHistoryTest.cs
+++ b/test/MeshWeaver.Threading.Test/LoadConversationHistoryTest.cs
@@ -305,7 +305,12 @@ public class LoadConversationHistoryTest(ITestOutputHelper output) : MonolithMes
     private async Task SeedRawContentCell(
         IMessageHub client, string threadPath, string cellId, string contentJson)
     {
-        var content = JsonDocument.Parse(contentJson).RootElement.Clone();
+        // Clone out of the document and dispose it right away — the clone owns its own memory, so
+        // nothing keeps the parser's pooled buffers alive across the create round-trip below.
+        JsonElement content;
+        using (var doc = JsonDocument.Parse(contentJson))
+            content = doc.RootElement.Clone();
+
         var resp = await client.Observe(
             new CreateNodeRequest(new MeshNode(cellId, threadPath)
             {

--- a/test/MeshWeaver.Threading.Test/LoadConversationHistoryTest.cs
+++ b/test/MeshWeaver.Threading.Test/LoadConversationHistoryTest.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.AI;
@@ -15,6 +17,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using MeshThread = MeshWeaver.AI.Thread;
@@ -147,6 +150,204 @@ public class LoadConversationHistoryTest(ITestOutputHelper output) : MonolithMes
 
         history.Should().HaveCount(2, "phantom cell never emits but the two real cells should still load");
         history.Select(m => m.Text!.TrimEnd()).Should().Equal("real question", FakeResponse);
+    }
+
+    /// <summary>
+    /// 🚨 #2290 — the MECHANISM test. The three consequence tests above only catch this defect
+    /// by TIMING (a degraded cell never satisfies the predicate, so it looks exactly like a slow
+    /// one); this one catches it by CONSTRUCTION.
+    ///
+    /// <para>The loader used to filter cells with <c>n.Content is ThreadMessage m</c> — the
+    /// trap-door AGENTS.md forbids by name. That matches only when the value ALREADY is that CLR
+    /// type, and misses silently for the untyped-JSON form the polymorphic converter DEGRADES an
+    /// unresolvable <c>$type</c> to, for the as-written DOM, and for a same-short-named record
+    /// from another collectible build. A miss is not "one lost message": the predicate never
+    /// matches → <c>Take(1)</c> never fires → the per-cell <c>Timeout</c> trips → the cell is
+    /// dropped as <c>HISTORY_CELL_DROP</c>; and once EVERY cell degrades — a cold start, where
+    /// grains are not activated and cells are not yet re-typed — the zero-loaded guard throws and
+    /// (since #2240 correctly made that terminal) HARD-ERRORS the user's round.</para>
+    ///
+    /// <para>The thread node two reads earlier already used <c>ContentAs</c>; the cells did not.
+    /// This test pins that they now do, and the mechanism guard below fails LOUD if the seeded
+    /// content ever stops arriving degraded — otherwise the test would keep passing while
+    /// testing nothing.</para>
+    /// </summary>
+    [Fact]
+    public async Task DegradedCells_AreReadAsThreadMessages_AndReachTheHistory()
+    {
+        var client = GetClient();
+        var threadPath = await CreateThread(client, "Loader degraded-content test");
+
+        // Two cells whose Content is UNTYPED JSON — the shape the polymorphic converter degrades
+        // an unresolvable `$type` to. In production the degradation is TRANSIENT (it lasts until
+        // the reading hub can re-type the content, which on a cold start is exactly the window the
+        // round runs in); here it is made permanent by seeding the cells without a NodeType, so
+        // nothing re-types them and the loader is deterministically handed the degraded form.
+        // Distinct timestamps pin the ordering the loader must preserve.
+        var t0 = new DateTime(2026, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+        await SeedDegradedCell(client, threadPath, "degraded-user", "user", "degraded question", t0);
+        await SeedDegradedCell(client, threadPath, "degraded-assistant", "assistant", "degraded answer", t0.AddMinutes(1));
+
+        await AppendCellIds(client, threadPath, "degraded-user", "degraded-assistant");
+
+        // 🚨 Mechanism guard: the seeded content MUST arrive as something other than a typed
+        // ThreadMessage, or this test is asserting the happy path under a misleading name.
+        var seededNode = await Mesh.GetWorkspace().GetMeshNodeStream($"{threadPath}/degraded-user")
+            .Where(n => n.Content is not null)
+            .Take(1).Timeout(30.Seconds())
+            .Should().Within(60.Seconds()).Emit();
+        seededNode.Content.Should().NotBeOfType<ThreadMessage>(
+            "the seeded cell must be DEGRADED (untyped JSON) — that is the whole mechanism under test");
+        seededNode.ContentAs<ThreadMessage>(Mesh.JsonSerializerOptions).Should().NotBeNull(
+            "…and ContentAs must be able to recover it — that is the fix");
+
+        var history = await ThreadExecution.LoadFullConversationHistoryFromMesh(
+                Mesh, threadPath,
+                excludeUserMessageId: null, excludeResponseMessageId: null,
+                NullLogger.Instance,
+                cellTimeout: 5.Seconds())
+            .Should().Within(60.Seconds()).Emit();
+
+        history.Should().HaveCount(2,
+            "degraded cells must be recovered by ContentAs, not dropped by a failed cast");
+        history.Select(m => m.Role).Should().Equal(ChatRole.User, ChatRole.Assistant);
+        history.Select(m => m.Text!.TrimEnd()).Should().Equal("degraded question", "degraded answer");
+    }
+
+    /// <summary>
+    /// 🚨 #2290, the OTHER direction: tolerating a degraded cell must NOT become "tolerate
+    /// anything". A cell whose content is genuinely not a <see cref="ThreadMessage"/> — here JSON
+    /// missing the required <c>role</c>/<c>text</c> members — must still be DROPPED, and the
+    /// <c>HISTORY_CELL_DROP</c> path must still log it. Silently substituting a blank message for
+    /// unreadable content would be #2226's silent-wrong-answer defect in a new place.
+    /// </summary>
+    [Fact]
+    public async Task UnreadableCell_IsStillDroppedAndLogged_WhileReadableOnesSurvive()
+    {
+        var client = GetClient();
+        var threadPath = await CreateThread(client, "Loader unreadable-cell test");
+
+        var t0 = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        await SeedDegradedCell(client, threadPath, "readable-user", "user", "readable question", t0);
+        // Not a ThreadMessage in any shape: the record's `Role`/`Text` are `required`, so
+        // deserialization throws and ContentAs returns null with a loud log.
+        await SeedRawContentCell(client, threadPath, "garbage-cell",
+            """{"somethingElse":"entirely","nested":{"n":1}}""");
+
+        await AppendCellIds(client, threadPath, "readable-user", "garbage-cell");
+
+        var logs = new CapturingLogger();
+        var history = await ThreadExecution.LoadFullConversationHistoryFromMesh(
+                Mesh, threadPath,
+                excludeUserMessageId: null, excludeResponseMessageId: null,
+                logs,
+                cellTimeout: 1.Seconds())
+            .Should().Within(60.Seconds()).Emit();
+
+        history.Should().HaveCount(1, "the unreadable cell must be dropped, not invented");
+        history.Single().Text!.TrimEnd().Should().Be("readable question");
+
+        logs.Messages.Should().Contain(m => m.Contains("HISTORY_CELL_DROP") && m.Contains("garbage-cell"),
+            "an unreadable cell must SAY it was dropped — a silent drop is what #2290 was about");
+        logs.Messages.Should().Contain(m => m.Contains("HISTORY_PARTIAL"),
+            "a partial load must still warn");
+    }
+
+    /// <summary>
+    /// 🚨 #2290 — the empty case must stay empty, not throw. The zero-loaded guard fires only when
+    /// cells were EXPECTED; a brand-new thread with no prior cells has nothing to load and must
+    /// return an empty history without erroring the round.
+    /// </summary>
+    [Fact]
+    public async Task NoPriorCells_ReturnsEmptyHistory_WithoutThrowing()
+    {
+        var client = GetClient();
+        var threadPath = await CreateThread(client, "Loader no-prior-cells test");
+
+        // Settle: the thread node exists and carries no cells yet.
+        var thread = await ThreadFlow.ReadThread(client, threadPath, t => t.Messages.Count == 0)
+            .Should().Within(60.Seconds()).Emit();
+        thread.Messages.Should().BeEmpty();
+
+        var history = await ThreadExecution.LoadFullConversationHistoryFromMesh(
+                Mesh, threadPath,
+                excludeUserMessageId: null, excludeResponseMessageId: null,
+                NullLogger.Instance,
+                cellTimeout: 1.Seconds())
+            .Should().Within(60.Seconds()).Emit();
+
+        history.Should().BeEmpty("no prior cells means no history — and no TimeoutException");
+    }
+
+    /// <summary>
+    /// Seeds a cell node whose <c>Content</c> is the UNTYPED JSON form of a
+    /// <see cref="ThreadMessage"/> — camelCase wire shape, no <c>$type</c>, so nothing can resolve
+    /// it back to the CLR type and every reader sees a raw <c>JsonElement</c>.
+    /// </summary>
+    private Task SeedDegradedCell(
+        IMessageHub client, string threadPath, string cellId, string role, string text, DateTime timestamp)
+        => SeedRawContentCell(client, threadPath, cellId,
+            $$"""
+              {"role":"{{role}}","text":"{{text}}","timestamp":"{{timestamp:O}}","status":"Completed"}
+              """);
+
+    /// <summary>
+    /// Creates a cell node carrying <paramref name="contentJson"/> verbatim.
+    ///
+    /// <para>🚨 <b>No <c>NodeType</c> deliberately.</b> A cell declared
+    /// <c>NodeType = ThreadMessage</c> gets a per-node hub configured
+    /// <c>WithContentType&lt;ThreadMessage&gt;()</c>, and that hub RE-TYPES any recoverable content
+    /// before a reader ever sees it — which is precisely why the production degradation is a
+    /// cold-start timing window rather than a steady state, and why it cannot be reproduced by
+    /// seeding a well-formed typed cell. Omitting the NodeType removes the re-typing step, so the
+    /// loader is handed the degraded form deterministically instead of racing a window.</para>
+    /// </summary>
+    private async Task SeedRawContentCell(
+        IMessageHub client, string threadPath, string cellId, string contentJson)
+    {
+        var content = JsonDocument.Parse(contentJson).RootElement.Clone();
+        var resp = await client.Observe(
+            new CreateNodeRequest(new MeshNode(cellId, threadPath)
+            {
+                MainNode = ContextPath,
+                Content = content
+            }),
+            o => o.WithTarget(Mesh.Address)).Should().Within(60.Seconds()).Emit();
+        resp.Message.Success.Should().BeTrue(resp.Message.Error ?? "");
+    }
+
+    /// <summary>Appends cell ids to the thread's <c>Messages</c> and waits until the write settles.</summary>
+    private async Task AppendCellIds(IMessageHub client, string threadPath, params string[] cellIds)
+    {
+        await Mesh.GetWorkspace().GetMeshNodeStream(threadPath).Update(node =>
+        {
+            var t = node.ContentAs<MeshThread>(Mesh.JsonSerializerOptions);
+            return t is null ? node : node with { Content = t with { Messages = t.Messages.AddRange(cellIds) } };
+        }).Should().Within(60.Seconds()).Emit();
+
+        await ThreadFlow.ReadThread(client, threadPath, t => cellIds.All(t.Messages.Contains))
+            .Should().Within(60.Seconds()).Emit();
+    }
+
+    /// <summary>
+    /// Records what the loader said. The drop path is only useful if it is AUDIBLE, so the
+    /// negative test asserts on the lines rather than on their absence of effect. Instance state
+    /// (never static) — it dies with the test.
+    /// </summary>
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly ConcurrentQueue<string> messages = new();
+
+        public IReadOnlyCollection<string> Messages => messages.ToArray();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => messages.Enqueue(formatter(state, exception));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #2290.

## The defect

`ThreadExecution.LoadFullConversationHistoryFromMesh` filtered each prior cell with the cast
AGENTS.md forbids by name:

```csharp
.Where(n => n.Content is ThreadMessage m && !string.IsNullOrEmpty(m.Text))   // 🚨
```

`n.Content is ThreadMessage` matches only when the value *already is* that CLR type, and misses
silently for the three shapes that actually occur in a running mesh: an untyped `JsonElement` (the
polymorphic converter **degrades** an unresolvable `$type` rather than throwing), the as-written
`JsonObject` DOM, and a same-short-named record from another collectible build.

The irony was local — the **thread node** two reads earlier already used `ContentAs`, and carries
the comment *"ContentAs (not `Content as`): a degraded JsonElement thread node LOGS instead"*. The
cells never got the same treatment. (The projector's `(ThreadMessage)n!.Content!` hard cast a few
lines below was the same bug's second half: had a degraded node ever reached it, it would have
thrown `InvalidCastException` instead of returning null.)

## Why it became user-visible

A miss here is not "one lost message". The predicate never matches → `Take(1)` never fires → the
per-cell `Timeout(5 s)` trips → the cell is dropped as `HISTORY_CELL_DROP`. Once *every* cell
degrades — a cold start: pod restart, grains not activated, cells not yet re-typed — the
zero-loaded guard throws, and since **#2240** (correctly) made that terminal, the user's round
hard-errors instead of quietly answering without context.

**#2240 is right and is untouched here.** This PR does not widen `perCellTimeout`, restore the
empty-history fallback, or add a retry: the timeout was the symptom.

## Evidence this bites in reality

CI run **32897466004** (job 97968988708, branch `fix/disposal-teardown-cluster`, 2026-08-25
21:15Z) — `OrleansChatHistoryTest.ColdStart_AgentSeesAllPreviousMessages`, whose own comment says
*"grains not yet activated, data in persistence"*, settled with #2240's new terminal text:

```
ThreadMessage { Role = assistant, Status = Error,
  Text = *Error: The earlier messages in this thread could not be loaded, so this round was
          stopped instead of answering without them. Submit again to retry.* }
```

Submit → `CompletedAt` was 13 s: the per-cell 5 s budgets tripping, exactly as described.

Two honest caveats, since the issue reads as if this were reproducible: that test has failed
**once** in CI since #2240 landed, on a branch (never on `main` — 10 of 12 post-#2240 `main` runs
had shard 0 green, and the 2 reds were `HubWorksAfterDisposal`), and it passes locally both in
isolation and across the full 193-test Orleans assembly. It catches this defect only by *timing*,
which is why the real proof below is a mechanism test.

## The fix

Read the cells the way the thread node already is — `ContentAs<ThreadMessage>(hub.JsonSerializerOptions, logger)`:
it returns an already-typed instance as-is, deserializes a degraded `JsonElement`/`JsonNode`,
recovers a same-short-named type from another build by JSON round-trip, and **logs why** when it
genuinely cannot convert. `.OfType<ThreadMessage>()` in the projector then drops the per-cell null
sentinels and re-types in one step, retiring the hard cast.

## Tests — red before, green after

`test/MeshWeaver.Threading.Test/LoadConversationHistoryTest.cs`, three new tests beside the three
existing consequence tests:

| Test | Pins |
|---|---|
| `DegradedCells_AreReadAsThreadMessages_AndReachTheHistory` | **the mechanism.** Two cells seeded as untyped JSON reach the history in order. It carries a **guard**: the seeded content must assert as *not* a `ThreadMessage` **and** as recoverable by `ContentAs` — so the test can never silently degrade into asserting the happy path. Pre-fix it fails with the real production symptom, `TimeoutException: expected 2 prior cells … but ALL timed out / lacked text`. |
| `UnreadableCell_IsStillDroppedAndLogged_WhileReadableOnesSurvive` | **the other direction.** Tolerating a degraded cell must not become tolerating anything: content that is genuinely not a `ThreadMessage` is still dropped, and `HISTORY_CELL_DROP` + `HISTORY_PARTIAL` still say so (asserted against a capturing logger — a silent drop is what this issue was about). |
| `NoPriorCells_ReturnsEmptyHistory_WithoutThrowing` | the empty case stays empty rather than tripping the zero-loaded guard. |

Note on the seeding, because it is the one thing that surprised me: a cell declared
`NodeType = ThreadMessage` gets a per-node hub configured `WithContentType<ThreadMessage>()`, and
that hub **re-types** any recoverable content before a reader sees it — which is exactly why the
production degradation is a cold-start *window* rather than a steady state, and why seeding a
well-formed typed cell cannot reproduce it (my first attempt tripped its own guard, which is the
guard doing its job). The mechanism test therefore seeds the cells without a NodeType, so the
loader is handed the degraded form deterministically instead of racing a window.

Verification: `-c Release -warnaserror`, `0 Error(s)` for `MeshWeaver.AI` and
`MeshWeaver.Threading.Test`; `MeshWeaver.Hosting.Orleans.Test` 193/193.

## Are these cells being read on the wrong hub?

AGENTS.md says to ask, so: **no — this is a genuine boundary, and `ContentAs` is the right answer
here rather than a papering-over.** The loader runs on `parentHub`, the per-node hub for the
*thread*; each cell `{threadPath}/{id}` is a satellite with its **own** per-node hub, which is
where `ThreadMessage` is registered (`ThreadMessageNodeType` → `WithContentType<ThreadMessage>()`).
"Read where the type is registered" would mean running the round on each cell's hub in turn, which
is not a thing — the round belongs to the thread, and reading N cells from it is the whole point of
the parallel fan-out. So a hub boundary is crossed by construction, and what crosses it is JSON
whose `$type` the thread hub resolves only once its own registry is warm.

The corroboration is that three sibling reads of this same content already conceded the boundary
and use `ContentAs`: `ThreadExecution.cs:1192` (the streaming cell write),
`LoadPriorUserMessagesFromMesh`, and `ThreadFlow.ReadMessage`. This call site was the outlier, not
the rule.

The narrower question worth keeping is whether the thread hub's registry should be warm *before*
the round's first read rather than concurrently with it — that would remove the window instead of
tolerating it, and it is a change to activation ordering, not to this read. Not in scope here.

## Sweep — other `Content is` / `Content as` sites

`src/**/*.cs` carries **351** of these, so I fixed the read path this issue is about and am listing
the rest rather than widening the PR. In `src/MeshWeaver.AI` the only `ThreadMessage`-shaped ones
were the two lines fixed here.

Worth its own issue, ranked by consequence:

- **`ChatClientAgentFactory.cs:678`** — the highest-value sibling. A live cross-hub read,
  `workspace.GetMeshNodeStream(subThreadPath).Subscribe(node => { if (node?.Content is not MeshThread t) return; … })`,
  watching a delegation sub-thread for `Running → Idle`. If that content degrades the watch never
  observes a terminal status, so it never self-disposes — and the comment directly above it warns
  that exactly this leaks *"one leaked sync hub per delegation, which accumulates until the portal
  wedges (the prod 2026-06-25 wedge: ~1778 leaked sync hubs)"*. Same defect, worse blast radius.
- `AgentChatClient.cs:816`, `MeshOperations.cs:3942-3974` — hand-rolled `is JsonElement` +
  `TryGetProperty` fallbacks: the degradation is *handled*, just open-coded rather than via
  `ContentAs`.
- The large remainder (`ThreadSubmission.cs`, `DelegationHandlers.cs`, `ThreadExecution.cs`'s own
  `Content is MeshThread` sites) are predominantly **inside `stream.Update` lambdas**, which run on
  the owning hub after it has re-typed — `DelegationHandlers.cs:133` documents precisely that. Those
  are the sanctioned form and I have deliberately left them alone; converting them wholesale would
  be churn without evidence.

Tests were not swept: `test/**` has ~25 `Content as ThreadMessage` reads, several of which already
carry a hand-written `is JsonElement` fallback (`OrleansChatHistoryTest` itself does) — a sign the
degradation was known at the read boundary long before this loader was written.
