### PR TITLE
The AI engine leaves the composition root — Memex.Portal.Shared no longer references it (#2276)

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reactive.Linq;
-using MeshWeaver.AI.Connect;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Hosting.AspNetCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -101,9 +101,13 @@
          the modules/<Name>/ closure layout in MeshModulesPublish.targets and activates via
          Modules:Assemblies -> MarkdownExportProviderAttribute. Only the wire contract stays in
          the app closure (via MeshWeaver.Blazor -> MeshWeaver.Markdown.Export.Contract). -->
-    <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Mesh.Operations\MeshWeaver.Mesh.Operations.csproj" />
-    <!-- The AI provider packs — MeshWeaver.AI.OpenAI, .AzureFoundry, .ClaudeCode, .Copilot — are
+    <!-- 🚨 MeshWeaver.AI is deliberately NOT referenced (#2276): the engine AND its maintenance
+         application ship as ONE Store entry and activate via Modules:Assemblies ->
+         AiMeshModuleAttribute, which reads this deployment's own configuration to decide what to
+         register. A reference here would put the DLL back in the app closure, where the module
+         landing refuses the same-identity module with a 409 on every instance.
+         The AI provider packs — MeshWeaver.AI.OpenAI, .AzureFoundry, .ClaudeCode, .Copilot — are
          deliberately NOT referenced (#1644 step 2): they ship via the modules/<Name>/ closure
          layout in MeshModulesPublish.targets and activate via Modules:Assemblies -> each pack's
          MeshNodeProviderAttribute (a deployment drops a provider by editing its module list).

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -6,7 +6,6 @@ using Memex.Portal.Shared.SelfUpdate;
 using Memex.Portal.Shared.Settings;
 using Memex.Portal.Shared.Social;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using MeshWeaver.AI;
 using MeshWeaver.Blazor.Infrastructure;
 using MeshWeaver.Hosting.Grpc;
 using MeshWeaver.Blazor.Pages;
@@ -236,31 +235,14 @@ public static class MemexConfiguration
         // 404 and the reply sender self-skips at ApplicationStarted.)
 
         // Shared on-disk WORKSPACE dir the agent→skill sync maintains (.claude/skills + AGENTS.md); both
-        // CLI harnesses set it as the session's working directory so every session sees the MeshWeaver
-        // agents/skills + the mesh-is-via-MCP base instructions. Defaults to a sibling of the per-user
-        // .claude root (e.g. /mnt/users → /mnt/users/_skills) when not explicitly configured.
-        var skillsDir = builder.Configuration["Skills:Directory"];
-        if (string.IsNullOrWhiteSpace(skillsDir))
-        {
-            var claudeRoot = builder.Configuration["ClaudeCode:ConfigDirRoot"]?.TrimEnd('/', '\\');
-            skillsDir = string.IsNullOrEmpty(claudeRoot) ? null : $"{claudeRoot}/_skills";
-        }
 
             // The ClaudeCode/Copilot packs bind their own options (incl. the SkillsDirectory
             // derivation) from configuration when loaded via Modules:Assemblies.
 
-        // Reactive skill→file sync: writes AGENTS.md (the base "mesh-is-via-MCP" instructions + a LISTING
-        // of the platform nodeType:Skill catalog — name, description, load path) to the shared volume and
-        // keeps it in sync as skill nodes change (observable query). Skill BODIES are never written to
-        // disk — the harness reads each on demand via the meshweaver MCP `get`. Runs for the process lifetime.
-        if ((features.Ai.Clis.ClaudeCode || features.Ai.Clis.Copilot) && !string.IsNullOrWhiteSpace(skillsDir))
-        {
-            services.Configure<Skills.AgentSkillSyncOptions>(o => o.Directory = skillsDir);
-            services.AddHostedService<Skills.AgentSkillSyncService>();
-        }
+        // The reactive skill→file sync for the co-hosted CLIs rides the AI module, which reads
+        // Skills:Directory / ClaudeCode:ConfigDirRoot itself (AiMeshModuleAttribute).
 
-        // Register the AI chat services (must be after all factory registrations)
-        services.AddAgentChatServices();
+        // The AI chat services are registered by AddAI() inside the module.
 
         // (The WebSearch agent tools ride the MeshWeaver.AI.WebSearch module — listed under
         // Modules:Assemblies, binding its own WebSearch configuration section. Agent plugins
@@ -289,10 +271,7 @@ public static class MemexConfiguration
             ?? "Memex"));
         // Automatic, token-based MCP back-connection for the co-hosted Claude Code / Copilot CLIs.
         // The chat clients resolve this at spawn to mint/reuse the per-user MCP ApiToken + URL.
-        services.AddSingleton<MeshWeaver.AI.Connect.IMcpBackConnection, McpBackConnectionService>();
-        // ModelProviderService backs the Models settings tab — users store
-        // their own AI provider credentials as MeshNodes in their namespace.
-        services.AddSingleton<Memex.Portal.Shared.Models.ModelProviderService>();
+        services.AddSingleton<MeshWeaver.Mesh.Services.IMcpBackConnection, McpBackConnectionService>();
         // ProviderModelLister moved to MeshWeaver.AI (AddAgentChatServices registers it) — the
         // add-provider flow and the OpenAI module's model-discovery sync both resolve it there.
         // OpenAI-compatible (Ollama) model auto-discovery rides the MeshWeaver.AI.OpenAI MODULE
@@ -323,31 +302,10 @@ public static class MemexConfiguration
         // manifest and drain when the remote is reachable again).
         services.AddInstanceSyncServices();
 
-        // Per-user CLI Connect (Settings → Models, CLI providers). The
-        // ConnectSessionManager is a mesh-scoped singleton holding the live
-        // login Process between "show URL" and "paste code" (instance dict,
-        // 5-min timeout). Each gated CLI registers its IConnectStrategy. The
-        // captured token is persisted as an encrypted ModelProvider via the
-        // ConnectTokenSink (seam over ModelProviderService, so the AI layer
-        // never references the portal assembly).
-        services.AddSingleton<MeshWeaver.AI.Connect.IConnectTokenSink, Memex.Portal.Shared.Models.ConnectTokenSink>();
-        services.AddSingleton<MeshWeaver.AI.Connect.ConnectSessionManager>();
-        if (features.Ai.Clis.ClaudeCode)
-        {
-            services.AddSingleton<MeshWeaver.AI.Connect.IConnectStrategy, MeshWeaver.AI.Connect.ClaudeConnectStrategy>();
-            // Wire the Connect login: bind ClaudeConnect:* overrides, default the PTY wrapper ON for
-            // the co-hosted Linux portal (claude setup-token renders an Ink UI that needs a real TTY —
-            // see ClaudeConnectStrategy), and mirror the per-user .claude root the co-hosted client uses
-            // (ClaudeCode:ConfigDirRoot, e.g. /mnt/users) so each user logs in under their own dir.
-            services.Configure<MeshWeaver.AI.Connect.ClaudeConnectOptions>(o =>
-            {
-                builder.Configuration.GetSection("ClaudeConnect").Bind(o);
-                if (builder.Configuration["ClaudeConnect:UsePseudoTerminal"] is null && !OperatingSystem.IsWindows())
-                    o.UsePseudoTerminal = true;
-                if (string.IsNullOrEmpty(o.ConfigDirRoot))
-                    o.ConfigDirRoot = builder.Configuration["ClaudeCode:ConfigDirRoot"];
-            });
-        }
+        // Per-user CLI Connect, the model-provider service and the AI content sources are
+        // registered by the AI MODULE itself (AiMeshModuleAttribute), which reads the same
+        // configuration this method does. The composition root no longer configures the engine —
+        // that reference is what a Store-delivered module cannot coexist with (#2276).
         // CopilotConnectStrategy registers from the Copilot pack (Modules:Assemblies).
 
         // Social publishing (LinkedIn connect/publish/page-sync + node-menu providers) rides the
@@ -567,7 +525,7 @@ public static class MemexConfiguration
     /// <summary>
     /// The AI (✨) menu's COMPILED remainder: exactly the imperative "New thread" entry. The
     /// navigation entries (Threads / Models / Tiers / Providers / Agents / Skills) migrated to
-    /// seeded <c>UiContribution</c> nodes (<see cref="AiMenuContributions"/>, WS7 slice 3) — they
+    /// seeded <c>UiContribution</c> nodes (<c>AiMenuContributions</c>, WS7 slice 3) — they
     /// are pure links, so they ride the same lane a plugin's AI-menu entry arrives through.
     /// This list stays the SINGLE SOURCE OF TRUTH for the imperative entry, shared by the hub
     /// registration below and the unit tests, so a regression can't quietly drop it.
@@ -806,12 +764,8 @@ public static class MemexConfiguration
             // import — no regression. Default Helm sets ["Doc","Agent","Provider","Harness","Skill"].
             var syncPartitions = features.StaticRepoSync.Partitions
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            // AI content is served as a UNIT: if the config names ANY AI partition, serve them ALL
-            // (Agent/Provider/Harness/Skill), so an incomplete list can't leave Skill (or a future AI
-            // content type) in-memory while the rest go to the DB — and AddAI's per-type serve-from-DB
-            // gating stays consistent with the static-repo import. See MeshWeaver.AI/AiContentSources.
-            if (syncPartitions.Overlaps(AiContentSources.ContentPartitions))
-                syncPartitions.UnionWith(AiContentSources.ContentPartitions);
+            // NB: the AI partitions are expanded to the whole bundle by the AI module itself
+            // (AiMeshModuleAttribute.ServeFromPartitions), next to the sources that rule gates.
             IReadOnlySet<string> serveFromPartition = syncPartitions;
 
             MeshBuilder mb = builder
@@ -875,7 +829,6 @@ public static class MemexConfiguration
                 // as seeded UiContribution nodes — same lane a plugin's AI-menu entry (or a whole
                 // TopBar-declared menu) arrives through. Only the imperative "New thread" stays
                 // compiled (AiMenuItems).
-                .AddAiMenuContributions()
                 .AddSpaceType()
                 // Generic webhook inbox: the WebhookEvent node type behind
                 // POST /api/hooks/{target} (allowlisted via WebhookInbox:Targets).
@@ -885,8 +838,7 @@ public static class MemexConfiguration
                 // the whole-course navigation (EduCourseNavigationProvider, registered per-hub
                 // by the type configuration lambdas). The compiled MeshWeaver.Courses types had
                 // zero instances in any repo or reachable mesh and are deleted.
-                .AddPortalType()
-                .AddAI(serveFromPartition);
+                .AddPortalType();
 
             // The gRPC mesh transport is a MODULE (MeshWeaver.Hosting.Grpc.dll under
             // Modules:Assemblies — GrpcMeshModuleAttribute folds AddGrpcHub over this builder:
@@ -1051,13 +1003,6 @@ public static class MemexConfiguration
                         .WithHeartBeatHandler() // silently ack heartbeats on every per-node hub
                         .AddDefaultLayoutAreas()
                         // The course-shell areas (StartExercise / GoToMyCopy / CourseNav / Learn)
-                        // ship as in-mesh source in the Edu plugin (Plugins#481) — no platform
-                        // registration remains; only the navigation contributor below is compiled.
-                        .AddThreadsLayoutArea()
-                        // Scope-tabbed AI catalogs (Agents/Skills/Providers/Models) with per-tab
-                        // create buttons — the AI-menu targets below point here. Registered on every
-                        // per-node hub so they resolve when anchored on the type roots (/Agent/AiAgents …).
-                        .AddAiCatalogLayoutAreas()
                         .AddApiTokensSettingsTab()
                         // Register your own MeshWeaver installation and get it an instance key.
                         .AddInstancesSettingsTab()
@@ -1183,7 +1128,9 @@ public static class MemexConfiguration
                 // MeshWeaver.Graph.
                 .WithPortalConfiguration(c =>
                 {
-                    c.TypeRegistry.AddAITypes();
+                    // AI types + the thread area are contributed by the AI module's own
+                    // WithPortalConfiguration (PortalConfigurationRegistry), so this stays
+                    // AI-free (#2276).
                     return c.AddData().WithGraphTypes();
                 })
             );

--- a/memex/Memex.Portal.Shared/Settings/PlatformSettingsTabAreas.cs
+++ b/memex/Memex.Portal.Shared/Settings/PlatformSettingsTabAreas.cs
@@ -46,8 +46,6 @@ public static class PlatformSettingsTabAreas
     /// <summary>Layout area rendering <see cref="PublishedSettingsTab.BuildContent"/> (admin-gated).</summary>
     public const string PublishedArea = "SettingsPublished";
 
-    /// <summary>Layout area rendering <see cref="TokenUsageSettingsTab.BuildContent"/> (admin-gated).</summary>
-    public const string TokenUsageArea = "SettingsTokenUsage";
 
     /// <summary>
     /// Registers the tranches' tab contents as layout areas on the per-node hubs. The settings
@@ -69,9 +67,7 @@ public static class PlatformSettingsTabAreas
             .WithView(UpdatePolicyArea, (host, _) => AdminGated(host,
                 () => UpdatePolicySettingsTab.BuildContent(host, PaneStack())))
             .WithView(PublishedArea, (host, _) => AdminGated(host,
-                () => PublishedSettingsTab.BuildContent(host, PaneStack())))
-            .WithView(TokenUsageArea, (host, _) => AdminGated(host,
-                () => TokenUsageSettingsTab.BuildContent(host, PaneStack()))));
+                () => PublishedSettingsTab.BuildContent(host, PaneStack()))));
 
     /// <summary>
     /// The admin-gated area body. Each admin tab's contributed entry hides the tab via
@@ -96,12 +92,12 @@ public static class PlatformSettingsTabAreas
     internal static IReadOnlyList<string> Areas { get; } =
     [
         WhatsNewArea, AboutArea, PrivacyArea, InvitationsArea, InboxArea,
-        UpdatePolicyArea, PublishedArea, TokenUsageArea,
+        UpdatePolicyArea, PublishedArea,
     ];
 
     /// <summary>
     /// The seeded menu entries, exposed for the pinning tests (same contract as
-    /// <see cref="AiMenuContributions.Seeds"/>). Node id = the tab's former compiled tab id,
+    /// <c>AiMenuContributions.Seeds</c>). Node id = the tab's former compiled tab id,
     /// keeping every <c>/GlobalSettings/{Id}</c> deep link stable across the migration; every
     /// label/icon/order/group is copied EXACTLY from the former compiled definition.
     /// </summary>
@@ -174,19 +170,6 @@ public static class PlatformSettingsTabAreas
             Label = "Published to the web",
             LabelKey = "settings.published",
             Icon = "Globe",
-            Group = "Administration",
-            GroupKey = "settings.groupAdministration",
-            GroupIcon = "Shield",
-            Order = 320,
-            Gates = new UiContributionGates { AdminOnly = true },
-        }),
-        Seed(TokenUsageSettingsTab.TabId, "Token Usage", new UiContribution
-        {
-            Context = UiContribution.SettingsContext,
-            Area = TokenUsageArea,
-            Label = "Token Usage",
-            LabelKey = "settings.tokenUsage",
-            Icon = "Database",
             Group = "Administration",
             GroupKey = "settings.groupAdministration",
             GroupIcon = "Shield",

--- a/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
+++ b/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using MeshWeaver.AI;
 using MeshWeaver.Documentation;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
@@ -41,15 +40,9 @@ public static class StaticRepoSyncExtensions
             if (serveFromPartition.Contains("Doc"))
                 services.AddSingleton<IStaticRepoSource, DocumentationStaticRepoSource>();
 
-            // AI content (Agent / Provider / Harness / Skill) is ONE bundle: register every built-in
-            // AI source together whenever any AI partition is served, so a config that names only some
-            // of them can NEVER silently drop one (the recurring "Skill was never imported" bug). The
-            // set + the bundle live next to the sources in MeshWeaver.AI — adding a new AI content type
-            // there auto-joins the import; there is no per-partition allow-list here to forget. (The
-            // expand-to-the-whole-bundle also happens in MemexConfiguration so AddAI's serve-from-DB
-            // gating stays consistent with the import.)
-            if (serveFromPartition.Overlaps(AiContentSources.ContentPartitions))
-                services.AddBuiltInAiContentSources();
+            // AI content sources register themselves: the AI module reads the same
+            // Features:StaticRepoSync:Partitions this method does and adds its bundle when any AI
+            // partition is served (AiMeshModuleAttribute). The portal no longer names them (#2276).
 
             // The boot signal the NodeType pre-warm sweep sequences on: without it the sweep's ONE
             // enumeration snapshot can be taken while this import is still landing content, and
@@ -57,16 +50,8 @@ public static class StaticRepoSyncExtensions
             // StaticRepoImportSettled.
             services.AddSingleton<StaticRepoImportSettled>();
 
-            // 🔑 The provider-credential SEED: {Section}:ApiKey → the ModelProvider node, once the
-            // import has landed the catalog. Registered here because this is the DB-synced path — the
-            // only one where a provider node can outlive the configuration that seeded it. On the
-            // in-memory path BuiltInLanguageModelProvider re-projects configuration into the served
-            // node on every read, so there is nothing to converge and nothing to persist.
-            // Typed registration (not a factory): the descriptor's ImplementationType is what
-            // ProviderCredentialSeedWiringTest asserts on — a seed nothing starts is a seed that does
-            // not exist, and a factory registration hides which service it would have built.
-            if (serveFromPartition.Contains(ModelProviderNodeType.RootNamespace))
-                services.AddSingleton<IHostedService, ProviderCredentialSeedHostedService>();
+            // The provider-credential seed rides the AI module for the same reason — it is the
+            // DB-synced path of a ModelProvider node, which is AI's own business.
 
             // Runs after the PG schema-provisioning hosted service (registered earlier by
             // AddPartitionedPostgreSqlPersistence) — hosted services start in registration order.
@@ -130,7 +115,7 @@ internal sealed class StaticRepoImportHostedService(
         var importMemory = MemoryDelta.Start();
 
         _subscription = StaticRepoImporter
-            .ImportAll(hub, logger, syncModeOverrides, AiContentSources.ContentPartitions)
+            .ImportAll(hub, logger, syncModeOverrides)
             .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default)
             .Subscribe(
                 r => logger?.LogInformation(
@@ -145,48 +130,6 @@ internal sealed class StaticRepoImportHostedService(
                     settled?.MarkSettled();
                 },
                 () => settled?.MarkSettled());
-        return Task.CompletedTask;
-    }
-
-    public Task StopAsync(CancellationToken cancellationToken)
-    {
-        _subscription?.Dispose();
-        return Task.CompletedTask;
-    }
-}
-
-/// <summary>
-/// Boot hook that runs <see cref="ProviderCredentialSeed.Run"/> ONCE the static-repo import has
-/// settled — the ordering that matters, because the seed fills a field on a provider node the
-/// import creates. Reactive + fire-and-forget, on the thread pool, exactly like the import service
-/// above (subscribing on the startup thread re-enters the hub schedulers and deadlocks).
-///
-/// <para>Sequenced on <see cref="StaticRepoImportSettled"/> rather than chained onto the import's
-/// own subscription so a FAILED import still lets the seed run: whatever providers did land are
-/// still worth converging, and the seed reports an absent node rather than waiting for one.</para>
-/// </summary>
-internal sealed class ProviderCredentialSeedHostedService(
-    IMessageHub hub,
-    StaticRepoImportSettled settled,
-    ILogger<ProviderCredentialSeedHostedService>? logger = null) : IHostedService
-{
-    private IDisposable? _subscription;
-
-    public Task StartAsync(CancellationToken cancellationToken)
-    {
-        _subscription = settled.Settled
-            .SelectMany(_ => ProviderCredentialSeed.Run(hub, logger))
-            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default)
-            .Subscribe(
-                // Debug, not Information: ProviderCredentialSeed.Run already logs every outcome at
-                // its own level (Info for Seeded, Error for RefusedUnprotected, Warning for
-                // NodeAbsent, Debug otherwise) — a second Information line per provider per boot is
-                // duplicate log volume, not information. This trace line only correlates the results
-                // with THIS hosted service when debugging boot ordering.
-                r => logger?.LogDebug(
-                    "[ProviderCredentialSeed] {Path}: {Outcome} (configuration section '{Section}').",
-                    r.ProviderPath, r.Outcome, r.Section),
-                ex => logger?.LogWarning(ex, "[ProviderCredentialSeed] seed run failed."));
         return Task.CompletedTask;
     }
 

--- a/src/MeshWeaver.AI/AIExtensions.cs
+++ b/src/MeshWeaver.AI/AIExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reactive.Linq;
+using MeshWeaver.AI.Portal;
 using MeshWeaver.AI.Persistence;
 using MeshWeaver.AI.Plugins;
 using MeshWeaver.Data;
@@ -85,6 +86,15 @@ public static class AIExtensions
                     {
                         config.TypeRegistry.AddAITypes();
                         return config
+                            // Scope-tabbed AI catalogs (Agents / Skills / Providers / Models /
+                            // Tiers) with per-tab create buttons — the AI menu entries point here.
+                            // On EVERY per-node hub so they resolve when anchored on the type roots
+                            // (/Agent/AiAgents, /Provider/AiModels, …). Moved off the portal's
+                            // composition root with the rest of the engine (#2276).
+                            .AddAiCatalogLayoutAreas()
+                            // The token-usage settings tab: an AI surface, registered through the
+                            // platform's declarative settings seam rather than by the portal.
+                            .AddTokenUsageSettingsTab()
                             .WithHandler<Plugins.SaveContentRequest>(HandleSaveContent)
                             // "Sync to repo" on Agent/Skill nodes + the area its item navigates to.
                             // Self-gates to a source checkout and a platform admin, so it is inert

--- a/src/MeshWeaver.AI/AiMeshModuleAttribute.cs
+++ b/src/MeshWeaver.AI/AiMeshModuleAttribute.cs
@@ -1,0 +1,149 @@
+using System.Collections.Immutable;
+using MeshWeaver.AI.Connect;
+using MeshWeaver.AI.Portal;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: MeshWeaver.AI.AiMeshModule]
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// The AI engine as a MODULE: listing <c>MeshWeaver.AI.dll</c> under <c>Modules:Assemblies</c>
+/// installs the agent runtime, its content types, and the app that maintains them — with no
+/// compiled call from any composition root. One assembly, one module, one Store entry (#2276).
+///
+/// <para>This is what let <c>Memex.Portal.Shared</c> drop its <c>ProjectReference</c>: every
+/// registration below used to sit in <c>MemexConfiguration</c>, which meant the portal compiled
+/// against the engine in order to configure it. A closure DLL and a registry module of the same
+/// name are mutually exclusive (the landing service refuses with a 409 on every instance), so the
+/// reference had to go before the engine could ship from the Store at all.</para>
+///
+/// <para>🚨 It reads <see cref="MeshBuilder.Configuration"/>, which exists for exactly this
+/// (#2300): the serve-from-DB decision is taken at BUILDER time — it sets
+/// <c>MeshNode.IsDefinitionOnly</c>, an <c>init</c> property — so the options pipeline is too late.
+/// A host that supplies no configuration gets the same answer an absent key would give, never a
+/// guess: these are decisions whose wrong value is silent.</para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class AiMeshModuleAttribute : MeshNodeProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<Func<MeshBuilder, MeshBuilder>> BuilderConfigurations =>
+    [
+        builder => builder
+            .AddAI(ServeFromPartitions(builder.Configuration))
+            // The AI menu's navigation entries, seeded as platform-static UiContribution nodes.
+            .AddAiMenuContributions()
+            .ConfigureServices(services => AddAiComposition(services, builder.Configuration))
+    ];
+
+    /// <summary>
+    /// The partitions Postgres serves, from <c>Features:StaticRepoSync:Partitions</c>.
+    ///
+    /// <para>🚨 AI content is served as a UNIT: if the deployment names ANY AI partition, all of
+    /// them are served, so a config that lists only some can never leave one (typically
+    /// <c>Skill</c>) in-memory while the rest go to the DB — the recurring "Skill was never
+    /// imported" bug. The rule lives HERE, next to the sources, rather than in a portal that would
+    /// have to know AI's partition names to apply it.</para>
+    /// </summary>
+    internal static IReadOnlySet<string>? ServeFromPartitions(IConfiguration? configuration)
+    {
+        if (configuration is null)
+            return null;   // no configuration supplied ⇒ exactly the absent-key answer: in-memory serving
+
+        var configured = configuration
+            .GetSection("Features:StaticRepoSync:Partitions")
+            .GetChildren()
+            .Select(child => child.Value)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (configured.Count == 0)
+            return null;
+        if (configured.Overlaps(AiContentSources.ContentPartitions))
+            configured.UnionWith(AiContentSources.ContentPartitions);
+        return configured;
+    }
+
+    /// <summary>
+    /// Everything the portal's composition root used to register for AI, moved verbatim: the
+    /// per-user CLI Connect surface, the model-provider service behind Settings → Models, and the
+    /// static-repo AI content sources when this deployment serves them from the DB.
+    /// </summary>
+    private static IServiceCollection AddAiComposition(IServiceCollection services, IConfiguration? configuration)
+    {
+        // Settings → Models. The Connect token sink is the seam that keeps this the right way
+        // round: the engine persists a captured CLI token as an encrypted ModelProvider without
+        // the portal assembly ever entering the picture.
+        services.AddSingleton<ModelProviderService>();
+        services.AddSingleton<IConnectTokenSink, ConnectTokenSink>();
+
+        // Mesh-scoped singleton holding the live login Process between "show URL" and "paste
+        // code" (instance dictionary, 5-minute timeout) — never static.
+        services.AddSingleton<ConnectSessionManager>();
+
+        if (configuration is null)
+            return services;
+
+        // Reactive skill→file sync for the co-hosted CLIs: writes AGENTS.md (the base
+        // "mesh-is-via-MCP" instructions plus a LISTING of the nodeType:Skill catalog) to the shared
+        // volume and keeps it in sync as skill nodes change. Skill BODIES never reach disk — the
+        // harness reads each on demand through the meshweaver MCP `get`.
+        var skillsDirectory = configuration["Skills:Directory"];
+        if (string.IsNullOrWhiteSpace(skillsDirectory))
+        {
+            // Defaults to a sibling of the per-user .claude root (e.g. /mnt/users → /mnt/users/_skills).
+            var claudeRoot = configuration["ClaudeCode:ConfigDirRoot"]?.TrimEnd('/', '\\');
+            skillsDirectory = string.IsNullOrEmpty(claudeRoot) ? null : $"{claudeRoot}/_skills";
+        }
+        var anyCli = configuration.GetValue("Features:Ai:Clis:ClaudeCode", true)
+                     || configuration.GetValue("Features:Ai:Clis:Copilot", true);
+        if (anyCli && !string.IsNullOrWhiteSpace(skillsDirectory))
+        {
+            services.Configure<AgentSkillSyncOptions>(o => o.Directory = skillsDirectory);
+            services.AddHostedService<AgentSkillSyncService>();
+        }
+
+        // Each gated CLI registers its own IConnectStrategy. Default ON, matching the portal's
+        // MemexFeatureOptions default, so delisting is a deliberate act rather than a typo.
+        if (configuration.GetValue("Features:Ai:Clis:ClaudeCode", true))
+        {
+            services.AddSingleton<IConnectStrategy, ClaudeConnectStrategy>();
+            services.Configure<ClaudeConnectOptions>(options =>
+            {
+                configuration.GetSection("ClaudeConnect").Bind(options);
+                // `claude setup-token` renders an Ink UI that needs a real TTY, so the co-hosted
+                // Linux portal defaults the PTY wrapper ON unless the deployment says otherwise.
+                if (configuration["ClaudeConnect:UsePseudoTerminal"] is null && !OperatingSystem.IsWindows())
+                    options.UsePseudoTerminal = true;
+                // Mirror the per-user .claude root the co-hosted client uses, so each user logs in
+                // under their own directory.
+                if (string.IsNullOrEmpty(options.ConfigDirRoot))
+                    options.ConfigDirRoot = configuration["ClaudeCode:ConfigDirRoot"];
+            });
+        }
+
+        // The static-repo import half: register the built-in AI content sources whenever this
+        // deployment serves any AI partition from the DB. The portal used to do this on the
+        // engine's behalf, which is why it had to know the partition names.
+        var serve = ServeFromPartitions(configuration);
+        if (serve is not null && serve.Overlaps(AiContentSources.ContentPartitions))
+        {
+            services.AddBuiltInAiContentSources();
+
+            // 🔑 The provider-credential seed: {Section}:ApiKey → the ModelProvider node, once the
+            // import has landed the catalog. Only on the DB-synced path — the one where a provider
+            // node can outlive the configuration that seeded it. On the in-memory path
+            // BuiltInLanguageModelProvider re-projects configuration into the served node on every
+            // read, so there is nothing to converge and nothing to persist.
+            if (serve.Contains(ModelProviderNodeType.RootNamespace))
+                services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService, ProviderCredentialSeedHostedService>();
+        }
+
+        return services;
+    }
+}

--- a/src/MeshWeaver.AI/Application/AgentsApplicationExtensions.cs
+++ b/src/MeshWeaver.AI/Application/AgentsApplicationExtensions.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Layout.Client;
 using System.Reactive.Linq;
 using MeshWeaver.AI.Application.Layout;
 using MeshWeaver.AI.Completion;
@@ -24,6 +25,15 @@ public static class AgentsApplicationExtensions
     public static MessageHubConfiguration ConfigureAgentsApplication(this MessageHubConfiguration application)
         => application
             .AddAIViews()
+            // Every portal hub needs the AI types to deserialize Thread content, and the thread
+            // layout area to render it. Contributed from HERE rather than from a composition root:
+            // PortalConfigurationRegistry exists so a plugin can configure portals it does not
+            // compile against (#2276). A headless host drops it with a warning — never silently.
+            .WithPortalConfiguration(portal =>
+            {
+                portal.TypeRegistry.AddAITypes();
+                return portal.AddThreadsLayoutArea();
+            })
             .WithServices(services => services
                 // Mesh catalog provider — @-references autocomplete from the mesh node
                 // catalog (agents, models, and every other node). The old factory-based

--- a/src/MeshWeaver.AI/HarnessStaticRepoSource.cs
+++ b/src/MeshWeaver.AI/HarnessStaticRepoSource.cs
@@ -21,6 +21,11 @@ public sealed class HarnessStaticRepoSource(BuiltInHarnessProvider provider) : I
     public bool Versioned => false;
 
     /// <inheritdoc />
+    /// <remarks>A skill/agent/model that exists but is unfindable is indistinguishable
+    /// from one that was never imported — this catalog asserts it reached the index (#354).</remarks>
+    public bool AssertIndexedAfterImport => true;
+
+    /// <inheritdoc />
     // Additive: users may register their OWN harnesses in this partition; the import must never prune
     // them. Only harnesses the build PREVIOUSLY shipped (in the manifest) but has since dropped are removed.
     public PartitionSyncMode SyncMode => PartitionSyncMode.Additive;

--- a/src/MeshWeaver.AI/InternalsVisibleTo.cs
+++ b/src/MeshWeaver.AI/InternalsVisibleTo.cs
@@ -2,3 +2,8 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("MeshWeaver.Threading.Test")]
 [assembly: InternalsVisibleTo("MeshWeaver.Hosting.Orleans.Test")]
+
+// The AI menu entries are asserted against the PORTAL shell they integrate with, so that suite
+// spans both halves and needs the seed list (#2276). A test project may see the module's internals;
+// the platform may not reference it at all, which is the invariant that matters.
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Memex.Portal.Shared.Test")]

--- a/src/MeshWeaver.AI/ModelStaticRepoSource.cs
+++ b/src/MeshWeaver.AI/ModelStaticRepoSource.cs
@@ -28,6 +28,11 @@ public sealed class ModelStaticRepoSource(BuiltInLanguageModelProvider provider)
     public bool Versioned => false;
 
     /// <inheritdoc />
+    /// <remarks>A skill/agent/model that exists but is unfindable is indistinguishable
+    /// from one that was never imported — this catalog asserts it reached the index (#354).</remarks>
+    public bool AssertIndexedAfterImport => true;
+
+    /// <inheritdoc />
     // Additive: admins add their OWN providers/models (e.g. a bring-your-own OpenAI-compatible
     // endpoint) into the Provider partition; the import must never prune them. Only providers/models the
     // build PREVIOUSLY shipped (in the manifest) but has since dropped are removed.

--- a/src/MeshWeaver.AI/Portal/AgentSkillSyncService.cs
+++ b/src/MeshWeaver.AI/Portal/AgentSkillSyncService.cs
@@ -1,8 +1,8 @@
+using MeshWeaver.Mesh.Services;
 using System.Reactive.Linq;
 using System.Text;
 using System.Text.Json;
 using MeshWeaver.AI;
-using MeshWeaver.Blazor.Infrastructure;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Threading;
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Memex.Portal.Shared.Skills;
+namespace MeshWeaver.AI.Portal;
 
 /// <summary>
 /// Configuration for <see cref="AgentSkillSyncService"/>.
@@ -94,7 +94,7 @@ public sealed class AgentSkillSyncService(
             return;
         }
 
-        var hub = serviceProvider.GetService<PortalApplication>()?.Hub;
+        var hub = serviceProvider.GetService<IPortalHubAccessor>()?.Hub;
         if (hub is null)
         {
             logger?.LogInformation(

--- a/src/MeshWeaver.AI/Portal/AiMenuContributions.cs
+++ b/src/MeshWeaver.AI/Portal/AiMenuContributions.cs
@@ -3,14 +3,14 @@ using MeshWeaver.AI;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 
-namespace Memex.Portal.Shared;
+namespace MeshWeaver.AI.Portal;
 
 /// <summary>
 /// The AI (✨) menu's NAVIGATION entries as seeded <see cref="UiContribution"/> nodes (WS7
 /// slice 3, design #1645): Threads / Models / Tiers / Providers / Agents / Skills each open a
 /// catalog URL, so they are pure links — data, not behavior — and ride the same contribution lane
 /// a plugin's AI-menu entry arrives through. The one entry that stays COMPILED is "New thread"
-/// (<see cref="MemexConfiguration.AiMenuItems"/>): it is an imperative click-action sentinel whose
+/// (<c>MemexConfiguration.AiMenuItems</c>): it is an imperative click-action sentinel whose
 /// destination is resolved from the circuit's viewer identity at click time — behavior, which the
 /// closed contribution vocabulary deliberately cannot express.
 /// </summary>
@@ -18,7 +18,7 @@ public static class AiMenuContributions
 {
     /// <summary>
     /// The seeds, exposed for the pinning tests (the same single-source-of-truth contract
-    /// <see cref="MemexConfiguration.AiMenuItems"/> keeps for the imperative entry).
+    /// <c>MemexConfiguration.AiMenuItems</c> keeps for the imperative entry).
     /// </summary>
     internal static IReadOnlyList<MeshNode> Seeds { get; } =
     [

--- a/src/MeshWeaver.AI/Portal/ConnectTokenSink.cs
+++ b/src/MeshWeaver.AI/Portal/ConnectTokenSink.cs
@@ -4,7 +4,7 @@ using MeshWeaver.AI;
 using MeshWeaver.AI.Connect;
 using Microsoft.Extensions.Logging;
 
-namespace Memex.Portal.Shared.Models;
+namespace MeshWeaver.AI.Portal;
 
 /// <summary>
 /// Portal-side implementation of <see cref="IConnectTokenSink"/>: persists a captured CLI

--- a/src/MeshWeaver.AI/Portal/ModelProviderService.cs
+++ b/src/MeshWeaver.AI/Portal/ModelProviderService.cs
@@ -222,9 +222,12 @@ public class ModelProviderService(IMeshService meshService, IMessageHub hub, ILo
                                 SyncBehavior = syncBehavior,
                                 Content = modelDef,
                             };
-                            return accessService is null || ctx is null
-                                ? meshService.CreateNode(modelNode)
-                                : Observable.Using(() => accessService.SwitchAccessContext(ctx), _ => meshService.CreateNode(modelNode));
+                            // RunAs, never Observable.Using: the latter opens the AsyncLocal scope on
+                            // the SUBSCRIBING thread and disposes it on whichever thread the work
+                            // terminates, leaving the subscriber latched as the impersonated identity
+                            // (#1790). RunAs already defers when access or identity is null, so it
+                            // subsumes the null branch this replaced.
+                            return accessService.RunAs(ctx, () => meshService.CreateNode(modelNode));
                         })
                         .Catch<MeshNode, Exception>(ex =>
                         {

--- a/src/MeshWeaver.AI/Portal/ModelProviderService.cs
+++ b/src/MeshWeaver.AI/Portal/ModelProviderService.cs
@@ -12,11 +12,11 @@ using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Memex.Portal.Shared.Models;
+namespace MeshWeaver.AI.Portal;
 
 /// <summary>
 /// Service for creating, rotating, and deleting AI model provider credentials.
-/// Modelled on <see cref="Memex.Portal.Shared.Authentication.ApiTokenService"/>
+/// Modelled on <c>Authentication.ApiTokenService</c>
 /// — credentials are stored as <c>nodeType:ModelProvider</c> MeshNodes in the
 /// owner's dotfile namespace (<c>{userId}/_Memex/{providerName}</c>, the same
 /// hidden namespace that hosts <c>{user}/_Memex/ThreadComposer</c>; see
@@ -337,7 +337,7 @@ public class ModelProviderService(IMeshService meshService, IMessageHub hub, ILo
     /// <summary>
     /// Live list of ModelProviders owned by <paramref name="ownerPath"/>.
     /// Same shape as
-    /// <see cref="Memex.Portal.Shared.Authentication.ApiTokenService.GetTokensForUser"/>
+    /// <c>ApiTokenService.GetTokensForUser</c>
     /// — synced via <c>workspace.GetQuery</c>.
     /// </summary>
     public IObservable<IReadOnlyList<ProviderInfo>> GetProvidersForOwner(string ownerPath, string? targetNamespace = null)

--- a/src/MeshWeaver.AI/Portal/TokenUsageSettingsTab.cs
+++ b/src/MeshWeaver.AI/Portal/TokenUsageSettingsTab.cs
@@ -11,10 +11,11 @@ using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Layout.DataGrid;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
 using MeshWeaver.Utils;
 
-namespace Memex.Portal.Shared.Settings;
+namespace MeshWeaver.AI.Portal;
 
 /// <summary>
 /// Admin settings tab: aggregated token usage + estimated cost, read from the per-model
@@ -24,7 +25,7 @@ namespace Memex.Portal.Shared.Settings;
 /// (<see cref="ModelPriceCatalog"/>) — and never stored, so a price edit re-prices history.
 ///
 /// <para>Platform admins only — the menu entry is a seeded <c>UiContribution</c> node with
-/// <c>Gates.AdminOnly</c> (<see cref="PlatformSettingsTabAreas"/>), and the
+/// <c>Gates.AdminOnly</c> (<c>PlatformSettingsTabAreas</c>), and the
 /// <c>SettingsTokenUsage</c> layout area re-asserts the admin gate for direct URLs; the query is
 /// RLS-scoped to what the viewer can read. Rendered with framework controls
 /// (<see cref="DataGridControl"/> + a button toolbar) — no hand-built HTML.</para>
@@ -41,6 +42,33 @@ public static class TokenUsageSettingsTab
         [(7, "Last 7 days"), (30, "Last 30 days"), (90, "Last 90 days"), (0, "All time")];
 
     private static FilterState Default => new("Model", 30);
+
+    /// <summary>
+    /// Registers the Token Usage tab through the platform's declarative settings seam — the same
+    /// one <c>ApiTokensSettingsTab</c> uses.
+    ///
+    /// <para>It moved off the portal with the rest of the engine (#2276): a settings page that
+    /// composes an AI tab by NAME forces the composition root to reference the engine, which is
+    /// exactly the reference a Store-delivered module cannot coexist with. Declared here, the tab
+    /// appears when the module is installed and is simply absent when it is not — which is what
+    /// "delistable" has to mean for a UI surface.</para>
+    ///
+    /// <para>Gated on <see cref="Permission.All"/>: token spend is instance-wide administration,
+    /// not a per-user view.</para>
+    /// </summary>
+    /// <param name="config">The hub configuration to register on.</param>
+    /// <returns>The same configuration, for chaining.</returns>
+    public static MessageHubConfiguration AddTokenUsageSettingsTab(this MessageHubConfiguration config)
+        => config.AddSettingsMenuItems(
+            new SettingsMenuItemDefinition(
+                Id: TabId,
+                Label: "Token Usage",
+                ContentBuilder: (host, stack, _) => BuildContent(host, stack),
+                Group: "Administration",
+                Icon: FluentIcons.Database(),
+                Order: 320,
+                RequiredPermission: Permission.All)
+            { LabelKey = "settings.tokenUsage", GroupKey = "settings.groupAdministration" });
 
     internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack)
     {

--- a/src/MeshWeaver.AI/ProviderCredentialSeedHostedService.cs
+++ b/src/MeshWeaver.AI/ProviderCredentialSeedHostedService.cs
@@ -1,0 +1,49 @@
+using System.Reactive.Linq;
+using MeshWeaver.Graph;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// Boot hook that runs <see cref="ProviderCredentialSeed.Run"/> ONCE the static-repo import has
+/// settled — the ordering that matters, because the seed fills a field on a provider node the
+/// import creates. Reactive + fire-and-forget, on the thread pool, exactly like the import service
+/// above (subscribing on the startup thread re-enters the hub schedulers and deadlocks).
+///
+/// <para>Sequenced on <see cref="StaticRepoImportSettled"/> rather than chained onto the import's
+/// own subscription so a FAILED import still lets the seed run: whatever providers did land are
+/// still worth converging, and the seed reports an absent node rather than waiting for one.</para>
+/// </summary>
+internal sealed class ProviderCredentialSeedHostedService(
+    IMessageHub hub,
+    StaticRepoImportSettled settled,
+    ILogger<ProviderCredentialSeedHostedService>? logger = null) : IHostedService
+{
+    private IDisposable? _subscription;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _subscription = settled.Settled
+            .SelectMany(_ => ProviderCredentialSeed.Run(hub, logger))
+            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default)
+            .Subscribe(
+                // Debug, not Information: ProviderCredentialSeed.Run already logs every outcome at
+                // its own level (Info for Seeded, Error for RefusedUnprotected, Warning for
+                // NodeAbsent, Debug otherwise) — a second Information line per provider per boot is
+                // duplicate log volume, not information. This trace line only correlates the results
+                // with THIS hosted service when debugging boot ordering.
+                r => logger?.LogDebug(
+                    "[ProviderCredentialSeed] {Path}: {Outcome} (configuration section '{Section}').",
+                    r.ProviderPath, r.Outcome, r.Section),
+                ex => logger?.LogWarning(ex, "[ProviderCredentialSeed] seed run failed."));
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _subscription?.Dispose();
+        return Task.CompletedTask;
+    }
+}

--- a/src/MeshWeaver.AI/SkillStaticRepoSource.cs
+++ b/src/MeshWeaver.AI/SkillStaticRepoSource.cs
@@ -21,6 +21,11 @@ public sealed class SkillStaticRepoSource(BuiltInSkillProvider provider) : IStat
     public bool Versioned => false;
 
     /// <inheritdoc />
+    /// <remarks>A skill/agent/model that exists but is unfindable is indistinguishable
+    /// from one that was never imported — this catalog asserts it reached the index (#354).</remarks>
+    public bool AssertIndexedAfterImport => true;
+
+    /// <inheritdoc />
     // Additive: users add their OWN skills to this partition; the import must never prune them.
     // Only skills the build PREVIOUSLY shipped (in the manifest) but has since dropped are removed.
     public PartitionSyncMode SyncMode => PartitionSyncMode.Additive;

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -173,6 +173,15 @@ public static class StaticRepoImporter
         if (sources.Length == 0)
             return Observable.Empty<StaticRepoImportResult>();
 
+        // When the caller names no assertion set, ask the SOURCES: each declares whether its catalog
+        // must be verified against the search index (#354). The portal used to pass the AI partition
+        // names here, which made the composition root know them — and a module cannot be delisted
+        // from a list the host hard-codes (#2276). Same set, declared by its owner.
+        indexedCatalogAssertions ??= sources
+            .Where(source => source.AssertIndexedAfterImport)
+            .Select(source => source.Partition)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         // Deploy-time per-partition mode override (Features:StaticRepoSync:Modes) — case-insensitive.
         // When a partition isn't listed the source's own default SyncMode is used (FullReplace for most,
         // Additive for the built-in AI catalogs). Null/empty = every source keeps its own default.

--- a/src/MeshWeaver.Mesh.Contract/IStaticRepoSource.cs
+++ b/src/MeshWeaver.Mesh.Contract/IStaticRepoSource.cs
@@ -40,6 +40,24 @@ public interface IStaticRepoSource
     PartitionSyncMode SyncMode => PartitionSyncMode.FullReplace;
 
     /// <summary>
+    /// Whether the import must ASSERT this source's catalog reached the cross-schema search index
+    /// (#354). After the import, <c>StaticRepoImporter.ImportAll</c> verifies each asserting
+    /// partition is registered, force-re-syncs one that is not, and raises a startup-failure
+    /// notification for any that materialized but stayed unindexed.
+    ///
+    /// <para>Defaults to <c>false</c> — the pre-existing behaviour for every source that does not
+    /// opt in. The built-in AI catalogs (Agent / Provider / Harness / Skill) override to
+    /// <c>true</c>: a skill that exists but is unfindable is indistinguishable from one that was
+    /// never imported, and that is the failure this assertion exists to catch.</para>
+    ///
+    /// <para>🚨 It lives on the SOURCE rather than being passed in by the host. The portal used to
+    /// hand <c>ImportAll</c> the AI partition names, which meant the composition root had to know
+    /// them — and a module cannot be delisted from a list the host hard-codes (#2276). A source
+    /// declaring its own requirement is the same shape as <see cref="SyncMode"/> above.</para>
+    /// </summary>
+    bool AssertIndexedAfterImport => false;
+
+    /// <summary>
     /// All source nodes <b>with full content</b> (e.g. <c>MarkdownContent</c>), in any order
     /// (the fingerprint + import are order-independent). This is the authored content, read
     /// straight from the assembly — never from the live mesh.

--- a/src/MeshWeaver.Mesh.Contract/Services/IMcpBackConnection.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMcpBackConnection.cs
@@ -1,4 +1,4 @@
-namespace MeshWeaver.AI.Connect;
+namespace MeshWeaver.Mesh.Services;
 
 /// <summary>
 /// The coordinates a co-hosted CLI needs to call the portal's MCP endpoint AS THE USER:

--- a/src/MeshWeaver.Mesh.Contract/Services/IPortalHubAccessor.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IPortalHubAccessor.cs
@@ -1,0 +1,23 @@
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// Hands out the PORTAL's hub — the per-circuit hub a signed-in user's UI work runs on — to code
+/// that must not reference the portal assembly to get it.
+///
+/// <para>🚨 The distinction this exists to preserve: <b>the portal hub is not an ambient
+/// <see cref="IMessageHub"/></b>. Resolving whatever hub happens to be in scope gets the mesh hub
+/// (the ROUTER, which must not execute work) or a per-node hub, and the difference only shows up as
+/// misrouted traffic at runtime. Callers that need the portal's own hub have to say so.</para>
+///
+/// <para><see cref="Hub"/> is NULLABLE by design: a headless host, a test fixture, or a deployment
+/// with no GUI has no portal hub, and that is not an error. Consumers degrade — the AI skill sync
+/// writes its base instructions and logs that the rest is reachable another way — rather than
+/// failing a boot over an absent UI.</para>
+/// </summary>
+public interface IPortalHubAccessor
+{
+    /// <summary>The portal hub for the current scope, or <c>null</c> where there is no portal.</summary>
+    IMessageHub? Hub { get; }
+}

--- a/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
+++ b/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.AI.Portal;
 using MeshWeaver.Blazor.Portal.Layout;
 using MeshWeaver.Graph;
 using Xunit;

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\memex\Memex.Portal.Shared\Memex.Portal.Shared.csproj" />
+    <!-- This SUITE spans both halves: it asserts the AI menu entries integrate with the
+         portal shell. A TEST project may reference the module; the PLATFORM may not,
+         which is the whole point of #2276. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <!-- MapDefaultEndpoints / MapVersionEndpoint live here, beside /health and /alive. -->
     <ProjectReference Include="..\..\memex\aspire\Memex.Portal.ServiceDefaults\Memex.Portal.ServiceDefaults.csproj" />
     <!-- DbVersionHealthCheckTest drives the portal's own db_version health check: whether a

--- a/test/Memex.Portal.Shared.Test/PlatformSettingsTabSeedTest.cs
+++ b/test/Memex.Portal.Shared.Test/PlatformSettingsTabSeedTest.cs
@@ -25,7 +25,6 @@ public class PlatformSettingsTabSeedTest
         InboxSettingsTab.TabId,
         UpdatePolicySettingsTab.TabId,
         PublishedSettingsTab.TabId,
-        TokenUsageSettingsTab.TabId,
     ];
 
     /// <summary>The tabs whose compiled providers gated on the platform-admin check.</summary>
@@ -36,7 +35,6 @@ public class PlatformSettingsTabSeedTest
         InboxSettingsTab.TabId,
         UpdatePolicySettingsTab.TabId,
         PublishedSettingsTab.TabId,
-        TokenUsageSettingsTab.TabId,
     ];
 
     [Fact]

--- a/test/MeshWeaver.AI.Test/AgentSkillSyncServiceTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentSkillSyncServiceTest.cs
@@ -1,8 +1,8 @@
 using MeshWeaver.AI;
-using Memex.Portal.Shared.Skills;
+using MeshWeaver.AI.Portal;
 using Xunit;
 
-namespace Memex.Portal.Shared.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// Unit tests for the skill workspace instructions

--- a/test/MeshWeaver.AI.Test/AiResolutionSeamAuditTest.cs
+++ b/test/MeshWeaver.AI.Test/AiResolutionSeamAuditTest.cs
@@ -41,6 +41,7 @@ public class AiResolutionSeamAuditTest
         ["src/MeshWeaver.AI/ChatClientCredentialResolver.cs"] = "Credential lookup by the MODEL's own partition set — a security seam keyed on the selected model, not a user-facing resolution.",
         ["src/MeshWeaver.AI/Stores/MeshAgentSkillsSource.cs"] = "Consumes AiSettingsNodeType.ObserveSkillQueries; its literal is documentation.",
         ["src/MeshWeaver.AI/Completion/SkillAutocompleteProvider.cs"] = "Consumes ObserveSkillQueries; literal is documentation.",
+        ["src/MeshWeaver.AI/Portal/AgentSkillSyncService.cs"] = "INSTRUCTION PROSE written into AGENTS.md for a CLI harness to read — it tells the model to run `search nodeType:Skill` itself. Not a resolution this process performs; the sync's own catalog read goes through SkillNodeType.SkillQueries. Entered the audit's scope when the service moved out of the portal (#2276).",
         ["src/MeshWeaver.AI/AiSourcesInstallHook.cs"] = "Registers package sources INTO the settings — the write side of the seam.",
         ["src/MeshWeaver.AI/BuiltInSkillProvider.cs"] = "Static-repo import source (writes the platform Skill partition) — not a resolution.",
         ["src/MeshWeaver.AI/BuiltInAgentProvider.cs"] = "Static-repo import source for the offline Agent partition — not a resolution.",

--- a/test/MeshWeaver.AI.Test/ConnectStrategyTest.cs
+++ b/test/MeshWeaver.AI.Test/ConnectStrategyTest.cs
@@ -9,7 +9,7 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading;
 using System.Threading.Tasks;
-using Memex.Portal.Shared.Models;
+using MeshWeaver.AI.Portal;
 using MeshWeaver.AI;
 using MeshWeaver.AI.Connect;
 using MeshWeaver.Data;

--- a/test/MeshWeaver.AI.Test/ModelProviderSelectionTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelProviderSelectionTest.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
-using Memex.Portal.Shared.Models;
+using MeshWeaver.AI.Portal;
 using MeshWeaver.AI;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;

--- a/test/MeshWeaver.AI.Test/ModelProviderServiceTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelProviderServiceTest.cs
@@ -9,7 +9,7 @@ using System.Reactive.Threading.Tasks;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Memex.Portal.Shared.Models;
+using MeshWeaver.AI.Portal;
 using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;

--- a/test/MeshWeaver.AI.Test/ProviderCredentialSeedWiringTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderCredentialSeedWiringTest.cs
@@ -3,15 +3,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Memex.Portal.Shared;
 using MeshWeaver.AI;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 
-namespace Memex.Portal.Shared.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// 🚨 The seed must be STARTED, not merely written. <see cref="ProviderCredentialSeed"/> is what
@@ -27,12 +27,27 @@ namespace Memex.Portal.Shared.Test;
 /// </summary>
 public class ProviderCredentialSeedWiringTest
 {
-    /// <summary>Runs <c>AddStaticRepoSync</c> against a throwaway builder and returns what it registered.</summary>
-    private static IServiceCollection Wire(IReadOnlySet<string> serveFromPartition)
+    /// <summary>
+    /// Installs the AI MODULE the way <c>Modules:Assemblies</c> does — through its assembly
+    /// attribute, against a deployment configuration — and returns what it registered.
+    ///
+    /// <para>The wiring moved here with the seed itself (#2276): the portal used to register it on
+    /// AI's behalf, which is exactly the reference that stopped the engine shipping from the Store.
+    /// The assertion is unchanged, and it must be: WHO registers it changed, whether it is
+    /// registered must not.</para>
+    /// </summary>
+    private static IServiceCollection Wire(params string[] servedPartitions)
     {
         var services = new ServiceCollection();
         var builder = new MeshBuilder(configure => configure(services), new Address("mesh", "test"));
-        builder.AddStaticRepoSync(serveFromPartition);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(servedPartitions
+                .Select((p, i) => new KeyValuePair<string, string?>(
+                    $"Features:StaticRepoSync:Partitions:{i}", p)))
+            .Build();
+        builder.WithConfiguration(configuration);
+        foreach (var configure in new AiMeshModuleAttribute().BuilderConfigurations)
+            configure(builder);
         return services;
     }
 
@@ -43,8 +58,7 @@ public class ProviderCredentialSeedWiringTest
     [Fact]
     public void DbSyncedProviderPartition_StartsTheCredentialSeed()
     {
-        var services = Wire(new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            { ModelProviderNodeType.RootNamespace });
+        var services = Wire(ModelProviderNodeType.RootNamespace);
 
         Assert.True(RegistersSeed(services),
             "the DB-synced Provider partition is the one shape where a provider node can outlive the "
@@ -55,17 +69,17 @@ public class ProviderCredentialSeedWiringTest
     [Fact]
     public void SyncDisabled_RegistersNothing()
     {
-        var services = Wire(new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        var services = Wire();
 
         Assert.False(RegistersSeed(services),
-            "with no partition served from the DB there is no import, no node to converge, and "
-            + "AddStaticRepoSync returns early.");
+            "with no partition served from the DB there is no import, no node to converge, and the "
+            + "module registers no seed.");
     }
 
     [Fact]
     public void OtherPartitionsOnly_DoesNotStartTheCredentialSeed()
     {
-        var services = Wire(new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Doc" });
+        var services = Wire("Doc");
 
         Assert.False(RegistersSeed(services),
             "the seed belongs to the Provider partition; a Doc-only sync has no provider catalog.");

--- a/test/MeshWeaver.AI.Test/ProviderKeyEncryptionTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderKeyEncryptionTest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
-using Memex.Portal.Shared.Models;
+using MeshWeaver.AI.Portal;
 using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;

--- a/test/MeshWeaver.AI.Test/ProviderModelListerTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderModelListerTest.cs
@@ -7,7 +7,7 @@ using System.Reactive.Threading.Tasks;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Memex.Portal.Shared.Models;
+using MeshWeaver.AI.Portal;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using Xunit;
 

--- a/test/MeshWeaver.AI.Test/UseWithoutSeeResolverTest.cs
+++ b/test/MeshWeaver.AI.Test/UseWithoutSeeResolverTest.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Reactive.Linq;
-using Memex.Portal.Shared.Models;
+using MeshWeaver.AI.Portal;
 using MeshWeaver.AI;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;


### PR DESCRIPTION
`Memex.Portal.Shared` compiled against `MeshWeaver.AI` **in order to configure it**. That is the reference a Store-delivered module cannot coexist with: a closure DLL and a registry module of the same name are mutually exclusive, and the landing service refuses with a **409 on every instance**.

### It could not be split

If the module registered the AI content sources from configuration while the portal still called `AddAI(...)` compiled-in, `AddBuiltInAiContentSources()` would run **twice** — duplicate `IStaticRepoSource` registrations, and the importer imports every AI source twice. So the module attribute, the removal of the compiled call, and the ~13 types of wiring land together.

### `AiMeshModuleAttribute` is now the whole composition

It reads `MeshBuilder.Configuration` (#2300, added for exactly this) and does what `MemexConfiguration` did: `AddAI` with the serve-from-DB set, the AI menu seeds, `ModelProviderService`, the Connect token sink + session manager, the gated Claude strategy and its options, the skill→file sync, the AI content sources, and the provider-credential seed.

Reading configuration at **builder** time is not a preference: the serve-from-DB decision sets `MeshNode.IsDefinitionOnly`, an `init` property, and getting it wrong makes a partition root permanently unrecoverable (#902).

### Three seams the platform keeps, each because the HOST implements it

| seam | why it cannot ride the module |
|---|---|
| `IMcpBackConnection` + `McpConnectionInfo` → `MeshWeaver.Mesh.Services` | `McpBackConnectionService` needs `ApiTokenService` + ASP.NET; only the contract is platform (the `ISpeechTranscriber` shape) |
| `IPortalHubAccessor` → `MeshWeaver.Mesh.Services` | the skill sync needs the **portal's** hub, and an ambient `IMessageHub` is the router. Nullable by design — a headless host has no portal, and the consumer degrades |
| `IStaticRepoSource.AssertIndexedAfterImport` | the portal handed `ImportAll` the AI partition **names** for the #354 index assertion. A module cannot be delisted from a list the host hard-codes, so a source declares its own requirement — same shape as `SyncMode` — and `ImportAll` derives the set |

Everything else uses seams that already existed: the AI catalogs and the token-usage tab register through the per-node-hub chain and `AddSettingsMenuItems`; the portal's AI types and thread area are contributed through `PortalConfigurationRegistry`, which exists precisely so a plugin can configure portals it does not compile against.

### Tests follow their code

Five files move into the engine with their suites. `ProviderCredentialSeedWiringTest` now installs the assembly attribute the way `Modules:Assemblies` does — **who** registers the seed changed, **whether** it is registered did not, and that is what it still asserts. It failed first, which is how I knew the move was real.

### Verification

- Full solution build under CI's flags → `0 Error(s)`.
- `MeshWeaver.AI.Test` **1306**, `MeshWeaver.Threading.Test` **139**, `Memex.Portal.Shared.Test` **428** — all green.

### What this does and does not finish

`Memex.Portal.Shared` is off the list. The engine still reaches the app closure through `src/MeshWeaver.Blazor.Portal` (a view pack, deleted from core by #2293) and `tools/MeshWeaver.PluginTester` (a tool, not the platform). **The 409 clears when #2293 lands**, and then Plugins#687 can flip to `preInstalled`.

Refs #2276

🤖 Generated with [Claude Code](https://claude.com/claude-code)