### PR TITLE
HOTFIX: main is red — restore the using MeshOperations needs

### DIFF
--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -1,3 +1,9 @@
+// 🚨 MeshOperations lives in ASSEMBLY MeshWeaver.Mesh.Operations but keeps NAMESPACE
+// MeshWeaver.AI, and that mismatch is deliberate (#2370): the type is reached by already-published
+// modules through [assembly: TypeForwardedTo], and a forwarder cannot rename — so the namespace is
+// frozen at whatever it was when those modules were built. Do not "tidy" this using to match the
+// assembly name; that is what broke main at 17:26.
+using MeshWeaver.AI;
 using MeshWeaver.Mesh;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;


### PR DESCRIPTION
## Main is red

```
memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs(335):
error CS0246: The type or namespace name 'MeshOperations' could not be found
```

Run 32994185103 on `c753ad2f5`. CD refuses a red tip, so the surface-manifest image is hard-blocked behind this.

## A semantic conflict — which is why every PR run was green

- **#2283** moved `MeshOperations` to namespace `MeshWeaver.Mesh` and updated this call site's `using` to match.
- **#2397** (the #2370 fix) restored the **original** namespace `MeshWeaver.AI`, because already-published modules reach the type through `[assembly: TypeForwardedTo]` and **a forwarder cannot rename**.

Each compiles against the main it was branched from. Only the combination fails, and no PR run built the combination — the 17:05 merge burst produced it.

## The fix: one line

`using MeshWeaver.AI;` returns to the file. Its sibling `Memex.LocalMesh/LocalMeshApiEndpoints.cs` **already had it**, which is why exactly one file broke; I checked every `.cs` referencing `MeshOperations` rather than assuming.

I also left a note at the `using`, because the shape invites a "tidy-up" that re-breaks it: the type lives in **assembly** `MeshWeaver.Mesh.Operations` but keeps **namespace** `MeshWeaver.AI`, deliberately and permanently.

## Why not revert #2397

Reverting would drop a live production fix (a `TypeLoadException` on **every** MCP tool call) *and* the gate that detects the whole class. The agreed criterion is main green on the very next run, and one line achieves that.

## Verification

`Memex.Portal.Shared` builds clean under `-c Release -warnaserror`.

🚨 Note the gate that would have caught this is **#2407**, still open: it makes a binary-compat failure block the merge. It would not have caught *this* particular break (a semantic conflict between two merges is a different class from a binary break), but it is the same family — a green solo run proving less than it appears to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)