### PR TITLE
The routing layer discarded every classification below it (#2346)

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -404,10 +404,11 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                 if (result.State == MessageDeliveryState.Failed)
                 {
                     // Preserve the RoutingGrain's message so the GUI's
-                    // IsExpectedUserActionFailure classifier can match it.
-                    var failureMessage = result.Properties.TryGetValue("Error", out var errObj) && errObj is string errStr
-                        ? errStr
-                        : $"Delivery failed to {address}";
+                    // IsExpectedUserActionFailure classifier can match it. GetFailureMessage, not a
+                    // raw `is string` test: a delivery that crossed a hub boundary can carry the text
+                    // as an untyped JsonElement, and dropping it would also drop the phrase the
+                    // classification fallback below matches on.
+                    var failureMessage = result.GetFailureMessage() ?? $"Delivery failed to {address}";
                     // 🚨 NOT every Failed result is terminal, and assuming so cost this project the
                     // shard-0 Orleans flake cluster. This comment used to read "Grain returned a
                     // non-transient failure (e.g. node doesn't exist)" and SendDeliveryFailure

--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -430,10 +430,26 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                     // all already treat "is shutting down" as retry-worthy, and NackThroughParent's
                     // own comment calls the wording CONTRACT. This makes the fourth layer agree with
                     // the other three rather than contradict them.
-                    var failureErrorType = ClassifyRoutedFailure(failureMessage);
+                    //
+                    // 🚨 The CARRIED verdict comes first, the text rule is only the FALLBACK — the
+                    // two must not diverge from the silo-side twin in RoutingGrain, because "a fix
+                    // landed on one site and missed the other" is precisely how #2346 outlived both
+                    // of its earlier fixes. A site that recorded a verdict (MessageService's intake
+                    // gate, MessageHubGrain's activation/disposal arms) knows more than any matcher
+                    // can recover from prose: "Hub disposed before delivery for …" is ShuttingDown
+                    // and contains no phrase a text rule could catch.
+                    var failureErrorType = result.GetFailureErrorType(ClassifyRoutedFailure(failureMessage));
                     logger.LogWarning("Orleans: delivery FAILED for {MessageType} to {Address}: {FailureMessage} (as {ErrorType})",
                         msgType, address, failureMessage, failureErrorType);
-                    SendDeliveryFailure(delivery, failureMessage, failureErrorType);
+
+                    // 🚨 ANSWER ONCE — the same contract MessageService.ReportRoutingFailure and
+                    // the silo-side RoutingGrain apply. FailedAndNacked DECLARES that the failing
+                    // site posted its own DeliveryFailure; answering again gives ONE request TWO
+                    // answers, and Observe resolves on whichever lands first.
+                    if (result.SenderWasNacked)
+                        OrleansRouteTrace.Write($"OrleansRoutingService.Deliver DISPATCH_FAILED_ALREADY_NACKED addr={address} id={delivery.Id}");
+                    else
+                        SendDeliveryFailure(delivery, failureMessage, failureErrorType);
                 }
                 else
                 {

--- a/src/MeshWeaver.Documentation/Data/Architecture/ErrorPropagationAndWedges.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ErrorPropagationAndWedges.md
@@ -74,6 +74,32 @@ re-derived downstream from message text) and whether it already answered the sen
 routing loop reports as `ErrorType.RoutingLoop`. A site that posts its own NACK (the routing
 services' `NotFound`, on a hot path) marks the delivery answered so the sender never gets two.
 
+#### Recording a verdict is not the same as delivering one (#2346)
+
+Both halves above are carried in the delivery's `Properties`, and both leaked between the site that
+wrote them and the site that acts on them. Worth knowing, because the failure is **silent in both
+directions** and the symptom appears somewhere else entirely — as a rotating cast of Orleans
+teardown flakes, which is how it was eventually found:
+
+- **The verdict did not survive a hub boundary** — the only trip it exists for. `Properties` is
+  `IReadOnlyDictionary<string, object>`, serialized by writing each value by its RUNTIME type, so an
+  `ErrorType` goes out as the enum NAME and comes back as a `string`. `GetFailureErrorType`'s
+  `value is ErrorType` test then failed and every consumer read its FALLBACK — the carefully-recorded
+  `ShuttingDown` reached the router as "no verdict was reached". It now recovers the enum, its name,
+  an integral value or a `JsonElement`; an unrecognised value still falls back, which is honest
+  rather than invented.
+- **The Orleans routing layer read neither.** `RoutingGrain.DeliverToGrainWithRetry` — the ONLY site
+  that reports a grain-routed delivery's failure, because `RouteMessage` returns `Forwarded`
+  unconditionally and delivers on a background route — hard-coded the terminal `ErrorType.Failed`
+  and ignored `SenderWasNacked`. So a disposal race was reported as permanent, *and* the sender got
+  a second, contradictory answer racing the hub's own.
+
+The rule the two together produce, and the one to apply at any new reporting site: **honour the
+answered flag first, then read the CARRIED verdict, and fall back to the shared text rule
+(`ClassifyRoutedFailure` — the same phrase list `AreaErrorClassifier.IsTransientHubFailure` and
+`MeshNodeStreamCache.IsTransientOwnerFailure` use) rather than to a terminal default.** A verdict
+that cannot be read is not evidence of a permanent failure.
+
 ### Long-running operations (activity → activity log)
 
 An import / compile / mirror runs as an activity. A fault must not strand the activity "Running" forever — it writes `Status = Error` with the message onto the activity node, which the activity log and any progress reader render. Persistence at the bottom of the stack never re-gates and never fail-closes a write that was already approved; it forwards. See [Activity Control Plane](/Doc/Architecture/ActivityControlPlane) and [Activity Operations](/Doc/Architecture/ActivityOperations).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-recycle-window-recovers.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-recycle-window-recovers.md
@@ -1,0 +1,25 @@
+---
+Name: A page caught mid-recycle recovers instead of erroring
+Category: Fix
+Description: A request that arrived while its node was restarting was reported as a permanent failure; it is now recognised as the temporary state it is, and the view reloads by itself.
+Icon: ArrowSync
+Order: -20260826
+---
+
+# A page caught mid-recycle recovers by itself
+
+Nodes restart routinely — you save an edit that recompiles a view, an administrator recycles a
+space, a background release rolls a node forward. Restarting takes a moment, and any request that
+arrives inside that moment cannot be served yet.
+
+The platform has always known the difference between *"this address is coming back in a second"* and
+*"this address is gone"*, and everything that reads live data is built to sit out the first and give
+up only on the second. What went wrong is that the verdict was being lost in transit: the node
+correctly said "I am restarting", and the layer that carried the answer back to the page rewrote it
+as a permanent failure. The page then stopped waiting and showed an error for something that had
+already fixed itself.
+
+Now the original verdict travels intact. In practice: a view you open (or that is already open)
+while its node is restarting waits the extra moment and renders, instead of showing an error you had
+to reload past. Genuinely missing content is unaffected — that still reports as missing straight
+away, with no retrying.

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -1013,9 +1013,12 @@ internal class RoutingGrain(
                         // The owning grain resolved but could NOT service the delivery (unmaterializable /
                         // unregistered node type, failed activation, access denial). Surface as a
                         // DeliveryFailure so the caller gets a fast, deterministic OnError instead of parking.
-                        var failMsg = result.Properties.TryGetValue("Error", out var errObj) && errObj is string errStr
-                            ? errStr
-                            : $"Delivery to '{addressPath}' failed at its owning hub.";
+                        // GetFailureMessage, not a raw `is string` test: Properties values come back
+                        // re-materialised from JSON, so the text can arrive as an untyped JsonElement.
+                        // Losing it here costs twice — the sender loses its diagnostic AND the
+                        // classification below loses the phrase its fallback rule matches on.
+                        var failMsg = result.GetFailureMessage()
+                            ?? $"Delivery to '{addressPath}' failed at its owning hub.";
 
                         // 🚨 CARRY the verdict the owning hub recorded; NEVER re-decide it here. This line
                         // read `ErrorType.Failed` — terminal, unconditionally — and that is issue #2346.

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -995,14 +995,56 @@ internal class RoutingGrain(
                     RoutingGrainTrace.Write($"RoutingGrain.RouteMessage GRAIN_CALL_OK id={deliveryId} grainKey={grainKey} state={result.State}");
                     if (result.State == MessageDeliveryState.Failed)
                     {
+                        // 🚨 ANSWER ONCE. FailedAndNacked DECLARES that the failing site already posted
+                        // its own DeliveryFailure — which MessageService.NackThroughParent does on every
+                        // targeted hub disposal (recycle, node delete). A second NACK from here gives ONE
+                        // request TWO answers, and Observe resolves on whichever lands first, so the
+                        // caller's verdict becomes a coin toss even once both sites classify correctly.
+                        // Same rule, same signal, as MessageService.ReportRoutingFailure.
+                        if (result.SenderWasNacked)
+                        {
+                            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage GRAIN_CALL_FAILED_ALREADY_NACKED id={deliveryId} grainKey={grainKey}");
+                            logger.LogDebug(
+                                "[ROUTE] Grain {GrainKey} returned Failed and had ALREADY answered the sender — not NACKing twice",
+                                grainKey);
+                            return;
+                        }
+
                         // The owning grain resolved but could NOT service the delivery (unmaterializable /
                         // unregistered node type, failed activation, access denial). Surface as a
                         // DeliveryFailure so the caller gets a fast, deterministic OnError instead of parking.
                         var failMsg = result.Properties.TryGetValue("Error", out var errObj) && errObj is string errStr
                             ? errStr
                             : $"Delivery to '{addressPath}' failed at its owning hub.";
-                        logger.LogWarning("[ROUTE] Grain {GrainKey} returned Failed: {Error}", grainKey, failMsg);
-                        postFailureToSender(failMsg, ErrorType.Failed);
+
+                        // 🚨 CARRY the verdict the owning hub recorded; NEVER re-decide it here. This line
+                        // read `ErrorType.Failed` — terminal, unconditionally — and that is issue #2346.
+                        //
+                        // Three layers below this one classify carefully and every one of those verdicts
+                        // died here: MessageService's intake gate answers a disposal race with
+                        // ShuttingDown (#2350), and MessageHubGrain.DeliverMessage classifies its own two
+                        // arms (Unavailable for an activation fault #1693, ShuttingDown for "hub disposed
+                        // before delivery"). This is the ONLY site that reports them, because
+                        // RouteMessage returns Forwarded unconditionally and delivers on a background
+                        // route — so the client-side classifier in OrleansRoutingService.DispatchObservable
+                        // never sees a Failed result for a grain-routed address and could not run.
+                        //
+                        // That is why OrleansMeshTests.HubWorksAfterDisposal kept failing in ~2.4 s with
+                        // the exact text "Hub is shutting down" raised INSIDE the retry that matches
+                        // ShuttingDown — on branches carrying both earlier fixes.
+                        //
+                        // The FALLBACK is the shared text rule, not the terminal default: a delivery that
+                        // crossed a hub boundary arrives with Properties values re-materialised from JSON,
+                        // so a recorded verdict can legitimately be unreadable here. ClassifyRoutedFailure
+                        // is the same rule AreaErrorClassifier.IsTransientHubFailure and
+                        // MeshNodeStreamCache.IsTransientOwnerFailure already apply, so all four layers
+                        // agree; everything it does not recognise stays terminal, which keeps "No node
+                        // found" authoritative.
+                        var failureErrorType = result.GetFailureErrorType(
+                            OrleansRoutingService.ClassifyRoutedFailure(failMsg));
+                        logger.LogWarning("[ROUTE] Grain {GrainKey} returned Failed: {Error} (as {ErrorType})",
+                            grainKey, failMsg, failureErrorType);
+                        postFailureToSender(failMsg, failureErrorType);
                     }
                 },
                 ex =>

--- a/src/MeshWeaver.Messaging.Contract/IMessageDelivery.cs
+++ b/src/MeshWeaver.Messaging.Contract/IMessageDelivery.cs
@@ -199,20 +199,74 @@ public interface IMessageDelivery
                 // Names only: Enum.TryParse also accepts a NUMERIC string and will happily mint an
                 // undefined member from it, so IsDefined is the gate, not decoration.
                 return Enum.TryParse(name, ignoreCase: true, out errorType) && Enum.IsDefined(errorType);
-            case int or long or short or byte:
-                errorType = (ErrorType)Convert.ToInt32(value);
-                return Enum.IsDefined(errorType);
+            case int number:
+                return TryReadErrorTypeNumber(number, out errorType);
+            case long number:
+                return TryReadErrorTypeNumber(number, out errorType);
+            case short number:
+                return TryReadErrorTypeNumber(number, out errorType);
+            case byte number:
+                return TryReadErrorTypeNumber(number, out errorType);
             case System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.String } json:
                 return TryReadErrorType(json.GetString(), out errorType);
-            case System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.Number } json
-                when json.TryGetInt32(out var number):
-                errorType = (ErrorType)number;
-                return Enum.IsDefined(errorType);
+            case System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.Number } json:
+                return json.TryGetInt64(out var raw)
+                    ? TryReadErrorTypeNumber(raw, out errorType)
+                    : Fail(out errorType);
             default:
-                errorType = default;
-                return false;
+                return Fail(out errorType);
+        }
+
+        static bool Fail(out ErrorType errorType)
+        {
+            errorType = default;
+            return false;
         }
     }
+
+    /// <summary>
+    /// An integral value read as an <see cref="ErrorType"/>, range-checked FIRST.
+    ///
+    /// <para>🚨 Deliberately not <c>Convert.ToInt32</c>: that THROWS <see cref="OverflowException"/>
+    /// on an out-of-range value, and this runs on the error-REPORTING path — the one place a throw
+    /// is worst, because it replaces a failure that was about to be described with a different,
+    /// undescribed one. An unreadable value is "no verdict was reached", which is exactly what the
+    /// caller's fallback is for.</para>
+    /// </summary>
+    private static bool TryReadErrorTypeNumber(long value, out ErrorType errorType)
+    {
+        errorType = default;
+        if (value is < int.MinValue or > int.MaxValue)
+            return false;
+        errorType = (ErrorType)(int)value;
+        return Enum.IsDefined(errorType);
+    }
+
+    /// <summary>
+    /// The failure TEXT recorded by <see cref="Failed(string)"/>, or null when this delivery carries
+    /// none — so a caller can tell "no message was recorded" from an empty one and supply its own
+    /// description.
+    ///
+    /// <para>Tolerant of the round-trip for the same reason <see cref="GetFailureErrorType"/> is:
+    /// <c>Properties</c> values come back re-materialised from JSON, and options WITHOUT
+    /// <c>ObjectPolymorphicConverter</c> leave a string as an untyped <c>JsonElement</c>. Reading
+    /// only the CLR <see cref="string"/> silently loses the message — which costs twice over at a
+    /// routing site, because the text is BOTH the sender's diagnostic AND the fallback the
+    /// classification rule matches on when the failing site recorded no verdict.</para>
+    /// </summary>
+    /// <returns>The recorded failure text, or null.</returns>
+    string? GetFailureMessage() =>
+        Properties.TryGetValue(nameof(Error), out var value)
+            ? value switch
+            {
+                string text => text,
+                System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.String } json
+                    => json.GetString(),
+                // Anything else recorded under this key is not a message. Null, so the caller
+                // describes the failure itself rather than printing a type name at a user.
+                _ => null,
+            }
+            : null;
 
     /// <summary>
     /// Returns a copy of this delivery with a single property set.

--- a/src/MeshWeaver.Messaging.Contract/IMessageDelivery.cs
+++ b/src/MeshWeaver.Messaging.Contract/IMessageDelivery.cs
@@ -153,13 +153,66 @@ public interface IMessageDelivery
     /// <summary>
     /// The classification recorded by <see cref="Failed(string, ErrorType)"/>, or
     /// <paramref name="fallback"/> when the failing site recorded none.
+    ///
+    /// <para>🚨 <b>The verdict must survive a HUB BOUNDARY, which is the only situation it exists
+    /// for.</b> This read used to be a bare <c>value is ErrorType</c> — the trap-door AGENTS.md
+    /// names: an <see cref="object"/> that crossed a boundary is no longer the CLR type it was
+    /// written as. <c>Properties</c> is serialized by
+    /// <c>ImmutableDictionaryOfStringObjectConverter</c>, which writes each value by its RUNTIME
+    /// type, so an <see cref="ErrorType"/> goes out as the enum NAME and comes back — through
+    /// <c>ObjectPolymorphicConverter</c>, which materialises a JSON string as
+    /// <see cref="string"/> — as a string. The type test then failed and EVERY consumer silently
+    /// read <paramref name="fallback"/> instead of the recorded verdict.</para>
+    ///
+    /// <para>Silently, and with real consequences: a disposal race classified
+    /// <see cref="ErrorType.ShuttingDown"/> at the hub (#2350) reached the router as the fallback,
+    /// so a delivery that raced a hub's disposal kept being reported to the sender as TERMINAL even
+    /// after every producing site had been fixed to classify it (#2346). Reading the serialized
+    /// forms back is what makes "carried, never re-derived from the message text" true rather than
+    /// aspirational.</para>
     /// </summary>
     /// <param name="fallback">The verdict to use when the failing site classified nothing.</param>
     /// <returns>The recorded classification, or <paramref name="fallback"/>.</returns>
     ErrorType GetFailureErrorType(ErrorType fallback) =>
-        Properties.TryGetValue(FailureErrorTypeProperty, out var value) && value is ErrorType errorType
+        Properties.TryGetValue(FailureErrorTypeProperty, out var value) && TryReadErrorType(value, out var errorType)
             ? errorType
             : fallback;
+
+    /// <summary>
+    /// Recovers an <see cref="ErrorType"/> from every shape a JSON round-trip can leave it in: the
+    /// CLR enum (never left this process), the enum NAME (the hub's own options — the enum
+    /// converter writes a string and <c>ObjectPolymorphicConverter</c> reads one back), an integral
+    /// value (options serializing enums numerically), or a raw <c>JsonElement</c> (options
+    /// without <c>ObjectPolymorphicConverter</c>, which leaves every <see cref="object"/> untyped).
+    ///
+    /// <para>An unrecognised or undefined value is NOT a verdict — it yields <c>false</c> so the
+    /// caller's fallback applies, which is the honest answer and never a silently invented one.</para>
+    /// </summary>
+    private static bool TryReadErrorType(object? value, out ErrorType errorType)
+    {
+        switch (value)
+        {
+            case ErrorType typed:
+                errorType = typed;
+                return true;
+            case string name:
+                // Names only: Enum.TryParse also accepts a NUMERIC string and will happily mint an
+                // undefined member from it, so IsDefined is the gate, not decoration.
+                return Enum.TryParse(name, ignoreCase: true, out errorType) && Enum.IsDefined(errorType);
+            case int or long or short or byte:
+                errorType = (ErrorType)Convert.ToInt32(value);
+                return Enum.IsDefined(errorType);
+            case System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.String } json:
+                return TryReadErrorType(json.GetString(), out errorType);
+            case System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.Number } json
+                when json.TryGetInt32(out var number):
+                errorType = (ErrorType)number;
+                return Enum.IsDefined(errorType);
+            default:
+                errorType = default;
+                return false;
+        }
+    }
 
     /// <summary>
     /// Returns a copy of this delivery with a single property set.

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutedFailureClassificationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutedFailureClassificationTest.cs
@@ -29,6 +29,18 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 ///
 /// <para>The fix makes the fourth layer agree with the three that already classify this phrase as
 /// transient, so whichever answer wins, the caller reads the same verdict.</para>
+///
+/// <para>🚨 <b>The MECHANISM above was right and the SITE was wrong — corrected in #2346.</b>
+/// <c>RoutingGrain.RouteMessage</c> returns <c>Forwarded</c> unconditionally and delivers to the
+/// owning grain on a BACKGROUND route, so the <c>DispatchObservable</c> branch this classifier feeds
+/// never sees a <c>Failed</c> result for a grain-routed address: on that path the fix could not run
+/// at all, and <c>HubWorksAfterDisposal</c> kept failing with the same text and the same duration on
+/// branches that carried it. The site that actually reports a grain-routed failure is
+/// <c>RoutingGrain.DeliverToGrainWithRetry</c>, which hard-coded the terminal verdict and ignored
+/// the answer-once flag — see <c>RoutingGrainFailureClassificationTest</c>. This classifier is still
+/// load-bearing as the FALLBACK for a failing site that recorded no verdict, and both routers now
+/// read <c>GetFailureErrorType</c> first and fall back to it, so the two cannot drift apart
+/// again.</para>
 /// </summary>
 public class RoutedFailureClassificationTest
 {

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainFailureClassificationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainFailureClassificationTest.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Concurrency;
+using System.Threading.Tasks;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// The shard-0 Orleans flake (#2346), at the layer that actually produces the NACK.
+///
+/// <para><b>The defect.</b> A hub that is disposing answers an inbound delivery with a CLASSIFIED
+/// failure — <c>MessageService</c>'s intake gate returns
+/// <c>Failed("Hub is shutting down", ErrorType.ShuttingDown)</c> (#2350), and
+/// <c>MessageHubGrain.DeliverMessage</c> classifies its own two arms
+/// (<see cref="ErrorType.Unavailable"/> for an activation fault,
+/// <see cref="ErrorType.ShuttingDown"/> for "hub disposed before delivery"). Every one of those
+/// verdicts was then DISCARDED by <c>RoutingGrain.DeliverToGrainWithRetry</c>, which lifted the
+/// failure TEXT out of <c>Properties["Error"]</c> and NACKed the sender with a hard-coded, terminal
+/// <see cref="ErrorType.Failed"/>.</para>
+///
+/// <para><b>Why the two previous fixes could not close it.</b> #2351 classified at the hub, and
+/// #2346's router fix classified in <c>OrleansRoutingService.DispatchObservable</c> — but
+/// <c>RoutingGrain.RouteMessage</c> returns <c>Forwarded</c> unconditionally and delivers to the
+/// owning grain on a BACKGROUND route, so the client-side router never sees a Failed result for a
+/// grain-routed address and its classifier cannot run. The one site on that path is this one, and
+/// it threw the verdict away. That is why <c>OrleansMeshTests.HubWorksAfterDisposal</c> kept
+/// failing in ~2.4 s with the exact text <c>"Hub is shutting down"</c> raised INSIDE the retry that
+/// matches <see cref="ErrorType.ShuttingDown"/> — on #2440, whose branch contains both earlier
+/// fixes.</para>
+///
+/// <para>Deterministic by construction: <c>DeliverToGrainWithRetry</c> takes the grain call and the
+/// NACK sink as parameters, so the whole path runs with no cluster, no network and no timing.</para>
+/// </summary>
+public class RoutingGrainFailureClassificationTest
+{
+    private static readonly Func<int, TimeSpan> NoBackoff = _ => TimeSpan.Zero;
+
+    /// <summary>
+    /// Runs one delivery whose grain answers with <paramref name="grainResult"/> and returns every
+    /// NACK the router emitted for it.
+    ///
+    /// <para>The grain call is an ALREADY-COMPLETED task and the retry runs on
+    /// <see cref="Scheduler.Immediate"/>, so the whole chain completes on this thread before the
+    /// call returns — which is what lets "no NACK at all" be asserted instantly and exactly, with
+    /// no wait to time out and no sleep to tune. If that ever stopped holding, the POSITIVE cases
+    /// below would fail first and loudly, so the negative one cannot quietly become vacuous.</para>
+    /// </summary>
+    private static List<(string Message, ErrorType Type)> RouteFailure(
+        IMessageDelivery grainResult, string addressPath = "app/Kernel")
+    {
+        var nacks = new List<(string Message, ErrorType Type)>();
+
+        RoutingGrain.DeliverToGrainWithRetry(
+            grainCall: () => Task.FromResult(grainResult),
+            grainKey: addressPath,
+            addressPath: addressPath,
+            deliveryId: "classify",
+            postFailureToSender: (m, t) => nacks.Add((m, t)),
+            logger: NullLogger.Instance,
+            backoff: NoBackoff,
+            scheduler: Scheduler.Immediate);
+
+        return nacks;
+    }
+
+    private static IMessageDelivery Delivery() => new MessageDelivery<string>();
+
+    /// <summary>
+    /// The regression itself. <c>MessageService</c>'s shutdown intake gate answers with
+    /// <see cref="ErrorType.ShuttingDown"/> — the address may reactivate on the very next probe —
+    /// and the router must carry that verdict, not overwrite it with the terminal
+    /// <see cref="ErrorType.Failed"/>.
+    /// </summary>
+    [Fact]
+    public void AHubsShutdownVerdict_ReachesTheSenderAsShuttingDown()
+    {
+        var nacks = RouteFailure(Delivery().Failed("Hub is shutting down", ErrorType.ShuttingDown));
+
+        var nack = Assert.Single(nacks);
+        Assert.Equal(ErrorType.ShuttingDown, nack.Type);
+        Assert.Equal("Hub is shutting down", nack.Message);
+    }
+
+    /// <summary>
+    /// The arm that proves the verdict must be CARRIED and cannot be re-derived from the text:
+    /// <c>MessageHubGrain</c>'s completion arm classifies <see cref="ErrorType.ShuttingDown"/> while
+    /// its prose says "disposed", which no "is shutting down" text matcher can recognise.
+    /// </summary>
+    [Fact]
+    public void ADisposedHubsVerdict_SurvivesEvenThoughItsTextSaysNothingAboutShuttingDown()
+    {
+        var nacks = RouteFailure(
+            Delivery().Failed("Hub disposed before delivery for app/Kernel.", ErrorType.ShuttingDown));
+
+        Assert.Equal(ErrorType.ShuttingDown, Assert.Single(nacks).Type);
+    }
+
+    /// <summary>
+    /// The activation-fault arm (#1693): "no verdict was reached, retryable by construction". A
+    /// caller that maps a terminal failure to a 500 must not be told this is one.
+    /// </summary>
+    [Fact]
+    public void AnActivationFaultsVerdict_ReachesTheSenderAsUnavailable()
+    {
+        var nacks = RouteFailure(
+            Delivery().Failed("Hub activation failed for app/Kernel: boom", ErrorType.Unavailable));
+
+        Assert.Equal(ErrorType.Unavailable, Assert.Single(nacks).Type);
+    }
+
+    /// <summary>
+    /// The answer-once contract. <c>FailedAndNacked</c> DECLARES that the failing site already
+    /// posted its own <see cref="DeliveryFailure"/> — <c>MessageService.NackThroughParent</c> does
+    /// exactly that during a targeted hub disposal. A second NACK from here gives one request two
+    /// answers, and <c>Observe</c> resolves on whichever lands first, which is what made the
+    /// classification a coin toss even once both sites classified.
+    /// </summary>
+    [Fact]
+    public void AFailureTheOwningHubAlreadyAnswered_IsNotNackedASecondTime()
+    {
+        var nacks = RouteFailure(Delivery().FailedAndNacked("Hub is shutting down"));
+
+        Assert.Empty(nacks);
+    }
+
+    /// <summary>
+    /// The fallback for a site that recorded NO verdict: the failure text is classified by the same
+    /// rule the other three layers already apply (<c>AreaErrorClassifier.IsTransientHubFailure</c>,
+    /// <c>MeshNodeStreamCache.IsTransientOwnerFailure</c>,
+    /// <c>OrleansRoutingService.ClassifyRoutedFailure</c>), so an unclassified teardown rejection is
+    /// still transient rather than terminal.
+    /// </summary>
+    [Fact]
+    public void AnUnclassifiedTeardownRejection_FallsBackToTheSharedTextRule()
+    {
+        var nacks = RouteFailure(Delivery().Failed(
+            "Hub app/Kernel is shutting down (RunLevel=DisposeHostedHubs) — cannot process "
+            + "PingRequest; the address may reactivate (recycle / restart). Rejecting now."));
+
+        Assert.Equal(ErrorType.ShuttingDown, Assert.Single(nacks).Type);
+    }
+
+    /// <summary>
+    /// The other half, and it matters just as much: an absent node is AUTHORITATIVE. Widening the
+    /// transient verdict to every failure would trade a flake for a re-probe storm against an
+    /// address that will never answer.
+    /// </summary>
+    [Fact]
+    public void AnUnclassifiedTerminalFailure_StaysTerminal()
+    {
+        var nacks = RouteFailure(Delivery().Failed("No node found at 'Doc/Missing'."));
+
+        Assert.Equal(ErrorType.Failed, Assert.Single(nacks).Type);
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainFailureClassificationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainFailureClassificationTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reactive.Concurrency;
+using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -141,6 +142,23 @@ public class RoutingGrainFailureClassificationTest
             + "PingRequest; the address may reactivate (recycle / restart). Rejecting now."));
 
         Assert.Equal(ErrorType.ShuttingDown, Assert.Single(nacks).Type);
+    }
+
+    /// <summary>
+    /// The same round-trip degradation applies to the failure TEXT, and at this site it costs twice:
+    /// the sender loses its diagnostic AND the classification fallback loses the phrase it matches
+    /// on, so an unclassified teardown rejection would read terminal again.
+    /// </summary>
+    [Fact]
+    public void ATeardownRejectionWhoseTextArrivedAsUntypedJson_IsStillReadAndStillTransient()
+    {
+        using var doc = JsonDocument.Parse("\"Hub app/Kernel is shutting down. Rejecting now.\"");
+        var nacks = RouteFailure(
+            Delivery().Failed("placeholder").WithProperty("Error", doc.RootElement.Clone()));
+
+        var nack = Assert.Single(nacks);
+        Assert.Equal("Hub app/Kernel is shutting down. Rejecting now.", nack.Message);
+        Assert.Equal(ErrorType.ShuttingDown, nack.Type);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Messaging.Hub.Test/DeliveryFailureClassificationWireTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DeliveryFailureClassificationWireTest.cs
@@ -119,6 +119,69 @@ public class DeliveryFailureClassificationWireTest(ITestOutputHelper output) : H
     }
 
     /// <summary>
+    /// 🚨 The reader runs on the error-REPORTING path, so it must never THROW — the one place a
+    /// throw is worst, because it replaces a failure that was about to be described with a
+    /// different, undescribed one. A junk or out-of-range value is "no verdict was reached", which
+    /// is precisely what the caller's fallback is for.
+    /// </summary>
+    [Theory]
+    [InlineData(long.MaxValue)]      // out of int range — Convert.ToInt32 would throw here
+    [InlineData(long.MinValue)]
+    [InlineData(9999)]               // in range, but no such member
+    public void AnOutOfRangeOrUndefinedVerdict_FallsBackInsteadOfThrowing(long recorded)
+    {
+        var delivery = ADelivery().Failed("boom")
+            .WithProperty(IMessageDelivery.FailureErrorTypeProperty, recorded);
+
+        delivery.GetFailureErrorType(ErrorType.Unavailable).Should().Be(ErrorType.Unavailable,
+            "an unreadable verdict is an absence of one, never an exception on the path whose whole "
+            + "job is to report a failure");
+    }
+
+    /// <summary>
+    /// A verdict written as text that names no member is equally not a verdict — <c>Enum.TryParse</c>
+    /// would also accept a NUMERIC string and mint an undefined member from it.
+    /// </summary>
+    [Theory]
+    [InlineData("NotAnErrorType")]
+    [InlineData("9999")]
+    [InlineData("")]
+    public void AnUnparseableVerdict_FallsBack(string recorded)
+    {
+        var delivery = ADelivery().Failed("boom")
+            .WithProperty(IMessageDelivery.FailureErrorTypeProperty, recorded);
+
+        delivery.GetFailureErrorType(ErrorType.Unavailable).Should().Be(ErrorType.Unavailable);
+    }
+
+    /// <summary>
+    /// The failure TEXT degrades exactly like the verdict does — options without
+    /// <c>ObjectPolymorphicConverter</c> leave it an untyped <see cref="JsonElement"/>. At a routing
+    /// site that costs twice: the sender loses its diagnostic, AND the classification fallback loses
+    /// the phrase it matches on, so a transient teardown silently reads terminal again.
+    /// </summary>
+    [Fact]
+    public void TheFailureText_IsReadableEvenWhenItArrivedAsUntypedJson()
+    {
+        using var doc = JsonDocument.Parse("\"Hub is shutting down\"");
+        var delivery = ADelivery().Failed("placeholder")
+            .WithProperty("Error", doc.RootElement.Clone());
+
+        delivery.GetFailureMessage().Should().Be("Hub is shutting down");
+    }
+
+    /// <summary>
+    /// And a value under that key which is NOT text is not a message: null, so the caller describes
+    /// the failure itself rather than printing a type name at a user.
+    /// </summary>
+    [Fact]
+    public void ANonTextValueUnderTheErrorKey_IsNotAMessage()
+    {
+        ADelivery().Failed("placeholder").WithProperty("Error", 42)
+            .GetFailureMessage().Should().BeNull();
+    }
+
+    /// <summary>
     /// The answer-once flag rides the same dictionary, and it is what stops one request being
     /// answered twice with contradictory verdicts. Key PRESENCE is the contract, so it must not
     /// depend on the value's CLR type surviving either.

--- a/test/MeshWeaver.Messaging.Hub.Test/DeliveryFailureClassificationWireTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DeliveryFailureClassificationWireTest.cs
@@ -79,6 +79,65 @@ public class DeliveryFailureClassificationWireTest(ITestOutputHelper output) : H
     }
 
     /// <summary>
+    /// 🚨 The verdict a FAILING SITE recorded on the DELIVERY must survive the wire too.
+    ///
+    /// <para><c>Failed(message, ErrorType)</c> exists so the classification is decided where the
+    /// condition is known and CARRIED, "never reconstructed downstream by pattern-matching the
+    /// message text". It is carried in <c>Properties["FailureErrorType"]</c>, an
+    /// <c>IReadOnlyDictionary&lt;string, object&gt;</c> — and every consumer reads it back through
+    /// <c>GetFailureErrorType</c>, whose test is <c>value is ErrorType</c>.</para>
+    ///
+    /// <para>That is the trap-door AGENTS.md names: an <c>object</c> that crossed a hub boundary is
+    /// no longer the CLR type it was written as. The dictionary converter writes each value by its
+    /// runtime type, so an <see cref="ErrorType"/> goes out as the JSON STRING the enum converter
+    /// produces and comes back — via <c>ObjectPolymorphicConverter</c>, which materialises a JSON
+    /// string as <see cref="string"/> — as a string. The type test then fails and every consumer
+    /// silently reads the FALLBACK instead of the verdict.</para>
+    ///
+    /// <para>Concretely: the disposal race is classified <see cref="ErrorType.ShuttingDown"/> at the
+    /// hub (#2350) and read back as the fallback by the router — which is why a delivery that raced
+    /// a hub's disposal kept reaching the sender as terminal even after every producing site had
+    /// been fixed to classify it (#2346).</para>
+    /// </summary>
+    [Theory]
+    [InlineData(ErrorType.ShuttingDown)]
+    [InlineData(ErrorType.Unavailable)]
+    [InlineData(ErrorType.NotFound)]
+    [InlineData(ErrorType.CompilationFailed)]
+    public void ADeliveryCarriedVerdict_SurvivesTheWire(ErrorType errorType)
+    {
+        var options = GetHost().JsonSerializerOptions;
+        var delivery = ADelivery().Failed("Hub is shutting down", errorType);
+
+        var json = JsonSerializer.Serialize(delivery, delivery.GetType(), options);
+        Output.WriteLine(json);
+        var round = JsonSerializer.Deserialize<IMessageDelivery>(json, options)!;
+
+        round.GetFailureErrorType(ErrorType.Unknown).Should().Be(errorType,
+            "the verdict is what the router acts on; falling back silently turns a transient "
+            + "race into a terminal answer. Serialized as: {0}", json);
+    }
+
+    /// <summary>
+    /// The answer-once flag rides the same dictionary, and it is what stops one request being
+    /// answered twice with contradictory verdicts. Key PRESENCE is the contract, so it must not
+    /// depend on the value's CLR type surviving either.
+    /// </summary>
+    [Fact]
+    public void TheAnswerOnceFlag_SurvivesTheWire()
+    {
+        var options = GetHost().JsonSerializerOptions;
+        var delivery = ADelivery().FailedAndNacked("Hub is shutting down");
+
+        var json = JsonSerializer.Serialize(delivery, delivery.GetType(), options);
+        var round = JsonSerializer.Deserialize<IMessageDelivery>(json, options)!;
+
+        round.SenderWasNacked.Should().BeTrue(
+            "the owning hub already answered the sender; a second NACK makes the classification "
+            + "a coin toss. Serialized as: {0}", json);
+    }
+
+    /// <summary>
     /// 🚨 ONE request, ONE failure response.
     ///
     /// <para>A caller's <c>Observe(...)</c> resolves on the FIRST DeliveryFailure it sees, so two


### PR DESCRIPTION
## The evidence that reopened this

`OrleansMeshTests.HubWorksAfterDisposal` — the test in #2346's title — failed **again** on #2440,
[run 33008808534](https://github.com/Systemorph/MeshWeaver/actions/runs/33008808534) (2026-08-26
20:39Z), on a branch that contains **both** of its earlier fixes: #2351 (`MessageService` classifies
its shutdown intake gate) and `3bc207d1d` (the client router reads `"is shutting down"` as
transient). Verified by ancestry, not assumed.

```
MeshWeaver.Hosting.Orleans.Test.OrleansMeshTests.HubWorksAfterDisposal(id: "HubFactory")   4.26 s
MeshWeaver.Hosting.Orleans.Test.OrleansMeshTests.HubWorksAfterDisposal(id: "Kernel")       2.35 s
  MeshWeaver.Messaging.DeliveryFailureException : Hub is shutting down
  at OrleansMeshTest.cs:line 52     <- INSIDE the retry that matches ErrorType.ShuttingDown
```

Seconds, not the budget — a wrong answer, not a hang. Both earlier fixes were correct; neither could
reach this. **Two defects**, each pinned by a deterministic test that fails on `main` in under a
second: no cluster, no timing, no load.

## 1. `RoutingGrain.DeliverToGrainWithRetry` overwrote the verdict with a terminal one

It lifted the owning hub's failure **text** verbatim out of `Properties["Error"]` and NACKed the
sender with a hard-coded `ErrorType.Failed`.

**It is the only site that reports a grain-routed delivery's failure.** `RoutingGrain.RouteMessage`
returns `Forwarded` unconditionally and delivers on a *background* route, so the client-side
classifier in `OrleansRoutingService.DispatchObservable` never sees a `Failed` result for a
grain-routed address — `3bc207d1d` could not run on this path at all. Three layers below it classify
carefully, and every verdict died here:

| who classified | verdict | what this site sent |
|---|---|---|
| `MessageService` intake gate (#2350) | `ShuttingDown` | `Failed` |
| `MessageHubGrain` activation fault (#1693) | `Unavailable` | `Failed` |
| `MessageHubGrain` "hub disposed before delivery" | `ShuttingDown` | `Failed` |

The third is the one that proves the verdict must be *carried*: its prose contains no phrase any
text matcher could recognise.

It also ignored `result.SenderWasNacked`. A hub disposing under a live parent answers the sender
**itself** through `NackThroughParent` — and a grain hub is a *hosted* hub of the silo mesh hub, so
the parent is always live for a targeted disposal. One request therefore got **two** answers with
contradictory verdicts, and `Observe` resolves on whichever lands first. That is the coin toss, and
why the failure was intermittent while both answers were always sent.

## 2. `GetFailureErrorType` could not read a verdict that had crossed a hub boundary

Which is the only situation it exists for. `value is ErrorType` is the trap-door AGENTS.md names:
`Properties` is serialized by `ImmutableDictionaryOfStringObjectConverter`, which writes each value
by its **runtime** type, so an `ErrorType` goes out as the enum name and returns through
`ObjectPolymorphicConverter` as a `string`. Straight from the new wire test's own output:

```json
"properties":{"FailureErrorType":"ShuttingDown","Error":"Hub is shutting down"}
```

The type test failed, and **every** consumer silently read its fallback instead —
`MessageService.ReportRoutingFailure` included. #2351's careful classification never survived to
anyone who acts on it.

Now recovered from each shape a round-trip can leave it in: the enum, its name, an integral value, a
`JsonElement`. An unrecognised value still yields the fallback — the honest answer, never an
invented one.

## The fix

At **both** routing layers, identically, so they cannot drift apart again — "a fix landed on one site
and missed the other" is exactly how this outlived its two previous fixes:

1. honour the answer-once flag;
2. read the **carried** verdict, falling back to the shared text rule (`ClassifyRoutedFailure`)
   rather than to the terminal default.

`"No node found"` stays authoritative: widening the transient verdict to every failure would trade a
flake for a re-probe storm against an address that will never answer.

## Tests

- **`RoutingGrainFailureClassificationTest`** (new, 6 cases) — 5 fail on `main` asserting the verdict,
  1 fails asserting the sender is not answered twice. Fully synchronous: an already-completed grain
  call on `Scheduler.Immediate`, which is what lets "no NACK at all" be asserted exactly, with no
  wait to time out and no sleep to tune.
- **`DeliveryFailureClassificationWireTest`** — 2 new cases for the wire half (4 of 5 parameterisations
  fail on `main`).
- **`RoutedFailureClassificationTest`** — docstring corrected. Its *mechanism* was right and its *site*
  was wrong; leaving that claim standing is how the next reader stops looking.

Verified locally, Release, `DOTNET_PROCESSOR_COUNT=4`: `MeshWeaver.Hosting.Orleans.Test` **222/222**,
`MeshWeaver.Messaging.Hub.Test` **284/284**, `MeshWeaver.Hosting.Monolith.Test` green,
`WhatsNewEntryIntegrityTest` green.

## Scope — what this does NOT claim

This closes **one** of the causes behind #2346, the one wearing its title. The cluster is genuinely
several defects:

- **`PartitionRootActivationTest`** fails with **silence** (no answer inside 5 s), not a wrong verdict
  — a `DeliveryFailure` would have thrown out of its `try`, which only catches `TimeoutException`.
  Different mechanism.
- **#2301 / #2338 / #2339** are closed against their own mechanisms; #2025, #2291, #2305 have
  separately-recorded ones.
- The heap/stall branch is #2393's.

`Refs #2346` rather than `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
