### PR TITLE
CD builds the portal host from plugins, and asserts every delivery leg ran

### DIFF
--- a/.github/workflows/edge-images.yml
+++ b/.github/workflows/edge-images.yml
@@ -36,6 +36,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       # The SDK container build overflows the runner's ~14 GB; reclaim preinstalled tooling.
+      - name: Check out MeshWeaver.Plugins (holds the portal host)
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver.Plugins
+          ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
+          path: plugins-repo
+          ssh-key: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
+          fetch-depth: 1
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
@@ -57,7 +65,7 @@ jobs:
         id: vars
         run: |
           set -euo pipefail
-          VERSION=$(dotnet msbuild memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj \
+          VERSION=$(dotnet msbuild src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj \
             -getProperty:Version -p:CIRun=true -nologo | tr -d '[:space:]')
           EDGE_VERSION="${VERSION/.ci./.edge.}"          # rc:    3.0.0-rc1.ci.N -> 3.0.0-rc1.edge.N
           EDGE_VERSION="${EDGE_VERSION/-ci./-edge.}"      # clean: 3.0.0-ci.N    -> 3.0.0-edge.N
@@ -81,7 +89,8 @@ jobs:
       # %3B is the MSBuild escape for a literal ';' inside a `;`-separated property value.
       - name: Build + push portal-ai (edge)
         run: >
-          dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+          dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+          -p:MeshWeaverRoot=${{ github.workspace }}
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
           -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
           -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"

--- a/.github/workflows/edge-images.yml
+++ b/.github/workflows/edge-images.yml
@@ -36,14 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       # The SDK container build overflows the runner's ~14 GB; reclaim preinstalled tooling.
-      - name: Check out MeshWeaver.Plugins (holds the portal host)
-        uses: actions/checkout@v7
-        with:
-          repository: Systemorph/MeshWeaver.Plugins
-          ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
-          path: plugins-repo
-          ssh-key: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
-          fetch-depth: 1
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
@@ -65,7 +57,7 @@ jobs:
         id: vars
         run: |
           set -euo pipefail
-          VERSION=$(dotnet msbuild src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj \
+          VERSION=$(dotnet msbuild memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj \
             -getProperty:Version -p:CIRun=true -nologo | tr -d '[:space:]')
           EDGE_VERSION="${VERSION/.ci./.edge.}"          # rc:    3.0.0-rc1.ci.N -> 3.0.0-rc1.edge.N
           EDGE_VERSION="${EDGE_VERSION/-ci./-edge.}"      # clean: 3.0.0-ci.N    -> 3.0.0-edge.N
@@ -89,8 +81,7 @@ jobs:
       # %3B is the MSBuild escape for a literal ';' inside a `;`-separated property value.
       - name: Build + push portal-ai (edge)
         run: >
-          dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
-          -p:MeshWeaverRoot=${{ github.workspace }}
+          dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
           -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
           -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1632,13 +1632,23 @@ jobs:
           PUBLISH: ${{ needs.gate.outputs.publish }}
           REASON: ${{ needs.gate.outputs.reason }}
           SHORT: ${{ needs.gate.outputs.short_sha }}
+          GATE_RESULT: ${{ needs.gate.result }}
+          PROMOTE_RESULT: ${{ needs.promote.result }}
         run: |
-          if [ "$PUBLISH" = "true" ]; then
+          # 🚨 NO-OP is keyed on the gate having been SKIPPED — never on an empty reason. An empty
+          # reason is ALSO what a gate that errored, was cancelled, or produced no outputs looks
+          # like, and this step runs under `if: always()`, so labelling that "NO-OP" would stamp a
+          # broken run with the one label that says nothing was due. (Caught in review.)
+          if [ "$GATE_RESULT" = "skipped" ]; then
+            echo "### ⚪ NO-OP — the gate did not run: not a push to main, so no delivery was due" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$PUBLISH" = "true" ] && [ "$PROMOTE_RESULT" = "success" ]; then
             echo "### ✅ PUBLISHED an image set for \`${SHORT}\` (reason: ${REASON})" >> "$GITHUB_STEP_SUMMARY"
-          elif [ -z "$REASON" ]; then
-            echo "### ⚪ NO-OP — not a push to main; no delivery was due" >> "$GITHUB_STEP_SUMMARY"
-          else
+          elif [ "$PUBLISH" = "true" ]; then
+            echo "### ❌ DELIVERY FAILED for \`${SHORT}\` — the gate decided to publish but promote=${PROMOTE_RESULT}; see the leg check above" >> "$GITHUB_STEP_SUMMARY"
+          elif [ -n "$REASON" ]; then
             echo "### 🕐 NO PUBLISH for \`${SHORT}\` (reason: ${REASON})" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### ❌ INCONCLUSIVE — gate=${GATE_RESULT} produced no verdict; this run is red above" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   alert-on-failure:

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -664,6 +664,21 @@ jobs:
         with:
           # Build the EXACT commit the tests passed on — not whatever main is now.
           ref: ${{ needs.gate.outputs.sha }}
+      # 🚨 The portal HOST lives in MeshWeaver.Plugins (#2293 removed it from here). This checkout is
+      # what makes the image buildable at all; without it the publish below has no project.
+      #
+      # ref defaults to `main` and is overridable by a repo variable, mirroring the plugins lane's
+      # own MW_PLATFORM_REF. The variable does not decouple "which plugins commit shipped with which
+      # core commit" — it makes that coupling STEERABLE, so pinning to a known-good plugins commit
+      # during an incident is a variable change rather than editing this file under pressure.
+      - name: Check out MeshWeaver.Plugins (holds the portal host)
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver.Plugins
+          ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
+          path: plugins-repo
+          ssh-key: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
+          fetch-depth: 1
       # The SDK container build + the publish output overflow the runner's ~14 GB; reclaim the
       # ~25 GB of preinstalled tooling a .NET build never touches (same as the test workflow).
       - name: Setup .NET
@@ -680,8 +695,23 @@ jobs:
         id: vars
         run: |
           set -euo pipefail
-          VERSION=$(dotnet msbuild memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj \
+          # 🚨 Read from a project that STAYS in this repo. This used to read
+          # Memex.Portal.Distributed, which moved to MeshWeaver.Plugins — and CD then failed here for
+          # every commit on main, publishing nothing, until someone noticed nothing had shipped.
+          # Version comes from the root Directory.Build.props, so ANY core project yields the same
+          # value; Mesh.Contract is picked because it is cheap and is not going anywhere.
+          #
+          # -getProperty: asks MSBuild for the COMPUTED value, deliberately not a grep of the props
+          # file: a regex keeps returning a plausible, well-formed, WRONG number after the definition
+          # moves — and that number gets published.
+          VERSION=$(dotnet msbuild src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj \
             -getProperty:Version -p:CIRun=true -nologo | tr -d '[:space:]')
+          # Refuse rather than invent: an empty version becomes `:` or `latest` somewhere downstream,
+          # which is the failure where a tag exists and points at the wrong thing.
+          if [ -z "$VERSION" ]; then
+            echo "::error::could not resolve Version from the platform checkout. Refusing to invent one."
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed image version: $VERSION (run #$GITHUB_RUN_NUMBER)"
       # OIDC federated login — no client secret stored. Requires a federated credential on the
@@ -728,10 +758,11 @@ jobs:
       # ships NOTHING on its own. `promote` applies version/sha/main once every leg has succeeded.
       - name: Build + push portal-ai (staging tag)
         run: >
-          dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+          dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
           -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:CIRun=true
+          -p:MeshWeaverRoot=${{ github.workspace }}
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=memex-portal-ai
           -p:ContainerImageTags=${{ needs.gate.outputs.staging_tag }}

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -664,21 +664,6 @@ jobs:
         with:
           # Build the EXACT commit the tests passed on — not whatever main is now.
           ref: ${{ needs.gate.outputs.sha }}
-      # 🚨 The portal HOST lives in MeshWeaver.Plugins (#2293 removed it from here). This checkout is
-      # what makes the image buildable at all; without it the publish below has no project.
-      #
-      # ref defaults to `main` and is overridable by a repo variable, mirroring the plugins lane's
-      # own MW_PLATFORM_REF. The variable does not decouple "which plugins commit shipped with which
-      # core commit" — it makes that coupling STEERABLE, so pinning to a known-good plugins commit
-      # during an incident is a variable change rather than editing this file under pressure.
-      - name: Check out MeshWeaver.Plugins (holds the portal host)
-        uses: actions/checkout@v7
-        with:
-          repository: Systemorph/MeshWeaver.Plugins
-          ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
-          path: plugins-repo
-          ssh-key: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
-          fetch-depth: 1
       # The SDK container build + the publish output overflow the runner's ~14 GB; reclaim the
       # ~25 GB of preinstalled tooling a .NET build never touches (same as the test workflow).
       - name: Setup .NET
@@ -695,23 +680,8 @@ jobs:
         id: vars
         run: |
           set -euo pipefail
-          # 🚨 Read from a project that STAYS in this repo. This used to read
-          # Memex.Portal.Distributed, which moved to MeshWeaver.Plugins — and CD then failed here for
-          # every commit on main, publishing nothing, until someone noticed nothing had shipped.
-          # Version comes from the root Directory.Build.props, so ANY core project yields the same
-          # value; Mesh.Contract is picked because it is cheap and is not going anywhere.
-          #
-          # -getProperty: asks MSBuild for the COMPUTED value, deliberately not a grep of the props
-          # file: a regex keeps returning a plausible, well-formed, WRONG number after the definition
-          # moves — and that number gets published.
-          VERSION=$(dotnet msbuild src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj \
+          VERSION=$(dotnet msbuild memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj \
             -getProperty:Version -p:CIRun=true -nologo | tr -d '[:space:]')
-          # Refuse rather than invent: an empty version becomes `:` or `latest` somewhere downstream,
-          # which is the failure where a tag exists and points at the wrong thing.
-          if [ -z "$VERSION" ]; then
-            echo "::error::could not resolve Version from the platform checkout. Refusing to invent one."
-            exit 1
-          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed image version: $VERSION (run #$GITHUB_RUN_NUMBER)"
       # OIDC federated login — no client secret stored. Requires a federated credential on the
@@ -758,11 +728,10 @@ jobs:
       # ships NOTHING on its own. `promote` applies version/sha/main once every leg has succeeded.
       - name: Build + push portal-ai (staging tag)
         run: >
-          dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+          dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
           -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:CIRun=true
-          -p:MeshWeaverRoot=${{ github.workspace }}
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=memex-portal-ai
           -p:ContainerImageTags=${{ needs.gate.outputs.staging_tag }}

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1514,7 +1514,10 @@ jobs:
   #     the hour — so failing there would be noise, and noise is how a real red gets ignored.
   delivery-verdict:
     name: "CD delivered, or had a good reason not to"
-    needs: [gate, promote]
+    # 🚨 Every delivery leg is a NEED, not just [gate, promote]. The verdict cannot assert that a
+    # publish actually happened while it can only see two of the nine jobs that make it happen.
+    needs: [preflight, gate, portal-image, migration-image, plugin-test-image, promote,
+            publish-bake, notify-platform-update, verify-images]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1584,6 +1587,59 @@ jobs:
           fi
 
           echo "OK — either something was published, or not publishing was the correct answer."
+
+      # 🚨 THE POSITIVE CHECK: a run that DECIDED to publish must have RUN every leg.
+      #
+      # The guards above classify the gate's VERDICT. They say nothing about whether the nine jobs
+      # that carry out a delivery actually executed — and a job that `skipped` renders the same
+      # grey/green tick as one that ran, so a publish missing a leg reports success. That is the
+      # repo's own CI invariant ("a gate that cannot run must not look like a gate that passed")
+      # applied to delivery itself rather than to the decision about delivery.
+      #
+      # Named results, compared to a literal 'success': `skipped`, `cancelled` and `failure` all
+      # fail here. There is deliberately no "if it is empty, assume fine" branch — that assumption
+      # is what made the verdict pass on an empty gate output in the first place.
+      - name: A publishing run must have RUN every leg, not skipped any
+        if: needs.gate.outputs.publish == 'true'
+        env:
+          LEGS: >-
+            preflight=${{ needs.preflight.result }}
+            portal-image=${{ needs.portal-image.result }}
+            migration-image=${{ needs.migration-image.result }}
+            plugin-test-image=${{ needs.plugin-test-image.result }}
+            promote=${{ needs.promote.result }}
+            publish-bake=${{ needs.publish-bake.result }}
+            notify-platform-update=${{ needs.notify-platform-update.result }}
+            verify-images=${{ needs.verify-images.result }}
+        run: |
+          set -euo pipefail
+          bad=""
+          for kv in $LEGS; do
+            name="${kv%%=*}"; res="${kv#*=}"
+            if [ "$res" != "success" ]; then bad="$bad $name=$res"; fi
+          done
+          if [ -n "$bad" ]; then
+            echo "::error::the gate decided to PUBLISH, but these delivery legs did not run to success:$bad. A skipped leg is not a delivery: the promote step tags all-or-nothing, so a missing leg means either no image set was published or one was published without its bake/notify. Read the named job rather than re-running."
+            exit 1
+          fi
+          echo "every delivery leg ran and succeeded: $LEGS"
+
+      # Make the outcome unmissable on the run page. A 3-second success and a 20-minute delivery
+      # are otherwise identical at a glance, which is how a merged fix sat unshipped.
+      - name: Say plainly what this run did
+        if: always()
+        env:
+          PUBLISH: ${{ needs.gate.outputs.publish }}
+          REASON: ${{ needs.gate.outputs.reason }}
+          SHORT: ${{ needs.gate.outputs.short_sha }}
+        run: |
+          if [ "$PUBLISH" = "true" ]; then
+            echo "### ✅ PUBLISHED an image set for \`${SHORT}\` (reason: ${REASON})" >> "$GITHUB_STEP_SUMMARY"
+          elif [ -z "$REASON" ]; then
+            echo "### ⚪ NO-OP — not a push to main; no delivery was due" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### 🕐 NO PUBLISH for \`${SHORT}\` (reason: ${REASON})" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   alert-on-failure:
     name: "Alert: CD failed on main"

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -31,14 +31,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Check out MeshWeaver.Plugins (holds the portal host)
-        uses: actions/checkout@v7
-        with:
-          repository: Systemorph/MeshWeaver.Plugins
-          ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
-          path: plugins-repo
-          ssh-key: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
-          fetch-depth: 1
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
@@ -98,8 +90,7 @@ jobs:
       # 2. portal-ai app image (SDK container build, layered on the multi-arch base; CLIs baked in).
       - name: Build + push portal-ai
         run: >
-          dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
-          -p:MeshWeaverRoot=${{ github.workspace }}
+          dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
           -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:Version=$VERSION
@@ -111,8 +102,7 @@ jobs:
       # 3. lean portal app image (default — already multi-arch — SDK aspnet base, no co-hosted CLIs).
       - name: Build + push portal (lean)
         run: >
-          dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
-          -p:MeshWeaverRoot=${{ github.workspace }}
+          dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
           -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:Version=$VERSION

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Check out MeshWeaver.Plugins (holds the portal host)
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver.Plugins
+          ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
+          path: plugins-repo
+          ssh-key: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
+          fetch-depth: 1
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
@@ -90,7 +98,8 @@ jobs:
       # 2. portal-ai app image (SDK container build, layered on the multi-arch base; CLIs baked in).
       - name: Build + push portal-ai
         run: >
-          dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+          dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+          -p:MeshWeaverRoot=${{ github.workspace }}
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
           -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:Version=$VERSION
@@ -102,7 +111,8 @@ jobs:
       # 3. lean portal app image (default — already multi-arch — SDK aspnet base, no co-hosted CLIs).
       - name: Build + push portal (lean)
         run: >
-          dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+          dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+          -p:MeshWeaverRoot=${{ github.workspace }}
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
           -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:Version=$VERSION

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -146,11 +146,17 @@ public class PlatformBakeLaneGuard
     }
 
     /// <summary>
-    /// 🚨 CD bakes ONLY the content the image itself embeds. Everything a deployment receives
-    /// already built — node-repo content (Plugins, Education, Reinsurance, SocialMedia), Store
-    /// packages, and the samples trees — is ADOPTED from a bundle its own lane published under the
-    /// same framework identity. Re-compiling it here would redo that work, burn CD wall-clock, and
-    /// re-derive assemblies that were meant to be authoritative.
+    /// 🚨 The platform's main build BUILDS EVERYTHING and publishes it atomically: core, every
+    /// plugin, the portal host, and the bake — one run, one framework identity. Maintainer decision
+    /// 2026-08-26 ("we want to run full plugin build in main memex build"; "plugins should not have
+    /// a lane in this sense"). That supersedes the earlier model in which plugins were ADOPTED from
+    /// a bundle their own lane published, and it removes the #1814 bake-identity class by
+    /// construction: nothing can be built against a framework other than the one shipping.
+    ///
+    /// <para>What this guard still refuses: the samples trees (no deployment embeds them), and any
+    /// checkout that is not <c>Systemorph/MeshWeaver.Plugins</c>. The plugins checkout is the ONE
+    /// deliberate cross-repo input — a second one would be a new decision, not an extension of
+    /// this one.</para>
     /// </summary>
     [Fact]
     public void PlatformBake_CompilesOnlyWhatTheImageEmbeds()
@@ -171,14 +177,17 @@ public class PlatformBakeLaneGuard
             + "still compile-GATE on every PR in dotnet-test.yml's doc-gate — that proves the "
             + "content, which is the part worth paying for.");
 
-        // The strongest form of "CD cannot compile someone else's module": it never checks out
-        // someone else's repository. One `repository:` input would make it possible.
+        // The main build checks out exactly ONE other repository — the plugins it builds and ships.
+        // Asserted POSITIVELY (present, and the only one) rather than as an absence: the portal
+        // host lives there now, so a main-cd without this checkout cannot build the deployment
+        // image at all (measured 2026-08-26: every push run failed at the version step and nothing
+        // published until this was restored). And a third `repository:` would be a new decision.
         var text = ExecutableLinesOf(File.ReadAllText(Path.Combine(FindRepoRoot(), Workflow)));
-        Assert.False(text.Contains("repository:", StringComparison.Ordinal),
-            $"{Workflow} must check out no repository but this one. Node-repo and Store content "
-            + "arrives already compiled and is adopted; a checkout of another repo here would let "
-            + "CD re-derive assemblies whose authoritative build belongs to that repo's own "
-            + "publish-bake lane.");
+        var repos = Regex.Matches(text, @"repository:\s*(\S+)")
+            .Select(m => m.Groups[1].Value.Trim())
+            .Distinct()
+            .ToList();
+        Assert.Equal(new[] { "Systemorph/MeshWeaver.Plugins" }, repos);
     }
 
     /// <summary>The block's lines that can actually DO something: YAML and shell comment lines


### PR DESCRIPTION
Raised while watching `main-cd` runs complete in **0 minutes** and report success: *"no cd run should complete in 0 minutes"* and *"we need a check that everything was actually run"*.

### What was already covered

`delivery-verdict` classifies the gate's **verdict** and fails on an empty one, a stuck reconcile, and a red-main push. Those guards are good and unchanged — they were added today after run `32914425222` passed on an empty gate output.

### What wasn't

Nothing checked that a run which **decided to publish** actually executed the nine jobs that carry out a delivery. `delivery-verdict` needed only `[gate, promote]`, so seven legs were invisible to it — and a `skipped` job renders the same grey/green tick as one that ran.

```
success   CD delivered, or had a good reason not to        3s
skipped   Resolve the target commit and decide whether to publish
skipped   Build + push portal-ai image   … and every other job
```

### The change

Every leg becomes a `needs`, and a publishing run asserts each concluded `success` **by name**. `skipped`, `cancelled`, `failure` and **empty** all fail, with the offending jobs named. No "empty means fine" branch — that assumption is what let the verdict pass on an empty gate output in the first place.

Plus a step-summary line saying plainly whether the run **PUBLISHED**, was a **NO-OP**, or **declined**. A 3-second success and a 20-minute delivery are otherwise identical at a glance, which is how a merged fix sat unshipped while its instance waited for it.

### On the 0-minute runs themselves

Those are CD firing on a *PR's* Build-and-Test — it triggers on every completed run while the gate is conditioned to push-on-main. That is a legitimate no-op, so it is **not** made to fail: erroring on every PR would train everyone to ignore the alarm, which is worse than the ambiguity. They are now labelled `⚪ NO-OP` in the summary. The missing thing was a visible difference, not a failure.

### Verified

Both directions under bash: all-success **passes**; one leg `skipped`, `cancelled`, or **empty** each **fails**, naming the leg.

No What's New entry: CI-internal.