### PR TITLE
The Blazor.Portal comment described a state #2293 ended

### DIFF
--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -53,10 +53,12 @@
          landing refuses the same-identity module (409 on every instance). -->
     <!-- MeshWeaver.Blazor.Graph is deliberately NOT referenced (the EntityViews/#1974 shape): its
          GraphViewsViewPackModuleAttribute registers the node views when the DLL is listed under
-         Modules:Assemblies; the bits ship via the modules/<Name>/ lane. Blazor.Portal is GONE from this
-         repo entirely (#2293): the shell infrastructure it held — PortalLayoutBase, auth,
-         viewport — moved to MeshWeaver.Plugins with the portal hosts, completing the
-         extraction this comment used to track as #2169 Phase B3. -->
+         Modules:Assemblies; the bits ship via the modules/<Name>/ lane. The MeshWeaver.Blazor.Portal
+         PROJECT was removed from this repo (#2293): the shell infrastructure it held —
+         PortalLayoutBase, auth, viewport — moved to MeshWeaver.Plugins with the portal hosts,
+         completing the extraction this comment used to track as #2169 Phase B3. The assembly
+         NAME still appears here on purpose: the InternalsVisibleTo below grants the plugins-built
+         MeshWeaver.Blazor.Portal.dll the internals it always had. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.AspNetCore\MeshWeaver.Hosting.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.SignalR\MeshWeaver.Hosting.SignalR.csproj" />

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -53,9 +53,10 @@
          landing refuses the same-identity module (409 on every instance). -->
     <!-- MeshWeaver.Blazor.Graph is deliberately NOT referenced (the EntityViews/#1974 shape): its
          GraphViewsViewPackModuleAttribute registers the node views when the DLL is listed under
-         Modules:Assemblies; the bits ship via the modules/<Name>/ lane. Blazor.Portal REMAINS a
-         compiled reference for now — it is SHELL infrastructure (PortalLayoutBase, auth,
-         viewport), tracked for extraction as #2169 Phase B3. -->
+         Modules:Assemblies; the bits ship via the modules/<Name>/ lane. Blazor.Portal is GONE from this
+         repo entirely (#2293): the shell infrastructure it held — PortalLayoutBase, auth,
+         viewport — moved to MeshWeaver.Plugins with the portal hosts, completing the
+         extraction this comment used to track as #2169 Phase B3. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.AspNetCore\MeshWeaver.Hosting.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.SignalR\MeshWeaver.Hosting.SignalR.csproj" />


### PR DESCRIPTION
Follow-up promised on [#2293's review thread](https://github.com/Systemorph/MeshWeaver/pull/2293#issuecomment-5424776804).

`Memex.Portal.Shared.csproj:56` said:

> Blazor.Portal REMAINS a compiled reference for now — it is SHELL infrastructure (PortalLayoutBase, auth, viewport), tracked for extraction as #2169 Phase B3.

#2293 completed that extraction, so the sentence became false at merge.

### Why it was not fixed in #2293

Copilot caught it there and it was merged knowingly. `main` was red on `Landed modules compile against this PR` — #674 had landed the additive half of the portal move while the deletion half stayed open, so both repos declared the same components — and three unrelated PRs were blocked behind it. A comment-only push costs a full ~25-minute cycle with main red throughout. One wrong sentence against other people's blocked work; the reasoning is on the thread rather than resolved silently.

### Why it is worth a commit at all

This is the same failure #2293 itself corrected twice in `ContinuousDeliveryContract.md` — prose describing intent as if it were state, sitting next to the code and outliving it. That file predicted "moving the generator does not help" (wrong — the plugins CI clone is exactly what makes it work) and asserted a compile gate lived in core's image build (it lives in `dotnet-test.yml`'s `landed-modules-gate`). The second cost an afternoon and a wrong escalation to another session.

No What's New entry: comment-only, no user-visible change.