### PR TITLE
fix(mesh): teardown no longer parks in the IoPool drain — Cancel() ran pooled-subscription teardown inline on the joining thread (#2394)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
@@ -419,8 +419,10 @@ So the mesh teardown awaits **all three**, in order, before the scope is dispose
    MESH TEARDOWN thread with no budget over it — the drain timeout covers only the gate join that
    comes *after* — so one clean-up leg that would not finish parked teardown silently and forever
    (#2394: a whole test assembly killed at its 8 min cap with no test named). `IoPool` now issues the
-   cancel on a dedicated thread and joins it last, under the same budget, adding it to the residual
-   when it does not finish. `Dispose()` issues it the same way and never joins — its wait lives on
+   cancel on a dedicated thread and joins it **first**, ahead of the gate join and under the same
+   budget, because the gate join's meaning depends on the cancel having landed ("once the pool token
+   is cancelled, no NEW leaf can take a permit"); a cancel that does not finish inside the budget is
+   added to the residual. `Dispose()` issues it the same way and never joins — its wait lives on
    `Disposed`.
 3. `AsyncDisposeQueue.DrainAsync(timeout)` — the queued async cleanup. A TPL `ActionBlock` drains it;
    `DrainAsync` `Complete()`s the block and awaits the remainder (bounded), so it converges even under

--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
@@ -410,6 +410,18 @@ So the mesh teardown awaits **all three**, in order, before the scope is dispose
    ThreadPool thread then dereferences a collectible node ALC's freed metadata after unload, a
    native use-after-unload **SIGSEGV**. `DrainAll()` cancels every leaf so it stops, then joins, and
    returns the count it had to leak.
+   🚨 **The cancel runs on its own thread, never on the joining one.**
+   `CancellationTokenSource.Cancel()` executes every registered callback *synchronously on the
+   caller*, and this token's callbacks are not bookkeeping: `SubscribeThroughPool` registers one per
+   live pooled subscription that runs that subscription's whole downstream teardown, and every gated
+   leaf links its subscriber token to the pool's, so cancelling also resumes each leaf's gate wait
+   into its observer. Cancelling inline therefore ran arbitrary application teardown on the
+   MESH TEARDOWN thread with no budget over it — the drain timeout covers only the gate join that
+   comes *after* — so one clean-up leg that would not finish parked teardown silently and forever
+   (#2394: a whole test assembly killed at its 8 min cap with no test named). `IoPool` now issues the
+   cancel on a dedicated thread and joins it last, under the same budget, adding it to the residual
+   when it does not finish. `Dispose()` issues it the same way and never joins — its wait lives on
+   `Disposed`.
 3. `AsyncDisposeQueue.DrainAsync(timeout)` — the queued async cleanup. A TPL `ActionBlock` drains it;
    `DrainAsync` `Complete()`s the block and awaits the remainder (bounded), so it converges even under
    continuous influx — a *version-target* wait would not (the queue is a message stream / endless

--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshLifecycle.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshLifecycle.md
@@ -132,11 +132,21 @@ if (disposeQueue is not null)
 // THEN dispose the scope
 ```
 
-Phases 0, 1 and 3 are **bounded** by a timeout. A wait that times out means a real bug — a
+Every phase is **bounded** by a timeout. A wait that times out means a real bug — a
 wedged action block (surfaced separately by `AnyHubQuiescingTimedOut`), a leaked
 I/O slot (a non-zero `leakedIoLeaves` / `IoPoolRegistry.TotalInFlight`), or a wedged async
 cleanup. The timeout keeps tear-down from hanging; it does **not** paper over the leak
 — log it and fix the leak, never just widen the timeout (see [the no-band-aids rule](/Doc/Architecture/ControlledIoPooling)).
+
+> 🚨 **Phase 2 was the exception, and it was invisible.** `IoPool.Drain()`'s budget covered only
+> the gate join; the `_poolCts.Cancel()` ahead of it ran on the CALLING thread — i.e. this very
+> teardown thread — and `CancellationTokenSource.Cancel()` executes every registered callback
+> synchronously there. Those callbacks tear down whole pooled subscriptions (see
+> [Controlled I/O Pooling](/Doc/Architecture/ControlledIoPooling)), so one clean-up leg that would
+> not return parked teardown for as long as anyone waited, writing nothing anywhere: issue #2394,
+> a whole test assembly killed at its 8 min wall-clock cap with no test named and not one line
+> after `DISPOSE_INVOKED`. The cancel now runs on its own thread and is joined under the same
+> budget, so a stuck leg is reported in `leakedIoLeaves` instead of hanging.
 
 ### The order is the whole point
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-shutdown-no-longer-parks-on-io-teardown.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-shutdown-no-longer-parks-on-io-teardown.md
@@ -1,0 +1,21 @@
+---
+Name: Shutdown no longer parks on background I/O clean-up
+Category: Fix
+Description: A mesh shutdown could park indefinitely while tearing down background I/O subscriptions, silently stalling a restart or a whole test run.
+Icon: Sparkle
+Order: -20260826
+---
+
+# Shutdown no longer parks on background I/O clean-up
+
+When a mesh shuts down — a portal instance rolling to a new version, or a test tearing down its
+own isolated mesh — it cancels the background I/O it still has running and waits for it to stop.
+Cancelling ran each background subscription's own clean-up inline on the very thread performing
+the shutdown, one after another, and with no time limit over it: the limit that exists covers only
+the step that follows. A single clean-up that could not finish therefore parked the whole shutdown
+for as long as anyone was willing to wait, and wrote nothing anywhere to say where it had stopped.
+
+Clean-up now runs on its own thread and is joined under the same budget as the rest of the drain,
+so shutdown either finishes or reports exactly what is still running. Test teardown also records
+each of its three shutdown phases, so if this part ever stalls again the log names it instead of
+leaving an unexplained silence.

--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1355,6 +1355,14 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
 
             using var cts = new CancellationTokenSource(DisposeTimeout);
             await WaitWithProgressAsync(testName, sw, cts.Token);
+            // 🚨 The three post-dispose phases are traced INDIVIDUALLY, because the gap between
+            // DISPOSE_INVOKED and DISPOSE_DONE was the one stretch of teardown that could hang
+            // with nothing at all written to the one file CI keeps: the hub-side wait above ends
+            // in a DISPOSE_TIMEOUT trace, but DrainAll() below is synchronous, unlogged and (until
+            // #2394) unbounded — so a wedge there presented as an 8&#160;min whole-assembly
+            // exit=124 naming no test and no phase. These markers make that phase attributable
+            // from the trace file alone, which is all a killed host leaves behind.
+            TestPhaseTrace(testName, "DISPOSE_IOPOOL_DRAIN_START", sw.ElapsedMilliseconds);
             // DisposalCompleted only drains the action blocks + message round-trips.
             // Offloaded I/O (IIoPool) runs on the ThreadPool independently and is NOT
             // covered — CANCEL + JOIN it here, BEFORE base.DisposeAsync tears down the
@@ -1364,10 +1372,14 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             // completes on its own, so a WAIT-only drain would time out and let the scope
             // dispose under it; DrainAll() cancels the leaf so it stops, then joins.
             var leakedIoLeaves = ioPools?.DrainAll() ?? 0;
+            TestPhaseTrace(testName, "DISPOSE_IOPOOL_DRAIN_DONE", sw.ElapsedMilliseconds,
+                $"leakedIoLeaves={leakedIoLeaves}");
             // After all the sync stuff is disposed (and everyone has enqueued their async
             // cleanup), quiesce the async dispose queue before the scope closes below.
             var asyncDisposeClean = asyncDisposeQueue is null
                 || await asyncDisposeQueue.DrainAsync(DisposeTimeout);
+            TestPhaseTrace(testName, "DISPOSE_ASYNC_QUEUE_DRAINED", sw.ElapsedMilliseconds,
+                $"clean={asyncDisposeClean}");
 
             // The terminal signal — DISPOSE_DONE is only true when this report is CLEAN. Fire it
             // before the scope disposes below so any subscriber ordering on "all is done" (ALC

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
@@ -534,7 +534,8 @@ public sealed class IoPool : IIoPool, IDisposable
     /// The number of leaves that did NOT unwind within the drain budget — gate permits that could not
     /// be re-acquired because an async leaf ignored its cancellation token, PLUS any blocking leaf
     /// (<see cref="InvokeBlocking{T}"/>) still running, which holds no permit and so is counted
-    /// separately. <c>0</c> means the join is REAL:
+    /// separately, PLUS one for a cancellation that is still running its registered teardown
+    /// callbacks (see <see cref="StartCancelOffCallerThread"/>). <c>0</c> means the join is REAL:
     /// no pool thread is still running when this returns. Anything else means teardown is about to
     /// proceed over live work (the use-after-unload SIGSEGV precondition) — the caller must surface
     /// it, never swallow it: a drain that silently gives up is how "disposal completed" becomes a
@@ -551,7 +552,18 @@ public sealed class IoPool : IIoPool, IDisposable
         if (!TryEnterGateRegion()) return 0;
         try
         {
-            _poolCts.Cancel();
+            // 🚨 NOT `_poolCts.Cancel()` on this thread — see StartCancelOffCallerThread. The
+            // callbacks this token carries run the pooled subscriptions' whole DOWNSTREAM teardown,
+            // and this thread is the mesh-teardown thread.
+            //
+            // Joined BEFORE the gate join, under the same budget, because the gate join's whole
+            // meaning depends on the cancel having landed: "once _poolCts is cancelled every waiting
+            // leaf's WaitAsync throws, so no NEW leaf can take a permit" (see the remarks above).
+            // A cancel still running would leave that premise false. In the healthy case this costs
+            // a thread start; a callback that never finishes costs one budget and is then REPORTED
+            // in the residual — which is the whole difference between #2394's silent 8-minute
+            // wall-clock kill and a named, failing teardown.
+            var cancelResidual = StartCancelOffCallerThread().Join(DrainTimeout) ? 0 : 1;
             var acquired = 0;
             for (var i = 0; i < _maxConcurrency; i++)
             {
@@ -573,20 +585,83 @@ public sealed class IoPool : IIoPool, IDisposable
             // Join them on their own idle signal, bounded by the SAME budget — no new timeout, no poll.
             // Re-read the counter when the wait expires: a leaf that finished between the signal reset
             // and our wait would otherwise be reported as surviving.
+            var blockingResidual = 0;
             if (!_blockingIdle.Wait(DrainTimeout))
             {
                 // _blockingInFlight, never _inFlight: an async leaf that ignored its token is ALREADY
                 // reported through gateResidual, so adding it again would double-count it.
-                var stillRunning = Volatile.Read(ref _blockingInFlight);
-                return gateResidual + stillRunning;
+                blockingResidual = Volatile.Read(ref _blockingInFlight);
             }
 
-            return gateResidual;
+            // A teardown callback still running is live application code on the very scope (and the
+            // very collectible node ALCs) the caller is about to release, so it belongs in the
+            // residual exactly like an un-unwound leaf.
+            return cancelResidual + gateResidual + blockingResidual;
         }
         finally
         {
             LeaveGateRegion();
         }
+    }
+
+    /// <summary>
+    /// Cancels <see cref="_poolCts"/> on a DEDICATED thread and returns that thread so the caller
+    /// can join it under its own budget.
+    ///
+    /// <para>🚨 <b><see cref="CancellationTokenSource.Cancel()"/> runs every registered callback
+    /// SYNCHRONOUSLY on the thread that calls it</b>, and the callbacks on this pool's token are
+    /// not bookkeeping. <see cref="SubscribeThroughPool{T}"/> registers one per LIVE pooled
+    /// subscription that performs that subscription's whole downstream teardown
+    /// (<c>inner.Dispose()</c> then <c>observer.OnCompleted()</c>) — layout-render pipelines, query
+    /// change feeds, routing dispatch bookkeeping. Every gated leaf additionally links its
+    /// subscriber token to this one, so cancelling also resumes each leaf's
+    /// <c>await _gate.WaitAsync(ct)</c>, whose <see cref="OperationCanceledException"/> surfaces to
+    /// that leaf's observer — more downstream teardown, inline on the same thread.</para>
+    ///
+    /// <para>The thread calling <see cref="Drain"/>/<see cref="Dispose"/> is the MESH TEARDOWN
+    /// thread (<c>IoPoolRegistry.DrainAll()</c>, from <c>MeshTeardownExtensions</c> and
+    /// <c>MonolithMeshTestBase.DisposeAsync</c>). Running arbitrary application teardown there was
+    /// unbounded by construction: <see cref="DrainTimeout"/> bounds only the gate join that comes
+    /// AFTER the cancel, no watchdog covers this phase (the hub's own watchdog ends at
+    /// <c>DisposalCompleted</c>, which teardown has already observed by then), and nothing on the
+    /// path logs. One teardown leg that blocks therefore parked mesh teardown SILENTLY and forever
+    /// — issue #2394: a whole test assembly killed at its 8&#160;min wall-clock cap with no test
+    /// named and not one line written after <c>DISPOSE_INVOKED</c>.</para>
+    ///
+    /// <para>A DEDICATED thread, never the ThreadPool or this pool's own blocking scheduler: the
+    /// work this cancel exists to unwind may be holding every one of those slots, so scheduling the
+    /// cancel behind it is the starvation deadlock <see cref="Dispose"/> already refuses.</para>
+    /// </summary>
+    private Thread StartCancelOffCallerThread()
+    {
+        // The region is taken HERE, on the caller's thread — not inside the new one — so disposal
+        // cannot complete (and dispose _poolCts) in the window between Start() and the thread
+        // actually getting scheduled.
+        Interlocked.Increment(ref _gateUsers);
+        var canceller = new Thread(() =>
+        {
+            try
+            {
+                _poolCts.Cancel();
+            }
+            catch (Exception)
+            {
+                // Cancel() aggregates whatever the registered teardown callbacks threw. Each of
+                // those callbacks is responsible for its own diagnostics; what must not happen is
+                // this thread dying before the finally hands the region back, because that hand-back
+                // is what completes disposal.
+            }
+            finally
+            {
+                LeaveGateRegion();
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "IoPool-cancel",
+        };
+        canceller.Start();
+        return canceller;
     }
 
     /// <summary>
@@ -608,10 +683,15 @@ public sealed class IoPool : IIoPool, IDisposable
         // OrderedRouteDispatcherTest hung for its full 30 s budget — the exact failure recorded
         // when this fix was first deferred. An 18-core dev box hides it completely.
         //
-        // So: cancel here (leaves unwind promptly), and put the WAITING on `Disposed`, which the
+        // So: cancel (leaves unwind promptly), and put the WAITING on `Disposed`, which the
         // caller awaits ASYNCHRONOUSLY. Resource release happens on the last leaf's way out —
         // see TryFinishDisposal — because a leaf still running would otherwise touch a disposed
         // _gate / _poolCts.
+        //
+        // 🚨 …and the cancel is issued OFF this thread (StartCancelOffCallerThread). "Cancel here"
+        // used to mean `_poolCts.Cancel()` inline, which is itself a blocking call: Cancel runs
+        // every registered callback synchronously on the caller, and this token's callbacks tear
+        // down whole downstream pipelines. #2394.
         if (Interlocked.CompareExchange(ref _disposing, 1, 0) != 0) return;
 
         // Set BEFORE the cancel so a leaf issued in the gap short-circuits to Cancelled<T>()
@@ -628,7 +708,12 @@ public sealed class IoPool : IIoPool, IDisposable
         Interlocked.Increment(ref _gateUsers);
         try
         {
-            _poolCts.Cancel();
+            // 🚨 The cancel itself runs OFF this thread — see StartCancelOffCallerThread. Cancel()
+            // executes every pooled subscription's downstream teardown synchronously on whoever
+            // calls it, so `_poolCts.Cancel()` here WAS a blocking call in the one method whose
+            // contract above says it must never block. Nothing joins it: the WAIT lives on
+            // Disposed, and the canceller's own region hand-back is what lets that fire.
+            StartCancelOffCallerThread();
         }
         finally
         {

--- a/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.Mesh.Threading;
 using Xunit;
@@ -767,5 +769,105 @@ public class IoPoolTest
         done.Wait(Timeout5).Should().BeTrue("the leaf should complete");
         bodyOnThreadPool.Should().BeTrue("the leaf must run on the ThreadPool, not the subscriber's thread");
         bodyThread.Should().NotBe(subscriberThread);
+    }
+    /// <summary>
+    /// 🚨 REPRO for #2394 — the SILENT teardown wedge.
+    ///
+    /// <para><see cref="CancellationTokenSource.Cancel()"/> runs every registered callback
+    /// SYNCHRONOUSLY on the thread that calls it, and <see cref="IoPool.SubscribeThroughPool{T}"/>
+    /// registers one per LIVE pooled subscription which performs that subscription's whole
+    /// downstream teardown (<c>inner.Dispose()</c> then <c>observer.OnCompleted()</c>) — layout
+    /// renders, query change feeds, routing dispatch. <see cref="IoPool.Drain"/> used to call
+    /// <c>_poolCts.Cancel()</c> inline, so <c>IoPoolRegistry.DrainAll()</c> — i.e. the MESH
+    /// TEARDOWN thread — executed arbitrary application teardown with nothing over it:
+    /// <c>DrainTimeout</c> bounds only the gate join that comes AFTER the cancel, no watchdog
+    /// covers the phase (the hub's own ends at <c>DisposalCompleted</c>, already observed), and
+    /// nothing on the path logs. One teardown leg that blocked parked mesh teardown FOREVER —
+    /// <c>MeshWeaver.Hosting.Monolith.Test</c> killed at its 8&#160;min wall-clock cap with no test
+    /// named and not one trace line after <c>DISPOSE_INVOKED</c>.</para>
+    ///
+    /// <para>Deterministic: the teardown leg below simply does not return promptly, which is the
+    /// only precondition the wedge ever needed.</para>
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task Drain_runsPooledSubscriptionTeardown_offTheCallersThread()
+    {
+        using var pool = new IoPool(4);
+        var source = new Subject<int>();
+        using var teardownEntered = new ManualResetEventSlim(false);
+        using var releaseTeardown = new ManualResetEventSlim(false);
+        var teardownThread = 0;
+
+        using var subscription = pool.SubscribeThroughPool<int>(source).Subscribe(
+            _ => { },
+            () =>
+            {
+                teardownThread = Environment.CurrentManagedThreadId;
+                teardownEntered.Set();
+                releaseTeardown.Wait(Timeout10);
+            });
+
+        SpinWait.SpinUntil(() => source.HasObservers, Timeout5)
+            .Should().BeTrue("the pooled subscribe must have completed before the drain");
+
+        var drainThread = 0;
+        var drain = Task.Run(
+            () =>
+            {
+                drainThread = Environment.CurrentManagedThreadId;
+                return pool.Drain();
+            },
+            TestContext.Current.CancellationToken);
+
+        teardownEntered.Wait(Timeout5, TestContext.Current.CancellationToken)
+            .Should().BeTrue("Drain cancels the pool, which terminates every pooled subscription");
+
+        teardownThread.Should().NotBe(drainThread,
+            "a pooled subscription's downstream teardown must never run on the thread that called "
+            + "Drain() — that thread is the mesh-teardown thread, and Cancel() executes registered "
+            + "callbacks synchronously on whoever calls it (#2394)");
+
+        releaseTeardown.Set();
+
+        var residual = await drain.WaitAsync(Timeout10, TestContext.Current.CancellationToken);
+        residual.Should().Be(0, "the teardown finished inside the budget — nothing to report");
+    }
+
+    /// <summary>
+    /// The other half of #2394: <see cref="IoPool.Dispose"/> documents "DISPOSE MUST NOT BLOCK" —
+    /// yet <c>_poolCts.Cancel()</c> IS a blocking call whenever a pooled subscription's teardown is
+    /// slow, for the same reason as above. `using var pool = …` in an async method runs Dispose on
+    /// a ThreadPool thread, so a blocking Dispose parks a pool thread while the work it is
+    /// unwinding needs pool threads — the starvation deadlock the method's own comment describes.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public void Dispose_doesNotBlockOnASlowPooledSubscriptionTeardown()
+    {
+        var pool = new IoPool(4);
+        var source = new Subject<int>();
+        using var teardownEntered = new ManualResetEventSlim(false);
+        using var releaseTeardown = new ManualResetEventSlim(false);
+
+        using var subscription = pool.SubscribeThroughPool<int>(source).Subscribe(
+            _ => { },
+            () =>
+            {
+                teardownEntered.Set();
+                releaseTeardown.Wait(Timeout5);
+            });
+
+        SpinWait.SpinUntil(() => source.HasObservers, Timeout5)
+            .Should().BeTrue("the pooled subscribe must have completed before disposal");
+
+        var sw = Stopwatch.StartNew();
+        pool.Dispose();
+        sw.Stop();
+
+        teardownEntered.Wait(Timeout5).Should().BeTrue("disposal must still terminate the subscription");
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2),
+            "Dispose must return immediately — the WAIT belongs on Disposed, and running the "
+            + "pooled subscriptions' teardown inline made Dispose block for as long as they took");
+
+        releaseTeardown.Set();
     }
 }


### PR DESCRIPTION
Closes #2394.

## Symptom

`MeshWeaver.Hosting.Monolith.Test (part 2/2)` exits **124 TIMEOUT** — the shard loop's 8-minute
per-project wall-clock cap — naming no test. The wedged host's phase trace stops dead after
`DISPOSE_INVOKED` and emits nothing but `MEM_WATCHDOG` heartbeats for the remaining **337 s**;
managed heap (83→86 MiB) and RSS (806→807 MiB) are flat throughout, so the process is parked, not
spinning.

## Where it hangs — by elimination, from the artifacts

Between `DISPOSE_INVOKED` and the next phase marker that could ever be written,
`MonolithMeshTestBase.DisposeAsync` runs exactly three statements:

1. `await WaitWithProgressAsync(…)` — bounded by a 30 s `CancellationTokenSource`; on expiry it
   writes a `DISPOSE_TIMEOUT` phase line. That line is **absent**, so it returned. (Its only other
   work is `GetDisposalDiagnostics()`, which is lock-free over `ConcurrentDictionary`s plus one
   short `lock (responseSubjects)` region that contains no blocking call.)
2. `ioPools.DrainAll()` — **synchronous, unlogged, and unbounded.**
3. `await asyncDisposeQueue.DrainAsync(30 s)` — bounded (2 × 30 s) and always falls through to
   `DISPOSE_DONE`, dirty or not. Also absent.

The mesh hub's own disposal watchdog (8 s, re-armed on progress) never logged
`DISPOSAL DEADLOCK DETECTED` either, and it does not cover this phase — it ends at
`DisposalCompleted`, which teardown had already observed. So the only candidate is (2).

## Root cause

`IoPool.Drain()` — and `IoPool.Dispose()` — called `_poolCts.Cancel()` **on the caller's thread**.
`CancellationTokenSource.Cancel()` executes every registered callback *synchronously on that
thread*, and this token's callbacks are not bookkeeping:

* `IoPool.SubscribeThroughPool` registers **one per live pooled subscription** whose body is that
  subscription's entire downstream teardown — `inner.Dispose()` then `observer.OnCompleted()`.
  Those subscriptions are layout-area renders (`LayoutAreaHost.ScheduleRenderSubscribe`), query
  change feeds (`MeshQuery.Query`), and silo routing dispatch.
* Every gated leaf additionally links its subscriber token to the pool token, so cancelling also
  resumes each leaf's `await _gate.WaitAsync(ct)` and surfaces the resulting
  `OperationCanceledException` into that leaf's observer — more downstream teardown, same thread.

The caller is the **mesh-teardown thread**: `IoPoolRegistry.DrainAll()`, reached from
`MonolithMeshTestBase.DisposeAsync` in tests and from `MeshTeardownExtensions` in production. So
teardown ran arbitrary application clean-up inline and serially, with nothing over it —
`DrainTimeout` bounds only the gate join that comes *after* the cancel, no watchdog covers the
phase, and nothing on the path logs. **One clean-up leg that does not return parks mesh teardown
silently and forever**, which is exactly what an `exit=124` with no test name and no trace line
looks like.

## Evidence: the mechanism reproduces the signature bit for bit

A throwaway `MonolithMeshTestBase` test that leaves behind one pooled subscription whose
`OnCompleted` does not return, run against **unfixed** code, produced:

```
DISPOSE_START
DISPOSE_HOSTED_SERVICES_STOPPED elapsed=0ms
DISPOSE_INVOKED elapsed=23ms
DISPOSE_IOPOOL_DRAIN_START elapsed=63ms          ← new marker (CI had no such line)
… nothing but MEM_WATCHDOG, managed flat at 45 MiB, RSS flat …
```

— i.e. the CI trace, including the flat memory. `dotnet-stack report` on that host names the frame
chain outright:

```
Thread.Sleep(∞)                                      ← the teardown leg that will not return
  AnonymousObserver`1.OnCompletedCore()
  AutoDetachObserver`1.OnCompletedCore()
  IoPool+<>c__DisplayClass30_2`1.<SubscribeThroughPoolCore>b__4()   ← the drain registration
  CancellationTokenSource.ExecuteCallbackHandlers(bool)             ← Cancel() runs it INLINE
  IoPool.Drain()
  IoPoolRegistry.DrainAll()
  MonolithMeshTestBase.<DisposeAsync>d__80.MoveNext()
```

## Fix

`IoPool` issues the cancel on a **dedicated thread** (`StartCancelOffCallerThread`) instead of on
the joining one:

* `Drain()` starts it and **joins it first**, under the existing `DrainTimeout`, because the gate
  join's meaning depends on the cancel having landed ("no NEW leaf can take a permit"). A callback
  that never finishes now costs one budget and is **reported** in the residual — which the test base
  turns into a named `DISPOSE_DIRTY_TEARDOWN` failure, and `MeshTeardownExtensions` surfaces the
  same way — instead of parking teardown.
* `Dispose()` issues it the same way and never joins: its contract already says
  *"DISPOSE MUST NOT BLOCK"*, and `_poolCts.Cancel()` was violating that contract for exactly the
  reason above. The wait stays on `Disposed`.
* A dedicated thread, never the ThreadPool or the pool's own blocking scheduler: the work this
  cancel exists to unwind may be holding those slots.

No timeout was raised, added or widened; the unbounded step was moved inside the budget that
already existed.

## Attributability

`MonolithMeshTestBase.DisposeAsync` now traces its three post-dispose phases individually
(`DISPOSE_IOPOOL_DRAIN_START`, `DISPOSE_IOPOOL_DRAIN_DONE leakedIoLeaves=N`,
`DISPOSE_ASYNC_QUEUE_DRAINED clean=…`). That gap was the one stretch of teardown that could hang
with nothing written to the single file CI keeps when a host is killed at its cap.

## Proof, both directions

Two new tests in `MeshWeaver.Hosting.Test/IoPoolTest.cs`:

| test | before the fix | after |
|---|---|---|
| `Drain_runsPooledSubscriptionTeardown_offTheCallersThread` | FAILS — teardown ran on thread 9, the `Drain()` caller | passes |
| `Dispose_doesNotBlockOnASlowPooledSubscriptionTeardown` | FAILS — `Dispose()` blocked `00:00:05.0015` for a 5 s teardown | passes |

`IoPoolTest` as a whole: 23/23 green in 1 s with the fix.

## 🚨 One correction to the issue

The issue lists three occurrences. Reading all three artifacts, only **two** are this defect:

| run | class | last phase | verdict |
|---|---|---|---|
| 32939560960 (`main`) | `MeshNodeLanguageServiceTest` | `DISPOSE_INVOKED` | this defect |
| 32977048720 | `MeshNodeLanguageServiceTest` | `DISPOSE_INVOKED` | this defect |
| 32965944797 | `CodeEditRecompileTest` | `INIT_MEM` (test body) | **different** — a hang inside the test, after `Failed to compile assembly for node 'TestData/ToolRetryType'` + a `NullReferenceException` compile failure. That is the `CodeEditRecompile` family, not teardown. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
