### PR TITLE
A test's Catch(...).Repeat() was a 54 kHz busy-wait that killed the whole test host (#2341)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-test-suite-busy-wait.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-test-suite-busy-wait.md
@@ -1,0 +1,16 @@
+---
+Name: Test suite no longer stalls a release
+Category: Fix
+Description: A busy-wait in three delegation tests could hang a whole test run, blocking releases from shipping.
+Icon: Sparkle
+Order: -20260826
+---
+
+# Test suite no longer stalls a release
+
+Three tests that wait for a delegated sub-thread used a retry loop that only paused between
+attempts when the underlying read failed. When the read instead returned "nothing yet", the loop
+retried tens of thousands of times a second, pinned a processor and never finished — taking the
+whole test run down with it and, on twelve occasions in a single day, blocking the build that ships
+new versions. The three tests now wait for the sub-thread to appear instead of polling for it, and a
+new build check refuses any future test that reintroduces the same loop.

--- a/test/MeshWeaver.Documentation.Test/UnthrottledResubscribeInTestRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/UnthrottledResubscribeInTestRatchetGuard.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance ratchet for the unthrottled-resubscribe defect class (#2341): a test may not wait on
+/// a mesh stream with Rx's argument-less <c>.Repeat()</c> / <c>.Retry()</c>.
+///
+/// <para><b>Why this is a defect and not a style preference.</b> Both operators re-subscribe to the
+/// source the instant it terminates, with NO delay of their own. The delay people believe they have
+/// added lives in a <c>.Catch(_ =&gt; Observable.Empty&lt;T&gt;().Delay(200.Milliseconds()))</c>
+/// handler — and <c>Catch</c> intercepts <b>OnError only</b>. A point read of a node that does not
+/// exist yet <b>completes without emitting</b>, so that handler never runs and the pair degenerates
+/// into a busy-wait. Measured on the #2341 site: <b>460 000 re-subscribes in 8.4 s (~54 kHz), zero
+/// OnError</b> — the 200 ms backoff never executed once.</para>
+///
+/// <para><b>And it costs the whole shard, not one test.</b> 🚨 Rx subscribes SYNCHRONOUSLY, so the
+/// loop runs inside the assertion's own <c>.ToTask()</c> call and the <c>await</c> is never reached.
+/// That puts it out of reach of every timeout the harness has — <c>.Within(...)</c>,
+/// <c>[Fact(Timeout)]</c>, <c>methodTimeout</c>, and <c>MonolithMeshTestBase</c>'s hard-deadline
+/// watchdog all need the test method to return or to park at an await. One xUnit worker pins a core
+/// forever; on a 4-vCPU runner that also starves the hub that has to create the very node the loop
+/// is waiting for, so it can never terminate. CI reports <c>exit=124 TIMEOUT</c> with no failing
+/// test named and no <c>.trx</c> — 12 occurrences in ~15 h across five branches and <c>main</c>
+/// (2026-08-25/26) before it was root-caused.
+/// This is the same signature as <see cref="BlockingBridgeInTestRatchetGuard"/>'s defect class and
+/// the reason that guard could not see this one: nothing here blocks, it spins.</para>
+///
+/// <para><b>The fix at a site</b> is the composition AGENTS.md prescribes for a node that may not
+/// exist yet — the keyed <c>GetQuery</c> listing for EXISTENCE (empty-on-absent, live) and only then
+/// the owner's stream for CONTENT:
+/// <code>
+/// hub.GetQuery(id, $"path:{parent} scope:children select:path")
+///    .Where(nodes =&gt; nodes.Any(n =&gt; string.Equals(n.Path, target, StringComparison.OrdinalIgnoreCase)))
+///    .Take(1)
+///    .SelectMany(_ =&gt; workspace.GetMeshNodeStream(target))
+///    .Select(n =&gt; n.ContentAs&lt;T&gt;(hub.JsonSerializerOptions))
+///    .Should().Within(...).Match(predicate);
+/// </code>
+/// Where a retry genuinely belongs (an owner that can transiently reject), use
+/// <c>.RetryWhen(errors =&gt; errors.Select((_, i) =&gt; i).TakeWhile(i =&gt; i &lt; n)
+/// .SelectMany(_ =&gt; Observable.Timer(...)))</c> — it re-subscribes on OnError ONLY, carries its own
+/// timer, and is bounded, so a completing source can never turn it into a spin.</para>
+///
+/// <para><b>The allow file is EMPTY, and must stay that way.</b> Unlike the blocking-bridge ratchet
+/// there was no inventory to seed: the three sites that existed (<c>SubThreadHangRepro</c> ×1,
+/// <c>SubThreadColdStartRepro</c> ×2 — all three waiting on a delegation sub-thread) are fixed in
+/// the change that adds this guard, so the correct count is zero. Adding a line here is not a fix.</para>
+/// </summary>
+public class UnthrottledResubscribeInTestRatchetGuard(ITestOutputHelper output)
+{
+    /// <summary>
+    /// <c>test/</c> only. <c>src/</c> has two deliberate <c>.Repeat()</c> sites over sources that
+    /// carry their own cadence (<c>InstanceSyncWorker</c>'s sweep timer,
+    /// <c>PackageInstaller</c>'s), where the operator is doing exactly what it says. The defect is
+    /// specific to a TEST waiting on a mesh read, where the source can terminate immediately and
+    /// nothing bounds the loop — and where the blast radius is the whole test host.
+    /// </summary>
+    private static readonly string[] ScannedRoots = ["test"];
+
+    /// <summary>
+    /// The argument-less spellings, as they appear in source. The overloads that TAKE an argument
+    /// (<c>Repeat(count)</c>, <c>RetryWhen(handler)</c>, <c>Retry(count)</c>) are deliberately not
+    /// matched: a bounded count terminates, and <c>RetryWhen</c> is the sanctioned replacement.
+    /// </summary>
+    private static readonly string[] Markers = [".Repeat()", ".Retry()"];
+
+    private const string AllowFileName = "UnthrottledResubscribeSites.allow";
+
+    [Fact]
+    public void NoTestWaitsOnAMeshStreamWithAnUnthrottledResubscribe()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var allowed = SourceScan.ReadAllowFile(Path.Combine(root, "test", AllowFileName), AllowFileName);
+        var found = Scan(root);
+
+        var failures = new List<string>();
+
+        foreach (var (file, count) in found.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            if (!allowed.TryGetValue(file, out var budget))
+                failures.Add(
+                    $"  NEW SITE   {file} ({count}) — `.Repeat()` / `.Retry()` re-subscribes with no "
+                    + "delay of its own, and `.Catch(...)` does NOT cover a source that COMPLETES. "
+                    + "Gate on existence with GetQuery and read content from the owner's stream, or "
+                    + "use `.RetryWhen(...)` with a timer. Do NOT add a line to " + AllowFileName + ".");
+            else if (count > budget)
+                failures.Add(
+                    $"  MORE       {file} ({count} > {budget} allowed) — an unthrottled resubscribe "
+                    + "was ADDED to a file that already carries the shape.");
+        }
+
+        foreach (var (file, budget) in allowed.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            var count = found.GetValueOrDefault(file, 0);
+            if (count < budget)
+                output.WriteLine(
+                    $"STALE (please tidy): {file} — {count} found, {budget} allowed. "
+                    + $"{(count == 0 ? "Delete the line" : $"Lower it to {count}")}.");
+        }
+
+        Assert.True(failures.Count == 0,
+            "An argument-less .Repeat()/.Retry() over a mesh read spins at tens of kHz the moment the "
+            + "source completes instead of erroring, INSIDE the assertion's synchronous subscribe — so "
+            + "no timeout in the harness can bound it and the whole test host dies at CI's 8 m cap "
+            + "with `exit=124` and no test named (#2341).\n"
+            + string.Join("\n", failures));
+    }
+
+    /// <summary>
+    /// Non-vacuity, pinned in the same run. This ratchet's inventory is EMPTY, so the usual
+    /// "the scanner found something" check would be vacuous — a scanner that matched nothing at all
+    /// (a renamed marker, a masker that blanked every file) would pass exactly like a clean tree.
+    /// So the scanner is exercised against a fixture written here: the shape in CODE must count, and
+    /// the same shape quoted in a COMMENT or a string must not — which is load-bearing, because the
+    /// guard's own remarks above quote <c>.Repeat()</c> verbatim several times.
+    /// </summary>
+    [Fact]
+    public void TheScannerSeesTheShapeInCodeAndIgnoresItInProse()
+    {
+        const string fixture = """
+            // a comment mentioning .Repeat() must NOT count
+            /* nor a block comment with .Retry() in it */
+            public class Sample
+            {
+                private const string Doc = "a string literal naming .Repeat() must not count";
+                public void M() => Source.Where(x => x).Repeat();
+            }
+            """;
+
+        Assert.Equal(1, CountMarkers(fixture));
+
+        // And the guard's own file — which quotes both markers repeatedly in prose — must scan clean,
+        // or every count this ratchet reports is measured against documentation rather than code.
+        var root = SourceScan.FindRepoRoot();
+        var self = Path.Combine(root, "test", "MeshWeaver.Documentation.Test",
+            "UnthrottledResubscribeInTestRatchetGuard.cs");
+        Assert.True(File.Exists(self), "the guard's own file must exist for this check to mean anything");
+        Assert.Contains(".Repeat()", File.ReadAllText(self), StringComparison.Ordinal);
+        Assert.Equal(0, CountSites(self));
+    }
+
+    private static Dictionary<string, int> Scan(string root) =>
+        SourceScan.SourceFiles(root, ScannedRoots)
+            .Select(f => (Relative: SourceScan.Relative(root, f), Count: CountSites(f)))
+            .Where(x => x.Count > 0)
+            .ToDictionary(x => x.Relative, x => x.Count, StringComparer.Ordinal);
+
+    private static int CountSites(string path)
+    {
+        string text;
+        try { text = File.ReadAllText(path); }
+        catch (IOException) { return 0; } // a file a concurrent build is writing is not evidence
+
+        return CountMarkers(text);
+    }
+
+    private static int CountMarkers(string text)
+    {
+        if (!Markers.Any(m => text.Contains(m, StringComparison.Ordinal))) return 0;
+
+        var code = SourceScan.MaskCommentsAndStrings(text);
+        var count = 0;
+        foreach (var marker in Markers)
+        {
+            var at = 0;
+            while ((at = code.IndexOf(marker, at, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                at += marker.Length;
+            }
+        }
+        return count;
+    }
+}

--- a/test/MeshWeaver.Threading.Test/SubThreadColdStartRepro.cs
+++ b/test/MeshWeaver.Threading.Test/SubThreadColdStartRepro.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -7,6 +8,7 @@ using System.Threading.Tasks;
 using MeshWeaver.AI;
 using MeshWeaver.AI.Delegation;
 using MeshWeaver.Data;
+using MeshWeaver.Graph;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
@@ -210,15 +212,27 @@ public class SubThreadColdStartRepro(ITestOutputHelper output) : SubThreadHeartb
         // ONLY way the sub-thread reaches a completed assistant response carrying that
         // text is if the heartbeat did NOT cancel it during first-token latency —
         // exactly the behaviour the fix restores.
-        var settled = await Observable.Defer(() =>
-                workspace.GetMeshNodeStream(subThreadPath)
-                    .Select(n => n.Content as MeshThread)
-                    .Where(t => t is { IsExecuting: false, Messages.Count: >= 2 })
-                    .Take(1))
-            .Catch<MeshThread?, Exception>(_ =>
-                Observable.Empty<MeshThread?>().Delay(200.Milliseconds()))
-            .Repeat()
-            .Should().Within(20.Seconds()).Emit();
+        // 🚨 Existence FIRST, content SECOND — the composition AGENTS.md prescribes for a node that
+        // may not exist yet (ExecuteDelegationAsync's CreateNode is fire-and-forget). NEVER
+        // `Defer(...).Catch(...).Repeat()`: `Catch` sees only OnError, the point read of the
+        // not-yet-created node COMPLETES without emitting, and `Repeat` then re-subscribes at
+        // ~54 kHz inside the assertion's SYNCHRONOUS subscribe — a busy-wait no timeout in the
+        // harness can reach, which kills the whole test host at CI's 8 m cap (#2341).
+        //
+        // The GetQuery id embeds the per-run sub-thread path: the "never compose an id per call"
+        // rule guards a production hot path, and here the call happens once on a mesh that is
+        // disposed with this [Fact].
+        var subThreadParent = subThreadPath[..subThreadPath.LastIndexOf('/')];
+        var settled = await client
+            .GetQuery($"subthread-exists:{subThreadPath}",
+                $"path:{subThreadParent} scope:children select:path")
+            .Where(nodes => nodes.Any(n =>
+                string.Equals(n.Path, subThreadPath, StringComparison.OrdinalIgnoreCase)))
+            .Take(1)
+            .SelectMany(_ => workspace.GetMeshNodeStream(subThreadPath))
+            .Select(n => n.ContentAs<MeshThread>(client.JsonSerializerOptions))
+            .Should().Within(20.Seconds())
+            .Match(t => t is { IsExecuting: false, Messages.Count: >= 2 });
 
         settled!.IsExecuting.Should().BeFalse();
 
@@ -294,15 +308,11 @@ public class SubThreadStallRepro(ITestOutputHelper output) : SubThreadHeartbeatT
             .Should().Within(15.Seconds()).Match(t => t is { IsExecuting: true });
 
         // The inter-activity timeout (1 s, past the 1 s grace) must fire and cancel it.
-        var settled = await Observable.Defer(() =>
-                workspace.GetMeshNodeStream(subThreadPath)
-                    .Select(n => n.Content as MeshThread)
-                    .Where(t => t is { IsExecuting: false })
-                    .Take(1))
-            .Catch<MeshThread?, Exception>(_ =>
-                Observable.Empty<MeshThread?>().Delay(200.Milliseconds()))
-            .Repeat()
-            .Should().Within(20.Seconds()).Emit();
+        // The wait above already read the node off its owner, so this is a plain authoritative
+        // point read — no existence gate and, above all, no `Catch(...).Repeat()` busy-wait (#2341).
+        var settled = await workspace.GetMeshNodeStream(subThreadPath)
+            .Select(n => n.ContentAs<MeshThread>(client.JsonSerializerOptions))
+            .Should().Within(20.Seconds()).Match(t => t is { IsExecuting: false });
 
         settled!.IsExecuting.Should().BeFalse(
             "a sub-agent that streamed then went silent past the inter-activity timeout " +

--- a/test/MeshWeaver.Threading.Test/SubThreadHangRepro.cs
+++ b/test/MeshWeaver.Threading.Test/SubThreadHangRepro.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Runtime.CompilerServices;
@@ -7,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.AI;
 using MeshWeaver.Data;
+using MeshWeaver.Graph;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
@@ -141,23 +143,43 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
         // sub-thread hub activated and its WatchForExecution started the
         // agent. The hanging IChatClient takes over from here.
         //
-        // 🚨 Race: WaitForDelegationPath returns as soon as the parent's
-        // tool call has DelegationPath stamped (synchronous), but
-        // ExecuteDelegationAsync's meshService.CreateNode(subThreadNode) is
-        // fire-and-forget — the per-node hub may not have activated yet.
-        // GetMeshNodeStream surfaces "missing satellite" as OnError
-        // (DeliveryFailureException) almost immediately (post-2026-05-24
-        // cache change f103be08a). .Catch+Defer retries with backoff so
-        // we wait for the create to land instead of failing fast.
-        var subThread = await Observable.Defer(() =>
-                workspace.GetMeshNodeStream(subThreadPath)
-                    .Select(n => n.Content as MeshThread)
-                    .Where(t => t is { IsExecuting: true })
-                    .Take(1))
-            .Catch<MeshThread?, Exception>(_ =>
-                Observable.Empty<MeshThread?>().Delay(200.Milliseconds()))
-            .Repeat()
-            .Should().Within(15.Seconds()).Emit();
+        // 🚨 Race: WaitForDelegationPath returns as soon as the parent's tool call has
+        // DelegationPath stamped (synchronous), but ExecuteDelegationAsync's
+        // meshService.CreateNode(subThreadNode) is fire-and-forget — the sub-thread node may not
+        // exist yet. That is exactly AGENTS.md's "a node that may NOT EXIST YET" case, and the
+        // canonical composition is the one below: the keyed GetQuery listing for EXISTENCE
+        // (empty-on-absent, live — the index trails the store, so "the index has seen it" implies
+        // "the store has it"), and only THEN the owner's stream for CONTENT.
+        //
+        // 🚨 NEVER `Defer(...).Catch(...).Repeat()` here — that shape is issue #2341, and it kills
+        // the whole test HOST rather than failing this test:
+        //   * `Catch` only intercepts OnError. A point read of the not-yet-created node
+        //     COMPLETES without emitting (measured: 460 000 subscribes in 8.4 s, zero OnError),
+        //     so the 200 ms backoff never ran and `Repeat` re-subscribed at ~54 kHz — a busy-wait
+        //     that burns a core and, on a 4-vCPU runner, starves the very hub that has to create
+        //     the node it is waiting for.
+        //   * Rx subscribes SYNCHRONOUSLY, so that loop runs inside the assertion's `.ToTask()`
+        //     call. The `await` is never reached, which puts it out of reach of EVERY timeout in
+        //     the harness: `.Within(...)`, `[Fact(Timeout)]`, `methodTimeout`, and
+        //     MonolithMeshTestBase's hard-deadline watchdog all need the method to return or to
+        //     park at an await. The host therefore never finishes and CI's per-project
+        //     `timeout 8m` kills it — exit=124, no .trx, no failing test named, whole shard red
+        //     (12 occurrences in ~15 h across 5 branches and main, 2026-08-25/26).
+        //
+        // The GetQuery id embeds the sub-thread path, which is per-run. "Never compose an id per
+        // call" guards against a production caller minting a new synced query on a hot path; here
+        // the call happens once and the registry entry lives on this [Fact]'s own mesh, which is
+        // disposed at teardown.
+        var subThreadParent = subThreadPath[..subThreadPath.LastIndexOf('/')];
+        var subThread = await client
+            .GetQuery($"subthread-exists:{subThreadPath}",
+                $"path:{subThreadParent} scope:children select:path")
+            .Where(nodes => nodes.Any(n =>
+                string.Equals(n.Path, subThreadPath, StringComparison.OrdinalIgnoreCase)))
+            .Take(1)
+            .SelectMany(_ => workspace.GetMeshNodeStream(subThreadPath))
+            .Select(n => n.ContentAs<MeshThread>(client.JsonSerializerOptions))
+            .Should().Within(15.Seconds()).Match(t => t is { IsExecuting: true });
         subThread!.IsExecuting.Should().BeTrue();
         Output.WriteLine($"Sub-thread reached IsExecuting=true at {DateTime.UtcNow:O}");
 
@@ -178,15 +200,13 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
         // The wait window: 30s watchdog + 15s slack for propagation through
         // parent stream emission → sub-thread cancel watcher → CTS cancel →
         // streaming loop exit → terminal Status flip. 45s total.
-        var settled = await Observable.Defer(() =>
-                workspace.GetMeshNodeStream(subThreadPath)
-                    .Select(n => n.Content as MeshThread)
-                    .Where(t => t is { IsExecuting: false })
-                    .Take(1))
-            .Catch<MeshThread?, Exception>(_ =>
-                Observable.Empty<MeshThread?>().Delay(500.Milliseconds()))
-            .Repeat()
-            .Should().Within(45.Seconds()).Emit();
+        //
+        // No existence gate and no retry here: the wait above already read the node off its
+        // owner, so the point stream is the authoritative live read AGENTS.md prescribes — and
+        // the `Catch(...).Repeat()` this replaces is the #2341 busy-wait (see above).
+        var settled = await workspace.GetMeshNodeStream(subThreadPath)
+            .Select(n => n.ContentAs<MeshThread>(client.JsonSerializerOptions))
+            .Should().Within(45.Seconds()).Match(t => t is { IsExecuting: false });
 
         settled!.IsExecuting.Should().BeFalse(
             "FIX: sub-thread settled within the 30s watchdog + 15s propagation " +
@@ -454,3 +474,4 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
 
     #endregion
 }
+

--- a/test/UnthrottledResubscribeSites.allow
+++ b/test/UnthrottledResubscribeSites.allow
@@ -1,0 +1,39 @@
+# UnthrottledResubscribeSites.allow — the unthrottled-resubscribe ratchet (#2341).
+#
+# Each line would be a test file that waits on a mesh stream with Rx's ARGUMENT-LESS
+#
+#     .Repeat()          .Retry()
+#
+# Both re-subscribe the instant the source terminates, with NO delay of their own. The delay people
+# believe they added lives in a `.Catch(_ => Observable.Empty<T>().Delay(200.Milliseconds()))`
+# handler — and Catch intercepts OnError ONLY. A point read of a node that does not exist yet
+# COMPLETES without emitting, so that handler never runs and the pair is a busy-wait: measured on
+# the #2341 site, 460 000 re-subscribes in 8.4 s (~54 kHz) with zero OnError.
+#
+# Rx subscribes SYNCHRONOUSLY, so the loop runs inside the assertion's own .ToTask() call and the
+# await is never reached — out of reach of .Within(...), [Fact(Timeout)], methodTimeout AND
+# MonolithMeshTestBase's hard-deadline watchdog, all of which need the method to return or park at
+# an await. One xUnit worker pins a core forever, on a 4-vCPU runner it starves the hub that has to
+# create the node it waits for, and CI kills the host at its 8 m cap: `exit=124 TIMEOUT`, no .trx,
+# no failing test named. Twelve occurrences in ~15 h across five branches and main, 2026-08-25/26.
+#
+# Format (should this file ever need an entry): <repo-relative path>\t<count>
+#
+# 🚨 THIS FILE IS DELIBERATELY EMPTY AND MUST STAY EMPTY.
+# There was no inventory to seed: the three sites that existed — SubThreadHangRepro ×1 and
+# SubThreadColdStartRepro ×2, all three waiting on a delegation sub-thread — are fixed in the change
+# that added the guard. Adding a line here is not a fix; it re-arms a defect that kills the shard.
+#
+# The fix at a site is the composition AGENTS.md prescribes for a node that may not exist yet —
+# GetQuery for EXISTENCE (empty-on-absent, live), then the owner's stream for CONTENT:
+#
+#     hub.GetQuery(id, $"path:{parent} scope:children select:path")
+#        .Where(nodes => nodes.Any(n => string.Equals(n.Path, target, StringComparison.OrdinalIgnoreCase)))
+#        .Take(1)
+#        .SelectMany(_ => workspace.GetMeshNodeStream(target))
+#        .Select(n => n.ContentAs<T>(hub.JsonSerializerOptions))
+#        .Should().Within(...).Match(predicate);
+#
+# Where a retry genuinely belongs (an owner that can transiently reject), use
+# `.RetryWhen(errors => errors.Select((_, i) => i).TakeWhile(i => i < n)
+#              .SelectMany(_ => Observable.Timer(...)))` — OnError only, its own timer, bounded.


### PR DESCRIPTION
Closes #2341.

`MeshWeaver.Threading.Test` died with `exit=124 TIMEOUT (8m wall-clock cap hit)` and no `.trx` — **12 times in ~15 h across five branches AND `main`** (first `2026-08-25T23:24Z`, latest `2026-08-26T12:35Z`; 400 runs scanned back to 2026-08-22, none before). It reddened shards on PRs whose diffs never touched the threading library.

## The issue's hypothesis is disproved, with evidence

#2341 named the two static `ManualResetEventSlim` signals in that assembly, on the theory that a signal set by one test makes a later test's guard vacuous. That cannot happen: `ParkingChatClient.Entered` and `ParkedDelegationFactory.DelegationEntered` are each referenced **only** from inside their own single-`[Fact]` class, so each is `Set()` and `Wait()`ed exactly once per process, by the same test; both waits are bounded (`Wait(30 s/60 s, ct)`); and in every wedged run's phase trace those two drain tests complete in **0.7–2 s**. They are still wrong per AGENTS.md's no-static-state rule — but they are not this defect, and this PR leaves them alone.

## What it actually is

The failing shards' own artifact carries the answer. In `collected-logs/_meshweaver-test-trace.log` the wedged host logs **112 `INIT_DONE` and 111 `DISPOSE_DONE`** — exactly one test method entered and never returned — and in all three failing runs whose artifacts survive it is the same one: **`SubThreadHangRepro`**. Everything else finishes ~36 s in; the process then looks idle for 7.5 min until CI kills it.

Reproduced locally **2 attempts out of 2** by running six hosts of the assembly at once under `DOTNET_PROCESSOR_COUNT=4` (12 sequential single-host runs on the same box were all green — the repro needs CPU contention). Both local wedges show the same trace imbalance, the same class, and one thread at 100 % CPU whose managed stack names the defect:

```
SubThreadHangRepro.<HungSubThread_WithoutUserCancel_StaysExecuting>d__4.MoveNext()
  ObservableAssertions.Emit -> WaitForFirst -> ToTask(...)          <- SYNCHRONOUS subscribe
    Timeout.Relative.Run -> ToList.Run -> Take.Count.Run
      ObservableAssertions.SubscribeHereOffSyncContext.b__0
        Do.OnNext.Run -> Concat.Run -> TailRecursiveSink.Drain()    <- Repeat()'s engine, spinning
          Producer.SubscribeRaw (Catch) -> Producer.SubscribeRaw (Defer) -> Defer.Run()
            SubThreadHangRepro+<>c__DisplayClass4_0.b__6()          <- the Defer lambda
              AutofacServiceProvider.GetService -> ResolveOperation.ExecuteOperation
```

The site:

```csharp
Observable.Defer(() => workspace.GetMeshNodeStream(subThreadPath) ... .Take(1))
    .Catch<MeshThread?, Exception>(_ => Observable.Empty<MeshThread?>().Delay(200.Milliseconds()))
    .Repeat()
```

`Catch` intercepts **OnError only**. A point read of the not-yet-created sub-thread node **completes without emitting**, so the 200 ms backoff never runs and `Repeat` re-subscribes immediately. Measured with a temporary probe on the real repro: **460 000 re-subscribes in 8.45 s (~54 kHz) and ZERO `OnError`** — the delay everyone believed was there had never executed once, on any run.

Two things turn that from wasteful into fatal:

* **Rx subscribes synchronously**, so the loop runs inside the assertion's own `.ToTask()` call and the `await` is never reached. That puts it out of reach of *every* timeout the harness has: `.Within(15 s)`, `[Fact(Timeout)]`, `methodTimeout`, and `MonolithMeshTestBase`'s hard-deadline watchdog all need the method to return or park at an await. Nothing can fail this test.
* **It starves what it waits for.** The spin pins a core and hammers Autofac + the node-stream cache; on a 4-vCPU runner that is a quarter of the machine plus lock traffic against the very hub that must create the sub-thread node. The condition stops arriving, so the loop that prevents it cannot end. On an idle 18-core box the node lands after ~170 ms and it exits — which is why this stayed invisible locally for the seven weeks the construct has existed.

Why it started on 2026-08-25: the construct dates from 2026-07-02 and its comment records the then-true behaviour (*"GetMeshNodeStream surfaces missing satellite as OnError almost immediately"*). The absent-node answer is now an empty **completion**, which silently made the `Catch` guard vacuous and flipped a 200 ms poll into a 54 kHz spin. Nothing in `src/` shares the shape — its only two `.Repeat()` sites are over sources that carry their own cadence.

## The fix

Both waits move to the composition AGENTS.md prescribes for a node that may not exist yet: the keyed `GetQuery` listing for **existence** (empty-on-absent, live — the index trails the store, so "the index has seen it" implies "the store has it"), then the owner's stream for **content**. No polling, no retry, no resubscribe; every wait is bounded by the assertion's own timeout again because nothing blocks the subscribe. The `n.Content as MeshThread` trap-door casts on the touched lines become `ContentAs<MeshThread>(...)`.

`SubThreadColdStartRepro` and `SubThreadStallRepro` carried the same construct in two more places (same assembly, same delegation wait) and are fixed identically — otherwise the wedge simply moves.

## The control

`UnthrottledResubscribeInTestRatchetGuard` refuses an argument-less `.Repeat()` / `.Retry()` anywhere under `test/`. Its allow file is deliberately **empty**: the three sites that existed are the three fixed here. `.Repeat(count)` / `.Retry(count)` / `.RetryWhen(handler)` are not matched — a bounded count terminates, and `RetryWhen` is the sanctioned replacement (OnError only, its own timer, bounded).

Proved non-vacuous two ways in the same run: a fixture asserts the scanner counts the shape in **code** and ignores it in comments and string literals (load-bearing — the guard's own prose quotes `.Repeat()` repeatedly), and it was **mutation-tested** by reintroducing one call site, which turns it red with `NEW SITE`.

## Verification

| | result |
|---|---|
| BEFORE — 6 concurrent hosts, `DOTNET_PROCESSOR_COUNT=4` | **2 wedges in 2 rounds**; stack + full dump captured for both |
| BEFORE — 12 sequential single-host runs, same box | all green (the repro needs contention) |
| BEFORE — CI | 12 × `exit=124` in the last 400 runs |
| **AFTER — 12 rounds × 6 concurrent hosts = 72 full-assembly runs** | **0 wedges** |
| `MeshWeaver.Threading.Test` | 139/139 green |
| `MeshWeaver.Documentation.Test` | 64/64 green (both ratchets + `DocumentationLinkIntegrityTest`) |
| `dotnet build -c Release -p:CIRun=true -warnaserror` | clean on both touched test projects |

## Follow-up worth a separate look (not changed here)

`MeshNodeStreamCache`'s cached entry tracks a terminal **OnError** (`MarkFaulted` → re-probe) but not a terminal **OnCompleted**, and the absent-node read now answers with an empty completion rather than the NotFound error the 2026-07 comment assumed. No other caller depends on that assumption today (checked: the only `.Repeat()` sites in `src/` are cadence-carrying), so this PR does not touch it — but it is the behaviour change that made the guard above vacuous, and worth a decision of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
