### PR TITLE
refactor(test): split the AI-menu pin so the portal suite stops referencing MeshWeaver.AI

### DIFF
--- a/src/MeshWeaver.AI/InternalsVisibleTo.cs
+++ b/src/MeshWeaver.AI/InternalsVisibleTo.cs
@@ -2,8 +2,3 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("MeshWeaver.Threading.Test")]
 [assembly: InternalsVisibleTo("MeshWeaver.Hosting.Orleans.Test")]
-
-// The AI menu entries are asserted against the PORTAL shell they integrate with, so that suite
-// spans both halves and needs the seed list (#2276). A test project may see the module's internals;
-// the platform may not reference it at all, which is the invariant that matters.
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Memex.Portal.Shared.Test")]

--- a/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
+++ b/test/Memex.Portal.Shared.Test/AiMenuNewThreadTest.cs
@@ -1,4 +1,3 @@
-using MeshWeaver.AI.Portal;
 using MeshWeaver.Blazor.Portal.Layout;
 using MeshWeaver.Graph;
 using Xunit;
@@ -27,14 +26,14 @@ public class AiMenuNewThreadTest
 
         // Order 0 → it sorts ahead of every other AI entry (Threads 10, Models 20, …). The menu
         // aggregator inserts into an ImmutableSortedSet keyed on Order, so this IS the positioning
-        // contract — there is no post-hoc OrderBy to fall back on. The navigation entries live in
-        // AiMenuContributions.Seeds now (WS7 slice 3), so the ordering contract spans both lists.
+        // contract — there is no post-hoc OrderBy to fall back on.
+        //
+        // 🚨 This is the portal's HALF of the ordering contract. The navigation entries are seeded
+        // UiContribution nodes contributed by the MeshWeaver.AI module; their complement (every seed
+        // is Order > 0, so all of them sort behind this one) is pinned by
+        // MeshWeaver.AI.Test.AiMenuContributionsTest. Disjoint Order ranges are what let the two
+        // halves add up to the whole contract without either test referencing the other's assembly.
         Assert.Equal(0, newThread.Order);
-        Assert.All(
-            AiMenuContributions.Seeds,
-            seed => Assert.True(
-                Assert.IsType<MeshWeaver.Graph.Configuration.UiContribution>(seed.Content).Order > 0,
-                $"'{seed.Name}' must sort after New thread"));
     }
 
     [Fact]
@@ -75,37 +74,17 @@ public class AiMenuNewThreadTest
     }
 
     [Fact]
-    public void Every_Other_AiMenu_Entry_Navigates_By_Href()
+    public void Only_The_Imperative_Entry_Stays_Compiled()
     {
-        // The inverse of the sentinel contract: everything that is NOT the imperative entry must be
-        // a plain navigation, so it works identically from any page and needs no client state.
-        // Those entries are seeded UiContribution nodes (WS7 slice 3) — data, because they carry no
-        // behavior; only the imperative "New thread" stays in the compiled list.
-        Assert.Single(MemexConfiguration.AiMenuItems);
-        Assert.NotEmpty(AiMenuContributions.Seeds);
-        Assert.All(AiMenuContributions.Seeds, seed =>
-        {
-            var contribution = Assert.IsType<MeshWeaver.Graph.Configuration.UiContribution>(seed.Content);
-            Assert.Equal("AI", contribution.Context);
-            Assert.False(string.IsNullOrEmpty(contribution.Href), $"'{seed.Name}' must navigate by Href");
-            Assert.False(string.IsNullOrEmpty(contribution.LabelKey), $"'{seed.Name}' must localize its label");
-        });
-    }
-
-    [Fact]
-    public void AiMenu_Entries_Are_Uniquely_Keyed()
-    {
-        // The aggregator dedupes on (Order, Label, Area) via ImmutableSortedSet — two entries
-        // colliding on all three would silently drop one from the rendered menu. Spans the compiled
-        // imperative entry AND the seeded navigation contributions.
-        var keys = MemexConfiguration.AiMenuItems
-            .Select(i => (i.Order, Label: (string?)i.Label, Area: (string?)i.Area))
-            .Concat(AiMenuContributions.Seeds.Select(s =>
-            {
-                var c = Assert.IsType<MeshWeaver.Graph.Configuration.UiContribution>(s.Content);
-                return (c.Order, Label: c.Label, Area: c.Area);
-            }))
-            .ToList();
-        Assert.Equal(keys.Count, keys.Distinct().Count());
+        // The compiled list holds exactly ONE entry, and it is the imperative sentinel. Everything
+        // that is merely a navigation is contributed as DATA (seeded UiContribution nodes from the
+        // MeshWeaver.AI module) precisely because it carries no behavior — so a second compiled entry
+        // appearing here means someone expressed a link as code when the contribution lane would do.
+        //
+        // 🚨 The seeds' own contract (Href + LabelKey present, unique keys, Order > 0) is pinned by
+        // MeshWeaver.AI.Test.AiMenuContributionsTest. Asserting it here would reintroduce a
+        // compile-time dependency from the portal onto the module.
+        var only = Assert.Single(MemexConfiguration.AiMenuItems);
+        Assert.Equal(PortalLayoutBase.AiNewThreadAction, only.Area);
     }
 }

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -23,10 +23,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\memex\Memex.Portal.Shared\Memex.Portal.Shared.csproj" />
-    <!-- This SUITE spans both halves: it asserts the AI menu entries integrate with the
-         portal shell. A TEST project may reference the module; the PLATFORM may not,
-         which is the whole point of #2276. -->
-    <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <!-- MapDefaultEndpoints / MapVersionEndpoint live here, beside /health and /alive. -->
     <ProjectReference Include="..\..\memex\aspire\Memex.Portal.ServiceDefaults\Memex.Portal.ServiceDefaults.csproj" />
     <!-- DbVersionHealthCheckTest drives the portal's own db_version health check: whether a

--- a/test/MeshWeaver.AI.Test/AiMenuContributionsTest.cs
+++ b/test/MeshWeaver.AI.Test/AiMenuContributionsTest.cs
@@ -1,0 +1,64 @@
+using MeshWeaver.AI.Portal;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the AI (✨) menu's NAVIGATION half — the seeded <see cref="UiContribution"/> nodes this
+/// module contributes. Its complement lives in <c>Memex.Portal.Shared.Test.AiMenuNewThreadTest</c>,
+/// which pins the ONE compiled imperative entry ("New thread") the portal keeps.
+/// <para>
+/// 🚨 The two halves are deliberately asserted SEPARATELY, and the seam is the Order value. The
+/// portal's imperative entry is Order 0; every seed here is Order &gt; 0. That single fact is what
+/// makes the split lossless: the aggregator dedupes on (Order, Label, Area), so two entries drawn
+/// from disjoint Order ranges can never collide, and neither test needs to reference the other
+/// side's assembly to prove it. Before the AI engine became a module both halves were asserted in
+/// one portal-side test, which meant the portal's test project had a compile-time dependency on
+/// MeshWeaver.AI — the very edge the module lane exists to remove.
+/// </para>
+/// </summary>
+public class AiMenuContributionsTest
+{
+    [Fact]
+    public void Every_Seed_Sorts_After_The_Imperative_Entry()
+    {
+        // Order > 0 is this side's half of the ordering contract: "New thread" holds Order 0 in the
+        // portal, so anything seeded here sorts behind it no matter what else is contributed.
+        Assert.NotEmpty(AiMenuContributions.Seeds);
+        Assert.All(AiMenuContributions.Seeds, seed => Assert.True(
+            Assert.IsType<UiContribution>(seed.Content).Order > 0,
+            $"'{seed.Name}' must sort after the imperative 'New thread' entry (Order 0)"));
+    }
+
+    [Fact]
+    public void Every_Seed_Navigates_By_Href_And_Localizes_Its_Label()
+    {
+        // The inverse of the portal's sentinel contract: everything contributed as DATA must be a
+        // plain navigation, so it works identically from any page and needs no client state. A seed
+        // without an Href would render as a menu entry that does nothing when clicked.
+        Assert.All(AiMenuContributions.Seeds, seed =>
+        {
+            var contribution = Assert.IsType<UiContribution>(seed.Content);
+            Assert.Equal(NodeMenuItemsExtensions.AiMenuContext, contribution.Context);
+            Assert.False(string.IsNullOrEmpty(contribution.Href), $"'{seed.Name}' must navigate by Href");
+            Assert.False(string.IsNullOrEmpty(contribution.LabelKey), $"'{seed.Name}' must localize its label");
+        });
+    }
+
+    [Fact]
+    public void Seeds_Are_Uniquely_Keyed()
+    {
+        // The aggregator dedupes on (Order, Label, Area) via ImmutableSortedSet — two entries
+        // colliding on all three would silently drop one from the rendered menu.
+        var keys = AiMenuContributions.Seeds
+            .Select(seed =>
+            {
+                var c = Assert.IsType<UiContribution>(seed.Content);
+                return (c.Order, c.Label, c.Area);
+            })
+            .ToList();
+
+        Assert.Equal(keys.Count, keys.Distinct().Count());
+    }
+}


### PR DESCRIPTION
Closes the last **unparked** test project holding a compile-time `ProjectReference` to `src/MeshWeaver.AI` — the exact edge #2276 exists to remove.

## Why it was there

`Memex.Portal.Shared.Test` referenced the module for **one file**. `AiMenuNewThreadTest` asserted both halves of the AI (✨) menu in the same test methods:

- the portal's ONE **compiled** imperative entry (`MemexConfiguration.AiMenuItems` — the "New thread" click-action sentinel), and
- `MeshWeaver.AI`'s **seeded** `UiContribution` nodes (Threads / Models / Tiers / Providers / Agents / Skills).

Three of its six methods spanned the boundary, which is what forced the reference — and an `InternalsVisibleTo("Memex.Portal.Shared.Test")` grant on the module so the suite could read the internal `Seeds` list.

## The seam already existed in the data

The portal's imperative entry is **Order 0**; every AI seed is **Order > 0**. The menu aggregator dedupes on `(Order, Label, Area)` via `ImmutableSortedSet`, so entries drawn from **disjoint Order ranges can never collide**. That makes the split lossless: each side asserts its own half plus its half of the ordering invariant, and the whole contract still follows — with neither test referencing the other's assembly.

| side | pins |
|---|---|
| `Memex.Portal.Shared.Test` | the single compiled entry; Order 0; the language-neutral ➕ glyph; the absent `Href` (it stays imperative); the `/User/{me}/Chat` destination |
| `MeshWeaver.AI.Test` (new `AiMenuContributionsTest`) | every seed is Order > 0; the `AI` context; `Href` + `LabelKey` present; unique keys |

**Coverage goes up, not down** — six methods become eight, because each cross-boundary assertion splits into a per-side one.

## Also dropped, with the coupling

- the `ProjectReference` in `Memex.Portal.Shared.Test.csproj`
- `InternalsVisibleTo("Memex.Portal.Shared.Test")` on `MeshWeaver.AI` — it existed solely for this suite

## Verification

- `dotnet build -c Release -p:CIRun=true -warnaserror` on **both** projects: `0 Warning(s)`, `0 Error(s)`
- both halves run green: **3** (AI) + **5** (portal)

No What's New entry — test-only refactor, no user-visible effect.

Refs #2276

🤖 Generated with [Claude Code](https://claude.com/claude-code)