### PR TITLE
Faulted stream mirrors are evicted, not replayed forever (#2387)

### DIFF
--- a/src/MeshWeaver.Data/Serialization/StreamLiveness.cs
+++ b/src/MeshWeaver.Data/Serialization/StreamLiveness.cs
@@ -33,11 +33,23 @@ namespace MeshWeaver.Data.Serialization;
 /// terminal), so the replacement fails the same check and the loop never terminates.</description></item>
 /// </list>
 ///
+/// <para>🚨 <b>A FAULTED stream is dead in exactly the same way, and that had to be said out loud
+/// (Systemorph/MeshWeaver#2387).</b> A store is a <c>ReplaySubject</c>, so a terminal <c>OnError</c>
+/// is permanent under the Rx grammar — the stream can never emit again, and every later subscriber
+/// replays that error INSTANTLY. Nothing disposes it either: the terminal arm of
+/// <c>CreateExternalClient</c> faults the stream and tears down only its keep-alive, leaving the
+/// object "errored but undisposed". So while this predicate asked about disposal alone, a cache
+/// kept handing the corpse back for the whole process lifetime, and the symptom was the opposite of
+/// a hang: a 30-second initial-state bound reported after 0.07 ms, because nothing waited for
+/// anything. Refusing to serve it is not a retry — the next natural caller opens a fresh stream,
+/// and a stream that is BORN dead is handed back rather than re-created, so create → fault → create
+/// cannot spin.</para>
+///
 /// <para><b>The verdict.</b> A stream is usable when it and every ancestor in its reduce chain is
-/// undisposed and owns a hub that has not begun winding down. <see cref="MessageHub.IsDisposing"/>
-/// is checked as well as <see cref="IMessageHub.RunLevel"/> because hub shutdown is asynchronous:
-/// right after <c>Dispose()</c> the RunLevel still reads <c>Started</c> while hosted-hub creation
-/// is already frozen.</para>
+/// undisposed, unfaulted, and owns a hub that has not begun winding down.
+/// <see cref="MessageHub.IsDisposing"/> is checked as well as <see cref="IMessageHub.RunLevel"/>
+/// because hub shutdown is asynchronous: right after <c>Dispose()</c> the RunLevel still reads
+/// <c>Started</c> while hosted-hub creation is already frozen.</para>
 /// </summary>
 internal static class StreamLiveness
 {
@@ -50,11 +62,11 @@ internal static class StreamLiveness
 
     /// <summary>
     /// True when <paramref name="stream"/> may be handed to a caller from a cache: it and every
-    /// ancestor in its reduce chain are undisposed and hub-backed.
+    /// ancestor in its reduce chain are undisposed, unfaulted and hub-backed.
     /// </summary>
     /// <param name="stream">The stream to judge, or <c>null</c>.</param>
-    /// <returns><c>false</c> for <c>null</c>, for a disposed stream, and for a live stream whose
-    /// source chain contains a disposed stream.</returns>
+    /// <returns><c>false</c> for <c>null</c>, for a disposed or terminally faulted stream, and for
+    /// a live stream whose source chain contains one.</returns>
     public static bool IsUsable(ISynchronizationStream? stream)
     {
         if (stream is null)
@@ -63,7 +75,16 @@ internal static class StreamLiveness
         var current = stream;
         for (var depth = 0; depth < MaxChainDepth; depth++)
         {
-            if (current is IStreamLivenessSource { IsDisposed: true })
+            // 🚨 FAULTED counts exactly as much as DISPOSED — Systemorph/MeshWeaver#2387.
+            // A stream's store is a ReplaySubject, so a terminal OnError is permanent: it can
+            // never emit again and every later subscriber replays that same error INSTANTLY. A
+            // cache that judged liveness on disposal alone therefore kept handing the corpse back
+            // for the whole process lifetime, and the symptom was the opposite of a hang — a
+            // 30-second bound reported after 0.07 ms, because nothing waited for anything. On the
+            // boot path that turned ONE unanswered SubscribeRequest to a busy per-node hub into a
+            // package this pod could never install again, including by the installer's own
+            // fall-back-to-full-install repair, which re-entered the same dead mirror.
+            if (current is IStreamLivenessSource { IsDisposed: true } or IStreamLivenessSource { IsFaulted: true })
                 return false;
             if (current.Hub is not { } hub
                 || hub.RunLevel > MessageHubRunLevel.Started
@@ -82,6 +103,23 @@ internal static class StreamLiveness
         // whether the chain was merely long or genuinely circular.
         return false;
     }
+
+    /// <summary>
+    /// True when <paramref name="stream"/> ITSELF took a terminal error — the one reason for being
+    /// unusable that a cache can and must CLOSE, rather than merely stop serving.
+    ///
+    /// <para>The distinction matters at teardown. A stream that is unusable because its hub is
+    /// winding down is already being disposed by that cascade, and closing it a second time from a
+    /// cache lookup would post an <c>UnsubscribeRequest</c> at a dying owner — which on Orleans
+    /// re-activates the very grain the teardown is retiring. A FAULTED stream has no such owner:
+    /// its store is terminal, so it can neither notify a reader nor be revived, and nothing else
+    /// will ever close it. Deliberately does NOT walk the source chain — a faulted ancestor is the
+    /// ancestor's cache's business, not this one's.</para>
+    /// </summary>
+    /// <param name="stream">The stream to judge, or <c>null</c>.</param>
+    /// <returns><c>true</c> only when this exact stream's store holds a terminal error.</returns>
+    public static bool HasFaulted(ISynchronizationStream? stream)
+        => stream is IStreamLivenessSource { IsFaulted: true };
 }
 
 /// <summary>
@@ -113,4 +151,11 @@ internal interface IStreamLivenessSource
     /// Whether this stream has been disposed. Its store is completed and it will never emit again.
     /// </summary>
     bool IsDisposed { get; }
+
+    /// <summary>
+    /// Whether this stream's store took a terminal error. It will never emit again either, and —
+    /// unlike a completed store — every later subscriber replays that error the instant it
+    /// subscribes, so serving it from a cache turns one transient failure into a permanent one.
+    /// </summary>
+    bool IsFaulted { get; }
 }

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -130,12 +130,12 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
 
         while (true)
         {
-            var lazy = sharedReduceCache.GetOrAdd(reference,
-                _ => new Lazy<ISynchronizationStream>(
-                    () => Reduce(reference, x => x)
-                          ?? throw new InvalidOperationException(
-                              $"Cannot reduce stream {StreamId} to {reference}"),
-                    LazyThreadSafetyMode.ExecutionAndPublication));
+            var mine = new Lazy<ISynchronizationStream>(
+                () => Reduce(reference, x => x)
+                      ?? throw new InvalidOperationException(
+                          $"Cannot reduce stream {StreamId} to {reference}"),
+                LazyThreadSafetyMode.ExecutionAndPublication);
+            var lazy = sharedReduceCache.GetOrAdd(reference, mine);
 
             ISynchronizationStream reduced;
             try
@@ -158,6 +158,19 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
                 return (ISynchronizationStream<TReduced>)reduced;
 
             Remove(reference, lazy);
+
+            // 🚨 A FRESH reduce that is ALREADY unusable means the SOURCE is dead — disposed, or
+            // (since #2387) terminally faulted, which the reduce chain propagates into every child
+            // it can ever build. Re-reducing is not a repair and repeating it is an unbounded
+            // spin, one SynchronizationStream and `sync/{id}` sub-hub per turn. Hand this one
+            // back: it is exactly what the plain uncached reduce produces, and its store already
+            // carries the terminal so a reader gets an END rather than a stale replay followed by
+            // eternal silence. The same guard Workspace.GetStream carries for its own cache.
+            if (ReferenceEquals(lazy, mine))
+                return (ISynchronizationStream<TReduced>)reduced;
+
+            // We lost the add race to another caller's entry and it was dead: drop it and let the
+            // next turn install ours. Every turn removes one entry, so this cannot spin.
         }
 
         void Remove(WorkspaceReference key, Lazy<ISynchronizationStream> entry) =>
@@ -261,6 +274,38 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
 
     /// <inheritdoc />
     bool IStreamLivenessSource.IsDisposed => isDisposed;
+
+    /// <inheritdoc />
+    bool IStreamLivenessSource.IsFaulted => faulted;
+
+    /// <summary>
+    /// Set the instant <see cref="Store"/> takes a terminal error, and never cleared.
+    ///
+    /// <para>🚨 A FAULT IS FOREVER on this type. <see cref="Store"/> is a
+    /// <see cref="ReplaySubject{T}"/>: once it holds an <c>OnError</c>, the Rx grammar says it can
+    /// never notify anything else again, and every LATER subscriber replays that same error
+    /// immediately. Nothing in the stream re-opens it — <c>Resubscribe</c> re-posts a
+    /// <c>SubscribeRequest</c>, but the answer lands in a store that is already terminal.</para>
+    ///
+    /// <para>That makes a faulted stream exactly as dead as a disposed one, which is why
+    /// <see cref="StreamLiveness.IsUsable"/> reads this flag: without it, a cache that keyed a
+    /// mirror by (owner, reference, identity) kept serving the corpse for the whole process
+    /// lifetime, so ONE unanswered SubscribeRequest turned into a permanent failure of that path
+    /// (Systemorph/MeshWeaver#2387).</para>
+    /// </summary>
+    private volatile bool faulted;
+
+    /// <summary>
+    /// The ONE way this stream's store takes a terminal error — it records
+    /// <see cref="faulted"/> and then errors the store. Every <c>Store.OnError</c> in this type
+    /// goes through here so the flag can never drift from the store's actual state.
+    /// </summary>
+    /// <param name="error">The terminal error to publish to subscribers.</param>
+    private void FaultStore(Exception error)
+    {
+        faulted = true;
+        Store.OnError(error);
+    }
 
     // Mirror of MeshWeaver.Mesh.Security.WellKnownUsers.System — Data sits below
     // Mesh.Contract in the project graph and cannot reference it. Same literal
@@ -859,7 +904,7 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
             }
             try
             {
-                Store.OnError(error);
+                FaultStore(error);
             }
             catch (Exception ex)
             {
@@ -998,7 +1043,7 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
             {
                 // Safe on a disposed stream: the store is completion-terminated on disposal,
                 // never disposed, and a terminated subject ignores OnError (Rx grammar).
-                Store.OnError(ex);
+                FaultStore(ex);
             }
             catch
             {
@@ -1735,7 +1780,7 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
         {
             tasks.TryRemove(task.Id, out var _);
             if (t is { IsFaulted: true, Exception: not null })
-                Store.OnError(t.Exception);
+                FaultStore(t.Exception);
         });
     }
 

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -205,6 +205,19 @@ public class Workspace : IWorkspace
         while (true)
         {
             var stream = GetRemoteStreamUnchecked<TReduced, TReference>(owner, reference);
+            // 🚨 Probe BEFORE the lease, and do NOT retry a stream that was already dead when it
+            // arrived. GetRemoteStreamUnchecked returns either a stream that was usable when it
+            // resolved it, or one it just built that is already dead (its own spin guard — a
+            // construction-time fault is reproducible, so re-resolving only mints another corpse,
+            // and repeating that here is the same unbounded spin one level up). Such a stream is
+            // out of the cache and already closed, so there is nothing to declare a hold on
+            // either: a lease could only pin a corpse in the bookkeeping. Hand it back with an
+            // empty lease and let the caller's subscribe collect the terminal.
+            if (!StreamLiveness.IsUsable(stream))
+                return (stream, System.Reactive.Disposables.Disposable.Empty);
+
+            // Live at resolve time: take the hold, then re-check. Only a reclaim landing in that
+            // window makes this disagree, and only that race is worth another turn.
             var lease = LeaseRemoteStream(stream);
             if (StreamLiveness.IsUsable(stream))
                 return (stream, lease);
@@ -573,7 +586,8 @@ public class Workspace : IWorkspace
 
             // Check if the cached stream is still alive — the ONE shared predicate, so this cache
             // cannot drift from the other two (StreamLiveness explains why it is not just a
-            // RunLevel probe, and why the stream's source chain counts too).
+            // RunLevel probe, why the stream's source chain counts too, and why a TERMINALLY
+            // FAULTED store is as dead as a disposed one).
             if (StreamLiveness.IsUsable(stream))
                 return (ISynchronizationStream<TReduced>)stream;
 
@@ -582,6 +596,58 @@ public class Workspace : IWorkspace
             // entry: only the original Lazy is removed.
             ((ICollection<KeyValuePair<(Address Owner, WorkspaceReference Reference, string Identity), Lazy<ISynchronizationStream>>>)_remoteStreamCache)
                 .Remove(new KeyValuePair<(Address Owner, WorkspaceReference Reference, string Identity), Lazy<ISynchronizationStream>>(key, lazy));
+
+            // 🚨 A mirror that FAULTED is undisposed, so removing it from the cache is not enough:
+            // it still owns a client `sync/` hub (and an owner-side twin) whose stale-callback
+            // scanner roots it in the TimerQueue forever — the #1324 leak, and nothing else will
+            // ever close it. Unlike the change-feed eviction, which parks a HEALTHY stream because
+            // a reader may still be attached, a faulted store can never notify anyone again (Rx
+            // grammar), so there is nobody left to keep it alive for. Faulted ONLY: a stream that
+            // is unusable because its hub is winding down is already inside that cascade — see
+            // StreamLiveness.HasFaulted for why closing that one from here would be wrong.
+            if (StreamLiveness.HasFaulted(stream))
+                DiscardFaultedRemoteStream(stream);
+
+            // 🚨 A stream WE JUST BUILT that is already dead is not a stale cache entry — the
+            // failure is reproducible at construction (a same-process owner NACKing our
+            // SubscribeRequest inline, an absent owner answering NotFound synchronously), so
+            // re-resolving is the create → fault → create spin, each turn minting a
+            // SynchronizationStream and its `sync/{id}` sub-hub. Hand this one back instead: its
+            // store already holds the terminal, so the caller gets the real error on subscribe
+            // and the NEXT call — this entry now being out of the cache — starts clean. Same
+            // reasoning, same shape, as GetStream's local-reduce guard below.
+            if (freshlyCreated)
+                return (ISynchronizationStream<TReduced>)stream;
+        }
+    }
+
+    /// <summary>
+    /// Closes a remote stream this workspace has just dropped from
+    /// <see cref="_remoteStreamCache"/> because its store took a terminal error. Parks it so the
+    /// lease bookkeeping owns its disposal, and disposes it at once when no holder is declared.
+    /// </summary>
+    /// <param name="stream">The faulted stream that was removed from the cache.</param>
+    private void DiscardFaultedRemoteStream(ISynchronizationStream stream)
+    {
+        _evictedRemoteStreams[stream] = 0;
+        if (_remoteStreamLeases.ContainsKey(stream))
+        {
+            // A declared holder is still mid-write against it; the last lease release reclaims.
+            ReclaimIfUnheld(stream);
+            return;
+        }
+        if (!_evictedRemoteStreams.TryRemove(stream, out _))
+            return;     // another edge (eviction, a lease release, Dispose) already took it
+        try
+        {
+            stream.Dispose();
+            _logger.LogDebug(
+                "Workspace {WorkspaceId} disposed faulted remote stream for {Owner}.", Id, stream.Owner);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "Workspace {WorkspaceId} error disposing faulted remote stream for {Owner}", Id, stream.Owner);
         }
     }
 

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SyncedQueryDataSource.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SyncedQueryDataSource.md
@@ -216,7 +216,16 @@ behind for the process lifetime — [#1324](https://github.com/Systemorph/MeshWe
 
 The full integrity story is a plain dictionary, single-threaded access, and shared-by-default semantics — made safe entirely by the actor model.
 
-The `RemoteStreamCacheTest` (`test/MeshWeaver.Query.Test`) pins this contract: two `GetRemoteStream(...)` calls for the same key are reference-equal, and a disposed **or faulted** stream is evicted before the next caller receives it.
+The `RemoteStreamCacheTest` (`test/MeshWeaver.Query.Test`) pins this contract: two calls for the same
+key are reference-equal, and a disposed **or faulted** stream is evicted before the next caller
+receives it. Two details the test makes explicit and this page should not blur:
+
+* **The key is a triple** — `(address, reference, subscribing identity)`, the identity resolved from
+  the same helper that stamps `SubscribeRequest.Identity`, so a stream can only ever be served back
+  to the identity it was subscribed for. It is not keyed on `(owner, reference)` alone.
+* **The test calls `GetRemoteStreamUnchecked<…>`**, deliberately bypassing the MeshNode guard — that
+  guard is not what is under test here, and going through it would make the test assert two things
+  at once.
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SyncedQueryDataSource.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SyncedQueryDataSource.md
@@ -190,10 +190,15 @@ The mechanism that makes the write path share a single subscription per node acr
 
 This is exactly what the `MeshNodeReference(path)` reducer registered by `AddSyncedQuery` relies on: when it returns `workspace.GetRemoteStream<MeshNode, MeshNodeReference>(new Address(path), new MeshNodeReference())`, every writer through the synced collection — and any other code in the workspace asking for the same `(addr, ref)` — gets back the same stream instance. One upstream pump per node, no matter how many writers share it.
 
-**Cache eviction** is lazy and happens in two cases:
+**Cache eviction** is lazy and happens in three cases:
 
 - When the cached stream's hub leaves `MessageHubRunLevel.Started` (disposed or failed), the next `GetRemoteStream` call replaces it with a fresh instance.
 - When an explicit `IMeshChangeFeed` event reports a path change (ownership churn — see `Workspace.EvictForPath`), open subscribers stay attached to their existing stream while new callers bind to a fresh one tied to the re-activated owner.
+- **When the cached stream has FAULTED** — its store took a terminal error, typically because the owner did not answer its `SubscribeRequest` inside the request budget. The next `GetRemoteStream` call drops it, closes it, and builds a fresh mirror.
+
+That third case is not cosmetic. A stream's store is a `ReplaySubject`, so an `OnError` on it is permanent under the Rx grammar: the stream can never emit again, and every later subscriber replays that same error the instant it subscribes. `CreateExternalClient`'s terminal arm faults the stream and tears down only its keep-alive, leaving the object *errored but undisposed* — so while liveness was judged on disposal alone, the cache kept serving the corpse for the whole process lifetime. Every later write to that node then failed **instantly** while reporting the 30-second initial-state bound, which is what made the symptom unreadable: a timeout announced after a fraction of a millisecond. On boot it cost each replica one of its default packages, and the installer's own fall-back-to-a-full-install repair re-entered the same dead mirror and could not possibly succeed — [#2387](https://github.com/Systemorph/MeshWeaver/issues/2387).
+
+Dropping a faulted stream is **not** a retry: nothing re-attempts on a timer and nothing loops. The next natural caller opens a fresh mirror, and a stream that is *born* dead (a construction-time fault — a same-process owner NACKing the subscribe inline) is handed back rather than re-created, so create → fault → create can never spin. This is the same contract `PromiseCache` states for pooled I/O: cache a success, evict a fault, and let the next caller re-attempt.
 
 **An evicted stream is closed as soon as its last declared holder lets go.** Eviction removes the
 stream from the cache but cannot dispose it at the eviction site — it does not know whether anyone
@@ -211,7 +216,7 @@ behind for the process lifetime — [#1324](https://github.com/Systemorph/MeshWe
 
 The full integrity story is a plain dictionary, single-threaded access, and shared-by-default semantics — made safe entirely by the actor model.
 
-The `RemoteStreamCacheTest` (`test/MeshWeaver.Query.Test`) pins this contract: two `GetRemoteStream(...)` calls for the same key are reference-equal, and a disposed stream is evicted before the next caller receives it.
+The `RemoteStreamCacheTest` (`test/MeshWeaver.Query.Test`) pins this contract: two `GetRemoteStream(...)` calls for the same key are reference-equal, and a disposed **or faulted** stream is evicted before the next caller receives it.
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-one-slow-owner-no-longer-poisons-a-path.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-one-slow-owner-no-longer-poisons-a-path.md
@@ -1,0 +1,46 @@
+---
+Name: One slow owner no longer poisons a path for the whole pod
+Category: Fix
+Description: A single unanswered subscription to a busy node left that node unwritable for the rest of the pod's life — every later write failed instantly while reporting a 30-second wait that never happened. On boot this cost each replica one of its default packages, with the installer's own retry unable to help. A connection that fails is now dropped instead of being remembered, so the next attempt starts fresh.
+Icon: Sparkle
+Order: -20260826
+---
+
+# One slow owner no longer poisons a path for the whole pod
+
+Reading or writing a node that another part of the mesh owns opens a live connection to that owner.
+Those connections are shared and kept, because opening one is not free — the second reader of a node
+joins the first reader's connection rather than making its own.
+
+A connection that **failed** was kept too. If the owner was busy and did not answer in time, the
+connection was left in place holding nothing but that failure, and everything that asked for the
+node afterwards was handed it. Each of those callers got the original error back instantly — not
+after waiting, but immediately, because there was nothing left to wait for. Only restarting the pod
+cleared it.
+
+The symptom was the opposite of a hang, and read as nonsense in the logs: a thirty-second timeout
+reported after a fraction of a millisecond.
+
+## What you will notice
+
+Most visibly, on startup. Every pod re-asserts the platform's default packages when it boots, and
+when several replicas boot together some node's owner is briefly too busy to answer. That one
+timeout used to be terminal: the package was stepped over, and the installer's own
+fall-back-to-a-full-install repair re-used the same dead connection and failed the same way in under
+a millisecond. Each replica came up missing exactly one of its ~34 baseline packages — a different
+one per pod — and only the next restart tried again.
+
+More generally, any node that had one slow moment stayed unwritable on that pod until it restarted:
+an edit that silently would not save, a view that never filled in, a background job that could not
+record its progress.
+
+## What changed
+
+A connection that has failed is now recognised as spent and dropped rather than remembered, so the
+next caller opens a fresh one. This is not a retry — nothing re-attempts on a timer, and nothing
+loops. It simply stops handing out something that is known to be broken, which is the same rule the
+rest of the platform's shared caches already follow: a successful result is worth keeping, a failure
+is not.
+
+Failures also now carry the real cause instead of a fixed sentence about a thirty-second wait, so a
+log line says which step actually gave up.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1149,8 +1149,13 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     ex =>
                     {
                         if (ex is TimeoutException)
+                            // 🚨 Carry the original as INNER. The wait is bounded at 30s, but the
+                            // terminal that ends it may be something else entirely — an owner that
+                            // never answered the SubscribeRequest inside the request budget reads
+                            // as a TimeoutException too, and flattening it to this sentence is
+                            // what made the boot-install failures unreadable (#2387).
                             observer.OnError(new TimeoutException(
-                                $"Update aborted: no initial state arrived for '{_path}' within 30s."));
+                                $"Update aborted: no initial state arrived for '{_path}' within 30s.", ex));
                         else observer.OnError(ex);
                     });
             composite.Add(initialSub);
@@ -1657,12 +1662,19 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             _workspace.Hub.Address, _path, ex.GetType().Name);
                         if (ex is TimeoutException)
                         {
+                            // 🚨 The original rides as INNER — this sentence names the bound, not
+                            // the terminal that ended the wait, and the two are routinely different
+                            // (an owner that never answered the SubscribeRequest inside the request
+                            // budget errors with a TimeoutException of its own). Flattening it left
+                            // the boot-install failures claiming a 30s wait that never happened
+                            // (#2387).
                             observer.OnError(new TimeoutException(
                                 $"Update aborted: no initial state arrived for '{_path}' within 30s. " +
                                 "Likely causes — (1) RLS silently rejected the prior CreateNode, " +
                                 "(2) the path is misspelled / points at a namespace no NodeType claims, " +
                                 "(3) the node was deleted between create and update, or (4) the per-node " +
-                                "hub activated but its MeshDataSource didn't load the node from persistence."));
+                                "hub activated but its MeshDataSource didn't load the node from persistence.",
+                                ex));
                         }
                         else
                         {

--- a/test/MeshWeaver.Query.Test/RemoteStreamCacheTest.cs
+++ b/test/MeshWeaver.Query.Test/RemoteStreamCacheTest.cs
@@ -90,4 +90,69 @@ public class RemoteStreamCacheTest(ITestOutputHelper output) : MonolithMeshTestB
         // Clean up.
         fresh.Dispose();
     }
+
+    /// <summary>
+    /// 🚨 A TERMINALLY FAULTED mirror is as dead as a disposed one, and must never be served again
+    /// — Systemorph/MeshWeaver#2387.
+    ///
+    /// <para><b>The defect.</b> A remote mirror's store is a <c>ReplaySubject</c>, so once it takes
+    /// an <c>OnError</c> the Rx grammar makes that permanent: it can never emit again, and every
+    /// LATER subscriber replays the same error the instant it subscribes. Nothing disposes it —
+    /// <c>CreateExternalClient</c>'s terminal arm faults the stream and tears down only its
+    /// keep-alive, leaving the object "errored but undisposed" — and the cache judged liveness on
+    /// disposal alone, so it kept handing the corpse back for the whole process lifetime.</para>
+    ///
+    /// <para><b>What that cost in production.</b> Three replicas booted together; a per-node hub
+    /// for one package was busy past the mirror's request budget, so that ONE
+    /// <c>SubscribeRequest</c> timed out and poisoned the path. Every later write to it failed in
+    /// <b>0.07 ms</b> while reporting <c>"no initial state arrived … within 30s"</c> — including
+    /// the default installer's own <c>falling back to full install</c> repair, which re-entered
+    /// the same dead mirror and could not possibly succeed. Each pod came up missing exactly one
+    /// baseline package, and only a restart cleared it.</para>
+    ///
+    /// <para>The assertion is two-sided: the identity check names the defect, and the replay
+    /// checks name the HARM — the corpse really is poisonous, and the replacement really does
+    /// start clean.</para>
+    /// </summary>
+    [Fact]
+    public async Task GetRemoteStream_AfterTerminalFault_ReturnsFreshInstance()
+    {
+        var path = $"{TargetNamespace}/gamma";
+
+        await NodeFactory.CreateNode(MakeNode("gamma", "Gamma")).Should().Emit();
+
+        var workspace = (MeshWeaver.Data.Workspace)Mesh.GetWorkspace();
+
+        var faulted = workspace.GetRemoteStreamUnchecked<MeshNode, MeshNodeReference>(
+            new Address(path), new MeshNodeReference());
+
+        // Exactly the terminal a real boot produces: the owning per-node hub did not answer this
+        // mirror's SubscribeRequest inside the request budget, so CreateExternalClient's error arm
+        // calls reduced.OnError(TimeoutException) and disposes the keep-alive.
+        faulted.OnError(new TimeoutException(
+            $"No response received for request SubscribeRequest → target {path}."));
+
+        Exception? replayed = null;
+        faulted.Subscribe(_ => { }, ex => replayed = ex).Dispose();
+        replayed.Should().BeOfType<TimeoutException>(
+            "the store is a ReplaySubject: a terminal error is replayed to every later subscriber "
+            + "INSTANTLY — which is why serving this instance from the cache converts one slow "
+            + "owner round-trip into a permanent failure of the path");
+
+        var fresh = workspace.GetRemoteStreamUnchecked<MeshNode, MeshNodeReference>(
+            new Address(path), new MeshNodeReference());
+
+        ReferenceEquals(fresh, faulted).Should().BeFalse(
+            "a faulted stream can never emit again, so the cache must evict it and build a new "
+            + "mirror — otherwise one transient owner timeout is terminal for the process");
+
+        Exception? onFresh = null;
+        fresh.Subscribe(_ => { }, ex => onFresh = ex).Dispose();
+        onFresh.Should().BeNull(
+            "the replacement must start clean; a fresh mirror that already carries the old "
+            + "terminal is the same defect one instance later");
+
+        // Clean up.
+        fresh.Dispose();
+    }
 }


### PR DESCRIPTION
Closes #2387.

## What was failing

Every boot, on every pod, `InstanceAutoRegistrationService`'s `[DefaultInstall]` pass reconciled 34
packages and ended with **exactly one failed** — `Import` on one replica, `Essentials` on the other
two, rotating between boots. The failing call was the cross-hub `stream.Update` on the package's
partition root, dying with `Update aborted: no initial state arrived for 'X' within 30s`.

## Root cause — a faulted mirror stayed in the cache and replayed its fault forever

Read off the affected pod (`memex-cloud/…-rk5gw`, boot 13:09Z), not inferred:

```
[UpdateQueue] FAILED path=Essentials seq=260 elapsedMs=30008.8   ← a real 30s wait
[UpdateQueue] FAILED path=Essentials seq=263 elapsedMs=29993.7
Incremental update of Essentials failed; falling back to full install.
[UpdateQueue] FAILED path=Essentials seq=264 elapsedMs=0.1226    ← 0.12 ms, same message
[UpdateQueue] FAILED path=Essentials seq=265 elapsedMs=0.0741    ← 0.07 ms
```

All four `[UpdateRemote] ERROR` lines name the **same** `SubscribeRequest` id
(`iXeKmgeTEkKJGabnLYGGMw`). The chain:

1. `MeshNodeStreamHandle.UpdateRemote` opens the package root's remote mirror through
   `Workspace.AcquireRemoteStreamUnchecked`, served from `Workspace._remoteStreamCache` keyed
   `(owner, reference, identity)`.
2. Three replicas booted together and `messagehub/Essentials` was executing one message for 90+ s
   (Orleans: *"was enqueued 00:01:30 ago and has now been executing for 00:01:30"*). The mirror's
   `SubscribeRequest` blew its request budget, so `CreateExternalClient`'s terminal arm called
   `reduced.OnError(TimeoutException)` and disposed only the keep-alive.
3. `SynchronizationStream.Store` is a `ReplaySubject<ChangeItem<T>>(1)`. Under the Rx grammar its
   `OnError` is **permanent**, and replayed to every later subscriber **instantly**.
4. `StreamLiveness.IsUsable` — the one predicate every stream cache consults — asked about disposal
   and hub run level, **not faultedness**. The stream is *errored but undisposed*, so the cache kept
   serving it.

One slow owner therefore made that path unwritable for the rest of the process. That is why the shape
is *one package per pod*: the installer walks packages sequentially, so whichever one's turn coincided
with a busy owner was poisoned — and the installer's own in-process repair
(`falling back to full install`) re-entered the same dead mirror and was **structurally incapable of
succeeding**, failing in 0.07 ms while reporting a 30-second bound.

**Siblings ruled out.** Not #2229 (no `CreateOrUpdateNodeRequest` timeout to `portal/nodeops-*`, no
`AdoptedSourceStamp`/`IsDirty` line in the pod log) and not #2008 (no `MonotonicWriteGuard` refusal).
The failure is entirely in the mirror's initial-state read.

**Is the deferral itself the bug?** No. The ledger write succeeded (no
`Could not update the default-install ledger` warning on the pod), the failure is named at `Error`,
and the next-boot retry is real. What was dishonest was the *in-process* repair that could not work,
and a message claiming a wait that never happened. Both are consequences of the latch.

## The fix — evict the fault, never replay it

The contract `PromiseCache` already states for pooled I/O ("caches success and **evicts a fault**;
the next caller re-attempts, it never retries on its own"), applied to the stream caches:

- `SynchronizationStream` records that its store took a terminal error; all three `Store.OnError`
  sites funnel through one `FaultStore`.
- `IStreamLivenessSource.IsFaulted`, and `StreamLiveness.IsUsable` returns false for a faulted
  stream or a faulted ancestor — one predicate, so no cache can drift from another (#1455's lesson).
- `Workspace` **closes** a faulted mirror when it drops it: it is undisposed and owns a client
  `sync/` hub plus its owner-side twin (the #1324 leak). `StreamLiveness.HasFaulted` keeps this to
  faults only — a stream that is unusable because its hub is winding down is already inside that
  cascade, and closing it from a cache lookup would post `UnsubscribeRequest` at a dying Orleans
  owner and re-activate the grain the teardown is retiring.
- Spin guards, so a *fresh* stream that is already dead is handed back instead of re-created:
  `_remoteStreamCache` and `ReduceShared` gain the guard `Workspace.GetStream`'s local cache already
  had. `AcquireRemoteStreamUnchecked` no longer retries a stream that was dead on arrival, and takes
  no lease on it.
- The initial-state `TimeoutException` now carries the real terminal as `InnerException`.

**No band-aid**: nothing re-attempts, no timer, no widened bound, no swallowed error. The change is
that a known-dead object stops being handed out.

## Test

`RemoteStreamCacheTest.GetRemoteStream_AfterTerminalFault_ReturnsFreshInstance` — proven both
directions on this branch:

- **unfixed**: `Failed: 1` — *"Expected value to be false because a faulted stream can never emit
  again, so the cache must evict it and build a new mirror … but found True"*, plus a leaked
  `Observe` callback at quiescing (the undisposed corpse).
- **fixed**: `Passed: 3`.

Two-sided: the identity check names the defect; the replay checks name the harm (the corpse really
does replay its error instantly, the replacement really does start clean).

Regression-run locally at `-c Release`: `MeshWeaver.Query.Test` 402/402, `MeshWeaver.Data.Test`
390/390, `MeshWeaver.Security.Test` 376/376, `MeshWeaver.Hosting.Monolith.Test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
