### PR TITLE
The ratchet fails a run for obeying the allow file — teach it "intermittent"

### DIFF
--- a/.github/samples-gate.allow
+++ b/.github/samples-gate.allow
@@ -41,3 +41,17 @@ PensionFund/BalanceSheet compile
 # default-suppression drops the property whose value equals the type's default. The stored
 # node then differs from the authored file and the unchanged-skip misses.
 PensionFund idempotence intermittent
+
+# 🚨 The `intermittent` token above is a REAL WEAKENING, and its failure mode is social rather than
+# technical: the next person with a deterministic red they cannot fix will find this token and reach
+# for it. It is legitimate for exactly one thing — a check that FLAPS, where a single green run does
+# not prove the debt is paid. It is NOT for a failure that is merely inconvenient, hard, or someone
+# else's. Marking a deterministic failure intermittent silences the ratchet permanently and is the
+# band-aid the ratchet exists to prevent.
+#
+# It buys exemption from STALE-DETECTION and nothing else: the entry still tolerates only the
+# scope/check it names, and a failure it does not name is still a new failure.
+#
+# Before adding one, prove the flap — two runs of the same commit disagreeing, or the git history of
+# this file showing an entry dropped as stale and restored. That is what justified this one:
+# 768f9ba0b dropped it, f32047e0e restored it one commit later.

--- a/.github/samples-gate.allow
+++ b/.github/samples-gate.allow
@@ -40,4 +40,4 @@ PensionFund/BalanceSheet compile
 # type is registered, the installer materialises a typed `Currency` and re-serialises it, and
 # default-suppression drops the property whose value equals the type's default. The stored
 # node then differs from the authored file and the unchanged-skip misses.
-PensionFund idempotence
+PensionFund idempotence intermittent

--- a/test/MeshWeaver.PluginTester.Test/GateAllowlistTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/GateAllowlistTest.cs
@@ -192,6 +192,19 @@ public class GateAllowlistTest
     }
 
     [Fact]
+    public void ToString_RendersTheEntryExactlyAsTheAllowFileHasIt()
+    {
+        // The gate prints entries in its diagnostics, and an operator reading that output is looking
+        // for the LINE TO EDIT. A rendering that drops the marker does not match the file and cannot
+        // be pasted back into it.
+        var plain = GateAllowlist.Parse(["Claims idempotence"]).Entries.Single();
+        var flappy = GateAllowlist.Parse(["Claims idempotence intermittent"]).Entries.Single();
+
+        Assert.Equal("Claims idempotence", plain.ToString());
+        Assert.Equal("Claims idempotence intermittent", flappy.ToString());
+    }
+
+    [Fact]
     public void Parse_RejectsAnUnknownThirdToken()
     {
         // A typo in the marker must not silently degrade to a plain entry — that would restore the

--- a/test/MeshWeaver.PluginTester.Test/GateAllowlistTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/GateAllowlistTest.cs
@@ -161,6 +161,46 @@ public class GateAllowlistTest
     // ── the stale rule ───────────────────────────────────────────────────────────────────────
 
     [Fact]
+    public void Evaluate_IntermittentEntryWhoseCheckPasses_IsNotStale()
+    {
+        // The ratchet's rule — a listed check that starts passing must be removed — assumes the
+        // check is DETERMINISTIC, so one green run proves the debt is paid. For a flapping check
+        // that inference is wrong. PensionFund idempotence was dropped as stale and restored one
+        // commit later for exactly this reason, after which the file carried the intent in a
+        // comment the parser strips, and the ratchet kept failing runs for obeying the file.
+        var healthy = new PackageResult("Claims");
+        var verdict = GateVerdict.Evaluate(
+            Report(healthy), GateAllowlist.Parse(["Claims idempotence intermittent"]));
+
+        Assert.Empty(verdict.Stale);
+        Assert.Empty(verdict.NewFailures);
+        Assert.True(verdict.Success);
+    }
+
+    [Fact]
+    public void Evaluate_IntermittentEntry_StillSuppressesItsOwnFailure()
+    {
+        // Marking an entry intermittent gives up stale-detection for that line and NOTHING else:
+        // it still tolerates the failure it names, exactly as before.
+        var verdict = GateVerdict.Evaluate(
+            Report(IdempotenceBroken("Claims")),
+            GateAllowlist.Parse(["Claims idempotence intermittent"]));
+
+        Assert.Empty(verdict.NewFailures);
+        Assert.Single(verdict.KnownDebt);
+        Assert.True(verdict.Success);
+    }
+
+    [Fact]
+    public void Parse_RejectsAnUnknownThirdToken()
+    {
+        // A typo in the marker must not silently degrade to a plain entry — that would restore the
+        // stale-failure the marker exists to prevent, with nothing pointing at the cause.
+        Assert.Throws<FormatException>(
+            () => GateAllowlist.Parse(["Claims idempotence intermitent"]));
+    }
+
+    [Fact]
     public void Evaluate_EntryWhoseCheckPasses_IsStale_AndFailsTheRun()
     {
         var healthy = new PackageResult("Claims");

--- a/tools/MeshWeaver.PluginTester/GateAllowlist.cs
+++ b/tools/MeshWeaver.PluginTester/GateAllowlist.cs
@@ -25,6 +25,18 @@ public sealed record GateAllowlist(IReadOnlyList<AllowEntry> Entries)
     /// Optional third token marking an entry whose check FLAPS. Such an entry is exempt from
     /// stale-detection: passing once does not prove the debt is paid, so the ratchet must not
     /// demand its removal. It still suppresses only the scope/check it names.
+    ///
+    /// <para>🚨 This is a REAL WEAKENING and its failure mode is social, not technical: the next
+    /// person with a deterministic red they cannot fix will find this token and reach for it. It is
+    /// legitimate for a check that genuinely flaps and for nothing else — marking a deterministic
+    /// failure intermittent silences the ratchet permanently, which is the band-aid the ratchet
+    /// exists to prevent. Prove the flap first (two runs of one commit disagreeing, or an entry
+    /// dropped as stale and restored in this file's history).</para>
+    ///
+    /// <para>The sibling rule is the same idea from the other direction: an entry listed but ABSENT
+    /// from a narrowed run is <c>Unverifiable</c> — warned, never failed. That one refuses to infer
+    /// from a check that did not run; this one refuses to infer from a check that ran once and
+    /// happened to pass. Both are <i>one observation is not proof</i>.</para>
     /// </summary>
     public const string IntermittentMarker = "intermittent";
 
@@ -52,7 +64,8 @@ public sealed record GateAllowlist(IReadOnlyList<AllowEntry> Entries)
                     $"allow file line {number}: expected '<scope> <check>' (optionally followed by " +
                     $"'{IntermittentMarker}') with check one of " +
                     $"[{string.Join(", ", Checks)}], got '{line}'");
-            entries.Add(new AllowEntry(parts[0], parts[1].ToLowerInvariant(), intermittent));
+            entries.Add(new AllowEntry(parts[0], parts[1].ToLowerInvariant())
+                { Intermittent = intermittent });
         }
         return new GateAllowlist(entries);
     }
@@ -109,8 +122,16 @@ public sealed record GateAllowlist(IReadOnlyList<AllowEntry> Entries)
 }
 
 /// <summary>One known-debt entry: a scope (package id or NodeType path) and a check name.</summary>
-public sealed record AllowEntry(string Scope, string Check, bool Intermittent = false)
+public sealed record AllowEntry(string Scope, string Check)
 {
+    /// <summary>
+    /// Whether this entry's check FLAPS — see <see cref="GateAllowlist.IntermittentMarker"/>.
+    /// Deliberately an init-only PROPERTY rather than a primary-constructor parameter: adding a
+    /// defaulted parameter to a public record's primary ctor is a binary-breaking change, which the
+    /// "Public record signatures" gate refuses. It caught exactly that on the first attempt here.
+    /// </summary>
+    public bool Intermittent { get; init; }
+
     /// <summary>Case-insensitive match, exact scope — no globs: an entry must name exactly the
     /// debt it tolerates, or the ratchet stops ratcheting.</summary>
     public bool Matches(string scope, string check) =>

--- a/tools/MeshWeaver.PluginTester/GateAllowlist.cs
+++ b/tools/MeshWeaver.PluginTester/GateAllowlist.cs
@@ -20,7 +20,6 @@ public sealed record GateAllowlist(IReadOnlyList<AllowEntry> Entries)
     /// <summary>The empty list — every failure is a new failure.</summary>
     public static readonly GateAllowlist Empty = new([]);
 
-    /// <summary>The valid check names, package-level and type-level.</summary>
     /// <summary>
     /// Optional third token marking an entry whose check FLAPS. Such an entry is exempt from
     /// stale-detection: passing once does not prove the debt is paid, so the ratchet must not
@@ -40,6 +39,7 @@ public sealed record GateAllowlist(IReadOnlyList<AllowEntry> Entries)
     /// </summary>
     public const string IntermittentMarker = "intermittent";
 
+    /// <summary>The valid check names, package-level and type-level.</summary>
     public static readonly IReadOnlySet<string> Checks =
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             { "install", "idempotence", "compile", "render", "tests" };
@@ -139,7 +139,16 @@ public sealed record AllowEntry(string Scope, string Check)
         && string.Equals(Check, check, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override string ToString() => $"{Scope} {Check}";
+    /// <summary>
+    /// The entry as it appears in the allow file — INCLUDING the intermittent marker. The gate
+    /// prints entries in its diagnostics ("unverifiable allow entry …: {entry}"), and an operator
+    /// reading that output is looking for the line to edit; a rendering that drops the marker does
+    /// not match the file and cannot be copy-pasted back into it.
+    /// </summary>
+    public override string ToString() =>
+        Intermittent
+            ? $"{Scope} {Check} {GateAllowlist.IntermittentMarker}"
+            : $"{Scope} {Check}";
 }
 
 /// <summary>One observed failure: where, which check, and the detail text.</summary>
@@ -184,9 +193,10 @@ public sealed record GateVerdict(
             // This never hides a NEW failure: an intermittent entry still only suppresses the
             // scope/check it names, and a failure it does not name is still a new failure. What it
             // gives up is stale-detection for that one line, which is the whole point.
-            if (entry.Intermittent && Passed(report, entry))
+            var passed = Passed(report, entry);
+            if (entry.Intermittent && passed)
                 continue;
-            (Passed(report, entry) ? stale : unverifiable).Add(entry);
+            (passed ? stale : unverifiable).Add(entry);
         }
         return new GateVerdict(newFailures, knownDebt, stale, unverifiable);
     }

--- a/tools/MeshWeaver.PluginTester/GateAllowlist.cs
+++ b/tools/MeshWeaver.PluginTester/GateAllowlist.cs
@@ -21,6 +21,13 @@ public sealed record GateAllowlist(IReadOnlyList<AllowEntry> Entries)
     public static readonly GateAllowlist Empty = new([]);
 
     /// <summary>The valid check names, package-level and type-level.</summary>
+    /// <summary>
+    /// Optional third token marking an entry whose check FLAPS. Such an entry is exempt from
+    /// stale-detection: passing once does not prove the debt is paid, so the ratchet must not
+    /// demand its removal. It still suppresses only the scope/check it names.
+    /// </summary>
+    public const string IntermittentMarker = "intermittent";
+
     public static readonly IReadOnlySet<string> Checks =
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             { "install", "idempotence", "compile", "render", "tests" };
@@ -38,11 +45,14 @@ public sealed record GateAllowlist(IReadOnlyList<AllowEntry> Entries)
             if (line.Length == 0)
                 continue;
             var parts = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length != 2 || !Checks.Contains(parts[1]))
+            var intermittent = parts.Length == 3
+                && string.Equals(parts[2], IntermittentMarker, StringComparison.OrdinalIgnoreCase);
+            if ((parts.Length != 2 && !intermittent) || !Checks.Contains(parts[1]))
                 throw new FormatException(
-                    $"allow file line {number}: expected '<scope> <check>' with check one of " +
+                    $"allow file line {number}: expected '<scope> <check>' (optionally followed by " +
+                    $"'{IntermittentMarker}') with check one of " +
                     $"[{string.Join(", ", Checks)}], got '{line}'");
-            entries.Add(new AllowEntry(parts[0], parts[1].ToLowerInvariant()));
+            entries.Add(new AllowEntry(parts[0], parts[1].ToLowerInvariant(), intermittent));
         }
         return new GateAllowlist(entries);
     }
@@ -99,7 +109,7 @@ public sealed record GateAllowlist(IReadOnlyList<AllowEntry> Entries)
 }
 
 /// <summary>One known-debt entry: a scope (package id or NodeType path) and a check name.</summary>
-public sealed record AllowEntry(string Scope, string Check)
+public sealed record AllowEntry(string Scope, string Check, bool Intermittent = false)
 {
     /// <summary>Case-insensitive match, exact scope — no globs: an entry must name exactly the
     /// debt it tolerates, or the ratchet stops ratcheting.</summary>
@@ -140,6 +150,20 @@ public sealed record GateVerdict(
         foreach (var entry in allow.Entries)
         {
             if (failures.Any(f => entry.Matches(f.Scope, f.Check)))
+                continue;
+            // 🚨 An INTERMITTENT entry that passed this run is NOT stale. The ratchet's rule — a
+            // listed check that starts passing fails the run until its line goes — assumes a check
+            // is deterministic, so one green run proves the debt is paid. For a flapping check that
+            // inference is wrong, and acting on it churns: PensionFund idempotence was dropped as
+            // stale (768f9ba0b) and RESTORED one commit later (f32047e0e, "the check is
+            // intermittent"), after which the allow file carried the intent in a COMMENT the parser
+            // strips — so the ratchet kept failing runs for obeying the file. Marking the entry
+            // instead puts that intent where the code can read it.
+            //
+            // This never hides a NEW failure: an intermittent entry still only suppresses the
+            // scope/check it names, and a failure it does not name is still a new failure. What it
+            // gives up is stale-detection for that one line, which is the whole point.
+            if (entry.Intermittent && Passed(report, entry))
                 continue;
             (Passed(report, entry) ? stale : unverifiable).Add(entry);
         }


### PR DESCRIPTION
`.github/samples-gate.allow` line 32 says, in a comment:

```
# PensionFund idempotence — INTERMITTENT known debt. Do not remove on a single green run.
```

**The parser strips comments, so the ratchet cannot read that.**

## The bug

The ratchet's rule — *a listed check that starts passing fails the run until its line is removed* — assumes the check is **deterministic**, so one green run proves the debt is paid. For a flapping check that inference is wrong, and the git history shows the loop it produces:

| commit | action |
|---|---|
| `768f9ba0b` | Drop the now-stale PensionFund idempotence allow entry |
| `f32047e0e` | **Restore** the PensionFund idempotence entry — the check is intermittent |

Since then, every run where PensionFund happens to pass fails the gate with `stale allow entr(ies)` and **0 new failures**. That is what is currently reddening **#2285**, a PR that touches nothing related.

## Why not just remove the entry

Both obvious fixes are wrong:
- **Remove it** — the file explicitly forbids it, and it was already tried and reverted one commit later.
- **Wait for the flake to fail again** — that is waiting on a coin flip, and the next PR hits the same wall.

So the intent moves out of a comment the parser discards and into a token it reads:

```
PensionFund idempotence intermittent
```

## What the marker does, and what it deliberately does not

An intermittent entry is exempt from **stale-detection** and nothing else. It still tolerates only the scope/check it names; a failure it does not name is still a new failure. What it gives up is stale-detection for that one line — which is the entire point, not a side effect.

This is a real weakening of one specific guarantee, so it is deliberately narrow: it cannot be applied by accident (a typo throws), it cannot broaden what an entry suppresses, and it leaves the `Unverifiable` bucket's meaning intact.

## Verified in both directions

A marker that cannot fail would be worse than the bug it fixes:

- an intermittent entry whose check **passes** is not stale — gate stays green
- an intermittent entry **still suppresses its own failure** — unchanged behaviour
- a **typo** in the marker (`intermitent`) throws `FormatException` rather than silently degrading to a plain entry, which would restore the stale-failure with nothing pointing at the cause

`22/22` in `MeshWeaver.PluginTester.Test`, `-c Release -warnaserror` clean.

## Scope

Found while diagnosing #2285's red. Its failure was `Doc content compiles and runs` — the same job name as the Northwind compile error fixed in #2308, but a **different check inside it**, which is why the fix that landed did not clear it.