### PR TITLE
Four AI tests move to the AI suite; Content.Test stops referencing the engine (#2276)

### DIFF
--- a/test/MeshWeaver.AI.Test/AgentFileParserTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentFileParserTest.cs
@@ -5,7 +5,7 @@ using MeshWeaver.Hosting.Persistence.Parsers;
 using MeshWeaver.Mesh;
 using Xunit;
 
-namespace MeshWeaver.Content.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// Unit tests for AgentFileParser - parsing and serialization of agent markdown files with YAML front matter.

--- a/test/MeshWeaver.AI.Test/ContributedParserPriorityTest.cs
+++ b/test/MeshWeaver.AI.Test/ContributedParserPriorityTest.cs
@@ -5,7 +5,7 @@ using MeshWeaver.Hosting.Persistence.Parsers;
 using MeshWeaver.Mesh;
 using Xunit;
 
-namespace MeshWeaver.Content.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// The agent file format left core hosting: <see cref="AgentFileParser"/> ships with

--- a/test/MeshWeaver.AI.Test/SpacesInFileNameTest.cs
+++ b/test/MeshWeaver.AI.Test/SpacesInFileNameTest.cs
@@ -13,7 +13,7 @@ using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using Xunit;
 
-namespace MeshWeaver.Content.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// Tests that files with spaces in their names work correctly through

--- a/test/MeshWeaver.AI.Test/ThreadMessageToolTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadMessageToolTest.cs
@@ -3,7 +3,7 @@ using MeshWeaver.AI.Plugins;
 using Microsoft.Extensions.AI;
 using Xunit;
 
-namespace MeshWeaver.Content.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// The <c>submit_message</c> tool's REFUSAL contract — the half a model actually collides with.

--- a/test/MeshWeaver.AI.Test/ThreadMessageToolTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadMessageToolTest.cs
@@ -26,13 +26,16 @@ public class ThreadMessageToolTest
     private static AIFunction Tool() =>
         (AIFunction)ThreadMessageTool.Create(hub: null!, chat: null!);
 
-    private static string Invoke(string? threadPath, string? text)
+    // await, never a blocking bridge: `.AsTask().GetAwaiter().GetResult()` parks the calling thread
+    // on a continuation that may need it, which is the deadlock shape BlockingBridgeInTestRatchetGuard
+    // exists to keep out of the suite.
+    private static async Task<string> InvokeAsync(string? threadPath, string? text)
     {
-        var result = Tool().InvokeAsync(new AIFunctionArguments
+        var result = await Tool().InvokeAsync(new AIFunctionArguments
         {
             ["threadPath"] = threadPath!,
             ["text"] = text!,
-        }).AsTask().GetAwaiter().GetResult();
+        });
         return result?.ToString() ?? string.Empty;
     }
 
@@ -54,11 +57,11 @@ public class ThreadMessageToolTest
     [InlineData("   ")]
     [InlineData("")]
     [InlineData(null)]
-    public void A_path_that_normalises_to_nothing_is_ANSWERED_not_thrown(string? path)
+    public async Task A_path_that_normalises_to_nothing_is_ANSWERED_not_thrown(string? path)
     {
         // The assertion is as much that this returns at all as what it returns: before the
         // normalised-value check, three of these aborted the round with ArgumentException.
-        var answer = Invoke(path, "hello");
+        var answer = await InvokeAsync(path, "hello");
 
         answer.Should().Contain("submit_message requires");
     }
@@ -67,18 +70,18 @@ public class ThreadMessageToolTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    public void Empty_text_is_refused_without_sending(string? text)
+    public async Task Empty_text_is_refused_without_sending(string? text)
     {
-        Invoke("alice/_Thread/review", text)
+        (await InvokeAsync("alice/_Thread/review", text))
             .Should().Contain("non-empty text");
     }
 
     [Fact]
-    public void An_ownerless_top_level_thread_path_is_refused_with_the_reason()
+    public async Task An_ownerless_top_level_thread_path_is_refused_with_the_reason()
     {
         // A bare `_Thread/{id}` has no partition and no per-node hub; submitting to it would
         // NotFound-storm the router. Saying so beats an agent retrying the same bad path.
-        var answer = Invoke("_Thread/orphan", "hello");
+        var answer = await InvokeAsync("_Thread/orphan", "hello");
 
         answer.Should().Contain("not a valid thread path");
         answer.Should().Contain("{owner}/_Thread/{id}",

--- a/test/MeshWeaver.Content.Test/MeshWeaver.Content.Test.csproj
+++ b/test/MeshWeaver.Content.Test/MeshWeaver.Content.Test.csproj
@@ -31,7 +31,6 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
-        <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Kernel.Hub\MeshWeaver.Kernel.Hub.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />


### PR DESCRIPTION
`MeshWeaver.Content.Test` referenced `MeshWeaver.AI` for four files that are **AI tests wearing a content-suite namespace**:

| test | subject |
|---|---|
| `AgentFileParserTest` | the agent markdown / YAML front-matter parser |
| `ThreadMessageToolTest` | the `submit_message` tool's refusal contract |
| `ContributedParserPriorityTest` | that `AgentFileParser` reaches `FileFormatParserRegistry` as a **contributed** parser |
| `SpacesInFileNameTest` | quoted `@"path"` references through `MarkdownReferenceExtractor` (which lives in `MeshWeaver.AI`) |

`ContributedParserPriorityTest` is the interesting one: it reads as a platform-mechanism test, but what it actually guards is that **AI's** parser is wired. Left behind while the engine leaves, it becomes a check with no subject.

That is the "guard stays behind while its subject moves" shape — three separate instances of it turned up in this repo in one night, and each time the destination looked complete because the *code* was there and only the *check* was missing. Caught here **before** the move rather than after.

Third of thirteen test projects cleared (#2317 took the two that referenced the engine and used nothing from it).

### Verification

- `MeshWeaver.Content.Test` — **237 passed** with the reference removed.
- All **61** moved tests green in `MeshWeaver.AI.Test`.
- Full solution build under CI's flags → `0 Error(s)`.

Refs #2276

🤖 Generated with [Claude Code](https://claude.com/claude-code)