### PR TITLE
Northwind dashboard: refer to the classes by the names they actually have

### DIFF
--- a/.github/samples-gate.allow
+++ b/.github/samples-gate.allow
@@ -4,7 +4,6 @@ FutuRe/AsiaRe/LineOfBusiness compile
 FutuRe/AsiaRe/TransactionMapping compile
 FutuRe/EuropeRe/LineOfBusiness compile
 FutuRe/EuropeRe/TransactionMapping compile
-Northwind/AnalyticsCatalog compile
 Northwind/Product compile
 
 # ── PensionFund: revealed by #2063, NOT caused by it ────────────────────────────────────────────

--- a/samples/Graph/Data/Northwind/AnalyticsCatalog/Source/DashboardLayoutAreas.cs
+++ b/samples/Graph/Data/Northwind/AnalyticsCatalog/Source/DashboardLayoutAreas.cs
@@ -33,25 +33,25 @@ public static class DashboardLayoutAreas
             .WithView(
                 Controls.Stack
                     .WithView(Controls.PaneHeader("Top 5 Orders Summary"))
-                    .WithView(Controls.LayoutArea(layoutArea.Hub.Address, nameof(OrderViews.OrderSummary))),
+                    .WithView(Controls.LayoutArea(layoutArea.Hub.Address, nameof(OrderLayoutAreas.OrderSummary))),
                 skin => skin.WithXs(12).WithSm(6)
             )
             .WithView(
                 Controls.Stack
                     .WithView(Controls.PaneHeader("Sales by Category"))
-                    .WithView(Controls.LayoutArea(layoutArea.Hub.Address, nameof(SalesViews.SalesByCategory))),
+                    .WithView(Controls.LayoutArea(layoutArea.Hub.Address, nameof(SalesLayoutAreas.SalesByCategory))),
                 skin => skin.WithXs(12).WithSm(6)
             )
             .WithView(
                 Controls.Stack
                     .WithView(Controls.PaneHeader("Supplier Summary"))
-                    .WithView(Controls.LayoutArea(layoutArea.Hub.Address, nameof(SupplierViews.SupplierSummary)).WithStyle(s => s.WithWidth("100%"))),
+                    .WithView(Controls.LayoutArea(layoutArea.Hub.Address, nameof(SupplierLayoutAreas.SupplierSummary)).WithStyle(s => s.WithWidth("100%"))),
                 skin => skin.WithXs(12).WithSm(6)
             )
             .WithView(
                 Controls.Stack
                     .WithView(Controls.PaneHeader("Top Products"))
-                    .WithView(Controls.LayoutArea(layoutArea.Hub.Address, nameof(ProductViews.ProductOverview))),
+                    .WithView(Controls.LayoutArea(layoutArea.Hub.Address, nameof(ProductLayoutAreas.ProductOverview))),
                 skin => skin.WithXs(12).WithSm(6)
             );
     }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-northwind-dashboard-compiles.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-northwind-dashboard-compiles.md
@@ -1,0 +1,13 @@
+---
+Name: Northwind dashboard renders again
+Category: Fix
+Description: The Northwind analytics dashboard failed to compile and showed nothing; its tiles are back.
+Icon: Sparkle
+Order: -20260826
+---
+
+# Northwind dashboard renders again
+
+The Northwind sample's analytics dashboard referred to four view classes by an old name, so the
+page failed to compile and its tiles did not appear. The references now use the current names and
+the dashboard renders as intended. The views themselves are unchanged.


### PR DESCRIPTION
`Northwind/AnalyticsCatalog` does not compile. `DashboardLayoutAreas.cs` names four classes that do not exist:

| Referenced | Actual class | Member named |
|---|---|---|
| `OrderViews.OrderSummary` | `OrderLayoutAreas` | already declares `OrderSummary` |
| `SalesViews.SalesByCategory` | `SalesLayoutAreas` | already declares `SalesByCategory` |
| `SupplierViews.SupplierSummary` | `SupplierLayoutAreas` | already declares `SupplierSummary` |
| `ProductViews.ProductOverview` | `ProductLayoutAreas` | already declares `ProductOverview` |

`Northwind/Product` then fails **after** it — `Supplier` and `Category` are declared in `AnalyticsCatalog`'s own `Source/`, so a red root makes the dependent red too.

## Behaviour is identical

All four sites are `nameof(X.Y)`, which evaluates to `"Y"` regardless of `X`. Every layout-area name passed to `Controls.LayoutArea` is byte-for-byte what it was. This repairs the compile and changes nothing at runtime.

## This is latent on main, not new

In-mesh source compiles at **runtime**, never in `dotnet build` — and a NodeType keeps its cached bundle until the **framework identity** changes, at which point every dynamic NodeType recompiles at once. So this breakage is invisible on main and detonates on the first change that mints a new framework build.

That is how it surfaced: it turned #2285 (which moves types between assemblies) red, on a gate that is green on `main` with the identical broken file. Worth noting for anyone reading that red as "#2285 broke Northwind" — it did not; it recompiled it.

## Verification

Deliberately **not** verified by `dotnet build`: `samples/Graph/**` is `<None>` content and is never type-checked by any build or test. The `Doc content compiles and runs` gate is the verification, which is where the failure was observed:

```
Compilation failed for 'Northwind/AnalyticsCatalog':
  CS0103 'OrderViews' does not exist in the current context   (+3 more)
Compilation failed for 'Northwind/Product':
  CS0246 The type or namespace name 'Supplier' could not be found   (+1 more)
NodeType 'Northwind/Product' PARKED after compile failure
```

Expected after this change: `31/31 NodeType(s) compiled` where the run showed `28/31`.