### PR TITLE
ci: the gate's core dumps were being collected and then thrown away

### DIFF
--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -299,6 +299,32 @@ jobs:
           docker run --rm --init -v "$REPO_MOUNT:/repo" "${DUMP_ARGS[@]}" \
             --entrypoint /app/mw-plugin-test "$IMAGE" /repo \
             "${ALLOW_ARGS[@]}"
+      # 🚨 The dump is written by the CONTAINER, which runs as root, so the file lands owned by
+      # root with a restrictive mode — a core dump can contain anything that was in memory, so the
+      # runtime writes it 0600 on purpose. `chmod 0777` on the mount DIRECTORY (above) lets the
+      # container create the file; it does nothing for the file's own permissions. So
+      # upload-artifact, which runs as the unprivileged `runner` user, failed with
+      #
+      #     Error: EACCES: permission denied, open '.../coredumps/mw-plugin-test-7.dmp'
+      #
+      # and the job then died in zip creation. Every crash produced exactly the evidence needed to
+      # diagnose it and then threw it away — which is why MeshWeaver.Reinsurance#98 stayed
+      # "different NodeTypes park on different runs" for weeks instead of being read as the SIGSEGV
+      # (exit 139) it actually is.
+      #
+      # `if: always()` because the only runs with a dump are the ones where the gate FAILED.
+      - name: Make core dumps readable by the uploader
+        if: always() && inputs.capture-coredumps
+        shell: bash
+        run: |
+          dir="${RUNNER_TEMP:-/tmp}/coredumps"
+          [ -d "$dir" ] || exit 0
+          # Not `|| true`: if a dump exists and cannot be made readable, say so here rather than
+          # letting the upload fail three steps later with a message about zip creation.
+          sudo chown -R "$(id -u):$(id -g)" "$dir"
+          sudo chmod -R u+rw "$dir"
+          ls -l "$dir" || true
+
       - name: Upload core dumps (if the gate crashed)
         if: always() && inputs.capture-coredumps
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## The bug

`capture-coredumps` mounts a `0777` directory into the container so the .NET runtime can write a minidump. It can — but the **file** lands owned by root, mode `0600`, because a core dump can contain anything that was in memory and the runtime writes it restrictively on purpose. **A mode on the directory says nothing about the mode on the file.**

So `actions/upload-artifact`, which runs as the unprivileged `runner` user, fails reading it:

```
Error: EACCES: permission denied, open '.../coredumps/mw-plugin-test-7.dmp'
An error has occurred while creating the zip file for upload
```

Every crash produces exactly the evidence needed to diagnose it, then destroys it — and the job dies in zip creation reporting nothing useful about the actual failure.

## Why it matters more than it looks

This is why [MeshWeaver.Reinsurance#98](https://github.com/Systemorph/MeshWeaver.Reinsurance/issues/98) has read as *"the ACR gate parks different NodeTypes on different runs"* for weeks. **It is not a compile flake.** The newest occurrence exits **139 — SIGSEGV**, and a process dying at a nondeterministic moment reports whichever type happened to be mid-compile. That is exactly the symptom that made it look like a cold-cache problem, and the dump would have said so on the very first occurrence.

Same-commit proof that it is a crash and not the diff, on `MeshWeaver.Reinsurance` at `a9d2e540`:

| run | outcome |
|---|---|
| 19:03 | success |
| 19:27 | **failure, exit 139** |

## The fix

A `chown` + `chmod` step before the upload, `if: always()` because the only runs with a dump are the ones where the gate **failed**.

Deliberately **not** `|| true` on the chown: if a dump exists and cannot be made readable, fail there, naming it, rather than three steps later with a message about zip creation. That opacity is half of what this PR is fixing.

Fixes evidence collection for every repo that calls this reusable workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)