### PR TITLE
The binary-compatibility gate can now block a merge

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1970,7 +1970,14 @@ jobs:
     # clients-gate is a NEEDS on the same principle as plugin-gate/doc-gate/licence-gate: a red
     # Clients workflow can stop ALL image publication (#1568), so it must be able to fail the
     # repo's only required status check.
-    needs: [precheck, preflight, build, test, plugin-gate, landed-modules-gate, doc-gate, licence-gate, clients-gate]
+    # record-signatures is a NEEDS on the same principle, and it is the one that had been
+    # missing: it carries BOTH binary-compatibility gates (public record primary constructors,
+    # and public types moving assembly without a TypeForwardedTo). #2283 moved four public types
+    # out of MeshWeaver.AI and shipped a TypeLoadException to production on EVERY MCP tool call
+    # (#2370) — a module's IL binds a NAME, so no source build can see it. The gate for exactly
+    # that now exists and is proven live, but until this line it could go RED while the PR merged
+    # anyway. A gate whose verdict nothing reads is decorative.
+    needs: [precheck, preflight, build, test, plugin-gate, landed-modules-gate, doc-gate, licence-gate, clients-gate, record-signatures]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -2317,6 +2324,20 @@ jobs:
       run: |
         echo "::error::A dependency licence is incompatible with shipping MeshWeaver under Apache-2.0 / MIT — see the 'Dependency licences' job for the offending package(s) and their licence."
         echo "::error::Fix it by removing the package or replacing it with a permissively-licensed one. Do NOT add it to EXCEPTIONS unless the upstream licence genuinely IS permissive and only the package metadata is missing."
+        exit 1
+
+    # ── …and a BINARY-COMPATIBILITY break decides it too ────────────────────────────────────
+    # 🚨 `needs:` alone is NOT enough under `if: always()` — same lesson as the steps above, and
+    # this is the case that already cost a production incident. A source build answers source
+    # compatibility; an already-published module binds a NAME in its IL. So a public type that
+    # moves assembly, or a public record whose primary constructor changes shape, breaks every
+    # module built before the change while every compile in the repo stays green.
+    - name: Fail if the binary-compatibility gate failed
+      if: needs.record-signatures.result == 'failure'
+      run: |
+        echo "::error::A public surface changed in a way that breaks ALREADY-PUBLISHED modules — see the 'Public surface (binary compatibility)' job for the exact types."
+        echo "::error::A moved public type needs [assembly: TypeForwardedTo] left behind in its ORIGINAL assembly (a forwarder keeps one type identity; a shim mints a second and reintroduces the is/as trap-door). A forwarder cannot rename, so the type keeps its original name."
+        echo "::error::Do NOT satisfy this by rebuilding the consumer: the point is that modules ALREADY shipped bind the old name. If a forwarder is impossible (it would need a reference cycle), the move has to be reverted or the whole set republished atomically — see #2398."
         exit 1
 
     # ── …and a missing CI INPUT decides it too ──────────────────────────────────────────────

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-a-binary-break-can-no-longer-merge.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-a-binary-break-can-no-longer-merge.md
@@ -1,0 +1,26 @@
+---
+Name: A change that breaks already-installed modules can no longer merge
+Category: Fix
+Description: The check that catches a public surface change breaking modules built earlier now blocks the merge instead of failing quietly beside it.
+Icon: ShieldCheckmark
+Order: -20260826
+---
+
+# A change that breaks already-installed modules can no longer merge
+
+A module that is already installed does not contain a copy of the platform's code — it contains
+*references* to it, by name. Move a public type to a different place and every module built before
+that move is still asking for the old name, which no longer exists. Nothing in the platform's own
+build notices, because the platform compiles perfectly well against its new layout; the failure only
+appears later, in an installed module, at the moment it tries to use the thing that moved.
+
+That is not hypothetical. It is how the MCP tools stopped working: four types moved, every compile
+stayed green, and each tool call failed at the point of use.
+
+A check for exactly this already existed and had just been extended to catch moved types as well as
+changed ones. But it sat *beside* the merge gate rather than in it — it could report a failure while
+the change merged anyway. It now blocks the merge, with a message naming the types and what to do:
+leave a forwarder behind in the original location, so both older and newer modules keep working.
+
+Where a forwarder genuinely cannot be used, the message says so rather than suggesting one, because
+the honest answer there is to reconsider the move or republish everything together.


### PR DESCRIPTION
## It could not block anything

`record-signatures` — the job carrying **both** binary-compatibility checks (public record primary constructors, and public types moving assembly without a `TypeForwardedTo`) — was absent from `collect-results`' `needs`. And `Consolidate test results` is the repo's **only** required status check.

```
required check:  Consolidate test results        (= the collect-results job)
its needs:       [precheck, preflight, build, test, plugin-gate,
                  landed-modules-gate, doc-gate, licence-gate, clients-gate]
the gates live in:  record-signatures            (dotnet-test.yml:212)
```

So the gate ran, failed, and nothing read the verdict.

## Why this is worse than the trapdoor already documented

`AGENTS.md` guards five times over against a gate that renders a **passing tick without running**. This one genuinely runs and genuinely fails — and from the merge button's point of view those are indistinguishable. **A red that stops nothing is decorative.**

The cost is already paid: #2283 moved four public types out of `MeshWeaver.AI` and shipped a `TypeLoadException` to production on **every MCP tool call** (#2370). A module's IL binds a NAME scoped to an `AssemblyRef`, so no source build in either repo can see it — and the verification that *was* run before merging (building the plugin's source against the branch) answers **source** compatibility, which is a different question. The gate for exactly that class now exists and is proven live in CI. As wired, it would have gone red on #2283 and #2283 would have merged regardless.

## The change

Two edits, in the shape this file already prescribes for every other gate:

1. `record-signatures` added to `collect-results`' `needs`.
2. **An explicit fail step** — because `needs:` alone is not enough under `if: always()`: a *skipped* dependency does not fail an `always()` job, which would re-open the trapdoor one level up. That lesson is already written beside `plugin-gate`, `doc-gate`, `licence-gate` and `clients-gate`; this makes the fifth consistent with them.

The failure message names the remedy **and its limits**, because the wrong fix here is tempting:

- leave `[assembly: TypeForwardedTo]` in the **original** assembly — one type identity; a shim mints a second and reintroduces the `is`/`as` trap-door;
- a forwarder **cannot rename**, so a moved type keeps its original name;
- do **not** satisfy it by rebuilding the consumer — the point is that modules *already shipped* bind the old name;
- where a forwarder is impossible because it would need a reference cycle, the move must be reverted or the set republished atomically (**#2398** tracks two such groups).

## What this will cost

Honestly: any PR that legitimately breaks a public surface now needs the forwarder **in the same change**. That is the intent, and it is friction. The alternative is the status quo, in which we find out from production.

## Verification

`dotnet-test.yml` parses; `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` 2/2, built first (the docs ship as an `<EmbeddedResource>`, so `--no-build` would have tested stale text).

🚨 This PR cannot fully demonstrate itself: its own run exercises the *wiring*, not a real binary break. The gate's ability to detect one is already proven — replaying #2283 names exactly the four types, with 20 self-tests running before the gate so a broken matcher fails loudly.

Refs #2398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)