### PR TITLE
Isolate a module whose service registration throws — the invocation-time gap #2275 left open

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-a-late-throwing-module-no-longer-crashes-the-pod.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-a-late-throwing-module-no-longer-crashes-the-pod.md
@@ -1,0 +1,28 @@
+---
+Name: A module whose registration fails no longer crashes the whole portal
+Category: Fix
+Description: A module that loaded fine but failed while registering its own features against the running platform used to abort the entire portal at boot. It is now isolated to that one module — skipped, reported, and the portal keeps serving.
+Icon: Sparkle
+Order: -20260826
+---
+
+# A module whose registration fails no longer crashes the whole portal
+
+Yesterday's fix (2026-08-25) stopped a module that fails to LOAD against the running platform from
+taking the whole portal down with it — that module is skipped, reported, and every other module still
+installs. It left one door open: a module can load successfully and still fail later, while it is
+registering its own features, if that step calls into a signature the running platform no longer has.
+That is exactly what happened twice — once building the crash that prompted yesterday's fix, and again
+the next morning on a different portal and a different module.
+
+## What changed
+
+A module's feature registration is now isolated the same way its loading already was: if it throws, that
+one module contributes nothing and is reported as incompatible, but the portal boots and every other
+module installs normally. Nothing before it is torn down, and nothing after it is blocked.
+
+## What you will notice
+
+A module that no longer matches the running platform shows up as a named, reported problem — never a
+portal that fails to start. The remedy is unchanged: a module and the platform it runs on have to move
+together.

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -130,9 +130,11 @@ public record MeshBuilder
         // pod aborted ~2 s into boot with no application logging (the pipeline is not up yet) —
         // memex-cloud could not start a pod for ~90 minutes.
         //
-        // Everything an attribute can THROW from is materialised here, before any builder state is
-        // mutated, so a module that fails leaves no half-applied configuration behind. The lambdas
-        // are the hazard: `a.Nodes` is what constructs the objects whose ctor may have moved.
+        // Everything an attribute's Nodes/AddressTypes/HubConfigurations getters can THROW from is
+        // materialised here, before any builder state is mutated, so a module that fails leaves no
+        // half-applied configuration behind. This captures the GlobalServiceConfigurations
+        // delegates a node carries as DATA — it does not invoke them. Invoking them is a separate,
+        // equally hazardous step, isolated per module just below.
         var pending = new List<PendingModuleInstall>();
         var incompatible = new List<IncompatibleModule>();
         foreach (var location in assemblyLocations)
@@ -155,10 +157,37 @@ public record MeshBuilder
             }
         }
 
+        // 🚨 A node's GlobalServiceConfigurations delegate is invoked IMMEDIATELY by
+        // ConfigureServices — it runs against the live IServiceCollection, not queued for later
+        // (see ConfigureServices / InstallServices below) — so it is exactly as hazardous as the
+        // attribute materialisation above, and it is where BOTH real #2234 incidents actually
+        // threw: the original report's stack named a GlobalServiceConfigurations callback
+        // (`AzureFoundryProvidersAttribute.<get_Nodes>b__1_0(IServiceCollection)`) being CALLED,
+        // and the systemorph recurrence named this exact frame
+        // (`MeshBuilder.InstallServices(IEnumerable'1 nodes)`) directly. Materialising `a.Nodes`
+        // above only captures the delegate; invoking it is what can throw. Folded per module, same
+        // shape as the BuilderConfigurations fold below, so one module's registration failure
+        // costs only that module — never the modules that load after it in this call.
+        var installed = new List<PendingModuleInstall>();
+        var installedNodes = new List<MeshNode>();
+        foreach (var module in pending)
+        {
+            try
+            {
+                installedNodes.AddRange(InstallServices(module.Nodes));
+                installed.Add(module);
+            }
+            catch (Exception exception)
+            {
+                incompatible.Add(ReportIncompatible(module.Assembly.Location, exception));
+            }
+        }
+        MeshNodes.AddRange(installedNodes);
+
         // Only the modules that actually installed are recorded as installed. A skewed one is
         // deliberately NOT in this list: it contributes no nodes, and letting it into the in-mesh
         // compile reference set would hand every dynamic NodeType the same broken signatures.
-        var assemblies = pending.Select(p => p.Assembly).ToArray();
+        var assemblies = installed.Select(p => p.Assembly).ToArray();
         // Record every installed module for the runtime surfaces that must SEE modules the way
         // they see the platform: the in-mesh compile reference set (a module leaving the publish
         // closure leaves TRUSTED_PLATFORM_ASSEMBLIES, so compilation composes TPA + these) and
@@ -171,10 +200,9 @@ public record MeshBuilder
                 services.AddSingleton(new InstalledModuleAssembly(assembly));
             return services;
         });
-        MeshNodes.AddRange(pending.SelectMany(p => InstallServices(p.Nodes)));
 
         // Register address types from attributes
-        var addressTypes = pending.SelectMany(p => p.AddressTypes).ToArray();
+        var addressTypes = installed.SelectMany(p => p.AddressTypes).ToArray();
         if (addressTypes.Length > 0)
         {
             ConfigureHub(config =>
@@ -187,9 +215,9 @@ public record MeshBuilder
         // Attribute-carried hub configuration — the surfaces a boot-loaded pack needs beyond
         // root DI: the mesh hub's own configuration and the every-per-node-hub chain
         // (Courses/Observability-shaped packs register types + default areas there).
-        foreach (var hubConfiguration in pending.SelectMany(p => p.HubConfigurations))
+        foreach (var hubConfiguration in installed.SelectMany(p => p.HubConfigurations))
             ConfigureHub(hubConfiguration);
-        foreach (var nodeHubConfiguration in pending.SelectMany(p => p.DefaultNodeHubConfigurations))
+        foreach (var nodeHubConfiguration in installed.SelectMany(p => p.DefaultNodeHubConfigurations))
             ConfigureDefaultNodeHub(nodeHubConfiguration);
 
         // Attribute-carried BUILDER configuration — the full-surface hook. Applied last so a
@@ -202,7 +230,7 @@ public record MeshBuilder
         // module. The fold keeps the builder from the last SUCCESSFUL configuration, so a module
         // that throws midway cannot strand the chain.
         var result = this;
-        foreach (var module in pending)
+        foreach (var module in installed)
         {
             try
             {

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -164,7 +164,7 @@ public record MeshBuilder
         // threw: the original report's stack named a GlobalServiceConfigurations callback
         // (`AzureFoundryProvidersAttribute.<get_Nodes>b__1_0(IServiceCollection)`) being CALLED,
         // and the systemorph recurrence named this exact frame
-        // (`MeshBuilder.InstallServices(IEnumerable'1 nodes)`) directly. Materialising `a.Nodes`
+        // (`MeshBuilder.InstallServices(IEnumerable`1 nodes)`) directly. Materialising `a.Nodes`
         // above only captures the delegate; invoking it is what can throw. Folded per module, same
         // shape as the BuilderConfigurations fold below, so one module's registration failure
         // costs only that module — never the modules that load after it in this call.
@@ -174,7 +174,16 @@ public record MeshBuilder
         {
             try
             {
-                installedNodes.AddRange(InstallServices(module.Nodes));
+                // 🚨 Materialise this module's nodes into a LOCAL buffer BEFORE touching
+                // installedNodes/MeshNodes. A module can carry several nodes; if an EARLIER one's
+                // config succeeds and a LATER one's throws, `.ToList()` still throws here (nothing
+                // is appended), so the module stays "contributes nothing" at the node-list level
+                // even though the earlier node's ConfigureServices call already mutated the live
+                // IServiceCollection for real and cannot be undone — the same asymmetry the
+                // BuilderConfigurations fold below already accepts (applied side effects stay
+                // applied; only chain/list MEMBERSHIP is what stays consistent).
+                var moduleNodes = InstallServices(module.Nodes).ToList();
+                installedNodes.AddRange(moduleNodes);
                 installed.Add(module);
             }
             catch (Exception exception)

--- a/test/MeshWeaver.AI.Test/ProviderModulePackBootTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderModulePackBootTest.cs
@@ -11,6 +11,8 @@ using MeshWeaver.AI.Test;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Agents.AI;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
@@ -134,6 +136,68 @@ public class ProviderModulePackBootTest
         Assert.DoesNotContain(services, d => d.ServiceType == typeof(IncompatibleModule));
     }
 
+    /// <summary>
+    /// The gap the first isolation pass (#2275) left open. That pass wraps everything an
+    /// attribute's <c>Nodes</c>/<c>AddressTypes</c>/<c>HubConfigurations</c> GETTERS can throw
+    /// from — but a node's <c>GlobalServiceConfigurations</c> delegate is still just DATA at that
+    /// point; <see cref="MeshBuilder"/> invokes it later, against a live <see cref="IServiceCollection"/>,
+    /// via the private <c>InstallServices</c> helper. BOTH real #2234 incidents threw from exactly
+    /// that later step, not from materialising <c>Nodes</c>: the original report's stack named a
+    /// <c>GlobalServiceConfigurations</c> callback (<c>AzureFoundryProvidersAttribute.&lt;get_Nodes&gt;b__1_0(IServiceCollection)</c>)
+    /// being CALLED, and the systemorph recurrence named <c>MeshBuilder.InstallServices</c> itself.
+    /// A fixture whose <c>Nodes</c> getter succeeds but whose registration delegate throws when
+    /// invoked is the one that pins this — <see cref="InstallAssemblies_WithAModuleItCannotLoad_KeepsTheGoodOne_AndDoesNotAbort"/>
+    /// above throws from <c>Assembly.LoadFrom</c> itself, which never reaches this code path.
+    ///
+    /// <para>The broken module has to be a genuinely SEPARATE assembly from the healthy probe pack:
+    /// an assembly-level attribute applies to the WHOLE assembly it lives in, so a permanently-
+    /// throwing one could not share <see cref="ProbeProviderPackAttribute"/>'s DLL without also
+    /// breaking <see cref="InstallAssemblies_WithEveryModuleLoadable_RecordsNoIncompatibility"/>,
+    /// which loads that same DLL expecting zero incompatibilities.</para>
+    /// </summary>
+    [Fact]
+    public void InstallAssemblies_WithAModuleWhoseServiceRegistrationThrowsAtInvocation_KeepsTheGoodOne_AndDoesNotAbort()
+    {
+        var brokenModulePath = CompileBrokenServiceRegistrationModule(out var brokenModuleName);
+
+        // 🚨 Deliberately NOT `configure => configurations.Add(configure)` (the pattern the other
+        // tests in this file use) — that defers every delegate to a later, test-owned Aggregate
+        // call, so nothing actually RUNS while InstallAssemblies is on the stack, and this test
+        // would pass for the wrong reason (or rather: it would fail in the test's own Aggregate
+        // call, outside InstallAssemblies' try/catch, exactly as this test did before this line
+        // was written this way — confirmed by actually running it). Production's real wiring,
+        // MeshHostApplicationBuilder(Host, address) : base(x => x.Invoke(Host.Services), address),
+        // invokes the delegate IMMEDIATELY against the live IServiceCollection, which is exactly
+        // why both #2234 incidents' stack traces show the throw happening synchronously inside
+        // MeshBuilder.InstallAssemblies/InstallServices. Mirroring that wiring here is what makes
+        // this test exercise the code path the incidents actually hit.
+        var services = (IServiceCollection)new ServiceCollection();
+        var builder = new MeshBuilder(configure => configure.Invoke(services),
+            AddressExtensions.CreateMeshAddress());
+
+        var exception = Record.Exception(() => builder.InstallAssemblies(
+            brokenModulePath,
+            typeof(ProbeProviderPackAttribute).Assembly.Location));
+
+        Assert.Null(exception);
+
+        // The healthy pack, in its OWN assembly, is unaffected by its neighbour's failure.
+        AssertFactoryAndCatalogSourceLanded(services);
+
+        // And the failure is RECORDED, with the exact missing signature — the sentence an
+        // operator acts on — rather than swallowed or left to abort the process.
+        var recorded = services
+            .Where(d => d.ServiceType == typeof(IncompatibleModule))
+            .Select(d => d.ImplementationInstance)
+            .OfType<IncompatibleModule>()
+            .ToList();
+        var broken = Assert.Single(recorded);
+        Assert.Equal(brokenModuleName, broken.Name);
+        Assert.Contains("CONTRIBUTING NOTHING", broken.Report());
+        Assert.Equal("Void MeshWeaver.AI.BrokenProbe.LanguageModelCatalogSource..ctor(System.String, System.String, System.Int32)",
+            broken.MissingMember);
+    }
+
     [Fact]
     public void TheFactoryClaimsItsOwnModels_AndNobodyElses()
     {
@@ -160,6 +224,69 @@ public class ProviderModulePackBootTest
             .SingleOrDefault();
         Assert.NotNull(catalog);
         Assert.Contains(catalog!.Sources, s => s.ProviderName == ProbeProviderPackAttribute.ProviderName);
+    }
+
+    /// <summary>
+    /// Compiles and emits a REAL, standalone assembly (never <see cref="ProbeProviderPackAttribute"/>'s)
+    /// carrying one <see cref="MeshNodeProviderAttribute"/> whose sole node's
+    /// <c>GlobalServiceConfigurations</c> delegate throws a <see cref="MissingMethodException"/>
+    /// when INVOKED — reproducing a binary-incompatible record ctor call against a live
+    /// <see cref="IServiceCollection"/>, not a load-time failure. References the process's own
+    /// TRUSTED_PLATFORM_ASSEMBLIES set, which in a test host already includes every assembly this
+    /// fixture needs (MeshWeaver.Mesh.Contract for <see cref="MeshNodeProviderAttribute"/>/
+    /// <see cref="MeshNode"/>, Microsoft.Extensions.DependencyInjection.Abstractions for
+    /// <see cref="IServiceCollection"/>) — the same pattern <c>EmitToDiskWithRetryTest.RealAssemblyBytes</c>
+    /// (MeshWeaver.Graph.Test) uses to emit a real fixture assembly for a test.
+    /// </summary>
+    private static string CompileBrokenServiceRegistrationModule(out string assemblyName)
+    {
+        assemblyName = $"MeshWeaver.AI.BrokenProbe.{Guid.NewGuid():N}";
+        var tree = CSharpSyntaxTree.ParseText(
+            """
+            using System;
+            using System.Collections.Generic;
+            using MeshWeaver.Mesh;
+
+            [assembly: MeshWeaver.AI.BrokenProbe.BrokenServiceRegistrationAttribute]
+
+            namespace MeshWeaver.AI.BrokenProbe;
+
+            [AttributeUsage(AttributeTargets.Assembly)]
+            public sealed class BrokenServiceRegistrationAttribute : MeshNodeProviderAttribute
+            {
+                public override IEnumerable<MeshNode> Nodes =>
+                [
+                    new MeshNode("MeshWeaver.AI.BrokenProbe")
+                    {
+                        Name = "Probe module whose service registration throws",
+                        NodeType = "ModuleDefinition",
+                    }
+                    .WithGlobalServiceRegistry(services =>
+                        throw new MissingMethodException(
+                            "Method not found: 'Void MeshWeaver.AI.BrokenProbe.LanguageModelCatalogSource..ctor"
+                            + "(System.String, System.String, System.Int32)'.")),
+                ];
+            }
+            """);
+
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string) ?? string.Empty)
+            .Split(Path.PathSeparator)
+            .Where(p => !string.IsNullOrEmpty(p) && File.Exists(p))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName, [tree], references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var path = Path.Combine(Path.GetTempPath(), $"{assemblyName}.dll");
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        if (!result.Success)
+            throw new InvalidOperationException(
+                "the broken-service-registration fixture assembly must compile: "
+                + string.Join("; ", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return path;
     }
 }
 

--- a/test/MeshWeaver.AI.Test/ProviderModulePackBootTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderModulePackBootTest.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using MeshWeaver.AI.Test;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Agents.AI;
 using Microsoft.CodeAnalysis;
@@ -198,6 +199,49 @@ public class ProviderModulePackBootTest
             broken.MissingMember);
     }
 
+    /// <summary>
+    /// The Copilot review on this PR flagged a real gap in the first version of this fix:
+    /// <c>InstallServices</c> is a generator that YIELDS each node right after ITS OWN
+    /// <c>GlobalServiceConfigurations</c> delegate succeeds, so a module with more than one node
+    /// could have an EARLIER node's contribution land in <c>MeshNodes</c> even though a LATER node
+    /// in the SAME module then throws and the whole module is recorded as
+    /// <see cref="IncompatibleModule"/> — a module documented as "contributing nothing" that, in
+    /// fact, contributed one node. This fixture has two nodes under one attribute: the first's
+    /// registration succeeds, the second's throws.
+    /// </summary>
+    [Fact]
+    public void InstallAssemblies_WithAModuleWhoseSecondNodeThrows_ContributesNoNodesAtAll()
+    {
+        var brokenModulePath = CompileTwoNodeModuleWhereTheSecondNodeThrows(
+            out var firstNodePath, out var secondNodePath);
+
+        var services = (IServiceCollection)new ServiceCollection();
+        var builder = new MeshBuilder(configure => configure.Invoke(services),
+            AddressExtensions.CreateMeshAddress());
+
+        var exception = Record.Exception(() => builder.InstallAssemblies(brokenModulePath));
+
+        Assert.Null(exception);
+
+        var nodePaths = services.BuildServiceProvider()
+            .EnumerateStaticNodes()
+            .Select(n => n.Path)
+            .ToList();
+
+        // NEITHER node from the broken module reaches MeshNodes — not even the one whose own
+        // ConfigureServices delegate ran successfully before its sibling threw. The module
+        // "contributes nothing", exactly as IncompatibleModule.Report() claims.
+        Assert.DoesNotContain(firstNodePath, nodePaths);
+        Assert.DoesNotContain(secondNodePath, nodePaths);
+
+        var recorded = services
+            .Where(d => d.ServiceType == typeof(IncompatibleModule))
+            .Select(d => d.ImplementationInstance)
+            .OfType<IncompatibleModule>()
+            .ToList();
+        Assert.Single(recorded);
+    }
+
     [Fact]
     public void TheFactoryClaimsItsOwnModels_AndNobodyElses()
     {
@@ -285,6 +329,76 @@ public class ProviderModulePackBootTest
         if (!result.Success)
             throw new InvalidOperationException(
                 "the broken-service-registration fixture assembly must compile: "
+                + string.Join("; ", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return path;
+    }
+
+    /// <summary>
+    /// As <see cref="CompileBrokenServiceRegistrationModule"/>, but with TWO nodes under one
+    /// attribute: the first's <c>GlobalServiceConfigurations</c> delegate succeeds (it registers a
+    /// harmless marker service), the second's throws. Pins that a module's node-list contribution
+    /// is all-or-nothing, not "whichever nodes got yielded before the throw".
+    /// </summary>
+    private static string CompileTwoNodeModuleWhereTheSecondNodeThrows(
+        out string firstNodePath, out string secondNodePath)
+    {
+        var assemblyName = $"MeshWeaver.AI.BrokenProbeMulti.{Guid.NewGuid():N}";
+        firstNodePath = "MeshWeaver.AI.BrokenProbeMulti.First";
+        secondNodePath = "MeshWeaver.AI.BrokenProbeMulti.Second";
+        var tree = CSharpSyntaxTree.ParseText(
+            """
+            using System;
+            using System.Collections.Generic;
+            using MeshWeaver.Mesh;
+            using Microsoft.Extensions.DependencyInjection;
+
+            [assembly: MeshWeaver.AI.BrokenProbeMulti.TwoNodeSecondThrowsAttribute]
+
+            namespace MeshWeaver.AI.BrokenProbeMulti;
+
+            [AttributeUsage(AttributeTargets.Assembly)]
+            public sealed class TwoNodeSecondThrowsAttribute : MeshNodeProviderAttribute
+            {
+                public override IEnumerable<MeshNode> Nodes =>
+                [
+                    new MeshNode("MeshWeaver.AI.BrokenProbeMulti.First")
+                    {
+                        Name = "First node — its registration succeeds",
+                        NodeType = "ModuleDefinition",
+                    }
+                    .WithGlobalServiceRegistry(services =>
+                        services.AddSingleton(new FirstNodeMarker())),
+                    new MeshNode("MeshWeaver.AI.BrokenProbeMulti.Second")
+                    {
+                        Name = "Second node — its registration throws",
+                        NodeType = "ModuleDefinition",
+                    }
+                    .WithGlobalServiceRegistry(services =>
+                        throw new MissingMethodException(
+                            "Method not found: 'Void MeshWeaver.AI.BrokenProbeMulti.LanguageModelCatalogSource"
+                            + "..ctor(System.String)'.")),
+                ];
+            }
+
+            public sealed class FirstNodeMarker;
+            """);
+
+        var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string) ?? string.Empty)
+            .Split(Path.PathSeparator)
+            .Where(p => !string.IsNullOrEmpty(p) && File.Exists(p))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName, [tree], references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var path = Path.Combine(Path.GetTempPath(), $"{assemblyName}.dll");
+        using var stream = File.Create(path);
+        var result = compilation.Emit(stream);
+        if (!result.Success)
+            throw new InvalidOperationException(
+                "the two-node fixture assembly must compile: "
                 + string.Join("; ", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
         return path;
     }


### PR DESCRIPTION
## Summary

Closes #2234, completing the isolation #2275 started.

**Verified against the code, not just the issue's hypothesis.** #2275 (merged 2026-08-25, before this
session started) and #2298 already fixed two of the three items the issue asked for:

- #2275 — `InstallAssemblies` isolates a module that fails to **load** (materialising a
  `MeshNodeProviderAttribute`'s `Nodes`/`AddressTypes`/`HubConfigurations` getters) against the
  running platform: it's recorded as `IncompatibleModule` and reported, the portal boots, every
  other module still installs.
- #2298 — a CI gate refuses a binary-breaking change to a public record's primary constructor
  (arity/default/type change), so the exact class of change that caused this incident can't land
  silently again.

**What was still open, and what this PR fixes:** a node's `GlobalServiceConfigurations` delegate is
still just *data* when `InstallAssemblies`'s existing try/catch runs — `MeshBuilder` invokes it
**later**, immediately, against the live `IServiceCollection`, via the private `InstallServices`
helper (`MeshNode.WithGlobalServiceRegistry`). That invocation is exactly where **both real #2234
incidents threw**:

- the original AzureFoundry report: `AzureFoundryProvidersAttribute.<get_Nodes>b__1_0(IServiceCollection)` — a `GlobalServiceConfigurations` callback being **called**, not materialised
- the systemorph recurrence: the stack names `MeshBuilder.InstallServices` directly

Neither is covered by #2275's existing try/catch, so a module that **loads** fine but throws while
**registering its own services** (a binary-incompatible ctor call, same as before) still aborted
`InstallAssemblies` — and therefore the whole portal boot — uncaught.

## The fix

Folds the `GlobalServiceConfigurations` invocation into the same per-module try/catch pattern
already used for `BuilderConfigurations`: iterate `pending` modules, try `InstallServices` for each,
catch-and-record as `IncompatibleModule` on failure, continue to the next module. Only modules that
survive this step feed the downstream `InstalledModuleAssembly`/`AddressTypes`/`HubConfigurations`/
`BuilderConfigurations` registrations — consistent with the "only fully-installed modules count as
installed" invariant #2275 already established.

## Repro

`ProviderModulePackBootTest` gained `InstallAssemblies_WithAModuleWhoseServiceRegistrationThrowsAtInvocation_KeepsTheGoodOne_AndDoesNotAbort`:

- Compiles a real, **separate** assembly (via Roslyn, to a temp DLL) carrying one
  `MeshNodeProviderAttribute` whose sole node's `GlobalServiceConfigurations` delegate throws
  `MissingMethodException` when invoked — has to be a separate assembly from the existing healthy
  probe pack, since an assembly-level attribute applies to the whole DLL.
- Wires `MeshBuilder`'s `ServiceConfig` the way production's `MeshHostApplicationBuilder` actually
  does — `configure => configure.Invoke(services)`, immediate invocation against a live
  `IServiceCollection` — not the other tests' `configure => configurations.Add(configure)`, which
  defers to a later `Aggregate` the test owns and would have hidden this exact gap (confirmed: with
  deferred wiring the test fails in the test's own `Aggregate` call, outside `InstallAssemblies`
  entirely).

**Verified against the pre-fix code**, not just written and assumed: reverted the `MeshBuilder.cs`
change locally, rebuilt, reran — the test fails with

```
System.MissingMethodException : Method not found: 'Void MeshWeaver.AI.BrokenProbe.LanguageModelCatalogSource..ctor(...)'.
   at MeshWeaver.AI.BrokenProbe.BrokenServiceRegistrationAttribute.<>c.<get_Nodes>b__1_0(IServiceCollection services)
   at MeshWeaver.Mesh.MeshBuilder.ConfigureServices(...)
   at MeshWeaver.Mesh.MeshBuilder.InstallServices(IEnumerable`1 nodes)+MoveNext()
   at MeshWeaver.Mesh.MeshBuilder.InstallAssemblies(String[] assemblyLocations)
```

— a near-verbatim match of both real incidents' stack traces. Reapplied the fix, reran: green.

## What was NOT in scope for this PR

The issue's escalation comments (bidirectional break — old module on new platform too; "roll always
via CD") are addressed by other work: #2298 (arity gate, prevention) and the CD atomic-move
discussion is an operational/pipeline concern, not a code fix in this repo's `InstallAssemblies`. This
PR is scoped to the one remaining gap in the runtime isolation: a module that loads but throws while
registering itself must not abort the boot either — matching the issue's own framing ("a module that
cannot bind must not take down the host").

## Test plan

- [x] `dotnet build src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj -c Release -warnaserror` — 0 warnings, 0 errors
- [x] `dotnet build test/MeshWeaver.AI.Test/MeshWeaver.AI.Test.csproj -c Release -warnaserror` — 0 warnings, 0 errors
- [x] `MeshWeaver.AI.Test` full suite: 1389 passed, 3 skipped (unrelated, env-gated), 0 failed
- [x] `MeshWeaver.Graph.Test` `InstalledModulesTest`: 3/3 passed
- [x] `MeshWeaver.PluginCatalog.Test` `RequiredModuleStatusTest` + `ModuleLoadReportTest`: 23/23 passed
- [x] `MeshWeaver.Hosting.Monolith.Test` module-contribution tests (Grpc/Social/StaticAsset/Endpoint/CellSurface/ConfigVisibility): 33/33 passed
- [x] `MeshWeaver.Documentation.Test` `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest`: 2/2 passed
- [x] New test fails against the pre-fix `MeshBuilder.cs` with a stack trace matching both real incidents, passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)