### PR TITLE
fix: main does not build — the MeshWeaver.AI using was restored TWICE

### DIFF
--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -3,6 +3,11 @@
 // modules through [assembly: TypeForwardedTo], and a forwarder cannot rename — so the namespace is
 // frozen at whatever it was when those modules were built. Do not "tidy" this using to match the
 // assembly name; that is what broke main at 17:26.
+//
+// This import is therefore load-bearing and is NOT an AI-assembly dependency. It was removed as a
+// "phantom" in #2349 and restored twice independently (#2408 and #2411) — once with this banner and
+// once inline further down, which is how main ended up with the SAME using twice and CS0105 under
+// warnings-as-errors. One directive, one explanation: keep them together.
 using MeshWeaver.AI;
 using MeshWeaver.Mesh;
 using System.Reactive.Linq;
@@ -12,11 +17,6 @@ using MeshWeaver.Hosting.AspNetCore.Portal; // PortalApplication
 using MeshWeaver.Hosting.AspNetCore;    // SessionHubResolver, McpConfiguration
 using MeshWeaver.Mesh.Security;         // WellKnownUsers
 using MeshWeaver.Mesh.Services;
-using MeshWeaver.AI;                    // MeshOperations — the TYPE ships in
-                                        // MeshWeaver.Mesh.Operations, but its namespace is a
-                                        // FROZEN binary contract (#2370), so this import is
-                                        // load-bearing and is NOT an AI-assembly dependency.
-                                        // Removed as a 'phantom' in #2349 and restored here.
 using MeshWeaver.Messaging;             // AccessService
 using Memex.Portal.Shared.Authentication;
 using Microsoft.AspNetCore.Builder;


### PR DESCRIPTION
## main is red

`main` at `7d7bf903e` fails **Build solution (once)** with:

```
error CS0105: The using directive for 'MeshWeaver.AI' appeared previously in this namespace
```

`memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs` carries `using MeshWeaver.AI;` **twice** — once at line 6 and again at line 15.

## How it got there

1. **#2349** removed the using as a "phantom". main went red with `CS0246: MeshOperations could not be found`.
2. **#2408** restored it at the top of the file, under a banner comment.
3. **#2411** restored it *again* further down, inline, with its own explanation.

Both landed. The second restore could not see the first, because the first was fifty lines away behind a different comment style.

## The fix

Keep **one** directive, and fold both explanations into the banner that sits directly above it — including the part each author had to rediscover: `MeshOperations` ships in assembly `MeshWeaver.Mesh.Operations` but keeps namespace `MeshWeaver.AI`, frozen by the `TypeForwardedTo` contract from #2370. The import looks removable and is load-bearing, and removing it has now cost three red-main incidents.

Splitting the directive from its rationale is what let this happen twice. One directive, one explanation, kept together.

## Verified

`dotnet build memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj` → **Build succeeded**, one `using MeshWeaver.AI;` remaining.

This also unblocks #2413 and #2395, which are byte-identical to main on this file and inherit the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)