### PR TITLE
Fix a live query's scope walk being queued on a foreign Rx trampoline and never running (#2377)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
@@ -212,6 +212,44 @@ No `SearchHub`, no `Channel`, no `await foreach`, no per-item insertion: one sub
 
 ---
 
+## 🚨 `IEnumerable.ToObservable()` on a read path — the emission that is queued and never runs
+
+**On a storage read or a query walk, never call the parameterless `IEnumerable<T>.ToObservable()`. Use `ToInlineObservable()`** (`MeshWeaver.Mesh.Services.InlineObservableExtensions`).
+
+Rx defaults `ToObservable()` to `SchedulerDefaults.Iteration`, which is `CurrentThreadScheduler` — and that scheduler does **not** mean "run it here, now". It means "run it on *this thread's* Rx trampoline". `CurrentThreadScheduler` keeps a `[ThreadStatic] bool` for "a trampoline is already running on this thread"; while it is set, `Schedule` **only enqueues and returns**, leaving the item for whoever owns that outer trampoline to drain.
+
+**Why an ordinary caller is inside a foreign trampoline — and why it is not a test-only concern.** Rx runs *every* operator subscription through that trampoline (`Producer.SubscribeRaw`), so the flag is set far more often than it looks. Worse, it escapes the pipeline: a `Task` completed from inside an Rx pipeline — exactly what `FirstAsync().ToTask()`, an `AsyncSubject`, or a `TaskCompletionSource` resolved on an `OnNext` does — resumes its awaiter **inline on that thread, still inside the trampoline**. Everything that continuation goes on to do inherits the flag. The captured 558-frame stack from a reproduction reads, bottom-up:
+
+```
+MessageService.DrainOne()                       // the hub's own pump, on a ThreadPool thread
+ → Producer.SubscribeRaw
+   → CurrentThreadScheduler.Schedule            // trampoline OPENED here; the flag is now set
+     → … ~500 Rx frames …
+       → ToTaskObserver.OnCompleted → TaskCompletionSource.TrySetResult   // a .ToTask() resolves
+         → AwaitTaskContinuation.RunOrScheduleAction(allowInlining: true) // awaiter resumes INLINE
+           → … the awaiting code, and everything it goes on to call …
+```
+
+The trampoline's owner is the **hub message pump**, not anything test-specific.
+
+**The failure it produces has no signature.** If such a frame subscribes a query and then blocks waiting for its first result, the walk it enqueued can only run once the frame returns, and the frame only returns once the walk runs:
+
+```csharp
+// ❌ WRONG — the walk is queued on whatever trampoline happens to own this thread.
+var nodePaths = level.NodePaths.ToObservable();
+
+// ✅ RIGHT — ImmediateScheduler; no ambient per-thread state, iterates during Subscribe.
+var nodePaths = level.NodePaths.ToInlineObservable();
+```
+
+**No exception, no completion, no row — forever.** In the portal that is a live children listing (chat token chip, notification bell, folder view) that opens and silently stays empty, while a point read of the same content returns immediately. Issue #2377: the pedestrian scope walk had this shape, and it made `LiveQueryHandoffDropTest` fail ~23% of cold whole-assembly runs on a 4-CPU Linux runner (its 30 s warm-up wait was the block) while every warm or single-test run passed. Under xUnit the reach was wider still — the inlined continuation in that stack was a mesh-teardown `await`, so the runner carried on *on that stack* and started subsequent tests inside the trampoline.
+
+`ImmediateScheduler` carries no such state: it invokes directly, and its recursive form is trampolined through a per-call `AsyncLock`, so a long sequence iterates without growing the stack. `LiveQueryForeignTrampolineTest` pins the contract deterministically — it subscribes from inside a real trampoline and blocks there, which is exactly the shape that used to strand.
+
+> This is *not* a licence to sprinkle `ImmediateScheduler` around. It applies where the code already promises to be synchronous on the subscribing thread: `IStorageAdapter` reads and the pedestrian query walk. Anything that genuinely does I/O still goes through `IIoPool` (above).
+
+---
+
 ## 🚨 Cold observables: Subscribe is mandatory
 
 Every method that performs a write or side effect returns a cold `IObservable<T>` — **the side effect runs on `Subscribe`, not on call.** Forgetting to subscribe means the work silently never happens.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-live-lists-no-longer-stall-empty.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-live-lists-no-longer-stall-empty.md
@@ -1,0 +1,20 @@
+---
+Name: Live lists no longer stall empty
+Category: Fix
+Description: A live children listing could open and never load — no error, no spinner resolution, just permanently empty — when the page opened it from certain code paths.
+Icon: DocumentBulletListMultiple
+Order: -20260826
+---
+
+# Live lists no longer stall empty
+
+Views that show a live list of nodes — a folder's children, the notification bell, a conversation's
+token-usage chip — open a query and then keep it open so the list updates as nodes are added.
+
+Under a specific timing, that query could be started in a state where the work that reads the nodes
+was queued behind the very code waiting for it. The list then never received its first result: no
+error was raised and nothing timed out, so the view simply stayed empty for as long as it was open,
+while opening the same content another way showed the nodes immediately.
+
+The read now always runs on the spot rather than being queued, so a live list always receives its
+first result and starts updating.

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlVersionQuery.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlVersionQuery.cs
@@ -49,7 +49,7 @@ public class PostgreSqlVersionQuery : IVersionQuery
         // The pg I/O pool runs the DB fetch on the ThreadPool behind its concurrency gate
         // with ConfigureAwait(false) — no custom TaskScheduler (Orleans) is ever captured.
         => _ioPool.Invoke(ct => FetchVersionsAsync(path, ct))
-            .SelectMany(versions => versions.ToObservable());
+            .SelectMany(versions => versions.ToInlineObservable());
 
     private async Task<List<MeshNodeVersion>> FetchVersionsAsync(string path, CancellationToken ct)
     {

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeVersionQuery.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeVersionQuery.cs
@@ -75,7 +75,7 @@ public class SnowflakeVersionQuery : IVersionQuery
         // The Snowflake I/O pool runs the DB fetch on the ThreadPool behind its concurrency gate
         // with ConfigureAwait(false) — no custom TaskScheduler (Orleans) is ever captured.
         => _ioPool.Invoke(ct => FetchVersionsAsync(path, ct))
-            .SelectMany(versions => versions.ToObservable());
+            .SelectMany(versions => versions.ToInlineObservable());
 
     /// <summary>
     /// I/O leaf for <see cref="GetVersions"/>: fetches every version summary for a node,

--- a/src/MeshWeaver.Hosting.Sqlite/SqliteStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.Sqlite/SqliteStorageAdapter.cs
@@ -331,7 +331,7 @@ public sealed class SqliteStorageAdapter : IStorageAdapter, IDisposable
                     ? (JsonSerializer.Deserialize<List<object>>(json, options) ?? new()).ToArray()
                     : [];
             }
-        }).SelectMany(arr => arr.ToObservable());
+        }).SelectMany(arr => arr.ToInlineObservable());
 
     /// <inheritdoc />
     public IObservable<Unit> SavePartitionObjects(

--- a/src/MeshWeaver.Hosting/Persistence/FileSystemVersionStore.cs
+++ b/src/MeshWeaver.Hosting/Persistence/FileSystemVersionStore.cs
@@ -111,7 +111,7 @@ public class FileSystemVersionStore : IVersionQuery
                     path, x.Version, new FileInfo(x.File).LastWriteTimeUtc,
                     null, null, null));
 
-            return versions.ToObservable();
+            return versions.ToInlineObservable();
         });
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
@@ -322,7 +322,7 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
         {
             var key = PartitionKey(nodePath, subPath);
             return _partitionObjects.TryGetValue(key, out var list)
-                ? list.ToObservable()
+                ? list.ToInlineObservable()
                 : Observable.Empty<object>();
         });
 

--- a/src/MeshWeaver.Hosting/Persistence/PartitionStorage/PartitionStorageHubExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PartitionStorage/PartitionStorageHubExtensions.cs
@@ -77,7 +77,7 @@ public static class PartitionStorageHubExtensions
         var adapter = hub.ServiceProvider.GetRequiredService<IStorageAdapter>();
 
         request.Message.Paths
-            .ToObservable()
+            .ToInlineObservable()
             .SelectMany(path => adapter.Delete(path))
             .ToList()
             .Subscribe(

--- a/src/MeshWeaver.Hosting/Persistence/PartitionStorage/RoutingProxyAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PartitionStorage/RoutingProxyAdapter.cs
@@ -146,7 +146,7 @@ public sealed class RoutingProxyAdapter : IStorageAdapter
         // Resolve every node's owning hub IN CALLER ORDER (Concat, not Merge — order is contract).
         return nodes
             .Select(n => _router.AddressFor(n.Path).Take(1).Select(addr => (Node: n, Address: addr)))
-            .ToObservable().Concat().ToList()
+            .ToInlineObservable().Concat().ToList()
             .SelectMany(pairs =>
             {
                 // Consecutive runs of the same address — one WriteBatchRequest per run.
@@ -171,7 +171,7 @@ public sealed class RoutingProxyAdapter : IStorageAdapter
                                 ? Observable.Throw<IReadOnlyList<MeshNode>>(
                                     new InvalidOperationException(d.Message.Error))
                                 : Observable.Return<IReadOnlyList<MeshNode>>(d.Message.WrittenNodes)))
-                    .ToObservable().Concat().ToList()
+                    .ToInlineObservable().Concat().ToList()
                     .Select(lists => (IReadOnlyList<MeshNode>)lists
                         .SelectMany(l => l).ToImmutableList());
             });

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceService.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceService.cs
@@ -408,7 +408,7 @@ public sealed class PersistenceService : IStorageAdapter
     public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)>
         ListChildPaths(string? parentPath)
         => _allOrdered
-            .ToObservable()
+            .ToInlineObservable()
             .SelectMany(p => p.Adapter.ListChildPaths(parentPath)
                 .Catch<(IEnumerable<string>, IEnumerable<string>), Exception>(_ =>
                     Observable.Return<(IEnumerable<string>, IEnumerable<string>)>(([], []))))
@@ -463,7 +463,7 @@ public sealed class PersistenceService : IStorageAdapter
     public IObservable<object> GetPartitionObjects(
         string nodePath, string? subPath, JsonSerializerOptions options)
         => _allOrdered
-            .ToObservable()
+            .ToInlineObservable()
             .SelectMany(p => p.Adapter.GetPartitionObjects(nodePath, subPath, options)
                 .Catch<object, Exception>(_ => Observable.Empty<object>()));
 

--- a/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
@@ -646,7 +646,7 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
             return WalkAdapter(basePath, QueryScope.Descendants)
                 .Where(path => !string.IsNullOrEmpty(path))
                 .ToList()
-                .SelectMany(allPaths => NamespaceFrontier.Frontier(basePath, allPaths).ToObservable())
+                .SelectMany(allPaths => NamespaceFrontier.Frontier(basePath, allPaths).ToInlineObservable())
                 .Where(path => emittedFrontier.Add(path))
                 .SelectMany(path => persistence.Read(path, options)
                     .Take(1)
@@ -764,7 +764,7 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
         }
 
         var matchedScopeNodes = walkPairs
-            .ToObservable()
+            .ToInlineObservable()
             .SelectMany(pair => WalkAdapter(pair.Root, pair.Scope))
             .Where(path => !string.IsNullOrEmpty(path))
             .Where(path => emittedPaths.Add(path))
@@ -836,12 +836,12 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                 string.Join(",", level.Item2 ?? Enumerable.Empty<string>())))
             .SelectMany(level =>
             {
-                var nodePaths = (level.Item1 ?? Enumerable.Empty<string>()).ToObservable();
+                var nodePaths = (level.Item1 ?? Enumerable.Empty<string>()).ToInlineObservable();
                 if (!recursive)
                     return nodePaths;
                 var nodesAndDeeper = nodePaths.SelectMany(p =>
                     Observable.Return(p).Concat(WalkLevel(p, recursive: true)));
-                var dirs = (level.Item2 ?? Enumerable.Empty<string>()).ToObservable()
+                var dirs = (level.Item2 ?? Enumerable.Empty<string>()).ToInlineObservable()
                     .SelectMany(d => WalkLevel(d, recursive: true));
                 return nodesAndDeeper.Concat(dirs);
             })
@@ -944,7 +944,7 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                     logger?.LogDebug("Validator {Validator} rejected read on node {Path}: {Error}",
                         v.GetType().Name, node.Path, r.ErrorMessage);
             }))
-            .ToObservable()
+            .ToInlineObservable()
             .Concat()
             .All(r => r.IsValid);
     }

--- a/src/MeshWeaver.Hosting/Persistence/SimpleMeshNodeStorage.cs
+++ b/src/MeshWeaver.Hosting/Persistence/SimpleMeshNodeStorage.cs
@@ -76,7 +76,7 @@ public abstract class SimpleMeshNodeStorage : IStorageAdapter
     private IObservable<string> WalkPaths(string? parent)
         => ListChildPaths(parent)
             .SelectMany(level =>
-                level.NodePaths.ToObservable()
+                level.NodePaths.ToInlineObservable()
                     .SelectMany(p => Observable.Return(p).Concat(WalkPaths(p)))
-                    .Concat(level.DirectoryPaths.ToObservable().SelectMany(WalkPaths)));
+                    .Concat(level.DirectoryPaths.ToInlineObservable().SelectMany(WalkPaths)));
 }

--- a/src/MeshWeaver.Mesh.Contract/Services/InlineObservableExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/InlineObservableExtensions.cs
@@ -1,0 +1,65 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// Turns an in-memory sequence into an observable that iterates <b>on the subscribing thread, during
+/// <c>Subscribe</c></b> — the shape every <see cref="IStorageAdapter"/> read and every pedestrian
+/// query walk in this codebase already claims to have.
+/// </summary>
+/// <remarks>
+/// <para>🚨 <b>Never use the parameterless <c>IEnumerable.ToObservable()</c> on a storage read or a
+/// query walk.</b> Rx defaults it to <c>SchedulerDefaults.Iteration</c>, which is
+/// <see cref="CurrentThreadScheduler"/> — and that scheduler does NOT mean "run it here now". It
+/// means "run it on <i>this thread's</i> Rx trampoline". <c>CurrentThreadScheduler</c> keeps a
+/// <c>[ThreadStatic] bool</c> saying whether a trampoline is already running on the thread; when one
+/// is, <c>Schedule</c> merely <b>enqueues</b> and returns, and the item is drained by whoever owns
+/// that outer trampoline — not by us.</para>
+///
+/// <para><b>The failure that motivated this (issue #2377), and it is not a test artefact.</b> Rx
+/// runs every operator subscription through that trampoline (<c>Producer.SubscribeRaw</c>), so a
+/// frame can be deep inside one without any local sign of it. The captured 558-frame stack from a
+/// reproduction reads, bottom-up:</para>
+///
+/// <code>
+/// MessageService.DrainOne()                       // the hub's own pump, on a ThreadPool thread
+///  → Producer.SubscribeRaw
+///    → CurrentThreadScheduler.Schedule            // trampoline OPENED here; the flag is now set
+///      → … ~500 Rx frames …
+///        → ToTaskObserver.OnCompleted → TaskCompletionSource.TrySetResult   // a .ToTask() resolves
+///          → AwaitTaskContinuation.RunOrScheduleAction(allowInlining: true) // awaiter resumes INLINE
+///            → … the awaiting code, and everything it goes on to call …
+/// </code>
+///
+/// <para>Completing a <c>Task</c> from inside an Rx pipeline — exactly what
+/// <c>FirstAsync().ToTask()</c>, an <c>AsyncSubject</c>, or a <c>TaskCompletionSource</c> resolved on
+/// an <c>OnNext</c> does — resumes the awaiter <b>on that thread, still inside the trampoline</b>,
+/// and everything it then calls inherits the flag. If such a frame subscribes a query and then
+/// BLOCKS waiting for its first result, the walk it just enqueued can only run after the block
+/// returns, and the block only returns when the walk runs: the query's <c>Initial</c> is
+/// <b>never emitted, with no error and no completion</b> — a live children listing that silently
+/// stays empty forever.</para>
+///
+/// <para>Under xUnit the reach is wider still: the resumed continuation was a mesh teardown await,
+/// so the test runner carried on <i>on that stack</i> and started subsequent tests inside the
+/// trampoline. That is why <c>LiveQueryHandoffDropTest</c> failed ~23% of cold whole-assembly runs on
+/// a 4-CPU Linux runner (its 30 s warm-up wait was the block) while passing every warm, single-test
+/// run.</para>
+///
+/// <para><see cref="ImmediateScheduler"/> has no such ambient state: it invokes the action directly,
+/// and its recursive form is trampolined through a per-call <c>AsyncLock</c>, so a long sequence
+/// iterates without growing the stack. <c>LiveQueryForeignTrampolineTest</c> pins this.</para>
+/// </remarks>
+public static class InlineObservableExtensions
+{
+    /// <summary>
+    /// Iterates <paramref name="source"/> inline on the subscribing thread — see the type remarks
+    /// for why the parameterless <c>ToObservable()</c> is unsafe on a read path.
+    /// </summary>
+    /// <typeparam name="T">Element type.</typeparam>
+    /// <param name="source">The sequence to emit.</param>
+    /// <returns>An observable that emits every element during <c>Subscribe</c>.</returns>
+    public static IObservable<T> ToInlineObservable<T>(this IEnumerable<T> source)
+        => source.ToObservable(ImmediateScheduler.Instance);
+}

--- a/test/MeshWeaver.Documentation.Test/BareToObservableOnReadPathGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/BareToObservableOnReadPathGuard.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard (#2377): no file on the storage / query read path may call the parameterless
+/// <c>IEnumerable.ToObservable()</c>. Use <c>ToInlineObservable()</c>
+/// (<c>MeshWeaver.Mesh.Services.InlineObservableExtensions</c>).
+///
+/// <para><b>Why a guard rather than care.</b> The two spellings are one word apart, the wrong one is
+/// what IntelliSense offers first, and the failure it produces is <b>completely silent</b>: no
+/// exception, no completion, no log line. Nothing about the call site looks wrong, and nothing in a
+/// normal test run reveals it — the defect needs a cold process, a real CPU budget and the whole
+/// assembly to show up at all. That is exactly the shape a text guard exists for.</para>
+///
+/// <para><b>The mechanism.</b> Rx defaults <c>ToObservable()</c> to <c>SchedulerDefaults.Iteration</c>
+/// = <c>CurrentThreadScheduler</c>, which does not mean "run it here now". It keeps a
+/// <c>[ThreadStatic] bool</c> for "a trampoline is already running on this thread", and while that is
+/// set <c>Schedule</c> only ENQUEUES, leaving the item for whoever owns the outer trampoline to
+/// drain. Rx opens such trampolines on every operator subscription, and a <c>Task</c> completed from
+/// inside an Rx pipeline (a <c>.ToTask()</c>, an <c>AsyncSubject</c>) resumes its awaiter INLINE
+/// inside one — the captured stack for #2377 had the hub's own <c>MessageService.DrainOne</c> pump at
+/// the bottom. A read subscribed from such a frame that then blocks on its first result deadlocks
+/// against its own queued iteration: the query's <c>Initial</c> is never emitted, and in the portal a
+/// live children listing silently stays empty forever.</para>
+///
+/// <para>🚨 The fix for a failure here is never to suppress it, and never to add an exemption: call
+/// <c>ToInlineObservable()</c>. It is <c>ImmediateScheduler</c>, which carries no ambient per-thread
+/// state and (per <c>InlineObservableExtensionsTest</c>) still iterates a long sequence without
+/// growing the stack. If a read genuinely must not run inline, it does I/O and belongs on
+/// <c>IIoPool</c> — not on the caller's trampoline.</para>
+/// </summary>
+public class BareToObservableOnReadPathGuard
+{
+    /// <summary>
+    /// The storage / query read path: everything that participates in producing a query's snapshot
+    /// or an <c>IStorageAdapter</c> read. These are the files whose contract is "synchronous on the
+    /// subscribing thread"; elsewhere in the tree a deferred iteration is merely a scheduling choice.
+    /// </summary>
+    private static readonly string[] ScannedRoots =
+    [
+        "src/MeshWeaver.Hosting/Persistence",
+        "src/MeshWeaver.Hosting.Sqlite",
+        "src/MeshWeaver.Hosting.PostgreSql",
+        "src/MeshWeaver.Hosting.Cosmos",
+        "src/MeshWeaver.Hosting.Snowflake",
+    ];
+
+    /// <summary>
+    /// The parameterless call only. <c>ToObservable(someScheduler)</c> is an explicit, reviewed
+    /// choice and is left alone.
+    /// </summary>
+    private static readonly Regex Bare = new(@"\.ToObservable\s*\(\s*\)", RegexOptions.Compiled);
+
+    /// <summary>Zero occurrences — there is no seeded inventory, because there are none left.</summary>
+    [Fact]
+    public void NoReadPathFile_UsesTheParameterlessToObservable()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var offenders = new List<string>();
+
+        // 🚨 A guard must never pass on no evidence. SourceFiles() silently drops a root that does
+        // not exist, so a renamed project or a typo here would turn this into a green check that
+        // scanned nothing — the exact skip-trapdoor shape AGENTS.md bans for CI gates. Assert the
+        // roots resolve, and that the scan actually read files, before believing the count of zero.
+        foreach (var scanned in ScannedRoots)
+            Assert.True(Directory.Exists(Path.Combine(root, scanned)),
+                $"Scanned root '{scanned}' does not exist — this guard would scan nothing and pass. "
+                + "Update ScannedRoots to match the tree; never delete the root to make it green.");
+
+        var files = SourceScan.SourceFiles(root, ScannedRoots).ToList();
+        Assert.True(files.Count > 20,
+            $"Only {files.Count} files were scanned across the read path — too few to be the real "
+            + "tree, so a pass here would mean nothing.");
+
+        foreach (var file in files)
+        {
+            // Mask first: several of these files DISCUSS the banned call in their remarks, and
+            // naming the problem is the opposite of committing it.
+            var code = SourceScan.MaskCommentsAndStrings(File.ReadAllText(file));
+            foreach (Match m in Bare.Matches(code))
+            {
+                var line = code.Take(m.Index).Count(c => c == '\n') + 1;
+                offenders.Add($"{SourceScan.Relative(root, file)}:{line}");
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Parameterless IEnumerable.ToObservable() on the storage/query read path — this defers "
+            + "the iteration to the CALLER's Rx trampoline, where it can be queued and never run "
+            + "(#2377: no error, no completion, a live listing that stays empty forever). Use "
+            + "ToInlineObservable(). Offenders:"
+            + Environment.NewLine + string.Join(Environment.NewLine, offenders));
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/FreshThread.cs
+++ b/test/MeshWeaver.Hosting.Test/FreshThread.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Reactive.Concurrency;
+using System.Threading;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Runs a probe on a thread that is guaranteed to carry no Rx <see cref="CurrentThreadScheduler"/>
+/// trampoline.
+///
+/// <para>🚨 This is load-bearing, not tidiness. <c>CurrentThreadScheduler.Schedule</c> only OPENS a
+/// trampoline when none is running on the thread; on a thread that already carries one it enqueues
+/// and returns <b>without running the action at all</b>. The xUnit test thread can genuinely be in
+/// that state — that is precisely the leak issue #2377 is about (a <c>.ToTask()</c> resolved inside
+/// the hub's Rx pipeline resumes its awaiter inline, and the runner carries on from there) — so a
+/// test that opens its trampoline from the test thread would intermittently skip its own body and
+/// report a pass, or fail on its own setup guard, for reasons unrelated to what it tests.</para>
+/// </summary>
+internal static class FreshThread
+{
+    /// <summary>
+    /// Runs <paramref name="probe"/> on a new background thread and rethrows whatever it threw, so
+    /// assertion failures keep their original message and stack.
+    /// </summary>
+    /// <param name="probe">The body to run.</param>
+    /// <param name="onTimeout">Message when the thread does not finish inside the budget.</param>
+    /// <param name="budget">Wall-clock cap; defaults to 30 s.</param>
+    internal static void Run(Action probe, string onTimeout, TimeSpan? budget = null)
+    {
+        Exception? failure = null;
+        var thread = new Thread(() =>
+        {
+            try { probe(); }
+            catch (Exception ex) { failure = ex; }
+        })
+        { IsBackground = true };
+        thread.Start();
+
+        Assert.True(thread.Join(budget ?? TimeSpan.FromSeconds(30)), onTimeout);
+        if (failure is not null)
+            throw failure;
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/InlineObservableExtensionsTest.cs
+++ b/test/MeshWeaver.Hosting.Test/InlineObservableExtensionsTest.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Holds <see cref="InlineObservableExtensions.ToInlineObservable{T}"/> to the two properties its
+/// callers rely on, both of which the type's own remarks assert in prose.
+/// </summary>
+public class InlineObservableExtensionsTest
+{
+    /// <summary>
+    /// The whole point: emission happens during <c>Subscribe</c>, on the subscribing thread, with no
+    /// dependence on whether an Rx trampoline is already running there. The parameterless
+    /// <c>ToObservable()</c> fails this inside a trampoline — see
+    /// <see cref="LiveQueryForeignTrampolineTest"/> for what that costs.
+    /// </summary>
+    [Fact]
+    public void Emits_during_Subscribe_even_inside_a_trampoline()
+        // A fresh thread, or opening the trampoline can silently no-op — see FreshThread.
+        => FreshThread.Run(
+            () =>
+            {
+                var outside = 0;
+                Enumerable.Range(0, 3).ToInlineObservable().Subscribe(_ => outside++);
+                Assert.Equal(3, outside);
+
+                var inside = 0;
+                var wasInsideTrampoline = false;
+                CurrentThreadScheduler.Instance.Schedule(() =>
+                {
+                    wasInsideTrampoline = !CurrentThreadScheduler.IsScheduleRequired;
+                    Enumerable.Range(0, 3).ToInlineObservable().Subscribe(_ => inside++);
+                    // Read the counter HERE, before returning to the trampoline: a deferred
+                    // iteration would still be sitting in its queue at this point.
+                    Assert.Equal(3, inside);
+                });
+                Assert.True(wasInsideTrampoline, "the probe never ran inside a trampoline");
+            },
+            "the probe thread never finished");
+
+    /// <summary>
+    /// 🚨 <see cref="ImmediateScheduler"/>'s recursive form is trampolined through a per-call
+    /// <c>AsyncLock</c>, so a long sequence iterates rather than recursing. Without that, swapping
+    /// <c>CurrentThreadScheduler</c> for <c>ImmediateScheduler</c> would trade a silent strand for a
+    /// StackOverflowException — uncatchable, and fatal to the process — on any large directory
+    /// listing. Measured: 500k elements in ~0.1 s.
+    /// </summary>
+    [Fact]
+    public void A_long_sequence_iterates_without_growing_the_stack()
+    {
+        var count = 0;
+        Enumerable.Range(0, 500_000).ToInlineObservable().Subscribe(_ => count++);
+        Assert.Equal(500_000, count);
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/LiveQueryForeignTrampolineTest.cs
+++ b/test/MeshWeaver.Hosting.Test/LiveQueryForeignTrampolineTest.cs
@@ -56,28 +56,13 @@ public class LiveQueryForeignTrampolineTest
     [InlineData("path:probe/_Usage scope:descendants")]
     [InlineData("path:probe/_Usage/one scope:exact")]
     public void Initial_arrives_when_subscribed_inside_a_foreign_trampoline(string query)
-    {
-        // 🚨 A DEDICATED thread, not the test thread — and this is load-bearing, not tidiness.
-        // CurrentThreadScheduler.Schedule only OPENS a trampoline when none is running on the
-        // thread; on a thread that already carries one it enqueues and returns without running the
-        // action at all. The xUnit test thread can genuinely be in that state (that is the very
-        // leak this test is about), so probing from it would silently skip the whole body. A fresh
-        // thread is guaranteed to have no trampoline, which makes the setup deterministic.
-        Exception? failure = null;
-        var probe = new Thread(() =>
-        {
-            try { RunProbe(query); }
-            catch (Exception ex) { failure = ex; }
-        })
-        { IsBackground = true };
-        probe.Start();
-
-        Assert.True(probe.Join(TimeSpan.FromSeconds(30)),
+        // 🚨 A DEDICATED thread, not the test thread — see FreshThread for why that is load-bearing
+        // here: the xUnit test thread can already carry a trampoline (that is the very leak this
+        // test is about), and opening one from there would silently skip the whole body.
+        => FreshThread.Run(
+            () => RunProbe(query),
             $"the probe thread never finished for [{query}] — the scope walk was queued on the "
             + "caller's trampoline instead of running inline, so it can never run (#2377)");
-        if (failure is not null)
-            throw failure;
-    }
 
     private static void RunProbe(string query)
     {

--- a/test/MeshWeaver.Hosting.Test/LiveQueryForeignTrampolineTest.cs
+++ b/test/MeshWeaver.Hosting.Test/LiveQueryForeignTrampolineTest.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Hosting.Persistence.Query;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Issue #2377 — a live query's <c>Initial</c> snapshot must be produced <b>during
+/// <c>Subscribe</c>, on the subscribing thread</b>, even when the subscribing frame is already
+/// inside somebody else's Rx <see cref="CurrentThreadScheduler"/> trampoline.
+///
+/// <para><b>The defect.</b> The pedestrian scope walk emitted its path lists with the parameterless
+/// <c>IEnumerable.ToObservable()</c>, which Rx schedules on <c>SchedulerDefaults.Iteration</c> —
+/// <see cref="CurrentThreadScheduler"/>. That scheduler does not mean "run it now": it keeps a
+/// <c>[ThreadStatic]</c> flag for "a trampoline is already running on this thread", and while that
+/// flag is set <c>Schedule</c> only <b>enqueues</b>, leaving the item for whoever owns the outer
+/// trampoline to drain. So a query subscribed from inside a foreign trampoline never walked at all:
+/// <c>Subscribe</c> returned with the walk sitting in someone else's queue, and if the caller then
+/// blocked waiting for its first result, the two waited on each other. <b>No error, no completion,
+/// no row — forever.</b> In the portal that is a live children listing (chat token chip,
+/// notification bell, folder view) that silently stays empty.</para>
+///
+/// <para><b>Why an ordinary caller lands inside a foreign trampoline.</b> Rx runs every operator
+/// subscription through that trampoline, and a <c>Task</c> completed from inside an Rx pipeline
+/// resumes its awaiter <i>inline on that thread</i> — so anything after an
+/// <c>await …FirstAsync().ToTask()</c> can be running inside one. Under xUnit that even leaks across
+/// tests, which is what made <c>LiveQueryHandoffDropTest</c> fail ~23% of cold whole-assembly runs on
+/// a 4-CPU Linux runner (its 30 s warm-up wait was the block) while every warm or single-test run
+/// passed.</para>
+///
+/// <para><b>The cure</b> is <c>ToInlineObservable()</c> (<see cref="InlineObservableExtensions"/>) —
+/// <see cref="ImmediateScheduler"/>, which carries no ambient per-thread state. This test holds the
+/// walk to that contract: it subscribes from inside a real trampoline and blocks there, which is
+/// exactly the shape that used to strand.</para>
+/// </summary>
+public class LiveQueryForeignTrampolineTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+
+    /// <summary>
+    /// Every walk-backed scope must still emit its Initial when subscribed inside a foreign
+    /// trampoline. <c>scope:exact</c> is included as the control: it never walked, so it passed
+    /// before the fix too.
+    /// </summary>
+    /// <param name="query">The query shape under test.</param>
+    [Theory]
+    [InlineData("path:probe/_Usage scope:children")]
+    [InlineData("path:probe/_Usage scope:subtree")]
+    [InlineData("path:probe/_Usage scope:descendants")]
+    [InlineData("path:probe/_Usage/one scope:exact")]
+    public void Initial_arrives_when_subscribed_inside_a_foreign_trampoline(string query)
+    {
+        // 🚨 A DEDICATED thread, not the test thread — and this is load-bearing, not tidiness.
+        // CurrentThreadScheduler.Schedule only OPENS a trampoline when none is running on the
+        // thread; on a thread that already carries one it enqueues and returns without running the
+        // action at all. The xUnit test thread can genuinely be in that state (that is the very
+        // leak this test is about), so probing from it would silently skip the whole body. A fresh
+        // thread is guaranteed to have no trampoline, which makes the setup deterministic.
+        Exception? failure = null;
+        var probe = new Thread(() =>
+        {
+            try { RunProbe(query); }
+            catch (Exception ex) { failure = ex; }
+        })
+        { IsBackground = true };
+        probe.Start();
+
+        Assert.True(probe.Join(TimeSpan.FromSeconds(30)),
+            $"the probe thread never finished for [{query}] — the scope walk was queued on the "
+            + "caller's trampoline instead of running inline, so it can never run (#2377)");
+        if (failure is not null)
+            throw failure;
+    }
+
+    private static void RunProbe(string query)
+    {
+        var adapter = new InMemoryStorageAdapter();
+        adapter.Write(new MeshNode("one", "probe/_Usage") { NodeType = "TokenUsage" }, Options)
+            .Subscribe();
+        var provider = new StorageAdapterMeshQueryProvider(adapter);
+        using var initial = new ManualResetEventSlim(false);
+        var insideTrampoline = false;
+
+        // Schedule() IS the trampoline: inside this action CurrentThreadScheduler reports that one
+        // is already running, which is precisely the state an await-resumed continuation inherits.
+        CurrentThreadScheduler.Instance.Schedule(() =>
+        {
+            insideTrampoline = !CurrentThreadScheduler.IsScheduleRequired;
+            using var sub = provider
+                .Query<MeshNode>(MeshQueryRequest.FromQueries([query], "system-security"), Options)
+                .Subscribe(c => { if (c.ChangeType == QueryChangeType.Initial) initial.Set(); });
+
+            // 🚨 Blocking HERE is the point, not a shortcut: the stranded walk could only ever run
+            // after this frame returns to the trampoline that owns it, so a caller that waits for
+            // its own Initial is the shape that deadlocked. A budget generous enough that only a
+            // never-scheduled walk can exhaust it — this work is microseconds.
+            Assert.True(initial.Wait(TimeSpan.FromSeconds(5)),
+                $"Initial never arrived for [{query}] — the scope walk was queued on the caller's "
+                + "trampoline instead of running inline, so it can never run (#2377)");
+        });
+
+        Assert.True(insideTrampoline,
+            "the probe never actually ran inside a trampoline — it would pass without testing anything");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/LiveQueryHandoffDropTest.cs
+++ b/test/MeshWeaver.Hosting.Test/LiveQueryHandoffDropTest.cs
@@ -43,17 +43,32 @@ namespace MeshWeaver.Hosting.Test;
 /// decision — backlog vs live buffer — is made inside the same critical section that publishes the
 /// buffer. Then a notification lands in exactly one of the two and can never fall between them.</para>
 ///
-/// <para>🚨 <b>Issue #2319 (2026-08-26): a SECOND, unrelated timing hazard, now closed by
-/// <see cref="WarmUpJitAndTypeLoad"/>.</b> After the fix above landed, this test still failed
-/// intermittently on CI's shard 2 — every single time on the FIRST test of the whole assembly to
-/// exercise this reactive pipeline in a fresh process. Root-caused (not guessed) by reproducing it
-/// in a Linux container capped at CI's 4 CPUs: an instrumented loop that repeats the gated scenario
-/// hundreds of times in one warm process never drops the notification, but the very FIRST call
-/// into <see cref="StorageAdapterMeshQueryProvider"/>'s pipeline in a cold process can itself take
-/// longer than the 10 s per-step budget below under real contention — JIT + generic-Rx-operator
-/// type load, not a dropped row. <see cref="WarmUpJitAndTypeLoad"/> pays that one-time cost on
-/// throwaway objects before the gated scenario begins, so a red below again means exactly what the
-/// class doc above says.</para>
+/// <para>🚨 <b>Issue #2319: a SECOND, unrelated timing hazard.</b> After the fix above landed, this
+/// test still failed intermittently on CI — every single time on the FIRST test of the whole
+/// assembly to exercise this reactive pipeline in a fresh process. An instrumented loop at CI's 4
+/// CPUs showed the gated scenario never drops the notification once warm (400 iterations, only ever
+/// iteration 0 failed), so <see cref="WarmUpJitAndTypeLoad"/> was added to pay the one-time
+/// JIT/type-load cost on throwaway objects before the gated scenario's budgets start. That is real
+/// and it stays.</para>
+///
+/// <para>🚨 <b>Issue #2377: it was NOT the whole story, and the rest was a framework bug.</b> The
+/// test kept failing afterwards — now inside the warm-up itself, the phase built to absorb cold JIT,
+/// stuck for its full 30 s against an EMPTY store. That is not slowness: a warm-process loop is
+/// structurally blind to anything that only manifests cold or via cross-test state, so it had never
+/// ruled anything out. Reproduced at ~23% by running the whole assembly cold in a Linux container
+/// capped at 4 CPUs, and traced: <c>Subscribe</c> returned having never walked, with no error and no
+/// completion, and the Initial never arrived at all.</para>
+///
+/// <para>Cause: the scope walk emitted its path lists with the parameterless
+/// <c>IEnumerable.ToObservable()</c>, which Rx schedules on <c>CurrentThreadScheduler</c> — and that
+/// scheduler only ENQUEUES while another trampoline is running on the thread. The captured stack
+/// shows whose: the hub's own <c>MessageService.DrainOne</c> pump opened one, ~500 frames down a
+/// <c>.ToTask()</c> resolved, and .NET resumed its awaiter INLINE on that stack — so xUnit carried on
+/// running tests inside a stranger's trampoline. This test then subscribed there and blocked on its
+/// own Initial, and the enqueued walk could not be drained until the blocked frame returned, which it
+/// never would. Fixed at the source with <c>ToInlineObservable()</c>
+/// (<see cref="InlineObservableExtensions"/>); <c>LiveQueryForeignTrampolineTest</c> pins it
+/// deterministically. A red below therefore means exactly what the class doc above says.</para>
 /// </summary>
 public class LiveQueryHandoffDropTest
 {
@@ -170,6 +185,12 @@ public class LiveQueryHandoffDropTest
     /// Warming it up here — on throwaway objects, fully independent of the gated scenario — moves
     /// that one-time cost out of the window the assertions below measure, so a red there again
     /// means what the class doc says: the row was actually dropped, not merely slow to JIT.</para>
+    ///
+    /// <para>🚨 It is NOT, however, what made this test fail AFTER the warm-up landed: that was the
+    /// framework bug in issue #2377 (a scope walk queued on a foreign Rx trampoline, so the Initial
+    /// never arrived at all), fixed in <c>StorageAdapterMeshQueryProvider</c>. Both budgets below
+    /// stay at 30 s and both stay FAIL-FAST: falling through silently would run the gated scenario
+    /// against a still-cold pipeline and let it misreport its own timeout as a dropped row.</para>
     /// </summary>
     private static void WarmUpJitAndTypeLoad()
     {


### PR DESCRIPTION
Closes #2377 (and supersedes the cold-JIT explanation in #2319 / #2338).

## Root cause — a framework bug, not a flaky test

The pedestrian scope walk emitted its path lists with the parameterless
`IEnumerable.ToObservable()`. Rx defaults that to `SchedulerDefaults.Iteration`, which is
`CurrentThreadScheduler` — and that scheduler does **not** mean "run it here, now". It keeps a
`[ThreadStatic] bool` for *"a trampoline is already running on this thread"*, and while that is set
`Schedule` **only enqueues and returns**, leaving the item for whoever owns the outer trampoline to
drain.

That flag is set far more often than it looks, and **its owner is production code**. The captured
558-frame stack from a reproduction, bottom-up:

```
MessageService.DrainOne()                 // the hub's own pump, on a ThreadPool thread
 -> Producer.SubscribeRaw
   -> CurrentThreadScheduler.Schedule     // trampoline OPENED here; the flag is now set
     -> ... ~500 Rx frames ...
       -> ToTaskObserver.OnCompleted -> TaskCompletionSource.TrySetResult   // a .ToTask() resolves
         -> AwaitTaskContinuation.RunOrScheduleAction(allowInlining: true)  // awaiter resumes INLINE
           -> ... the awaiting code, and everything it goes on to call ...
```

A `Task` completed from inside an Rx pipeline — `FirstAsync().ToTask()`, an `AsyncSubject`, a
`TaskCompletionSource` resolved on an `OnNext` — resumes its awaiter **inline on that thread, still
inside the trampoline**, and everything it then calls inherits the flag. If such a frame subscribes a
query and then **blocks** on its first result, the walk it just enqueued can only run once the block
returns, and the block only returns once the walk runs.

**`Initial` is never emitted — no error, no completion, no row.** In the portal that is a live
children listing (chat token chip, notification bell, folder view) that opens and silently stays
empty, while a point read of the same content returns immediately.

Under xUnit the reach was wider still: the inlined continuation in that stack was a mesh-teardown
`await`, so the runner carried on *on that stack* and started subsequent tests inside the trampoline.
That is why `LiveQueryHandoffDropTest` failed on a cold whole-assembly run and never in isolation.

## The fix

`ToInlineObservable()` — `ImmediateScheduler`, which carries no ambient per-thread state, and whose
recursive form is trampolined through a per-call `AsyncLock` so long sequences still iterate without
growing the stack.

Applied to **all 12 sites** on the storage / query read path, not only the ones the reproduction
happened to reach. The sweep is what found `PersistenceService.ListChildPaths` — **the walk the
portal actually uses** (the raw adapter is the test path). Fixing only the reproduced sites would
have fixed the test and not the product.

`BareToObservableOnReadPathGuard` then ratchets it to zero across `MeshWeaver.Hosting/Persistence`
and the Sqlite / PostgreSql / Cosmos / Snowflake adapters — a guard rather than care, because the two
spellings are one word apart, the wrong one is what IntelliSense offers first, and the failure is
completely silent. Verified in both directions: reintroducing one bare call makes it fail and names
the file and line.

**No budget was widened and no fail-fast weakened.** The `WarmUpJitAndTypeLoad` phase and both its
30 s fail-fast asserts are untouched; only its stale prose is corrected.

## Proof, both directions

| check | result |
|---|---|
| `LiveQueryForeignTrampolineTest` **without** the fix | **3 of 4 shapes FAIL**, 15.1 s |
| `LiveQueryForeignTrampolineTest` **with** the fix | 4 of 4 pass, 0.08 s |
| Whole assembly, cold, `--cpus 4` + `DOTNET_PROCESSOR_COUNT=4` — **before** | **3 failures / 13 runs (~23%)** |
| Whole assembly, same conditions — **after** | **0 failures / 40 runs**, then 0 / 30 again after the sweep |
| `BareToObservableOnReadPathGuard` with one bare call reintroduced | fails, naming file and line |

The repro is deterministic and needs no container: it subscribes from inside a real trampoline and
blocks there, which is exactly the shape that stranded. It was re-verified in both directions by
temporarily reverting only the scheduler argument. `scope:exact` is kept in the theory as the control
— it never walked, so it passed before the fix too.

Test suites: `Hosting.Test` 238/238 · `Hosting.Monolith.Test` full pass · `Persistence.Test` 957/957 ·
`Hosting.Sqlite.Test` 30/30 · `Documentation.Test` 63/63. All touched projects build clean under
`-c Release -warnaserror`.

## Why the earlier diagnosis was incomplete (not wrong)

The 400-iteration warm-process loop behind #2338 is real — only ever iteration 0 failed — and the
warm-up it produced stays. But a warm-process loop is structurally blind to anything that only
manifests cold or via cross-test state, so it never ruled this out. The post-warm-up failures were
inside the warm-up itself, stuck the full 30 s against an **empty** store: not slowness, a permanent
strand.

Two hypotheses on the ticket are also disproved rather than left open: `StorageAdapterMeshQueryProvider._ioPool`
is assigned and **never invoked** (so `IoPool.Unbounded` is not on the failing path, and neither is the
`Scheduler.Default` hop, which runs only after `Initial`), and the pool was measured healthy at the
moment of failure (`threads=4 pending=0 avail=32766/1000`) — nothing was starved, the work was never
queued to the pool at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
