### PR TITLE
🚨 main does not compile — restore the MeshOperations using I deleted as a phantom

### DIFF
--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -6,6 +6,11 @@ using MeshWeaver.Hosting.AspNetCore.Portal; // PortalApplication
 using MeshWeaver.Hosting.AspNetCore;    // SessionHubResolver, McpConfiguration
 using MeshWeaver.Mesh.Security;         // WellKnownUsers
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.AI;                    // MeshOperations — the TYPE ships in
+                                        // MeshWeaver.Mesh.Operations, but its namespace is a
+                                        // FROZEN binary contract (#2370), so this import is
+                                        // load-bearing and is NOT an AI-assembly dependency.
+                                        // Removed as a 'phantom' in #2349 and restored here.
 using MeshWeaver.Messaging;             // AccessService
 using Memex.Portal.Shared.Authentication;
 using Microsoft.AspNetCore.Builder;


### PR DESCRIPTION
**main is broken and it is my regression.** Merging this restores it.

## The break

`48b3e31a3` (#2349) removed `using MeshWeaver.AI;` from `memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs` as the "fourth phantom" of a repo-wide sweep. Line 335 takes a `Func<MeshOperations, IObservable<string>>`, and `MeshOperations` lives in namespace `MeshWeaver.AI`.

Control, on **pristine main `c753ad2` with no edits**:

```
error CS0246: The type or namespace name 'MeshOperations' could not be found
Memex.Portal.Shared → Build FAILED, 1 Error(s)
```

With the using restored: `0 Error(s)`.

## Why the sweep was wrong

It classified imports by asking whether the project can reach the **MeshWeaver.AI assembly** through `ProjectReference`. `Memex.Portal.Shared` cannot — and the import was still load-bearing, because:

> `MeshOperations` **ships** in `MeshWeaver.Mesh.Operations` while **declaring** `namespace MeshWeaver.AI`.

That namespace is a **frozen binary contract** (#2370) — `ec56366a1` kept it deliberately, because a plugin compiled against it breaks if it moves.

The right question is *"does any referenced assembly contribute a type to this namespace"*, not *"can we reach the assembly of the same name"*.

🚨 **This is the `FuzzyScorer` pattern with the opposite intent.** `FuzzyScorer` declaring `MeshWeaver.AI.Completion` from `MeshWeaver.Data` was an accident that manufactured phantom imports, and #2349 correctly fixed it. `MeshOperations` declaring `MeshWeaver.AI` from `MeshWeaver.Mesh.Operations` is deliberate and load-bearing. Same shape, opposite meaning — I documented the first and then failed to recognise the second in the same sweep.

The using is restored **with the reason it exists**, so the next sweep does not delete it again.

## It merged green, which is a second finding

The required check passed while `Memex.Portal.Shared` did not compile. My final verification was a solution build on the **pre-merge branch**; nothing rebuilt that project against the merged tree. Worth a look at whether the green-tree reuse path can mark a suite green for a tree that was never built in that combination.

## Verification

- pristine main: **FAILS** (`CS0246`)
- this commit: `dotnet build memex/Memex.Portal.Shared -c Release -p:CIRun=true -warnaserror` → **0 Error(s)**

Refs #2344, #2370

🤖 Generated with [Claude Code](https://claude.com/claude-code)