### PR TITLE
A merge burst cancels its own main runs — and publishes nothing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,9 +232,11 @@ so never relax it. Three consequences that trip people up, all SILENT:
 3. 🚨 **Back-to-back merges CANCEL each other's main run, so a merge burst publishes NOTHING.**
    `dotnet-test.yml`'s concurrency group is `build-test-${{ … || github.ref }}` — every push to main
    groups as `refs/heads/main`, so each merge cancels the in-flight run for the previous one (#2316,
-   which buys ~28% of runner demand and is worth keeping). But CD needs a run that **completes**:
-   a `cancelled` run never fires `workflow_run`. So during a burst main carries no completed run at
-   all, and every intermediate publish that "would have happened" simply does not. Observed
+   which buys ~28% of runner demand and is worth keeping). CD **does** still fire on those runs —
+   `main-cd.yml` subscribes with `types: [completed]`, and a cancelled run is "completed" — but its
+   delivery gate keys on the required check **`Consolidate test results` reaching `success` for that
+   SHA**, which a cancelled run never produces. So CD wakes, decides "nothing will be built", and
+   every intermediate publish that "would have happened" simply does not. Observed
    2026-08-26: #2316 merged at 12:55:25Z and main's next **five** runs were cancelled back-to-back,
    leaving 45 minutes with no completed run and no publish.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,14 @@ so never relax it. Three consequences that trip people up, all SILENT:
    2026-08-26 a routine merge killed the run another session was watching to end a CD freeze — no
    damage beyond a lost cycle, but the fix is coordination, not care.
 
+   🚨 **A hold reaches your hands, NOT your subagents' — push it to them explicitly.** An agent
+   briefed to "root-cause and open a PR" follows this file's own merge-on-green default, which is
+   correct on any other day. The same 2026-08-26 hold was then broken **twice more, by two
+   subagents**, each merging a perfectly good fix at exactly the wrong moment. When you take a hold:
+   message every running agent, tell them to push and PARK, and disarm any auto-merge already
+   armed. The general form — **a constraint is only as complete as the set of hands it reaches** —
+   applies to anything you delegate, not just merges.
+
 **None of these is terminal any more.** CD carries a **reconciler**: an hourly `schedule` (plus its own
 `workflow_dispatch`) resolves main's tip through the API, asks ACR whether that commit has the
 complete four-image set, and publishes only when it does not — bounded at 3 attempts per commit,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ a live daily throttle, until #1778.
 `main-cd.yml` builds and pushes the deployment images. Its `workflow_run` path is still gated on
 `event == 'push' && head_branch == 'main'` — that gate is what stops a **fork's** pull_request run
 (whose `head_branch` can also be "main") from publishing untrusted code with this repo's secrets,
-so never relax it. Two consequences that trip people up, both SILENT:
+so never relax it. Three consequences that trip people up, all SILENT:
 
 1. **No Build-and-Test run on main at all.** CD reacts to that workflow completing; if it never ran
    on the merge commit (a CI incident, a stalled queue), CD sits `SKIPPED` with nothing to react to.
@@ -229,8 +229,24 @@ so never relax it. Two consequences that trip people up, both SILENT:
    Test" --ref main` RUNS and genuinely tests the merge commit, so main shows a **green
    Build-and-Test** — but its `event` is `workflow_dispatch`, not `push`, so CD still skips. The
    most convincing possible "it shipped" signal, and no image.
+3. 🚨 **Back-to-back merges CANCEL each other's main run, so a merge burst publishes NOTHING.**
+   `dotnet-test.yml`'s concurrency group is `build-test-${{ … || github.ref }}` — every push to main
+   groups as `refs/heads/main`, so each merge cancels the in-flight run for the previous one (#2316,
+   which buys ~28% of runner demand and is worth keeping). But CD needs a run that **completes**:
+   a `cancelled` run never fires `workflow_run`. So during a burst main carries no completed run at
+   all, and every intermediate publish that "would have happened" simply does not. Observed
+   2026-08-26: #2316 merged at 12:55:25Z and main's next **five** runs were cancelled back-to-back,
+   leaving 45 minutes with no completed run and no publish.
 
-**Neither is terminal any more.** CD carries a **reconciler**: an hourly `schedule` (plus its own
+   Publishing only the **tip** of a burst is correct — intermediate commits never needed their own
+   image set, and it is the batching `CD_BATCH_WINDOW_MINUTES` already wants. The trap is that the
+   burst has to **end**: keep merging and the tip run is cancelled every time, the push path stops
+   publishing entirely, and the hourly reconciler silently becomes the only publisher. So when a
+   merge must actually ship (a fix you are waiting on), **merge, then wait for that merge commit's
+   Build-and-Test to COMPLETE before merging the next** — ~20 min per merge, and the only way
+   "merge on green" still means "an image ships".
+
+**None of these is terminal any more.** CD carries a **reconciler**: an hourly `schedule` (plus its own
 `workflow_dispatch`) resolves main's tip through the API, asks ACR whether that commit has the
 complete four-image set, and publishes only when it does not — bounded at 3 attempts per commit,
 with every attempt and the final give-up written to the `ci-failure` issue. So:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,12 +239,20 @@ so never relax it. Three consequences that trip people up, all SILENT:
    leaving 45 minutes with no completed run and no publish.
 
    Publishing only the **tip** of a burst is correct — intermediate commits never needed their own
-   image set, and it is the batching `CD_BATCH_WINDOW_MINUTES` already wants. The trap is that the
-   burst has to **end**: keep merging and the tip run is cancelled every time, the push path stops
-   publishing entirely, and the hourly reconciler silently becomes the only publisher. So when a
-   merge must actually ship (a fix you are waiting on), **merge, then wait for that merge commit's
-   Build-and-Test to COMPLETE before merging the next** — ~20 min per merge, and the only way
-   "merge on green" still means "an image ships".
+   image set, and it is the batching `CD_BATCH_WINDOW_MINUTES` already wants. So do NOT wait between
+   ordinary merges; batching them is right, and the tip's image contains them all.
+
+   🚨 **The wait is owed to a merge that must ship ON ITS OWN** (a CD fix, a hotfix someone is
+   verifying): merge it, then wait for **that merge commit's** Build-and-Test to COMPLETE — and
+   check the completed run's **head SHA is your merge commit**, because "a run completed" and "the
+   run for my commit completed" diverge during exactly the burst you are working around.
+
+   🚨 **A merge cancels whatever is in flight — including a run ANOTHER SESSION is waiting on.**
+   Several sessions merge into this repo at once, so "wait for the run" only works if *everyone*
+   waits; two sessions each merging politely still cancel each other. Before merging, check whether
+   main has a run in flight that someone is gating a deploy on, and if so **hold and say so**. On
+   2026-08-26 a routine merge killed the run another session was watching to end a CD freeze — no
+   damage beyond a lost cycle, but the fix is coordination, not care.
 
 **None of these is terminal any more.** CD carries a **reconciler**: an hourly `schedule` (plus its own
 `workflow_dispatch`) resolves main's tip through the API, asks ACR whether that commit has the

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -159,9 +159,16 @@ CD's `workflow_run` trigger reacts to a **real push**, and — more exactly — 
    push path stops publishing altogether, and the hourly reconciler quietly becomes the only
    publisher — which reads exactly like "CD is frozen".
 
-   **When a specific merge must ship, merge it and then wait for that merge commit's Build-and-Test
-   to COMPLETE before merging the next.** ~20 min per merge, and the only way "merge on green" still
-   means "an image ships". 🚨 Do not diagnose this from the tag alone: "no new tag" here has at
+   **Ordinary merges should still be batched** — the tip's image contains them all. The wait is owed
+   only to a merge that must ship **on its own** (a CD fix, a hotfix under verification): merge it,
+   wait for **that merge commit's** Build-and-Test to complete, and confirm the completed run's
+   **head SHA is your merge commit** — "a run completed" and "the run for my commit completed"
+   diverge during precisely the burst this is about.
+
+   🚨 **And a merge cancels whatever is in flight, including a run another session is waiting on.**
+   With several sessions merging into one repo, "wait for the run" only works if everyone waits —
+   two sessions each merging politely still cancel each other. Check for an in-flight run someone is
+   gating a deploy on before you merge, and hold if there is one. 🚨 Do not diagnose this from the tag alone: "no new tag" here has at
    least three causes — the batch window, a repoint/version-step failure on a run that *did*
    complete, and this. They stack, and naming only one leaves the other live.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -172,7 +172,13 @@ CD's `workflow_run` trigger reacts to a **real push**, and — more exactly — 
    🚨 **And a merge cancels whatever is in flight, including a run another session is waiting on.**
    With several sessions merging into one repo, "wait for the run" only works if everyone waits —
    two sessions each merging politely still cancel each other. Check for an in-flight run someone is
-   gating a deploy on before you merge, and hold if there is one. 🚨 Do not diagnose this from the tag alone: "no new tag" here has at
+   gating a deploy on before you merge, and hold if there is one.
+
+   🚨 **A hold does not propagate to subagents.** An agent told to "root-cause and open a PR" will
+   merge on green, because that is this repo's documented default. On 2026-08-26 one hold was broken
+   three times — once by the operator and twice by subagents — each time by a correct fix landing at
+   the wrong moment. Push the hold to every running agent explicitly and disarm any armed
+   auto-merge: **a constraint is only as complete as the set of hands it reaches.** 🚨 Do not diagnose this from the tag alone: "no new tag" here has at
    least three causes — the batch window, a repoint/version-step failure on a run that *did*
    complete, and this. They stack, and naming only one leaves the other live.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -149,8 +149,12 @@ CD's `workflow_run` trigger reacts to a **real push**, and — more exactly — 
 4. 🚨 **A merge burst cancels its own runs, and publishes nothing.** `dotnet-test.yml` groups by
    `build-test-${{ … || github.ref }}`, so every push to main shares the group `refs/heads/main` and
    each merge **cancels the in-flight run of the one before it** (#2316 — worth ~28% of runner
-   demand, keep it). A `cancelled` run never fires `workflow_run`, so through a burst main carries
-   no completed run and no publish happens. Observed 2026-08-26: #2316 merged 12:55:25Z, the next
+   demand, keep it). CD still **fires** on those runs — this workflow subscribes with
+   `types: [completed]` and a cancelled run counts as completed — but the delivery gate keys on the
+   required check **`Consolidate test results` reaching `success` for that SHA**, which a cancelled
+   run never produces (and gating on the required check rather than the run's umbrella conclusion is
+   deliberate — see the DELIVERY GATE comment). So CD wakes, decides "nothing will be built", and
+   through a burst nothing publishes. Observed 2026-08-26: #2316 merged 12:55:25Z, the next
    **five** main runs cancelled back-to-back, 45 minutes with no completed run.
 
    Publishing only the burst's **tip** is the right outcome — intermediate commits never needed

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -126,8 +126,8 @@ is preserved by a stronger check rather than by a proxy.
 
 ## The standing trap — verify the IMAGE, never the tick
 
-CD's `workflow_run` trigger reacts to a **real push**. Two consequences trip people up, and both are
-silent:
+CD's `workflow_run` trigger reacts to a **real push**, and — more exactly — to one that
+**completes**. The consequences below all trip people up, and all are silent:
 
 1. **No Build-and-Test run on the merge commit at all** (a CI incident, a stalled queue). CD reacts
    to that workflow completing; with nothing to react to it sits `SKIPPED`.
@@ -145,6 +145,25 @@ silent:
    never a quiet skip.** The operator move is unchanged by the alarm: read the failing test; a
    flake → `gh run rerun <id> --failed` (a green rerun fires a fresh `workflow_run`, which
    publishes by itself); a real failure → fixing main IS the release path.
+
+4. 🚨 **A merge burst cancels its own runs, and publishes nothing.** `dotnet-test.yml` groups by
+   `build-test-${{ … || github.ref }}`, so every push to main shares the group `refs/heads/main` and
+   each merge **cancels the in-flight run of the one before it** (#2316 — worth ~28% of runner
+   demand, keep it). A `cancelled` run never fires `workflow_run`, so through a burst main carries
+   no completed run and no publish happens. Observed 2026-08-26: #2316 merged 12:55:25Z, the next
+   **five** main runs cancelled back-to-back, 45 minutes with no completed run.
+
+   Publishing only the burst's **tip** is the right outcome — intermediate commits never needed
+   their own image set, and it is the same batching `CD_BATCH_WINDOW_MINUTES` wants. The hazard is
+   that the burst must **end**: while merges keep arriving the tip run is cancelled every time, the
+   push path stops publishing altogether, and the hourly reconciler quietly becomes the only
+   publisher — which reads exactly like "CD is frozen".
+
+   **When a specific merge must ship, merge it and then wait for that merge commit's Build-and-Test
+   to COMPLETE before merging the next.** ~20 min per merge, and the only way "merge on green" still
+   means "an image ships". 🚨 Do not diagnose this from the tag alone: "no new tag" here has at
+   least three causes — the batch window, a repoint/version-step failure on a run that *did*
+   complete, and this. They stack, and naming only one leaves the other live.
 
 Two diagnosis cheats, both learned the hard way on 2026-08-22:
 


### PR DESCRIPTION
## What this documents

`#2316` made every push to `main` cancel the superseded in-flight Build-and-Test (concurrency group `build-test-${{ … || github.ref }}`). That is worth keeping — ~28% of runner demand. But **CD's `workflow_run` path needs a run that COMPLETES**, and a `cancelled` run never fires it.

So through a burst of back-to-back merges, `main` carries no completed Build-and-Test at all, and nothing publishes.

**Observed today**, which is what prompted this:

```
13:10 484af535 in_progress
13:00 c2f4917a cancelled
12:58 dbb4528d cancelled
12:56 8b773456 cancelled
12:55 117b55de cancelled
12:55 71387f84 cancelled     ← #2316 merged 12:55:25Z
12:25 d9b59b6b success       ← last completed run on main
```

45 minutes, no completed run, no image.

## This is a property, not a defect

Publishing only the burst's **tip** is the right outcome: intermediate commits never needed their own image set, and it is the same batching `CD_BATCH_WINDOW_MINUTES` already wants. Nothing here argues for reverting #2316.

The hazard is that the burst has to **end**. While merges keep arriving the tip run is cancelled every time, the push path stops publishing altogether, and the hourly reconciler quietly becomes the only publisher — which presents exactly as *"CD is frozen"*.

Hence the operator rule now written down: **when a specific merge must ship, merge it and wait for that merge commit's Build-and-Test to COMPLETE before merging the next.** ~20 min per merge, and the only way "merge on green" still means "an image ships".

## Why it is worth the words

"No new tag" now has **at least three stacking causes**: the batch window, a version-step failure on a run that *did* complete, and this. Today's diagnosis went wrong in both directions before all three were on the table — one session called CD frozen naming only the first cause, and I initially read these cancellations as a regression in #2316. Both readings were half-right, which is the expensive kind.

## Changes

- `AGENTS.md` → the CD section's "two consequences that trip people up" becomes three.
- `ContinuousDeliveryContract.md` → same, plus the explicit warning against diagnosing from the tag alone.

Documentation only — no workflow or code change.

## Verification

`DocumentationLinkIntegrityTest` and `WhatsNewEntryIntegrityTest`: **2 passed, 0 failed** (built first, not `--no-build` against a stale tree).

No What's New entry: this is guidance for agents working in the repo, not a user-visible change, and adding one would put CI-internals noise in the user-facing changelog. Happy to add one if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)