### PR TITLE
Chart Drift: mint a GitHub App installation token instead of a stored PAT (#1709)

### DIFF
--- a/.github/workflows/chart-drift.yml
+++ b/.github/workflows/chart-drift.yml
@@ -48,15 +48,25 @@ name: Chart Drift
 #
 #      Regenerate after any deliberate helm change, or the gate compares against a stale intent.
 #
-#   3. [OUTSTANDING] A fine-grained read-only PAT for Systemorph/Memex (Contents: Read-only, nothing
-#      else) added as secrets.MEMEX_DEPLOY_REPO_TOKEN. A PAT cannot be minted through the API or
-#      CLI, so this step is necessarily manual. Do NOT substitute the existing broad `GH_PAT` (it
-#      widens what this job can reach for no benefit), and do NOT move the overlays into this public
-#      repo to dodge the token — that would publish the deployment inventory.
+#   3. [DONE] Read access to Systemorph/Memex, as a GitHub App installation token minted per run
+#      (secrets.MESHWEAVER_APP_ID + MESHWEAVER_APP_PRIVATE_KEY, the org's `meshweaver-cloud` App).
 #
-# Until 3 lands, every run fails with the list above and nobody is misled about whether the cluster
-# matches the chart. Drift found by a run that DOES complete is reported the same way: red, with
-# each divergence classified CLUSTER-ONLY / CHART-ONLY / DIFFERS.
+#      🚨 This step used to read "a fine-grained read-only PAT ... a PAT cannot be minted through
+#      the API or CLI, so this step is necessarily manual". The first half is true and the second
+#      does not follow: an App INSTALLATION token is mintable, and the org already had an App
+#      installed with access to this repo. The PAT route was tried and it rotted precisely as PATs
+#      do — provisioned 2026-08-17, HTTP 401 "Bad credentials" on all nine runs after, so the check
+#      never ran once (#1709). A stored PAT has no owner, no expiry anyone watches, and fails in a
+#      way indistinguishable from a scope problem. The installation token is minted fresh each run
+#      and scoped to `repositories: Memex` with `permission-contents: read`, which is narrower than
+#      the PAT it replaces. Rotation has ONE home: Key Vault `Systemorph/github-app-privatekey`.
+#
+#      Still true, and still worth saying: do NOT substitute the broad `GH_PAT` (it widens what this
+#      job can reach for no benefit), and do NOT move the overlays into this public repo to dodge
+#      the credential — that would publish the deployment inventory.
+#
+# Drift found by a run that completes is reported red, with each divergence classified
+# CLUSTER-ONLY / CHART-ONLY / DIFFERS.
 #
 # 🔒 WHICH ENVIRONMENTS EXIST IS NOT PUBLIC. This workflow used to carry the namespace list and the
 # cluster/resource-group names inline — deployment identities, in a public repo, describing an
@@ -101,13 +111,15 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          MEMEX_DEPLOY_REPO_TOKEN: ${{ secrets.MEMEX_DEPLOY_REPO_TOKEN }}
+          MESHWEAVER_APP_ID: ${{ secrets.MESHWEAVER_APP_ID }}
+          MESHWEAVER_APP_PRIVATE_KEY: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
         run: |
           missing=()
           [ -n "$AZURE_CLIENT_ID" ]       || missing+=("secrets.AZURE_CLIENT_ID        OIDC app registration for azure/login")
           [ -n "$AZURE_TENANT_ID" ]       || missing+=("secrets.AZURE_TENANT_ID        the Systemorph AAD tenant")
           [ -n "$AZURE_SUBSCRIPTION_ID" ] || missing+=("secrets.AZURE_SUBSCRIPTION_ID  the subscription holding the AKS cluster")
-          [ -n "$MEMEX_DEPLOY_REPO_TOKEN" ] || missing+=("secrets.MEMEX_DEPLOY_REPO_TOKEN  read-only PAT for $DEPLOY_REPO, where the per-env values.<env>.public.yaml overlays live (see this file's header — they must be committed there first, secret-free)")
+          [ -n "$MESHWEAVER_APP_ID" ]     || missing+=("secrets.MESHWEAVER_APP_ID          app id of the org GitHub App that reads $DEPLOY_REPO, where the per-env values.<env>.public.yaml overlays live")
+          [ -n "$MESHWEAVER_APP_PRIVATE_KEY" ] || missing+=("secrets.MESHWEAVER_APP_PRIVATE_KEY  that App's private key (PEM); source of truth is Key Vault Systemorph/github-app-privatekey")
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::chart-drift cannot run — provision the following, then re-run:"
             for m in "${missing[@]}"; do echo "  • $m"; done
@@ -127,9 +139,23 @@ jobs:
       # the real API, and name what each rejection means, because the three causes are
       # indistinguishable from the checkout error and take very different fixes. Read-only, one
       # request, no `if:`, no continue-on-error: it fails RED like everything else here.
+      # Cross-repo reads are a GitHub App installation token minted per run, never a stored PAT.
+      # A PAT was the original design and it rotted exactly as PATs do: provisioned 2026-08-17,
+      # HTTP 401 on every run after (#1709). An installation token cannot rot — it is minted fresh
+      # here, expires in an hour, and is scoped to the one repository named below.
+      - name: Mint an installation token for the deploy repo
+        id: deploy-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.MESHWEAVER_APP_ID }}
+          private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+          owner: Systemorph
+          repositories: Memex
+          permission-contents: read
+
       - name: The token can actually READ the deploy repo
         env:
-          MEMEX_DEPLOY_REPO_TOKEN: ${{ secrets.MEMEX_DEPLOY_REPO_TOKEN }}
+          DEPLOY_TOKEN: ${{ steps.deploy-token.outputs.token }}
         run: |
           # 🚨 `|| code=000` is not defensive noise. `run:` steps are `bash -e`, so a curl that
           # fails at the TRANSPORT level (DNS, TLS, connection refused) makes this assignment
@@ -141,32 +167,31 @@ jobs:
           # answer into a 20-minute one.
           code=$(curl -sS -o /dev/null -w '%{http_code}' \
             --connect-timeout 10 --max-time 30 \
-            -H "Authorization: Bearer $MEMEX_DEPLOY_REPO_TOKEN" \
+            -H "Authorization: Bearer $DEPLOY_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/$DEPLOY_REPO") || code=000
           case "$code" in
             200)
-              echo "secrets.MEMEX_DEPLOY_REPO_TOKEN reads $DEPLOY_REPO (HTTP 200)." ;;
+              echo "The minted installation token reads $DEPLOY_REPO (HTTP 200)." ;;
             401)
-              echo "::error::secrets.MEMEX_DEPLOY_REPO_TOKEN is set but GitHub rejects it (HTTP 401, Bad credentials)."
-              echo "  The stored value is not a usable token. Most often it is not the token at all —"
-              echo "  a clipboard-piped 'gh secret set' stores whatever was on the clipboard — or the"
-              echo "  token was revoked, expired, or truncated on copy. Re-mint at"
-              echo "  https://github.com/settings/personal-access-tokens and store it again."
+              echo "::error::The minted installation token is rejected (HTTP 401, Bad credentials)."
+              echo "  The mint step succeeded, so the App id and key are a matching pair — but the"
+              echo "  token GitHub returned is not being accepted. This is the one outcome that"
+              echo "  should be impossible here; treat it as a GitHub-side fault and re-run. If it"
+              echo "  persists, confirm the App has not been deleted out from under the install."
               exit 1 ;;
             403)
-              echo "::error::secrets.MEMEX_DEPLOY_REPO_TOKEN is refused (HTTP 403)."
-              echo "  The token exists but is not authorised for $DEPLOY_REPO's organisation. A"
-              echo "  fine-grained PAT whose resource owner is an org stays inert until an org owner"
-              echo "  APPROVES it — check https://github.com/settings/personal-access-tokens for a"
-              echo "  'Pending owner approval' badge, and the org's pending-requests page to grant it."
+              echo "::error::The minted installation token is refused (HTTP 403)."
+              echo "  The App is installed but suspended, or its installation permissions were"
+              echo "  narrowed below Contents: Read. Check the App's installation on the Systemorph"
+              echo "  org and re-approve the permissions it requests."
               exit 1 ;;
             404)
-              echo "::error::secrets.MEMEX_DEPLOY_REPO_TOKEN authenticates but cannot see $DEPLOY_REPO (HTTP 404)."
+              echo "::error::The token authenticates but cannot see $DEPLOY_REPO (HTTP 404)."
               echo "  GitHub returns 404 rather than 403 for a repository a token may not read, so this"
-              echo "  is a SCOPE problem: the PAT's repository access does not include $DEPLOY_REPO, or"
-              echo "  it lacks 'Contents: Read-only'. Re-scope it — no other permission is needed."
+              echo "  is a SCOPE problem: the App's installation no longer includes $DEPLOY_REPO. Add"
+              echo "  the repository to the installation — no other permission is needed."
               exit 1 ;;
             000)
               echo "::error::Could not reach api.github.com to probe $DEPLOY_REPO (no HTTP response)."
@@ -181,7 +206,7 @@ jobs:
               echo "  re-run when the incident clears. Failing closed: indeterminate is not a pass."
               exit 1 ;;
             *)
-              echo "::error::Unexpected HTTP $code probing $DEPLOY_REPO with secrets.MEMEX_DEPLOY_REPO_TOKEN."
+              echo "::error::Unexpected HTTP $code probing $DEPLOY_REPO with the minted token."
               echo "  Treating as FAILURE: an indeterminate answer must never read as a working token."
               exit 1 ;;
           esac
@@ -195,11 +220,24 @@ jobs:
       aks_cluster: ${{ steps.envs.outputs.aks_cluster }}
       aks_resource_group: ${{ steps.envs.outputs.aks_resource_group }}
     steps:
+      # Cross-repo reads are a GitHub App installation token minted per run, never a stored PAT.
+      # A PAT was the original design and it rotted exactly as PATs do: provisioned 2026-08-17,
+      # HTTP 401 on every run after (#1709). An installation token cannot rot — it is minted fresh
+      # here, expires in an hour, and is scoped to the one repository named below.
+      - name: Mint an installation token for the deploy repo
+        id: deploy-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.MESHWEAVER_APP_ID }}
+          private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+          owner: Systemorph
+          repositories: Memex
+          permission-contents: read
       - name: Check out the deployment repo
         uses: actions/checkout@v7
         with:
           repository: ${{ env.DEPLOY_REPO }}
-          token: ${{ secrets.MEMEX_DEPLOY_REPO_TOKEN }}
+          token: ${{ steps.deploy-token.outputs.token }}
           path: deploy-repo
       # No `if:`, no `continue-on-error:` — same rule as preflight, and for a sharper reason. An
       # empty or unreadable manifest yields an empty matrix, and an empty matrix SKIPS every drift
@@ -264,11 +302,24 @@ jobs:
         env: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v7
+      # Cross-repo reads are a GitHub App installation token minted per run, never a stored PAT.
+      # A PAT was the original design and it rotted exactly as PATs do: provisioned 2026-08-17,
+      # HTTP 401 on every run after (#1709). An installation token cannot rot — it is minted fresh
+      # here, expires in an hour, and is scoped to the one repository named below.
+      - name: Mint an installation token for the deploy repo
+        id: deploy-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.MESHWEAVER_APP_ID }}
+          private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+          owner: Systemorph
+          repositories: Memex
+          permission-contents: read
       - name: Check out the per-env overlays
         uses: actions/checkout@v7
         with:
           repository: ${{ env.DEPLOY_REPO }}
-          token: ${{ secrets.MEMEX_DEPLOY_REPO_TOKEN }}
+          token: ${{ steps.deploy-token.outputs.token }}
           path: deploy-repo
       - name: Install helm
         uses: azure/setup-helm@v5


### PR DESCRIPTION
Closes #1709.

`Chart Drift` has failed **every run since it was added** — nine for nine. The preflight named `secrets.MEMEX_DEPLOY_REPO_TOKEN` as unprovisioned; it was in fact provisioned on 2026-08-17 (`created_at == updated_at`) and has returned **HTTP 401 Bad credentials** on every run since. It authenticates as nothing. Drift detection for `memex`, `memex-cloud` and `atioz` has never run once.

## The header's premise was half right

> A PAT cannot be minted through the API or CLI, so this step is necessarily manual.

True of a PAT. But the conclusion doesn't follow: a GitHub App **installation token** *is* mintable, and the org already has the `meshweaver-cloud` App (id 4220566) installed with access to all 32 repos — `Systemorph/Memex` among them. Verified by minting one and reading the repo: HTTP 200.

So the credential stops being a stored secret that rots:

| | before | after |
|---|---|---|
| lifetime | until someone notices it died | one hour, minted per run |
| scope | `Contents: Read` on Memex | `repositories: Memex` + `permission-contents: read` — narrower |
| rotation | manual, no owner | Key Vault `Systemorph/github-app-privatekey` |

`secrets.MESHWEAVER_APP_ID` / `MESHWEAVER_APP_PRIVATE_KEY` are provisioned.

## The other two prerequisites were already done

The issue listed three things. Only the token was outstanding:

1. **Overlays committed** — `deployments/aks/{memex,memex-cloud,atioz}/values.<release>.public.yaml` all exist in `Systemorph/Memex`, with the optional `portal-patch.json` beside them.
3. **AKS access granted** — `github-actions-deploy` holds *Azure Kubernetes Service Cluster Admin Role* **and** *Contributor Role* on `memexaks-cluster`; Contributor covers `Microsoft.ContainerService/managedClusters/*`, i.e. `runCommand/action`.

## What is deliberately unchanged

The validity probe stays, because its lesson is the durable one — *PRESENT is not VALID*, learned here the hard way when an empty-string check went green over a dead token. It still fails RED, no `if:`, no `continue-on-error`. Only the diagnostics change: 401/403/404 mean different things for an installation token than for a PAT, and each takes a different fix.

## Expect the first completing run to be red

Legitimately, and that is the point — the header documents 121 divergences found in a local run against `memex` on 2026-08-17, including `Authentication__Microsoft__ClientId` still being `CHANGE_ME_...` in the chart. That backlog is the finding, not a defect in the gate.

**What's New:** skipped — CI credential plumbing, no user-visible effect.