### PR TITLE
Cancelled/errored rounds record an estimated token count when the provider reports none (#595)

### DIFF
--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -2775,6 +2775,23 @@ internal static class ThreadExecution
                         // already aggregated any UsageContent seen prior to the
                         // OperationCanceledException — so the cell + thread reflect what
                         // the round actually cost.
+                        // 🪙 #595: an OpenAI-compatible provider emits usage ONLY in its terminal
+                        // chunk — a cancel this early means the streaming loop above never saw a
+                        // UsageContent block at all, so inputTokens/outputTokens are still null and
+                        // RecordUsage below would silently no-op while the provider had already
+                        // billed the prompt it processed. When the provider reported NOTHING (not a
+                        // partial figure — genuinely nothing), fall back to a deterministic,
+                        // provider-independent character estimate: the prompt actually sent is known
+                        // before the request was issued (allMessages — the exact list handed to
+                        // GetStreamingResponseAsync at :2335), and the text actually streamed before
+                        // the cancel is exactly cancelText. Never invented when the provider DID
+                        // report something for either counter — only fills the total silence.
+                        var cancelUsageEstimated = inputTokens is null && outputTokens is null;
+                        if (cancelUsageEstimated)
+                        {
+                            inputTokens = TokenUsageNodeType.EstimateTokens(allMessages.Sum(m => m.Text?.Length ?? 0));
+                            outputTokens = TokenUsageNodeType.EstimateTokens(cancelText.Length);
+                        }
                         totalTokens = NormalizeTotal(totalTokens, inputTokens, outputTokens);
                         // 🪙 #476: the model that ACTUALLY ran, exactly as the Completed branch and
                         // RecordUsage record it — a cancelled round's cell must not claim the
@@ -2808,7 +2825,7 @@ internal static class ThreadExecution
                         TokenUsageNodeType.RecordUsage(parentHub, threadPath,
                             AgentPickerProjection.PartitionOf(threadPath),
                             actualModel ?? effectiveModel ?? request.ModelName, inputTokens, outputTokens, execLogger,
-                            cacheReadTokens, cacheWriteTokens)
+                            cacheReadTokens, cacheWriteTokens, isEstimate: cancelUsageEstimated)
                         .Subscribe(
                             _ => { },
                             ex => execLogger?.LogWarning(ex,
@@ -2950,6 +2967,18 @@ internal static class ThreadExecution
                         // forbidden per feedback_no_totask_in_src.md / AsynchronousCalls.md.)
                         // Record tokens consumed before the fault (same rationale as the
                         // Cancelled branch) so an errored round still reports its cost.
+                        // 🪙 #595: same fallback as the Cancelled branch above — when the provider
+                        // reported NOTHING before the fault (an OpenAI-compatible provider's usage
+                        // arrives only in a terminal chunk the failure pre-empted), estimate from
+                        // the prompt actually sent (allMessages) and the text actually streamed
+                        // before the error (errorTextBase — NOT errorText, which has the
+                        // diagnostic "*Error: …*" prose appended and is never model output).
+                        var errorUsageEstimated = inputTokens is null && outputTokens is null;
+                        if (errorUsageEstimated)
+                        {
+                            inputTokens = TokenUsageNodeType.EstimateTokens(allMessages.Sum(m => m.Text?.Length ?? 0));
+                            outputTokens = TokenUsageNodeType.EstimateTokens(errorTextBase.Length);
+                        }
                         totalTokens = NormalizeTotal(totalTokens, inputTokens, outputTokens);
                         // 🪙 #476 — THE issue's repro: a round asked for model X, ran on the fallback
                         // Y, and died on Y's 429. The error cell stamped `request.ModelName` (X), so
@@ -2980,7 +3009,7 @@ internal static class ThreadExecution
                         TokenUsageNodeType.RecordUsage(parentHub, threadPath,
                             AgentPickerProjection.PartitionOf(threadPath),
                             servingModel, inputTokens, outputTokens, execLogger,
-                            cacheReadTokens, cacheWriteTokens)
+                            cacheReadTokens, cacheWriteTokens, isEstimate: errorUsageEstimated)
                         .Subscribe(
                             _ => { },
                             recEx => execLogger?.LogWarning(recEx,

--- a/src/MeshWeaver.AI/TokenUsage.cs
+++ b/src/MeshWeaver.AI/TokenUsage.cs
@@ -197,13 +197,16 @@ public static class TokenUsageNodeType
     /// terminal path finds the provider reported NOTHING at all (an OpenAI-compatible provider
     /// emits usage exclusively in its terminal chunk, which a cancel or transport failure can
     /// pre-empt) — never in place of a real provider-reported count, and never on the Completed
-    /// path. A positive character count always estimates to at least 1 token (a round that sent
-    /// or streamed *something* consumed at least that much); zero/negative estimates to 0.
+    /// path. CEILING division (not truncating): every character counts toward the estimate, so
+    /// e.g. 5–7 chars round UP to 2 tokens rather than truncating back down to 1 — truncation
+    /// would flatten the estimate's growth for any count not a multiple of 4, defeating the
+    /// point of a monotonic floor (Copilot review, PR #2375). A positive character count always
+    /// estimates to at least 1 token; zero/negative estimates to 0.
     /// </summary>
     /// <param name="charCount">The character length of the text being estimated (a prompt or a
     /// streamed completion).</param>
     /// <returns>The estimated token count.</returns>
-    public static int EstimateTokens(int charCount) => charCount <= 0 ? 0 : Math.Max(1, charCount / 4);
+    public static int EstimateTokens(int charCount) => charCount <= 0 ? 0 : (charCount + 3) / 4;
 
     /// <summary>
     /// Records ONE round's token usage onto the per-model satellite at

--- a/src/MeshWeaver.AI/TokenUsage.cs
+++ b/src/MeshWeaver.AI/TokenUsage.cs
@@ -57,14 +57,29 @@ public record TokenUsage
     /// </summary>
     public long CacheWriteTokens { get; init; }
 
+    /// <summary>
+    /// True once ANY round folded into this satellite contributed an ESTIMATED count (see
+    /// <see cref="TokenUsageNodeType.EstimateTokens(int)"/> / <c>RecordUsage</c>'s <c>isEstimate</c>
+    /// parameter) rather than a provider-reported one. Sticky by design: <see cref="InputTokens"/> /
+    /// <see cref="OutputTokens"/> are a single running total that no longer separates the two
+    /// sources once mixed, so once any contribution was an estimate the whole total must be
+    /// presented as approximate. False for a satellite whose every round reported real
+    /// provider usage.
+    /// </summary>
+    public bool IsEstimated { get; init; }
+
     /// <summary>Returns a copy with the given round's counts added.</summary>
-    public TokenUsage Add(long inputTokens, long outputTokens, long cacheReadTokens = 0, long cacheWriteTokens = 0)
+    /// <param name="isEstimated">True when <paramref name="inputTokens"/>/<paramref name="outputTokens"/>
+    /// are a deterministic character-based ESTIMATE (the provider reported nothing before a
+    /// Cancelled/Error terminal path), not a provider-reported count.</param>
+    public TokenUsage Add(long inputTokens, long outputTokens, long cacheReadTokens = 0, long cacheWriteTokens = 0, bool isEstimated = false)
         => this with
         {
             InputTokens = InputTokens + inputTokens,
             OutputTokens = OutputTokens + outputTokens,
             CacheReadTokens = CacheReadTokens + cacheReadTokens,
             CacheWriteTokens = CacheWriteTokens + cacheWriteTokens,
+            IsEstimated = IsEstimated || isEstimated,
         };
 }
 
@@ -175,6 +190,22 @@ public static class TokenUsageNodeType
         new(NormalizeModelId(modelId).Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray());
 
     /// <summary>
+    /// Deterministic, provider-independent token estimate from a character count — ~4
+    /// characters/token, the SAME conservative heuristic already used for context-budget
+    /// trimming (<c>AgentChatClient.MaxContextChars</c>: "Rough by design — a conservative char
+    /// count, not a real tokenizer"). Used ONLY as a floor when a round's Cancelled/Error
+    /// terminal path finds the provider reported NOTHING at all (an OpenAI-compatible provider
+    /// emits usage exclusively in its terminal chunk, which a cancel or transport failure can
+    /// pre-empt) — never in place of a real provider-reported count, and never on the Completed
+    /// path. A positive character count always estimates to at least 1 token (a round that sent
+    /// or streamed *something* consumed at least that much); zero/negative estimates to 0.
+    /// </summary>
+    /// <param name="charCount">The character length of the text being estimated (a prompt or a
+    /// streamed completion).</param>
+    /// <returns>The estimated token count.</returns>
+    public static int EstimateTokens(int charCount) => charCount <= 0 ? 0 : Math.Max(1, charCount / 4);
+
+    /// <summary>
     /// Records ONE round's token usage onto the per-model satellite at
     /// <c>{threadPath}/_Usage/{modelKey}</c>, ACCUMULATING input/output across the thread's rounds
     /// (keyed by model). A no-token round is a no-op. Returns an <see cref="IObservable{T}"/> that
@@ -205,10 +236,16 @@ public static class TokenUsageNodeType
     /// visible, and only rounds 2+ pay for a read-modify-write. It costs nothing to do it this way —
     /// the create already had to carry a content instance.</para>
     /// </summary>
+    /// <param name="isEstimate">True when <paramref name="inputTokens"/>/<paramref name="outputTokens"/>
+    /// are a deterministic character-based ESTIMATE (see <see cref="EstimateTokens"/>) rather than a
+    /// provider-reported count — stamped onto the satellite's <see cref="TokenUsage.IsEstimated"/> so
+    /// downstream cost/report readers can flag the total as approximate. Defaults to false: every
+    /// existing caller (the Completed path, and Cancelled/Error whenever the provider DID report
+    /// something) is unaffected.</param>
     public static IObservable<System.Reactive.Unit> RecordUsage(
         IMessageHub hub, string threadPath, string? userId,
         string? modelId, int? inputTokens, int? outputTokens, ILogger? logger = null,
-        int? cacheReadTokens = null, int? cacheWriteTokens = null)
+        int? cacheReadTokens = null, int? cacheWriteTokens = null, bool isEstimate = false)
     {
         long inTok = inputTokens ?? 0;
         long outTok = outputTokens ?? 0;
@@ -276,6 +313,7 @@ public static class TokenUsageNodeType
                 OutputTokens = outTok,
                 CacheReadTokens = cacheReadTok,
                 CacheWriteTokens = cacheWriteTok,
+                IsEstimated = isEstimate,
             },
         };
 
@@ -298,7 +336,7 @@ public static class TokenUsageNodeType
                     {
                         var cur = node.ContentAs<TokenUsage>(hub.JsonSerializerOptions, logger)
                                   ?? new TokenUsage { UserId = userId, ThreadId = threadPath, Model = model };
-                        return node with { Content = cur.Add(inTok, outTok, cacheReadTok, cacheWriteTok) };
+                        return node with { Content = cur.Add(inTok, outTok, cacheReadTok, cacheWriteTok, isEstimate) };
                     })
                     .Select(_ => System.Reactive.Unit.Default))
             // Subscribed as an INDEPENDENT side effect (NOT chained before the terminal status write),

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-cancelled-and-errored-rounds-keep-their-token-usage.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-cancelled-and-errored-rounds-keep-their-token-usage.md
@@ -1,0 +1,18 @@
+---
+Name: Cancelled and errored rounds keep their token usage
+Category: Fix
+Description: Stopping a round or hitting a provider error no longer drops the tokens it already consumed from usage and cost reporting.
+Icon: Money
+Order: -20260826
+---
+
+# Cancelled and errored rounds keep their token usage
+
+When a conversation round was stopped mid-flight, or failed on a provider error, some providers
+only report their token counts in a final message that never arrived — so nothing was recorded at
+all, even though the prompt had already been sent and billed. Usage and cost reporting silently
+lost that spend.
+
+Cancelled and errored rounds now always record at least an estimate of what was consumed — the
+prompt actually sent and the reply actually generated so far — clearly marked as an estimate when
+the provider itself never confirmed a count. Nothing is invisible to cost tracking any more.

--- a/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
@@ -82,6 +82,15 @@ public class ThreadTokenUsageTest : AITestBase
     // deterministically lands after token aggregation, with no sleep.
     private const string UsageMarker = "[usage-accounted]";
 
+    // The lone text chunk a provider-reports-nothing client streams before blocking/throwing.
+    // Deliberately longer than the framework's own initial "Generating response..." placeholder
+    // (22 chars) — PushToResponseMessage's monotonic-growth guard keeps whichever of
+    // current/incoming text is LONGER while Status is Streaming, so anything shorter would never
+    // actually replace the placeholder on the cell (see the comment at the yield site).
+    // No trailing whitespace: StripSummaryBlock (the streaming push's TrimEnd) would strip it
+    // before the text reaches the cell, breaking an exact-suffix Contains check on the gate below.
+    private const string NoReportWorkingText = "Working — no provider usage report on this stream.";
+
     public ThreadTokenUsageTest(ITestOutputHelper output) : base(output) { }
 
     protected override bool ShareMeshAcrossTests => true;
@@ -97,6 +106,8 @@ public class ThreadTokenUsageTest : AITestBase
                 services.AddSingleton<IChatClientFactory>(new UsageCacheChatClientFactory());
                 services.AddSingleton<IChatClientFactory>(new UsageResolvedCancelFactory());
                 services.AddSingleton<IChatClientFactory>(new UsageResolvedErrorFactory());
+                services.AddSingleton<IChatClientFactory>(new UsageNoProviderUsageCancelFactory());
+                services.AddSingleton<IChatClientFactory>(new UsageNoProviderUsageErrorFactory());
                 return services;
             });
 
@@ -408,6 +419,85 @@ public class ThreadTokenUsageTest : AITestBase
         cell.OutputTokens.Should().Be(OutTokens);
     }
 
+    // ─── Provider reports NOTHING before the terminal path (#595 — the estimate floor) ───
+    //
+    // An OpenAI-compatible provider emits usage ONLY in a successful stream's terminal chunk —
+    // a cancel or a fault pre-empting that chunk means the streaming loop above never saw a
+    // UsageContent block at all, so inputTokens/outputTokens are still null when the terminal
+    // path runs. Before this fix RecordUsage's all-zero guard made this a silent no-op: the round
+    // vanished from accounting even though the provider had already billed the prompt it
+    // processed. These pin the ESTIMATE floor: TokenUsageNodeType.EstimateTokens derives a
+    // non-zero input estimate from the prompt actually sent (allMessages) and a non-zero output
+    // estimate from the text actually streamed before the terminal path, and the satellite is
+    // flagged IsEstimated so a reader never conflates it with a provider-reported count.
+
+    [Fact]
+    public async Task CancelledRound_ProviderReportsNothing_RecordsEstimatedTokens()
+    {
+        var threadPath = await SeedThread();
+        var client = GetClient();
+        client.SubmitMessage(threadPath, "cancel me, provider never reports usage", modelName: "usage-cancel-noreport-model", createdBy: TestUser);
+
+        var executing = await WaitForThread(threadPath,
+            t => t.IsExecuting && t.ActiveMessageId != null, SettleBudgetMs);
+        var cellId = executing.ActiveMessageId!;
+
+        // No usage marker exists on this path (the provider never emits UsageContent) — gate on
+        // the text that DOES stream before requesting the cancel, so it deterministically lands
+        // after the streaming loop has something to estimate from.
+        await WaitForCell(threadPath, cellId, m => (m.Text ?? "").Contains(NoReportWorkingText), SettleBudgetMs);
+
+        await client.GetWorkspace().GetMeshNodeStream(threadPath)
+            .Update(curr => curr?.Content is MeshThread t
+                ? curr with { Content = t with { RequestedStatus = ThreadExecutionStatus.Cancelled } }
+                : curr!)
+            .FirstAsync().ToTask();
+
+        await WaitForThread(threadPath,
+            t => t.Status == ThreadExecutionStatus.Cancelled, SettleBudgetMs);
+
+        var usage = await WaitForUsage(threadPath, "usage_cancel_noreport_model",
+            u => u.InputTokens > 0, SettleBudgetMs);
+        usage.IsEstimated.Should().BeTrue(
+            "the provider reported no usage at all before the cancel — the recorded counts are a character estimate, never a provider count");
+        usage.InputTokens.Should().BeGreaterThan(0,
+            "the prompt actually sent is known before the request was issued, even when the provider never confirms it");
+        usage.OutputTokens.Should().BeGreaterThan(0,
+            "the text chunk streamed before the cancel — that much output is known too");
+
+        var cell = await WaitForCell(threadPath, cellId,
+            m => m.Status == ThreadMessageStatus.Cancelled, SettleBudgetMs);
+        cell.InputTokens.GetValueOrDefault().Should().BeGreaterThan(0,
+            "the cancelled cell reflects the same estimate recorded on the satellite");
+    }
+
+    [Fact]
+    public async Task ErrorRound_ProviderReportsNothing_RecordsEstimatedTokens()
+    {
+        var threadPath = await SeedThread();
+        var client = GetClient();
+        client.SubmitMessage(threadPath, "throw, provider never reports usage", modelName: "usage-error-noreport-model", createdBy: TestUser);
+
+        var terminal = await WaitForThread(threadPath,
+            t => t.Status == ThreadExecutionStatus.Idle
+                 && t.IngestedMessageIds.Count >= 1
+                 && t.Messages.Count >= 2,
+            20_000);
+
+        var usage = await WaitForUsage(threadPath, "usage_error_noreport_model",
+            u => u.InputTokens > 0, SettleBudgetMs);
+        usage.IsEstimated.Should().BeTrue(
+            "the provider reported no usage at all before the fault — the recorded counts are a character estimate, never a provider count");
+        usage.InputTokens.Should().BeGreaterThan(0);
+        usage.OutputTokens.Should().BeGreaterThan(0,
+            "the text chunk streamed before the throw — that much output is known too");
+
+        var cell = await WaitForCell(threadPath, terminal.Messages[^1],
+            m => m.Status == ThreadMessageStatus.Error, SettleBudgetMs);
+        cell.InputTokens.GetValueOrDefault().Should().BeGreaterThan(0,
+            "the errored cell reflects the same estimate recorded on the satellite");
+    }
+
     // ─── Provider reports only in/out (pins the total-derivation fallback) ───
 
     [Fact]
@@ -596,8 +686,14 @@ public class ThreadTokenUsageTest : AITestBase
     /// <paramref name="modelId"/>, when set, stamps every update's ModelId — modelling a provider
     /// or harness that reports the RESOLVED model it actually ran (ThreadExecution captures it as
     /// actualModel), distinct from the requested alias the factory routes on.
+    /// <paramref name="omitUsageContent"/>, when true, NEVER emits a <see cref="UsageContent"/>
+    /// block at all — models an OpenAI-compatible provider that reports usage ONLY in the
+    /// terminal chunk of a successful stream, which a cancel/fault pre-empts by construction
+    /// (there is no terminal chunk to omit it from — the round never reaches one). Only "Working. "
+    /// streams before <paramref name="mode"/> takes over, so the streaming loop's
+    /// inputTokens/outputTokens stay null all the way to the terminal path (#595's estimate floor).
     /// </summary>
-    private sealed class UsageChatClient(bool reportTotal, PostUsage mode, bool emitCache = false, string? modelId = null) : IChatClient
+    private sealed class UsageChatClient(bool reportTotal, PostUsage mode, bool emitCache = false, string? modelId = null, bool omitUsageContent = false) : IChatClient
     {
         public ChatClientMetadata Metadata => new("UsageProvider");
 
@@ -611,29 +707,41 @@ public class ThreadTokenUsageTest : AITestBase
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             // Text first — the round is genuinely streaming past the Executing flip.
-            yield return new ChatResponseUpdate(ChatRole.Assistant, "Working. ") { ModelId = modelId };
-            // The usage report — this is what ThreadExecution aggregates. When emitCache is set, the
-            // cache breakdown rides in AdditionalCounts under MIXED provider keys (OpenAI's
-            // "InputTokenDetails.CachedTokenCount" for read, Claude's "CacheCreationInputTokens" for
-            // write) so the test proves UsageTokens.SplitCache is provider-agnostic.
-            var details = new UsageDetails
+            // 🚨 omitUsageContent's text must OUTGROW the framework's own initial
+            // "Generating response..." placeholder (22 chars): PushToResponseMessage's
+            // monotonic-growth guard keeps the LONGER of current vs incoming text while
+            // Status is Streaming, so a shorter chunk ("Working. ", 9 chars) would never
+            // actually land on the cell — silently starving any test that waits for it
+            // (caught by CancelledRound_ProviderReportsNothing_RecordsEstimatedTokens
+            // timing out with the placeholder still showing, not a product bug).
+            yield return new ChatResponseUpdate(ChatRole.Assistant,
+                omitUsageContent ? NoReportWorkingText : "Working. ") { ModelId = modelId };
+
+            if (!omitUsageContent)
             {
-                InputTokenCount = InTokens,
-                OutputTokenCount = OutTokens,
-                TotalTokenCount = reportTotal ? TotalTokens : (long?)null
-            };
-            if (emitCache)
-                details.AdditionalCounts = new AdditionalPropertiesDictionary<long>
+                // The usage report — this is what ThreadExecution aggregates. When emitCache is set,
+                // the cache breakdown rides in AdditionalCounts under MIXED provider keys (OpenAI's
+                // "InputTokenDetails.CachedTokenCount" for read, Claude's "CacheCreationInputTokens"
+                // for write) so the test proves UsageTokens.SplitCache is provider-agnostic.
+                var details = new UsageDetails
                 {
-                    ["InputTokenDetails.CachedTokenCount"] = CacheReadTokens,
-                    [UsageTokens.CacheWriteKey] = CacheWriteTokens
+                    InputTokenCount = InTokens,
+                    OutputTokenCount = OutTokens,
+                    TotalTokenCount = reportTotal ? TotalTokens : (long?)null
                 };
-            yield return new ChatResponseUpdate(ChatRole.Assistant, new AIContent[]
-            {
-                new UsageContent(details)
-            }) { ModelId = modelId };
-            // Post-usage marker — once it lands on the cell, the usage above was provably pulled.
-            yield return new ChatResponseUpdate(ChatRole.Assistant, UsageMarker) { ModelId = modelId };
+                if (emitCache)
+                    details.AdditionalCounts = new AdditionalPropertiesDictionary<long>
+                    {
+                        ["InputTokenDetails.CachedTokenCount"] = CacheReadTokens,
+                        [UsageTokens.CacheWriteKey] = CacheWriteTokens
+                    };
+                yield return new ChatResponseUpdate(ChatRole.Assistant, new AIContent[]
+                {
+                    new UsageContent(details)
+                }) { ModelId = modelId };
+                // Post-usage marker — once it lands on the cell, the usage above was provably pulled.
+                yield return new ChatResponseUpdate(ChatRole.Assistant, UsageMarker) { ModelId = modelId };
+            }
 
             switch (mode)
             {
@@ -738,5 +846,24 @@ public class ThreadTokenUsageTest : AITestBase
         public override IReadOnlyList<string> Models => ["usage-error-alias"];
         protected override IChatClient CreateClient() => new UsageChatClient(
             reportTotal: true, PostUsage.Throw, modelId: "usage-error-resolved");
+    }
+
+    // Models an OpenAI-compatible provider: usage arrives ONLY in a successful terminal chunk,
+    // which the cancel pre-empts — the terminal path must fall back to the character estimate.
+    private sealed class UsageNoProviderUsageCancelFactory : UsageFactoryBase
+    {
+        public override string Name => "UsageNoProviderUsageCancelFactory";
+        public override IReadOnlyList<string> Models => ["usage-cancel-noreport-model"];
+        protected override IChatClient CreateClient() => new UsageChatClient(
+            reportTotal: true, PostUsage.BlockUntilCancel, omitUsageContent: true);
+    }
+
+    // Same for the Error terminal path.
+    private sealed class UsageNoProviderUsageErrorFactory : UsageFactoryBase
+    {
+        public override string Name => "UsageNoProviderUsageErrorFactory";
+        public override IReadOnlyList<string> Models => ["usage-error-noreport-model"];
+        protected override IChatClient CreateClient() => new UsageChatClient(
+            reportTotal: true, PostUsage.Throw, omitUsageContent: true);
     }
 }

--- a/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
@@ -447,10 +447,16 @@ public class ThreadTokenUsageTest : AITestBase
         // after the streaming loop has something to estimate from.
         await WaitForCell(threadPath, cellId, m => (m.Text ?? "").Contains(NoReportWorkingText), SettleBudgetMs);
 
+        // ContentAs, not `curr?.Content is MeshThread t` — Copilot review, PR #2375: the trap-door
+        // AGENTS.md forbids (a degraded JsonElement/DOM shape would silently skip the update).
         await client.GetWorkspace().GetMeshNodeStream(threadPath)
-            .Update(curr => curr?.Content is MeshThread t
-                ? curr with { Content = t with { RequestedStatus = ThreadExecutionStatus.Cancelled } }
-                : curr!)
+            .Update(curr =>
+            {
+                var t = curr.ContentAs<MeshThread>(Mesh.JsonSerializerOptions);
+                return t is not null
+                    ? curr with { Content = t with { RequestedStatus = ThreadExecutionStatus.Cancelled } }
+                    : curr!;
+            })
             .FirstAsync().ToTask();
 
         await WaitForThread(threadPath,


### PR DESCRIPTION
## Fixes #595

Closes the last open scope of #595 — see the issue's history for the earlier surgical fixes
(model attribution, the RecordUsage-nested-in-cell-push bug, the all-zero no-op debug log)
that already landed in PR #933/#862. This PR is the substantive remainder the issue was
explicitly re-scoped to and then reopened over: the OpenAI-compatible provider case.

## The gap

Cancelled/Error terminal paths already carry forward whatever `UsageContent` the streaming
loop aggregated. But an OpenAI-compatible provider reports usage **only in a successful
stream's terminal chunk** — a Stop-button cancel, or a transport failure, that pre-empts
that chunk leaves `inputTokens`/`outputTokens` null. `TokenUsageNodeType.RecordUsage`'s
all-zero guard then silently no-ops: the round consumed real, already-billed tokens (the
provider processed the prompt before failing/being cancelled) and none of it reaches usage
or cost reporting.

## The fix

When the provider reports **nothing at all** (both counters null — not a partial figure),
the Cancelled and Error terminal paths fall back to a deterministic, provider-independent
character estimate:
- input ≈ `allMessages` (the exact prompt handed to `GetStreamingResponseAsync`) / 4 chars-per-token
- output ≈ the text actually streamed before the cancel/fault / 4 chars-per-token

This is the SAME conservative heuristic the codebase already uses for context-budget
trimming (`AgentChatClient.MaxContextChars`: "~4 chars/token ... Rough by design, not a
real tokenizer") — not a new invented mechanism.

The `TokenUsage` satellite gains a sticky `IsEstimated` flag (`RecordUsage`'s new
`isEstimate` parameter, defaulted false so every existing caller is unaffected) so a reader
can tell an estimate from a provider-reported count rather than silently mixing them.

## Deliberately NOT done

No tokenizer dependency, no threading a full accurate token count through the pipeline —
the estimate is intentionally rough (matching the issue's own acceptance criterion: "at
least the input tokens consumed"), and it only ever fires on the narrow all-null path; a
provider that reports partial usage is untouched.

## Tests

`ThreadTokenUsageTest` gains two cases against a scripted `IChatClient` that streams one
text chunk then blocks-until-cancel / throws WITHOUT ever emitting `UsageContent` (modelling
the OpenAI-compatible terminal-chunk-only shape):
- `CancelledRound_ProviderReportsNothing_RecordsEstimatedTokens`
- `ErrorRound_ProviderReportsNothing_RecordsEstimatedTokens`

Both assert the satellite's `IsEstimated == true` and non-zero input/output, and that the
response cell reflects the same estimate.

- `ThreadTokenUsageTest` — 12/12 passed (all existing cases + the 2 new ones)
- `TokenUsageModelKeyTest` — 9/9 passed (unaffected by this change)
- `DelegationSubThreadUsageTest` — 1/1 passed (unaffected)
- `WhatsNewEntryIntegrityTest` — 1/1 passed
- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.AI` and `MeshWeaver.AI.Test`

## Coordination note

`MeshWeaver.AI` is being carved out of core by a separate concurrent program (#2276) with
several AI test suites being re-homed. This diff is minimal (2 source files + 1 test file +
1 doc node) and touches only `TokenUsage.cs`/`ThreadExecution.cs` call sites that already
existed pre-#2276; no new files, no namespace changes. Flagging in case of a rebase collision
with that program's in-flight moves.

## #2305 — investigated, NOT included here (needs a design decision)

The task that produced this PR was also asked to look at #2305 ("AutoExecute: a Completed
response cell still holds the 'Generating response…' placeholder"). PR #2326 already
disproved that issue's own hypothesis and found (then reverted, per CI) a fix that broke two
load-bearing invariant tests (`PatchDataRequestTest`, `CrossHubPatchAtomicityTest`) that pin
independent per-field merge/refuse resolution within one cross-hub patch as INTENTIONAL
design.

I did not re-attempt that reverted approach. Tracing it further: the specific race looks
like a **self-race**, not a foreign-writer conflict — `PushToResponseMessage`'s streaming
chunks are subscribed fire-and-forget (unawaited) on a `Sample(100ms)` cadence, while the
terminal write is awaited; both target the SAME cross-hub mirror path
(`GetMeshNodeStream(curResponsePath)`). If the terminal write's patch is built from a `base`
snapshot that predates one of the round's own in-flight streaming pushes, `Text` (a full
replacement) reads as "conflicting since base" and gets refused-and-kept-live (the terminal
push's own `Status=Completed` has no such collision, since nothing else touches `Status`, so
it applies cleanly) — reproducing the exact symptom. The existing per-field merge is correct
for genuinely concurrent DIFFERENT writers (that's what the two invariant tests pin); it has
no way to distinguish that case from a writer racing its OWN earlier write, which needs
either sequencing/writer-identity on the patch or serializing a round's own writes on the
SAME path — both real design changes, not a mechanical fix. Flagging as a scope call rather
than pushing a guess through; #595's fix here does not depend on it.

## Test plan
- [x] `ThreadTokenUsageTest` — 12/12 (build: Debug + Release/-warnaserror clean)
- [x] `TokenUsageModelKeyTest` — 9/9
- [x] `DelegationSubThreadUsageTest` — 1/1
- [x] `WhatsNewEntryIntegrityTest` — 1/1
- [x] `dotnet build -c Release -warnaserror` clean: `MeshWeaver.AI`, `MeshWeaver.AI.Test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)