### PR TITLE
feat(slideshow): SlideShowControl gains frames mode — the whole deck, pre-rendered

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-slide-shows-can-carry-the-whole-deck.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-slide-shows-can-carry-the-whole-deck.md
@@ -1,0 +1,23 @@
+---
+Name: Slide shows can carry the whole deck at once
+Category: Feature
+Description: The presenter view can now be handed every slide pre-rendered, so advancing a slide is instant instead of a page load.
+Icon: Sparkle
+Order: -20260826
+---
+
+# Slide shows can carry the whole deck at once
+
+Presenting used to reload the page on every keypress: each arrow re-resolved the next slide on the
+server and rendered it from scratch, which is slow on a cold deck and simply fails when that round
+trip breaks.
+
+The slide show now accepts a whole deck up front — every slide already rendered — together with the
+slide to open on and the shape of the address-bar link. The presenter holds all of them and switches
+between them in the browser on the usual keys and on click, so advancing is immediate and cannot
+fail on a lost round trip, while the address bar keeps the current slide's shareable link and Back
+still leaves the deck in one step. Links inside a slide keep navigating normally, and Escape still
+exits the presentation.
+
+This is the presenter's side of the change; the deck view starts handing it whole decks next, and
+until it does, decks present exactly as they do today.

--- a/src/MeshWeaver.Layout/LayoutExtensions.cs
+++ b/src/MeshWeaver.Layout/LayoutExtensions.cs
@@ -214,6 +214,12 @@ public static class LayoutExtensions
                 typeof(KpiItem),
                 typeof(TowerBand),
                 typeof(ComparisonPair),
+                // A slide show's pre-rendered frames ride inside SlideShowControl.Frames — plain
+                // records, so the IUiControl sweep above misses them. Unregistered, the receiving
+                // hub would adopt SlideFrame under an auto short-name as a side effect of the read,
+                // and a hub that did not would hand the view untyped JsonElements: a deck that
+                // renders no slides at all.
+                typeof(SlideFrame),
                 // Icon lives in MeshWeaver.Domain, so the IUiControl/Skin reflection sweep above
                 // cannot see it — yet it rides inside control state on almost every control
                 // (IconStart/IconEnd, NavItem, MenuItem, ProgressMessage). Unregistered, it

--- a/src/MeshWeaver.Layout/SlideShowControl.cs
+++ b/src/MeshWeaver.Layout/SlideShowControl.cs
@@ -1,35 +1,72 @@
+using System.Collections.Immutable;
+
 namespace MeshWeaver.Layout;
 
 /// <summary>
-/// Invisible presenter-mode keyboard driver for a slide show. It renders no chrome — it is
-/// placed inside a deck's (or a slide's) <c>Present</c> area so that the presentation view can
-/// be driven from the keyboard with the standard PowerPoint bindings. Its Blazor view
-/// (<c>SlideShowView</c>) attaches a document-level <c>keydown</c> listener and navigates to
-/// the matching href via the framework's standard navigation mechanism (no bespoke messages):
+/// One pre-rendered slide of a client-side slide show: the slide body as READY HTML (markdown
+/// already rendered server-side) plus its background. Carried by
+/// <see cref="SlideShowControl.Frames"/> so the presenter view can swap slides locally —
+/// no navigation, no server round trip, no per-slide hub activation.
+/// </summary>
+public record SlideFrame(string Html, string? Background);
+
+/// <summary>
+/// Presenter-mode driver for a slide show, in one of two modes:
 /// <list type="bullet">
-///   <item><b>Right / Down / PageDown / Space / Enter</b> → <see cref="NextHref"/> (advance)</item>
-///   <item><b>Left / Up / PageUp</b> → <see cref="PreviousHref"/> (go back)</item>
-///   <item><b>Home</b> → <see cref="FirstHref"/> · <b>End</b> → <see cref="LastHref"/></item>
-///   <item><b>Esc</b> → <see cref="ExitHref"/> (leave the presentation)</item>
+///   <item><b>Frames mode</b> (<see cref="Frames"/> non-empty): the view renders EVERY slide
+///     pre-rendered into the page and swaps them client-side on the standard PowerPoint keys
+///     (and click-to-advance), updating the address bar via <c>history.replaceState</c> with
+///     <see cref="UrlTemplate"/> — the URL stays deep-linkable while navigation never leaves
+///     the page. This is the fix for the per-slide full round trip: switching slides used to
+///     be a route change that re-resolved and re-rendered the slide server-side (seconds per
+///     keypress on a cold hub, and a failure mode when that round trip broke).</item>
+///   <item><b>Href mode</b> (no frames — the original behavior): an invisible keyboard driver;
+///     each key navigates to the matching href via the framework's standard navigation.</item>
 /// </list>
-/// A <c>null</c> href makes that key a no-op — e.g. <see cref="NextHref"/> is null on the last
-/// slide, so advancing past the end does nothing.
+/// Keys in both modes: Right/Down/PageDown/Space/Enter → next · Left/Up/PageUp → prev ·
+/// Home → first · End → last · <b>Esc</b> → <see cref="ExitHref"/> (a real navigation in both
+/// modes). A <c>null</c> href makes that key a no-op in href mode.
 /// </summary>
 public record SlideShowControl()
     : UiControl<SlideShowControl>(ModuleSetup.ModuleName, ModuleSetup.ApiVersion)
 {
-    /// <summary>Href to navigate to for Home (first slide). Null disables the key.</summary>
+    /// <summary>Href to navigate to for Home (first slide). Href mode only; null disables the key.</summary>
     public string? FirstHref { get; init; }
 
-    /// <summary>Href to navigate to for Left / Up / PageUp (previous slide). Null disables the key (at the start).</summary>
+    /// <summary>Href to navigate to for Left / Up / PageUp (previous slide). Href mode only; null disables the key (at the start).</summary>
     public string? PreviousHref { get; init; }
 
-    /// <summary>Href to navigate to for Right / Down / PageDown / Space / Enter (next slide). Null disables the key (at the end).</summary>
+    /// <summary>Href to navigate to for Right / Down / PageDown / Space / Enter (next slide). Href mode only; null disables the key (at the end).</summary>
     public string? NextHref { get; init; }
 
-    /// <summary>Href to navigate to for End (last slide). Null disables the key.</summary>
+    /// <summary>Href to navigate to for End (last slide). Href mode only; null disables the key.</summary>
     public string? LastHref { get; init; }
 
     /// <summary>Href to navigate to for Esc (exit the presentation, e.g. back to the deck overview). Null disables the key.</summary>
     public string? ExitHref { get; init; }
+
+    /// <summary>
+    /// Every slide of the deck, pre-rendered — non-empty switches the control into frames mode:
+    /// the view renders all of them and swaps client-side, so advancing a slide costs no server
+    /// round trip at all.
+    /// <para>Frames mode is a progressive enhancement of the wire contract: clients that do not
+    /// (yet) implement it — the React and React Native drivers are href-only — ignore this
+    /// payload, so a producer emitting frames SHOULD keep populating the href fields alongside
+    /// them. Frames-capable clients ignore the hrefs for slide swapping (only
+    /// <see cref="ExitHref"/> navigates); href-only clients keep presenting exactly as before.
+    /// </para>
+    /// </summary>
+    public ImmutableList<SlideFrame>? Frames { get; init; }
+
+    /// <summary>The slide to show first in frames mode (clamped to the frame count) — typically
+    /// parsed off the deep link's <c>?i</c>.</summary>
+    public int StartIndex { get; init; }
+
+    /// <summary>
+    /// Address-bar template for frames mode, with <c>{0}</c> for the slide index (e.g.
+    /// <c>/MyDeck/Present?i={0}</c>). Each client-side swap calls
+    /// <c>history.replaceState</c> with it, so the URL stays shareable and reload lands on the
+    /// same slide — without a navigation. Null leaves the address bar alone.
+    /// </summary>
+    public string? UrlTemplate { get; init; }
 }

--- a/test/MeshWeaver.Layout.Test/SlideShowControlTest.cs
+++ b/test/MeshWeaver.Layout.Test/SlideShowControlTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using MeshWeaver.Domain;
 using MeshWeaver.Fixture;
 using MeshWeaver.Messaging;
@@ -37,6 +38,21 @@ public class SlideShowControlTest(ITestOutputHelper output) : HubTestBase(output
 
         var json = JsonSerializer.Serialize<UiControl>(control, options);
         Output.WriteLine(json);
+
+        // The WIRE, not just the round trip: object equality after a deserialize would still hold
+        // if the JSON shape drifted (a renamed or dropped $type, a differently-nested frames array),
+        // because both ends move together. The view reads this JSON, so pin the JSON.
+        json.Should().Contain("\"frames\":[",
+            because: "the frames array is the payload the presenter renders every slide from");
+        Regex.Matches(json, "\"\\$type\":\"SlideFrame\"").Count.Should().Be(2,
+            because: "each frame must carry its discriminator — without it a hub that has not " +
+                     "registered SlideFrame reads untyped JsonElements and the deck renders empty");
+        json.Should().Contain("\"startIndex\":1", because: "the opening slide travels on the wire");
+        json.Should().Contain("\"urlTemplate\":\"/MyDeck/Present?i={0}\"",
+            because: "the address-bar template is what keeps a client-side swap deep-linkable");
+        json.Should().NotContain("\"background\":null",
+            because: "a slide with no background of its own omits the field rather than sending null");
+
         var back = JsonSerializer.Deserialize<UiControl>(json, options)
             .Should().BeOfType<SlideShowControl>().Subject;
 
@@ -78,6 +94,16 @@ public class SlideShowControlTest(ITestOutputHelper output) : HubTestBase(output
         var control = new SlideShowControl { NextHref = "/d/Present?i=1", ExitHref = "/d" };
 
         var json = JsonSerializer.Serialize<UiControl>(control, options);
+        Output.WriteLine(json);
+
+        // The progressive-enhancement contract, asserted as the BYTES an href-only client receives:
+        // an href-mode slide show must serialise exactly as it did before frames mode existed. The
+        // three new fields are absent, not null — React and React Native present from this payload
+        // and must see nothing new in it.
+        json.Should().Be(
+            $$"""{"$type":"SlideShowControl","nextHref":"/d/Present?i=1","exitHref":"/d","moduleName":"{{ModuleSetup.ModuleName}}","apiVersion":"{{ModuleSetup.ApiVersion}}","skins":[]}""",
+            because: "adding frames mode must not change one byte of the href-mode wire shape");
+
         var back = JsonSerializer.Deserialize<UiControl>(json, options)
             .Should().BeOfType<SlideShowControl>().Subject;
 

--- a/test/MeshWeaver.Layout.Test/SlideShowControlTest.cs
+++ b/test/MeshWeaver.Layout.Test/SlideShowControlTest.cs
@@ -1,0 +1,88 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using MeshWeaver.Domain;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Pins the frames-mode contract of <see cref="SlideShowControl"/> (client-side slide swapping):
+/// the pre-rendered frames, the start index and the address-bar template must survive the hub
+/// serializer byte-for-byte, because the Blazor view renders EVERY frame from this payload and
+/// swaps them without any further server round trip — a frame lost or reordered on the wire is
+/// a slide silently missing from the presentation.
+/// </summary>
+public class SlideShowControlTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutTypes();
+
+    [Fact]
+    public void Frames_mode_round_trips_through_the_hub_serializer()
+    {
+        var options = GetClient().JsonSerializerOptions;
+        var control = new SlideShowControl
+        {
+            Frames = ImmutableList.Create(
+                new SlideFrame("<h1>One</h1>", "linear-gradient(135deg,#0b1020,#4c1d95)"),
+                new SlideFrame("<h1>Two</h1>", null)),
+            StartIndex = 1,
+            UrlTemplate = "/MyDeck/Present?i={0}",
+            ExitHref = "/MyDeck",
+        };
+
+        var json = JsonSerializer.Serialize<UiControl>(control, options);
+        Output.WriteLine(json);
+        var back = JsonSerializer.Deserialize<UiControl>(json, options)
+            .Should().BeOfType<SlideShowControl>().Subject;
+
+        back.Frames.Should().NotBeNull();
+        back.Frames!.Should().HaveCount(2);
+        back.Frames![0].Should().Be(new SlideFrame("<h1>One</h1>", "linear-gradient(135deg,#0b1020,#4c1d95)"));
+        back.Frames![1].Should().Be(new SlideFrame("<h1>Two</h1>", null));
+        back.StartIndex.Should().Be(1);
+        back.UrlTemplate.Should().Be("/MyDeck/Present?i={0}");
+        back.ExitHref.Should().Be("/MyDeck");
+    }
+
+    /// <summary>
+    /// <see cref="SlideFrame"/> must be registered EXPLICITLY by <c>AddLayoutTypes</c>, exactly like
+    /// the other plain records that ride inside control state (KpiItem, TowerBand, ComparisonPair,
+    /// Icon). It is not an <c>IUiControl</c>, so the reflection sweep cannot see it — and without an
+    /// explicit registration the polymorphic writer emits an auto short-name that the RECEIVING hub
+    /// adopts as a side effect of the read. That fallback makes the round-trip above pass while the
+    /// contract is still missing, so this asserts the registry BEFORE anything is serialised: a hub
+    /// that never happens to read a frame first would hand the view untyped JsonElements, and a deck
+    /// whose frames read as absent presents no slides at all.
+    /// </summary>
+    [Fact]
+    public void SlideFrame_is_explicitly_registered_on_the_hub()
+    {
+        var typeRegistry = GetClient().ServiceProvider.GetRequiredService<ITypeRegistry>();
+
+        typeRegistry.TryGetCollectionName(typeof(SlideFrame), out var typeName).Should().BeTrue(
+            "AddLayoutTypes must register SlideFrame explicitly — the IUiControl sweep cannot see it");
+        typeName.Should().Be(nameof(SlideFrame));
+        typeRegistry.TryGetType(nameof(SlideFrame), out var definition).Should().BeTrue();
+        definition!.Type.Should().Be(typeof(SlideFrame));
+    }
+
+    [Fact]
+    public void Href_mode_stays_the_legacy_wire_shape()
+    {
+        var options = GetClient().JsonSerializerOptions;
+        var control = new SlideShowControl { NextHref = "/d/Present?i=1", ExitHref = "/d" };
+
+        var json = JsonSerializer.Serialize<UiControl>(control, options);
+        var back = JsonSerializer.Deserialize<UiControl>(json, options)
+            .Should().BeOfType<SlideShowControl>().Subject;
+
+        back.Frames.Should().BeNull("no frames means the original href-driver behavior");
+        back.NextHref.Should().Be("/d/Present?i=1");
+        back.ExitHref.Should().Be("/d");
+    }
+}


### PR DESCRIPTION
## What changed

`SlideShowControl` gains **frames mode**: `Frames` (every slide pre-rendered as `SlideFrame { Html, Background }`), `StartIndex`, and `UrlTemplate`. A non-empty `Frames` tells a capable client to hold the whole deck and swap slides locally — advancing a slide costs no server round trip and cannot fail on a broken one.

Frames mode is a **progressive enhancement of the wire shape**, not a replacement: the href fields keep their exact meaning, so a producer emitting frames should keep populating them, and href-only clients (React, React Native) ignore the new payload and present exactly as they do today.

`SlideFrame` is registered explicitly in `AddLayoutTypes` — see below.

## Why this PR exists (the split of #2179)

#2179 cannot merge. Two of its four files — `SlideShowView.razor` and `SlideShowView.razor.js` — **moved to MeshWeaver.Plugins** in the GUI extraction, so merging `main` into that branch produces a `modify/delete` conflict. Resolving it the obvious way (accept the deletion) silently discards frames mode with nothing left to show it had gone, which is the failure mode that lost a merged icon fix earlier today (Plugins#711).

So #2179 is being landed as two PRs, **core first**:

1. **this PR** — the control, its type registration, and its test.
2. **MeshWeaver.Plugins** — the view + JS driver, ported by content onto the current plugins copy.

Core must land first: the plugins `portal-hosts` job builds against a checkout of `Systemorph/MeshWeaver@main`, so the view can only reference a shape that is already on main here.

## The defect this fixes on the way

`SlideFrame` was not registered in the type registry. It is not an `IUiControl`, so `AddLayoutTypes`' reflection sweep cannot see it, and it rides *inside* control state — the same shape as `KpiItem` / `TowerBand` / `ComparisonPair` / `Icon`, each of which is listed there for exactly this reason. Unregistered, the polymorphic writer emits an auto short-name that the **receiving** hub adopts as a side effect of the read (the resolver logs it: `Unregistered type MeshWeaver.Layout.SlideFrame … auto short-name`); a hub that has not yet read a frame hands the view untyped `JsonElement`s instead — a deck that renders with no slides in it.

The round-trip test passes either way, because the fallback cures it in-process. So the guard asserts the **registry**, before anything is serialised.

## How it was tested

- `SlideShowControlTest` — 3/3 green:
  - frames payload round-trips the hub serializer (`$type: SlideFrame` on the wire, unchanged by the registration);
  - href mode keeps the legacy wire shape;
  - `SlideFrame` is explicitly registered — **verified by falsification**: removing `typeof(SlideFrame)` from `AddLayoutTypes` makes exactly that test fail, and nothing else does.
- Full `MeshWeaver.Layout.Test` suite: **431/431** green.
- `MeshWeaver.Layout` + `MeshWeaver.Layout.Test` + `MeshWeaver.Documentation.Test` build clean with `-c Release -warnaserror`; What's New + documentation link-integrity tests green.

## What this PR does NOT do

Nothing emits `Frames` yet. The producer is the Publish module's deck `Present` area, which is **in-mesh source** in MeshWeaver.Plugins (`Publish/Deck/Source/DeckLayoutAreas.cs`) and is compiled in CI against the *pinned platform image* — so it can only switch over once this change reaches a published core image. Until then decks present exactly as they do today, and the What's New entry says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)