### PR TITLE
Forward the six #2276 types that left MeshWeaver.AI without one (#2398)

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -227,8 +227,22 @@ jobs:
     - name: "Refuse a binary-breaking primary-constructor change"
       run: |
         set -euo pipefail
-        base="origin/${{ github.base_ref }}"
         git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
+        # 🚨 The MERGE BASE, not the base branch tip — same reasoning as the type-move gate below.
+        # This step disagreed with its own script until #2398: check-record-signatures.py's
+        # docstring says it compares "the merge base against the working tree", while the step
+        # handed it `origin/<base_ref>`.
+        #
+        # The half that was wrong is NOT the file list — that uses the three-dot
+        # `git diff --name-only {base}...HEAD`, which resolves the merge base itself. It is the
+        # BEFORE CONTENT: `git show {base}:{file}` reads the literal ref, so with the tip, a record
+        # whose primary constructor changed on main while this PR is open gets compared against
+        # THAT change rather than against what this PR branched from — and the PR reads as
+        # reverting it. A red on somebody else's commit, on a gate whose whole value is that people
+        # believe it. Passing the merge-base SHA fixes both halves consistently (`sha...HEAD`
+        # degenerates to `sha`, since it is an ancestor of HEAD).
+        base=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+        echo "Comparing against merge base $base"
         python3 scripts/check-record-signatures.py --base "$base"
     # The OTHER half of the same class (#2370): a public TYPE moving assemblies, which no repo-local
     # build can see. `landed-modules-gate` compiles the plugins repo's module SOURCE against this PR

--- a/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.AI;   // IProviderKeyProtector & co keep their ORIGINAL namespace in MeshWeaver.Mesh.Contract (#2398 forwarders)
 using MeshWeaver.Mesh.Security;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;

--- a/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.AI.Connect;   // IMcpBackConnection/McpConnectionInfo keep their ORIGINAL namespace in MeshWeaver.Mesh.Contract (#2398 forwarders)
 using System.Collections.Concurrent;
 using System.Reactive.Linq;
 using MeshWeaver.Mesh.Services;

--- a/scripts/check-type-forwards.py
+++ b/scripts/check-type-forwards.py
@@ -170,7 +170,23 @@ def parse_declarations(path: str, text: str) -> list[Decl]:
 
 
 def parse_forwards(text: str) -> set[str]:
-    return {m.group("type") for m in FORWARD_RE.finditer(text)}
+    # 🚨 A COMMENTED-OUT forwarder must not count. FORWARD_RE is a plain regex over the file text,
+    # so before this line `// [assembly: TypeForwardedTo(typeof(X))]` satisfied the gate — the exact
+    # false-PASS shape this gate exists to prevent, and the likeliest way a forwarder gets disabled
+    # during a refactor (comment first, delete later). Found by running the gate's own negative
+    # control while fixing #2398: commenting the six new lines out left it GREEN, deleting them
+    # turned it red, so "the forwarder is disabled" and "the forwarder is there" read identically.
+    #
+    # Line comments only. A forwarder buried in a /* ... */ block would still count; closing that
+    # needs a real C# tokenizer rather than a regex, which is out of proportion for a CI script and
+    # a far less likely way to disable one line. Truncating at `//` can also cut a string literal
+    # containing a URL; harmless here, because the two regexes match declarations and assembly
+    # attributes, neither of which lives inside a string.
+    return {
+        m.group("type")
+        for line in text.splitlines()
+        for m in FORWARD_RE.finditer(line.split("//", 1)[0])
+    }
 
 
 # ─────────────────────────────── tree readers ───────────────────────────────
@@ -417,6 +433,40 @@ SELF_TESTS: list[tuple[str, dict[str, str], dict[str, str], bool]] = [
             "src/B/Foo.cs": FOO_N,
             "src/A/Keep.cs": KEEP_A,
             "src/A/Fwd.cs": "using N;\n[assembly: TypeForwardedTo(typeof(Foo))]\n",
+        },
+        True,
+    ),
+    (
+        # The gate's own negative control found this hole (#2398): commenting the forwarders out
+        # left the gate GREEN, so a disabled forwarder and a present one read the same.
+        "a COMMENTED-OUT forwarder does not count",
+        {"src/A/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        {
+            "src/B/Foo.cs": FOO_N,
+            "src/A/Keep.cs": KEEP_A,
+            "src/A/Fwd.cs": "// [assembly: TypeForwardedTo(typeof(N.Foo))]\n",
+        },
+        False,
+    ),
+    (
+        "...nor one left behind mid-line in a note about its removal",
+        {"src/A/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        {
+            "src/B/Foo.cs": FOO_N,
+            "src/A/Keep.cs": KEEP_A,
+            "src/A/Fwd.cs": "// dropped in #9999: [assembly: TypeForwardedTo(typeof(N.Foo))]\n",
+        },
+        False,
+    ),
+    (
+        # ...but a REAL forwarder carrying a trailing comment is still a forwarder. Without this
+        # row, "strip everything after //" would look correct while silencing live forwarders.
+        "a forwarder followed by an explanatory comment still counts",
+        {"src/A/Foo.cs": FOO_N, "src/A/Keep.cs": KEEP_A},
+        {
+            "src/B/Foo.cs": FOO_N,
+            "src/A/Keep.cs": KEEP_A,
+            "src/A/Fwd.cs": "[assembly: TypeForwardedTo(typeof(N.Foo))]  // moved in #1234\n",
         },
         True,
     ),

--- a/src/MeshWeaver.AI/TypeForwards.cs
+++ b/src/MeshWeaver.AI/TypeForwards.cs
@@ -35,3 +35,25 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(MeshWeaver.AI.MeshExportManifest))]
 [assembly: TypeForwardedTo(typeof(MeshWeaver.AI.MeshExportFileEntry))]
 [assembly: TypeForwardedTo(typeof(MeshWeaver.AI.NodeReadOutcome))]
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// The SAME class again, found by replaying the gate across v3.0.0-rc7 → main (#2398).
+// #2276 moved the platform's credential-protection and MCP-back-connection contracts out of this
+// assembly into MeshWeaver.Mesh.Contract, renaming their namespaces on the way. Three of them have
+// a PROVEN module consumer on Systemorph/MeshWeaver.Plugins@main:
+//
+//   IMcpBackConnection     MeshWeaver.AI.ClaudeCode/{ClaudeCodeChatClient,ClaudeCodeHarness}.cs
+//                          MeshWeaver.AI.Copilot/{CopilotChatClient,CopilotHarness}.cs
+//   McpConnectionInfo      MeshWeaver.AI.ClaudeCode/ClaudeCodeChatClient.cs
+//   IProviderKeyProtector  MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+//
+// Their SOURCE was updated in the same wave, so `landed-modules-gate` is green and a REBUILT
+// bundle is correct. What that says nothing about is a deployment still running a bundle
+// published BEFORE the wave: it holds the old TypeRef and dies exactly like #2370 the moment its
+// platform rolls. These forwarders are what makes that ordering irrelevant.
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.IMasterKeyProvider))]
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.ConfigMasterKeyProvider))]
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.IProviderKeyProtector))]
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.ProviderKeyProtector))]
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.Connect.IMcpBackConnection))]
+[assembly: TypeForwardedTo(typeof(MeshWeaver.AI.Connect.McpConnectionInfo))]

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -185,6 +185,28 @@ all. `scripts/check-type-forwards.py` (wired into the *Public surface (binary co
 beside #2298's `check-record-signatures.py`) is what refuses the next one; its allow file is a
 statement that no shipped module can hold the TypeRef, not a way to make it quiet.
 
+**It had already happened again before the gate existed.** Replaying that gate across
+`v3.0.0-rc7 → main` found **17** unguarded moves; #2370 fixed four, and #2398 fixed six more that
+#2276 made when it moved the credential-protection and MCP-back-connection contracts into
+`MeshWeaver.Mesh.Contract` — `IProviderKeyProtector`, `ProviderKeyProtector`, `IMasterKeyProvider`,
+`ConfigMasterKeyProvider`, `IMcpBackConnection`, `McpConnectionInfo`. Three of those have a proven
+module consumer in the plugins repo today. So when reading a file under `src/MeshWeaver.Mesh.Contract`
+that declares `namespace MeshWeaver.AI` (or `MeshWeaver.AI.Connect`) — and the one under
+`src/MeshWeaver.Mesh.Operations` that does the same — that mismatch is **the contract, not a
+leftover**. A forwarder cannot rename, so tidying the namespace to match its assembly re-breaks
+every module built before the move. `MovedTypeBinaryContractTest` pins each name at runtime.
+
+🚨 **A forwarder is not always available, and that is a decision rather than a workaround.** The
+forwarder must live in the assembly being LEFT, so that assembly has to reference the type's new
+home — impossible when the move runs *against* the existing reference direction. Two of #2276's
+moves are exactly that (`MeshWeaver.GitSync → MeshWeaver.AI` and `MeshWeaver.Hosting →
+MeshWeaver.AI`; `MeshWeaver.AI` references both, so neither can reference it back). When a move has
+that shape there are only two honest options — **move the type back**, or accept the break and do
+the **atomic** republish: rebuild and republish every affected bundle, then roll the image, so no
+deployment is ever running an old bundle against a new platform. Inventing a shim to dodge the cycle
+is the one thing that must not happen: it mints a SECOND type identity and reintroduces the `as`/`is`
+trap-door that reads as a silent null.
+
 ### 🚨 An ACTIVATED entry with no bytes — the boot-GC race (#2303)
 
 The "Missing DLL" skip above is the SYMPTOM; #2303 traced one concrete way an entry ends up

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-installed-tools-survive-a-platform-update.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-installed-tools-survive-a-platform-update.md
@@ -1,0 +1,34 @@
+---
+Name: Installed tools keep working after a platform update
+Category: Fix
+Description: Six platform contracts had moved to another assembly without leaving a redirect, so an installed tool built before the move would have stopped loading the next time the portal updated — the same failure that briefly took the MCP tools down.
+Icon: PlugConnected
+Order: -20260826
+---
+
+# Installed tools keep working after a platform update
+
+An installed tool does not remember *what* a platform type is called. It
+remembers the name **and** which platform component carries it. Move the type to
+a different component and the tool is left asking for something that no longer
+exists there — so it fails to load, all at once, the next time the portal
+updates. Nothing warns about it beforehand: the tool's own source still compiles
+against the new platform perfectly well, because source and binary are asking
+different questions.
+
+That is what briefly took every MCP tool call down earlier: `get`, `search`,
+`create` and the rest all failed identically, for every external client, from a
+change that had reviewed as a tidy refactor.
+
+The fix for that one also produced a check that can be run over any span of
+history — and running it back to the last release turned up six more contracts
+that had moved the same way, untouched. Three of them are used by tools people
+have installed today: the co-hosted Claude Code and Copilot harnesses, and the
+provider-key protection the chat view relies on. Each was a working portal one
+platform update away from the same outage, purely as a matter of which order
+things happened to be rebuilt in.
+
+All six now leave a redirect behind at the old address, so a tool built before
+the move and a tool built after it both resolve to the same thing. Nothing needs
+rebuilding, reinstalling, or updating in any particular order — which is the
+whole point: the ordering stops mattering.

--- a/src/MeshWeaver.GitSync/GitHubCredential.cs
+++ b/src/MeshWeaver.GitSync/GitHubCredential.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.AI;   // IProviderKeyProtector & co keep their ORIGINAL namespace in MeshWeaver.Mesh.Contract (#2398 forwarders)
 using MeshWeaver.Mesh.Security;
 using System.ComponentModel;
 
@@ -7,7 +8,7 @@ namespace MeshWeaver.GitSync;
 /// A per-user GitHub OAuth credential, stored as a MeshNode at
 /// <c>{userId}/_Provider/GitHub</c> on the user's own partition. The
 /// <see cref="AccessToken"/> (and optional <see cref="RefreshToken"/>) are
-/// encrypted at rest via <see cref="MeshWeaver.Mesh.Security.IProviderKeyProtector"/>
+/// encrypted at rest via <see cref="MeshWeaver.AI.IProviderKeyProtector"/>
 /// (AES-256-GCM, <c>enc:v1:…</c>) — the same protector that guards LLM provider
 /// keys. The token is the <b>committing user's</b>: every push authenticates as
 /// this user and the commit is authored as them.

--- a/src/MeshWeaver.GitSync/GitHubCredentialService.cs
+++ b/src/MeshWeaver.GitSync/GitHubCredentialService.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.AI;   // IProviderKeyProtector & co keep their ORIGINAL namespace in MeshWeaver.Mesh.Contract (#2398 forwarders)
 using System.Reactive.Linq;
 using System.Security.Cryptography;
 using MeshWeaver.Data;

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reactive.Linq;
+using MeshWeaver.AI;   // IProviderKeyProtector & co keep their ORIGINAL namespace in MeshWeaver.Mesh.Contract (#2398 forwarders)
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Data;
 using MeshWeaver.Domain;

--- a/src/MeshWeaver.Mesh.Contract/Security/ConfigMasterKeyProvider.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/ConfigMasterKeyProvider.cs
@@ -3,7 +3,15 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace MeshWeaver.Mesh.Security;
+// 🚨 The NAMESPACE is part of the binary contract, and it does NOT follow the assembly.
+// This type used to live in MeshWeaver.AI; a module compiled before it moved holds a TypeRef to
+// `MeshWeaver.AI.ConfigMasterKeyProvider` scoped to the `MeshWeaver.AI` AssemblyRef. The
+// [assembly: TypeForwardedTo] in src/MeshWeaver.AI/TypeForwards.cs redirects that TypeRef here —
+// but ONLY while the full type NAME is unchanged, because a forwarder CANNOT rename. So
+// `namespace MeshWeaver.AI;` inside MeshWeaver.Mesh.Contract is DELIBERATE AND PERMANENT.
+// Tidying it to `MeshWeaver.Mesh.Security` is the #2370 outage all over again (#2398);
+// MovedTypeBinaryContractTest and scripts/check-type-forwards.py both refuse it.
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// Default <see cref="IMasterKeyProvider"/> — reads a base64 master key from

--- a/src/MeshWeaver.Mesh.Contract/Security/IMasterKeyProvider.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/IMasterKeyProvider.cs
@@ -1,4 +1,12 @@
-namespace MeshWeaver.Mesh.Security;
+// 🚨 The NAMESPACE is part of the binary contract, and it does NOT follow the assembly.
+// This type used to live in MeshWeaver.AI; a module compiled before it moved holds a TypeRef to
+// `MeshWeaver.AI.IMasterKeyProvider` scoped to the `MeshWeaver.AI` AssemblyRef. The
+// [assembly: TypeForwardedTo] in src/MeshWeaver.AI/TypeForwards.cs redirects that TypeRef here —
+// but ONLY while the full type NAME is unchanged, because a forwarder CANNOT rename. So
+// `namespace MeshWeaver.AI;` inside MeshWeaver.Mesh.Contract is DELIBERATE AND PERMANENT.
+// Tidying it to `MeshWeaver.Mesh.Security` is the #2370 outage all over again (#2398);
+// MovedTypeBinaryContractTest and scripts/check-type-forwards.py both refuse it.
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// Supplies the symmetric master key used by <see cref="IProviderKeyProtector"/>

--- a/src/MeshWeaver.Mesh.Contract/Security/IProviderKeyProtector.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/IProviderKeyProtector.cs
@@ -1,4 +1,12 @@
-namespace MeshWeaver.Mesh.Security;
+// 🚨 The NAMESPACE is part of the binary contract, and it does NOT follow the assembly.
+// This type used to live in MeshWeaver.AI; a module compiled before it moved holds a TypeRef to
+// `MeshWeaver.AI.IProviderKeyProtector` scoped to the `MeshWeaver.AI` AssemblyRef. The
+// [assembly: TypeForwardedTo] in src/MeshWeaver.AI/TypeForwards.cs redirects that TypeRef here —
+// but ONLY while the full type NAME is unchanged, because a forwarder CANNOT rename. So
+// `namespace MeshWeaver.AI;` inside MeshWeaver.Mesh.Contract is DELIBERATE AND PERMANENT.
+// Tidying it to `MeshWeaver.Mesh.Security` is the #2370 outage all over again (#2398);
+// MovedTypeBinaryContractTest and scripts/check-type-forwards.py both refuse it.
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// Encrypts / decrypts a literal credential before it is persisted to (and read back from) the

--- a/src/MeshWeaver.Mesh.Contract/Security/ProviderKeyProtector.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/ProviderKeyProtector.cs
@@ -2,7 +2,15 @@ using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
-namespace MeshWeaver.Mesh.Security;
+// 🚨 The NAMESPACE is part of the binary contract, and it does NOT follow the assembly.
+// This type used to live in MeshWeaver.AI; a module compiled before it moved holds a TypeRef to
+// `MeshWeaver.AI.ProviderKeyProtector` scoped to the `MeshWeaver.AI` AssemblyRef. The
+// [assembly: TypeForwardedTo] in src/MeshWeaver.AI/TypeForwards.cs redirects that TypeRef here —
+// but ONLY while the full type NAME is unchanged, because a forwarder CANNOT rename. So
+// `namespace MeshWeaver.AI;` inside MeshWeaver.Mesh.Contract is DELIBERATE AND PERMANENT.
+// Tidying it to `MeshWeaver.Mesh.Security` is the #2370 outage all over again (#2398);
+// MovedTypeBinaryContractTest and scripts/check-type-forwards.py both refuse it.
+namespace MeshWeaver.AI;
 
 /// <summary>
 /// AES-256-GCM <see cref="IProviderKeyProtector"/>. Stored form is

--- a/src/MeshWeaver.Mesh.Contract/Services/IMcpBackConnection.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMcpBackConnection.cs
@@ -1,4 +1,12 @@
-namespace MeshWeaver.Mesh.Services;
+// 🚨 The NAMESPACE is part of the binary contract, and it does NOT follow the assembly.
+// This type used to live in MeshWeaver.AI; a module compiled before it moved holds a TypeRef to
+// `MeshWeaver.AI.Connect.IMcpBackConnection` scoped to the `MeshWeaver.AI` AssemblyRef. The
+// [assembly: TypeForwardedTo] in src/MeshWeaver.AI/TypeForwards.cs redirects that TypeRef here —
+// but ONLY while the full type NAME is unchanged, because a forwarder CANNOT rename. So
+// `namespace MeshWeaver.AI.Connect;` inside MeshWeaver.Mesh.Contract is DELIBERATE AND PERMANENT.
+// Tidying it to `MeshWeaver.Mesh.Services` is the #2370 outage all over again (#2398);
+// MovedTypeBinaryContractTest and scripts/check-type-forwards.py both refuse it.
+namespace MeshWeaver.AI.Connect;
 
 /// <summary>
 /// The coordinates a co-hosted CLI needs to call the portal's MCP endpoint AS THE USER:

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.AI;   // IProviderKeyProtector & co keep their ORIGINAL namespace in MeshWeaver.Mesh.Contract (#2398 forwarders)
 using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Concurrency;

--- a/src/MeshWeaver.PluginCatalog/SyncTokenSigningKeyService.cs
+++ b/src/MeshWeaver.PluginCatalog/SyncTokenSigningKeyService.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.AI;   // IProviderKeyProtector & co keep their ORIGINAL namespace in MeshWeaver.Mesh.Contract (#2398 forwarders)
 using System.Reactive.Linq;
 using System.Security.Cryptography;
 using System.Text;

--- a/test/MeshWeaver.AI.Test/MovedTypeBinaryContractTest.cs
+++ b/test/MeshWeaver.AI.Test/MovedTypeBinaryContractTest.cs
@@ -32,38 +32,65 @@ namespace MeshWeaver.AI.Test;
 /// repo's module SOURCE against the PR and therefore goes green on exactly this change.</para>
 ///
 /// <para><b>What this pins.</b> Each moved type must still resolve <i>through</i>
-/// <c>MeshWeaver.AI</c> under its ORIGINAL full name, and must resolve to the type that now lives
-/// in <c>MeshWeaver.Mesh.Operations</c> — i.e. a real <c>[TypeForwardedTo]</c> yielding ONE type
-/// identity, not a shim duplicating the surface. A forwarder cannot rename, so the full name
-/// (namespace included) is frozen: this test is what fails if someone tidies
-/// <c>namespace MeshWeaver.AI</c> in <c>MeshWeaver.Mesh.Operations</c>.</para>
+/// <c>MeshWeaver.AI</c> under its ORIGINAL full name, and must resolve to the assembly that carries
+/// it today — i.e. a real <c>[TypeForwardedTo]</c> yielding ONE type identity, not a shim
+/// duplicating the surface. A forwarder cannot rename, so the full name (namespace included) is
+/// frozen: this test is what fails if someone tidies <c>namespace MeshWeaver.AI</c> in the assembly
+/// that now hosts it.</para>
+///
+/// <para><b>It happened twice.</b> Replaying <c>scripts/check-type-forwards.py</c> across
+/// <c>v3.0.0-rc7 → main</c> found 17 unguarded moves; #2370 fixed four of them, and #2398 fixed the
+/// six that #2276 made when it moved the credential-protection and MCP-back-connection contracts
+/// into <c>MeshWeaver.Mesh.Contract</c> — three with a proven module consumer on
+/// Systemorph/MeshWeaver.Plugins. That is why the frozen list below is a map from name to hosting
+/// assembly rather than one constant: the two waves landed in different places.</para>
 /// </summary>
 public class MovedTypeBinaryContractTest
 {
     /// <summary>The assembly a module's TypeRef names — the simple name it binds by at runtime.</summary>
     private const string BoundAssembly = "MeshWeaver.AI";
 
-    /// <summary>Where the types actually live since #2283.</summary>
-    private const string HostingAssembly = "MeshWeaver.Mesh.Operations";
-
     /// <summary>
-    /// The frozen names. A module compiled before #2283 holds exactly these strings in its
-    /// metadata; changing one is a break no consumer's compiler will ever warn about.
+    /// The frozen names, each mapped to the assembly that carries it TODAY. A module compiled
+    /// before the type moved holds exactly these strings in its metadata; changing one is a break
+    /// no consumer's compiler will ever warn about.
+    ///
+    /// <para>Two waves, two destinations — which is why this is a map and not one constant:</para>
+    /// <list type="bullet">
+    ///   <item>#2283 moved the <c>MeshOperations</c> family to <c>MeshWeaver.Mesh.Operations</c>
+    ///     (the move that caused #2370).</item>
+    ///   <item>#2276 moved the credential-protection and MCP-back-connection contracts to
+    ///     <c>MeshWeaver.Mesh.Contract</c>. That one shipped WITHOUT forwarders and was found by
+    ///     replaying <c>scripts/check-type-forwards.py</c> across <c>v3.0.0-rc7 → main</c> (#2398);
+    ///     three of them have a proven module consumer in Systemorph/MeshWeaver.Plugins.</item>
+    /// </list>
     /// </summary>
-    private static readonly string[] FrozenNames =
+    private static readonly (string Name, string Assembly)[] Frozen =
     [
-        "MeshWeaver.AI.MeshOperations",
-        "MeshWeaver.AI.MeshExportManifest",
-        "MeshWeaver.AI.MeshExportFileEntry",
-        "MeshWeaver.AI.NodeReadOutcome",
+        ("MeshWeaver.AI.MeshOperations", "MeshWeaver.Mesh.Operations"),
+        ("MeshWeaver.AI.MeshExportManifest", "MeshWeaver.Mesh.Operations"),
+        ("MeshWeaver.AI.MeshExportFileEntry", "MeshWeaver.Mesh.Operations"),
+        ("MeshWeaver.AI.NodeReadOutcome", "MeshWeaver.Mesh.Operations"),
+        ("MeshWeaver.AI.IMasterKeyProvider", "MeshWeaver.Mesh.Contract"),
+        ("MeshWeaver.AI.ConfigMasterKeyProvider", "MeshWeaver.Mesh.Contract"),
+        ("MeshWeaver.AI.IProviderKeyProtector", "MeshWeaver.Mesh.Contract"),
+        ("MeshWeaver.AI.ProviderKeyProtector", "MeshWeaver.Mesh.Contract"),
+        ("MeshWeaver.AI.Connect.IMcpBackConnection", "MeshWeaver.Mesh.Contract"),
+        ("MeshWeaver.AI.Connect.McpConnectionInfo", "MeshWeaver.Mesh.Contract"),
     ];
 
     /// <summary>The same list, as theory rows.</summary>
-    public static TheoryData<string> ForwardedTypeNames() => [.. FrozenNames];
+    public static TheoryData<string, string> ForwardedTypeNames()
+    {
+        var data = new TheoryData<string, string>();
+        foreach (var (name, assembly) in Frozen)
+            data.Add(name, assembly);
+        return data;
+    }
 
     [Theory]
     [MemberData(nameof(ForwardedTypeNames))]
-    public void OldName_StillResolves_ThroughTheAssemblyModulesBind(string fullName)
+    public void OldName_StillResolves_ThroughTheAssemblyModulesBind(string fullName, string hostingAssembly)
     {
         // Assembly-qualified on purpose: this is the resolution a module's TypeRef performs —
         // "find `fullName` in the assembly named `MeshWeaver.AI`" — and it is the exact step that
@@ -78,7 +105,7 @@ public class MovedTypeBinaryContractTest
             + "platform roll — the #2370 outage. Restore the name and its [assembly: TypeForwardedTo] "
             + "in src/MeshWeaver.AI/TypeForwards.cs.");
 
-        Assert.Equal(HostingAssembly, resolved!.Assembly.GetName().Name);
+        Assert.Equal(hostingAssembly, resolved!.Assembly.GetName().Name);
     }
 
     [Fact]
@@ -92,7 +119,7 @@ public class MovedTypeBinaryContractTest
             .Select(t => t.FullName)
             .ToHashSet(StringComparer.Ordinal);
 
-        Assert.All(FrozenNames, name => Assert.Contains(name, forwarded));
+        Assert.All(Frozen, f => Assert.Contains(f.Name, forwarded));
     }
 
     [Fact]
@@ -106,6 +133,19 @@ public class MovedTypeBinaryContractTest
         Assert.Equal("MeshWeaver.AI.MeshExportFileEntry", typeof(MeshExportFileEntry).FullName);
         Assert.Equal("MeshWeaver.AI.NodeReadOutcome", typeof(MeshWeaver.AI.NodeReadOutcome).FullName);
 
-        Assert.Equal(HostingAssembly, typeof(MeshOperations).Assembly.GetName().Name);
+        // #2276 / #2398 — the SAME pin for the wave that landed in MeshWeaver.Mesh.Contract. These
+        // four keep `namespace MeshWeaver.AI` and the pair below keeps `namespace
+        // MeshWeaver.AI.Connect`, both inside an assembly named neither of those things. That
+        // mismatch is the contract, not an oversight.
+        Assert.Equal("MeshWeaver.AI.IMasterKeyProvider", typeof(IMasterKeyProvider).FullName);
+        Assert.Equal("MeshWeaver.AI.ConfigMasterKeyProvider", typeof(ConfigMasterKeyProvider).FullName);
+        Assert.Equal("MeshWeaver.AI.IProviderKeyProtector", typeof(IProviderKeyProtector).FullName);
+        Assert.Equal("MeshWeaver.AI.ProviderKeyProtector", typeof(ProviderKeyProtector).FullName);
+        Assert.Equal("MeshWeaver.AI.Connect.IMcpBackConnection", typeof(Connect.IMcpBackConnection).FullName);
+        Assert.Equal("MeshWeaver.AI.Connect.McpConnectionInfo", typeof(Connect.McpConnectionInfo).FullName);
+
+        Assert.Equal("MeshWeaver.Mesh.Operations", typeof(MeshOperations).Assembly.GetName().Name);
+        Assert.Equal("MeshWeaver.Mesh.Contract", typeof(IProviderKeyProtector).Assembly.GetName().Name);
+        Assert.Equal("MeshWeaver.Mesh.Contract", typeof(Connect.IMcpBackConnection).Assembly.GetName().Name);
     }
 }

--- a/test/MeshWeaver.GitSync.Test/GitHubSyncTestBase.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubSyncTestBase.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.AI;   // IProviderKeyProtector & co keep their ORIGINAL namespace in MeshWeaver.Mesh.Contract (#2398 forwarders)
 using MeshWeaver.Mesh.Security;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;

--- a/test/MeshWeaver.Graph.Test/ProviderKeyProtectorRegistrationTest.cs
+++ b/test/MeshWeaver.Graph.Test/ProviderKeyProtectorRegistrationTest.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.AI;   // IProviderKeyProtector & co keep their ORIGINAL namespace in MeshWeaver.Mesh.Contract (#2398 forwarders)
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh.Security;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Fixes the forwardable part of #2398. **#2398 stays open**, narrowed to the two groups that cannot be forwarded at all — those need a maintainer decision, not a clever workaround.

## What this is

#2370 was one instance of a class, not a one-off. A module's IL binds `Namespace.Type` scoped to an **AssemblyRef**, and the module lane's gate is a **semver floor** that cannot see a type at all — so a public type that changes assembly or namespace breaks every module compiled earlier, at the next platform roll, with no warning anywhere. **No source build in either repo can observe it**: building the plugin's source against the branch answers *source* compatibility, which is a different question. That is precisely why #2283 shipped a `TypeLoadException` on every MCP tool call having been verified exactly that way.

Replaying #2370's gate across `v3.0.0-rc7 → main` found **17** unguarded moves. #2370 fixed four. This fixes **six** more — the ones #2276 made when it moved the credential-protection and MCP-back-connection contracts into `MeshWeaver.Mesh.Contract`:

| type (frozen full name) | left | now in |
|---|---|---|
| `MeshWeaver.AI.IMasterKeyProvider` | `MeshWeaver.AI` | `MeshWeaver.Mesh.Contract` |
| `MeshWeaver.AI.ConfigMasterKeyProvider` | `MeshWeaver.AI` | `MeshWeaver.Mesh.Contract` |
| `MeshWeaver.AI.IProviderKeyProtector` | `MeshWeaver.AI` | `MeshWeaver.Mesh.Contract` |
| `MeshWeaver.AI.ProviderKeyProtector` | `MeshWeaver.AI` | `MeshWeaver.Mesh.Contract` |
| `MeshWeaver.AI.Connect.IMcpBackConnection` | `MeshWeaver.AI` | `MeshWeaver.Mesh.Contract` |
| `MeshWeaver.AI.Connect.McpConnectionInfo` | `MeshWeaver.AI` | `MeshWeaver.Mesh.Contract` |

**Three have a proven module consumer** on `Systemorph/MeshWeaver.Plugins@main` — confirmed by grepping the repo, not assumed: `IMcpBackConnection` + `McpConnectionInfo` in `MeshWeaver.AI.ClaudeCode` / `MeshWeaver.AI.Copilot`, `IProviderKeyProtector` in `MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs` and `Memex.Portal.Gui/MemexPortalComposition.cs`.

Their *source* was updated in the same wave, so `landed-modules-gate` is green and a **rebuilt** bundle is correct. What that says nothing about is a deployment still running a bundle published **before** the wave: it holds the old TypeRef and dies exactly like #2370 the moment its platform rolls. **A forwarder makes that ordering irrelevant** — which is the whole point, since the ordering is not something we control.

## The two non-obvious constraints, both already load-bearing here

**A forwarder cannot rename.** So each type keeps its **original** full name in its new home: five files under `src/MeshWeaver.Mesh.Contract` now declare `namespace MeshWeaver.AI` / `MeshWeaver.AI.Connect`. That mismatch is the contract, not a leftover — the same shape `MeshOperations` already has in `MeshWeaver.Mesh.Operations`. Each file carries a comment saying so, because a "tidy-up" of exactly that broke `main` today. Consumers gain a `using`.

**No shim types.** A forwarder keeps **one** type identity via the CLR's ExportedType table. A shim class left behind in `MeshWeaver.AI` would satisfy a naive resolution check while minting a *second* identity — reintroducing the `is`/`as` trap-door that reads as a silent null. `MovedTypeBinaryContractTest.TheForwardersAreForwarders_NotDuplicatedTypes` reads the ExportedType table specifically to refuse that.

## Proven, not asserted

- **The gate.** `python3 scripts/check-type-forwards.py --base v3.0.0-rc7` reports **13** findings without the forwarders — exactly the list in #2398 — and **7** with them, all of which are the cycle-blocked group below. Against `origin/main` (what CI runs) it is green.
- **The runtime test.** `MovedTypeBinaryContractTest` extended from 4 frozen names to 10. With the six forwarder lines deleted it fails **7/12**; with them it passes **12/12**. The frozen list became a `name → hosting assembly` map, because the two waves landed in different assemblies.
- Touched projects build clean with CI's flags (`-c Release -warnaserror`, one project per invocation): `Mesh.Contract`, `AI`, `PluginCatalog`, `Memex.Portal.Shared`, `AI.Test`, `GitSync.Test`, `Graph.Test`, `Documentation.Test`. Tests run: 40 in `AI.Test` (forwarder + provider-key + credential-seed), `ProviderKeyProtectorRegistrationTest`, `WhatsNewEntryIntegrityTest`, `DocumentationLinkIntegrityTest` — all green.

## Two gate defects found while doing it

**A commented-out forwarder counted.** `check-type-forwards.py`'s `FORWARD_RE` ran over raw file text, so `// [assembly: TypeForwardedTo(typeof(X))]` satisfied the gate. That is the gate's own **false-PASS** shape, and the likeliest way a forwarder gets disabled in a refactor (comment first, delete later) — it is literally what made the first negative control here look green. `parse_forwards` now truncates each line at `//`. Three self-test rows pin it, including that a **real** forwarder with a trailing comment still counts (without that row, the fix would look correct while silencing live forwarders). 20 → 23 self-tests, all passing. Line comments only; a `/* … */`-buried forwarder would still count, and the docstring says so rather than implying coverage that is not there.

**`check-record-signatures.py`'s step anchored on the base branch TIP** while the script's own docstring says merge base (recorded on #2398). The half that was wrong is *not* the file list — the three-dot `git diff --name-only {base}...HEAD` already resolves the merge base. It is the **before content**: `git show {base}:{file}` reads the literal ref, so a record whose primary constructor changes on main while a PR is open reads as *that PR reverting it* — a red on somebody else's commit. Now passes the merge-base SHA, matching what the type-forwards step already did.

## What is NOT fixed, and why it is a decision rather than a task

Two groups **cannot be forwarded at all**. The forwarder must live in the assembly being *left*, so that assembly must reference the type's new home — and `MeshWeaver.AI` already references both of these, so the forwarder would be a **reference cycle**:

- `MeshWeaver.GitSync → MeshWeaver.AI`: `AiContentDiskWriter`, `AiContentSyncArea`, `AiContentSyncMenuProvider`, `AiContentSyncResult`, `HubAiContentSyncExtensions`, `PullRequestDraftService`
- `MeshWeaver.Hosting → MeshWeaver.AI`: `MeshWeaver.Hosting.Persistence.Parsers.AgentFileParser`

**Exposure, confirmed rather than assumed:** zero consumers of those seven names in `MeshWeaver.Plugins`, `MeshWeaver.Reinsurance` or `MeshWeaver.SocialMedia`. So it does look core-only — but "no consumer in the repos I can see" is not the same as "no published bundle holds the TypeRef", which is the question that actually matters and the one #2370 answered the expensive way.

The two honest options, both of them a maintainer call: **move the types back**, or accept the break and do the **atomic republish** (#2234) — rebuild and republish every affected bundle, then roll the image, so no deployment is ever running an old bundle against a new platform — recording it in `scripts/type-forwards.allow`. Full detail on #2398.

~~Also worth a separate decision, unchanged here on purpose: the *Public surface (binary compatibility)* job is **not** in `collect-results`' `needs`.~~ **Superseded while this PR was open** — #2407 (`5ce64c984`) landed on `main` and wired `record-signatures` into `collect-results`' `needs` plus the explicit fail step, so both binary-compat gates can now block a merge. Nothing to do here; this branch predates it and the two edits touch different hunks of `dotnet-test.yml`, so they merge cleanly (`mergeStateStatus` is `BLOCKED` on checks, not `DIRTY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
