### PR TITLE
MeshWeaver.AI: one InternalsVisibleTo list, not two

### DIFF
--- a/src/MeshWeaver.AI/InternalsVisibleTo.cs
+++ b/src/MeshWeaver.AI/InternalsVisibleTo.cs
@@ -1,4 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("MeshWeaver.Threading.Test")]
-[assembly: InternalsVisibleTo("MeshWeaver.Hosting.Orleans.Test")]

--- a/src/MeshWeaver.AI/MeshWeaver.AI.csproj
+++ b/src/MeshWeaver.AI/MeshWeaver.AI.csproj
@@ -60,5 +60,6 @@
     <ItemGroup>
         <InternalsVisibleTo Include="MeshWeaver.AI.Test" />
         <InternalsVisibleTo Include="MeshWeaver.Threading.Test" />
+        <InternalsVisibleTo Include="MeshWeaver.Hosting.Orleans.Test" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #2342.

## The problem

`src/MeshWeaver.AI` declared `InternalsVisibleTo` in two places:

`MeshWeaver.AI.csproj`:
```xml
<InternalsVisibleTo Include="MeshWeaver.AI.Test" />
<InternalsVisibleTo Include="MeshWeaver.Threading.Test" />
```

`InternalsVisibleTo.cs`:
```csharp
[assembly: InternalsVisibleTo("MeshWeaver.Threading.Test")]
[assembly: InternalsVisibleTo("MeshWeaver.Hosting.Orleans.Test")]
```

Both mechanisms compile to the same kind of assembly-level attribute, so `MeshWeaver.Threading.Test` was granted **twice** with no distinguishing comment, `MeshWeaver.AI.Test` only via the csproj, and `MeshWeaver.Hosting.Orleans.Test` only via the `.cs` file. No single file answered "who can see this assembly's internals?" — which already misled the automated review on #2340 into flagging a missing grant that in fact existed (in the other file).

## Verifying which grants were live before touching anything

Per the issue's own caution, I did not reason from source — I checked the **compiled assembly's attributes**:

```
$ strings -a MeshWeaver.AI.dll | grep -E "^MeshWeaver\.(AI\.Test|Threading\.Test|Hosting\.Orleans\.Test)$"
MeshWeaver.AI.Test
MeshWeaver.Hosting.Orleans.Test
MeshWeaver.Threading.Test
```

All three were genuinely effective (`MeshWeaver.Hosting.Orleans.Test` really does reference `MeshWeaver.AI`, confirmed via its `.csproj`'s `ProjectReference`). So this is a pure consolidation, not a removal.

## Fix

Collapsed to the csproj `<InternalsVisibleTo>` items (moved `MeshWeaver.Hosting.Orleans.Test` across) and deleted `InternalsVisibleTo.cs`. One list, in the file that also declares the project's references — same shape the issue suggested.

## Verification

- `dotnet build src/MeshWeaver.AI/MeshWeaver.AI.csproj -c Release -p:CIRun=true -warnaserror` → `0 Warning(s)`, `0 Error(s)`
- Re-checked the rebuilt assembly: all three grants present, exactly once each
- Built the three consuming test projects clean under the same flags: `MeshWeaver.AI.Test`, `MeshWeaver.Threading.Test`, `MeshWeaver.Hosting.Orleans.Test`

## Scope note

This PR does **not** touch `#2344` (the `FuzzyScorer` namespace mismatch) — that's covered separately by #2349. Confirmed disjoint: `git diff origin/main...HEAD --stat` here shows only `src/MeshWeaver.AI/MeshWeaver.AI.csproj` and the deleted `src/MeshWeaver.AI/InternalsVisibleTo.cs`.

No What's New entry — internal build-hygiene only, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
