### PR TITLE
memex-local: §14 can see the signal it waits for, and names the right remedy

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -78,6 +78,10 @@ readonly PF_SCRIPT="$LOCAL_HOME/port-forward.sh"
 readonly PF_LOG="$LOCAL_HOME/port-forward.log"
 readonly PLIST_LABEL="com.memex.local"
 readonly PLIST_DST="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+# How long to wait for the launchd port-forward to actually BIND before reporting it did not.
+# Seconds. Bounded on purpose: over budget means the agent is not coming up, which is a state to
+# report (see wait_port_forward), never one to keep waiting out.
+readonly PF_BIND_BUDGET="${MEMEX_PF_BIND_BUDGET:-30}"
 
 # ---------------------------------------------------------------------------
 # Output helpers
@@ -562,8 +566,20 @@ helm_deploy() {
 # ---------------------------------------------------------------------------
 apply_logging() {
   step "Applying verbose logging (Logging__LogLevel__Default=$LOG_LEVEL) as a deployment-config override"
+  # 🚨 Default alone is NOT enough, and the gap is invisible from out here. The portal image's
+  # appsettings.json caps the whole `MeshWeaver` prefix at Warning, and a Default override does
+  # not lift a MORE SPECIFIC prefix — .NET resolves a category against its longest matching key.
+  # §14 settles its view-pack wait on `[DefaultInstall] reconciled`, which is LogInformation under
+  # MeshWeaver.PluginCatalog, so with Default alone that line reached stdout on NO install ever:
+  # the wait could not settle early, burned its full budget (600 s on `update`) on every run, and
+  # then reported "the boot reconcile has not reported completion" — a statement about the logging
+  # config, not about the install. The FAILURE variant of that same line is LogError and was
+  # always visible, which is exactly why only the SUCCESS path was silent and the gap survived.
+  # This is a deployment-config override on the local install; the committed appsettings*.json and
+  # every Log* call in src/ stay untouched (AGENTS.md — never edit log levels in code to debug).
   kubectl set env deployment/memex-portal-deployment -n "$NAMESPACE" \
-    "Logging__LogLevel__Default=$LOG_LEVEL"
+    "Logging__LogLevel__Default=$LOG_LEVEL" \
+    "Logging__LogLevel__MeshWeaver.PluginCatalog=Information"
 }
 
 # ---------------------------------------------------------------------------
@@ -607,6 +623,41 @@ install_launchd() {
   launchctl bootout "gui/$(id -u)" "$PLIST_DST" >/dev/null 2>&1 || true
   launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
   ok "launchd agent '$PLIST_LABEL' loaded (logs: $PF_LOG)"
+  # 🚨 NOT a gate — verify_usable is, and it runs next in every caller. This wait exists so that
+  # what the gate reports is the POD's state and not a race against the host transport, which is
+  # why a port-forward that never binds must warn and let the run continue to that report rather
+  # than aborting here.
+  wait_port_forward || true
+}
+
+# Block until the launchd port-forward is actually usable, or say that it is not.
+#
+# 🚨 `launchctl bootstrap` returns once launchd has ACCEPTED the job — NOT once the kubectl
+# port-forward inside it has bound :8443. cmd_up, cmd_update and cmd_port_forward all go straight
+# from install_launchd into the verification, so without this the first probes hit a socket that
+# does not exist yet: §14 then reports "no answer" for a portal that is serving perfectly, and
+# sends the developer to read a healthy pod log.
+#
+# The wait ends on ANY http status, 503 included. A status of any kind proves the socket is bound
+# and proxying, and judging WHICH status is check 1's job — so this can never mask a broken portal,
+# it only stops the gate from racing its own transport. Waiting on the port is waiting on the
+# actual precondition; there is no sleep-and-hope here and the budget is a report, not a retry.
+wait_port_forward() {
+  local deadline code
+  deadline=$(( $(date +%s) + PF_BIND_BUDGET ))
+  while :; do
+    code="$(probe_http /)"
+    if [ "$code" != "000" ]; then
+      ok "port-forward is bound (:${HOST_PORT} answered HTTP $code)"
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then break; fi
+    sleep 1
+  done
+  warn "the launchd port-forward did not bind :${HOST_PORT} within ${PF_BIND_BUDGET}s — nothing on
+     this Mac is listening, so every check below reports 'no answer' however healthy the pod is.
+     Remedy: 'memex-local status', then read $PF_LOG."
+  return 1
 }
 
 uninstall_launchd() {
@@ -686,7 +737,7 @@ probe_default_install_done() {
 # The HTTP half. Echoes the STATUS CODE (000 when no request completed), because judging curl's own
 # exit code instead of the code it fetched is the bug this whole function replaces.
 probe_http() {
-  local path="$1" caroot ca=()
+  local path="$1" caroot code ca=()
   if command -v mkcert >/dev/null 2>&1; then
     caroot="$(mkcert -CAROOT 2>/dev/null || true)"
     if [ -n "$caroot" ] && [ -f "$caroot/rootCA.pem" ]; then ca=(--cacert "$caroot/rootCA.pem"); fi
@@ -694,8 +745,21 @@ probe_http() {
   # ${x[@]+"${x[@]}"} — NOT a style tic. macOS ships bash 3.2, where `set -u` treats "${x[@]}" on an
   # EMPTY array as an unbound variable and kills the script. This tool is macOS-only, so every
   # possibly-empty array expansion in this file has to carry the guard (see helm_deploy).
-  curl ${ca[@]+"${ca[@]}"} -sS -o /dev/null -w '%{http_code}' --max-time 15 \
-    "https://${HOSTNAME_LOCAL}:${HOST_PORT}${path}" 2>/dev/null || printf '000'
+  # 🚨 curl WRITES its %{http_code} and THEN exits non-zero when it cannot connect — and the code
+  # it writes in exactly that case is ALREADY '000'. So a trailing `|| printf '000'` does not
+  # supply a missing status, it APPENDS a second one: the function returned '000000', which
+  # matches no arm of the caller's case statement and fell through to the generic "that is not a
+  # serving portal", naming the INGRESS. The one red state with a precise, local remedy — nothing
+  # bound on :8443 — was therefore the one state reported wrongly, and it is the state `up` and
+  # `update` produce most often, because both restart the port-forward and verify immediately.
+  # Capture first, then normalise to exactly three digits; the fallback also covers curl being
+  # absent altogether, which writes nothing at all.
+  code="$(curl ${ca[@]+"${ca[@]}"} -sS -o /dev/null -w '%{http_code}' --max-time 15 \
+    "https://${HOSTNAME_LOCAL}:${HOST_PORT}${path}" 2>/dev/null || true)"
+  case "$code" in
+    [0-9][0-9][0-9]) printf '%s' "$code" ;;
+    *)               printf '000' ;;
+  esac
 }
 
 verify_usable() {
@@ -734,6 +798,13 @@ verify_usable() {
      The login pages compile INTO the image from MeshWeaver.Plugins/src/Memex.Portal.Gui, so a 404
      means the image predates the GUI move (MeshWeaver#2293/#2367).
      Remedy: rebuild it — 'memex-local update --build', with the plugins checkout on main."
+         failed=1 ;;
+    # 🚨 Nothing answered, so this check learned NOTHING about the sign-in route and must not
+    # pretend otherwise. Check 1 has already named the transport and its remedy; repeating a
+    # different remedy here ('memex-local logs') sends the developer to a healthy pod a second
+    # time for one cause. One cause, one diagnosis — the transport is check 1's to own.
+    000) warn "/login could not be reached either — this check cannot judge the sign-in route
+     until something answers on :${HOST_PORT}. See the remedy above; it is the same cause."
          failed=1 ;;
     *)  warn "/login answered HTTP $code — the sign-in route is not usable.
      Remedy: 'memex-local logs'."

--- a/deploy/homebrew/test/run-tests.sh
+++ b/deploy/homebrew/test/run-tests.sh
@@ -35,6 +35,7 @@ bad() { printf '  FAIL  %s\n' "$1"; printf '        %s\n' "${2:-}"; fail=$((fail
 #   FAKE_HTTP_ROOT  / FAKE_HTTP_LOGIN — the status code curl reports per path
 #   FAKE_MODULES                      — the lines the in-pod probe prints
 #   FAKE_EXEC_FAILS                   — kubectl exec exits non-zero (unreadable pod)
+#   FAKE_CURL_FAILS                   — curl cannot connect at all (no port-forward bound)
 # ---------------------------------------------------------------------------
 STUBS="$(mktemp -d)"
 trap 'rm -rf "$STUBS"' EXIT
@@ -45,9 +46,16 @@ exit 0
 EOF
 
 # curl is called as: curl [--cacert X] -sS -o /dev/null -w '%{http_code}' --max-time 15 <url>
+# 🚨 The FAKE_CURL_FAILS arm emulates the one curl behaviour that matters here and that a
+# stub which only ever exits 0 can never reach: on a CONNECTION failure curl still WRITES its
+# %{http_code} — the literal '000' — and THEN exits non-zero. probe_http's `|| printf '000'`
+# therefore APPENDED a second '000', and the resulting '000000' matched no arm of the caller's
+# case statement. That is how "nothing is listening on :8443" got reported as a serving-portal
+# fault with the INGRESS as its remedy. The old stub is why this suite never saw it.
 cat > "$STUBS/curl" <<'EOF'
 #!/usr/bin/env bash
 url="${!#}"
+if [ -n "${FAKE_CURL_FAILS:-}" ]; then printf '000'; exit 7; fi
 case "$url" in
   */login) printf '%s' "${FAKE_HTTP_LOGIN:-200}" ;;
   *)       printf '%s' "${FAKE_HTTP_ROOT:-200}" ;;
@@ -112,6 +120,37 @@ reports "no answer at all is reported" "did NOT answer" \
 
 reports "a deleted login page is caught" "NOT ROUTED" \
   FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=404 FAKE_MODULES="$BOTH_PRESENT"
+
+# 🚨 The single most common red state a developer meets, and the one §14 misnamed. `up` and
+# `update` both restart the launchd port-forward and go STRAIGHT into the verification, so the
+# probes routinely arrive before :8443 is bound. Real curl writes '000' and exits non-zero, the
+# fallback appended a second '000', and '000000' fell through every arm of the case statement to
+# the generic "that is not a serving portal" — which names the INGRESS. The developer is then sent
+# to `memex-local logs` to read a healthy pod, for a socket that is missing on their own Mac.
+reports "a connection failure is 'no answer', not a serving-portal fault" "did NOT answer" \
+  FAKE_CURL_FAILS=1 FAKE_MODULES="$BOTH_PRESENT"
+
+run_verify FAKE_CURL_FAILS=1 FAKE_MODULES="$BOTH_PRESENT"
+case "$OUT" in
+  *000000*) bad "a connection failure reports ONE status, not a doubled one" \
+              "reported HTTP 000000 — probe_http concatenated curl's own '000' with its fallback: $OUT" ;;
+  *) ok "a connection failure reports ONE status, not a doubled one" ;;
+esac
+case "$OUT" in
+  *port-forward*) ok "a connection failure names the port-forward as the remedy" ;;
+  *) bad "a connection failure names the port-forward as the remedy" \
+       "nothing is listening on the host; sending the developer at the ingress wastes the session: $OUT" ;;
+esac
+
+# 🚨 Check 2 must not diagnose the sign-in ROUTE when nothing answered at all — it cannot know
+# anything about /login through a transport that is not there, and "Remedy: memex-local logs"
+# sends the developer to a healthy pod for a second time in the same output. One cause must
+# produce one diagnosis; the transport is check 1's to name and check 2 defers to it.
+case "$OUT" in
+  *"/login answered HTTP 000"*) bad "a connection failure does not also indict /login" \
+       "check 2 judged the sign-in route through a transport that never connected: $OUT" ;;
+  *) ok "a connection failure does not also indict /login" ;;
+esac
 
 reports "a missing view pack is caught" "MeshWeaver.Blazor.Views" \
   FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 \
@@ -222,6 +261,38 @@ for c in cmd_up cmd_update; do
     *) bad "${c} runs the usability verification" "no verify_usable call in ${c}()" ;;
   esac
 done
+
+echo "── a gate's own INPUT must be reachable (static — needs a live pod) ──"
+
+# 🚨 §14 decides the boot reconcile has SETTLED by grepping the pod log for
+# `[DefaultInstall] reconciled`. That call is LogInformation on a MeshWeaver.PluginCatalog.*
+# category, and the portal image's appsettings.json caps the whole `MeshWeaver` prefix at Warning
+# — so the line never reaches stdout on ANY install. The wait could therefore never settle early:
+# it burned its full --wait budget (600 s on `update`) and then reported "the boot reconcile has
+# not reported completion", which is a statement about the LOGGING CONFIG, not about the install.
+# apply_logging set only Logging__LogLevel__Default, and a Default override does not lift a more
+# specific prefix. Same defect class as the unreadable pod above: the check could not read its own
+# input. Asserted statically — proving it dynamically needs a running portal.
+body="$(awk -v f='^apply_logging\\(\\)' '$0 ~ f { on=1 } on { print } on && /^}$/ { exit }' "$CLI")"
+case "$body" in
+  *Logging__LogLevel__MeshWeaver.PluginCatalog=Information*)
+    ok "apply_logging lifts the category the DefaultInstall probe greps" ;;
+  *) bad "apply_logging lifts the category the DefaultInstall probe greps" \
+       "appsettings caps 'MeshWeaver' at Warning, so [DefaultInstall] reconciled is suppressed and the wait can never settle: ${body}" ;;
+esac
+
+# 🚨 `launchctl bootstrap` returns when launchd has ACCEPTED the job, not when the kubectl
+# port-forward inside it has bound the socket. Both cmd_up and cmd_update go straight from
+# install_launchd into verify_usable, so the verification routinely probes a socket that does not
+# exist yet and reports a portal that is in fact fine. Waiting on the port is waiting on the
+# actual precondition — and any HTTP status at all, 503 included, proves the socket is bound and
+# is check 1's business to judge, so the wait cannot mask a genuinely broken portal.
+body="$(awk -v f='^install_launchd\\(\\)' '$0 ~ f { on=1 } on { print } on && /^}$/ { exit }' "$CLI")"
+case "$body" in
+  *wait_port_forward*) ok "install_launchd waits for the socket to actually bind" ;;
+  *) bad "install_launchd waits for the socket to actually bind" \
+       "it returns as soon as launchd accepts the job, and every caller verifies immediately after: ${body}" ;;
+esac
 
 echo "── the CLI still knows every command it documents ────────────────"
 


### PR DESCRIPTION
Three defects in `memex-local`'s §14 usability verification, each of which made it report a cause
other than the real one. Found while diagnosing a local portal that `update` declared unusable after
burning its full 600 s budget — the portal was fine to the extent the gate could tell, and every line
it printed pointed somewhere else.

## 1. `probe_http` returned `000000`, not `000`

curl **writes** its `%{http_code}` and **then** exits non-zero when it cannot connect, and the code it
writes in that case is already `000`. The trailing `|| printf '000'` did not supply a missing status —
it appended a second one. `000000` matches no arm of the caller's case statement, so it fell through
to the generic *"that is not a serving portal"*, which names the **ingress**:

```
warn portal answered https://memex.localhost:8443/ with HTTP 000000 — that is not a serving portal.
     Remedy: 'memex-local logs'. A 503 is the ingress with no ready endpoint behind it.
```

The actual cause is a host-side port-forward that is not bound — the one red state with a precise,
local remedy, and the state `up` and `update` produce most often, since both restart the port-forward
and verify immediately. Now:

```
warn portal did NOT answer at https://memex.localhost:8443/ — no HTTP status at all.
     Remedy: 'memex-local status' (is the pod ready, is the port-forward up?), then
     'memex-local port-forward'.
```

## 2. Check 2 diagnosed `/login` through a transport that never connected

With no answer at all it still reported *"the sign-in route is not usable"* and sent the developer to
`memex-local logs` — a second remedy, for the same cause, pointing at a healthy pod. One cause, one
diagnosis: the transport is check 1's to own, and check 2 now defers to it.

## 3. `apply_logging` set only `Logging__LogLevel__Default`

The portal image's `appsettings.json` caps the whole `MeshWeaver` prefix at `Warning`, and a `Default`
override does not lift a more specific prefix — .NET resolves a category against its longest matching
key. §14 settles its view-pack wait on `[DefaultInstall] reconciled`, which is `LogInformation` under
`MeshWeaver.PluginCatalog`, so **that line reached stdout on no install, ever**.

The wait could therefore never settle early: it burned its full budget (600 s on `update`) on every
run and then reported *"the boot reconcile has not reported completion"* — a statement about the
logging config, not about the install. The **failure** variant of the same line is `LogError` and was
always visible, which is exactly why only the success path was silent and this survived.

Same defect class as the unreadable-pod case the suite already covers: the check could not read its
own input.

**Verified on a live local portal.** With the override in place the current pod logs 37
`[DefaultInstall]` lines where every previous pod logged zero, and the reconcile settles in seconds:

```
[DefaultInstall] bake settled as NotApplicable — starting provisioning
[DefaultInstall] 34 package(s), in dependency order — Agent, Analysis, …, DefaultViews, …, GraphViews, …
[DefaultInstall] reconciled: 0 installed, 34 up to date, 0 failed
```

This is a deployment-config override on the local install only. The committed `appsettings*.json` and
every `Log*` call in `src/` are untouched — AGENTS.md forbids editing log levels in code to debug.

## Also: `install_launchd` now waits for the socket

`launchctl bootstrap` returns when launchd **accepts** the job, not when the `kubectl port-forward`
inside it has bound `:8443`, and every caller goes straight into `verify_usable`. The new
`wait_port_forward` ends on **any** HTTP status — 503 included — because a status of any kind proves
the socket is bound, and judging *which* status is check 1's job. So it cannot mask a broken portal;
it only stops the gate racing its own transport. Bounded (30 s, `MEMEX_PF_BIND_BUDGET`), and over
budget is reported, not retried.

## Tests

TDD, red first. **The curl stub could only ever exit 0** — which is precisely why the doubled status
survived every previous run of this suite. It now emulates the real connection-failure behaviour
(`FAKE_CURL_FAILS`: write `000`, exit 7), and six new assertions cover the three defects, two of them
static because proving them dynamically needs a running portal.

All five new assertions failed before the fix and pass after: **31 passed, 0 failed**. `bash -n` clean.

## Scope

**This does not fix the missing view packs.** That is Systemorph/MeshWeaver#2417 — a local install has
no source of module binaries, so `DefaultViews`/`GraphViews` can never land. This change only makes
the gate report that honestly and in seconds instead of timing out and blaming the boot reconcile.

**No What's New entry**: `deploy/homebrew/` is the developer-facing local-stack CLI. Nothing here is
visible to a portal user, so per the skill's rule this is a pure-internal change and the note is
deliberately skipped.
