### PR TITLE
Three more test suites stop referencing MeshWeaver.AI

### DIFF
--- a/test/MeshWeaver.AI.Test/AgentChatClientNoSuitableAgentTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentChatClientNoSuitableAgentTest.cs
@@ -5,9 +5,9 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading;
 using System.Threading.Tasks;
-using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Mesh;
@@ -18,7 +18,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace MeshWeaver.Hosting.Monolith.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// Reproduces the production "No suitable agent found to handle the request"

--- a/test/MeshWeaver.AI.Test/AgentNamespacePolicyTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentNamespacePolicyTest.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// The Agent provider's static read-only policy: an Admin over the <c>Agent</c> namespace is capped
+/// to read/execute/api/export by the <c>PartitionAccessPolicy</c> node that provider emits from
+/// <c>GetStaticNodes()</c> — never create/update/delete.
+///
+/// <para>Moved out of <c>MeshWeaver.Security.Test.StaticNamespacePolicyTests</c> (#2276), which
+/// pinned the same contract for the Doc, Agent and Role providers together. The contract is
+/// general and stays there; each INSTANCE of it belongs with the provider that emits the policy,
+/// and MeshWeaver.AI is leaving this repository — a policy test for its provider has to leave with
+/// it, or it becomes a test of something the repo no longer contains.</para>
+/// </summary>
+public class AgentNamespacePolicyTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // NOT opted into ShareMeshAcrossTests — static policy caps differ between fresh and reused
+    // service providers, which is why the original class carried the same note.
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddAgentType()
+            .AddRowLevelSecurity()
+            .AddMeshNodes(AssignmentNodeFactory.UserRole("admin_agent", "Admin", ""));
+
+    [Fact(Timeout = 20000)]
+    public async Task AgentNamespace_AdminCappedToReadOnly()
+    {
+        var expected = Permission.Read | Permission.Execute | Permission.Api | Permission.Export;
+        await Mesh.GetEffectivePermissions("Agent/ThreadNamer", "admin_agent")
+            .Should().Match(p => p == expected, "Agent namespace has a static read-only policy");
+    }
+}

--- a/test/MeshWeaver.AI.Test/AgentSyncedQueryFromHostedHubTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentSyncedQueryFromHostedHubTest.cs
@@ -3,9 +3,9 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
-using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Mesh;
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace MeshWeaver.Hosting.Monolith.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// End-to-end test for the "chat dropdown shows agents + models" symptom.

--- a/test/MeshWeaver.AI.Test/AiSourcesInstallHookTest.cs
+++ b/test/MeshWeaver.AI.Test/AiSourcesInstallHookTest.cs
@@ -4,7 +4,6 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
-using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
@@ -14,7 +13,7 @@ using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace MeshWeaver.Hosting.Monolith.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// 🚨 #1127: pins <see cref="AiSourcesInstallHook"/>'s user enumeration against the <c>User</c>

--- a/test/MeshWeaver.AI.Test/LanguageModelSyncedQueryTest.cs
+++ b/test/MeshWeaver.AI.Test/LanguageModelSyncedQueryTest.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
-using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Mesh;
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace MeshWeaver.Hosting.Monolith.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// Integration test for the chat picker's data source — the

--- a/test/MeshWeaver.AI.Test/MeshPluginAccessContextTest.cs
+++ b/test/MeshWeaver.AI.Test/MeshPluginAccessContextTest.cs
@@ -2,7 +2,6 @@ using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using MeshWeaver.AI;
 using MeshWeaver.AI.Persistence;
 using MeshWeaver.Graph;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -16,7 +15,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace MeshWeaver.NodeOperations.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// Tests that MeshPlugin tool calls restore the user's access context.

--- a/test/MeshWeaver.AI.Test/ThreadAccessTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadAccessTest.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Reactive.Threading.Tasks;
 using System.Reactive.Linq;
-using MeshWeaver.AI;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Hosting.Security;
@@ -17,7 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using MeshThread = MeshWeaver.AI.Thread;
 
-namespace MeshWeaver.Security.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// Tests Thread and ThreadMessage access rights:

--- a/test/MeshWeaver.AI.Test/ThreadSelfAccessCreationTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadSelfAccessCreationTest.cs
@@ -28,9 +28,12 @@ public class ThreadSelfAccessCreationTest(ITestOutputHelper output) : MonolithMe
         => ConfigureMeshBase(builder).AddThreadType();
 
     /// <summary>
-    /// Tests that a user can create a Thread node under their own User node
-    /// via the self-access check (User/{ObjectId} scope).
-    /// This is the permission path used by the dashboard chat to create threads.
+    /// Tests that a user can create a Thread node under their own top-level partition
+    /// via the self-access check.
+    /// <para>The authorized shape is the partition named exactly after the user id —
+    /// <c>{ObjectId}</c> / <c>{ObjectId}/…</c> — NOT a legacy <c>User/{ObjectId}</c> path; the body
+    /// below builds <c>{userId}/TestThread_…</c> accordingly. This is the permission path the
+    /// dashboard chat uses to create threads.</para>
     /// </summary>
     [Fact(Timeout = 15000)]
     public async Task CreateThread_UnderOwnUserNode_Succeeds()

--- a/test/MeshWeaver.AI.Test/ThreadSelfAccessCreationTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadSelfAccessCreationTest.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.ShortGuid;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Creating a Thread under one's OWN user node, through the self-access check — the permission path
+/// the dashboard chat uses.
+///
+/// <para>Moved out of <c>MeshWeaver.Security.Test.NodeCreationAccessTest</c> (#2276). Its sibling
+/// (creating under ANOTHER user's node must throw) is type-agnostic access control and stays in core
+/// with a Markdown fixture. This one cannot: it asserts <c>MainNode</c> points at the parent, which
+/// is SATELLITE wiring, and Thread is a satellite type. Substituting a non-satellite type made it
+/// pass vacuously on the path but fail the MainNode assertion — the property under test is Thread's,
+/// so the test belongs with Thread.</para>
+/// </summary>
+public class ThreadSelfAccessCreationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder).AddThreadType();
+
+    /// <summary>
+    /// Tests that a user can create a Thread node under their own User node
+    /// via the self-access check (User/{ObjectId} scope).
+    /// This is the permission path used by the dashboard chat to create threads.
+    /// </summary>
+    [Fact(Timeout = 15000)]
+    public async Task CreateThread_UnderOwnUserNode_Succeeds()
+    {
+        // Arrange — log in as a user whose ObjectId matches a User node path
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var userId = "self-access-user";
+        var userContext = new AccessContext { ObjectId = userId, Name = "Self Access User" };
+        accessService.SetContext(userContext);
+        accessService.SetHostIdentity(userContext);
+
+        try
+        {
+            // Act — create a Thread under {userId} (self-access should grant permission).
+            // Post-v10: per-user partition lives at root namespace, so the user's
+            // own scope is just "{userId}" rather than the legacy "User/{userId}".
+            var threadPath = $"{userId}/TestThread_{Guid.NewGuid().AsString()}";
+            var threadNode = MeshNode.FromPath(threadPath) with
+            {
+                Name = "Test Chat Thread",
+                NodeType = ThreadNodeType.NodeType
+            };
+
+            var created = await NodeFactory.CreateNode(threadNode).Should().Emit();
+
+            // Assert
+            created.Should().NotBeNull("User should be able to create threads under their own User node");
+            created.State.Should().Be(MeshNodeState.Active);
+            created.Path.Should().Be(threadPath);
+            created.MainNode.Should().Be(userId, "Satellite thread MainNode should point to parent node");
+            Output.WriteLine($"Thread created successfully at: {created.Path}, MainNode: {created.MainNode}");
+        }
+        finally
+        {
+            TestUsers.DevLogin(Mesh);
+        }
+    }
+
+}

--- a/test/MeshWeaver.AI.Test/ThreadStreamingIdentityTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadStreamingIdentityTest.cs
@@ -5,7 +5,6 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading;
 using System.Threading.Tasks;
-using MeshWeaver.AI;
 using MeshWeaver.AI.Persistence;
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
@@ -23,7 +22,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using MeshThread = MeshWeaver.AI.Thread;
 
-namespace MeshWeaver.Security.Test;
+namespace MeshWeaver.AI.Test;
 
 /// <summary>
 /// Tests that thread chat streaming works end-to-end with RLS enabled.

--- a/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
@@ -6,7 +6,6 @@ using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
@@ -16,7 +16,6 @@
         <PackageReference Include="UglyToad.PdfPig" />
       <!-- Direct on purpose: the app closure no longer carries the view packs (#2169 Phase B) —
            tests that exercise pack types reference them like any other pack test. -->
-      <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
       <ProjectReference Include="..\..\src\MeshWeaver.Social\MeshWeaver.Social.csproj" />
   </ItemGroup>
     <ItemGroup>

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
@@ -7,7 +7,6 @@ using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;

--- a/test/MeshWeaver.NodeOperations.Test/MeshWeaver.NodeOperations.Test.csproj
+++ b/test/MeshWeaver.NodeOperations.Test/MeshWeaver.NodeOperations.Test.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />

--- a/test/MeshWeaver.Security.Test/MeshWeaver.Security.Test.csproj
+++ b/test/MeshWeaver.Security.Test/MeshWeaver.Security.Test.csproj
@@ -21,7 +21,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
         <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />

--- a/test/MeshWeaver.Security.Test/NodeCreationAccessTest.cs
+++ b/test/MeshWeaver.Security.Test/NodeCreationAccessTest.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Reactive.Threading.Tasks;
 using System.Reactive.Linq;
-using MeshWeaver.AI;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Hosting.Security;
@@ -31,8 +30,7 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
     {
         // ConfigureMeshBase adds RLS + graph (incl. Markdown)
-        return ConfigureMeshBase(builder)
-            .AddThreadType();
+        return ConfigureMeshBase(builder);
     }
 
     /// <summary>
@@ -244,48 +242,6 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
     }
 
     /// <summary>
-    /// Tests that a user can create a Thread node under their own User node
-    /// via the self-access check (User/{ObjectId} scope).
-    /// This is the permission path used by the dashboard chat to create threads.
-    /// </summary>
-    [Fact(Timeout = 15000)]
-    public async Task CreateThread_UnderOwnUserNode_Succeeds()
-    {
-        // Arrange — log in as a user whose ObjectId matches a User node path
-        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
-        var userId = "self-access-user";
-        var userContext = new AccessContext { ObjectId = userId, Name = "Self Access User" };
-        accessService.SetContext(userContext);
-        accessService.SetHostIdentity(userContext);
-
-        try
-        {
-            // Act — create a Thread under {userId} (self-access should grant permission).
-            // Post-v10: per-user partition lives at root namespace, so the user's
-            // own scope is just "{userId}" rather than the legacy "User/{userId}".
-            var threadPath = $"{userId}/TestThread_{Guid.NewGuid().AsString()}";
-            var threadNode = MeshNode.FromPath(threadPath) with
-            {
-                Name = "Test Chat Thread",
-                NodeType = ThreadNodeType.NodeType
-            };
-
-            var created = await NodeFactory.CreateNode(threadNode).Should().Emit();
-
-            // Assert
-            created.Should().NotBeNull("User should be able to create threads under their own User node");
-            created.State.Should().Be(MeshNodeState.Active);
-            created.Path.Should().Be(threadPath);
-            created.MainNode.Should().Be(userId, "Satellite thread MainNode should point to parent node");
-            Output.WriteLine($"Thread created successfully at: {created.Path}, MainNode: {created.MainNode}");
-        }
-        finally
-        {
-            TestUsers.DevLogin(Mesh);
-        }
-    }
-
-    /// <summary>
     /// Tests that a user CANNOT create a Thread under another user's node.
     /// </summary>
     [Fact(Timeout = 15000)]
@@ -299,19 +255,19 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
 
         try
         {
-            // Act — try to create a thread under another user's node
+            // Act — try to create a node under another user's node
             var threadPath = "User/other-user/MaliciousThread";
             var threadNode = MeshNode.FromPath(threadPath) with
             {
                 Name = "Malicious Thread",
-                NodeType = ThreadNodeType.NodeType
+                NodeType = MarkdownNodeType.NodeType
             };
 
             Func<Task> act = () => NodeFactory.CreateNode(threadNode).FirstAsync().ToTask();
 
             // Assert
             await act.Should().ThrowAsync<UnauthorizedAccessException>(
-                "User should NOT be able to create threads under another user's node");
+                "User should NOT be able to create nodes under another user's node");
         }
         finally
         {

--- a/test/MeshWeaver.Security.Test/RlsIntegrationTests.cs
+++ b/test/MeshWeaver.Security.Test/RlsIntegrationTests.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Reactive.Threading.Tasks;
 using System.Reactive.Linq;
-using MeshWeaver.AI;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -31,8 +30,7 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
     {
         // ConfigureMeshBase adds persistence + RLS + graph
-        var configured = ConfigureMeshBase(builder)
-            .AddThreadType();
+        var configured = ConfigureMeshBase(builder);
 
         // Seed every per-test AccessAssignment statically (via AddMeshNodes →
         // IStaticNodeProvider → SecurityService._staticAccessAssignments).
@@ -563,7 +561,7 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
         var threadNode = new MeshNode("Thread1", parentPath)
         {
             Name = "Editor Thread",
-            NodeType = "Thread"
+            NodeType = "Markdown"
         };
         var editorResponse = await client.Observe(new CreateNodeRequest(threadNode) { CreatedBy = editorId }, o => o.WithTarget(Mesh.Address)).Should().Emit();
 
@@ -571,7 +569,7 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
         var commenterThread = new MeshNode("Thread2", parentPath)
         {
             Name = "Commenter Thread",
-            NodeType = "Thread"
+            NodeType = "Markdown"
         };
         var commenterResponse = await client.Observe(new CreateNodeRequest(commenterThread) { CreatedBy = commenterId }, o => o.WithTarget(Mesh.Address)).Should().Emit();
 

--- a/test/MeshWeaver.Security.Test/RlsIntegrationTests.cs
+++ b/test/MeshWeaver.Security.Test/RlsIntegrationTests.cs
@@ -548,7 +548,7 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
     }
 
     [Fact]
-    public async Task CreateThread_RequiresUpdatePermission()
+    public async Task CreateNode_RequiresUpdatePermission()
     {
         // Arrange — "editor_thr"/"commenter_thr" seeded statically with Editor/Commenter at parentPath.
         var client = GetClient();
@@ -557,25 +557,25 @@ public class RlsIntegrationTests(ITestOutputHelper output) : MonolithMeshTestBas
         const string commenterId = "commenter_thr";
         const string parentPath = "rls/threads";
 
-        // Act - editor creates a Thread
-        var threadNode = new MeshNode("Thread1", parentPath)
+        // Act - editor creates a node
+        var editorNode = new MeshNode("Node1", parentPath)
         {
-            Name = "Editor Thread",
+            Name = "Editor Node",
             NodeType = "Markdown"
         };
-        var editorResponse = await client.Observe(new CreateNodeRequest(threadNode) { CreatedBy = editorId }, o => o.WithTarget(Mesh.Address)).Should().Emit();
+        var editorResponse = await client.Observe(new CreateNodeRequest(editorNode) { CreatedBy = editorId }, o => o.WithTarget(Mesh.Address)).Should().Emit();
 
-        // Commenter tries to create a Thread
-        var commenterThread = new MeshNode("Thread2", parentPath)
+        // Commenter tries to create a node
+        var commenterNode = new MeshNode("Node2", parentPath)
         {
-            Name = "Commenter Thread",
+            Name = "Commenter Node",
             NodeType = "Markdown"
         };
-        var commenterResponse = await client.Observe(new CreateNodeRequest(commenterThread) { CreatedBy = commenterId }, o => o.WithTarget(Mesh.Address)).Should().Emit();
+        var commenterResponse = await client.Observe(new CreateNodeRequest(commenterNode) { CreatedBy = commenterId }, o => o.WithTarget(Mesh.Address)).Should().Emit();
 
         // Assert
         editorResponse.Message.Success.Should().BeTrue("Editor has Update permission");
-        commenterResponse.Message.Success.Should().BeFalse("Commenter lacks Update permission for Thread creation");
+        commenterResponse.Message.Success.Should().BeFalse("Commenter lacks Update permission for node creation");
         commenterResponse.Message.RejectionReason.Should().Be(NodeCreationRejectionReason.ValidationFailed);
     }
 

--- a/test/MeshWeaver.Security.Test/SecurityServiceTests.cs
+++ b/test/MeshWeaver.Security.Test/SecurityServiceTests.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MeshWeaver.AI;
 using MeshWeaver.Documentation;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting;
@@ -797,8 +796,12 @@ public class PartitionAccessPolicyTests(ITestOutputHelper output) : MonolithMesh
 }
 
 /// <summary>
-/// Tests that static node providers (Doc, Agent, Role) enforce read-only policies
+/// Tests that static node providers (Doc, Role) enforce read-only policies
 /// via PartitionAccessPolicy nodes emitted from their GetStaticNodes() methods.
+/// <para>The Agent provider's own policy is pinned beside it, in
+/// <c>MeshWeaver.AI.Test.AgentNamespacePolicyTest</c> (#2276): the contract is general, but
+/// each instance of it belongs with the provider that emits it — MeshWeaver.AI is leaving
+/// this repository, and a policy test for its provider must leave with it.</para>
 /// </summary>
 public class StaticNamespacePolicyTests(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -809,12 +812,10 @@ public class StaticNamespacePolicyTests(ITestOutputHelper output) : MonolithMesh
     {
         return ConfigureMeshBase(builder)
             .AddDocumentation()
-            .AddAgentType()
             .AddRowLevelSecurity()
             .AddMeshNodes(
                 AssignmentNodeFactory.UserRole("admin_doc", "Admin", ""),
                 AssignmentNodeFactory.UserRole("editor_doc", "Editor", "Doc"),
-                AssignmentNodeFactory.UserRole("admin_agent", "Admin", ""),
                 AssignmentNodeFactory.UserRole("admin_role", "Admin", ""),
                 AssignmentNodeFactory.UserRole("admin_other", "Admin", ""),
                 AssignmentNodeFactory.UserRole("admin_docroot", "Admin", ""));
@@ -834,14 +835,6 @@ public class StaticNamespacePolicyTests(ITestOutputHelper output) : MonolithMesh
         var expected = Permission.Read | Permission.Comment | Permission.Execute | Permission.Thread | Permission.Api | Permission.Export;
         await Mesh.GetEffectivePermissions("Doc/AI/AgenticAI", "editor_doc")
             .Should().Match(p => p == expected, "Doc namespace allows read + comment + thread + export but not create/update/delete");
-    }
-
-    [Fact(Timeout = 20000)]
-    public async Task AgentNamespace_AdminCappedToReadOnly()
-    {
-        var expected = Permission.Read | Permission.Execute | Permission.Api | Permission.Export;
-        await Mesh.GetEffectivePermissions("Agent/ThreadNamer", "admin_agent")
-            .Should().Match(p => p == expected, "Agent namespace has a static read-only policy");
     }
 
     [Fact(Timeout = 20000)]


### PR DESCRIPTION
`Hosting.Monolith.Test`, `NodeOperations.Test` and `Security.Test` each drop their `ProjectReference` to the AI engine — #2276.

Everything AI-specific moves to `MeshWeaver.AI.Test`, which travels to MeshWeaver.Plugins with the engine. What stays is core coverage that merely used an AI type as a fixture.

| suite | moved to `AI.Test` | stayed |
|---|---|---|
| `Hosting.Monolith.Test` | 4 AI tests (AgentChatClient, LanguageModelSyncedQuery, AgentSyncedQueryFromHostedHub, AiSourcesInstallHook) | — the other two `using`s were genuinely dead |
| `NodeOperations.Test` | `MeshPluginAccessContextTest` (drives MeshPlugin tool calls) | — |
| `Security.Test` | `ThreadAccessTest`, `ThreadStreamingIdentityTest`, and the **Agent case** of `StaticNamespacePolicyTests` | Doc + Role cases |

On that last one: the contract *"static providers cap to read-only"* is general and stays in core. Only the **instance** belongs with the provider that emits the policy — same reasoning as the parser-registry split in #2345.

## 🚨 One re-point was wrong, and the tests caught it

I re-pointed `NodeCreationAccessTest.CreateThread_UnderOwnUserNode_Succeeds` to `MarkdownNodeType`, treating the node type as an incidental fixture. It is not:

```csharp
created.MainNode.Should().Be(userId, "Satellite thread MainNode should point to parent node");
```

That asserts **satellite wiring**. `Thread` is a satellite type; `Markdown` is not. It failed on exactly that assertion — `MainNode` came back as the node's own path instead of the parent.

**The rule this sharpened:** substituting a type is safe only when the type is *incidental to what is asserted*. When the test asserts a property the type **confers** — satellite-ness, a policy, a parser — substitution silently changes the subject, and the test has to move instead.

So it now lives in `AI.Test` as `ThreadSelfAccessCreationTest` with `ThreadNodeType` restored, while its sibling (creating under ANOTHER user's node must throw) is genuinely type-agnostic and stays in core on Markdown. `RlsIntegrationTests`' `"Thread"` fixture was also genuinely incidental — row-level-security assertions say nothing about the type — so that one is re-pointed rather than moved.

## Verification

- all four projects build `-c Release -p:CIRun=true -warnaserror` → `0 Warning(s)`, `0 Error(s)`
- `Security.Test` `NodeCreationAccessTest`: **6/6**
- moved tests green in their new home: **15 + 1**

No What's New entry — test-only refactor.

Refs #2276

🤖 Generated with [Claude Code](https://claude.com/claude-code)