### PR TITLE
test: make process B's own-node diagnostics reach CI output (#2008)

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/CrossProcessChangeFeedTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CrossProcessChangeFeedTest.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
+using MeshWeaver.Fixture;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -281,8 +282,27 @@ public class CrossProcessChangeFeedTest(ITestOutputHelper output) : MonolithMesh
     private SecondProcess BuildSecondProcess()
     {
         var services = new ServiceCollection();
-        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
-        services.AddLogging(l => l.ClearProviders());
+        // 🚨 Wire the SAME XUnitFileLoggerProvider process A gets from TestBase, pointed at the
+        // SAME FileOutput — and grant MeshNodeTypeSource (this test's own file has the matching
+        // "MeshWeaver.Graph.MeshNodeTypeSource": "Debug" override) Debug level via an in-memory
+        // config, since this process builds its OWN IConfiguration rather than loading
+        // appsettings.json. Without this, process B — the mirror this test asserts on, and the
+        // hub #2008's own-node-versioning hypothesis is about — had ZERO logging providers: every
+        // MeshNodeTypeSource.LogDebug/LogWarning call from its own-node reconcile (adds/updates/
+        // deletes counts, durable-seed reads) went nowhere, not xUnit output, not the log file, on
+        // every run, including a failing one. See #2008.
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Logging:LogLevel:Default"] = "Warning",
+                ["Logging:LogLevel:MeshWeaver.Graph.MeshNodeTypeSource"] = "Debug",
+            })
+            .Build());
+        services.AddLogging(l =>
+        {
+            l.ClearProviders();
+            l.Services.AddSingleton<ILoggerProvider>(sp => new XUnitFileLoggerProvider(() => FileOutput, sp));
+        });
         services.AddOptions();
 
         var builder = new MeshBuilder(c => c.Invoke(services), AddressExtensions.CreateMeshAddress())

--- a/test/MeshWeaver.Hosting.Monolith.Test/appsettings.json
+++ b/test/MeshWeaver.Hosting.Monolith.Test/appsettings.json
@@ -5,6 +5,7 @@
       "MeshWeaver.Graph.HandleCreateRelease": "Warning",
       "MeshWeaver.Graph.CompileWatcher": "Warning",
       "MeshWeaver.Graph.NodeTypeCompileActivity": "Warning",
+      "MeshWeaver.Graph.MeshNodeTypeSource": "Debug",
       "Microsoft": "Warning",
       "System": "Warning"
     }


### PR DESCRIPTION
## Summary
- `CrossProcessChangeFeedTest`'s process B (`BuildSecondProcess`) built its own `IConfiguration` and called `services.AddLogging(l => l.ClearProviders())` with no provider added back — so every `ILogger` call in process B, including `MeshNodeTypeSource`'s own-node reconcile diagnostics (`UpdateImpl: adds=/updates=/deletes=`, `durable activation seed ...`), went nowhere: not xUnit's captured output, not the log file, on every run — including a failing one.
- #2008 tracks an intermittent (~1.3%, 4/300 CI runs) failure of `AWriteInOneProcess_ReachesTheOtherProcessesLiveMirror_WithoutARecycle` where process B's mirror converges on the write's content at durable+1 — a version the store never held. The issue's own investigation built a falsifiable hypothesis and named exactly what's needed to confirm or refute it on the next CI occurrence: the two `LogDebug` lines already in `MeshNodeTypeSource`, which today never reach any CI artifact for process B.
- This PR wires process B's logging the same way process A's already is (`TestBase`'s `XUnitFileLoggerProvider`, pointed at the shared `FileOutput`) and grants `MeshWeaver.Graph.MeshNodeTypeSource` a `Debug` override — in `appsettings.json` for process A (matching the file's existing per-category overrides) and via an in-memory `IConfiguration` for process B (which never loads `appsettings.json`).
- Verified locally: before this change process B produced zero `MeshNodeTypeSource` log lines under any conditions (zero providers registered); after this change, process B's own-node reconcile diagnostics reach the captured test output.

## Investigation note (not a fix — #2008 stays open)
Read through the mechanism the issue's hypothesis rests on (a second own-node reconcile path that re-emits into `MeshNodeTypeSource.BuildInstanceCollection`, bypassing `UpdateImpl`'s diff/version-stamping, racing `SubscribeToOwnDeletion`'s `reReadTrigger → AdoptDurable → AdoptPersisted` path) and found a correction worth recording: `MonolithRoutingService.CreateHub` supplies the routing leg's `_ownNodeStream` as a **one-shot** `Observable.Return(enriched)` ("One-shot is fine on Monolith — cross-hub MeshNode updates flow through IDataChangeNotifier / IMeshChangeFeed already"). That stream completes at hub activation, well before the write under test happens, so for the event this test exercises only `SubscribeToOwnDeletion`'s single reconcile path is live — the "two independent re-read consumers" shape in the issue's hypothesis reads like it describes Orleans' `PathResolutionService` invalidation-driven re-resolve, not Monolith. Posted as a comment on #2008 rather than guessing further at a fix to the versioning core; the actual mechanism needs a live trace, which is what this PR sets up to capture.

No production code changed. This is test-infrastructure-only (visibility), not a behavior fix.

## What's New
Skipped — pure test-infrastructure/observability change, no user-visible effect.

## Test plan
- [x] `dotnet build test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj -c Release -warnaserror` — 0 Warning(s), 0 Error(s)
- [x] `dotnet test test/MeshWeaver.Hosting.Monolith.Test -c Release --no-build --filter "FullyQualifiedName~CrossProcessChangeFeedTest"` — 3/3 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)