### PR TITLE
docs: PR capability is per-credential — the "gh cannot merge" line was false and costly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,27 @@ what the change set IS, or when the work turns out to need a scope call the user
 one line, then stop. A change set spanning repos (education, MeshWeaver.Plugins) is finished when
 every part is merged in dependency order: platform first, then what depends on it.
 
-`gh` CLI has **read + push** only — cannot merge, resolve threads, or request reviewers.
+🚨 **PR capability is PER-CREDENTIAL, not per-repo — measure it, never remember it.** This
+line used to read *"`gh` CLI has read + push only — cannot merge, resolve threads, or request
+reviewers"*, which contradicted the very code block below it and was wrong in a way that cost real
+throughput: believing it makes a session stop at the finish line and hand the merge back, exactly
+the pause the PR-flow rule above says not to take once CI is green.
+
+What makes it unrememberable is that **two sessions on the same day get different answers for the
+same repo** (2026-08-26): one measured `admin:false, maintain:false` on `MeshWeaver` with scopes
+`gist, read:org, repo, workflow`, while another measured `admin:true, maintain:true` with
+`admin:org, delete:packages, gist, repo, workflow, write:packages` — and merged #2328 and #2429
+there. So the constraint is the credential the session happens to hold, not the repository, and any
+static table of either shape will be false for somebody. Check:
+
+```bash
+gh api repos/Systemorph/<repo> --jq '.permissions'   # push is normally enough to merge
+gh auth status                                        # scopes, if the above surprises you
+```
+
+Merging and resolving threads both work wherever the credential allows them (verified on
+`MeshWeaver`, `Memex` and `MeshWeaver.Education` on 2026-08-26). **Never reach for `--admin`** — a
+refusal is information about the gate, not an obstacle to route around.
 
 ```bash
 # Find unresolved review threads

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,18 +173,20 @@ what the change set IS, or when the work turns out to need a scope call the user
 one line, then stop. A change set spanning repos (education, MeshWeaver.Plugins) is finished when
 every part is merged in dependency order: platform first, then what depends on it.
 
-🚨 **PR capability is PER-CREDENTIAL, not per-repo — measure it, never remember it.** This
-line used to read *"`gh` CLI has read + push only — cannot merge, resolve threads, or request
-reviewers"*, which contradicted the very code block below it and was wrong in a way that cost real
-throughput: believing it makes a session stop at the finish line and hand the merge back, exactly
-the pause the PR-flow rule above says not to take once CI is green.
+🚨 **PR capability is CREDENTIAL × REPO — measure it for the repo you are in, never
+remember it.** This line used to read *"`gh` CLI has read + push only — cannot merge, resolve
+threads, or request reviewers"*, which contradicted the very code block below it and was wrong in a
+way that cost real throughput: believing it makes a session stop at the finish line and hand the
+merge back, exactly the pause the PR-flow rule above says not to take once CI is green.
 
-What makes it unrememberable is that **two sessions on the same day get different answers for the
-same repo** (2026-08-26): one measured `admin:false, maintain:false` on `MeshWeaver` with scopes
-`gist, read:org, repo, workflow`, while another measured `admin:true, maintain:true` with
-`admin:org, delete:packages, gist, repo, workflow, write:packages` — and merged #2328 and #2429
-there. So the constraint is the credential the session happens to hold, not the repository, and any
-static table of either shape will be false for somebody. Check:
+Both factors are real and neither alone predicts the answer. **The repo half** is what the rest of
+this file already documents — branch protection, `strict`, required checks, who may bypass. **The
+credential half** is the one nobody expects, because it makes the SAME repo answer differently to
+two sessions on the same day (2026-08-26): one measured `admin:false, maintain:false` on
+`MeshWeaver` with scopes `gist, read:org, repo, workflow`, while another measured
+`admin:true, maintain:true` with `admin:org, delete:packages, gist, repo, workflow, write:packages`
+— and merged #2328 and #2429 there. So a static table of either shape is false for somebody, and a
+refusal you hit is not evidence about anyone else's session. Check both:
 
 ```bash
 gh api repos/Systemorph/<repo> --jq '.permissions'   # push is normally enough to merge


### PR DESCRIPTION
Closes #2434.

## The contradiction

`AGENTS.md` → **GitHub PR Operations** opened with:

> `gh` CLI has **read + push** only — cannot merge, resolve threads, or request reviewers.

…three lines above a code block containing `gh pr merge PR_NUMBER --merge` and the `resolveReviewThread` mutation. #2434 raised this without picking a reading, which was the right call — **both readings are wrong.**

## The measurement

The capability is not a property of the repository. Two sessions measured **the same repo** on the same day (2026-08-26) and got different answers:

| | `admin` | `maintain` | scopes |
|---|---|---|---|
| session A (#2434's) | false | false | `gist, read:org, repo, workflow` |
| session B (this one) | **true** | **true** | `admin:org, delete:packages, gist, repo, workflow, write:packages` |

Session B merged **#2328** and **#2429** on `MeshWeaver` — the thing #2434 explicitly could not establish, because it declined to create side effects on a live PR to find out. That was the correct instinct; it just meant the decisive data point had to come from somewhere else.

So the axis is the **credential the session holds**, not the repo. That matters for the fix: #2434's proposed shape — a per-repo table mirroring the existing `strict` treatment — would be false for somebody too, and would be *confidently* false, which is worse than the sentence it replaced.

## The change

The claim is replaced by the measurement:

```bash
gh api repos/Systemorph/<repo> --jq '.permissions'   # push is normally enough to merge
gh auth status                                        # scopes, if the above surprises you
```

plus what is actually verified (merge and thread-resolve work on `MeshWeaver`, `Memex` and `MeshWeaver.Education`), and an explicit **never reach for `--admin`** — a refusal is information about the gate, not an obstacle to route around.

## Answers to all three questions in #2434

1. **Q1 — is the sentence stale or are the commands wrong?** The sentence. The commands are current and work.
2. **Q2 — should it get per-repo treatment like `strict`?** No — per-repo is the wrong axis. Scoping the sentence to one repo would not have fixed it, since the two sessions above disagree *within* one repo.
3. **Q3 — what is the actual constraint?** Not the CLI, not an org policy, not the ruleset, and not `maintain=false` as a repo property. It is which credential the session was started with — which is also why the existing `! gh auth login` remedy is the right one, and why it is the only one.

## Why this was worth fixing rather than clarifying

It sits directly above the merge instructions, so a wrong reading is *acted on* rather than noticed: it makes a session stop at the finish line and hand a green PR back to the user — precisely the pause the PR-flow rule five lines above forbids.

## Verification

`MeshWeaver.Documentation.Test` 69/69 (link integrity + What's New guards), Release `-warnaserror`, `0 Error(s)`.
