### PR TITLE
The delivery verdict passed on an EMPTY verdict — a CD run that checked nothing read as one that delivered

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1526,9 +1526,41 @@ jobs:
           COMPLETE: ${{ needs.gate.outputs.complete }}
           GREEN: ${{ needs.gate.outputs.green }}
           SHORT: ${{ needs.gate.outputs.short_sha }}
+          GATE_RESULT: ${{ needs.gate.result }}
+          UPSTREAM_EVENT: ${{ github.event.workflow_run.event }}
+          UPSTREAM_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
-          echo "reason=$REASON publish=$PUBLISH complete=$COMPLETE green=$GREEN sha=$SHORT"
+          echo "gate=$GATE_RESULT reason=$REASON publish=$PUBLISH complete=$COMPLETE green=$GREEN sha=$SHORT"
+
+          # 🚨 THIS JOB MUST NOT PASS ON AN EMPTY VERDICT.
+          #
+          # Both guards below compare REASON against a literal. When `gate` is SKIPPED every
+          # `needs.gate.outputs.*` is the EMPTY STRING, so neither comparison can match, and this
+          # job printed "not publishing was the correct answer" and exited 0 having evaluated
+          # NOTHING. Measured 2026-08-26: run 32914425222 reported `reason= publish= complete=
+          # green= sha=` and a green tick, while every image job read `skipped`. A no-op and a
+          # real delivery were indistinguishable on the wall — which is exactly how a merged fix
+          # sat unshipped while its instance waited for it.
+          #
+          # That is the repo's own CI invariant (#3/#4) turned inward: a gate that CANNOT run must
+          # not look like a gate that passed. So classify the three cases explicitly.
+          if [ -z "$REASON" ]; then
+            # (a) LEGITIMATE no-op: CD fires on every completed Build-and-Test, and `gate` is
+            # deliberately conditioned to push-on-main. A PR run reaching here is expected, and
+            # saying so is not the same as claiming a delivery.
+            if [ "$GATE_RESULT" = "skipped" ] \
+               && [ "${GITHUB_EVENT_NAME}" = "workflow_run" ] \
+               && { [ "$UPSTREAM_EVENT" != "push" ] || [ "$UPSTREAM_BRANCH" != "main" ]; }; then
+              echo "not applicable — upstream was '${UPSTREAM_EVENT}' on '${UPSTREAM_BRANCH}', not a push to main. No delivery was due, and none is claimed."
+              exit 0
+            fi
+            # (b) EVERYTHING ELSE with no verdict is the invisible state this job exists to catch:
+            # the gate errored, was cancelled, or ran and produced no outputs at all. Reporting
+            # success here is the failure mode, not the safe default.
+            echo "::error::the delivery gate produced NO verdict (gate=${GATE_RESULT}, event=${GITHUB_EVENT_NAME}, upstream='${UPSTREAM_EVENT}' on '${UPSTREAM_BRANCH}'), so this run cannot say whether delivery was due. Refusing to report success on an unevaluated gate — a CD run that checked nothing must never be indistinguishable from one that delivered."
+            exit 1
+          fi
 
           if [ "$REASON" = "reconcile" ] && [ "$PUBLISH" != "true" ] \
              && [ "$COMPLETE" = "false" ] && [ "$GREEN" = "true" ]; then


### PR DESCRIPTION
`delivery-verdict` exists to catch invisible non-delivery. **It could not catch its own.**

Both guards compare `REASON` against a literal. When `gate` is **skipped**, every `needs.gate.outputs.*` is the **empty string**, so neither comparison can match:

```
reason= publish= complete= green= sha=
OK — either something was published, or not publishing was the correct answer.
```

Exit 0, having evaluated nothing.

## Why this matters more than it looks

Measured 2026-08-26 on run `32914425222`: a green tick on *"CD delivered, or had a good reason not to"*, with **every image job reading `skipped`**. A no-op and a real delivery are indistinguishable in the run list.

That is why **#2296 sat unshipped** while the instance waiting for it stayed on the old build — the run list showed successful CD runs, so nothing looked wrong. I asserted *"the image exists, ancestry-verified"* for a dozen turns on the strength of a **commit** that no image was ever built from. The run that "succeeded" had built nothing, and said so only in the shape of its skipped jobs.

This is the repo's own CI invariant turned inward: **a gate that cannot run must not look like a gate that passed.**

## The three cases, now distinguished

| case | verdict |
|---|---|
| `REASON` empty, gate skipped, upstream **not** push-on-main | **legitimate.** CD fires on every completed Build-and-Test and `gate` is deliberately conditioned to push-on-main, so a PR run reaching here is expected. Says *"not applicable"* rather than implying delivery. |
| `REASON` empty for **any other** reason — gate errored, cancelled, or produced no outputs | **RED**, naming gate result, event and upstream. This is the state the job exists to expose, and the one state it could not see. |
| `REASON` present | **unchanged** — the existing reason-based guards run exactly as before. |

## Proven, not reasoned

I ran the step's shell directly under all four paths rather than arguing about it:

```
PR run (legit no-op)                        exit=0   not applicable — upstream was 'pull_request'
gate FAILED, no verdict (was invisible)     exit=1   ::error:: gate produced NO verdict (gate=failure)
push-on-main but gate skipped (the bug)     exit=1   ::error:: gate produced NO verdict (gate=skipped)
real verdict present                        exit=0   (falls through to the existing guards)
```

**The two that now exit 1 both exited 0 before.** That is the whole change.