### PR TITLE
Two test projects reference the AI engine and never use it (#2276)

### DIFF
--- a/test/MeshWeaver.Autocomplete.Test/MeshWeaver.Autocomplete.Test.csproj
+++ b/test/MeshWeaver.Autocomplete.Test/MeshWeaver.Autocomplete.Test.csproj
@@ -26,7 +26,6 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
-    <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Documentation\MeshWeaver.Documentation.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Blazor\MeshWeaver.Blazor.csproj" />

--- a/test/MeshWeaver.Hosting.Snowflake.Test/MeshWeaver.Hosting.Snowflake.Test.csproj
+++ b/test/MeshWeaver.Hosting.Snowflake.Test/MeshWeaver.Hosting.Snowflake.Test.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Snowflake\MeshWeaver.Hosting.Snowflake.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />


### PR DESCRIPTION
`MeshWeaver.Autocomplete.Test` and `MeshWeaver.Hosting.Snowflake.Test` each carry a `ProjectReference` to `MeshWeaver.AI` and contain **not one file** that names an AI type.

Verified two ways: scanning both trees for `MeshWeaver.AI` / `AddAI` (zero hits), and building each project with the reference removed (`0 Error(s)`, `-c Release -warnaserror`).

They are residue — Autocomplete.Test's AI usage left when the autocomplete providers moved; Snowflake.Test never had any.

**A reference nothing uses is not free.** It drags the engine into two more app closures, and the closure is exactly what decides whether the engine can ship as a Store module: a closure DLL and a registry module of the same name are mutually exclusive, and the landing service refuses with a 409 on every instance.

Part of taking `MeshWeaver.AI` out of core entirely (#2276). Thirteen test projects reference it; these two needed nothing but the line deleted.

Refs #2276

🤖 Generated with [Claude Code](https://claude.com/claude-code)