### PR TITLE
fix(local): memex-local still looked for the web clients in the platform repo

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -296,6 +296,27 @@ image_build_local() {                                  # §3 Option B
   verify_image_resolvable "$MIGRATION_IMAGE"
 }
 
+# The checkout that holds the web CLIENTS. They left the platform repo (MeshWeaver 044a85618 /
+# Plugins #665) and now live in the plugins checkout — while the .proto they generate from stays
+# in the platform's .NET tree. So this build spans TWO checkouts, and neither is assumed by name:
+# the clients repo is whichever candidate actually carries clients/portal-next/Dockerfile.
+#
+# 🚨 Probe a FILE the clients bring with them, never the directory. After the move the platform's
+# clients/grpc-web/ still had a node_modules/ and a lockfile, so `[ -d clients/grpc-web ]` was
+# still true while the package was gone — the exact reason the first failure read as ENOENT on
+# package.json rather than as a missing checkout.
+resolve_clients_repo() {
+  local p repo
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    if [ -f "$p/clients/portal-next/Dockerfile" ]; then printf '%s' "$p"; return 0; fi
+  done < <(plugin_repo_paths)
+  # Pre-move layout: a platform checkout from before 044a85618 still carries them itself.
+  repo="$(resolve_repo 2>/dev/null)" || return 1
+  if [ -f "$repo/clients/portal-next/Dockerfile" ]; then printf '%s' "$repo"; return 0; fi
+  return 1
+}
+
 # Build the Next.js React GUI image (clients/portal-next) into Colima's Docker store so k3s loads
 # it IfNotPresent. The build CONTEXT is clients/ (the app aliases @meshweaver/react +
 # @meshweaver/client-web to their SOURCE trees in ../react + ../grpc-web — see the Dockerfile).
@@ -303,24 +324,29 @@ image_build_local() {                                  # §3 Option B
 # Portal:ReactAppUrl config that lights up the opt-in "Try the new frontend" toggle. This is a
 # fast Node build (no .NET), so it runs OUTSIDE image_build_local's host-saturation lock.
 portal_next_build_local() {
-  local repo
+  local repo clients
   repo="$(resolve_repo)" || die "portal-next build needs the repo — set MEMEX_REPO to your MeshWeaver checkout"
+  clients="$(resolve_clients_repo)" || die "portal-next build needs the web clients — they live in a MeshWeaver.Plugins checkout (clients/portal-next); clone it beside your MeshWeaver checkout or set MEMEX_PLUGIN_REPOS"
   need docker docker
   need node node
   # grpc-web consumes protobuf TS generated from the mesh .proto via `buf generate` — buf +
   # protoc-gen-es are grpc-web devDeps and the .proto (src/MeshWeaver.Hosting.Grpc/Protos) lives in
-  # the .NET tree, OUTSIDE the clients/ Docker context. buf also ships glibc binaries, so we generate
-  # on the HOST (arm64 macOS) rather than inside the musl Alpine image; the output
+  # the PLATFORM tree, OUTSIDE the clients/ Docker context. buf also ships glibc binaries, so we
+  # generate on the HOST (arm64 macOS) rather than inside the musl Alpine image; the output
   # (clients/grpc-web/src/gen, gitignored) is then copied into the build context. grpc-web has no
   # committed lockfile (gitignored), so `npm install` — NOT `npm ci`.
+  #
+  # MESHWEAVER_CORE is passed explicitly: the client's own resolver (scripts/resolve-core.cjs)
+  # would otherwise fall back to guessing a side-by-side checkout, and this script already knows
+  # which platform tree it is building from.
   step "Generating grpc-web protobuf TS on the host (buf generate) for portal-next"
-  npm --prefix "$repo/clients/grpc-web" install --no-audit --no-fund
-  npm --prefix "$repo/clients/grpc-web" run gen
+  npm --prefix "$clients/clients/grpc-web" install --no-audit --no-fund
+  MESHWEAVER_CORE="$repo" npm --prefix "$clients/clients/grpc-web" run gen
   step "Building portal-next (Next.js React GUI) image → $PORTAL_NEXT_IMAGE (arm64)"
   docker build --platform linux/arm64 \
-    -f "$repo/clients/portal-next/Dockerfile" \
+    -f "$clients/clients/portal-next/Dockerfile" \
     -t "$PORTAL_NEXT_IMAGE" \
-    "$repo/clients"
+    "$clients/clients"
   ok "portal-next image built: $PORTAL_NEXT_IMAGE (visible to k3s via IfNotPresent; helm enables /next)"
 }
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-local-install-follows-the-clients.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-local-install-follows-the-clients.md
@@ -1,0 +1,31 @@
+---
+Name: The local install follows the web clients to their new home
+Category: Fix
+Description: memex-local stopped part-way through every update with "ENOENT ... clients/grpc-web/package.json". The web clients had moved to the plugins repository and the local installer was still looking for them in the platform checkout; it now finds them wherever they are.
+Icon: Laptop
+Order: -20260826
+---
+
+# The local install follows the web clients to their new home
+
+The web clients — grpc-web, portal-next and their siblings — left the platform repository for the
+plugins repository. The local installer did not hear about it, and every `memex-local update` since
+has stopped part-way through with
+
+```
+npm error enoent Could not read package.json: ENOENT: no such file or directory,
+  open '.../MeshWeaver/clients/grpc-web/package.json'
+```
+
+Two more dead paths were queued behind that one, so the Next.js frontend could not be built locally
+at all.
+
+The installer now resolves the clients and the platform separately, because they genuinely live
+apart: the protobuf definitions the clients generate from stay with the platform, and the clients
+themselves come from whichever checkout actually carries them. Neither is assumed by name — it looks
+for the file, and says plainly what to clone if it cannot find it.
+
+One detail is worth keeping in mind whenever something moves: the old directory did not disappear.
+`clients/grpc-web/` was still there afterwards, holding a `node_modules/` and a lockfile that no
+move takes with it — so "does the folder exist" would have answered yes while the package was gone.
+The installer, and the guard that now watches it, both probe for a file the move actually carries.

--- a/test/MeshWeaver.Documentation.Test/MemexLocalRepoPathGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/MemexLocalRepoPathGuard.cs
@@ -1,0 +1,117 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>Every path <c>memex-local</c> builds under the platform checkout must still be there.</b>
+///
+/// <para>The script composes absolute paths from <c>resolve_repo()</c> — <c>"$repo/clients/…"</c>,
+/// <c>"$repo/memex/aspire/…"</c> — and hands them to <c>npm</c> and <c>docker build</c>. Nothing
+/// links those strings to the tree, so when a directory MOVES the script keeps pointing at where it
+/// used to be and fails at the developer's machine rather than in CI.</para>
+///
+/// <para>That is not hypothetical: <c>044a85618</c> ("The GUI leaves the platform: the view packs
+/// and the web clients") moved every web client to MeshWeaver.Plugins and did not touch
+/// <c>deploy/homebrew/</c>. The next <c>memex-local update</c> died on
+/// <c>ENOENT … clients/grpc-web/package.json</c>, with two more dead paths queued behind it.</para>
+///
+/// <para><b>Existence on disk is NOT the check.</b> The leftover <c>clients/grpc-web/</c> still had
+/// a <c>node_modules/</c> and a lockfile after the move, so the directory was there and only the
+/// package was gone — a <c>Directory.Exists</c> guard would have passed while the script was
+/// broken. The assertions below therefore check what each COMMAND needs: an <c>npm --prefix</c>
+/// target needs a <c>package.json</c>; a <c>docker build -f</c> target needs that file.</para>
+/// </summary>
+public class MemexLocalRepoPathGuard
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    private static string Script(string root) =>
+        File.ReadAllText(Path.Combine(root, "deploy", "homebrew", "bin", "memex-local"));
+
+    private static string Under(string root, string relative) =>
+        Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+
+    /// <summary>Every <c>npm --prefix "$repo/X"</c> in the script, as X.</summary>
+    private static IEnumerable<string> NpmPrefixTargets(string script) =>
+        Regex.Matches(script, @"npm\s+--prefix\s+""\$repo/(?<path>[^""]+)""")
+            .Select(m => m.Groups["path"].Value)
+            .Distinct();
+
+    /// <summary>
+    /// Every <c>docker build -f "$repo/X"</c> in the script, as X.
+    ///
+    /// <para>🚨 <c>-f</c> is also shell's "file exists" test, and the script uses it to PROBE for
+    /// paths that may legitimately be absent — <c>[ -f "$repo/clients/portal-next/Dockerfile" ]</c>
+    /// is how it recognises a pre-move checkout. Matching every <c>-f</c> flags that probe as a
+    /// missing Dockerfile, which is a guard failing on the code written to survive the very move it
+    /// is guarding against. Test expressions are excluded by the line they sit on.</para>
+    /// </summary>
+    private static IEnumerable<string> DockerfileTargets(string script) =>
+        script.Split('\n')
+            .Where(line => !line.Contains("[ -f", StringComparison.Ordinal))
+            .SelectMany(line => Regex.Matches(line, @"-f\s+""\$repo/(?<path>[^""]+)""")
+                .Select(m => m.Groups["path"].Value))
+            .Distinct();
+
+    /// <summary>Every <c>"$repo/X"</c> naming a file with an extension — project files and the like.</summary>
+    private static IEnumerable<string> FileTargets(string script) =>
+        Regex.Matches(script, @"""\$repo/(?<path>[^""]*\.[A-Za-z0-9]+)""")
+            .Select(m => m.Groups["path"].Value)
+            .Distinct();
+
+    [Fact]
+    public void EveryNpmPrefixUnderTheRepo_HasAPackageJson()
+    {
+        var root = RepoRoot();
+        var missing = NpmPrefixTargets(Script(root))
+            .Where(p => !File.Exists(Under(root, p + "/package.json")))
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "memex-local runs `npm --prefix` against a directory in this repo that has no "
+            + "package.json — npm fails with ENOENT and the local install stops: "
+            + string.Join(", ", missing)
+            + ". If the package MOVED, point the script at the checkout that now holds it; the "
+            + "directory being present is not enough, node_modules survives a move.");
+    }
+
+    [Fact]
+    public void EveryDockerfileUnderTheRepo_Exists()
+    {
+        var root = RepoRoot();
+        var missing = DockerfileTargets(Script(root))
+            .Where(p => !File.Exists(Under(root, p)))
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "memex-local passes `docker build -f` a Dockerfile that is not in this repo: "
+            + string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void EveryFileUnderTheRepo_Exists()
+    {
+        var root = RepoRoot();
+        var missing = FileTargets(Script(root))
+            .Where(p => !File.Exists(Under(root, p)))
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "memex-local names a file under the platform checkout that is not there: "
+            + string.Join(", ", missing));
+    }
+}


### PR DESCRIPTION
## The defect

Every `memex-local update` has stopped part-way through since last night:

```
npm error enoent Could not read package.json: ENOENT: no such file or directory,
  open '.../MeshWeaver/clients/grpc-web/package.json'
```

`044a85618` ("The GUI leaves the platform: the view packs and the web clients", Plugins #665) moved
every web client to MeshWeaver.Plugins and did not touch `deploy/homebrew/`.
`portal_next_build_local()` composes its paths from `resolve_repo()`, so **all three** of its client
paths pointed at a tree that no longer holds them — grpc-web's package, portal-next's Dockerfile,
and the docker build context. The ENOENT was simply the first of the three.

## The fix

The clients and the platform genuinely live apart now: the `.proto` the clients generate from stays
in `src/MeshWeaver.Hosting.Grpc/Protos`. So this step spans two checkouts.

`resolve_clients_repo()` finds the one that actually carries `clients/portal-next/Dockerfile` —
searching the plugin checkouts the script already resolves, then the platform itself for a pre-move
layout — and `MESHWEAVER_CORE` is passed explicitly so the client's own resolver
(`scripts/resolve-core.cjs`) never has to guess which platform tree this build is for.

### Probe a file, never the directory

The old `clients/grpc-web/` is still on disk: `node_modules/` and a lockfile survive a move that
takes the package. `[ -d clients/grpc-web ]` was true the whole time the script was broken — which
is why the failure surfaced as ENOENT on `package.json` rather than as a missing checkout, and why
both the resolver and the guard probe for a file the move actually carries.

## Test first

`MemexLocalRepoPathGuard` asserts what each **command** needs, not that a path exists: an
`npm --prefix` target needs a `package.json`; a `docker build -f` target needs that file.

| | |
|---|---|
| written **before** the fix | **2 failed** — `clients/grpc-web`, `clients/portal-next/Dockerfile` |
| after the fix | **3 passed** |
| each path pointed back at the platform | its own assertion fails, naming the path |

The guard also caught a false positive in itself: `-f` is shell's file test as well as docker's flag,
so it flagged the resolver's own `[ -f … ]` probe — a guard failing on the code written to survive
the very move it guards against. Test expressions are now excluded by the line they sit on.

## Verified end to end

Not path arithmetic — the two commands that failed were run against the resolved paths:

```
npm install   → completed
npm run gen   → regenerated clients/grpc-web/src/gen/mesh_pb.ts
```

## Gates

```
MeshWeaver.Documentation.Test   58 / 58
bash -n deploy/homebrew/bin/memex-local   clean
```

Ships with a `Category: Fix` What's New entry — this is a break every local developer hits on their
next update.

## Note for reviewers

This is the second caller left behind by the client migration that I have seen today; the first was
Education's install e2e (MeshWeaver.Education#212). A move that spans repositories has callers in
both, and the ones outside the moved tree are the easy ones to miss. The guard added here covers
`memex-local` specifically, not the general case.
