### PR TITLE
Two unrelated silent failures: the restart nobody was told about (#1979), and the RLS filter that strands (#2087 residual)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-installs-say-when-a-restart-is-the-last-step.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-installs-say-when-a-restart-is-the-last-step.md
@@ -1,0 +1,27 @@
+---
+Name: Installs say when a restart is the last step
+Category: Fix
+Description: A package that adds compiled code needs a restart before that code runs — the package card now says so instead of reading simply "Installed".
+Icon: ArrowClockwise
+Order: -20260826
+---
+
+# Installs say when a restart is the last step
+
+Some packages ship compiled code alongside their content. That code is put in place immediately, but
+it only starts running after the portal restarts — a deliberate design, since swapping code out from
+under a running portal is not safe.
+
+Until now nothing said so. The package card reported "Installed", the feature it promised was not
+there, and there was no way to find out that a restart was the missing half. The only place the
+information appeared was an operator health endpoint, which the person who installed the package
+never sees.
+
+The card now carries a "restart required to finish activating this package" note whenever this
+portal has code in place that a restart would start running — and it appears the moment the install
+finishes, not on some later visit. The note clears itself after the restart, because it is derived
+from what this portal has actually loaded rather than remembered as a flag.
+
+Two cases deliberately show nothing rather than a misleading prompt: when the portal cannot read its
+own activation record (an operator problem, reported to operators, that a restart would not fix), and
+when the code cannot be started by any restart at all (which needs a re-install, not waiting).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-permission-filtered-lists-no-longer-stall.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-permission-filtered-lists-no-longer-stall.md
@@ -1,0 +1,23 @@
+---
+Name: Permission-filtered lists no longer stall
+Category: Fix
+Description: A list narrowed to what you are allowed to see could open and never load — no error, no spinner resolution, just permanently empty.
+Icon: ShieldTask
+Order: -20260826
+---
+
+# Permission-filtered lists no longer stall
+
+Most live lists in the portal are filtered to what the person looking at them is allowed to read.
+That filter runs over every update the list receives, keeping the entries you have access to and
+dropping the rest.
+
+Under a specific timing, the filter's work could be queued behind the very code that was waiting for
+it. The list then never received that update at all: nothing was raised and nothing timed out, so the
+view simply stayed as it was — empty, for a list that had not loaded yet — for as long as it stayed
+open, while the same content opened another way appeared immediately. An empty result stalled the
+same way a populated one did, so "you have access to nothing here" and "this never answered" looked
+identical on screen.
+
+The filter now always runs on the spot rather than being queued, so a permission-filtered list
+always receives its updates — including the ones that legitimately come back empty.

--- a/src/MeshWeaver.Fixture/FreshThread.cs
+++ b/src/MeshWeaver.Fixture/FreshThread.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Reactive.Concurrency;
 using System.Threading;
-using Xunit;
 
-namespace MeshWeaver.Hosting.Test;
+namespace MeshWeaver.Fixture;
 
 /// <summary>
-/// Runs a probe on a thread that is guaranteed to carry no Rx <see cref="CurrentThreadScheduler"/>
+/// Runs a probe on a thread that is guaranteed to carry no Rx <c>CurrentThreadScheduler</c>
 /// trampoline.
 ///
 /// <para>🚨 This is load-bearing, not tidiness. <c>CurrentThreadScheduler.Schedule</c> only OPENS a
@@ -16,8 +14,12 @@ namespace MeshWeaver.Hosting.Test;
 /// the hub's Rx pipeline resumes its awaiter inline, and the runner carries on from there) — so a
 /// test that opens its trampoline from the test thread would intermittently skip its own body and
 /// report a pass, or fail on its own setup guard, for reasons unrelated to what it tests.</para>
+///
+/// <para>Shared rather than copied per assembly: the same-class residual in
+/// <c>MeshWeaver.Graph</c> (#2087) needs exactly this scaffolding, and a second copy is a second
+/// thing to get subtly wrong.</para>
 /// </summary>
-internal static class FreshThread
+public static class FreshThread
 {
     /// <summary>
     /// Runs <paramref name="probe"/> on a new background thread and rethrows whatever it threw, so
@@ -26,8 +28,12 @@ internal static class FreshThread
     /// <param name="probe">The body to run.</param>
     /// <param name="onTimeout">Message when the thread does not finish inside the budget.</param>
     /// <param name="budget">Wall-clock cap; defaults to 30 s.</param>
-    internal static void Run(Action probe, string onTimeout, TimeSpan? budget = null)
+    /// <exception cref="TimeoutException">The probe thread did not finish inside
+    /// <paramref name="budget"/> — which for a trampoline probe means the work it was waiting on
+    /// was queued on a foreign trampoline and can never run.</exception>
+    public static void Run(Action probe, string onTimeout, TimeSpan? budget = null)
     {
+        ArgumentNullException.ThrowIfNull(probe);
         Exception? failure = null;
         var thread = new Thread(() =>
         {
@@ -37,7 +43,8 @@ internal static class FreshThread
         { IsBackground = true };
         thread.Start();
 
-        Assert.True(thread.Join(budget ?? TimeSpan.FromSeconds(30)), onTimeout);
+        if (!thread.Join(budget ?? TimeSpan.FromSeconds(30)))
+            throw new TimeoutException(onTimeout);
         if (failure is not null)
             throw failure;
     }

--- a/src/MeshWeaver.Graph/SyncedQueryDataSourceExtensions.cs
+++ b/src/MeshWeaver.Graph/SyncedQueryDataSourceExtensions.cs
@@ -268,17 +268,42 @@ public static class SyncedQueryDataSourceExtensions
             // has Read on. PermissionEvaluator caches per-scope via the
             // process-wide IMeshNodeStreamCache so repeated checks for the
             // same user are cheap.
-            return upstream.SelectMany(snapshot =>
-                snapshot.ToObservable()
-                    .SelectMany(node =>
-                        hub.CheckPermission(node.Path ?? string.Empty, userId, Permission.Read)
-                            .Take(1)
-                            .Where(hasPerm => hasPerm)
-                            .Select(_ => node))
-                    .ToList()
-                    .Select(filtered => (IEnumerable<MeshNode>)filtered));
+            return FilterByReadPermission(
+                upstream,
+                node => hub.CheckPermission(node.Path ?? string.Empty, userId, Permission.Read));
         });
     }
+
+    /// <summary>
+    /// The RLS filter itself, with the permission probe as a parameter so it can be exercised
+    /// without a hub: for each upstream snapshot, emit the subset the probe says Read is granted on.
+    ///
+    /// <para>🚨 <c>ToInlineObservable()</c>, never the parameterless <c>ToObservable()</c> (#2087,
+    /// the residual of #2377). This runs on the DELIVERY thread of an upstream emission, which in a
+    /// live portal is routinely inside somebody else's Rx <c>CurrentThreadScheduler</c> trampoline —
+    /// the hub's own pump opens one per operator subscription, and a <c>Task</c> completed inside an
+    /// Rx pipeline resumes its awaiter INLINE there. On such a thread the parameterless overload
+    /// only ENQUEUES the iteration for whoever owns that trampoline, so the inner sequence never
+    /// runs, <c>.ToList()</c> never completes, and this emission is silently dropped: no error, no
+    /// completion, the user's listing simply stays as it was (empty, for a first snapshot) for as
+    /// long as the view is open. That is the same permanent, signal-free stall #2377 fixed on the
+    /// storage read paths, one layer up — and note it strands an EMPTY snapshot too, since even a
+    /// zero-element sequence has to schedule its <c>OnCompleted</c>.</para>
+    /// </summary>
+    /// <param name="upstream">The System-loaded snapshots to filter.</param>
+    /// <param name="canRead">Whether the subscriber may Read the given node.</param>
+    /// <returns>The same stream, with each snapshot narrowed to the readable nodes.</returns>
+    internal static IObservable<IEnumerable<MeshNode>> FilterByReadPermission(
+        IObservable<IEnumerable<MeshNode>> upstream,
+        Func<MeshNode, IObservable<bool>> canRead) =>
+        upstream.SelectMany(snapshot =>
+            snapshot.ToInlineObservable()
+                .SelectMany(node => canRead(node)
+                    .Take(1)
+                    .Where(hasPerm => hasPerm)
+                    .Select(_ => node))
+                .ToList()
+                .Select(filtered => (IEnumerable<MeshNode>)filtered));
 }
 
 /// <summary>

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -532,6 +532,7 @@
   "ui.removeSource": "Quelle entfernen",
   "ui.removeInstallRecord": "Installationseintrag entfernen",
   "ui.requiresGlobalAdmin": "Erfordert Global Admin",
+  "ui.restartRequiredToActivate": "Neustart erforderlich, um dieses Paket vollständig zu aktivieren",
   "ui.orphanedInstallRecords": "Verwaiste Installationseinträge",
   "ui.requestAccess": "Zugriff anfragen",
   "ui.resetToDefault": "Auf Standard zurücksetzen",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -532,6 +532,7 @@
   "ui.removeSource": "Remove source",
   "ui.removeInstallRecord": "Remove install record",
   "ui.requiresGlobalAdmin": "Requires Global Admin",
+  "ui.restartRequiredToActivate": "Restart required to finish activating this package",
   "ui.orphanedInstallRecords": "Orphaned install records",
   "ui.requestAccess": "Request Access",
   "ui.resetToDefault": "Reset to default",

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -83,10 +83,68 @@ public static class CatalogLayoutAreas
     {
         var installed = ObserveInstalled(host);
         return ObserveAvailable(host, source, sourceRef)
-            .CombineLatest(installed, ObserveViewerIsGlobalAdmin(host),
-                (available, inst, isAdmin) => (UiControl?)BuildCatalog(
-                    host, source, sourceRef, description, sourceLabel, available, inst, isAdmin))
+            .CombineLatest(installed, ObserveViewerIsGlobalAdmin(host), ObserveActivation(host),
+                (available, inst, isAdmin, activation) => (UiControl?)BuildCatalog(
+                    host, source, sourceRef, description, sourceLabel, available, inst, isAdmin, activation))
             .StartWith((UiControl?)Controls.Markdown(host.Localize("ui.mdLoadingCatalog")));
+    }
+
+    /// <summary>
+    /// The restart-as-activation state of THIS process, as a live leg of the catalog render (#1979).
+    ///
+    /// <para><b>Why the catalog is where this belongs.</b> Loading a module is restart-as-activation
+    /// by design, so the restart IS the last step of an install that declares one — and an install
+    /// whose last step is invisible reads as a broken install: buy, "installed", the feature is not
+    /// there, and nothing anywhere says why. This is the surface the person is looking at when the
+    /// install completes, which is why the note goes on the package card rather than only on the
+    /// operator health check that already reports the same report object.</para>
+    ///
+    /// <para><b>Why it needs the change signal and not a timer.</b> The module lands strictly AFTER
+    /// the install record is written, so the record's own re-render arrives too early to see it.
+    /// <see cref="ModuleLandingService.ActivationChanged"/> fires on the write itself — one emission
+    /// per landing, nothing polled and nothing retried — and this leg re-derives the report from it.
+    /// Every emission RE-READS: the state changes underneath a running process (that is the whole
+    /// point), so a cached answer would be wrong exactly when it matters.</para>
+    ///
+    /// <para>The read is a small file read, and it runs on the shared FileSystem IO pool rather than
+    /// the render thread or the landing service's own cap-1 pool — the latter would queue this read
+    /// behind the very landing that announced it.</para>
+    /// </summary>
+    private static IObservable<ModuleActivationReport> ObserveActivation(LayoutAreaHost host)
+    {
+        var pending = host.Hub.ServiceProvider.GetService<PendingModuleActivations>();
+        if (pending is null)
+            // No module lane on this host at all (a mesh without the plugin catalog's services).
+            // An EMPTY report, not an undetermined one: nothing here can ever be pending, which is
+            // a known answer, and rendering "could not determine" would be a claim about a
+            // mechanism this deployment does not have.
+            return Observable.Return(new ModuleActivationReport([]));
+
+        var pool = host.Hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem)
+                   ?? IoPool.Unbounded;
+        var landing = host.Hub.ServiceProvider.GetService<ModuleLandingService>();
+        var changed = landing?.ActivationChanged ?? Observable.Empty<System.Reactive.Unit>();
+
+        return changed
+            .StartWith(System.Reactive.Unit.Default)
+            // Switch, not SelectMany: two landings in quick succession must not race their reads
+            // into the view out of order. The newest read wins and an in-flight stale one is
+            // dropped — which is right for a view whose only job is to show the CURRENT state.
+            .Select(_ => pool.InvokeBlocking(ct => pending.Read())
+                .Catch((Exception ex) =>
+                {
+                    // The reader already turns an unreadable record into an UNDETERMINED report; a
+                    // throw here is the pool refusing the work (teardown). Reported as undetermined
+                    // for the same reason — never as "nothing pending", which is the one answer that
+                    // would silently promise the install finished.
+                    Logger(host)?.LogWarning(ex, "Catalog: reading the module activation state failed.");
+                    return Observable.Return(new ModuleActivationReport(
+                        [], "the activation state could not be read on this host"));
+                }))
+            .Switch()
+            // So the catalog renders immediately instead of waiting on a file read — never a
+            // Take(1) anywhere here: this feeds a live data-bound view.
+            .StartWith(new ModuleActivationReport([]));
     }
 
     /// <summary>
@@ -180,7 +238,8 @@ public static class CatalogLayoutAreas
 
     private static UiControl BuildCatalog(
         LayoutAreaHost host, IPackageSource? source, string sourceRef, string? description, string? sourceLabel,
-        IReadOnlyList<PackageManifest> available, IReadOnlyList<MeshNode> installed, bool viewerIsGlobalAdmin)
+        IReadOnlyList<PackageManifest> available, IReadOnlyList<MeshNode> installed, bool viewerIsGlobalAdmin,
+        ModuleActivationReport activation)
     {
         var installedById = installed
             .Select(n => n.ContentAs<PackageManifest>(host.Hub.JsonSerializerOptions))
@@ -217,7 +276,8 @@ public static class CatalogLayoutAreas
             n++;
             installedById.TryGetValue(pkg.Id, out var inst);
             container = container.WithView(
-                BuildCard(host, source, sourceRef, pkg, inst, viewerIsGlobalAdmin, available, installedIds),
+                BuildCard(host, source, sourceRef, pkg, inst, viewerIsGlobalAdmin, available, installedIds,
+                    activation),
                 $"pkg-{n}");
         }
 
@@ -316,7 +376,8 @@ public static class CatalogLayoutAreas
     private static UiControl BuildCard(
         LayoutAreaHost host, IPackageSource? source, string sourceRef, PackageManifest pkg,
         PackageManifest? installed, bool viewerIsGlobalAdmin,
-        IReadOnlyList<PackageManifest> catalog, IReadOnlySet<string> installedIds)
+        IReadOnlyList<PackageManifest> catalog, IReadOnlySet<string> installedIds,
+        ModuleActivationReport activation)
     {
         var card = Controls.Stack
             .WithWidth("100%")
@@ -364,6 +425,25 @@ public static class CatalogLayoutAreas
                     return Task.CompletedTask;
                 }));
         }
+
+        // 🚨 The LAST STEP of the install, said out loud (#1979). Loading a module is
+        // restart-as-activation by design, so for a package that declares one the install is not
+        // finished when the content lands — and until this line existed nothing anywhere said so:
+        // the card read "✓ Installed", the feature was absent, and the person who installed it had
+        // no way to learn that a restart was the missing half. Rendered UNDER the status line
+        // rather than instead of it, because both facts are true: the package IS installed, and its
+        // module is not running yet.
+        //
+        // Derived from the report the operator health check reads, so the two surfaces can never
+        // tell different stories — and matched on the install record's PATH, which is exactly what
+        // the landing recorded on the activation entry (InstallOrUpdateCore passes
+        // "{InstalledPartition}/{pkg.Id}" to AdoptModule). A blank/undetermined answer renders
+        // nothing: see ModuleActivationReport.IsPendingForPackage for why silence is the honest
+        // fallback here.
+        if (activation.IsPendingForPackage($"{PackageInstaller.InstalledPartition}/{pkg.Id}"))
+            card = card.WithView(Controls.Body($"🔄 {host.Localize("ui.restartRequiredToActivate")}")
+                .WithStyle("color: var(--warning-foreground, #9d5d00); font-size: 12px; "
+                           + "display: block; margin-top: 6px;"));
 
         return card;
     }

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -559,19 +559,21 @@ public sealed class ModuleLandingService : IDisposable
             throw new ArgumentException($"Invalid {what}: '{value}'.");
     }
 
-    /// <inheritdoc />
     /// <summary>
-    /// Announces that the persisted activation record changed. A subscriber's fault is logged and
-    /// contained rather than propagated: a surface that failed to re-render must never turn a
-    /// landing that genuinely succeeded into a reported failure, and the write it is announcing has
-    /// already happened by the time this runs. The fault is NOT swallowed silently — it is the only
-    /// evidence a surface stopped following the signal.
+    /// Announces that the persisted activation record changed, containing a subscriber's fault
+    /// rather than propagating it: a surface that failed to re-render must never turn a landing that
+    /// genuinely succeeded into a reported failure — the write being announced has already happened
+    /// by the time this runs — and on the teardown path it must never turn a clean dispose into a
+    /// throwing one. The fault is NOT swallowed silently: this line is the only evidence a surface
+    /// stopped following the signal.
     /// </summary>
-    private void AnnounceActivationChanged()
+    /// <param name="notify">The emission to make — <c>OnNext</c> after a write, <c>OnCompleted</c>
+    /// at dispose.</param>
+    private void Announce(Action<Subject<Unit>> notify)
     {
         try
         {
-            activationChanged.OnNext(Unit.Default);
+            notify(activationChanged);
         }
         catch (Exception exception)
         {
@@ -580,10 +582,12 @@ public sealed class ModuleLandingService : IDisposable
         }
     }
 
-    /// <summary>Disposes the IO pool and completes the activation-change signal.</summary>
+    private void AnnounceActivationChanged() => Announce(subject => subject.OnNext(Unit.Default));
+
+    /// <inheritdoc />
     public void Dispose()
     {
-        activationChanged.OnCompleted();
+        Announce(subject => subject.OnCompleted());
         activationChanged.Dispose();
         pool.Dispose();
     }

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -189,6 +189,17 @@ public sealed class ModuleLandingService : IDisposable
     private readonly ILogger<ModuleLandingService>? logger;
     private readonly Subject<Unit> activationChanged = new();
 
+    // 🚨 Every EMISSION goes through the synchronized façade, never `activationChanged` directly.
+    // An Rx Subject is not safe for concurrent OnNext/OnCompleted: its observer list can be observed
+    // mid-mutation, which tears delivery. The two callers here genuinely can overlap — a landing
+    // announces on whichever thread the pool result lands on, while Dispose completes on the
+    // teardown thread — so this is a real race, not a theoretical one. Subject.Synchronize is Rx's
+    // own answer and stays inside the reactive model (no lock of ours, nothing hand-woven); it is
+    // the same wrapper MeshNodeStreamCache, ThreadInboxChannel and this project's own
+    // ModuleDiscoveryService already use. Subscribe still goes to the subject itself — the
+    // synchronization is only needed on the write side. (Copilot review, #2437.)
+    private readonly ISubject<Unit> announce;
+
     /// <summary>
     /// Fires once each time THIS process changes the persisted activation record — a landing, a
     /// shelving, or a removal. The announcement half of restart-as-activation (#1979).
@@ -224,6 +235,7 @@ public sealed class ModuleLandingService : IDisposable
     {
         this.logger = logger;
         this.baseDirectory = baseDirectory ?? AppContext.BaseDirectory;
+        announce = Subject.Synchronize(activationChanged);
     }
 
     /// <summary>The deployment root the <c>modules/</c> tree lives under — exposed so the serving
@@ -568,12 +580,12 @@ public sealed class ModuleLandingService : IDisposable
     /// stopped following the signal.
     /// </summary>
     /// <param name="notify">The emission to make — <c>OnNext</c> after a write, <c>OnCompleted</c>
-    /// at dispose.</param>
-    private void Announce(Action<Subject<Unit>> notify)
+    /// at dispose. Always applied to the SYNCHRONIZED façade; see the field's remarks.</param>
+    private void Announce(Action<ISubject<Unit>> notify)
     {
         try
         {
-            notify(activationChanged);
+            notify(announce);
         }
         catch (Exception exception)
         {

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -1,5 +1,7 @@
 using System.IO;
 using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.Logging;
 
@@ -185,6 +187,32 @@ public sealed class ModuleLandingService : IDisposable
     private readonly IoPool pool = new(1);
     private readonly string baseDirectory;
     private readonly ILogger<ModuleLandingService>? logger;
+    private readonly Subject<Unit> activationChanged = new();
+
+    /// <summary>
+    /// Fires once each time THIS process changes the persisted activation record — a landing, a
+    /// shelving, or a removal. The announcement half of restart-as-activation (#1979).
+    ///
+    /// <para><b>Why it has to exist for the reader to be usable.</b>
+    /// <see cref="PendingModuleActivations"/> answers "is a restart pending for this package?" by
+    /// reading the record on demand, which is correct and always current — but a view has to know
+    /// WHEN to ask again. On the install path the module lands strictly AFTER the install record
+    /// node is written (the content install completes, then the bundle is fetched and landed), so
+    /// the node-driven re-render that flips a card to "installed" happens BEFORE the restart is
+    /// pending. Without this signal the one moment the buyer is looking at the card is exactly the
+    /// moment it cannot say so, and the note appears only on some later, unrelated render.</para>
+    ///
+    /// <para>Announcing a write so its readers can react is the same discipline the mesh applies to
+    /// storage writes (#817/#824) — not a poll and not a watchdog: it fires on the write, or not at
+    /// all. It is deliberately a bare signal rather than the new state, because the state is
+    /// per-process and derived; every subscriber re-derives it from the record and the assemblies it
+    /// has actually loaded, so two surfaces can never disagree.</para>
+    ///
+    /// <para>🚨 Emitted AFTER the pool work item completes, never inside it. This service's pool is
+    /// cap-1, so a subscriber that reacted by asking this service to read would queue behind the
+    /// very work item that notified it.</para>
+    /// </summary>
+    public IObservable<Unit> ActivationChanged => activationChanged;
 
     /// <summary>Creates the service.</summary>
     /// <param name="logger">Diagnostics — every landing, refusal and removal is logged.</param>
@@ -240,7 +268,8 @@ public sealed class ModuleLandingService : IDisposable
             LandCore(name, assemblies, frameworkMvid, packagePath, version, minMeshVersion,
                 staticAssets, holdAboveFloor: false);
             return Unit.Default;
-        });
+        })
+        .Do(_ => AnnounceActivationChanged());
 
     /// <summary>
     /// Lands a module onto the REGISTRY SHELF (2026-08-22) — the publish path's entry, identical to
@@ -287,7 +316,8 @@ public sealed class ModuleLandingService : IDisposable
         IReadOnlyList<(string RelativePath, byte[] Bytes)>? staticAssets = null)
         => pool.InvokeBlocking(_ =>
             LandCore(name, assemblies, frameworkMvid, packagePath, version, minMeshVersion,
-                staticAssets, holdAboveFloor: true));
+                staticAssets, holdAboveFloor: true))
+            .Do(_ => AnnounceActivationChanged());
 
     /// <summary>
     /// Validates one module-relative asset path: forward slashes, no rooting, no traversal, and
@@ -328,7 +358,8 @@ public sealed class ModuleLandingService : IDisposable
         {
             RemoveCore(name);
             return Unit.Default;
-        });
+        })
+        .Do(_ => AnnounceActivationChanged());
 
     private ModuleLandingOutcome LandCore(
         string name,
@@ -529,7 +560,33 @@ public sealed class ModuleLandingService : IDisposable
     }
 
     /// <inheritdoc />
-    public void Dispose() => pool.Dispose();
+    /// <summary>
+    /// Announces that the persisted activation record changed. A subscriber's fault is logged and
+    /// contained rather than propagated: a surface that failed to re-render must never turn a
+    /// landing that genuinely succeeded into a reported failure, and the write it is announcing has
+    /// already happened by the time this runs. The fault is NOT swallowed silently — it is the only
+    /// evidence a surface stopped following the signal.
+    /// </summary>
+    private void AnnounceActivationChanged()
+    {
+        try
+        {
+            activationChanged.OnNext(Unit.Default);
+        }
+        catch (Exception exception)
+        {
+            logger?.LogWarning(exception,
+                "A subscriber to ActivationChanged faulted; the module landing itself succeeded.");
+        }
+    }
+
+    /// <summary>Disposes the IO pool and completes the activation-change signal.</summary>
+    public void Dispose()
+    {
+        activationChanged.OnCompleted();
+        activationChanged.Dispose();
+        pool.Dispose();
+    }
 }
 
 /// <summary>

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -39,6 +39,28 @@ public sealed record ModuleActivationReport(
     /// The FAULT half of the report — a restart does not clear it.</summary>
     public bool HasUnresolvable => !IsUndetermined && !Unresolvable.IsEmpty;
 
+    /// <summary>
+    /// Whether the install record at <paramref name="packagePath"/> landed a module that has not
+    /// loaded in this process — the per-PACKAGE question a package card asks so it can say "restart
+    /// required to finish activating this" instead of a bare "installed" (#1979).
+    ///
+    /// <para>Lives on the REPORT rather than only on the reader so a surface rendering many cards
+    /// answers them all from ONE read of the activation record, instead of re-reading it per card.
+    /// <see cref="PendingModuleActivations.IsPendingForPackage"/> is the same rule with the read
+    /// attached — one rule, two entry points, so their answers cannot diverge.</para>
+    ///
+    /// <para>🚨 Returns <c>false</c> when the state is UNDETERMINED, and that is deliberate: this
+    /// answers a per-package question whose only honest fallback is "I have nothing to say about
+    /// this package". An unreadable activation record is an OPERATOR signal — the health check
+    /// reports it, where it is actionable — and putting "restart required" on every package card
+    /// because a file would not parse is noise a buyer cannot act on.</para>
+    /// </summary>
+    /// <param name="packagePath">The install record's mesh path. Blank matches nothing; it is not a
+    /// wildcard, so a card with no path to match on cannot inherit another package's restart.</param>
+    /// <returns>True when a restart of THIS process would activate a module this package landed.</returns>
+    public bool IsPendingForPackage(string? packagePath) =>
+        !IsUndetermined && ModuleActivationStatus.IsPendingForPackage(Pending, packagePath);
+
     /// <summary>The one line every surface renders, so nobody is told two different stories.</summary>
     public string Describe() =>
         UndeterminedReason is { } reason
@@ -127,10 +149,5 @@ public sealed class PendingModuleActivations(string moduleRoot)
     /// unreadable sidecar is actionable — putting "restart required" on every package card because
     /// a file could not be parsed would be noise a buyer cannot act on.</para>
     /// </summary>
-    public bool IsPendingForPackage(string? packagePath)
-    {
-        var report = Read();
-        return !report.IsUndetermined
-            && ModuleActivationStatus.IsPendingForPackage(report.Pending, packagePath);
-    }
+    public bool IsPendingForPackage(string? packagePath) => Read().IsPendingForPackage(packagePath);
 }

--- a/test/MeshWeaver.Documentation.Test/BareToObservableOnReadPathGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/BareToObservableOnReadPathGuard.cs
@@ -52,6 +52,22 @@ public class BareToObservableOnReadPathGuard
     ];
 
     /// <summary>
+    /// Individual read-path files that sit inside a project whose OTHER files legitimately use the
+    /// parameterless overload (a <c>Task.ToObservable()</c> bridge, or a deferred write fan-out
+    /// where scheduling is a free choice). Naming the file rather than widening
+    /// <see cref="ScannedRoots"/> keeps the ratchet at zero without inventing exemptions inside it.
+    ///
+    /// <para><c>SyncedQueryDataSourceExtensions</c> is the per-user RLS filter every synced-query
+    /// emission passes through — #2087, the residual of #2377 that the storage-root sweep could not
+    /// see. It re-emits a snapshot on the DELIVERY thread of an upstream emission, which is exactly
+    /// the "already inside somebody's trampoline" frame the mechanism below strands on.</para>
+    /// </summary>
+    private static readonly string[] ScannedFiles =
+    [
+        "src/MeshWeaver.Graph/SyncedQueryDataSourceExtensions.cs",
+    ];
+
+    /// <summary>
     /// The parameterless call only. <c>ToObservable(someScheduler)</c> is an explicit, reviewed
     /// choice and is left alone.
     /// </summary>
@@ -73,7 +89,17 @@ public class BareToObservableOnReadPathGuard
                 $"Scanned root '{scanned}' does not exist — this guard would scan nothing and pass. "
                 + "Update ScannedRoots to match the tree; never delete the root to make it green.");
 
-        var files = SourceScan.SourceFiles(root, ScannedRoots).ToList();
+        // Same reason, per FILE: a moved or renamed file would silently drop out of the scan and
+        // leave a green tick over a call site nobody is checking any more.
+        foreach (var scanned in ScannedFiles)
+            Assert.True(File.Exists(Path.Combine(root, scanned)),
+                $"Scanned file '{scanned}' does not exist — this guard would stop checking it and "
+                + "still pass. Point ScannedFiles at where the file moved to; never delete the "
+                + "entry to make it green.");
+
+        var files = SourceScan.SourceFiles(root, ScannedRoots)
+            .Concat(ScannedFiles.Select(f => Path.Combine(root, f)))
+            .ToList();
         Assert.True(files.Count > 20,
             $"Only {files.Count} files were scanned across the read path — too few to be the real "
             + "tree, so a pass here would mean nothing.");

--- a/test/MeshWeaver.Graph.Test/SyncedQueryRlsForeignTrampolineTest.cs
+++ b/test/MeshWeaver.Graph.Test/SyncedQueryRlsForeignTrampolineTest.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Threading;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Issue #2087 — the per-user RLS filter on a synced query is the residual of #2377's class that
+/// #2389's sweep did not reach (it ratcheted <c>src/MeshWeaver.Hosting/Persistence</c> and the
+/// storage adapters; this filter lives in <c>MeshWeaver.Graph</c>).
+///
+/// <para><b>The defect.</b> <c>WrapWithPerUserRls</c> re-emitted each upstream snapshot through the
+/// parameterless <c>IEnumerable.ToObservable()</c>. Rx schedules that on
+/// <c>SchedulerDefaults.Iteration</c> = <see cref="CurrentThreadScheduler"/>, which does NOT mean
+/// "run it here now": it keeps a <c>[ThreadStatic]</c> flag for "a trampoline is already running on
+/// this thread", and while that flag is set <c>Schedule</c> only <b>enqueues</b>. The filter runs on
+/// the DELIVERY thread of an upstream emission — in a live portal routinely inside the hub pump's own
+/// trampoline, or inside the one an await-resumed continuation inherits — so the per-node iteration
+/// was handed to a queue nobody was going to drain, <c>.ToList()</c> never completed, and the
+/// snapshot was dropped with no error and no completion. The user's listing stays exactly as it was:
+/// empty, for a first snapshot, for as long as the view is open.</para>
+///
+/// <para><b>Why the empty case matters as much as the populated one.</b> Even a zero-element
+/// sequence has to schedule its <c>OnCompleted</c>, so a legitimately empty snapshot stranded too —
+/// which is the difference between "this listing is empty" and "this listing never answered", and
+/// the two are indistinguishable on screen.</para>
+///
+/// <para>The cure is <c>ToInlineObservable()</c> (<c>ImmediateScheduler</c>, no ambient per-thread
+/// state). This test subscribes from inside a real trampoline and blocks there — the shape that used
+/// to strand — so it fails on the parameterless overload and passes on the inline one.</para>
+/// </summary>
+public class SyncedQueryRlsForeignTrampolineTest
+{
+    /// <summary>
+    /// The filter must deliver its filtered snapshot when the subscribing frame is already inside a
+    /// foreign Rx trampoline. The empty snapshot is not padding: it strands on exactly the same
+    /// mechanism, and it is the case a fresh listing hits first.
+    /// </summary>
+    /// <param name="nodeCount">How many nodes the upstream snapshot carries.</param>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(5)]
+    public void Filtered_snapshot_arrives_when_subscribed_inside_a_foreign_trampoline(int nodeCount)
+        // 🚨 A DEDICATED thread, not the test thread — the xUnit thread can already carry a
+        // trampoline (that is the very leak this class of defect is about), and opening one from
+        // there would silently skip the whole body. See FreshThread.
+        => FreshThread.Run(
+            () => RunProbe(nodeCount, granted: true, expected: nodeCount),
+            $"the probe thread never finished for {nodeCount} node(s) — the RLS filter's per-node "
+            + "iteration was queued on the caller's trampoline instead of running inline, so it can "
+            + "never run (#2087)");
+
+    /// <summary>
+    /// The same contract when the probe DENIES every node: an all-filtered-out snapshot must still
+    /// be delivered as an empty list. Dropping it instead is what makes a permission change look
+    /// like a hung view rather than an empty one.
+    /// </summary>
+    [Fact]
+    public void A_fully_denied_snapshot_is_delivered_as_empty_not_dropped()
+        => FreshThread.Run(
+            () => RunProbe(nodeCount: 3, granted: false, expected: 0),
+            "the probe thread never finished — a fully denied snapshot was dropped instead of "
+            + "delivered as an empty list (#2087)");
+
+    private static void RunProbe(int nodeCount, bool granted, int expected)
+    {
+        var snapshot = Enumerable.Range(0, nodeCount)
+            .Select(i => new MeshNode($"n{i}", "probe"))
+            .ToArray();
+
+        // Observable.Return uses ImmediateScheduler, so the snapshot is delivered during Subscribe,
+        // on the subscribing thread — i.e. inside the trampoline opened below. That is the whole
+        // point: it reproduces the delivery thread a live upstream emission actually arrives on.
+        var upstream = Observable.Return<IEnumerable<MeshNode>>(snapshot);
+
+        using var arrived = new ManualResetEventSlim(false);
+        IEnumerable<MeshNode>? filtered = null;
+        var insideTrampoline = false;
+
+        // Schedule() IS the trampoline: inside this action CurrentThreadScheduler reports that one
+        // is already running, which is precisely the state an await-resumed continuation inherits.
+        CurrentThreadScheduler.Instance.Schedule(() =>
+        {
+            insideTrampoline = !CurrentThreadScheduler.IsScheduleRequired;
+            using var sub = SyncedQueryDataSourceExtensions
+                .FilterByReadPermission(upstream, _ => Observable.Return(granted))
+                .Subscribe(result => { filtered = result; arrived.Set(); });
+
+            // 🚨 Blocking HERE is the point, not a shortcut: the stranded iteration could only ever
+            // run after this frame returns to the trampoline that owns it, so a caller that waits
+            // for its own snapshot is the shape that deadlocked. A budget generous enough that only
+            // a never-scheduled iteration can exhaust it — this work is microseconds.
+            Assert.True(arrived.Wait(TimeSpan.FromSeconds(5)),
+                $"the filtered snapshot never arrived for {nodeCount} node(s) — the per-node "
+                + "iteration was queued on the caller's trampoline instead of running inline, so it "
+                + "can never run (#2087)");
+        });
+
+        Assert.True(insideTrampoline,
+            "the probe never actually ran inside a trampoline — it would pass without testing anything");
+        Assert.NotNull(filtered);
+        Assert.Equal(expected, filtered!.Count());
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/InlineObservableExtensionsTest.cs
+++ b/test/MeshWeaver.Hosting.Test/InlineObservableExtensionsTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Fixture;
 using Xunit;
 
 namespace MeshWeaver.Hosting.Test;

--- a/test/MeshWeaver.Hosting.Test/LiveQueryForeignTrampolineTest.cs
+++ b/test/MeshWeaver.Hosting.Test/LiveQueryForeignTrampolineTest.cs
@@ -7,6 +7,7 @@ using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Hosting.Persistence.Query;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Fixture;
 using Xunit;
 
 namespace MeshWeaver.Hosting.Test;

--- a/test/MeshWeaver.PluginCatalog.Test/RestartRequiredCardTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RestartRequiredCardTest.cs
@@ -1,0 +1,215 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Issue #1979 — a landed module needs a restart, the mesh knows it, and until this test nobody was
+/// told.
+///
+/// <para><b>The finding was the absence of a caller.</b> <c>PendingModuleActivations</c> and
+/// <c>IsPendingForPackage</c> were built and unit-tested, and had ZERO production callers: the
+/// operator health check reported the fleet-wide report, while the person who actually installed the
+/// package saw a card reading "✓ Installed" for a module that was not running and would not run
+/// until some unrelated restart. So a unit test of the predicate cannot close this — it is what
+/// already existed. This test renders the REAL catalog view through the same
+/// <c>GetRemoteStream</c>/<c>GetControlStream</c> binding the portal uses, and asserts the note
+/// reaches the card.</para>
+///
+/// <para><b>And it pins the timing, which is the part a static render would miss.</b> On the install
+/// path the module lands strictly AFTER the install record node is written, so the node-driven
+/// re-render that flips a card to "installed" happens BEFORE the restart is pending. The test
+/// therefore renders first, waits for the card WITHOUT the note, and only then lands a module —
+/// touching no mesh node at all. The note can only appear if
+/// <see cref="ModuleLandingService.ActivationChanged"/> drove the re-render, which is exactly the
+/// moment the buyer is looking at the card. (It also means the emission cannot be observed early:
+/// the signal is hot, so the area must already be subscribed — which the first assertion proves.)</para>
+/// </summary>
+public class RestartRequiredCardTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The module name is deliberately not an assembly this process loads, so the derived
+    /// report can honestly call it "landed but not loaded here".</summary>
+    private const string ModuleName = "Fake.Restart.Probe";
+
+    private const string PackageId = "pack-a";
+    private const string CatalogPath = "rbuergi/restart-catalog";
+
+    /// <summary>The language-neutral half of the note — asserted instead of the English text so the
+    /// test does not encode one locale's wording (the sentence beside it is a catalog key with a
+    /// German translation).</summary>
+    private const string RestartGlyph = "🔄";
+
+    private readonly string landingRoot =
+        Path.Combine(Path.GetTempPath(), "mw-restart-card-" + Guid.NewGuid().ToString("N"));
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        Directory.CreateDirectory(Path.Combine(landingRoot, "modules"));
+        return base.ConfigureMesh(builder).AddPluginCatalog()
+            // Both halves rooted at the SAME per-test temp tree, never the test host's own bin
+            // folder: the activation record is a persistent file, and a reader looking at a
+            // different directory than the writer is how "installed, and nothing happened" becomes
+            // unexplainable — the exact failure mode the DI registration warns about.
+            .ConfigureServices(services => services
+                .AddSingleton(new ModuleLandingService(baseDirectory: landingRoot))
+                .AddSingleton(new PendingModuleActivations(landingRoot)));
+    }
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddPluginCatalogTypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+        try
+        {
+            if (Directory.Exists(landingRoot))
+                Directory.Delete(landingRoot, recursive: true);
+        }
+        catch
+        {
+            // Best-effort: a straggling handle on a just-written file must never turn a green test
+            // red — leaked temp dirs are the OS's to reap.
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task ALandedModule_PutsTheRestartNoteOnItsPackageCard()
+    {
+        var repo = CreateTempRepo();
+        try
+        {
+            var git = new GitCli(Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>());
+            WriteFile(repo, $"catalog/{PackageId}/package.json",
+                $$"""{"id":"{{PackageId}}","name":"Package A","kind":"content","targetPartition":"PartA","version":"1.0.0"}""");
+            WriteFile(repo, $"catalog/{PackageId}/A.md", "# A");
+            await git.Run(repo, ["init"]).FirstAsync().ToTask();
+            await git.Run(repo, ["add", "-A"]).FirstAsync().ToTask();
+            await git.Run(repo, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"])
+                .FirstAsync().ToTask();
+
+            await NodeFactory.CreateNode(MeshNode.FromPath(CatalogPath) with
+            {
+                Name = "Catalog",
+                NodeType = "PluginCatalog",
+                Content = new PluginCatalogContent
+                {
+                    SourceRepoPath = repo,
+                    SourceRef = "HEAD",
+                    SourceSubdir = "catalog",
+                },
+            }).Should().Emit();
+
+            var workspace = GetClient(c => c.AddData()).GetWorkspace();
+            var reference = new LayoutAreaReference(CatalogLayoutAreas.CatalogArea);
+            var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+                new Address(CatalogPath), reference);
+
+            // 1. The card renders, and says nothing about a restart — nothing has landed yet. This
+            //    assertion is load-bearing twice over: it is the control for step 3, and it is what
+            //    proves the area is SUBSCRIBED before the hot ActivationChanged signal fires.
+            var cardArea = await CardArea(stream, reference);
+            (await CardTexts(stream, cardArea)).Should()
+                .NotContain(t => t.Contains(RestartGlyph, StringComparison.Ordinal),
+                    "nothing has landed yet, so a restart note here would be a prompt no restart can clear");
+
+            // 2. Land a module recorded against this package's install record — the ONLY thing that
+            //    changes. No mesh node is written, so nothing else can drive a re-render. (A real
+            //    activation entry with this PackagePath exists only because the package was
+            //    installed; the install itself is covered by ModuleFunnelTest and is not what this
+            //    test is about.)
+            var landing = Mesh.ServiceProvider.GetRequiredService<ModuleLandingService>();
+            await landing.LandModule(
+                    ModuleName,
+                    [($"{ModuleName}.dll", [1, 2, 3, 4])],
+                    packagePath: $"{PackageInstaller.InstalledPartition}/{PackageId}",
+                    version: "1.0.0")
+                .FirstAsync().ToTask();
+
+            // 3. …and the card now says so, on the surface the person who installed it is looking at.
+            await CardTextStream(stream, cardArea)
+                .Should().Within(30.Seconds())
+                .Match(texts => texts.Any(t => t.Contains(RestartGlyph, StringComparison.Ordinal)));
+
+            await NodeFactory.DeleteNode(CatalogPath).Should().Emit();
+        }
+        finally
+        {
+            TryDelete(repo);
+        }
+    }
+
+    /// <summary>The single package card's area name, once the catalog has listed the repo.</summary>
+    private static async Task<string> CardArea(
+        ISynchronizationStream<JsonElement> stream, LayoutAreaReference reference)
+    {
+        var stack = (StackControl)(await stream.GetControlStream(reference.Area!)
+            .Should().Within(60.Seconds()).Match(c =>
+                c is StackControl s
+                && s.Areas.Count(a => a.Area?.ToString()?.Contains("/pkg-", StringComparison.Ordinal) == true) == 1))!;
+        return stack.Areas
+            .Select(a => a.Area?.ToString())
+            .First(p => p is not null && p.Contains("/pkg-", StringComparison.Ordinal))!;
+    }
+
+    /// <summary>
+    /// Every label the card currently renders. A card is a stack of named sub-areas, so its text is
+    /// only readable by resolving each one — the same walk the Blazor renderer does.
+    /// </summary>
+    private static IObservable<IReadOnlyList<string>> CardTextStream(
+        ISynchronizationStream<JsonElement> stream, string cardArea) =>
+        stream.GetControlStream(cardArea)
+            .Select(c => c as StackControl)
+            .Where(s => s is not null)
+            .SelectMany(s => s!.Areas
+                .Select(a => a.Area?.ToString())
+                .Where(a => a is not null)
+                .Select(a => stream.GetControlStream(a!).Select(c => (c as LabelControl)?.Data?.ToString() ?? string.Empty))
+                .CombineLatest()
+                .Select(texts => (IReadOnlyList<string>)texts));
+
+    private static async Task<IReadOnlyList<string>> CardTexts(
+        ISynchronizationStream<JsonElement> stream, string cardArea) =>
+        await CardTextStream(stream, cardArea).FirstAsync().ToTask();
+
+    private static string CreateTempRepo()
+    {
+        var p = Path.Combine(Path.GetTempPath(), "restartcard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(p);
+        return p;
+    }
+
+    private static void WriteFile(string root, string relative, string content)
+    {
+        var full = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); }
+        catch { /* best effort */ }
+    }
+}


### PR DESCRIPTION
Two defects, **no shared root**, kept as two commits.

- **#1979** is a *missing consumer*: a mechanism that was built, unit-tested, and never called.
- **#2087's residual** is a *scheduler* bug: the parameterless `IEnumerable.ToObservable()` on a read path.

They meet only in that both fail **silently** — nothing raised, nothing logged, a surface that looks finished.

---

## 1. `PendingModuleActivations.IsPendingForPackage` had zero production callers — fix #1979

Re-verified on `origin/main` @ `432703090`: the only references were its own declaration and the unit tests. The mesh knew a landed module needed a restart and told **only an operator**, through a health endpoint the buyer never sees. The card they *were* looking at read "✓ Installed" for a module that was not running.

**Surface: the plugin-catalog package card** — the surface the person is already looking at when the install completes, and the one the issue names. The note renders *under* the status line, not instead of it: both facts are true.

**The timing needed more than a call site.** The module lands strictly **after** the install record node is written (`InstallOrUpdateCore.WithModule` wraps the content install), so the node-driven re-render that flips a card to "installed" happens *before* the restart is pending — the one moment it matters is the one moment a node-only render cannot see. So `ModuleLandingService` now **announces its own write** (`ActivationChanged`, one emission per landing/shelving/removal) and the catalog re-derives the report from it.

That is the discipline the mesh already applies to storage writes (#817/#824) — **not a poller and not a watchdog**: it fires on the write, or not at all. The signal carries no state; every subscriber re-reads, because the state changes underneath a running process and that is the whole point.

Deliberate details:
- Emitted **after** the pool work item, never inside it — the landing pool is cap-1, so a subscriber reading through it from inside would queue behind the very work item that notified it. The catalog's read runs on the shared FileSystem pool for the same reason, and off the render thread.
- A subscriber's fault is logged and contained (a surface that failed to re-render must not turn a successful landing into a reported failure) but **never swallowed silently** — the log line is the only evidence it stopped following.
- `Switch`, not `SelectMany`: two landings must not race their reads into the view out of order. **No `Take(1)` anywhere** — this feeds a live data-bound view.
- **UNDETERMINED renders nothing.** Telling a buyer to restart because a file would not parse is noise they cannot act on — that state is the operator's, and the health check already reports it. Same for an UNRESOLVABLE entry (#2093): a restart does not clear it, so a restart prompt would be a promise every restart breaks.
- 🔄 plus a translated sentence (`ui.restartRequiredToActivate`, en + de).

### Evidence

`RestartRequiredCardTest` renders the **real** catalog through the same `GetRemoteStream`/`GetControlStream` binding the portal uses, asserts the card **without** the note, then lands a module and asserts the note appears — **touching no mesh node in between**, so only the announcement can have driven the re-render.

- Disabling only the card line: **fails** after a 30 s wait — `Last of 1 emission(s) was: [Package A, v1.0.0 · Content · → PartA]`.
- With the fix: **passes in 448 ms**.

A unit test of the predicate could not close this — that is exactly what already existed.

---

## 2. The per-user RLS filter strands on a foreign Rx trampoline — fix #2087's residual

#2389 fixed the bare `ToObservable()` across `src/MeshWeaver.Hosting/Persistence` and the storage adapters, and armed `BareToObservableOnReadPathGuard` over those roots. One site of the same class sat outside them and was **flagged in #2087's triage rather than fixed**:

```
src/MeshWeaver.Graph/SyncedQueryDataSourceExtensions.cs:272
    upstream.SelectMany(snapshot => snapshot.ToObservable() … .ToList() …)
```

That is the per-user Read filter **every synced-query emission** passes through. It runs on the delivery thread of an upstream emission — in a live portal routinely already inside somebody's `CurrentThreadScheduler` trampoline — where the parameterless overload only **enqueues** the per-node iteration. `.ToList()` never completes and the snapshot is dropped: no error, no completion, the listing stays as it was for as long as the view is open.

An **empty** snapshot strands identically (a zero-element sequence still has to schedule its `OnCompleted`), so "you may read nothing here" and "this never answered" are indistinguishable on screen. That is the half a populated-only repro would miss.

Fix: `ToInlineObservable()`, with the filter extracted to `FilterByReadPermission(upstream, canRead)` so the permission probe is a parameter and the shape is testable without a hub.

### Evidence

- `SyncedQueryRlsForeignTrampolineTest` subscribes from inside a real trampoline and blocks there: **4 of 4 cases fail in 20.8 s** without the fix (verified by reverting only the scheduler call), **4 of 4 pass in 1.1 s** with it.
- The **guard**, extended to scan this file, also fails on the reverted tree naming `SyncedQueryDataSourceExtensions.cs:300` — so a ratchet, not care, keeps this at zero. `ScannedFiles` names the file rather than widening `ScannedRoots` to all of `MeshWeaver.Graph` (whose other `.ToObservable()` calls are `Task` bridges and deferred write fan-outs), and asserts the file exists so a rename cannot turn the check into a silent pass.
- `FreshThread` moves to `MeshWeaver.Fixture` so both test assemblies share one definition.

### 🚨 Attribution — this does **not** close #2087

This is a real defect of the class #2087's own triage ranked, and it is **not** the same defect as the #817/#824 announce-loss class the issue is titled for (#2353 closed a real gap there). **Neither retires the other.** I have no access to the education CI mesh, so #2087 stays open on its existing criterion: a measured recurrence stopping across a roll that carries the fix.

---

## Verification

Release + `-warnaserror`, one project per invocation: PluginCatalog, Graph, Fixture, Documentation, Memex.Portal.Shared, and every touched test project — all `0 Warning(s) 0 Error(s)`.

| suite | result |
|---|---|
| `MeshWeaver.Graph.Test` | 1630 / 1630 |
| `MeshWeaver.PluginCatalog.Test` | 651 / 651 |
| `MeshWeaver.Security.Test` | 376 / 376 |
| `MeshWeaver.Hosting.Test` | 240 / 240 |
| `MeshWeaver.Documentation.Test` | 69 / 69 |
| `MeshWeaver.Messaging.Hub.Test` (LocalizationTest) | 56 / 56 |
| `MeshWeaver.AccessControl.Test` | 29 / 29 |

Two What's New entries, both `Category: Fix` — a user notices both.

**Note on the i18n mirror:** `clients/react` no longer exists in this repo (one catalog copy, and `clients.yml`'s only remaining job is the Python SDK), so there is no mirror to update. AGENTS.md's mirror paragraph is stale here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)