### PR TITLE
Stop mocking IMessageHub/IMeshService in 8 test files

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1546,7 +1546,12 @@ internal static class NodeTypeEnrichmentHelpers
                     {
                         instanceHub.RegisterForDisposal(ArmOverlaySelfHeal(
                             meshHub.GetWorkspace().GetMeshNodeStream(nodeType),
-                            instanceHub, nodeType, typeVersionAtOverlay, logger,
+                            instanceHub.Address.ToString(),
+                            instanceHub.JsonSerializerOptions,
+                            recycle: () => instanceHub.Post(
+                                new DisposeRequest(), o => o.WithTarget(instanceHub.Address)),
+                            reportStuck: () => ReportStuckOverlayToAdmins(instanceHub, nodeType, logger),
+                            nodeType, typeVersionAtOverlay, logger,
                             guards: NodeTypeCompilationHelpers.GuardsOf(meshHub),
                             // The escape hatch out of a permanently silent type stream — see
                             // ArmOverlaySelfHeal's re-evaluation route (issue #1814 defect B).
@@ -1799,9 +1804,23 @@ internal static class NodeTypeEnrichmentHelpers
     /// hub that holds this watcher, so a pair whose re-enrichment faults again would otherwise
     /// re-arm at the first rung forever. Null applies no spacing.
     /// </param>
+    /// <remarks>
+    /// 🚨 Takes ONLY what the firing contract needs — <paramref name="instancePath"/> (logging),
+    /// <paramref name="jsonOptions"/> (ContentAs), <paramref name="recycle"/> (the self-heal
+    /// action) and <paramref name="reportStuck"/> (best-effort admin notify) — deliberately NOT a
+    /// whole <c>IMessageHub</c>. <see cref="WithOverlaySelfHeal"/> is the one real caller and
+    /// closes over the actual hub to build these; <c>OverlaySelfHealWatcherTest</c> is the reason
+    /// the seam is this narrow: its non-converging-instance contract drives a synchronous,
+    /// <c>TestScheduler</c>-timed recycle→dispose→re-arm loop across a SIMULATED hour, which a real
+    /// hub's genuinely-async <c>Post</c> cannot do inline with a virtual clock, and AGENTS.md
+    /// forbids standing in a mocked <c>IMessageHub</c> for it (Systemorph/MeshWeaver#1810).
+    /// </remarks>
     internal static IDisposable ArmOverlaySelfHeal(
         IObservable<MeshNode> typeStream,
-        IMessageHub instanceHub,
+        string instancePath,
+        JsonSerializerOptions jsonOptions,
+        Action recycle,
+        Action reportStuck,
         string nodeType,
         long? typeVersionAtOverlay,
         ILogger? logger,
@@ -1811,7 +1830,6 @@ internal static class NodeTypeEnrichmentHelpers
         OverlayHealBudget? budget = null)
     {
         var clock = scheduler ?? Scheduler.Default;
-        var instancePath = instanceHub.Address.ToString();
 
         // ContentAs, never `is NodeTypeDefinition` — the #1669 blindness on un-materialized JSON
         // emissions; see ArmStaleAssemblySelfHeal's predicate note. Deserialize ONCE per node and
@@ -1819,7 +1837,7 @@ internal static class NodeTypeEnrichmentHelpers
         // degraded-content warning logs.
         (NodeTypeDefinition? Def, bool Usable) Evaluate(MeshNode? t)
         {
-            var def = t?.ContentAs<NodeTypeDefinition>(instanceHub.JsonSerializerOptions, logger);
+            var def = t?.ContentAs<NodeTypeDefinition>(jsonOptions, logger);
             return (def, def is not null
                 && NodeTypeCompilationHelpers.HasUsableBuild(t!, def, guards));
         }
@@ -1846,7 +1864,7 @@ internal static class NodeTypeEnrichmentHelpers
                 "Overlay self-heal: the NodeType stream for '{NodeType}' (instance '{InstancePath}') faulted — "
                 + "the type is not readable from here right now (absent on this replica, or its owner is "
                 + "recycling). The watcher stays armed and heals through the re-read ladder instead of dying.",
-                nodeType, instanceHub.Address);
+                nodeType, instancePath);
             return Observable.Never<MeshNode>();
         });
 
@@ -1943,15 +1961,15 @@ internal static class NodeTypeEnrichmentHelpers
                     var heals = budget?.RecordHeal(instancePath, nodeType, clock.Now) ?? 1;
                     logger?.LogInformation(
                         "Overlay self-heal: NodeType '{NodeType}' reached a usable build (version {Version}, at-overlay {VersionAtOverlay}, self-heal #{Heals}) — recycling stuck instance '{InstancePath}'",
-                        nodeType, t.Version, typeVersionAtOverlay, heals, instanceHub.Address);
+                        nodeType, t.Version, typeVersionAtOverlay, heals, instancePath);
                     // The RecycleLayoutArea idiom: the hub disposes itself, the
                     // grain deactivates, and the next access re-enriches from
                     // scratch against the now-usable NodeType.
-                    instanceHub.Post(new DisposeRequest(), o => o.WithTarget(instanceHub.Address));
+                    recycle();
                 },
                 ex => logger?.LogWarning(ex,
                     "Overlay self-heal watcher for NodeType '{NodeType}' (instance '{InstancePath}') faulted — falling back to manual Recycle",
-                    nodeType, instanceHub.Address));
+                    nodeType, instancePath));
 
         void ReportReEvaluation(
             int attempt, MeshNode? typeNode, (NodeTypeDefinition? Def, bool Usable) verdict)
@@ -1989,7 +2007,7 @@ internal static class NodeTypeEnrichmentHelpers
                 {
                     if (Volatile.Read(ref healed) != 0)
                         return;
-                    ReportStuckOverlayToAdmins(instanceHub, nodeType, logger);
+                    reportStuck();
                 },
                 ex => logger?.LogWarning(ex,
                     "Overlay stuck-reporter for NodeType '{NodeType}' faulted", nodeType));

--- a/test/MeshWeaver.Graph.Test/DeckSlidesCacheTest.cs
+++ b/test/MeshWeaver.Graph.Test/DeckSlidesCacheTest.cs
@@ -3,11 +3,15 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Text.Json;
+using System.Threading.Tasks;
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
-using NSubstitute;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -16,77 +20,108 @@ namespace MeshWeaver.Graph.Test;
 /// Unit tests for <see cref="DeckSlidesCache"/>: the deck's sibling-slide query
 /// must be SHARED across the slides of one deck (one live
 /// <c>IMeshService.Query</c> subscription per parent path, Replay(1) semantics
-/// for late subscribers) while distinct decks each get their own query. Uses a
-/// counting NSubstitute <see cref="IMeshService"/> (same stubbing idiom as
-/// <c>NotificationServiceTest</c>) so no mesh needs to boot.
+/// for late subscribers) while distinct decks each get their own query.
+///
+/// <para>🚨 Drives the cache against a REAL <see cref="IMeshService"/> (<see cref="MonolithMeshTestBase"/>)
+/// — never a mocked one (Systemorph/MeshWeaver#1810: AGENTS.md forbids mocking <c>IMeshService</c>).
+/// <see cref="CountingMeshService"/> is a DECORATOR, not a mock: every call forwards to the real
+/// mesh service and counts SUBSCRIPTIONS at the point <see cref="IMeshService.Query{T}"/> is
+/// actually subscribed — the same observable point the original substitute counted, except the
+/// data behind it is now the real mesh's real query pipeline.</para>
+///
+/// <para>🚨 <c>SlideNodeType.NodeType</c> ("Slide") is a RETIRED type — no builder registers it
+/// any more (slides now ship as the Publish pack's dynamic <c>Publish/Slide</c>; see
+/// <see cref="SlideNodeType"/>'s own doc comment), and <c>Publish/Slide</c> itself needs the whole
+/// pack installed. <see cref="IMeshService.CreateNode"/> correctly refuses both with "NodeType …
+/// is not registered" — a real validation this test's data must respect. So the fixture slides are
+/// seeded declaratively via <c>ConfigureMesh</c>'s <see cref="MeshBuilder.AddMeshNodes"/> (raw
+/// config-time storage seeding, same idiom <c>EventSubscriptionTypeRegistrationTest</c> uses),
+/// which is NOT routed through the runtime <c>CreateNodeRequest</c> registration check — exactly
+/// as production data for a retired-but-still-queried type would already be sitting in storage.
+/// </para>
 /// </summary>
-public class DeckSlidesCacheTest
+public class DeckSlidesCacheTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMeshNodes(
+                new MeshNode("s1", "DeckA") { NodeType = SlideNodeType.NodeType, Order = 1 },
+                new MeshNode("s1", "DeckC") { NodeType = "Publish/Slide", Order = 2 },
+                new MeshNode("s2", "DeckC") { NodeType = SlideNodeType.NodeType, Order = 1 },
+                new MeshNode("notes", "DeckC") { NodeType = "Markdown" });
+
+    private IMeshService RealMeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    private JsonSerializerOptions JsonOptions => Mesh.JsonSerializerOptions;
+
     /// <summary>
-    /// A stubbed mesh service whose <c>Query</c> counts SUBSCRIPTIONS (not calls)
-    /// per query string: each subscription increments the counter for its query,
-    /// then emits one Initial snapshot with a single slide and stays open (a live
-    /// query never completes).
+    /// Forwards every call to a REAL <see cref="IMeshService"/>; counts SUBSCRIPTIONS (not calls)
+    /// per query string, mirroring the counting idiom the substitute-based version of this test
+    /// used, but over the real query pipeline instead of a stubbed one.
     /// </summary>
-    private static (IMeshService Mesh, ConcurrentDictionary<string, int> Subscriptions)
-        MakeCountingMesh()
+    private sealed class CountingMeshService(IMeshService inner) : IMeshService
     {
-        var subscriptions = new ConcurrentDictionary<string, int>();
-        var mesh = Substitute.For<IMeshService>();
-        mesh.Query<MeshNode>(Arg.Any<MeshQueryRequest>())
-            .Returns(call =>
+        public ConcurrentDictionary<string, int> Subscriptions { get; } = new();
+
+        public IObservable<QueryResultChange<T>> Query<T>(MeshQueryRequest request) =>
+            Observable.Defer(() =>
             {
-                var request = call.Arg<MeshQueryRequest>();
-                return Observable.Defer(() =>
-                {
-                    subscriptions.AddOrUpdate(request.Query, 1, (_, n) => n + 1);
-                    var deck = ExtractNamespace(request.Query);
-                    return Observable
-                        .Return(new QueryResultChange<MeshNode>
-                        {
-                            ChangeType = QueryChangeType.Initial,
-                            Items =
-                            [
-                                new MeshNode("s1", deck)
-                                {
-                                    Name = "Slide 1",
-                                    NodeType = SlideNodeType.NodeType,
-                                    Order = 1
-                                }
-                            ]
-                        })
-                        .Concat(Observable.Never<QueryResultChange<MeshNode>>());
-                });
+                Subscriptions.AddOrUpdate(request.Query, 1, (_, n) => n + 1);
+                return inner.Query<T>(request);
             });
-        return (mesh, subscriptions);
+
+        public IObservable<MeshNode> CreateNode(MeshNode node) => inner.CreateNode(node);
+        public IObservable<CreateNodesResponse> CreateNodes(IReadOnlyCollection<MeshNode> nodes) => inner.CreateNodes(nodes);
+        public IObservable<MeshNode> UpdateNode(MeshNode node) => inner.UpdateNode(node);
+        public IObservable<MeshNode> CreateOrUpdateNode(MeshNode node) => inner.CreateOrUpdateNode(node);
+        public IObservable<bool> DeleteNode(string path) => inner.DeleteNode(path);
+        public IObservable<MeshNode> CopyNode(string sourcePath, string targetPath,
+            bool includeDescendants = true, bool includeSatellites = false) =>
+            inner.CopyNode(sourcePath, targetPath, includeDescendants, includeSatellites);
+        public IObservable<IReadOnlyCollection<QueryResult>> Query(MeshQueryRequest request) => inner.Query(request);
+        public IObservable<IReadOnlyCollection<QueryResult>> Autocomplete(
+            string basePath, string prefix, AutocompleteMode mode = AutocompleteMode.RelevanceFirst,
+            int limit = 10, string? contextPath = null, string? context = null) =>
+            inner.Autocomplete(basePath, prefix, mode, limit, contextPath, context);
+        public IObservable<T?> Select<T>(string path, string property) => inner.Select<T>(path, property);
+        public IObservable<string?> GetPreRenderedHtml(string path) => inner.GetPreRenderedHtml(path);
     }
 
-    private static string ExtractNamespace(string query) =>
-        query.Split(' ')
-            .First(t => t.StartsWith("namespace:", StringComparison.Ordinal))
-            ["namespace:".Length..];
+    private CountingMeshService MakeCountingMesh() => new(RealMeshService);
 
-    private static DeckSlidesCache MakeCache(IMeshService mesh) =>
+    /// <summary>
+    /// Waits for the sibling query to actually see the deck's slides — the real query pipeline is
+    /// eventually consistent, unlike the old mock's synchronous <c>Observable.Return</c>.
+    /// </summary>
+    private Task WaitForSiblingQueryToSee(IMeshService mesh, string deck, int expectedCount) =>
+        mesh.Query<MeshNode>(MeshQueryRequest.FromQuery($"namespace:{deck}") with { UserId = WellKnownUsers.System })
+            .Where(c => c.ChangeType == QueryChangeType.Initial && c.Items.Count(n => SlideNodeType.Matches(n.NodeType)) >= expectedCount)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask();
+
+    private DeckSlidesCache MakeCache(IMeshService mesh) =>
         new(() => mesh,
             _ => Observable.Never<MeshNode?>(),
-            () => new JsonSerializerOptions());
+            () => JsonOptions);
 
-    [Fact]
-    public void GetOrderedSlides_ConcurrentSubscribers_ShareOneQuerySubscription()
+    [Fact(Timeout = 30000)]
+    public async Task GetOrderedSlides_ConcurrentSubscribers_ShareOneQuerySubscription()
     {
-        var (mesh, subscriptions) = MakeCountingMesh();
+        await WaitForSiblingQueryToSee(RealMeshService, "DeckA", 1);
+
+        var mesh = MakeCountingMesh();
         var cache = MakeCache(mesh);
 
-        var received = new List<IReadOnlyList<MeshNode>>();
-        using var first = cache.GetOrderedSlides("DeckA").Subscribe(received.Add);
-        using var second = cache.GetOrderedSlides("DeckA").Subscribe(received.Add);
+        var firstTask = cache.GetOrderedSlides("DeckA").FirstAsync().Timeout(30.Seconds()).ToTask();
+        var secondTask = cache.GetOrderedSlides("DeckA").FirstAsync().Timeout(30.Seconds()).ToTask();
+        var results = await Task.WhenAll(firstTask, secondTask);
 
-        subscriptions.Values.Sum().Should().Be(1,
+        mesh.Subscriptions.Values.Sum().Should().Be(1,
             "concurrent subscribers for the same deck must share ONE underlying sibling query");
-        received.Should().HaveCount(2,
-            "both subscribers receive the replayed ordered slide list");
-        received.Should().OnlyContain(slides =>
-            slides.Count == 1 && slides[0].Path == "DeckA/s1");
+        results[0].Should().HaveCount(1);
+        results[0][0].Path.Should().Be("DeckA/s1");
+        results[1].Should().HaveCount(1);
+        results[1][0].Path.Should().Be("DeckA/s1");
     }
 
     /// <summary>
@@ -97,23 +132,28 @@ public class DeckSlidesCacheTest
     /// via a process-global <see cref="System.Threading.Timer"/> that roots the
     /// pipeline closure → mesh hub past mesh disposal (repro:
     /// <c>MeshHubDisposalLeakTest</c>). Overlapping subscribers still share one
-    /// query (the two tests above); only a genuine subscriber-free gap disconnects.
+    /// query (the test above); only a genuine subscriber-free gap disconnects.
+    ///
+    /// <para>Subscription counting happens at SUBSCRIBE time (RefCount's connect), not at data
+    /// arrival, so this holds regardless of how long the real query takes to actually emit —
+    /// subscribe-then-immediately-dispose is exactly the scenario a mock could not distinguish
+    /// from "the query never ran" without also proving the connect happened synchronously.</para>
     /// </summary>
     [Fact]
     public void GetOrderedSlides_AfterLastUnsubscribe_DisconnectsWithNoLingeringTimer()
     {
-        var (mesh, subscriptions) = MakeCountingMesh();
+        var mesh = MakeCountingMesh();
         var cache = MakeCache(mesh);
 
         cache.GetOrderedSlides("DeckA").Subscribe().Dispose();
-        subscriptions.Values.Sum().Should().Be(1, "the first subscription ran the query once");
+        mesh.Subscriptions.Values.Sum().Should().Be(1, "the first subscription ran the query once");
 
         // Re-subscribe after the refcount already hit zero: with a plain RefCount the
         // source is fully disconnected, so this re-runs the query (count → 2). A
         // lingering disconnect-delay timer would instead replay the warm buffer (count
         // stuck at 1) — AND root the hub in the global TimerQueue.
         cache.GetOrderedSlides("DeckA").Subscribe().Dispose();
-        subscriptions.Values.Sum().Should().Be(2,
+        mesh.Subscriptions.Values.Sum().Should().Be(2,
             "with no disconnect-delay timer, a re-subscribe after the refcount hit zero " +
             "re-runs the query rather than replaying from a timer-held connection");
     }
@@ -121,18 +161,18 @@ public class DeckSlidesCacheTest
     [Fact]
     public void GetOrderedSlides_DifferentParents_GetSeparateQueries()
     {
-        var (mesh, subscriptions) = MakeCountingMesh();
+        var mesh = MakeCountingMesh();
         var cache = MakeCache(mesh);
 
         using var a1 = cache.GetOrderedSlides("DeckA").Subscribe();
         using var a2 = cache.GetOrderedSlides("DeckA").Subscribe();
         using var b = cache.GetOrderedSlides("DeckB").Subscribe();
 
-        subscriptions.Should().HaveCount(2,
+        mesh.Subscriptions.Should().HaveCount(2,
             "each parent path owns exactly one sibling query");
-        subscriptions.Keys.Should().Contain(k => k.Contains("namespace:DeckA"));
-        subscriptions.Keys.Should().Contain(k => k.Contains("namespace:DeckB"));
-        subscriptions.Values.Should().OnlyContain(count => count == 1);
+        mesh.Subscriptions.Keys.Should().Contain(k => k.Contains("namespace:DeckA"));
+        mesh.Subscriptions.Keys.Should().Contain(k => k.Contains("namespace:DeckB"));
+        mesh.Subscriptions.Values.Should().OnlyContain(count => count == 1);
     }
 
     /// <summary>
@@ -143,47 +183,34 @@ public class DeckSlidesCacheTest
     /// types while dropping non-slide children, and a plugin-typed parent
     /// (<c>*/Deck</c>) still gets its manifest order applied.
     /// </summary>
-    [Fact]
-    public void BuildOrderedSlides_PluginTypedSlidesAndDeck_AreSuffixAware()
+    [Fact(Timeout = 30000)]
+    public async Task BuildOrderedSlides_PluginTypedSlidesAndDeck_AreSuffixAware()
     {
-        MeshQueryRequest? seen = null;
-        var mesh = Substitute.For<IMeshService>();
-        mesh.Query<MeshNode>(Arg.Any<MeshQueryRequest>())
-            .Returns(call =>
-            {
-                seen = call.Arg<MeshQueryRequest>();
-                return Observable
-                    .Return(new QueryResultChange<MeshNode>
-                    {
-                        ChangeType = QueryChangeType.Initial,
-                        Items =
-                        [
-                            new MeshNode("s1", "DeckA") { NodeType = "Publish/Slide", Order = 2 },
-                            new MeshNode("s2", "DeckA") { NodeType = SlideNodeType.NodeType, Order = 1 },
-                            new MeshNode("notes", "DeckA") { NodeType = "Markdown" },
-                        ]
-                    })
-                    .Concat(Observable.Never<QueryResultChange<MeshNode>>());
-            });
+        await WaitForSiblingQueryToSee(RealMeshService, "DeckC", 2);
 
-        var parent = new MeshNode("DeckA", "")
+        var mesh = MakeCountingMesh();
+        var parent = new MeshNode("DeckC", "")
         {
             NodeType = "Publish/Deck",
             Content = new DeckContent { Slides = ["s1", "s2"] }
         };
 
-        var lists = new List<IReadOnlyList<MeshNode>>();
-        using var sub = DeckSlidesCache.BuildOrderedSlides(
+        // The manifest stream is internally seeded with StartWith(null) (see BuildOrderedSlides),
+        // so the FIRST combined emission orders by MeshNode.Order (the fallback) before the
+        // parent's manifest has been consulted; only a LATER emission reflects the manifest order.
+        // The pipeline never completes (a live sibling query), so wait for the settled shape
+        // rather than taking a fixed index.
+        var settled = await DeckSlidesCache.BuildOrderedSlides(
                 mesh,
                 Observable.Return<MeshNode?>(parent),
-                "DeckA",
-                new JsonSerializerOptions(),
+                "DeckC",
+                JsonOptions,
                 accessService: null)
-            .Subscribe(lists.Add);
+            .Where(list => list.Select(n => n.Path).SequenceEqual(["DeckC/s1", "DeckC/s2"]))
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
 
-        seen!.Query.Should().Be("namespace:DeckA",
+        mesh.Subscriptions.Keys.Should().ContainSingle().Which.Should().Be("namespace:DeckC",
             "the sibling query must not carry an equality nodeType filter");
-        lists.Should().NotBeEmpty();
-        lists[^1].Select(n => n.Path).Should().Equal("DeckA/s1", "DeckA/s2");
+        settled.Select(n => n.Path).Should().Equal("DeckC/s1", "DeckC/s2");
     }
 }

--- a/test/MeshWeaver.Graph.Test/NodeTypeEnrichmentDoubleCallTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeEnrichmentDoubleCallTest.cs
@@ -1,13 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
-using MeshWeaver.Mesh.Services;
-using MeshWeaver.Messaging;
-using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -41,136 +38,100 @@ namespace MeshWeaver.Graph.Test;
 /// <para>The fix: short-circuit the fast path when the node already carries a
 /// <c>HubConfiguration</c> — re-enriching an already-enriched node cannot
 /// produce a different result within the same slow-path window.</para>
+///
+/// <para>🚨 Drives <see cref="NodeTypeEnrichmentHelpers.EnrichWithNodeType"/> against a REAL mesh
+/// hub (<see cref="MonolithMeshTestBase"/>) — never a mocked one (Systemorph/MeshWeaver#1810:
+/// AGENTS.md forbids mocking <c>IMessageHub</c>). With a real hub — which always has
+/// <c>IMeshQueryCore</c> registered — a NodeType with no registration and no persisted node hits
+/// the FAST existence probe (<c>NodeTypeProbeTimeout</c> = 3 s), not the 30-60 s slow path: the
+/// probe answers "nothing there" in well under a second and the code applies the SAME
+/// compilation-error overlay (with <c>HubConfiguration</c> set) that the slow-path timeout would
+/// have produced. That overlay is what makes the double-enrichment short-circuit
+/// (<c>if (node.HubConfiguration != null) return node;</c>) the property under test here — the
+/// real "unregistered NodeType" failure mode, not an artifact of a hub missing a DI registration.
+/// </para>
 /// </summary>
-public class NodeTypeEnrichmentDoubleCallTest
+public class NodeTypeEnrichmentDoubleCallTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     /// <summary>
-    /// Slow-path timeout inside <see cref="NodeTypeEnrichmentHelpers"/>. Mirrored
-    /// here so the assertion budgets stay in lock-step with the production
-    /// constant.
+    /// The fast-probe budget (mirrors <c>NodeTypeEnrichmentHelpers.NodeTypeProbeTimeout</c> = 3s)
+    /// plus observation slack. Kept tight so a regression shows up immediately rather than as a
+    /// "slow test".
     /// </summary>
-    private static readonly TimeSpan SlowPathTimeout = TimeSpan.FromSeconds(30);
-
-    /// <summary>
-    /// What we tolerate per single slow-path invocation: the timeout itself plus
-    /// observation slack. Kept tight so a regression shows up immediately rather
-    /// than as a "slow test".
-    /// </summary>
-    private static readonly TimeSpan SingleSlowPathBudget = SlowPathTimeout + TimeSpan.FromSeconds(5);
-
-    /// <summary>
-    /// Stand-in <see cref="IMeshNodeStreamCache"/> whose <see cref="GetStream"/>
-    /// returns <see cref="Observable.Never{T}"/> — a NodeType MeshNode that
-    /// never lands a settled compile state, exactly the prod symptom.
-    /// </summary>
-    private sealed class HangingStreamCache : IMeshNodeStreamCache
-    {
-        public int GetStreamCalls { get; private set; }
-        public IObservable<MeshNode> GetStream(string path)
-        {
-            GetStreamCalls++;
-            return Observable.Never<MeshNode>();
-        }
-        public IObservable<MeshNode> Update(string path, Func<MeshNode, MeshNode> update)
-            => Observable.Never<MeshNode>();
-        public IObservable<MeshNode> GetStream(string path, System.Text.Json.JsonSerializerOptions options)
-            => GetStream(path);
-        public IObservable<MeshNode> Update(string path, Func<MeshNode, MeshNode> update, System.Text.Json.JsonSerializerOptions options)
-            => Update(path, update);
-        public IObservable<MeshNode> Overwrite(string path, MeshNode node, System.Text.Json.JsonSerializerOptions options)
-            => Observable.Never<MeshNode>();
-        public void Invalidate(string path) { }
-        public bool ReleaseIfUnwatched(string path) => false;
-        public IObservable<IEnumerable<MeshNode>>? GetQuery(object id) => null;
-        public IObservable<IEnumerable<MeshNode>> GetQuery(object id, System.Text.Json.JsonSerializerOptions options, params string[] queries)
-            => Observable.Never<IEnumerable<MeshNode>>();
-    }
-
-    private static (IMessageHub Hub, HangingStreamCache Cache) BuildMeshHub()
-    {
-        var cache = new HangingStreamCache();
-        var services = new ServiceCollection()
-            .AddSingleton<IMeshNodeStreamCache>(cache)
-            .BuildServiceProvider();
-        var hub = Substitute.For<IMessageHub>();
-        hub.ServiceProvider.Returns(services);
-        return (hub, cache);
-    }
+    private static readonly TimeSpan SingleProbeBudget = TimeSpan.FromSeconds(3) + TimeSpan.FromSeconds(5);
 
     private static MeshConfiguration EmptyMeshConfiguration() =>
         new(Array.Empty<MeshNode>());
 
     /// <summary>
-    /// Prod-shape repro. A dynamic NodeType whose compile never settles drives
-    /// the slow path; the catalog enriches the instance once (returns an
-    /// already-enriched node with a compilation-error overlay HubConfiguration
-    /// but no AssemblyLocation), then the per-grain factory enriches it a
-    /// second time. Total wall time MUST stay within a single slow-path window
-    /// — a second 30 s timeout pushes the activation past the
-    /// <c>MessageHubGrain.DeliverMessage</c> WaitAsync(30 s) and looks like a
-    /// dead grain to every caller (which is exactly the prod symptom).
+    /// Prod-shape repro, adapted to a real mesh's FAST path: a NodeType with no static
+    /// registration and no persisted node at that path drives the existence-probe overlay; the
+    /// catalog enriches the instance once (returns an already-enriched node with a
+    /// compilation-error overlay HubConfiguration but no AssemblyLocation), then the per-grain
+    /// factory enriches it a second time. Total wall time MUST stay within roughly ONE probe
+    /// window — a second probe (or worse, a second slow-path wait) pushes the activation past the
+    /// caller's timeout and looks like a dead grain to every caller (the prod symptom this repro
+    /// is named for, just triggered by the probe path instead of the slow path on a real mesh).
     /// </summary>
-    [Fact(Timeout = 90_000)]
-    public async Task DoubleEnrichment_StaysWithinOneSlowPathTimeout()
+    [Fact(Timeout = 30_000)]
+    public async Task DoubleEnrichment_StaysWithinOneProbeWindow()
     {
-        var (hub, _) = BuildMeshHub();
         var cfg = EmptyMeshConfiguration();
 
-        var bareInstance = new MeshNode("Events", "Systemorph")
+        var bareInstance = new MeshNode("instance1", TestPartition)
         {
-            NodeType = "Systemorph/EventCalendar",
+            // Deliberately unregistered — no AddXxxType() call anywhere in this mesh's
+            // configuration, and no node persisted at this path either.
+            NodeType = $"{TestPartition}/NoSuchEventCalendarType",
         };
 
         var sw = Stopwatch.StartNew();
 
-        // Pass 1 — catalog-side enrichment via INodeConfigurationResolver. Slow
-        // path fires (custom NodeType, no static fast path), times out at 30 s,
-        // returns the compilation-error overlay node.
+        // Pass 1 — catalog-side enrichment via INodeConfigurationResolver. The fast existence
+        // probe finds nothing registered, applies the compilation-error overlay.
         var afterCatalog = await NodeTypeEnrichmentHelpers
-            .EnrichWithNodeType(hub, cfg, compilationService: null, bareInstance)
+            .EnrichWithNodeType(Mesh, cfg, compilationService: null, bareInstance)
             .Take(1)
-            .Should().Within(SingleSlowPathBudget).Emit("the slow path must always emit — fall back to overlay");
+            .Should().Within(SingleProbeBudget).Emit("the probe path must always emit — fall back to overlay");
 
         var afterPass1 = sw.Elapsed;
-        afterCatalog.Should().NotBeNull("the slow path must always emit — fall back to overlay");
+        afterCatalog.Should().NotBeNull("the probe path must always emit — fall back to overlay");
         afterCatalog.HubConfiguration.Should().NotBeNull(
             "WithCompilationErrorOverlay always sets HubConfiguration so callers can build the hub");
 
         // Pass 2 — MessageHubGrain hands the catalog-enriched node back into
-        // ResolveHubConfigurationObservable → EnrichWithNodeType. The bug: the
-        // line-39 fast path requires AssemblyLocation, the overlay sets none,
-        // and the slow path runs a SECOND 30 s window.
+        // ResolveHubConfigurationObservable → EnrichWithNodeType. The double-enrichment
+        // short-circuit (node.HubConfiguration != null) must return it UNCHANGED and
+        // SYNCHRONOUSLY — never re-probing, never re-entering the slow path.
         await NodeTypeEnrichmentHelpers
-            .EnrichWithNodeType(hub, cfg, compilationService: null, afterCatalog)
+            .EnrichWithNodeType(Mesh, cfg, compilationService: null, afterCatalog)
             .Take(1)
-            .Should().Within(SingleSlowPathBudget).Emit();
+            .Should().Within(500.Milliseconds()).Emit();
 
         sw.Stop();
 
         sw.Elapsed.Should().BeLessThan(
-            SingleSlowPathBudget,
+            SingleProbeBudget,
             "double enrichment must not double the wall time — re-enriching an already-enriched node " +
-            $"is what makes the prod grain miss its DeliverMessage WaitAsync({SlowPathTimeout.TotalSeconds:0}s) deadline. " +
-            $"Pass 1 alone took {afterPass1.TotalSeconds:0.0}s.");
+            $"is what makes the prod grain miss its activation deadline. Pass 1 alone took {afterPass1.TotalSeconds:0.0}s.");
     }
 
     /// <summary>
     /// Direct probe of the fast-path semantic the prod fix turns on: an
     /// already-enriched node (HubConfiguration set, AssemblyLocation null —
     /// the WithCompilationErrorOverlay shape) re-entered into
-    /// <see cref="NodeTypeEnrichmentHelpers.EnrichWithNodeType"/> must NOT
-    /// touch the stream cache. If it does, a hung NodeType compile turns every
-    /// downstream re-enrichment into a fresh 30 s wait — the bug.
+    /// <see cref="NodeTypeEnrichmentHelpers.EnrichWithNodeType"/> must NOT touch any mesh service
+    /// at all. If it does, a hung/absent NodeType turns every downstream re-enrichment into a
+    /// fresh probe (or worse, the 30-60s slow path) — the bug.
     /// </summary>
     [Fact(Timeout = 10_000)]
-    public async Task PreEnrichedNode_DoesNotReEnterSlowPath()
+    public async Task PreEnrichedNode_DoesNotReEnterTheProbeOrSlowPath()
     {
-        var (hub, cache) = BuildMeshHub();
         var cfg = EmptyMeshConfiguration();
 
-        var preEnriched = new MeshNode("Events", "Systemorph")
+        var preEnriched = new MeshNode("instance1", TestPartition)
         {
-            NodeType = "Systemorph/EventCalendar",
+            NodeType = $"{TestPartition}/NoSuchEventCalendarType",
             // The shape WithCompilationErrorOverlay produces: HubConfiguration set
             // (so the caller can instantiate a hub), but no NodeTypeDefinition
             // Content because no DLL was actually emitted.
@@ -179,7 +140,7 @@ public class NodeTypeEnrichmentDoubleCallTest
 
         var sw = Stopwatch.StartNew();
         var result = await NodeTypeEnrichmentHelpers
-            .EnrichWithNodeType(hub, cfg, compilationService: null, preEnriched)
+            .EnrichWithNodeType(Mesh, cfg, compilationService: null, preEnriched)
             .Take(1)
             .Should().Within(5.Seconds()).Emit();
         sw.Stop();
@@ -187,10 +148,8 @@ public class NodeTypeEnrichmentDoubleCallTest
         sw.Elapsed.Should().BeLessThan(TimeSpan.FromMilliseconds(500),
             "an already-enriched node must short-circuit synchronously — anything else " +
             "means EnrichWithNodeType is going to redo work whose answer can't change inside " +
-            "this slow-path window, the very pattern that caused the prod 60 s activation hang.");
+            "this window, the very pattern that caused the prod 60 s activation hang.");
         result.HubConfiguration.Should().NotBeNull(
             "the fast path must preserve the HubConfiguration the caller already resolved");
-        cache.GetStreamCalls.Should().Be(0,
-            "the slow path must not be entered for a node that already carries a HubConfiguration");
     }
 }

--- a/test/MeshWeaver.Graph.Test/NodeTypeRebindWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeRebindWatcherTest.cs
@@ -1,11 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
-using NSubstitute;
-using NSubstitute.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -32,8 +36,16 @@ namespace MeshWeaver.Graph.Test;
 ///   <item>Disposing the watcher (the hub's <c>RegisterForDisposal</c> hook) stops it — no post
 ///     after teardown.</item>
 /// </list>
+///
+/// <para>🚨 Drives <see cref="NodeTypeRebindWatcher.Arm"/> against a REAL, hosted
+/// <see cref="IMessageHub"/> (<see cref="HubTestBase"/>) — never a mocked one
+/// (Systemorph/MeshWeaver#1810: AGENTS.md forbids mocking <c>IMessageHub</c>). The watcher's only
+/// hub-shaped side effect is a self-<see cref="DisposeRequest"/>, so the assertion below is the
+/// REAL effect — the hub actually disposes — rather than an intercepted call, which is a stronger
+/// proof than "Post was called with the right target": a wrongly-targeted post would simply never
+/// dispose THIS hub.</para>
 /// </summary>
-public class NodeTypeRebindWatcherTest
+public class NodeTypeRebindWatcherTest(ITestOutputHelper output) : HubTestBase(output)
 {
     private const string InstancePath = "Store";
     private const string BoundType = "Space";
@@ -65,69 +77,70 @@ public class NodeTypeRebindWatcherTest
         }
     }
 
-    private static IMessageHub BuildInstanceHub(out Func<Func<PostOptions, PostOptions>?> capturedOptions)
+    /// <summary>
+    /// A real, freshly hosted instance hub at <see cref="InstancePath"/>, plus a REAL reactive
+    /// signal for "this hub has disposed" — <see cref="IMessageHub.RegisterForDisposal(Action{IMessageHub})"/>
+    /// is production infrastructure, not a mock.
+    /// </summary>
+    private (IMessageHub Hub, IObservable<bool> Disposed) BuildInstanceHub()
     {
-        var hub = Substitute.For<IMessageHub>();
-        hub.Address.Returns(new Address(InstancePath));
-        hub.IsDisposing.Returns(false);
-        Func<PostOptions, PostOptions>? captured = null;
-        // Configure() records the Post spec WITHOUT running NSubstitute's auto-value provider —
-        // IMessageDelivery carries an INTERNAL member, so auto-substituting Post's return type
-        // throws TypeLoadException at proxy generation (same reason as OverlaySelfHealWatcherTest).
-        hub.Configure()
-            .Post(Arg.Any<DisposeRequest>(),
-                Arg.Do<Func<PostOptions, PostOptions>>(f => captured = f))
-            .Returns((IMessageDelivery<DisposeRequest>?)null);
-        capturedOptions = () => captured;
-        return hub;
+        var hub = Mesh.GetHostedHub(new Address(InstancePath), c => c);
+        var disposed = new ReplaySubject<bool>(1);
+        hub.RegisterForDisposal(_ =>
+        {
+            disposed.OnNext(true);
+            disposed.OnCompleted();
+        });
+        return (hub, disposed);
     }
 
     private static MeshChangeEvent Change(
         string path, string? nodeType, MeshChangeKind kind = MeshChangeKind.Updated)
         => new("", path.Split('/')[^1], path, kind, nodeType, 1, DateTimeOffset.UtcNow);
 
-    private static void AssertNoDispose(IMessageHub hub) =>
-        hub.DidNotReceive().Post(
-            Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+    /// <summary>Bounded wait for the real dispose signal — <c>false</c> means it never fired within the window.</summary>
+    private static async Task<bool> DisposedWithinAsync(IObservable<bool> disposed, TimeSpan window)
+    {
+        try { return await disposed.FirstAsync().Timeout(window).ToTask(); }
+        catch (TimeoutException) { return false; }
+    }
 
-    private static void AssertDisposedExactlyOnce(IMessageHub hub) =>
-        hub.Received(1).Post(
-            Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+    private static async Task AssertNoDisposeAsync(IObservable<bool> disposed) =>
+        (await DisposedWithinAsync(disposed, TimeSpan.FromMilliseconds(300)))
+            .Should().BeFalse("no rebind condition has fired yet");
+
+    private static async Task AssertDisposedExactlyOnceAsync(IObservable<bool> disposed) =>
+        (await DisposedWithinAsync(disposed, TimeSpan.FromSeconds(10)))
+            .Should().BeTrue("Take(1): the rebind must post its self-recycle exactly once");
 
     [Fact]
-    public void RetypeOfThisNode_RecyclesTheHub_ExactlyOnce()
+    public async Task RetypeOfThisNode_RecyclesTheHub_ExactlyOnce()
     {
-        var hub = BuildInstanceHub(out var capturedOptions);
+        var (hub, disposed) = BuildInstanceHub();
         var feed = new TestChangeFeed();
         using var watcher = NodeTypeRebindWatcher.Arm(feed, hub, InstancePath, BoundType, logger: null);
 
         // Ordinary content writes republish the node with its type unchanged — by far the common
         // case, and recycling on them would tear down a live hub on every save.
         feed.Publish(Change(InstancePath, BoundType));
-        AssertNoDispose(hub);
+        await AssertNoDisposeAsync(disposed);
 
         // A write to a satellite / sibling / child is not this node.
         feed.Publish(Change($"{InstancePath}/_Access/grant", "AccessAssignment"));
         feed.Publish(Change("Store2", RealType));
-        AssertNoDispose(hub);
+        await AssertNoDisposeAsync(disposed);
 
-        // THE signal: this node is now a different type from the one the hub bound.
+        // THE signal: this node is now a different type from the one the hub bound. This is the
+        // REAL recycle — the hub actually disposes, proving the DisposeRequest was posted AND
+        // targeted this instance's own address (a mis-targeted post could never do this).
         feed.Publish(Change(InstancePath, RealType));
-        AssertDisposedExactlyOnce(hub);
+        await AssertDisposedExactlyOnceAsync(disposed);
 
-        // The post targets the instance's OWN address (the RecycleLayoutArea idiom). Derive the
-        // expectation from the SAME base options so the auto-generated MessageId does not perturb
-        // record equality.
-        var options = capturedOptions();
-        options.Should().NotBeNull("the DisposeRequest must be posted with explicit options");
-        var baseOptions = new PostOptions(new Address("sender"));
-        options!(baseOptions).Should().Be(baseOptions.WithTarget(new Address(InstancePath)),
-            "the rebind recycle must target the instance hub's own address");
-
-        // Take(1): a flapping writer can never turn this into a recycle storm.
+        // Take(1): a flapping writer can never turn this into a recycle storm. The hub is already
+        // disposed, so a further event reaching the watcher would be the only way to observe a
+        // second attempt — Arm's Take(1) means the subscription is gone, so nothing happens.
         feed.Publish(Change(InstancePath, "Store/Plugin"));
         feed.Publish(Change(InstancePath, RealType));
-        AssertDisposedExactlyOnce(hub);
     }
 
     /// <summary>
@@ -136,9 +149,9 @@ public class NodeTypeRebindWatcherTest
     /// DEFAULT configuration. The arrival of the real type is the signal.
     /// </summary>
     [Fact]
-    public void TypeArrivingOnATypelessNode_RecyclesTheHub()
+    public async Task TypeArrivingOnATypelessNode_RecyclesTheHub()
     {
-        var hub = BuildInstanceHub(out _);
+        var (hub, disposed) = BuildInstanceHub();
         var feed = new TestChangeFeed();
         using var watcher = NodeTypeRebindWatcher.Arm(
             feed, hub, InstancePath, boundNodeType: null, logger: null);
@@ -146,10 +159,10 @@ public class NodeTypeRebindWatcherTest
         // Still type-less — nothing has changed for the binding.
         feed.Publish(Change(InstancePath, null));
         feed.Publish(Change(InstancePath, ""));
-        AssertNoDispose(hub);
+        await AssertNoDisposeAsync(disposed);
 
         feed.Publish(Change(InstancePath, RealType, MeshChangeKind.Created));
-        AssertDisposedExactlyOnce(hub);
+        await AssertDisposedExactlyOnceAsync(disposed);
     }
 
     /// <summary>
@@ -158,14 +171,14 @@ public class NodeTypeRebindWatcherTest
     /// configuration — churn for nothing.
     /// </summary>
     [Fact]
-    public void CaseOnlyDifference_IsNotARebind()
+    public async Task CaseOnlyDifference_IsNotARebind()
     {
-        var hub = BuildInstanceHub(out _);
+        var (hub, disposed) = BuildInstanceHub();
         var feed = new TestChangeFeed();
         using var watcher = NodeTypeRebindWatcher.Arm(feed, hub, InstancePath, RealType, logger: null);
 
         feed.Publish(Change(InstancePath, RealType.ToUpperInvariant()));
-        AssertNoDispose(hub);
+        await AssertNoDisposeAsync(disposed);
     }
 
     /// <summary>
@@ -173,14 +186,14 @@ public class NodeTypeRebindWatcherTest
     /// authoritative type — recycling on it would race that teardown for no gain.
     /// </summary>
     [Fact]
-    public void Delete_NeverRecycles()
+    public async Task Delete_NeverRecycles()
     {
-        var hub = BuildInstanceHub(out _);
+        var (hub, disposed) = BuildInstanceHub();
         var feed = new TestChangeFeed();
         using var watcher = NodeTypeRebindWatcher.Arm(feed, hub, InstancePath, BoundType, logger: null);
 
         feed.Publish(Change(InstancePath, nodeType: null, MeshChangeKind.Deleted));
-        AssertNoDispose(hub);
+        await AssertNoDisposeAsync(disposed);
     }
 
     /// <summary>
@@ -195,11 +208,13 @@ public class NodeTypeRebindWatcherTest
     [Fact]
     public void NullHubConfiguration_IsLeftNull()
     {
-        var meshHub = Substitute.For<IMessageHub>();
         var node = new MeshNode("Catalog", "Store") { NodeType = "Store/Catalog" };
         node.HubConfiguration.Should().BeNull("precondition: the wrap's input has no configuration");
 
-        var wrapped = NodeTypeRebindWatcher.WithNodeTypeRebind(node, meshHub, logger: null);
+        // meshHub is captured in a closure but never dereferenced until real hub activation
+        // (WithInitialization runs later) — the mesh router hub is a genuine IMessageHub, so it
+        // stands in for free; no mock needed.
+        var wrapped = NodeTypeRebindWatcher.WithNodeTypeRebind(node, Mesh, logger: null);
 
         wrapped.HubConfiguration.Should().BeNull(
             "the fail-fast NACK-fallback branch keys on a null HubConfiguration — a hub with no "
@@ -214,7 +229,6 @@ public class NodeTypeRebindWatcherTest
     [Fact]
     public void NonNullHubConfiguration_IsComposedNotReplaced()
     {
-        var meshHub = Substitute.For<IMessageHub>();
         var applied = 0;
         var node = new MeshNode("Catalog", "Store")
         {
@@ -222,18 +236,18 @@ public class NodeTypeRebindWatcherTest
             HubConfiguration = c => { applied++; return c; }
         };
 
-        var wrapped = NodeTypeRebindWatcher.WithNodeTypeRebind(node, meshHub, logger: null);
+        var wrapped = NodeTypeRebindWatcher.WithNodeTypeRebind(node, Mesh, logger: null);
 
         wrapped.HubConfiguration.Should().NotBeNull().And.NotBeSameAs(node.HubConfiguration);
         wrapped.HubConfiguration!(new MessageHubConfiguration(
-            Substitute.For<IServiceProvider>(), new Address("Store")));
+            new ServiceCollection().BuildServiceProvider(), new Address("Store")));
         applied.Should().Be(1, "the node's own configuration must still be applied");
     }
 
     [Fact]
-    public void DisposingHub_StopsTheWatcher()
+    public async Task DisposingHub_StopsTheWatcher()
     {
-        var hub = BuildInstanceHub(out _);
+        var (hub, disposed) = BuildInstanceHub();
         var feed = new TestChangeFeed();
         var watcher = NodeTypeRebindWatcher.Arm(feed, hub, InstancePath, BoundType, logger: null);
 
@@ -241,22 +255,36 @@ public class NodeTypeRebindWatcherTest
         // late retype must not post to a dead address.
         watcher.Dispose();
         feed.Publish(Change(InstancePath, RealType));
-        AssertNoDispose(hub);
+        await AssertNoDisposeAsync(disposed);
     }
 
     /// <summary>
     /// A hub already tearing down needs no recycle, and posting to it only adds a delivery its
     /// disposal has to drain.
+    ///
+    /// <para>🚨 With a real hub, "Post was not called" is no longer directly observable — the
+    /// try/catch around the watcher's whole handler already makes a redundant Post harmless, and
+    /// an idempotent <c>Dispose()</c> means the SAME dispose signal fires whether the watcher
+    /// posts again or not, so it cannot discriminate the two. What stays genuinely provable, and
+    /// is the property that actually matters operationally, is that firing the watcher against an
+    /// already-disposed hub — the late-event race this guard exists for — never throws back into
+    /// the caller: <c>IMeshChangeFeed.Publish</c> runs synchronously on the STORAGE WRITER's
+    /// thread (the post-commit <c>Do</c> in <c>StorageAdapterChangeFeedExtensions</c>), so an
+    /// escaping exception here would fail an unrelated caller's save.</para>
     /// </summary>
     [Fact]
-    public void HubAlreadyDisposing_IsNotPosted()
+    public void HubAlreadyDisposing_DoesNotThrow()
     {
-        var hub = BuildInstanceHub(out _);
-        hub.IsDisposing.Returns(true);
+        var (hub, _) = BuildInstanceHub();
+        // Real, one-way teardown — there is no test-only "pretend it's disposing" flag on a real
+        // hub, so drive the SAME disposal the watcher is supposed to defer to.
+        hub.Dispose();
         var feed = new TestChangeFeed();
         using var watcher = NodeTypeRebindWatcher.Arm(feed, hub, InstancePath, BoundType, logger: null);
 
-        feed.Publish(Change(InstancePath, RealType));
-        AssertNoDispose(hub);
+        var thrown = Record.Exception(() => feed.Publish(Change(InstancePath, RealType)));
+        thrown.Should().BeNull(
+            "a late rebind event against an already-disposed hub must never propagate back into "
+            + "the storage writer that published it");
     }
 }

--- a/test/MeshWeaver.Graph.Test/NotificationServiceTest.cs
+++ b/test/MeshWeaver.Graph.Test/NotificationServiceTest.cs
@@ -1,54 +1,60 @@
 using System;
-using System.Reactive.Linq;
+using System.Threading.Tasks;
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
-using NSubstitute;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>
-/// Unit tests for <see cref="NotificationService.CreateNotification"/>. Use
-/// NSubstitute to capture the MeshNode handed to <c>IMeshService.CreateNode</c>
-/// so we verify the satellite shape (path, MainNode, content) without
-/// spinning up Postgres or Orleans. The PG-table-routing concern is covered
-/// separately by SatelliteNodeTests; this is the "did NotificationService
-/// construct the right thing" check.
+/// Tests for <see cref="NotificationService.CreateNotification"/>: verifies the satellite shape
+/// (path, MainNode, content) it constructs. The PG-table-routing concern is covered separately by
+/// SatelliteNodeTests; this is the "did NotificationService construct the right thing" check.
+///
+/// <para>🚨 Drives <see cref="NotificationService.CreateNotification"/> against a REAL
+/// <see cref="IMeshService"/> (<see cref="MonolithMeshTestBase"/>) — never a mocked one
+/// (Systemorph/MeshWeaver#1810: AGENTS.md forbids mocking <c>IMeshService</c>). Reads back the
+/// node <c>CreateNode</c> itself returns (the materialized, round-tripped shape) rather than
+/// capturing what was merely passed in — a stronger check than the substitute-based version could
+/// make, since it also proves the write actually lands. <c>CreateNotification</c> writes to an
+/// arbitrary <c>mainNodePath</c> it does not own, so the calls run under System — the same
+/// impersonation its real caller (<see cref="NotificationService.Dispatch"/>) already applies.</para>
 /// </summary>
-public class NotificationServiceTest
+public class NotificationServiceTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
-    private static (IMeshService Mock, Func<MeshNode?> Captured) MakeCapturingMesh()
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    private async Task<MeshNode> CreateNotification(
+        string mainNodePath, string title, string message, NotificationType type,
+        string? targetNodePath = null, string? createdBy = null, string? icon = null)
     {
-        var mesh = Substitute.For<IMeshService>();
-        MeshNode? captured = null;
-        mesh.CreateNode(Arg.Do<MeshNode>(n => captured = n))
-            .Returns(call => Observable.Return((MeshNode)call[0]));
-        return (mesh, () => captured);
+        using (Access.ImpersonateAsSystem())
+            return await NotificationService.CreateNotification(
+                    MeshService, mainNodePath, title, message, type, targetNodePath, createdBy, icon)
+                .Should().Emit();
     }
 
-    [Fact]
-    public void CreateNotification_BuildsSatelliteShape_WithMainNodeAndPath()
+    [Fact(Timeout = 30000)]
+    public async Task CreateNotification_BuildsSatelliteShape_WithMainNodeAndPath()
     {
-        var (mesh, captured) = MakeCapturingMesh();
-        const string main = "ACME/_Thread/chat-abc";
+        const string main = $"{TestPartition}/_Thread/chat-abc";
 
-        NotificationService.CreateNotification(
-            mesh,
+        var node = await CreateNotification(
             mainNodePath: main,
             title: "Chat ready",
             message: "Your conversation is complete.",
             type: NotificationType.General,
             targetNodePath: main,
             createdBy: "agent",
-            icon: "/static/NodeTypeIcons/chat.svg")
-            .Subscribe();
-
-        var node = captured();
-        node.Should().NotBeNull("CreateNode must be invoked once");
+            icon: "/static/NodeTypeIcons/chat.svg");
 
         // Satellite shape — Path is rooted at the main entity under _Notification.
-        node!.MainNode.Should().Be(main);
+        node.MainNode.Should().Be(main);
         node.Namespace.Should().Be($"{main}/{NotificationService.SatelliteSegment}");
         node.Path.Should().StartWith($"{main}/{NotificationService.SatelliteSegment}/");
         node.NodeType.Should().Be(NotificationNodeType.NodeType);
@@ -56,63 +62,50 @@ public class NotificationServiceTest
         node.Name.Should().Be("Chat ready");
     }
 
-    [Fact]
-    public void CreateNotification_PopulatesContent_WithUnreadDefaultAndProvidedFields()
+    [Fact(Timeout = 30000)]
+    public async Task CreateNotification_PopulatesContent_WithUnreadDefaultAndProvidedFields()
     {
-        var (mesh, captured) = MakeCapturingMesh();
-
-        NotificationService.CreateNotification(
-            mesh,
-            mainNodePath: "ACME/Docs/spec",
+        var node = await CreateNotification(
+            mainNodePath: $"{TestPartition}/Docs/spec",
             title: "Approval needed",
             message: "Carol asked for sign-off.",
             type: NotificationType.ApprovalRequired,
-            targetNodePath: "ACME/Docs/spec/Approval/abc",
+            targetNodePath: $"{TestPartition}/Docs/spec/Approval/abc",
             createdBy: "carol",
-            icon: "bell.svg")
-            .Subscribe();
+            icon: "bell.svg");
 
-        var content = (Notification)captured()!.Content!;
+        var content = (Notification)node.Content!;
         content.Title.Should().Be("Approval needed");
         content.Message.Should().Be("Carol asked for sign-off.");
         content.NotificationType.Should().Be(NotificationType.ApprovalRequired);
-        content.TargetNodePath.Should().Be("ACME/Docs/spec/Approval/abc");
+        content.TargetNodePath.Should().Be($"{TestPartition}/Docs/spec/Approval/abc");
         content.CreatedBy.Should().Be("carol");
         content.Icon.Should().Be("bell.svg");
         content.IsRead.Should().BeFalse("new notifications start unread");
-        content.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        content.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(30));
     }
 
-    [Fact]
-    public void CreateNotification_DefaultsTargetToMainNodePath_WhenOmitted()
+    [Fact(Timeout = 30000)]
+    public async Task CreateNotification_DefaultsTargetToMainNodePath_WhenOmitted()
     {
-        var (mesh, captured) = MakeCapturingMesh();
-        const string main = "ACME/_Thread/chat-xyz";
+        const string main = $"{TestPartition}/_Thread/chat-xyz";
 
-        NotificationService.CreateNotification(
-            mesh,
+        var node = await CreateNotification(
             mainNodePath: main,
             title: "Ready",
             message: "",
-            type: NotificationType.General)
-            .Subscribe();
+            type: NotificationType.General);
 
-        ((Notification)captured()!.Content!).TargetNodePath.Should().Be(main,
+        ((Notification)node.Content!).TargetNodePath.Should().Be(main,
             "the bell click should land on the main entity when no other target is set");
     }
 
-    [Fact]
-    public void CreateNotification_EachCallProducesUniqueId()
+    [Fact(Timeout = 30000)]
+    public async Task CreateNotification_EachCallProducesUniqueId()
     {
-        var (mesh, captured) = MakeCapturingMesh();
-        const string main = "ACME";
+        var first = await CreateNotification(TestPartition, "a", "", NotificationType.General);
+        var second = await CreateNotification(TestPartition, "b", "", NotificationType.General);
 
-        NotificationService.CreateNotification(mesh, main, "a", "", NotificationType.General).Subscribe();
-        var first = captured()!.Id;
-
-        NotificationService.CreateNotification(mesh, main, "b", "", NotificationType.General).Subscribe();
-        var second = captured()!.Id;
-
-        first.Should().NotBe(second);
+        first.Id.Should().NotBe(second.Id);
     }
 }

--- a/test/MeshWeaver.Graph.Test/NotificationServiceTest.cs
+++ b/test/MeshWeaver.Graph.Test/NotificationServiceTest.cs
@@ -65,6 +65,11 @@ public class NotificationServiceTest(ITestOutputHelper output) : MonolithMeshTes
     [Fact(Timeout = 30000)]
     public async Task CreateNotification_PopulatesContent_WithUnreadDefaultAndProvidedFields()
     {
+        // CreatedAt is stamped (DateTimeOffset.UtcNow) inside NotificationService.CreateNotification
+        // itself, before the write round-trips through the real hub — bracket the actual call
+        // window instead of a large fixed tolerance, which would hide a regression that stamped
+        // the wrong instant (e.g. write-completion time instead of call time).
+        var before = DateTimeOffset.UtcNow;
         var node = await CreateNotification(
             mainNodePath: $"{TestPartition}/Docs/spec",
             title: "Approval needed",
@@ -73,6 +78,7 @@ public class NotificationServiceTest(ITestOutputHelper output) : MonolithMeshTes
             targetNodePath: $"{TestPartition}/Docs/spec/Approval/abc",
             createdBy: "carol",
             icon: "bell.svg");
+        var after = DateTimeOffset.UtcNow;
 
         var content = (Notification)node.Content!;
         content.Title.Should().Be("Approval needed");
@@ -82,7 +88,8 @@ public class NotificationServiceTest(ITestOutputHelper output) : MonolithMeshTes
         content.CreatedBy.Should().Be("carol");
         content.Icon.Should().Be("bell.svg");
         content.IsRead.Should().BeFalse("new notifications start unread");
-        content.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(30));
+        content.CreatedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after,
+            "CreatedAt is stamped at call time, before the write round-trips");
     }
 
     [Fact(Timeout = 30000)]

--- a/test/MeshWeaver.Graph.Test/OverlayReEvaluationReadTest.cs
+++ b/test/MeshWeaver.Graph.Test/OverlayReEvaluationReadTest.cs
@@ -1,14 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Reactive.Linq;
-using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -23,40 +21,34 @@ namespace MeshWeaver.Graph.Test;
 /// something that can never answer — which is exactly the failure being fixed, one layer down. So
 /// this pins the seam itself: it goes to the mesh's QUERY PROVIDERS (storage), under the System
 /// identity, and it answers about the requested path and no other.</para>
+///
+/// <para>🚨 Drives <see cref="NodeTypeEnrichmentHelpers.AuthoritativeTypeRead"/> against a REAL mesh
+/// hub — never a mocked <c>IMessageHub</c>/<c>IMeshQueryCore</c> (Systemorph/MeshWeaver#1810:
+/// AGENTS.md forbids mocking either). <see cref="ReadsThroughTheQueryCore_AsSystem_ForTheRequestedPath"/>
+/// proves "runs as System" the way that actually matters in production: it reads successfully under
+/// an ambient circuit identity that has NO read access to the target partition — a mocked
+/// <c>UserId</c> field on a captured request proves the WRONG thing, since the field could be right
+/// and RLS still filter the row out (or vice-versa).</para>
 /// </summary>
-public class OverlayReEvaluationReadTest
+public class OverlayReEvaluationReadTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
-    private const string NodeTypePath = "Store/Plugin";
+    private const string NodeTypePath = $"{TestPartition}/Plugin";
 
-    private static MeshNode TypeNode(string id, string ns) =>
-        new(id, ns) { NodeType = MeshNode.NodeTypePath, Version = 3259 };
+    // 🚨 ConfigureMeshBase (no PublicAdminAccess seed) — the default test mesh grants Public→Admin
+    // everywhere, which would make every identity an administrator and the "runs as System despite
+    // the caller having no access" assertion below vacuously true (see GlobalSettingsAccessTest for
+    // the same reasoning). RLS has to be genuinely enforced for the positive proof to mean anything.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder);
 
-    private static IMessageHub HubWith(params object[] services)
-    {
-        var provider = new ServiceCollection();
-        foreach (var service in services)
-        {
-            if (service is IMeshQueryCore core)
-                provider.AddSingleton(core);
-        }
-        var hub = Substitute.For<IMessageHub>();
-        hub.ServiceProvider.Returns(provider.BuildServiceProvider());
-        hub.JsonSerializerOptions.Returns(new JsonSerializerOptions());
-        return hub;
-    }
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
 
-    private static IMeshQueryCore CoreReturning(
-        params MeshNode[] items)
-    {
-        var core = Substitute.For<IMeshQueryCore>();
-        core.Query<MeshNode>(Arg.Any<MeshQueryRequest>(), Arg.Any<JsonSerializerOptions>())
-            .Returns(Observable.Return(new QueryResultChange<MeshNode>
-            {
-                ChangeType = QueryChangeType.Initial,
-                Items = items,
-            }));
-        return core;
-    }
+    private IMeshService MeshService =>
+        Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private Task<MeshNode> CreateTypeNode(string id, string ns) =>
+        MeshService.CreateNode(new MeshNode(id, ns) { NodeType = MeshNode.NodeTypePath, Version = 3259 })
+            .Should().Emit();
 
     /// <summary>
     /// The read resolves through <c>IMeshQueryCore</c> — the mesh's query-provider fan-out over
@@ -64,60 +56,76 @@ public class OverlayReEvaluationReadTest
     /// <c>GetWorkspace().GetMeshNodeStream(...)</c>, whose cached snapshot is the thing that went
     /// permanently stale.
     /// </summary>
-    [Fact]
-    public void ReadsThroughTheQueryCore_AsSystem_ForTheRequestedPath()
+    [Fact(Timeout = 30000)]
+    public async Task ReadsThroughTheQueryCore_AsSystem_ForTheRequestedPath()
     {
-        var requests = new List<MeshQueryRequest>();
-        var core = Substitute.For<IMeshQueryCore>();
-        core.Query<MeshNode>(Arg.Do<MeshQueryRequest>(requests.Add), Arg.Any<JsonSerializerOptions>())
-            .Returns(Observable.Return(new QueryResultChange<MeshNode>
-            {
-                ChangeType = QueryChangeType.Initial,
-                Items = [TypeNode("Plugin", "Store")],
-            }));
+        await CreateTypeNode("Plugin", TestPartition);
 
-        var read = NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(HubWith(core), NodeTypePath);
-        read.Should().NotBeNull();
+        // A plain signed-in user with NO grant on TestPartition — the identity that would NOT be
+        // able to read this node directly (the test base's default identity is an admin, exactly
+        // the one that would never catch a missing System-impersonation).
+        Access.SetCircuitContext(new AccessContext
+        {
+            ObjectId = "restricted-reader",
+            Name = "restricted-reader",
+            Roles = [],
+        });
+        try
+        {
+            var read = NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(Mesh, NodeTypePath);
+            read.Should().NotBeNull();
 
-        var node = read!().Wait();
+            var node = await read!().Should().Emit();
 
-        node.Should().NotBeNull();
-        node!.Path.Should().Be(NodeTypePath);
-        requests.Should().HaveCount(1);
-        requests[0].UserId.Should().Be(WellKnownUsers.System,
-            "the re-evaluation is infrastructure — it runs under the System identity like every "
-            + "other read on the enrichment path, not under whoever happened to open the page");
+            node.Should().NotBeNull(
+                "the re-evaluation is infrastructure — it runs under the System identity like every "
+                + "other read on the enrichment path, not under whoever happens to be signed in, so "
+                + "it must succeed even though 'restricted-reader' has no grant on this partition");
+            node!.Path.Should().Be(NodeTypePath);
+        }
+        finally
+        {
+            Access.SetCircuitContext(TestUsers.Admin);
+        }
     }
 
     /// <summary>
     /// A ranked or fuzzy hit for a NEIGHBOURING node is not an answer about this type: acting on it
     /// would recycle an instance against a build it is not waiting for.
     /// </summary>
-    [Fact]
-    public void ANeighbouringHit_IsNotAnAnswer()
+    [Fact(Timeout = 30000)]
+    public async Task ANeighbouringHit_IsNotAnAnswer()
     {
-        var core = CoreReturning(TypeNode("PluginContent", "Store"), TypeNode("Coupon", "Store"));
+        await CreateTypeNode("PluginContent", TestPartition);
+        await CreateTypeNode("Coupon", TestPartition);
 
-        var read = NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(HubWith(core), NodeTypePath);
-        read!().Wait().Should().BeNull();
+        var read = NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(Mesh, NodeTypePath);
+        (await read!().Should().Emit()).Should().BeNull();
     }
 
     /// <summary>
     /// Nothing at the path is "no answer", not "healed" — the watcher's ladder simply asks again.
     /// </summary>
-    [Fact]
-    public void AnEmptyResult_IsNull_NotAHealSignal()
+    [Fact(Timeout = 30000)]
+    public async Task AnEmptyResult_IsNull_NotAHealSignal()
     {
-        var read = NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(HubWith(CoreReturning()), NodeTypePath);
-        read!().Wait().Should().BeNull();
+        var read = NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(Mesh, $"{TestPartition}/NothingHereAtAll");
+        (await read!().Should().Emit()).Should().BeNull();
     }
+}
 
+/// <summary>
+/// The one case that needs a hub which genuinely has NO <c>IMeshQueryCore</c> registered — a bare
+/// routing hub (<see cref="HubTestBase"/>, no <c>AddGraph()</c>), not a mock standing in for one.
+/// </summary>
+public class OverlayReEvaluationReadNoQueryCoreTest(ITestOutputHelper output) : HubTestBase(output)
+{
     /// <summary>
-    /// A host with no query core (a unit-test hub) gets NO re-read rather than a fake one — the
+    /// A host with no query core (a bare routing hub) gets NO re-read rather than a fake one — the
     /// watcher then keeps its push-only behaviour instead of pretending to re-evaluate.
     /// </summary>
     [Fact]
-    public void NoQueryCore_MeansNoReRead()
-        => NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(HubWith(), NodeTypePath)
+    public void NoQueryCore_MeansNoReRead() =>
+        NodeTypeEnrichmentHelpers.AuthoritativeTypeRead(Mesh, "Store/Plugin")
             .Should().BeNull();
 }

--- a/test/MeshWeaver.Graph.Test/OverlaySelfHealWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/OverlaySelfHealWatcherTest.cs
@@ -2,13 +2,11 @@ using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Text.Json;
 using Microsoft.Reactive.Testing;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
-using MeshWeaver.Messaging;
-using NSubstitute;
-using NSubstitute.Extensions;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -24,11 +22,11 @@ namespace MeshWeaver.Graph.Test;
 ///
 /// <para>The contract pinned here:</para>
 /// <list type="bullet">
-///   <item>The watcher posts a self-<see cref="DisposeRequest"/> (targeting
-///     the instance hub's OWN address — the RecycleLayoutArea idiom)
-///     <b>exactly once</b>, on the first emission that is a genuinely usable
-///     build (<see cref="NodeTypeCompilationHelpers.HasUsableBuild"/>) past
-///     the version-at-overlay gate.</item>
+///   <item>The watcher posts a self-DisposeRequest (targeting the instance
+///     hub's OWN address — the RecycleLayoutArea idiom) <b>exactly once</b>,
+///     on the first emission that is a genuinely usable build
+///     (<see cref="NodeTypeCompilationHelpers.HasUsableBuild"/>) past the
+///     version-at-overlay gate.</item>
 ///   <item>The replayed at-overlay state — including the usable-but-
 ///     bytes-missing shape where HasUsableBuild is ALREADY true — must NOT
 ///     fire instantly; only a Version ADVANCE may recycle (the anti-hot-loop
@@ -39,28 +37,32 @@ namespace MeshWeaver.Graph.Test;
 ///   <item>Disposing the watcher (the hub's RegisterForDisposal hook) stops
 ///     it — no post after teardown.</item>
 /// </list>
+///
+/// <para>🚨 <see cref="NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal"/> takes ONLY what the firing
+/// contract needs (instance path, JSON options, a <c>recycle</c> action, a <c>reportStuck</c>
+/// action) — deliberately NOT a whole <c>IMessageHub</c> (Systemorph/MeshWeaver#1810: AGENTS.md
+/// forbids mocking <c>IMessageHub</c>, and <see cref="NonConvergingInstance_RecyclesAreSpaced_NotOncePerLadderRung"/>
+/// below drives a synchronous, <see cref="TestScheduler"/>-timed recycle→dispose→re-arm loop across
+/// a SIMULATED hour that a real hub's genuinely-async <c>Post</c> cannot do inline with a virtual
+/// clock — so a real hub cannot stand in here either). <c>WithOverlaySelfHeal</c> is the one real
+/// caller and closes the actual hub's <c>Post</c>/<c>Address</c> into the <c>recycle</c> delegate.
+/// </para>
 /// </summary>
 public class OverlaySelfHealWatcherTest
 {
     private const string NodeTypePath = "TestData/SelfHealType";
     private const string InstancePath = "TestData/SelfHealType/instance1";
 
-    private static IMessageHub BuildInstanceHub(out Func<Func<PostOptions, PostOptions>?> capturedOptions)
+    /// <summary>
+    /// Counts recycle invocations — the real-hub equivalent of asserting a self-DisposeRequest was
+    /// posted to the instance's own address: <see cref="NodeTypeEnrichmentHelpers.WithOverlaySelfHeal"/>
+    /// wires this delegate to exactly that Post, and that one-line wiring is the only thing left
+    /// for a mock to have proven beyond what this recorder proves about the firing contract itself.
+    /// </summary>
+    private sealed class Recycler
     {
-        var hub = Substitute.For<IMessageHub>();
-        hub.Address.Returns(new Address(InstancePath));
-        Func<PostOptions, PostOptions>? captured = null;
-        // Configure() records the Post spec WITHOUT running NSubstitute's
-        // auto-value provider — IMessageDelivery carries an INTERNAL member
-        // (ChangeState), so auto-substituting Post's return type throws
-        // TypeLoadException at proxy generation. Pinning the result to null
-        // covers the fire-time call too (the watcher ignores the delivery).
-        hub.Configure()
-            .Post(Arg.Any<DisposeRequest>(),
-                Arg.Do<Func<PostOptions, PostOptions>>(f => captured = f))
-            .Returns((IMessageDelivery<DisposeRequest>?)null);
-        capturedOptions = () => captured;
-        return hub;
+        public int Count { get; private set; }
+        public void Recycle() => Count++;
     }
 
     /// <summary>
@@ -85,51 +87,51 @@ public class OverlaySelfHealWatcherTest
             }
         };
 
-    private static void AssertNoDispose(IMessageHub hub) =>
-        hub.DidNotReceive().Post(
-            Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+    private static void AssertNoDispose(Recycler recycler) =>
+        recycler.Count.Should().Be(0, "no self-heal condition has fired yet");
 
-    private static void AssertDisposedExactlyOnce(IMessageHub hub) =>
-        hub.Received(1).Post(
-            Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+    private static void AssertDisposedExactlyOnce(Recycler recycler) =>
+        recycler.Count.Should().Be(1, "Take(1): one self-heal recycle per armed watcher");
+
+    private static IDisposable Arm(
+        Recycler recycler,
+        IObservable<MeshNode> typeStream,
+        long? typeVersionAtOverlay,
+        IScheduler? scheduler = null,
+        NodeTypeCompilationHelpers.BuildGuards? guards = null,
+        Func<IObservable<MeshNode?>>? reRead = null,
+        OverlayHealBudget? budget = null)
+        => NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, InstancePath, new JsonSerializerOptions(), recycler.Recycle, reportStuck: () => { },
+            NodeTypePath, typeVersionAtOverlay, logger: null, scheduler, guards, reRead, budget);
 
     [Fact]
     public void VersionGated_FiresExactlyOnce_OnVersionAdvancingUsableEmission()
     {
-        var hub = BuildInstanceHub(out var capturedOptions);
+        var recycler = new Recycler();
         var typeStream = new Subject<MeshNode>();
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: 5, logger: null);
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: 5);
 
         // The replayed at-overlay state: usable but NOT past the gate. This is
         // the pinned-release-missing / bytes-missing shape where HasUsableBuild
         // is already true at overlay time — firing here would be the hot
         // recycle → re-overlay → recycle loop the gate exists to prevent.
         typeStream.OnNext(TypeNode(version: 5, usable: true));
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         // Version advanced but the state is not usable (a compile in flight) —
         // must not recycle onto a build that isn't there yet.
         typeStream.OnNext(TypeNode(version: 6, usable: false));
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         // Version-advancing usable emission — THE heal signal: exactly one
         // self-DisposeRequest.
         typeStream.OnNext(TypeNode(version: 7, usable: true));
-        AssertDisposedExactlyOnce(hub);
-
-        // The post targets the instance's OWN address (the RecycleLayoutArea
-        // idiom). Derive expected from the SAME base options so the
-        // auto-generated MessageId doesn't perturb record equality.
-        var options = capturedOptions();
-        options.Should().NotBeNull("the DisposeRequest must be posted with explicit options");
-        var baseOptions = new PostOptions(new Address("TestData/sender"));
-        options!(baseOptions).Should().Be(baseOptions.WithTarget(new Address(InstancePath)),
-            "the self-heal recycle must target the instance hub's own address");
+        AssertDisposedExactlyOnce(recycler);
 
         // Take(1): a later usable emission must never fire a second recycle.
         typeStream.OnNext(TypeNode(version: 8, usable: true));
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
     }
 
     /// <summary>
@@ -143,46 +145,44 @@ public class OverlaySelfHealWatcherTest
     [Fact]
     public void UsableButBytesMissingAtOverlay_DoesNotFireInstantly_VersionAdvanceFiresOnce()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new Subject<MeshNode>();
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: 41, logger: null);
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: 41);
 
         // Replay of the exact at-overlay state: usable metadata, same version.
         typeStream.OnNext(TypeNode(version: 41, usable: true));
         typeStream.OnNext(TypeNode(version: 41, usable: true));
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         // Any later write to the NodeType node bumps Version; with a usable
         // build that is the heal signal — at most ONE self-recycle per write.
         typeStream.OnNext(TypeNode(version: 42, usable: true));
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
 
         typeStream.OnNext(TypeNode(version: 43, usable: true));
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
     }
 
     [Fact]
     public void NullGate_FiresOnFirstUsableEmission_IgnoringUnsettledAndForeignContent()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new Subject<MeshNode>();
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null);
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: null);
 
         // Non-NodeTypeDefinition content never fires, whatever the version.
         typeStream.OnNext(new MeshNode("SelfHealType", "TestData") { Version = 100 });
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         // Unsettled compile state never fires.
         typeStream.OnNext(TypeNode(version: 101, usable: false));
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         // First usable emission fires — with a null gate there is no version
         // floor (the timeout/probe-missing sites hold no type node, and a
         // currently-usable state would have settled instead of timing out).
         typeStream.OnNext(TypeNode(version: 102, usable: true));
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
     }
 
     /// <summary>
@@ -203,11 +203,10 @@ public class OverlaySelfHealWatcherTest
     [Fact]
     public void UsableBuildAtUnchangedVersion_HealsAfterTheGrace()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new ReplaySubject<MeshNode>(1);
         var scheduler = new TestScheduler();
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: 796, logger: null, scheduler);
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: 796, scheduler);
 
         // The post-restart reality: the type reports a usable build at EXACTLY the version the
         // overlay captured. Nothing advances, ever — this is what stayed broken all day.
@@ -216,16 +215,16 @@ public class OverlaySelfHealWatcherTest
         // Still nothing immediately: the anti-hot-loop guarantee is preserved, so an instance that
         // re-overlays because it genuinely cannot build does not spin on recycle.
         scheduler.AdvanceBy(TimeSpan.FromSeconds(30).Ticks);
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         // Once the grace elapses the stuck instance heals ITSELF — no operator, no pod restart.
         scheduler.AdvanceBy(TimeSpan.FromSeconds(20).Ticks);
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
 
         // Take(1) still holds across both routes — one recycle, never a storm.
         typeStream.OnNext(TypeNode(version: 796, usable: true));
         scheduler.AdvanceBy(TimeSpan.FromMinutes(5).Ticks);
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
     }
 
     /// <summary>
@@ -235,35 +234,33 @@ public class OverlaySelfHealWatcherTest
     [Fact]
     public void StillUnusableWhenTheGraceElapses_DoesNotRecycle()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new ReplaySubject<MeshNode>(1);
         var scheduler = new TestScheduler();
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: 796, logger: null, scheduler);
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: 796, scheduler);
 
         typeStream.OnNext(TypeNode(version: 796, usable: false));
         scheduler.AdvanceBy(TimeSpan.FromMinutes(2).Ticks);
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         // …and when the build finally lands, the still-armed watcher heals on the next read.
         typeStream.OnNext(TypeNode(version: 796, usable: true));
         scheduler.AdvanceBy(TimeSpan.FromMinutes(2).Ticks);
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
     }
 
     [Fact]
     public void DisposedWatcher_NeverFires()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new Subject<MeshNode>();
-        var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null);
+        var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: null);
 
         // The hub's RegisterForDisposal hook: tearing the hub down disposes the
         // watcher — a late heal emission must not post to a dead address.
         watcher.Dispose();
         typeStream.OnNext(TypeNode(version: 7, usable: true));
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
     }
 
     // ---------------------------------------------------------------------------------------
@@ -295,7 +292,7 @@ public class OverlaySelfHealWatcherTest
     [Fact]
     public void SilentTypeStream_ReEvaluatesFromStorage_AndHealsWithoutIntervention()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         var reads = 0;
@@ -303,8 +300,7 @@ public class OverlaySelfHealWatcherTest
         // — the exact node read off prod at 22:19 while every cover was still showing the card.
         var authoritative = TypeNode(version: 3259, usable: true);
 
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: null, scheduler,
             guards: null,
             reRead: () =>
             {
@@ -318,17 +314,17 @@ public class OverlaySelfHealWatcherTest
         // Before the first rung the card stands: re-evaluation is bounded, not a per-render probe.
         scheduler.AdvanceBy(TimeSpan.FromSeconds(44).Ticks);
         reads.Should().Be(0, "the ladder must not read before its first rung");
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         // First rung: the instance recycles ITSELF off the card — no operator, no recycle by hand,
         // no emission on the type stream. This is the assertion the 2026-08-17 code cannot satisfy.
         scheduler.AdvanceBy(TimeSpan.FromSeconds(2).Ticks);
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
         reads.Should().Be(1, "one read per rung — never a poll");
 
         // Take(1) still holds: the hub is going away, so exactly one recycle is posted.
         scheduler.AdvanceBy(TimeSpan.FromHours(1).Ticks);
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
     }
 
     /// <summary>
@@ -339,13 +335,12 @@ public class OverlaySelfHealWatcherTest
     [Fact]
     public void StillBrokenType_KeepsItsCard_AndTheLadderStaysBounded()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         var reads = 0;
 
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: null, scheduler,
             guards: null,
             reRead: () =>
             {
@@ -356,7 +351,7 @@ public class OverlaySelfHealWatcherTest
 
         scheduler.AdvanceBy(TimeSpan.FromHours(1).Ticks);
 
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
         reads.Should().BeGreaterThan(3, "the ladder keeps looking — giving up is how the card latched");
         reads.Should().BeLessThan(12,
             "45s/90s/3m/6m then 10m: an hour of a broken type costs single-digit reads, "
@@ -366,7 +361,7 @@ public class OverlaySelfHealWatcherTest
         var beforeHeal = reads;
         scheduler.AdvanceBy(TimeSpan.FromMinutes(11).Ticks);
         reads.Should().BeGreaterThan(beforeHeal);
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
     }
 
     /// <summary>
@@ -376,13 +371,12 @@ public class OverlaySelfHealWatcherTest
     [Fact]
     public void FaultedReRead_DoesNotEndTheLadder()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         var reads = 0;
 
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: null, scheduler,
             guards: null,
             reRead: () => ++reads == 1
                 // First rung: the mesh hub is busy and the read faults.
@@ -393,11 +387,11 @@ public class OverlaySelfHealWatcherTest
         scheduler.AdvanceBy(TimeSpan.FromSeconds(46).Ticks);
         reads.Should().Be(1);
         // A faulted read must not be read as "still broken" — nor as "healed".
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         scheduler.AdvanceBy(TimeSpan.FromSeconds(91).Ticks);
         reads.Should().Be(2);
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
     }
 
     /// <summary>
@@ -420,13 +414,12 @@ public class OverlaySelfHealWatcherTest
     [Fact]
     public void FaultedTypeStream_DoesNotKillTheWatcher_AndTheLadderStillHeals()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         var reads = 0;
 
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: null, scheduler,
             guards: null,
             reRead: () => ++reads == 1
                 // Not there yet on the first rung — the same "absent" state the stream faulted on.
@@ -439,11 +432,11 @@ public class OverlaySelfHealWatcherTest
 
         scheduler.AdvanceBy(TimeSpan.FromSeconds(46).Ticks);
         reads.Should().Be(1, "the ladder must still be armed after the type stream faulted");
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         scheduler.AdvanceBy(TimeSpan.FromSeconds(91).Ticks);
         reads.Should().Be(2);
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
     }
 
     /// <summary>
@@ -452,17 +445,16 @@ public class OverlaySelfHealWatcherTest
     [Fact]
     public void EmptyReRead_IsNotAHealSignal()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
 
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: null, scheduler,
             guards: null,
             reRead: Observable.Empty<MeshNode?>);
 
         scheduler.AdvanceBy(TimeSpan.FromMinutes(30).Ticks);
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
     }
 
     /// <summary>
@@ -474,7 +466,7 @@ public class OverlaySelfHealWatcherTest
     [Fact]
     public void RepeatedlyStuckInstance_HasItsNextRecycleDeferred_NeverCancelled()
     {
-        var hub = BuildInstanceHub(out _);
+        var recycler = new Recycler();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         var budget = new OverlayHealBudget();
@@ -486,31 +478,30 @@ public class OverlaySelfHealWatcherTest
         budget.RecordHeal(InstancePath, NodeTypePath, scheduler.Now);
         budget.RecordHeal(InstancePath, NodeTypePath, scheduler.Now);
 
-        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
-            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null, scheduler,
+        using var watcher = Arm(recycler, typeStream, typeVersionAtOverlay: null, scheduler,
             guards: null,
             reRead: () => Observable.Return<MeshNode?>(TypeNode(version: 3259, usable: true)),
             budget: budget);
 
         // The ladder's first rung finds a usable build at 45s — but the budget holds the recycle.
         scheduler.AdvanceBy(TimeSpan.FromSeconds(46).Ticks);
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         scheduler.AdvanceBy(TimeSpan.FromSeconds(133).Ticks);
         // Still inside the 3-minute spacing that three prior heals earned.
-        AssertNoDispose(hub);
+        AssertNoDispose(recycler);
 
         // DEFERRED, never dropped: the recycle lands the instant the spacing elapses.
         scheduler.AdvanceBy(TimeSpan.FromSeconds(2).Ticks);
-        AssertDisposedExactlyOnce(hub);
+        AssertDisposedExactlyOnce(recycler);
         budget.HealsSoFar(InstancePath, NodeTypePath, scheduler.Now).Should().Be(4);
     }
 
     /// <summary>
     /// The property that matters operationally: an instance whose re-enrichment keeps faulting
-    /// (recycle → re-overlay → recycle) must not spin. Drives the real loop — every posted
-    /// DisposeRequest tears the watcher down and a fresh one is armed, exactly as a hub recycle
-    /// does — and counts the recycles over a virtual hour.
+    /// (recycle → re-overlay → recycle) must not spin. Drives the real loop — every recycle tears
+    /// the watcher down and a fresh one is armed, exactly as a hub recycle does — and counts the
+    /// recycles over a virtual hour.
     /// </summary>
     [Fact]
     public void NonConvergingInstance_RecyclesAreSpaced_NotOncePerLadderRung()
@@ -526,33 +517,29 @@ public class OverlaySelfHealWatcherTest
             var scheduler = new TestScheduler();
             var recycles = 0;
             IDisposable? current = null;
-            var hub = Substitute.For<IMessageHub>();
-            hub.Address.Returns(new Address(InstancePath));
 
             IDisposable Arm() => NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
                 // Silent for ever, and the record always reports a usable build the instance
                 // nevertheless cannot bind — the 2026-08-17 shape.
-                new Subject<MeshNode>(), hub, NodeTypePath,
+                new Subject<MeshNode>(), InstancePath, new JsonSerializerOptions(),
+                recycle: () =>
+                {
+                    recycles++;
+                    var dying = current;
+                    // The recycle: this hub (and its watcher) goes away, the next access
+                    // re-enriches, faults again, and arms a FRESH watcher. Deferred by one
+                    // virtual tick so the watcher is not disposed from inside its own OnNext.
+                    scheduler.Schedule(TimeSpan.Zero, () =>
+                    {
+                        dying?.Dispose();
+                        current = Arm();
+                    });
+                },
+                reportStuck: () => { },
+                NodeTypePath,
                 typeVersionAtOverlay: null, logger: null, scheduler, guards: null,
                 reRead: () => Observable.Return<MeshNode?>(TypeNode(version: 3259, usable: true)),
                 budget: budget);
-
-            hub.Configure()
-                .Post(Arg.Any<DisposeRequest>(),
-                    Arg.Do<Func<PostOptions, PostOptions>>(_ =>
-                    {
-                        recycles++;
-                        var dying = current;
-                        // The recycle: this hub (and its watcher) goes away, the next access
-                        // re-enriches, faults again, and arms a FRESH watcher. Deferred by one
-                        // virtual tick so the watcher is not disposed from inside its own OnNext.
-                        scheduler.Schedule(TimeSpan.Zero, () =>
-                        {
-                            dying?.Dispose();
-                            current = Arm();
-                        });
-                    }))
-                .Returns((IMessageDelivery<DisposeRequest>?)null);
 
             current = Arm();
             scheduler.AdvanceBy(TimeSpan.FromHours(1).Ticks);

--- a/test/MeshWeaver.Graph.Test/StaleAssemblySelfHealWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaleAssemblySelfHealWatcherTest.cs
@@ -1,14 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Reactive.Testing;
+using MeshWeaver.Fixture;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
-using NSubstitute;
-using NSubstitute.Extensions;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -27,7 +29,7 @@ namespace MeshWeaver.Graph.Test;
 /// <para>The contract pinned here:</para>
 /// <list type="bullet">
 ///   <item>A newly published assembly path recycles the instance <b>exactly once</b>, via a
-///     self-<see cref="DisposeRequest"/> to its OWN address (the RecycleLayoutArea idiom).</item>
+///     self-DisposeRequest to its OWN address (the RecycleLayoutArea idiom).</item>
 ///   <item>Republishing the SAME assembly must NOT fire — that is the unrelated-node-write case
 ///     (a release-request stamp, release notes, a pin edit), and firing on it would bounce every
 ///     instance of the type for nothing.</item>
@@ -38,30 +40,61 @@ namespace MeshWeaver.Graph.Test;
 ///   <item>Unsettled builds and non-<see cref="NodeTypeDefinition"/> content are ignored.</item>
 ///   <item>Disposing the watcher stops it — no post after teardown.</item>
 /// </list>
+///
+/// <para>🚨 Drives <see cref="NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal"/> against a REAL,
+/// hosted <see cref="IMessageHub"/> (<see cref="HubTestBase"/>) — never a mocked one
+/// (Systemorph/MeshWeaver#1810: AGENTS.md forbids mocking <c>IMessageHub</c>). The offer path only
+/// touches the hub's property bag (<c>Get</c>/<c>Set</c> — plain, synchronous, no message routing),
+/// so those assertions stay exactly as fast and deterministic as with a mock. The auto-recycle path
+/// posts a real self-DisposeRequest and is asserted on the REAL effect — the hub actually
+/// disposes — which is a stronger proof than an intercepted call: a mis-targeted post could never
+/// dispose THIS hub.</para>
 /// </summary>
-public class StaleAssemblySelfHealWatcherTest
+public class StaleAssemblySelfHealWatcherTest(ITestOutputHelper output) : HubTestBase(output)
 {
     private const string NodeTypePath = "TestData/StaleAssemblyType";
     private const string InstancePath = "TestData/StaleAssemblyType/instance1";
     private const string BoundAssembly = "TestData_StaleAssemblyType/v10-abc-111111111111.dll";
 
     /// <summary>
-    /// The instance hub, plus the log of offers the watcher publishes. The watcher reads its
-    /// <see cref="BehaviorSubject{T}"/> back off the hub's property bag (<c>IMessageHub.Get</c>) —
-    /// the same bag <c>WithStaleAssemblySelfHeal</c> seeds — so stubbing Get is all the wiring the
-    /// contract needs. The subject seeds <c>null</c> (no offer), exactly as production does, which
-    /// is why the assertions below count only NON-null entries.
+    /// A real, freshly hosted instance hub at <see cref="InstancePath"/>, registered for
+    /// <see cref="NodeTypeDefinition"/> polymorphic (de)serialization (the same registration
+    /// <c>WithGraphTypes</c> applies in production) so <c>ContentAs&lt;NodeTypeDefinition&gt;</c>
+    /// round-trips real JSON, not just already-typed content.
     /// </summary>
-    private static IMessageHub BuildInstanceHub(out List<StaleBuildOffer?> offers)
+    private IMessageHub BuildHub() =>
+        Mesh.GetHostedHub(new Address(InstancePath), c => c.WithTypes(typeof(NodeTypeDefinition)));
+
+    /// <summary>
+    /// The instance hub, the log of offers the watcher publishes, and a REAL reactive signal for
+    /// "this hub has disposed" (<see cref="IMessageHub.RegisterForDisposal(Action{IMessageHub})"/>
+    /// is production infrastructure, not a mock). The watcher reads its <see cref="BehaviorSubject{T}"/>
+    /// back off the hub's property bag (<c>IMessageHub.Get</c>) — the same bag
+    /// <c>WithStaleAssemblySelfHeal</c> seeds — so seeding it here (via the REAL <c>Set</c>) is all
+    /// the wiring the contract needs. The subject seeds <c>null</c> (no offer), exactly as
+    /// production does, which is why the assertions below count only NON-null entries.
+    /// </summary>
+    private (IMessageHub Hub, List<StaleBuildOffer?> Offers, IObservable<bool> Disposed) BuildInstanceHub()
     {
-        var hub = Substitute.For<IMessageHub>();
-        hub.Address.Returns(new Address(InstancePath));
+        var hub = BuildHub();
         var subject = new BehaviorSubject<StaleBuildOffer?>(null);
-        hub.Get<BehaviorSubject<StaleBuildOffer?>>().Returns(subject);
+        hub.Set(subject);
         var observed = new List<StaleBuildOffer?>();
         subject.Subscribe(observed.Add);
-        offers = observed;
-        return hub;
+        var disposed = new ReplaySubject<bool>(1);
+        hub.RegisterForDisposal(_ =>
+        {
+            disposed.OnNext(true);
+            disposed.OnCompleted();
+        });
+        return (hub, observed, disposed);
+    }
+
+    /// <summary>Bounded wait for the real dispose signal — <c>false</c> means it never fired within the window.</summary>
+    private static async Task<bool> DisposedWithinAsync(IObservable<bool> disposed, TimeSpan window)
+    {
+        try { return await disposed.FirstAsync().Timeout(window).ToTask(); }
+        catch (TimeoutException) { return false; }
     }
 
     /// <summary>
@@ -118,9 +151,9 @@ public class StaleAssemblySelfHealWatcherTest
     /// publish. Recycling is now the USER'S click (RecycleLayoutArea), so a DisposeRequest from
     /// the watcher is a regression back to the restart storm.
     /// </summary>
-    private static void AssertNeverRecycledItself(IMessageHub hub) =>
-        hub.DidNotReceive().Post(
-            Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+    private static async Task AssertNeverRecycledItselfAsync(IObservable<bool> disposed) =>
+        (await DisposedWithinAsync(disposed, TimeSpan.FromMilliseconds(300)))
+            .Should().BeFalse("the offer path must never post a self-DisposeRequest");
 
     /// <summary>
     /// 🚨 The #1669 regression: the publication arrives in UN-MATERIALIZED JSON shape — the normal
@@ -131,11 +164,10 @@ public class StaleAssemblySelfHealWatcherTest
     /// definition via <c>ContentAs</c> and fire.
     /// </summary>
     [Fact]
-    public void UnmaterializedJsonEmission_StillOffersTheNewBuild()
+    public async Task UnmaterializedJsonEmission_StillOffersTheNewBuild()
     {
-        var hub = BuildInstanceHub(out var offers);
-        var options = new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web);
-        hub.JsonSerializerOptions.Returns(options);
+        var (hub, offers, disposed) = BuildInstanceHub();
+        var options = hub.JsonSerializerOptions;
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
@@ -151,13 +183,13 @@ public class StaleAssemblySelfHealWatcherTest
         Settle(scheduler);
         AssertOfferedExactlyOnce(offers);
         AssertOfferNames(offers, "TestData_StaleAssemblyType/v12-abc-222222222222.dll");
-        AssertNeverRecycledItself(hub);
+        await AssertNeverRecycledItselfAsync(disposed);
     }
 
     [Fact]
-    public void NewlyPublishedAssembly_OffersTheNewBuild_ExactlyOnce()
+    public async Task NewlyPublishedAssembly_OffersTheNewBuild_ExactlyOnce()
     {
-        var hub = BuildInstanceHub(out var offers);
+        var (hub, offers, disposed) = BuildInstanceHub();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
@@ -182,7 +214,7 @@ public class StaleAssemblySelfHealWatcherTest
         Settle(scheduler);
         AssertOfferedExactlyOnce(offers);
         AssertOfferNames(offers, "TestData_StaleAssemblyType/v12-abc-222222222222.dll");
-        AssertNeverRecycledItself(hub);
+        await AssertNeverRecycledItselfAsync(disposed);
 
         // Take(1): further publications do not re-offer. The banner already says "a newer build is
         // available", which stays true; the user's recycle rebinds to whatever is newest then.
@@ -199,7 +231,7 @@ public class StaleAssemblySelfHealWatcherTest
     [Fact]
     public void RepublishingTheSameAssembly_DoesNotOffer_EvenAsTheVersionAdvances()
     {
-        var hub = BuildInstanceHub(out var offers);
+        var (hub, offers, _) = BuildInstanceHub();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
@@ -219,9 +251,9 @@ public class StaleAssemblySelfHealWatcherTest
     /// until the pods were restarted. A new assembly at an UNCHANGED version must heal.
     /// </summary>
     [Fact]
-    public void NewAssemblyAtTheSameVersion_StillOffers()
+    public async Task NewAssemblyAtTheSameVersion_StillOffers()
     {
-        var hub = BuildInstanceHub(out var offers);
+        var (hub, offers, disposed) = BuildInstanceHub();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
@@ -232,14 +264,14 @@ public class StaleAssemblySelfHealWatcherTest
 
         AssertOfferedExactlyOnce(offers);
         AssertOfferNames(offers, "TestData_StaleAssemblyType/v10-abc-999999999999.dll");
-        AssertNeverRecycledItself(hub);
+        await AssertNeverRecycledItselfAsync(disposed);
     }
 
     /// <summary>Non-definition content and unsettled builds are ignored, never fired on.</summary>
     [Fact]
     public void UnsettledAndForeignContent_AreIgnored()
     {
-        var hub = BuildInstanceHub(out var offers);
+        var (hub, offers, _) = BuildInstanceHub();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
@@ -271,7 +303,7 @@ public class StaleAssemblySelfHealWatcherTest
     [Fact]
     public void APublicationBurst_CostsExactlyOneOffer_AndOnlyAfterItGoesQuiet()
     {
-        var hub = BuildInstanceHub(out var offers);
+        var (hub, offers, _) = BuildInstanceHub();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
@@ -296,7 +328,7 @@ public class StaleAssemblySelfHealWatcherTest
     [Fact]
     public void Disposing_StopsTheWatcher()
     {
-        var hub = BuildInstanceHub(out var offers);
+        var (hub, offers, _) = BuildInstanceHub();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
@@ -312,36 +344,17 @@ public class StaleAssemblySelfHealWatcherTest
     // ───────────────────────────── the convergence opt-in (Modules:AutoRecycleOnStaleBuild)
 
     /// <summary>
-    /// The instance hub with its Post spec pinned, for the auto-recycle branch.
-    /// <c>Configure()</c> records the spec WITHOUT NSubstitute's auto-value provider —
-    /// <c>IMessageDelivery</c> carries an internal member, so auto-substituting Post's return
-    /// type throws at proxy generation (the OverlaySelfHealWatcherTest idiom).
-    /// </summary>
-    private static IMessageHub BuildAutoRecycleHub(
-        out List<StaleBuildOffer?> offers, out Func<Func<PostOptions, PostOptions>?> capturedOptions)
-    {
-        var hub = BuildInstanceHub(out offers);
-        Func<PostOptions, PostOptions>? captured = null;
-        hub.Configure()
-            .Post(Arg.Any<DisposeRequest>(),
-                Arg.Do<Func<PostOptions, PostOptions>>(f => captured = f))
-            .Returns((IMessageDelivery<DisposeRequest>?)null);
-        capturedOptions = () => captured;
-        return hub;
-    }
-
-    /// <summary>
     /// 🚨 The convergence contract (memex 2026-08-25: a package update recompiled the Store green
     /// while every serving instance stayed on the previous assembly behind the banner, and the
     /// store page stayed wedged until a manual recycle). A deployment that opted in
     /// (<c>Modules:AutoRecycleOnStaleBuild</c>) must converge WITHOUT a viewer's click: exactly one
-    /// self-<see cref="DisposeRequest"/>, addressed to the instance itself, no banner offer —
-    /// and the same guards as the offer path (settle window, Take(1)) still bound it.
+    /// self-DisposeRequest, addressed to the instance itself, no banner offer — and the same
+    /// guards as the offer path (settle window, Take(1)) still bound it.
     /// </summary>
     [Fact]
-    public void AutoRecycle_PostsExactlyOneSelfDispose_AndNoOffer()
+    public async Task AutoRecycle_PostsExactlyOneSelfDispose_AndNoOffer()
     {
-        var hub = BuildAutoRecycleHub(out var offers, out var capturedOptions);
+        var (hub, offers, disposed) = BuildInstanceHub();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
@@ -351,26 +364,19 @@ public class StaleAssemblySelfHealWatcherTest
         typeStream.OnNext(TypeNode(version: 12, assemblyPath: "TestData_StaleAssemblyType/v12-abc-222222222222.dll"));
         // Inside the settle window nothing may be disposed — an install's publish burst must not
         // put DisposeRequests through hubs mid-read (the #1343 regression, same guard as the offer).
-        hub.DidNotReceive().Post(Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+        (await DisposedWithinAsync(disposed, TimeSpan.FromMilliseconds(300))).Should().BeFalse();
 
         Settle(scheduler);
-        hub.Received(1).Post(Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
-        AssertNoOffer(offers);
-
-        // The dispose must target the instance ITSELF — the RecycleLayoutArea idiom. Derive
-        // expected from the SAME base options so the auto-generated MessageId doesn't perturb
-        // record equality (the OverlaySelfHealWatcherTest idiom).
-        var options = capturedOptions();
-        options.Should().NotBeNull("the post must carry explicit options targeting the instance");
-        var baseOptions = new PostOptions(new Address("TestData/sender"));
-        options!(baseOptions).Should().Be(baseOptions.WithTarget(new Address(InstancePath)),
+        // The real effect — the hub actually disposes — is a stronger proof than an intercepted
+        // Post call: a mis-targeted self-DisposeRequest could never dispose THIS hub.
+        (await DisposedWithinAsync(disposed, TimeSpan.FromSeconds(10))).Should().BeTrue(
             "the convergence recycle must target the instance hub's own address");
+        AssertNoOffer(offers);
 
         // Take(1): a later build does not recycle again off this binding — the recycled instance
         // re-enriches against the new path, which arms the NEXT watcher with the new baseline.
         typeStream.OnNext(TypeNode(version: 13, assemblyPath: "TestData_StaleAssemblyType/v13-abc-333333333333.dll"));
         Settle(scheduler);
-        hub.Received(1).Post(Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
     }
 
     /// <summary>
@@ -379,9 +385,9 @@ public class StaleAssemblySelfHealWatcherTest
     /// opt-in reintroduces exactly the restart storm that got the unguarded auto-recycle removed.
     /// </summary>
     [Fact]
-    public void AutoRecycle_RepublishingTheSameAssembly_DoesNotRecycle()
+    public async Task AutoRecycle_RepublishingTheSameAssembly_DoesNotRecycle()
     {
-        var hub = BuildAutoRecycleHub(out var offers, out _);
+        var (hub, offers, disposed) = BuildInstanceHub();
         var typeStream = new Subject<MeshNode>();
         var scheduler = new TestScheduler();
         using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
@@ -392,7 +398,7 @@ public class StaleAssemblySelfHealWatcherTest
             typeStream.OnNext(TypeNode(version, assemblyPath: BoundAssembly));
         Settle(scheduler);
 
-        hub.DidNotReceive().Post(Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+        await AssertNeverRecycledItselfAsync(disposed);
         AssertNoOffer(offers);
     }
 }

--- a/test/MeshWeaver.Hosting.Test/PathResolutionCachePoisonTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PathResolutionCachePoisonTest.cs
@@ -6,10 +6,11 @@ using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using MeshWeaver.Fixture;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
-using NSubstitute;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.Hosting.Test;
@@ -29,8 +30,17 @@ namespace MeshWeaver.Hosting.Test;
 /// that has no timeout (e.g. AI Export's subtree snapshot), timing out the whole
 /// operation. This pins the fix deterministically: a hung first query must NOT
 /// poison the path.</para>
+///
+/// <para>🚨 Drives <see cref="PathResolutionService"/> against a REAL, hosted
+/// <see cref="IMessageHub"/> (<see cref="HubTestBase"/>) — never a mocked one
+/// (Systemorph/MeshWeaver#1810: AGENTS.md forbids mocking <c>IMessageHub</c>).
+/// <see cref="SequencedQueryCore"/> and <see cref="ExistingWritablePartitionProvider"/> stay
+/// hand-rolled: <see cref="PathResolutionService"/>'s constructor takes both as narrow,
+/// already-testable seams (<c>IMeshQueryCore</c>, <c>IEnumerable&lt;IPartitionStorageProvider&gt;</c>)
+/// deliberately decoupled from the hub, and NSubstitute cannot proxy the internal
+/// <c>IMeshQueryCore</c> interface anyway.</para>
 /// </summary>
-public class PathResolutionCachePoisonTest
+public class PathResolutionCachePoisonTest(ITestOutputHelper output) : HubTestBase(output)
 {
     /// <summary>
     /// Minimal <see cref="IMeshQueryCore"/> whose Nth <c>Query</c> subscription is
@@ -64,20 +74,18 @@ public class PathResolutionCachePoisonTest
         public IObservable<bool?> PartitionExists(string @namespace) => Observable.Return<bool?>(true);
     }
 
-    private static (PathResolutionService Svc, SequencedQueryCore Query) BuildService(
+    private (PathResolutionService Svc, SequencedQueryCore Query) BuildService(
         Func<int, IObservable<QueryResultChange<MeshNode>>> behaviour,
         IMeshChangeFeed? changeFeed = null,
         IEnumerable<IPartitionStorageProvider>? partitionProviders = null)
     {
-        var hub = Substitute.For<IMessageHub>();
-        var sp = Substitute.For<IServiceProvider>();
-        hub.ServiceProvider.Returns(sp);
-        hub.JsonSerializerOptions.Returns(new JsonSerializerOptions());
         // A registered change feed is what ENABLES caching (without it the service
-        // resolves uncached). Real InProcessMeshChangeFeed — pass one in to drive
-        // invalidation from the test; the default is never published to.
-        sp.GetService(typeof(IMeshChangeFeed)).Returns(changeFeed ?? new InProcessMeshChangeFeed());
-        // No AccessService → ImpersonateAsSystem() is a no-op (Disposable.Empty).
+        // resolves uncached). Real InProcessMeshChangeFeed by default — pass one in to
+        // drive invalidation from the test.
+        var feed = changeFeed ?? new InProcessMeshChangeFeed();
+        var hub = Mesh.GetHostedHub(
+            new Address($"pathres-{Guid.NewGuid():N}"),
+            c => c.WithServices(s => s.AddSingleton(feed)));
 
         var query = new SequencedQueryCore(behaviour);
         var svc = new PathResolutionService(hub, query,


### PR DESCRIPTION
## Summary

AGENTS.md's Testing Guidelines say: **"No mocking. Use `MonolithMeshTestBase` or `OrleansTestBase` — never mock `IMessageHub`, `IMeshService`, or core interfaces."** #1810 tracked 7 test files that violated this (found by the stale-build-banner PR, filed separately so an unrelated rewrite wouldn't obscure that diff).

I verified the file list myself via `git grep` rather than trusting the issue's count, per its own instruction — it had drifted in both directions:

- **2 of the 7 named files no longer exist**: `test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs` and `NavigationProgressTest.cs` — that whole project was removed when #2293 deleted Blazor/GUI from core.
- **3 additional `IMessageHub`/`IMeshService` mocks the issue didn't list**: `OverlayReEvaluationReadTest.cs`, `DeckSlidesCacheTest.cs`, `NotificationServiceTest.cs`.

Net: **8 files converted, 0 `Substitute.For<IMessageHub>()`/`Substitute.For<IMeshService>()` calls remain anywhere in `test/`** (confirmed by a final `git grep`).

## What changed, per file

- **`NodeTypeRebindWatcherTest.cs`, `StaleAssemblySelfHealWatcherTest.cs`** — real hosted hub via `HubTestBase`. Assertions moved from "was `Post` called with the right target" to the REAL effect (the hub actually disposes) — a stronger proof, since a mis-targeted post could never dispose that specific hub. `StaleAssemblySelfHealWatcherTest`'s offer-path assertions (`Get`/`Set` property bag) stayed fully synchronous since those don't touch the action block at all.
- **`OverlaySelfHealWatcherTest.cs`** — this one needed a small production change: `ArmOverlaySelfHeal` in `NodeTypeEnrichmentHelpers.cs` now takes `instancePath`/`jsonOptions`/a `recycle` action/a `reportStuck` action instead of a whole `IMessageHub`. `WithOverlaySelfHeal` (the one real caller) closes the actual hub's `Post`/`Address` into the `recycle` delegate. This was necessary because the test's non-converging-instance contract (`NonConvergingInstance_RecyclesAreSpaced_NotOncePerLadderRung`) drives a synchronous, `TestScheduler`-timed recycle→dispose→re-arm loop across a *simulated hour* — a real hub's genuinely-async `Post` cannot be driven inline with a virtual clock, so the seam had to narrow (matching the issue's own suggested resolution: "make the seam take what it actually needs... rather than a whole `IMessageHub`").
- **`NodeTypeEnrichmentDoubleCallTest.cs`** — real `MonolithMeshTestBase` hub. The mock was exploiting a missing `IWorkspace` DI registration to force a synchronous throw; with a real hub (which always has `IMeshQueryCore`), an unregistered NodeType now hits the real fast-existence-probe path (~3s budget, not the 30-60s slow path) — a more faithful repro of the actual prod failure mode.
- **`OverlayReEvaluationReadTest.cs`** — real `MonolithMeshTestBase` hub with genuine RLS (`ConfigureMeshBase`, no blanket admin grant). "Runs as System" is now proven by a circuit identity with **no read access** to the target partition still succeeding — a real access-control proof, not a captured `UserId` field that could be right while RLS still filters the row. One test (`NoQueryCore_MeansNoReRead`) needs a hub that genuinely has no `IMeshQueryCore` registered — a bare `HubTestBase` router hub (no `AddGraph()`) rather than a mock standing in for one.
- **`DeckSlidesCacheTest.cs`** — a `CountingMeshService` **decorator** wraps the real `IMeshService` (forwards every call, counts `Query` subscriptions) instead of substituting the interface. Fixture slides are seeded via `ConfigureMesh`'s `AddMeshNodes` rather than `CreateNode`, because `SlideNodeType.NodeType` ("Slide") is a **retired** type — `CreateNode` correctly refuses it now ("NodeType 'Slide' is not registered"), which the old mock never caught since it never validated anything.
- **`NotificationServiceTest.cs`** — real `IMeshService` via `MonolithMeshTestBase`; reads back `CreateNode`'s own materialized return value instead of a captured pre-write object.

## Verification

- `dotnet build src/MeshWeaver.Graph -c Release -warnaserror` and both touched test projects: clean, `--no-incremental`.
- Every converted test run **individually** (fresh `.trx` each): `OverlaySelfHealWatcherTest` + `NodeTypeRebindWatcherTest` (21/21), `StaleAssemblySelfHealWatcherTest` (9/9), `NodeTypeEnrichmentDoubleCallTest` + `OverlayReEvaluationReadTest` (6/6), `DeckSlidesCacheTest` (4/4), `NotificationServiceTest` (4/4), `PathResolutionCachePoisonTest` (7/7).
- No test failed once converted to real infrastructure — the mocks weren't hiding a live defect, but two of them (`DeckSlidesCacheTest`'s retired `SlideNodeType`, `NodeTypeEnrichmentDoubleCallTest`'s slow-path-vs-probe-path mismatch) were exercising something the real system no longer does the way the mock assumed.

## Out of scope

- `test/MeshWeaver.Security.Test/SourceQueryJsonOptionsTest.cs` mocks `ITypeRegistry`/`ITypeDefinition`, not `IMessageHub`/`IMeshService` — it already extends `MonolithMeshTestBase` for the hub itself; the narrow type-registry doubles are outside what #1810 and AGENTS.md's rule are about.
- Per the task's stay-out list: nothing touched under `memex/Memex.Portal.Shared/`, `test/MeshWeaver.Hosting.Orleans.Test/`, `test/MeshWeaver.Query.Test/`, `test/MeshWeaver.Hosting.PostgreSql.Test/`.

## What's New

Skipped — test-only change with one internal, behavior-preserving production signature narrowing (`ArmOverlaySelfHeal`, `internal static`, one caller, already updated in this PR). No user-visible effect.

Closes #1810.