### PR TITLE
fix(localmesh): install the AI engine so the shells' chat can start threads

### DIFF
--- a/memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs
+++ b/memex/Memex.LocalMesh/LocalMeshApiEndpoints.cs
@@ -127,6 +127,25 @@ public static class LocalMeshApiEndpoints
             return Results.Json(new { onboarded });
         });
 
+        // The caller's mesh identity — the sidecar twin of the portal's POST /api/mesh/whoami
+        // (Memex.Portal.Shared MeshApiEndpoints), same {userId, name, email} shape, so a shell
+        // resolves "whose home partition am I?" identically against either backend. This host
+        // authenticates nobody — every caller IS the device user (GrpcOptions.AnonymousUser) —
+        // so the answer is the device identity once onboarded, nulls before (the shells show
+        // onboarding first). Without this the WEB shell served from wwwroot had no way to learn
+        // its own partition: chat threads had nowhere to anchor while the native shells worked.
+        group.MapPost("/whoami", async (IServiceProvider services, CancellationToken ct) =>
+        {
+            var onboarded = await DeviceSeed.IsOnboarded(RootHub(services)).FirstAsync().ToTask(ct);
+            string? userId = onboarded ? DeviceSeed.DeviceUserId : null;
+            return Results.Json(new
+            {
+                userId,
+                name = onboarded ? DeviceSeed.DeviceUser.Name : null,
+                email = userId is null ? null : $"{userId}@local",
+            });
+        });
+
         return endpoints;
     }
 

--- a/memex/Memex.LocalMesh/Memex.LocalMesh.csproj
+++ b/memex/Memex.LocalMesh/Memex.LocalMesh.csproj
@@ -22,6 +22,13 @@
          portal's endpoint does — so the sidecar compiles and runs whether or not voice is
          installed. The Whisper client itself arrives as a MODULE (below). -->
     <ProjectReference Include="..\..\src\MeshWeaver.Speech.Contract\MeshWeaver.Speech.Contract.csproj" />
+    <!-- The AI engine (Thread/Agent/Skill node types + the chat runtime), the portal's thin lane:
+         the DLL rides the app closure so ResolveModulePath's BaseDirectory fallback finds it, and
+         Modules:Assemblies in appsettings.json is what activates it (a MeshNodeProviderAttribute
+         is read ONLY by InstallConfiguredModules — the reference alone contributes nothing).
+         Without it the sidecar refuses every chat send with "NodeType 'Thread' is not
+         registered" — the RN shells' composer is a dead surface on the local mesh. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
   </ItemGroup>
 
   <!-- ═════════ The RN web client is BAKED at publish — never hand-copied ═════════

--- a/memex/Memex.LocalMesh/appsettings.json
+++ b/memex/Memex.LocalMesh/appsettings.json
@@ -8,6 +8,11 @@
     // turns it on. Delist it and the sidecar still starts — POST /api/speech/transcribe simply
     // answers 503, exactly as a portal without the module does.
     "Assemblies": [
+      // The AI engine — Thread/Agent/Skill node types + the chat runtime (the same entry the
+      // portal lists). The RN shells' composer submits threads; without this every send is
+      // refused with "NodeType 'Thread' is not registered". The DLL rides the app closure
+      // (ProjectReference in the csproj — the portal's documented thin lane).
+      "MeshWeaver.AI.dll"
     ]
   },
   "Speech": {

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-localmesh-chat-threads.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-localmesh-chat-threads.md
@@ -1,0 +1,15 @@
+---
+Name: Chat works on the local mesh
+Category: Fix
+Description: The local sidecar now carries the AI engine, so starting a chat thread from the mobile/web shells works instead of failing silently.
+Icon: Sparkle
+Order: -20260826
+---
+
+# Chat works on the local mesh
+
+Starting a chat from the mobile or web shell against the local mesh used to do nothing: the
+sidecar did not know the Thread node type, so every send was refused behind the scenes and the
+conversation never appeared. The local mesh now ships the AI engine, so threads are created under
+your own space, your message is queued and answered, and configuring a model provider is done the
+same way as on a portal.


### PR DESCRIPTION
## What changed

The mobile/web shells' chat composer was a dead surface against the local mesh, in two layers:

1. **Thread type absent** — every send's `CreateNodeRequest` was refused with **"NodeType 'Thread' is not registered"** (`rejectionReason: InvalidNodeType`): `Memex.LocalMesh` composed Graph/Kernel/Documentation/Grpc but never the AI engine. Wired the portal's documented thin lane: a `ProjectReference` so `MeshWeaver.AI.dll` rides the app closure (`ResolveModulePath`'s BaseDirectory fallback), activated by listing it in `Modules:Assemblies` — the same entry `Memex.Portal.Monolith` carries; the `AiMeshModule` assembly attribute registers everything through `InstallConfiguredModules`, which the host already calls.
2. **No identity for the served web shell** — the portal answers `POST /api/mesh/whoami`, the sidecar had no twin, so the web app it serves from `wwwroot` could never learn whose home partition to paint and a new thread had nowhere to anchor (the native shells hardcode the device user; web has no such shortcut). Added the whoami twin in the portal's exact `{userId, name, email}` shape: the device identity once onboarded, nulls before.

The client half of the bug — the `{ error, rejectionReason }` refusal shape resolving as *success* so the app hung instead of showing the error, plus the composer's missing viewer-partition fallback and the web shell's whoami probe — is MeshWeaver.Plugins#713.

## Why

Chat is the shells' primary surface and the sidecar is their default mesh. A composer whose every send is silently refused reads as "the app is broken" (it was reported exactly that way).

## How tested

- Scratch sidecar (scratch port + SQLite): onboard → `Mesh.startThread("device-user", …)` over gRPC-web lands `device-user/_Thread/{id}`, the submission watcher executes the round (`EXECUTION_COMPLETE … success=True`), and with no provider configured the reply is the honest "No IChatClientFactory is registered…". The per-user `ThreadComposer` node is seeded.
- **Real-browser end-to-end** (Playwright, the web export served by this host at same-origin): the home renders the device user's composer, typing + Send shows the user bubble, the assistant's no-provider reply streams in, and the thread node exists on the mesh.
- `dotnet build memex/Memex.LocalMesh -c Release -p:CIRun=true -warnaserror` clean.
- What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)