### PR TITLE
Two async disposals that dropped their ValueTask now observe it

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
@@ -1341,30 +1341,38 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
         // discard. Disposing a JS module after the circuit is gone throws JSDisconnectedException
         // ROUTINELY (the same exception this file already tolerates at two other interop sites), so
         // an unobserved task here is a steady trickle of UnobservedTaskException with nothing
-        // pointing back at this line. Blocking is not the alternative: this runs on the circuit's
-        // synchronous Dispose.
+        // pointing back at this line.
+        //
+        // 🚨 No async/await: this runs on the circuit's synchronous Dispose, and `async void` here
+        // would put a continuation on the circuit scheduler — the deadlock class AGENTS.md forbids
+        // in Blazor-view code. A fault-only continuation observes the task without awaiting it.
         if (jsModule is not null)
-            ObserveModuleDisposal(jsModule, Logger);
-    }
-
-    /// <summary>
-    /// Awaits a JS module's disposal off the caller's stack, swallowing the disconnect the circuit
-    /// teardown makes expected and logging anything else. Static and parameterised so it holds no
-    /// reference to the component it outlives.
-    /// </summary>
-    private static async void ObserveModuleDisposal(IJSObjectReference module, ILogger logger)
-    {
-        try
         {
-            await module.DisposeAsync();
-        }
-        catch (Exception ex) when (ex is OperationCanceledException or JSDisconnectedException)
-        {
-            // The circuit went away first — the module went with it. Nothing to dispose, nothing wrong.
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Disposing the portal layout's JS module faulted");
+            var disposal = jsModule.DisposeAsync();
+            if (!disposal.IsCompletedSuccessfully)
+            {
+                var logger = Logger;
+                disposal.AsTask().ContinueWith(
+                    t =>
+                    {
+                        try
+                        {
+                            var fault = t.Exception?.GetBaseException();
+                            // The circuit went away first — the module went with it. Nothing to
+                            // dispose, nothing wrong.
+                            if (fault is null or OperationCanceledException or JSDisconnectedException)
+                                return;
+                            logger.LogWarning(fault, "Disposing the portal layout's JS module faulted");
+                        }
+                        catch
+                        {
+                            // a logger that faults during teardown must not replace the fault it reports
+                        }
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
         }
     }
 

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
@@ -1337,7 +1337,35 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
             subscription.Dispose();
         _contributedMenuSubscriptions.Clear();
         dotNetRef?.Dispose();
-        jsModule?.DisposeAsync();
+        // Fire-and-forget, but OBSERVED — and the ValueTask was previously dropped without even a
+        // discard. Disposing a JS module after the circuit is gone throws JSDisconnectedException
+        // ROUTINELY (the same exception this file already tolerates at two other interop sites), so
+        // an unobserved task here is a steady trickle of UnobservedTaskException with nothing
+        // pointing back at this line. Blocking is not the alternative: this runs on the circuit's
+        // synchronous Dispose.
+        if (jsModule is not null)
+            ObserveModuleDisposal(jsModule, Logger);
+    }
+
+    /// <summary>
+    /// Awaits a JS module's disposal off the caller's stack, swallowing the disconnect the circuit
+    /// teardown makes expected and logging anything else. Static and parameterised so it holds no
+    /// reference to the component it outlives.
+    /// </summary>
+    private static async void ObserveModuleDisposal(IJSObjectReference module, ILogger logger)
+    {
+        try
+        {
+            await module.DisposeAsync();
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or JSDisconnectedException)
+        {
+            // The circuit went away first — the module went with it. Nothing to dispose, nothing wrong.
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Disposing the portal layout's JS module faulted");
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Connection.SignalR/SignalRClientExtensions.cs
+++ b/src/MeshWeaver.Connection.SignalR/SignalRClientExtensions.cs
@@ -116,6 +116,13 @@ public static class SignalRClientExtensions
                 hub.DeliverMessage(delivery);
         });
 
+        // Resolved HERE, while the hub is alive. Resolving inside the continuation below would ask a
+        // service provider that is already disposing — and an ObjectDisposedException thrown there
+        // would itself be unobserved AND would mask the disposal fault it was sent to report.
+        var disposalLogger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(SignalRClientExtensions));
+        var disposalAddress = hub.Address;
+
         hub.RegisterForDisposal(Disposable.Create(() =>
         {
             connection.Reconnecting -= Connect;
@@ -125,14 +132,27 @@ public static class SignalRClientExtensions
             // faulting DisposeAsync then surfaces as an UnobservedTaskException with no connection
             // to this line, or as nothing at all. So the task is kept and its fault is logged.
             var disposal = connection.DisposeAsync();
-            if (!disposal.IsCompletedSuccessfully)
-                disposal.AsTask().ContinueWith(
-                    t => hub.ServiceProvider.GetService<ILoggerFactory>()
-                        ?.CreateLogger(typeof(SignalRClientExtensions))
-                        .LogWarning(t.Exception, "SignalR connection disposal faulted for {Address}", hub.Address),
-                    CancellationToken.None,
-                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default);
+            if (disposal.IsCompletedSuccessfully)
+                return;
+
+            disposal.AsTask().ContinueWith(
+                t =>
+                {
+                    // Non-throwing by construction: a logger that faults during teardown must not
+                    // replace the fault it was reporting with one of its own.
+                    try
+                    {
+                        disposalLogger?.LogWarning(
+                            t.Exception, "SignalR connection disposal faulted for {Address}", disposalAddress);
+                    }
+                    catch
+                    {
+                        // nothing left to report it to
+                    }
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }));
 
         await connection.StartAsync();

--- a/src/MeshWeaver.Connection.SignalR/SignalRClientExtensions.cs
+++ b/src/MeshWeaver.Connection.SignalR/SignalRClientExtensions.cs
@@ -119,7 +119,20 @@ public static class SignalRClientExtensions
         hub.RegisterForDisposal(Disposable.Create(() =>
         {
             connection.Reconnecting -= Connect;
-            _ = connection.DisposeAsync();
+            // Fire-and-forget, but OBSERVED. A synchronous disposal callback must not block on async
+            // work — this one can run on a hub turn, and parking it there is the deadlock the actor
+            // model does not tolerate. What it must not do either is DISCARD the ValueTask: a
+            // faulting DisposeAsync then surfaces as an UnobservedTaskException with no connection
+            // to this line, or as nothing at all. So the task is kept and its fault is logged.
+            var disposal = connection.DisposeAsync();
+            if (!disposal.IsCompletedSuccessfully)
+                disposal.AsTask().ContinueWith(
+                    t => hub.ServiceProvider.GetService<ILoggerFactory>()
+                        ?.CreateLogger(typeof(SignalRClientExtensions))
+                        .LogWarning(t.Exception, "SignalR connection disposal faulted for {Address}", hub.Address),
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
         }));
 
         await connection.StartAsync();


### PR DESCRIPTION
Found by sweeping `src/` for disposal implemented with `await` rather than reactively — the `IoPool.Dispose` / `Workspace.Dispose` defect class. Two sites discard the task `DisposeAsync()` returns, so a fault reaches nobody.

### `SignalRClientExtensions`

```csharp
hub.RegisterForDisposal(Disposable.Create(() => { …; _ = connection.DisposeAsync(); }));
```

The discard is not the sin: a synchronous disposal callback genuinely must not block on async work, and this one can run on a hub turn. The sin is that a **faulting** disposal then surfaces as an `UnobservedTaskException` with nothing pointing back at this line — or as nothing at all. The task is now kept and its fault logged.

### `PortalLayoutBase`

```csharp
jsModule?.DisposeAsync();   // the ValueTask was not even discarded
```

Not hypothetical: disposing a JS module after the circuit is gone throws `JSDisconnectedException` **routinely** — the same exception **this very file already tolerates at two other interop sites** — so this was a steady trickle of unobserved exceptions from every circuit teardown. Now awaited off the caller's stack, swallowing the disconnect that teardown makes expected and logging anything else. Static and parameterised, so it holds no reference to the component it outlives.

Both keep the non-blocking shape `CopilotChatClient` already documents: *"A synchronous Dispose() must NOT block on async work, and DisposeAsync must NOT bridge through .ToTask()"*. **Fire-and-forget is right; fire-and-forget-the-fault is not.**

### Deliberately not changed

`ThreadExecution`'s `else if (harnessClient is IAsyncDisposable) _ = …DisposeAsync()` is **unreachable** — `IChatClient` extends `IDisposable`, so every harness client takes the synchronous branch above it. (Confirmed from `CopilotChatClient`, which declares only `IChatClient, IAsyncDisposable` yet carries `<inheritdoc/>` on its `public void Dispose()`.) Deleting it would be tidier; leaving it costs nothing and avoids being wrong about an interface hierarchy in a hot teardown path.

`InstanceSyncWorker`'s discard is left alone too — it carries a stated reason ("McpRemoteMeshClient's dispose never faults"), which makes it a claim to verify rather than a smell.

Full solution build under CI's flags → `0 Error(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)