### PR TITLE
A shutdown race must reach the sender as ShuttingDown, not Unavailable

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -810,10 +810,29 @@ public class MessageService : IMessageService
             // path, and ANY terminal treatment killed the sync stream's resubscribe latch —
             // each wedged every read of the mid-recycle NodeType.
             fate?.Add($"DROPPED_SHUTTING_DOWN runLevel={hub.RunLevel}", Address);
-            NackThroughParent(delivery,
+
+            // 🚨 Both halves matter, and this site got both wrong until #2350.
+            //
+            // NackThroughParent DECLINES (returns false) when there is no parent, or the parent is
+            // itself past DisposeHostedHubs. Ignoring the result meant: answered → the reporting
+            // path NACKed a SECOND time, because only FailedAndNacked sets SenderWasNacked;
+            // declined → the sender got nothing from here at all. In both cases the delivery
+            // carried NO classification, so ReportFailure fell back to ErrorType.Unavailable while
+            // the message still read "Hub is shutting down" — a transient race wearing an
+            // authoritative label.
+            //
+            // That defeats every consumer written against the documented contract, which is the
+            // whole reason Failed(string, ErrorType) exists: SynchronizationStream's resubscribe
+            // latch, MeshNodeStreamCache's shutdown-drop handling and PackageInstaller's retry all
+            // ride out ShuttingDown and treat anything else as terminal. Same idiom as
+            // AnswerUnreleasableDelivery above: honour the return value, and classify either way.
+            var reason =
                 $"Hub {Address} is shutting down (RunLevel={hub.RunLevel}) — cannot process "
-                + $"{typeName}; the address may reactivate (recycle / restart). Rejecting now.");
-            return delivery.Failed("Hub is shutting down");
+                + $"{typeName}; the address may reactivate (recycle / restart). Rejecting now.";
+
+            return NackThroughParent(delivery, reason)
+                ? delivery.FailedAndNacked("Hub is shutting down")
+                : delivery.Failed("Hub is shutting down", ErrorType.ShuttingDown);
         }
 
         // STORM CIRCUIT-BREAKER. Detect an unbounded retry/resubscribe/repost loop —
@@ -1833,7 +1852,13 @@ public class MessageService : IMessageService
             }
 
             postFate?.Add($"POST_REFUSED_SHUTTING_DOWN runLevel={hub.RunLevel}", Address);
-            return ((IMessageDelivery)delivery).Failed("Hub is shutting down");
+
+            // Classified, for the same reason as the intake gate (#2350): a refused POST during
+            // shutdown is transient — the address may reactivate — and an unclassified failure
+            // reaches the sender as ErrorType.Unavailable, which its recovery machinery reads as
+            // terminal. This site does NOT answer the sender itself, so Failed (not
+            // FailedAndNacked) stays correct; only the classification was missing.
+            return ((IMessageDelivery)delivery).Failed("Hub is shutting down", ErrorType.ShuttingDown);
         }
 
         // TODO V10: Which cancellation token to pass here? (12.01.2025, Roland Bürgi)

--- a/test/MeshWeaver.Messaging.Hub.Test/TeardownFailureClassificationGuard.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/TeardownFailureClassificationGuard.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Every teardown-time failure <c>MessageService</c> produces must carry a CLASSIFICATION — either
+/// <c>Failed(message, ErrorType)</c>, or <c>FailedAndNacked(message)</c> when the site already
+/// answered the sender itself.
+///
+/// <para>🚨 <b>Why a source guard rather than a behavioural test.</b> This file's own
+/// <c>DeletedAddressMessage</c> comment states the failure mode: "a drift here is SILENT: it does
+/// not fail to compile, it quietly re-opens #1029 at whichever site was missed. Which is exactly
+/// what happened — the fix landed only on the abandoned-delivery site, and the accepted-then-faulted
+/// site kept answering the transient ErrorType.ShuttingDown with the raw exception text." The bug
+/// class is a site that LOOKS right and is never exercised by the test that covers its sibling.
+/// Nothing about it is racy, so pinning it racily would trade a silent bug for a flaky one.</para>
+///
+/// <para><b>What goes wrong when a classification is missing (#2350).</b> The reporting path reads
+/// <c>delivery.GetFailureErrorType(ErrorType.Unavailable)</c> — so an unclassified failure reaches
+/// the sender as <c>Unavailable</c> while its message still says "shutting down": a transient race
+/// wearing an authoritative label. Every consumer written against the documented contract then
+/// treats it as terminal — <c>SynchronizationStream</c>'s resubscribe latch, <c>MeshNodeStreamCache</c>'s
+/// shutdown-drop handling, <c>PackageInstaller</c>'s retry — which is the precise outcome
+/// <c>Failed(string, ErrorType)</c> exists to prevent, in its own words.</para>
+///
+/// <para>The guard is deliberately narrow: it only asks about failures whose MESSAGE mentions
+/// shutting down / disposing. A genuine bug must stay terminal and unclassified is right for it.</para>
+/// </summary>
+public class TeardownFailureClassificationGuard
+{
+    /// <summary>Failure text that means "teardown", i.e. transient and retryable.</summary>
+    private static readonly string[] TeardownWords = ["shutting down", "shut down", "disposing"];
+
+    [Fact]
+    public void EveryTeardownFailure_InMessageService_CarriesAClassification()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(), "src", "MeshWeaver.Messaging.Hub", "MessageService.cs"));
+
+        // `Failed("...")` with a single STRING-LITERAL argument — the overload that records no
+        // ErrorType. Two args (message, ErrorType) and FailedAndNacked(message) both classify, and
+        // neither matches: the pattern requires the closing paren straight after the literal.
+        var unclassified = Regex
+            .Matches(source, """(?<!AndNacked)\bFailed\(\s*"([^"]*)"\s*\)""")
+            .Select(m => m.Groups[1].Value)
+            .Where(message => TeardownWords.Any(w => message.Contains(w, StringComparison.OrdinalIgnoreCase)))
+            .Distinct()
+            .ToArray();
+
+        Assert.True(unclassified.Length == 0,
+            "MessageService produces a teardown failure with NO ErrorType. It will reach the sender "
+            + "as ErrorType.Unavailable (the reporting fallback) while saying it is shutting down, so "
+            + "consumers that ride out ShuttingDown will treat a recoverable race as terminal (#2350).\n"
+            + "Use Failed(message, ErrorType.ShuttingDown), or FailedAndNacked(message) if the site "
+            + "already answered the sender — see AnswerUnreleasableDelivery for the idiom.\n"
+            + "Unclassified:\n  - " + string.Join("\n  - ", unclassified));
+    }
+
+    /// <summary>
+    /// The interpolated form of the same mistake. Kept separate so the failure message can say which
+    /// shape it found — an interpolated literal is easy to add without noticing it took the
+    /// single-argument overload.
+    /// </summary>
+    [Fact]
+    public void EveryInterpolatedTeardownFailure_InMessageService_CarriesAClassification()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(), "src", "MeshWeaver.Messaging.Hub", "MessageService.cs"));
+
+        var unclassified = Regex
+            .Matches(source, """(?<!AndNacked)\bFailed\(\s*\$"([^"]*)"\s*\)""")
+            .Select(m => m.Groups[1].Value)
+            .Where(message => TeardownWords.Any(w => message.Contains(w, StringComparison.OrdinalIgnoreCase)))
+            .Distinct()
+            .ToArray();
+
+        Assert.True(unclassified.Length == 0,
+            "MessageService produces an interpolated teardown failure with NO ErrorType (#2350). "
+            + "Use Failed(message, ErrorType.ShuttingDown) or FailedAndNacked(message).\n"
+            + "Unclassified:\n  - " + string.Join("\n  - ", unclassified));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName ?? throw new InvalidOperationException("repo root not found");
+    }
+}


### PR DESCRIPTION
Closes #2350. Root cause of the two `HubWorksAfterDisposal` failures in #2346 — found by reading the failure, not by re-running it.

## The defect

`MessageService`'s intake shutdown gate called `NackThroughParent` and then returned `delivery.Failed("Hub is shutting down")` — the overload that records **no** classification — while ignoring the `bool` that `NackThroughParent` returns.

Both branches were wrong:

| `NackThroughParent` | what the sender got |
|---|---|
| **answered** | the typed NACK **and a second one**, because only `FailedAndNacked` sets `SenderWasNacked` — and that second failure took `ReportFailure`'s fallback |
| **declined** (no parent, or parent past `DisposeHostedHubs`) | **nothing** from here, so the fallback was its only answer |

Either way the failure arrived as `ErrorType.Unavailable` carrying the text "Hub is shutting down" — **a transient race wearing an authoritative label**.

## Why that is not cosmetic

`Failed(string, ErrorType)` says why it exists, in its own docs:

> a disposal race **MUST** reach the sender as the transient `ErrorType.ShuttingDown` so consumers with their own recovery machinery (chiefly `SynchronizationStream`'s resubscribe latch) ride it out instead of tearing down.

Consumers written exactly that way, each treating anything else as terminal:

- `SynchronizationStream`'s resubscribe latch — named above
- `MeshNodeStreamCache.cs:1283` — shutdown-drop handling
- `PackageInstaller.cs:1149` — `if (e is DeliveryFailureException { Failure.ErrorType: ErrorType.ShuttingDown })`
- `BlazorHostingExtensions.cs:591`

So a hub recycling under load could tear down a stream that was supposed to rehydrate.

## The fix is an idiom already in this file

`AnswerUnreleasableDelivery`, ~400 lines above, honours the return value **and** classifies:

```csharp
if (!NackThroughParent(delivery, reason))
    ReportFailure(delivery.WithProperty("Error", reason),
        hub.IsShuttingDown ? ErrorType.ShuttingDown : ErrorType.Failed);
```

The gate now does the same. The post-refusal site at the other end of the file gets the classification too — it does not answer the sender itself, so `Failed` (not `FailedAndNacked`) stays correct there; only the `ErrorType` was missing.

## Evidence, not theory

`OrleansMeshTests.HubWorksAfterDisposal` failed on #2340 and #2343 with `DeliveryFailureException : Hub is shutting down` raised **inside** the retry that already exists for this race. That retry matches `ErrorType.ShuttingDown` — so the failure it saw was classified as something else. That is this bug, observed.

Duration **2.3 s** (`09:08:35.731` → `09:08:38.017`), so a real assertion failure and not a hang — which is what ruled out the resource-pressure reading the surrounding cluster invites. I had started down that path and the duration check stopped it.

## 🚨 Why a SOURCE guard

This file's own `DeletedAddressMessage` comment records the failure mode:

> a drift here is SILENT: it does not fail to compile, it quietly re-opens #1029 at whichever site was missed. **Which is exactly what happened** — the fix landed only on the abandoned-delivery site, and the accepted-then-faulted site kept answering […]

The bug class is a site that looks right and no test exercises. Nothing about it is racy, so pinning it racily would trade a silent bug for a flaky one — and the existing `HubDisposalFailureClassificationTest` covers the *sibling* path, which is precisely how this one stayed uncovered.

Proven in both directions: green as committed, **red naming the exact string** when the classification is removed again.

## Verification

- `-c Release -p:CIRun=true -warnaserror`: `0 Warning(s)`, `0 Error(s)`
- the 12 neighbouring disposal/classification tests pass (`DisposalRaceNackTest`, `HubDisposalFailureClassificationTest`, `DeferredDeliveryNackedOnDisposeTest`, `DeletedAddressNackClassificationTest`, `RoutingFailureReportedTest`)

## Scope

This explains the two `HubWorksAfterDisposal` occurrences in #2346. It does **not** claim to explain the other four tests in that cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)