### PR TITLE
memex-local reports when the local portal came up unusable (#2367)

### DIFF
--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -124,6 +124,25 @@ jobs:
       - name: Behaviour tests
         run: deploy/aks/operator/test/run-tests.sh
 
+      # 🚨 memex-local is the OTHER operator script in this repo — ~2000 lines that stand up every
+      # developer's local portal — and nothing in CI opened it until MeshWeaver#2367. What that
+      # cost, in one file: `memex-local help` was an unbounded FORK BOMB (a backtick in an unquoted
+      # heredoc re-entered main()); `helm_deploy` aborted on macOS bash 3.2 for the paths the script
+      # itself calls normal; and `up`/`update` reported success on a portal with no sign-in page and
+      # no view packs. Three live defects, zero red ticks, because nothing ever ran it.
+      - name: memex-local parses
+        run: bash -n deploy/homebrew/bin/memex-local
+
+      - name: shellcheck (memex-local)
+        run: shellcheck -S warning deploy/homebrew/bin/memex-local deploy/homebrew/test/run-tests.sh
+
+      # 🚨 This runner is bash 5 and has no colima/kubectl/helm, so what it CAN prove is asserted by
+      # running the CLI against stub tools (every red state of the usability verification, plus that
+      # a green one is reachable) and by static assertions for the two traps a Linux runner can
+      # never reach by execution — the heredoc backtick and macOS bash 3.2's empty-array abort.
+      - name: Behaviour tests (memex-local)
+        run: deploy/homebrew/test/run-tests.sh
+
   image:
     name: Operator image builds
     runs-on: ubuntu-latest

--- a/deploy/homebrew/README.md
+++ b/deploy/homebrew/README.md
@@ -57,6 +57,7 @@ memex-local status             # colima / pods / ingress / port-forward / health
 memex-local logs               # tail the portal logs (verbose; see "Full logging")
 memex-local logs --migration   # tail the migration job
 memex-local update             # roll portal+migration to a newer image, refresh forward
+memex-local verify             # is the portal USABLE? serves + /login routed + view packs present
 memex-local autoroll up        # AUTO-redeploy portal+migration whenever a fresh image is built
 memex-local autoroll status    # show the watcher + last-rolled portal/migration digests
 memex-local autoroll down      # stop auto-rolling
@@ -151,7 +152,7 @@ rolled in place; the **migration** is re-run as a Job (it has no Deployment).
 | §10 Local LLM | `OLLAMA_HOST=0.0.0.0:11434 ollama serve`; `ollama pull qwen3.6`; `ollama cp … qwen3.6-code` | `setup_ollama()` + overlay `ollama.external` + `OpenAICompatible__*` |
 | §11 Observability | `helm upgrade --install loki grafana/loki-stack …` | `cmd_observability()` |
 | §12 Instance identity | `Portal__InstanceName/Color` | overlay `config.memex_portal` |
-| §14 Verify | `curl --cacert …/rootCA.pem https://memex.localhost:8443/` | `verify_endpoint()` |
+| §14 Verify | assert the portal is USABLE — it serves, `/login` is routed, and the DefaultViews/GraphViews packs are present | `verify_usable()` (`up` / `update` / `verify`; behaviour-tested in `test/run-tests.sh`) |
 | §14 Troubleshoot (stale forward) | restart the port-forward after a rollout | `cmd_port_forward()`; `update` auto-refreshes it |
 | §16 Plugin registry | mount the plugin checkouts + configure them as sources/grants | `plugin_repo_paths()` + the `pluginCatalog.*` `--set`s in `helm_deploy()` |
 | §16 New instance | mint an `mwr_` key → own DB → deploy a self-registering portal → verify | `cmd_instance()` (`inst_mint_key`, `inst_registered_id`, `inst_installed_packages`) |

--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -239,6 +239,12 @@ base_build_local() {
   docker push "$PORTAL_BASE_REF" >/dev/null
 }
 
+# $1 (optional): --rebuild-base, forwarded to base_build_local.
+#
+# 🚨 It was forwarded from here (`base_build_local "${1:-}"`) and ADVERTISED by that function's own
+# "Pass --rebuild-base to force" line — but no caller ever passed it, because neither `up` nor
+# `update` accepted the flag. A documented escape hatch that nothing can reach. Both accept it now
+# (MeshWeaver#2367); shellcheck's SC2120 is what pointed at it.
 image_build_local() {                                  # §3 Option B
   local repo
   repo="$(resolve_repo)" || die "local build (Option B) needs the repo — set MEMEX_REPO to your MeshWeaver checkout, or use 'up --from-acr'"
@@ -1443,7 +1449,7 @@ cmd_e2e() {
       [ "${1:-}" = "--skip-build" ] && skip_build="yes"
       preflight
       e2e_require_stack
-      [ "$skip_build" = "yes" ] || { image_build_local; portal_next_build_local; }  # §3 Option B — current working tree
+      [ "$skip_build" = "yes" ] || { image_build_local ""; portal_next_build_local; }  # §3 Option B — current working tree
       e2e_ensure_db
       e2e_migrate
       e2e_deploy
@@ -1514,7 +1520,7 @@ cmd_e2e() {
 # Subcommands
 # ===========================================================================
 cmd_up() {
-  local image_source="build" acr_tag="$ACR_DEFAULT_TAG" with_obs="no"
+  local image_source="build" acr_tag="$ACR_DEFAULT_TAG" with_obs="no" rebuild_base=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --from-acr) image_source="acr" ;;
@@ -1522,6 +1528,7 @@ cmd_up() {
       --skip-image) image_source="skip" ;;
       --tag) shift; acr_tag="${1:?--tag needs a value}" ;;
       --with-observability) with_obs="yes" ;;
+      --rebuild-base) rebuild_base="--rebuild-base" ;;
       *) die "up: unknown flag '$1'" ;;
     esac
     shift
@@ -1532,7 +1539,7 @@ cmd_up() {
   start_colima                                   # §2
 
   case "$image_source" in                        # §3
-    build) image_build_local; portal_next_build_local ;;   # portal + migration, then the /next React GUI
+    build) image_build_local "$rebuild_base"; portal_next_build_local ;;   # portal + migration, then the /next React GUI
     acr)   image_pull_acr "$acr_tag" ;;
     skip)  info "Skipping image step (--skip-image); relying on IfNotPresent/cache" ;;
   esac
@@ -1646,11 +1653,16 @@ cmd_logs() {
 }
 
 cmd_update() {
-  local image_source="build" acr_tag="$ACR_DEFAULT_TAG"
+  local image_source="build" acr_tag="$ACR_DEFAULT_TAG" rebuild_base=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --from-acr|--acr) image_source="acr" ;;
       --build) image_source="build" ;;
+      # Force a rebuild of the portal-ai BASE (the Node + Claude Code + Copilot layer). It is cached
+      # by image presence, so a changed deploy/base-images/portal-ai/Dockerfile is otherwise never
+      # picked up. base_build_local has always advertised this flag; until MeshWeaver#2367 no caller
+      # accepted it, so nothing could reach it.
+      --rebuild-base) rebuild_base="--rebuild-base" ;;
       # Re-apply CONFIG only, reusing the images already in Colima's store. `up` has had this
       # since the start; `update` did not, so re-rendering the chart after a values/flag change
       # forced a full ~10-minute rebuild of images that were already current — or tempted you
@@ -1667,7 +1679,7 @@ cmd_update() {
 
   step "Rolling memex to a newer image ($image_source)"
   case "$image_source" in
-    build) image_build_local; portal_next_build_local ;;   # §3 Option B — portal + migration, then the /next React GUI
+    build) image_build_local "$rebuild_base"; portal_next_build_local ;;   # §3 Option B — portal + migration, then the /next React GUI
     acr)   image_pull_acr "$acr_tag" ;;          # §3 Option A — retags onto the chart's image names
     skip)  info "reusing the images already in Colima's store — config re-apply only" ;;
   esac
@@ -1794,7 +1806,7 @@ USAGE:
   memex-local <command> [flags]
 
 COMMANDS:
-  up [--build|--from-acr|--skip-image] [--tag T] [--with-observability]
+  up [--build|--from-acr|--skip-image] [--tag T] [--with-observability] [--rebuild-base]
                   Bring the whole stack up (idempotent). Default image source:
                   --build (Option B, native arm64 into Colima's Docker store —
                   the no-cloud-creds path). --from-acr pulls multi-arch from ACR.
@@ -1818,8 +1830,11 @@ COMMANDS:
   status          colima / pods / ingress / port-forward / health.
   logs [--migration|--postgres] [--tail N] [--no-follow]
                   Tail logs (portal by default). Log level: $LOG_LEVEL.
-  update [--build|--from-acr|--skip-image] [--tag T]
+  update [--build|--from-acr|--skip-image] [--tag T] [--rebuild-base]
                   Roll portal+migration to a newer image, then refresh forward.
+                  --rebuild-base forces a rebuild of the portal-ai base layer
+                  (Node + the Claude Code / Copilot CLIs), which is otherwise
+                  cached by image presence; \`up\` takes it too.
   verify [--wait S] [--repair]
                   Is this portal USABLE? Asserts it serves, that /login is routed,
                   and that the DefaultViews/GraphViews packs are present — without

--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -15,6 +15,7 @@
 #   status        Show colima / pods / ingress / port-forward / health.
 #   logs          Tail the portal logs (kubectl logs). --migration for migration.
 #   update        Roll the portal+migration to a newer image (build or ACR pull).
+#   verify        Is the portal USABLE — serving, /login routed, view packs present?
 #   port-forward  (Re)start the host:8443 -> ingress:443 forward (troubleshooting).
 #   observability Install Grafana/Loki/Promtail/Prometheus (LocalColimaMac.md §11).
 #   doctor        Preflight: check required tools + cluster reachability.
@@ -260,6 +261,9 @@ image_build_local() {                                  # §3 Option B
       sleep 5; _w=$((_w + 5))
     done
     echo "$$" > "$_bl/pid"
+    # shellcheck disable=SC2064  # expanding $_bl NOW is the point: it is a local, and by the time
+    # RETURN fires the variable is out of scope, so a single-quoted trap would rm -rf '' and leak
+    # the lock directory to every later build.
     trap "rm -rf '$_bl' 2>/dev/null" RETURN
     ok "Acquired build lock — building serially (set MEMEX_NO_BUILD_LOCK=1 to disable)"
   fi
@@ -498,8 +502,14 @@ helm_deploy() {
   # by design, so the mismatch is invisible (an empty catalog, no error). Observed for real: a
   # worktree at /Users/me/code/MWP-main produced source "MWP-main" against InstallByDefault
   # "Plugins/*", and a fresh instance installed nothing at all.
+  # 🚨 ${x[@]+"${x[@]}"}, not "${x[@]}". macOS ships bash 3.2, where `set -u` treats "${x[@]}" on an
+  # EMPTY array as an UNBOUND VARIABLE and kills the script — and every array below is legitimately
+  # empty on a normal run: next_args whenever the portal-next image is absent (which is every
+  # --from-acr / --skip-image run, as the info line above says), plugin_args/install_names whenever
+  # no plugin checkout was found. So the deploy died on "unbound variable" for exactly the paths the
+  # script itself documents as normal. This tool is macOS-only; the guard is not optional here.
   local n i=0
-  for n in "${install_names[@]}"; do
+  for n in ${install_names[@]+"${install_names[@]}"}; do
     plugin_args+=(--set "pluginCatalog.installByDefault[$i]=$n/*")
     i=$((i + 1))
   done
@@ -517,8 +527,8 @@ helm_deploy() {
     -f "$OVERLAY" \
     --set persistDataVolume=true \
     --set "config.memex_portal.Bootstrap__Secret=$LOCAL_BOOTSTRAP_SECRET" \
-    "${plugin_args[@]}" \
-    "${next_args[@]}" \
+    ${plugin_args[@]+"${plugin_args[@]}"} \
+    ${next_args[@]+"${next_args[@]}"} \
     -n "$NAMESPACE" --create-namespace \
     --force-conflicts
 
@@ -602,18 +612,185 @@ uninstall_launchd() {
 }
 
 # ---------------------------------------------------------------------------
-# §14 — end-to-end verify
+# §14 — end-to-end verify: is the portal USABLE, or merely ANSWERING?
+#
+# 🚨 This was `verify_endpoint`, and it could not fail. It curl'd `/` and printed `ok "Portal
+# reachable"` whenever curl itself exited 0 — so a 503, a 404 and a 200 that renders every control
+# as its `ToString()` all produced the same green line. MeshWeaver#2367 is what that costs: a
+# developer ran `memex-local up && memex-local update`, both printed ok, and got a portal with no
+# way to sign in and nothing but debug text where the UI should be. `update` verified NOTHING at all
+# — it ended on `ok "update complete"` straight after `rollout status`.
+#
+# The three things a local portal is unusable without, each asserted, each naming its own remedy:
+#
+#   1. The portal SERVES — an HTTP status in the serving range, not merely a completed conversation.
+#   2. The SIGN-IN route is routed. The login pages compile INTO the image
+#      (MeshWeaver.Plugins/src/Memex.Portal.Gui/Pages/{Login,DevLogin}.razor): they are a shell
+#      concern, not a pack, so a 404 here means the image predates the GUI move (MeshWeaver#2293)
+#      and the remedy is to rebuild it — never to install something.
+#   3. The VIEW PACKS are present. DefaultViews (MeshWeaver.Blazor.Views) and GraphViews
+#      (MeshWeaver.Blazor.Graph) left the image in MeshWeaver#2169 Phase B2 and now reach a
+#      deployment ONLY as registry bundles. Without them every control renders as its `ToString()`
+#      — and the documented repair (Settings ▸ Administration ▸ Plugin Catalog) is itself rendered
+#      by the missing views, so the portal cannot repair itself through its own UI. Which is exactly
+#      why this has to be asserted from OUT HERE.
+#
+# 🚨 Check 3 WAITS rather than samples. Both packs declare `preInstalled: true`, so the boot
+# reconcile installs them on every boot — fresh install or existing — but that install runs
+# sequentially and compiles node types, so sampling the instant `rollout status` returns would
+# false-fail a portal that is merely still working. A gate that cries wolf gets deleted.
+#
+# 🚨 And it REPAIRS the one state that is a missing step rather than a fault: modules landed with
+# the `.pending-restart` marker are on disk but not in the running process. That is one restart,
+# which this performs — the point of MeshWeaver#2367 is that following the docs must not leave a
+# manual recovery step.
 # ---------------------------------------------------------------------------
-verify_endpoint() {
-  step "Verifying TLS + routing end-to-end (§14)"
-  local caroot; caroot="$(mkcert -CAROOT 2>/dev/null)"
-  local url="https://${HOSTNAME_LOCAL}:${HOST_PORT}/"
-  if curl --cacert "$caroot/rootCA.pem" -sS -o /dev/null \
-       -w 'http=%{http_code} ssl_verify=%{ssl_verify_result}\n' "$url"; then
-    ok "Portal reachable at $url"
-  else
-    warn "Portal not reachable yet at $url — give pods a moment, then 'memex-local status'"
+
+# The two packs a Blazor portal cannot render without. MODULE (assembly) names — what the landing
+# lane writes on disk; the catalog package names are DefaultViews and GraphViews.
+readonly VIEW_PACK_MODULES="MeshWeaver.Blazor.Views MeshWeaver.Blazor.Graph"
+
+# One in-pod probe answering the whole of check 3: for each module, is it resolvable at all — landed
+# under <Modules:Root>/modules/<name>[@<generation>]/<name>.dll, or shipped in the image's own app
+# closure — and is a restart pending? Emits parseable lines so the caller never re-execs.
+probe_view_packs() {
+  kubectl -n "$NAMESPACE" exec "deploy/$PORTAL_DEPLOYMENT" -- sh -c '
+    root="${Modules__Root:-/app}"
+    for m in $1; do
+      if ls "$root"/modules/*/"$m".dll >/dev/null 2>&1 || [ -f "/app/$m.dll" ]; then
+        echo "module=$m present"
+      else
+        echo "module=$m missing"
+      fi
+    done
+    if [ -e "$root/modules/activation.d/.pending-restart" ]; then echo "pending-restart=yes"; fi
+    exit 0
+  ' sh "$VIEW_PACK_MODULES" 2>/dev/null
+}
+
+# Has the boot reconcile FINISHED? `[DefaultInstall] reconciled…` is the line it writes when the
+# whole selection has been installed (or failed), so it is the real completion signal — which is
+# what check 3 waits on, rather than a stopwatch. Before it, a missing pack means "still working";
+# after it, the same observation means "it will not arrive", and the wait can stop being patient.
+probe_default_install_done() {
+  kubectl -n "$NAMESPACE" logs "deploy/$PORTAL_DEPLOYMENT" --tail=4000 2>/dev/null \
+    | grep -c '\[DefaultInstall\] reconciled' || true
+}
+
+# The HTTP half. Echoes the STATUS CODE (000 when no request completed), because judging curl's own
+# exit code instead of the code it fetched is the bug this whole function replaces.
+probe_http() {
+  local path="$1" caroot ca=()
+  if command -v mkcert >/dev/null 2>&1; then
+    caroot="$(mkcert -CAROOT 2>/dev/null || true)"
+    if [ -n "$caroot" ] && [ -f "$caroot/rootCA.pem" ]; then ca=(--cacert "$caroot/rootCA.pem"); fi
   fi
+  # ${x[@]+"${x[@]}"} — NOT a style tic. macOS ships bash 3.2, where `set -u` treats "${x[@]}" on an
+  # EMPTY array as an unbound variable and kills the script. This tool is macOS-only, so every
+  # possibly-empty array expansion in this file has to carry the guard (see helm_deploy).
+  curl ${ca[@]+"${ca[@]}"} -sS -o /dev/null -w '%{http_code}' --max-time 15 \
+    "https://${HOSTNAME_LOCAL}:${HOST_PORT}${path}" 2>/dev/null || printf '000'
+}
+
+verify_usable() {
+  local budget=0 repair="no"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --wait) shift; budget="${1:?--wait needs seconds}" ;;
+      --repair) repair="yes" ;;
+      *) die "verify: unknown flag '$1'" ;;
+    esac
+    shift
+  done
+  case "$budget" in ''|*[!0-9]*) die "verify: --wait needs whole seconds, got '$budget'" ;; esac
+
+  step "Verifying the portal is USABLE, not merely answering (§14)"
+  local failed=0 url="https://${HOSTNAME_LOCAL}:${HOST_PORT}" code
+
+  # ── 1. the portal serves ─────────────────────────────────────────────────
+  code="$(probe_http /)"
+  case "$code" in
+    2??|3??) ok "portal serves $url/ (HTTP $code)" ;;
+    000) warn "portal did NOT answer at $url/ — no HTTP status at all.
+     Remedy: 'memex-local status' (is the pod ready, is the port-forward up?), then
+     'memex-local port-forward'."
+         failed=1 ;;
+    *)  warn "portal answered $url/ with HTTP $code — that is not a serving portal.
+     Remedy: 'memex-local logs'. A 503 is the ingress with no ready endpoint behind it."
+        failed=1 ;;
+  esac
+
+  # ── 2. the sign-in route is routed ───────────────────────────────────────
+  code="$(probe_http /login)"
+  case "$code" in
+    2??|3??) ok "sign-in route /login is served (HTTP $code)" ;;
+    404) warn "/login is NOT ROUTED (HTTP 404) — this portal has no way to sign in.
+     The login pages compile INTO the image from MeshWeaver.Plugins/src/Memex.Portal.Gui, so a 404
+     means the image predates the GUI move (MeshWeaver#2293/#2367).
+     Remedy: rebuild it — 'memex-local update --build', with the plugins checkout on main."
+         failed=1 ;;
+    *)  warn "/login answered HTTP $code — the sign-in route is not usable.
+     Remedy: 'memex-local logs'."
+        failed=1 ;;
+  esac
+
+  # ── 3. the view packs are present ────────────────────────────────────────
+  local deadline probe missing pending settled=0
+  deadline=$(( $(date +%s) + budget ))
+  while :; do
+    probe="$(probe_view_packs || true)"
+    missing="$(printf '%s\n' "$probe" | awk '/ missing$/ { sub(/^module=/,""); sub(/ missing$/,""); print }')"
+    pending="$(printf '%s\n' "$probe" | grep -c '^pending-restart=yes$' || true)"
+    if [ -z "$missing" ]; then settled=1; break; fi
+    # The reconcile has reported: a pack still missing now is a verdict, not a work-in-progress.
+    if [ "$(probe_default_install_done)" -gt 0 ]; then settled=1; break; fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then break; fi
+    info "waiting for the boot reconcile to install the view packs (missing: $(echo "$missing" | tr '\n' ' '))…"
+    sleep 10
+  done
+
+  if [ -n "$missing" ] && [ "$settled" -eq 0 ] && [ "$budget" -gt 0 ]; then
+    # 🚨 Distinct from "not installed", deliberately. The install has neither delivered the packs nor
+    # reported that it finished, so the honest answer is "not usable YET, and still working" — which
+    # is still not a success, because the portal cannot render right now.
+    warn "the boot reconcile has not reported completion after ${budget}s, and the view packs are
+     not there yet — the portal is not usable at this moment. This is 'still installing', not
+     'failed': a first boot compiles as it installs.
+     Remedy: watch it with 'memex-local logs | grep DefaultInstall', then 'memex-local verify'."
+    return 1
+  fi
+
+  if [ -z "$probe" ]; then
+    warn "could not read the module state from the portal pod — check 3 verified NOTHING.
+     Remedy: 'kubectl -n $NAMESPACE get pods'; a pod that cannot be exec'd is not a pod serving."
+    failed=1
+  elif [ -n "$missing" ]; then
+    warn "view pack(s) NOT installed: $(echo "$missing" | tr '\n' ' ')
+     Every control renders as its ToString(), and the Plugin Catalog that would repair it is itself
+     one of the missing views — the portal CANNOT repair itself through its own UI (MeshWeaver#2367).
+     DefaultViews/GraphViews declare preInstalled, so the boot reconcile installs them from the
+     plugin repo this install serves. It did not.
+     Remedy: read why with
+       memex-local logs --no-follow --tail 400 | grep DefaultInstall
+     then put the plugins checkout on main and re-run 'memex-local update --skip-image'."
+    failed=1
+  elif [ "$pending" -gt 0 ] && [ "$repair" = "yes" ]; then
+    step "View packs landed but not yet active — restarting the portal once to activate them"
+    kubectl -n "$NAMESPACE" rollout restart "deploy/$PORTAL_DEPLOYMENT"
+    kubectl -n "$NAMESPACE" rollout status "deploy/$PORTAL_DEPLOYMENT" --timeout=300s || \
+      warn "the activation restart did not complete — 'memex-local status'"
+    ok "view packs present and activated"
+  elif [ "$pending" -gt 0 ]; then
+    warn "view packs are LANDED but a restart is PENDING — on disk, not in the running process, so
+     controls still render as ToString().
+     Remedy: 'memex-local verify --repair', or
+       kubectl -n $NAMESPACE rollout restart deploy/$PORTAL_DEPLOYMENT"
+    failed=1
+  else
+    ok "view packs present: $VIEW_PACK_MODULES"
+  fi
+
+  return "$failed"
 }
 
 # ---------------------------------------------------------------------------
@@ -1372,7 +1549,11 @@ cmd_up() {
 
   install_launchd                                 # §7
   [ "$with_obs" = "yes" ] && cmd_observability    # §11 (opt-in)
-  verify_endpoint                                 # §14
+  # §14 — and it can FAIL. `up` used to end green on a portal with no sign-in page and no view
+  # packs (MeshWeaver#2367); a command that cannot report that is not a verification.
+  verify_usable --wait 600 --repair || \
+    die "memex is deployed but NOT USABLE — see the checks above. Nothing further will fix itself: \
+each line names its own remedy."
 
   echo
   ok "memex is up — open https://${HOSTNAME_LOCAL}:${HOST_PORT}"
@@ -1432,7 +1613,15 @@ cmd_status() {
     warn "agent '$PLIST_LABEL' not loaded"
   fi
   step "Health"
-  verify_endpoint
+  # Diagnostic: report every check, never abort the rest of `status` on a red one.
+  verify_usable || true
+}
+
+# `memex-local verify` — ask the running install the ONE question `status` used to be unable to
+# answer: is this portal usable? Exits non-zero when it is not, so it composes in a script.
+cmd_verify() {
+  colima_running || die "Colima is not running — run 'memex-local up' first"
+  verify_usable "$@"
 }
 
 cmd_logs() {
@@ -1525,6 +1714,11 @@ cmd_update() {
   fi
   info "A rollout invalidates the old port-forward binding — refreshing it (§8/§14)"
   install_launchd
+  # §14 — `update` verified NOTHING before this: it printed "update complete" straight after the
+  # rollout, which is exactly how MeshWeaver#2367's portal reported success while unusable.
+  verify_usable --wait 600 --repair || \
+    die "the roll completed but the portal is NOT USABLE — see the checks above; each names its \
+own remedy."
   ok "update complete"
   echo
   info "Self-update note: this same chart carries the in-pod self-updater. With"
@@ -1566,7 +1760,7 @@ cmd_doctor() {
   step "Checking required tools"
   local tools=(colima kubectl helm mkcert ollama openssl curl)
   local t
-  for t in "${tools[@]}"; do
+  for t in ${tools[@]+"${tools[@]}"}; do
     if command -v "$t" >/dev/null 2>&1; then ok "$t: $(command -v "$t")"; else warn "$t: MISSING"; fi
   done
   if command -v dotnet >/dev/null 2>&1; then
@@ -1586,6 +1780,13 @@ cmd_doctor() {
 }
 
 cmd_help() {
+  # 🚨 EVERY BACKTICK IN HERE MUST BE \` — this heredoc is UNQUOTED (it interpolates
+  # ${HOSTNAME_LOCAL} / ${HOST_PORT} / ${E2E_PORT}), so a bare backtick is COMMAND SUBSTITUTION, not
+  # punctuation. The autoroll paragraph mentioned the \`main\` tag, and \`main\` is this script's own
+  # entry function: \`memex-local help\` re-entered main → cmd_help → main → …, forking at every
+  # level. It was an unbounded fork bomb until MeshWeaver#2367, and nothing caught it because
+  # nothing in CI had ever run this script. deploy/homebrew/test/run-tests.sh now asserts it
+  # STATICALLY — a regression here hangs, and a hang is not a failure signal.
   cat <<EOF
 memex-local — local memex on Colima k3s (1:1 with LocalColimaMac.md)
 
@@ -1619,12 +1820,19 @@ COMMANDS:
                   Tail logs (portal by default). Log level: $LOG_LEVEL.
   update [--build|--from-acr|--skip-image] [--tag T]
                   Roll portal+migration to a newer image, then refresh forward.
+  verify [--wait S] [--repair]
+                  Is this portal USABLE? Asserts it serves, that /login is routed,
+                  and that the DefaultViews/GraphViews packs are present — without
+                  them every control renders as its ToString() and the Plugin
+                  Catalog that would repair it is one of the missing views.
+                  Exits non-zero when it is not, naming each remedy. \`up\` and
+                  \`update\` run this for you (--wait 600 --repair).
   autoroll <up [--acr]|down|status>
                   Auto-redeploy the portal whenever a fresh local image is built
                   (launchd watcher → rollout restart on a new :latest digest).
-                  With --acr, ALSO track the registry's promoted `main` tag —
-                  every green merge rolls in automatically (needs `az` logged in;
-                  plain `up` returns to build-only for the local dev loop) — and
+                  With --acr, ALSO track the registry's promoted \`main\` tag —
+                  every green merge rolls in automatically (needs \`az\` logged in;
+                  plain \`up\` returns to build-only for the local dev loop) — and
                   keep the mounted Plugins checkout on origin/main so modules and
                   plugin content auto-roll too (restart-as-fan-out, as in prod).
                   The local equivalent of the AKS in-pod self-update.
@@ -1927,6 +2135,7 @@ main() {
     status)        cmd_status "$@" ;;
     logs)          cmd_logs "$@" ;;
     update)        cmd_update "$@" ;;
+    verify)        cmd_verify "$@" ;;
     autoroll)      cmd_autoroll "$@" ;;
     port-forward)  cmd_port_forward "$@" ;;
     observability) cmd_observability "$@" ;;

--- a/deploy/homebrew/test/run-tests.sh
+++ b/deploy/homebrew/test/run-tests.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Tests for memex-local — the local-stack CLI every developer's setup runs.
+#
+# 🚨 WHY THIS EXISTS. deploy/homebrew/bin/memex-local is ~2000 lines that stand up the whole local
+# portal, and until MeshWeaver#2367 NOTHING in CI opened it: no shellcheck, no parse, no behaviour.
+# The bug that issue reported was a verification that could not fail — `verify_endpoint` curl'd `/`
+# and printed `ok "Portal reachable"` whenever curl exited 0, so a 503, a 404 and a portal rendering
+# every control as its `ToString()` all produced the same green line. A gate that cannot fail is not
+# a gate, and the only way to know a gate can fail is to make it fail.
+#
+# WHAT THIS CAN AND CANNOT PROVE, stated plainly so a green run is not read as more than it is.
+# memex-local drives colima, docker, helm, kubectl, mkcert and curl against a live Colima VM; a CI
+# runner has none of those, and mocking them would only assert that the mocks agree with themselves.
+# So this covers the layer that IS testable and is where this class of bug lives:
+#
+#   • the usability verification — every red state it must report, and that it reports each one
+#     with a REMEDY rather than a bare failure
+#   • argument handling — an unknown flag must refuse, not be silently ignored
+#   • that a green run is actually reachable, so the tests above are not passing vacuously
+#
+# What it does NOT cover: whether `kubectl exec` finds the module directory on a real pod. That is
+# settled by a real `memex-local up`, which is why the probe's shape is kept identical to the
+# diagnostic commands in MeshWeaver#2367's own repro.
+
+set -uo pipefail
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CLI="$HERE/../bin/memex-local"
+
+pass=0; fail=0; RC=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; printf '        %s\n' "${2:-}"; fail=$((fail+1)); }
+
+# ---------------------------------------------------------------------------
+# A fake toolchain. Each stub answers from an env var, so one test = one state.
+#   FAKE_HTTP_ROOT  / FAKE_HTTP_LOGIN — the status code curl reports per path
+#   FAKE_MODULES                      — the lines the in-pod probe prints
+#   FAKE_EXEC_FAILS                   — kubectl exec exits non-zero (unreadable pod)
+# ---------------------------------------------------------------------------
+STUBS="$(mktemp -d)"
+trap 'rm -rf "$STUBS"' EXIT
+
+cat > "$STUBS/colima" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+# curl is called as: curl [--cacert X] -sS -o /dev/null -w '%{http_code}' --max-time 15 <url>
+cat > "$STUBS/curl" <<'EOF'
+#!/usr/bin/env bash
+url="${!#}"
+case "$url" in
+  */login) printf '%s' "${FAKE_HTTP_LOGIN:-200}" ;;
+  *)       printf '%s' "${FAKE_HTTP_ROOT:-200}" ;;
+esac
+EOF
+
+# kubectl exec — the in-pod module probe. Everything else is a no-op success.
+cat > "$STUBS/kubectl" <<'EOF'
+#!/usr/bin/env bash
+for a in "$@"; do
+  if [ "$a" = "exec" ]; then
+    [ -n "${FAKE_EXEC_FAILS:-}" ] && exit 1
+    printf '%s\n' "${FAKE_MODULES:-}"
+    exit 0
+  fi
+done
+exit 0
+EOF
+
+chmod +x "$STUBS"/colima "$STUBS"/curl "$STUBS"/kubectl
+export PATH="$STUBS:$PATH"
+
+BOTH_PRESENT='module=MeshWeaver.Blazor.Views present
+module=MeshWeaver.Blazor.Graph present'
+
+# Run `memex-local verify [$VERIFY_FLAGS]` in a given state, leaving output in OUT and status in RC.
+# 🚨 Not `OUT=$(run_verify …)`: a command substitution is a SUBSHELL, so an RC assigned inside one
+# never reaches the caller — the first draft of this file did exactly that and every assertion read
+# a stale RC=0, i.e. the suite reported "exited 0" for runs that had exited 1. A test harness that
+# cannot see the exit code it is asserting on is the same defect as the gate it is testing.
+OUT=""
+VERIFY_FLAGS=""
+run_verify() {
+  # shellcheck disable=SC2086  # VERIFY_FLAGS is a deliberate word-split of flags under test
+  OUT="$(env "$@" "$CLI" verify $VERIFY_FLAGS 2>&1)"; RC=$?
+}
+
+# A red state must EXIT NON-ZERO and SAY WHAT TO DO. "It failed" without a remedy sends the
+# developer to the source; that is the whole complaint in MeshWeaver#2367.
+reports() {
+  local what="$1" phrase="$2"; shift 2
+  local out
+  run_verify "$@"; out="$OUT"
+  if [ "$RC" -eq 0 ]; then bad "$what" "exited 0 — it should have reported a problem. Said: $out"; return; fi
+  case "$out" in
+    *"$phrase"*) ;;
+    *) bad "$what" "failed, but never said '${phrase}'. Said: ${out}"; return ;;
+  esac
+  case "$out" in
+    *Remedy:*) ok "$what" ;;
+    *) bad "$what" "reported the problem but named no remedy: ${out}" ;;
+  esac
+}
+
+echo "── the verification can FAIL (each red state, with a remedy) ─────"
+
+reports "a 503 portal is not 'reachable'" "HTTP 503" \
+  FAKE_HTTP_ROOT=503 FAKE_HTTP_LOGIN=503 FAKE_MODULES="$BOTH_PRESENT"
+
+reports "no answer at all is reported" "did NOT answer" \
+  FAKE_HTTP_ROOT=000 FAKE_HTTP_LOGIN=000 FAKE_MODULES="$BOTH_PRESENT"
+
+reports "a deleted login page is caught" "NOT ROUTED" \
+  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=404 FAKE_MODULES="$BOTH_PRESENT"
+
+reports "a missing view pack is caught" "MeshWeaver.Blazor.Views" \
+  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 \
+  FAKE_MODULES='module=MeshWeaver.Blazor.Views missing
+module=MeshWeaver.Blazor.Graph present'
+
+reports "both view packs missing is caught" "ToString()" \
+  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 \
+  FAKE_MODULES='module=MeshWeaver.Blazor.Views missing
+module=MeshWeaver.Blazor.Graph missing'
+
+reports "landed-but-pending-restart is not green" "restart is PENDING" \
+  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 \
+  FAKE_MODULES="$BOTH_PRESENT
+pending-restart=yes"
+
+# 🚨 The check that cannot read its own input must FAIL, never pass quietly. An unreadable pod
+# used to be indistinguishable from a healthy one, which is the skip-trapdoor shape AGENTS.md bans.
+reports "an unreadable pod fails the check, not passes it" "verified NOTHING" \
+  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 FAKE_EXEC_FAILS=1
+
+# 🚨 "Still installing" must read differently from "will never arrive" — and must still not be a
+# success, because the portal cannot render at the moment the command returns. With a wait budget
+# and no `[DefaultInstall] reconciled` line in the log, that is the state, and the message has to
+# say so rather than accusing the install of having failed.
+VERIFY_FLAGS="--wait 1"
+reports "an install still in progress says so, and is still not green" "still installing" \
+  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 \
+  FAKE_MODULES='module=MeshWeaver.Blazor.Views missing
+module=MeshWeaver.Blazor.Graph missing'
+VERIFY_FLAGS=""
+
+echo "── …and a green run is reachable (so the above is not vacuous) ───"
+
+run_verify FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 FAKE_MODULES="$BOTH_PRESENT"
+if [ "$RC" -ne 0 ]; then
+  bad "a healthy portal verifies green" "exited ${RC}: ${OUT}"
+elif case "$OUT" in *"view packs present"*) false ;; *) true ;; esac; then
+  bad "a healthy portal verifies green" "no 'view packs present' line in: ${OUT}"
+else
+  ok "a healthy portal verifies green"
+fi
+
+# A 302 to the sign-in page is the NORMAL anonymous response — treating it as red would make the
+# gate fire on every healthy install and get it deleted within a day.
+run_verify FAKE_HTTP_ROOT=302 FAKE_HTTP_LOGIN=200 FAKE_MODULES="$BOTH_PRESENT"
+if [ "$RC" -eq 0 ]; then ok "a 302 to sign-in is healthy, not a failure"
+else bad "a 302 to sign-in is healthy, not a failure" "exited ${RC}: ${OUT}"; fi
+
+echo "── argument handling ─────────────────────────────────────────────"
+
+out="$(env FAKE_MODULES="$BOTH_PRESENT" "$CLI" verify --nope 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ]; then bad "an unknown verify flag refuses" "exited 0: $out"
+else case "$out" in *"unknown flag"*) ok "an unknown verify flag refuses" ;;
+     *) bad "an unknown verify flag refuses" "refused without saying why: $out" ;; esac; fi
+
+out="$(env FAKE_MODULES="$BOTH_PRESENT" "$CLI" verify --wait forever 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ]; then bad "--wait must be numeric" "exited 0: $out"
+else case "$out" in *"whole seconds"*) ok "--wait must be numeric" ;;
+     *) bad "--wait must be numeric" "refused without saying why: $out" ;; esac; fi
+
+echo "── the help text is TEXT, not code ───────────────────────────────"
+
+# 🚨 `cmd_help` is `cat <<EOF` — an UNQUOTED heredoc, so a backtick in the prose is COMMAND
+# SUBSTITUTION. The usage text mentioned the autoroll `main` tag, and `main` is this script's own
+# entry function: `memex-local help` re-entered main → cmd_help → main → … forking on every level.
+# `memex-local help` was an unbounded fork bomb on main until MeshWeaver#2367, and nothing noticed
+# because nothing in CI ever ran this script.
+#
+# Asserted STATICALLY, not by running `help` and waiting: a regression here HANGS, and a hang is not
+# a failure signal — a suite that waits for it just times out with nothing to read. (The delimiter
+# cannot simply be quoted: the text interpolates ${HOSTNAME_LOCAL}, ${HOST_PORT}, ${E2E_PORT}.)
+heredoc="$(awk '/^  cat <<EOF$/ { on=1; next } on && /^EOF$/ { exit } on' "$CLI")"
+bare="$(printf '%s\n' "$heredoc" | grep -c '[^\\]`' || true)"
+if [ "$bare" -eq 0 ]; then ok "no unescaped backtick in the help heredoc (it would re-enter main())"
+else bad "no unescaped backtick in the help heredoc" \
+  "${bare} line(s) run a command instead of printing it: $(printf '%s\n' "$heredoc" | grep -n '[^\\]`')"; fi
+
+echo "── macOS bash 3.2 safety (the runner is bash 5 — assert it statically) ──"
+
+# 🚨 This tool runs ONLY on macOS, whose /bin/bash is 3.2, where `set -u` treats "${x[@]}" on an
+# EMPTY array as an unbound variable and kills the script. CI runs bash 5, which tolerates it — so a
+# runner can never reach this by executing the code, and the assertion has to be static or it does
+# not exist. It was not theoretical: helm_deploy expanded next_args/plugin_args unguarded, both of
+# which are empty on the paths the script itself calls normal (--from-acr, no plugin checkout), so
+# the deploy died on "unbound variable" for them.
+# The safe form is ${x[@]+"${x[@]}"} — which CONTAINS the unsafe spelling, so the guarded form and
+# whole-line comments are removed before looking for what is left. ("$@" is a special parameter, not
+# an array, and is always safe.)
+unsafe="$(grep -vE '^[[:space:]]*#' "$CLI" \
+  | sed 's/\${[A-Za-z_][A-Za-z0-9_]*\[@\]+"\${[A-Za-z_][A-Za-z0-9_]*\[@\]}"}//g' \
+  | grep -nE '"\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}"' || true)"
+if [ -z "$unsafe" ]; then ok 'no unguarded "${array[@]}" (bash 3.2 + set -u would abort)'
+else bad 'no unguarded "${array[@]}"' "use \${x[@]+\"\${x[@]}\"} at: ${unsafe}"; fi
+
+echo "── up/update actually RUN the verification ───────────────────────"
+
+# The whole point of MeshWeaver#2367 is that these two reported success on an unusable portal.
+# Deleting the call is the easy regression, and it leaves no trace anywhere else.
+for c in cmd_up cmd_update; do
+  body="$(awk -v f="^${c}\\\\(\\\\) \\\\{" '$0 ~ f { on=1 } on { print } on && /^}$/ { exit }' "$CLI")"
+  case "$body" in
+    *"verify_usable --wait"*) ok "${c} runs the usability verification" ;;
+    *) bad "${c} runs the usability verification" "no verify_usable call in ${c}()" ;;
+  esac
+done
+
+echo "── the CLI still knows every command it documents ────────────────"
+
+help_out="$("$CLI" help 2>&1)"
+for cmd in up down status logs update verify port-forward observability doctor; do
+  case "$help_out" in
+    *"$cmd"*) ;;
+    *) bad "help documents '$cmd'" "not in the usage text"; continue ;;
+  esac
+  if grep -q "^    ${cmd})" "$CLI"; then ok "help documents '$cmd', and main dispatches it"
+  else bad "help documents '$cmd'" "no dispatch arm in main()"; fi
+done
+
+echo
+printf 'passed %d, failed %d\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/deploy/homebrew/test/run-tests.sh
+++ b/deploy/homebrew/test/run-tests.sh
@@ -198,21 +198,25 @@ echo "── macOS bash 3.2 safety (the runner is bash 5 — assert it staticall
 # not exist. It was not theoretical: helm_deploy expanded next_args/plugin_args unguarded, both of
 # which are empty on the paths the script itself calls normal (--from-acr, no plugin checkout), so
 # the deploy died on "unbound variable" for them.
-# The safe form is ${x[@]+"${x[@]}"} — which CONTAINS the unsafe spelling, so the guarded form and
-# whole-line comments are removed before looking for what is left. ("$@" is a special parameter, not
-# an array, and is always safe.)
+# The safe form ${x[@]+"${x[@]}"} CONTAINS the unsafe spelling, so lines carrying the guard marker
+# `[@]+"` are dropped along with whole-line comments, and whatever still matches is unguarded. (A
+# line holding a guarded AND an unguarded expansion would slip through; grep beats a portable-regex
+# argument with sed for a check that has to behave identically on BSD and GNU. "$@" is a special
+# parameter, not an array, and is always safe.)
 unsafe="$(grep -vE '^[[:space:]]*#' "$CLI" \
-  | sed 's/\${[A-Za-z_][A-Za-z0-9_]*\[@\]+"\${[A-Za-z_][A-Za-z0-9_]*\[@\]}"}//g' \
-  | grep -nE '"\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}"' || true)"
+  | grep -v '\[@\]+"' \
+  | grep -E '"\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}"' || true)"
 if [ -z "$unsafe" ]; then ok 'no unguarded "${array[@]}" (bash 3.2 + set -u would abort)'
-else bad 'no unguarded "${array[@]}"' "use \${x[@]+\"\${x[@]}\"} at: ${unsafe}"; fi
+else bad 'no unguarded "${array[@]}"' "use \${x[@]+\"\${x[@]}\"} on: ${unsafe}"; fi
 
 echo "── up/update actually RUN the verification ───────────────────────"
 
 # The whole point of MeshWeaver#2367 is that these two reported success on an unusable portal.
 # Deleting the call is the easy regression, and it leaves no trace anywhere else.
 for c in cmd_up cmd_update; do
-  body="$(awk -v f="^${c}\\\\(\\\\) \\\\{" '$0 ~ f { on=1 } on { print } on && /^}$/ { exit }' "$CLI")"
+  # No `{` in the pattern: it opens an interval in ERE, and awk implementations disagree about
+  # whether `\{` is an error, a warning or a literal. `^cmd_up\(\)` is unambiguous everywhere.
+  body="$(awk -v f="^${c}\\\\(\\\\)" '$0 ~ f { on=1 } on { print } on && /^}$/ { exit }' "$CLI")"
   case "$body" in
     *"verify_usable --wait"*) ok "${c} runs the usability verification" ;;
     *) bad "${c} runs the usability verification" "no verify_usable call in ${c}()" ;;

--- a/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
@@ -123,9 +123,27 @@ Both pipelines build **multi-arch manifest lists** (`linux/amd64` + `linux/arm64
 
 When you've changed source that isn't in any pushed tag, build straight into Colima's Docker store. The verified rebuild loop (a few minutes on an M-series Mac):
 
+> **🚨 The portal host lives in `MeshWeaver.Plugins`, not here.** The GUI extraction (#2169 / #2293)
+> moved `Memex.Portal.Distributed`, `Memex.Portal.Monolith`, `Memex.AppHost` **and the login pages**
+> (`Memex.Portal.Gui/Pages/{Login,DevLogin,DevLoginConfirm}.razor`) into the plugins repo. The
+> commands below publish from a checkout of it beside this one; `memex-local` resolves the same path
+> and fails loudly if it is missing (override with `MEMEX_PLUGINS_REPO`). The migration image stays
+> here — it is not GUI.
+>
+> Two consequences worth stating, because each presented as something else when they were missed
+> (#2367): **the login UI is compiled INTO the image** (it is shell, not a pack — a portal serving
+> 404 on `/login` is running an image built before the move, and the fix is to rebuild), while
+> **the view packs are NOT** — `DefaultViews`/`GraphViews` left the image in #2169 Phase B2 and
+> arrive only as registry bundles, which the boot reconcile installs because both declare
+> `preInstalled`. A portal missing them renders every control as its `ToString()`, and the Plugin
+> Catalog that would repair it is itself one of the missing views. `memex-local up`/`update` verify
+> both and refuse to report success otherwise; `memex-local verify` asks the same question of a
+> running install at any time.
+
 ```bash
 # 1. Publish a native arm64 container image straight into Colima's Docker store.
-dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj -c Release \
+#    ../MeshWeaver.Plugins is the sibling checkout; $(MeshWeaverRoot) defaults to this repo.
+dotnet publish ../MeshWeaver.Plugins/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj -c Release \
   -t:PublishContainer -p:ContainerRepository=memex-portal-ai-local
 
 # 2. Tag it to the name the chart expects (IfNotPresent then finds it locally).
@@ -306,7 +324,7 @@ If you want the URL without the `:8443` suffix, forward the privileged port 443.
 
 ## 9. Auth — Microsoft Entra OAuth
 
-The Distributed portal authenticates via **Microsoft Entra OAuth** (the callback path is `/signin-microsoft`, set in `AuthenticationBuilderExtensions.cs`). Create a **dedicated app registration** for local dev (so its redirect URIs don't collide with the cloud apps):
+The Distributed portal authenticates via **Microsoft Entra OAuth** (the callback path is `/signin-microsoft`, set in `MeshWeaver.Plugins/src/MeshWeaver.Blazor.Portal/Authentication/AuthenticationBuilderExtensions.cs` — the portal GUI moved there with #2293). The sign-in page itself is `Memex.Portal.Gui/Pages/Login.razor` in the same repo, and it is compiled into the image: `curl -sk -o /dev/null -w '%{http_code}' https://memex.localhost:8443/login` answering 404 means the image predates the move, not that a package is missing. Create a **dedicated app registration** for local dev (so its redirect URIs don't collide with the cloud apps):
 
 1. Azure Portal → **App registrations** → **New registration** (or reuse a dedicated local-dev app).
 2. Under **Authentication → Web → Redirect URIs**, register the local callbacks. Register both the no-port (443) and `:8443` forms so either port works:
@@ -323,7 +341,7 @@ The Distributed portal authenticates via **Microsoft Entra OAuth** (the callback
 
 OAuth over `http://localhost` originally failed with `/login?error=auth_failed` and a portal log line `AuthenticationFailureException: Correlation failed` (`.AspNetCore.Correlation.* cookie not found`). Root cause: the OIDC **correlation + nonce cookies are `SameSite=None`** (the Microsoft callback is a cross-site `form_post`), and browsers **drop a `SameSite=None` cookie that isn't also `Secure`**. The handler's default `SecurePolicy = SameAsRequest` left them non-Secure over plain HTTP, so they were never stored.
 
-The fix in `src/MeshWeaver.Blazor.Portal/Authentication/AuthenticationBuilderExtensions.cs` (`AddMicrosoftAuthentication`) forces them Secure:
+The fix in `MeshWeaver.Plugins/src/MeshWeaver.Blazor.Portal/Authentication/AuthenticationBuilderExtensions.cs` (`AddMicrosoftAuthentication`) forces them Secure:
 
 ```csharp
 options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
@@ -409,7 +427,7 @@ So a "Local" tab is unmistakable next to Test/Prod, the portal supports two opti
 | `Portal__InstanceName` | Browser-tab **title** becomes this name, and the favicon becomes a distinct **colored badge** showing the name's initial. Empty (prod) = default Memex branding. |
 | `Portal__InstanceColor` | Badge fill color (hex, e.g. `#f59e0b`). Empty = amber default. |
 
-These are implemented in `memex/Memex.Portal.Shared/App.razor`: when `Portal:InstanceName` is set it emits an inline-SVG data-URI favicon (a rounded-square badge with the initial) and a small `MutationObserver` that pins the tab title to the instance name. Unset → the standard `favicon.ico` and `Memex Portal` title. Set `Portal__InstanceName: "Local"` in your overlay so your local tab is obvious at a glance.
+These are implemented in `MeshWeaver.Plugins/src/Memex.Portal.Gui/App.razor` (the portal GUI moved there with #2293): when `Portal:InstanceName` is set it emits an inline-SVG data-URI favicon (a rounded-square badge with the initial) and a small `MutationObserver` that pins the tab title to the instance name. Unset → the standard `favicon.ico` and `Memex Portal` title. Set `Portal__InstanceName: "Local"` in your overlay so your local tab is obvious at a glance.
 
 🚨 **On a node page the NODE's icon wins over the badge, by design.** `ApplicationPage` publishes the
 node's own icon into the head from inside `HeadOutlet`, which App.razor places *after* the badge —
@@ -456,8 +474,23 @@ The result: every device trusts the cert out of the box (no mkcert CA install), 
 | `instance up` fails `409 — Instance id '<id>' is already registered` | An instance id is claimed **globally** on the registry, and dropping the instance's database does not release it. Use `memex-local instance down --id <id>` (which releases the claim and restarts the registry) before re-running, or pick a new id. |
 | A plugin install fails with `NodeType(s) not registered: <Other>/<Type>` | The package depends on another that is not installed yet. The default install orders by the manifest's `requires`; a package that depends on something **outside** the granted set cannot be ordered against and will fail. Grant the dependency too (§16). |
 | Instance pod OOMs mid-install (`OutOfMemoryException`, often surfacing inside Npgsql) and the remaining packages never install | A first boot compiles every default-installed plugin's node types back to back, and each compile **retains** its collectible ALC. `memex-local` sizes the instance pod 3cpu/6Gi for this; a smaller pod dies partway. Installing fewer packages by default (a narrower `InstallByDefault`) is the other lever. |
+| **Every control renders as debug text** — `NamedAreaControl { Id = , Style = , … }` instead of UI | The **view packs are not installed**. `DefaultViews`/`GraphViews` left the image in #2169 Phase B2 and arrive only as registry bundles; without them nothing has a view and the control falls back to its `ToString()`. 🚨 The documented repair — Settings ▸ Administration ▸ Plugin Catalog — is *itself* rendered by the missing views, so the portal cannot repair itself through its own UI. Diagnose from outside: `memex-local verify`. Both packs declare `preInstalled`, so the boot reconcile installs them from your checkout on every boot; if it did not, `memex-local logs --no-follow --tail 400 \| grep DefaultInstall` says why (a source name that matches no grant, an unreadable repo, a platform floor). (#2367) |
+| **`/login` 404s** — no way to sign in at all | The login pages are Blazor pages compiled **into** the image (`MeshWeaver.Plugins/src/Memex.Portal.Gui/Pages/`), so this is an image built before the GUI move (#2293), not a missing package. Rebuild: `memex-local update --build`, with the plugins checkout on `main`. (#2367) |
 
-**Verify end-to-end** that TLS + routing + the app are all working:
+**Verify end-to-end** that the portal is *usable*, not merely answering:
+
+```bash
+memex-local verify
+# Asserts three things and exits non-zero, naming a remedy, if any fails:
+#   • the portal SERVES        — an HTTP status in the serving range (a 503 is not "reachable")
+#   • /login is ROUTED         — there is a way to sign in
+#   • the view packs are there — MeshWeaver.Blazor.Views + MeshWeaver.Blazor.Graph
+```
+
+🚨 `up` and `update` run this for you and refuse to report success without it. The check it replaced
+curl'd `/` and printed "Portal reachable" whenever **curl** exited 0 — so a 503, a 404 and a portal
+rendering every control as its `ToString()` all produced the same green line (#2367). If you want the
+raw TLS/routing signal on its own:
 
 ```bash
 curl --cacert "$(mkcert -CAROOT)/rootCA.pem" \

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-local-portal-verifies-it-is-usable.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-local-portal-verifies-it-is-usable.md
@@ -1,0 +1,46 @@
+---
+Name: The local portal says when it came up unusable
+Category: Fix
+Description: Bringing up a local portal reported success even when it had no sign-in page and no view packs — every control rendering as debug text, with no way in and no way to repair it from its own UI. The bring-up now checks all three and refuses to report success without them.
+Icon: ShieldCheckmark
+Order: -20260826
+---
+
+# The local portal says when it came up unusable
+
+`memex-local up && memex-local update` printed two green lines and handed back a portal that could
+not be signed into and could not be read: `/login` served nothing, and every control on every page
+rendered as its own `ToString()` — `NamedAreaControl { Id = , Style = , … }` where the UI should be.
+
+The verification could not have said otherwise. It fetched the home page and printed
+*"Portal reachable"* whenever **curl itself** exited 0 — so a 503, a 404, and a portal rendering
+debug text all produced the same line. `update` was worse: it printed *"update complete"* straight
+after the rollout, having verified nothing at all.
+
+It now asserts the three things a local portal is unusable without, and each failure names its own
+remedy:
+
+- **The portal serves** — an HTTP status in the serving range, judged on the code rather than on
+  whether the request completed.
+- **The sign-in route is routed.** The login pages compile *into* the portal image, so a 404 here
+  means the image predates the GUI extraction and the answer is to rebuild it — never to install
+  something.
+- **The view packs are present.** The default control views and the mesh-node views left the image
+  and now arrive as installable packages. Without them nothing has a view, so every control falls
+  back to its `ToString()` — and the documented repair, the Plugin Catalog, is itself one of the
+  missing views. A portal in that state cannot repair itself through its own UI, which is exactly
+  why this has to be asked from outside it.
+
+The last check waits rather than samples, because the packages install at boot and compile as they
+go; and where they are on disk but not yet in the running process it performs the one restart that
+activates them, instead of leaving it as a manual step. `memex-local verify` asks the same question
+of a running install at any time.
+
+Two further faults surfaced while proving the new check could fail. `memex-local help` was an
+unbounded fork bomb: a backtick in the usage text re-entered the script's own entry point. And the
+deploy aborted on macOS's bash for the exact paths the tool itself calls normal — an empty option
+list is an error there, and both option lists are empty on a plain pull-from-registry run.
+
+None of the three had ever gone red, because nothing in CI had ever opened this script. It is now
+parsed, linted and behaviour-tested on every build, including static assertions for the two traps a
+Linux runner cannot reach by executing anything.


### PR DESCRIPTION
Closes #2367.

## What #2367 actually is, after checking both repos

Both root causes the issue names were **already closed by work that landed 2026-08-25**, one day before it was filed — which is why the issue reads as two separate mysteries:

| Issue's claim | State on `main` + `MeshWeaver.Plugins@main` |
|---|---|
| "`83356b3d5` removed `Login.razor` / `DevLogin.razor` / `DevLoginConfirm.razor`" | **Moved, not deleted** — `MeshWeaver.Plugins/src/Memex.Portal.Gui/Pages/{Login,DevLogin,DevLoginConfirm}.razor`, ProjectReferenced by both `Memex.Portal.Distributed` and `Memex.Portal.Monolith`, i.e. **compiled into the image `memex-local` builds** (it already resolves `$MEMEX_PLUGINS_REPO/src/Memex.Portal.Distributed`). The issue checked the core repo only. |
| "`InstallByDefault` seeds a fresh installation only, so an existing mesh never picks the new packages up" | Both packs now declare **`"preInstalled": true`** (plugins `9b634584`, 2026-08-25). `PluginCatalog:InstallPreInstalledPackages` defaults **true** and is reconciled on **every boot**, explicitly exempt from the seed ledger — the lane built for "a package newly added to the repo" and for healing a lost baseline (#902). #2221/#2224 (the registry shelf dropping every pack's `wwwroot`) also merged 2026-08-25. |

So the **bootstrap question the issue poses answers itself, and both ways**: the login UI is genuinely shell and ships **in the image**; the views are genuinely a pack and the **default install lands them on every boot**, fresh or existing. Neither needs a scope decision.

What was left is the issue's own third option — **the tooling and docs no longer match reality, and nothing guards either.** That is this PR.

## The verification could not fail

```bash
$ curl -sk -o /dev/null -w 'http=%{http_code}\n' https://memex.localhost:8443/
http=503
$ echo $?
0     # ← what `verify_endpoint` tested, and why it printed "ok Portal reachable"
```

`verify_endpoint` judged **curl's exit code**, not the code it fetched, so a 503, a 404 and a 200 rendering `NamedAreaControl { Id = , Style = , … }` all produced one green line. `update` was worse — it printed `ok "update complete"` straight after `rollout status`, verifying nothing at all. That is the whole of "both printed ok, and the portal was unusable".

`verify_usable` asserts the three things a local portal is unusable without, each naming its own remedy:

1. **The portal serves** — a status code in the serving range.
2. **`/login` is routed** — a 404 means an image built before the GUI move, so the remedy is *rebuild*, never *install*.
3. **The view packs are present** — `MeshWeaver.Blazor.Views` + `MeshWeaver.Blazor.Graph`, landed under `<Modules:Root>/modules/…` or in the app closure. Without them every control falls back to `ToString()`, and the documented repair (Settings ▸ Administration ▸ Plugin Catalog) *is* one of the missing views — which is exactly why it has to be asked from outside the portal.

Check 3 **waits on the real signal** (`[DefaultInstall] reconciled`) rather than a stopwatch, so a first boot still installing reports as *still installing* rather than as a failure; and where the packs are landed with the `.pending-restart` marker it performs the **one restart that activates them** instead of leaving a manual recovery step. `up` and `update` both run it and refuse to report success without it; `memex-local verify` asks the same question of a running install at any time.

## Two more live defects, found by making the new check fail

- **`memex-local help` was an unbounded fork bomb.** `cmd_help` is `cat <<EOF` — *unquoted*, because the text interpolates `${HOSTNAME_LOCAL}` / `${HOST_PORT}` — and the autoroll paragraph mentioned the `` `main` `` tag. `main` is this script's own entry function, so `help` re-entered `main` → `cmd_help` → `main` → …, forking at every level. (I found it by running the CLI; the suite now asserts it **statically**, because a regression here *hangs*, and a hang is not a failure signal.)
- **`helm_deploy` aborted on macOS bash 3.2** for the paths the script itself documents as normal. `set -u` treats `"${x[@]}"` on an **empty** array as unbound and kills the shell, and `next_args` is empty on every `--from-acr` / `--skip-image` run while `plugin_args`/`install_names` are empty with no plugin checkout. Also asserted statically — CI runs bash 5 and can never reach it by executing anything.

## The script had no CI at all

`deploy/homebrew/bin/memex-local` is ~2000 lines that stand up every developer's local portal, and **nothing in this repo had ever opened it** — no shellcheck, no `bash -n`, no behaviour test. Three live defects, zero red ticks. It is now parsed, linted and behaviour-tested on every build via the existing **Hosting Operator** gate, with `deploy/homebrew/test/run-tests.sh`: **25 assertions** driving the real CLI against stub tools through every red state *and* a reachable green one (so the red assertions cannot pass vacuously), plus the two static traps above and an assertion that `up`/`update` still call the verification at all.

## Docs

`LocalColimaMac.md` still pointed §3 Option B at `memex/aspire/Memex.Portal.Distributed` and §9/§12 at `src/MeshWeaver.Blazor.Portal` / `memex/Memex.Portal.Shared` — all deleted from this repo by #2293 — and its §14 "verify end-to-end" *was* the curl that could not fail. Corrected, with the two symptoms from #2367 added to the troubleshooting table. **PR #2380 covers the other twelve docs and does not touch this file**, so there is no overlap.

## Verification

- `deploy/homebrew/test/run-tests.sh` — **25 passed, 0 failed**; every assertion was watched fail first (the harness itself had a subshell bug that made `RC` always read 0, which is called out in the file).
- `deploy/aks/operator/test/run-tests.sh` — 29 passed, unchanged.
- `shellcheck -S warning` clean on both files; `bash -n` clean.
- `dotnet test test/MeshWeaver.Documentation.Test -c Release` — **62 passed** (link integrity, What's New integrity, `MemexLocalRepoPathGuard`).
- **Real-tool smoke test** against the live Colima cluster (isolated `KUBECONFIG`, read-only, no `--repair`): real `curl` → `503`, real `kubectl exec` against a portal scaled to 0 → unreadable, **exit 1 with all three remedies** — the exact state the old check called "ok Portal reachable".

🚨 **What I could not verify:** a full `memex-local up` end-to-end. The local stack here is in a degraded state (`memex-portal-deployment` at 0/0, `portal-next` in `ImagePullBackOff`) and a full image publish + deploy is long and disruptive on this machine. So the in-pod probe is proven against stubs and against a real `kubectl exec` on a real cluster, but not against a *running* portal pod; its command shape is kept identical to #2367's own diagnostic (`kubectl -n memex exec deploy/memex-portal-deployment -- ls …`). Likewise, the two upstream fixes above are established by reading the plugins tree, not by booting a portal. If a real bring-up disagrees, the new check now says precisely which of the three failed and why — which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
