### PR TITLE
A write conflict names the writer: the durable row's provenance, in the warning and the trace

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-write-conflict-names-the-writer.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-write-conflict-names-the-writer.md
@@ -1,0 +1,17 @@
+---
+Name: A write conflict now says whose row won
+Category: Fix
+Description: The write-conflict record and its warning now identify the row that won, so you can tell which component wrote it.
+Icon: Sparkle
+Order: -20260826
+---
+
+# A write conflict now says whose row won
+
+When two components write the same node and one of them loses, the platform keeps the newer row,
+merges what it can, and records what it had to drop. That record used to say *what* was dropped but
+nothing about *who* had written the row that won — so tracking the other writer down meant guessing.
+
+Both the warning and the durable record now describe the winning row, including where its content
+came from. A row copied into place from somewhere else in the mesh names its source directly, which
+is usually enough to identify the component that wrote it on sight.

--- a/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
@@ -19,12 +19,20 @@ namespace MeshWeaver.Hosting.Persistence;
 /// <see cref="MeshNode.NextVersion"/>, which is <c>current.Version + 1</c>, and an unchanged
 /// node is re-persisted at the version it already carries — so a correctly-produced write is
 /// ALWAYS &gt;= the version already stored. A write that
-/// regresses is therefore never a legitimate newer state — it is a stale snapshot that some
-/// component adopted as live (a cache-seeded reactivation, a lagging change-feed echo, a
-/// debounce buffer that outlived its state) about to overwrite acked, durable data. Before
+/// regresses is therefore never a legitimate NEWER state: it was produced against an older
+/// durable state than the row now holds, and letting it land overwrites acked data. Before
 /// this guard the store took it silently: the observed production shape was
 /// <c>Version=12 / ApiKey=sk-v6</c> → <c>Version=2 / ApiKey=sk-v0</c>, six acknowledged
 /// writes destroyed while the write reported success.</para>
+///
+/// <para>🚨 That says the write is OLD — it does not say WHY, and the two causes want different
+/// investigations (#2403). One is a stale snapshot some component adopted as live (a cache-seeded
+/// reactivation, a lagging change-feed echo, a debounce buffer that outlived its state). The other
+/// is a second, entirely legitimate writer that simply reached the path first, so the loser's write
+/// was measured against a row it had never seen — the shape behind #2403, where a cross-partition
+/// skill MIRROR created a path an installer was about to write. Asserting the stale-snapshot cause
+/// in the warning sent that investigation hunting for a bug in the losing writer, where there was
+/// none. <see cref="MeshNode.MainNode"/> is what separates the two on sight.</para>
 ///
 /// <para><b>Two-stage, so it costs nothing on the happy path.</b> A per-path in-process
 /// high-water mark (fed by every write AND every read this process performs — no extra I/O)
@@ -215,8 +223,9 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
         logger?.LogWarning(
             "[MonotonicWriteGuard] CONFLICT on {Path}: a write at Version={IncomingVersion} lost the race against "
             + "the durable Version={StoredVersion}. MeshNode.Version is the owner's monotonic persistence clock "
-            + "(MeshNode.NextVersion floors every mint at current+1), so the losing write is a STALE snapshot, not a "
-            + "newer state. Resolved by merging into the durable row: merged={MergedMembers}; "
+            + "(MeshNode.NextVersion floors every mint at current+1), so this write was PRODUCED AGAINST AN OLDER "
+            + "durable state than the row now holds — either a stale snapshot some component adopted as live, or a "
+            + "second writer that reached this path first. Resolved by merging into the durable row: merged={MergedMembers}; "
             + "latest-wins (stale values DROPPED)={OverwrittenMembers}. The durable row: nodeType={StoredNodeType} "
             + "name='{StoredName}' category='{StoredCategory}' mainNode='{StoredMainNode}' "
             + "lastModifiedBy='{StoredLastModifiedBy}' lastModified={StoredLastModified:O}. Find the writer — a "

--- a/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
@@ -199,20 +199,35 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
         // category say which SHAPE of node it is. All cheap scalars — no content is serialized
         // here (a NodeType's content can be a collectible-ALC type, which reflecting over during
         // teardown is its own crash class).
+        // 🚨 MainNode is the field that NAMES the writer, and it is the one this line used to
+        // withhold (#2403). The losing write is not always a stale own-node snapshot: it is just as
+        // often a SECOND, legitimate writer that got to the path first — and a cross-partition
+        // writer records where its row came from in MainNode. The worked case: the plugins gate's
+        // intermittent `Skill/presentation` + `Skill/slide` failure was `Store/Publishing`'s
+        // pre-installed-skill MIRROR (in-mesh source in MeshWeaver.Plugins — invisible to
+        // `dotnet build` and to any `grep --include='*.cs'` over this repo) creating
+        // `Skill/{id}` from `Publish/Skill/{id}`. Its rows carry
+        // `mainNode='Publish/Skill/presentation'`: one line, writer identified. Without it, three
+        // full local gate reproductions and two sessions of static analysis could not name it — the
+        // durable row's own content had to be matched byte-for-byte against every candidate file
+        // instead. LastModifiedBy does not close that gap (a system-impersonated writer stamps
+        // `system-security`, which every framework writer shares).
         logger?.LogWarning(
             "[MonotonicWriteGuard] CONFLICT on {Path}: a write at Version={IncomingVersion} lost the race against "
             + "the durable Version={StoredVersion}. MeshNode.Version is the owner's monotonic persistence clock "
             + "(MeshNode.NextVersion floors every mint at current+1), so the losing write is a STALE snapshot, not a "
             + "newer state. Resolved by merging into the durable row: merged={MergedMembers}; "
             + "latest-wins (stale values DROPPED)={OverwrittenMembers}. The durable row: nodeType={StoredNodeType} "
-            + "name='{StoredName}' category='{StoredCategory}' lastModifiedBy='{StoredLastModifiedBy}' "
-            + "lastModified={StoredLastModified:O}. Find the writer that adopted a stale "
-            + "own-node snapshot; do not relax this guard.",
+            + "name='{StoredName}' category='{StoredCategory}' mainNode='{StoredMainNode}' "
+            + "lastModifiedBy='{StoredLastModifiedBy}' lastModified={StoredLastModified:O}. Find the writer — a "
+            + "mainNode pointing OUTSIDE this path's own partition names a cross-partition mirror; otherwise look "
+            + "for a writer that adopted a stale own-node snapshot. Do not relax this guard.",
             path, stale.Version, latest.Version,
             Describe(resolution.MergedMembers), Describe(resolution.OverwrittenMembers),
-            latest.NodeType, latest.Name, latest.Category, latest.LastModifiedBy, latest.LastModified);
+            latest.NodeType, latest.Name, latest.Category, latest.MainNode,
+            latest.LastModifiedBy, latest.LastModified);
 
-        RecordConflictActivity(path, stale.Version, latest.Version, resolution, options);
+        RecordConflictActivity(path, stale.Version, latest, resolution, options);
 
         if (resolution.IsLatestUnchanged)
             return Observable.Return<MeshNode?>(latest);   // nothing salvageable — the durable row already IS the answer
@@ -248,18 +263,27 @@ internal sealed class MonotonicWriteGuardStorageAdapter(
     /// <c>_Activity</c> namespace, so a conflict on a trace can never write a trace about a trace.</para>
     /// </summary>
     private void RecordConflictActivity(
-        string path, long staleVersion, long latestVersion,
+        string path, long staleVersion, MeshNode latest,
         MeshNodeConflictResolution resolution, JsonSerializerOptions options)
     {
         if (string.IsNullOrEmpty(path)
             || path.Contains("/_Activity/", StringComparison.OrdinalIgnoreCase))
             return;
 
+        var latestVersion = latest.Version;
         var messages = ImmutableList<LogMessage>.Empty
             .Add(new LogMessage(
                 $"A write at Version={staleVersion} lost the race against the durable Version={latestVersion} "
                 + $"on '{path}' and was merged into it.",
                 LogLevel.Information));
+        // The durable row's PROVENANCE — the same identification the warning above carries, kept on
+        // the durable trace because a portal's logs are gone long before someone opens this node
+        // (#2403). A MainNode outside this path's own partition names a cross-partition mirror.
+        messages = messages.Add(new LogMessage(
+            $"The durable row: nodeType='{latest.NodeType}' name='{latest.Name}' "
+            + $"category='{latest.Category}' mainNode='{latest.MainNode}' "
+            + $"lastModifiedBy='{latest.LastModifiedBy}'.",
+            LogLevel.Information));
         messages = resolution.OverwrittenMembers.Aggregate(messages, (acc, member) => acc.Add(
             new LogMessage(
                 $"'{member}' was not auto-resolvable — the newer value was kept and the losing write's value dropped.",

--- a/test/MeshWeaver.Hosting.Test/MonotonicWriteGuardTests.cs
+++ b/test/MeshWeaver.Hosting.Test/MonotonicWriteGuardTests.cs
@@ -1,9 +1,11 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using MeshWeaver.Data;
 using MeshWeaver.Fixture;
 using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Mesh;
@@ -207,5 +209,37 @@ public class MonotonicWriteGuardTests
 
         (await store.Read("TestData/b", JsonOptions).Should().Emit())!.Version.Should().Be(1);
         (await store.Read("TestData/a", JsonOptions).Should().Emit())!.Version.Should().Be(90);
+    }
+
+    /// <summary>
+    /// 🚨 The durable trace must IDENTIFY the row that won, not merely count what was dropped
+    /// (#2403). The losing write is often not a stale own-node snapshot at all but a SECOND,
+    /// legitimate writer that reached the path first — and a cross-partition writer records where
+    /// its row came from in <see cref="MeshNode.MainNode"/>. That is the one field that names it:
+    /// the plugins gate's intermittent <c>Skill/presentation</c> failure was a pre-installed-skill
+    /// MIRROR created from <c>Publish/Skill/presentation</c>, and identifying it took two sessions
+    /// and three full local gate reproductions precisely because neither the warning nor this trace
+    /// carried the provenance. <c>LastModifiedBy</c> does not close the gap — every
+    /// system-impersonated writer stamps the same principal.
+    /// </summary>
+    [Fact]
+    public async Task ConflictTrace_NamesTheDurableRowsProvenance()
+    {
+        var (store, leaf) = BuildStore();
+
+        // The winner: a MIRROR of a node in ANOTHER partition — its MainNode is the source path.
+        await store.Write(
+                Node("mirror", 1) with { MainNode = "Publish/Skill/presentation" }, JsonOptions)
+            .Should().Emit();
+
+        // The loser: an installer's authored node, written at the version its repo file carries (0).
+        await store.Write(Node("authored", 0), JsonOptions).Should().Emit();
+
+        var trace = await leaf.Read($"{Path}/_Activity/write-conflict-1", JsonOptions).Should().Emit();
+        var log = trace!.ContentAs<ActivityLog>(JsonOptions);
+        log.Should().NotBeNull("the guard records a durable trace for every resolved conflict");
+        log!.Messages.Select(m => m.Message).Should().Contain(
+            m => m.Contains("mainNode='Publish/Skill/presentation'", StringComparison.Ordinal),
+            "the trace has to name the writer, and provenance is what names a cross-partition mirror");
     }
 }


### PR DESCRIPTION
## What

The `MonotonicWriteGuard` conflict warning and its durable `{path}/_Activity/write-conflict-{n}`
record now carry the winning row's **`MainNode`** — the field that identifies who wrote it.

## Why — #2403 took two sessions and three full gate reproductions for want of one line

The guard's message ends *"Find the writer that adopted a stale own-node snapshot"*. On #2403 the
losing write was **not** a stale snapshot at all: it was a second, legitimate writer that reached the
path first — `Store/Publishing`'s pre-installed-skill **mirror**, in-mesh C# in MeshWeaver.Plugins
(so invisible to `dotnet build` and to any `grep --include='*.cs'` over this repo), creating
`Skill/{id}` from `Publish/Skill/{id}` through `mesh.CreateNode` under `system-security`.

Its rows carry `mainNode='Publish/Skill/presentation'`. With that in the line, the writer is named on
sight. Without it, the durable row's content had to be matched byte-for-byte against every candidate
file across two repos to conclude the same thing — see the
[RCA on #2403](https://github.com/Systemorph/MeshWeaver/issues/2403#issuecomment-5430453455).

`LastModifiedBy` — already in the line since #2402 — cannot close the gap: every system-impersonated
writer stamps the same principal. `MainNode` can, because a cross-partition writer records where its
row came from.

## The change

- **Warning**: adds `mainNode='…'`, and its closing instruction now distinguishes the two shapes
  instead of asserting one — *"a mainNode pointing OUTSIDE this path's own partition names a
  cross-partition mirror; otherwise look for a writer that adopted a stale own-node snapshot"*.
- **Durable trace**: the `_Activity/write-conflict-{n}` satellite gains an `Information` line
  describing the same row. #2403 explicitly pointed at that node as "another place to look on a
  portal where this happens" — and a portal's logs are long gone before anyone opens it.
- The comment above the log records the worked case, so the next reader does not repeat the hunt.

## Proven able to fail

`ConflictTrace_NamesTheDurableRowsProvenance` (`test/MeshWeaver.Hosting.Test`) writes a mirror-shaped
winner (`MainNode` in another partition) and then an installer-shaped loser at `Version=0`, and
asserts the trace names the provenance. Verified against `main` by reverting only the source file:

```
Failed MeshWeaver.Hosting.Test.MonotonicWriteGuardTests.ConflictTrace_NamesTheDurableRowsProvenance
  Expected collection to contain an item matching the predicate because the trace has to name the
  writer, and provenance is what names a cross-partition mirror.
```

With the fix: `Passed! - Failed: 0, Passed: 10` for the whole `MonotonicWriteGuardTests` class.

`StoreLevelWriteConflictTest` filters that trace to **Warning**-level entries, so the new
`Information` line leaves it untouched.

## Not in scope, deliberately

The *collision* behind #2403 is already resolved in the repo that owns the content:
MeshWeaver.Plugins#714 deleted the duplicate skill copies (`Publish/Skill/presentation.json` +
`slide.json` among them) and gated recurrence with `check_one_skill_master`. Nothing here changes
write behaviour — this is diagnostics only.

A separate defect found on the way, reported on #2403 for the plugins repo: `PreInstall.Mirror`
drops `Category` and `Order`, so every mirrored skill sits in the global registry with no category
and order 0, and `MirrorEquals` does not compare them so the loss is not self-healing.

Closes #2403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
