### PR TITLE
Built-in _Policy nodes carry their MainNode, so they stop listing as content (#2383)

### DIFF
--- a/src/MeshWeaver.AI/BuiltInAgentProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInAgentProvider.cs
@@ -54,6 +54,11 @@ public class BuiltInAgentProvider : IStaticNodeProvider
         // The write caps keep the built-in agents unmodifiable.
         yield return new MeshNode("_Policy", RootNamespace)
         {
+            // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
+            // constructor defaults MainNode to the node's own path, which makes _Policy a main
+            // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
+            // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+            MainNode = RootNamespace,
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",
             Content = new PartitionAccessPolicy

--- a/src/MeshWeaver.AI/BuiltInHarnessProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInHarnessProvider.cs
@@ -23,6 +23,11 @@ public sealed class BuiltInHarnessProvider(IEnumerable<IHarness> harnesses) : IS
         // World-readable catalog, unmodifiable — same shape as the agent catalog.
         yield return new MeshNode("_Policy", HarnessNodeType.RootNamespace)
         {
+            // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
+            // constructor defaults MainNode to the node's own path, which makes _Policy a main
+            // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
+            // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+            MainNode = HarnessNodeType.RootNamespace,
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",
             Content = new PartitionAccessPolicy

--- a/src/MeshWeaver.AI/BuiltInLanguageModelProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInLanguageModelProvider.cs
@@ -283,6 +283,11 @@ public class BuiltInLanguageModelProvider : IStaticNodeProvider
         // ALWAYS seed the read-only access policy for the catalog partition.
         yield return new MeshNode("_Policy", ModelProviderNodeType.RootNamespace)
         {
+            // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
+            // constructor defaults MainNode to the node's own path, which makes _Policy a main
+            // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
+            // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+            MainNode = ModelProviderNodeType.RootNamespace,
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",
             Content = new PartitionAccessPolicy
@@ -321,6 +326,11 @@ public class BuiltInLanguageModelProvider : IStaticNodeProvider
         if (!string.Equals(LanguageModelNodeType.RootNamespace, ModelProviderNodeType.RootNamespace, StringComparison.Ordinal))
             yield return new MeshNode("_Policy", LanguageModelNodeType.RootNamespace)
             {
+                // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
+                // constructor defaults MainNode to the node's own path, which makes _Policy a main
+                // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
+                // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+                MainNode = LanguageModelNodeType.RootNamespace,
                 NodeType = "PartitionAccessPolicy",
                 Name = "Access Policy",
                 Content = new PartitionAccessPolicy

--- a/src/MeshWeaver.AI/BuiltInSkillProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInSkillProvider.cs
@@ -40,6 +40,11 @@ public class BuiltInSkillProvider : IStaticNodeProvider
         // (the Harness wedge, prod 2026-06-15). The write caps keep the built-in skills unmodifiable.
         yield return new MeshNode("_Policy", SkillNodeType.RootNamespace)
         {
+            // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
+            // constructor defaults MainNode to the node's own path, which makes _Policy a main
+            // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
+            // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+            MainNode = SkillNodeType.RootNamespace,
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",
             Content = new PartitionAccessPolicy

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-access-policy-no-longer-listed-as-content.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-access-policy-no-longer-listed-as-content.md
@@ -1,0 +1,11 @@
+---
+Name: Access Policy no longer appears as page content
+Category: Fix
+Description: The built-in Agent, Skill, Model, Harness and Documentation covers stop listing their internal access-policy node under Contents.
+Icon: DocumentBulletList
+Order: -20260826
+---
+
+# Access Policy no longer appears as page content
+
+The contents section of the built-in Agent, Skill, Model, Harness and Documentation pages no longer shows an "Access Policy" entry. That entry is an internal security setting, not content, and it was appearing because it had been created without saying which page it belongs to.

--- a/src/MeshWeaver.Documentation/DocumentationExtensions.cs
+++ b/src/MeshWeaver.Documentation/DocumentationExtensions.cs
@@ -134,6 +134,11 @@ public static class DocumentationExtensions
         builder.AddMeshNodes(
             new MeshNode("_Policy", DocumentationNodeProvider.RootNamespace)
             {
+                // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
+                // constructor defaults MainNode to the node's own path, which makes _Policy a main
+                // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
+                // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+                MainNode = DocumentationNodeProvider.RootNamespace,
                 NodeType = "PartitionAccessPolicy",
                 Name = "Documentation Access Policy",
                 Content = new PartitionAccessPolicy

--- a/src/MeshWeaver.Mesh.Contract/MeshNode.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNode.cs
@@ -102,8 +102,9 @@ public record MeshNode([property: Key] string Id, [property: Editable(false)] st
     /// <c>is:main</c> is literally <c>MainNode != Path</c>). 🚨 Minting a satellite with
     /// <c>new MeshNode(id, ns)</c> leaves MainNode defaulting to ITSELF, which makes it a main node
     /// by definition — that is how <c>Access Policy</c> came to be listed as content on every
-    /// package cover (#2383). Use this for <c>_Policy</c>, <c>_Access</c> and every other
-    /// underscore-prefixed sibling.
+    /// package cover (#2383). Use this for <c>_Policy</c> and every other underscore-prefixed
+    /// SIBLING node. (Access assignments are not siblings — they live under a <c>_Access/</c>
+    /// namespace, e.g. <c>Doc/_Access/{id}</c> — so they are not what this factory is for.)
     /// </summary>
     public static MeshNode Satellite(string id, string mainNode) =>
         new(id, mainNode) { MainNode = mainNode };

--- a/src/MeshWeaver.Mesh.Contract/MeshNode.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNode.cs
@@ -96,6 +96,19 @@ public record MeshNode([property: Key] string Id, [property: Editable(false)] st
     public string MainNode { get; init; } = string.IsNullOrEmpty(Namespace) ? Id : $"{Namespace}/{Id}";
 
     /// <summary>
+    /// A SATELLITE of the node at <paramref name="mainNode"/>: created with <see cref="MainNode"/>
+    /// already pointing at its primary, which is what the doc on <see cref="MainNode"/> promises and
+    /// what every listing relies on to keep satellites out of a node's contents (the catalog's
+    /// <c>is:main</c> is literally <c>MainNode != Path</c>). 🚨 Minting a satellite with
+    /// <c>new MeshNode(id, ns)</c> leaves MainNode defaulting to ITSELF, which makes it a main node
+    /// by definition — that is how <c>Access Policy</c> came to be listed as content on every
+    /// package cover (#2383). Use this for <c>_Policy</c>, <c>_Access</c> and every other
+    /// underscore-prefixed sibling.
+    /// </summary>
+    public static MeshNode Satellite(string id, string mainNode) =>
+        new(id, mainNode) { MainNode = mainNode };
+
+    /// <summary>
     /// Single segments as used for matching and addressing.
     /// Must be a computed property (not a readonly field) so that it reflects
     /// updated Namespace/Id after record copy via 'with {}'.

--- a/test/MeshWeaver.Data.Test/MeshNodeSatelliteTest.cs
+++ b/test/MeshWeaver.Data.Test/MeshNodeSatelliteTest.cs
@@ -1,7 +1,7 @@
 using MeshWeaver.Mesh;
 using Xunit;
 
-namespace MeshWeaver.Mesh.Contract.Test;
+namespace MeshWeaver.Data.Test;
 
 public class MeshNodeSatelliteTest
 {

--- a/test/MeshWeaver.Data.Test/MeshNodeSatelliteTest.cs
+++ b/test/MeshWeaver.Data.Test/MeshNodeSatelliteTest.cs
@@ -1,0 +1,24 @@
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Mesh.Contract.Test;
+
+public class MeshNodeSatelliteTest
+{
+    [Fact]
+    public void A_satellite_points_at_its_main_node_not_at_itself()
+    {
+        var policy = MeshNode.Satellite("_Policy", "Teams");
+        Assert.Equal("Teams/_Policy", policy.Path);
+        Assert.Equal("Teams", policy.MainNode);
+        Assert.NotEqual(policy.Path, policy.MainNode); // the catalog's is:main predicate
+    }
+
+    /// <summary>The trap this factory exists to close: the plain constructor makes a MAIN node.</summary>
+    [Fact]
+    public void The_plain_constructor_defaults_MainNode_to_itself()
+    {
+        var node = new MeshNode("_Policy", "Teams");
+        Assert.Equal(node.Path, node.MainNode);
+    }
+}


### PR DESCRIPTION
Core half of #2383 (the Store-package half is a converging-predicate change in MeshWeaver.Plugins' `PluginGate.cs`, owned there).

Six built-in providers mint a partition's `_Policy` as `new MeshNode("_Policy", ns) { … }` without setting `MainNode`. The plain constructor defaults it to the node's **own** path (`MeshNode.cs:96`), while line 329 of the same type states the satellite contract. The catalog's `is:main` is literally `MainNode != Path`, so a `_Policy` minted this way is a main node by definition — and **"Access Policy" appears under Contents** on the Agent, Skill, LanguageModel, Harness and Doc covers. The listing was never wrong; the mint was.

### Change
- each of the six initializers sets `MainNode = <partition root>` — static seeds, re-registered on boot, so it takes effect on the next deploy with no repair step
- `MeshNode.Satellite(id, mainNode)` for new satellites, with a test pinning both that it points at its main node **and** that the plain constructor does not (the trap this closes)

### Not an access defect
`MeshWeaver.Security` never reads `MainNode`; `PartitionAccessPolicy` resolves by path.

### Verified
Mesh.Contract, AI, Documentation: 0 errors under `-warnaserror`; 2/2 tests. What's New: `Fix`.