### PR TITLE
The gRPC Kestrel test owns its ports — closes the FreePort() TOCTOU race (#2379)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-grpc-test-no-longer-loses-its-port.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-grpc-test-no-longer-loses-its-port.md
@@ -1,0 +1,21 @@
+---
+Name: A gRPC test no longer loses its port to another process
+Category: Fix
+Description: A test that picked a free port and released it before use could red an unrelated pull request when anything else on the machine took that port first.
+Icon: Sparkle
+Order: -20260826
+---
+
+# A gRPC test no longer loses its port to another process
+
+The trusted-endpoint test needed two free network ports before it could start its server, and it
+found them the usual way: open a socket, ask the operating system which port it assigned, then close
+it again. Between that close and the server's own bind, the port belonged to nobody — so anything
+else on the machine could take it, and the server then refused to start with *address already in
+use*. On a quiet machine the gap is invisible; on a loaded build agent it is wide enough to catch,
+which is how the failure kept appearing on pull requests that had not touched the code at all.
+
+The test now keeps the socket it opened and hands that same socket to the server, so the port is
+owned continuously and there is no moment for anything else to claim it. A new check runs the losing
+interleaving on purpose — a rival process grabbing the port at exactly the wrong instant — and fails
+if the port is ever left unowned again.

--- a/test/MeshWeaver.Hosting.Grpc.Test/MeshGrpcTrustedKestrelTest.cs
+++ b/test/MeshWeaver.Hosting.Grpc.Test/MeshGrpcTrustedKestrelTest.cs
@@ -15,6 +15,7 @@ using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -52,26 +53,33 @@ public class MeshGrpcTrustedKestrelTest(ITestOutputHelper output) : MonolithMesh
     [Fact]
     public async Task Trusted_port_is_detected_on_real_kestrel_with_config_bound_options()
     {
-        var publicPort = FreePort();
-        var trustedPort = FreePort();
+        using var publicPort = LoopbackPort.Reserve();
+        using var trustedPort = LoopbackPort.Reserve();
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
-        // The exact shape the helm chart injects: Grpc__TrustedPort → Grpc:TrustedPort.
+        // The exact shape the helm chart injects: Grpc__TrustedPort → Grpc:TrustedPort. The number
+        // has to be known BEFORE the host starts — which is why the endpoints cannot simply bind :0
+        // and read the port back afterwards, and why the ports are RESERVED instead (see LoopbackPort).
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["Grpc:TrustedPort"] = trustedPort.ToString(),
+            ["Grpc:TrustedPort"] = trustedPort.Port.ToString(),
         });
         builder.Services.AddGrpc();
         builder.Services.AddOptions<GrpcOptions>().BindConfiguration(GrpcOptions.SectionName);
         // The gRPC service resolves the MESH's hub + registry (the app is just the transport shell).
         builder.Services.AddSingleton(Mesh);
         builder.Services.AddSingleton(Mesh.ServiceProvider.GetRequiredService<GrpcConnectionRegistry>());
+        LoopbackPort.Handover(builder.Services, publicPort, trustedPort);
         builder.WebHost.ConfigureKestrel(kestrel =>
         {
             // h2c needs a dedicated Http2 endpoint — the same layout the chart configures.
-            kestrel.ListenLocalhost(publicPort, l => l.Protocols = HttpProtocols.Http2);
-            kestrel.ListenLocalhost(trustedPort, l => l.Protocols = HttpProtocols.Http2);
+            // Listen(IPAddress.Loopback, …), not ListenLocalhost: the latter binds the IPv4 AND the
+            // IPv6 loopback, i.e. TWO sockets for one port number, and only one of them can be the
+            // reserved one. The clients below therefore dial 127.0.0.1 explicitly — which is also
+            // the address GrpcOptions.TrustedPort documents (http://127.0.0.1:{TrustedPort}).
+            kestrel.Listen(IPAddress.Loopback, publicPort.Port, l => l.Protocols = HttpProtocols.Http2);
+            kestrel.Listen(IPAddress.Loopback, trustedPort.Port, l => l.Protocols = HttpProtocols.Http2);
         });
 
         await using var app = builder.Build();
@@ -80,14 +88,14 @@ public class MeshGrpcTrustedKestrelTest(ITestOutputHelper output) : MonolithMesh
         try
         {
             // 1) trusted + carried context → passes through (the gate acts as the requesting user).
-            Assert.Equal("alice", await WhoAmIOver($"http://localhost:{trustedPort}",
+            Assert.Equal("alice", await WhoAmIOver($"http://127.0.0.1:{trustedPort.Port}",
                 new AccessContext { ObjectId = "alice", Name = "Alice" }));
 
             // 2) trusted + no context → the well-known System principal.
-            Assert.Equal(WellKnownUsers.System, await WhoAmIOver($"http://localhost:{trustedPort}", null));
+            Assert.Equal(WellKnownUsers.System, await WhoAmIOver($"http://127.0.0.1:{trustedPort.Port}", null));
 
             // 3) public port + forged context → re-stamped to the connection's (Anonymous) identity.
-            Assert.Equal(WellKnownUsers.Anonymous, await WhoAmIOver($"http://localhost:{publicPort}",
+            Assert.Equal(WellKnownUsers.Anonymous, await WhoAmIOver($"http://127.0.0.1:{publicPort.Port}",
                 new AccessContext { ObjectId = "alice", Name = "Alice" }));
         }
         finally
@@ -134,12 +142,144 @@ public class MeshGrpcTrustedKestrelTest(ITestOutputHelper output) : MonolithMesh
         throw new TimeoutException("no WhoAmIResponse frame received");
     }
 
-    private static int FreePort()
+}
+
+/// <summary>
+/// Pins the ownership property <see cref="LoopbackPort"/> exists for (issue #2379), by running the
+/// interleaving that reds CI <b>deterministically</b> rather than waiting for a loaded runner to
+/// produce it: a rival grabs the port in the window between "which port is free?" and Kestrel's bind.
+/// </summary>
+public class LoopbackPortReservationTest
+{
+    /// <summary>
+    /// Both halves are load-bearing, and each fails against the discover-then-release shape this
+    /// replaced:
+    /// <list type="number">
+    /// <item>the rival is REFUSED — with a released port it wins, and Kestrel then cannot start
+    /// (<c>IOException: … address already in use</c>, the exact CI failure);</item>
+    /// <item>Kestrel binds and serves that port WHILE the reservation is still held — which is only
+    /// possible because it adopts the reserved socket. Drop the handover and this half fails, because
+    /// the reservation itself would be what blocks Kestrel.</item>
+    /// </list>
+    /// </summary>
+    [Fact]
+    public async Task Kestrel_binds_a_reserved_port_no_rival_can_take()
     {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
+        using var reserved = LoopbackPort.Reserve();
+
+        Assert.Equal(SocketError.AddressAlreadyInUse, RivalBind(reserved.Port));
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        LoopbackPort.Handover(builder.Services, reserved);
+        builder.WebHost.ConfigureKestrel(kestrel =>
+            kestrel.Listen(IPAddress.Loopback, reserved.Port, l => l.Protocols = HttpProtocols.Http1));
+
+        await using var app = builder.Build();
+        app.MapGet("/", () => "served");
+        await app.StartAsync();
+        try
+        {
+            using var http = new HttpClient();
+            Assert.Equal("served", await http.GetStringAsync($"http://127.0.0.1:{reserved.Port}/"));
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
     }
+
+    /// <summary>
+    /// What a competing process does to the port. Returns the refusal, or <c>null</c> when the rival
+    /// took it — which is what "the port was unowned for a moment" looks like from outside.
+    /// </summary>
+    private static SocketError? RivalBind(int port)
+    {
+        using var rival = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        try
+        {
+            rival.Bind(new IPEndPoint(IPAddress.Loopback, port));
+            rival.Listen(1);
+            return null;
+        }
+        catch (SocketException ex)
+        {
+            return ex.SocketErrorCode;
+        }
+    }
+}
+
+/// <summary>
+/// A loopback port this test <b>owns</b> from the moment it is chosen until Kestrel stops serving on
+/// it — the cure for the time-of-check/time-of-use race that the previous <c>FreePort()</c> helper
+/// was (issue #2379).
+///
+/// <para><b>The race.</b> <c>FreePort()</c> bound a socket to <c>:0</c>, read the port the kernel
+/// assigned, and then <b>released it</b>. Between that release and Kestrel's own bind the port is
+/// owned by nobody, so anything else on the machine — another test, another CI shard's process, an
+/// ephemeral outbound connection — can take it, and Kestrel then fails to start with
+/// <c>IOException: Failed to bind to address http://127.0.0.1:NNNNN: address already in use</c>. The
+/// window is narrow on an idle box and wide on a loaded CI runner, which is why it reads as a flake
+/// while being a plain ownership bug.</para>
+///
+/// <para><b>The cure is structural, not a retry.</b> The reservation socket is bound AND listening
+/// and is never closed: the kernel refuses every other bind for as long as this object lives, so the
+/// unowned window does not exist. Kestrel does not open a second socket for the port either — it is
+/// handed <i>this</i> one through <see cref="SocketTransportOptions.CreateBoundListenSocket"/>, so
+/// discovery and use are the same socket and there is nothing in between to lose. A retry loop, a
+/// wider port range or a sleep would each only make the window smaller
+/// (AGENTS.md → "No band-aids": never raise a bound to make a race less likely).</para>
+///
+/// <para>Binding <c>:0</c> and reading the port back from <c>IServerAddressesFeature</c> — the usual
+/// cure — is not available here: this test's whole subject is <c>Grpc:TrustedPort</c> bound from
+/// configuration <em>before</em> the host starts, so the number has to exist up front.</para>
+/// </summary>
+internal sealed class LoopbackPort : IDisposable
+{
+    private readonly Socket socket;
+
+    private LoopbackPort(Socket socket)
+    {
+        this.socket = socket;
+        Port = ((IPEndPoint)socket.LocalEndPoint!).Port;
+    }
+
+    /// <summary>The reserved port. Owned by this object — no other process can bind it.</summary>
+    public int Port { get; }
+
+    /// <summary>Takes a free loopback port and keeps listening on it.</summary>
+    public static LoopbackPort Reserve()
+    {
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        // Listen, not just Bind: a bound-but-not-listening socket already blocks rival binds, but
+        // Kestrel takes this exact socket over and expects a listener. Kestrel calls Listen again
+        // with its own backlog, which on every platform just updates the accept queue depth.
+        socket.Listen(512);
+        return new LoopbackPort(socket);
+    }
+
+    /// <summary>
+    /// Makes Kestrel adopt the reserved sockets instead of opening its own. The socket transport asks
+    /// this factory for the listen socket of every endpoint it binds; for a reserved port we hand
+    /// back the socket that already owns it, so the port is never re-acquired and can never be lost
+    /// in between.
+    /// </summary>
+    public static void Handover(IServiceCollection services, params LoopbackPort[] reserved) =>
+        services.Configure<SocketTransportOptions>(options =>
+        {
+            var byPort = reserved.ToDictionary(r => r.Port, r => r.socket);
+            var openNewSocket = options.CreateBoundListenSocket;
+            options.CreateBoundListenSocket = endpoint =>
+                endpoint is IPEndPoint ip && byPort.TryGetValue(ip.Port, out var mine)
+                    ? mine
+                    : openNewSocket(endpoint);
+        });
+
+    /// <summary>
+    /// Releases the port. Kestrel disposes the listen socket when it unbinds, and this disposes the
+    /// same <see cref="Socket"/> instance — one handle, so the second dispose is a no-op rather than
+    /// a double close.
+    /// </summary>
+    public void Dispose() => socket.Dispose();
 }


### PR DESCRIPTION
Closes #2379.

## The race

`MeshGrpcTrustedKestrelTest.FreePort()` bound a socket to `:0`, read the port the kernel assigned, and then **released it**. Kestrel bound that number later. Between the release and the bind the port was owned by nobody, so anything else on the machine — another test, another CI shard's process, an ephemeral outbound connection — could take it, and Kestrel then failed to start:

```
System.IO.IOException : Failed to bind to address http://127.0.0.1:35145: address already in use.
```

Narrow window on an idle box, wide one on a loaded runner — which is why it reads as a flake while being a plain ownership bug. It redded #2364, whose diff is three workflow YAMLs and one Documentation.Test guard.

## The fix — structural, not a retry

`LoopbackPort.Reserve()` binds **and listens** and never closes: the kernel refuses every rival bind for as long as it lives. Kestrel does not open a second socket for that port either — it is handed *this* one via `SocketTransportOptions.CreateBoundListenSocket`, so **discovery and use are the same socket** and there is nothing in between to lose.

No retry loop, no wider range, no sleep — each of those only makes the window smaller (AGENTS.md → "No band-aids": never raise a bound to make a race less likely).

The issue's option 1 — bind `:0` and read the port back from `IServerAddressesFeature` — is not available here: the test's whole subject is `Grpc:TrustedPort` bound from configuration **before** the host starts, so the number has to exist up front. Option 2 (`SO_REUSEADDR` alongside) and option 3 (reserving from the OS ephemeral range) are both declined for the reasons the issue gives.

`ListenLocalhost` → `Listen(IPAddress.Loopback, …)`: the former binds the IPv4 **and** IPv6 loopback, i.e. two sockets for one port number, and only one of them can be the reserved one. The clients now dial `127.0.0.1` explicitly — also the address `GrpcOptions.TrustedPort` documents (`http://127.0.0.1:{TrustedPort}`).

## The test fails without the fix — deterministically

`LoopbackPortReservationTest.Kestrel_binds_a_reserved_port_no_rival_can_take` runs the losing interleaving on purpose rather than waiting for a loaded runner to produce it. Both halves are load-bearing:

1. the rival must be **refused** — with a released port it wins;
2. Kestrel must bind that port **while the reservation is still held** — only possible because it adopts the reserved socket. Drop the handover and this half fails, because the reservation itself would be what blocks Kestrel.

**Evidence** (macOS 25.5.0, .NET 10.0.301, `-c Release -warnaserror`, 0 warnings / 0 errors):

- `Reserve()` temporarily regressed to the old release-after-discovery shape ⇒ the new test fails in **17 ms**: `Assert.Equal() Failure — Expected: AddressAlreadyInUse, Actual: null` (the rival took the port). No load needed.
- A standalone probe of the same regressed shape, with the rival *holding* the port, reproduces the issue's exact failure: `IOException: Failed to bind to address http://127.0.0.1:56067: address already in use.`
- With the fix: **20/20** iterations of the new test and **5/5** of the full 12-test project pass (68 s wall clock).

## Not in scope

Two other sites reserve-then-release the same way, and neither can use this cure:

- `test/MeshWeaver.Graph.Test/TestOgServer.cs:43` — `HttpListener` cannot be handed a socket;
- `test/MeshWeaver.Persistence.Test/StorageAndDb.cs:10` — hands the port to Azurite, an external process.

Both need a different fix; filing separately rather than widening this one. (`MeshGrpcLiveTest` already does the right thing — it binds `:0`, because it does not need the number up front.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)