### PR TITLE
A moved type is a binary break: the MCP module could not construct its plugin (#2370)

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -210,7 +210,7 @@ jobs:
   # Cost when it misses: one ~15 s job (checkout + one ls-remote) in front of a
   # ~22 min suite. Cost when it hits: the whole suite, skipped.
   record-signatures:
-    name: "Public record signatures (binary compatibility)"
+    name: "Public surface (binary compatibility)"
     timeout-minutes: 8
     runs-on: ubuntu-latest
     # 🚨 Runs on PRs only, and deliberately does NOT depend on precheck: this is a DIFF gate, so
@@ -222,7 +222,7 @@ jobs:
       with:
         # The gate compares HEAD against the merge base, so the base commit must be present.
         fetch-depth: 0
-    - name: "Prove the gate is not vacuous"
+    - name: "Prove the record gate is not vacuous"
       run: python3 scripts/check-record-signatures.py --self-test
     - name: "Refuse a binary-breaking primary-constructor change"
       run: |
@@ -230,6 +230,19 @@ jobs:
         base="origin/${{ github.base_ref }}"
         git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
         python3 scripts/check-record-signatures.py --base "$base"
+    # The OTHER half of the same class (#2370): a public TYPE moving assemblies, which no repo-local
+    # build can see. `landed-modules-gate` compiles the plugins repo's module SOURCE against this PR
+    # and therefore goes GREEN on exactly this break — the module that is already published binds a
+    # TypeRef, not a `using`.
+    - name: "Prove the type-move gate is not vacuous"
+      run: python3 scripts/check-type-forwards.py --self-test
+    - name: "Refuse a public type moving assemblies without a forwarder"
+      run: |
+        set -euo pipefail
+        base="origin/${{ github.base_ref }}"
+        # Already fetched above for the record gate; harmless and explicit if the steps are reordered.
+        git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
+        python3 scripts/check-type-forwards.py --base "$base"
 
   precheck:
     name: "Check for an already-green tree"

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -239,9 +239,14 @@ jobs:
     - name: "Refuse a public type moving assemblies without a forwarder"
       run: |
         set -euo pipefail
-        base="origin/${{ github.base_ref }}"
-        # Already fetched above for the record gate; harmless and explicit if the steps are reordered.
+        # Already fetched above for the record gate; repeated explicitly so the steps can be reordered.
         git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
+        # 🚨 The MERGE BASE, not the base branch tip. This is a diff question, and a public type that
+        # moves on main while this PR is open reads, against the tip, as THIS PR moving it back — a
+        # red on somebody else's change. Four such moves landed on main in one day (#2398), so this
+        # is the difference between a gate people believe and one they learn to allow-list past.
+        base=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+        echo "Comparing against merge base $base"
         python3 scripts/check-type-forwards.py --base "$base"
 
   precheck:

--- a/memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs
+++ b/memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.AI;   // MeshOperations — the namespace is its frozen binary contract (#2370)
 using MeshWeaver.Mesh;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;

--- a/scripts/check-type-forwards.py
+++ b/scripts/check-type-forwards.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""Refuse moving a PUBLIC type between platform assemblies without leaving a type forwarder.
+
+WHY THIS EXISTS
+---------------
+A module is a plain assembly that binds platform types BY SIMPLE ASSEMBLY NAME, and the module
+lane's only gate is a SEMVER FLOOR — never MVID equality — precisely so that "a landed module
+keeps loading across ordinary platform updates" (Doc/Architecture/Modules -> the skip rules).
+That sentence is a promise about BINARY compatibility.
+
+A module's IL does not hold "MeshOperations". It holds
+
+    TypeRef  MeshWeaver.AI.MeshOperations     scope: AssemblyRef MeshWeaver.AI
+
+so the FULL TYPE NAME **and** the assembly that carries it are both part of the contract. Move
+the type to another assembly, or rename its namespace, and every module compiled earlier dies
+the moment the platform rolls:
+
+    System.TypeLoadException: Could not load type 'MeshWeaver.AI.MeshOperations'
+        from assembly 'MeshWeaver.AI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null'
+
+That is #2370, and it took down the WHOLE /mcp surface of a production deployment: the MCP SDK
+constructs its tool target per invocation, so every get / search / create / update / render_area
+call from every external client (Claude Code, Copilot) failed identically until the platform
+carried the type again.
+
+WHY REVIEW AND THE OTHER GATES CANNOT CATCH IT
+----------------------------------------------
+The change that caused #2370 was verified by BUILDING the plugins repo's MeshWeaver.Mcp against
+the branch, and it compiled cleanly — the module's source carries `using` directives for both
+namespaces, so SOURCE compatibility survived a break that BINARY compatibility did not. The same
+blind spot is structural in CI:
+
+  * `landed-modules-gate` compiles the plugins repo's module SOURCE against the PR. It answers
+    "will the module still COMPILE", never "will the module ALREADY PUBLISHED still BIND".
+  * `check-record-signatures.py` (#2298) covers the other half of the same class — a public
+    record's primary constructor — and stops at constructors.
+  * The semver floor cannot see a type at all.
+
+WHAT IT CHECKS
+--------------
+Comparing the merge base against the working tree, for every `public` top-level type declared
+under `src/<Assembly>/`:
+
+    the type is no longer declared in <Assembly>, but a type of the same SIMPLE NAME is now
+    declared in a DIFFERENT src/ assembly
+
+...i.e. it MOVED. That is binary-breaking unless the old assembly leaves a forwarder, so the gate
+requires `src/<OldAssembly>/**.cs` to contain
+
+    [assembly: TypeForwardedTo(typeof(<OldNamespace>.<Name>))]
+
+A forwarder CANNOT rename, so a move that also changes the namespace fails until the original
+full name is restored in the new assembly (which is exactly the #2370 fix: the moved types keep
+`namespace MeshWeaver.AI` inside MeshWeaver.Mesh.Operations, and MeshWeaver.AI forwards).
+
+WHAT IT DELIBERATELY DOES NOT CHECK
+-----------------------------------
+A public type that disappears from `src/` ENTIRELY is out of scope, and that is a scoping
+decision rather than an oversight. An assembly that leaves this repo for a node repo (#2276)
+keeps its assembly name and keeps serving its consumers, so every one of its types would be a
+false positive; and a genuine deletion reads AS a deletion in review, whereas a move reads as a
+refactor and reviews as one. The silent shape is the one gated here.
+
+THE ESCAPE HATCH
+----------------
+`scripts/type-forwards.allow` takes one `Assembly:Namespace.Type` per line with a reason. An
+entry is a statement that no shipped module can be holding that TypeRef — not a way to make the
+gate quiet. A STALE entry (listed, but the type did not move in this diff) FAILS, exactly like
+the repo's other ratchets, so it cannot outlive its change and hide the next break.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ALLOW_FILE = "scripts/type-forwards.allow"
+
+# `public sealed record Foo(` / `public partial class Bar<T> :` / `public enum Baz` / `public
+# delegate void Qux(`. Anchored at column 0 so NESTED types (always indented in this repo, and
+# never independently bindable by their simple name) are out of scope.
+TYPE_RE = re.compile(
+    r"^public\s+"
+    r"(?:(?:sealed|abstract|partial|readonly|ref|unsafe|static)\s+)*"
+    r"(?:class|record|struct|interface|enum|delegate)\s+"
+    r"(?:(?:class|struct)\s+)?"          # `record class` / `record struct`
+    r"(?P<name>[A-Za-z_]\w*)",
+    re.MULTILINE,
+)
+
+# `namespace Foo.Bar;` (file-scoped) or `namespace Foo.Bar {`
+NAMESPACE_RE = re.compile(r"^namespace\s+(?P<ns>[A-Za-z_][\w.]*)\s*[;{]", re.MULTILINE)
+
+FORWARD_RE = re.compile(
+    r"\[assembly:\s*TypeForwardedTo\s*\(\s*typeof\(\s*(?P<type>[A-Za-z_][\w.]*)\s*\)\s*\)\s*\]"
+)
+
+# Paths under src/ that are NOT compiled into their assembly. `MeshWeaver.Documentation/Data` is
+# in-mesh node source shipped as content (AGENTS.md: compiled at RUNTIME, never by any build), so
+# a type "moving" between two doc samples is not a binary event at all.
+EXCLUDED_PREFIXES = ("src/MeshWeaver.Documentation/Data/",)
+
+
+@dataclass(frozen=True)
+class Decl:
+    assembly: str
+    namespace: str
+    name: str
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.namespace}.{self.name}" if self.namespace else self.name
+
+    @property
+    def key(self) -> str:
+        return f"{self.assembly}:{self.full_name}"
+
+
+def _is_scanned(path: str) -> bool:
+    if not path.startswith("src/") or not path.endswith(".cs"):
+        return False
+    if "/bin/" in path or "/obj/" in path:
+        return False
+    return not path.startswith(EXCLUDED_PREFIXES)
+
+
+def _assembly_of(path: str) -> str:
+    # src/<Assembly>/... — the project directory IS the assembly name throughout this repo.
+    return path.split("/")[1]
+
+
+def parse_declarations(path: str, text: str) -> list[Decl]:
+    """Public top-level types declared by one file, with the namespace in force."""
+    assembly = _assembly_of(path)
+    namespaces = [(m.start(), m.group("ns")) for m in NAMESPACE_RE.finditer(text)]
+    out: list[Decl] = []
+    for m in TYPE_RE.finditer(text):
+        ns = ""
+        for start, candidate in namespaces:
+            if start < m.start():
+                ns = candidate
+            else:
+                break
+        out.append(Decl(assembly, ns, m.group("name")))
+    return out
+
+
+def parse_forwards(text: str) -> set[str]:
+    return {m.group("type") for m in FORWARD_RE.finditer(text)}
+
+
+# ─────────────────────────────── tree readers ───────────────────────────────
+
+
+def _run(args: list[str]) -> str:
+    return subprocess.run(args, check=True, capture_output=True, text=True).stdout
+
+
+def read_base_tree(base: str) -> tuple[dict[str, Decl], set[str], set[str]]:
+    # ONE `git cat-file --batch` for the whole base tree rather than a `git show` per file: the
+    # scanned set is ~1500 files, and a subprocess each turns a 2-second gate into a 25-second one.
+    wanted: list[tuple[str, str]] = []
+    for line in _run(["git", "ls-tree", "-r", base]).splitlines():
+        meta, _, path = line.partition("\t")
+        if not _is_scanned(path):
+            continue
+        wanted.append((meta.split()[2], path))
+
+    decls: dict[str, Decl] = {}
+    forwards: set[str] = set()
+    assemblies = {_assembly_of(path) for _, path in wanted}
+    if not wanted:
+        return decls, forwards, assemblies
+
+    proc = subprocess.run(
+        ["git", "cat-file", "--batch"],
+        input=("\n".join(oid for oid, _ in wanted) + "\n").encode(),
+        check=True,
+        capture_output=True,
+    )
+    blob = proc.stdout
+    cursor = 0
+    for _, path in wanted:
+        header_end = blob.index(b"\n", cursor)
+        size = int(blob[cursor:header_end].split()[2])
+        body = blob[header_end + 1 : header_end + 1 + size]
+        cursor = header_end + 1 + size + 1  # trailing newline after each object
+        text = body.decode("utf-8", errors="replace")
+        for d in parse_declarations(path, text):
+            decls[d.key] = d
+        forwards |= {f"{_assembly_of(path)}:{t}" for t in parse_forwards(text)}
+    return decls, forwards, assemblies
+
+
+def read_work_tree(root: Path) -> tuple[dict[str, Decl], set[str], set[str]]:
+    decls: dict[str, Decl] = {}
+    forwards: set[str] = set()
+    assemblies: set[str] = set()
+    for file in sorted((root / "src").rglob("*.cs")):
+        path = file.relative_to(root).as_posix()
+        if not _is_scanned(path):
+            continue
+        text = file.read_text(encoding="utf-8", errors="replace")
+        assemblies.add(_assembly_of(path))
+        for d in parse_declarations(path, text):
+            decls[d.key] = d
+        forwards |= {f"{_assembly_of(path)}:{t}" for t in parse_forwards(text)}
+    return decls, forwards, assemblies
+
+
+def read_allow(root: Path) -> dict[str, str]:
+    file = root / ALLOW_FILE
+    if not file.exists():
+        return {}
+    entries: dict[str, str] = {}
+    for line in file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, reason = line.partition(" ")
+        entries[key.strip()] = reason.strip()
+    return entries
+
+
+# ─────────────────────────────── the check ───────────────────────────────
+
+
+def find_moves(
+    before: dict[str, Decl],
+    after: dict[str, Decl],
+    forwards: set[str],
+    head_assemblies: set[str] | None = None,
+) -> tuple[list[tuple[str, str]], set[str]]:
+    """Returns ([(key, message)] failures, keys that legitimately moved).
+
+    The key is what `scripts/type-forwards.allow` names, so `check` can match an allow entry
+    EXACTLY — a substring match on the message would let one entry silence a same-named type in a
+    different assembly."""
+    by_simple_name: dict[str, list[Decl]] = {}
+    for d in after.values():
+        by_simple_name.setdefault(d.name, []).append(d)
+
+    failures: list[tuple[str, str]] = []
+    moved: set[str] = set()
+    for key, old in sorted(before.items()):
+        if key in after:
+            continue
+        if head_assemblies is not None and old.assembly not in head_assemblies:
+            # The WHOLE assembly left this repo (the #2276 wave moves several to MeshWeaver.Plugins).
+            # There is nowhere here to put a forwarder, and the assembly keeps its name and its
+            # consumers wherever it is now built — so a same-simple-named type elsewhere in src/ is a
+            # coincidence, not a move. Skipping this is what keeps the gate honest: without it, the
+            # Blazor exit alone produces 15 false positives that would train people to allow-list.
+            continue
+        landed = [d for d in by_simple_name.get(old.name, []) if d.assembly != old.assembly]
+        if not landed:
+            continue  # gone from src/ entirely — out of scope, see the module docstring
+        moved.add(key)
+        if key in forwards:
+            continue  # the old assembly forwards the ORIGINAL full name: binary-compatible
+        destinations = ", ".join(sorted(f"{d.assembly} ({d.full_name})" for d in landed))
+        renamed = all(d.full_name != old.full_name for d in landed)
+        remedy = (
+            f"      A forwarder cannot rename. Restore `namespace {old.namespace};` on the type in "
+            f"its new assembly, then add the forwarder."
+            if renamed
+            else f"      Add to src/{old.assembly}: "
+            f"[assembly: TypeForwardedTo(typeof({old.full_name}))]"
+        )
+        failures.append((
+            key,
+            f"  {old.full_name}\n"
+            f"      left  {old.assembly}\n"
+            f"      now in {destinations}\n"
+            f"      No [assembly: TypeForwardedTo(typeof({old.full_name}))] in src/{old.assembly}, so "
+            f"every module compiled\n"
+            f"      against the old platform binds a TypeRef that no longer resolves (#2370).\n"
+            f"{remedy}",
+        ))
+    return failures, moved
+
+
+def check(root: Path, base: str, head: str | None = None) -> int:
+    before, _, _ = read_base_tree(base)
+    after, forwards, head_assemblies = (
+        read_base_tree(head) if head else read_work_tree(root)
+    )
+    allow = read_allow(root)
+
+    failures, moved = find_moves(before, after, forwards, head_assemblies)
+
+    unmatched = [key for key in allow if key not in moved]
+    remaining = [message for key, message in failures if key not in allow]
+
+    if not remaining and not unmatched:
+        print(f"OK — no unguarded public-type move against {base}.")
+        return 0
+
+    if remaining:
+        print(
+            "\nA PUBLIC TYPE MOVED ASSEMBLIES WITHOUT A TYPE FORWARDER — binary-breaking for every\n"
+            "module compiled against an earlier platform (#2370):\n"
+        )
+        print("\n\n".join(remaining))
+        print(
+            f"\nIf no shipped module can hold this TypeRef, record that in {ALLOW_FILE} with a reason.\n"
+        )
+    for key in sorted(unmatched):
+        print(
+            f"STALE ALLOW ENTRY: {ALLOW_FILE} lists `{key}`, but nothing of that name moved in this\n"
+            f"  diff. Delete the line — an entry that outlives its change hides the next break."
+        )
+    return 1
+
+
+# ─────────────────────────────── self-test ───────────────────────────────
+#
+# Every FAILING case keeps a second file in the OLD assembly ("Keep"): an assembly with no files
+# left at HEAD has left the repo, and the gate skips it deliberately (see find_moves).
+
+AI_OPS_OLD = "namespace MeshWeaver.AI;\npublic class MeshOperations\n{\n}\n"
+OPS_NEW_NS = "namespace MeshWeaver.Mesh;\npublic class MeshOperations\n{\n}\n"
+AI_KEEP = "namespace MeshWeaver.AI;\npublic class MeshPlugin\n{\n}\n"
+FOO_N = "namespace N;\npublic sealed record Foo(int X);\n"
+FOO_GENERIC = "namespace N;\npublic sealed record class Foo<T> where T : notnull\n{\n}\n"
+FOO_BLOCK_NS = "namespace N\n{\n}\npublic class Foo\n{\n}\n"
+KEEP_A = "namespace N;\npublic class Keep\n{\n}\n"
+DOC_KEEP = "namespace MeshWeaver.Documentation;\npublic class Doc\n{\n}\n"
+BLAZOR_PORTAL_APP = "namespace MeshWeaver.Blazor.Infrastructure;\npublic class PortalApplication\n{\n}\n"
+ASPNET_PORTAL_APP = "namespace MeshWeaver.Hosting.AspNetCore.Portal;\npublic class PortalApplication\n{\n}\n"
+ASPNET_KEEP = "namespace MeshWeaver.Hosting.AspNetCore;\npublic class Other\n{\n}\n"
+ENUM_E = "namespace N;\npublic enum E\n{\n    A,\n}\n"
+DELEGATE_D = "namespace N;\npublic delegate void D(int x);\n"
+
+SELF_TESTS: list[tuple[str, dict[str, str], dict[str, str], bool]] = [
+    (
+        "the #2370 move: assembly AND namespace changed, no forwarder",
+        {
+            "src/MeshWeaver.AI/MeshOperations.cs": AI_OPS_OLD,
+            "src/MeshWeaver.AI/MeshPlugin.cs": AI_KEEP,
+        },
+        {
+            "src/MeshWeaver.Mesh.Operations/MeshOperations.cs": OPS_NEW_NS,
+            "src/MeshWeaver.AI/MeshPlugin.cs": AI_KEEP,
+        },
+        False,
+    ),
+    (
+        "the #2370 fix: original full name kept, forwarder left behind",
+        {
+            "src/MeshWeaver.AI/MeshOperations.cs": AI_OPS_OLD,
+            "src/MeshWeaver.AI/MeshPlugin.cs": AI_KEEP,
+        },
+        {
+            "src/MeshWeaver.Mesh.Operations/MeshOperations.cs": AI_OPS_OLD,
+            "src/MeshWeaver.AI/MeshPlugin.cs": AI_KEEP,
+            "src/MeshWeaver.AI/TypeForwards.cs":
+                "[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.MeshOperations))]\n",
+        },
+        True,
+    ),
+    (
+        "assembly move only (namespace unchanged), but the forwarder is missing",
+        {"src/A/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        {"src/B/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        False,
+    ),
+    (
+        "assembly move only, forwarder present",
+        {"src/A/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        {
+            "src/B/Foo.cs": FOO_N,
+            "src/A/Keep.cs": KEEP_A,
+            "src/A/Fwd.cs": "[assembly: TypeForwardedTo(typeof(N.Foo))]\n",
+        },
+        True,
+    ),
+    (
+        "a forwarder in the WRONG assembly does not count",
+        {"src/A/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        {
+            "src/B/Foo.cs": FOO_N,
+            "src/A/Keep.cs": KEEP_A,
+            "src/C/Fwd.cs": "[assembly: TypeForwardedTo(typeof(N.Foo))]\n",
+        },
+        False,
+    ),
+    (
+        "a forwarder for a DIFFERENT full name does not count (a forwarder cannot rename)",
+        {"src/A/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        {
+            "src/B/Foo.cs": "namespace M;\npublic class Foo\n{\n}\n",
+            "src/A/Keep.cs": KEEP_A,
+            "src/A/Fwd.cs": "[assembly: TypeForwardedTo(typeof(M.Foo))]\n",
+        },
+        False,
+    ),
+    (
+        "type deleted outright — out of scope, must not fire",
+        {"src/A/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        {"src/A/Keep.cs": KEEP_A},
+        True,
+    ),
+    (
+        # The Blazor exit (#2276) is exactly this, 15 times over. Without the whole-assembly-left
+        # rule the gate reports every one and teaches people to allow-list.
+        "an assembly LEAVES the repo while a same-named type exists elsewhere — must not fire",
+        {
+            "src/MeshWeaver.Blazor/Infrastructure/PortalApplication.cs": BLAZOR_PORTAL_APP,
+            "src/MeshWeaver.Hosting.AspNetCore/Other.cs": ASPNET_KEEP,
+        },
+        {"src/MeshWeaver.Hosting.AspNetCore/Portal/PortalApplication.cs": ASPNET_PORTAL_APP},
+        True,
+    ),
+    (
+        "...but a move out of an assembly that IS still here still fires",
+        {
+            "src/MeshWeaver.Blazor/Infrastructure/PortalApplication.cs": BLAZOR_PORTAL_APP,
+            "src/MeshWeaver.Blazor/Keep.cs": "namespace MeshWeaver.Blazor;\npublic class Keep\n{\n}\n",
+        },
+        {
+            "src/MeshWeaver.Blazor/Keep.cs": "namespace MeshWeaver.Blazor;\npublic class Keep\n{\n}\n",
+            "src/MeshWeaver.Hosting.AspNetCore/Portal/PortalApplication.cs": ASPNET_PORTAL_APP,
+        },
+        False,
+    ),
+    (
+        "moving a file WITHIN one assembly is not a move at all",
+        {"src/A/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        {"src/A/Sub/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        True,
+    ),
+    (
+        "an INTERNAL type moving is not a binary contract",
+        {"src/A/Foo.cs": "namespace N;\ninternal class Foo\n{\n}\n", "src/A/Keep.cs": KEEP_A},
+        {"src/B/Foo.cs": "namespace M;\ninternal class Foo\n{\n}\n", "src/A/Keep.cs": KEEP_A},
+        True,
+    ),
+    (
+        "a NESTED public type is not independently bindable — indented, so out of scope",
+        {
+            "src/A/Foo.cs": "namespace N;\npublic class Foo\n{\n    public class Inner\n    {\n    }\n}\n",
+            "src/A/Keep.cs": KEEP_A,
+        },
+        {
+            "src/A/Foo.cs": FOO_N,
+            "src/A/Keep.cs": KEEP_A,
+            "src/B/Inner.cs": "namespace M;\npublic class Inner\n{\n}\n",
+        },
+        True,
+    ),
+    (
+        "`public record class` / generics parse (they are the shapes that make a matcher lie)",
+        {"src/A/Foo.cs": FOO_GENERIC, "src/A/Keep.cs": KEEP_A},
+        {"src/B/Foo.cs": FOO_GENERIC, "src/A/Keep.cs": KEEP_A},
+        False,
+    ),
+    (
+        "block-scoped namespaces resolve to the enclosing declaration",
+        {"src/A/Foo.cs": FOO_BLOCK_NS, "src/A/Keep.cs": KEEP_A},
+        {"src/B/Foo.cs": FOO_BLOCK_NS, "src/A/Keep.cs": KEEP_A},
+        False,
+    ),
+    (
+        "an in-mesh doc sample is not compiled, so it is not a binary move",
+        {
+            "src/MeshWeaver.Documentation/Data/X/Source/Foo.cs": FOO_N,
+            "src/MeshWeaver.Documentation/Doc.cs": DOC_KEEP,
+        },
+        {
+            "src/MeshWeaver.Documentation/Data/Y/Source/Foo.cs": FOO_N,
+            "src/MeshWeaver.Documentation/Doc.cs": DOC_KEEP,
+        },
+        True,
+    ),
+    (
+        "a public enum is a type too",
+        {"src/A/E.cs": ENUM_E, "src/A/Keep.cs": KEEP_A},
+        {"src/B/E.cs": ENUM_E, "src/A/Keep.cs": KEEP_A},
+        False,
+    ),
+    (
+        "a public delegate is a type too",
+        {"src/A/D.cs": DELEGATE_D, "src/A/Keep.cs": KEEP_A},
+        {"src/B/D.cs": DELEGATE_D, "src/A/Keep.cs": KEEP_A},
+        False,
+    ),
+]
+
+
+def self_test() -> int:
+    failed = 0
+    for label, base_files, head_files, should_pass in SELF_TESTS:
+        before: dict[str, Decl] = {}
+        for path, text in base_files.items():
+            if _is_scanned(path):
+                for d in parse_declarations(path, text):
+                    before[d.key] = d
+        after: dict[str, Decl] = {}
+        forwards: set[str] = set()
+        head_assemblies: set[str] = set()
+        for path, text in head_files.items():
+            if not _is_scanned(path):
+                continue
+            head_assemblies.add(_assembly_of(path))
+            for d in parse_declarations(path, text):
+                after[d.key] = d
+            forwards |= {f"{_assembly_of(path)}:{t}" for t in parse_forwards(text)}
+        failures, _ = find_moves(before, after, forwards, head_assemblies)
+        passed = not failures
+        if passed != should_pass:
+            failed += 1
+            print(f"SELF-TEST FAILED: {label}")
+            print(f"  expected {'pass' if should_pass else 'FAIL'}, got {'pass' if passed else 'FAIL'}")
+            for _, message in failures:
+                print(message)
+        else:
+            print(f"ok: {label}")
+    if failed:
+        print(f"\n{failed} self-test(s) failed — the gate cannot be trusted.")
+        return 1
+    print(f"\nAll {len(SELF_TESTS)} self-tests passed.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", help="commit-ish to compare against (e.g. origin/main)")
+    ap.add_argument(
+        "--head",
+        help="commit-ish to check INSTEAD of the working tree — for replaying real history "
+        "(e.g. --base b53aed0aa^1 --head b53aed0aa reproduces the #2370 break)",
+    )
+    ap.add_argument("--self-test", action="store_true", help="prove the matcher is not vacuous")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.base:
+        ap.error("--base is required unless --self-test is given")
+
+    root = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"], check=True, capture_output=True, text=True
+        ).stdout.strip()
+    )
+    return check(root, args.base, args.head)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-type-forwards.py
+++ b/scripts/check-type-forwards.py
@@ -261,8 +261,12 @@ def find_moves(
         if not landed:
             continue  # gone from src/ entirely — out of scope, see the module docstring
         moved.add(key)
-        if key in forwards:
-            continue  # the old assembly forwards the ORIGINAL full name: binary-compatible
+        # The old assembly forwards the ORIGINAL full name: binary-compatible. Accept the
+        # unqualified `typeof(Foo)` spelling too — C# resolves it against that file's usings, and a
+        # gate that only understood one of the two spellings would demand a forwarder that is
+        # already there.
+        if key in forwards or f"{old.assembly}:{old.name}" in forwards:
+            continue
         destinations = ", ".join(sorted(f"{d.assembly} ({d.full_name})" for d in landed))
         renamed = all(d.full_name != old.full_name for d in landed)
         remedy = (
@@ -377,6 +381,16 @@ SELF_TESTS: list[tuple[str, dict[str, str], dict[str, str], bool]] = [
             "src/B/Foo.cs": FOO_N,
             "src/A/Keep.cs": KEEP_A,
             "src/A/Fwd.cs": "[assembly: TypeForwardedTo(typeof(N.Foo))]\n",
+        },
+        True,
+    ),
+    (
+        "an UNQUALIFIED forwarder counts — `typeof(Foo)` resolves through the file's usings",
+        {"src/A/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        {
+            "src/B/Foo.cs": FOO_N,
+            "src/A/Keep.cs": KEEP_A,
+            "src/A/Fwd.cs": "using N;\n[assembly: TypeForwardedTo(typeof(Foo))]\n",
         },
         True,
     ),

--- a/scripts/check-type-forwards.py
+++ b/scripts/check-type-forwards.py
@@ -82,10 +82,13 @@ from pathlib import Path
 ALLOW_FILE = "scripts/type-forwards.allow"
 
 # `public sealed record Foo(` / `public partial class Bar<T> :` / `public enum Baz` / `public
-# delegate void Qux(`. Anchored at column 0 so NESTED types (always indented in this repo, and
-# never independently bindable by their simple name) are out of scope.
+# delegate void Qux(`. The leading indent is CAPTURED rather than forbidden: 38 files under `src/`
+# still use a block-scoped namespace, which indents every top-level type by four spaces
+# (`MeshWeaver.Data/TypeDescription.cs`), and anchoring at column 0 skipped all of them — a gate
+# that quietly covers less is the exact failure mode this change exists to stop. Nesting is then
+# excluded by comparing that indent against the enclosing namespace's form (see TOP_LEVEL_INDENT).
 TYPE_RE = re.compile(
-    r"^public\s+"
+    r"^(?P<indent>[ \t]*)public\s+"
     r"(?:(?:sealed|abstract|partial|readonly|ref|unsafe|static)\s+)*"
     r"(?:class|record|struct|interface|enum|delegate)\s+"
     r"(?:(?:class|struct)\s+)?"          # `record class` / `record struct`
@@ -93,8 +96,15 @@ TYPE_RE = re.compile(
     re.MULTILINE,
 )
 
-# `namespace Foo.Bar;` (file-scoped) or `namespace Foo.Bar {`
-NAMESPACE_RE = re.compile(r"^namespace\s+(?P<ns>[A-Za-z_][\w.]*)\s*[;{]", re.MULTILINE)
+# `namespace Foo.Bar;` (file-scoped), `namespace Foo.Bar {`, or `namespace Foo.Bar` with the brace
+# on the next line. The terminator is captured because it decides where a TOP-LEVEL type sits.
+NAMESPACE_RE = re.compile(
+    r"^namespace\s+(?P<ns>[A-Za-z_][\w.]*)[ \t]*(?P<form>[;{]|$)", re.MULTILINE
+)
+
+# Column at which a top-level type is declared, by namespace form. A DEEPER indent is a nested
+# type, which no module binds by its own simple name and which is therefore out of scope.
+TOP_LEVEL_INDENT = {";": 0, "{": 4, "": 4}
 
 FORWARD_RE = re.compile(
     r"\[assembly:\s*TypeForwardedTo\s*\(\s*typeof\(\s*(?P<type>[A-Za-z_][\w.]*)\s*\)\s*\)\s*\]"
@@ -134,18 +144,27 @@ def _assembly_of(path: str) -> str:
     return path.split("/")[1]
 
 
+def _indent_width(raw: str) -> int:
+    return sum(4 if ch == "\t" else 1 for ch in raw)
+
+
 def parse_declarations(path: str, text: str) -> list[Decl]:
-    """Public top-level types declared by one file, with the namespace in force."""
+    """Public TOP-LEVEL types declared by one file, with the namespace in force."""
     assembly = _assembly_of(path)
-    namespaces = [(m.start(), m.group("ns")) for m in NAMESPACE_RE.finditer(text)]
+    namespaces = [
+        (m.start(), m.group("ns"), TOP_LEVEL_INDENT[m.group("form") or ""])
+        for m in NAMESPACE_RE.finditer(text)
+    ]
     out: list[Decl] = []
     for m in TYPE_RE.finditer(text):
-        ns = ""
-        for start, candidate in namespaces:
+        ns, expected = "", 0
+        for start, candidate, indent in namespaces:
             if start < m.start():
-                ns = candidate
+                ns, expected = candidate, indent
             else:
                 break
+        if _indent_width(m.group("indent")) != expected:
+            continue  # nested inside another type — not independently bindable by its simple name
         out.append(Decl(assembly, ns, m.group("name")))
     return out
 
@@ -332,7 +351,14 @@ OPS_NEW_NS = "namespace MeshWeaver.Mesh;\npublic class MeshOperations\n{\n}\n"
 AI_KEEP = "namespace MeshWeaver.AI;\npublic class MeshPlugin\n{\n}\n"
 FOO_N = "namespace N;\npublic sealed record Foo(int X);\n"
 FOO_GENERIC = "namespace N;\npublic sealed record class Foo<T> where T : notnull\n{\n}\n"
-FOO_BLOCK_NS = "namespace N\n{\n}\npublic class Foo\n{\n}\n"
+FOO_BLOCK_NS = "namespace N\n{\n    public record Foo(int X);\n}\n"
+FOO_BLOCK_NS_BRACE = "namespace N {\n    public record Foo(int X);\n}\n"
+FOO_BLOCK_NS_NESTED = (
+    "namespace N\n{\n    public class Foo\n    {\n        public class Inner\n        {\n"
+    "        }\n    }\n}\n"
+)
+INNER_MOVED = "namespace M;\npublic class Inner\n{\n}\n"
+KEEP_A_BLOCK = "namespace N\n{\n    public class Keep\n    {\n    }\n}\n"
 KEEP_A = "namespace N;\npublic class Keep\n{\n}\n"
 DOC_KEEP = "namespace MeshWeaver.Documentation;\npublic class Doc\n{\n}\n"
 BLAZOR_PORTAL_APP = "namespace MeshWeaver.Blazor.Infrastructure;\npublic class PortalApplication\n{\n}\n"
@@ -475,10 +501,29 @@ SELF_TESTS: list[tuple[str, dict[str, str], dict[str, str], bool]] = [
         False,
     ),
     (
-        "block-scoped namespaces resolve to the enclosing declaration",
-        {"src/A/Foo.cs": FOO_BLOCK_NS, "src/A/Keep.cs": KEEP_A},
-        {"src/B/Foo.cs": FOO_BLOCK_NS, "src/A/Keep.cs": KEEP_A},
+        # 38 files under src/ still declare a block-scoped namespace, which indents every top-level
+        # type by four. An earlier revision anchored the matcher at column 0 and skipped all of
+        # them — covering less while still reporting green.
+        "a block-scoped namespace indents its TOP-LEVEL types, and they are still in scope",
+        {"src/A/Foo.cs": FOO_BLOCK_NS, "src/A/Keep.cs": KEEP_A_BLOCK},
+        {"src/B/Foo.cs": FOO_BLOCK_NS, "src/A/Keep.cs": KEEP_A_BLOCK},
         False,
+    ),
+    (
+        "…with the brace on the namespace's own line, too",
+        {"src/A/Foo.cs": FOO_BLOCK_NS_BRACE, "src/A/Keep.cs": KEEP_A_BLOCK},
+        {"src/B/Foo.cs": FOO_BLOCK_NS_BRACE, "src/A/Keep.cs": KEEP_A_BLOCK},
+        False,
+    ),
+    (
+        "…but a type NESTED inside a block-scoped namespace's type stays out of scope",
+        {"src/A/Foo.cs": FOO_BLOCK_NS_NESTED, "src/A/Keep.cs": KEEP_A_BLOCK},
+        {
+            "src/A/Foo.cs": "namespace N\n{\n    public class Foo\n    {\n    }\n}\n",
+            "src/A/Keep.cs": KEEP_A_BLOCK,
+            "src/B/Inner.cs": INNER_MOVED,
+        },
+        True,
     ),
     (
         "an in-mesh doc sample is not compiled, so it is not a binary move",

--- a/scripts/type-forwards.allow
+++ b/scripts/type-forwards.allow
@@ -1,0 +1,20 @@
+# Public types that may move between src/ assemblies in this PR WITHOUT a type forwarder.
+#
+# An entry is a STATEMENT THAT NO SHIPPED MODULE CAN BE HOLDING THAT TypeRef — not a way to make
+# the gate quiet. A module's IL binds `Namespace.Type` scoped to an AssemblyRef, so moving a public
+# type between assemblies (or renaming its namespace) is binary-breaking for every module compiled
+# earlier: it dies with `TypeLoadException: Could not load type '…'` the moment the platform rolls.
+# That is #2370 — it took down the whole /mcp surface of a production deployment.
+#
+# The FIX is normally a forwarder, not an entry here:
+#
+#     [assembly: TypeForwardedTo(typeof(Old.Namespace.TheType))]     // in src/<OldAssembly>
+#
+# and, because a forwarder cannot rename, the type keeps its ORIGINAL full name in its new home.
+#
+# One `Assembly:Namespace.Type` per line, then a reason. DELETE the line once the change has
+# shipped: a stale entry FAILS the gate, because an entry that outlives its change hides the
+# next break.
+#
+# Example:
+#   MeshWeaver.Foo:MeshWeaver.Foo.Widget  #1234 — added and moved inside one unreleased wave

--- a/src/MeshWeaver.AI/TypeForwards.cs
+++ b/src/MeshWeaver.AI/TypeForwards.cs
@@ -1,0 +1,37 @@
+using System.Runtime.CompilerServices;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// THE BINARY CONTRACT THIS ASSEMBLY OWES EVERY MODULE COMPILED AGAINST AN EARLIER PLATFORM
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+//
+// A module is a plain assembly that binds platform types BY SIMPLE ASSEMBLY NAME, and the module
+// lane's only gate is a SEMVER FLOOR — never MVID equality — precisely so "a landed module keeps
+// loading across ordinary platform updates" (Doc/Architecture/Modules → the skip rules). That
+// sentence is a promise about BINARY compatibility, and it is the promise #2370 broke.
+//
+// #2283 moved `MeshOperations`, `MeshExportManifest`, `MeshExportFileEntry` and `NodeReadOutcome`
+// out of this assembly into MeshWeaver.Mesh.Operations. The change was verified by BUILDING the
+// plugins repo's MeshWeaver.Mcp against the branch — which proves SOURCE compatibility and says
+// nothing at all about the module that was already published. That module's IL holds
+//
+//     TypeRef  MeshWeaver.AI.MeshOperations   scope: AssemblyRef MeshWeaver.AI
+//
+// so when the platform rolled, every single MCP tool call died in the McpMeshPlugin constructor
+// with `TypeLoadException: Could not load type 'MeshWeaver.AI.MeshOperations' from assembly
+// 'MeshWeaver.AI, Version=3.0.0.0'` — the whole /mcp surface, for every external client.
+//
+// These forwarders are what makes the move survivable: the CLR resolves that TypeRef through this
+// assembly's ExportedType table into MeshWeaver.Mesh.Operations, yielding the SAME type identity.
+// A forwarder cannot rename, so the full type NAME (namespace included) is frozen by this file —
+// which is why those types still declare `namespace MeshWeaver.AI` in an assembly that is not AI.
+//
+// 🚨 Deleting a line here re-breaks every module built before #2283. `scripts/check-type-forwards.py`
+// refuses that, and MovedTypeBinaryContractTest proves the forwarders actually resolve at runtime.
+// If this assembly ever leaves the platform repo (#2276), the forwarders leave WITH it.
+// Fully qualified deliberately: `NodeReadOutcome` is ambiguous under this project's global
+// usings (MeshWeaver.Mesh has a read-classifier type of the same simple name), and a
+// forwarder that pointed at the wrong one would compile and forward the wrong identity.
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.MeshOperations))]
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.MeshExportManifest))]
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.MeshExportFileEntry))]
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.NodeReadOutcome))]

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -141,6 +141,50 @@ never reach disk), and a refusal of any module whose entry DLL name collides wit
 assembly — `ResolveModulePath` probes `modules/<name>/` first, so such a module would silently
 shadow the platform's own binary at the next boot.
 
+### 🚨 "Keeps loading across ordinary platform updates" is a promise the PLATFORM owes (#2370)
+
+The semver floor above is not a weaker gate than MVID equality — it is a **different contract**, and
+the platform side of it is: *a public type a module can bind must keep its full name and keep being
+reachable from the assembly it was bound in*. A module's IL holds neither a `using` nor a source
+reference; it holds
+
+```
+TypeRef  MeshWeaver.AI.MeshOperations     scope: AssemblyRef MeshWeaver.AI
+```
+
+so **moving a public type to another assembly, or renaming its namespace, breaks every module
+compiled earlier** — at the next roll, with no warning anywhere:
+
+```
+System.TypeLoadException: Could not load type 'MeshWeaver.AI.MeshOperations'
+    from assembly 'MeshWeaver.AI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null'
+```
+
+That is #2370. `MeshOperations` moved to `MeshWeaver.Mesh.Operations` and the store-installed
+`MeshWeaver.Mcp` could no longer construct `McpMeshPlugin`; because the MCP SDK builds its tool
+target per invocation, EVERY tool call — `get`, `search`, `create`, `render_area`, the LSP and chunk
+tools — failed identically. A full outage of the deployment's `/mcp` surface, for every external
+client, from a change that was source-compatible and reviewed as a refactor.
+
+**The move is fine; losing the name is not.** Leave a forwarder in the old assembly and keep the
+type's ORIGINAL full name in its new home — a forwarder cannot rename:
+
+```csharp
+// src/MeshWeaver.AI/TypeForwards.cs
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.MeshOperations))]
+```
+
+The CLR then resolves the module's TypeRef through the old assembly to ONE type identity — not a
+shim, which would mint a second identity and reintroduce the `as`/`is` trap-door.
+
+🚨 **No repo-local build can see this break, and two green gates specifically cannot.**
+`landed-modules-gate` compiles the plugins repo's module SOURCE against the PR, which is a different
+question from whether the module ALREADY PUBLISHED still binds — and on #2370 it passed, because the
+module's source carried `using` directives for both namespaces. The semver floor cannot see a type at
+all. `scripts/check-type-forwards.py` (wired into the *Public surface (binary compatibility)* job
+beside #2298's `check-record-signatures.py`) is what refuses the next one; its allow file is a
+statement that no shipped module can hold the TypeRef, not a way to make it quiet.
+
 ### 🚨 An ACTIVATED entry with no bytes — the boot-GC race (#2303)
 
 The "Missing DLL" skip above is the SYMPTOM; #2303 traced one concrete way an entry ends up

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-mcp-tools-work-again-after-a-platform-update.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-mcp-tools-work-again-after-a-platform-update.md
@@ -1,0 +1,56 @@
+---
+Name: MCP tools work again after a platform update
+Category: Fix
+Description: Every MCP tool call from an external client — get, search, create, update, render_area and the rest — failed with a type-loading error after the last platform update, because a piece of the platform the MCP module needs had been filed under a new name. The old name is restored and redirected, so already-installed modules keep working across updates, and a new check refuses the next change of this shape.
+Icon: PlugConnected
+Order: -20260826
+---
+
+# MCP tools work again after a platform update
+
+The MCP surface is how external clients — Claude Code, the Copilot harness, any MCP-speaking tool —
+reach a deployment's mesh. After the platform updated on 26 August, every one of those calls failed
+the moment it arrived:
+
+```
+System.TypeLoadException: Could not load type 'MeshWeaver.AI.MeshOperations'
+    from assembly 'MeshWeaver.AI, Version=3.0.0.0, …'
+```
+
+Not one tool: **all** of them. The MCP server builds its tool target freshly for each invocation, so
+the failure sat in a constructor that every single call has to run — `get`, `search`, `create`,
+`update`, `render_area`, the diagnostics and chunk tools alike. Nothing was wrong with the requests,
+and nothing was recoverable from the client side.
+
+## What happened
+
+The MCP server ships as an installed module: a compiled add-on, delivered separately from the
+platform and deliberately allowed to keep working across ordinary platform updates. That promise
+holds as long as the platform keeps the *names* the module was built against.
+
+A tidy-up moved the shared mesh-operations code into its own component and renamed it on the way.
+Nothing in the source noticed — the module still compiled perfectly against the new platform. But the
+copy of the module already installed on the deployment was compiled earlier, and it looks the code up
+by its old name. The name was gone, so the lookup failed, and it failed on every call.
+
+## What changed
+
+The old names are restored and formally redirected to the code's new home, so a module built against
+either the old or the new platform finds it. The redirect is the mechanism .NET provides for exactly
+this — one piece of code, reachable under both names, never a copy that could drift.
+
+Two guards now stop it happening again:
+
+- a test that fails the build if any of those names stops resolving, or drifts;
+- a repository check that refuses any change moving a shared, publicly usable piece of the platform
+  to a new name without leaving the redirect behind — the missing half of an existing check that
+  already covers a related shape.
+
+The pre-existing check that compiles installed modules against each change could not catch this, and
+still cannot by construction: it proves the module's *source* still compiles, while the module a
+deployment is actually running was compiled weeks earlier.
+
+## What you will notice
+
+MCP tools work again, and installed modules keep working across platform updates rather than needing
+to be rebuilt in lockstep.

--- a/src/MeshWeaver.Mesh.Operations/MeshExportManifest.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshExportManifest.cs
@@ -1,7 +1,8 @@
 using System.Collections.Generic;
 using MeshWeaver.Mesh;
 
-namespace MeshWeaver.Mesh;
+// The namespace is a binary contract, not a filing decision — see MeshOperations.cs.
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// The <c>manifest.json</c> at the root of a mesh export ZIP produced by

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -29,7 +29,15 @@ using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace MeshWeaver.Mesh;
+// 🚨 The NAMESPACE is part of the binary contract, and it does NOT follow the assembly.
+// A module compiled earlier holds a TypeRef to `MeshWeaver.AI.MeshOperations` scoped to the
+// `MeshWeaver.AI` AssemblyRef. Moving the type to this assembly is survivable — a
+// [TypeForwardedTo] in MeshWeaver.AI redirects that TypeRef here — but ONLY while the full
+// type NAME is unchanged, because a forwarder cannot rename. Renaming the namespace to
+// `MeshWeaver.Mesh` (#2283) is what took the /mcp surface down in #2370: every tool call
+// died with `TypeLoadException: Could not load type 'MeshWeaver.AI.MeshOperations'`.
+// Do not "tidy" this namespace. See MeshWeaver.Mesh.Operations/README.md.
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// Shared mesh operations for AI agents and MCP tools.
@@ -855,7 +863,7 @@ public class MeshOperations
     /// owning per-node hub's <c>MeshNodeReference</c> reducer — the authoritative
     /// source of truth, no catalog lag. <c>GetDataRequest</c> activates the cold
     /// per-node hub on receipt; the response carries the live MeshNode.
-    /// Returns a <see cref="NodeReadResult"/> that keeps the three cases apart (issue #974):
+    /// Returns a <see cref="NodeReadOutcome"/> that keeps the three cases apart (issue #974):
     /// the node, a DEFINITIVE absence, or an UNAVAILABLE read that reached no verdict.
     /// See <c>Doc/Architecture/CqrsAndContentAccess.md</c>.
     ///
@@ -865,7 +873,7 @@ public class MeshOperations
     /// prevent; the budget below is the ONLY place that knows the read gave up, so it is the place
     /// that classifies.</para>
     /// </summary>
-    private IObservable<NodeReadResult> FetchNode(string resolvedPath, int timeoutSeconds = 10)
+    private IObservable<NodeReadOutcome> FetchNode(string resolvedPath, int timeoutSeconds = 10)
     {
         // 🚨 SECURITY: capture the caller's identity HERE, synchronously, while we are still on the
         // caller's execution context — and re-establish it around the subscribe below.
@@ -906,7 +914,7 @@ public class MeshOperations
         var callerIdentity = accessService?.Context ?? accessService?.CircuitContext
             ?? new AccessContext { ObjectId = WellKnownUsers.Anonymous, Name = "Anonymous", IsVirtual = true };
 
-        return Observable.Create<NodeReadResult>(observer =>
+        return Observable.Create<NodeReadOutcome>(observer =>
         {
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
             var emitted = 0;
@@ -921,7 +929,7 @@ public class MeshOperations
             // Matches the GetMeshNode shape in MeshNodeStreamExtensions.cs.
             IDisposable? innerSubscription = null;
 
-            void EmitOnce(NodeReadResult outcome)
+            void EmitOnce(NodeReadOutcome outcome)
             {
                 if (Interlocked.Exchange(ref emitted, 1) != 0) return;
                 observer.OnNext(outcome);
@@ -933,7 +941,7 @@ public class MeshOperations
             // gets an authoritative routing NotFound (classified in FromReadFailure), it does not
             // sit silent. Reporting the silence as "Not found" is what made callers delete and
             // recreate nodes that existed. Widening this budget would only make the lie rarer.
-            cts.Token.Register(() => EmitOnce(NodeReadResult.Unavailable(
+            cts.Token.Register(() => EmitOnce(NodeReadOutcome.Unavailable(
                 $"read of '{resolvedPath}' reached no verdict within {timeoutSeconds}s")));
 
             try
@@ -962,7 +970,7 @@ public class MeshOperations
                         && string.Equals(n.Path, resolvedPath, StringComparison.OrdinalIgnoreCase))
                     .Take(1)
                     .Subscribe(
-                        node => EmitOnce(NodeReadResult.Found(node!)),
+                        node => EmitOnce(NodeReadOutcome.Found(node!)),
                         ex =>
                         {
                             // Classify at the READ, where the failure's type is still intact
@@ -971,7 +979,7 @@ public class MeshOperations
                             // deliberately so, because saying "denied" would disclose that a
                             // gated node exists at this exact path. Anything else is an
                             // availability failure and is named as one.
-                            var outcome = NodeReadResult.FromReadFailure(resolvedPath, ex);
+                            var outcome = NodeReadOutcome.FromReadFailure(resolvedPath, ex);
                             if (ex is UnauthorizedAccessException)
                                 logger.LogInformation(
                                     "FetchNode DENIED for {Path} — caller lacks Read (gated content)",
@@ -988,7 +996,7 @@ public class MeshOperations
                         // The stream completed without ever passing the exact-path filter: the
                         // read DID reach an answer and there is nothing readable here. Absent,
                         // not unavailable — and reaching it here beats sitting out the budget.
-                        () => EmitOnce(NodeReadResult.Absent));
+                        () => EmitOnce(NodeReadOutcome.Absent));
             }
             catch (Exception ex)
             {
@@ -997,7 +1005,7 @@ public class MeshOperations
                 // the availability condition this method exists to name. A synchronous throw here
                 // is NOT evidence the node is missing.
                 logger.LogWarning(ex, "FetchNode read setup failed for {Path}", resolvedPath);
-                EmitOnce(NodeReadResult.Unavailable(
+                EmitOnce(NodeReadOutcome.Unavailable(
                     $"read setup for '{resolvedPath}' faulted: {ex.GetType().Name}: {ex.Message}"));
             }
 

--- a/src/MeshWeaver.Mesh.Operations/NodeReadOutcome.cs
+++ b/src/MeshWeaver.Mesh.Operations/NodeReadOutcome.cs
@@ -1,7 +1,11 @@
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 
-namespace MeshWeaver.Mesh;
+// The namespace is a binary contract, not a filing decision — see MeshOperations.cs. It is also
+// why this type kept its ORIGINAL name: `NodeReadOutcome` (#2283) was a rename chosen to dodge a
+// collision with MeshWeaver.Mesh's read-classifier `NodeReadOutcome`, and in MeshWeaver.AI there
+// is no collision to dodge.
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// The outcome of ONE bounded node read — the seam that keeps "we could not find out" apart from
@@ -32,7 +36,7 @@ namespace MeshWeaver.Mesh;
 /// completed read with a definitive answer ("nothing readable here for you"), so it is not an
 /// availability failure and must not become one.</para>
 /// </summary>
-public sealed record NodeReadResult
+public sealed record NodeReadOutcome
 {
     /// <summary>The node, when the read found one. <c>null</c> on Absent AND on Unavailable —
     /// where it carries no meaning at all.</summary>
@@ -46,13 +50,13 @@ public sealed record NodeReadResult
     public bool IsUnavailable => UnavailableReason is not null;
 
     /// <summary>The read completed and found the node.</summary>
-    public static NodeReadResult Found(MeshNode node) => new() { Node = node };
+    public static NodeReadOutcome Found(MeshNode node) => new() { Node = node };
 
     /// <summary>The read completed; there is nothing readable at this path. Definitive.</summary>
-    public static NodeReadResult Absent { get; } = new();
+    public static NodeReadOutcome Absent { get; } = new();
 
     /// <summary>The read reached no verdict — report unavailable, never absent.</summary>
-    public static NodeReadResult Unavailable(string reason) => new() { UnavailableReason = reason };
+    public static NodeReadOutcome Unavailable(string reason) => new() { UnavailableReason = reason };
 
     /// <summary>
     /// Classifies a read FAULT into Absent vs. Unavailable — decided here, on the TYPED failure,
@@ -71,7 +75,7 @@ public sealed record NodeReadResult
     /// "unavailable" costs a retry, while a false "not found" invites deleting a node that
     /// exists.</para>
     /// </summary>
-    public static NodeReadResult FromReadFailure(string path, Exception error)
+    public static NodeReadOutcome FromReadFailure(string path, Exception error)
     {
         for (var e = error; e is not null; e = e.InnerException)
         {

--- a/src/MeshWeaver.Mesh.Operations/README.md
+++ b/src/MeshWeaver.Mesh.Operations/README.md
@@ -33,21 +33,38 @@ external boundary (`.FirstAsync().ToTask()` in an MCP/REST adapter) — never in
 
 ## Reading a node that may not be there
 
-`NodeReadResult` keeps three answers apart — **Found**, **Absent** (a definitive negative, the only
+`NodeReadOutcome` keeps three answers apart — **Found**, **Absent** (a definitive negative, the only
 one that may be reported as `"Not found: …"`), and **Unavailable** (no answer was reached). A caller
 that collapses them into one `null` reports "not found" for a read that simply timed out.
 
-## The namespace is `MeshWeaver.Mesh`, and that is deliberate
+## 🚨 The namespace is `MeshWeaver.AI`, and it may never change
 
-The assembly is new; the namespace is not. Plugin source is type-checked by two gates against two
-different frameworks — `compile-check.py --image` against core `main`, and the pack lane against the
-newest RELEASED framework (rc7, cut 2026-08-22). A brand-new namespace would resolve on neither
-until a release moved the floor, so every plugin using these types would break on the plugins repo's
-MAIN rather than on the PR that caused it.
+The assembly moved. The **names did not, and cannot** — they are a binary contract.
 
-`MeshWeaver.Mesh` exists in rc7, so the move needs no cross-repo coordination at all: the one real
-consumer, `MeshWeaver.Mcp`, already carries `using MeshWeaver.Mesh;` and reaches this assembly
-transitively through its `MeshWeaver.AI` reference. Verified by building it against this branch — 0
-errors, no plugin change. `NodeReadResult` carries its new name for the same reason: at
-`MeshWeaver.Mesh.NodeReadOutcome` it would have collided with the read-classifier type already
-there.
+A module is a plain assembly binding platform types by simple assembly name, gated on a **semver
+floor and never MVID equality**, precisely so that "a landed module keeps loading across ordinary
+platform updates" (`Doc/Architecture/Modules` → the skip rules). That promise is about BINARY
+compatibility, and a module's IL does not hold a `using`; it holds
+
+```
+TypeRef  MeshWeaver.AI.MeshOperations     scope: AssemblyRef MeshWeaver.AI
+```
+
+so the full type name **and** the assembly that carries it are both part of it. The first cut of this
+move renamed the namespace to `MeshWeaver.Mesh` and left nothing behind, and when the platform rolled,
+every MCP tool call in production died in the `McpMeshPlugin` constructor with
+`TypeLoadException: Could not load type 'MeshWeaver.AI.MeshOperations'` — the whole `/mcp` surface,
+for every external client of the deployment (Systemorph/MeshWeaver#2370).
+
+The move survives because `MeshWeaver.AI` leaves **type forwarders** (`src/MeshWeaver.AI/TypeForwards.cs`)
+for `MeshOperations`, `MeshExportManifest`, `MeshExportFileEntry` and `NodeReadOutcome`: the CLR
+resolves the old TypeRef through this assembly, yielding ONE type identity rather than a shim. **A
+forwarder cannot rename**, which is why these types keep `namespace MeshWeaver.AI` in an assembly
+that is not AI, and why `NodeReadOutcome` kept its original name instead of the `NodeReadResult` the
+first cut chose. `MovedTypeBinaryContractTest` fails if either drifts, and
+`scripts/check-type-forwards.py` refuses the next such move repo-wide.
+
+**Source compatibility is not the question.** The first cut was verified by BUILDING the plugins
+repo's `MeshWeaver.Mcp` against the branch — 0 errors — and that build proved nothing about the
+module that was already published. `landed-modules-gate` has the same blind spot by construction: it
+compiles module SOURCE.

--- a/test/MeshWeaver.AI.Test/MovedTypeBinaryContractTest.cs
+++ b/test/MeshWeaver.AI.Test/MovedTypeBinaryContractTest.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// The binary contract <c>MeshWeaver.AI</c> owes every module that was compiled against an earlier
+/// platform — pinned as a test because no repo-local build can see it.
+///
+/// <para><b>What went wrong (#2370).</b> #2283 moved <c>MeshOperations</c>,
+/// <c>MeshExportManifest</c>, <c>MeshExportFileEntry</c> and <c>NodeReadOutcome</c> out of
+/// <c>MeshWeaver.AI</c> into <c>MeshWeaver.Mesh.Operations</c>, renaming their namespace on the way.
+/// It was verified by BUILDING the plugins repo's <c>MeshWeaver.Mcp</c> against the branch — which
+/// answers "does the module's SOURCE still compile", a different question from the one that
+/// mattered. The module that was already published holds
+/// <c>TypeRef MeshWeaver.AI.MeshOperations</c> scoped to the <c>MeshWeaver.AI</c> AssemblyRef, and
+/// the MCP SDK constructs its tool target per invocation, so when the platform rolled, EVERY MCP
+/// tool call — <c>get</c>, <c>search</c>, <c>create</c>, … — died in the <c>McpMeshPlugin</c>
+/// constructor with:
+/// <code>
+/// System.TypeLoadException: Could not load type 'MeshWeaver.AI.MeshOperations'
+///     from assembly 'MeshWeaver.AI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null'.
+/// </code>
+/// The whole <c>/mcp</c> surface, for every external client of the deployment.
+/// </para>
+///
+/// <para><b>Why a test and not more care.</b> The module lane's gate is a SEMVER FLOOR, never MVID
+/// equality, precisely so "a landed module keeps loading across ordinary platform updates"
+/// (Doc/Architecture/Modules). That is a promise about BINARY compatibility, and a semver floor
+/// cannot see a type-level break — nor can <c>landed-modules-gate</c>, which compiles the plugins
+/// repo's module SOURCE against the PR and therefore goes green on exactly this change.</para>
+///
+/// <para><b>What this pins.</b> Each moved type must still resolve <i>through</i>
+/// <c>MeshWeaver.AI</c> under its ORIGINAL full name, and must resolve to the type that now lives
+/// in <c>MeshWeaver.Mesh.Operations</c> — i.e. a real <c>[TypeForwardedTo]</c> yielding ONE type
+/// identity, not a shim duplicating the surface. A forwarder cannot rename, so the full name
+/// (namespace included) is frozen: this test is what fails if someone tidies
+/// <c>namespace MeshWeaver.AI</c> in <c>MeshWeaver.Mesh.Operations</c>.</para>
+/// </summary>
+public class MovedTypeBinaryContractTest
+{
+    /// <summary>The assembly a module's TypeRef names — the simple name it binds by at runtime.</summary>
+    private const string BoundAssembly = "MeshWeaver.AI";
+
+    /// <summary>Where the types actually live since #2283.</summary>
+    private const string HostingAssembly = "MeshWeaver.Mesh.Operations";
+
+    /// <summary>
+    /// The frozen names. A module compiled before #2283 holds exactly these strings in its
+    /// metadata; changing one is a break no consumer's compiler will ever warn about.
+    /// </summary>
+    private static readonly string[] FrozenNames =
+    [
+        "MeshWeaver.AI.MeshOperations",
+        "MeshWeaver.AI.MeshExportManifest",
+        "MeshWeaver.AI.MeshExportFileEntry",
+        "MeshWeaver.AI.NodeReadOutcome",
+    ];
+
+    /// <summary>The same list, as theory rows.</summary>
+    public static TheoryData<string> ForwardedTypeNames() => [.. FrozenNames];
+
+    [Theory]
+    [MemberData(nameof(ForwardedTypeNames))]
+    public void OldName_StillResolves_ThroughTheAssemblyModulesBind(string fullName)
+    {
+        // Assembly-qualified on purpose: this is the resolution a module's TypeRef performs —
+        // "find `fullName` in the assembly named `MeshWeaver.AI`" — and it is the exact step that
+        // threw TypeLoadException in production. An unqualified Type.GetType would search only the
+        // calling assembly and could never observe the forwarder either way.
+        var resolved = Type.GetType($"{fullName}, {BoundAssembly}", throwOnError: false);
+
+        Assert.True(
+            resolved is not null,
+            $"'{fullName}' no longer resolves from assembly '{BoundAssembly}'. Every module compiled "
+            + "before it moved binds that exact name and will die with TypeLoadException on the next "
+            + "platform roll — the #2370 outage. Restore the name and its [assembly: TypeForwardedTo] "
+            + "in src/MeshWeaver.AI/TypeForwards.cs.");
+
+        Assert.Equal(HostingAssembly, resolved!.Assembly.GetName().Name);
+    }
+
+    [Fact]
+    public void TheForwardersAreForwarders_NotDuplicatedTypes()
+    {
+        // A shim class left behind in MeshWeaver.AI would satisfy the resolution above while
+        // minting a SECOND type identity — the trap-door AGENTS.md names for `as`/`is`. Reading the
+        // ExportedType table proves the CLR is redirecting, not that we re-declared the surface.
+        var forwarded = typeof(MeshPlugin).Assembly
+            .GetForwardedTypes()
+            .Select(t => t.FullName)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.All(FrozenNames, name => Assert.Contains(name, forwarded));
+    }
+
+    [Fact]
+    public void TheMovedTypes_KeepTheirOriginalFullNames()
+    {
+        // The same pin from the other side: `typeof` is compiled here, so this fails at BUILD time
+        // in any tree where the namespace was changed but the forwarder file was updated to match —
+        // the shape that would otherwise make the theory above pass while the contract is gone.
+        Assert.Equal("MeshWeaver.AI.MeshOperations", typeof(MeshOperations).FullName);
+        Assert.Equal("MeshWeaver.AI.MeshExportManifest", typeof(MeshExportManifest).FullName);
+        Assert.Equal("MeshWeaver.AI.MeshExportFileEntry", typeof(MeshExportFileEntry).FullName);
+        Assert.Equal("MeshWeaver.AI.NodeReadOutcome", typeof(MeshWeaver.AI.NodeReadOutcome).FullName);
+
+        Assert.Equal(HostingAssembly, typeof(MeshOperations).Assembly.GetName().Name);
+    }
+}

--- a/test/MeshWeaver.AI.Test/NodeReadOutcomeClassifierTest.cs
+++ b/test/MeshWeaver.AI.Test/NodeReadOutcomeClassifierTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace MeshWeaver.AI.Test;
 
 /// <summary>
-/// Pins <see cref="NodeReadResult.FromReadFailure"/> — the point where a failed node read decides
+/// Pins <see cref="NodeReadOutcome.FromReadFailure"/> — the point where a failed node read decides
 /// between "there is nothing here" and "we could not find out" (issue #974, split out of #637).
 ///
 /// <para><b>The bug.</b> <c>MeshOperations.FetchNode</c> mapped every failure — and its own 10s
@@ -43,7 +43,7 @@ public class NodeReadOutcomeClassifierTest
         // The authoritative "this node does not exist" — the router resolved the address and found
         // nothing. This is the ONLY failure that may be reported as "Not found", and it must keep
         // working: a fix that made everything unavailable would be just as useless.
-        var outcome = NodeReadResult.FromReadFailure(
+        var outcome = NodeReadOutcome.FromReadFailure(
             Path, Nack($"No node found at '{Path}'.", ErrorType.NotFound));
 
         Assert.False(outcome.IsUnavailable);
@@ -57,7 +57,7 @@ public class NodeReadOutcomeClassifierTest
         // readable here for you"), so it is not an availability failure. Reporting it as one would
         // also disclose that a gated node exists at this exact path — the non-disclosure property
         // this leg has always had, and which the fix must not break.
-        var outcome = NodeReadResult.FromReadFailure(
+        var outcome = NodeReadOutcome.FromReadFailure(
             Path, new UnauthorizedAccessException("lacks Read"));
 
         Assert.False(outcome.IsUnavailable);
@@ -67,7 +67,7 @@ public class NodeReadOutcomeClassifierTest
     [Fact]
     public void ADenialNestedUnderAnotherException_IsStillAbsent()
     {
-        var outcome = NodeReadResult.FromReadFailure(
+        var outcome = NodeReadOutcome.FromReadFailure(
             Path, new InvalidOperationException("wrapped", new UnauthorizedAccessException("lacks Read")));
 
         Assert.False(outcome.IsUnavailable);
@@ -79,7 +79,7 @@ public class NodeReadOutcomeClassifierTest
     public void RequestTimeout_IsUnavailable_NotNotFound()
     {
         // 🚨 The regression pin. A read that timed out says nothing about whether the node exists.
-        var outcome = NodeReadResult.FromReadFailure(
+        var outcome = NodeReadOutcome.FromReadFailure(
             Path, new TimeoutException($"No response received in hub … target {Path}"));
 
         Assert.True(outcome.IsUnavailable);
@@ -92,7 +92,7 @@ public class NodeReadOutcomeClassifierTest
         // A grain that idle-collected rejects the next delivery while it reactivates. The node
         // exists; the very next probe lands on the fresh activation. Calling it "not found" is how
         // a transient miss turns into a delete-and-recreate.
-        var outcome = NodeReadResult.FromReadFailure(
+        var outcome = NodeReadOutcome.FromReadFailure(
             Path,
             Nack("Forwarding failed: tried to forward message … to invalid activation. Rejecting now.",
                 ErrorType.Failed));
@@ -105,7 +105,7 @@ public class NodeReadOutcomeClassifierTest
     {
         // A delivery that raced the target hub's disposal — the address may reactivate on the very
         // next probe (ErrorType.ShuttingDown is documented as retry-worthy, never terminal).
-        var outcome = NodeReadResult.FromReadFailure(
+        var outcome = NodeReadOutcome.FromReadFailure(
             Path, Nack($"Hub '{Path}' is shutting down", ErrorType.ShuttingDown));
 
         Assert.True(outcome.IsUnavailable);
@@ -114,7 +114,7 @@ public class NodeReadOutcomeClassifierTest
     [Fact]
     public void DatabaseBlackout_IsUnavailable()
     {
-        var outcome = NodeReadResult.FromReadFailure(
+        var outcome = NodeReadOutcome.FromReadFailure(
             Path, new InvalidOperationException("Failed to connect to 10.0.0.4:5432"));
 
         Assert.True(outcome.IsUnavailable);
@@ -126,7 +126,7 @@ public class NodeReadOutcomeClassifierTest
         // 🚨 The direction of the default is itself load-bearing. An unrecognised fault is by
         // definition one nobody has reasoned about; admitting we do not know costs a retry, while
         // guessing "not found" invites deleting a node that exists.
-        var outcome = NodeReadResult.FromReadFailure(Path, new Exception("something new"));
+        var outcome = NodeReadOutcome.FromReadFailure(Path, new Exception("something new"));
 
         Assert.True(outcome.IsUnavailable);
     }
@@ -136,7 +136,7 @@ public class NodeReadOutcomeClassifierTest
     {
         // Same rule at the typed layer: only ErrorType.NotFound is a definitive absence. A generic
         // Failed NACK is an infrastructure outcome, whatever its wording happens to be.
-        var outcome = NodeReadResult.FromReadFailure(
+        var outcome = NodeReadOutcome.FromReadFailure(
             Path, Nack("Delivery to 'x' failed: something went wrong", ErrorType.Failed));
 
         Assert.True(outcome.IsUnavailable);
@@ -148,13 +148,13 @@ public class NodeReadOutcomeClassifierTest
     public void Found_CarriesTheNode_AndAbsentCarriesNothing()
     {
         var node = new MeshNode("Statement", "AgenticPension");
-        Assert.Same(node, NodeReadResult.Found(node).Node);
-        Assert.False(NodeReadResult.Found(node).IsUnavailable);
+        Assert.Same(node, NodeReadOutcome.Found(node).Node);
+        Assert.False(NodeReadOutcome.Found(node).IsUnavailable);
 
-        Assert.Null(NodeReadResult.Absent.Node);
-        Assert.False(NodeReadResult.Absent.IsUnavailable);
+        Assert.Null(NodeReadOutcome.Absent.Node);
+        Assert.False(NodeReadOutcome.Absent.IsUnavailable);
 
-        Assert.True(NodeReadResult.Unavailable("stalled").IsUnavailable);
-        Assert.Null(NodeReadResult.Unavailable("stalled").Node);
+        Assert.True(NodeReadOutcome.Unavailable("stalled").IsUnavailable);
+        Assert.Null(NodeReadOutcome.Unavailable("stalled").Node);
     }
 }

--- a/test/MeshWeaver.Autocomplete.Test/AutocompleteMultiSourceTest.cs
+++ b/test/MeshWeaver.Autocomplete.Test/AutocompleteMultiSourceTest.cs
@@ -6,6 +6,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using MeshWeaver.AI;   // MeshOperations — its namespace is a frozen binary contract (#2370)
 using MeshWeaver.Reactive;
 using Memex.Portal.Shared;
 using MeshWeaver.ContentCollections;

--- a/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
@@ -6,6 +6,7 @@ using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using MeshWeaver.AI;   // MeshOperations — its namespace is a frozen binary contract (#2370)
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
@@ -7,6 +7,7 @@ using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using MeshWeaver.AI;   // MeshOperations — its namespace is a frozen binary contract (#2370)
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;

--- a/tools/MeshWeaver.PluginTester/GateAllowlist.cs
+++ b/tools/MeshWeaver.PluginTester/GateAllowlist.cs
@@ -128,7 +128,8 @@ public sealed record AllowEntry(string Scope, string Check)
     /// Whether this entry's check FLAPS — see <see cref="GateAllowlist.IntermittentMarker"/>.
     /// Deliberately an init-only PROPERTY rather than a primary-constructor parameter: adding a
     /// defaulted parameter to a public record's primary ctor is a binary-breaking change, which the
-    /// "Public record signatures" gate refuses. It caught exactly that on the first attempt here.
+    /// <c>scripts/check-record-signatures.py</c> gate refuses. It caught exactly that on the first
+    /// attempt here.
     /// </summary>
     public bool Intermittent { get; init; }
 


### PR DESCRIPTION
Closes #2370.

## The failure

Every MCP tool call from every external client of the deployment died in the `McpMeshPlugin`
constructor:

```
System.TypeLoadException: Could not load type 'MeshWeaver.AI.MeshOperations'
    from assembly 'MeshWeaver.AI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null'
```

Not `search` — **all** of them. The MCP SDK builds its tool target per invocation
(`CreateTarget` → `ActivatorUtilities.CreateInstance`), so the failure sits in a constructor every
call has to run: `get`, `create`, `update`, `render_area`, the LSP and chunk tools alike.

## Root cause, from evidence

| | |
|---|---|
| the move | #2283 (`b53aed0aa`, merged 2026-08-26 00:56Z) took `MeshOperations`, `MeshExportManifest`, `MeshExportFileEntry`, `NodeReadOutcome` out of `MeshWeaver.AI` into the new `MeshWeaver.Mesh.Operations`, renaming their namespace to `MeshWeaver.Mesh` |
| what a module binds | not a `using` — `TypeRef MeshWeaver.AI.MeshOperations` scoped to the `MeshWeaver.AI` **AssemblyRef** |
| the shipped module | `MeshWeaver.Mcp` 1.1.4, built before the move |
| first sighting | 2026-08-26 12:25Z, hours after the platform rolled |

The module lane's gate is a **semver floor, never MVID equality**, precisely so that *"a landed
module keeps loading across ordinary platform updates"* (`Doc/Architecture/Modules` → the skip
rules). That sentence is a promise about **binary** compatibility. Moving a public type to another
assembly, or renaming its namespace, breaks it for every module compiled earlier.

**The verification that passed was the wrong one.** #2283 was checked by *building* the plugins
repo's `MeshWeaver.Mcp` against the branch — 0 errors. That answers "does the module's SOURCE still
compile", not "does the module ALREADY PUBLISHED still bind"; the module's source imports both
namespaces. `landed-modules-gate` has the identical blind spot by construction and went green on the
change that caused the outage. `check-record-signatures.py` (#2298) covers the constructor half of
this class and stops at constructors. The semver floor cannot see a type at all.

## The fix

**Keep the move, restore the names, forward the types.**

- The four types keep their **original full names** — `namespace MeshWeaver.AI`, inside
  `MeshWeaver.Mesh.Operations` — and `src/MeshWeaver.AI/TypeForwards.cs` carries
  `[assembly: TypeForwardedTo]` for each. The CLR resolves the module's old TypeRef through
  `MeshWeaver.AI` to **one type identity**, not a shim (a shim would mint a second identity and
  reintroduce the `as`/`is` trap-door AGENTS.md forbids).
- A forwarder **cannot rename**, so the namespace is now marked frozen where it is declared, and
  `NodeReadOutcome` gets its original name back (`NodeReadResult` was a rename chosen to dodge a
  collision that exists only in `MeshWeaver.Mesh`).

## …and the class, not just the instance

`scripts/check-type-forwards.py` refuses any public type moving between `src/` assemblies without a
forwarder for its original full name.

- **17 self-tests**, run as their own step *before* the gate, so a broken matcher fails loudly
  rather than passing everything.
- **Verified in situ against real history.** Replaying the breaking merge names all four types and
  exits 1:
  ```
  python3 scripts/check-type-forwards.py --base b53aed0aa^1 --head b53aed0aa
  ```
  Across the **last 25 merges on main** it reports zero.
- An assembly that leaves the repo entirely is deliberately **out of scope**, with a self-test
  pinning it — without that rule the Blazor exit alone produces 15 false positives, and a gate that
  cries wolf teaches people to allow-list.
- The allow file is a statement that no shipped module can hold the TypeRef; a **stale entry fails**,
  same ratchet as the repo's others.

It runs beside #2298's gate in the same job, renamed *Public surface (binary compatibility)*.

`MovedTypeBinaryContractTest` proves the forwarders resolve the way a module's TypeRef does — with
`TypeForwards.cs` removed, **5 of its 6 assertions fail**; the sixth pins the names from the other
side (compile-time `typeof`).

## Verification

- Full solution build under CI's flags (`-c Release -p:CIRun=true -warnaserror`) — **0 warnings, 0 errors**.
- The plugins repo's `src/MeshWeaver.Mcp` at its own `main`, built against this branch with
  `-p:MeshWeaverRoot=…` — **0 warnings, 0 errors**. That is `landed-modules-gate` parity for the
  module that broke, so **no MeshWeaver.Plugins change is required**: with the forwarders, a bundle
  built before *or* after #2283 loads.
- `MovedTypeBinaryContractTest` + `NodeReadOutcomeClassifierTest`: 16 passed.
- `WhatsNewEntryIntegrityTest`, `DocumentationLinkIntegrityTest`, `MigrationWorkloadModelGuard`: 5 passed.

## Not fixed here — reported separately

Running the new gate over `v3.0.0-rc7 → main` finds **17** unguarded public-type moves; this PR
covers four. Three of the remaining thirteen have a proven module consumer in the plugins repo
(`IMcpBackConnection`, `McpConnectionInfo`, `IProviderKeyProtector`) and are already being worked on
in dedicated branches. Two groups (`MeshWeaver.GitSync` → `MeshWeaver.AI`, `MeshWeaver.Hosting` →
`MeshWeaver.AI`) **cannot** be forwarded at all — the forwarder must live in the assembly being left,
which would need a reference cycle — so those require either moving the type back or a genuinely
atomic republish (#2234). Details in the follow-up issue.
