### PR TITLE
Sign-in redirects only follow local URLs; the webhook inbox actually caps its body

### DIFF
--- a/memex/Memex.Portal.Shared/Api/BoundedBody.cs
+++ b/memex/Memex.Portal.Shared/Api/BoundedBody.cs
@@ -1,0 +1,33 @@
+using System.Text;
+
+namespace Memex.Portal.Shared.Api;
+
+/// <summary>
+/// Reads a request body up to a hard byte cap, and says so when the cap is exceeded.
+///
+/// <para>🚨 <c>WebhookInboxEndpoints</c> checked <c>Content-Length</c> and then read the body with a
+/// plain <c>StreamReader.ReadToEndAsync()</c> — while a comment beside it described "the capped
+/// reader below" that did not exist (#2302). A chunked request carries no Content-Length, so that
+/// path buffered an unbounded body into memory on a PUBLIC endpoint. This is the reader the comment
+/// promised. Pure over a <see cref="Stream"/> so it is unit-tested with a MemoryStream.</para>
+/// </summary>
+public static class BoundedBody
+{
+    /// <summary>
+    /// The body as UTF-8 text, or <c>null</c> if it exceeds <paramref name="maxBytes"/>. Reads at
+    /// most <c>maxBytes + 1</c> bytes, so an oversized body is refused without being buffered.
+    /// </summary>
+    public static async Task<string?> ReadAsync(Stream body, long maxBytes, CancellationToken ct)
+    {
+        var buffer = new MemoryStream();
+        var chunk = new byte[16 * 1024];
+        while (true)
+        {
+            var read = await body.ReadAsync(chunk, ct);
+            if (read == 0) break;
+            if (buffer.Length + read > maxBytes) return null;
+            buffer.Write(chunk, 0, read);
+        }
+        return Encoding.UTF8.GetString(buffer.GetBuffer(), 0, (int)buffer.Length);
+    }
+}

--- a/memex/Memex.Portal.Shared/Api/BoundedBody.cs
+++ b/memex/Memex.Portal.Shared/Api/BoundedBody.cs
@@ -23,7 +23,13 @@ public static class BoundedBody
         var chunk = new byte[16 * 1024];
         while (true)
         {
-            var read = await body.ReadAsync(chunk, ct);
+            // 🚨 Ask for no more than the remaining budget PLUS ONE byte. A full-chunk request let the
+            // socket read overshoot the cap by up to a chunk before this returned null — the buffer
+            // never exceeded the cap, but the stated contract ("at most max+1 bytes READ") was not what
+            // the code did. Caught in review. The +1 is what detects "over the cap" without holding it.
+            var remaining = maxBytes + 1 - buffer.Length;
+            var want = (int)Math.Min(chunk.Length, remaining);
+            var read = await body.ReadAsync(chunk.AsMemory(0, want), ct);
             if (read == 0) break;
             if (buffer.Length + read > maxBytes) return null;
             buffer.Write(chunk, 0, read);

--- a/memex/Memex.Portal.Shared/Api/WebhookInboxEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/WebhookInboxEndpoints.cs
@@ -55,9 +55,11 @@ public static class WebhookInboxEndpoints
         // below still guards chunked bodies that lie about their size).
         if (request.ContentLength is > WebhookInbox.MaxBodyBytes)
             return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
-        string body;
-        using (var reader = new StreamReader(request.Body))
-            body = await reader.ReadToEndAsync(ct);
+        // 🚨 The cap the comment above always promised. Content-Length is advisory (absent on a
+        // chunked request, and a client may lie); the reader enforces the byte limit itself.
+        var body = await BoundedBody.ReadAsync(request.Body, WebhookInbox.MaxBodyBytes, ct);
+        if (body is null)
+            return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
 
         var headers = request.Headers.Select(h =>
             new KeyValuePair<string, string>(h.Key, h.Value.ToString()));

--- a/memex/Memex.Portal.Shared/Authentication/ExternalAuthController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ExternalAuthController.cs
@@ -86,7 +86,7 @@ public class ExternalAuthController : ControllerBase
                 ExpiresUtc = DateTimeOffset.UtcNow.AddDays(14)
             });
 
-        return Redirect(returnUrl ?? "/");
+        return Redirect(ReturnUrlPolicy.Sanitize(returnUrl));
     }
 
     /// <summary>
@@ -97,7 +97,7 @@ public class ExternalAuthController : ControllerBase
     public async Task<IActionResult> Logout([FromQuery] string? returnUrl)
     {
         await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-        return Redirect(returnUrl ?? "/");
+        return Redirect(ReturnUrlPolicy.Sanitize(returnUrl));
     }
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/Authentication/ReturnUrlPolicy.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ReturnUrlPolicy.cs
@@ -1,0 +1,26 @@
+namespace Memex.Portal.Shared.Authentication;
+
+/// <summary>
+/// The ONE rule for a <c>returnUrl</c> that arrives from the outside world: it is honoured only if
+/// it is LOCAL — a path on this host. Anything else falls back to the root.
+///
+/// <para>🚨 Before this existed, <c>ExternalAuthController</c> redirected to
+/// <c>returnUrl ?? "/"</c> unvalidated on both the sign-in callback and logout — a classic open
+/// redirect (#2302): a crafted link to our own <c>/auth/external/callback?returnUrl=https://evil</c>
+/// signs the victim in HERE and then sends them THERE, on a page that looks like the tail of our
+/// own login flow. Pure and static so it is unit-tested without constructing a controller.</para>
+/// </summary>
+public static class ReturnUrlPolicy
+{
+    /// <summary>A safe target: the given URL if it is local, otherwise <c>"/"</c>.</summary>
+    public static string Sanitize(string? returnUrl)
+    {
+        if (string.IsNullOrWhiteSpace(returnUrl)) return "/";
+        var u = returnUrl.Trim();
+        // Local = a single leading slash, and NOT protocol-relative ("//evil.com") or a
+        // backslash variant browsers normalise to one ("/\evil.com").
+        if (u.Length == 0 || u[0] != '/') return "/";
+        if (u.Length > 1 && (u[1] == '/' || u[1] == '\\')) return "/";
+        return u;
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-auth-return-url-and-webhook-body-cap.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-auth-return-url-and-webhook-body-cap.md
@@ -1,0 +1,13 @@
+---
+Name: Sign-in redirects stay on this site; webhook bodies are size-capped
+Category: Fix
+Description: External sign-in and logout only follow local return URLs, and the webhook inbox refuses oversized bodies instead of buffering them.
+Icon: ShieldCheckmark
+Order: -20260826
+---
+
+# Sign-in redirects stay on this site; webhook bodies are size-capped
+
+After signing in through an external provider — or signing out — the portal now only follows a return URL that points back to a page on this site. A link that tried to send you somewhere else after login is ignored and you land on the home page instead.
+
+Separately, the webhook inbox now enforces its body-size limit for every request, including ones that do not declare a length up front, and answers *413 Payload Too Large* rather than reading an unbounded body.

--- a/test/Memex.Portal.Shared.Test/BoundedBodyTest.cs
+++ b/test/Memex.Portal.Shared.Test/BoundedBodyTest.cs
@@ -22,6 +22,35 @@ public class BoundedBodyTest
         Assert.Null(await BoundedBody.ReadAsync(s, maxBytes: 1000, CancellationToken.None));
     }
 
+    /// <summary>The contract is on bytes READ, not bytes buffered: an oversized body must be refused
+    /// after at most max+1 bytes have been pulled from the stream. Only a byte counter can tell an
+    /// enforced cap from a promised one — null comes back either way.</summary>
+    [Fact]
+    public async Task Never_reads_more_than_max_plus_one_bytes_from_the_stream()
+    {
+        var counting = new CountingStream(new MemoryStream(Encoding.UTF8.GetBytes(new string('x', 100_000))));
+        Assert.Null(await BoundedBody.ReadAsync(counting, maxBytes: 1000, CancellationToken.None));
+        Assert.True(counting.BytesRead <= 1001, $"read {counting.BytesRead} bytes; the contract is at most 1001");
+    }
+
+    private sealed class CountingStream(Stream inner) : Stream
+    {
+        public long BytesRead { get; private set; }
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
+        { var n = await inner.ReadAsync(buffer, ct); BytesRead += n; return n; }
+        public override int Read(byte[] buffer, int offset, int count)
+        { var n = inner.Read(buffer, offset, count); BytesRead += n; return n; }
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
     [Fact]
     public async Task Empty_body_is_empty_string_not_null()
     {

--- a/test/Memex.Portal.Shared.Test/BoundedBodyTest.cs
+++ b/test/Memex.Portal.Shared.Test/BoundedBodyTest.cs
@@ -1,0 +1,31 @@
+using System.Text;
+using Memex.Portal.Shared.Api;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+public class BoundedBodyTest
+{
+    [Fact]
+    public async Task Body_within_the_cap_is_returned_intact()
+    {
+        var text = new string('x', 1000);
+        using var s = new MemoryStream(Encoding.UTF8.GetBytes(text));
+        Assert.Equal(text, await BoundedBody.ReadAsync(s, maxBytes: 1000, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Body_over_the_cap_is_refused_not_buffered()
+    {
+        // No Content-Length is involved at all — this is the chunked-request shape.
+        using var s = new MemoryStream(Encoding.UTF8.GetBytes(new string('x', 1001)));
+        Assert.Null(await BoundedBody.ReadAsync(s, maxBytes: 1000, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Empty_body_is_empty_string_not_null()
+    {
+        using var s = new MemoryStream();
+        Assert.Equal("", await BoundedBody.ReadAsync(s, maxBytes: 10, CancellationToken.None));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/ReturnUrlPolicyTest.cs
+++ b/test/Memex.Portal.Shared.Test/ReturnUrlPolicyTest.cs
@@ -1,0 +1,27 @@
+using Memex.Portal.Shared.Authentication;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+public class ReturnUrlPolicyTest
+{
+    [Theory]
+    [InlineData(null, "/")]
+    [InlineData("", "/")]
+    [InlineData("   ", "/")]
+    [InlineData("/", "/")]
+    [InlineData("/Doc/Architecture", "/Doc/Architecture")]
+    [InlineData("/a?b=c#d", "/a?b=c#d")]
+    public void Local_paths_are_honoured_and_empty_falls_back(string? input, string expected)
+        => Assert.Equal(expected, ReturnUrlPolicy.Sanitize(input));
+
+    [Theory]
+    [InlineData("https://evil.example/phish")]
+    [InlineData("http://evil.example")]
+    [InlineData("//evil.example/protocol-relative")]
+    [InlineData("/\\evil.example/backslash-variant")]
+    [InlineData("evil.example")]
+    [InlineData("javascript:alert(1)")]
+    public void Anything_not_local_falls_back_to_root(string input)
+        => Assert.Equal("/", ReturnUrlPolicy.Sanitize(input));
+}


### PR DESCRIPTION
Two of the ten findings on #2302, both **verified live on main today**, both in the half of `Memex.Portal.Shared` that stays in core.

### 1. Open redirect
`ExternalAuthController` redirected to `returnUrl ?? "/"` unvalidated on the sign-in callback (`:89`) and logout (`:100`) — no `IsLocalUrl` anywhere in the file. `ReturnUrlPolicy.Sanitize` honours a return URL only if it is a local path (one leading slash; rejects `//host`, `/\\host`, absolute URLs, `javascript:`). Everything else lands on `/`.

### 2. Unbounded body read
`WebhookInboxEndpoints` checked `Content-Length`, then read with a plain `StreamReader.ReadToEndAsync()` — beneath a comment promising *"the capped reader below still guards chunked bodies"*. **That reader did not exist.** A chunked request has no Content-Length, so a public endpoint buffered an unbounded body. `BoundedBody.ReadAsync` reads at most `max+1` bytes and the endpoint answers **413** — refused, never buffered.

### Verified
Both helpers are pure/static and unit-tested without a controller or HttpContext — **15 cases**, including chunked-with-no-Content-Length. `Memex.Portal.Shared` + test project: 0 errors under `-warnaserror`.

What's New: `Category: Fix` — a user can notice both (post-login destination; webhook 413).

The other eight #2302 findings remain open.