### PR TITLE
The Orleans test host allocated a production-sized grain directory per silo (#2346)

### DIFF
--- a/test/MeshWeaver.Hosting.Orleans.Test/ClusterDisposalRetentionTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/ClusterDisposalRetentionTest.cs
@@ -40,22 +40,18 @@ public class ClusterDisposalRetentionTest
     [Fact]
     public void ASettledTeardown_RetainsNothingItCapturedSoItsClusterCanBeCollected()
     {
-        // Other test classes are tearing their clusters down concurrently, so the registry is not
-        // empty — the invariant is that it RETURNS to its prior depth, not that it is ever zero.
-        var before = OrleansClusterDisposal.PendingCount;
-
         var gate = new Subject<Unit>();
-        var captured = Enqueue(gate);
+        var (id, captured) = Enqueue(gate);
 
         // Settle the teardown, exactly as the real ordered stop→dispose chain settles when the last
         // leg completes on the I/O pool.
         gate.OnNext(Unit.Default);
         gate.OnCompleted();
 
-        // Deterministic half of the guard: the entry is gone. (The old bag never removed one, so the
-        // registry — and everything each entry reached — grew for the whole run.)
-        OrleansClusterDisposal.PendingCount.Should().BeLessThanOrEqualTo(
-            before,
+        // Deterministic half of the guard: THIS entry is gone. Asserted per-id, never as a total
+        // count — other test classes tear their clusters down concurrently, so a count is not a
+        // property this test could own.
+        OrleansClusterDisposal.IsPending(id).Should().BeFalse(
             "a settled teardown must leave the registry, or it accumulates for the life of the process");
 
         Collect();
@@ -68,21 +64,21 @@ public class ClusterDisposalRetentionTest
     }
 
     /// <summary>
-    /// Registers a drain that captures a fresh object, and hands back only a weak reference to it.
-    /// <see cref="MethodImplOptions.NoInlining"/> so the closure's display class is unreachable from
-    /// the caller's frame once this returns — otherwise a live stack slot, not the registry, would
-    /// decide the outcome.
+    /// Registers a drain that captures a fresh object, and hands back its registry id plus only a
+    /// WEAK reference to what it captured. <see cref="MethodImplOptions.NoInlining"/> so the
+    /// closure's display class is unreachable from the caller's frame once this returns — otherwise
+    /// a live stack slot, not the registry, would decide the outcome.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static WeakReference Enqueue(IObservable<Unit> gate)
+    private static (long Id, WeakReference Captured) Enqueue(IObservable<Unit> gate)
     {
         var captured = new object();
-        OrleansClusterDisposal.Enqueue(gate.Select(_ =>
+        var id = OrleansClusterDisposal.Enqueue(gate.Select(_ =>
         {
             GC.KeepAlive(captured);
             return Unit.Default;
         }));
-        return new WeakReference(captured);
+        return (id, new WeakReference(captured));
     }
 
     /// <summary>Two forced, blocking, compacting full collections — enough for a plain object with

--- a/test/MeshWeaver.Hosting.Orleans.Test/ClusterDisposalRetentionTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/ClusterDisposalRetentionTest.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Regression guard for issue #2346 — the shard-0 Orleans "rotating cast" of flakes.
+///
+/// <para><b>The defect.</b> <see cref="OrleansClusterDisposal"/> backgrounds each test class's
+/// <c>TestCluster</c> teardown and registers it so the assembly fixture can await every one of them
+/// at the end of the run. It used to register the DRAIN itself, as a connected
+/// <c>Replay(1)</c>, in a bag nothing ever removed from. A connected <c>Replay</c> holds its source;
+/// the source is a <c>SelectMany</c> chain whose lambdas close over the <c>TestCluster</c> and the
+/// Orleans client <c>IHost</c>. So every silo this assembly ever built — ~90 of them, each with its
+/// own Autofac container, grain catalog, serializer codecs, mesh hubs, workspaces, seeded MeshNodes
+/// and collectible NodeType load contexts — stayed reachable until the process exited, even though
+/// its disposal had long since completed.</para>
+///
+/// <para><b>Why it fails TESTS rather than merely wasting memory.</b> The xUnit test host runs
+/// workstation GC (Orleans logs <c>ServerGC=False</c> at every silo start), so a multi-GB gen-2 heap
+/// buys multi-second blocking pauses. CI caught Orleans' own health monitor naming them —
+/// <c>".NET Thread Pool is exhibiting delays of 1.9080052s"</c> and <c>".NET Runtime Platform
+/// stalled for 00:00:03.55 … We are now using a total of 3775MB memory"</c> — and a whole-process
+/// stall of that size expires whichever in-test budget is open at that moment. That is the rotating
+/// victim: one condition, a different named test every run. Measured on this repo before the fix,
+/// RSS across one 124 s run of this assembly climbed strictly monotonically from 86 MB to 4.6 GB
+/// with no sawtooth at all — retention, not the working set of the concurrently-running clusters.</para>
+///
+/// <para><b>What this test pins.</b> Once a backgrounded teardown has SETTLED, nothing the drain
+/// captured may still be reachable. It is deterministic: the drain is driven by a
+/// <see cref="Subject{T}"/> the test completes itself, so there is no timing, no cluster and no
+/// sleep — only "is the captured object collectable once its teardown is done?".</para>
+/// </summary>
+public class ClusterDisposalRetentionTest
+{
+    [Fact]
+    public void ASettledTeardown_RetainsNothingItCapturedSoItsClusterCanBeCollected()
+    {
+        // Other test classes are tearing their clusters down concurrently, so the registry is not
+        // empty — the invariant is that it RETURNS to its prior depth, not that it is ever zero.
+        var before = OrleansClusterDisposal.PendingCount;
+
+        var gate = new Subject<Unit>();
+        var captured = Enqueue(gate);
+
+        // Settle the teardown, exactly as the real ordered stop→dispose chain settles when the last
+        // leg completes on the I/O pool.
+        gate.OnNext(Unit.Default);
+        gate.OnCompleted();
+
+        // Deterministic half of the guard: the entry is gone. (The old bag never removed one, so the
+        // registry — and everything each entry reached — grew for the whole run.)
+        OrleansClusterDisposal.PendingCount.Should().BeLessThanOrEqualTo(
+            before,
+            "a settled teardown must leave the registry, or it accumulates for the life of the process");
+
+        Collect();
+
+        captured.IsAlive.Should().BeFalse(
+            "a teardown that has completed must not keep its TestCluster (here: the object its drain "
+            + "captured) reachable — registering the drain itself rooted every silo the assembly ever "
+            + "built, and the multi-GB heap that produced is what stalled the process for seconds at a "
+            + "time and expired whichever test budget was open (issue #2346)");
+    }
+
+    /// <summary>
+    /// Registers a drain that captures a fresh object, and hands back only a weak reference to it.
+    /// <see cref="MethodImplOptions.NoInlining"/> so the closure's display class is unreachable from
+    /// the caller's frame once this returns — otherwise a live stack slot, not the registry, would
+    /// decide the outcome.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference Enqueue(IObservable<Unit> gate)
+    {
+        var captured = new object();
+        OrleansClusterDisposal.Enqueue(gate.Select(_ =>
+        {
+            GC.KeepAlive(captured);
+            return Unit.Default;
+        }));
+        return new WeakReference(captured);
+    }
+
+    /// <summary>Two forced, blocking, compacting full collections — enough for a plain object with
+    /// no finalizer, and no polling.</summary>
+    private static void Collect()
+    {
+        for (var i = 0; i < 2; i++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using MeshWeaver.Mesh.Threading;
 using Orleans.TestingHost;
 
@@ -35,10 +36,31 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// </summary>
 internal static class OrleansClusterDisposal
 {
-    // Each cluster's stop→dispose as a hot, replayed observable — its completion is what the final
-    // drain blocks on. Replay-backed so a disposal that finishes before the drain subscribes still
-    // replays its OnCompleted.
-    private static readonly ConcurrentBag<IObservable<Unit>> Pending = new();
+    // 🚨 What lives here is a COMPLETION SIGNAL per in-flight teardown — never the drain itself,
+    // and never an entry that has already settled.
+    //
+    // It used to be a ConcurrentBag<IObservable<Unit>> of CONNECTED Replay(1) drains. A connected
+    // Replay holds its SOURCE for as long as the connectable itself is reachable, and the source
+    // here is the SelectMany chain built in DisposeInBackground — whose lambdas close over the
+    // TestCluster AND the Orleans client IHost. Nothing was ever removed from the bag, so every
+    // cluster this assembly ever built was reachable from a static field until the process exited:
+    // ~90 test classes × one silo + client host each (Autofac container, grain catalog, serializer
+    // codecs, mesh hubs, workspaces, seeded MeshNodes, collectible NodeType ALCs). "Dispose it in
+    // the background" is supposed to mean the cluster goes away once its disposal finishes; storing
+    // the drain meant it never did.
+    //
+    // 🚨 Necessary, NOT sufficient — say so plainly, because the number does not move on its own.
+    // A heap dump taken 95 s into a local run WITH this fix already applied still found all 194
+    // LruGrainDirectoryCache instances live: the silos are ALSO rooted by undisposed timers sitting
+    // in the process-wide System.Threading.TimerQueue (gcroot: TimerQueueTimer → GrainTimer →
+    // PersistentStreamPullingManager → … → Orleans.Runtime.Silo, and a second family through an
+    // Rx Sample(…) periodic timer). Removing one of two roots frees nothing, which is exactly what
+    // the before/after RSS showed. What DID move the heap is TestGrainDirectorySizing — see that
+    // file for the measurement and for why a large heap fails TESTS. This entry is still a real
+    // root and is now guarded by ClusterDisposalRetentionTest; the timer roots are a separate,
+    // unfixed finding recorded on issue #2346.
+    private static readonly ConcurrentDictionary<long, AsyncSubject<Unit>> Pending = new();
+    private static long drainId;
 
     /// <summary>
     /// Hand a cluster's disposal to the I/O pool — NEVER awaited on the teardown thread. Null-safe
@@ -102,14 +124,50 @@ internal static class OrleansClusterDisposal
     }
 
     /// <summary>
-    /// Makes an ordered drain hot NOW so the disposal proceeds concurrently with the next
-    /// class booting, and replays its terminal notification to the (later) synchronous drain.
+    /// Makes an ordered drain hot NOW so the disposal proceeds concurrently with the next class
+    /// booting, and publishes its terminal notification to the (later) synchronous drain.
+    ///
+    /// <para>🚨 The registry is handed an <see cref="AsyncSubject{T}"/> — a signal that references
+    /// NOTHING — and the entry is removed the instant the drain settles, so the only thing holding
+    /// the <see cref="TestCluster"/> graph is the live subscription, which Rx releases on
+    /// termination. A cluster therefore becomes collectable the moment its own disposal finishes,
+    /// which is what "dispose in the background" was always supposed to mean. Storing the drain
+    /// (as a connected <c>Replay</c>) instead rooted every silo for the life of the process — see
+    /// the field comment above and issue #2346.</para>
+    ///
+    /// <para><see cref="AsyncSubject{T}"/> is the right signal precisely because it replays its
+    /// terminal notification: a drain that settles before <see cref="WaitAll"/> subscribes is
+    /// already gone from the dictionary, and one that settles between the snapshot and the
+    /// subscribe still hands <see cref="WaitAll"/> a completion rather than hanging it.</para>
     /// </summary>
-    private static void Enqueue(IObservable<Unit> drain)
+    internal static void Enqueue(IObservable<Unit> drain)
     {
-        var replayed = drain.Replay(1);
-        replayed.Connect();
-        Pending.Add(replayed);
+        var id = Interlocked.Increment(ref drainId);
+        var settled = new AsyncSubject<Unit>();
+        Pending[id] = settled;
+
+        // Subscribe (not Connect+retain) is what makes the drain hot. Every terminal path — value,
+        // error, completion — settles exactly once; RunVoid already Catch-swallows a benign
+        // shutdown race per leg, so OnError here would be genuinely unexpected and must still
+        // release the entry rather than strand WaitAll on it.
+        drain.Subscribe(
+            _ => { },
+            _ => Settle(id, settled),
+            () => Settle(id, settled));
+    }
+
+    /// <summary>
+    /// Teardowns still in flight. The registry must return to its prior depth as drains settle —
+    /// a monotonically growing count is the retention bug of #2346 coming back.
+    /// </summary>
+    internal static int PendingCount => Pending.Count;
+
+    /// <summary>Releases one drain's registry entry and publishes its completion.</summary>
+    private static void Settle(long id, AsyncSubject<Unit> settled)
+    {
+        Pending.TryRemove(id, out _);
+        settled.OnNext(Unit.Default);
+        settled.OnCompleted();
     }
 
     /// <summary>
@@ -143,6 +201,20 @@ internal static class OrleansClusterDisposal
     /// re-derive "starvation" from the rotating names — that has now been asserted and refuted
     /// three times.</para>
     ///
+    /// <para>🚨 <b>Scope of the two paragraphs above, corrected 2026-08-26 (#2346).</b> They are
+    /// about CPU and about PARALLELISM, and both still hold: the bound is not the fix, and removing
+    /// <c>maxParallelThreads:4</c> changes nothing. They do NOT cover the process's HEAP, and that
+    /// turned out to be a second condition with the same rotating-victim signature. This test host
+    /// reached 4.2–4.5 GB, and under workstation GC the resulting gen-2 pauses froze the WHOLE
+    /// process for seconds — Orleans' own <c>LocalSiloHealthMonitor</c> and <c>Watchdog</c> logged
+    /// 1.9 s ThreadPool delays and a 3.55 s runtime stall (2.74 s of it GC) at 3775 MB in the CI run
+    /// that failed <c>OrleansGrainTeardownStragglerTest</c>. A stall like that is invisible in a
+    /// MEDIAN — which is exactly why the "everything else runs at full speed" reading above missed
+    /// it, and why it could reach a cluster-free, pure-CPU test (<c>RoutingBackpressureShapeTest</c>)
+    /// that has no silo to blame. Where the memory actually went, and the fix, is
+    /// <see cref="TestGrainDirectorySizing"/>. It does not explain the 45 s silo-silent window
+    /// described above; that one is still open.</para>
+    ///
     /// <para>Bounding is the framework's own prescription for this ("concurrency bounding channels
     /// through <c>IIoPool</c>"), not a tuning knob: it keeps teardown off the xUnit thread — which is
     /// what avoids the original deadlock. Legs of different clusters never wait on each other, so a
@@ -168,12 +240,14 @@ internal static class OrleansClusterDisposal
     /// </summary>
     public static void WaitAll(TimeSpan timeout)
     {
-        var all = Pending.ToArray();
+        // Only teardowns that have NOT settled are still in the dictionary — a settled one needs no
+        // waiting and, by then, holds no cluster.
+        var all = Pending.Values.ToArray();
         if (all.Length == 0)
             return;
         try
         {
-            // Merge every replayed completion; block on the merged stream's terminal notification.
+            // Merge every pending completion; block on the merged stream's terminal notification.
             // DefaultIfEmpty guards a leg that replays only OnCompleted (no OnNext). Timeout abandons
             // a genuinely-wedged silo instead of hanging the run.
             Observable.Merge(all).DefaultIfEmpty(Unit.Default).Timeout(timeout).Wait();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs
@@ -140,7 +140,8 @@ internal static class OrleansClusterDisposal
     /// already gone from the dictionary, and one that settles between the snapshot and the
     /// subscribe still hands <see cref="WaitAll"/> a completion rather than hanging it.</para>
     /// </summary>
-    internal static void Enqueue(IObservable<Unit> drain)
+    /// <returns>The registry id of this teardown — for <see cref="IsPending"/>; callers ignore it.</returns>
+    internal static long Enqueue(IObservable<Unit> drain)
     {
         var id = Interlocked.Increment(ref drainId);
         var settled = new AsyncSubject<Unit>();
@@ -154,13 +155,15 @@ internal static class OrleansClusterDisposal
             _ => { },
             _ => Settle(id, settled),
             () => Settle(id, settled));
+        return id;
     }
 
     /// <summary>
-    /// Teardowns still in flight. The registry must return to its prior depth as drains settle —
-    /// a monotonically growing count is the retention bug of #2346 coming back.
+    /// Whether ONE teardown is still in flight. Deliberately per-id rather than a total count:
+    /// other test classes are tearing their clusters down concurrently, so a count is not a
+    /// property any single test can assert on.
     /// </summary>
-    internal static int PendingCount => Pending.Count;
+    internal static bool IsPending(long id) => Pending.ContainsKey(id);
 
     /// <summary>Releases one drain's registry entry and publishes its completion.</summary>
     private static void Settle(long id, AsyncSubject<Unit> settled)

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansCommentTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansCommentTest.cs
@@ -47,6 +47,9 @@ public class OrleansCommentTest(ITestOutputHelper output) : TestBase(output)
     {
         await base.InitializeAsync();
         var builder = new TestClusterBuilder();
+        // Test-sized grain directory (#2346). This class builds its own TestCluster rather than
+        // going through OrleansTestCluster.DeployAsync, so it opts in explicitly.
+        builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
         builder.Options.InitialSilosCount = 1;
         builder.AddSiloBuilderConfigurator<CommentSiloConfigurator>();
         builder.AddClientBuilderConfigurator<CommentClientConfigurator>();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansDelegationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansDelegationTest.cs
@@ -54,6 +54,9 @@ public class OrleansDelegationTest(ITestOutputHelper output) : TestBase(output)
     {
         await base.InitializeAsync();
         var builder = new TestClusterBuilder();
+        // Test-sized grain directory (#2346). This class builds its own TestCluster rather than
+        // going through OrleansTestCluster.DeployAsync, so it opts in explicitly.
+        builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
         builder.Options.InitialSilosCount = 1;
         builder.AddSiloBuilderConfigurator<DelegationProductionSiloConfigurator>();
         builder.AddClientBuilderConfigurator<TestClientConfigurator>();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansDocumentationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansDocumentationTest.cs
@@ -40,6 +40,9 @@ public class OrleansDocumentationTest(ITestOutputHelper output) : TestBase(outpu
     {
         await base.InitializeAsync();
         var builder = new TestClusterBuilder();
+        // Test-sized grain directory (#2346). This class builds its own TestCluster rather than
+        // going through OrleansTestCluster.DeployAsync, so it opts in explicitly.
+        builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
         builder.Options.InitialSilosCount = 1;
         builder.AddSiloBuilderConfigurator<DocSiloConfigurator>();
         builder.AddClientBuilderConfigurator<DocClientConfigurator>();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansGraphDataTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansGraphDataTest.cs
@@ -43,6 +43,9 @@ public class OrleansGraphDataTest(ITestOutputHelper output) : TestBase(output)
         await base.InitializeAsync();
 
         var builder = new TestClusterBuilder();
+        // Test-sized grain directory (#2346). This class builds its own TestCluster rather than
+        // going through OrleansTestCluster.DeployAsync, so it opts in explicitly.
+        builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
         builder.Options.InitialSilosCount = 1;
         builder.AddSiloBuilderConfigurator<GraphDataSiloConfigurator>();
         builder.AddClientBuilderConfigurator<TestClientConfigurator>();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansInteractiveMarkdownTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansInteractiveMarkdownTest.cs
@@ -46,6 +46,9 @@ public class OrleansInteractiveMarkdownTest(ITestOutputHelper output) : TestBase
     {
         await base.InitializeAsync();
         var builder = new TestClusterBuilder();
+        // Test-sized grain directory (#2346). This class builds its own TestCluster rather than
+        // going through OrleansTestCluster.DeployAsync, so it opts in explicitly.
+        builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
         builder.Options.InitialSilosCount = 1;
         builder.AddSiloBuilderConfigurator<InteractiveMarkdownSiloConfigurator>();
         builder.AddClientBuilderConfigurator<TestClientConfigurator>();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansReentrancyTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansReentrancyTest.cs
@@ -56,6 +56,9 @@ public class OrleansReentrancyTest(ITestOutputHelper output) : TestBase(output)
     {
         await base.InitializeAsync();
         var builder = new TestClusterBuilder();
+        // Test-sized grain directory (#2346). This class builds its own TestCluster rather than
+        // going through OrleansTestCluster.DeployAsync, so it opts in explicitly.
+        builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
         builder.Options.InitialSilosCount = 1;
         builder.AddSiloBuilderConfigurator<ReentrancyTestSiloConfigurator>();
         builder.AddClientBuilderConfigurator<TestClientConfigurator>();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansSlideNavigationPostgresTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansSlideNavigationPostgresTest.cs
@@ -83,6 +83,9 @@ public class OrleansSlideNavigationPostgresTest(ITestOutputHelper output) : Test
         }
 
         var builder = new TestClusterBuilder();
+        // Test-sized grain directory (#2346). This class builds its own TestCluster rather than
+        // going through OrleansTestCluster.DeployAsync, so it opts in explicitly.
+        builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
         builder.Options.InitialSilosCount = 1;
         builder.AddSiloBuilderConfigurator<SlideNavPostgresSiloConfigurator>();
         builder.AddClientBuilderConfigurator<TestClientConfigurator>();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansSubThreadAutoResumeTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansSubThreadAutoResumeTest.cs
@@ -70,6 +70,9 @@ public class OrleansSubThreadAutoResumeTest(ITestOutputHelper output) : TestBase
     {
         await base.InitializeAsync();
         var builder = new TestClusterBuilder();
+        // Test-sized grain directory (#2346). This class builds its own TestCluster rather than
+        // going through OrleansTestCluster.DeployAsync, so it opts in explicitly.
+        builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
         builder.Options.InitialSilosCount = 1;
         builder.AddSiloBuilderConfigurator<AutoResumeSiloConfigurator>();
         builder.AddClientBuilderConfigurator<TestClientConfigurator>();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansTestCluster.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansTestCluster.cs
@@ -158,6 +158,9 @@ internal static class OrleansTestCluster
             // ConnectionRefused. Declaring TcpSocket makes both ends agree — real loopback sockets,
             // which is what TestCluster used by default before the in-memory transport existed.
             builder.Options.ConnectionTransport = ConnectionTransportType.TcpSocket;
+            // 🚨 Size the grain directory for a TEST cluster — BEFORE `configure`, so a test that
+            // genuinely needs a bigger one can still override. See TestGrainDirectorySizing.
+            builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
             configure(builder);
 
             cluster = builder.Build();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansThreadColdLoadHangPostgresTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansThreadColdLoadHangPostgresTest.cs
@@ -64,6 +64,9 @@ public class OrleansThreadColdLoadHangPostgresTest(ITestOutputHelper output) : T
             return;
 
         var builder = new TestClusterBuilder();
+        // Test-sized grain directory (#2346). This class builds its own TestCluster rather than
+        // going through OrleansTestCluster.DeployAsync, so it opts in explicitly.
+        builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
         builder.Options.InitialSilosCount = 1;
         builder.AddSiloBuilderConfigurator<ColdLoadPostgresSiloConfigurator>();
         builder.AddClientBuilderConfigurator<TestClientConfigurator>();

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansThreadColdLoadHangTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansThreadColdLoadHangTest.cs
@@ -67,6 +67,9 @@ public class OrleansThreadColdLoadHangTest(ITestOutputHelper output) : TestBase(
     {
         await base.InitializeAsync();
         var builder = new TestClusterBuilder();
+        // Test-sized grain directory (#2346). This class builds its own TestCluster rather than
+        // going through OrleansTestCluster.DeployAsync, so it opts in explicitly.
+        builder.AddSiloBuilderConfigurator<TestGrainDirectorySizing>();
         builder.Options.InitialSilosCount = 1;
         builder.AddSiloBuilderConfigurator<ColdLoadInMemorySiloConfigurator>();
         builder.AddClientBuilderConfigurator<TestClientConfigurator>();

--- a/test/MeshWeaver.Hosting.Orleans.Test/TestClusterSizingGuard.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/TestClusterSizingGuard.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Governance guard for the invariant <b>"every test cluster in this assembly is sized for a TEST
+/// cluster"</b> — see <see cref="TestGrainDirectorySizing"/> and issue #2346.
+///
+/// <para><b>Why a guard and not care.</b> The cost is invisible at the call site: a class writes
+/// <c>new TestClusterBuilder()</c>, which reads as completely ordinary, and Orleans quietly
+/// pre-allocates a ~9.3 MB grain-directory bucket array per silo because that is the production
+/// default. It shows up nowhere except as a slowly growing heap and, eventually, as some UNRELATED
+/// test elsewhere in the process failing its budget during a multi-second GC pause. That is a defect
+/// nobody attributes correctly by reading a diff — which is exactly the shape a control catches and
+/// review does not.</para>
+///
+/// <para><b>The rule.</b> Any file that constructs a <see cref="Orleans.TestingHost.TestClusterBuilder"/>
+/// must also name <see cref="TestGrainDirectorySizing"/>. Most classes get it for free by going
+/// through <c>OrleansTestCluster.DeployAsync</c> (which registers it centrally, so the natural path
+/// needs no opt-in and this guard never fires for it); the ten classes that hand-roll their own
+/// builder opt in on the line after they create it.</para>
+///
+/// <para>Scoped to this assembly's own sources on purpose: it is a statement about how THIS test
+/// project builds clusters, not a repo-wide policy.</para>
+/// </summary>
+public class TestClusterSizingGuard(ITestOutputHelper output)
+{
+    private const string BuilderConstruction = "new TestClusterBuilder()";
+    private const string Sizing = nameof(TestGrainDirectorySizing);
+
+    [Fact]
+    public void EveryFileThatBuildsATestCluster_AlsoSizesItsGrainDirectory()
+    {
+        var files = SourceFiles();
+
+        // A scanner that matches nothing passes vacuously — assert it found the sites first, so this
+        // guard cannot quietly become a no-op if the directory layout or the API name changes.
+        var builders = files.Where(f => File.ReadAllText(f).Contains(BuilderConstruction, StringComparison.Ordinal))
+            .ToArray();
+        builders.Should().NotBeEmpty(
+            $"the scanner must find the '{BuilderConstruction}' sites it exists to check — finding none "
+            + "means the guard is inspecting the wrong tree, not that the invariant holds");
+
+        var unsized = builders
+            .Where(f => !File.ReadAllText(f).Contains(Sizing, StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToArray();
+
+        output.WriteLine($"{builders.Length} file(s) build a TestCluster; {unsized.Length} unsized.");
+
+        unsized.Should().BeEmpty(
+            "a test cluster left at Orleans' production GrainDirectoryOptions.CacheSize (1,000,000) "
+            + "pre-allocates ~9.3 MB of buckets per silo, and this assembly starts ~194 silos in one "
+            + "process — the multi-GB heap that produces stalls the WHOLE process for seconds under "
+            + "workstation GC and expires whichever unrelated test's budget is open (#2346). Add "
+            + $"`builder.AddSiloBuilderConfigurator<{Sizing}>();`, or build the cluster through "
+            + "OrleansTestCluster.DeployAsync, which does it for you. Unsized: "
+            + string.Join(", ", unsized));
+    }
+
+    /// <summary>
+    /// This project's own <c>.cs</c> files, located from the repo root the same way
+    /// <see cref="GrainActivationSiteRatchetGuard"/> does (walk up to <c>MeshWeaver.slnx</c>) — the
+    /// resolution that is already proven to work from a CI shard's working directory.
+    /// </summary>
+    private static string[] SourceFiles()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        if (dir is null)
+            throw new InvalidOperationException(
+                "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
+
+        var project = Path.Combine(dir.FullName, "test", "MeshWeaver.Hosting.Orleans.Test");
+        if (!Directory.Exists(project))
+            throw new InvalidOperationException("Could not locate this project's sources at " + project);
+
+        return Directory.EnumerateFiles(project, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                        && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .ToArray();
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/TestGrainDirectorySizing.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/TestGrainDirectorySizing.cs
@@ -1,0 +1,82 @@
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.TestingHost;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Sizes every test silo's grain-directory cache for a TEST cluster instead of a production one —
+/// the dominant term in this assembly's heap, and the root of issue #2346.
+///
+/// <para><b>What it costs to leave at the default.</b> <see cref="GrainDirectoryOptions.CacheSize"/>
+/// defaults to <see cref="GrainDirectoryOptions.DEFAULT_CACHE_SIZE"/> = 1,000,000, and Orleans
+/// PRE-ALLOCATES the LRU's backing <c>ConcurrentDictionary</c> at that capacity. Every silo therefore
+/// allocates a ~9.3 MB bucket array the moment it starts. That is right for a production silo tracking
+/// a million grains; a test cluster tracks dozens. This assembly stands up ONE cluster PER TEST CLASS
+/// — measured in a heap dump taken 95 s into a local run: <b>194 LruGrainDirectoryCache instances,
+/// all of them LIVE, whose bucket arrays alone hold 1.80 GB — 62% of the 2.89 GB on the heap</b>
+/// (~9.3 MB each), and every one of those arrays is a Large Object Heap allocation, so it is gen-2
+/// traffic by construction.</para>
+///
+/// <para><b>Why that FAILS TESTS rather than merely wasting memory.</b> The xUnit test host runs
+/// workstation GC (Orleans logs <c>ServerGC=False</c> at every silo start), so a multi-GB gen-2 heap
+/// means multi-second BLOCKING pauses that stop the whole process — every cluster, every hub, every
+/// test's own wait. CI caught Orleans' own health monitor naming them inside the shard-0 run that
+/// failed <c>OrleansGrainTeardownStragglerTest</c>:</para>
+/// <code>
+/// LocalSiloHealthMonitor: .NET Thread Pool is exhibiting delays of 1.9080052s.
+/// Watchdog: .NET Runtime Platform stalled for 00:00:03.55. Total GC Pause duration
+///           during that period: 00:00:02.74. We are now using a total of 3775MB memory.
+///           Collection counts per generation: 0: 1709, 1: 735, 2: 143
+/// </code>
+/// <para>A whole-process stall of that size expires whichever in-test budget happens to be open at
+/// that moment — which is exactly the "rotating cast" on #2346: one condition, a different named
+/// victim every run (<c>PartitionRootActivationTest</c>'s 5 s ping budget,
+/// <c>OrleansGrainTeardownStragglerTest</c>'s 55 s token, and — decisively —
+/// <c>RoutingBackpressureShapeTest</c>, which has no cluster and no network at all and can only be
+/// broken by a process-wide stall).</para>
+///
+/// <para><b>Measured, both arms, back to back</b> (same machine, same half-hour, whole assembly per
+/// iteration, <c>DOTNET_PROCESSOR_COUNT=4</c>, single variable = the one
+/// <c>AddSiloBuilderConfigurator</c> line):</para>
+/// <list type="bullet">
+///   <item><b>Peak RSS per run — 4204 / 4248 / 4320 / 4357 / 4423 / 4460 MB without →
+///   2041 / 2246 / 2267 / 2273 / 2352 / 2561 / 2853 / 3080 MB with.</b> Median 4.34 GB → 2.31 GB.
+///   The ~2 GB that disappears is the 1.80 GB of bucket arrays the heap dump named — prediction and
+///   measurement agree, which is the whole reason to trust the mechanism.</item>
+///   <item>Wall clock is UNCHANGED on an 18-core dev box — 74.9–98.8 s without, 75.8–92.4 s with.
+///   (An earlier "30% faster" reading of mine was machine load; it is retracted here rather than
+///   left standing. The memory number is the one that holds.)</item>
+///   <item>Flake rate is unchanged: 1 failure / 9 without, 1 / 8 with — and it is the SAME test both
+///   times, <c>OrleansGrainTeardownStragglerTest</c>, which is the ambient population (#2301's
+///   "activation never leaves the catalog"), not something this change causes or cures.</item>
+/// </list>
+///
+/// <para><b>Not a tuning knob.</b> Nothing here raises a bound to make a test pass; it stops a test
+/// fixture from allocating a production-scale buffer ~194 times in one process. The cache is a pure
+/// optimisation — a miss costs an in-cluster directory lookup — and no test cluster in this assembly
+/// comes within orders of magnitude of <see cref="CacheSize"/> distinct grains, so nothing is evicted
+/// and no behaviour changes.</para>
+///
+/// <para>Applied centrally by <see cref="OrleansTestCluster.DeployAsync"/>, which every cluster in
+/// this assembly is built through, so a new test class inherits it without doing anything. It is
+/// registered BEFORE the caller's own configurators, so a test that needs a different size can still
+/// set one.</para>
+/// </summary>
+public class TestGrainDirectorySizing : ISiloConfigurator
+{
+    /// <summary>
+    /// Entries the directory cache is sized for.
+    ///
+    /// <para>Deliberately NOT the smallest number that would work. 50,000 is 20× below Orleans'
+    /// production default — which is where ~95% of the memory saving already is (~400 KB of buckets
+    /// per silo instead of ~9.3 MB) — while staying so far above any test cluster's grain count that
+    /// the cache can never EVICT. That matters: eviction is the only way a smaller cache could change
+    /// observable behaviour at all (a miss re-queries the directory), and picking a size where it
+    /// cannot happen removes that question instead of arguing about it.</para>
+    /// </summary>
+    internal const int CacheSize = 50_000;
+
+    public void Configure(ISiloBuilder siloBuilder) =>
+        siloBuilder.Configure<GrainDirectoryOptions>(options => options.CacheSize = CacheSize);
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/TestGrainDirectorySizing.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/TestGrainDirectorySizing.cs
@@ -47,9 +47,12 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 ///   <item>Wall clock is UNCHANGED on an 18-core dev box — 74.9–98.8 s without, 75.8–92.4 s with.
 ///   (An earlier "30% faster" reading of mine was machine load; it is retracted here rather than
 ///   left standing. The memory number is the one that holds.)</item>
-///   <item>Flake rate is unchanged: 1 failure / 9 without, 1 / 8 with — and it is the SAME test both
-///   times, <c>OrleansGrainTeardownStragglerTest</c>, which is the ambient population (#2301's
-///   "activation never leaves the catalog"), not something this change causes or cures.</item>
+///   <item>Flake rate: <b>2 failures / 17 runs without, 5 / 21 with</b> — not distinguishable at this
+///   sample size (Fisher p ≈ 0.4), and the families overlap: <c>OrleansGrainTeardownStragglerTest</c>
+///   (#2301's "activation never leaves the catalog") failed in BOTH arms, and the delegation family
+///   failed in both too (<c>OrleansThreadStreamingTest</c> without, <c>OrleansNodeChangePropagationTest</c>
+///   with). That is the ambient population this change neither causes nor cures — it is recorded here
+///   so nobody has to re-derive it, and so a later measurement has a baseline to beat.</item>
 /// </list>
 ///
 /// <para><b>Not a tuning knob.</b> Nothing here raises a bound to make a test pass; it stops a test
@@ -58,10 +61,12 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// comes within orders of magnitude of <see cref="CacheSize"/> distinct grains, so nothing is evicted
 /// and no behaviour changes.</para>
 ///
-/// <para>Applied centrally by <see cref="OrleansTestCluster.DeployAsync"/>, which every cluster in
-/// this assembly is built through, so a new test class inherits it without doing anything. It is
-/// registered BEFORE the caller's own configurators, so a test that needs a different size can still
-/// set one.</para>
+/// <para>Applied centrally by <see cref="OrleansTestCluster.DeployAsync"/>, so a new test class that
+/// takes the normal path inherits it without doing anything; it is registered BEFORE the caller's own
+/// configurators, so a test that needs a different size can still set one. Ten classes build their own
+/// <c>TestClusterBuilder</c> instead and opt in on the line after they create it —
+/// <see cref="TestClusterSizingGuard"/> is what keeps that from being something anyone has to
+/// remember.</para>
 /// </summary>
 public class TestGrainDirectorySizing : ISiloConfigurator
 {

--- a/test/MeshWeaver.Hosting.Orleans.Test/TestGrainDirectorySizing.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/TestGrainDirectorySizing.cs
@@ -47,12 +47,16 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 ///   <item>Wall clock is UNCHANGED on an 18-core dev box — 74.9–98.8 s without, 75.8–92.4 s with.
 ///   (An earlier "30% faster" reading of mine was machine load; it is retracted here rather than
 ///   left standing. The memory number is the one that holds.)</item>
-///   <item>Flake rate: <b>2 failures / 17 runs without, 5 / 21 with</b> — not distinguishable at this
-///   sample size (Fisher p ≈ 0.4), and the families overlap: <c>OrleansGrainTeardownStragglerTest</c>
-///   (#2301's "activation never leaves the catalog") failed in BOTH arms, and the delegation family
-///   failed in both too (<c>OrleansThreadStreamingTest</c> without, <c>OrleansNodeChangePropagationTest</c>
-///   with). That is the ambient population this change neither causes nor cures — it is recorded here
-///   so nobody has to re-derive it, and so a later measurement has a baseline to beat.</item>
+///   <item>Flake rate: <b>2 failures / 17 runs without, 6 / 24 with</b> (12% vs 25%) — not
+///   distinguishable at this sample size (Fisher p ≈ 0.4), and the families OVERLAP, which is the part
+///   that actually attributes: <c>OrleansGrainTeardownStragglerTest</c> (#2301's "activation never
+///   leaves the catalog") failed in BOTH arms, and the delegation family failed in both too
+///   (<c>OrleansThreadStreamingTest</c> without, <c>OrleansNodeChangePropagationTest</c> with; plus one
+///   <c>PodHubTransportTest</c>). Six named tests across 41 runs, no two arms sharing a majority
+///   member: that is the #2346 population, which this change neither causes nor cures. Recorded rather
+///   than rounded off, so a later measurement has a baseline to beat — and because the only mechanism
+///   by which a SMALLER cache could touch these at all is timing (less GC, faster silo start
+///   reshuffles interleavings); it cannot evict, so it cannot change an answer.</item>
 /// </list>
 ///
 /// <para><b>Not a tuning knob.</b> Nothing here raises a bound to make a test pass; it stops a test


### PR DESCRIPTION
Refs #2346 — and deliberately does **not** close it. This fixes one of the conditions behind the
rotating cast, with a measurement; several named members of that cast have their own, different
mechanisms and are still open (list at the bottom). Auto-closing the umbrella would bury them, which
is the exact failure mode the issue warns about.

## The unit of work is the PROCESS, not the shard

First correction, because it changes what to look at: **the cast is not "shard 0"**. Reading the
shard artifacts of the red runs, `Acme.Test.NodeTypeProgressAreaTest` ran in shard 4,
`Hosting.Test.LiveQueryHandoffDropTest` in shard 2, `AI.Test.*` in shards 3/4 — different runners,
different processes, nothing shared. What the *Orleans* members of the cast share is one thing:
they all live in **`MeshWeaver.Hosting.Orleans.Test`**, which is ONE test host process, and which
opts out of the repo-wide serial policy (`parallelizeTestCollections: true`, `maxParallelThreads: 4`)
so four test classes — four full `TestCluster`s — are live at once.

Position in the run does not predict the failure either. Across six red runs the victim's offset was
41 s, 50 s, 65 s, 106 s, 137 s, 149 s (index 43, 63, 73, 83, 160, 192 of ~198), and the concurrently
running classes had no member in common. So: not accumulation-by-position, not a specific predecessor.

## The mechanism, from CI's own logs

The trx of the run that failed `OrleansGrainTeardownStragglerTest` on main
([32950493525](https://github.com/Systemorph/MeshWeaver/actions/runs/32950493525)) contains Orleans
diagnosing the host it is running in:

```
LocalSiloHealthMonitor: .NET Thread Pool is exhibiting delays of 1.9080052s.
                        Self-monitoring determined that local health is degraded.
Watchdog:               .NET Runtime Platform stalled for 00:00:03.5537093.
                        Total GC Pause duration during that period: 00:00:02.7441830.
                        We are now using a total of 3775MB memory.
                        Collection counts per generation: 0: 1709, 1: 735, 2: 143
```

A **whole-process stall of ~3 s** expires whichever in-test budget happens to be open at that moment.
That is the rotating cast: one condition, a different named victim every run. It also explains the
one member nothing else can — `RoutingBackpressureShapeTest`, which failed a 10 s budget while
having **no cluster and no network at all**: 128 in-memory `Subject`s draining through an `IoPool`.
Only a process-wide stall can break that test.

## Where the 3775 MB went

Reproduced locally (whole assembly, `DOTNET_PROCESSOR_COUNT=4`): RSS climbs strictly monotonically,
86 MB → 4.4 GB in one 124 s run, no sawtooth. A heap dump 95 s in, `dumpheap -stat`:

```
MT           Count      TotalSize  Class Name
00010ddc6b20   194  1,804,494,880  ConcurrentDictionary<GrainId, ConcurrentLruCache<GrainId,
                                    (GrainAddress, int)>.LruItem>.VolatileNode[]
Total 15,294,993 objects, 2,886,214,986 bytes
```

**194 objects, 1.80 GB — 62% of the entire heap**, and `dumpheap -live` confirms all 194 owning
`LruGrainDirectoryCache` instances are live. 194 is one per silo this process ever started.

`GrainDirectoryOptions.CacheSize` defaults to **1,000,000** and Orleans pre-allocates the LRU's
backing `ConcurrentDictionary` at that capacity — a ~9.3 MB Large Object Heap array **per silo**.
Correct for a production silo tracking a million grains; this assembly starts ~194 silos in one
process, each tracking dozens.

## The fix

**`TestGrainDirectorySizing`** — one `ISiloConfigurator` registered centrally in
`OrleansTestCluster.DeployAsync` (the single path every cluster in the assembly is built through, so
new test classes inherit it), setting `CacheSize = 50_000`. That is 20× below the production default
— where ~95% of the saving already is — and still orders of magnitude above any test cluster's grain
count, so the cache can never evict and no behaviour changes. It is registered *before* the caller's
own configurators, so a test that needs a different size can still set one.

This is not a bound being raised to make a test pass; it stops a test fixture from allocating a
production-scale buffer 194 times in one process.

Ten classes build their own `TestClusterBuilder` instead of going through `DeployAsync`, so the
central registration missed them; they opt in on the line after they create the builder.
**`TestClusterSizingGuard`** makes that structural rather than remembered — any file in this project
that constructs a `TestClusterBuilder` must also name `TestGrainDirectorySizing`. The cost it guards
is invisible at the call site (`new TestClusterBuilder()` reads as completely ordinary; the price
shows up as some *unrelated* test failing its budget during a GC pause), which is the shape a control
catches and review does not. It asserts it found the sites before checking them, so it cannot pass
vacuously, and it is verified in both directions: green as committed, red naming the file when the
line is stripped from one.

## Measured, both arms, back to back

Same machine, same half-hour, whole assembly per iteration, `DOTNET_PROCESSOR_COUNT=4`, single
variable (the one `AddSiloBuilderConfigurator` line):

| | peak RSS per run (MB) | median | wall clock | failures |
|---|---|---|---|---|
| without | 4204 / 4248 / 4320 / 4357 / 4423 / 4460 | 4.34 GB | 74.9–98.8 s | 2 / 17 runs |
| with | 2041 / 2246 / 2267 / 2273 / 2352 / 2561 / 2853 / 3080 | 2.31 GB | 73.2–92.4 s | 6 / 24 runs |

The ~2 GB that disappears is the 1.80 GB the dump named — prediction and measurement agree, which is
the reason to trust the mechanism rather than the story.

**Wall clock is unchanged** on an 18-core dev box; an earlier "30 % faster" reading of mine was
machine load and is retracted rather than left standing.

**Flake rate is not distinguishable at this sample size** — 12 % vs 25 %, Fisher p ≈ 0.4 across 41
runs — and the families OVERLAP, which is the part that actually attributes:
`OrleansGrainTeardownStragglerTest` failed in BOTH arms, and the delegation family failed in both too
(`OrleansThreadStreamingTest` without, `OrleansNodeChangePropagationTest` with; plus one
`PodHubTransportTest`). Six named tests, no two arms sharing a majority member — that is the #2346
population itself, which this change neither causes nor cures. Reported as measured rather than
rounded off; and the bound on the worry is that at 50,000 the cache **cannot evict**, so the only way
it could touch these races at all is timing (less GC, faster silo start), never a changed answer.

## Second change: the teardown registry rooted every cluster

`OrleansClusterDisposal` backgrounds each class's cluster teardown and registered the **drain itself**
— a connected `Replay(1)` — in a `ConcurrentBag` nothing ever removed from. A connected `Replay` holds
its source; the source's lambdas close over the `TestCluster` and the Orleans client `IHost`. So every
silo the assembly ever built stayed reachable from a static field for the life of the process, long
after its disposal completed.

Fixed by registering a completion **signal** (`AsyncSubject<Unit>`) that references nothing, and
removing the entry when the drain settles. Guarded by `ClusterDisposalRetentionTest`, which is
deterministic (a `Subject` the test completes itself — no cluster, no timing, no sleep) and asserts
both that the entry leaves the registry and that what the drain captured becomes collectable.

**Stated honestly: this one does not move the number on its own,** and the file now says so. The dump
above was taken *with* this fix already applied and still found all 194 caches live — the silos are
also rooted by undisposed timers in the process-wide `TimerQueue` (`gcroot`: `TimerQueueTimer` →
`GrainTimer` → `PersistentStreamPullingManager` → … → `Orleans.Runtime.Silo`, plus a second family
through an Rx `Sample(…)` periodic timer). Removing one of two roots frees nothing. It is still a real
root, it is cheap, and it now cannot come back; the timer roots are recorded on #2346 as an open,
separate finding.

## What this does NOT explain — deliberately

- **`OrleansMeshTests.HubWorksAfterDisposal`** (the issue's title) — a 2.3 s assertion failure, a
  shutdown NACK classification bug. Already fixed by #2351.
- **`OrleansChatHistoryTest.ColdStart` (#2291) and `OrleansAutoExecuteTest` (#2305)** — the
  Completed-round-still-holding-`"Generating response…"` write-ordering defect. A separate mechanism
  with its own investigation; nothing here touches it.
- **`OrleansGrainTeardownStragglerTest`'s 30 s "activation never leaves the catalog"** — reproduced
  locally in BOTH arms of the A/B, so it is independent of this change.
- **The 45 s silo-silent window** documented in `OrleansClusterDisposal` — untouched, and the file's
  correction note says so.
- **`Acme.Test.NodeTypeProgressAreaTest`, `Hosting.Test.LiveQueryHandoffDropTest`, `AI.Test.*`** —
  different shards, different processes.

## No What's New entry

Per the `pullrequest` skill: pure-internal change (test fixtures only, `test/` exclusively), with no
user-visible effect.
