### PR TITLE
The ack gate rebuilt the whole node to read two scalars, once per waiting write, per frame

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1492,14 +1492,26 @@ public static class DataExtensions
 
         // Resolve the target id SYNCHRONOUSLY from the reduced stream's Current (Id is immutable)
         // — never a nested Take(1).Subscribe that re-enters the owner.
+        // 🚨 Off the CONTRACT, not off a rebuilt document — the same O(1) rule as the ack gate
+        // (#2339), and this one runs on the handler's TURN: every patch in a burst paid a full
+        // node serialisation here before the merge could even be queued, so the waste was
+        // charged straight to the action block that the whole burst is serialised on.
         string? preReadId = null;
         var currentSnapshot = stream.Current is { } cur ? cur.Value : default;
         if (currentSnapshot is not null)
         {
-            var snapObj = System.Text.Json.JsonSerializer
-                .SerializeToNode(currentSnapshot, currentSnapshot.GetType(), jsonOpts)
-                as System.Text.Json.Nodes.JsonObject;
-            preReadId = (snapObj?[idKey] ?? snapObj?["Id"] ?? snapObj?["id"])?.GetValue<string>();
+            if (TryReadIdentityFromContract(
+                    currentSnapshot, idKey, versionKey, jsonOpts, out var snapshotId, out _))
+            {
+                preReadId = snapshotId;
+            }
+            else
+            {
+                var snapObj = System.Text.Json.JsonSerializer
+                    .SerializeToNode(currentSnapshot, currentSnapshot.GetType(), jsonOpts)
+                    as System.Text.Json.Nodes.JsonObject;
+                preReadId = (snapObj?[idKey] ?? snapObj?["Id"] ?? snapObj?["id"])?.GetValue<string>();
+            }
         }
 
         // ATOMIC read-merge-write on the primary action-block turn — a PURE, bounded transform.
@@ -1667,6 +1679,22 @@ public static class DataExtensions
     /// churn — acking on either flushed stale state and reported success for a write that
     /// never landed (TwoSiloRecycleConvergenceTest, runs 30068597014 / 30079395006).
     /// Internal for the deterministic pin in <c>MeshWeaver.Data.Test</c>.
+    ///
+    /// <para>🚨 O(1) IN THE NODE, and that is load-bearing — issue #2339. This predicate is
+    /// evaluated once per STILL-PENDING patch on EVERY emission of the owner's reduced stream,
+    /// so a burst of K concurrent cross-hub writes to one node evaluates it K(K+1)/2 times
+    /// (41 616 at K=288). Materialising the whole node just to read two scalars made each of
+    /// those a full document serialisation — measured on a thread node at 0.9 ms per call at
+    /// 144 entries and 1.9 ms at 288 — and the cost is SELF-AMPLIFYING: the longer emissions
+    /// lag the merges, the more patches are still pending, and the more full serialisations
+    /// every subsequent emission has to pay before it can be delivered. That feedback loop is
+    /// why the owner applied all 288 writes of <c>CrossHubPatchAtomicityTest</c>'s burst in
+    /// 1.5 s while every subscriber sat through a ~2.7 s wall with no frames at all — the lag
+    /// that put the test past its settle bound on a loaded runner. Read the two values straight
+    /// off the serialization CONTRACT (<see cref="System.Text.Json.Serialization.Metadata.JsonTypeInfo"/>
+    /// — the same names and getters the serializer itself would use) and never build the
+    /// document. The full-serialisation path below survives only for a value whose contract
+    /// cannot be resolved from these options.</para>
     /// </summary>
     internal static bool ChangeContainsStampedWrite(
         object? value,
@@ -1678,6 +1706,12 @@ public static class DataExtensions
     {
         if (stampedVersion < 0 || string.IsNullOrEmpty(stampedId) || value is null)
             return false;
+
+        // Contract-driven read: no document, no allocation proportional to the node.
+        if (TryReadIdentityFromContract(value, idKey, versionKey, jsonOpts, out var fastId, out var fastVersion))
+            return string.Equals(fastId, stampedId, StringComparison.Ordinal)
+                && fastVersion >= stampedVersion;
+
         var obj = System.Text.Json.JsonSerializer
             .SerializeToNode(value, value.GetType(), jsonOpts) as System.Text.Json.Nodes.JsonObject;
         if (obj is null)
@@ -1692,6 +1726,75 @@ public static class DataExtensions
             && verValue.TryGetValue<long>(out var parsed))
             ver = parsed;
         return ver >= stampedVersion;
+    }
+
+    /// <summary>
+    /// Reads the write-identity pair (entity id, Version) off <paramref name="value"/>'s
+    /// serialization contract instead of off a materialised document — see the O(1) note on
+    /// <see cref="ChangeContainsStampedWrite"/>. Property lookup goes through
+    /// <see cref="System.Text.Json.Serialization.Metadata.JsonPropertyInfo.Name"/>, which is the
+    /// EFFECTIVE JSON name (naming policy and <c>[JsonPropertyName]</c> already applied), so the
+    /// keys matched here are exactly the keys the serializer would have written — the same
+    /// ranked <c>idKey ?? "Id" ?? "id"</c> ladder the document path uses, and
+    /// <paramref name="versionKey"/> alone for the version, defaulting to 0 when absent (a
+    /// Version of 0 is omitted from the document by <c>WhenWritingDefault</c>, which is exactly
+    /// why the document path defaults the same way).
+    /// <para>Returns <c>false</c> — deferring to the document path — only when the contract is
+    /// genuinely unavailable: options with no <c>TypeInfoResolver</c> (a bare
+    /// <c>JsonSerializerOptions</c> that has not serialized anything yet), a resolver that does
+    /// not describe this type, or a type that is not serialized as a JSON object (a custom
+    /// converter). Those cannot be answered from properties at all, so they must fall through
+    /// rather than be guessed at.</para>
+    /// </summary>
+    private static bool TryReadIdentityFromContract(
+        object value,
+        string idKey,
+        string versionKey,
+        System.Text.Json.JsonSerializerOptions jsonOpts,
+        out string? id,
+        out long version)
+    {
+        id = null;
+        version = 0;
+        if (jsonOpts.TypeInfoResolver is null
+            || !jsonOpts.TryGetTypeInfo(value.GetType(), out var typeInfo)
+            || typeInfo is null
+            || typeInfo.Kind != System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Object)
+            return false;
+
+        // The document path resolves the id as `obj[idKey] ?? obj["Id"] ?? obj["id"]`, so the
+        // three spellings are RANKED, not interchangeable — collect them separately and apply
+        // the same precedence rather than taking whichever the contract happens to list first.
+        System.Text.Json.Serialization.Metadata.JsonPropertyInfo? idExact = null;
+        System.Text.Json.Serialization.Metadata.JsonPropertyInfo? idPascal = null;
+        System.Text.Json.Serialization.Metadata.JsonPropertyInfo? idCamel = null;
+        System.Text.Json.Serialization.Metadata.JsonPropertyInfo? versionProperty = null;
+        foreach (var property in typeInfo.Properties)
+        {
+            if (property.Get is null)
+                continue;
+            if (string.Equals(property.Name, idKey, StringComparison.Ordinal))
+                idExact ??= property;
+            else if (string.Equals(property.Name, "Id", StringComparison.Ordinal))
+                idPascal ??= property;
+            else if (string.Equals(property.Name, "id", StringComparison.Ordinal))
+                idCamel ??= property;
+            if (string.Equals(property.Name, versionKey, StringComparison.Ordinal))
+                versionProperty ??= property;
+        }
+
+        if ((idExact ?? idPascal ?? idCamel) is { Get: { } getId })
+            id = getId(value) as string;
+        if (versionProperty is { Get: { } getVersion })
+            version = getVersion(value) switch
+            {
+                long l => l,
+                int i => i,
+                short s => s,
+                byte b => b,
+                _ => 0L
+            };
+        return true;
     }
 
     private static Type? WalkBaseForGeneric(Type type, Type genericDef)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-busy-nodes-stop-freezing-every-viewer.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-busy-nodes-stop-freezing-every-viewer.md
@@ -1,0 +1,63 @@
+---
+Name: A busy node stops freezing every viewer
+Category: Fix
+Description: When many writers edited the same node at once, everyone watching it went blank for seconds and then caught up in a rush — and the busier it got, the worse it got. The owner had already applied every edit; it was the delivery that was doing avoidable work, once per waiting write, on every single update.
+Icon: TopSpeed
+Order: -20260826
+---
+
+# A busy node stops freezing every viewer
+
+When a lot of writes landed on **one** node at the same time — an agent streaming a reply while its
+tools write alongside it, an import or sync pushing a batch, several people in one thread — every
+view of that node could **stop updating for seconds at a time**, then take every missed update in
+one burst.
+
+It looked like the writes were slow, or stuck. They were not. The owner of the node had already
+applied all of them, in order, correctly. Nothing was ever lost. What lagged was the *delivery* of
+those changes to everyone watching.
+
+## What was happening
+
+Every cross-hub write waits for proof that its own change has been committed before it reports
+success. To find that proof it inspects each update the node publishes and asks one question: *is
+this the state that contains my write?* — a comparison of two small values, an identity and a
+version number.
+
+To read those two values it was rebuilding the **entire node as a document**, every time.
+
+On its own that is merely wasteful. What made it bite is who pays it and when. Every write still
+waiting for its proof asks that question about every update that goes past — so a hundred writes in
+flight meant a hundred full rebuilds of the node before the next update could be delivered. And the
+node they were rebuilding was itself growing with every write.
+
+That is a loop that feeds itself. The more the delivery fell behind, the more writes were still
+waiting; the more writes were waiting, the more work each further update had to do before it could
+go out; and so on. It did not degrade gently — it held steady and then hit a wall.
+
+Counted on a burst of 288 writes to one node: delivering those 288 changes rebuilt the whole node
+**9 455 times**. The owner had finished applying every one of them in **1.5 seconds**, while
+everyone watching sat through a **2.7-second gap with no updates at all** before the rest arrived
+in a rush.
+
+## What changed
+
+The check now reads those two values **directly off the node**, using the same names the document
+would have used, and never builds the document. The answer is identical; the cost no longer depends
+on how big the node is or on how many writes are waiting.
+
+The same burst now rebuilds the node **zero** times. Delivery to every watcher completes in
+**2.5 seconds instead of 5.4**, allocating a third less memory along the way — and a watcher that
+had previously been left stranded three-quarters of the way through now finishes with everyone
+else.
+
+## What you will notice
+
+A busy node keeps moving. Live views of a thread, a document or a folder under heavy concurrent
+editing update steadily instead of freezing and lurching, and the effect grows with how busy things
+are — the case that used to be worst improves most.
+
+It also removes a knock-on: a write whose confirmation arrives too late is reported as a conflict
+and re-attempted against what the writer can see. While delivery was stalled, writers could not see
+anything newer, so those re-attempts had nothing fresh to rebase on. Keeping delivery current keeps
+that recovery path working the way it was designed to.

--- a/test/MeshWeaver.Data.Test/PatchAckWriteIdentityTest.cs
+++ b/test/MeshWeaver.Data.Test/PatchAckWriteIdentityTest.cs
@@ -112,6 +112,118 @@ public class PatchAckWriteIdentityTest
         acked.Should().Be(CommitV13);
     }
 
+    /// <summary>Probe payload whose converter COUNTS every time the node is turned into a
+    /// document — the instrument for the O(1) pin below. Instance state on a per-test options
+    /// object, never static.</summary>
+    private sealed class CountingPayload
+    {
+        public string Text { get; init; } = "payload";
+    }
+
+    private sealed class CountingPayloadConverter : System.Text.Json.Serialization.JsonConverter<CountingPayload>
+    {
+        public int Writes { get; private set; }
+
+        public override CountingPayload Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => new();
+
+        public override void Write(
+            Utf8JsonWriter writer, CountingPayload value, JsonSerializerOptions options)
+        {
+            Writes++;
+            writer.WriteStartObject();
+            writer.WriteString("text", value.Text);
+            writer.WriteEndObject();
+        }
+    }
+
+    private sealed record PayloadNode(string Id, long Version, CountingPayload Payload);
+
+    private static JsonSerializerOptions CountingOptions(
+        CountingPayloadConverter counter, JsonNamingPolicy? namingPolicy = null)
+    {
+        var options = new JsonSerializerOptions
+        {
+            // Explicit so the gate's contract lookup is available on the FIRST call — a bare
+            // options object has no resolver until something serializes through it.
+            TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver(),
+            PropertyNamingPolicy = namingPolicy
+        };
+        options.Converters.Add(counter);
+        return options;
+    }
+
+    /// <summary>
+    /// 🚨 The gate must answer from the node's two identity scalars WITHOUT materialising the
+    /// node — issue #2339. It is evaluated once per still-pending patch on EVERY emission of the
+    /// owner's reduced stream, so a burst of K concurrent cross-hub writes runs it K(K+1)/2
+    /// times; building the whole document each time made that O(K² · nodeSize) and, because a
+    /// slower emission leaves MORE patches pending, self-amplifying — the owner applied 288
+    /// writes in 1.5 s while its subscribers saw a ~2.7 s wall with no frames at all.
+    /// <para>Deterministic, not a timing assertion: the payload converter fires exactly when a
+    /// document is built, so the count IS the observation. The explicit serialisation first is
+    /// the control — it proves the instrument can fire, so the zero after it means something.</para>
+    /// </summary>
+    [Fact]
+    public void TheGate_AnswersWithoutMaterialisingTheNode()
+    {
+        var counter = new CountingPayloadConverter();
+        var options = CountingOptions(counter);
+        var node = new PayloadNode("Anthropic", 13, new CountingPayload());
+
+        // Control: the instrument fires when the document really is built.
+        JsonSerializer.SerializeToNode(node, node.GetType(), options);
+        counter.Writes.Should().Be(1, "the converter must be reached by a genuine serialisation");
+
+        for (var i = 0; i < 50; i++)
+        {
+            GateWith(node, "Anthropic", 13, options).Should().BeTrue();
+            GateWith(node, "Anthropic", 14, options).Should().BeFalse();
+            GateWith(node, "Other", 13, options).Should().BeFalse();
+        }
+
+        counter.Writes.Should().Be(1,
+            "150 gate evaluations must not build a single document — the ack watcher runs this "
+            + "predicate once per pending patch per emission, so any per-call serialisation is "
+            + "quadratic in the burst and self-amplifying (#2339)");
+    }
+
+    /// <summary>The contract read must resolve the SAME identity the document path resolves,
+    /// including under a naming policy — the keys it matches are the effective JSON names.</summary>
+    [Fact]
+    public void TheGate_ResolvesTheSameIdentity_UnderACamelCasePolicy()
+    {
+        var counter = new CountingPayloadConverter();
+        var options = CountingOptions(counter, JsonNamingPolicy.CamelCase);
+        var node = new PayloadNode("Anthropic", 13, new CountingPayload());
+
+        DataExtensions.ChangeContainsStampedWrite(node, "Anthropic", 13, "id", "version", options)
+            .Should().BeTrue("camelCase is the naming policy the mesh hub serializes MeshNode with");
+        DataExtensions.ChangeContainsStampedWrite(node, "Anthropic", 14, "id", "version", options)
+            .Should().BeFalse();
+        counter.Writes.Should().Be(0);
+    }
+
+    /// <summary>A version the serializer OMITS (0 under WhenWritingDefault) must read as 0 —
+    /// the same default the document path applies when the key is absent.</summary>
+    [Fact]
+    public void NeverStampedVersion_ReadsAsZero_AndCannotAck()
+    {
+        var counter = new CountingPayloadConverter();
+        var options = CountingOptions(counter);
+        var node = new PayloadNode("Anthropic", 0, new CountingPayload());
+
+        GateWith(node, "Anthropic", 1, options).Should().BeFalse(
+            "a node still at Version 0 cannot contain a write stamped at 1");
+        GateWith(node, "Anthropic", 0, options).Should().BeTrue(
+            "stampedVersion 0 is satisfied by version 0 — the >= rule, unchanged");
+    }
+
+    private static bool GateWith(object? value, string? stampedId, long stampedVersion, JsonSerializerOptions options)
+        => DataExtensions.ChangeContainsStampedWrite(
+            value, stampedId, stampedVersion, IdKey, VersionKey, options);
+
     [Fact]
     public void CounterfactualOldCountingShape_TakesTheLoadEcho()
     {

--- a/test/MeshWeaver.Data.Test/PatchAckWriteIdentityTest.cs
+++ b/test/MeshWeaver.Data.Test/PatchAckWriteIdentityTest.cs
@@ -126,7 +126,15 @@ public class PatchAckWriteIdentityTest
 
         public override CountingPayload Read(
             ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            => new();
+        {
+            // A converter MUST leave the reader positioned on the last token of the value it
+            // consumed; returning without advancing would strand the reader mid-value and throw
+            // on the next read. This converter exists to count WRITES, so the value itself is
+            // discarded — but it is still consumed properly, so the type stays deserializable if
+            // a later test round-trips it.
+            reader.Skip();
+            return new();
+        }
 
         public override void Write(
             Utf8JsonWriter writer, CountingPayload value, JsonSerializerOptions options)
@@ -173,8 +181,11 @@ public class PatchAckWriteIdentityTest
         var node = new PayloadNode("Anthropic", 13, new CountingPayload());
 
         // Control: the instrument fires when the document really is built.
-        JsonSerializer.SerializeToNode(node, node.GetType(), options);
+        var document = JsonSerializer.Serialize(node, node.GetType(), options);
         counter.Writes.Should().Be(1, "the converter must be reached by a genuine serialisation");
+        // ...and the probe type really does round-trip, so the converter's Read consumes its
+        // value rather than stranding the reader mid-document.
+        JsonSerializer.Deserialize<PayloadNode>(document, options)!.Id.Should().Be("Anthropic");
 
         for (var i = 0; i < 50; i++)
         {


### PR DESCRIPTION
Closes #2339.

## The issue's title is wrong in both halves, and the measurements say why

`MergeGuard` is not refusing a legitimate concurrent write, and nothing is dropped. Counted over
1 008 concurrent cross-hub writes in this test's shape:

```
MergeGuard refusal keys: {'lastModified': 1001}
```

**Every** refusal is on `lastModified` — which conflicts on every concurrent write by construction,
since each writer stamps it from its own base. **Zero** refusals on a data key, zero write errors,
and the owner ends holding every entry. Per-field partial resolution behaves exactly as #2305
established it must, and this PR does not touch it. `CrossHubPatchAtomicityTest` is **unmodified**.

## The actual defect: the ack gate rebuilt the whole node to read two scalars

`DataExtensions.ChangeContainsStampedWrite` is the write-identity gate that every cross-hub
`stream.Update` waits on. For each emission of the owner's reduced stream it asks *"is this the
state that contains my write?"* — a comparison of an entity id and a version number. To read those
two values it serialized the **entire node** to a `JsonNode`.

The gate runs once per **still-pending** patch on **every** emission, so a burst of K concurrent
writes to one node runs it up to K(K+1)/2 times, against a node that grows with every write.

**It is self-amplifying**, which is why it presents as a cliff rather than a slope: the further
emissions lag the merges, the more patches are still pending, and the more full rebuilds every next
emission must pay *before it can be delivered*. Instrumented on `CrossHubPatchAtomicityTest`'s own
6×48 burst, the owner applied all 288 patches in **1.5 s** (285 merge-turn log lines inside a
1 500 ms window) while **both** subscribers — the shared-cache mirror and a direct bypass mirror —
stopped at v213/v214 and saw a **~2.7 s gap with no frames at all**, one of them still stranded when
the owner-truth probe was taken. That lag is what put the test past its 30 s settle bound on a
loaded runner.

### Measured, on the real burst

| | before | after |
|---|---|---|
| full-node rebuilds by the gate | **9 455** | **0** |
| allocation over the burst | 4 407 MB | 2 896 MB |
| mirror convergence | 5 356 ms | 2 537 ms |

Same instrumented harness on both sides, same box, back to back. Cost of one rebuild, measured on
the same node shape: **0.9 ms at 144 entries, 1.9 ms at 288** — so those 9 455 rebuilds are seconds
of CPU, serialised on the owner's emission path ahead of every frame.

The `0` also proves the new path is genuinely live under the production hub's
`JsonSerializerOptions` rather than silently falling back to the old one.

## The fix

Read the two values off the serialization **contract** (`JsonTypeInfo` — the same effective JSON
names and getters the serializer itself would use) and never build the document. Same answer, same
ranked `idKey ?? "Id" ?? "id"` lookup, same version-absent-reads-as-0 rule. The document path stays
as the fallback for a value whose contract these options cannot resolve.

The identical waste at the handler's `preReadId` — a full node serialization per patch, charged
straight to the action block the whole burst is serialised on — goes through the same helper.

## Pinned deterministically, not on a clock

`PatchAckWriteIdentityTest` counts document builds through a payload converter, so the count **is**
the observation — no timing assertion. 150 gate evaluations now build **one** document (the control
serialisation that proves the instrument can fire) instead of 151. Verified in both directions:
reverting the source and rebuilding turns the new tests red (`151` vs `1`, `2` vs `0`); restoring it
turns them green. Two further tests pin that the contract read resolves the *same* identity as the
document path, including under a camelCase naming policy.

## Verification

- `MeshWeaver.Data.Test` — **388/388**.
- `MeshWeaver.AI.Test` — **1397/1401**, `CrossHubPatchAtomicityTest` passing inside the full
  assembly under load 48 on an 18-core box.
- `dotnet build -c Release -warnaserror` clean (0 warnings, 0 errors) on `MeshWeaver.Data`,
  `MeshWeaver.Data.Test`, `MeshWeaver.AI.Test`, `MeshWeaver.Documentation.Test`.
- `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` green.

### One unrelated local failure, attributed

`MeshPluginContentAccessTest.Autocomplete_RoundTrip_LowercaseQuery_QuotedInsertText_GetsContent`
failed once locally and passed on a control run of the full assembly against `origin/main`'s
`DataExtensions.cs` with everything else identical. It is not reachable from this diff:
`ChangeContainsStampedWrite` and the new `TryReadIdentityFromContract` have **zero callers** outside
the cross-hub `PatchDataRequest` handler, while that test asserts on an `AutocompleteRequest`
response. The failure's own diagnostics show the autocomplete returned 15 items — every layout area
and data collection, and **no content files at all** — i.e. the just-written file had not been
enumerated yet, not a fuzzy-match miss. Content collections are `FileSystemWatcher`-driven, and the
test writes a file into a brand-new directory and queries within 10 s; on a box running four
concurrent test suites that is a real race in the test, in the known content-collection-watcher
family. Flagged rather than re-run.

## Relationship to #2229

Stated explicitly because it changes the stakes, and the two halves differ:

- **A cross-hub write can genuinely fail to converge from this.** `UpdateRemote`'s conflict recovery
  (`RebaseSource`) waits up to `ConflictRebaseBound` = 5 s for *the writer's own mirror* to advance
  past the version the owner refused, then rebuilds the patch against whatever it has. A stalled
  mirror has not advanced — `STALE_MIRROR` fires, the re-attempt is rebuilt from the same base and
  is refused identically. The stall that disarms that recovery is worst precisely when many
  concurrent writers hit one node, i.e. exactly when refusals cluster ("five in one burst"), and the
  measured stalls were 2.5–2.7 s on an **idle** 18-core box — a loaded 4-vCPU pod clears 5 s easily.
- **It does not explain the `[AdoptedSourceStamp] … IsDirty=true` line itself.** That watcher writes
  via `workspace.GetMeshNodeStream()` with no path — the **own-node** path (`UpdateOwn`), which never
  goes through `MergeGuard` or `UpdateRemote`. The five refusals prove concurrent cross-hub writers
  were active on that node in that window (this defect's precondition), but that is co-occurrence,
  not a causal chain. **#2229's recurrence still needs its own owner for the own-write half.**

Also unrelated: #2291/#2305's `Status=Completed` with a placeholder `Text` is per-field merge
resolution, which this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
