### PR TITLE
HOTFIX: main red with CS0105 — remove the duplicate using I added

### DIFF
--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -1,9 +1,3 @@
-// 🚨 MeshOperations lives in ASSEMBLY MeshWeaver.Mesh.Operations but keeps NAMESPACE
-// MeshWeaver.AI, and that mismatch is deliberate (#2370): the type is reached by already-published
-// modules through [assembly: TypeForwardedTo], and a forwarder cannot rename — so the namespace is
-// frozen at whatever it was when those modules were built. Do not "tidy" this using to match the
-// assembly name; that is what broke main at 17:26.
-using MeshWeaver.AI;
 using MeshWeaver.Mesh;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;


### PR DESCRIPTION
## Main does not compile, and this one is mine

```
memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs(15,7):
error CS0105: The using directive for 'MeshWeaver.AI' appeared previously in this namespace
```

Reproduced locally against `origin/main` (`cd8d42d3d`) with CI's flags before writing this.

## What happened

Another session had **already fixed** the original `CS0246` in **#2408** — *"restore the MeshOperations using I deleted as a phantom"* — merged at 17:44, with main green at **17:44:57**.

I diagnosed the same break independently, wrote the same fix as **#2411**, and merged it at **18:01** — **without re-checking whether main was still red.** Result: two identical `using MeshWeaver.AI;` directives, and under `-warnaserror` `CS0105` is an error.

## The fix

Remove **my** block; keep #2408's, which landed first and already carries the explanation. Net effect on main becomes exactly #2408's fix, which is what it should have been all along.

## The lesson, which is the cheap one I skipped

**Before landing a hotfix, re-verify the failure still reproduces on the current tip.** Main had moved twice while I worked — #2408 at 17:44 and #2410 at 18:02. A red main is exactly when several people converge on the same fix, so it is exactly when *"is it still broken?"* has to be re-asked rather than assumed. I was optimising for speed on a blocked deploy and skipped the one check that would have made the speed unnecessary.

Worth noting it also fits this repo's own theme: I acted on a **stale observation** — accurate when I made it, false by the time I used it — which is the same failure mode as an agent reporting "still outstanding" from behind an outage.

## Verification

`Memex.Portal.Shared` builds clean under `-c Release -warnaserror` with this change; the identical build **fails** on `origin/main` without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)