### PR TITLE
Sibling satellites derive their MainNode at the write boundary (#2383)

### DIFF
--- a/src/MeshWeaver.AI/BuiltInAgentProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInAgentProvider.cs
@@ -56,8 +56,9 @@ public class BuiltInAgentProvider : IStaticNodeProvider
         {
             // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
             // constructor defaults MainNode to the node's own path, which makes _Policy a main
-            // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
-            // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+            // node by the catalog's definition (is:main KEEPS exactly the rows where MainNode ==
+            // Path) and lists "Access Policy" as content on every cover. New satellites:
+            // MeshNode.Satellite(id, main).
             MainNode = RootNamespace,
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",

--- a/src/MeshWeaver.AI/BuiltInHarnessProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInHarnessProvider.cs
@@ -25,8 +25,9 @@ public sealed class BuiltInHarnessProvider(IEnumerable<IHarness> harnesses) : IS
         {
             // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
             // constructor defaults MainNode to the node's own path, which makes _Policy a main
-            // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
-            // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+            // node by the catalog's definition (is:main KEEPS exactly the rows where MainNode ==
+            // Path) and lists "Access Policy" as content on every cover. New satellites:
+            // MeshNode.Satellite(id, main).
             MainNode = HarnessNodeType.RootNamespace,
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",

--- a/src/MeshWeaver.AI/BuiltInLanguageModelProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInLanguageModelProvider.cs
@@ -285,8 +285,9 @@ public class BuiltInLanguageModelProvider : IStaticNodeProvider
         {
             // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
             // constructor defaults MainNode to the node's own path, which makes _Policy a main
-            // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
-            // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+            // node by the catalog's definition (is:main KEEPS exactly the rows where MainNode ==
+            // Path) and lists "Access Policy" as content on every cover. New satellites:
+            // MeshNode.Satellite(id, main).
             MainNode = ModelProviderNodeType.RootNamespace,
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",
@@ -328,8 +329,9 @@ public class BuiltInLanguageModelProvider : IStaticNodeProvider
             {
                 // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
                 // constructor defaults MainNode to the node's own path, which makes _Policy a main
-                // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
-                // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+                // node by the catalog's definition (is:main KEEPS exactly the rows where MainNode ==
+                // Path) and lists "Access Policy" as content on every cover. New satellites:
+                // MeshNode.Satellite(id, main).
                 MainNode = LanguageModelNodeType.RootNamespace,
                 NodeType = "PartitionAccessPolicy",
                 Name = "Access Policy",

--- a/src/MeshWeaver.AI/BuiltInSkillProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInSkillProvider.cs
@@ -42,8 +42,9 @@ public class BuiltInSkillProvider : IStaticNodeProvider
         {
             // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
             // constructor defaults MainNode to the node's own path, which makes _Policy a main
-            // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
-            // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+            // node by the catalog's definition (is:main KEEPS exactly the rows where MainNode ==
+            // Path) and lists "Access Policy" as content on every cover. New satellites:
+            // MeshNode.Satellite(id, main).
             MainNode = SkillNodeType.RootNamespace,
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-governance-nodes-stop-listing-as-page-content.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-governance-nodes-stop-listing-as-page-content.md
@@ -1,0 +1,23 @@
+---
+Name: Governance nodes stop listing as page content
+Category: Fix
+Description: Access policies, install ledgers and other internal bookkeeping no longer appear under Contents or in mesh-wide search on the pages they belong to.
+Icon: ShieldTask
+Order: -20260826
+---
+
+# Governance nodes stop listing as page content
+
+Internal bookkeeping filed alongside a page — its access policy, an install ledger, a sync
+configuration — no longer shows up as if it were content of that page. It had been appearing under
+**Contents**, and turning up in search results across the whole workspace, because each of these
+nodes was created without recording which page it belongs to.
+
+An earlier fix corrected the five built-in catalogs (Agents, Skills, Models, Harnesses,
+Documentation). This one covers the rest: the Roles, Licenses and Settings catalogs, the second
+Documentation entry, the access policy you create from the **Set partition policy** dialog, and the
+plugin install ledger.
+
+The platform now works this out for itself whenever such a node is saved, so bookkeeping created
+from here on is filed correctly without anyone having to remember. Existing entries in the built-in
+catalogs correct themselves the next time the deployment starts.

--- a/src/MeshWeaver.Documentation/DocumentationExtensions.cs
+++ b/src/MeshWeaver.Documentation/DocumentationExtensions.cs
@@ -136,8 +136,9 @@ public static class DocumentationExtensions
             {
                 // 🚨 A satellite must point at its MAIN node, not at itself (#2383): the plain
                 // constructor defaults MainNode to the node's own path, which makes _Policy a main
-                // node by the catalog's definition (is:main == MainNode != Path) and lists "Access
-                // Policy" as content on every cover. New satellites: MeshNode.Satellite(id, main).
+                // node by the catalog's definition (is:main KEEPS exactly the rows where MainNode ==
+                // Path) and lists "Access Policy" as content on every cover. New satellites:
+                // MeshNode.Satellite(id, main).
                 MainNode = DocumentationNodeProvider.RootNamespace,
                 NodeType = "PartitionAccessPolicy",
                 Name = "Documentation Access Policy",

--- a/src/MeshWeaver.Documentation/DocumentationNodeProvider.cs
+++ b/src/MeshWeaver.Documentation/DocumentationNodeProvider.cs
@@ -42,8 +42,12 @@ public class DocumentationNodeProvider : IStaticNodeProvider
     /// <returns>The full set of static documentation MeshNodes.</returns>
     public IEnumerable<MeshNode> GetStaticNodes()
     {
-        // Read-only policy for the Doc namespace — all documentation is unmodifiable
-        yield return new MeshNode("_Policy", RootNamespace)
+        // Read-only policy for the Doc namespace — all documentation is unmodifiable.
+        // Satellite(): MainNode = "Doc", not the node's own path — see #2383. This provider is
+        // the SECOND Doc policy mint (DocumentationExtensions seeds the same node on the
+        // AddMeshNodes path); both must agree or the DB-synced partition keeps whichever the
+        // static-repo importer wrote first.
+        yield return MeshNode.Satellite("_Policy", RootNamespace) with
         {
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",

--- a/src/MeshWeaver.Graph/AccessControlLayoutArea.cs
+++ b/src/MeshWeaver.Graph/AccessControlLayoutArea.cs
@@ -563,7 +563,11 @@ public static class AccessControlLayoutArea
                             {
                                 // First-time create — only IMeshService.CreateNode
                                 // brings the per-node hub into existence.
-                                var policyNode = new MeshNode("_Policy", nodePath ?? "")
+                                // Satellite(): MainNode = the scope this policy caps, not the
+                                // policy's own path (#2383). CreateNode normalises this too, but a
+                                // writer that states its own parentage is what makes the durable row
+                                // right on EVERY backend, including the ones that bypass the handler.
+                                var policyNode = MeshNode.Satellite("_Policy", nodePath ?? "") with
                                 {
                                     NodeType = "PartitionAccessPolicy",
                                     Name = "Access Policy",

--- a/src/MeshWeaver.Graph/Configuration/GlobalSettingsNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/GlobalSettingsNodeType.cs
@@ -94,8 +94,9 @@ public static class GlobalSettingsNodeType
     /// the admin tabs contain. Modelled on <c>LicenseNodeType</c>'s policy, which is world-readable
     /// for the same reason — you must be able to read the page before you can act on it.</para>
     /// </summary>
+    // Satellite(): MainNode = the partition root, not the node's own path — see #2383.
     private static MeshNode CreatePolicy() =>
-        new("_Policy", SettingsPath)
+        MeshNode.Satellite("_Policy", SettingsPath) with
         {
             NodeType = PartitionAccessPolicyNodeType.NodeType,
             Name = "Access Policy",

--- a/src/MeshWeaver.Graph/Configuration/LicenseNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/LicenseNodeType.cs
@@ -62,8 +62,9 @@ public static class LicenseNodeType
 
     // World-readable, non-writable: everyone must be able to read the terms BEFORE accepting them,
     // and nobody but System may author the shipped catalog.
+    // Satellite(): MainNode = the partition root, not the node's own path — see #2383.
     private static MeshNode CreatePolicy() =>
-        new("_Policy", WellKnownLicenses.Partition)
+        MeshNode.Satellite("_Policy", WellKnownLicenses.Partition) with
         {
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",

--- a/src/MeshWeaver.Graph/Configuration/RoleNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/RoleNodeType.cs
@@ -79,8 +79,9 @@ public static class RoleNodeType
     {
         private static readonly MeshNode[] Nodes =
         [
-            // Read-only policy for the Role namespace — built-in roles are unmodifiable
-            new("_Policy", "Role")
+            // Read-only policy for the Role namespace — built-in roles are unmodifiable.
+            // Satellite(): MainNode = "Role", not the node's own path — see #2383.
+            MeshNode.Satellite("_Policy", "Role") with
             {
                 NodeType = "PartitionAccessPolicy",
                 Name = "Access Policy",

--- a/src/MeshWeaver.Hosting.Monolith.TestBase/AssignmentNodeFactory.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/AssignmentNodeFactory.cs
@@ -51,9 +51,14 @@ public static class AssignmentNodeFactory
         };
     }
 
-    /// <summary>PartitionAccessPolicy node at <c>{ns}/_Policy</c>.</summary>
+    /// <summary>
+    /// PartitionAccessPolicy node at <c>{ns}/_Policy</c>. <c>Satellite()</c>, so the node a test
+    /// builds carries the same MainNode the framework derives on a real write (#2383) — a factory
+    /// that minted the self-referential default would hand every test the defect shape as its
+    /// baseline.
+    /// </summary>
     public static MeshNode Policy(string ns, PartitionAccessPolicy policy)
-        => new("_Policy", ns)
+        => MeshNode.Satellite("_Policy", ns) with
         {
             NodeType = "PartitionAccessPolicy",
             Name = "Access Policy",

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlAccessControl.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlAccessControl.cs
@@ -197,7 +197,12 @@ public class PostgreSqlAccessControl
             : "'{}'::jsonb";
 
         var mnTable = Q("mesh_nodes");
-        var mainNode = string.IsNullOrEmpty(ns) ? "_Policy" : $"{ns}/_Policy";
+        // 🚨 The SCOPE the policy caps, NOT the policy's own path (#2383). This writer bypasses the
+        // handler that would normalise it (MeshExtensions.NormalizeSatelliteMainNode), so the value
+        // has to be right here. `main_node = path` is what search_across_schemas selects on, so the
+        // self-referential spelling put every `_Policy` row into mesh-wide search results as though
+        // it were partition content. A root-scope policy (empty namespace) has no owner: "".
+        var mainNode = ns;
         await using var cmd = _dataSource.CreateCommand(
             $"""
             INSERT INTO {mnTable} (namespace, id, name, node_type, content, main_node, state)

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeAccessControl.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeAccessControl.cs
@@ -356,12 +356,20 @@ public class SnowflakeAccessControl
         var jsonBuild = $"OBJECT_CONSTRUCT({string.Join(", ", contentParts)})";
 
         var mnTable = Q("mesh_nodes");
-        var mainNode = string.IsNullOrEmpty(ns) ? "_Policy" : $"{ns}/_Policy";
+        // 🚨 TWO different values that used to share one variable. `path` is the node's own address;
+        // `main_node` is the SCOPE it caps (#2383). Spelling main_node as the policy's own path made
+        // every `_Policy` row satisfy `main_node = path`, which is what search_across_schemas selects on
+        // and what the catalog's `is:main` means — so an internal governance node listed as partition
+        // content. This writer bypasses MeshExtensions.NormalizeSatelliteMainNode, so it must be right
+        // here. A root-scope policy (empty namespace) has no owner: "".
+        var path = string.IsNullOrEmpty(ns) ? "_Policy" : $"{ns}/_Policy";
+        var mainNode = ns;
         await using var connection = await _source.OpenAsync(ct).ConfigureAwait(false);
 
         void BindAll(DbCommand cmd)
         {
             SnowflakeConnectionSource.AddParam(cmd, "namespace", ns, DbType.String);
+            SnowflakeConnectionSource.AddParam(cmd, "path", path, DbType.String);
             SnowflakeConnectionSource.AddParam(cmd, "main_node", mainNode, DbType.String);
         }
 
@@ -380,7 +388,7 @@ public class SnowflakeAccessControl
                     "state" = 2
                 WHEN NOT MATCHED THEN INSERT
                     ("namespace", "id", "path", "name", "node_type", "content", "main_node", "state")
-                VALUES (s."namespace", s."id", :main_node, 'Access Policy', 'PartitionAccessPolicy',
+                VALUES (s."namespace", s."id", :path, 'Access Policy', 'PartitionAccessPolicy',
                         s."content", :main_node, 2)
                 """;
             BindAll(merge);
@@ -399,7 +407,7 @@ public class SnowflakeAccessControl
             insert.CommandText =
                 $"INSERT INTO {mnTable} " +
                 "(\"namespace\", \"id\", \"path\", \"name\", \"node_type\", \"content\", \"main_node\", \"state\") " +
-                $"SELECT :namespace, '_Policy', :main_node, 'Access Policy', 'PartitionAccessPolicy', {jsonBuild}, :main_node, 2";
+                $"SELECT :namespace, '_Policy', :path, 'Access Policy', 'PartitionAccessPolicy', {jsonBuild}, :main_node, 2";
             BindAll(insert);
             await insert.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -4099,12 +4099,35 @@ public static class MeshExtensions
     ///
     /// <para>Idempotent: once MainNode differs from Path the node is returned unchanged, so calling
     /// it twice on one write is safe.</para>
+    ///
+    /// <para>🚨 <b>A satellite is recognised by its ID as well as by its type</b> (#2383). Gating
+    /// this on <c>IsSatelliteNodeType</c> alone covered only the types whose definition node carries
+    /// <see cref="MeshNode.IsSatelliteType"/> — the ones that also live in their own satellite TABLE.
+    /// The <c>_</c>-prefixed SIBLINGS that share <c>mesh_nodes</c> (<c>_Policy</c>, <c>_Provider</c>,
+    /// <c>_GitSync</c>, <c>_DefaultInstallLedger</c>) were therefore normalised by NOTHING, and every
+    /// writer had to remember the field by hand — which most of them did not, leaving self-referential
+    /// satellites in <c>mesh_nodes</c>. Flagging those types instead was not an option: the flag also
+    /// RELOCATES a node (<c>CreateLayoutArea</c> files a flagged type under <c>{ns}/_{Type}/{id}</c>)
+    /// and routes it to a satellite table, which would hide <c>{ns}/_Policy</c> from the permission
+    /// evaluator's <c>id = '_Policy'</c> lookup. Parentage and storage are different questions; this
+    /// asks only the first, via <see cref="SatelliteTableMapping.IsSiblingSatellite"/>.</para>
+    ///
+    /// <para>The owner still comes from <see cref="SatelliteTableMapping.OwnerOfSatellitePath"/> over
+    /// the NAMESPACE, which is what keeps a satellite CONTAINER collapsing correctly
+    /// (<c>{owner}/_Access</c> → <c>{owner}</c>) while leaving a partition that merely happens to
+    /// start with an underscore intact (<c>_Setting/_Policy</c> → <c>_Setting</c>, NOT <c>""</c> —
+    /// the empty prefix is a ROOT-scope grant under <c>COALESCE(main_node, namespace)</c>).</para>
+    ///
+    /// <para>The trigger stays <c>MainNode == Path</c>, so this can only ever rewrite the record's
+    /// never-explicitly-set default — a MainNode a caller set deliberately is untouched, and a genuine
+    /// main node has no satellite-shaped id to match.</para>
     /// </summary>
     private static MeshNode NormalizeSatelliteMainNode(MeshNode node, MeshConfiguration meshConfig) =>
         !string.IsNullOrEmpty(node.NodeType)
         && !string.IsNullOrEmpty(node.Namespace)
-        && meshConfig.IsSatelliteNodeType(node.NodeType)
         && node.MainNode == node.Path
+        && (meshConfig.IsSatelliteNodeType(node.NodeType)
+            || SatelliteTableMapping.IsSiblingSatellite(node))
             ? node with { MainNode = SatelliteTableMapping.OwnerOfSatellitePath(node.Namespace) }
             : node;
 

--- a/src/MeshWeaver.Mesh.Contract/MeshNode.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNode.cs
@@ -99,7 +99,9 @@ public record MeshNode([property: Key] string Id, [property: Editable(false)] st
     /// A SATELLITE of the node at <paramref name="mainNode"/>: created with <see cref="MainNode"/>
     /// already pointing at its primary, which is what the doc on <see cref="MainNode"/> promises and
     /// what every listing relies on to keep satellites out of a node's contents (the catalog's
-    /// <c>is:main</c> is literally <c>MainNode != Path</c>). 🚨 Minting a satellite with
+    /// <c>is:main</c> KEEPS exactly the rows where <c>MainNode == Path</c> — SQL
+    /// <c>n.main_node = n.path</c> — so a satellite is excluded precisely because its MainNode
+    /// DIFFERS from its path). 🚨 Minting a satellite with
     /// <c>new MeshNode(id, ns)</c> leaves MainNode defaulting to ITSELF, which makes it a main node
     /// by definition — that is how <c>Access Policy</c> came to be listed as content on every
     /// package cover (#2383). Use this for <c>_Policy</c> and every other underscore-prefixed

--- a/src/MeshWeaver.Mesh.Contract/SatelliteTableMapping.cs
+++ b/src/MeshWeaver.Mesh.Contract/SatelliteTableMapping.cs
@@ -119,4 +119,69 @@ public sealed record SatelliteTableMapping(string Segment, string Table, params 
         => segment.Length > 1 && segment[0] == '_'
            && Defaults.Any(m => m.Segment.Length > 0 && m.Segment[0] == '_'
                                 && string.Equals(m.Segment, segment, StringComparison.Ordinal));
+
+    /// <summary>
+    /// True if <paramref name="id"/> is a <b>satellite-shaped node id</b>: an underscore followed by
+    /// an upper-case letter (<c>_Policy</c>, <c>_Provider</c>, <c>_GitSync</c>,
+    /// <c>_DefaultInstallLedger</c>, <c>_Entitlements</c>, …). A node with such an id is a SIBLING
+    /// satellite — governance bookkeeping filed next to the node it belongs to — so its
+    /// <see cref="MeshNode.MainNode"/> is its namespace, never itself (#2383).
+    ///
+    /// <para>This is the repo-wide convention, not a new one: <c>StaticRepoImporter</c>,
+    /// <c>InstanceSyncService</c>, <c>GitHubSyncService</c>, <c>PackageInstaller</c>,
+    /// <c>DeleteLayoutArea</c>, <c>MarkdownOverviewLayoutArea</c> and the bulk-create refusal all
+    /// classify a <c>_</c>-prefixed segment exactly this way. <c>CachingStorageAdapter</c>'s
+    /// <c>ExtractMainNodePath</c> uses the same underscore+upper-case test.</para>
+    ///
+    /// <para>🚨 Deliberately DIFFERENT from <see cref="IsSatelliteSegment"/>, and the two must not be
+    /// merged. That one answers <i>"which TABLE does this row live in"</i> and is therefore
+    /// restricted to the enumerated <see cref="Defaults"/> — widening it would move <c>_Policy</c>
+    /// out of <c>mesh_nodes</c> and hide it from the permission evaluator's
+    /// <c>id = '_Policy'</c> lookup, the regression the remark on <see cref="IsSatellitePath"/>
+    /// records. This one answers <i>"does this node belong to the node above it"</i>, which is a
+    /// question about PARENTAGE, not storage. <c>_Policy</c> is a <c>mesh_nodes</c> row AND a
+    /// satellite; both are true at once.</para>
+    ///
+    /// <para>🚨 The test is on the node's OWN ID, never on its whole path — because a PARTITION may
+    /// legitimately be named with a leading underscore. <c>GlobalSettingsNodeType.SettingsPath</c> is
+    /// literally <c>_Setting</c>, so scanning the path would resolve <c>_Setting/_Policy</c>'s owner
+    /// to <c>""</c>, the empty prefix that <c>COALESCE(main_node, namespace)</c> projects as a
+    /// ROOT-scope grant. The owner comes from <see cref="OwnerOfSatellitePath"/> over the NAMESPACE,
+    /// which leaves a non-container namespace like <c>_Setting</c> intact.</para>
+    /// </summary>
+    public static bool IsSatelliteId(string? id)
+        => id is { Length: > 1 } && id[0] == '_' && char.IsUpper(id[1]);
+
+    /// <summary>
+    /// The namespace of the partition CATALOG — <c>Admin/Partition/{partitionName}</c>. Entries there
+    /// are partition DECLARATIONS, so their id is a name being declared rather than a relationship
+    /// being expressed. Mirrors <c>PartitionNodeType.Namespace</c>, which lives in MeshWeaver.Graph
+    /// and so cannot be referenced from here.
+    /// </summary>
+    private const string PartitionCatalogNamespace = "Admin/Partition";
+
+    /// <summary>
+    /// True if <paramref name="node"/> is a SIBLING satellite — governance bookkeeping filed next to
+    /// the node it belongs to, whose <see cref="MeshNode.MainNode"/> is therefore its namespace and
+    /// never itself (#2383). The ONE definition of that classification, shared by the create/upsert
+    /// normalization and by the guard that sweeps the static seeds; a second, subtly different copy
+    /// would give a subtly different inventory.
+    ///
+    /// <para>Three conditions, and each excludes a real node that would otherwise be misread:</para>
+    /// <list type="number">
+    ///   <item>The id is satellite-shaped (<see cref="IsSatelliteId"/>).</item>
+    ///   <item>🚨 It HAS a namespace. A partition root is a main node even when its own name begins
+    ///     with an underscore — <c>GlobalSettingsNodeType.SettingsPath</c> is literally
+    ///     <c>_Setting</c> — and <c>MainNode == Path</c> is correct for it.</item>
+    ///   <item>🚨 It is not an entry in the partition CATALOG. <c>Admin/Partition/_Access</c>
+    ///     DECLARES the global root-scope access partition; its id is that partition's NAME. It is a
+    ///     main node of the catalog that lists it, and re-pointing its MainNode would drop it out of
+    ///     the catalog's own <c>is:main</c> listing — turning a fix into a disappearance.</item>
+    /// </list>
+    /// </summary>
+    public static bool IsSiblingSatellite(MeshNode node)
+        => node is not null
+           && !string.IsNullOrEmpty(node.Namespace)
+           && IsSatelliteId(node.Id)
+           && !string.Equals(node.Namespace, PartitionCatalogNamespace, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -659,7 +659,12 @@ public sealed class InstanceAutoRegistrationService(
 
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
-        var node = new MeshNode("_DefaultInstallLedger", PackageInstaller.InstalledPartition)
+        // Satellite(): MainNode = the Plugins partition root, not the ledger's own path (#2383).
+        // Bookkeeping that points at itself IS a main node by the catalog's definition: `is:main`
+        // KEEPS exactly the rows where MainNode == Path (SQL `n.main_node = n.path`), which is also
+        // what search_across_schemas hard-filters every union branch on. So the self-default listed
+        // the ledger as partition CONTENT and put it in mesh-wide search.
+        var node = MeshNode.Satellite("_DefaultInstallLedger", PackageInstaller.InstalledPartition) with
         {
             Name = "Default install ledger",
             // 🚨 NOT PackageNodeType. The ledger lives in the Plugins partition but is bookkeeping,

--- a/test/MeshWeaver.Documentation.Test/SatelliteMainNodeMintGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/SatelliteMainNodeMintGuard.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard for the self-referential-satellite defect class (#2383): a node filed as a
+/// <c>_</c>-prefixed SIBLING of another node — <c>{ns}/_Policy</c>, <c>{ns}/_Provider</c>,
+/// <c>{ns}/_GitSync</c>, <c>Plugins/_DefaultInstallLedger</c> — must carry
+/// <see cref="MeshNode.MainNode"/> pointing at the node it belongs to, never at ITSELF.
+///
+/// <para><b>Why a guard and not just correct mint sites.</b> <see cref="MeshNode.MainNode"/>
+/// self-defaults to the node's own path, so getting this right is an act of memory at every writer.
+/// Careful hand-fixing of the sites found by grepping <c>new MeshNode("_…</c> corrected six of them
+/// and missed seven — the target-typed spelling <c>new("_Policy", ns)</c> does not match that
+/// pattern, and two writers are raw SQL. A control that enumerates the nodes the mesh ACTUALLY
+/// serves cannot be fooled by a spelling.</para>
+///
+/// <para><b>What a self-referential satellite costs.</b> <c>MainNode == Path</c> is the framework's
+/// literal definition of a MAIN node, so the node becomes content: <c>is:main</c> KEEPS exactly the
+/// rows where <c>MainNode == Path</c> (<c>PostgreSqlSqlGenerator</c> emits
+/// <c>n.main_node = n.path</c>; <c>StaticNodeQueryProvider</c> skips a node when
+/// <c>MainNode != Path</c>), and <c>search_across_schemas</c> hard-filters every union branch on the
+/// same predicate — unconditionally, not only when the caller asks for <c>is:main</c>. A satellite
+/// is normally excluded PRECISELY because its MainNode differs from its path; one pointing at itself
+/// passes instead. An internal governance node therefore lists under "Contents" on the page and
+/// appears in mesh-wide search. It also mis-classifies the node on copy/move
+/// (<c>MeshExtensions</c> splits <c>IncludeSatellites</c> from <c>IncludeDescendants</c> on
+/// <c>MainNode != Path</c>) and, for the types that delegate permissions, defeats
+/// <c>SatelliteAccessRule</c>'s delegation — its degenerate branch falls back to a path-based check
+/// the moment <c>MainNode</c> equals the node's own path.</para>
+/// </summary>
+public class SatelliteMainNodeMintGuard(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// The seeds this sweep MUST have reached. Without this the test is vacuous: a composition that
+    /// registered none of the providers would sweep an empty set and report success, which is the
+    /// "a verification step that cannot fail is not a verification step" trap. Each entry is a
+    /// distinct mint site in a distinct assembly, so the list also documents the inventory.
+    /// </summary>
+    private static readonly string[] RequiredInventory =
+    [
+        "Role/_Policy",      // MeshWeaver.Graph  — RoleNodeType.BuiltInRolesProvider
+        "License/_Policy",   // MeshWeaver.Graph  — LicenseNodeType.CreatePolicy
+        "_Setting/_Policy",  // MeshWeaver.Graph  — GlobalSettingsNodeType.CreatePolicy
+        "Doc/_Policy",       // MeshWeaver.Documentation — DocumentationNodeProvider
+    ];
+
+    [Fact]
+    public void EveryStaticallySeededSatelliteCarriesItsMainNode()
+    {
+        // Both seeding routes at once: AddMeshNodes(...) surfaces through StaticMeshNodeListProvider,
+        // and every IStaticNodeProvider registers here too. DocumentationNodeProvider is added
+        // explicitly — it is a legacy provider the test mesh does not register, and it holds the
+        // SECOND Doc policy mint.
+        var nodes = Mesh.ServiceProvider.GetServices<IStaticNodeProvider>()
+            .SelectMany(p => p.GetStaticNodes())
+            .Concat(new DocumentationNodeProvider(Mesh.ServiceProvider).GetStaticNodes())
+            .ToList();
+
+        var seen = nodes.Select(n => n.Path).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var missing = RequiredInventory.Where(p => !seen.Contains(p)).ToList();
+        Assert.True(missing.Count == 0,
+            "The sweep never reached " + string.Join(", ", missing)
+            + " — it would have passed having verified nothing. Either the composition stopped "
+            + "registering that seed (a separate defect) or the path was renamed; fix the inventory "
+            + "deliberately, never by deleting the entry.");
+
+        var offenders = nodes
+            // The SAME classifier the create/upsert normalization uses — one definition, so the
+            // guard's inventory and the framework's behaviour cannot drift apart.
+            .Where(SatelliteTableMapping.IsSiblingSatellite)
+            .Where(n => string.Equals(n.MainNode, n.Path, StringComparison.Ordinal))
+            .Select(n => n.Path)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "These satellites are minted pointing at THEMSELVES, which makes them main nodes by the "
+            + "framework's own definition (is:main keeps exactly the rows where MainNode == Path) — "
+            + "they list as content and show up in mesh-wide search:\n  "
+            + string.Join("\n  ", offenders)
+            + "\nMint them with MeshNode.Satellite(id, mainNode) — never `new MeshNode(id, ns)`, "
+            + "whose MainNode defaults to the node's own path.");
+    }
+
+    /// <summary>
+    /// The framework half: a sibling satellite written through the create handler gets its MainNode
+    /// DERIVED, so a writer that forgets the field can no longer persist the defect shape. Static
+    /// seeds bypass this handler entirely — which is why the sweep above exists as well.
+    /// </summary>
+    [Fact]
+    public async Task CreatingASiblingSatellite_DerivesItsMainNode()
+    {
+        var created = await NodeFactory.CreateNode(
+            // Deliberately the RAW constructor — MainNode arrives equal to the node's own path,
+            // exactly as every unfixed mint site produces it.
+            new MeshNode("_Policy", TestPartition)
+            {
+                NodeType = "PartitionAccessPolicy",
+                Name = "Access Policy",
+                Content = new PartitionAccessPolicy { Create = false, Update = false, Delete = false },
+            }).Should().Emit();
+
+        Assert.Equal($"{TestPartition}/_Policy", created.Path);
+        Assert.Equal(TestPartition, created.MainNode);
+        Assert.NotEqual(created.Path, created.MainNode);
+    }
+
+    /// <summary>
+    /// The other direction, and the one that bounds the blast radius: ordinary content is NOT
+    /// touched. A main node must keep <c>MainNode == Path</c> or it drops out of every <c>is:main</c>
+    /// listing and out of <c>search_across_schemas</c> — i.e. the fix would hide real content.
+    /// </summary>
+    [Fact]
+    public async Task CreatingOrdinaryContent_LeavesItAMainNode()
+    {
+        var id = $"Page{Guid.NewGuid():N}"[..12];
+        var created = await NodeFactory.CreateNode(
+            new MeshNode(id, TestPartition) { NodeType = "Markdown", Name = "A page" })
+            .Should().Emit();
+
+        Assert.Equal($"{TestPartition}/{id}", created.Path);
+        Assert.Equal(created.Path, created.MainNode);
+    }
+
+    /// <summary>
+    /// An explicitly-chosen MainNode is never rewritten. The derivation triggers only on the
+    /// record's never-set default (<c>MainNode == Path</c>), so a writer that deliberately points a
+    /// node at a parent keeps its choice.
+    /// </summary>
+    [Fact]
+    public async Task AnExplicitMainNode_IsPreserved()
+    {
+        var id = $"Cfg{Guid.NewGuid():N}"[..10];
+        var created = await NodeFactory.CreateNode(
+            new MeshNode($"_{id}", TestPartition)
+            {
+                NodeType = "Markdown",
+                Name = "Explicitly parented",
+                MainNode = TestPartition,
+            }).Should().Emit();
+
+        Assert.Equal(TestPartition, created.MainNode);
+    }
+}

--- a/test/MeshWeaver.PathResolution.Test/SatelliteOwnerPathTest.cs
+++ b/test/MeshWeaver.PathResolution.Test/SatelliteOwnerPathTest.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using MeshWeaver.Mesh;
 using Xunit;
 
@@ -57,5 +58,106 @@ public class SatelliteOwnerPathTest
                  })
             Assert.False(SatelliteTableMapping.IsSatellitePath(
                 SatelliteTableMapping.OwnerOfSatellitePath(path)));
+    }
+
+    // ── IsSatelliteId — the PARENTAGE question, #2383 ───────────────────────────────────────────
+
+    /// <summary>
+    /// <see cref="SatelliteTableMapping.IsSatelliteId"/> classifies a node's OWN id as a sibling
+    /// satellite. It is what decides whether the create/upsert handler derives MainNode instead of
+    /// leaving the record's self-default in place, so the boundary cases are load-bearing.
+    /// </summary>
+    [Theory]
+    // The sibling satellites that share mesh_nodes — the population #2383 is about.
+    [InlineData("_Policy", true)]
+    [InlineData("_Provider", true)]
+    [InlineData("_GitSync", true)]
+    [InlineData("_DefaultInstallLedger", true)]
+    [InlineData("_Entitlements", true)]
+    // The enumerated table segments are satellite-shaped too, so one rule covers both families.
+    [InlineData("_Access", true)]
+    [InlineData("_Thread", true)]
+    [InlineData("_Comment", true)]
+    // Ordinary content is never a satellite, whatever its case.
+    [InlineData("Readme", false)]
+    [InlineData("Source", false)]
+    [InlineData("alice_Access", false)]
+    // 🚨 Underscore + LOWER-case is NOT a satellite. Authored content may legitimately be named
+    // `_index` / `_draft`, and re-pointing its MainNode would drop it out of every `is:main`
+    // listing and out of search_across_schemas (`WHERE main_node = path`) — i.e. hide real content.
+    [InlineData("_index", false)]
+    [InlineData("_draft", false)]
+    // Degenerate ids: a bare underscore has no type name after it.
+    [InlineData("_", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsSatelliteId_MatchesUnderscoreUpperOnly(string? id, bool expected)
+        => Assert.Equal(expected, SatelliteTableMapping.IsSatelliteId(id));
+
+    /// <summary>
+    /// 🚨 The reason the OWNER is still derived from <see cref="SatelliteTableMapping.OwnerOfSatellitePath"/>
+    /// over the NAMESPACE rather than by scanning the whole path: a PARTITION may legitimately be
+    /// named with a leading underscore. <c>GlobalSettingsNodeType.SettingsPath</c> is literally
+    /// <c>_Setting</c>, and a path scan would resolve <c>_Setting/_Policy</c>'s owner to <c>""</c> —
+    /// the empty prefix that <c>COALESCE(main_node, namespace)</c> projects as a ROOT-scope grant
+    /// over every partition. The namespace-based derivation leaves it intact.
+    /// </summary>
+    [Fact]
+    public void OwnerOfAnUnderscoreNamedPartition_IsThePartition_NotRoot()
+    {
+        Assert.True(SatelliteTableMapping.IsSatelliteId("_Policy"),
+            "the POLICY is the satellite — that is what triggers derivation");
+        Assert.Equal("_Setting", SatelliteTableMapping.OwnerOfSatellitePath("_Setting"));
+        Assert.NotEqual("", SatelliteTableMapping.OwnerOfSatellitePath("_Setting"));
+    }
+
+    /// <summary>
+    /// <see cref="SatelliteTableMapping.IsSiblingSatellite"/> — the node-level classification shared
+    /// by the create/upsert normalization and the static-seed guard. Its two carve-outs are the ones
+    /// a purely syntactic id test gets wrong, and both are real nodes in this repo.
+    /// </summary>
+    [Fact]
+    public void IsSiblingSatellite_ExcludesPartitionRootsAndPartitionDeclarations()
+    {
+        // The population it IS for.
+        Assert.True(SatelliteTableMapping.IsSiblingSatellite(new MeshNode("_Policy", "Teams")));
+        Assert.True(SatelliteTableMapping.IsSiblingSatellite(
+            new MeshNode("_DefaultInstallLedger", "Plugins")));
+
+        // 🚨 A PARTITION ROOT whose own name starts with an underscore. `_Setting` is a real
+        // top-level partition (GlobalSettingsNodeType.SettingsPath); it is a main node.
+        Assert.False(SatelliteTableMapping.IsSiblingSatellite(new MeshNode("_Setting")));
+
+        // 🚨 A partition DECLARATION. `Admin/Partition/_Access` declares the global root-scope
+        // access partition — its id is that partition's NAME, and it is a main node of the catalog
+        // that lists it. Re-pointing its MainNode would delete it from that catalog's listing.
+        Assert.False(SatelliteTableMapping.IsSiblingSatellite(
+            new MeshNode("_Access", "Admin/Partition")));
+
+        // Ordinary content is never a sibling satellite.
+        Assert.False(SatelliteTableMapping.IsSiblingSatellite(new MeshNode("Readme", "Teams")));
+    }
+
+    /// <summary>
+    /// The two classifications answer different questions and must stay separable: every enumerated
+    /// <see cref="SatelliteTableMapping.Defaults"/> segment is satellite-SHAPED, but the converse is
+    /// false — <c>_Policy</c> is a satellite that lives in <c>mesh_nodes</c>. Merging them would move
+    /// <c>_Policy</c> to a satellite table and hide it from the permission evaluator.
+    /// </summary>
+    [Fact]
+    public void EveryTableRoutedSatelliteSegment_IsAlsoSatelliteShaped()
+    {
+        var underscoreSegments = SatelliteTableMapping.Defaults
+            .Select(m => m.Segment)
+            .Where(s => s.StartsWith('_'))
+            .ToArray();
+        Assert.NotEmpty(underscoreSegments);
+        foreach (var segment in underscoreSegments)
+            Assert.True(SatelliteTableMapping.IsSatelliteId(segment),
+                $"'{segment}' routes to a satellite table, so it must also read as satellite-shaped");
+
+        // …and the converse does NOT hold, which is the whole point.
+        Assert.True(SatelliteTableMapping.IsSatelliteId("_Policy"));
+        Assert.False(SatelliteTableMapping.IsSatellitePath("Space/_Policy"));
     }
 }


### PR DESCRIPTION
Closes #2383. Completes the core half — #2388 fixed six of the fifteen mint sites; this fixes the root and the remaining nine.

## Root cause

`MeshNode.MainNode` self-defaults to the node's own path. The framework already has a compensating normalizer — `MeshExtensions.NormalizeSatelliteMainNode`, applied on **both** the `CreateNode` and `UpsertNode` paths — but it was gated on `meshConfig.IsSatelliteNodeType(node.NodeType)`, i.e. only the types whose definition node carries `IsSatelliteType` and which therefore also live in their own satellite **table**.

The `_`-prefixed **siblings** that share `mesh_nodes` — `_Policy`, `_Provider`, `_GitSync`, `_DefaultInstallLedger` — are deliberately *not* such types (`SatelliteTableMapping` line 71 records why: routing them to a satellite table hid `{ns}/_Policy` from the permission evaluator). So they were normalised by **nothing**, and every writer had to remember the field by hand. Fifteen writers exist in core; none did.

`MainNode == Path` is the framework's literal definition of a MAIN node, so such a satellite becomes content:
- the catalog's `is:main` is exactly `MainNode != Path` (`PostgreSqlSqlGenerator` emits `n.main_node = n.path`);
- `search_across_schemas` **hard-filters every union branch** on the same predicate — that one is not opt-in, so the row reached mesh-wide search as well as the Contents section.

## Why not just fix the mint sites again

#2388 corrected six by hand. Its grep — `new MeshNode("_` — cannot match the target-typed spelling `new("_Policy", ns)`, and two writers are raw SQL. Nine were missed. Hand-sweeping is the wrong instrument here, so:

- **`NormalizeSatelliteMainNode` now also fires on a satellite-shaped ID** (`SatelliteTableMapping.IsSiblingSatellite`), so `CreateNode`/`UpsertNode` derive the field for `_Policy` and every future sibling. Flagging the types instead was not an option — the flag also *relocates* the node (`CreateLayoutArea` files a flagged type under `{ns}/_{Type}/{id}`) and routes it to a satellite table, which is the regression `SatelliteTableMapping` warns about.
- **The nine missed writers are corrected**: `DocumentationNodeProvider` (the **second** Doc policy mint), `RoleNodeType`, `LicenseNodeType`, `GlobalSettingsNodeType`, `AccessControlLayoutArea`, `InstanceAutoRegistrationService`, `AssignmentNodeFactory`, plus `PostgreSqlAccessControl` and `SnowflakeAccessControl`. Static seeds bypass the handler entirely, so the mint fixes are needed *alongside* the framework fix, not instead of it.
- **A guard sweeps the static seeds the mesh actually serves**, so the next writer that forgets is caught by a control rather than by a grep.

## Two traps the classifier has to avoid

Both are real nodes in this repo, and both are pinned by tests:

1. **A partition may legitimately be named with a leading underscore.** `GlobalSettingsNodeType.SettingsPath` is literally `_Setting`. The owner is therefore still derived by `OwnerOfSatellitePath` over the **namespace**, never by scanning the path — a path scan resolves `_Setting/_Policy` to `""`, the empty prefix that `COALESCE(main_node, namespace)` projects as a **root-scope grant**.
2. **`Admin/Partition/_Access` is a partition DECLARATION**, not a satellite: its id is the partition's *name*, and it is a main node of the catalog that lists it. Re-pointing its MainNode would delete it from that listing. **The guard caught this on its first run** — my own predicate was wrong, and the control found it.

`SnowflakeAccessControl` also had `main_node` and `path` sharing one variable, so the INSERT wrote the policy's own path into **both** columns. They are now separate; `path` is unchanged.

## Is this an access defect? No — but the issue's reasoning for that was wrong

The issue concluded "not an access defect" from *"`MeshWeaver.Security` contains no reference to `MainNode`"*. **`src/MeshWeaver.Security/` does not exist** — the security rules live in `src/MeshWeaver.Graph/Security/`, and they do read `MainNode`. The conclusion happens to hold, but for a different reason, so it is worth stating properly:

- **Both policy readers resolve by `id = '_Policy'` keyed on `namespace`** — `rebuild_user_effective_permissions` (`PostgreSqlSchemaInitializer.cs:1894`, `:1921`) and the in-memory `PermissionEvaluator` (`:443`, `:764`) — **never by `main_node`**. So what a policy grants or denies is unaffected by this change, in both directions.
- `MainNode` **is** security-relevant in general: `SatelliteAccessRule` delegates a satellite's permissions to it and has an explicit degenerate branch that abandons delegation the moment `MainNode == Path`; grants project at `COALESCE(main_node, namespace)`; and the SQL read clause matches `n.main_node LIKE prefix || '%'`. But `PartitionAccessPolicy` registers no `SatelliteAccessRule` and is not an `AccessAssignment`, so none of those apply to the population here.

**Verdict: disclosure-shaped, not an access-control bypass** — an internal governance node listed as page content and returned by mesh-wide search. Real, worth fixing, not urgent.

**No StackOverflow risk either** (the self-referential-`record` failure mode): `MainNode` is a `string` path, `MeshNode` has no object-valued back-reference (`Content` is `object?` but nothing in `src/` ever puts a `MeshNode` in it), `GetHashCode` deliberately excludes `Content`, and nothing anywhere recurses by following `MainNode` — every read is a single dereference.

## Already-minted rows

- **DB-synced partitions repair themselves, with no migration.** `PartitionSourceFingerprint` frames `MainNode` into the per-partition hash, so changing the static seeds changes the fingerprint; the static-repo importer then takes the full re-import path instead of the content-skip and upserts the corrected node. Worth flagging that #2388's "static seeds … no repair step" was not quite right on its own: `SkillStaticRepoSource`/`HarnessStaticRepoSource` explicitly include the `_Policy` in `EnumerateSourceNodes`, so those rows *are* durable — it is the fingerprint change that heals them.
- **Rows written by `AccessControlLayoutArea` or the raw-SQL writers before this change keep their old value.** They are cosmetic per the section above, so no `LogonAction` and no migration: a `RunOnce` action would cost a per-user write across every partition to correct a listing artefact, and a raw `UPDATE` on a live portal bypasses the workspace cache (AGENTS.md). New writes are correct from here.
- **Store packages are owned in MeshWeaver.Plugins** (`PluginGate.cs:936/956`, which assigns the self-reference *explicitly*, and whose `PolicyMatches` compares content only) — per the issue's own split.

## Verification

Release + `-warnaserror`, 0 errors: Mesh.Contract, Graph, Documentation, PluginCatalog, Hosting.PostgreSql, Hosting.Snowflake, Hosting.Monolith.TestBase.

**2692 tests green** — Data 390, Security 376, Graph 1626, PathResolution 155, NodeOperations 76, Documentation 69.

**Both directions proven by reverting the fix and re-running:**

| reverted | result |
|---|---|
| the four static mint fixes | sweep fails naming `Doc/_Policy`, `License/_Policy`, `Role/_Policy`, `_Setting/_Policy` |
| the normalization widening | `CreatingASiblingSatellite_DerivesItsMainNode` fails, `Actual: "TestData/_Policy"` |

The two negative controls — ordinary content stays a main node, an explicit `MainNode` is preserved — pass in **every** configuration, which is what bounds the blast radius. The guard also asserts a named inventory floor, so it fails loudly rather than passing vacuously if the composition ever stops registering a seed.

What's New: `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
