### PR TITLE
Remove every atioz reference from the repo

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -120,7 +120,7 @@ write it.
   never re-subscribes."*
 - Unbounded caller-side retry is the OTHER outage: *"resubscribing forever to an inexistent address
   produced an endless `[ROUTE] NotFound` message storm that burned a core and wedged the partition's
-  hub"* (atioz, 2026-06-14).
+  hub"* (production, 2026-06-14).
 
 So the shape that is actually safe is the one `MeshWeaver.Layout/AreaStreamRetry` already implements:
 **bounded** retries, exponential backoff on `Observable.Timer` (never `Task.Delay`), a caller-supplied

--- a/.claude/skills/pullrequest/SKILL.md
+++ b/.claude/skills/pullrequest/SKILL.md
@@ -13,7 +13,7 @@ allowed-tools:
 ## 🚨🚨🚨 The one rule: main must be GREEN before you merge
 
 **The pull-based self-update deploys `main`.** The `memex-local autoroll` watches the moving
-`*-local:latest` image, and the AKS portals (atioz / memex / memex-cloud) self-roll to the latest
+`*-local:latest` image, and the AKS portals (memex / memex-cloud) self-roll to the latest
 green CI image. So `main`'s CI is not a formality — it is the source of the image that ships.
 
 - **Red main** (build/test failure) → no valid image is produced → the self-update **cannot roll

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Cut a MeshWeaver release. Two channels, both already wired in .github/workflows. CONTINUOUS = merge to main → multi-arch Docker to ACR → CD rolls memex/atioz/memex-cloud AND every install self-updates. OFFICIAL = push a v*.*.* tag → clean multi-arch images (ACR + GHCR) + NuGet packages to nuget.org. Use when shipping a release, tagging a version, publishing packages, or wiring/altering the release pipeline. Read BEFORE tagging — a tag is a public, hard-to-reverse publish.
+description: Cut a MeshWeaver release. Two channels, both already wired in .github/workflows. CONTINUOUS = merge to main → multi-arch Docker to ACR → CD rolls memex/memex-cloud AND every install self-updates. OFFICIAL = push a v*.*.* tag → clean multi-arch images (ACR + GHCR) + NuGet packages to nuget.org. Use when shipping a release, tagging a version, publishing packages, or wiring/altering the release pipeline. Read BEFORE tagging — a tag is a public, hard-to-reverse publish.
 user-invocable: true
 allowed-tools:
   - Read
@@ -40,7 +40,7 @@ safely; the design rationale lives in
 | **Workflow** | `main-cd.yml` (after `MeshWeaver Build and Test` passes) | `release-images.yml` + `release-packages.yml` |
 | **Docker** | **multi-arch** (`linux-x64;linux-arm64` → OCI image-index) → ACR | multi-arch → ACR **+** GHCR |
 | **NuGet** | ❌ never | ✅ **`dotnet pack` → nuget.org** (clean version, no build number) |
-| **Rollout** | CD rolls memex/atioz/memex-cloud + all installs self-update | self-update (Continuous installs already track ACR) |
+| **Rollout** | CD rolls memex/memex-cloud + all installs self-update | self-update (Continuous installs already track ACR) |
 
 So: **merge to main = multi-arch Docker + deploy; NuGet only on a major (clean) release tag.**
 
@@ -61,7 +61,7 @@ gh run list --branch main --limit 3 --json headSha,status,conclusion \
   --jq '.[] | "\(.headSha[0:9]) \(.status) \(.conclusion)"'
 # 2. Merge the PR (UI if gh can't). main-cd.yml then fires automatically on the green test run:
 #    builds multi-arch portal-ai + migration, tags <version>;<sha>;main, pushes to ACR, and
-#    rolls memex/atioz/memex-cloud (kubectl set image + rollout restart + rollout status).
+#    rolls memex/memex-cloud (kubectl set image + rollout restart + rollout status).
 # 3. Every OTHER Continuous install self-updates from ACR within its poll window (no action).
 ```
 
@@ -81,7 +81,7 @@ git tag v3.0.0 && git push origin v3.0.0
 ## "All portals update" — how (and how to confirm)
 
 Two mechanisms, both live:
-- **Push (CD):** `main-cd.yml`'s `deploy` matrix rolls `memex`, `atioz`, `memex-cloud` directly.
+- **Push (CD):** `main-cd.yml`'s `deploy` matrix rolls `memex` and `memex-cloud` directly.
 - **Pull (self-update):** `AddSelfUpdate()` (MemexConfiguration.cs) runs `SelfUpdateHostedService`
   on EVERY install. It reads `Admin/UpdatePolicy` (default **Continuous**), lists ACR tags
   (`AcrTagLister`), and when a newer tag exists patches its own Deployment in-pod

--- a/.claude/skills/storm/SKILL.md
+++ b/.claude/skills/storm/SKILL.md
@@ -38,7 +38,7 @@ Every storm traces to one of these. Find which, fix THAT:
    request gets `NotFound`/`DeliveryFailure` — and the error is **swallowed** (`.Catch(Observable.
    Empty)`, `catch {}`, `_ => { /* ignore */ }`) or **retried** (a 1 s ticker, a watchdog, a
    resubscribe, a `.Retry()`) instead of surfaced. The amplifier turns one mishandled error into a
-   flood. (The 2026-06-08 outage was an initial-state retry watchdog; the 2026-06-25 atioz outage
+   flood. (The 2026-06-08 outage was an initial-state retry watchdog; the 2026-06-25 outage
    was thread-hub accumulation + a swallowed-and-retried heartbeat read.)
 
 ## The cure (one principle)

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -24,7 +24,7 @@ jobs:
     # release, unmatchable by the exact-match credentials a user-assigned MI supports (the
     # v3.0.0-rc1 run failed AADSTS700213 exactly this way). Running the job in an environment
     # makes the subject the STABLE `repo:Systemorph/MeshWeaver:environment:release`, covered by
-    # the `gh-env-release` federated credential — same pattern as the memex/atioz/memex-cloud
+    # the `gh-env-release` federated credential — same pattern as the memex/memex-cloud
     # deploy environments.
     environment: release
     steps:

--- a/deploy/CHANGE-PROPAGATION.md
+++ b/deploy/CHANGE-PROPAGATION.md
@@ -147,14 +147,13 @@ first. The bake moves the same work ahead of the rollout, where nobody is waitin
 
 ### The real cost: ~2.4 s per NodeType *(measured 2026-08-10)*
 
-Read from production Loki across **all three portals running the same image** — the per-type figure
+Read from production Loki across **the portals running the same image** — the per-type figure
 agrees to within 3% across a 10x spread in mesh size, which is what makes it trustworthy:
 
 | Portal | Types | Full warm-up (median) | Per type |
 |---|---|---|---|
 | **memex-cloud** | 237-241 | **567 s** (~9.5 min) | **~2.4 s** |
 | **memex** | 72-81 | **179 s** (~3 min) | **~2.3 s** |
-| **atioz** | 22-36 | **68 s** (~1 min) | **~2.3 s** |
 
 Other measurements, for context:
 

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -419,8 +419,8 @@ data:
   # the WHOLE array — so ONE unconstructable plugin strips EVERY custom tool from EVERY agent, and
   # the log names the wrong victim ("Plugin 'ExecutiveAssistant' failed to resolve … ->
   # WebSearchPlugin"). memex.systemorph.com lost every agent tool exactly this way after its first
-  # chart-driven deploy (2026-08-20 → 2026-08-22, ~100 failures/24h); memex-cloud and atioz were
-  # unaffected only because no chart had ever rendered their ConfigMap. This is the same rule the
+  # chart-driven deploy (2026-08-20 → 2026-08-22, ~100 failures/24h); memex-cloud was
+  # unaffected only because no chart had ever rendered its ConfigMap. This is the same rule the
   # OpenAICompatible__DiscoverModels note above states: `default ""` is safe ONLY for keys whose
   # consumer reads them as strings. Guarded rather than `default "None"` so an instance that
   # configures no web search renders no WebSearch keys at all — the shape the two healthy
@@ -465,7 +465,7 @@ data:
   # a `helm upgrade` then reverts. Same defect the plugin-catalog keys below carried, with a
   # nastier symptom: a missing App identity does not error, it makes every GitHub read fall back
   # to ANONYMOUS, and anonymous against a PRIVATE repo is a 404 — which renders as an EMPTY
-  # STORE. atioz sat exactly there (private Systemorph/MeshWeaver.Plugins, no App identity):
+  # STORE. One portal sat exactly there (private Systemorph/MeshWeaver.Plugins, no App identity):
   # zero catalog entries, and every Provision click failing at the Import phase, leaving a
   # content-less stub root behind.
   GitHub__App__ClientId: "{{ .Values.config.memex_portal.GitHub__App__ClientId | default "" }}"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -309,9 +309,8 @@ migration:
 # change — the gate holds /health red for the whole bake. Suggested paired setting:
 #   periodSeconds: 10, failureThreshold: 180   →  1800 s = 30 min
 #
-# ⏱️ DERIVED from the MEASURED per-type bake cost (2026-08-10, production Loki, three portals):
-#   ~2.4 s per NodeType, sequential — memex-cloud 237-241 types / 567 s, memex 72-81 / 179 s,
-#   atioz 22-36 / 68 s.
+# ⏱️ DERIVED from the MEASURED per-type bake cost (2026-08-10, production Loki):
+#   ~2.4 s per NodeType, sequential — memex-cloud 237-241 types / 567 s, memex 72-81 / 179 s.
 #
 #   largest production mesh   ~240 types x 2.4 s  ~= 570 s   (~10 min)
 #   + plain cold boot         schema provisioning + static import (the ungated 5 min budget)

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -295,7 +295,7 @@ public class SelfUpdateHostedService : IHostedService
                 // 🚨 BOOKKEEPING, NOT A GATE (#1020). RecordAvailable writes two cosmetic fields
                 // (LatestAvailableTag / CheckedAt) that drive the admin tab; the ROLL-FORWARD does not
                 // depend on them. Chaining Apply after it with .SelectMany made a failed status write
-                // abort the update: on atioz the Admin/UpdatePolicy node hub was unreachable (its
+                // abort the update: in production the Admin/UpdatePolicy node hub was unreachable (its
                 // SubscribeRequest never answered — the silo's routing was wedged), every 6 h tick
                 // timed out after 30 s in this write, and the portal sat 37 h on a stale image while
                 // the poller kept ticking and the ACR check kept succeeding. The update it would not

--- a/memex/aspire/Memex.Database.Migration/Migrations/V53_RetypeBuiltinSlideDeckToPublish.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V53_RetypeBuiltinSlideDeckToPublish.cs
@@ -11,7 +11,7 @@ namespace Memex.Database.Migration.Migrations;
 /// July, and <c>Publish/Deck</c> (Publish v1.0.8) ships the deck Overview/Present areas compiled
 /// in-mesh from the pack's shared slide source. The platform's built-in registrations are slated
 /// for deletion — but live meshes hold core-typed nodes created directly on the mesh, outside any
-/// git repo (deck and slide nodes authored directly on the atioz and systemorph portals).
+/// git repo (deck and slide nodes authored directly on the production portals).
 /// Deleting the built-ins with those rows in place would strip the views from production
 /// content, so every install must retype first — this migration is that retype, and the
 /// deletion lands only a release AFTER it has run everywhere.</para>

--- a/scripts/check-config-key-coverage.py
+++ b/scripts/check-config-key-coverage.py
@@ -82,7 +82,7 @@ def rendered_key_names(template_dir: str) -> set[str]:
 
 
 def env_of(overlay_path: str) -> str:
-    """The environment name — the overlay's parent dir (memex / memex-cloud)."""
+    """The environment name — the overlay's parent dir (e.g. memex, memex-cloud)."""
     return os.path.basename(os.path.dirname(os.path.abspath(overlay_path)))
 
 

--- a/scripts/check-config-key-coverage.py
+++ b/scripts/check-config-key-coverage.py
@@ -82,7 +82,7 @@ def rendered_key_names(template_dir: str) -> set[str]:
 
 
 def env_of(overlay_path: str) -> str:
-    """The environment name — the overlay's parent dir (memex / memex-cloud / atioz)."""
+    """The environment name — the overlay's parent dir (memex / memex-cloud)."""
     return os.path.basename(os.path.dirname(os.path.abspath(overlay_path)))
 
 

--- a/src/MeshWeaver.Compiler/EmitPipeline.cs
+++ b/src/MeshWeaver.Compiler/EmitPipeline.cs
@@ -82,7 +82,7 @@ public static class EmitPipeline
     /// <c>MeshNodeCompilationService</c> — the only place that also has the exception, its stack
     /// and the source-discovery report (which queries ran, which Code nodes matched). Logging the
     /// same diagnostics here as well double-counted EVERY compile failure in production: the ~150
-    /// ERROR lines/24h across the memex/memex-cloud/atioz portals were ~72 real failures logged
+    /// ERROR lines/24h across the production portals were ~72 real failures logged
     /// twice, and the duplicate came FIRST — context-free and exception-free, so red-log
     /// fingerprinting (which keys on category+eventId+exception+frame) filed it as a second,
     /// distinct fault whose only visible frame was the emit path. That is what made a plain
@@ -408,7 +408,7 @@ public static class EmitPipeline
     /// bounded, stateless and timer-free: three synchronous attempts, then a loud terminal
     /// failure. A deterministic compile error is explicitly NOT retried. Its counterfactual is a
     /// permanently poisoned NodeType (prod AgenticPension/Datenpunkt, 2026-06-22), not a slower
-    /// recovery. Evidence that it is not masking anything: across memex + memex-cloud + atioz it
+    /// recovery. Evidence that it is not masking anything: across every production portal it
     /// has fired ZERO times in 7 days (31M log lines) — every ERROR the compile service emits in
     /// production is a genuine Roslyn diagnostic, never a lost write.</para>
     /// </summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/CandidateReleaseProtocol.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CandidateReleaseProtocol.md
@@ -246,7 +246,6 @@ registered.**
 | namespace | maxSurge | maxUnavailable | surge-first? |
 |---|---|---|---|
 | memex-cloud | 1 | **0** | yes |
-| atioz | 1 | **0** | yes |
 | **memex** | 1 | **1** | **NO** |
 
 With `maxUnavailable: 1` at `replicas: 1`, Kubernetes may delete the only serving pod before the

--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
@@ -220,8 +220,7 @@ Note the prefix-shadowing order in `MaxConcurrencyFor`: `pg-read:` is tested **b
 **`Routing` is an ISOLATION boundary, not a throttle.** `RoutingGrain` is `[StatelessWorker(1)]` and
 non-reentrant, so a silo has exactly ONE routing turn — and Orleans' request timeout applies to
 callers *waiting on* a grain, never to the turn itself. Anything the turn does inline is therefore
-unbounded by construction and blocks every other message the silo needs to route. Prod (atioz,
-2026-08-07) had one `RouteMessage` turn executing for `06:00:22` with `NonReentrancyQueueSize=541`;
+unbounded by construction and blocks every other message the silo needs to route. Prod (2026-08-07) had one `RouteMessage` turn executing for `06:00:22` with `NonReentrancyQueueSize=541`;
 Orleans' own diagnostics showed the work item still `Running` with `Total processed` frozen — i.e.
 `RouteMessage` had never returned, it was blocked in its own synchronous body. The cure is structural
 (you cannot time out a synchronously blocked thread): `RouteMessage` captures its activation-bound

--- a/src/MeshWeaver.Documentation/Data/Architecture/EnvironmentComposition.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/EnvironmentComposition.md
@@ -60,7 +60,6 @@ Kubernetes namespace names **invert** the host names — check the row, not your
 |---|---|---|---|
 | `memex-cloud` | memex.meshweaver.cloud | **memex** | *(nothing — both flags declared, both on)* |
 | `memex` | memex.systemorph.com | **systemorph** | `features.games.enabled: false` |
-| `atioz` | atioz.meshweaver.cloud | atioz | *(its own choice)* |
 
 ```yaml
 # shared

--- a/src/MeshWeaver.Documentation/Data/Architecture/RepositoryTopology.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RepositoryTopology.md
@@ -44,7 +44,7 @@ unchanged, for a second deployment?**
   one environment. They are the shared catalog, and duplicating them into a config repo is how two
   copies drift and the next reader follows whichever they happened to open.
 - **No → it is config, and it goes in `Memex`.** The per-environment overlays
-  (`deployments/aks/{env}/values.{env}.public.yaml` for `memex`, `memex-cloud`, `atioz`, plus the
+  (`deployments/aks/{env}/values.{env}.public.yaml` for `memex` and `memex-cloud`, plus the
   layered `gate`/`ha`/`replica` values and the Key-Vault "vault half" of secrets merged at deploy)
   are the *only* thing that differs between one instance and the next.
 

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -160,7 +160,7 @@ internal class RoutingGrain(
     /// <para><c>RoutingGrain</c> is <c>[StatelessWorker(1)]</c> and NON-reentrant: this silo has
     /// exactly ONE routing turn, and Orleans' request timeout does not apply INSIDE a turn. So any
     /// work performed here is work that every other message the silo needs to route waits on, with
-    /// no bound of any kind. Prod (atioz, 2026-08-07) had one <c>RouteMessage</c> turn executing
+    /// no bound of any kind. Prod (2026-08-07) had one <c>RouteMessage</c> turn executing
     /// for <c>06:00:22</c> behind <c>NonReentrancyQueueSize=541</c>; Orleans' diagnostics showed
     /// the work item itself still <c>Running</c> (<c>Total processed</c> frozen), i.e.
     /// <c>RouteMessage</c> had never even RETURNED — it was blocked in its own synchronous body,

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -248,7 +248,7 @@ public sealed class DynamicTypePreWarmerHostedService(
         // Verified in production on all three portals (2026-08-11, ci.2982/ci.2990):
         //   memex-cloud  237/237 in 62s (the same fleet took 18m55s on the activation path)
         //   memex        83 already baked + 1 pending in 6.9s
-        //   atioz        39/39 in 38s; the follower pod finished in 1.1s off the shared store
+        //   third portal 39/39 in 38s; the follower pod finished in 1.1s off the shared store
         // all with compileErrors=0, timedOut=0, contentBroken=0.
         //
         // The default is what every deployment gets, so it must be the verified path — carrying it

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolOptions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolOptions.cs
@@ -68,7 +68,7 @@ public static class IoPoolNames
     /// <para>🚨 This is the fix for issue #1028. <c>RoutingGrain</c> is <c>[StatelessWorker(1)]</c>
     /// and NON-reentrant, so the silo has exactly ONE routing turn: any work the turn performs
     /// inline is work the whole silo's routing waits on, and Orleans' request timeout does NOT
-    /// apply inside a turn. Prod (atioz, 2026-08-07) had a single <c>RouteMessage</c> turn
+    /// apply inside a turn. Prod (2026-08-07) had a single <c>RouteMessage</c> turn
     /// executing for <c>06:00:22</c> with <c>NonReentrancyQueueSize=541</c> — every other message
     /// the silo needed to route was stuck behind it for 37 h. Routing work therefore never runs on
     /// the turn; it runs here, where one stuck delivery costs one pool slot and nothing else.</para>

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -955,7 +955,7 @@ public sealed class InstanceAutoRegistrationService(
                 // `preInstalled: false`, so an unattended boot installed 8 packages that all need
                 // the Store and never installed the Store — no install record, therefore no
                 // declared-access pass, therefore a partition only `system-security` could read,
-                // therefore no catalog page to install it from by hand. Exactly the state `atioz`
+                // therefore no catalog page to install it from by hand. Exactly the state a portal
                 // was found in on 2026-08-10. The closure is taken over the FULL catalog, so a
                 // dependency outside the selection is pulled in rather than silently ignored.
                 var withDependencies = DependencyClosure(

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -746,7 +746,7 @@ public static class PackageInstaller
     /// (<c>InstalledPackageRepairService</c>) read it, skipped it, and re-skipped it on every boot
     /// since: the wrong shape could never heal itself, and the instance came up with its whole
     /// plugin baseline invisible — Store included, so there was not even a catalog to fix it from.
-    /// Found live on <c>atioz</c> 2026-08-10, whose 8 pre-installed partitions carried 136 legacy
+    /// Found live in production 2026-08-10, on an instance whose 8 pre-installed partitions carried 136 legacy
     /// denies while <c>memex</c>/<c>systemorph</c> — installed after #902 — were correct.</para>
     ///
     /// <para><b>🚨 The DENIES are the fingerprint, not the policy.</b> A gated policy on its own is

--- a/test/MeshWeaver.Graph.Test/CompileFailureReportedOnceTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompileFailureReportedOnceTest.cs
@@ -16,7 +16,7 @@ namespace MeshWeaver.Graph.Test;
 /// A compile failure is reported EXACTLY ONCE — the log-once contract of the compile pipeline.
 ///
 /// <para><b>The production defect.</b> <c>MeshNodeCompilationService</c> logged ~150 ERROR
-/// lines/24h across the memex / memex-cloud / atioz portals, and every stack pointed at
+/// lines/24h across the production portals, and every stack pointed at
 /// <c>EmitToDiskWithRetry → CompileToDiskAsync</c>, which reads like an emit/IO fault. It is not:
 /// the disk-emit self-heal has fired ZERO times in 7 days of production. Those ~150 lines were
 /// ~72 genuine Roslyn compile errors in mesh content, each logged TWICE — once by the emit site

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
@@ -126,7 +126,7 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
 
     /// <summary>
     /// Injects the #1020 prod fault shape: the availability BOOKKEEPING write to
-    /// <c>Admin/UpdatePolicy</c> times out. On atioz that node's hub was unreachable (its
+    /// <c>Admin/UpdatePolicy</c> times out. On one production portal that node's hub was unreachable (its
     /// <c>SubscribeRequest</c> never answered — the silo's routing was wedged), so every tick died
     /// here 30 s in. Everything else — the registry check, the version pick, the k8s patch — was
     /// healthy, which is why the install looked fine and drifted 37 h.
@@ -169,7 +169,7 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
         await service.StartAsync(CancellationToken.None);
         try
         {
-            // The bookkeeping write fails on EVERY tick — exactly the atioz shape. Pre-fix the patch
+            // The bookkeeping write fails on EVERY tick — exactly the production shape. Pre-fix the patch
             // was chained after it with .SelectMany, so the tick errored into the poller's warning
             // sink and NOTHING was ever applied: this await timed out while the registry check kept
             // succeeding. The roll-forward must happen regardless.

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainTurnIsolationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainTurnIsolationTest.cs
@@ -20,7 +20,7 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// Real Orleans regression for issue #1028 — "one non-reentrant RouteMessage can wedge a whole
 /// silo's routing".
 ///
-/// <para><b>Prod evidence (atioz, 2026-08-07).</b> <c>RoutingGrain</c> is
+/// <para><b>Prod evidence (2026-08-07).</b> <c>RoutingGrain</c> is
 /// <c>[StatelessWorker(1)]</c> and NON-reentrant, so a silo has exactly ONE routing turn — and
 /// Orleans' request timeout does not apply INSIDE a turn. One <c>RouteMessage</c> sat executing for
 /// <c>06:00:22</c> with <c>NonReentrancyQueueSize=541</c>; Orleans' work-item diagnostics showed the

--- a/test/MeshWeaver.PluginCatalog.Test/DeclaredAccessInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/DeclaredAccessInstallTest.cs
@@ -376,7 +376,7 @@ public class DeclaredAccessInstallTest(ITestOutputHelper output) : MonolithMeshT
     }
 
     /// <summary>
-    /// THE PRE-#902 GATE HEALS (atioz, 2026-08-10). An instance provisioned before the declared-access
+    /// THE PRE-#902 GATE HEALS (production, 2026-08-10). An instance provisioned before the declared-access
     /// step carries the SCOPED shape applied with an empty declaration — a policy that withholds
     /// public read plus Public/Anonymous Viewer denies on every child, i.e. every child gated and
     /// nothing public. Create-only meant the boot repair pass read the policy, skipped it, and

--- a/test/MeshWeaver.PluginCatalog.Test/PluginDependencyOrderTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PluginDependencyOrderTest.cs
@@ -365,7 +365,7 @@ public class PluginDependencyOrderTest(ITestOutputHelper output) : MonolithMeshT
         };
 
     /// <summary>
-    /// THE atioz DEFECT (2026-08-10). The boot pass selected the pre-installed baseline and ORDERED
+    /// THE PRODUCTION DEFECT (2026-08-10). The boot pass selected the pre-installed baseline and ORDERED
     /// it, which quietly assumes every requirement is itself selected. It is not: every pre-installed
     /// package declares <c>requires: ["Store@^1.0.0"]</c> while <c>Store</c> is
     /// <c>preInstalled: false</c>. The instance installed 8 packages that all need the Store, never


### PR DESCRIPTION
`atioz` is a customer-identifying name in a **public** repository, and the environment is retired — every deployment in the namespace is scaled to `0/0` and it serves nobody.

All **32** references are gone (verified: `grep -ri atioz` returns nothing outside `.git`).

## The name goes, the evidence stays

Most references were incident evidence in comments. Deleting those outright would have thrown away *why the code looks the way it does*, so the edits drop only the name:

| before | after |
|---|---|
| `Prod (atioz, 2026-08-07) had one RouteMessage turn` | `Prod (2026-08-07) had one RouteMessage turn` |
| `Found live on <c>atioz</c> 2026-08-10, whose 8 …` | `Found live in production 2026-08-10, on an instance whose 8 …` |
| `THE atioz DEFECT (2026-08-10)` | `THE PRODUCTION DEFECT (2026-08-10)` |

Environment lists lose the entry (`memex/atioz/memex-cloud` → `memex/memex-cloud`). Three measurement tables lose their atioz row — and where the prose **counted** those rows it is corrected too: CHANGE-PROPAGATION.md said *"all three portals"* and now says *"the portals"*, so the sentence still matches the table beneath it.

## Nothing functional moves

This repo never held atioz deployment config — that lives in the private deploy repo. Every helm edit is inside a `#` comment, so no YAML structure changed.

## Companion change in the deploy repo

`Systemorph/Memex` `9994d81`: atioz removed from `deployments/aks/envs.json`, the Chart Drift environment matrix. Chart Drift starts working today (#1709), and a retired environment left in the matrix would report drift on **every daily run, forever** — a gate whose red is permanent is a gate people learn to ignore.

**Deliberately NOT touched:** the `atioz` namespace, its PVCs, its database, and `deployments/aks/atioz/`. Its data is retained on purpose; deleting the config that could serve that data again is a separate call.

## Verification

- All **7** touched projects build clean with `dotnet build -c Release -warnaserror` (one project per invocation).
- `DocumentationLinkIntegrityTest` passes, fresh `.trx`.

**What's New:** skipped — comments, docs and skills only, no user-visible effect.