### PR TITLE
Local-dev docs: the portal hosts live in MeshWeaver.Plugins now (#2367)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,7 +465,7 @@ The `memex` portal runs on the shared **AKS cluster** `<aks-cluster>` (RG `<aks-
 ```bash
 az acr login -n meshweaver
 # Portal (custom base) AND migration (the migration is what creates schema + the matview):
-dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj -c Release \
+dotnet publish ../MeshWeaver.Plugins/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj -c Release \
   -t:PublishContainer -p:ContainerRegistry=meshweaver.azurecr.io \
   -p:ContainerRepository=memex-portal-ai -p:ContainerImageTag=<tag> \
   -p:ContainerBaseImage=meshweaver.azurecr.io/memex-portal-ai-base:latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,10 +500,10 @@ old `C:\dev\MeshWeaver` here predated the worktree rule above). Avoid chained co
 dotnet build                                              # Build solution (ONE project arg max — several is an MSB1008 no-op)
 dotnet build test/MeshWeaver.Data.Test/MeshWeaver.Data.Test.csproj   # Build one project — required before --no-build
 dotnet test test/MeshWeaver.Data.Test --no-build          # Run one test project (built above; unbuilt = silent exit 0)
-dotnet run --project memex/Memex.Portal.Monolith          # Monolith standalone (https://localhost:7122, http://localhost:5022)
-dotnet run --project memex/aspire/Memex.AppHost           # Aspire (requires Docker) — portal at https://localhost:7202, http://localhost:5202
-aspire run --project memex/aspire/Memex.AppHost           # Aspire via CLI (registers with `aspire mcp`) — same URLs as above
-aspire start --no-build --project memex/aspire/Memex.AppHost  # Background + NO rebuild — fast bring-up; `aspire ps` / `aspire stop` to manage. --no-build reuses the last build (won't pick up source edits)
+dotnet run --project ../MeshWeaver.Plugins/src/Memex.Portal.Monolith          # Monolith standalone (https://localhost:7122, http://localhost:5022)
+dotnet run --project ../MeshWeaver.Plugins/src/Memex.AppHost           # Aspire (requires Docker) — portal at https://localhost:7202, http://localhost:5202
+aspire run --project ../MeshWeaver.Plugins/src/Memex.AppHost           # Aspire via CLI (registers with `aspire mcp`) — same URLs as above
+aspire start --no-build --project ../MeshWeaver.Plugins/src/Memex.AppHost  # Background + NO rebuild — fast bring-up; `aspire ps` / `aspire stop` to manage. --no-build reuses the last build (won't pick up source edits)
 ```
 
 ### Restarting just the Portal (no full Aspire restart)
@@ -512,7 +512,7 @@ When you change code in `Memex.Portal.Distributed` or any project it references,
 
 1. **Hot reload (cheapest)** — start with `dotnet watch` instead of `dotnet run` / `aspire run`:
    ```bash
-   dotnet watch --project memex/aspire/Memex.AppHost
+   dotnet watch --project ../MeshWeaver.Plugins/src/Memex.AppHost
    ```
    File save → Aspire restarts the affected resource only. Preserves the dashboard, the Postgres container, and the SignalR endpoints. Most code changes apply within seconds.
 2. **Aspire dashboard UI** — open `https://localhost:17200/` → Resources tab → click the ⋯ next to `memex-portal-distributed` → **Restart**. Runs `dotnet build` + restart in-place.
@@ -807,8 +807,8 @@ Full treatment: [CqrsAndContentAccess.md](src/MeshWeaver.Documentation/Data/Arch
 | Environment | Base URL |
 |---|---|
 | Prod | `https://memex.meshweaver.cloud` |
-| Dev — Aspire (`memex/aspire/Memex.AppHost`) | `https://localhost:7202` (HTTP fallback `http://localhost:5202`) |
-| Dev — Monolith standalone (`memex/Memex.Portal.Monolith`) | `https://localhost:7122` (HTTP fallback `http://localhost:5022`) |
+| Dev — Aspire (`../MeshWeaver.Plugins/src/Memex.AppHost`) | `https://localhost:7202` (HTTP fallback `http://localhost:5202`) |
+| Dev — Monolith standalone (`../MeshWeaver.Plugins/src/Memex.Portal.Monolith`) | `https://localhost:7122` (HTTP fallback `http://localhost:5022`) |
 
 ## `@/` is Local-Only
 
@@ -856,7 +856,7 @@ Actor-model message hub (`MeshWeaver.Messaging.Hub`) with address-based partitio
 |---|---|
 | `src/` | Core framework (50+ projects) |
 | `samples/Graph/Data/` | Sample data nodes (ACME, Northwind, Cornerstone, etc.) |
-| `memex/Memex.Portal.Monolith/` | Dev portal with full Graph + Documentation support |
+| `../MeshWeaver.Plugins/src/Memex.Portal.Monolith/` | Dev portal with full Graph + Documentation support |
 | `memex/aspire/` | Microservices with .NET Aspire orchestration |
 
 **Request-Response:** `hub.Observe<TResponse>(request, o => o.WithTarget(address)).Subscribe(resp => …, ex => …)`  

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ MeshWeaver is an open-source framework for building **data meshes**: documents, 
 ```bash
 git clone https://github.com/Systemorph/MeshWeaver.git
 cd MeshWeaver
-dotnet run --project memex/Memex.Portal.Monolith
+dotnet run --project ../MeshWeaver.Plugins/src/Memex.Portal.Monolith
 ```
 
 Opens at `https://localhost:7122`. Single process, no Docker — if you are unsure which setup to pick, pick this one.
@@ -19,7 +19,7 @@ Opens at `https://localhost:7122`. Single process, no Docker — if you are unsu
 For the microservices setup orchestrated with .NET Aspire (requires Docker):
 
 ```bash
-dotnet run --project memex/aspire/Memex.AppHost
+dotnet run --project ../MeshWeaver.Plugins/src/Memex.AppHost
 ```
 
 Portal at `https://localhost:7202`, with PostgreSQL persistence and the Aspire dashboard.

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -405,7 +405,7 @@ az acr build --registry <acrName> --image memex-portal-ai-base:latest \
 # them into an OCI Image Index (manifest list). ContainerRuntimeIdentifiers MUST be a subset of
 # RuntimeIdentifiers (set them equal). The arm64 leg layers on the multi-arch base above.
 az acr login --name <acrName>
-dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj \
+dotnet publish ../MeshWeaver.Plugins/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj \
   -c Release --no-self-contained -t:PublishContainer -p:PublishProfile= \
   -p:RuntimeIdentifiers="linux-x64;linux-arm64" -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64" \
   -p:ContainerRegistry=<acrName>.azurecr.io -p:ContainerRepository=memex-portal-ai \

--- a/samples/Graph/Data/Cornerstone/Documentation/GettingStarted.md
+++ b/samples/Graph/Data/Cornerstone/Documentation/GettingStarted.md
@@ -26,7 +26,7 @@ dotnet build
 ## Start the Portal
 
 ```bash
-cd memex/Memex.Portal.Monolith
+cd ../MeshWeaver.Plugins/src/Memex.Portal.Monolith
 dotnet run
 ```
 

--- a/samples/Graph/Data/Northwind/Documentation/GettingStarted.md
+++ b/samples/Graph/Data/Northwind/Documentation/GettingStarted.md
@@ -63,7 +63,7 @@ dotnet build
 ## Start the Portal
 
 ```bash
-cd memex/Memex.Portal.Monolith
+cd ../MeshWeaver.Plugins/src/Memex.Portal.Monolith
 dotnet run
 ```
 

--- a/samples/Graph/README.md
+++ b/samples/Graph/README.md
@@ -13,4 +13,4 @@ The Memex Portal loads graph nodes from `Data/` via `AddGraph()` at startup. Con
 
 ## Related Projects
 - [MeshWeaver.Graph](../../src/MeshWeaver.Graph/README.md) -- Graph node framework
-- [Memex.Portal.Monolith](../../memex/Memex.Portal.Monolith/) -- Development portal that consumes this data
+- [Memex.Portal.Monolith](../../../MeshWeaver.Plugins/src/Memex.Portal.Monolith/) -- Development portal that consumes this data

--- a/samples/Graph/README.md
+++ b/samples/Graph/README.md
@@ -13,4 +13,4 @@ The Memex Portal loads graph nodes from `Data/` via `AddGraph()` at startup. Con
 
 ## Related Projects
 - [MeshWeaver.Graph](../../src/MeshWeaver.Graph/README.md) -- Graph node framework
-- [Memex.Portal.Monolith](../../../MeshWeaver.Plugins/src/Memex.Portal.Monolith/) -- Development portal that consumes this data
+- [Memex.Portal.Monolith](https://github.com/Systemorph/MeshWeaver.Plugins/tree/main/src/Memex.Portal.Monolith) (MeshWeaver.Plugins) -- Development portal that consumes this data

--- a/src/MeshWeaver.Documentation/Data/AI/ModelProviderSetup.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ModelProviderSetup.md
@@ -160,7 +160,7 @@ Each provider package self-registers its config section via `AddLanguageModelCat
 
 ### Aspire deploy auto-seeds; the Helm/AKS chart does not
 
-A stock **Aspire** deploy (`memex/aspire/Memex.AppHost`) sets the catalog env vars, so the system catalog populates out of the box:
+A stock **Aspire** deploy (`../MeshWeaver.Plugins/src/Memex.AppHost`) sets the catalog env vars, so the system catalog populates out of the box:
 
 ```text
 Anthropic__Endpoint, Anthropic__ApiKey, Anthropic__Models__0..2   (= ModelTier heavy/standard/light)

--- a/src/MeshWeaver.Documentation/Data/AI/ProviderConfiguration.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ProviderConfiguration.md
@@ -77,7 +77,7 @@ MeshWeaver speaks to multiple LLM providers — Claude via Anthropic, GPT-class 
 
 ## One Azure Foundry Key, Two Providers
 
-A single Aspire parameter — `azure-foundry-key`, declared in `memex/aspire/Memex.AppHost/Program.cs:51` — backs both the Anthropic and AzureAIS credentials:
+A single Aspire parameter — `azure-foundry-key`, declared in `../MeshWeaver.Plugins/src/Memex.AppHost/Program.cs:51` — backs both the Anthropic and AzureAIS credentials:
 
 | Env var | Provider | Endpoint path |
 |---|---|---|
@@ -99,7 +99,7 @@ Endpoints are never literal strings in source code. In development they come fro
 | `embedding-endpoint` | `Embedding__Endpoint` |
 | `embedding-model` | `Embedding__Model` |
 
-> **Section-name caveat (latent bug):** the code binds the **`AzureFoundry:`** section (`AzureFoundryConfiguration`, `AddAzureFoundry`, and the catalog source). The Aspire AppHost currently emits `AzureAIS__Endpoint` / `AzureAIS__ApiKey`, which **nothing in `src/` binds** — so that config is dead. Use `AzureFoundry__*`. The Helm chart (`deploy/helm`) already uses the correct names; the AppHost (`memex/aspire/Memex.AppHost/Program.cs`) should be renamed `AzureAIS__* → AzureFoundry__*`.
+> **Section-name caveat (latent bug):** the code binds the **`AzureFoundry:`** section (`AzureFoundryConfiguration`, `AddAzureFoundry`, and the catalog source). The Aspire AppHost currently emits `AzureAIS__Endpoint` / `AzureAIS__ApiKey`, which **nothing in `src/` binds** — so that config is dead. Use `AzureFoundry__*`. The Helm chart (`deploy/helm`) already uses the correct names; the AppHost (`../MeshWeaver.Plugins/src/Memex.AppHost/Program.cs`) should be renamed `AzureAIS__* → AzureFoundry__*`.
 
 The embedding pair establishes the canonical pattern — a sibling `endpoint` + `model` parameter per provider. Chat providers follow the same shape.
 
@@ -206,7 +206,7 @@ To wire in a new provider (a second Azure OpenAI deployment, a hosted local mode
 
 1. **Implement `IChatClientFactory`** and register it via DI (`services.AddAzureOpenAI(...)` or similar).
 2. **Bind its options** from a new section in `MemexConfiguration.cs` — endpoint and auth fields only, **not** model names.
-3. **Add Aspire parameters** in `memex/aspire/Memex.AppHost/Program.cs` for the endpoint (and a key, if it doesn't share `azure-foundry-key`).
+3. **Add Aspire parameters** in `../MeshWeaver.Plugins/src/Memex.AppHost/Program.cs` for the endpoint (and a key, if it doesn't share `azure-foundry-key`).
 4. **Label the new model's node** with a `tier` (`ModelDefinition.Tier`), so agents reach it by declaring `modelTier` in their front matter. An agent names a tier, never a model id — there is no per-agent "preferred model" field.
 
 > **Do not hardcode model identifiers in framework code.** If you find yourself writing `"gpt-4o"` or `"claude-sonnet-4-5"` in a `.cs` file outside an agent definition, that is precisely the pattern this page exists to prevent.

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
@@ -64,7 +64,7 @@ Two sanctioned paths to raise verbosity:
 | Context | What to edit |
 |---|---|
 | Test debugging session | `test/<Suite>/bin/Debug/net10.0/appsettings.json` (or the shared `test/appsettings.json` at the runtime location). `reloadOnChange: true` is wired, so the level flips mid-run without a rebuild. **Revert before committing.** |
-| Production debugging session | `memex/aspire/Memex.Portal.Distributed/appsettings.json` under the top-level `Logging:LogLevel`. That gates what reaches stdout, which Promtail ships to Loki. |
+| Production debugging session | `../MeshWeaver.Plugins/src/Memex.Portal.Distributed/appsettings.json` under the top-level `Logging:LogLevel`. That gates what reaches stdout, which Promtail ships to Loki. |
 
 If a `Log*` call is genuinely too noisy or too quiet at its current level, fix it permanently with a commit explaining the cost/value trade-off — never sneak it in alongside an unrelated change.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/Deployment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Deployment.md
@@ -42,7 +42,7 @@ The two routes provision and run on different platforms (raw AKS deployments + H
 Full local development with Docker containers (PostgreSQL pgvector + Azurite, Orleans in-process):
 
 ```bash
-aspire run --project memex/aspire/Memex.AppHost/Memex.AppHost.csproj -- --mode local
+aspire run --project ../MeshWeaver.Plugins/src/Memex.AppHost/Memex.AppHost.csproj -- --mode local
 ```
 
 ## Monolith (standalone, no Docker)
@@ -50,9 +50,9 @@ aspire run --project memex/aspire/Memex.AppHost/Memex.AppHost.csproj -- --mode l
 Lighter setup without Orleans or external infrastructure:
 
 ```bash
-dotnet run --project memex/Memex.Portal.Monolith
+dotnet run --project ../MeshWeaver.Plugins/src/Memex.Portal.Monolith
 # or via the AppHost:
-aspire run --project memex/aspire/Memex.AppHost/Memex.AppHost.csproj -- --mode monolith
+aspire run --project ../MeshWeaver.Plugins/src/Memex.AppHost/Memex.AppHost.csproj -- --mode monolith
 ```
 
 ---
@@ -77,7 +77,7 @@ For single-tenant apps, configure the tenant ID explicitly — the default `/com
 
 Secrets are stored in `dotnet user-secrets` for local development and in GitHub secrets for CI/CD. (On AKS, secrets come from the Key Vault `SecretProviderClass` wired by `deploy/aks/envs/<env>/deploy.sh`.)
 
-Parameters for distributed modes (the authoritative list is the `builder.AddParameter(...)` calls in `memex/aspire/Memex.AppHost/Program.cs`):
+Parameters for distributed modes (the authoritative list is the `builder.AddParameter(...)` calls in `../MeshWeaver.Plugins/src/Memex.AppHost/Program.cs`):
 
 | Parameter | Description | If unset |
 |---|---|---|
@@ -103,7 +103,7 @@ Parameters for distributed modes (the authoritative list is the `builder.AddPara
 Set a secret with:
 
 ```bash
-cd memex/aspire/Memex.AppHost
+cd ../MeshWeaver.Plugins/src/Memex.AppHost
 dotnet user-secrets set "Parameters:azure-foundry-key" "<your-key>"
 ```
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -21,7 +21,7 @@ A **code update** is three steps: build the images, point the Deployments at the
 az acr login -n meshweaver
 
 # Portal — needs the prebuilt custom base image. MULTI-ARCH: never pass `-r linux-x64`.
-dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj -c Release \
+dotnet publish ../MeshWeaver.Plugins/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj -c Release \
   --no-self-contained -t:PublishContainer -p:PublishProfile= \
   -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"' \
   -p:ContainerRegistry=meshweaver.azurecr.io \

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentContainerApps.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentContainerApps.md
@@ -7,7 +7,7 @@ Icon: Cloud
 
 # Deploying to Azure Container Apps
 
-This is **one of two deploy routes**. Use it for the **.NET Aspire `test` / `prod` modes**, which provision and run on **Azure Container Apps** (Sweden Central) — the AppHost (`memex/aspire/Memex.AppHost`) is the single source of truth for every resource (PostgreSQL, Blob Storage, Orleans clustering, Application Insights). For the shared AKS-cluster portal (`memex` namespace), see [DeploymentAKS.md](/Doc/Architecture/DeploymentAKS). These are **different routes to different targets** — choose by where you're deploying.
+This is **one of two deploy routes**. Use it for the **.NET Aspire `test` / `prod` modes**, which provision and run on **Azure Container Apps** (Sweden Central) — the AppHost (`../MeshWeaver.Plugins/src/Memex.AppHost`) is the single source of truth for every resource (PostgreSQL, Blob Storage, Orleans clustering, Application Insights). For the shared AKS-cluster portal (`memex` namespace), see [DeploymentAKS.md](/Doc/Architecture/DeploymentAKS). These are **different routes to different targets** — choose by where you're deploying.
 
 ## Deployment Modes
 
@@ -91,7 +91,7 @@ Running `aspire deploy` on its own **silently passes when the db-migration conta
 
 The wrapper script closes that gap in three steps:
 
-1. Runs `aspire deploy --project memex/aspire/Memex.AppHost/Memex.AppHost.csproj -- --mode <prod|test>` (the command Aspire docs sanction).
+1. Runs `aspire deploy --project ../MeshWeaver.Plugins/src/Memex.AppHost/Memex.AppHost.csproj -- --mode <prod|test>` (the command Aspire docs sanction).
 2. Discovers the deployed Postgres FQDN — `az postgres flexible-server list -g <rg> --query "[0].fullyQualifiedDomainName"` — because the server name carries a random suffix that changes whenever the resource group is reprovisioned.
 3. **Polls the database, not the container**: loops `dotnet script tools/check-db-version.csx -- <mode> <pg-fqdn>` every 15 s against a 10-minute deadline. First success exits 0; on deadline it fails the deploy and dumps `az containerapp logs show -n db-migration --tail 100`.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/LocalDevWorkflow.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LocalDevWorkflow.md
@@ -13,6 +13,16 @@ Tags:
 
 ## Quick reference
 
+> 🚨 **The portal hosts live in `MeshWeaver.Plugins` since 2026-08-26** (MeshWeaver#2293 — the GUI
+> extraction). `Memex.Portal.Monolith`, `Memex.AppHost` and `Memex.Portal.Distributed` are under
+> `src/` **in that repository**, and so are the login pages (`Memex.Portal.Gui`). A core checkout on
+> its own has no portal to run: following an older copy of this page from core alone gives a
+> process with no login UI and no control views (#2367). Every command below assumes the standard
+> sibling layout — `MeshWeaver/` and `MeshWeaver.Plugins/` side by side — which is what plugins'
+> `src/Directory.Build.props` defaults `MeshWeaverRoot` to (`../MeshWeaver`); set
+> `-p:MeshWeaverRoot=<path>` if yours differs.
+
+
 When you change code in `Memex.Portal.Distributed` (or any project it references — `MeshWeaver.AI`, `MeshWeaver.Graph`, `MeshWeaver.Hosting.Orleans`, …), you have **three** ways to apply the change without touching the whole Aspire stack:
 
 <svg viewBox="0 0 760 340" xmlns="http://www.w3.org/2000/svg" style="width:100%;max-width:760px;height:auto;display:block;margin:20px auto;" font-family="sans-serif" font-size="13">
@@ -56,7 +66,7 @@ When you change code in `Memex.Portal.Distributed` (or any project it references
 
 | Approach | Typical cost | When to use |
 |---|---|---|
-| `dotnet watch --project memex/aspire/Memex.AppHost` | Seconds | Default. File save triggers a per-resource restart automatically. |
+| `dotnet watch --project ../MeshWeaver.Plugins/src/Memex.AppHost` | Seconds | Default. File save triggers a per-resource restart automatically. |
 | Dashboard UI: Resources → ⋯ → **Restart** | ~10 s | Watch isn't running, or it missed a change. |
 | Kill the portal process (`pkill -f Memex.Portal.Distributed`) | ~5 s | Last resort — dashboard hangs or AppHost is wedged. |
 
@@ -71,18 +81,18 @@ Three modes — pick by whether you want to hold a terminal and whether you need
 ```bash
 # A. Interactive (foreground) — builds, holds the terminal, prints live status.
 #    Registers with `aspire mcp` so MCP tools can drive it. Ctrl+C to stop.
-aspire run --project memex/aspire/Memex.AppHost
+aspire run --project ../MeshWeaver.Plugins/src/Memex.AppHost
 
 # B. Background daemon — detaches and returns immediately; survives across shells.
 #    `--no-build` reuses the existing binaries (fast — no rebuild). Drop --no-build
 #    to build first. Also registers with `aspire mcp`.
-aspire start --no-build --project memex/aspire/Memex.AppHost
+aspire start --no-build --project ../MeshWeaver.Plugins/src/Memex.AppHost
 aspire ps                 # list running AppHosts (Path · PID · dashboard URL)
 aspire stop               # stop the background AppHost
 aspire logs [<resource>]  # tail logs without the dashboard
 
 # C. Visual Studio's "F5" path.
-dotnet run --project memex/aspire/Memex.AppHost
+dotnet run --project ../MeshWeaver.Plugins/src/Memex.AppHost
 ```
 
 > 🚨 **`aspire start --no-build` reuses the LAST build.** It's the fast way to bring the
@@ -97,7 +107,7 @@ dotnet run --project memex/aspire/Memex.AppHost
 Dashboard:  https://localhost:17200/login?t=<TOKEN>
 ```
 
-Open that URL in your browser. The token is per-process — restart Aspire and you get a new one. To skip token authentication in development, add the following to `memex/aspire/Memex.AppHost/Properties/launchSettings.json`:
+Open that URL in your browser. The token is per-process — restart Aspire and you get a new one. To skip token authentication in development, add the following to `../MeshWeaver.Plugins/src/Memex.AppHost/Properties/launchSettings.json`:
 
 ```json
 "environmentVariables": {
@@ -137,7 +147,7 @@ dotnet build-server shutdown
 dotnet build memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj --no-restore
 
 # 4. Start fast, reusing the build from step 3 (no second compile):
-aspire start --no-build --project memex/aspire/Memex.AppHost
+aspire start --no-build --project ../MeshWeaver.Plugins/src/Memex.AppHost
 ```
 
 On Windows (PowerShell), step 1's force-kill is instead:
@@ -155,7 +165,7 @@ Get-Process Memex.AppHost,Memex.Portal.Distributed,aspire -ErrorAction SilentlyC
 ## Option 1 — Hot reload with `dotnet watch`
 
 ```bash
-dotnet watch --project memex/aspire/Memex.AppHost
+dotnet watch --project ../MeshWeaver.Plugins/src/Memex.AppHost
 ```
 
 Save a file and Aspire detects the change, rebuilds the affected project, and restarts only that resource. The Postgres container, blob-storage container, and dashboard all stay up. Most edits apply within seconds.
@@ -215,8 +225,8 @@ If `mcp__aspire__list_apphosts` returns `[]` even though Aspire is running, the 
 Fix — stop the current AppHost and restart with either CLI form:
 
 ```bash
-aspire run --project memex/aspire/Memex.AppHost     # foreground
-aspire start --project memex/aspire/Memex.AppHost   # background daemon
+aspire run --project ../MeshWeaver.Plugins/src/Memex.AppHost     # foreground
+aspire start --project ../MeshWeaver.Plugins/src/Memex.AppHost   # background daemon
 ```
 
 After this, MCP tools (`list_resources`, `list_traces`, `list_structured_logs`, `execute_resource_command`) all work against the running AppHost.

--- a/src/MeshWeaver.Documentation/Data/Architecture/LocalDevWorkflow.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LocalDevWorkflow.md
@@ -141,10 +141,11 @@ pkill -f Memex.AppHost; pkill -f Memex.Portal.Distributed
 #    process". Killing the portal is NOT enough; you must shut the build server too:
 dotnet build-server shutdown
 
-# 3. Rebuild the portal project. Building Memex.Portal.Distributed also rebuilds every project
-#    it references (MeshWeaver.AI, .Graph, .Blazor.Portal, .Mesh.Contract, …), so ALL your edits
+# 3. Rebuild the portal project (it lives in the sibling MeshWeaver.Plugins checkout; MeshWeaverRoot
+#    resolves back to this repo). Building Memex.Portal.Distributed also rebuilds every project it
+#    references here (MeshWeaver.AI, .Graph, .Mesh.Contract, …) and in plugins (.Blazor.Portal), so ALL your edits
 #    compile — this doubles as your compile gate before bringing the stack up:
-dotnet build memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj --no-restore
+dotnet build ../MeshWeaver.Plugins/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj --no-restore
 
 # 4. Start fast, reusing the build from step 3 (no second compile):
 aspire start --no-build --project ../MeshWeaver.Plugins/src/Memex.AppHost

--- a/src/MeshWeaver.Documentation/Data/Architecture/MacLocalStack.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MacLocalStack.md
@@ -136,7 +136,7 @@ portal / db-migration ──OTLP/HTTP──▶ otel-collector ─┬─ logs   �
 | `prometheus` | `prom/prometheus` | 9090 | metrics (remote-write receiver) |
 | `grafana` | `grafana/grafana` | 3000 | dashboards (anonymous admin, datasources pre-provisioned) |
 
-These are **CPU-only**, so containers are fine. Configs live in `memex/aspire/Memex.AppHost/observability/`;
+These are **CPU-only**, so containers are fine. Configs live in `../MeshWeaver.Plugins/src/Memex.AppHost/observability/`;
 data persists in volumes across restarts. OTLP uses **HTTP/protobuf** (4318) rather than gRPC to avoid
 http/2-through-proxy fragility. Open **Grafana** from the Aspire dashboard's resource list → Explore → Loki.
 
@@ -155,8 +155,8 @@ ollama serve &                       # only if you enabled --localai
 ollama pull qwen3-coder:30b
 
 # The local cluster, with both extras:
-aspire run --project memex/aspire/Memex.AppHost -- --observability true --localai true
-#   • plain:                 aspire run --project memex/aspire/Memex.AppHost
+aspire run --project ../MeshWeaver.Plugins/src/Memex.AppHost -- --observability true --localai true
+#   • plain:                 aspire run --project ../MeshWeaver.Plugins/src/Memex.AppHost
 #   • observability only:    ... -- --observability true
 #   • local AI only:         ... -- --localai true
 ```
@@ -180,8 +180,8 @@ metrics, and the **portal** for the app. The MAUI client is separate — see [§
 
 | Concern | File |
 |---|---|
-| Local-cluster extras (LGTM + Ollama/Qwen wiring, opt-in flags) | `memex/aspire/Memex.AppHost/MemexLocalStack.cs` |
-| Observability configs (collector, Loki, Tempo, Prometheus, Grafana datasources) | `memex/aspire/Memex.AppHost/observability/` |
+| Local-cluster extras (LGTM + Ollama/Qwen wiring, opt-in flags) | `../MeshWeaver.Plugins/src/Memex.AppHost/MemexLocalStack.cs` |
+| Observability configs (collector, Loki, Tempo, Prometheus, Grafana datasources) | `../MeshWeaver.Plugins/src/Memex.AppHost/observability/` |
 | OpenTelemetry emission (already wired) | `memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs` |
 | OpenAI-compatible provider (serves Ollama) | `src/MeshWeaver.AI.OpenAI/OpenAIExtensions.cs` |
 | On-device voice + CoreML apple image | [On-device voice](/Doc/Architecture/OnDeviceVoice) · `memex/Memex.Client/Voice/` |

--- a/src/MeshWeaver.Documentation/Data/Architecture/MemexCloudDeployment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MemexCloudDeployment.md
@@ -110,7 +110,7 @@ Build and push the portal (no Dockerfile — the SDK's `PublishContainer` pushes
 
 ```bash
 az acr login --name <registry>
-dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj \
+dotnet publish ../MeshWeaver.Plugins/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj \
   -c Release --no-self-contained -t:PublishContainer -p:PublishProfile= \
   -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"' \
   -p:ContainerRegistry=<registry>.azurecr.io -p:ContainerRepository=memex-portal-ai \

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
@@ -109,7 +109,7 @@ dotnet pack -c Release                       # → 3.0.0-rc1.ci.<build>.nupkg
 dotnet pack -c Release -p:PublicRelease=true # → 3.0.0-rc1.nupkg
 
 # RELEASED Docker image (CD) — clean 3.0.0-rc1 baked into the binary
-dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj -c Release \
+dotnet publish ../MeshWeaver.Plugins/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj -c Release \
   -t:PublishContainer -p:PublicRelease=true -p:PlatformVersion=3.0.0-rc1 \
   -p:ContainerImageTag=3.0.0-rc1
 ```

--- a/test/MeshWeaver.Portal.E2E.Test/README.md
+++ b/test/MeshWeaver.Portal.E2E.Test/README.md
@@ -10,7 +10,7 @@ browser and **Skip themselves** unless E2E is enabled.
 
 ```bash
 # 1. Start the standalone monolith (one terminal). Note the URL it prints.
-dotnet run --project memex/Memex.Portal.Monolith
+dotnet run --project ../MeshWeaver.Plugins/src/Memex.Portal.Monolith
 
 # 2. First time only — install the browser the tests drive.
 dotnet build test/MeshWeaver.Portal.E2E.Test
@@ -24,7 +24,7 @@ E2E_BASE_URL=https://localhost:7122 dotnet test test/MeshWeaver.Portal.E2E.Test
 
 ```bash
 E2E_LAUNCH=1 dotnet test test/MeshWeaver.Portal.E2E.Test
-# Boots memex/Memex.Portal.Monolith on http://localhost:5099, runs, then tears it down.
+# Boots ../MeshWeaver.Plugins/src/Memex.Portal.Monolith on http://localhost:5099, runs, then tears it down.
 ```
 
 ## Configuration (environment variables)


### PR DESCRIPTION
Fixes the docs half of #2367.

A developer following the local-dev docs from a core checkout got a portal with **no login UI and no control views**. The docs said `dotnet run --project memex/Memex.Portal.Monolith` / `memex/aspire/Memex.AppHost` — paths #2293 deleted, together with the login pages, when the GUI extraction moved the hosts to plugins.

**Twelve files** carried those commands (`AGENTS.md`, `Readme.md`, `Deployment.md`, `LocalDevWorkflow.md`, `MacLocalStack.md`, the two sample GettingStarted pages, the AI provider docs, the E2E README, +2). Every occurrence now points at `../MeshWeaver.Plugins/src/Memex.Portal.Monolith` / `…/Memex.AppHost`, which runs **unchanged from the documented cwd** under the standard sibling layout — plugins' `src/Directory.Build.props` defaults `MeshWeaverRoot` to `../MeshWeaver`. A note at the top of `LocalDevWorkflow.md` explains where the hosts went and how to override the root.

The second half of #2367 (`DefaultViews`/`GraphViews` reaching a deployment only as registry bundles) is #2169 Phase B2's decision, not a docs matter — left open there.

`DocumentationLinkIntegrityTest` passes. No What's New entry: developer docs only.