### PR TITLE
fix(ai): usage satellites key on the model id, never a node path

### DIFF
--- a/src/MeshWeaver.AI/TokenUsage.cs
+++ b/src/MeshWeaver.AI/TokenUsage.cs
@@ -118,6 +118,62 @@ public static class TokenUsageNodeType
                 .WithContentType<TokenUsage>())
     };
 
+    /// <summary>The sentinel stored when no model identifier reached the recorder.</summary>
+    public const string UnknownModel = "(unknown)";
+
+    /// <summary>
+    /// The identifier a usage satellite is keyed and reported by. Pure.
+    ///
+    /// <para>🚨 <b>Why this exists.</b> <see cref="RecordUsage"/>'s callers pass
+    /// <c>actualModel ?? effectiveModel ?? request.ModelName</c>, and <c>ThreadComposer.ModelName</c>
+    /// is BY DESIGN a node PATH (its <c>[MeshNode]</c> picker persists the catalogue node's path).
+    /// Stored verbatim, a path became the key dimension beside the catalogue id that denotes the very
+    /// same model — measured in production 2026-08-26, where one DeepSeek model was recorded under
+    /// four spellings, one of them <c>_Provider/Anthropic/DeepSeek-V3-0324</c> (a path, under the
+    /// wrong provider). Usage split across rows and no catalogue lookup could price it.</para>
+    ///
+    /// <para>So a registry path is reduced to the catalogue id it denotes: the id is everything after
+    /// <c>{Registry}/{Provider}/</c>, which is exactly how the catalogue node is addressed
+    /// (<c>Provider/OpenRouter/anthropic/claude-opus-5</c> → <c>anthropic/claude-opus-5</c>). The
+    /// legacy underscore registry (<c>_Provider/…</c>) reduces the same way.</para>
+    ///
+    /// <para><b>What this deliberately does NOT do:</b> reconcile a provider's DISPLAY NAME
+    /// (<c>DeepSeek-V4-Pro</c>) with the catalogue id (<c>deepseek/deepseek-v4-pro</c>). That needs a
+    /// catalogue alias lookup, not string surgery — guessing would merge genuinely distinct models.
+    /// Everything that is not a registry path is passed through untouched.</para>
+    /// </summary>
+    /// <param name="modelId">The identifier as handed to the recorder — a catalogue id, a provider's
+    /// reported model, or a catalogue node path.</param>
+    /// <returns>The normalized identifier, or <see cref="UnknownModel"/> when none was supplied.</returns>
+    public static string NormalizeModelId(string? modelId)
+    {
+        if (string.IsNullOrWhiteSpace(modelId))
+            return UnknownModel;
+        var trimmed = modelId.Trim().Trim('/');
+        if (trimmed.Length == 0)
+            return UnknownModel;
+
+        // A registry path is {Registry}/{Provider}/{catalogue id}; the id itself may contain a
+        // slash (vendor/model), so only the first TWO segments are the address, never more.
+        var segments = trimmed.Split('/');
+        if (segments.Length > 2
+            && (segments[0].Equals("Provider", StringComparison.OrdinalIgnoreCase)
+                || segments[0].Equals("_Provider", StringComparison.OrdinalIgnoreCase)))
+            return string.Join('/', segments.Skip(2));
+
+        return trimmed;
+    }
+
+    /// <summary>
+    /// The satellite's node id for a model identifier: <see cref="NormalizeModelId"/> with every
+    /// non-alphanumeric mapped to <c>_</c>, so the key is a path-safe slug and a path keys identically
+    /// to the catalogue id it denotes. Pure.
+    /// </summary>
+    /// <param name="modelId">The identifier as handed to the recorder.</param>
+    /// <returns>The satellite node id (the <c>{modelKey}</c> in <c>{thread}/_Usage/{modelKey}</c>).</returns>
+    public static string SatelliteKey(string? modelId) =>
+        new(NormalizeModelId(modelId).Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray());
+
     /// <summary>
     /// Records ONE round's token usage onto the per-model satellite at
     /// <c>{threadPath}/_Usage/{modelKey}</c>, ACCUMULATING input/output across the thread's rounds
@@ -170,8 +226,8 @@ public static class TokenUsageNodeType
             return Observable.Return(System.Reactive.Unit.Default); // no-token round → no-op
         }
 
-        var model = string.IsNullOrWhiteSpace(modelId) ? "(unknown)" : modelId!;
-        var key = new string(model.Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray());
+        var model = NormalizeModelId(modelId);
+        var key = SatelliteKey(modelId);
         var ns = $"{threadPath}/{SatelliteSegment}";
         var usagePath = $"{ns}/{key}";
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-token-usage-model-key.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-token-usage-model-key.md
@@ -1,0 +1,15 @@
+---
+Name: Token usage is attributed to one model, not several spellings
+Category: Fix
+Description: A model selected from the picker could have its token usage recorded under a node path instead of the model id, splitting one model across several rows in the usage report.
+Icon: Database
+Order: -20260826
+---
+
+# Token usage is attributed to one model, not several spellings
+
+Token usage is recorded per model on each conversation. When a model was picked from the dropdown
+and the provider did not report back which model answered, the usage was filed under the model's
+node path rather than its identifier — so the same model showed up as two separate rows in the
+token-usage report, and the row keyed by path could not be priced. Usage is now always recorded
+under the model's identifier, whichever way the model reached the conversation.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-token-usage-model-key.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-token-usage-model-key.md
@@ -1,7 +1,7 @@
 ---
 Name: Token usage is attributed to one model, not several spellings
 Category: Fix
-Description: A model selected from the picker could have its token usage recorded under a node path instead of the model id, splitting one model across several rows in the usage report.
+Description: A model selected from the picker could have its token usage recorded under a node path instead of the model id, splitting one model across two rows in the usage report.
 Icon: Database
 Order: -20260826
 ---
@@ -11,5 +11,5 @@ Order: -20260826
 Token usage is recorded per model on each conversation. When a model was picked from the dropdown
 and the provider did not report back which model answered, the usage was filed under the model's
 node path rather than its identifier — so the same model showed up as two separate rows in the
-token-usage report, and the row keyed by path could not be priced. Usage is now always recorded
-under the model's identifier, whichever way the model reached the conversation.
+token-usage report, and the row keyed by path could not be priced. Usage is no longer keyed by that
+path: a model picked from the dropdown now records onto the same row as the model's identifier.

--- a/test/MeshWeaver.AI.Test/TokenUsageModelKeyTest.cs
+++ b/test/MeshWeaver.AI.Test/TokenUsageModelKeyTest.cs
@@ -1,0 +1,110 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the model-identifier normalization behind the per-model usage satellite
+/// (<c>{thread}/_Usage/{modelKey}</c>).
+///
+/// <para><b>The defect.</b> <see cref="TokenUsageNodeType.RecordUsage"/> stored whatever identifier
+/// its callers handed it — <c>actualModel ?? effectiveModel ?? request.ModelName</c> — and
+/// <c>ThreadComposer.ModelName</c> is BY DESIGN a node PATH (its <c>[MeshNode]</c> picker persists
+/// the catalogue node's path). So when a provider reported no serving model and no resolved model
+/// was available, a PATH became the satellite's key and its stored <c>Model</c> dimension.</para>
+///
+/// <para>Measured on memex.systemorph.com (2026-08-26): the same DeepSeek model appeared under four
+/// spellings — <c>deepseek/deepseek-v4-pro</c> (catalogue id), <c>DeepSeek-V4-Pro</c> (the provider's
+/// display name), <c>DeepSeek-V3-0324</c>, and <c>_Provider/Anthropic/DeepSeek-V3-0324</c> — a path,
+/// filed under the WRONG provider. 10% of all recorded input tokens keyed to identifiers no catalogue
+/// lookup can price, and one model's usage split across rows.</para>
+///
+/// <para><b>Scope.</b> Normalization strips the registry prefix so a path keys identically to the
+/// catalogue id it denotes. Reconciling a provider's DISPLAY NAME with the catalogue id is a
+/// catalogue-alias lookup, deliberately out of scope here — pinned below as documented behaviour so
+/// the boundary is explicit rather than accidental.</para>
+/// </summary>
+public class TokenUsageModelKeyTest
+{
+    [Fact]
+    public void ARegistryPath_IsReducedToTheCatalogueId()
+    {
+        // The catalogue node id is everything after {Registry}/{Provider}/.
+        Assert.Equal("anthropic/claude-opus-5",
+            TokenUsageNodeType.NormalizeModelId("Provider/OpenRouter/anthropic/claude-opus-5"));
+        Assert.Equal("auto", TokenUsageNodeType.NormalizeModelId("Provider/Auto/auto"));
+    }
+
+    [Fact]
+    public void TheLegacyUnderscoreRegistry_IsReducedTheSameWay()
+    {
+        // The exact value observed in production.
+        Assert.Equal("DeepSeek-V3-0324",
+            TokenUsageNodeType.NormalizeModelId("_Provider/Anthropic/DeepSeek-V3-0324"));
+    }
+
+    [Fact]
+    public void APathAndItsCatalogueId_ProduceTheSameSatelliteKey()
+    {
+        // The regression that matters: both spellings must accumulate onto ONE satellite.
+        Assert.Equal(
+            TokenUsageNodeType.SatelliteKey("anthropic/claude-opus-5"),
+            TokenUsageNodeType.SatelliteKey("Provider/OpenRouter/anthropic/claude-opus-5"));
+    }
+
+    [Fact]
+    public void APlainCatalogueId_IsUntouched()
+    {
+        Assert.Equal("anthropic/claude-opus-5",
+            TokenUsageNodeType.NormalizeModelId("anthropic/claude-opus-5"));
+        Assert.Equal("deepseek/deepseek-v4-pro",
+            TokenUsageNodeType.NormalizeModelId("deepseek/deepseek-v4-pro"));
+    }
+
+    [Fact]
+    public void AProviderDisplayName_IsLeftAlone_TheDocumentedBoundary()
+    {
+        // Mapping "DeepSeek-V4-Pro" onto "deepseek/deepseek-v4-pro" needs a catalogue alias lookup,
+        // NOT string surgery — guessing here would merge genuinely distinct models.
+        Assert.Equal("DeepSeek-V4-Pro", TokenUsageNodeType.NormalizeModelId("DeepSeek-V4-Pro"));
+        Assert.Equal("gpt-5.2", TokenUsageNodeType.NormalizeModelId("gpt-5.2"));
+    }
+
+    [Fact]
+    public void OnlyTheRegistryPrefix_IsStripped_NeverAnIdThatMerelyResemblesOne()
+    {
+        // A two-segment id is a catalogue id (vendor/model), not a path — stripping it would
+        // destroy the identifier.
+        Assert.Equal("providers/some-model",
+            TokenUsageNodeType.NormalizeModelId("providers/some-model"));
+        Assert.Equal("x-ai/grok-4.6", TokenUsageNodeType.NormalizeModelId("x-ai/grok-4.6"));
+    }
+
+    [Fact]
+    public void AbsentOrBlank_StaysTheUnknownSentinel()
+    {
+        Assert.Equal("(unknown)", TokenUsageNodeType.NormalizeModelId(null));
+        Assert.Equal("(unknown)", TokenUsageNodeType.NormalizeModelId("   "));
+    }
+
+    [Fact]
+    public void SurroundingWhitespaceAndSlashes_DoNotForkTheKey()
+    {
+        Assert.Equal("anthropic/claude-opus-5",
+            TokenUsageNodeType.NormalizeModelId("  /Provider/OpenRouter/anthropic/claude-opus-5/ "));
+        Assert.Equal(
+            TokenUsageNodeType.SatelliteKey("anthropic/claude-opus-5"),
+            TokenUsageNodeType.SatelliteKey(" anthropic/claude-opus-5 "));
+    }
+
+    [Fact]
+    public void TheKeyStaysAPathSafeSlug()
+    {
+        // The key is a node id — no slashes, no dots; the existing scheme maps every
+        // non-alphanumeric to '_' and must keep doing so.
+        Assert.Equal("anthropic_claude_opus_5",
+            TokenUsageNodeType.SatelliteKey("anthropic/claude-opus-5"));
+        Assert.Equal("z_ai_glm_5_3", TokenUsageNodeType.SatelliteKey("z-ai/glm-5.3"));
+    }
+}


### PR DESCRIPTION
## The bug

`TokenUsageNodeType.RecordUsage` stored whatever identifier its callers handed it. Those callers pass `actualModel ?? effectiveModel ?? request.ModelName`, and **`ThreadComposer.ModelName` is by design a node PATH** — its `[MeshNode]` picker persists the catalogue node's path, not the model id. So a round whose provider reported no serving model, with no resolved model available, keyed its usage satellite by path: the same model then occupied two rows in the usage report, and the path-keyed one matched no catalogue entry, so it could not be priced.

## Evidence

Measured on memex.systemorph.com on 2026-08-26 by rolling up the `{thread}/_Usage/{model}` satellites (16 threads readable, 14 satellites). One DeepSeek model was recorded under **four** spellings:

| recorded `Model` | what it is |
|---|---|
| `deepseek/deepseek-v4-pro` | the catalogue id — correct |
| `DeepSeek-V4-Pro` | the provider's reported display name |
| `DeepSeek-V3-0324` | a bare id, no catalogue entry |
| `_Provider/Anthropic/DeepSeek-V3-0324` | **a node path** — and under the wrong provider |

665K tokens — 10% of all recorded input — keyed to identifiers no catalogue lookup can resolve.

## The change

- **`NormalizeModelId`** (pure) reduces a registry path to the catalogue id it denotes: the id is everything after `{Registry}/{Provider}/`, and may itself contain a slash (`Provider/OpenRouter/anthropic/claude-opus-5` → `anthropic/claude-opus-5`). The legacy `_Provider/` spelling reduces the same way.
- **`SatelliteKey`** (pure) slugs it with the existing non-alphanumeric → `_` scheme, so a path and its catalogue id accumulate onto **one** satellite.
- `RecordUsage` uses both — one place, covering all three call sites in `ThreadExecution`.

## Deliberately out of scope

Reconciling a provider's **display name** (`DeepSeek-V4-Pro`) with the catalogue id (`deepseek/deepseek-v4-pro`) needs a catalogue alias lookup, not string surgery — guessing there would merge genuinely distinct models. A test pins that pass-through so the boundary is explicit rather than accidental. This fixes 2 of the 4 spellings above.

Existing satellites keep their historical keys: this changes what is written from here on, not the recorded past. A migration for the old rows would be separate.

## Tests — written first

Nine cases in `TokenUsageModelKeyTest`, red before the implementation (neither helper existed): registry-path reduction, the legacy `_Provider/` spelling, path-and-id producing the same key, plain catalogue ids untouched, the display-name boundary, no over-stripping of a two-segment id, the `(unknown)` sentinel, whitespace/slash tolerance, and the key staying a path-safe slug.

- `TokenUsage` tests: **19/19**.
- Full `MeshWeaver.AI.Test`: **1309 passed, 0 failed, 3 skipped**.
- Mutation check (against a *verified* build — the first attempt was a false pass off a stale DLL): disabling the prefix reduction fails 4 of the 9.
- `-c Release -warnaserror` clean for `MeshWeaver.AI` and the test project.

What's New entry included (`Category: Fix`).

## Not a bug — checked and withdrawn

While investigating I also suspected the `TokenUsage` satellites were missing from the search index. They are not: the type declares `ExcludeFromContext = {"search","create","content"}` and is `IsSatelliteType`, so exclusion from search is intended, exactly as for Activity/Comment. The admin token-usage tab and the thread token chip read through workspace synced queries, which are unaffected. No change proposed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
