### PR TITLE
fix: a hub never writes back the durable row it read on activation (#2008)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeVersioning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeVersioning.md
@@ -172,13 +172,43 @@ For a patch, both used to fire. That is not merely a wasted write: **the two are
 
 **`PostCommitFlushRegistry` is what keeps it to one.** The flush records `path → durable version` on the write's emission; `HandleSaveMeshNode` and the dispose-time `FlushPendingOwnSave` drop any sampled state at or below that mark. Three properties make the predicate sound:
 
-- **A version, not a snapshot stamp.** The sampler's gate chain runs in the *same synchronous fan-out* as the flush and — having subscribed at hub init — runs **first**, so nothing the flush stamps can be visible to it. The mark is therefore read at **handler** time, after the flush settled. (This is why `OwnNodeCache.PersistedSnapshot`, which works fine for the initial-**load** echo, cannot serve here.)
+- **A version, not a snapshot stamp.** The sampler's gate chain runs in the *same synchronous fan-out* as the flush and — having subscribed at hub init — runs **first**, so nothing the flush stamps can be visible to it. The mark is therefore read at **handler** time, after the flush settled. `OwnNodeCache.PersistedSnapshot` cannot serve here — and, it turned out, could not serve the initial-**load** echo it was written for either: see below.
 - **`<=` cannot suppress newer content.** Two distinct own states never share a version — `MeshNodeTypeSource.UpdateImpl` re-stamps any own update arriving at or below its previous version with `NextVersion`.
 - **It fails open.** The mark is raised only on a write that actually emitted (a failed flush, or the try-then-claim `null` sentinel, leaves the sampler as the writer of record), and it is dropped on delete so a same-id recreate at `Version = 1` is never read as already-persisted.
 
 It is registered at the mesh **root** (`MeshBuilder`, next to `RecentlyDeletedRegistry`) because the flush is a mesh-level singleton while its reader runs on the per-node owner hub; a hub-level registration would hand each side its own instance and neither would see the other's writes.
 
 Pinned by `PatchWriteRouteCollapseTest`: one patch ⇒ exactly one durable write; a sequential writer's deleted text is not resurrected; and a genuine second writer still trips the guard, merge and `_Activity/write-conflict-*` record.
+
+### The activation seed is an observation, and it goes on the same mark
+
+A hub's **durable activation seed** — the row `MeshNodeTypeSource.DurableSeed` reads at startup — is
+state the hub did not mint, so it must never reach either write route. That was supposed to be the
+job of the sampler's initial-load gate, a reference comparison against
+`OwnNodeCache.PersistedSnapshot`. **It does not hold, and never did.** `PersistedSnapshot` is one
+slot, while `Initialize` builds **two** collections back to back — the durable seed, then the
+routing-supplied leg — before the workspace hands either to the sampler. The slot therefore holds
+the *routing* instance, the *seed* emission fails the reference test, and the sampler dispatches the
+row the hub had just read as though it were a local edit.
+
+On a quiet node that is an equal-version rewrite and invisible. On a node another replica is writing
+it is the regression this whole page is about: the guard refuses the echo, `AdoptDurableTruth`
+correctly rebases the refusing owner at `durable + 1`, and a hub that **never edited anything** ends
+up holding a revision the store never held, with an `_Activity/write-conflict-*` record to match
+([issue #2008](https://github.com/Systemorph/MeshWeaver/issues/2008) — it surfaced as an
+intermittent cross-process test failure at ~1.3% of CI runs, because whether the echo or the real
+write reached the store first was a coin flip).
+
+So `DurableSeed` raises the same high-water, through `PostCommitFlushRegistry.RecordObservedDurable`
+— a **read-sourced** raise, distinct from `Record`: it never resolves an in-flight `Claim`, because
+a read is not a completed write and answering a waiter "persisted" on a write that may still fail
+would trade this duplicate-write bug for a lost-write one. `MeshNodeStreamHandle.AdoptPersisted`
+already did the equivalent for the *other* durable-observation path (a storage change notification);
+the activation seed was the one that did not. A real edit is unaffected — `UpdateImpl` mints it
+strictly above the seed, so it is above the mark and still writes.
+
+Pinned by `CrossProcessChangeFeedTest.AMirroringProcess_NeverWritesTheNode_NotEvenItsActivationSeed`:
+a process that only mirrors a node performs **zero** writes to it.
 
 ## Never-Mutated Nodes Keep Their Seed Version
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-mirrors-no-longer-rewrite-the-node-they-read.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-mirrors-no-longer-rewrite-the-node-they-read.md
@@ -1,0 +1,28 @@
+---
+Name: A node you only opened is no longer rewritten
+Category: Fix
+Description: Opening a node on a second replica re-saved the row it had just read, which could bump the node to a revision that was never stored and file a write-conflict record against an edit nobody made.
+Icon: ShieldCheckmark
+Order: -20260826
+---
+
+# A node you only opened is no longer rewritten
+
+Every time a node became active on a replica, that replica read the stored row —
+and then saved it straight back. Reading is not editing, so the write was never
+supposed to happen; on a quiet node it was invisible, because re-saving an
+unchanged row leaves it unchanged.
+
+It stopped being invisible the moment somebody else was editing the same node at
+the same time. The replica's echo of the row it had read is, by then, an *older*
+revision than the one your colleague just saved. The store's write guard
+correctly refused it — and refusing it made the refusing replica reconcile
+itself one revision *above* the stored row, so a replica that had only ever
+displayed the node ended up holding a version number the store never had, and
+filed a "write conflict" record against an edit nobody made.
+
+Now the row a node reads on activation is recorded as already-stored, so it is
+never queued for saving. A real edit still saves exactly as before — it carries a
+higher revision and is unaffected. What disappears is the redundant write on
+every activation, the phantom revision it could produce, and the conflict record
+that came with it.

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -871,6 +871,12 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
     /// <summary>
     /// One-shot read of this node's DURABLE row — the authoritative activation seed.
     ///
+    /// <para><b>It is an OBSERVATION, never an edit.</b> The version it reads is recorded on
+    /// <see cref="PostCommitFlushRegistry"/> so the per-node persistence sampler and the
+    /// dispose-time flush cannot write it back — see the comment at the record site for why the
+    /// sampler's reference-identity echo gate cannot cover this emission, and what the write-back
+    /// costs when a rival replica writes in the same window (#2008/#1432).</para>
+    ///
     /// <para><b>This is a raw <see cref="IStorageAdapter.Read"/>, NOT
     /// <c>MeshNodeStreamExtensions.GetMeshNode</c>.</b> It reads the row directly out of the
     /// store; there is no owner round-trip, no routing, and therefore no
@@ -910,9 +916,40 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
 
         return _persistenceCore.Read(_hubPath, _workspace.Hub.JsonSerializerOptions)
             .Take(1)
-            .Do(seed => _logger?.LogDebug(
-                "MeshNodeTypeSource[{HubPath}]: durable activation seed {Outcome} (version={Version})",
-                _hubPath, seed is null ? "found no row" : "read", seed?.Version))
+            .Do(seed =>
+            {
+                _logger?.LogDebug(
+                    "MeshNodeTypeSource[{HubPath}]: durable activation seed {Outcome} (version={Version})",
+                    _hubPath, seed is null ? "found no row" : "read", seed?.Version);
+                // 🚨 The seed IS the durable row, so record its version on the per-path high-water
+                // that HandleSaveMeshNode / FlushPendingOwnSave consult — the same thing
+                // MeshNodeStreamHandle.AdoptPersisted does for the OTHER durable-observation path
+                // (a storage change notification), and sound for the same #1249 reason: two
+                // DISTINCT own-node states can never share a version, because UpdateImpl re-stamps
+                // any own update arriving at or below its previous version with NextVersion. A
+                // later LOCAL edit therefore always carries a strictly higher version and still
+                // writes; only the observation itself is suppressed. RecordObservedDurable, not
+                // Record: a read must never resolve an in-flight flush CLAIM (see its doc).
+                //
+                // Without this, activation re-persisted the row it had just READ. The
+                // reference-identity echo gate in the persistence sampler
+                // (MeshDataSourceExtensions.SubscribeToOwnDeletion: !ReferenceEquals(n,
+                // OwnNodeCache.PersistedSnapshot)) cannot cover it: PersistedSnapshot is ONE slot,
+                // and Initialize builds TWO collections back-to-back (this seed, then the
+                // routing-supplied leg) before the workspace delivers either to the sampler — so
+                // the slot holds the routing instance and the SEED emission fails the reference
+                // test and is dispatched as if it were a local edit. Measured directly: a mirror
+                // process activating over a shared store wrote its own seed back on every
+                // activation. Harmless while the row has not moved (an equal-version rewrite), but
+                // when a rival replica's real write lands first the seed write is a strict
+                // REGRESSION: MonotonicWriteGuard refuses it and AdoptDurableTruth then rebases
+                // this hub at durable + 1 — a revision the store never held (#1432), reached by a
+                // hub that never edited anything. That is the intermittent #2008 failure, and this
+                // is its root: an observation must never enter the write path.
+                if (seed is not null)
+                    _workspace.Hub.ServiceProvider.GetService<PostCommitFlushRegistry>()
+                        ?.RecordObservedDurable(seed.Path, seed.Version);
+            })
             .Catch<MeshNode?, Exception>(ex =>
             {
                 _logger?.LogWarning(ex,

--- a/src/MeshWeaver.Mesh.Contract/Services/PostCommitFlushRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/PostCommitFlushRegistry.cs
@@ -154,16 +154,31 @@ public sealed class PostCommitFlushRegistry
             return new Entry(Math.Max(current.Version, version), now, null);
         });
         Resolve(resolved, persisted: true);
+        PruneExpired(now);
+    }
 
+    /// <summary>
+    /// Amortised, time-gated sweep of expired entries — at most one O(n) pass per <see cref="Ttl"/>,
+    /// so a write (or read) burst stays O(1) per call while the map stays bounded even for paths
+    /// nothing ever looks up again (<see cref="HighWater"/> only prunes the key it is asked for).
+    ///
+    /// <para>🚨 EVERY method that can ADD an entry must call this. It used to live inline in
+    /// <see cref="Record"/>, which was sound only while the flush was the sole way in. It is not:
+    /// <see cref="RecordObservedDurable"/> adds an entry per node ACTIVATION, and a process that
+    /// only mirrors — reading and activating many nodes, writing none — never reaches
+    /// <see cref="Record"/> at all. Leaving the sweep on the write path alone would let exactly that
+    /// process accumulate one entry per path it ever activated, for its whole uptime.</para>
+    /// </summary>
+    private void PruneExpired(DateTimeOffset now)
+    {
         var last = Interlocked.Read(ref lastPruneTicks);
-        if (now.UtcTicks - last > Ttl.Ticks
-            && Interlocked.CompareExchange(ref lastPruneTicks, now.UtcTicks, last) == last)
-        {
-            foreach (var kv in highWater)
-                // Never prune an entry with an unresolved claim — someone is waiting on it.
-                if (kv.Value.Pending is null && now - kv.Value.At > Ttl)
-                    highWater.TryRemove(kv.Key, out _);
-        }
+        if (now.UtcTicks - last <= Ttl.Ticks
+            || Interlocked.CompareExchange(ref lastPruneTicks, now.UtcTicks, last) != last)
+            return;
+        foreach (var kv in highWater)
+            // Never prune an entry with an unresolved claim — someone is waiting on it.
+            if (kv.Value.Pending is null && now - kv.Value.At > Ttl)
+                highWater.TryRemove(kv.Key, out _);
     }
 
     /// <summary>
@@ -192,6 +207,9 @@ public sealed class PostCommitFlushRegistry
             current.Pending is not null || current.Version >= version
                 ? current
                 : new Entry(version, now, null));
+        // This path ADDS entries — one per node activation — and a mirror-only process never calls
+        // Record, so the sweep has to run from here too or nothing ever bounds the map.
+        PruneExpired(now);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/Services/PostCommitFlushRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/PostCommitFlushRegistry.cs
@@ -5,9 +5,15 @@ using System.Threading;
 namespace MeshWeaver.Mesh.Services;
 
 /// <summary>
-/// 🚨 Per-path DURABLE-VERSION HIGH-WATER for the post-commit flush — the record of what the
-/// cross-hub patch path has ALREADY written to storage, so the per-node persistence sampler does
-/// not write it a second time (#1249).
+/// 🚨 Per-path DURABLE-VERSION HIGH-WATER — the record of what is ALREADY in storage, so the
+/// per-node persistence sampler does not write it a second time (#1249).
+///
+/// <para>Two things raise it, and they are the two ways a hub comes to hold state it did not mint:
+/// the post-commit flush confirming its own write (<see cref="Claim"/> → <see cref="Record"/>), and
+/// a DURABLE READ observing the row (<see cref="RecordObservedDurable"/> — the per-node hub's
+/// activation seed; <c>MeshNodeStreamHandle.AdoptPersisted</c> does the same for a storage change
+/// notification). Both mean "the row is durable at or above V", which is exactly what the skip
+/// predicate below needs.</para>
 ///
 /// <para><b>The defect it closes.</b> One patch-driven own-node change reached durable storage by
 /// TWO independent routes:</para>
@@ -65,11 +71,12 @@ namespace MeshWeaver.Mesh.Services;
 /// <c>Version = 1</c> is never mistaken for already-persisted state — the same rule
 /// <c>MonotonicWriteGuardStorageAdapter.Forget</c> follows.</para>
 ///
-/// <para>Footprint: one <c>path → (long, timestamp)</c> entry per node this process has patched,
-/// dropped on delete and TTL-bounded (same shape and the same amortised time-gated sweep as
-/// <see cref="RecentlyDeletedRegistry"/>) so a portal that patches many distinct paths over a long
-/// uptime cannot accumulate entries forever. Instance state on a mesh-scoped singleton — it dies
-/// with the mesh, never a static.</para>
+/// <para>Footprint: one <c>path → (long, timestamp)</c> entry per node this process has patched or
+/// activated, dropped on delete and TTL-bounded (same shape and the same amortised time-gated sweep
+/// as <see cref="RecentlyDeletedRegistry"/>) so a portal that touches many distinct paths over a
+/// long uptime cannot accumulate entries forever — the 30 s window is what bounds it, and it is two
+/// orders of magnitude above the 200 ms sampler debounce every reader is racing. Instance state on
+/// a mesh-scoped singleton — it dies with the mesh, never a static.</para>
 /// </summary>
 public sealed class PostCommitFlushRegistry
 {
@@ -157,6 +164,34 @@ public sealed class PostCommitFlushRegistry
                 if (kv.Value.Pending is null && now - kv.Value.At > Ttl)
                     highWater.TryRemove(kv.Key, out _);
         }
+    }
+
+    /// <summary>
+    /// Raises the mark from a DURABLE READ — the caller has just read <paramref name="path"/> out
+    /// of storage at <paramref name="version"/>, so the row IS durable at or above it. Used by the
+    /// per-node hub's activation seed (<c>MeshNodeTypeSource.DurableSeed</c>), so the persistence
+    /// sampler cannot write that read straight back (#2008).
+    ///
+    /// <para>🚨 <b>Why not <see cref="Record"/>.</b> Record is the FLUSH's completion signal: it
+    /// clears <c>Pending</c> and answers every waiter "persisted: true". A read is not a completed
+    /// write, and a read that happens to land while a flush's claim is unresolved would resolve
+    /// that claim on the flush's behalf — telling a deferred <c>SaveMeshNodeRequest</c> to drop
+    /// itself for a write that may still fail. That turns this suppression into the lost-write bug
+    /// <see cref="PendingClaim"/> exists to prevent. So an observation NEVER touches a claim: while
+    /// one is unresolved the flush owns the entry and this call is a no-op (the claim resolves in
+    /// its own turn, and the redundant echo it lets through in that narrow window is the
+    /// equal-version rewrite the store has always accepted). It also never lowers the mark, and
+    /// never leaves a waiter stranded — the two ways a raise here could do harm.</para>
+    /// </summary>
+    public void RecordObservedDurable(string? path, long version)
+    {
+        if (string.IsNullOrEmpty(path) || version <= 0)
+            return;
+        var now = DateTimeOffset.UtcNow;
+        highWater.AddOrUpdate(path, new Entry(version, now, null), (_, current) =>
+            current.Pending is not null || current.Version >= version
+                ? current
+                : new Entry(version, now, null));
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/CrossProcessChangeFeedTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CrossProcessChangeFeedTest.cs
@@ -131,6 +131,102 @@ public class CrossProcessChangeFeedTest(ITestOutputHelper output) : MonolithMesh
             + "nowhere, is not a mirror learning of a write");
     }
 
+    /// <summary>
+    /// The ROOT of #2008, as a deterministic assertion rather than the race it surfaces as:
+    /// <b>a process that only MIRRORS a node must never write that node</b> — not even the
+    /// activation seed it just read out of the same store.
+    ///
+    /// <para>Against the unfixed framework this fails on every run: process B's per-node hub reads
+    /// the durable row as its activation seed, and the persistence sampler dispatches that read
+    /// straight back to storage as if it were a local edit. The sampler's echo suppression is a
+    /// reference comparison against <c>OwnNodeCache.PersistedSnapshot</c>, which is ONE slot, while
+    /// <c>MeshNodeTypeSource.Initialize</c> builds TWO collections back-to-back (the durable seed,
+    /// then the routing-supplied leg) before the workspace hands either to the sampler — so the
+    /// slot holds the routing instance and the SEED emission is not recognised as a load.</para>
+    ///
+    /// <para><b>Why that write is the version defect and not merely a wasted round-trip.</b> It is
+    /// harmless exactly while the row has not moved. When the other process's real write lands
+    /// first — which is the whole point of a cross-process test, and what CI hits at ~1.3% — the
+    /// seed write is a strict version regression: <c>MonotonicWriteGuardStorageAdapter</c> refuses
+    /// it, and <c>AdoptDurableTruth</c> then correctly (for a hub that has something of its own to
+    /// save) rebases this owner at <c>durable + 1</c>. So a mirror that never edited anything ends
+    /// up holding a revision the store never held, carrying the right content — "converging on
+    /// content by accident, at a version that exists nowhere" (#1432), which is exactly what
+    /// <see cref="AWriteInOneProcess_ReachesTheOtherProcessesLiveMirror_WithoutARecycle"/> reports
+    /// when it fails. That test asserts the SYMPTOM under a race; this one asserts the CAUSE.</para>
+    ///
+    /// <para>🚨 <b>Two nodes, and the reason is the whole point.</b> The mirrored node under test
+    /// (<c>seed</c>) is NEVER written by anyone after B activates, so nothing can rescue B's seed
+    /// echo: the only thing that suppresses it on the unfixed framework is B adopting a HIGHER
+    /// durable version for that same path first (<c>AdoptPersisted</c> records the adopted version
+    /// on <c>PostCommitFlushRegistry</c>, which <c>HandleSaveMeshNode</c> then drops the stale save
+    /// against). Assert on a path A also writes and that rescue fires often enough to turn the red
+    /// into a coin flip — the same coin flip #2008 IS. The second node (<c>clock</c>) supplies the
+    /// wait instead: B converging on a write to a DIFFERENT path proves B ran a full
+    /// notification → re-read → adopt cycle, which begins after activation and ends past the 200 ms
+    /// persistence-sample window that dispatches the seed echo. Load stretches that cycle while the
+    /// sample window stays a wall-clock 200 ms from activation, so a busy runner makes this red
+    /// MORE reliable, not less.</para>
+    /// </summary>
+    [Fact(Timeout = 90_000)]
+    public async Task AMirroringProcess_NeverWritesTheNode_NotEvenItsActivationSeed()
+    {
+        var seedId = $"seed-echo-{Guid.NewGuid():N}";
+        var seedPath = $"{TestPartition}/{seedId}";
+        var clockId = $"seed-clock-{Guid.NewGuid():N}";
+        var clockPath = $"{TestPartition}/{clockId}";
+
+        await NodeFactory.CreateNode(new MeshNode(seedId, TestPartition)
+            { Name = "v1", NodeType = "Markdown", State = MeshNodeState.Active })
+            .Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode(clockId, TestPartition)
+            { Name = "v1", NodeType = "Markdown", State = MeshNodeState.Active })
+            .Should().Within(30.Seconds()).Emit();
+        var durableSeed = await WaitDurable(seedPath, n => n.Name == "v1");
+        await WaitDurable(clockPath, n => n.Name == "v1");
+
+        using var processB = BuildSecondProcess();
+        using var wire = Bridge(processB);
+        var adapterB = processB.ServiceProvider.GetRequiredService<CrossProcessFeedAdapter>();
+
+        // Both mirrors go live — this is what activates B's per-node hubs and runs the durable
+        // activation-seed read whose echo is under test. keepAlive holds them open, so the sampler
+        // window belongs to LIVE hubs rather than ones already tearing down.
+        var mirror = processB.Hub.GetWorkspace().GetMeshNodeStream(seedPath)
+            .Where(n => n is not null).Replay(1).RefCount();
+        using var keepAlive = mirror.Subscribe();
+        var clockMirror = processB.Hub.GetWorkspace().GetMeshNodeStream(clockPath)
+            .Where(n => n is not null).Replay(1).RefCount();
+        using var clockAlive = clockMirror.Subscribe();
+        await mirror.Should().Within(30.Seconds()).Match(n => n.Name == "v1");
+        await clockMirror.Should().Within(30.Seconds()).Match(n => n.Name == "v1");
+
+        // The clock: A writes the OTHER node and we wait for B to learn of it. Never a bare sleep,
+        // and never "the counter is still 0" — that would pass before the sampler had even fired.
+        Mesh.GetWorkspace().GetMeshNodeStream(clockPath)
+            .Update(n => n with { Name = "written-in-A" })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"[A clock write error] {ex.Message}"));
+        await WaitDurable(clockPath, n => n.Name == "written-in-A");
+        await clockMirror.Should().Within(30.Seconds()).Match(n => n.Name == "written-in-A");
+
+        var writesSeed = await Settle(() => adapterB.WriteCount(seedPath));
+        Output.WriteLine($"[B writes] seed={writesSeed} clock={adapterB.WriteCount(clockPath)} "
+            + $"(store seed v={_rows[seedPath].Version})");
+
+        writesSeed.Should().Be(0,
+            "a mirroring process READS this node and never edits it, so nothing it holds may reach "
+            + "storage. The activation seed IS the durable row — writing it back is an observation "
+            + "entering the write path, and the moment another process's write gets there first "
+            + "that echo becomes a version REGRESSION the monotonic guard refuses, after which the "
+            + "refusal rebase leaves this mirror at durable+1 (#1432/#2008)");
+
+        // …and the store is untouched: the seed row still sits at exactly the version A created it
+        // at, no rewrite of any kind.
+        _rows[seedPath].Version.Should().Be(durableSeed.Version,
+            "nobody wrote this node after it was created, so its durable revision must not have "
+            + "moved — a store that advanced has taken a write from a process that only mirrors");
+    }
+
     [Fact(Timeout = 90_000)]
     public async Task AnEntitylessEchoOfTheOwnWrite_IsSuppressed_AndWritesNothingBack()
     {
@@ -291,16 +387,30 @@ public class CrossProcessChangeFeedTest(ITestOutputHelper output) : MonolithMesh
         // MeshNodeTypeSource.LogDebug/LogWarning call from its own-node reconcile (adds/updates/
         // deletes counts, durable-seed reads) went nowhere, not xUnit output, not the log file, on
         // every run, including a failing one. See #2008.
-        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+        var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Logging:LogLevel:Default"] = "Warning",
                 ["Logging:LogLevel:MeshWeaver.Graph.MeshNodeTypeSource"] = "Debug",
             })
-            .Build());
+            .Build();
+        services.AddSingleton<IConfiguration>(configuration);
         services.AddLogging(l =>
         {
             l.ClearProviders();
+            // AddConfiguration is what makes the override above REAL, and it is the half #2348
+            // missed. Registering a provider only wires WHERE a record goes; the level deciding
+            // whether it is emitted at all lives in LoggerFilterOptions, which ILoggerFactory
+            // consults BEFORE any provider and which defaults to Information. So process B
+            // delivered its Warning/Error records (already a strict improvement on the
+            // ClearProviders-with-nothing-added-back state, which delivered none) while every
+            // LogDebug the same change added — including the MeshNodeTypeSource own-node
+            // reconcile lines the exercise was for — was still dropped by the factory, and the
+            // Debug lines that then showed up in CI were process A's. Process A gets this wiring
+            // from ServiceSetup.CreateServiceCollection; B builds its own container, so B must do
+            // it itself. Verified by reading ILogger<MeshNodeTypeSource>.IsEnabled(Debug) in both
+            // processes: A true, B false.
+            l.AddConfiguration(configuration.GetSection("Logging"));
             l.Services.AddSingleton<ILoggerProvider>(sp => new XUnitFileLoggerProvider(() => FileOutput, sp));
         });
         services.AddOptions();


### PR DESCRIPTION
Closes #2008.

## The defect

**A per-node hub writes its own activation seed back to storage** — the durable row it has just *read*.

`MeshNodeTypeSource.Initialize` builds **two** instance collections back to back — the durable seed, then the routing-supplied leg — and each stamps `OwnNodeCache.PersistedSnapshot`. That stamp is a **single slot**, and the persistence sampler's initial-load echo suppression is a reference comparison against it. So by the time the workspace delivers the **seed** emission to the sampler, the slot already holds the **routing** instance: the seed fails the reference test and is dispatched as a `SaveMeshNodeRequest` as though it were a local edit.

Instrumented directly (raw file probe, both processes tagged, so it does not depend on any logging wiring):

```
BIC hub=TestData/x v=1 hash=44597241            <- emission #1, the durable seed
BIC hub=TestData/x v=1 hash=60718826            <- emission #2, the routing leg — overwrites the stamp
SAMPLER-IN   proc=B v=1 refEq=False hash=44597241 persistedHash=60718826
SAMPLER-POST proc=B v=1
HANDLE-HW    proc=B v=1 hw=0
WRITE        proc=B v=1                          <- the mirror writes back the row it just READ
```

On a quiet node that is an equal-version rewrite and invisible. When another process's real write lands first, it is a strict version **regression**: `MonotonicWriteGuard` refuses it, `AdoptDurableTruth` (correctly, for a hub that *has* something of its own to save) rebases the refusing owner at `durable + 1`, and a hub that **never edited anything** ends up holding a revision the store never held — #1432's phantom, with an `_Activity/write-conflict-*` record to match.

That is #2008: whether the echo or the real write reached the store first was a coin flip, which is why it read as a ~1.3% flake.

It also explains the two observables the issue flagged as its best clues, both of which had no explanation before:

* **`readsB` 4→9 instead of 4→7** — the two extra reads are the guard's verification read plus the rebase's read.
* **`writesB=0` while the guard still fired** — `ResolveConflict` returns early on `IsLatestUnchanged` without calling the inner adapter, which is also exactly what `merged=(none); latest-wins (stale values DROPPED)=Name` in the CI log reported.

## The fix

`DurableSeed` records the version it read on `PostCommitFlushRegistry`, so `HandleSaveMeshNode` **and** the dispose-time `FlushPendingOwnSave` drop the echo. This is the suppression `MeshNodeStreamHandle.AdoptPersisted` already applies to the *other* durable-observation path (a storage change notification) — the activation seed was the one durable read that did not.

Through a **new `RecordObservedDurable`, not `Record`**: `Record` is the flush's completion signal and resolves any unresolved `Claim` with "persisted: true". A read is not a completed write, and resolving someone else's in-flight claim would tell a deferred `SaveMeshNodeRequest` to drop itself for a write that may still fail — trading a duplicate-write bug for a lost-write one. The observation therefore never touches a claim, never lowers the mark, and never strands a waiter.

**Why not repair the `PersistedSnapshot` slot instead?** Because reference identity is broken by *any* hop — a second `BuildInstanceCollection`, a `with`-copy, a serialization round-trip — and the sampler's own comment already concedes it "fails open to a redundant echo". This PR's finding is that a redundant echo is not free. The version high-water is the framework's existing, ordering-sound predicate for exactly this question ("is this state already durable?"), and it does not care how many instances were minted along the way.

A real edit is unaffected: `UpdateImpl` mints it strictly above the seed, so it is above the mark and still writes.

## Also: the diagnostics gap #2348 half-closed

#2348 gave process B a logger *provider*, but not `AddConfiguration` — and the level that decides whether a record is emitted at all lives in `LoggerFilterOptions`, which `ILoggerFactory` consults **before** any provider and which defaults to `Information`. So B's `Warning`/`Error` records started arriving, while every `LogDebug` the same change added — including the two own-node reconcile lines the exercise was for — was still dropped by the factory.

Measured: `ILogger<MeshNodeTypeSource>.IsEnabled(Debug)` is **true in A, false in B**. Consequence worth stating plainly: the `MeshNodeTypeSource` Debug lines quoted on #2008 as "what process B actually did" are **process A's**. Fixed here.

## Proof, both directions

New test `CrossProcessChangeFeedTest.AMirroringProcess_NeverWritesTheNode_NotEvenItsActivationSeed`: a process that only mirrors a node performs **zero** writes to it.

It uses **two** nodes deliberately. The mirrored node under test is never written by anyone, so nothing can rescue B's echo — asserting on a path A *also* writes lets B's own `AdoptPersisted` record the high-water first and turns the red back into the same coin flip #2008 is (verified: that shape passed on unfixed code). A sibling node A does write supplies the wait instead: B converging on it proves a full notification → re-read → adopt cycle ran, which ends past the 200 ms sample window. Load stretches that cycle while the sample window stays a wall-clock 200 ms from activation, so a busy runner makes the red *more* reliable, not less.

| | result |
|---|---|
| new test, framework fix reverted | **10/10 RED** (`[B writes] seed=1 clock=0`) |
| new test + the 3 existing ones, fix applied | **10/10 GREEN** |
| `MeshWeaver.Graph.Test` | 1607/1607 green |
| `-c Release -warnaserror` on every touched project | clean |

Environment: macOS, `DOTNET_PROCESSOR_COUNT=4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## One local red, attributed rather than waved away

The full-suite run *with* the fix showed a second failure:
`BuildCoordinationTest.Follower_StandsDown_SoTheNextBuildCanStillBeClaimed`, a
`TimeoutException` on a 15 s `WaitBudget` that took 32 s. It is not this change, and here is why —
stated because "unrelated flake" is exactly the claim that should never be taken on trust:

| evidence | result |
|---|---|
| control full suite, **fix reverted**, same machine, 10 m 50 s vs 10 m 55 s | **passed** — the control's only failure is the new test |
| the class in isolation, **with** the fix, 8 runs × 16 tests | **128/128 passed** |
| machine state during the failing run | load average **28**, a second agent session running `dotnet test` concurrently |
| can the change reach it? | no — it suppresses only a save whose version is `<=` the version read at activation, while every state transition in that test mints a strictly higher version, and the test asserts on the in-RAM node stream, never on the store |

Both full-suite runs report the identical `Passed: 773`; they differ by exactly those two tests, one
in each direction.
