### PR TITLE
Progress-streaming tests gate the script on an attached subscriber (#2421 was a subscribe-late race, not batching)

### DIFF
--- a/test/MeshWeaver.AI.Test/ActivityLogStreamTest.cs
+++ b/test/MeshWeaver.AI.Test/ActivityLogStreamTest.cs
@@ -96,11 +96,16 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Polling progress: a script writes 4 log lines spaced ~150 ms apart. Subscribers
-    /// of the ActivityLog stream must see the message count grow GRADUALLY — not just
-    /// the final 4-message snapshot. Proves the Activity-hosted kernel publishes
-    /// intermediate snapshots via <c>DataChangeRequest.Update</c> as the script runs,
-    /// instead of buffering everything until the script returns.
+    /// Progress streaming: a script writes 4 log lines, each in its own publish window.
+    /// Subscribers of the ActivityLog stream must see the message count grow GRADUALLY — not just
+    /// the final 4-message snapshot. Proves the Activity-hosted kernel publishes intermediate
+    /// snapshots via <c>stream.Update</c> as the script runs, instead of buffering everything
+    /// until the script returns.
+    ///
+    /// <para>🚨 Gated on a <see cref="ProgressGate"/> — see that type for why counting a
+    /// subscriber's snapshots is racy without one, and for the #2421 measurement. The steps are
+    /// 250 ms because <c>ActivityLogLogger</c> coalesces running-state publishes into 100 ms
+    /// windows; one step per window is what "gradually" can mean here.</para>
     /// </summary>
     [Fact]
     public async Task Progress_Messages_Stream_Gradually_Not_Just_At_The_End()
@@ -114,53 +119,61 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
             NodeType = "Code",
             Content = new CodeConfiguration
             {
-                Code = """
+                Code = ProgressGate.ScriptPrologue + """
                        Log.LogInformation("step-1");
-                       System.Threading.Thread.Sleep(200);
+                       System.Threading.Thread.Sleep(250);
                        Log.LogInformation("step-2");
-                       System.Threading.Thread.Sleep(200);
+                       System.Threading.Thread.Sleep(250);
                        Log.LogInformation("step-3");
-                       System.Threading.Thread.Sleep(200);
+                       System.Threading.Thread.Sleep(250);
                        Log.LogInformation("step-4");
                        """,
                 IsExecutable = true
             }
         }).Should().Within(30.Seconds()).Emit();
 
+        var gatePath = await ProgressGate.Seed(mesh, ScriptsPartition);
+
         var exec = (await Mesh.Observe(
-            new ExecuteScriptRequest(),
+            new ExecuteScriptRequest { Inputs = ProgressGate.Inputs(gatePath) },
             o => o.WithTarget(new Address(path)))
             .Should().Within(60.Seconds()).Emit()).Message;
         exec.Success.Should().BeTrue(exec.Error ?? "exec failed");
         exec.ActivityLog.Should().NotBeNullOrEmpty();
 
-        // Collect every distinct snapshot we observe up to and including the
-        // 4-message terminal state. Each snapshot is the full ActivityLog at
-        // that moment; the count of messages grows monotonically.
+        // ONE subscription feeds both the "am I attached?" await and the collection below —
+        // Replay means waiting for attachment cannot cost us the emissions that follow it.
         var workspace = GetClient().GetWorkspace();
-        // Stream every distinct message-count. Close as soon as we observe the
-        // terminal snapshot (4 messages) by using TakeUntil — and re-include
-        // that final emission via the wrapping Concat.
-        var counts = workspace
+        var live = workspace
             .GetMeshNodeStream(exec.ActivityLog!)
-            .Select(change => change?.Content as ActivityLog)
-            .Where(log => log is not null)
-            .Select(log => log!.Messages.Count)
-            .DistinctUntilChanged();
+            .Select(change => (change?.Content as ActivityLog)?.Messages.Count ?? 0)
+            .Replay();
+        using var connection = live.Connect();
 
-        var snapshots = await counts
-            .Where(c => c <= 4)
+        (await live.Should().Within(30.Seconds()).Emit()).Should().Be(0,
+            "the gate must still be shut when the subscription is established — a non-empty first "
+            + "snapshot means the script ran ahead of the gate, and this test would then be "
+            + "measuring subscribe latency instead of gradual delivery");
+
+        // Armed BEFORE the gate opens: ObservableAssertions attaches synchronously on the
+        // calling thread, so nothing between here and the flip below slips past unobserved.
+        var collected = live
+            .DistinctUntilChanged()
             .TakeUntil(c => c >= 4)
             .ToList()
             .Should().Within(30.Seconds()).Emit();
 
-        // Gradual streaming → at least 3 distinct snapshots before we hit 4.
+        await ProgressGate.Release(workspace, gatePath).Should().Within(30.Seconds()).Emit();
+
+        var snapshots = await collected;
+
+        // Gradual streaming → at least 3 distinct snapshots carrying progress.
         // (We allow batching of two adjacent log calls but not all-at-once.)
-        snapshots.Should().HaveCountGreaterThanOrEqualTo(3,
+        snapshots.Where(c => c > 0).Should().HaveCountGreaterThanOrEqualTo(3,
             "ActivityLog should publish intermediate snapshots as messages land — " +
             "not buffer everything until script completion. Snapshots seen: [" +
             string.Join(", ", snapshots) + "]");
-        snapshots.Last().Should().Be(4, "terminal snapshot must contain all 4 log lines");
+        snapshots[^1].Should().Be(4, "the last snapshot must contain all 4 log lines");
     }
 
     [Fact]

--- a/test/MeshWeaver.AI.Test/ActivityLogStreamTest.cs
+++ b/test/MeshWeaver.AI.Test/ActivityLogStreamTest.cs
@@ -143,10 +143,15 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
 
         // ONE subscription feeds both the "am I attached?" await and the collection below —
         // Replay means waiting for attachment cannot cost us the emissions that follow it.
-        var workspace = GetClient().GetWorkspace();
+        // 🚨 ContentAs, never `as ActivityLog`: content reaching a CLIENT hub can legitimately
+        // arrive as untyped JSON, and a silent null would read here as "0 messages" — i.e. as a
+        // passing attach guard followed by an opaque timeout.
+        var client = GetClient();
+        var workspace = client.GetWorkspace();
         var live = workspace
             .GetMeshNodeStream(exec.ActivityLog!)
-            .Select(change => (change?.Content as ActivityLog)?.Messages.Count ?? 0)
+            .Select(change => change.ContentAs<ActivityLog>(client.JsonSerializerOptions)
+                ?.Messages.Count ?? 0)
             .Replay();
         using var connection = live.Connect();
 

--- a/test/MeshWeaver.AI.Test/ProgressGate.cs
+++ b/test/MeshWeaver.AI.Test/ProgressGate.cs
@@ -1,0 +1,71 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Reactive.Assertions;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// A happens-before for tests that assert a subscriber observes script progress INCREMENTALLY.
+///
+/// <para>🚨 Such a test is racy by construction unless the subscriber is provably attached before
+/// the script logs anything, and "attached" is not something a test may assume.
+/// <c>GetMeshNodeStream</c>'s first emission is the OWNER's snapshot AT SUBSCRIBE TIME, so a
+/// subscription that lands after the run has finished correctly sees ONE terminal snapshot
+/// carrying the whole history — no batching anywhere, and an assertion counting snapshots reads
+/// that as a framework defect. #2421 is the recorded instance: a ~350 ms run against a ~914 ms
+/// subscribe under CI contention, reported as <c>Observed: [4@914ms], but found 1</c>.</para>
+///
+/// <para>The gate closes that by inverting the order: the script BLOCKS on a node until the test
+/// — having seen its own first snapshot of the activity — flips it. Waiting is reactive
+/// (<c>GetMeshNodeStream(...).Where(...).FirstAsync()</c>), never a poll or a sleep, and the
+/// open/shut literals live here so the script text and the test's flip cannot drift apart.</para>
+/// </summary>
+internal static class ProgressGate
+{
+    /// <summary><c>ExecuteScriptRequest.Inputs</c> key carrying the gate node's path.</summary>
+    private const string InputKey = "gate";
+
+    /// <summary><see cref="MeshNode.Name"/> of a gate that has been released.</summary>
+    private const string OpenMarker = "go";
+
+    /// <summary>
+    /// Prepend to a script body (it opens with <c>using</c> directives, which C# scripting requires
+    /// before any statement). Blocks the run until <see cref="Release"/> flips the gate node.
+    /// </summary>
+    public const string ScriptPrologue = $$"""
+        using System.Reactive.Threading.Tasks;
+        // Wait for the test's go-ahead. It flips this node only after its subscription to the
+        // activity has produced a first snapshot — so everything logged below is guaranteed to
+        // happen with a live subscriber attached.
+        await Mesh.GetMeshNodeStream(Inputs["{{InputKey}}"].GetString()!)
+            .Where(node => node is not null && node.Name == "{{OpenMarker}}")
+            .FirstAsync().ToTask(Ct);
+
+        """;
+
+    /// <summary>Creates a shut gate node in <paramref name="partition"/> and returns its path.</summary>
+    public static async Task<string> Seed(IMeshService mesh, string partition)
+    {
+        var id = $"gate-{Guid.NewGuid():N}";
+        // Plain node, no content — Name alone carries the open/shut bit.
+        await mesh.CreateNode(new MeshNode(id, partition) { Name = "wait", NodeType = "Markdown" })
+            .Should().Within(TimeSpan.FromSeconds(30)).Emit();
+        return $"{partition}/{id}";
+    }
+
+    /// <summary>The <c>Inputs</c> payload that tells the script which gate to wait on.</summary>
+    public static ImmutableDictionary<string, JsonElement> Inputs(string gatePath)
+        => ImmutableDictionary<string, JsonElement>.Empty
+            .Add(InputKey, JsonSerializer.SerializeToElement(gatePath));
+
+    /// <summary>Opens the gate. Cold — the caller subscribes (typically by awaiting the assertion).</summary>
+    public static IObservable<MeshNode> Release(IWorkspace workspace, string gatePath)
+        => workspace.GetMeshNodeStream(gatePath).Update(node => node with { Name = OpenMarker });
+}

--- a/test/MeshWeaver.AI.Test/ScriptExecutionInUserHomeTest.cs
+++ b/test/MeshWeaver.AI.Test/ScriptExecutionInUserHomeTest.cs
@@ -100,45 +100,112 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
     }
 
     /// <summary>
-    /// Subscribers must observe progress messages **as they are emitted**, not
-    /// only at the terminal snapshot. Each step in the script sleeps ~80 ms;
-    /// we record the wall-clock time we observed each new message-count and
-    /// assert no two adjacent observations are squashed into a single tick at
-    /// the end. That proves the executor isn't blocking the activity hub.
+    /// Number of progress lines <see cref="GatedFireworksScript"/> logs once released.
+    /// </summary>
+    private const int ProgressLines = 4;
+
+    /// <summary>
+    /// The fireworks script, held at a <see cref="ProgressGate"/> until the subscriber is
+    /// provably attached.
+    ///
+    /// <para>The steps are 250 ms rather than the 80 ms this test used to sleep because
+    /// <c>ActivityLogLogger</c> deliberately coalesces running-state publishes into 100 ms
+    /// windows (its <c>ThrottleMs</c>): four messages inside 240 ms are ENTITLED to arrive as
+    /// two snapshots, so the old script asserted more than the publisher ever promised. One
+    /// step per throttle window is what "incremental" actually means here.</para>
+    /// </summary>
+    private const string GatedFireworksScript = ProgressGate.ScriptPrologue + """
+        Log.LogInformation("Loading fuse...");
+        System.Threading.Thread.Sleep(250);
+        Log.LogInformation("Lighting...");
+        System.Threading.Thread.Sleep(250);
+        Log.LogInformation("3... 2... 1...");
+        System.Threading.Thread.Sleep(250);
+        Log.LogInformation("Boom!");
+        MeshWeaver.Layout.Controls.Html(
+            "<div style='font-size:48px;text-align:center;animation:pulse 1s infinite'>" +
+            "🎆 🎇 🎆 🎇 🎆" +
+            "</div>")
+        """;
+
+    /// <summary>
+    /// Subscribers must observe progress messages <b>as they are emitted</b>, not only at the
+    /// terminal snapshot — that is what proves the executor never blocks the activity hub.
+    ///
+    /// <para>🚨 The subscriber has to be ATTACHED before the progress it asserts on exists, and
+    /// "attached" is not something a test may assume. <c>GetMeshNodeStream</c>'s first emission is
+    /// the OWNER's snapshot AT SUBSCRIBE TIME, so a subscription that lands after the run finished
+    /// correctly sees one terminal snapshot carrying the whole history — no batching anywhere.
+    /// That is exactly what #2421 recorded (<c>Observed: [4@914ms], but found 1</c>): a ~350 ms run
+    /// and a ~914 ms subscribe under CI contention. Measured, not reasoned — delaying this test's
+    /// subscribe by 900 ms reproduces that line verbatim, while a 1.5 s-per-step script delivers
+    /// every step to an attached subscriber within 1–3 ms of its own timestamp.</para>
+    ///
+    /// <para>So the script BLOCKS on a gate node until this test has seen its first snapshot of
+    /// THIS activity, and the test asserts that snapshot is EMPTY. The happens-before is then
+    /// established rather than raced, and no timing bound is involved.</para>
     /// </summary>
     [Fact]
     public async Task Run_StreamsProgressTimely_NotBuffered()
     {
-        var (codePath, _) = await SeedExecutableCode(FireworksScript);
+        var (codePath, mesh) = await SeedExecutableCode(GatedFireworksScript);
+        var gatePath = await ProgressGate.Seed(mesh, UserHome);
 
         var execMessage = (await Mesh.Observe(
-            new ExecuteScriptRequest(),
+            new ExecuteScriptRequest { Inputs = ProgressGate.Inputs(gatePath) },
             o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;
-        execMessage.Success.Should().BeTrue();
+        execMessage.Success.Should().BeTrue(execMessage.Error ?? "exec failed");
         var activityPath = execMessage.ActivityLog!;
 
         var sw = Stopwatch.StartNew();
         var workspace = GetClient().GetWorkspace();
-        var observations = await workspace
+        // ONE subscription feeds both the "am I attached?" await and the collection below —
+        // Replay means waiting for attachment cannot cost us the emissions that follow it.
+        var live = workspace
             .GetMeshNodeStream(activityPath)
-            .Select(change => (Count: (change?.Content as ActivityLog)?.Messages.Count ?? 0,
-                               ElapsedMs: sw.ElapsedMilliseconds))
-            .DistinctUntilChanged(o => o.Count)
+            .Select(node => (Log: node?.Content as ActivityLog, ElapsedMs: sw.ElapsedMilliseconds))
+            .Replay();
+        using var connection = live.Connect();
+
+        var attached = await live.Should().Within(30.Seconds()).Emit();
+        (attached.Log?.Messages.Count ?? 0).Should().Be(0,
+            "the gate must still be shut when the subscription is established — a non-empty first "
+            + "snapshot means the script ran ahead of the gate, and this test would then be "
+            + "measuring subscribe latency instead of incremental delivery");
+
+        // Armed BEFORE the gate opens: ObservableAssertions attaches synchronously on the calling
+        // thread, so nothing between here and the flip below can slip past unobserved.
+        var collected = live
+            .DistinctUntilChanged(o => o.Log?.Messages.Count ?? 0)
             // 4 progress lines. The fireworks RETURN VALUE is a control, which UpdateView renders
             // and KernelExecutor deliberately does not also log — so it never becomes a message.
-            .TakeUntil(o => o.Count >= 4)
+            // Terminal status also ends the take, so a script that FAILS reports through the
+            // assertions below instead of timing out with nothing to read.
+            .TakeUntil(o => (o.Log?.Messages.Count ?? 0) >= ProgressLines
+                            || o.Log is { Status: not ActivityStatus.Running })
             .ToList()
             .Should().Within(30.Seconds()).Emit();
 
-        observations.Should().HaveCountGreaterThanOrEqualTo(3,
-            "subscribers should observe at least 3 distinct snapshots before the terminal one — "
-            + "single-tick delivery would mean the executor blocked the activity hub. Observed: ["
-            + string.Join(", ", observations.Select(o => $"{o.Count}@{o.ElapsedMs}ms")) + "]");
+        // Only now does the script get to log anything.
+        await ProgressGate.Release(workspace, gatePath).Should().Within(30.Seconds()).Emit();
 
-        observations.Last().Count.Should().Be(4,
-            "terminal snapshot should contain the 4 progress messages; the fireworks return value "
-            + "is a control, rendered by UpdateView rather than logged as its record ToString()");
+        var observations = await collected;
+        var seen = "Observed: ["
+            + string.Join(", ", observations.Select(o =>
+                $"{o.Log?.Messages.Count ?? 0}@{o.ElapsedMs}ms/{o.Log?.Status}"))
+            + "]";
+
+        observations.Where(o => (o.Log?.Messages.Count ?? 0) > 0).Should()
+            .HaveCountGreaterThanOrEqualTo(3,
+                "an attached subscriber must observe the progress lines arriving one throttle "
+                + "window at a time — single-tick delivery would mean the executor blocked the "
+                + "activity hub. " + seen);
+
+        (observations[^1].Log?.Messages.Count ?? 0).Should().Be(ProgressLines,
+            "the last snapshot should contain the 4 progress messages; the fireworks return value "
+            + "is a control, rendered by UpdateView rather than logged as its record ToString(). "
+            + seen);
     }
 
     /// <summary>

--- a/test/MeshWeaver.AI.Test/ScriptExecutionInUserHomeTest.cs
+++ b/test/MeshWeaver.AI.Test/ScriptExecutionInUserHomeTest.cs
@@ -159,12 +159,18 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
         var activityPath = execMessage.ActivityLog!;
 
         var sw = Stopwatch.StartNew();
-        var workspace = GetClient().GetWorkspace();
+        var client = GetClient();
+        var workspace = client.GetWorkspace();
         // ONE subscription feeds both the "am I attached?" await and the collection below —
         // Replay means waiting for attachment cannot cost us the emissions that follow it.
+        // 🚨 ContentAs, never `as ActivityLog`: content reaching a CLIENT hub can legitimately
+        // arrive as untyped JSON, and a silent null would read here as "0 messages" — i.e. as a
+        // passing attach guard followed by an opaque timeout, the worst possible failure shape
+        // for this test.
         var live = workspace
             .GetMeshNodeStream(activityPath)
-            .Select(node => (Log: node?.Content as ActivityLog, ElapsedMs: sw.ElapsedMilliseconds))
+            .Select(node => (Log: node.ContentAs<ActivityLog>(client.JsonSerializerOptions),
+                             ElapsedMs: sw.ElapsedMilliseconds))
             .Replay();
         using var connection = live.Connect();
 


### PR DESCRIPTION
Closes #2421.

## Verdict: the production progress path was CORRECT. The test was racing its own subscription.

#2421 reported `Run_StreamsProgressTimely_NotBuffered` seeing **one** snapshot already carrying all
four progress messages (`Observed: [4@914ms], but found 1`) and offered two mechanisms with opposite
fixes: a #2377-style trampoline batching defect on the progress path, or a subscribe-late race in
the test. They were split by **measurement**, not by picking the likelier one.

### (A) batching on the progress path — DISPROVEN

Widen the script's steps to 1500 ms so each publish window is unambiguous, and every write reaches
the subscriber **as its own emission within 1–3 ms of its own `LogMessage.Timestamp`**:

```
=== SLOW(1500ms steps) ===  emissions = 6
  emit @+  492ms  count=1   msgs: 17.494 A
  emit @+ 1982ms  count=2   msgs: … 18.996 B
  emit @+ 3482ms  count=3   msgs: … 20.497 C
  emit @+ 4983ms  count=4   msgs: … 21.998 D
  emit @+ 4991ms  count=4   status=Succeeded
```

Nothing batches. Consistent with the code: **zero** bare `.ToObservable()` anywhere on that path
(`MeshWeaver.Kernel.Hub`, `MeshWeaver.Kernel`, `MeshWeaver.Data.Contract`), and `KernelExecutor`
already runs off the hub (`SubscribeOn(TaskPoolScheduler.Default)` + the bounded Compile `IIoPool`).

**`BareToObservableOnReadPathGuard`'s `ScannedRoots` therefore stays as it is.** It is storage-only
and the progress path is outside it — but a ratchet guard widens on a demonstrated violation, and
there is none here.

### (B) subscribe-late — REPRODUCES THE CI LINE VERBATIM

`GetMeshNodeStream(path)`'s first emission is the **owner's snapshot at subscribe time**. Delay the
subscribe by 900 ms — what CI actually paid — and the reported failure comes back exactly:

```
=== FAST(80ms steps) + 900ms subscribe delay ===  emissions = 1
  emit @+  931ms  status=Succeeded count=4
  writes-before-first-emission: 4/4
```

Without the delay the same script gives `0@44ms, 1@86ms, 3@247ms, 4@335ms` — the healthy first
emission is **empty**. That is the discriminator: a good run's initial snapshot carries 0 messages,
the CI failure's carried 4. The CI log agrees — response at `18:43:45.920`, `TEST END` at
`18:43:46.845`; the sole emission at 914 ms landed at the very end of a 925 ms window, after a
~350 ms run had already finished.

So one terminal snapshot carrying the whole history was the **correct** answer to a late
subscription. **Nothing in `src/` changes.**

## The fix: a happens-before, not a wider bound

The ≥3-snapshot assertion is right and is **not** weakened — it is strengthened to count only
snapshots that carry progress. What was missing is the guarantee that the subscriber is *attached*
before the progress it counts exists, and "attached" is not something a test may assume.

New `ProgressGate` (test-only): the script blocks reactively on a gate node until the test — having
observed its own first snapshot of that activity — flips it. The test **asserts that first snapshot
is empty** before releasing, so a broken gate fails loudly instead of silently re-opening the race.
No sleep, no poll, no timing bound.

Two things found while measuring:

- The old 80 ms steps sat **below `ActivityLogLogger`'s 100 ms publish-coalescing window**, so four
  messages inside 240 ms were entitled to arrive as two snapshots. The *stimulus* was
  under-specified, not the tolerance — steps are now 250 ms, one per window.
- `ActivityLogStreamTest.Progress_Messages_Stream_Gradually_Not_Just_At_The_End` carried the
  **identical** subscribe-after-response race and the identical assertion. Gated the same way rather
  than left to flake into a second investigation.

## Verification that can fail

Forcing `ActivityLogLogger.ThrottleMs` to 5000 so the publisher genuinely coalesces makes the new
test **fail**, with the attach guard still holding:

```
Expected collection to have at least 3 item(s) … Observed: [0@54ms/Running, 1@539ms/Running, 4@1296ms/Succeeded], but found 2.
```

Reverted, of course — `src/` is untouched in this PR. Both affected test classes pass locally
(12/12), and `dotnet build test/MeshWeaver.AI.Test -c Release -warnaserror` is clean:
`0 Warning(s), 0 Error(s)`.

## Not folded in

The two `ROUTER_TRAFFIC` errors in the same log are **unrelated to the batching** — they appear in
every measurement run above, including the ones that delivered every write incrementally. They are a
test-harness violation (`MonolithMeshTestBase.Mesh` *is* the root mesh hub, and 32 test files use it
as a request client). Filed as **#2423** with the evidence.

No What's New entry: test-only change, no user-visible behaviour difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
