### PR TITLE
The release fact: one published package, recorded rather than inferred

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/Release.cs
+++ b/src/MeshWeaver.Mesh.Contract/Release.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// One published package, recorded as a durable fact rather than inferred from a notification.
+///
+/// <para>🚨 This exists because the release BROADCAST is deliberately reporter-class:
+/// <c>FrameworkReleaseBroadcaster</c>'s contract is that "a lost dispatch costs at most one delayed
+/// rebake wave — never a hard failure". That property is only safe while nobody accumulates state
+/// from the dispatches. A consumer that built its dependency set by adding up events would be
+/// permanently wrong after ONE lost dispatch, and nothing would report it — the failure would
+/// present as "that repo just never rebuilt".</para>
+///
+/// <para>So the event is a WAKE-UP and this node is the TRUTH: on wake a consumer QUERIES the
+/// current release facts rather than remembering what it was told. A lost event then costs latency,
+/// never correctness — the same rule as the delivery verdict refusing to pass on an empty verdict,
+/// and as CD's reconciler asking the registry whether a commit's image set is complete rather than
+/// trusting that a job ran.</para>
+///
+/// <para>One fact per PACKAGE, never one per repo: a repo that ships several packages publishes
+/// several, and a platform rebuild publishes the platform plus every package rebuilt against it.</para>
+/// </summary>
+public record Release
+{
+    /// <summary>Stable identity of this fact: <c>{Repository}/{PackageId}/{Version}</c>.</summary>
+    [Browsable(false)]
+    [Key]
+    public string Id { get; init; } = null!;
+
+    /// <summary>The repository that published it, as <c>owner/name</c>.</summary>
+    [Description("The repository that published this package.")]
+    public string Repository { get; init; } = null!;
+
+    /// <summary>The package identifier, e.g. <c>MeshWeaver.Blazor.EntityViews</c>.</summary>
+    [Description("The published package identifier.")]
+    public string PackageId { get; init; } = null!;
+
+    /// <summary>The published version.</summary>
+    [Description("The published version.")]
+    public string Version { get; init; } = null!;
+
+    /// <summary>
+    /// The framework identity these bytes were built against.
+    ///
+    /// <para>Not decoration: bundles are ADOPTED, not rebuilt, and a consumer can only adopt bytes
+    /// built against a framework identity it can resolve. This is the same equality
+    /// <c>BakeEquivalenceTest</c> pins between the bake and the gate, carried on the fact so a
+    /// consumer can check it without re-deriving it.</para>
+    /// </summary>
+    [Description("The framework identity these bytes were built against.")]
+    public string? Platform { get; init; }
+
+    /// <summary>The commit the package was built from.</summary>
+    [Description("The commit this package was built from.")]
+    public string? Commit { get; init; }
+
+    /// <summary>When the publication was OBSERVED — never when a job started.</summary>
+    [Description("When the publication was observed.")]
+    public DateTime Released { get; init; }
+
+    /// <summary>
+    /// The stable id for a package release. Deliberately derived rather than random: the same
+    /// publication observed twice (a redelivered webhook, a reconciler sweep) must land on the SAME
+    /// node instead of minting a duplicate fact. Idempotent ingest is what lets the wake-up be
+    /// unreliable without the truth becoming unreliable too.
+    /// </summary>
+    public static string IdFor(string repository, string packageId, string version) =>
+        $"{repository}/{packageId}/{version}";
+}

--- a/src/MeshWeaver.Mesh.Contract/Release.cs
+++ b/src/MeshWeaver.Mesh.Contract/Release.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using MeshWeaver.Messaging;
 
 namespace MeshWeaver.Mesh;
 
@@ -31,14 +32,17 @@ public record Release
 
     /// <summary>The repository that published it, as <c>owner/name</c>.</summary>
     [Description("The repository that published this package.")]
+    [Translation("de", "Das Repository, das dieses Paket veröffentlicht hat.")]
     public string Repository { get; init; } = null!;
 
     /// <summary>The package identifier, e.g. <c>MeshWeaver.Blazor.EntityViews</c>.</summary>
     [Description("The published package identifier.")]
+    [Translation("de", "Die Kennung des veröffentlichten Pakets.")]
     public string PackageId { get; init; } = null!;
 
     /// <summary>The published version.</summary>
     [Description("The published version.")]
+    [Translation("de", "Die veröffentlichte Version.")]
     public string Version { get; init; } = null!;
 
     /// <summary>
@@ -50,14 +54,17 @@ public record Release
     /// consumer can check it without re-deriving it.</para>
     /// </summary>
     [Description("The framework identity these bytes were built against.")]
+    [Translation("de", "Die Framework-Identität, gegen die diese Bytes gebaut wurden.")]
     public string? Platform { get; init; }
 
     /// <summary>The commit the package was built from.</summary>
     [Description("The commit this package was built from.")]
+    [Translation("de", "Der Commit, aus dem dieses Paket gebaut wurde.")]
     public string? Commit { get; init; }
 
     /// <summary>When the publication was OBSERVED — never when a job started.</summary>
     [Description("When the publication was observed.")]
+    [Translation("de", "Wann die Veröffentlichung beobachtet wurde.")]
     public DateTime Released { get; init; }
 
     /// <summary>
@@ -67,5 +74,17 @@ public record Release
     /// unreliable without the truth becoming unreliable too.
     /// </summary>
     public static string IdFor(string repository, string packageId, string version) =>
-        $"{repository}/{packageId}/{version}";
+        // 🚨 Repository and package id are NORMALIZED; version is not.
+        //
+        // GitHub repositories are case-insensitive — RepoIdentity.Matches compares Owner and Repo
+        // with OrdinalIgnoreCase — and so are NuGet package ids. Composing the key from raw strings
+        // would let "Systemorph/MeshWeaver" and "systemorph/meshweaver" mint TWO facts for ONE
+        // publication, which is precisely the duplication this derived id exists to prevent: the
+        // whole reason ingest can tolerate an unreliable wake-up is that observing the same
+        // publication twice lands on the same node.
+        //
+        // The VERSION is deliberately left alone. SemVer states that pre-release identifiers are
+        // case-sensitive, so "1.0.0-RC1" and "1.0.0-rc1" are different versions and folding them
+        // would merge two genuinely distinct releases — the opposite failure, and the worse one.
+        $"{repository.ToLowerInvariant()}/{packageId.ToLowerInvariant()}/{version}";
 }

--- a/test/MeshWeaver.Messaging.Hub.Test/ReleaseFactTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/ReleaseFactTest.cs
@@ -1,0 +1,61 @@
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// The release fact's identity is what makes ingest idempotent, and idempotent ingest is what lets
+/// the release BROADCAST stay unreliable without the truth becoming unreliable too. A webhook that
+/// redelivers, a reconciler that sweeps, two silos that both observe one publication — all must land
+/// on ONE node.
+/// </summary>
+public class ReleaseFactTest
+{
+    [Fact]
+    public void IdFor_IsStableAcrossObservationsOfOnePublication()
+    {
+        // The same publication observed twice — a redelivered webhook, a reconciler sweep — must
+        // resolve to the same node, or the truth accumulates duplicates exactly where it is supposed
+        // to be authoritative.
+        var first = Release.IdFor("Systemorph/MeshWeaver.Plugins", "MeshWeaver.Blazor.EntityViews", "3.0.0-rc8.ci.5432");
+        var second = Release.IdFor("Systemorph/MeshWeaver.Plugins", "MeshWeaver.Blazor.EntityViews", "3.0.0-rc8.ci.5432");
+
+        Assert.Equal(first, second);
+    }
+
+    [Theory]
+    // one package, two versions — a new release, not a restatement of the old one
+    [InlineData("Systemorph/MeshWeaver.Plugins", "MeshWeaver.Blazor.EntityViews", "3.0.0-rc8.ci.5433")]
+    // same package NAME from a different repo — a distinct artefact that must not collide
+    [InlineData("Systemorph/MeshWeaver", "MeshWeaver.Blazor.EntityViews", "3.0.0-rc8.ci.5432")]
+    // same repo and version, different package — a repo publishes SEVERAL facts per release
+    [InlineData("Systemorph/MeshWeaver.Plugins", "MeshWeaver.Blazor.Radzen", "3.0.0-rc8.ci.5432")]
+    public void IdFor_SeparatesFactsThatMustNotCollide(string repository, string packageId, string version)
+    {
+        var baseline = Release.IdFor("Systemorph/MeshWeaver.Plugins", "MeshWeaver.Blazor.EntityViews", "3.0.0-rc8.ci.5432");
+
+        Assert.NotEqual(baseline, Release.IdFor(repository, packageId, version));
+    }
+
+    [Fact]
+    public void Platform_IsCarriedOnTheFact_NotDerivedByTheConsumer()
+    {
+        // Bundles are ADOPTED, not rebuilt, so a consumer can only adopt bytes built against a
+        // framework identity it can resolve. Carrying it on the fact is what lets the consumer check
+        // rather than re-derive — the #1814 failure was two hosts resolving two identities for one
+        // commit, with nothing comparing them.
+        var release = new Release
+        {
+            Id = Release.IdFor("Systemorph/MeshWeaver.Plugins", "MeshWeaver.Blazor.Radzen", "3.0.0-rc8.ci.5432"),
+            Repository = "Systemorph/MeshWeaver.Plugins",
+            PackageId = "MeshWeaver.Blazor.Radzen",
+            Version = "3.0.0-rc8.ci.5432",
+            Platform = "s4d400050c6d76f830c95d0a21e56febc",
+            Commit = "dbdbebc4e",
+            Released = new DateTime(2026, 8, 26, 8, 0, 0, DateTimeKind.Utc)
+        };
+
+        Assert.Equal("s4d400050c6d76f830c95d0a21e56febc", release.Platform);
+        Assert.Equal(release.Id, Release.IdFor(release.Repository, release.PackageId, release.Version));
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/ReleaseFactTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/ReleaseFactTest.cs
@@ -24,6 +24,34 @@ public class ReleaseFactTest
     }
 
     [Theory]
+    // GitHub repositories are case-insensitive (cf. RepoIdentity.Matches, which compares Owner and
+    // Repo with OrdinalIgnoreCase), and so are NuGet package ids. Two observations of ONE
+    // publication that differ only in casing must not mint two facts — that duplication is exactly
+    // what the derived id exists to prevent.
+    [InlineData("systemorph/meshweaver.plugins", "MeshWeaver.Blazor.EntityViews")]
+    [InlineData("Systemorph/MeshWeaver.Plugins", "meshweaver.blazor.entityviews")]
+    [InlineData("SYSTEMORPH/MESHWEAVER.PLUGINS", "MESHWEAVER.BLAZOR.ENTITYVIEWS")]
+    public void IdFor_IsCaseInsensitiveOnRepositoryAndPackage(string repository, string packageId)
+    {
+        var canonical = Release.IdFor(
+            "Systemorph/MeshWeaver.Plugins", "MeshWeaver.Blazor.EntityViews", "3.0.0-rc8.ci.5432");
+
+        Assert.Equal(canonical, Release.IdFor(repository, packageId, "3.0.0-rc8.ci.5432"));
+    }
+
+    [Fact]
+    public void IdFor_KeepsVersionCaseSensitive()
+    {
+        // SemVer states pre-release identifiers ARE case-sensitive, so 1.0.0-RC1 and 1.0.0-rc1 are
+        // genuinely different versions. Folding them would merge two distinct releases into one
+        // fact — the opposite failure to the one above, and the worse of the two.
+        var lower = Release.IdFor("Systemorph/MeshWeaver", "MeshWeaver.Blazor", "1.0.0-rc1");
+        var upper = Release.IdFor("Systemorph/MeshWeaver", "MeshWeaver.Blazor", "1.0.0-RC1");
+
+        Assert.NotEqual(lower, upper);
+    }
+
+    [Theory]
     // one package, two versions — a new release, not a restatement of the old one
     [InlineData("Systemorph/MeshWeaver.Plugins", "MeshWeaver.Blazor.EntityViews", "3.0.0-rc8.ci.5433")]
     // same package NAME from a different repo — a distinct artefact that must not collide


### PR DESCRIPTION
First implementable piece of the release event bus (contract: #2328). **One record, one test, no behaviour yet** — the ingest branch and the dependency gate build on this.

## Why a durable node and not just the event

The release broadcast is deliberately **reporter-class**. `FrameworkReleaseBroadcaster`'s own contract:

> *"a lost dispatch costs at most one delayed rebake wave — never a hard failure"*

That property is only safe while **nobody accumulates state from the dispatches**. A consumer that built its dependency set by adding up events would be permanently wrong after **one** lost dispatch, and nothing would report it — the failure would present as *"that repo just never rebuilt"*.

> **The event is a WAKE-UP. This node is the TRUTH.**

A consumer queries rather than remembers, so a lost event costs latency instead of correctness. Same rule as `delivery-verdict` refusing to pass on an empty verdict (#2311), and as CD's reconciler asking the registry whether a commit's image set is complete rather than trusting that a job ran.

## Two design points that carry weight

**`IdFor` is derived, not random.** The same publication observed twice — a redelivered webhook, a reconciler sweep, two silos both seeing it — must land on **one** node. Idempotent ingest is precisely what lets the wake-up be unreliable without the truth becoming unreliable too. Pinned by tests in both directions: stable across repeat observations, and separating facts that must not collide (same package different version, same package different repo, same release different package).

**`Platform` is carried on the fact, not re-derived per consumer.** Bundles are **adopted, not rebuilt**, so a consumer can only adopt bytes whose framework identity it can resolve. #1814 was two hosts resolving two identities for one commit with nothing comparing them — carrying it lets a consumer check rather than reconstruct.

## Shape

One fact per **package**, never one per repo: a repo shipping several publishes several, and a platform rebuild publishes the platform version plus everything rebuilt against it.

`5/5`, `-c Release -warnaserror` clean.