### PR TITLE
Close the boot-GC race that lets a module activation entry outlive its bytes

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -141,6 +141,39 @@ never reach disk), and a refusal of any module whose entry DLL name collides wit
 assembly — `ResolveModulePath` probes `modules/<name>/` first, so such a module would silently
 shadow the platform's own binary at the next boot.
 
+### 🚨 An ACTIVATED entry with no bytes — the boot-GC race (#2303)
+
+The "Missing DLL" skip above is the SYMPTOM; #2303 traced one concrete way an entry ends up
+pointing at nothing: a race between `ModuleLandingService.CollectGarbage` (run at every pod's boot,
+before its own module set is computed) and a landing happening on a DIFFERENT replica at the same
+moment.
+
+A landing is two writes on the shared `/data` volume, deliberately ordered bytes-then-entry: it
+`Directory.Move`s the new generation into place, THEN writes the sidecar entry that names it
+(`LandCore`). Those two writes are adjacent in one synchronous call on the landing replica, but
+nothing serializes them against a GC pass on ANOTHER replica — the per-module sidecar file and the
+landing service's IO pool both bound a single process, not a cross-process sequence. If a GC pass
+reads the sidecar in the gap between the other replica's two writes, the new generation directory
+is on disk but no entry references it YET — indistinguishable from a genuinely orphaned directory —
+and GC deletes it a moment before the landing's `WriteEntry` lands, pointing a real, enabled
+activation entry at bytes that no longer exist. Nothing throws anywhere: the landing that raced GC
+reports success (both of ITS writes succeeded), and the entry only reveals itself as unresolvable
+the next time something reads it — `ModuleActivationStatus.Unresolvable`'s loud startup report and
+`Degraded` health check (#2093), or a boot that silently skips the module via the "Missing DLL" rule
+above. That is the exact shape #2303 reported for `MeshWeaver.Blazor.EntityViews`: an ACTIVATED
+entry whose landed assembly was gone, with no exception or stack frame naming why — likeliest to
+fire during a rolling restart landing (or auto-updating) a module while sibling pods are cycling
+through boot at the same time.
+
+The fix cannot be a lock — replica coordination here is deliberately structural, not a gate. Instead
+`CollectGarbage` carries a grace period (`ModuleLandingService.DefaultGarbageMinAge`, 5 minutes):
+an unreferenced generation (or `.staging-`/`.pending-` leftover) younger than the window is left for
+a LATER pass rather than reclaimed immediately. A directory that survives the window and is STILL
+unreferenced is a genuine orphan and is collected exactly as before — the grace period defers
+reclamation, it does not disable it. The two writes of a real landing are back-to-back with no I/O
+between them, so the actual exposure the window has to cover is low-single-digit seconds even over
+a slow network volume; five minutes is generous headroom on top of that.
+
 Why a sidecar file and not a mesh node: the list is consumed before any storage provider, hub, or
 connection string exists, and it must move with the DLLs it describes — the landing service writes
 both in one operation onto the same volume, so they cannot drift apart.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-store-module-cleanup-no-longer-races-a-landing.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-store-module-cleanup-no-longer-races-a-landing.md
@@ -1,0 +1,32 @@
+---
+Name: Store-module cleanup no longer races a landing
+Category: Fix
+Description: On a multi-replica deployment, one pod's boot-time cleanup of old module folders could delete a module another pod was landing at the same moment, leaving that module marked installed with no bytes behind it — silently absent until someone re-installed it. Cleanup now waits a few minutes before reclaiming anything unreferenced, closing the race.
+Icon: Sparkle
+Order: -20260826
+---
+
+# Store-module cleanup no longer races a landing
+
+Installing or auto-updating a Store module writes its files first, then records that the module is
+installed. Separately, every pod that boots cleans up old module folders nothing refers to any more.
+On a deployment with several replicas, those two things could overlap: a cleanup pass on one pod
+could read the installed-module list a moment before another pod finished writing its record, see
+the just-written files as "nothing refers to this yet", and delete them — a heartbeat before the
+other pod's record pointed at them.
+
+The result was a module marked installed and switched on, with its files gone. No restart brought
+it back, and nothing said why — the feature it provided (in the reported case, entity edit forms)
+simply stopped working on that pod until someone re-installed the package.
+
+## What changed
+
+Cleanup now waits a few minutes before reclaiming a module folder nothing refers to, instead of
+reclaiming it the moment it looks unused. A folder that is still unreferenced after that window is a
+genuine leftover and is removed as before; one that was actually mid-install survives long enough for
+its installation record to catch up.
+
+## What you will notice
+
+Store-installed modules keep working through a rolling restart or a concurrent auto-update — no more
+silent, unrecoverable "installed but missing" state that only a re-install could fix.

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -55,6 +55,13 @@ namespace MeshWeaver.PluginCatalog;
 /// PER MODULE (<see cref="ModuleActivationSidecar"/>) and a landing writes only its own — two
 /// replicas landing different modules share no path, cannot lose each other's entry, and never
 /// contend for one file's SMB lease.</para>
+///
+/// <para><b>…except boot-time GC against a CONCURRENT landing (#2303).</b> A landing's two writes
+/// (move the bytes, then <see cref="ModuleActivationSidecar.WriteEntry"/>) are not atomic across
+/// replicas, so another replica's <see cref="CollectGarbage"/> can observe the new generation
+/// directory before the entry that claims it exists and delete it as "unreferenced" — leaving a
+/// real activation entry pointing at nothing a moment later. See
+/// <see cref="DefaultGarbageMinAge"/> for the race and the grace-period fix.</para>
 /// </summary>
 public sealed class ModuleLandingService : IDisposable
 {
@@ -69,15 +76,58 @@ public sealed class ModuleLandingService : IDisposable
             string.IsNullOrWhiteSpace(entry?.Directory) ? moduleName : entry!.Directory!);
 
     /// <summary>
+    /// How long an UNREFERENCED directory under <c>modules/</c> must sit before
+    /// <see cref="CollectGarbage"/> treats it as truly orphaned rather than the first half of a
+    /// landing this replica has not seen the SECOND half of yet — the race behind #2303.
+    ///
+    /// <para>🚨 <b>The race.</b> A landing is two writes on the shared <c>/data</c> volume,
+    /// deliberately ordered bytes-then-entry (<see cref="LandCore"/>): <c>Directory.Move</c> lands
+    /// the generation directory, THEN <see cref="ModuleActivationSidecar.WriteEntry"/> records the
+    /// pointer. Those two writes are adjacent in one synchronous call on the LANDING replica, but
+    /// nothing serializes them against a GC pass running on ANOTHER replica at the same moment —
+    /// this pool and the per-module sidecar file both bound a single process
+    /// (<c>Cross-REPLICA safety is structural</c>, above), not a cross-process sequence. If a GC
+    /// pass reads the sidecar in the gap between the other replica's two writes, the new
+    /// generation is on disk but no entry references it YET — indistinguishable from a genuinely
+    /// orphaned directory — and GC deletes it a moment before the landing's
+    /// <c>WriteEntry</c> lands, pointing a real, enabled activation entry at bytes that no longer
+    /// exist. Nothing throws anywhere: the landing reports success (its own two writes both
+    /// succeeded), and the entry only reveals itself as unresolvable the next time something reads
+    /// it — <see cref="ModuleActivationStatus.Unresolvable"/>'s loud report, or a boot that skips
+    /// the module outright. That is the exact shape #2303 reported for
+    /// <c>MeshWeaver.Blazor.EntityViews</c>: an ACTIVATED entry whose landed assembly was gone,
+    /// with no exception or stack frame naming why.</para>
+    ///
+    /// <para>The fix cannot be a lock — this design is deliberately lock-free across replicas. A
+    /// grace period is the correct primitive instead: refusing to reclaim anything younger than the
+    /// window costs a genuinely orphaned directory nothing (the very next GC pass that still finds
+    /// it unreferenced, now past the window, collects it) and closes the race, because the two
+    /// writes of a real landing are back-to-back with no I/O between them — the actual exposure is
+    /// low-single-digit seconds even over a slow network volume, and this window is generous on
+    /// top of that.</para>
+    /// </summary>
+    public static readonly TimeSpan DefaultGarbageMinAge = TimeSpan.FromMinutes(5);
+
+    /// <summary>
     /// Boot-time garbage collection over <c>modules/</c>: deletes generation directories
     /// (<c>&lt;name&gt;@&lt;id&gt;</c>) no activation entry references, leftover
     /// <c>.staging-*</c>, and the retired <c>.pending-*</c> folders of the abandoned deferred-swap
-    /// scheme. Skip-on-locked: a directory some still-running pod holds open simply survives to
-    /// the next boot. Never touches legacy <c>&lt;name&gt;/</c> folders — entries without a
-    /// generation still resolve there.
+    /// scheme — but only once they are older than <paramref name="minAge"/>
+    /// (<see cref="DefaultGarbageMinAge"/>): see that constant for why an UNREFERENCED directory is
+    /// not proof of an orphan (#2303). Skip-on-locked: a directory some still-running pod holds
+    /// open simply survives to the next boot. Never touches legacy <c>&lt;name&gt;/</c> folders —
+    /// entries without a generation still resolve there.
     /// </summary>
+    /// <param name="baseDirectory">The deployment root whose <c>modules/</c> folder is swept.</param>
+    /// <param name="logger">Diagnostics — every removal and every age-deferred skip is logged.</param>
+    /// <param name="minAge">The grace period below which an unreferenced directory is left alone.
+    /// Defaults to <see cref="DefaultGarbageMinAge"/>; a test seam otherwise.</param>
+    /// <param name="nowUtc">The reference "now" the age check compares against. Defaults to
+    /// <see cref="DateTime.UtcNow"/>; a test seam so the race and its fix are provable without a
+    /// real sleep.</param>
     /// <returns>How many directories were removed.</returns>
-    public static int CollectGarbage(string baseDirectory, ILogger? logger = null)
+    public static int CollectGarbage(
+        string baseDirectory, ILogger? logger = null, TimeSpan? minAge = null, DateTime? nowUtc = null)
     {
         var modulesRoot = Path.Combine(baseDirectory, "modules");
         if (!Directory.Exists(modulesRoot))
@@ -88,6 +138,7 @@ public sealed class ModuleLandingService : IDisposable
             .Where(e => !string.IsNullOrWhiteSpace(e.Directory))
             .Select(e => e.Directory!)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var cutoff = (nowUtc ?? DateTime.UtcNow) - (minAge ?? DefaultGarbageMinAge);
         var removed = 0;
         foreach (var dir in Directory.EnumerateDirectories(modulesRoot))
         {
@@ -98,6 +149,19 @@ public sealed class ModuleLandingService : IDisposable
                 || (leaf.Contains('@') && !referenced.Contains(leaf));
             if (!collectable)
                 continue;
+            // 🚨 #2303: an unreferenced directory younger than the grace window may simply be a
+            // landing this replica has not seen the ACTIVATION ENTRY for yet — see
+            // DefaultGarbageMinAge. Left for a later pass, which re-reads the sidecar and either
+            // finds the entry now present (survives, correctly) or is still unreferenced and past
+            // the window (a genuine orphan, collected then).
+            if (Directory.GetLastWriteTimeUtc(dir) > cutoff)
+            {
+                logger?.LogDebug(
+                    "Modules GC: {Dir} is unreferenced but younger than the {MinAge} grace period "
+                    + "— left in case a concurrent landing's activation entry has not landed yet.",
+                    leaf, minAge ?? DefaultGarbageMinAge);
+                continue;
+            }
             try
             {
                 Directory.Delete(dir, recursive: true);

--- a/test/MeshWeaver.PluginCatalog.Test/PendingLandingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PendingLandingTest.cs
@@ -52,17 +52,28 @@ public class PendingLandingTest : IDisposable
             ModuleLandingService.ModuleDirectoryFor(root, "MeshWeaver.Widget", null));
     }
 
+    /// <summary>Backdates a directory's write time past the default GC grace window so a test can
+    /// assert immediate collection of a genuinely orphaned (not merely fresh) directory.</summary>
+    private static void Backdate(string dir) =>
+        Directory.SetLastWriteTimeUtc(dir,
+            DateTime.UtcNow - ModuleLandingService.DefaultGarbageMinAge - TimeSpan.FromMinutes(1));
+
     [Fact]
     public void CollectGarbage_RemovesOnlyTheUnreferenced()
     {
         // Two generations of Widget; the sidecar references the second. Plus legacy folder,
         // leftover staging, and a retired pending — the legacy folder must SURVIVE (entries
-        // without a generation still resolve there), everything else goes.
+        // without a generation still resolve there), everything else goes. All three collectable
+        // directories are backdated past the grace window (#2303) — they are genuine orphans here,
+        // not a landing whose entry has not landed yet, which is the OTHER test below.
         Write("MeshWeaver.Widget@old00001", "MeshWeaver.Widget.dll", "OLD");
         Write("MeshWeaver.Widget@new00002", "MeshWeaver.Widget.dll", "NEW");
         Write("MeshWeaver.Widget", "MeshWeaver.Widget.dll", "LEGACY");
         Write(".staging-MeshWeaver.Widget-x", "half.dll", "H");
         Write(".pending-MeshWeaver.Widget", "MeshWeaver.Widget.dll", "P");
+        Backdate(Path.Combine(Modules, "MeshWeaver.Widget@old00001"));
+        Backdate(Path.Combine(Modules, ".staging-MeshWeaver.Widget-x"));
+        Backdate(Path.Combine(Modules, ".pending-MeshWeaver.Widget"));
         ModuleActivationSidecar.Write(root, new ModuleActivationList
         {
             Entries = [new ModuleActivationEntry
@@ -82,6 +93,65 @@ public class PendingLandingTest : IDisposable
             "the referenced generation survives");
         Assert.True(Directory.Exists(Path.Combine(Modules, "MeshWeaver.Widget")),
             "the legacy fixed folder survives — un-generationed entries resolve there");
+    }
+
+    /// <summary>
+    /// #2303's root cause, pinned: a landing's two writes (move the bytes, THEN write the
+    /// activation entry) are not atomic across replicas. A GC pass that runs in the gap — after
+    /// the bytes landed, before the entry that claims them — must NOT delete the generation just
+    /// because nothing references it YET, or a real activation entry ends up pointing at nothing a
+    /// moment later. This reproduces the exact interleave without threads: land the bytes (as
+    /// <c>LandCore</c>'s <c>Directory.Move</c> would, freshly timestamped), run GC BEFORE the entry
+    /// exists, then write the entry — the generation must have survived GC for the entry to be
+    /// resolvable.
+    /// </summary>
+    [Fact]
+    public void CollectGarbage_LeavesAFreshGeneration_ThatNoEntryReferencesYet()
+    {
+        // The bytes land first — exactly LandCore's ordering — with NO activation entry yet.
+        Write("MeshWeaver.Widget@race00001", "MeshWeaver.Widget.dll", "RACE");
+
+        // A concurrent replica's boot GC runs in the gap before this landing's WriteEntry.
+        var removed = ModuleLandingService.CollectGarbage(root);
+
+        Assert.Equal(0, removed);
+        Assert.True(Directory.Exists(Path.Combine(Modules, "MeshWeaver.Widget@race00001")),
+            "a fresh, unreferenced generation must survive GC — it may be a landing whose entry "
+            + "has not reached this replica's read yet (#2303)");
+
+        // The landing's second write lands afterward, exactly as LandCore performs it.
+        ModuleActivationSidecar.WriteEntry(root, new ModuleActivationEntry
+        {
+            Name = "MeshWeaver.Widget",
+            Directory = "MeshWeaver.Widget@race00001",
+        });
+
+        Assert.True(ModuleActivationBoot.LandedModuleDllExists(root,
+            ModuleActivationSidecar.Read(root).Entries.Single(e => e.Name == "MeshWeaver.Widget")),
+            "the entry's bytes must still be there — GC must not have won the race");
+    }
+
+    /// <summary>The other half of the invariant: once a directory is genuinely old AND still
+    /// unreferenced, GC must still reclaim it — the grace period defers collection, it does not
+    /// disable it (a real orphan is not a permanent leak).</summary>
+    [Fact]
+    public void CollectGarbage_ReclaimsAnUnreferencedGeneration_OnceItIsOldEnough()
+    {
+        Write("MeshWeaver.Widget@stale00001", "MeshWeaver.Widget.dll", "STALE");
+
+        // Still inside the window: survives.
+        var removedTooSoon = ModuleLandingService.CollectGarbage(
+            root, minAge: TimeSpan.FromMinutes(5),
+            nowUtc: DateTime.UtcNow + TimeSpan.FromMinutes(4));
+        Assert.Equal(0, removedTooSoon);
+        Assert.True(Directory.Exists(Path.Combine(Modules, "MeshWeaver.Widget@stale00001")));
+
+        // Past the window: a real orphan is still collected — the fix defers, never leaks.
+        var removed = ModuleLandingService.CollectGarbage(
+            root, minAge: TimeSpan.FromMinutes(5),
+            nowUtc: DateTime.UtcNow + TimeSpan.FromMinutes(6));
+        Assert.Equal(1, removed);
+        Assert.False(Directory.Exists(Path.Combine(Modules, "MeshWeaver.Widget@stale00001")));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #2303 — root-caused and fixed.

`ModuleLandingService.CollectGarbage` runs at every pod's boot and deletes any generation directory under `modules/` that no activation entry references. A landing writes two things on the shared `/data` volume, deliberately ordered bytes-then-entry (`Directory.Move`, then `ModuleActivationSidecar.WriteEntry`) so a crash mid-landing leaves an orphan rather than a dangling entry — but those two writes are only atomic on the landing replica. Nothing serializes them against a GC pass on a **different** replica at the same moment (rolling restart / auto-update landing while a sibling pod boots).

If a GC pass reads the sidecar in the gap between the other replica's two writes, the freshly-landed generation directory looks "unreferenced" — indistinguishable from a genuine orphan — and GC deletes it a moment before the landing's `WriteEntry` lands, pointing a real, enabled activation entry at bytes that no longer exist. Nothing throws anywhere: both of the landing's own writes succeeded. The entry only reveals itself as unresolvable the next time something reads it — exactly the shape #2303 reported for `MeshWeaver.Blazor.EntityViews`: an ACTIVATED module whose landed assembly was gone, with no exception naming why.

### Fix

`CollectGarbage` now carries a 5-minute grace period (`ModuleLandingService.DefaultGarbageMinAge`): an unreferenced directory younger than the window is left for a later pass instead of reclaimed immediately. A directory still unreferenced past the window is a genuine orphan and is collected exactly as before — the grace period **defers** reclamation, it never leaks. The two writes of a real landing are back-to-back with no I/O between them, so the actual exposure is low-single-digit seconds even over a slow network volume; 5 minutes is generous headroom.

### On PR #2293 (Blazor + the portal hosts moved out of core, merged the same day)

Checked whether the extraction changed this issue rather than assuming either way:

- The **detection/reporting** half — `ModuleActivationStatus`'s Pending-vs-Unresolvable split, the loud startup `LogError`, and the `Degraded` health check (#2093) — lives in `src/MeshWeaver.PluginCatalog`, is untouched by the move, and is exactly what produced the issue's own log evidence (the reporter was working correctly; it was reporting a real defect in the landing lane).
- Core's `memex/Memex.Portal.Shared/MemexConfiguration.cs` lost the *call site* that used to invoke its `ReportUnloadedActivatedModules` (the caller, a Blazor-typed `StartMemexApplication<TApp>`, moved out) — but I verified the moved `Memex.Portal.Distributed` host in `Systemorph/MeshWeaver.Plugins` carries its **own** copy of that wiring (`Memex.Portal.Gui/MemexPortalComposition.cs`), and it still calls **this repo's** `ConfigureMemexMesh` (which calls `CollectGarbage`) and `ModuleLandingService`. So this fix reaches the real, currently-deployed portal with **no cross-repo change** required. (The now-dead private method left behind in core's `MemexConfiguration.cs` is harmless — unused, no build impact — and out of scope here per the stay-out list for that file.)

### Tests

- `CollectGarbage_LeavesAFreshGeneration_ThatNoEntryReferencesYet` pins the race directly: land bytes, run GC *before* the entry exists, then write the entry — the generation must survive GC for the entry to resolve.
- `CollectGarbage_ReclaimsAnUnreferencedGeneration_OnceItIsOldEnough` proves the grace period defers collection rather than disabling it.
- `CollectGarbage_RemovesOnlyTheUnreferenced` (pre-existing) is updated to backdate its genuine orphans past the grace window.

## Test plan

- [x] `dotnet build src/MeshWeaver.PluginCatalog -c Release -warnaserror` — clean
- [x] `dotnet build test/MeshWeaver.PluginCatalog.Test -c Release -warnaserror` — clean
- [x] `dotnet test test/MeshWeaver.PluginCatalog.Test -c Release --no-build` — 649/649 passed (fresh .trx)
- [x] `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` — clean
- [x] `dotnet test test/MeshWeaver.Documentation.Test -c Release --no-build --filter WhatsNewEntryIntegrityTest|DocumentationLinkIntegrityTest` — 2/2 passed
- [x] What's New entry added (`Category: Fix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)