### PR TITLE
🚨 main is red — two parallel hotfixes both added the MeshOperations using (CS0105)

### DIFF
--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -3,7 +3,6 @@
 // modules through [assembly: TypeForwardedTo], and a forwarder cannot rename — so the namespace is
 // frozen at whatever it was when those modules were built. Do not "tidy" this using to match the
 // assembly name; that is what broke main at 17:26.
-using MeshWeaver.AI;
 using MeshWeaver.Mesh;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;


### PR DESCRIPTION
**main does not compile.** `using MeshWeaver.AI;` appears twice in `MeshApiEndpoints.cs`, and `CS0105` is an error under `-warnaserror`.

## How

My #2349 removed that import and broke main. **Two sessions then fixed it independently:**

| commit | what it added |
|---|---|
| `c01ed6946` | "HOTFIX: main is red — MeshApiEndpoints lost sight of MeshOperations" — bare import |
| `3a6f95553` (#2408) | annotated import explaining why it must never be deleted |

Both merged. Neither collided in git — they touched different lines — so the duplicate only appears at COMPILE time.

## The fix

Keep the **annotated** import (it carries the explanation of why the import exists, which is exactly what was missing when I deleted it), drop the bare duplicate.

```
removed the bare duplicate at line 6: using MeshWeaver.AI;
remaining: 1
Memex.Portal.Shared → 0 Error(s)
```

## 🚨 The lesson, which I had already been taught today

A defect can exist **only in the combination**. I verified main green at `831e63b` and said so publicly; the other hotfix merged afterwards and my statement was stale the moment I made it.

A clean build on my own branch says nothing about main once main has moved — **only main's own post-merge run is authoritative**. That is precisely what caught the original regression, and precisely what I failed to consult before declaring main healthy.

Refs #2344, #2370, #2408

🤖 Generated with [Claude Code](https://claude.com/claude-code)