### PR TITLE
MCP endpoint: /api/mcp becomes the primary path, and /Mcp renders the partition cover

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/McpAuthenticationExtensions.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpAuthenticationExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.AspNetCore.Authentication;
 using ModelContextProtocol.Authentication;
@@ -75,6 +76,11 @@ public static class McpAuthenticationExtensions
     /// </summary>
     public static IServiceCollection AddMcpAuthentication(this IServiceCollection services)
     {
+        // The /api/mcp → /mcp endpoint alias (see McpEndpointRoutes): self-wired at the front of
+        // the pipeline so the PRIMARY path is served by every host that has MCP auth, without the
+        // composition needing an extra call.
+        services.AddTransient<IStartupFilter, McpEndpointRoutes.StartupFilter>();
+
         services.AddAuthentication()
             .AddScheme<AuthenticationSchemeOptions, ApiTokenAuthenticationHandler>(
                 ApiTokenAuthenticationHandler.SchemeName, _ => { })
@@ -147,9 +153,21 @@ public static class McpAuthenticationExtensions
             {
                 var req = ctx.HttpContext.Request;
                 var origin = $"{req.Scheme}://{req.Host}";
+                // RFC 9728 path-inserted discovery: McpEndpointRoutes rewrites
+                // /.well-known/oauth-protected-resource/{api/mcp|mcp} onto this bare document
+                // and stashes which resource the client asked about — answer with THAT resource
+                // so a strict client's "resource matches the server URL" validation passes for
+                // both the primary (/api/mcp) and the compatibility (/mcp) endpoint. A fetch of
+                // the bare document (the URL the WWW-Authenticate challenge names) keeps
+                // answering /mcp — the value every already-connected client validated against.
+                var resourcePath =
+                    ctx.HttpContext.Items.TryGetValue(McpEndpointRoutes.ResourcePathItem, out var stashed)
+                    && stashed is string s
+                        ? s
+                        : McpEndpointRoutes.CompatibilityEndpoint;
                 ctx.ResourceMetadata = new ProtectedResourceMetadata
                 {
-                    Resource = $"{origin}/mcp",
+                    Resource = $"{origin}{resourcePath}",
                     BearerMethodsSupported = { "header" },
                     ScopesSupported = { "mcp" },
                     AuthorizationServers = { origin },

--- a/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
@@ -12,13 +12,15 @@ namespace Memex.Portal.Shared.Authentication;
 /// <see cref="IMcpBackConnection"/>. The co-hosted Claude Code / GitHub Copilot CLIs call
 /// <see cref="EnsureForUser"/> at spawn time (every execution); on a cache miss this mints a
 /// long-lived per-user MeshWeaver <c>ApiToken</c> via <see cref="ApiTokenService"/> — with NO manual
-/// step — and returns the composed <c>{baseUrl}/mcp</c> URL plus the raw <c>mw_…</c> token to present
-/// as <c>Authorization: Bearer</c>. Internal portal↔CLI↔/mcp comms are therefore token-based and
+/// step — and returns the composed <c>{baseUrl}/api/mcp</c> URL (the PRIMARY endpoint path — see
+/// <see cref="McpEndpointRoutes"/>; safe to use here because the back-connection targets THIS
+/// portal, whose image carries the alias) plus the raw <c>mw_…</c> token to present
+/// as <c>Authorization: Bearer</c>. Internal portal↔CLI↔MCP comms are therefore token-based and
 /// scoped to the user's own permissions (the ApiToken carries the user's roles).
 ///
 /// <para>The per-user token is cached on this singleton's instance dictionary (NEVER static — it
 /// dies with the host) for the process lifetime; a fresh replica mints its own (the prior token
-/// stays valid). A revoked token surfaces as a 401 on the next <c>/mcp</c> call, which the
+/// stays valid). A revoked token surfaces as a 401 on the next MCP call, which the
 /// auth-on-exception path turns into a re-mint.</para>
 /// </summary>
 internal sealed class McpBackConnectionService : IMcpBackConnection
@@ -46,7 +48,7 @@ internal sealed class McpBackConnectionService : IMcpBackConnection
         if (string.IsNullOrWhiteSpace(baseUrl) || string.IsNullOrWhiteSpace(userId))
             return Observable.Return<McpConnectionInfo?>(null);
 
-        var mcpUrl = $"{baseUrl!.TrimEnd('/')}/mcp";
+        var mcpUrl = $"{baseUrl!.TrimEnd('/')}{McpEndpointRoutes.PrimaryEndpoint}";
 
         // Reuse the cached token (long-lived, no expiry) — cheap hot path, no mint.
         if (tokensByUser.TryGetValue(userId, out var cached))

--- a/memex/Memex.Portal.Shared/Authentication/McpEndpointRoutes.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpEndpointRoutes.cs
@@ -1,0 +1,107 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+
+namespace Memex.Portal.Shared.Authentication;
+
+/// <summary>
+/// The portal's MCP endpoint path contract: <c>/api/mcp</c> is the PRIMARY published
+/// URL, <c>/mcp</c> is the permanent compatibility alias every existing client config points at
+/// (Claude Code harnesses, plugin MCP servers, <c>IMcpBackConnection</c> consumers,
+/// <c>McpRemoteMeshClient</c> mirrors). Both serve the identical endpoint.
+///
+/// <para><b>How the alias works.</b> The MeshWeaver.Mcp module maps its streamable-HTTP
+/// transport at <c>/mcp</c> (via <c>MapMeshModuleEndpoints</c>). <see cref="Middleware"/> —
+/// self-wired through an <see cref="IStartupFilter"/> registered by
+/// <see cref="McpAuthenticationExtensions.AddMcpAuthentication"/>, so it runs at the very FRONT
+/// of the pipeline — rewrites <c>/api/mcp[/…]</c> to <c>/mcp[/…]</c> before routing. Everything
+/// downstream (the MCP auth policy, the middleware exclusion lists, the module's route) then
+/// treats <c>/api/mcp</c> traffic byte-for-byte like <c>/mcp</c> traffic. This deliberately
+/// does NOT depend on the module's own mapping moving: the alias works against every module
+/// generation, and there is no cross-repo ordering window where <c>/api/mcp</c> maps to
+/// nothing. If the module's pattern ever moves to <c>/api/mcp</c> natively, INVERT this rewrite
+/// in the same change (<c>/mcp</c> → <c>/api/mcp</c>) — never map both without removing it, or
+/// the module-endpoint collision check refuses startup.</para>
+///
+/// <para><b>OAuth discovery (RFC 9728).</b> A strict MCP client derives the path-inserted
+/// protected-resource-metadata URL from the endpoint it connects to:
+/// <c>/.well-known/oauth-protected-resource/api/mcp</c> for the primary,
+/// <c>…/mcp</c> for the alias. The MCP SDK serves ONE metadata document at the bare
+/// <c>/.well-known/oauth-protected-resource</c>, so the middleware rewrites both path-inserted
+/// forms onto the bare path and stashes the resource path in
+/// <see cref="ResourcePathItem"/>; <c>OnResourceMetadataRequest</c> (which runs AFTER
+/// <c>UseForwardedHeaders</c>, so its origin is the public one) reads the stash and answers
+/// with the matching <c>resource</c> value. The bare document keeps answering
+/// <c>{origin}/mcp</c> — the value every already-connected client validated against.</para>
+/// </summary>
+public static class McpEndpointRoutes
+{
+    /// <summary>The primary MCP endpoint path. New client configs point here.</summary>
+    public const string PrimaryEndpoint = "/api/mcp";
+
+    /// <summary>The compatibility alias — the path the MCP module actually maps, and the one
+    /// every pre-#2378 client config uses. Permanent: breaking it breaks every existing
+    /// harness/plugin/back-connection config in the field.</summary>
+    public const string CompatibilityEndpoint = "/mcp";
+
+    /// <summary>The bare RFC 9728 protected-resource-metadata path the MCP SDK serves.</summary>
+    public const string ResourceMetadataPath = "/.well-known/oauth-protected-resource";
+
+    /// <summary><see cref="HttpContext.Items"/> key carrying the resource path
+    /// (<see cref="PrimaryEndpoint"/> or <see cref="CompatibilityEndpoint"/>) a path-inserted
+    /// metadata request was addressed to.</summary>
+    public const string ResourcePathItem = "Memex.Mcp.ResourcePath";
+
+    /// <summary>
+    /// The front-of-pipeline rewrite described in the type remarks. Pure path logic — no
+    /// response is written and no origin is composed here, precisely because this runs before
+    /// <c>UseForwardedHeaders</c>.
+    /// </summary>
+    public static IApplicationBuilder UseMcpEndpointAlias(this IApplicationBuilder app)
+        => app.Use(Middleware);
+
+    private static Task Middleware(HttpContext context, RequestDelegate next)
+    {
+        var path = context.Request.Path;
+
+        // /api/mcp[/…] → /mcp[/…] — segment-exact (never /api/mcpx), case-insensitive
+        // (route matching is; a client typing /API/MCP gets the same endpoint).
+        if (path.StartsWithSegments(PrimaryEndpoint, StringComparison.OrdinalIgnoreCase, out var remaining))
+        {
+            context.Request.Path = new PathString(CompatibilityEndpoint).Add(remaining);
+            return next(context);
+        }
+
+        // Path-inserted RFC 9728 discovery for both resource names → the SDK's bare document,
+        // with the requested resource path stashed for OnResourceMetadataRequest.
+        if (path.StartsWithSegments(ResourceMetadataPath, StringComparison.OrdinalIgnoreCase, out var resource)
+            && resource.HasValue)
+        {
+            if (resource.Equals(new PathString(PrimaryEndpoint), StringComparison.OrdinalIgnoreCase))
+            {
+                context.Items[ResourcePathItem] = PrimaryEndpoint;
+                context.Request.Path = ResourceMetadataPath;
+            }
+            else if (resource.Equals(new PathString(CompatibilityEndpoint), StringComparison.OrdinalIgnoreCase))
+            {
+                context.Items[ResourcePathItem] = CompatibilityEndpoint;
+                context.Request.Path = ResourceMetadataPath;
+            }
+        }
+
+        return next(context);
+    }
+
+    /// <summary>Self-wires <see cref="Middleware"/> at the front of every host that registers
+    /// MCP authentication — the composition (which lives in the plugins repo) needs no extra
+    /// call, so there is no cross-repo window where the primary path is unserved.</summary>
+    internal sealed class StartupFilter : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+            => app =>
+            {
+                app.UseMcpEndpointAlias();
+                next(app);
+            };
+    }
+}

--- a/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
@@ -84,7 +84,12 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
         // content route mesh images/PDFs/downloads use (issue #587).
         "/api/content",
         "/favicon.ico",
+        // Both MCP endpoint paths. The McpEndpointRoutes front-of-pipeline rewrite normally
+        // turns /api/mcp into /mcp before this middleware runs; the explicit /api/mcp entry is
+        // defense-in-depth against pipeline reordering — an MCP client bounced to /onboarding
+        // cannot follow the redirect.
         "/mcp",
+        "/api/mcp",
         "/signin-",
         "/bootstrap",
         "/api/email",

--- a/memex/Memex.Portal.Shared/Authentication/VirtualUserMiddleware.cs
+++ b/memex/Memex.Portal.Shared/Authentication/VirtualUserMiddleware.cs
@@ -22,8 +22,11 @@ public class VirtualUserMiddleware(RequestDelegate next, ILogger<VirtualUserMidd
 {
     private const string CookieName = "meshweaver_virtual_user";
 
+    // "/api/mcp" beside "/mcp": the McpEndpointRoutes rewrite normally folds the primary path
+    // onto /mcp before this runs; the explicit entry is defense-in-depth against reordering —
+    // Bearer-authed MCP traffic must never provision guest VUsers.
     private static readonly string[] ExcludedPrefixes =
-        ["/_framework", "/_content", "/_blazor", "/static/", "/favicon.ico", "/mcp", "/bootstrap", "/healthz"];
+        ["/_framework", "/_content", "/_blazor", "/static/", "/favicon.ico", "/mcp", "/api/mcp", "/bootstrap", "/healthz"];
 
     // 🚨 Anonymous, high-frequency infrastructure routes. They are polled by machines that keep no
     // cookie, so the VUser flow can only ever churn: it re-derives an id and stamps a guest context

--- a/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
+++ b/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
@@ -44,9 +44,13 @@ public static class SeoResolver
     /// <summary>Per-request stash key so the head and body components resolve ONCE.</summary>
     public const string HttpContextItem = "Memex.Seo.PageData";
 
-    /// <summary>Route prefixes that are never mesh nodes — skipped without touching the mesh.</summary>
+    /// <summary>Route prefixes that are never mesh nodes — skipped without touching the mesh.
+    /// "mcp" is deliberately NOT here: <c>Mcp</c> is a real partition (the MCP Server store
+    /// plugin) whose cover renders at <c>/Mcp</c>, so it resolves like any node page; MCP
+    /// protocol traffic never reaches the page render path this resolver serves (the endpoint
+    /// route and <c>NonfileRouteConstraint</c> keep it off).</summary>
     private static readonly string[] NonNodePrefixes =
-        ["login", "api", "_blazor", "_framework", "_content", "dev", "mcp", "static", "webhooks"];
+        ["login", "api", "_blazor", "_framework", "_content", "dev", "static", "webhooks"];
 
     /// <summary>Whether the request path can be a node page worth resolving.</summary>
     public static bool IsCandidatePath(string? path)

--- a/src/MeshWeaver.Documentation/Data/AI/McpAuthentication.md
+++ b/src/MeshWeaver.Documentation/Data/AI/McpAuthentication.md
@@ -14,7 +14,7 @@ Tags:
   - "API Tokens"
 ---
 
-The MeshWeaver MCP endpoint (`/mcp`) uses bearer token authentication. Every MCP client — Claude Code, Cursor, or a custom integration — must include a valid API token in its `Authorization` header. Without one, requests receive `401 Unauthorized` and never reach the MCP handler.
+The MeshWeaver MCP endpoint (`/api/mcp`, with `/mcp` as a permanent compatibility alias — both serve the identical endpoint) uses bearer token authentication. Every MCP client — Claude Code, Cursor, or a custom integration — must include a valid API token in its `Authorization` header. Without one, requests receive `401 Unauthorized` and never reach the MCP handler.
 
 Tokens are personal. Each token is tied to a specific user, so all MCP operations run under that user's identity with full row-level security (RLS) enforced.
 
@@ -104,7 +104,7 @@ Add the MCP server to your Claude Code configuration (`.claude/settings.json` or
   "mcpServers": {
     "meshweaver": {
       "type": "sse",
-      "url": "https://your-portal.com/mcp",
+      "url": "https://your-portal.com/api/mcp",
       "headers": {
         "Authorization": "Bearer mw_dGhpcyBpcyBhIHNhbXBsZSB0b2tlbg"
       }
@@ -126,7 +126,7 @@ Authorization: Bearer mw_<your-token>
 #### Smoke-test with curl
 
 ```bash
-curl -X POST https://your-portal.com/mcp \
+curl -X POST https://your-portal.com/api/mcp \
   -H "Authorization: Bearer mw_dGhpcyBpcyBhIHNhbXBsZSB0b2tlbg" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}'

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-mcp-endpoint-api-mcp-and-cover.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-mcp-endpoint-api-mcp-and-cover.md
@@ -1,0 +1,20 @@
+---
+Name: MCP endpoint at /api/mcp, and the MCP Server page renders
+Category: Fix
+Description: The MCP endpoint's primary URL is now /api/mcp (/mcp keeps working for every existing client), and opening /Mcp in the browser now shows the MCP Server page instead of a 404.
+Icon: PlugConnected
+Order: -20260826
+---
+
+# MCP endpoint at /api/mcp, and the MCP Server page renders
+
+The mesh's MCP endpoint now lives at `/api/mcp` as its primary URL. Every existing
+client configuration pointing at `/mcp` — Claude Code, Claude Desktop, Copilot,
+plugin MCP servers — keeps working unchanged: `/mcp` remains a permanent alias for
+the same endpoint, and OAuth discovery answers for both URLs.
+
+Opening `/Mcp` in the browser now renders the MCP Server page (the pre-installed
+store plugin with connection instructions) instead of answering "not found". MCP
+protocol traffic is unaffected — an agent's JSON calls never see an HTML page, and
+a portal whose MCP module is missing still answers an honest 404 rather than a
+misleading web page.

--- a/src/MeshWeaver.Hosting.AspNetCore/McpConfiguration.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/McpConfiguration.cs
@@ -9,7 +9,8 @@ namespace MeshWeaver.Hosting.AspNetCore;
 /// 🚨 It lives PLATFORM-side, not in <c>MeshWeaver.Mcp</c>, because three surfaces read it and
 /// only one of them is the MCP module: the REST mirror <c>/api/mesh/navigate_to</c> +
 /// <c>/api/mesh/base_url</c>, the co-hosted CLI back-connection (which composes
-/// <c>{BaseUrl}/mcp</c>), and the MCP <c>navigate_to</c> tool itself. Delisting
+/// <c>{BaseUrl}/api/mcp</c> — the primary MCP endpoint path; <c>/mcp</c> is the permanent
+/// compatibility alias), and the MCP <c>navigate_to</c> tool itself. Delisting
 /// <c>MeshWeaver.Mcp</c> from <c>Modules:Assemblies</c> must not take the other two with it.
 /// The section name stays <c>Mcp</c> so no deployment's configuration changes.
 /// </para>

--- a/src/MeshWeaver.Hosting.AspNetCore/Portal/NonfileRouteConstraint.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/Portal/NonfileRouteConstraint.cs
@@ -9,7 +9,7 @@ namespace MeshWeaver.Hosting.AspNetCore.Portal;
 
 /// <summary>
 /// Route constraint that excludes paths for static file prefixes used by Blazor and RCLs,
-/// plus infrastructure endpoints (auth, dev, mcp, OAuth callbacks). Applied to the root
+/// plus infrastructure endpoints (auth, dev, OAuth callbacks). Applied to the root
 /// catch-all page endpoint via <see cref="NonfileRouteConstraintExtensions.ExcludeStaticAssetPaths{TBuilder}"/>
 /// so that requests under these prefixes are never swallowed by the Blazor application page
 /// (a miss falls through to a proper 404 instead of an HTML shell).
@@ -27,9 +27,18 @@ public class NonfileRouteConstraint : IRouteConstraint
     private static readonly HashSet<string> ExcludedPrefixes = new(StringComparer.OrdinalIgnoreCase)
     {
         "_framework", "_content", "_blazor", "favicon.ico",
-        "auth", "dev", "mcp",
+        "auth", "dev",
         "signin-microsoft", "signin-google", "signin-linkedin", "signin-apple"
     };
+
+    /// <summary>
+    /// The MCP endpoint's first path segment. NOT in <see cref="ExcludedPrefixes"/> any more:
+    /// <c>Mcp</c> is ALSO a mesh partition (the Store plugin node whose cover a browser
+    /// navigation to <c>/Mcp</c> must render), so the exclusion is by REQUEST SHAPE, not by
+    /// path alone — see <see cref="IsMcpProtocolRequest"/>. Route templates are case-insensitive,
+    /// and so is this check: <c>/mcp</c> and <c>/Mcp</c> are the same path family.
+    /// </summary>
+    private const string McpSegment = "mcp";
 
     /// <summary>
     /// Returns false when the route value for <paramref name="routeKey"/> begins with an excluded prefix;
@@ -59,6 +68,9 @@ public class NonfileRouteConstraint : IRouteConstraint
         if (ExcludedPrefixes.Contains(firstSegment.ToString()))
             return false;
 
+        if (IsMcpProtocolRequest(httpContext, firstSegment))
+            return false;
+
         // 🚨 A path that IS a real file in webroot is never a page route. The prefix list above
         // only covers the KNOWN asset roots (_framework, _content, …); anything else physically
         // present — a hand-dropped wwwroot file, a published SPA bundle, an asset outside the
@@ -71,6 +83,46 @@ public class NonfileRouteConstraint : IRouteConstraint
         // mesh Document nodes legitimately end in .pdf/.docx/.txt, and rejecting dotted paths is
         // exactly the agentic-pensions#10 regression this class was written to fix.
         return !FileExistsInWebRoot(httpContext, path);
+    }
+
+    /// <summary>
+    /// Whether this request is MCP PROTOCOL traffic on the <c>/mcp</c> path family — traffic the
+    /// page route must never swallow. The <c>Mcp</c> segment is special because it is BOTH the MCP
+    /// endpoint (streamable-HTTP JSON-RPC, mapped by the MeshWeaver.Mcp module) AND a mesh
+    /// partition whose Store cover a browser renders at <c>/Mcp</c>:
+    ///
+    /// <list type="bullet">
+    /// <item><description>Non-GET/HEAD (the JSON-RPC POST, session DELETE) → protocol. When the
+    /// module is loaded its own literal route outranks this catch-all anyway; when it is NOT
+    /// loaded (the #2093 failure mode) the request must answer an honest 404 — never a 200 HTML
+    /// shell that an MCP client cannot parse and an operator reads as "the endpoint works".
+    /// </description></item>
+    /// <item><description>GET/HEAD asking for <c>text/event-stream</c> or <c>application/json</c>
+    /// (SSE channel probes, API-shaped reads) → protocol, same reasoning.</description></item>
+    /// <item><description>GET/HEAD wanting <c>text/html</c> (a browser navigation to
+    /// <c>/Mcp</c>) → NOT protocol: the page route serves the partition cover. The MCP module
+    /// maps no GET in stateless mode, so nothing shadows this.</description></item>
+    /// </list>
+    ///
+    /// Null context (URL generation / non-request evaluation) counts as protocol — the
+    /// conservative pre-existing behavior of the blanket "mcp" prefix exclusion.
+    /// </summary>
+    private static bool IsMcpProtocolRequest(HttpContext? httpContext, ReadOnlySpan<char> firstSegment)
+    {
+        if (!firstSegment.Equals(McpSegment, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (httpContext is null)
+            return true;
+
+        var request = httpContext.Request;
+        if (!HttpMethods.IsGet(request.Method) && !HttpMethods.IsHead(request.Method))
+            return true;
+
+        var accept = request.Headers.Accept.ToString();
+        if (accept.Contains("text/html", StringComparison.OrdinalIgnoreCase))
+            return false;
+        return accept.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase)
+               || accept.Contains("application/json", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>True when <paramref name="path"/> resolves to a file that physically exists in the
@@ -102,10 +154,12 @@ public static class NonfileRouteConstraintExtensions
     /// <summary>
     /// Applies <see cref="NonfileRouteConstraint"/> to the root catch-all page endpoint
     /// (ApplicationPage's <c>/{**Path}</c>) so static-asset and infrastructure prefixes
-    /// (<c>_framework</c>, <c>_content</c>, <c>favicon.ico</c>, <c>auth</c>, <c>mcp</c>, ...)
-    /// are not swallowed by the Blazor application page: a request under those prefixes that
-    /// no static file or explicit endpoint handles falls through to 404 instead of rendering
-    /// the HTML shell. Chain on the builder returned by <c>MapRazorComponents</c>.
+    /// (<c>_framework</c>, <c>_content</c>, <c>favicon.ico</c>, <c>auth</c>, ...) — plus
+    /// MCP-protocol-shaped requests on the <c>/mcp</c> path family — are not swallowed by the
+    /// Blazor application page: a request under those prefixes that no static file or explicit
+    /// endpoint handles falls through to 404 instead of rendering the HTML shell. A browser
+    /// navigation to <c>/Mcp</c> is deliberately NOT excluded — it renders the Mcp partition's
+    /// cover. Chain on the builder returned by <c>MapRazorComponents</c>.
     ///
     /// This is an endpoint convention, NOT an inline template constraint, because only the
     /// ASP.NET endpoint layer honors custom constraints — the Blazor Router's inline-constraint

--- a/src/MeshWeaver.Hosting/Persistence/Http/McpRemoteMeshClient.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Http/McpRemoteMeshClient.cs
@@ -66,8 +66,14 @@ public sealed class McpRemoteMeshClient : IRemoteMeshClient, IAsyncDisposable
     private readonly PromiseSlot<McpClient> _connect = new();
 
     /// <summary>
-    /// Creates a remote-mesh client targeting a portal's <c>/mcp</c> endpoint. The
+    /// Creates a remote-mesh client targeting a portal's MCP endpoint. The
     /// MCP connection is opened lazily on first use, not in the constructor.
+    ///
+    /// <para>Deliberately composes the <c>/mcp</c> COMPATIBILITY path, not the primary
+    /// <c>/api/mcp</c>: this client dials REMOTE portals whose version is unknown, and
+    /// <c>/mcp</c> is the alias every portal generation serves (the primary path exists only
+    /// on portals carrying the <c>McpEndpointRoutes</c> alias). <c>/mcp</c> is permanent by
+    /// contract — do not "modernize" this line.</para>
     /// </summary>
     /// <param name="remoteBaseUrl">Base URL of the remote MeshWeaver portal; <c>/mcp</c> is appended. Required.</param>
     /// <param name="remoteToken">API token sent as <c>Authorization: Bearer</c> on every request. Required.</param>

--- a/src/MeshWeaver.Mesh.Contract/Services/IMcpBackConnection.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMcpBackConnection.cs
@@ -2,7 +2,9 @@ namespace MeshWeaver.Mesh.Services;
 
 /// <summary>
 /// The coordinates a co-hosted CLI needs to call the portal's MCP endpoint AS THE USER:
-/// the fully-composed <c>{baseUrl}/mcp</c> URL and the Bearer token to present.
+/// the fully-composed <c>{baseUrl}/api/mcp</c> URL (the primary MCP endpoint path; <c>/mcp</c>
+/// remains the permanent compatibility alias for existing client configs) and the Bearer token
+/// to present.
 /// </summary>
 public sealed record McpConnectionInfo(string McpUrl, string BearerToken);
 

--- a/test/Memex.Portal.Shared.Test/GuiShellSwitchTest.cs
+++ b/test/Memex.Portal.Shared.Test/GuiShellSwitchTest.cs
@@ -59,6 +59,7 @@ public class GuiShellSwitchTest
     [InlineData("/login")]
     [InlineData("/next/Doc")]
     [InlineData("/mcp")]
+    [InlineData("/api/mcp")]
     public void NonPageSurfaces_NeverRedirect(string path)
     {
         var (redirect, _) = GuiShellSwitch.Decide("GET", path, Html, null, "next", "Blazor");

--- a/test/Memex.Portal.Shared.Test/McpRoutingTest.cs
+++ b/test/Memex.Portal.Shared.Test/McpRoutingTest.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Hosting.AspNetCore.Portal;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The MCP endpoint routing contract: <c>/api/mcp</c> is the primary published path,
+/// <c>/mcp</c> the permanent compatibility alias, and <c>/Mcp</c> — the SAME path family,
+/// route matching being case-insensitive — is ALSO the Mcp partition's page (its Store cover).
+///
+/// <para>This pins the resolution of that collision end-to-end over a real routing pipeline,
+/// because it shipped broken in both directions: the blanket "mcp" prefix in
+/// <see cref="NonfileRouteConstraint"/> made <c>GET /Mcp</c> answer 404 forever (the partition
+/// cover was unreachable on every deployment), while the module-not-loaded failure mode (#2093)
+/// needs MCP-protocol traffic to keep answering an honest 404 — never a 200 HTML shell an MCP
+/// client cannot parse and an operator reads as healthy.</para>
+///
+/// <para>The MCP endpoint itself is a stand-in POST route here (the real one is mapped by the
+/// MeshWeaver.Mcp module, which lives in the plugins repo) — what is under test is the
+/// platform's routing around it: the <see cref="McpEndpointRoutes"/> front-of-pipeline alias,
+/// the shape-based page-route constraint, and the RFC 9728 path-inserted discovery rewrite.</para>
+/// </summary>
+public class McpRoutingTest
+{
+    private const string McpEndpointBody = "mcp-endpoint";
+
+    /// <summary>
+    /// The pipeline under test: the alias startup filter exactly as
+    /// <see cref="McpAuthenticationExtensions.AddMcpAuthentication"/> registers it, a literal
+    /// POST <c>/mcp</c> endpoint standing in for the module's streamable-HTTP transport
+    /// (stateless mode maps no GET — mirrored here, it is what frees browser GETs for the page),
+    /// a bare protected-resource-metadata endpoint echoing the stashed resource path, and a
+    /// GET+POST catch-all page route carrying the real <see cref="NonfileRouteConstraint"/>
+    /// (razor-components page endpoints accept POST for enhanced forms, so the emulation must
+    /// too — otherwise the "protocol POST never renders the shell" half would be vacuous).
+    /// </summary>
+    private static WebApplication BuildApp(bool mapMcpEndpoint)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.Services.AddTransient<IStartupFilter, McpEndpointRoutes.StartupFilter>();
+
+        var app = builder.Build();
+
+        if (mapMcpEndpoint)
+            app.MapPost("/mcp", () => McpEndpointBody);
+
+        app.MapGet(McpEndpointRoutes.ResourceMetadataPath,
+            (HttpContext ctx) =>
+                ctx.Items.TryGetValue(McpEndpointRoutes.ResourcePathItem, out var stashed)
+                && stashed is string resourcePath
+                    ? resourcePath
+                    : "(bare)");
+
+        app.MapMethods("/{**path}", ["GET", "POST"],
+                (string? path) => $"page:{path}")
+            .ExcludeStaticAssetPaths();
+
+        return app;
+    }
+
+    private static HttpRequestMessage JsonPost(string url) =>
+        new(HttpMethod.Post, url)
+        {
+            Content = new StringContent(
+                """{"jsonrpc":"2.0","id":1,"method":"initialize"}""",
+                Encoding.UTF8,
+                "application/json"),
+        };
+
+    [Theory]
+    [InlineData("/mcp")]        // the compatibility alias every existing client config uses
+    [InlineData("/api/mcp")]    // the primary path — rewritten onto the module's route
+    [InlineData("/API/MCP")]    // route matching is case-insensitive; the rewrite must be too
+    public async Task JsonPost_ReachesTheMcpEndpoint(string url)
+    {
+        await using var app = BuildApp(mapMcpEndpoint: true);
+        await app.StartAsync();
+        using var client = app.GetTestClient();
+
+        var response = await client.SendAsync(JsonPost(url));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be(McpEndpointBody);
+    }
+
+    [Fact]
+    public async Task BrowserGetOfMcp_RendersThePartitionPage()
+    {
+        await using var app = BuildApp(mapMcpEndpoint: true);
+        await app.StartAsync();
+        using var client = app.GetTestClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/Mcp");
+        request.Headers.TryAddWithoutValidation("Accept", "text/html,application/xhtml+xml");
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be("page:Mcp",
+            because: "a browser navigation to /Mcp must render the Mcp partition's cover, "
+                     + "not fall into the endpoint-or-404 hole that shipped");
+    }
+
+    [Theory]
+    [InlineData("text/event-stream")]                    // streamable-HTTP SSE channel probe
+    [InlineData("application/json, text/event-stream")]  // API-shaped read
+    public async Task ProtocolShapedGet_NeverGetsTheHtmlShell(string accept)
+    {
+        await using var app = BuildApp(mapMcpEndpoint: true);
+        await app.StartAsync();
+        using var client = app.GetTestClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/mcp");
+        request.Headers.TryAddWithoutValidation("Accept", accept);
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ModuleNotLoaded_JsonPostAnswersAnHonest404_NeverTheShell()
+    {
+        // The #2093 failure mode: the MeshWeaver.Mcp module never host-loaded, so nothing maps
+        // /mcp. A protocol POST must answer 404 — the signal that made that outage findable —
+        // and never a 200 HTML shell.
+        await using var app = BuildApp(mapMcpEndpoint: false);
+        await app.StartAsync();
+        using var client = app.GetTestClient();
+
+        foreach (var url in new[] { "/mcp", "/api/mcp" })
+        {
+            var response = await client.SendAsync(JsonPost(url));
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+                because: $"a JSON POST to {url} with no MCP endpoint mapped must fail loud");
+        }
+
+        // …while the partition page stays reachable for browsers even then.
+        var browser = new HttpRequestMessage(HttpMethod.Get, "/Mcp");
+        browser.Headers.TryAddWithoutValidation("Accept", "text/html");
+        var page = await client.SendAsync(browser);
+        (await page.Content.ReadAsStringAsync()).Should().Be("page:Mcp");
+    }
+
+    [Fact]
+    public async Task ApiMcpPrefixIsSegmentExact_NeverRewritesNeighbours()
+    {
+        await using var app = BuildApp(mapMcpEndpoint: true);
+        await app.StartAsync();
+        using var client = app.GetTestClient();
+
+        var response = await client.SendAsync(JsonPost("/api/mcpx"));
+
+        (await response.Content.ReadAsStringAsync()).Should().NotBe(McpEndpointBody,
+            because: "/api/mcpx is not the MCP endpoint; the rewrite matches whole segments");
+    }
+
+    [Theory]
+    [InlineData("/.well-known/oauth-protected-resource/api/mcp", "/api/mcp")]
+    [InlineData("/.well-known/oauth-protected-resource/mcp", "/mcp")]
+    [InlineData("/.well-known/oauth-protected-resource", "(bare)")]
+    public async Task PathInsertedResourceMetadata_ReachesTheBareDocument_WithTheResourceStashed(
+        string url, string expectedStash)
+    {
+        // RFC 9728: a strict MCP client derives the metadata URL from the endpoint path it
+        // connects to. Both derivations must answer, each naming ITS resource; the bare
+        // document (the URL the WWW-Authenticate challenge carries) keeps its default.
+        await using var app = BuildApp(mapMcpEndpoint: true);
+        await app.StartAsync();
+        using var client = app.GetTestClient();
+
+        var response = await client.GetAsync(url);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be(expectedStash);
+    }
+
+    [Fact]
+    public void AddMcpAuthentication_RegistersTheAliasStartupFilter()
+    {
+        // The alias is self-wired: the composition (plugins repo) calls AddMcpAuthentication and
+        // nothing else — if this registration goes missing, /api/mcp silently stops being served
+        // while every test above still passes on its explicit registration.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMcpAuthentication();
+
+        services.Should().Contain(d =>
+            d.ServiceType == typeof(IStartupFilter)
+            && d.ImplementationType == typeof(McpEndpointRoutes.StartupFilter));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/OnboardingMiddlewareExclusionTest.cs
+++ b/test/Memex.Portal.Shared.Test/OnboardingMiddlewareExclusionTest.cs
@@ -21,6 +21,7 @@ public class OnboardingMiddlewareExclusionTest
     [InlineData("/static/img.png")]
     [InlineData("/favicon.ico")]
     [InlineData("/mcp")]
+    [InlineData("/api/mcp")]
     [InlineData("/signin-microsoft")]
     public async Task ExcludedPrefixes_SkipOnboardingCheck(string path)
     {

--- a/test/Memex.Portal.Shared.Test/VirtualUserMiddlewareExclusionTest.cs
+++ b/test/Memex.Portal.Shared.Test/VirtualUserMiddlewareExclusionTest.cs
@@ -88,6 +88,8 @@ public class VirtualUserMiddlewareExclusionTest
     [Theory]
     [InlineData("/mcp")]
     [InlineData("/mcp/tools")]
+    [InlineData("/api/mcp")]
+    [InlineData("/api/mcp/tools")]
     public async Task McpPath_StillExcluded(string path)
     {
         var nextCalled = false;


### PR DESCRIPTION
## What

Implements the decided MCP-routing direction: **`/api/mcp` is the primary MCP endpoint URL, `/mcp` stays as the permanent compatibility alias** (every existing client config — Claude Code harnesses, plugin MCP servers, `IMcpBackConnection` consumers, `McpRemoteMeshClient` mirrors — keeps working unchanged), and **`GET /Mcp` now renders the Mcp partition's cover** (the pre-installed "MCP Server" store plugin page) instead of 404ing on every deployment.

## Diagnosis (live, 2026-08-26 ~19:20Z, both portals)

| request | memex.systemorph.com | memex.meshweaver.cloud |
|---|---|---|
| POST /mcp, `Content-Type: application/json` | 401 (endpoint mapped, auth) | 401 |
| POST /mcp, no Content-Type | 404 | 404 |
| GET /Mcp, `Accept: text/html` | **404 (empty)** | **404 (empty)** |
| GET /Store, `Accept: text/html` (control) | — | 200 |

- The `/Mcp` 404 is `NonfileRouteConstraint`'s blanket case-insensitive `"mcp"` prefix exclusion on the Blazor catch-all — the partition cover was unreachable **by construction** on every deployment.
- The MCP module maps **POST only** in stateless mode (GET /mcp → 404 anonymous, not 401; DELETE → 405), so a browser GET is free to fall through to the page once the exclusion is shape-based.
- The "systemorph errors on every tool call" half of today's symptoms is a **separate, already-fixed** defect: #2370's `TypeLoadException: MeshWeaver.AI.MeshOperations` (store-installed MeshWeaver.Mcp 1.1.4 built before the assembly move), fixed on main by `efd657ebe` (type forwarders). Both portals still run `ci.5670` (pre-fix); `ci.5876` (= main tip `4327030`, containing the forwarders) is published — the outage heals when the self-update rolls the fleet. No code change for it here.

## How

All platform-side; the module's `/mcp` mapping in the plugins repo is deliberately untouched, so there is **no cross-repo ordering window** where `/api/mcp` maps to nothing:

- **`McpEndpointRoutes`** (new): front-of-pipeline rewrite `/api/mcp[/…]` → `/mcp[/…]`, self-wired via an `IStartupFilter` registered by `AddMcpAuthentication` (the composition needs no extra call). Also rewrites both RFC 9728 path-inserted discovery URLs (`/.well-known/oauth-protected-resource/{api/mcp,mcp}`) onto the SDK's bare metadata document with the resource path stashed; `OnResourceMetadataRequest` answers with the matching `resource`, so strict clients' resource-match validation passes for both endpoints while the bare document keeps its `/mcp` default.
- **`NonfileRouteConstraint`**: the `"mcp"` exclusion becomes request-shaped — protocol traffic (non-GET, or GET asking for `text/event-stream`/`application/json`) still gets an honest 404 when the module isn't loaded (the #2093 diagnosability contract), while a browser GET renders the cover.
- **Back-connection** composes `{baseUrl}/api/mcp` (same image carries the alias); `McpRemoteMeshClient` stays on `/mcp` by contract (remote portals of unknown version) and now documents why.
- `SeoResolver` stops treating `mcp` as a non-node prefix; Onboarding/VirtualUser exclusion lists gain `/api/mcp` as defense-in-depth.

## Verification

- `dotnet build test/Memex.Portal.Shared.Test -c Release -warnaserror` — 0 errors.
- New **`McpRoutingTest`** (real routing pipeline via TestServer): JSON POST to `/mcp`, `/api/mcp`, `/API/MCP` reaches the endpoint; `GET /Mcp` (text/html) renders the page; protocol-shaped GETs 404; with no MCP endpoint mapped the POSTs 404 honestly while the page stays reachable; rewrite is segment-exact; both path-inserted metadata URLs answer with their own resource; `AddMcpAuthentication` registers the filter. 74/74 green across the touched test classes (incl. `MeshApiCookieAuthTest`, the exclusion tests, `GuiShellSwitchTest`).
- `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` green (What's New entry: Category Fix).

Follow-up (mesh content, not this repo): the MCP Server plugin's cover body and the plugins-repo docs still say "connect to `/mcp`" — update to name `/api/mcp` as primary once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)