### PR TITLE
A finished round no longer keeps the "Generating response…" placeholder (#2305)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
@@ -115,8 +115,8 @@ There are **two identities on the read path, and they must never be mixed**:
 
 `handle.Update(fn)` is **cold**: nothing happens until `Subscribe`. On subscribe, the write enters the path's **serial update queue**:
 
-1. Your lambda runs against the **freshest** node state (the previous write's echo has already landed on the shared stream).
-2. The handle diffs `current` vs `fn(current)` and ships only the JSON-merge patch.
+1. Your lambda runs against the **freshest** node state — the previous write's result, whether or not its echo has come back yet (see below).
+2. The handle diffs `current` vs `fn(current)` and ships only the JSON-merge patch, **plus the base values it diffed against**.
 3. The owner applies it on its action block and broadcasts; your observable completes with the result.
 
 The queue exists because RFC 7396 merges JSON *objects* key-by-key but **replaces arrays wholesale** — two concurrent writers appending to the same `ImmutableList` from the same snapshot would each ship a full-array replacement and the owner would keep only the last one. Serialising per path makes every lambda see its predecessor's result, so list appends compose instead of clobbering. A stuck owner response can't starve the queue: it advances on a bounded signal while the in-flight write keeps waiting for its real terminal.
@@ -127,6 +127,16 @@ hub.SubmitMessage(threadPath, "first");
 hub.SubmitMessage(threadPath, "second");
 hub.SubmitMessage(threadPath, "third");
 ```
+
+### 🚨 "Freshest" means the predecessor's RESULT, not the mirror
+
+The queue advances on a write's **local** terminal — the owner's ack, or, on a busy owner, an optimistic emit — and deliberately **never waits for the echo**. So step 1 cannot mean "read the mirror": under load the mirror is still showing the node as it was *before* the write that just released the slot. This page used to say the echo "has already landed", and nothing delivered that.
+
+The distinction is not academic. The base values shipped in step 2 are how the owner detects a stale/reordered cross-hub write: a leaf whose live value has moved past the writer's base is REFUSED (`MeshNodePatchMerge`). A successor that diffed against the un-echoed mirror therefore shipped a base **it had itself superseded one write earlier**, and the owner refused the conflicting leaves of a write that nothing was concurrent with — while the write's *other* leaves applied and the whole thing still acked `Success`. Issues #2305 / #2291: an agent response cell that reached `Status = Completed` with `Summary` holding the answer and `Text` still reading `"Generating response..."`, because only `Text` conflicted. Generalised: a streaming cell's text froze at the first chunk that landed, for as long as the echo lagged the write rate.
+
+So the queue **hands each write the node the owner acknowledged taking from its predecessor**, and the write diffs against that. The moment the mirror carries anything newer — the echo, or a genuinely different writer's commit, since the owner mints `Version + 1` on every applied change — the mirror wins again and real cross-mirror conflicts are detected exactly as before. The hand-forward is one-shot (it can inform only the next write), and a `Conflict` re-attempt still re-reads the owner's state. `[UpdateRemote] SELF_REBASE` in the debug log is a write saying it took this path.
+
+🚨 **Acknowledged, not merely computed.** A base taken from the *optimistic* snapshot — a write whose owner ack never arrived — is self-perpetuating, because a write that did not land mints no version and so nothing ever corrects it: a caller that retries the same write then diffs against its own unlanded value, computes an **empty** patch, and skips the write **silently, forever**. `TwoSiloRecycleConvergenceTest` catches exactly that (the post-recycle write retried past a disposing owner and the store never advanced). So a rejected, timed-out or retried write publishes nothing and its successor reads the mirror — the pre-existing behaviour, which is the correct direction to degrade in.
 
 ## Big strings ship as a SPLICE, not as the whole value
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-finished-answers-no-longer-stick-on-generating-response.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-finished-answers-no-longer-stick-on-generating-response.md
@@ -1,0 +1,44 @@
+---
+Name: Finished answers no longer stick on "Generating response…"
+Category: Fix
+Description: Under load, a chat message could finish with its answer written but still show "Generating response…" forever — and a streaming answer could freeze on its first few words. Consecutive writes to the same node now build on each other instead of on a view of it that is one write out of date, so the last thing written is what you see.
+Icon: Sparkle
+Order: -20260826
+---
+
+# Finished answers no longer stick on "Generating response…"
+
+When an agent answered you, the message could end up finished and empty of the answer: the bubble
+still reading *"Generating response…"*, with nothing to indicate anything had gone wrong. The round
+had completed correctly — the answer existed — but the message never showed it. From the outside it
+was indistinguishable from an agent that had hung, and waiting or reloading did not help.
+
+The same fault had a quieter form: a streaming answer that stopped growing after its first words
+while the rest of the reply was being written. Both got more likely the busier the server was.
+
+## Why it happened
+
+Everything written to a node — each chunk of a streaming reply, then the final answer — goes through
+one ordered queue, and each write is sent as a small description of what changed relative to the
+version the writer last saw. The queue did not wait for confirmation that a write had been stored
+before starting the next one, and the next one read the node's last *confirmed* state. Under load
+that state was one write behind, so a write described its change relative to a version that had
+already moved on — by its own hand, a moment earlier.
+
+The owner of the node is right to reject a change described against an out-of-date version: that is
+what stops two people editing at once from overwriting each other. But here there was only ever one
+writer, in order. So the final answer's text was rejected as a conflict with itself, while the rest
+of the same write — the "finished" marker, the usage figures — was accepted. One write, two
+outcomes, and no error anywhere: hence a finished message with no answer in it.
+
+## What changed
+
+Each write now builds on what the previous write in the same queue actually produced, rather than on
+a view of the node that has not caught up yet. The instant the node carries anything newer — a
+confirmation, or a change from a genuinely different writer — that newer state takes over again, so
+real conflicts between real concurrent editors are still detected and resolved exactly as before.
+
+## What you will notice
+
+A message that says it is finished shows its answer. Streaming replies keep growing to the end,
+including on a loaded server.

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -393,6 +393,25 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
 
     private static readonly TimeSpan UpdateQueueSlidingExpiration = TimeSpan.FromMinutes(10);
 
+    // 🚨 The state the LAST write on a path left the node in AS ACKNOWLEDGED BY THE OWNER, held only
+    // until the next write on that path consumes it (issues #2305 / #2291). It exists because the
+    // queue above advances on a write's local terminal, NOT on the owner's echo — so the successor's
+    // mirror can still be showing the node as it was BEFORE its predecessor's patch. Diffing against
+    // that ships a base this mirror itself superseded, and the owner three-way-merges it as a conflict
+    // that never happened: the leaf is refused and the writer's newer value is silently dropped while
+    // its non-conflicting siblings land. (An agent round's response cell kept "Generating response..."
+    // in Text while Status went Completed and Summary carried the answer — one write, two verdicts.)
+    //
+    // 🚨 ACKNOWLEDGED, not merely computed — see MeshNodeStreamHandle's onLocalState. A base taken
+    // from a write that never landed is self-perpetuating: it mints no version, so nothing corrects
+    // it, and the next write diffs its own unlanded value into an empty patch and skips silently.
+    //
+    // ONE-SHOT by construction: the dispatch below TryRemoves it, so a stale entry can influence at
+    // most the single next write, and MeshNodeStreamHandle.PatchBaseSource ignores it the moment the
+    // mirror carries a newer Version — which the owner mints on EVERY applied change, from any
+    // writer. Bounded like the queues: the per-path eviction callback drops it, and so does Dispose.
+    private readonly ConcurrentDictionary<string, MeshNode> _pendingSelfWrites = new();
+
     private sealed record UpdateQueueEntry(Subject<UpdateRequest> Subject, IDisposable ConcatSubscription);
 
     private readonly record struct UpdateRequest(
@@ -717,6 +736,10 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         //    nothing roots the disposed mesh's exceptions/identities.
         _negative.Clear();
         _transientStreaks.Clear();
+
+        // 6. Pending per-path write bases. The queue eviction callbacks above already drop the ones
+        //    whose queue still existed; this covers a path whose queue had expired first.
+        _pendingSelfWrites.Clear();
     }
 
     /// <summary>
@@ -1694,6 +1717,9 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 logger.LogDebug(
                     "[UpdateQueue] EVICTED path={Path} reason={Reason}",
                     key, reason);
+                // The pending base outlives nothing: a path with no queue has no successor to hand it to.
+                if (key is string evictedPath)
+                    _pendingSelfWrites.TryRemove(evictedPath, out _);
                 if (value is Lazy<UpdateQueueEntry> { IsValueCreated: true } lz)
                 {
                     try { lz.Value.ConcatSubscription.Dispose(); } catch { /* best-effort */ }
@@ -1707,13 +1733,22 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// Builds the per-path Concat pipeline that processes <see cref="UpdateRequest"/>s
     /// serially. Each request applies its patch through the local <c>Handle</c>
     /// (LOCAL_EMIT) and completes immediately — it does NOT wait for the patch's echo
-    /// from the owner. The owning node hub's single-threaded action block already
-    /// serialises patches, so the next queued Update sees post-patch state via the
-    /// local Handle. The former 3-second echo wait DEADLOCKED when the echo could never
+    /// from the owner. The former 3-second echo wait DEADLOCKED when the echo could never
     /// arrive (a write to a freshly-created node defers on the owner's [Initialize]
     /// gate; or the writing hub's own action block is the one that would deliver the
     /// echo) and otherwise serialised 3s per update. Per-stage timing logs:
     /// ENQUEUE → START → LOCAL_EMIT → COMPLETE; missing LOCAL_EMIT = Handle.Update hung.
+    ///
+    /// <para>🚨 This used to add: "the owning node hub's single-threaded action block already
+    /// serialises patches, so the next queued Update sees post-patch state via the local Handle."
+    /// The first clause is true and the second does not follow from it — and nothing delivered it.
+    /// The owner serialises the APPLY; the successor reads this hub's MIRROR, which advances only on
+    /// the echo this queue deliberately does not wait for. So under load write N+1 diffed against
+    /// state older than write N's, shipped that as its base, and the owner refused the conflicting
+    /// leaves of a write that nothing was concurrent with (#2305 / #2291). The invariant is now
+    /// DELIVERED rather than asserted: the predecessor's locally-computed node is handed to the
+    /// successor via <see cref="_pendingSelfWrites"/>, and <c>MeshNodeStreamHandle.PatchBaseSource</c>
+    /// prefers it only while the mirror carries nothing newer.</para>
     /// </summary>
     private IObservable<MeshNode> BuildUpdateQueueObservable(string path, Subject<UpdateRequest> subject) =>
         subject
@@ -1740,10 +1775,24 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                     ? accessService.SwitchAccessContext(req.Caller)
                     : null;
 
+                // 🚨 Consume the predecessor's locally-computed state — see _pendingSelfWrites. Taken
+                // (and REMOVED) here rather than read in place so it can only ever inform the single
+                // next write: if this one produces no local emit, the write after it reads the mirror.
+                _pendingSelfWrites.TryRemove(path, out var pendingSelfWrite);
+
                 // FullNode set ⇒ overwrite (ChangeType.Full wholesale replace); else field-merge.
                 var update = req.FullNode is not null
+                    // An Overwrite asserts the whole node, so it needs no base and leaves none: the
+                    // write after it re-reads the mirror, as it must.
                     ? entry.Handle.Overwrite(req.FullNode)
-                    : entry.Handle.Update(req.Update);
+                    // 🚨 The successor's base is published by the write path itself, not read off the
+                    // emission below: the emission has been re-typed for callers, and re-serialising a
+                    // re-typed node need not reproduce the JSON the diff was built from. The callback
+                    // fires only on the owner's ACK (or a no-op) — a rejected, timed-out or retried
+                    // write publishes nothing, so the entry stays removed and the next write reads the
+                    // mirror, exactly as it did before this change.
+                    : entry.Handle.UpdateQueued(
+                        req.Update, pendingSelfWrite, local => _pendingSelfWrites[path] = local);
 
                 // 🚨 Deliver the write's terminal to the caller's result on a subscription
                 // whose lifetime is INDEPENDENT of the queue slot. entry.Handle.Update is

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -198,6 +198,60 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                         + "land; re-issue it."))
                     : Observable.Return(node));
 
+    /// <summary>
+    /// 🚨 The base a QUEUED write diffs against — issues #2305 / #2291.
+    ///
+    /// <para><b>The defect.</b> <c>MeshNodeStreamCache</c> funnels every write to a path through one
+    /// per-path serial queue, and its own contract said "the next queued Update sees post-patch state
+    /// via the local Handle". It did not. The queue advances on the write's LOCAL emit (the owner's ack
+    /// or, on a busy owner, the optimistic snapshot) — never on the owner's ECHO — while the next write
+    /// reads <c>mirror.Take(1)</c>, i.e. the mirror as it stands. Under load the echo has not arrived,
+    /// so write N+1 ships a base that PREDATES write N. The owner then three-way-merges an
+    /// already-applied value against a base it has moved past, sees a string changed on both sides with
+    /// overlapping edits, and REFUSES the leaf — keeping the value write N wrote.</para>
+    ///
+    /// <para><b>Why that is not a concurrent-writer conflict.</b> The two writes are the SAME mirror's,
+    /// strictly ordered by the queue. The staleness is self-inflicted: the writer superseded its own
+    /// base and then told the owner otherwise. The owner is right to refuse a stale base — the writer is
+    /// wrong to ship one.</para>
+    ///
+    /// <para><b>The symptom it produced.</b> An agent round's response cell. Push 1 writes
+    /// <c>Text = "Generating response..."</c>; the terminal push writes <c>Text</c> = the answer,
+    /// <c>Status = Completed</c> and <c>Summary</c>. With a stale base only <c>Text</c> conflicts, so
+    /// <c>Status</c> and <c>Summary</c> land and <c>Text</c> is refused — a COMPLETED cell still reading
+    /// "Generating response..." while the answer sits in <c>Summary</c>. Partial per-field resolution is
+    /// intentional (<c>PatchDataRequestTest</c>, <c>CrossHubPatchAtomicityTest</c>) and is NOT what is
+    /// wrong here; the stale base is. More generally this froze a streaming cell's text at the first
+    /// chunk that landed, for as long as the echo lagged the write rate.</para>
+    ///
+    /// <para><b>The rule.</b> While the mirror has not advanced past the state the previous queued write
+    /// produced, that state IS this mirror's freshest knowledge of the node — diff against it. The
+    /// instant the mirror carries anything newer (the echo, or ANOTHER writer's commit — the owner mints
+    /// <c>Version + 1</c> on every applied change) the mirror wins again and a genuine cross-mirror
+    /// conflict is detected exactly as before. So this can only remove FALSE conflicts: it never hides a
+    /// real one, and it never suppresses a base.</para>
+    ///
+    /// <para>Static, with the mirror and the pending state as seams, so the rule is asserted
+    /// deterministically — no hub, no cluster, no wall clock.</para>
+    /// </summary>
+    /// <param name="source">The mirror emission a write would otherwise diff against.</param>
+    /// <param name="pendingSelfWrite">The node the PREVIOUS write on this path's serial queue computed
+    /// locally, or <c>null</c> when there is none (a first write, a write after an error, or a retry —
+    /// a CONFLICT re-attempt must re-read the owner's state, never the value it just superseded).</param>
+    internal static IObservable<MeshNode> PatchBaseSource(
+        IObservable<MeshNode> source,
+        MeshNode? pendingSelfWrite)
+        => pendingSelfWrite is null
+            ? source
+            : source.Select(node =>
+                // Same node, and the mirror has not yet carried anything past what we wrote ⇒ our own
+                // pending state is the freshest base this mirror has. Path equality is a guard against
+                // a mis-keyed hand-off, not an expected case — the queue is per path.
+                string.Equals(node.Path, pendingSelfWrite.Path, StringComparison.OrdinalIgnoreCase)
+                && pendingSelfWrite.Version >= node.Version
+                    ? pendingSelfWrite
+                    : node);
+
     internal MeshNodeStreamHandle(IWorkspace workspace, string? path = null,
         IMeshNodeStreamCache? cache = null, bool bypassCache = false)
     {
@@ -634,6 +688,41 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// rather than letting a <c>Content as T ?? new T()</c> write defaults over real fields.</para>
     /// </summary>
     public IObservable<MeshNode> Update(Func<MeshNode, MeshNode> update)
+        => UpdateQueued(update, pendingSelfWrite: null);
+
+    /// <summary>
+    /// <c>Update</c> with the state the PREVIOUS write on this path's serial queue computed locally.
+    /// Only <see cref="IMeshNodeStreamCache"/>'s per-path queue may pass one — it is the single caller
+    /// that can prove the two writes are ordered and come from this same mirror. See
+    /// <see cref="PatchBaseSource"/> for why the mirror alone is not a sound base (#2305 / #2291).
+    /// <para>A distinct NAME rather than an overload: <c>Update</c> is referenced from a dozen
+    /// <c>&lt;see cref&gt;</c>s across this file and its callers, and an overload makes every one of
+    /// them ambiguous (CS0419).</para>
+    /// </summary>
+    /// <param name="update">The caller's lambda, as for <c>Update</c>.</param>
+    /// <param name="pendingSelfWrite">What the PREVIOUS queued write on this path computed, or null.</param>
+    /// <param name="onLocalState">Receives the node the OWNER has acknowledged taking, to be handed to
+    /// the next queued write as its base.
+    /// <para>🚨 Invoked ONLY on the owner's success ack — never on the optimistic emit, never on a
+    /// rejection, never on a retry. A write that did not land mints no version, so a base published
+    /// from an unlanded write is never corrected by anything: the next write diffs its own unlanded
+    /// value, produces an EMPTY patch, and is skipped as a no-op — silently, and for every retry after
+    /// it. That regression is real and was caught by <c>TwoSiloRecycleConvergenceTest</c>. When the ack
+    /// does not arrive inside the response bound, publishing nothing degrades to the previous
+    /// behaviour, which is the correct direction to fail.</para>
+    /// <para>🚨 Invoked with the node in the shape the write path itself diffs — BEFORE the
+    /// typed-Content projection on the returned observable, and AFTER the audit stamp. Taking it off
+    /// the observable instead would hand the successor a re-typed node whose re-serialisation need not
+    /// match (a recovered <c>$type</c>, a suppressed default), and the successor's diff would then
+    /// carry phantom keys.</para>
+    /// <para>A CONFLICT/OwnerDisposing re-enqueue deliberately does not carry this on either: those run
+    /// asynchronously and could land after a LATER write already published, replacing a newer base with
+    /// an older one.</para>
+    /// </param>
+    internal IObservable<MeshNode> UpdateQueued(
+        Func<MeshNode, MeshNode> update,
+        MeshNode? pendingSelfWrite,
+        Action<MeshNode>? onLocalState = null)
     {
         // 🚨 AccessContext capture for the LAMBDA invocation. The user's
         // `update` lambda runs on whatever thread the underlying writer fires
@@ -729,7 +818,8 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                         // faulted). It also confirms read-after-write (waits for the commit).
                         // Overwrite (full-replace, static-repo import) stays on the
                         // sync-stream path — see Overwrite below.
-                        ? UpdateRemote(wrappedUpdate)
+                        ? UpdateRemote(wrappedUpdate,
+                            pendingSelfWrite: pendingSelfWrite, onLocalState: onLocalState)
                         : throw new InvalidOperationException(
                             $"Cross-hub MeshNode write to '{_path}' requires an IMeshNodeStreamCache "
                             + $"on hub '{_workspace.Hub.Address}', but none is registered. All non-own "
@@ -1177,7 +1267,8 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// (<see cref="RebaseSource"/>). 0 for a caller write and for the re-enqueue codes that never
     /// reached a merge.</param>
     private IObservable<MeshNode> UpdateRemote(
-        Func<MeshNode, MeshNode> update, int attempt = 0, long refusedBaseVersion = 0)
+        Func<MeshNode, MeshNode> update, int attempt = 0, long refusedBaseVersion = 0,
+        MeshNode? pendingSelfWrite = null, Action<MeshNode>? onLocalState = null)
         => Observable.Create<MeshNode>(observer =>
         {
             var diagLogger = _workspace.Hub.ServiceProvider
@@ -1226,18 +1317,36 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             // refused. See RebaseSource: re-running the lambda against the SAME mirror emission
             // recomputes the same values from the same base and is refused identically, so the
             // re-enqueue cannot converge (#1910).
-            var initialSub = RebaseSource(
-                    remoteStream
-                        .Timeout(TimeSpan.FromSeconds(30))
-                        .Where(change => change.Value is not null)
-                        .Select(change => change.Value!),
-                    refusedBaseVersion,
-                    staleVersion => diagLogger?.LogWarning(
-                        "[UpdateRemote] STALE_MIRROR hub={Hub} target={Path} attempt={Attempt} — the "
-                        + "owner refused this write as stale at version {Version}, but this hub's "
-                        + "mirror did not advance past it within {Bound}; rebuilding the patch "
-                        + "against the state it has. The re-attempt may be refused again",
-                        _workspace.Hub.Address, _path, attempt, staleVersion, ConflictRebaseBound))
+            //
+            // 🚨 …and when the PREVIOUS write on this path's serial queue has not been echoed back
+            // yet, the mirror is behind THIS mirror's own last write — diffing against it ships a
+            // base the writer itself superseded, which the owner refuses as a conflict that never
+            // happened (#2305 / #2291). See PatchBaseSource.
+            var initialSub = PatchBaseSource(
+                    RebaseSource(
+                        remoteStream
+                            .Timeout(TimeSpan.FromSeconds(30))
+                            .Where(change => change.Value is not null)
+                            .Select(change => change.Value!),
+                        refusedBaseVersion,
+                        staleVersion => diagLogger?.LogWarning(
+                            "[UpdateRemote] STALE_MIRROR hub={Hub} target={Path} attempt={Attempt} — the "
+                            + "owner refused this write as stale at version {Version}, but this hub's "
+                            + "mirror did not advance past it within {Bound}; rebuilding the patch "
+                            + "against the state it has. The re-attempt may be refused again",
+                            _workspace.Hub.Address, _path, attempt, staleVersion, ConflictRebaseBound)),
+                    pendingSelfWrite)
+                // Says which base this write actually built on — the one question worth asking when a
+                // cross-hub write's field comes back refused. SELF_REBASE means the mirror had not
+                // caught up and we diffed against our own predecessor's result instead.
+                .Do(node =>
+                {
+                    if (ReferenceEquals(node, pendingSelfWrite))
+                        diagLogger?.LogDebug(
+                            "[UpdateRemote] SELF_REBASE hub={Hub} target={Path} version={Version} — the "
+                            + "mirror has not carried the previous queued write yet; diffing against it",
+                            _workspace.Hub.Address, _path, node.Version);
+                })
                 .Subscribe(
                     current =>
                     {
@@ -1268,6 +1377,11 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                         "[UpdateRemote] NO-OP hub={Hub} target={Path} contentType={ContentType} — lambda returned the node unchanged; nothing to write",
                                         _workspace.Hub.Address, _path,
                                         current.Content?.GetType().Name ?? "<null>");
+                                // Nothing written, so nothing new to claim — but `current` is a state
+                                // the owner is believed to hold (the mirror, or a predecessor's ACKED
+                                // result). Carrying it keeps the chain intact across a no-op instead
+                                // of dropping the successor back onto a mirror that may be behind.
+                                onLocalState?.Invoke(current);
                                 observer.OnNext(current);
                                 observer.OnCompleted();
                                 return;
@@ -1294,6 +1408,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                 diagLogger?.LogDebug(
                                     "[UpdateRemote] NO-OP hub={Hub} target={Path} — diff empty after serialisation",
                                     _workspace.Hub.Address, _path);
+                                onLocalState?.Invoke(current);
                                 observer.OnNext(current);
                                 observer.OnCompleted();
                                 return;
@@ -1594,6 +1709,23 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                         else
                                         {
                                             // Success ack — patch accepted; the activity is started.
+                                            //
+                                            // 🚨 ONLY HERE may this write's result become the next
+                                            // queued write's base (#2305 / #2291). The ack is the
+                                            // owner stating it took the patch, and nothing weaker
+                                            // will do: publishing the OPTIMISTIC snapshot instead
+                                            // hands the successor a value the owner may never have
+                                            // taken, and — because a write that did not land mints
+                                            // no version — nothing ever clears it. A caller that
+                                            // retries the same write then diffs against its own
+                                            // unlanded value, computes an EMPTY patch, and skips
+                                            // the write silently, forever
+                                            // (TwoSiloRecycleConvergenceTest: the post-recycle
+                                            // write retried past a disposing owner and the store
+                                            // never advanced). This runs before EmitTerminal, which
+                                            // is what releases the queue slot, so the successor
+                                            // cannot start before the hand-off.
+                                            onLocalState?.Invoke(updated);
                                             EmitTerminal();
                                         }
                                     },
@@ -1727,7 +1859,9 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// <see cref="PatchStringSplice.MinSpliceLength"/>, or when the splice would not
     /// actually be smaller, the full value is emitted exactly as before.</para>
     /// </summary>
-    private static System.Text.Json.Nodes.JsonObject ComputeMergePatchDiff(
+    // internal (not private) so a test can drive the REAL diff a cross-hub write ships, rather than a
+    // hand-rolled stand-in that would drift from it — see ResponseTextSurvivesUnechoedWriteTest.
+    internal static System.Text.Json.Nodes.JsonObject ComputeMergePatchDiff(
         System.Text.Json.Nodes.JsonObject current,
         System.Text.Json.Nodes.JsonObject updated)
     {

--- a/test/MeshWeaver.Query.Test/ResponseTextSurvivesUnechoedWriteTest.cs
+++ b/test/MeshWeaver.Query.Test/ResponseTextSurvivesUnechoedWriteTest.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json.Nodes;
+using MeshWeaver.Data.Serialization;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Query.Test;
+
+/// <summary>
+/// 🚨 A round that reaches a terminal <c>Status</c> must never still carry the placeholder —
+/// issues #2305 and #2291(A), which are ONE defect seen from two tests.
+///
+/// <para><b>The reported state.</b> An agent response cell, finished and wrong:</para>
+/// <code>
+/// Text    = Generating response...
+/// Status  = Completed
+/// Summary = I received 6 messages. [0:system:Echo agent. … ]
+/// </code>
+/// <para>The answer is right there in <c>Summary</c>; <c>Text</c> never moved off the framework's
+/// own placeholder. To a user that is a finished message reading "Generating response..." forever —
+/// indistinguishable from a hung agent, and silent.</para>
+///
+/// <para><b>What it is NOT.</b> Not <c>ThreadExecution</c>'s <c>terminalLocked</c> guard, which
+/// correctly stops a LATE placeholder push from clobbering a terminal cell. Not the owner's
+/// per-field partial merge resolution either — that a disjoint string merges while a conflicting
+/// scalar is independently refused is deliberate, load-bearing and separately pinned
+/// (<c>PatchDataRequestTest</c>, <c>CrossHubPatchAtomicityTest</c>); making the whole patch atomic
+/// was tried and reverted because it drops entries under concurrent load.</para>
+///
+/// <para><b>What it IS.</b> The terminal write shipped a BASE it had itself already superseded.
+/// <c>MeshNodeStreamCache</c> funnels every write to a path through one per-path serial queue, and
+/// that queue advances on a write's LOCAL emit — never on the owner's echo. The next write then read
+/// <c>mirror.Take(1)</c>: the node as it stood BEFORE its predecessor's patch. The owner
+/// three-way-merges that against live state it has already moved past, sees the string changed on
+/// both sides with overlapping edits, and refuses the leaf — keeping exactly the value the
+/// predecessor wrote. The write's non-conflicting siblings (<c>Status</c>, <c>Summary</c>,
+/// <c>CompletedAt</c>) land, so ONE write gets two verdicts and the ack is <c>Success</c>. The two
+/// writes were never concurrent: same mirror, strictly ordered by the queue. The conflict is
+/// manufactured.</para>
+///
+/// <para>Generalised, the same mechanism froze a streaming cell's text at the first chunk that
+/// landed for as long as the echo lagged the write rate; the placeholder is simply the first chunk
+/// of every round.</para>
+///
+/// <para>Deterministic: the mirror and the queue hand-off are both seams. No hub, no cluster, no
+/// wall clock — the interleaving that makes this rare locally and common on a loaded CI runner is
+/// CONSTRUCTED here rather than raced for. The merge half runs the REAL owner-side pipeline
+/// (<c>ComputeMergePatchDiff</c> → <c>ExtractBaseValues</c> → <c>MeshNodePatchMerge.Apply</c>), so
+/// it cannot drift from what production computes.</para>
+/// </summary>
+public class ResponseTextSurvivesUnechoedWriteTest
+{
+    private const string CellPath = "TestUser/_Thread/history-cold-start/msg-response";
+
+    /// <summary>What the framework writes when it allocates the response cell.</summary>
+    private const string Allocating = "Allocating agent...";
+
+    /// <summary>The round's FIRST push — a progress placeholder, not agent output.</summary>
+    private const string Placeholder = "Generating response...";
+
+    /// <summary>The round's terminal push: the answer the user is waiting for.</summary>
+    private const string Answer = "I received 6 messages. [0:system:Echo agent.]";
+
+    private static MeshNode NodeAt(long version, string text, string status, string? summary = null)
+        => MeshNode.FromPath(CellPath) with
+        {
+            NodeType = "ThreadMessage",
+            Version = version,
+            Content = Cell(text, status, summary)
+        };
+
+    private static JsonObject Cell(string text, string status, string? summary)
+    {
+        var content = new JsonObject
+        {
+            ["role"] = "assistant",
+            ["text"] = text,
+            ["status"] = status
+        };
+        if (summary is not null)
+            content["summary"] = summary;
+        return content;
+    }
+
+    /// <summary>The node as JSON, in the shape the cross-hub patch path serialises it to.</summary>
+    private static JsonObject Serialize(MeshNode node) => new()
+    {
+        ["id"] = node.Id,
+        ["namespace"] = node.Namespace,
+        ["nodeType"] = node.NodeType,
+        ["version"] = node.Version,
+        ["content"] = ((JsonObject)node.Content!).DeepClone()
+    };
+
+    /// <summary>
+    /// The owner's side of ONE cross-hub write, end to end: diff the writer's lambda output against
+    /// the base it read, extract that base, and three-way-merge the result onto the owner's live
+    /// state. Returns the live node as the owner leaves it, plus the leaves it refused.
+    /// </summary>
+    private static (JsonObject Live, IReadOnlyList<string> Refused) ApplyAtOwner(
+        MeshNode live, MeshNode writerBase, MeshNode writerResult)
+    {
+        var baseJson = Serialize(writerBase);
+        var patch = MeshNodeStreamHandle.ComputeMergePatchDiff(baseJson, Serialize(writerResult));
+        var baseValues = MeshNodePatchMerge.ExtractBaseValues(baseJson, patch);
+
+        var liveJson = Serialize(live);
+        var refused = new List<string>();
+        MeshNodePatchMerge.Apply(liveJson, patch, baseValues, refused.Add);
+        return (liveJson, refused);
+    }
+
+    private static string TextOf(JsonObject node) => node["content"]!["text"]!.GetValue<string>();
+    private static string StatusOf(JsonObject node) => node["content"]!["status"]!.GetValue<string>();
+
+    /// <summary>
+    /// 🚨 THE regression pin, in the form of the acceptance criterion from #2305: a cell that reaches
+    /// a terminal Status must not still carry the placeholder.
+    ///
+    /// <para>The round's first push has landed at the OWNER (live: the placeholder, version bumped)
+    /// but its echo has not reached this mirror yet (still the allocation text at the old version).
+    /// The terminal push is dispatched from the same per-path queue in that window.</para>
+    /// </summary>
+    [Fact]
+    public void A_terminal_write_lands_its_text_when_its_predecessors_echo_has_not_arrived()
+    {
+        // The mirror as the queue's next write finds it: BEFORE push 1, because the echo lags.
+        var mirror = new ReplaySubject<MeshNode>(1);
+        mirror.OnNext(NodeAt(5, Allocating, "Streaming"));
+
+        // Push 1's locally-computed result — what the queue hands forward (the fix's seam).
+        var pendingSelfWrite = NodeAt(5, Placeholder, "Streaming");
+
+        // The base the terminal write actually diffs against.
+        MeshNode? writerBase = null;
+        MeshNodeStreamHandle.PatchBaseSource(mirror.Take(1), pendingSelfWrite)
+            .Subscribe(node => writerBase = node);
+        writerBase.Should().NotBeNull();
+
+        // ThreadExecution's terminal push, run against that base: Text = the answer, Status =
+        // Completed, Summary = the answer. (terminalLocked does not fire — the base is not terminal.)
+        var writerResult = writerBase! with
+        {
+            Content = Cell(Answer, "Completed", Answer)
+        };
+
+        // The owner, where push 1 HAS applied: placeholder live, version minted.
+        var live = NodeAt(6, Placeholder, "Streaming");
+        var (merged, refused) = ApplyAtOwner(live, writerBase!, writerResult);
+
+        StatusOf(merged).Should().Be("Completed",
+            "the terminal status write was never in doubt — it is the half that always landed");
+        TextOf(merged).Should().Be(Answer,
+            "a round that reaches a terminal Status must never still carry the placeholder (#2305): "
+            + "the write is the same mirror's own successor, not a concurrent writer, so its base is "
+            + "the state its predecessor produced and nothing about it conflicts");
+        refused.Should().BeEmpty("there was no concurrent writer, so there is nothing to refuse");
+    }
+
+    /// <summary>
+    /// NEGATIVE CONTROL — the shape <c>UpdateRemote</c> had, written out. One operator, and it is the
+    /// whole defect: the queued write reads the mirror as it stands, which is still its own
+    /// predecessor's input. Keeping it here means the pin above cannot quietly become vacuous.
+    ///
+    /// <para>This reproduces the EXACT state both issues report — including that the write is
+    /// half-applied and would still ack <c>Success</c>.</para>
+    /// </summary>
+    [Fact]
+    public void NegativeControl_ReadingTheMirrorAloneLeavesACompletedCellOnThePlaceholder()
+    {
+        var mirror = new ReplaySubject<MeshNode>(1);
+        mirror.OnNext(NodeAt(5, Allocating, "Streaming"));
+
+        // origin/main: the queued write's base is `mirror.Take(1)` and nothing else.
+        MeshNode? writerBase = null;
+        mirror.Take(1).Subscribe(node => writerBase = node);
+
+        var writerResult = writerBase! with { Content = Cell(Answer, "Completed", Answer) };
+        var live = NodeAt(6, Placeholder, "Streaming");
+        var (merged, refused) = ApplyAtOwner(live, writerBase!, writerResult);
+
+        StatusOf(merged).Should().Be("Completed");
+        TextOf(merged).Should().Be(Placeholder,
+            "THIS is the reported defect: Text is refused as a stale/reordered conflict against a "
+            + "value this very writer wrote a moment earlier, so a Completed cell keeps the "
+            + "placeholder while Summary carries the answer");
+        refused.Should().Equal(["text"],
+            "one write, two verdicts — and because Status/Summary DID land the owner still acks "
+            + "Success, so nothing surfaces and nothing is retried");
+    }
+
+    /// <summary>
+    /// The same defect on the SPLICE branch, which a real (long) agent answer takes. Above
+    /// <see cref="PatchStringSplice.MinSpliceLength"/> the patch ships offsets plus a fingerprint of
+    /// the base, and the owner refuses outright when the fingerprint does not vouch for its live text
+    /// — no rebase is even attempted. So a long answer is lost by a stale base just as surely as a
+    /// short one, and the fix has to cover both branches.
+    /// </summary>
+    [Fact]
+    public void A_long_answer_survives_too_where_the_patch_is_a_splice()
+    {
+        var longAnswer = new string('x', PatchStringSplice.MinSpliceLength + 64);
+        var mirror = new ReplaySubject<MeshNode>(1);
+        mirror.OnNext(NodeAt(5, Allocating, "Streaming"));
+        var live = NodeAt(6, Placeholder, "Streaming");
+
+        MeshNode? stale = null;
+        mirror.Take(1).Subscribe(node => stale = node);
+        var (staleMerged, staleRefused) = ApplyAtOwner(
+            live, stale!, stale! with { Content = Cell(longAnswer, "Completed", longAnswer) });
+        TextOf(staleMerged).Should().Be(Placeholder, "the splice's base fingerprint cannot vouch for live text the writer never saw");
+        staleRefused.Should().Equal(["text"]);
+
+        MeshNode? rebased = null;
+        MeshNodeStreamHandle
+            .PatchBaseSource(mirror.Take(1), NodeAt(5, Placeholder, "Streaming"))
+            .Subscribe(node => rebased = node);
+        var (fixedMerged, fixedRefused) = ApplyAtOwner(
+            live, rebased!, rebased! with { Content = Cell(longAnswer, "Completed", longAnswer) });
+        TextOf(fixedMerged).Should().Be(longAnswer);
+        fixedRefused.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// 🚨 Why the hand-forward may only carry a base the OWNER ACKNOWLEDGED, never the optimistic
+    /// snapshot — the constraint that makes the whole mechanism safe, and the one I got wrong first.
+    ///
+    /// <para>A write that did not land mints no version, so nothing ever corrects a base taken from
+    /// it. A caller that retries the same write then diffs its own unlanded value and gets the patch
+    /// below: <b>empty</b>. An empty patch is not sent, so the store never advances, so the mirror
+    /// never advances, so the next retry is empty too — silently, forever.</para>
+    ///
+    /// <para><c>TwoSiloRecycleConvergenceTest.PostRecycleUpdate_NonOwnerSiloMirror_ConvergesInsteadOfOrphaning</c>
+    /// is the integration gate that caught it (its post-recycle write retries past a disposing owner);
+    /// this is the same fact deterministically, so the reason the gate exists is legible here.</para>
+    /// </summary>
+    [Fact]
+    public void An_unlanded_base_would_make_the_retry_an_empty_patch_which_is_never_sent()
+    {
+        // The base a rejected write would have published, had it published one.
+        var neverLanded = NodeAt(7, "sk-post-recycle", "Streaming");
+
+        // The caller retries the identical write against it.
+        var retry = neverLanded with { Content = Cell("sk-post-recycle", "Streaming", null) };
+
+        var patch = MeshNodeStreamHandle.ComputeMergePatchDiff(
+            Serialize(neverLanded), Serialize(retry));
+
+        patch.Count.Should().Be(0,
+            "the retry is byte-identical to a value the owner never took — so it produces nothing to "
+            + "send, the write is skipped as a no-op, and no version is ever minted to break the "
+            + "cycle. This is why onLocalState fires on the owner's ACK and on nothing weaker");
+    }
+
+    /// <summary>
+    /// 🚨 The hand-forward is not a blanket override — it yields the moment the mirror knows more.
+    /// The owner mints <c>Version + 1</c> on EVERY applied change from ANY writer, so a mirror that
+    /// has moved past the pending state is carrying something this mirror did not write, and a real
+    /// cross-mirror conflict must still be detected exactly as before.
+    /// </summary>
+    [Fact]
+    public void The_mirror_wins_again_the_moment_it_carries_anything_newer()
+    {
+        var pending = NodeAt(5, Placeholder, "Streaming");
+
+        var caughtUp = new ReplaySubject<MeshNode>(1);
+        caughtUp.OnNext(NodeAt(6, "somebody else's text", "Streaming"));
+        MeshNode? chosen = null;
+        MeshNodeStreamHandle.PatchBaseSource(caughtUp.Take(1), pending).Subscribe(n => chosen = n);
+        chosen!.Version.Should().Be(6);
+        ((JsonObject)chosen.Content!)["text"]!.GetValue<string>().Should().Be("somebody else's text",
+            "a mirror that advanced past our pending write is showing state we did not produce — "
+            + "diffing against ours would hide a genuine conflict");
+
+        // A pending write for a DIFFERENT path can never be adopted (guard against a mis-keyed
+        // hand-off; the queue is per path, so this is defence, not an expected case).
+        var other = MeshNode.FromPath("TestUser/_Thread/other/msg-1") with { Version = 9 };
+        MeshNode? forOtherPath = null;
+        MeshNodeStreamHandle
+            .PatchBaseSource(Observable.Return(NodeAt(5, Allocating, "Streaming")), other)
+            .Subscribe(n => forOtherPath = n);
+        forOtherPath!.Path.Should().Be(CellPath);
+
+        // No pending state at all (a first write, or one after an error) reads the mirror unchanged.
+        MeshNode? none = null;
+        MeshNodeStreamHandle
+            .PatchBaseSource(Observable.Return(NodeAt(5, Allocating, "Streaming")), null)
+            .Subscribe(n => none = n);
+        none!.Version.Should().Be(5);
+    }
+}


### PR DESCRIPTION
Fixes #2305.

`OrleansAutoExecuteTest.AutoExecute_UpdateThreadMessageContent_RoutesToResponseGrain` and
`OrleansChatHistoryTest.ColdStart_AgentSeesAllPreviousMessages` (shape **A** of #2291) are **one
defect**, and it is not in the AI pipeline at all — it is in the cross-hub write path that every mesh
node write goes through.

## The reported state

```
Text    = Generating response...
Status  = Completed
Summary = I received 6 messages. […]
```

A round that finished correctly, with the answer in a field the chat surface does not show and `Text`
still on the framework's own placeholder. User-visible and silent — indistinguishable from a hung
agent.

## Root cause — a write shipped a base it had superseded itself

`MeshNodeStreamCache` funnels every write to a path through one **per-path serial queue**. Its own
contract said:

> the owning node hub's single-threaded action block already serialises patches, **so the next queued
> Update sees post-patch state via the local Handle**

The first clause is true; the second does not follow, and nothing delivered it. The queue advances on
a write's **local** terminal — the owner's ack, or on a busy owner an optimistic emit — and
deliberately never waits for the echo (the old 3 s echo wait deadlocked). The next write then read
`mirror.Take(1)`: this hub's mirror, which under load is still showing the node as it was **before**
its predecessor's patch.

Cross-hub writes ship the base values they diffed against, and the owner refuses any leaf whose live
value has moved past that base. So write N+1 presented a base **write N had already replaced**, and
the owner three-way-merged it as a stale/reordered conflict — between two writers that never existed.
They are the same mirror's writes, strictly ordered by the queue.

For a round: push 1 writes `Text = "Generating response..."`; the terminal push writes `Text` = the
answer, `Status = Completed`, `Summary`. Only `Text` conflicts, so `Status` and `Summary` land, `Text`
is refused, and — because *something* landed — the owner acks **`Success`**. One write, two verdicts,
no error, no retry.

Generalised, the same mechanism froze a **streaming cell's text at the first chunk that landed** for
as long as the echo lagged the write rate. The placeholder is just the first chunk of every round.

## What this is NOT (all re-checked)

- **Not `terminalLocked`** in `ThreadExecution.PushToResponseMessage`. That guard works as designed —
  and with the base fixed it now gets a truthful `current` to guard against, so the reverse ordering
  (a late placeholder push after the terminal write) is pinned too. Untouched by this PR.
- **Not the owner's per-field partial resolution.** That a disjoint string merges while a conflicting
  scalar is independently refused is deliberate and load-bearing
  (`PatchDataRequestTest.PatchDataRequest_StaleBase_MergesStringAndRefusesScalar`,
  `CrossHubPatchAtomicityTest`). Making the whole patch atomic was built and reverted before for
  exactly that reason; **this PR does not touch the merge at all**.
- **Not #2290 / the history loader** — unreachable from the AutoExecute test, and the write path
  already used `ContentAs`.

## Re-measured on current `main` first

Post #2377 / #2008 / #2339 / #2341, all three named tests **pass locally** (real `.trx`, real
durations) — exactly as they did before those merges. So today's merges did not move this, and the
defect remains what the prior investigation found: not locally reproducible on this hardware; it needs
an echo that lags the write rate, which is a loaded-runner condition. The mechanism therefore had to
be reasoned about and then pinned deterministically, which is what the tests below do.

## The fix

Deliver the invariant the queue's contract already claimed, instead of asserting it:

- `MeshNodeStreamCache` hands each queued write the node its predecessor left the node in
  (`_pendingSelfWrites` — one entry per path, consumed by the next write, dropped with the path's
  queue). It is published by the write path itself (post-audit-stamp, pre-typed-projection) so its
  re-serialisation is byte-identical to what the next diff builds its base from.
- `MeshNodeStreamHandle.PatchBaseSource` prefers that state **only while the mirror carries nothing
  newer**. The owner mints `Version + 1` on every applied change from any writer, so the instant the
  mirror advances — the echo, or a genuinely different mirror's commit — the mirror wins again and a
  real cross-mirror conflict is detected exactly as before.

So the change can only remove **false** conflicts. It never hides a real one, never suppresses a base,
and costs no round-trip. `Overwrite` leaves no base; a `Conflict` re-attempt still re-reads the owner's
state (#1910's `RebaseSource` is unchanged and composes ahead of this). `[UpdateRemote] SELF_REBASE`
in the debug log is a write saying it took this path.

## 🚨 A regression I introduced, and the control that caught it

My first version published the base from the **optimistic** snapshot, before the owner's verdict. That
is self-perpetuating: a write that did not land mints no version, so nothing ever corrects the base —
and a caller that retries the same write diffs its own unlanded value, computes an **empty** patch, and
skips the write **silently, forever**.

`TwoSiloRecycleConvergenceTest.PostRecycleUpdate_NonOwnerSiloMirror_ConvergesInsteadOfOrphaning` failed
on exactly that (`Store never advanced past version 7` — its post-recycle write retries past a
disposing owner). The fix is the ack gate: the base is published **only on the owner's success ack**,
never on the optimistic emit, a rejection, or a retry. When the ack does not arrive inside the response
bound the write publishes nothing and its successor reads the mirror — the pre-existing behaviour, which
is the correct direction to degrade in. That test is the standing gate for this constraint, and
`An_unlanded_base_would_make_the_retry_an_empty_patch_which_is_never_sent` states the same fact
deterministically so the reason is legible without a two-silo cluster.

## Tests

`test/MeshWeaver.Query.Test/ResponseTextSurvivesUnechoedWriteTest.cs` — deterministic (mirror and queue
hand-off as seams, no hub, no cluster, no wall clock), with the merge half running the **real**
owner-side pipeline (`ComputeMergePatchDiff` → `ExtractBaseValues` → `MeshNodePatchMerge.Apply`) so it
cannot drift from production:

- **the gate** — a terminal write lands its `Text` when its predecessor's echo has not arrived;
- **the negative control** — the old shape (`mirror.Take(1)` alone) reproduces the reported state
  exactly: `Status = Completed`, `Text` = the placeholder, refused leaf = `["text"]`;
- the **splice branch** too (a real long answer is >1 kB, where a stale base fingerprint is refused
  outright with no rebase attempted);
- the yield rule — the mirror wins again the moment it carries anything newer, a foreign path is never
  adopted, and no pending state reads the mirror unchanged;
- the ack-gate rationale, above.

## #2291

Left open, narrowed to shape **B** — the `SharedOrleansFixture` deploy fault
(`InvalidProgramException` in `TestClusterHostFactory`) that took 13 tests down under this test's name.
Unrelated ALC/teardown defect; only shape A is fixed here.

## ⚠️ CI

Opened during the declared **GitHub Actions major outage** (from ~15:11 UTC — throttled inbound
traffic / upstream Vitess). Runs from this window are not measurements: cancelled jobs poison the
umbrella conclusion, `startup_failure` appears with zero jobs, and some runs are never created at all.
**Do not merge on a green or investigate a red from that window** — re-verify once Actions is healthy.
Local verification is recorded above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
