### PR TITLE
fix(ai): provider is the primary key in the model picker sort

### DIFF
--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -789,9 +789,22 @@ public static class AgentPickerProjection
                 byPath[node.Path] = info;
         }
 
+        // 🚨 Provider is the PRIMARY key, not Order (#2331). `Order` does double duty: a global
+        // minimum picks the deployment DEFAULT (ObserveDefaultComposer re-sorts by it independently
+        // of this display order) and a per-model pin (ModelOrdering.Defaults) promotes ONE model
+        // within its provider (e.g. z-ai/glm-5.3 at -2 among OpenRouter's uniform Order-6 siblings).
+        // Sorting by Order first let that pin lift the model out of its provider's run entirely —
+        // the group stopped being contiguous, so the picker (which renders a header whenever the
+        // group key changes, same as ProjectAgents' harness grouping) rendered the provider TWICE.
+        // Grouping by Provider first makes every block contiguous BY CONSTRUCTION — same shape as
+        // ProjectAgents' GroupName-first sort — and Order still does its promotion job as the
+        // tie-break INSIDE the group, which is exactly what a pin is for.
         return byPath.Values
-            .OrderBy(m => m.Order)
+            // Auto (the router / composer default) leads every concrete provider, mirroring its
+            // RouterOrder = -10 intent — it is the one entry meant to sort ahead of everything else.
+            .OrderByDescending(m => m.IsRouter)
             .ThenBy(m => m.Provider, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(m => m.Order)
             .ThenBy(m => m.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-model-picker-groups-stay-together.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-model-picker-groups-stay-together.md
@@ -1,0 +1,16 @@
+---
+Name: A pinned model no longer splits its provider's group in the model picker
+Category: Fix
+Description: A promoted model could tear its provider's block in two, making the same provider appear under two separate headers in the model picker.
+Icon: List
+Order: -20260826
+---
+
+# A pinned model no longer splits its provider's group in the model picker
+
+The model picker groups models by provider. Promoting one model within a provider — so it becomes
+the deployment's default — could push that single model out of its provider's run in the list,
+making the provider render as two separate headers with the promoted model stranded between them.
+Provider is now the primary grouping key, so every provider's models always render as one
+contiguous block; a promotion still moves the model to the top of its own group, exactly as
+intended, without tearing the group apart.

--- a/test/MeshWeaver.AI.Test/AgentPickerModelOrderingTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentPickerModelOrderingTest.cs
@@ -1,0 +1,126 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Linq;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the fix for #2331 — a per-model <c>Order</c> pin split its provider's block in the model
+/// picker, rendering the same provider's header twice.
+///
+/// <para><b>Why it happened.</b> <see cref="AgentPickerProjection.ProjectModels"/> used to sort
+/// <c>Order</c> FIRST and <c>Provider</c> second. <c>Order</c> does double duty: a global minimum
+/// picks the deployment default (<c>ObserveDefaultComposer</c> re-sorts by it independently), and
+/// <see cref="ModelOrdering.Defaults"/> pins a SPECIFIC model id below its provider's uniform Order
+/// so it can win that global minimum without re-ordering the whole provider (e.g. an OpenRouter model
+/// pinned to <c>-2</c> while its eleven siblings stay at the source's uniform <c>Order 6</c>). Sorting
+/// by Order first let that pin lift the one model out of its provider's contiguous run — the dropdown
+/// (which renders a header whenever the group key changes) rendered the provider a second time,
+/// bracketing the rest of its models.</para>
+///
+/// <para><b>The fix.</b> Provider is now the PRIMARY key — mirrors <c>ProjectAgents</c>'s
+/// <c>GroupName</c>-first sort — so every provider's models are contiguous BY CONSTRUCTION. The
+/// per-model <c>Order</c> becomes the tie-break INSIDE the group, which is exactly what a pin is
+/// for: it still promotes the pinned model to the top of its own provider's block instead of
+/// tearing the block in half. The router (Auto) is pinned ahead of every concrete provider via an
+/// explicit <c>IsRouter</c>-first key, preserving its documented "sorts ahead of everything" intent
+/// (<c>RouterOrder = -10</c>) independently of where "Auto" would otherwise fall alphabetically.</para>
+/// </summary>
+public class AgentPickerModelOrderingTest
+{
+    private static readonly JsonSerializerOptions Json = new();
+
+    private static MeshNode ModelNode(
+        string id, string provider, int order, bool isRouter = false) =>
+        new(id, $"Provider/{provider}")
+        {
+            NodeType = LanguageModelNodeType.NodeType,
+            Name = id,
+            Content = new ModelDefinition
+            {
+                Id = id,
+                Provider = provider,
+                Order = order,
+                IsRouter = isRouter,
+            },
+        };
+
+    [Fact]
+    public void APinnedModel_StaysInsideItsProvidersContiguousBlock()
+    {
+        // The reported shape: OpenRouter's eleven siblings share the source's uniform Order 6, but
+        // one of them (glm) is pinned to -2 so it can win the deployment-wide default. A second,
+        // unrelated provider (Anthropic) sits at Order 1 — squarely between the pin and the rest of
+        // OpenRouter's block under the OLD (Order-first) comparer.
+        var snapshot = new[]
+        {
+            ModelNode("z-ai/glm-5.3", "OpenRouter", order: -2),
+            ModelNode("anthropic/claude-opus-5", "OpenRouter", order: 6),
+            ModelNode("qwen/qwen4", "OpenRouter", order: 6),
+            ModelNode("claude-sonnet-5", "Anthropic", order: 1),
+        };
+
+        var projected = AgentPickerProjection.ProjectModels(snapshot, Json);
+
+        // One contiguous run per provider — no provider's name appears, breaks, then appears again.
+        var providerRuns = projected
+            .Select(m => m.Provider)
+            .Zip(projected.Skip(1).Select(m => m.Provider).Append(null),
+                (current, next) => (current, next))
+            .Count(pair => pair.current != pair.next);
+        var distinctProviders = projected.Select(m => m.Provider).Distinct().Count();
+        providerRuns.Should().Be(distinctProviders,
+            "each provider must render as ONE contiguous block, however its models are pinned");
+
+        // The pin still does its job: glm sorts to the TOP of OpenRouter's own block.
+        var openRouterBlock = projected.Where(m => m.Provider == "OpenRouter").ToList();
+        openRouterBlock.First().Name.Should().Be("z-ai/glm-5.3",
+            "the Order pin promotes the model within its OWN provider's block");
+        openRouterBlock.Select(m => m.Name).Should().Equal(
+            "z-ai/glm-5.3", "anthropic/claude-opus-5", "qwen/qwen4");
+    }
+
+    [Fact]
+    public void ProvidersWithNaturallyInterleavedOrders_StillRenderOneHeaderEach()
+    {
+        // The shape #1880 also described: two providers whose models' Order values interleave
+        // (AzureFoundry at 1/6, OpenRouter at 2/5) — nobody pinned anything, the source-level
+        // Orders just happen to interleave. The OLD Order-first comparer would render
+        // AzureFoundry, then OpenRouter, then AzureFoundry again.
+        var snapshot = new[]
+        {
+            ModelNode("DeepSeek-V4-Flash", "AzureFoundry", order: 1),
+            ModelNode("moonshotai/kimi-k3", "OpenRouter", order: 2),
+            ModelNode("z-ai/glm-5.3", "OpenRouter", order: 5),
+            ModelNode("DeepSeek-V4-Pro", "AzureFoundry", order: 6),
+        };
+
+        var projected = AgentPickerProjection.ProjectModels(snapshot, Json);
+
+        projected.Select(m => m.Provider).Should().Equal(
+            new[] { "AzureFoundry", "AzureFoundry", "OpenRouter", "OpenRouter" },
+            "each provider must render as one contiguous block even when the providers' Order "
+            + "ranges interleave, with no per-model pin involved");
+    }
+
+    [Fact]
+    public void TheRouter_LeadsEveryConcreteProvider_RegardlessOfAlphabeticalPosition()
+    {
+        // "Auto" would sort between Anthropic and Azure alphabetically — but it must still lead the
+        // whole list, matching its RouterOrder = -10 / composer-default intent.
+        var snapshot = new[]
+        {
+            ModelNode("claude-sonnet-5", "Anthropic", order: 1),
+            ModelNode("gpt-5", "Azure", order: 2),
+            ModelNode("auto", "Auto", order: -10, isRouter: true),
+        };
+
+        var projected = AgentPickerProjection.ProjectModels(snapshot, Json);
+
+        projected.First().IsRouter.Should().BeTrue("Auto must lead the picker regardless of its provider name's alphabetical position");
+        projected.Select(m => m.Provider).Should().Equal("Auto", "Anthropic", "Azure");
+    }
+}

--- a/test/MeshWeaver.AI.Test/AgentPickerModelOrderingTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentPickerModelOrderingTest.cs
@@ -66,12 +66,13 @@ public class AgentPickerModelOrderingTest
         var projected = AgentPickerProjection.ProjectModels(snapshot, Json);
 
         // One contiguous run per provider — no provider's name appears, breaks, then appears again.
-        var providerRuns = projected
-            .Select(m => m.Provider)
-            .Zip(projected.Skip(1).Select(m => m.Provider).Append(null),
-                (current, next) => (current, next))
-            .Count(pair => pair.current != pair.next);
-        var distinctProviders = projected.Select(m => m.Provider).Distinct().Count();
+        // Run count = 1 (for the first element) + the number of adjacent pairs that differ; no
+        // null sentinel needed (Provider is non-nullable).
+        var providers = projected.Select(m => m.Provider).ToList();
+        var providerRuns = providers.Count == 0
+            ? 0
+            : 1 + providers.Zip(providers.Skip(1), (current, next) => current != next).Count(differs => differs);
+        var distinctProviders = providers.Distinct().Count();
         providerRuns.Should().Be(distinctProviders,
             "each provider must render as ONE contiguous block, however its models are pinned");
 


### PR DESCRIPTION
## Summary

- Fixes #2331 — a per-model `Order` pin (`ModelOrdering.Defaults`, used to promote one model to be
  the deployment default) split its provider's block in the model picker, because
  `AgentPickerProjection.ProjectModels` sorted by `Order` first and `Provider` second. When a
  provider's models don't all share one `Order` value, that isn't guaranteed to be contiguous — the
  provider rendered under two separate headers, with the pinned model stranded at the top.
- `Provider` is now the primary sort key (mirrors `ProjectAgents`' `GroupName`-first sort), so every
  provider's models are contiguous **by construction**. `Order` is the tie-break *inside* the group —
  a pin still promotes its model to the top of its own provider's block, preserving the pin's
  intended effect without tearing the group apart.
- The router (`Auto`) is pinned ahead of every concrete provider via an explicit `IsRouter`-first
  key, preserving its documented "sorts ahead of everything" intent (`RouterOrder = -10`) regardless
  of where "Auto" would otherwise land alphabetically. `ObserveDefaultComposer`'s default-selection
  logic re-sorts by `Order` independently of this display order, so default resolution is
  unaffected.

## Coordination check (per AGENTS.md)

`MeshWeaver.AI` is being carved out of core in a separate live effort (#2276). Checked
`git log origin/main -- src/MeshWeaver.AI` and every open PR's file list before editing — none
touch `AgentPickerProjection.cs`. Diff is scoped to that file, its test, and one What's New entry.

## Related: #1880 (already closed separately)

While investigating, re-verified #1880 ("duplicate/mislabelled Azure Foundry provider group") end
to end and found all of it already resolved — **not by this PR**, so I closed it directly rather
than lumping it in here:
- Defects 2 (slash-id loses its header) and 3 (stale seeded label) were code, fixed by #1881
  (merged 2026-08-19). The old grouping mechanism that issue investigated
  (`ThreadChatView.razor.cs`'s path-based `ArrangePickerGroups`) no longer exists in this repo — it
  left with #2293. Today's `AgentPickerProjection.ProjectModels` groups by the `Provider` string
  field, not by splitting the node path, so defect 2's failure mode can't recur by construction;
  `AgentPickerModelOrderingTest` (added here) exercises slash-containing ids for coverage against
  the current mechanism, replacing the regression test that moved out with the Blazor GUI.
- Defect 1 (duplicate `Provider/Azure` / `Provider/AzureFoundry` nodes) was data. Verified live via
  MCP: `Provider/Azure` no longer exists, and `Provider/AzureFoundry` now carries
  `name: "Azure Foundry"` — both edits the issue asked for are done.

## Test plan

- [x] `dotnet build src/MeshWeaver.AI/MeshWeaver.AI.csproj -c Release -warnaserror` — clean
- [x] `dotnet build test/MeshWeaver.AI.Test/MeshWeaver.AI.Test.csproj -c Release -warnaserror` — clean
- [x] New `AgentPickerModelOrderingTest` (3 tests) — green, pins: a pinned model stays inside its
      own provider's block; naturally interleaved provider Orders (no pin) still render one header
      per provider; the router leads regardless of alphabetical position
- [x] Re-ran the surrounding picker/model-resolution suites (`AgentPickerQueryTest`,
      `AgentPickerQueriesTest`, `AgentPickerDeduplicationTest`, `AgentPickerUtilityFilterTest`,
      `AgentRosterContentShapeTest`, `AiResolutionSeamAuditTest`, `BuiltInLanguageModelProviderTest`,
      `AutoModelRouterTest`, `AutoRouterDispatchTest`, `ChatClientCredentialResolverTest`,
      `ModelTierCatalogTest`, `ModelPriceCatalogTest`) — all green, no regressions
- [x] `WhatsNewEntryIntegrityTest` / `DocumentationLinkIntegrityTest` — green after adding the
      What's New entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)