### PR TITLE
main groups by SHA — cancel-in-progress:false does not protect a QUEUED run

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -157,7 +157,19 @@ concurrency:
   # folded (`>-`) scalar, continuation lines indented deeper than the first are preserved
   # literally rather than folded, so a "tidier" multi-line version silently changes the
   # string rather than just its layout.
-  group: build-test-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  # 🚨 `main` groups by SHA, not by ref (#2412 follow-up). `cancel-in-progress: false` below
+  # protects a run that is ALREADY RUNNING — it does not protect a QUEUED one: GitHub keeps only
+  # ONE pending run per group and supersedes the older pending run whatever this setting says. That
+  # distinction is invisible while runners are free (a run starts within seconds, so "queued" barely
+  # exists) and decisive when they are not: on 2026-08-26 the shared 60-job pool was saturated by a
+  # sibling repo, main's runs never reached in-progress, and each merge cancelled the previously
+  # PENDING one — including `7faac22`, the very commit that merged the never-cancel fix. Six
+  # consecutive main commits produced no completed run, so CD's gate stayed `skipped` and no image
+  # published for hours while production ran ~11-hour-old code.
+  # Grouping by SHA gives each main commit its own group, so nothing can supersede it, queued or
+  # running. PR runs keep grouping by ref — superseding there is correct and is where #2316's
+  # runner saving comes from.
+  group: build-test-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref == 'refs/heads/main' && github.sha || github.ref }}
   # 🚨 NEVER cancel a run on `main` (#2412). Superseding is safe on a PR branch — the later
   # push tests a strict successor of what was cancelled, and that is where #2316's ~28% of
   # runner demand is saved. On `main` it is neither safe nor recoverable, for two reasons:


### PR DESCRIPTION
## What #2447 fixed, and what it did not

#2447 exempted `main` from cancel-in-progress. Correct and necessary — **and it does not hold when runners are scarce.**

`cancel-in-progress: false` protects a run that is **already running**. GitHub still keeps only **one pending run per concurrency group**, and a newer run supersedes the older *pending* one regardless of that setting.

While runners are free this is invisible: a run starts within seconds, so "queued" barely exists. When the pool is saturated it is decisive.

## Observed today, after #2447 merged

The shared 60-job pool was saturated by a sibling repo (12 concurrent runs in MeshWeaver.Plugins). Main's runs never reached in-progress:

```
7faac22   pending → cancelled   (never ran — and this IS the #2447 merge commit)
9e427c0   pending → cancelled   (never ran)
667b74d   pending → cancelled
08d82de / 444c6a9 / fe12f91 / 71e3ec2   cancelled
```

Six consecutive main commits, no completed Build-and-Test between them.

## What that cost

`main-cd.yml` gates delivery on `Consolidate test results` succeeding **for that SHA**. With no completed run its gate job stayed `skipped`:

```
GATE_RESULT: skipped
gate=skipped reason= publish= complete= green= sha=
```

Every CD run then reported **success** having published nothing — every image job simply `skipped`. Meanwhile plugin modules kept republishing against a newer core, so `memex-cloud` ran an older image against newer landed modules and every new pod aborted at boot (`IHostedService[] -> OpenAICompatibleModelSync` — blast radius in #2449). Production served **~11-hour-old code** with a wedged rollout, and the first symptom was a user noticing.

## The change

```diff
- group: build-test-${{ … workflow_dispatch && run_id || github.ref }}
+ group: build-test-${{ … workflow_dispatch && run_id
+                      || github.ref == 'refs/heads/main' && github.sha
+                      || github.ref }}
```

Each main commit gets its own group, so nothing can supersede it — queued or running — and CD always has a completed run to gate on.

**PR runs are untouched**: they keep grouping by ref, where superseding is correct and is where #2316's ~28% runner saving comes from.

## Cost

During a burst, several main runs proceed in parallel instead of one surviving. That is the point: runner minutes are what buys a publishable image, and the alternative is what happened today.

Worth pairing with the underlying capacity problem (#2457): the bake is the heavy part of CI and belongs on a dedicated worker, not on the shared pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)