### PR TITLE
Autocomplete.Test drops MeshWeaver.AI — keeping the import that only looks like one

### DIFF
--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -6,6 +6,11 @@ using MeshWeaver.Hosting.AspNetCore.Portal; // PortalApplication
 using MeshWeaver.Hosting.AspNetCore;    // SessionHubResolver, McpConfiguration
 using MeshWeaver.Mesh.Security;         // WellKnownUsers
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.AI;                    // MeshOperations — the TYPE ships in
+                                        // MeshWeaver.Mesh.Operations, but its namespace is a
+                                        // FROZEN binary contract (#2370), so this import is
+                                        // load-bearing and is NOT an AI-assembly dependency.
+                                        // Removed as a 'phantom' in #2349 and restored here.
 using MeshWeaver.Messaging;             // AccessService
 using Memex.Portal.Shared.Authentication;
 using Microsoft.AspNetCore.Builder;

--- a/test/MeshWeaver.AI.Test/MarkdownReferenceExtractorTest.cs
+++ b/test/MeshWeaver.AI.Test/MarkdownReferenceExtractorTest.cs
@@ -402,4 +402,23 @@ public class MarkdownReferenceExtractorTest
     }
 
     #endregion
+
+    /// <summary>
+    /// Both UCR content forms — <c>content/…</c> and <c>content:…</c>, bare or partition-qualified.
+    ///
+    /// <para>Moved from <c>MeshWeaver.Autocomplete.Test.UnifiedReferenceAutocompleteProviderTest</c>
+    /// (#2276). <see cref="MarkdownReferenceExtractor"/> ships with MeshWeaver.AI and was that
+    /// suite's last real dependency on the engine; the autocomplete pipeline it sits beside is core
+    /// and stays there.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("@content/docs/readme.md", "content/docs/readme.md")]
+    [InlineData("@ACME/content/readme.md", "ACME/content/readme.md")]
+    [InlineData("@content:docs/readme.md", "content:docs/readme.md")]
+    [InlineData("@ACME/content:readme.md", "ACME/content:readme.md")]
+    public void HandlesBothContentFormats(string input, string expectedPath)
+    {
+        var paths = MarkdownReferenceExtractor.GetUniquePaths(input);
+        paths.Should().ContainSingle().Which.Should().Be(expectedPath);
+    }
 }

--- a/test/MeshWeaver.Autocomplete.Test/MeshWeaver.Autocomplete.Test.csproj
+++ b/test/MeshWeaver.Autocomplete.Test/MeshWeaver.Autocomplete.Test.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />

--- a/test/MeshWeaver.Autocomplete.Test/UnifiedReferenceAutocompleteProviderTest.cs
+++ b/test/MeshWeaver.Autocomplete.Test/UnifiedReferenceAutocompleteProviderTest.cs
@@ -565,18 +565,4 @@ public class UnifiedReferenceAutocompleteProviderTest : MonolithMeshTestBase
 
     #endregion
 
-    #region Content Reference Extraction Tests
-
-    [Theory]
-    [InlineData("@content/docs/readme.md", "content/docs/readme.md")]
-    [InlineData("@ACME/content/readme.md", "ACME/content/readme.md")]
-    [InlineData("@content:docs/readme.md", "content:docs/readme.md")]
-    [InlineData("@ACME/content:readme.md", "ACME/content:readme.md")]
-    public void MarkdownExtractor_HandlesBothContentFormats(string input, string expectedPath)
-    {
-        var paths = AI.MarkdownReferenceExtractor.GetUniquePaths(input);
-        paths.Should().ContainSingle().Which.Should().Be(expectedPath);
-    }
-
-    #endregion
 }


### PR DESCRIPTION
Eighth suite cleared for #2276.

## Two imports named `MeshWeaver.AI`, one dependency

| file | import | verdict |
|---|---|---|
| `UnifiedReferenceAutocompleteProviderTest` | `AI.MarkdownReferenceExtractor` | **real AI type** — its one `[Theory]` moves to `AI.Test`'s existing `MarkdownReferenceExtractorTest` |
| `AutocompleteMultiSourceTest` | `MeshOperations` | **stays** — ships in `MeshWeaver.Mesh.Operations` while declaring `namespace MeshWeaver.AI`, a **frozen binary contract** (#2370) |

## 🚨 The second case is the one that broke main

In #2349 I deleted exactly this kind of import from `MeshApiEndpoints.cs` as a "phantom". My sweep asked *"can this project reach the MeshWeaver.AI **assembly**?"* — it cannot — when the right question is *"does any referenced assembly contribute a type to this **namespace**?"*. It does, and main stopped compiling. #2408 restores it.

Same shape as `FuzzyScorer`, opposite intent:

- `FuzzyScorer` declaring `MeshWeaver.AI.Completion` from `MeshWeaver.Data` — an **accident** that manufactured phantom imports. #2349 correctly fixed it.
- `MeshOperations` declaring `MeshWeaver.AI` from `MeshWeaver.Mesh.Operations` — **deliberate**, load-bearing, must be preserved.

This PR applies the distinction in both directions on the same file set, which is the first time I have got both halves right in one pass.

## Dependency

Requires **#2408**. Without the `MeshOperations` restoration, `Memex.Portal.Shared` does not compile and neither project here builds.

## Verification

- both projects `-c Release -p:CIRun=true -warnaserror` → `0 Error(s)`
- `AI.Test` `MarkdownReferenceExtractorTest`: **41/41**
- `Autocomplete.Test`: **146/146**

Refs #2276, #2370

🤖 Generated with [Claude Code](https://claude.com/claude-code)