### PR TITLE
The registry client's budget cannot cover the registry's own latency

### DIFF
--- a/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
@@ -50,7 +50,43 @@ public static class ServiceDefaults
 #pragma warning disable EXTEXP0001
         builder.Services.AddHttpClient("plugin-registry")
             .RemoveAllResilienceHandlers()
-            .AddStandardResilienceHandler();
+            .AddStandardResilienceHandler(options =>
+            {
+                // 🚨 The STANDARD defaults (10s per attempt, 30s total) cannot serve this client,
+                // and the failure is deterministic rather than flaky.
+                //
+                // Measured 2026-08-26 from inside two production portals: GET
+                // /api/plugins/bundles/index.json — an 8.7 KB document — connects in ~0.03s and
+                // then takes 12–19s to first byte, because the registry evaluates entitlement per
+                // package and runs a mesh query on every request. TTFB alone therefore exceeds the
+                // 10s ATTEMPT timeout, so every attempt is cancelled, all three retries are
+                // cancelled the same way, and the pipeline reports TotalRequestTimeout at 30s.
+                //
+                // What that looked like in production: `Module 'MeshWeaver.SelfUpdate.Aks' of
+                // Hosting: landing failed`, repeatedly, on memex.systemorph.com. The consequences
+                // were three deep and none of them named a timeout:
+                //   1. modules stopped landing — 40 present against a sibling's 55;
+                //   2. the ones that did land pre-dated the asset fix, so `_content/…` 404'd and
+                //      pages died with "Importing a module script failed";
+                //   3. MeshWeaver.SelfUpdate.Aks never landed, so the real Kubernetes patcher was
+                //      never registered, IDeploymentUpdater stayed DetectOnly, and the instance
+                //      recorded an available version forever while patching nothing. Self-update
+                //      was silently off.
+                //
+                // These are DOWNLOADS, not API calls: a bundle is megabytes and the registry is a
+                // long way from a p99. So the budget is sized for a slow large transfer instead of
+                // a chatty JSON endpoint. Raising it is a mitigation, not the cure — the registry
+                // being this slow to serve 8.7 KB is its own defect and wants caching — but a
+                // client whose budget cannot cover the server's OBSERVED latency will keep failing
+                // even after the server improves, and it fails invisibly.
+                //
+                // Polly validates these against each other: TotalRequestTimeout must exceed
+                // AttemptTimeout, and the breaker's SamplingDuration must be at least twice the
+                // AttemptTimeout — so all three move together or the handler throws at startup.
+                options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(120);
+                options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(5);
+                options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(240);
+            });
 #pragma warning restore EXTEXP0001
 
         builder.Services.AddRequestTimeouts();

--- a/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
@@ -48,41 +48,61 @@ public static class ServiceDefaults
         // designed opt-in, and it is the ONLY way to override the defaults pipeline per client
         // without stacking a second retry-inside-retry pipeline on top of it.
 #pragma warning disable EXTEXP0001
+        // 🚨 TWO clients, because the registry serves two call shapes with OPPOSITE budgets.
+        //
+        // What the standard defaults (10s per attempt, 30s total) cost us, measured 2026-08-26 from
+        // inside two production portals: GET /api/plugins/bundles/index.json — an 8.7 KB document —
+        // connects in ~0.03s and then takes 12–19s to first byte, because the registry evaluates
+        // entitlement per package and runs a mesh query on every request. TTFB alone exceeds the
+        // 10s ATTEMPT timeout, so every attempt is cancelled, all three retries are cancelled the
+        // same way, and the pipeline reports TotalRequestTimeout at 30s.
+        //
+        // In production that read as `Module 'MeshWeaver.SelfUpdate.Aks' of Hosting: landing
+        // failed`, repeatedly, on memex.systemorph.com — three consequences deep, none naming a
+        // timeout:
+        //   1. modules stopped landing — 40 present against a sibling's 55;
+        //   2. the ones that did land pre-dated the asset fix, so `_content/…` 404'd and pages
+        //      died with "Importing a module script failed";
+        //   3. MeshWeaver.SelfUpdate.Aks never landed, so the real Kubernetes patcher was never
+        //      registered, IDeploymentUpdater stayed DetectOnly, and the instance recorded an
+        //      available version forever while patching nothing. Self-update was silently off.
+        //
+        // Raising the budget is a MITIGATION, not the cure — a registry this slow to serve 8.7 KB
+        // is its own defect and wants caching — but a client whose budget cannot cover the server's
+        // OBSERVED latency keeps failing after the server improves, and it fails invisibly.
+        //
+        // 🚨 The raise must NOT be shared, though, and that is the half worth reading twice. Bundle
+        // transfers are megabytes off that slow index and legitimately want minutes. Registration
+        // and the /Store catalog listing are rendered on a PAGE, where minutes are not resilience —
+        // they are a hang. One pipeline for both would have traded a silent module failure for a
+        // /Store that spins for five minutes against an unreachable registry.
+        //
+        // Polly validates each set against itself: TotalRequestTimeout must exceed AttemptTimeout,
+        // and the breaker's SamplingDuration must be at least twice AttemptTimeout — so the three
+        // values move together or the handler throws at startup.
+
+        // Both names are STRING LITERALS on purpose: this assembly does not reference
+        // MeshWeaver.PluginCatalog and should not start to for two constants. They must match
+        // InstanceRegistrationClient.HttpClientName / .BundleHttpClientName, whose doc comments say
+        // the same thing from the other side. A name that drifts does not fail — the factory simply
+        // hands back an unconfigured client and the budget below applies to nothing.
+
+        // Page-facing: registration + the catalog listing. Generous enough to cover the measured
+        // 12–19s TTFB with headroom, bounded tightly enough that a user is never left waiting.
         builder.Services.AddHttpClient("plugin-registry")
             .RemoveAllResilienceHandlers()
             .AddStandardResilienceHandler(options =>
             {
-                // 🚨 The STANDARD defaults (10s per attempt, 30s total) cannot serve this client,
-                // and the failure is deterministic rather than flaky.
-                //
-                // Measured 2026-08-26 from inside two production portals: GET
-                // /api/plugins/bundles/index.json — an 8.7 KB document — connects in ~0.03s and
-                // then takes 12–19s to first byte, because the registry evaluates entitlement per
-                // package and runs a mesh query on every request. TTFB alone therefore exceeds the
-                // 10s ATTEMPT timeout, so every attempt is cancelled, all three retries are
-                // cancelled the same way, and the pipeline reports TotalRequestTimeout at 30s.
-                //
-                // What that looked like in production: `Module 'MeshWeaver.SelfUpdate.Aks' of
-                // Hosting: landing failed`, repeatedly, on memex.systemorph.com. The consequences
-                // were three deep and none of them named a timeout:
-                //   1. modules stopped landing — 40 present against a sibling's 55;
-                //   2. the ones that did land pre-dated the asset fix, so `_content/…` 404'd and
-                //      pages died with "Importing a module script failed";
-                //   3. MeshWeaver.SelfUpdate.Aks never landed, so the real Kubernetes patcher was
-                //      never registered, IDeploymentUpdater stayed DetectOnly, and the instance
-                //      recorded an available version forever while patching nothing. Self-update
-                //      was silently off.
-                //
-                // These are DOWNLOADS, not API calls: a bundle is megabytes and the registry is a
-                // long way from a p99. So the budget is sized for a slow large transfer instead of
-                // a chatty JSON endpoint. Raising it is a mitigation, not the cure — the registry
-                // being this slow to serve 8.7 KB is its own defect and wants caching — but a
-                // client whose budget cannot cover the server's OBSERVED latency will keep failing
-                // even after the server improves, and it fails invisibly.
-                //
-                // Polly validates these against each other: TotalRequestTimeout must exceed
-                // AttemptTimeout, and the breaker's SamplingDuration must be at least twice the
-                // AttemptTimeout — so all three move together or the handler throws at startup.
+                options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(30);
+                options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(90);
+                options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(60);
+            });
+
+        // Transfer-facing: bundle downloads only. Nothing renders behind this, so it may wait.
+        builder.Services.AddHttpClient("plugin-registry-bundles")
+            .RemoveAllResilienceHandlers()
+            .AddStandardResilienceHandler(options =>
+            {
                 options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(120);
                 options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(5);
                 options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(240);

--- a/src/MeshWeaver.PluginCatalog/InstanceRegistrationClient.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceRegistrationClient.cs
@@ -52,6 +52,22 @@ public sealed class InstanceRegistrationClient(IMessageHub hub)
     /// </summary>
     public const string HttpClientName = "plugin-registry";
 
+    /// <summary>
+    /// The named <see cref="HttpClient"/> for BUNDLE TRANSFERS — <see cref="PluginBundleClient"/>
+    /// and nothing else.
+    ///
+    /// <para>🚨 It is separate from <see cref="HttpClientName"/> because the two call shapes want
+    /// opposite budgets, and one budget cannot serve both. A bundle is MEGABYTES and its index is
+    /// served slowly enough to need minutes; a catalog listing is rendered on a PAGE, where a
+    /// multi-minute budget is not resilience but a hang. Sharing one name meant the raise that
+    /// fixed module landing would also have let <c>/Store</c> spin for five minutes against an
+    /// unreachable registry — trading a silent failure for a stuck page.</para>
+    ///
+    /// <para>A host that registers no pipeline for this name still works: the factory returns a
+    /// plain client, exactly as for the name above.</para>
+    /// </summary>
+    public const string BundleHttpClientName = "plugin-registry-bundles";
+
     private static readonly HttpClient SharedHttp = new();
 
     private readonly IIoPool _httpPool =

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -74,8 +74,11 @@ public sealed class PluginBundleClient
         _token = (token ?? "").Trim();
         _httpPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http)
                     ?? IoPool.Unbounded;
+        // The BUNDLE client, not the shared registry one: these are megabyte transfers off a slow
+        // index and they need a budget measured in minutes, which a page-rendering caller must not
+        // inherit. See InstanceRegistrationClient.BundleHttpClientName.
         _http = hub.ServiceProvider.GetService<IHttpClientFactory>()
-            ?.CreateClient(InstanceRegistrationClient.HttpClientName) ?? SharedHttp;
+            ?.CreateClient(InstanceRegistrationClient.BundleHttpClientName) ?? SharedHttp;
         _logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger<PluginBundleClient>();
         _ledger = hub.ServiceProvider.GetService<BundleAdoptionLedger>();


### PR DESCRIPTION
**Self-update on `memex.systemorph.com` has been silently off, and this is the cause.** It also explains the rendering failure a user reported tonight.

## The arithmetic

Measured from inside **two** production portals — so it is the registry, not one instance's network:

```
GET https://memex.meshweaver.cloud/api/plugins/bundles/index.json   (8.7 KB)

from memex        code=200 size=8785 connect=0.024s  ttfb=12.44s
from memex-cloud  code=200 size=8785 connect=0.055s  ttfb=19.24s
```

Connect is instant; **time-to-first-byte is 12–19 seconds** for 8.7 KB, because the index handler evaluates entitlement per package and runs a mesh query on every request.

`AddStandardResilienceHandler()` defaults to **10 s per attempt** and 30 s total. TTFB alone exceeds one attempt, so every attempt is cancelled at 10 s, all three retries are cancelled the same way, and the pipeline reports `TotalRequestTimeout` at 30 s. **This is not flaky — it is arithmetically unable to succeed.**

## What it actually cost

The production log named none of the above. It said:

```
warn: MeshWeaver.PluginCatalog.PluginBundleClient
      Module 'MeshWeaver.SelfUpdate.Aks' of Hosting: landing failed
      Polly.Timeout.TimeoutRejectedException: … '00:00:30'
```

Three consequences, each further from the cause:

1. **Modules stopped landing** — 40 on systemorph against the sibling portal's 55.
2. **The ones that did land pre-dated the static-asset fix**, so `_content/MeshWeaver.Blazor.EntityViews/…`, `…Analysis/…`, `Radzen.Blazor.js` and `OpenStreetMapView.razor.js` all 404 — and a page died with *"Importing a module script failed."* That is the bug that was reported as a rendering problem.
3. **`MeshWeaver.SelfUpdate.Aks` never landed**, so the real Kubernetes patcher was never registered, `IDeploymentUpdater` stayed `DetectOnly`, and the instance has been recording `latestAvailableTag: 3.0.0-rc8.ci.5363` while patching nothing. **Self-update was off and nothing said so.**

## The change

These are **downloads, not API calls** — a bundle is megabytes — so the budget is sized for a slow large transfer rather than a chatty JSON endpoint:

| | was | now |
|---|---|---|
| `AttemptTimeout` | 10 s | **120 s** |
| `TotalRequestTimeout` | 30 s | **5 min** |
| `CircuitBreaker.SamplingDuration` | default | **240 s** |

All three move together because Polly validates them against each other at startup (total > attempt; sampling ≥ 2× attempt).

## 🚨 This is a mitigation, not the cure

A registry taking 12–19 s to serve 8.7 KB is **its own defect** and wants caching on the entitlement / mesh-query path — filed separately is the right home for that, and I did not want to guess at a caching strategy for an entitlement-sensitive endpoint.

But the client half is worth fixing on its own merits: a budget that cannot cover the server's **observed** latency will keep failing after the server improves, and it fails *invisibly* — as a module that quietly does not land.

Build: `Memex.Portal.ServiceDefaults` Release, 0 warnings, 0 errors.

Related: #2274 (the combo gate that is never called), #2234 (atomic module/platform movement).