### PR TITLE
Correct PromptCell's stale "TrainingSimResponder is retired" comment

### DIFF
--- a/src/MeshWeaver.Layout/PromptCell.cs
+++ b/src/MeshWeaver.Layout/PromptCell.cs
@@ -24,8 +24,10 @@ public record PromptCellResponse(string Code, UiControl Output);
 ///   <c>prompt → (code, output)</c> function; no AI infrastructure involved.</item>
 ///   <item><b>Live</b> — a responder that submits the prompt to a real agent thread
 ///   (<c>hub.StartThread</c>, the <c>TrainingSim</c> agent node) and projects the
-///   reply. The old compiled adapter (<c>TrainingSimResponder</c>) is retired; the
-///   agent runs from its mesh node.</item>
+///   reply. Today that responder is still the compiled adapter
+///   (<c>MeshWeaver.AI.TrainingSimResponder.Live</c>) — retiring it in favour of a
+///   mesh-node-only implementation is tracked in #1610 and is NOT done; do not
+///   delete the compiled class on the strength of this comment.</item>
 /// </list>
 /// </summary>
 public record PromptCellConfig


### PR DESCRIPTION
## Summary
- `PromptCell.cs`'s doc comment on the `Live` responder mode claimed `TrainingSimResponder` "is retired; the agent runs from its mesh node." That's false on `origin/main` today: `src/MeshWeaver.AI/TrainingSimResponder.cs` still exists and has 12 live callers in the Education repo (`AgenticEngineering/**`), per #1610's investigation.
- Left as-is, the comment would authorise a bad deletion sweep — someone greps, finds "retired," deletes the class, and breaks 12 course pages. Flagged explicitly in #1610's own comments as worth a one-line correction PR regardless of that issue's fate.
- Points the comment at #1610 instead of asserting a state that isn't true.

Pure doc-comment fix — no behavioural change, no What's New entry.

## Test plan
- [x] `dotnet build src/MeshWeaver.Layout/MeshWeaver.Layout.csproj -c Release -warnaserror` — 0 warnings, 0 errors.
- [x] Comment-only change; no other files touched (`git diff --stat` confirms one file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)