### PR TITLE
Retry a transient pod-hub delivery rejection instead of NACKing on the first attempt

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-a-blip-to-a-hub-no-longer-drops-the-message.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-a-blip-to-a-hub-no-longer-drops-the-message.md
@@ -1,0 +1,25 @@
+---
+Name: A blip reaching a hub no longer drops the message
+Category: Fix
+Description: A message aimed at a hub whose server briefly restarted or reconnected used to be reported as failed immediately; it is now retried so it lands once the target is reachable again.
+Icon: ArrowSync
+Order: -20260826
+---
+
+# A blip reaching a hub no longer drops the message
+
+Servers roll over routinely — a new version ships, a pod restarts, a connection briefly drops.
+Most of the platform already treats that as ordinary: a message aimed at a hub going through that
+moment is retried a few times, and once the hub is reachable again the message lands as if nothing
+happened.
+
+One delivery path did not get that treatment. Messages routed to a hub that lives in its own
+process — a portal session, a cache, a background sync — were given exactly one attempt. If that
+attempt landed during the brief window a server was reconnecting or finishing its own restart, the
+sender was told immediately that the message had failed, even though a moment later the very same
+delivery would have succeeded.
+
+Now that path retries too, the same way every other delivery in the platform does: a few attempts
+with a short, increasing pause between them, before giving up and reporting a real failure. A
+passing hiccup is absorbed instead of surfacing as a dropped message, and only a destination that is
+genuinely gone still gets a prompt, honest failure.

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -343,6 +343,38 @@ internal class RoutingGrain(
     /// now checks for a subscriber before it publishes and NACKs when there is none. Full plan,
     /// including the one log line that says when the overlap window has closed:
     /// <c>Doc/Architecture/PodHubDeliveryRollPlan</c>.</para>
+    ///
+    /// <para>🚨 <b>Issue #2299: a TRANSIENT rejection used to be treated exactly like a terminal
+    /// one.</b> Prod evidence names two distinct transports-level rejections for the same underlying
+    /// condition — "the pod hub you were routed to did not answer" — that Orleans itself marks
+    /// retryable: a <c>ConnectionFailedException</c> wrapped in <c>OrleansMessageRejectionException</c>
+    /// ("…will retry after Nms", i.e. Orleans' own transport considered it transient), and a
+    /// <c>Forwarding failed: … "DeactivateOnIdle was called." … Rejecting now</c> — the SAME shape
+    /// <see cref="BuildGrainRoute"/> already retries via <see cref="DeliverToGrainWithRetry"/> for a
+    /// per-node hub. This leg had no analogous retry at all: the FIRST attempt's failure — unless it
+    /// was specifically <see cref="PodHubNotHereException"/> — went straight to
+    /// <c>TerminalCallFailure</c>. Now the delivery call itself goes through
+    /// <see cref="DeliverToGrainObservable"/>, the SAME transient-retry-with-fresh-resolve primitive
+    /// <see cref="BuildGrainRoute"/> uses: each retry re-invokes <c>GetGrain&lt;IPodHubGrain&gt;</c>,
+    /// so a blip that heals (the connection reconnects, or the mid-<c>DeactivateOnIdle</c> activation
+    /// finishes tearing down) is served on a later attempt instead of dead-ending the message.</para>
+    ///
+    /// <para><b>Retrying here does not fight the "no deactivating silo activates a grain" invariant
+    /// (PR #2270) — it relies on it.</b> <see cref="RoutingGrain"/>'s grain calls are deliberately
+    /// left UNGATED because they are the DRAIN: a message already accepted for routing must still
+    /// land, and it is Orleans' OWN placement — <c>Catalog.GetOrCreateActivation</c>,
+    /// <c>PlacementService.GetCompatibleSilos</c> — that refuses to place a NEW activation on a silo
+    /// that has left the ACTIVE set, retry or no retry. So a retry here can only ever land a fresh
+    /// activation on a silo Orleans itself still considers healthy; it never coerces one onto a silo
+    /// that is stopping.</para>
+    ///
+    /// <para><b><see cref="PodHubNotHereException"/> is still never retried at this layer</b> — it is
+    /// not in <see cref="IsTransientFailure"/>'s classification, so
+    /// <see cref="DeliverToGrainObservable"/>'s <c>RetryWhen</c> rethrows it on the FIRST attempt,
+    /// exactly as before. Retrying it here would fight <see cref="IPodHubGrain.Deliver"/>'s own
+    /// documented contract: with <c>[PreferLocalPlacement]</c> a retry would just place the next
+    /// attempt on the CALLER again, and the loop would never converge — that bounded bounce-and-give-up
+    /// already lives in <c>OrleansRoutingService.AttachPodHub</c>'s claim retry, one layer up.</para>
     /// </summary>
     private IObservable<Unit> BuildPodHubRoute(
         IMessageDelivery delivery,
@@ -354,8 +386,9 @@ internal class RoutingGrain(
         void PostFailureToSender(string failureMessage, ErrorType errorType) =>
             PostFailure(delivery, address, streamProvider, grainFactory, failureMessage, errorType);
 
-        return Observable
-            .Defer(() => grainFactory.GetGrain<IPodHubGrain>(addressPath).Deliver(delivery).ToObservable())
+        return DeliverToGrainObservable(
+                () => grainFactory.GetGrain<IPodHubGrain>(addressPath).Deliver(delivery),
+                addressPath, delivery.Id, logger)
             .Select(_ =>
             {
                 RoutingGrainTrace.Write($"RoutingGrain.RouteMessage POD_HUB_OK addr={addressPath} id={delivery.Id}");
@@ -363,9 +396,10 @@ internal class RoutingGrain(
             })
             .Catch<Unit, Exception>(ex => IsPodHubNotHere(ex)
                 ? FallBackToStream()
-                // A REAL failure of the call — the owning silo threw, went away mid-call, or the
-                // placement could not be made. This is the whole gain over a publish: it is
-                // OBSERVABLE, so it becomes a terminal answer for the sender instead of silence.
+                // A REAL failure of the call, transient retries exhausted (or a non-transient
+                // fault) — the owning silo threw, went away mid-call, or the placement could not
+                // be made. This is the whole gain over a publish: it is OBSERVABLE, so it becomes
+                // a terminal answer for the sender instead of silence.
                 : TerminalCallFailure(ex))
             // Composition-time faults must ALSO reach the sender — see BuildGrainRoute's trailing
             // Catch for the full rationale (the classic one: GetStream NRE'ing out of
@@ -993,9 +1027,16 @@ internal class RoutingGrain(
     /// <summary>
     /// The cold, awaitable retry observable underlying <see cref="DeliverToGrainWithRetry"/> — a single
     /// grain delivery that re-invokes <paramref name="grainCall"/> on each TRANSIENT rejection (so Orleans
-    /// activates a fresh instance), throws the last exception once retries are exhausted / on a non-transient
-    /// fault, and otherwise emits the grain's result. Split out so tests can <c>await … .ToTask()</c> it
-    /// deterministically.
+    /// re-resolves placement, activating a fresh instance where one is needed), throws the last exception
+    /// once retries are exhausted / on a non-transient fault, and otherwise emits the grain's result. Split
+    /// out so tests can <c>await … .ToTask()</c> it deterministically.
+    ///
+    /// <para>Grain-type agnostic by construction (<paramref name="grainCall"/> is a bare
+    /// <c>Func&lt;Task&lt;IMessageDelivery&gt;&gt;</c>), so <see cref="BuildGrainRoute"/> uses it for
+    /// <c>IMessageHubGrain.DeliverMessage</c> and <see cref="BuildPodHubRoute"/> uses it for
+    /// <c>IPodHubGrain.Deliver</c> (issue #2299) — one retry-with-fresh-resolve primitive for both
+    /// forward legs, so a transient rejection is handled identically regardless of which transport the
+    /// destination hub happens to use.</para>
     /// </summary>
     internal static IObservable<IMessageDelivery> DeliverToGrainObservable(
         Func<Task<IMessageDelivery>> grainCall,

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainPodHubDeliveryRetryTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainPodHubDeliveryRetryTest.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Reactive.Concurrency;
+using System.Reactive.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Runtime;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Pins issue #2299 — "RoutingGrain turns a stale pod-hub route into a sender-visible
+/// DeliveryFailure instead of re-resolving it" — at the routing layer.
+///
+/// <para><b>The defect, verified against the code before this fix.</b>
+/// <see cref="RoutingGrain.BuildGrainRoute"/> (per-node hub, <c>IMessageHubGrain</c>) already
+/// retries a transient Orleans rejection via <see cref="RoutingGrain.DeliverToGrainObservable"/>
+/// — proven by <see cref="RoutingGrainDeliveryRetryTest"/>. <c>BuildPodHubRoute</c> (pod-process
+/// hub, <c>IPodHubGrain</c>) had NO analogous retry: its single <c>Deliver</c> call went straight
+/// into a <c>Catch</c> that treated anything other than <see cref="PodHubNotHereException"/> as a
+/// TERMINAL failure on the very first attempt. Prod evidence (issue #2299) names exactly the two
+/// rejections Orleans itself marks retryable — a <c>ConnectionFailedException</c> wrapped in
+/// <c>OrleansMessageRejectionException</c> ("…will retry after Nms") and a
+/// <c>Forwarding failed: … "DeactivateOnIdle was called." … Rejecting now</c> — both surfaced as an
+/// immediate sender-visible <c>DeliveryFailure</c> instead of a retry.</para>
+///
+/// <para><b>The fix.</b> <c>BuildPodHubRoute</c> now drives its <c>IPodHubGrain.Deliver</c> call
+/// through the SAME <see cref="RoutingGrain.DeliverToGrainObservable"/> primitive
+/// <c>BuildGrainRoute</c> already uses — grain-type agnostic, so these tests exercise the identical
+/// mechanism the fix relies on, wired to a fake <c>IPodHubGrain</c>-shaped call sequence.</para>
+///
+/// <para><b>Why this does not need a live cluster.</b> The retry decision
+/// (<see cref="RoutingGrain.IsTransientFailure"/>) and the primitive that acts on it
+/// (<see cref="RoutingGrain.DeliverToGrainObservable"/>) are both pure and <c>internal static</c>;
+/// a fake <c>grainCall</c> reproduces the exact exception shapes from the prod log with no Orleans
+/// runtime involved — the same style <see cref="RoutingGrainDeliveryRetryTest"/> already uses for
+/// the sibling node-hub route.</para>
+/// </summary>
+public class RoutingGrainPodHubDeliveryRetryTest
+{
+    private static readonly Func<int, TimeSpan> NoBackoff = _ => TimeSpan.Zero;
+
+    // OrleansMessageRejectionException has no public constructor — materialise the real prod
+    // exception TYPE (what RoutingGrain.IsTransientFailure pattern-matches) without invoking a ctor.
+    // This is the exact class Orleans throws for BOTH prod shapes in issue #2299: the wrapped
+    // ConnectionFailedException ("...will retry after Nms") and the forwarding rejection
+    // ("...DeactivateOnIdle was called...Rejecting now").
+    private static Exception TransientPodHubRejection() =>
+        (Exception)RuntimeHelpers.GetUninitializedObject(typeof(OrleansMessageRejectionException));
+
+    [Fact]
+    public async Task TransientPodHubRejection_IsRetried_NotSurfacedAsTerminalOnFirstAttempt()
+    {
+        // Reproduces issue #2299's exact log shape: the pod hub the router directed the delivery to
+        // rejects the first two attempts transiently (the owning silo's connection is momentarily
+        // unreachable, or its activation is mid-DeactivateOnIdle), then a later attempt lands on a
+        // silo Orleans still considers ACTIVE (the same connection recovers, or the deactivation
+        // finishes and the address is re-resolved).
+        var calls = 0;
+
+        var result = await RoutingGrain.DeliverToGrainObservable(
+                grainCall: () =>
+                {
+                    calls++;
+                    return calls <= 2
+                        ? Task.FromException<IMessageDelivery>(TransientPodHubRejection())
+                        : Task.FromResult<IMessageDelivery>(new MessageDelivery<string>());
+                },
+                grainKey: "cache/EYgshhMBE0CsSP9e2xj-Pw",
+                deliveryId: "pod-hub-t1",
+                logger: NullLogger.Instance,
+                backoff: NoBackoff,
+                scheduler: Scheduler.Immediate)
+            .ToTask();
+
+        // Pre-fix, BuildPodHubRoute called the grain exactly ONCE — any rejection other than
+        // PodHubNotHereException went straight to TerminalCallFailure, so `calls` would be 1 and
+        // this Task would have faulted with the FIRST rejection instead of returning a result.
+        Assert.Equal(3, calls);
+        Assert.NotEqual(MessageDeliveryState.Failed, result.State);
+    }
+
+    [Fact]
+    public async Task TransientPodHubRejection_PropagatesOnceRetriesAreExhausted()
+    {
+        // A pod hub that never recovers within the retry budget: still bounded, still eventually a
+        // terminal answer for the sender — just no longer on the FIRST attempt.
+        var calls = 0;
+
+        await Assert.ThrowsAsync<OrleansMessageRejectionException>(() =>
+            RoutingGrain.DeliverToGrainObservable(
+                    grainCall: () =>
+                    {
+                        calls++;
+                        return Task.FromException<IMessageDelivery>(TransientPodHubRejection());
+                    },
+                    grainKey: "cache/EYgshhMBE0CsSP9e2xj-Pw",
+                    deliveryId: "pod-hub-t2",
+                    logger: NullLogger.Instance,
+                    maxRetries: 3,
+                    backoff: NoBackoff,
+                    scheduler: Scheduler.Immediate)
+                .ToTask());
+
+        Assert.Equal(4, calls); // initial attempt + maxRetries (3)
+    }
+
+    [Fact]
+    public async Task PodHubNotHere_IsNeverRetried_PropagatesOnFirstAttempt()
+    {
+        // 🚨 The contract IPodHubGrain.Deliver documents: retrying PodHubNotHereException would
+        // fight [PreferLocalPlacement] (a retry would just place the next attempt on the CALLER
+        // again, and the loop would never converge) — that bounded bounce-and-give-up already lives
+        // one layer up, in OrleansRoutingService.AttachPodHub's claim retry. This pins that wiring
+        // BuildPodHubRoute through the shared retry primitive did NOT start retrying it: it must
+        // still propagate on the very first attempt so the router's Catch can route it to the
+        // stream fallback exactly as before this fix.
+        var calls = 0;
+
+        var thrown = await Assert.ThrowsAsync<PodHubNotHereException>(() =>
+            RoutingGrain.DeliverToGrainObservable(
+                    grainCall: () =>
+                    {
+                        calls++;
+                        return Task.FromException<IMessageDelivery>(new PodHubNotHereException("portal/nodeops"));
+                    },
+                    grainKey: "portal/nodeops",
+                    deliveryId: "pod-hub-t3",
+                    logger: NullLogger.Instance,
+                    backoff: NoBackoff,
+                    scheduler: Scheduler.Immediate)
+                .ToTask());
+
+        Assert.Equal(1, calls);
+        Assert.True(RoutingGrain.IsPodHubNotHere(thrown));
+    }
+
+    [Fact]
+    public void IsTransientFailure_ClassifiesPodHubRejection_ButNotPodHubNotHere()
+    {
+        // The classification boundary the whole fix leans on: a genuine transport rejection is
+        // transient (retry-worthy); the grain's own definitive "not through this transport" answer
+        // is not, so it is never caught by the retry loop above.
+        Assert.True(RoutingGrain.IsTransientFailure(TransientPodHubRejection()));
+        Assert.False(RoutingGrain.IsTransientFailure(new PodHubNotHereException("portal/nodeops")));
+    }
+}


### PR DESCRIPTION
## The mechanism, verified against the code

`RoutingGrain.BuildGrainRoute` (per-node hub, `IMessageHubGrain`) already retries a transient
Orleans rejection via `DeliverToGrainObservable` — re-resolving the grain (fresh `GetGrain` call)
on every attempt. `BuildPodHubRoute` (pod-process hub, `IPodHubGrain` — `cache/…`, `portal/…`,
`client/…` addresses) had **no retry at all**: any rejection other than `PodHubNotHereException`
went straight to a terminal, sender-visible `DeliveryFailure` on the very first attempt.

Issue #2299's own evidence is exactly the shape `BuildGrainRoute` already handles for the OTHER
route:
- `ConnectionFailedException` wrapped in `OrleansMessageRejectionException` ("…will retry after
  Nms" — Orleans' own transport already considered it transient), and
- `Forwarding failed: … "DeactivateOnIdle was called." … Rejecting now` — a grain mid-deactivation,
  the same shape `BuildGrainRoute`'s `DeliverToGrainWithRetry` was written for.

Both are `OrleansMessageRejectionException`, which `RoutingGrain.IsTransientFailure` already
classifies as retryable — `BuildPodHubRoute` simply never used that classification.

## The fix

`BuildPodHubRoute` now drives its `IPodHubGrain.Deliver` call through the same
`DeliverToGrainObservable` primitive `BuildGrainRoute` already uses (it's grain-call-shape
agnostic — `Func<Task<IMessageDelivery>>` — so this is reuse, not a new mechanism).
`PodHubNotHereException` stays un-retried at this layer (it isn't in `IsTransientFailure`'s
classification), so the existing "definitive not-here → fall back to the stream" contract is
unchanged — retrying it would fight `[PreferLocalPlacement]`'s own documented bounce-and-loop risk.

## Does not fight "no deactivating silo activates a grain" (#2270)

I read PR #2270 (open, same author) before writing this. Its own doctrine is the reason retrying
here is safe: `RoutingGrain`'s grain calls are the deliberately-**ungated DRAIN** — a message
already accepted for routing must still land, and it is Orleans' *own* placement
(`Catalog.GetOrCreateActivation`, `PlacementService.GetCompatibleSilos`) that refuses to place a
NEW activation on a silo that has left the ACTIVE set, retry or not. A retry here can only land a
fresh activation on a silo Orleans itself still considers healthy — never on one that is stopping.
#2270 does not touch `RoutingGrain.cs` at all (only `OrleansRoutingService.cs` + two new test
files), so this PR is disjoint from it.

I also checked #2199 ("Hub is shutting down is TRANSIENT") — it classifies a textual `Failed`
*result* in `OrleansRoutingService`, a different code path from the *exception* classification
this PR touches in `RoutingGrain.cs`. Also disjoint. `git diff origin/main...HEAD --stat` shows
only the three files below.

## On #2307 — the claim doesn't fully hold, and I'm saying so

#2307 hypothesizes something calls `IMessageHubGrain.DeliverMessage` in a "~1 Hz loop… without
re-resolving placement." I verified: `RoutingGrain`'s `DeliverToGrainWithRetry` is the **only**
caller of `GetGrain<IMessageHubGrain>` in the entire codebase (`grep -rn "GetGrain<IMessageHubGrain>" src/ test/`),
and it already re-resolves (fresh `GetGrain` per retry) and is bounded (6 attempts, exponential
backoff capped ~3s, ~10s total) — not an unbounded loop. So the issue's literal claim about that
path does not hold against the code as written.

What #2307 *does* independently name as a likely contributor: "the incident control plane appears
to be one such caller, which would make part of this volume self-inflicted," and the pod-hub
`DeliveryFailure`s are called out as the probable cause of the sibling incidents. That's exactly
the #2299 gap this PR closes — a pod-hub-addressed delivery (several of #2307's own destinations,
e.g. `cache/…`) that used to fail terminally on one blip now gets several chances to land, which
directly reduces that cascade. Any residual portion of #2307 attributable to Orleans' own
cluster-membership death-detection latency (how long a genuinely-dead silo takes to leave the
ACTIVE set cluster-wide) is outside what `RoutingGrain.cs` controls, and I found no code-level
defect there to fix — so I'm not inventing one; per AGENTS.md this PR does not widen any bound to
paper over that possibility.

## Tests

New: `test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainPodHubDeliveryRetryTest.cs` — deterministic,
no cluster (same style as the existing `RoutingGrainDeliveryRetryTest`). Pins:
1. a transient pod-hub rejection (materialised as the real `OrleansMessageRejectionException` type)
   is retried and recovers instead of surfacing on the first attempt,
2. retries exhausted still propagates as a terminal answer (bounded, not silent),
3. `PodHubNotHereException` is never retried at this layer (propagates on attempt 1),
4. `IsTransientFailure` classifies the former true and the latter false — the boundary the whole
   fix relies on.

## Verification

- `dotnet build src/MeshWeaver.Hosting.Orleans -c Release -warnaserror` — clean, 0 warnings.
- `dotnet build test/MeshWeaver.Hosting.Orleans.Test -c Release -warnaserror` — clean, 0 warnings.
- New tests: 4/4 pass.
- `RoutingGrainDeliveryRetryTest` (sibling node-hub retry suite): 7/7 pass, unaffected.
- `PodHubTransportTest` (real Orleans cluster, 4 tests covering claim/move/unclaimed/NACK): 4/4
  pass in isolation.
- `RoutingGrainTurnIsolationTest`, `RoutingGrainStreamPostBoundTest`, `MessageHubGrainKeepAliveTest`,
  `MessageHubGrainActivationSourceTest`: all pass.
- Full `MeshWeaver.Hosting.Orleans.Test`: **197/198**. The one failure,
  `PodHubTransportTest.CrossSiloNack_ReachesASenderWhoseStreamSubscriptionIsGone`, exercises
  `RoutingGrain.PostFailure`'s NACK leg — a method this PR does not touch (only `BuildPodHubRoute`'s
  forward-delivery call changed) — passed cleanly when run in isolation with its sibling tests, and
  is the SAME test PR #2270 (unrelated diff, same file area) already documented as flaking under
  full-suite load ("Load-induced timeout on a machine under memory pressure… flagging it as a
  possibly load-sensitive test rather than editing someone else's test"). #2301 independently
  tracks this test project's broader pattern of load-sensitive Orleans-cluster flakes hitting
  unrelated diffs. Not chased further as caused by this change; will watch this PR's CI run for it.

Closes #2299
Closes #2307

🤖 Generated with [Claude Code](https://claude.com/claude-code)