### PR TITLE
A live query's early→live handoff dropped a change notification permanently

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-live-lists-stop-missing-a-just-created-node.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-live-lists-stop-missing-a-just-created-node.md
@@ -1,0 +1,50 @@
+---
+Name: Live lists stop missing a just-created node
+Category: Fix
+Description: A view watching a folder could permanently miss a node created a fraction of a second after it opened — the token counter reading zero, a notification never appearing — while opening the same thing fresh showed it immediately. The change notification was being dropped in a handoff; now it is never dropped.
+Icon: List
+Order: -20260826
+---
+
+# Live lists stop missing a just-created node
+
+A view that watches a set of nodes — the chat token counter over a thread's usage, a notification
+bell, a folder listing — could **miss a node created moments after the view opened, and never
+recover**. Not show it late: never show it, for as long as that view stayed open, while opening the
+same list again showed the node immediately.
+
+The give-away was how strange it looked. The node was written, correct, and readable: ask for it by
+path and it came back at once. Only the view that had been watching all along failed to see it.
+
+## What was happening
+
+Every live list works the same way: it takes a snapshot, then follows the change notifications that
+follow. Until now it did that with **two** subscriptions to the change feed — one that buffered
+notifications while the snapshot was still being taken, and a second that took over once it was
+done, at which point the first was closed.
+
+The change feed decides who a notification goes to *before* it delivers it, which it must, because
+subscribers come and go while a notification is on its way. So a write published in the instant
+before the second subscription existed was addressed only to the first — and by the time it arrived,
+the handoff had happened and the first subscription had been told to stop buffering. It discarded
+the notification. The second never received it, because it had not been on the list when the
+notification set out.
+
+Nothing asks again after that. The list re-reads only when a notification arrives, so a lost
+notification means a lost row, permanently.
+
+## What changed
+
+A live list now keeps **one** subscription for its whole life. It buffers, then switches to
+following — and the decision about which of the two a notification belongs to is made in the same
+indivisible step that performs the switch. There is no longer an in-between for a notification to
+fall into.
+
+The same handoff existed in all four storage backends and was corrected in all of them.
+
+## What you will notice
+
+Nothing, most of the time — the window was small. What it removes is a rare, confusing class of
+"the page is stale and reloading fixes it": a token counter stuck at zero after a reply that plainly
+used tokens, a folder that does not show a file that is certainly there, a list that quietly stopped
+keeping up. Token usage was always recorded correctly; only the reading of it could go missing.

--- a/src/MeshWeaver.Hosting.Cosmos/CosmosMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.Cosmos/CosmosMeshQuery.cs
@@ -372,20 +372,40 @@ public class CosmosMeshQuery : IMeshQueryProvider
             // subscribe to the adapter's Changes BEFORE running the initial query so
             // notifications fired during the initial query's I/O window are captured
             // in a backlog instead of dropped (Changes is a plain Subject — no buffering).
+            //
+            // 🚨 ONE subscription for the query's whole lifetime — it buffers into the backlog
+            // until Initial, then routes into the live buffer. Never a SECOND subscription
+            // attached at Initial with this one disposed: that handoff drops a notification
+            // permanently, because IsolatedChangeFeed snapshots its observer list BEFORE
+            // delivering, so a write published just before the live subscription was attached
+            // reaches only the early observer — which by then sees initialDone == true and
+            // discards it — while the live observer was never in that snapshot. Nothing
+            // re-triggers the re-query, so the row stays invisible to that subscription for its
+            // whole life. Reproduced and measured in MeshWeaver.AI.Test (#1040, #1812, #2001).
             var earlyBacklog = new List<DataChangeNotification>();
             var earlyLock = new object();
             var initialDone = false;
-            var earlySubscription = _adapter.Changes
+            // Published under `earlyLock` in the same critical section that sets initialDone.
+            Subject<DataChangeNotification>? liveBuffer = null;
+            disposables.Add(_adapter.Changes
                 .Where(n => PathMatcher.ShouldNotify(n.Path, normalizedBasePath, effectiveScope))
                 .Subscribe(n =>
                 {
+                    Subject<DataChangeNotification>? live;
                     lock (earlyLock)
                     {
                         if (!initialDone)
+                        {
                             earlyBacklog.Add(n);
+                            return;
+                        }
+                        live = liveBuffer;
                     }
-                });
-            disposables.Add(earlySubscription);
+                    if (live is null)
+                        return;
+                    try { live.OnNext(n); }
+                    catch (ObjectDisposedException) { }
+                }));
 
             disposables.Add(RunQuery().Subscribe(
                 initialResults =>
@@ -405,10 +425,6 @@ public class CosmosMeshQuery : IMeshQueryProvider
                     var changeBuffer = new Subject<DataChangeNotification>();
                     disposables.Add(changeBuffer);
                     disposables.Add(
-                        _adapter.Changes
-                            .Where(n => PathMatcher.ShouldNotify(n.Path, normalizedBasePath, effectiveScope))
-                            .Subscribe(changeBuffer));
-                    disposables.Add(
                         changeBuffer
                             .Select(n => RunQuery()
                                 .Select(newResults => (batch: (IList<DataChangeNotification>)new[] { n }, newResults)))
@@ -417,14 +433,16 @@ public class CosmosMeshQuery : IMeshQueryProvider
                                 t => ProcessBatch(t.batch, t.newResults, currentItems, parsedQuery, observer),
                                 ex => observer.OnError(ex)));
 
-                    // 2) Snapshot + clear the early backlog under lock.
+                    // 2) Snapshot + clear the backlog, publish the live buffer and flip the gate —
+                    //    ONE critical section, so the feeding subscription's next notification
+                    //    routes to exactly one of the two and can never fall between them.
                     lock (earlyLock)
                     {
                         backlog = earlyBacklog.ToArray();
                         earlyBacklog.Clear();
+                        liveBuffer = changeBuffer;
                         initialDone = true;
                     }
-                    earlySubscription.Dispose();
 
                     observer.OnNext(new QueryResultChange<T>
                     {

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlMeshQuery.cs
@@ -694,33 +694,52 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
             // EffectivePermissionPostgresTest.RuntimeCreateNode_AccessAssignment_PgBacked_GrantsPermission)
             // never see writes that complete during the first Initial query.
             //
-            // Approach: accumulate early notifications under a lock until the
-            // initial query completes. Inside the initialResults callback:
-            //   1) Set up the LIVE Buffer(100ms) pipeline first (captures live events).
-            //   2) Snapshot+clear the backlog under lock; set initialDone=true.
-            //   3) Dispose the early subscription (live carries everything now).
-            //   4) Emit Initial.
-            //   5) Drain the backlog as one synthetic batch by re-querying and
+            // Approach: ONE subscription for the query's whole lifetime. It accumulates
+            // notifications into a backlog under a lock until the initial query completes, then
+            // routes straight into the live re-query pipeline. Inside the initialResults callback:
+            //   1) Set up the LIVE pipeline.
+            //   2) Snapshot+clear the backlog, publish the live buffer and set initialDone=true —
+            //      all in ONE critical section.
+            //   3) Emit Initial.
+            //   4) Drain the backlog as one synthetic batch by re-querying and
             //      diffing against the just-populated currentItems via ProcessBatch.
-            // Events fired between live-set-up (step 1) and backlog-swap (step 2)
-            // may be double-captured — ProcessBatch is idempotent against
-            // currentItems, so duplicate processing is wasted CPU but correct.
+            //
+            // 🚨 Never attach a SECOND subscription at Initial and dispose this one. That handoff
+            // DROPS a notification permanently: IsolatedChangeFeed snapshots its observer list
+            // BEFORE delivering, so a write published just before the live subscription was
+            // attached is delivered against a snapshot holding ONLY the early observer — which by
+            // then sees initialDone == true and throws it away, while the live observer was never
+            // in that snapshot. Nothing re-triggers the re-query, so the node stays invisible to
+            // that subscription for its whole life even though a point read returns it. Measured
+            // and reproduced in MeshWeaver.AI.Test; it is the long-running `WaitForUsage` red
+            // (#1040, #1812, #2001) and, in the portal, a live children listing that silently
+            // misses a node created in that window. With one subscription the window cannot exist.
             var earlyBacklog = new List<DataChangeNotification>();
             var earlyLock = new object();
             var initialDone = false;
+            // Published under `earlyLock` in the same critical section that sets initialDone.
+            Subject<DataChangeNotification>? liveBuffer = null;
 
-            var earlySubscription = _changeFeed
+            disposables.Add(_changeFeed
                 .Where(n => parsedFilters.Any(f =>
                     PathMatcher.ShouldNotifyForQuery(n.Path, f.BasePath, f.Scope, f.Namespaces)))
                 .Subscribe(n =>
                 {
+                    Subject<DataChangeNotification>? live;
                     lock (earlyLock)
                     {
                         if (!initialDone)
+                        {
                             earlyBacklog.Add(n);
+                            return;
+                        }
+                        live = liveBuffer;
                     }
-                });
-            disposables.Add(earlySubscription);
+                    if (live is null)
+                        return;
+                    try { live.OnNext(n); }
+                    catch (ObjectDisposedException) { }
+                }));
 
             disposables.Add(RunQuery().Subscribe(
                 initialResults =>
@@ -734,20 +753,15 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                     }
 
                     DataChangeNotification[] backlog;
-                    // 1) Set up live subscription first — starts buffering immediately.
+                    // 1) Set up the live pipeline the ONE feeding subscription hands off to.
                     var changeBuffer = new Subject<DataChangeNotification>();
-                    // 🚨 ORDER MATTERS. CompositeDisposable disposes in INSERTION order, so the
-                    // feeding subscription must be registered BEFORE the buffer it writes into.
-                    // The other way round, teardown disposes changeBuffer first while the
-                    // subscription is still live, and a write landing in that window calls OnNext
-                    // on a disposed Subject → ObjectDisposedException thrown back into the
-                    // adapter's fan-out. That is what starved the $security-access query of its
-                    // notification and froze the permission fold (see IsolatedChangeFeed).
-                    disposables.Add(
-                        _changeFeed
-                            .Where(n => parsedFilters.Any(f =>
-                                PathMatcher.ShouldNotifyForQuery(n.Path, f.BasePath, f.Scope, f.Namespaces)))
-                            .Subscribe(changeBuffer));
+                    // 🚨 ORDER MATTERS. CompositeDisposable disposes in INSERTION order, and the
+                    // feeding subscription was registered above, BEFORE this buffer. The other way
+                    // round, teardown disposes changeBuffer first while the subscription is still
+                    // live, and a write landing in that window calls OnNext on a disposed Subject
+                    // → ObjectDisposedException thrown back into the adapter's fan-out. That is
+                    // what starved the $security-access query of its notification and froze the
+                    // permission fold (see IsolatedChangeFeed).
                     disposables.Add(changeBuffer);
                     // 🚨 Strict unit-of-work + zero debounce: every change
                     // triggers its own RunQuery, serialised via Concat so the
@@ -769,17 +783,16 @@ public class PostgreSqlMeshQuery : IMeshQueryProvider, IVectorSearchProvider
                                 t => ProcessBatch(t.batch, t.newResults, currentItems, firstParsed, observer),
                                 ex => observer.OnError(ex)));
 
-                    // 2) Snapshot + clear early backlog under lock; gate further early-capture.
+                    // 2) Snapshot + clear the backlog, publish the live buffer and flip the gate —
+                    //    ONE critical section, so the feeding subscription's next notification
+                    //    routes to exactly one of the two and can never fall between them.
                     lock (earlyLock)
                     {
                         backlog = earlyBacklog.ToArray();
                         earlyBacklog.Clear();
+                        liveBuffer = changeBuffer;
                         initialDone = true;
                     }
-
-                    // 3) Early subscription is now redundant — live pipeline carries
-                    //    all subsequent events. Dispose to free the upstream sub.
-                    earlySubscription.Dispose();
 
                     observer.OnNext(new QueryResultChange<T>
                     {

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionedMeshQuery.cs
@@ -451,18 +451,38 @@ public sealed class PostgreSqlPartitionedMeshQuery : IMeshQueryProvider
             // Subscribe to the feed BEFORE the initial query so a write landing during the
             // fan-out's I/O window is captured rather than dropped (the merged feed is a plain
             // Subject with no buffering) — same race-fix as PostgreSqlMeshQuery / the pedestrian.
+            //
+            // 🚨 ONE subscription for the query's whole lifetime — it buffers into the backlog
+            // until Initial, then routes into the live buffer. Never a SECOND subscription
+            // attached at Initial with this one disposed: that handoff drops a notification
+            // permanently, because IsolatedChangeFeed snapshots its observer list BEFORE
+            // delivering, so a write published just before the live subscription was attached
+            // reaches only the early observer — which by then sees initialDone == true and
+            // discards it — while the live observer was never in that snapshot. Nothing
+            // re-triggers the re-query, so the row stays invisible to that subscription for its
+            // whole life. Reproduced and measured in MeshWeaver.AI.Test (#1040, #1812, #2001).
             var earlyBacklog = new List<DataChangeNotification>();
             var earlyLock = new object();
             var initialDone = false;
-            var earlySubscription = feed.Where(IsRelevant).Subscribe(n =>
+            // Published under `earlyLock` in the same critical section that sets initialDone.
+            IObserver<DataChangeNotification>? liveBuffer = null;
+            disposables.Add(feed.Where(IsRelevant).Subscribe(n =>
             {
+                IObserver<DataChangeNotification>? live;
                 lock (earlyLock)
                 {
                     if (!initialDone)
+                    {
                         earlyBacklog.Add(n);
+                        return;
+                    }
+                    live = liveBuffer;
                 }
-            });
-            disposables.Add(earlySubscription);
+                if (live is null)
+                    return;
+                try { live.OnNext(n); }
+                catch (ObjectDisposedException) { }
+            }));
 
             disposables.Add(RunQuery().Subscribe(
                 initialResults =>
@@ -487,12 +507,11 @@ public sealed class PostgreSqlPartitionedMeshQuery : IMeshQueryProvider
                     // is not the same object.
                     var innerBuffer = new System.Reactive.Subjects.Subject<DataChangeNotification>();
                     var changeBuffer = System.Reactive.Subjects.Subject.Synchronize(innerBuffer);
-                    // 🚨 ORDER MATTERS. CompositeDisposable disposes in INSERTION order, so the
-                    // feeding subscription must be registered BEFORE the buffer it writes into —
-                    // the other way round, teardown disposes changeBuffer while the subscription
-                    // is still live and a write in that window calls OnNext on a disposed Subject
+                    // 🚨 ORDER MATTERS. CompositeDisposable disposes in INSERTION order, and the
+                    // ONE feeding subscription was registered above, BEFORE this buffer — the
+                    // other way round, teardown disposes changeBuffer while the subscription is
+                    // still live and a write in that window calls OnNext on a disposed Subject
                     // (the ObjectDisposedException that starved the $security-access fold, #889).
-                    disposables.Add(feed.Where(IsRelevant).Subscribe(changeBuffer));
                     disposables.Add(innerBuffer);
                     // One re-query per relevant change, serialised via Concat so currentItems is
                     // never raced. No debounce: a batching window is exactly the gap in which a
@@ -507,12 +526,12 @@ public sealed class PostgreSqlPartitionedMeshQuery : IMeshQueryProvider
                     {
                         backlog = earlyBacklog.ToArray();
                         earlyBacklog.Clear();
+                        liveBuffer = changeBuffer;
                         initialDone = true;
                         // Same instant, for IsRelevant's lock-free read: from here on a delete is
                         // classified against the (now existing) result set instead of blanket-kept.
                         Volatile.Write(ref initialEstablished, 1);
                     }
-                    earlySubscription.Dispose();
 
                     observer.OnNext(Change(QueryChangeType.Initial, initialItems));
 

--- a/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
@@ -1272,27 +1272,70 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                     });
 
             // Subscribe to persistence.Changes BEFORE running the initial query so
-            // notifications during the I/O window are captured. After Initial,
-            // swap to a live Buffer pipeline that re-queries on each batch.
+            // notifications during the I/O window are captured. After Initial, the SAME
+            // subscription routes straight into the live re-query pipeline.
             // persistence.Changes is the adapter-level Subject (in-process);
             // cross-process change visibility relies on the backend's own change
             // feed (PG LISTEN/NOTIFY, Cosmos change feed) feeding per-process
             // Subjects — same shape as prod.
+            //
+            // 🚨 ONE subscription for this query's whole lifetime — never a second one attached
+            // at Initial. This used to be two: an "early" one that buffered into earlyBacklog
+            // while `!initialDone`, and a "live" one attached inside the initialResults callback,
+            // after which the early one was disposed. That handoff DROPPED a notification, and it
+            // dropped it PERMANENTLY:
+            //
+            //   IsolatedChangeFeed.OnNext snapshots its observer list BEFORE delivering (it must —
+            //   a subscriber may attach or detach mid-publish). A write published just before the
+            //   live subscription was attached is therefore delivered against a snapshot that
+            //   contains ONLY the early observer — and by the time that delivery ran, the callback
+            //   had already set initialDone = true and drained the (empty) backlog. The early
+            //   handler's `if (!initialDone)` then threw the notification away, the live observer
+            //   never saw it because it was not in the snapshot, and nothing re-triggers the
+            //   re-query. The node stayed invisible to that subscription for its whole life, while
+            //   a point read and any FRESH subscription returned it immediately.
+            //
+            //   Measured, not theorised: instrumenting both observers reproduced it in
+            //   MeshWeaver.AI.Test (4-wide, DOTNET_PROCESSOR_COUNT=4) — the notification arrives
+            //   with match=True on the early observer AFTER `Initial items=0 backlog=0`, and no
+            //   live delivery and no re-query for that base path ever follow. That is the
+            //   long-running ThreadTokenUsageTest/ModelSubstitutionTest `WaitForUsage` red
+            //   (#1040, #1812, #2001), and in the portal the same shape makes any live children
+            //   listing — the chat token chip, a notification bell, a folder view — miss a node
+            //   created in that window until something else changes under the same base path.
+            //
+            // With a single subscription the window cannot exist: the routing decision is made
+            // inside the same lock that publishes the buffer, so every notification lands either
+            // in the backlog or in the live buffer, and never between them.
             var earlyBacklog = new List<DataChangeNotification>();
             var earlyLock = new object();
             var initialDone = false;
-            var earlySubscription = persistence.Changes
+            // Published under `earlyLock` in the same critical section that sets initialDone.
+            Subject<DataChangeNotification>? liveBuffer = null;
+            disposables.Add(persistence.Changes
                 .Where(n => scopeFilters.Any(sf =>
                     PathMatcher.ShouldNotify(n.Path, sf.BasePath, sf.Scope)))
                 .Subscribe(n =>
                 {
+                    Subject<DataChangeNotification>? live;
                     lock (earlyLock)
                     {
                         if (!initialDone)
+                        {
                             earlyBacklog.Add(n);
+                            return;
+                        }
+                        live = liveBuffer;
                     }
-                });
-            disposables.Add(earlySubscription);
+                    if (live is null)
+                        return;
+                    // Torn down between the read and the push — teardown disposes this
+                    // subscription BEFORE the buffer (insertion order, see below), so this is
+                    // narrow, and swallowing it here keeps a disposal race from reaching the
+                    // adapter's fan-out.
+                    try { live.OnNext(n); }
+                    catch (ObjectDisposedException) { }
+                }));
 
             disposables.Add(
                 RunQuery().Subscribe(
@@ -1309,19 +1352,14 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                         DataChangeNotification[] backlog;
                         var changeBuffer = new Subject<DataChangeNotification>();
                         // 🚨 ORDER MATTERS (mirror of PostgreSqlMeshQuery's live pipeline).
-                        // CompositeDisposable disposes in INSERTION order, so the feeding
-                        // subscription must be registered BEFORE the buffer it writes into.
-                        // The other way round, teardown disposes changeBuffer first while the
-                        // subscription is still live, and a write landing in that window calls
-                        // OnNext on a disposed Subject → ObjectDisposedException thrown back
-                        // into the adapter's change-feed fan-out — where a plain-Subject merge
-                        // aborts delivery to every later subscriber, and IsolatedChangeFeed's
+                        // CompositeDisposable disposes in INSERTION order, and the ONE feeding
+                        // subscription was registered above, BEFORE this buffer. The other way
+                        // round, teardown disposes changeBuffer first while the subscription is
+                        // still live, and a write landing in that window calls OnNext on a
+                        // disposed Subject → ObjectDisposedException thrown back into the
+                        // adapter's change-feed fan-out — where a plain-Subject merge aborts
+                        // delivery to every later subscriber, and IsolatedChangeFeed's
                         // disposed-observer branch can misattribute the throw (issue #889).
-                        disposables.Add(
-                            persistence.Changes
-                                .Where(n => scopeFilters.Any(sf =>
-                                    PathMatcher.ShouldNotify(n.Path, sf.BasePath, sf.Scope)))
-                                .Subscribe(changeBuffer));
                         disposables.Add(changeBuffer);
                         // 🚨 Strict unit-of-work + zero debounce: every change
                         // triggers its own RunQuery, serialised via Concat so
@@ -1374,13 +1412,16 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                                     newResults => ProcessBatch(newResults, currentItems, parsedQuery, observer),
                                     ex => observer.OnError(ex)));
 
+                        // Publish the live buffer and flip the gate in ONE critical section, so
+                        // the feeding subscription's next notification routes to exactly one of
+                        // the two and can never fall between them.
                         lock (earlyLock)
                         {
                             backlog = earlyBacklog.ToArray();
                             earlyBacklog.Clear();
+                            liveBuffer = changeBuffer;
                             initialDone = true;
                         }
-                        earlySubscription.Dispose();
 
                         observer.OnNext(new QueryResultChange<T>
                         {

--- a/test/MeshWeaver.Hosting.Test/LiveQueryHandoffDropTest.cs
+++ b/test/MeshWeaver.Hosting.Test/LiveQueryHandoffDropTest.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Hosting.Persistence.Query;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins the early→live handoff of a LIVE query subscription: a change notification whose fan-out
+/// SNAPSHOT was taken before the Initial snapshot was established, but which is DELIVERED after,
+/// must still reach the re-query.
+///
+/// <para><b>The defect this kills.</b> Every live query used to open TWO subscriptions on the
+/// adapter's change feed: an "early" one that buffered notifications into a backlog while
+/// <c>!initialDone</c>, and a "live" one attached inside the initial-results callback, after which
+/// the early one was disposed. <see cref="IsolatedChangeFeed"/> — correctly — snapshots its observer
+/// list BEFORE delivering, because a subscriber may attach or detach mid-publish. So a write
+/// published just before the live subscription was attached is delivered against a snapshot holding
+/// ONLY the early observer, and by the time that delivery ran the callback had already set
+/// <c>initialDone = true</c>. The early handler's <c>if (!initialDone)</c> then threw the
+/// notification away; the live observer never saw it because it was not in the snapshot; and
+/// nothing re-triggers the re-query. The row stayed invisible to that subscription <b>for its whole
+/// life</b> — while a point read, and any FRESH subscription, returned it immediately.</para>
+///
+/// <para>That is a permanent miss dressed as a timeout, which is why raising a budget could never
+/// fix it. It is the long-running <c>ThreadTokenUsageTest</c>/<c>ModelSubstitutionTest</c>
+/// <c>WaitForUsage</c> red (#1040, #1812, #2001): the token-usage satellite WAS written, with the
+/// right counts, on both the Completed and the Cancelled path — the reader's listing simply never
+/// learned of it. In the portal the same shape makes any live children listing (the chat token
+/// chip, a notification bell, a folder view) silently miss a node created in that window until
+/// something else changes under the same base path.</para>
+///
+/// <para>The cure is structural: ONE subscription for the query's whole lifetime, whose routing
+/// decision — backlog vs live buffer — is made inside the same critical section that publishes the
+/// buffer. Then a notification lands in exactly one of the two and can never fall between them.</para>
+/// </summary>
+public class LiveQueryHandoffDropTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+    private const string Base = "rbuergi/_Usage";
+    private const string ChildPath = "rbuergi/_Usage/some_model";
+
+    /// <summary>
+    /// A change feed with the SAME snapshot-then-deliver semantics as <see cref="IsolatedChangeFeed"/>,
+    /// but with the two halves separated so a test can interleave work between them. That interleaving
+    /// is the whole window: nothing here is artificial — the production feed takes exactly this
+    /// snapshot, and any thread scheduled between the snapshot and the delivery reproduces it.
+    /// </summary>
+    private sealed class SnapshotThenDeliverFeed : IObservable<DataChangeNotification>
+    {
+        private ImmutableList<IObserver<DataChangeNotification>> observers =
+            ImmutableList<IObserver<DataChangeNotification>>.Empty;
+        private readonly object gate = new();
+
+        public IDisposable Subscribe(IObserver<DataChangeNotification> observer)
+        {
+            lock (gate) observers = observers.Add(observer);
+            return System.Reactive.Disposables.Disposable.Create(() =>
+            {
+                lock (gate) observers = observers.Remove(observer);
+            });
+        }
+
+        /// <summary>Takes the fan-out snapshot NOW; the returned action performs the delivery.</summary>
+        public Action PublishDeferred(DataChangeNotification n)
+        {
+            var snapshot = Volatile.Read(ref observers);
+            return () =>
+            {
+                foreach (var o in snapshot)
+                {
+                    try { o.OnNext(n); }
+                    catch (ObjectDisposedException) { }
+                }
+            };
+        }
+    }
+
+    /// <summary>
+    /// Delegates every read/write to a real <see cref="InMemoryStorageAdapter"/>, but exposes the
+    /// test's own feed and lets the test hold <see cref="ListChildPaths"/> open — so the Initial
+    /// snapshot can be pinned to a known moment relative to the notification's fan-out snapshot.
+    /// </summary>
+    private sealed class GatedAdapter(InMemoryStorageAdapter inner, SnapshotThenDeliverFeed feed)
+        : IStorageAdapter
+    {
+        public readonly ManualResetEventSlim ReadEntered = new(false);
+        public readonly ManualResetEventSlim ReleaseRead = new(true);
+        /// <summary>Holds the FIRST walk of the query's own base path only — later reads run free.</summary>
+        public string? GateOn;
+        private int gateArmed = 1;
+
+        public IObservable<DataChangeNotification> Changes => feed;
+
+        public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)>
+            ListChildPaths(string? parentPath)
+            // .Do runs AFTER inner has produced the child list, so the (still empty) result is
+            // already captured when we park — the write below cannot leak into this Initial.
+            => inner.ListChildPaths(parentPath).Do(_ =>
+            {
+                if (!string.Equals(parentPath, GateOn, StringComparison.OrdinalIgnoreCase)) return;
+                if (Interlocked.Exchange(ref gateArmed, 0) != 1) return;
+                ReadEntered.Set();
+                ReleaseRead.Wait(TimeSpan.FromSeconds(7));
+            });
+
+        public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
+            => inner.Read(path, options);
+        public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
+            => inner.Write(node, options);
+        public IObservable<string> Delete(string path) => inner.Delete(path);
+        public IObservable<bool> Exists(string path) => inner.Exists(path);
+        public IObservable<object> GetPartitionObjects(
+            string nodePath, string? subPath, JsonSerializerOptions options)
+            => inner.GetPartitionObjects(nodePath, subPath, options);
+        public IObservable<Unit> SavePartitionObjects(
+            string nodePath, string? subPath, IReadOnlyCollection<object> objects, JsonSerializerOptions options)
+            => inner.SavePartitionObjects(nodePath, subPath, objects, options);
+        public IObservable<Unit> DeletePartitionObjects(string nodePath, string? subPath = null)
+            => inner.DeletePartitionObjects(nodePath, subPath);
+        public IObservable<DateTimeOffset?> GetPartitionMaxTimestamp(string nodePath, string? subPath = null)
+            => inner.GetPartitionMaxTimestamp(nodePath, subPath);
+    }
+
+    [Fact]
+    public void A_notification_snapshotted_before_Initial_and_delivered_after_still_reaches_the_query()
+    {
+        var inner = new InMemoryStorageAdapter();
+        var feed = new SnapshotThenDeliverFeed();
+        var adapter = new GatedAdapter(inner, feed);
+        var provider = new StorageAdapterMeshQueryProvider(adapter);
+
+        var changes = new List<QueryResultChange<MeshNode>>();
+        var initial = new ManualResetEventSlim(false);
+        var added = new ManualResetEventSlim(false);
+
+        // Hold the query's own scope walk open so the Initial snapshot cannot be established
+        // until we say so.
+        adapter.GateOn = Base;
+        adapter.ReleaseRead.Reset();
+
+        // 🚨 Subscribe OFF the test thread. The provider's scope walk runs inline on the
+        // subscribing thread, so parking it from the test thread would park the test itself.
+        IDisposable? sub = null;
+        var subscriber = new Thread(() =>
+            sub = provider
+                .Query<MeshNode>(
+                    MeshQueryRequest.FromQueries([$"path:{Base} scope:children"], "system-security"),
+                    Options)
+                .Subscribe(c =>
+                {
+                    lock (changes) changes.Add(c);
+                    if (c.ChangeType == QueryChangeType.Initial) initial.Set();
+                    else if (c.Items.Any(n => string.Equals(n.Path, ChildPath, StringComparison.OrdinalIgnoreCase)))
+                        added.Set();
+                }))
+        { IsBackground = true };
+        subscriber.Start();
+
+        try
+        {
+            // The query's ONE feed subscription is attached and its scope walk is parked.
+            Assert.True(adapter.ReadEntered.Wait(TimeSpan.FromSeconds(10)),
+                "the query never started its scope walk");
+
+            // The write COMMITS to the store (so any re-query can see it) …
+            inner.Write(new MeshNode("some_model", Base) { NodeType = "TokenUsage" }, Options)
+                .Subscribe();
+
+            // … and its notification's fan-out snapshot is taken HERE — before the Initial is
+            // established, so it holds only what the query has attached so far.
+            var deliver = feed.PublishDeferred(DataChangeNotification.Updated(ChildPath, null));
+
+            // Now let the Initial land. Its rows were read before the write, so it is EMPTY — the
+            // query's only route to the row is the notification whose snapshot we already hold.
+            adapter.ReleaseRead.Set();
+            Assert.True(initial.Wait(TimeSpan.FromSeconds(10)), "the query never emitted its Initial");
+
+            // The setup is only meaningful if the Initial genuinely predates the write — otherwise
+            // the row would arrive through the snapshot and this test would prove nothing.
+            QueryResultChange<MeshNode> initialChange;
+            lock (changes) initialChange = changes.First(c => c.ChangeType == QueryChangeType.Initial);
+            Assert.Empty(initialChange.Items);
+
+            // Deliver against the pre-Initial snapshot. This is the exact window the old
+            // two-subscription handoff dropped on the floor.
+            deliver();
+
+            Assert.True(added.Wait(TimeSpan.FromSeconds(10)),
+                "a change notification whose fan-out snapshot predates the Initial, delivered after "
+                + "it, must still reach the live re-query. Dropping it loses the row PERMANENTLY: "
+                + "nothing re-triggers the query, so the subscription never learns of a node a "
+                + "point read returns immediately.");
+        }
+        finally
+        {
+            adapter.ReleaseRead.Set();
+            subscriber.Join(TimeSpan.FromSeconds(10));
+            sub?.Dispose();
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/LiveQueryHandoffDropTest.cs
+++ b/test/MeshWeaver.Hosting.Test/LiveQueryHandoffDropTest.cs
@@ -98,6 +98,16 @@ public class LiveQueryHandoffDropTest
         /// <summary>Holds the FIRST walk of the query's own base path only — later reads run free.</summary>
         public string? GateOn;
         private int gateArmed = 1;
+        private int gateTimedOut;
+
+        /// <summary>
+        /// True when the gate gave up instead of being released. 🚨 The test MUST assert this is
+        /// false: a gate that times out lets the scope walk continue on its own, so the Initial is
+        /// no longer pinned relative to the notification's fan-out snapshot — the window the test
+        /// exists to hold open would never have been held, and the test could pass having verified
+        /// nothing.
+        /// </summary>
+        public bool GateTimedOut => Volatile.Read(ref gateTimedOut) != 0;
 
         public IObservable<DataChangeNotification> Changes => feed;
 
@@ -110,7 +120,8 @@ public class LiveQueryHandoffDropTest
                 if (!string.Equals(parentPath, GateOn, StringComparison.OrdinalIgnoreCase)) return;
                 if (Interlocked.Exchange(ref gateArmed, 0) != 1) return;
                 ReadEntered.Set();
-                ReleaseRead.Wait(TimeSpan.FromSeconds(7));
+                if (!ReleaseRead.Wait(TimeSpan.FromSeconds(10)))
+                    Volatile.Write(ref gateTimedOut, 1);
             });
 
         public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
@@ -184,6 +195,13 @@ public class LiveQueryHandoffDropTest
             // query's only route to the row is the notification whose snapshot we already hold.
             adapter.ReleaseRead.Set();
             Assert.True(initial.Wait(TimeSpan.FromSeconds(10)), "the query never emitted its Initial");
+
+            // 🚨 The gate must have been RELEASED, not given up on. A timed-out gate lets the walk
+            // continue by itself, which un-pins the Initial from the notification's snapshot — the
+            // test would then pass without ever holding the window it exists to hold.
+            Assert.False(adapter.GateTimedOut,
+                "the scope-walk gate timed out instead of being released — the Initial was no longer "
+                + "pinned relative to the notification's fan-out snapshot, so this run verified nothing");
 
             // The setup is only meaningful if the Initial genuinely predates the write — otherwise
             // the row would arrive through the snapshot and this test would prove nothing.


### PR DESCRIPTION
## A live query's early→live handoff dropped a change notification — permanently

Every live children/descendants query opened **two** subscriptions on the adapter's change feed: an
"early" one that buffered into a backlog while `!initialDone`, and a "live" one attached inside the
initial-results callback, after which the early one was disposed.

`IsolatedChangeFeed` snapshots its observer list **before** delivering — it must, because
subscribers attach and detach mid-publish. So a write published in the instant before the live
subscription was attached is delivered against a snapshot holding **only the early observer**, and
by the time that delivery ran the callback had already set `initialDone = true`. The early
handler's `if (!initialDone)` threw the notification away; the live observer never saw it because it
was not in the snapshot; and **nothing re-triggers the re-query**. The row stayed invisible to that
subscription for its whole life — while a point read, and any *fresh* subscription, returned it
immediately.

A permanent miss dressed as a timeout, which is why no budget could ever have fixed it.

## Measured, not inferred

This started as an investigation into whether **cancelled agent rounds go unbilled** — the writer
hypothesis #2244 pre-registered when its reader-side fix did not stop the `WaitForUsage` reds.
**The writer is exonerated.** Instrumenting the wait to read the node back at failure time, and
reproducing locally (`MeshWeaver.AI.Test` 4-wide with `DOTNET_PROCESSOR_COUNT=4`, one `dotnet test`
at a time, ~1 failure in 8 runs):

```
[USAGE-DIAG] leg1 emissions during the wait: 1
[USAGE-DIAG]   leg1 21:37:06.565 n=0 []
[USAGE-DIAG] listing(_Usage children) count=1   ← a FRESH listing, 3 ms later
[USAGE-DIAG]   listed …/_Usage/usage_model content={"inputTokens":137,"outputTokens":89}
[USAGE-DIAG]   cell e4533be4: status=Completed model=usage-model in=137 out=89 total=226
[USAGE-DIAG] POINT READ OK: …/_Usage/usage_model {"inputTokens":137,"outputTokens":89}
```

The satellite is written, with the right counts, keyed by the right model — on the Completed **and**
the Cancelled path. The test's own live subscription emitted exactly one snapshot, the empty
Initial, then nothing for the full 20 s.

Subscribing the **same shared upstream** under System (which makes `WrapWithPerUserRls`
short-circuit to the raw, unfiltered stream) exonerated the per-user RLS filter too — raw saw
exactly what filtered saw. Instrumenting the provider then named the culprit outright:

```
[QDIAG] SUBSCRIBE base=…/_Usage scope=Children
[QDIAG] INITIAL   base=…/_Usage items=0 backlog=0
[QDIAG] NOTIFY seen base=…/_Usage path=…/_Usage/usage_model match=True   ← EARLY observer, after the handoff
```

…and, for that base path, **zero** `LIVE seen` and **zero** `REQUERY` for the rest of the run.

## The fix

**One** subscription for the query's whole lifetime. The backlog-vs-live routing decision is made
inside the same critical section that publishes the buffer, so a notification lands in exactly one
of the two and can never fall between them. The same shape existed in all four providers —
`StorageAdapterMeshQueryProvider`, `PostgreSqlMeshQuery`, `PostgreSqlPartitionedMeshQuery`,
`CosmosMeshQuery` — and is corrected in all four. It also removes the double-capture window the old
comments accepted, and puts Cosmos's disposal order right as a side effect.

No budget was widened, no retry or watchdog added.

## The test

`LiveQueryHandoffDropTest` pins the window deterministically: it holds the query's scope walk open,
commits the write, takes the notification's fan-out snapshot while only the pre-Initial subscriber
exists, releases the walk, asserts the Initial is genuinely empty, and only then delivers.

- **Fails on the pre-fix code** (verified by reverting the provider: 10 s, the assertion's message).
- **Passes on the fix** in 43 ms.

`MeshWeaver.Hosting.Test` is 226/226 green.

## Scope note

Related but **not** fixed here, and deliberately kept separate: a round whose provider never emitted
usage before the cancel/error records **zero** tokens, silently (a Debug-level no-op, no tokenizer
or estimate anywhere in the tree). That is real unbilled spend and it is #595, which I reopened —
its last comment said *"Keeping this issue open, scoped to that estimate"* and it was then
auto-closed as COMPLETED by a PR that shipped only the two surgical items.

Also noticed while reading the logs, not changed here: `MeshQuery.InitialStallProbeDelay` is 20 s
and `ThreadTokenUsageTest.SettleBudgetMs` is 20 000 — so in CI run `32894972304` the one warning
that would have named a stalled query provider fired ~30 ms after `TEST END`. A stall probe armed at
exactly the consumer's budget can never explain that consumer's timeout.

Root-causes the `WaitForUsage` flake family closed prematurely as #1040, #1812 and #2001 — each of
those diagnosed a different reader shape and none reached the notification drop underneath. Reported
on #1384 (the flake-population umbrella), which stays open.
