### PR TITLE
Shared node-repo workflows: mint the stage-repo token from a GitHub App (#2249)

### DIFF
--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -33,7 +33,8 @@ name: Node repo gate (reusable)
 #     secrets:
 #       acr-username: ${{ secrets.ACR_USERNAME }}
 #       acr-password: ${{ secrets.ACR_PASSWORD }}
-#       stage-repo-token: ${{ secrets.MESHWEAVER_REPO_TOKEN }}
+#       stage-repo-app-id: ${{ secrets.MESHWEAVER_APP_ID }}
+#       stage-repo-app-private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
 
 on:
   workflow_call:
@@ -103,8 +104,16 @@ on:
       acr-password:
         description: Registry password for that user.
         required: true
-      stage-repo-token:
-        description: Token able to read stage-repo (needed only when stage-modules is set).
+      stage-repo-app-id:
+        description: >
+          App id of a GitHub App installed on stage-repo's org with Contents: Read (needed only
+          when stage-modules is set). Replaces the former stage-repo-token PAT: an installation
+          token is minted per run and scoped to stage-repo alone, so it cannot rot the way a
+          stored PAT does — and, unlike a PAT, it resolves for dependabot-triggered runs once
+          provisioned in the caller's Dependabot secret store as well (#2249).
+        required: false
+      stage-repo-app-private-key:
+        description: Private key (PEM) of that App.
         required: false
 
 jobs:
@@ -153,12 +162,36 @@ jobs:
       # Cross-repo `requires` must resolve for the package roots to bind — the tester installs
       # whatever the mount holds, so the required modules are STAGED into it, exactly like
       # production resolves the requires from the store's package sources.
+      # 🚨 A PAT here was a permanent two-way failure. It rots — the platform's own copy went
+      # HTTP 401 and a daily check never ran once (#1709) — and, because GitHub hands a
+      # dependabot-triggered run the DEPENDABOT secret store rather than the Actions one, a PAT
+      # provisioned for normal runs left every dependabot PR in every satellite permanently RED
+      # (#2249). An installation token is minted here, per run, scoped to stage-repo alone.
+      - name: Resolve the stage repo's owner and name
+        id: stage-repo-parts
+        if: inputs.stage-modules != ''
+        env:
+          STAGE_REPO: ${{ inputs.stage-repo }}
+        run: |
+          set -euo pipefail
+          echo "owner=${STAGE_REPO%%/*}" >> "$GITHUB_OUTPUT"
+          echo "name=${STAGE_REPO##*/}"  >> "$GITHUB_OUTPUT"
+      - name: Mint an installation token for the stage repo
+        id: stage-token
+        if: inputs.stage-modules != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.stage-repo-app-id }}
+          private-key: ${{ secrets.stage-repo-app-private-key }}
+          owner: ${{ steps.stage-repo-parts.outputs.owner }}
+          repositories: ${{ steps.stage-repo-parts.outputs.name }}
+          permission-contents: read
       - name: Stage cross-repo modules
         if: inputs.stage-modules != ''
         uses: actions/checkout@v7
         with:
           repository: ${{ inputs.stage-repo }}
-          token: ${{ secrets.stage-repo-token }}
+          token: ${{ steps.stage-token.outputs.token }}
           path: cross-repo-stage
           sparse-checkout: ${{ inputs.stage-modules }}
       - name: Import + compile + render + run tests for each node repo

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -162,6 +162,38 @@ jobs:
       # Cross-repo `requires` must resolve for the package roots to bind — the tester installs
       # whatever the mount holds, so the required modules are STAGED into it, exactly like
       # production resolves the requires from the store's package sources.
+      # 🚨 Assert the staging inputs BEFORE minting, so a missing one fails RED naming what to
+      # provision rather than surfacing as an opaque create-github-app-token or checkout error two
+      # steps later (Copilot review, #2310). The `if:` is on the declared INPUT stage-modules —
+      # i.e. whether staging was requested at all — never on whether a secret happens to be set,
+      # which is the skip-trapdoor AGENTS.md forbids.
+      - name: "Preflight: the stage-repo credentials must be provisioned"
+        if: inputs.stage-modules != ''
+        env:
+          STAGE_REPO: ${{ inputs.stage-repo }}
+          STAGE_APP_ID: ${{ secrets.stage-repo-app-id }}
+          STAGE_APP_KEY: ${{ secrets.stage-repo-app-private-key }}
+        run: |
+          set -euo pipefail
+          missing=()
+          case "${STAGE_REPO:-}" in
+            "")  missing+=("stage-repo (input) — owner/name of the repo modules are staged from") ;;
+            */*) : ;;
+            *)   missing+=("stage-repo (input) — must be owner/name, got '${STAGE_REPO}'") ;;
+          esac
+          [ -n "${STAGE_APP_ID:-}" ]  || missing+=("stage-repo-app-id (secret) — app id of a GitHub App able to read ${STAGE_REPO:-the stage repo}")
+          [ -n "${STAGE_APP_KEY:-}" ] || missing+=("stage-repo-app-private-key (secret) — that App's private key, PEM")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::stage-modules is set, so the cross-repo staging inputs are required:"
+            for m in "${missing[@]}"; do echo "  • $m"; done
+            # 🚨 The store split that made every satellite dependabot PR red (#2249).
+            if [ "${GITHUB_ACTOR:-}" = "dependabot[bot]" ]; then
+              echo "::error::This run reads the DEPENDABOT secret store, not Actions — provision the pair there too (#2249)."
+            fi
+            exit 1
+          fi
+          echo "Staging ${STAGE_REPO} — credentials present."
+
       # 🚨 A PAT here was a permanent two-way failure. It rots — the platform's own copy went
       # HTTP 401 and a daily check never ran once (#1709) — and, because GitHub hands a
       # dependabot-triggered run the DEPENDABOT secret store rather than the Actions one, a PAT

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -282,15 +282,21 @@ jobs:
           [ -n "${ACR_PASSWORD:-}" ]           || missing+=("acr-password (secret) — registry password for that user")
           [ -n "${BAKE_PUBLISH_TARGETS:-}" ]   || missing+=("bake-publish-targets (input, from the caller's repo VARIABLE) — the portals' Azure Files targets, whitespace-separated <account>/<share>[/<base-path>]")
           if [ -n "${STAGE_MODULES:-}" ]; then
-            [ -n "${STAGE_APP_ID:-}" ]  || missing+=("stage-repo-app-id (secret) — app id of a GitHub App that can read the stage repo (stage-modules is set)")
-            [ -n "${STAGE_APP_KEY:-}" ] || missing+=("stage-repo-app-private-key (secret) — that App's private key, PEM (stage-modules is set)")
-            # 🚨 If this fires on a dependabot PR, the secrets exist but in the WRONG STORE.
-            # GitHub hands a dependabot-triggered run the Dependabot secret store, never the
-            # Actions one, so a value provisioned only for normal runs is simply absent here and
-            # every dependabot PR stays red forever (#2249). Provision the same pair under
+            stage_missing=0
+            [ -n "${STAGE_APP_ID:-}" ]  || { stage_missing=1; missing+=("stage-repo-app-id (secret) — app id of a GitHub App that can read the stage repo (stage-modules is set)"); }
+            [ -n "${STAGE_APP_KEY:-}" ] || { stage_missing=1; missing+=("stage-repo-app-private-key (secret) — that App's private key, PEM (stage-modules is set)"); }
+            # 🚨 Gated on the STAGE credentials specifically, never on "any input is missing".
+            # This hint names one cause, so it must only fire for the input that has that cause:
+            # a missing acr-password is not a Dependabot-store problem, and a hint that says it is
+            # sends the next person to the wrong settings page (Copilot review, #2310).
+            #
+            # When it DOES fire, the secrets usually exist — in the WRONG STORE. GitHub hands a
+            # dependabot-triggered run the Dependabot secret store, never the Actions one, so a
+            # value provisioned only for push runs is simply absent here and every dependabot PR
+            # stays red forever (#2249). Provision the same pair under
             # Settings -> Secrets and variables -> Dependabot in the CALLING repo.
-            if [ "${GITHUB_ACTOR:-}" = "dependabot[bot]" ] && [ ${#missing[@]} -gt 0 ]; then
-              echo "::warning::Secret source for this run is the DEPENDABOT store, not Actions."
+            if [ "$stage_missing" = "1" ] && [ "${GITHUB_ACTOR:-}" = "dependabot[bot]" ]; then
+              echo "::warning::This run reads the DEPENDABOT secret store, not Actions. stage-repo-app-id/stage-repo-app-private-key must be provisioned there too (#2249)."
             fi
           fi
           # 🚨 Declaring dependents is declaring an OBLIGATION: those repos exit on their own

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -80,7 +80,8 @@ name: Node repo publish-bake (reusable)
 #       azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
 #       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
 #       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-#       stage-repo-token: ${{ secrets.MESHWEAVER_REPO_TOKEN }}
+#       stage-repo-app-id: ${{ secrets.MESHWEAVER_APP_ID }}
+#       stage-repo-app-private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
 #
 # The real topology, and the order it produces without any central scheduler:
 #
@@ -234,8 +235,16 @@ on:
       azure-subscription-id:
         description: Subscription of the storage accounts.
         required: true
-      stage-repo-token:
-        description: Token able to read stage-repo (needed only when stage-modules is set).
+      stage-repo-app-id:
+        description: >
+          App id of a GitHub App installed on stage-repo's org with Contents: Read (needed only
+          when stage-modules is set). Replaces the former stage-repo-token PAT: an installation
+          token is minted per run and scoped to stage-repo alone, so it cannot rot the way a
+          stored PAT does — and, unlike a PAT, it resolves for dependabot-triggered runs once
+          provisioned in the caller's Dependabot secret store as well (#2249).
+        required: false
+      stage-repo-app-private-key:
+        description: Private key (PEM) of that App.
         required: false
 
 jobs:
@@ -257,7 +266,8 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.azure-subscription-id }}
           ACR_USERNAME: ${{ secrets.acr-username }}
           ACR_PASSWORD: ${{ secrets.acr-password }}
-          STAGE_TOKEN: ${{ secrets.stage-repo-token }}
+          STAGE_APP_ID: ${{ secrets.stage-repo-app-id }}
+          STAGE_APP_KEY: ${{ secrets.stage-repo-app-private-key }}
           BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
           STAGE_MODULES: ${{ inputs.stage-modules }}
           NARROW: ${{ inputs.narrow-by-affected }}
@@ -271,8 +281,17 @@ jobs:
           [ -n "${ACR_USERNAME:-}" ]           || missing+=("acr-username (secret) — registry user able to pull the test image")
           [ -n "${ACR_PASSWORD:-}" ]           || missing+=("acr-password (secret) — registry password for that user")
           [ -n "${BAKE_PUBLISH_TARGETS:-}" ]   || missing+=("bake-publish-targets (input, from the caller's repo VARIABLE) — the portals' Azure Files targets, whitespace-separated <account>/<share>[/<base-path>]")
-          if [ -n "${STAGE_MODULES:-}" ] && [ -z "${STAGE_TOKEN:-}" ]; then
-            missing+=("stage-repo-token (secret) — token able to read the stage repo (stage-modules is set)")
+          if [ -n "${STAGE_MODULES:-}" ]; then
+            [ -n "${STAGE_APP_ID:-}" ]  || missing+=("stage-repo-app-id (secret) — app id of a GitHub App that can read the stage repo (stage-modules is set)")
+            [ -n "${STAGE_APP_KEY:-}" ] || missing+=("stage-repo-app-private-key (secret) — that App's private key, PEM (stage-modules is set)")
+            # 🚨 If this fires on a dependabot PR, the secrets exist but in the WRONG STORE.
+            # GitHub hands a dependabot-triggered run the Dependabot secret store, never the
+            # Actions one, so a value provisioned only for normal runs is simply absent here and
+            # every dependabot PR stays red forever (#2249). Provision the same pair under
+            # Settings -> Secrets and variables -> Dependabot in the CALLING repo.
+            if [ "${GITHUB_ACTOR:-}" = "dependabot[bot]" ] && [ ${#missing[@]} -gt 0 ]; then
+              echo "::warning::Secret source for this run is the DEPENDABOT store, not Actions."
+            fi
           fi
           # 🚨 Declaring dependents is declaring an OBLIGATION: those repos exit on their own
           # upstream gate and are woken only by the event this job fires. A missing token would
@@ -468,12 +487,36 @@ jobs:
         run: mw-platform-gate/.github/scripts/bake-scope.sh
       # Same staging the caller's gate does, for the same reason: cross-repo `requires` must
       # resolve for the package roots to bind.
+      # 🚨 A PAT here was a permanent two-way failure. It rots — the platform's own copy went
+      # HTTP 401 and a daily check never ran once (#1709) — and, because GitHub hands a
+      # dependabot-triggered run the DEPENDABOT secret store rather than the Actions one, a PAT
+      # provisioned for normal runs left every dependabot PR in every satellite permanently RED
+      # (#2249). An installation token is minted here, per run, scoped to stage-repo alone.
+      - name: Resolve the stage repo's owner and name
+        id: stage-repo-parts
+        if: inputs.stage-modules != ''
+        env:
+          STAGE_REPO: ${{ inputs.stage-repo }}
+        run: |
+          set -euo pipefail
+          echo "owner=${STAGE_REPO%%/*}" >> "$GITHUB_OUTPUT"
+          echo "name=${STAGE_REPO##*/}"  >> "$GITHUB_OUTPUT"
+      - name: Mint an installation token for the stage repo
+        id: stage-token
+        if: inputs.stage-modules != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.stage-repo-app-id }}
+          private-key: ${{ secrets.stage-repo-app-private-key }}
+          owner: ${{ steps.stage-repo-parts.outputs.owner }}
+          repositories: ${{ steps.stage-repo-parts.outputs.name }}
+          permission-contents: read
       - name: Stage cross-repo modules
         if: inputs.stage-modules != ''
         uses: actions/checkout@v7
         with:
           repository: ${{ inputs.stage-repo }}
-          token: ${{ secrets.stage-repo-token }}
+          token: ${{ steps.stage-token.outputs.token }}
           path: cross-repo-stage
           sparse-checkout: ${{ inputs.stage-modules }}
       - name: Set up Node for the pre-bake hook


### PR DESCRIPTION
Platform half of #2249. The satellite callers follow in their own PRs, together with their pin bump.

## The cause is a store split, not a missing value

Every dependabot PR in `MeshWeaver.SocialMedia` and `MeshWeaver.Reinsurance` is permanently red, so the automated bumps **of these very workflows' pins** can never merge. GitHub hands a dependabot-triggered run the **Dependabot** secret store, never the Actions one — `MESHWEAVER_REPO_TOKEN` exists for push runs and is simply absent for dependabot ones.

The preflight is behaving correctly and is **not** changed to skip. A dependency bump is precisely when you want the compile gate to run.

## Why not just copy the PAT into the second store

That fixes today and rots tomorrow. It is the same credential class that left `Chart Drift` at HTTP 401 for nine consecutive runs while reporting a missing secret (#1709). So the credential stops being stored:

| | before | after |
|---|---|---|
| secret | `stage-repo-token` (PAT) | `stage-repo-app-id` + `stage-repo-app-private-key` |
| lifetime | until someone notices it died | one hour, minted per run |
| scope | whatever the PAT was scoped to | `owner`/`repositories` = the stage repo alone, `permission-contents: read` |
| dependabot runs | absent → red forever | resolves, because the pair is provisioned in **both** stores |

`MESHWEAVER_APP_ID` / `MESHWEAVER_APP_PRIVATE_KEY` are provisioned in the Actions **and** Dependabot stores of SocialMedia, Reinsurance and Plugins.

## One diagnostic added

The bake preflight still fails RED when `stage-modules` is set and the credentials are absent. It now also says, when the actor is dependabot, that the secret source for this run was the Dependabot store — the fact the last person had to infer from a bare 'not provisioned'.

## Scope note

The issue lists Plugins among the affected repos. It is not affected by this mechanism: Plugins does not pass `stage-repo-token` and its ci.yml records that it no longer checks out the private core repo. Its one open dependabot PR (#629, `actions/setup-node` 6→7) is unrelated.

## Safety of landing this alone

Callers are SHA-pinned, so nothing moves until a caller bumps — and the currently-open bump PRs are red and cannot merge, so there is no window in which a caller lands on this workflow while still passing the old secret name.

**Verified:** `UpstreamBuildGateGuard` 4/4 passed against the edited workflow (fresh trx); both files parse as YAML.

**What's New:** skipped — CI credential plumbing, no user-visible effect.