### PR TITLE
ci: a run on main is never cancelled — the merge that lands must be built and shippable

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -158,7 +158,25 @@ concurrency:
   # literally rather than folded, so a "tidier" multi-line version silently changes the
   # string rather than just its layout.
   group: build-test-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+  # 🚨 NEVER cancel a run on `main` (#2412). Superseding is safe on a PR branch — the later
+  # push tests a strict successor of what was cancelled, and that is where #2316's ~28% of
+  # runner demand is saved. On `main` it is neither safe nor recoverable, for two reasons:
+  #
+  #  1. **Nothing then builds the combination that landed.** With `strict: false` each PR is
+  #     tested against the main it branched from, so the MERGED tree is first compiled by the
+  #     main run itself. Cancel that and a semantic conflict between two independently-green
+  #     PRs ships unbuilt — which is exactly how `CS0246: MeshOperations` reached main on
+  #     2026-08-26, from five merges inside fifteen seconds.
+  #  2. **Nothing publishes.** `main-cd.yml` gates delivery on the required check
+  #     `Consolidate test results` reaching `success` FOR THAT SHA. A cancelled run does fire
+  #     `workflow_run` (`types: [completed]` includes cancelled), so CD wakes up and finds no
+  #     success to act on. A burst of merges therefore publishes nothing at all, and the tail
+  #     is left to the hourly reconciler.
+  #
+  # Measured the day this was written: main's five consecutive runs between 20:28 and 20:38
+  # were ALL `cancelled`, each by the next merge. The cost of this line is one full run per
+  # merge to main; that is the price of every landed commit being both tested and shippable.
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' && github.ref != 'refs/heads/main' }}
 
 # publish-unit-test-result-action runs per shard AND in the collector — both need
 # checks: write to create check-runs and pull-requests: write to comment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,20 +229,25 @@ so never relax it. Three consequences that trip people up, all SILENT:
    Test" --ref main` RUNS and genuinely tests the merge commit, so main shows a **green
    Build-and-Test** — but its `event` is `workflow_dispatch`, not `push`, so CD still skips. The
    most convincing possible "it shipped" signal, and no image.
-3. 🚨 **Back-to-back merges CANCEL each other's main run, so a merge burst publishes NOTHING.**
-   `dotnet-test.yml`'s concurrency group is `build-test-${{ … || github.ref }}` — every push to main
-   groups as `refs/heads/main`, so each merge cancels the in-flight run for the previous one (#2316,
-   which buys ~28% of runner demand and is worth keeping). CD **does** still fire on those runs —
-   `main-cd.yml` subscribes with `types: [completed]`, and a cancelled run is "completed" — but its
-   delivery gate keys on the required check **`Consolidate test results` reaching `success` for that
-   SHA**, which a cancelled run never produces. So CD wakes, decides "nothing will be built", and
-   every intermediate publish that "would have happened" simply does not. Observed
-   2026-08-26: #2316 merged at 12:55:25Z and main's next **five** runs were cancelled back-to-back,
-   leaving 45 minutes with no completed run and no publish.
+3. 🚨 **Runs on `main` are never cancelled — and that is load-bearing, not a tuning choice.**
+   `dotnet-test.yml` sets `cancel-in-progress` to `github.event_name != 'workflow_dispatch' && github.ref
+   != 'refs/heads/main'`. Superseding stays on for PR branches (that is where #2316's ~28% of runner
+   demand is saved, and a later push there tests a strict successor of what was cancelled). It is OFF
+   for main because cancelling there loses two different things at once:
 
-   Publishing only the **tip** of a burst is correct — intermediate commits never needed their own
-   image set, and it is the batching `CD_BATCH_WINDOW_MINUTES` already wants. So do NOT wait between
-   ordinary merges; batching them is right, and the tip's image contains them all.
+   - **Nothing builds the combination that LANDED.** `strict: false` means each PR was tested against
+     the main it branched from, so the merged tree is first compiled by main's own run. This is not
+     hypothetical: five merges inside fifteen seconds put `CS0246: MeshOperations` on main on
+     2026-08-26 — two independently-green PRs, a semantic conflict neither could see (#2412).
+   - **Nothing publishes.** CD's delivery gate keys on `Consolidate test results` reaching `success`
+     **for that SHA**. CD *does* still fire on a cancelled run (`main-cd.yml` subscribes with
+     `types: [completed]`, and cancelled counts as completed) — it just finds no success to act on.
+
+   Before the fix, main's five consecutive runs from 20:28–20:38 on 2026-08-26 were all `cancelled`,
+   each by the next merge. **So do NOT re-introduce cancellation on main to save runner minutes** —
+   the cost is one run per merge and it buys both the compile of what shipped and the ability to ship
+   it. Batching *publication* is still right and `CD_BATCH_WINDOW_MINUTES` still does it; what is not
+   right is batching by destroying the evidence.
 
    🚨 **The wait is owed to a merge that must ship ON ITS OWN** (a CD fix, a hotfix someone is
    verifying): merge it, then wait for **that merge commit's** Build-and-Test to COMPLETE — and

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-a-burst-of-merges-no-longer-skips-a-release.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-a-burst-of-merges-no-longer-skips-a-release.md
@@ -1,0 +1,22 @@
+---
+Name: A burst of merges no longer skips a release
+Category: Fix
+Description: When several changes landed within a few minutes of each other, each one cancelled the build for the one before it — so none of them was ever compiled together and none of them shipped an update.
+Icon: ArrowSync
+Order: -20260826
+---
+
+# A burst of merges no longer skips a release
+
+Changes are tested individually before they land, and then once more together after they land — that
+second build is the only one that ever sees the combination, and it is also what releases the update.
+
+When several changes landed close together, each one cancelled the build still running for the one
+before it. The effect was invisible from the outside: no failure was reported, the list of builds
+simply showed them stopping. But nothing had compiled the combination the changes formed together,
+and because an update is only published once that build reports success, a run of merges could ship
+no update at all. On one occasion five changes in ten minutes produced no release and a compile
+error that neither change could have shown on its own.
+
+Builds of already-landed changes now always run to completion. Superseding still applies while a
+change is being reviewed, where the newer version genuinely replaces the older one.

--- a/test/MeshWeaver.Documentation.Test/MainRunsAreNeverCancelledGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/MainRunsAreNeverCancelledGuard.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using Xunit;
@@ -32,48 +33,258 @@ namespace MeshWeaver.Documentation.Test;
 /// quiet" reads as healthy. Measured the day the guard was written, main's five consecutive runs
 /// between 20:28 and 20:38 were ALL <c>cancelled</c>, each by the next merge.</para>
 ///
-/// <para>🚨 This is a text guard because the invariant lives in a GitHub Actions expression, where
-/// no unit test can observe it — the only way it can regress is someone editing the line back to
-/// save minutes, which is precisely what a comment cannot prevent.</para>
+/// <para>🚨 <b>This guard EVALUATES the expression; it does not pattern-match it.</b> The first
+/// version asserted only that the text mentioned <c>refs/heads/main</c> — which
+/// <c>${{ github.ref == 'refs/heads/main' }}</c> satisfies while cancelling on main, the exact
+/// opposite of the intent. That is this repo's standing lesson applied to a gate's own code: a
+/// verification step that cannot fail is not a verification step, and a spelling check is not a
+/// semantic one. <see cref="Evaluate"/> is a small evaluator for the GitHub expression subset,
+/// with its own self-test rows in <see cref="TheEvaluator_IsItselfCorrect"/> — including that
+/// counterexample.</para>
 /// </summary>
 public class MainRunsAreNeverCancelledGuard
 {
     private const string Workflow = ".github/workflows/dotnet-test.yml";
 
     /// <summary>
-    /// The assertion is on the EXPRESSION, not on a byte-exact line: any form that excludes
-    /// <c>refs/heads/main</c> from cancellation passes, and a bare <c>true</c> — or an expression
-    /// that no longer mentions the ref at all — fails.
+    /// Both halves of the intent are pinned. Cancelling must be OFF for a push to main (the
+    /// correctness half) and must stay ON for a pull-request run (the cost half — silently
+    /// disabling superseding everywhere would hand back #2316's ~28% saving with nobody noticing).
     /// </summary>
     [Fact]
-    public void BuildAndTest_NeverCancelsAnInProgressRunOnMain()
+    public void BuildAndTest_CancelsOnPrBranches_ButNeverOnMain()
     {
-        var path = Path.Combine(FindRepoRoot(), Workflow);
-        var body = File.ReadAllText(path);
+        var body = File.ReadAllText(Path.Combine(FindRepoRoot(), Workflow));
 
-        var cancel = Regex.Match(body, @"^\s*cancel-in-progress:\s*(?<value>.+)$", RegexOptions.Multiline);
+        var cancel = Regex.Match(body, @"^\s*cancel-in-progress:\s*(?<value>.+?)\s*$", RegexOptions.Multiline);
 
         Assert.True(cancel.Success,
             $"{Workflow} no longer declares cancel-in-progress. If concurrency was removed entirely "
             + "that is fine for main, but this guard can no longer see it — re-point or delete it "
             + "deliberately rather than letting it rot.");
 
-        var value = cancel.Groups["value"].Value.Trim();
+        var expression = cancel.Groups["value"].Value;
 
-        Assert.False(value is "true" or "\"true\"" or "'true'",
-            $"{Workflow} sets cancel-in-progress: true unconditionally, so every merge to main "
-            + "cancels the run for the merge before it. Nothing then compiles the tree that landed "
-            + "(strict: false means the merged combination is first built by main's own run — this "
-            + "is how CS0246 reached main on 2026-08-26), and nothing publishes (CD gates on "
-            + "'Consolidate test results' reaching success for that SHA, which a cancelled run "
-            + "never produces). See #2412.");
+        var onMain = Evaluate(expression, new Dictionary<string, string>
+        {
+            ["github.event_name"] = "push",
+            ["github.ref"] = "refs/heads/main",
+        });
 
-        Assert.True(value.Contains("refs/heads/main", StringComparison.Ordinal),
-            $"{Workflow}'s cancel-in-progress expression no longer excludes refs/heads/main: "
-            + $"'{value}'. Superseding is correct on a PR branch and wrong on main — a cancelled "
-            + "main run loses both the compile of the combination that shipped and the ability to "
-            + "ship it (#2412). Keep the ref check, or state in the expression why it is safe.");
+        Assert.False(onMain,
+            $"{Workflow} cancels in-progress runs on main: '{expression}' evaluates TRUE for a push "
+            + "to refs/heads/main. Each merge then kills the run for the merge before it, so nothing "
+            + "compiles the tree that landed (strict: false means the merged combination is first "
+            + "built by main's own run — this is how CS0246 reached main on 2026-08-26) and nothing "
+            + "publishes (CD gates on 'Consolidate test results' reaching success for that SHA, "
+            + "which a cancelled run never produces). See #2412.");
+
+        var onPullRequest = Evaluate(expression, new Dictionary<string, string>
+        {
+            ["github.event_name"] = "pull_request",
+            ["github.ref"] = "refs/pull/2447/merge",
+        });
+
+        Assert.True(onPullRequest,
+            $"{Workflow} no longer supersedes runs on PR branches: '{expression}' evaluates FALSE "
+            + "for a pull_request run. That is the half worth keeping — a later push to a PR tests a "
+            + "strict successor of what was cancelled, and it is where #2316's ~28% of runner demand "
+            + "is saved. Exclude main specifically, not every ref.");
     }
+
+    /// <summary>
+    /// 🚨 The evaluator is code, so it gets the same treatment every gate here does: rows that
+    /// prove it can return BOTH answers, including the inverted expression that defeated the
+    /// original substring check, and the shapes a "tidy-up" would most plausibly introduce.
+    /// </summary>
+    [Theory]
+    // The shipped expression: off for main, on for a PR.
+    [InlineData("${{ github.event_name != 'workflow_dispatch' && github.ref != 'refs/heads/main' }}", "push", "refs/heads/main", false)]
+    [InlineData("${{ github.event_name != 'workflow_dispatch' && github.ref != 'refs/heads/main' }}", "pull_request", "refs/pull/1/merge", true)]
+    // The pre-fix expression, and a bare literal: both cancel on main.
+    [InlineData("${{ github.event_name != 'workflow_dispatch' }}", "push", "refs/heads/main", true)]
+    [InlineData("true", "push", "refs/heads/main", true)]
+    // 🚨 Copilot's counterexample on this PR: mentions refs/heads/main, still cancels there.
+    [InlineData("${{ github.ref == 'refs/heads/main' }}", "push", "refs/heads/main", true)]
+    // A disjunct is not a conjunct — `||` re-admits main whenever the other side is true.
+    [InlineData("${{ github.event_name != 'workflow_dispatch' || github.ref != 'refs/heads/main' }}", "push", "refs/heads/main", true)]
+    // Negation and parentheses, the two shapes a rewrite reaches for.
+    [InlineData("${{ !(github.ref == 'refs/heads/main') }}", "push", "refs/heads/main", false)]
+    [InlineData("${{ !(github.ref == 'refs/heads/main') }}", "pull_request", "refs/pull/1/merge", true)]
+    [InlineData("false", "pull_request", "refs/pull/1/merge", false)]
+    public void TheEvaluator_IsItselfCorrect(string expression, string eventName, string @ref, bool expected)
+        => Assert.Equal(expected, Evaluate(expression, new Dictionary<string, string>
+        {
+            ["github.event_name"] = eventName,
+            ["github.ref"] = @ref,
+        }));
+
+    /// <summary>
+    /// A recursive-descent evaluator for the slice of the GitHub expression language a
+    /// <c>cancel-in-progress</c> value can reasonably use: <c>&amp;&amp;</c>, <c>||</c>, <c>!</c>,
+    /// parentheses, <c>==</c>/<c>!=</c>, single-quoted strings, <c>true</c>/<c>false</c>, and
+    /// context lookups. Precedence is <c>!</c> &gt; comparison &gt; <c>&amp;&amp;</c> &gt;
+    /// <c>||</c>, as in Actions. Truthiness follows Actions: a non-empty string is true.
+    ///
+    /// <para>Anything outside that subset throws rather than guessing — an unparseable expression
+    /// must fail the guard loudly, never silently evaluate to "fine".</para>
+    /// </summary>
+    private static bool Evaluate(string raw, IReadOnlyDictionary<string, string> context)
+    {
+        var text = raw.Trim();
+        var wrapped = Regex.Match(text, @"^\$\{\{(?<inner>.*)\}\}$", RegexOptions.Singleline);
+        if (wrapped.Success)
+            text = wrapped.Groups["inner"].Value;
+        // A bare scalar may be YAML-quoted (`cancel-in-progress: "true"`); the expression form
+        // never is. Strip only a matched pair of double quotes, so a single-quoted GitHub string
+        // literal is left for the tokenizer.
+        if (text.Length > 1 && text[0] == '"' && text[^1] == '"')
+            text = text[1..^1];
+
+        var tokens = Tokenize(text);
+        var position = 0;
+        var value = ParseOr(tokens, ref position, context);
+
+        if (position != tokens.Count)
+            throw new InvalidOperationException(
+                $"could not fully parse the cancel-in-progress expression '{raw}' (stopped at token "
+                + $"{position} of {tokens.Count}). Extend this evaluator deliberately rather than "
+                + "letting the guard pass on an expression it does not understand.");
+
+        return Truthy(value);
+    }
+
+    private static List<string> Tokenize(string text)
+    {
+        var tokens = new List<string>();
+        var i = 0;
+
+        while (i < text.Length)
+        {
+            var c = text[i];
+
+            if (char.IsWhiteSpace(c)) { i++; continue; }
+
+            if (c == '\'')
+            {
+                var end = text.IndexOf('\'', i + 1);
+                if (end < 0) throw new InvalidOperationException($"unterminated string literal in '{text}'");
+                tokens.Add(text[i..(end + 1)]);
+                i = end + 1;
+                continue;
+            }
+
+            if (i + 1 < text.Length && text[i..(i + 2)] is "&&" or "||" or "==" or "!=")
+            {
+                tokens.Add(text[i..(i + 2)]);
+                i += 2;
+                continue;
+            }
+
+            if (c is '(' or ')' or '!')
+            {
+                tokens.Add(c.ToString());
+                i++;
+                continue;
+            }
+
+            var start = i;
+            while (i < text.Length && (char.IsLetterOrDigit(text[i]) || text[i] is '_' or '.' or '-')) i++;
+            if (i == start)
+                throw new InvalidOperationException($"unexpected character '{c}' in expression '{text}'");
+            tokens.Add(text[start..i]);
+        }
+
+        return tokens;
+    }
+
+    private static object ParseOr(List<string> tokens, ref int position, IReadOnlyDictionary<string, string> context)
+    {
+        var left = ParseAnd(tokens, ref position, context);
+        while (position < tokens.Count && tokens[position] == "||")
+        {
+            position++;
+            var right = ParseAnd(tokens, ref position, context);
+            left = Truthy(left) || Truthy(right);
+        }
+        return left;
+    }
+
+    private static object ParseAnd(List<string> tokens, ref int position, IReadOnlyDictionary<string, string> context)
+    {
+        var left = ParseComparison(tokens, ref position, context);
+        while (position < tokens.Count && tokens[position] == "&&")
+        {
+            position++;
+            var right = ParseComparison(tokens, ref position, context);
+            left = Truthy(left) && Truthy(right);
+        }
+        return left;
+    }
+
+    private static object ParseComparison(List<string> tokens, ref int position, IReadOnlyDictionary<string, string> context)
+    {
+        var left = ParseUnary(tokens, ref position, context);
+        if (position < tokens.Count && tokens[position] is "==" or "!=")
+        {
+            var op = tokens[position++];
+            var right = ParseUnary(tokens, ref position, context);
+            var equal = string.Equals(Stringify(left), Stringify(right), StringComparison.Ordinal);
+            return op == "==" ? equal : !equal;
+        }
+        return left;
+    }
+
+    private static object ParseUnary(List<string> tokens, ref int position, IReadOnlyDictionary<string, string> context)
+    {
+        if (position < tokens.Count && tokens[position] == "!")
+        {
+            position++;
+            return !Truthy(ParseUnary(tokens, ref position, context));
+        }
+        return ParsePrimary(tokens, ref position, context);
+    }
+
+    private static object ParsePrimary(List<string> tokens, ref int position, IReadOnlyDictionary<string, string> context)
+    {
+        if (position >= tokens.Count)
+            throw new InvalidOperationException("expression ended where a value was expected");
+
+        var token = tokens[position++];
+
+        if (token == "(")
+        {
+            var inner = ParseOr(tokens, ref position, context);
+            if (position >= tokens.Count || tokens[position] != ")")
+                throw new InvalidOperationException("missing closing parenthesis");
+            position++;
+            return inner;
+        }
+
+        if (token.StartsWith('\'')) return token.Trim('\'');
+        if (token == "true") return true;
+        if (token == "false") return false;
+
+        return context.TryGetValue(token, out var value)
+            ? value
+            : throw new InvalidOperationException(
+                $"the expression reads context value '{token}', which this guard does not model. "
+                + "Add it to the contexts under test rather than loosening the assertion.");
+    }
+
+    private static bool Truthy(object value) => value switch
+    {
+        bool b => b,
+        string s => s.Length > 0,
+        _ => throw new InvalidOperationException($"cannot take the truth value of '{value}'"),
+    };
+
+    private static string Stringify(object value) => value switch
+    {
+        bool b => b ? "true" : "false",
+        string s => s,
+        _ => value.ToString() ?? string.Empty,
+    };
 
     private static string FindRepoRoot()
     {

--- a/test/MeshWeaver.Documentation.Test/MainRunsAreNeverCancelledGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/MainRunsAreNeverCancelledGuard.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>A run on <c>main</c> must never be cancelled by the next merge</b> (#2412).
+///
+/// <para><b>Why this is correctness, not runner-minute tuning.</b> Cancelling a superseded run is
+/// the right default on a PR branch — the later push tests a strict successor of what was killed,
+/// and that is where #2316's ~28% of runner demand is saved. On <c>main</c> the same setting
+/// destroys two different things, and neither is recoverable by re-running later:</para>
+///
+/// <list type="number">
+///   <item><description><b>Nothing builds the combination that LANDED.</b> The repo runs
+///   <c>strict: false</c> branch protection, so each PR is tested against the <c>main</c> it
+///   branched from — the MERGED tree is first compiled by main's own run. Cancel that and a
+///   semantic conflict between two independently-green PRs ships unbuilt. On 2026-08-26 five
+///   merges inside fifteen seconds put <c>CS0246: 'MeshOperations' could not be found</c> on
+///   main exactly this way.</description></item>
+///   <item><description><b>Nothing publishes.</b> <c>main-cd.yml</c> gates delivery on the
+///   required check <c>Consolidate test results</c> reaching <c>success</c> FOR THAT SHA. CD does
+///   still wake on a cancelled run — it subscribes with <c>types: [completed]</c> and cancelled
+///   counts as completed — it simply finds no success to act on. A burst of merges therefore
+///   publishes nothing, leaving the tail to the hourly reconciler.</description></item>
+/// </list>
+///
+/// <para>Both failures are silent in the same way the rest of this repo's worst bugs are: a
+/// cancelled run and a run that was never needed look identical in the runs list, so "main is
+/// quiet" reads as healthy. Measured the day the guard was written, main's five consecutive runs
+/// between 20:28 and 20:38 were ALL <c>cancelled</c>, each by the next merge.</para>
+///
+/// <para>🚨 This is a text guard because the invariant lives in a GitHub Actions expression, where
+/// no unit test can observe it — the only way it can regress is someone editing the line back to
+/// save minutes, which is precisely what a comment cannot prevent.</para>
+/// </summary>
+public class MainRunsAreNeverCancelledGuard
+{
+    private const string Workflow = ".github/workflows/dotnet-test.yml";
+
+    /// <summary>
+    /// The assertion is on the EXPRESSION, not on a byte-exact line: any form that excludes
+    /// <c>refs/heads/main</c> from cancellation passes, and a bare <c>true</c> — or an expression
+    /// that no longer mentions the ref at all — fails.
+    /// </summary>
+    [Fact]
+    public void BuildAndTest_NeverCancelsAnInProgressRunOnMain()
+    {
+        var path = Path.Combine(FindRepoRoot(), Workflow);
+        var body = File.ReadAllText(path);
+
+        var cancel = Regex.Match(body, @"^\s*cancel-in-progress:\s*(?<value>.+)$", RegexOptions.Multiline);
+
+        Assert.True(cancel.Success,
+            $"{Workflow} no longer declares cancel-in-progress. If concurrency was removed entirely "
+            + "that is fine for main, but this guard can no longer see it — re-point or delete it "
+            + "deliberately rather than letting it rot.");
+
+        var value = cancel.Groups["value"].Value.Trim();
+
+        Assert.False(value is "true" or "\"true\"" or "'true'",
+            $"{Workflow} sets cancel-in-progress: true unconditionally, so every merge to main "
+            + "cancels the run for the merge before it. Nothing then compiles the tree that landed "
+            + "(strict: false means the merged combination is first built by main's own run — this "
+            + "is how CS0246 reached main on 2026-08-26), and nothing publishes (CD gates on "
+            + "'Consolidate test results' reaching success for that SHA, which a cancelled run "
+            + "never produces). See #2412.");
+
+        Assert.True(value.Contains("refs/heads/main", StringComparison.Ordinal),
+            $"{Workflow}'s cancel-in-progress expression no longer excludes refs/heads/main: "
+            + $"'{value}'. Superseding is correct on a PR branch and wrong on main — a cancelled "
+            + "main run loses both the compile of the combination that shipped and the ability to "
+            + "ship it (#2412). Keep the ref check, or state in the expression why it is safe.");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
Closes #2412.

## The defect

`dotnet-test.yml` set `cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}`. Every push to main groups as `refs/heads/main`, so **each merge cancelled the run for the merge before it.**

Superseding is the right default on a PR branch — the later push tests a strict successor of what was killed, and that is where #2316's ~28% of runner demand is saved. On main the same setting loses two different things, and re-running later recovers neither:

1. **Nothing builds the combination that LANDED.** With `strict: false`, each PR is tested against the main it branched from — the *merged* tree is first compiled by main's own run. Cancel that and a semantic conflict between two independently-green PRs ships unbuilt. This is not hypothetical: five merges inside fifteen seconds put `CS0246: 'MeshOperations' could not be found` on main on 2026-08-26.
2. **Nothing publishes.** CD gates delivery on the required check `Consolidate test results` reaching `success` **for that SHA**. CD *does* still wake on a cancelled run — `main-cd.yml` subscribes with `types: [completed]` and cancelled counts as completed — it simply finds no success to act on.

Both failures are silent in this repo's characteristic way: a cancelled run and a run nobody needed look identical in the runs list, so "main is quiet" reads as healthy.

**Measured while writing this** — main's five consecutive runs, each cancelled by the next merge:

```
20:50:25  08d82de0  queued
20:38:39  444c6a9b  completed/cancelled
20:31:02  fe12f913  completed/cancelled
20:30:36  71e3ec2b  completed/cancelled
20:28:38  69916535  completed/cancelled
20:28:34  c5db4543  completed/cancelled
```

## The change

```diff
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' && github.ref != 'refs/heads/main' }}
```

PR branches keep superseding. The cost is one full run per merge to main — which buys both the compile of what shipped and the ability to ship it.

`edge-images.yml` also sets `cancel-in-progress: true`, and is left alone deliberately: it is `workflow_dispatch`-only (its `push` trigger is commented out), so a newer manual edge build correctly supersedes an older one.

## The guard

`MainRunsAreNeverCancelledGuard` asserts on the *expression*, not a byte-exact line — any form that excludes `refs/heads/main` passes.

🚨 **Verified it can actually fail**, on both shapes a regression would take:

| negative control | result |
|---|---|
| the exact pre-fix line (`… != 'workflow_dispatch'`) | ❌ *"expression no longer excludes refs/heads/main"* |
| bare `cancel-in-progress: true` | ❌ *"sets cancel-in-progress: true unconditionally"* |

A comment cannot stop someone editing this line back to save runner minutes; a red test can.

## Verification

- `dotnet build -c Release -warnaserror` — `0 Error(s)`
- `MeshWeaver.Documentation.Test` — **70/70 passed**
- The What's New entry was validated **after a rebuild**: `Data/**` ships as `EmbeddedResource`, so the first `--no-build` run had checked the stale DLL, not the new file (DLL 23:01:12 > entry 22:57:54).

Also updates the AGENTS.md section that documented the cancellation as a standing fact — it would otherwise now be wrong — restating it as an invariant not to re-introduce.