### PR TITLE
Impersonation ratchet sees AccessContextScope (and the wrapped call) — 19 sites converted, 0 new allowances (#2441)

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -517,9 +517,15 @@ public class SelfUpdateHostedService : IHostedService
     {
         var accessService = _hub.ServiceProvider.GetService<AccessService>();
         var jsonOptions = _hub.JsonSerializerOptions;
-        return Observable.Using(
-            () => AccessContextScope.AsSystem(accessService),
-            _ => _hub.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+        // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790):
+        // `AsSystem(x)` IS `x.ImpersonateAsSystem()`, so the helper hides the shape. The write here
+        // is CROSS-HUB, which is the worst case for `Using` — Rx disposes the scope when the inner
+        // observable terminates, i.e. on the Admin partition hub's response thread, while the
+        // subscriber (the self-update poller's tick) keeps `system-security` latched. RunAsSystem
+        // opens and closes inside one Subscribe; the Update is still ISSUED as System, which is what
+        // the cross-hub patch stamps.
+        return accessService.RunAsSystem(
+            () => _hub.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
                 .Update(node =>
                 {
                     var cur = UpdatePolicyNodeType.ParseContent(node.Content, jsonOptions);
@@ -609,9 +615,10 @@ public class SelfUpdateHostedService : IHostedService
     {
         var accessService = _hub.ServiceProvider.GetService<AccessService>();
         var jsonOptions = _hub.JsonSerializerOptions;
-        return Observable.Using(
-            () => AccessContextScope.AsSystem(accessService),
-            _ => _hub.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+        // RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` — see
+        // RecordHold above (#1444/#1790).
+        return accessService.RunAsSystem(
+            () => _hub.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
                 .Update(node =>
                 {
                     var cur = UpdatePolicyNodeType.ParseContent(node.Content, jsonOptions);

--- a/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
@@ -169,9 +169,14 @@ public static class UpdatePolicyNodeType
             Content = new UpdatePolicyContent { Policy = defaultPolicy },
         };
 
-        return Observable.Using(
-            () => AccessContextScope.AsSystem(accessService),
-            _ => workspace
+        // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790):
+        // `AsSystem(x)` IS `x.ImpersonateAsSystem()`, so the helper hides the shape rather than
+        // changing it. RecordVerification below already states the reason — impersonation is an
+        // AsyncLocal and `Using` disposes it on whichever thread the sequence terminates on, leaving
+        // the caller latched as System — and hand-rolls the seal with Observable.Create; this is the
+        // same seal, taken off the framework shelf.
+        return accessService.RunAsSystem(
+            () => workspace
                 .GetQuery($"{NodeType}|{NodePath}", $"path:{NodePath} nodeType:{NodeType}")
                 .Take(1)
                 .SelectMany(nodes =>

--- a/memex/Memex.Portal.Shared/Settings/PrivacyStatementNode.cs
+++ b/memex/Memex.Portal.Shared/Settings/PrivacyStatementNode.cs
@@ -143,9 +143,13 @@ public static class PrivacyStatementNode
             Content = new MarkdownContent { Content = DefaultStatement },
         };
 
-        return Observable.Using(
-            () => AccessContextScope.AsSystem(accessService),
-            _ => workspace
+        // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790):
+        // `AsSystem(x)` IS `x.ImpersonateAsSystem()`. `Using` opens the AsyncLocal on the
+        // SUBSCRIBING thread — here the settings tab's render/circuit — and disposes it wherever the
+        // create terminates, leaving that thread running as `system-security`. RunAsSystem seals
+        // both ends inside one Subscribe; the read-then-create below is unchanged.
+        return accessService.RunAsSystem(
+            () => workspace
                 .GetQuery($"{NodeId}|{NodePath}", $"path:{NodePath} nodeType:Markdown")
                 .Take(1)
                 // A never-emitting query (backend routing/subscription failure) must not hang the
@@ -178,9 +182,14 @@ public static class PrivacyStatementNode
     {
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var workspace = hub.GetWorkspace();
-        return Observable.Using(
-                () => AccessContextScope.AsSystem(accessService),
-                _ => workspace
+        // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790).
+        // This is the sharpest instance of the defect in the tree: the subscriber is the ANONYMOUS
+        // /privacy request. `Using` would leave `system-security` latched on that ASP.NET request
+        // thread after the read — an unauthenticated flow continuing with Permission.All, with no
+        // audit trail. RunAsSystem opens and closes the scope inside the one Subscribe, so the
+        // System read still happens and the request thread is handed back exactly what it had.
+        return accessService.RunAsSystem(
+                () => workspace
                     .GetQuery($"{NodeId}|{NodePath}", $"path:{NodePath} nodeType:Markdown")
                     .Take(1)
                     // A never-emitting query must not hang the anonymous page — trip to OnError so

--- a/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
+++ b/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
@@ -212,9 +212,14 @@ public static class ShippedReleaseSeed
             Content = new MarkdownContent { Content = body },
         };
 
-        return Observable.Using(
-            () => AccessContextScope.AsSystem(accessService),
-            _ => workspace
+        // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790):
+        // `AsSystem(x)` IS `x.ImpersonateAsSystem()`, so the helper hides the shape rather than
+        // changing it. `Using` opens the AsyncLocal on the SUBSCRIBING thread — a startup hosted
+        // service's — and disposes it on whichever thread the create/update terminates, latching
+        // System onto the subscriber. RunAsSystem seals both ends inside one Subscribe; the whole
+        // read-then-write below stays inside the work factory, so it still runs as System.
+        return accessService.RunAsSystem(
+            () => workspace
                 .GetQuery($"{PlatformVersionId}|{PlatformVersionNodePath}",
                     $"path:{PlatformVersionNodePath} nodeType:Markdown")
                 .Take(1)
@@ -284,9 +289,9 @@ public static class ShippedReleaseSeed
         logger?.LogInformation(
             "[PlatformStartup] recording boot activity at {Path} (version {Version}, {Count} release(s)).",
             node.Path, version, triggered.Count);
-        return Observable.Using(
-            () => AccessContextScope.AsSystem(accessService),
-            _ => meshService.CreateNode(node).Select(_ => Unit.Default));
+        // RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` — see above (#1790).
+        return accessService.RunAsSystem(
+            () => meshService.CreateNode(node).Select(_ => Unit.Default));
     }
 
     /// <summary>True if the exception (or any inner) reports an "already exists" outcome — the idempotent-create success signal.</summary>
@@ -313,9 +318,11 @@ public static class ShippedReleaseSeed
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var workspace = hub.GetWorkspace();
 
-        return Observable.Using(
-            () => AccessContextScope.AsSystem(accessService),
-            _ => partitions
+        // RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` — see
+        // SeedPlatformVersionNode above (#1790). Every partition's work is composed inside the work
+        // factory, so it still runs under ONE System scope; only the boundary is sealed.
+        return accessService.RunAsSystem(
+            () => partitions
                 .ToObservable()
                 .SelectMany(partition => SeedPartition(meshService, workspace, partition, logger)));
     }

--- a/src/MeshWeaver.AI/AiSourcesInstallHook.cs
+++ b/src/MeshWeaver.AI/AiSourcesInstallHook.cs
@@ -129,11 +129,15 @@ public sealed class AiSourcesInstallHook(IMessageHub hub) : IPartitionInstallHoo
                 };
                 // Scoped around the WRITE, never ambient across the pipeline's scheduler hops —
                 // an ambient impersonation does not survive those (PackageInstaller says the same).
-                return Observable
-                    .Using(
-                        () => accessService?.ImpersonateAsSystem()
-                              ?? (IDisposable)System.Reactive.Disposables.Disposable.Empty,
-                        _ => meshService.CreateOrUpdateNode(target with { Content = merged }))
+                // 🚨 RunAsSystem, never `Observable.Using(access.ImpersonateAsSystem, …)`
+                // (#1444/#1790): `Using` disposes the scope wherever the write terminates (the
+                // owning partition hub's response thread) while the SUBSCRIBING thread — an
+                // onboarding/install hook running as the new user — keeps `system-security`
+                // latched. RunAsSystem opens and closes inside one Subscribe; the write is still
+                // ISSUED as System, which is what the post stamps.
+                return accessService
+                    .RunAsSystem(
+                        () => meshService.CreateOrUpdateNode(target with { Content = merged }))
                     .Do(_ => logger?.LogInformation(
                         "Registered {Partition} agent + skill sources for {User}", partition, user))
                     .Select(_ => Unit.Default);

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingActivity.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingActivity.cs
@@ -127,101 +127,121 @@ internal static class ContentIndexingActivity
             // STEP 2 (separate): run under the activity OWNER. The indexing command +
             // its Append/Finish writes fire on IIoPool / reactive hops where the
             // originating AccessContext has cleared — re-establish the owner AT THE
-            // SUBSCRIBE via Observable.Using(FromNode), and re-stamp it on each
-            // cross-hub write (Append/Finish) at its own .Update() invocation. Mirrors
-            // the thread-round owner model + MeshWeaver.GitSync.ActivityRunner.
+            // SUBSCRIBE via RunAs (below), and re-stamp it on each cross-hub write
+            // (Append/Finish) at its own .Update() invocation. Mirrors the thread-round
+            // owner model + MeshWeaver.GitSync.ActivityRunner.
             var owner = OwnerContextOf(created);
-            return Observable.Using(
-                () => AccessContextScope.FromNode(created, accessService, logger),
-                _ =>
-                {
-                    var cts = new CancellationTokenSource();
-                    // Cancel watcher: RequestedStatus = Cancelled trips the command's token (Activity
-                    // Control Plane). Subscribed for the life of the run; disposed on completion.
-                    //
-                    // 🚨 Gated on an EXACT-PATH query first, never a bare exact-path subscribe AND
-                    // never a children listing. STEP 1 above (CreateNode) proves the activity is
-                    // PERSISTED, not that it is ROUTABLE — the read route can answer an authoritative
-                    // NotFound for a path whose write has already landed (Systemorph/MeshWeaver#2229
-                    // item A: "the create SUCCEEDS and the REPLY is lost" / reads that lie for minutes
-                    // under load). An exact-path GetMeshNodeStream hitting that NotFound TERMINATES the
-                    // stream with an error — and this subscribe had no onError, so an unhandled
-                    // OnError rethrows on whatever thread is delivering it.
-                    //
-                    // `path:{x}` with no `scope:` qualifier is QueryScope.Exact, whose contract for an
-                    // absent path is "answered ZERO ROWS with no error" — empty-on-absent, no routing
-                    // NotFound, no storm-breaker window, same as a listing. UNLIKE a `scope:children …`
-                    // listing, it cannot page past the one row it can return — `_Activity` is
-                    // explicitly un-pruned (StaticRepoImport.md), so it grows without bound, and a
-                    // children listing anchored at the CONTAINER can miss this activity once the
-                    // partition has enough of them (the same false "not there yet" this fix exists to
-                    // remove, reintroduced by a rarer route). See PackageInstaller.WaitForGating and
-                    // CqrsAndContentAccess.md → "An OPTIONAL node".
-                    //
-                    // No `select:` projection: MeshNode.Path is COMPUTED (Namespace + "/" + Id), so a
-                    // projection omitting either input yields an empty path — the query below relies
-                    // on Count, not a path comparison, but the same trap applies to any `select:`
-                    // added here later.
-                    var cancelWatch = meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(
-                            $"path:{activityPath} nodeType:Activity"))
-                        .Where(change => change.Items.Count > 0)
-                        .Take(1)
-                        .SelectMany(_ => workspace.GetMeshNodeStream(activityPath))
-                        .Select(n => n.ContentAs<ActivityLog>(hub.JsonSerializerOptions)?.RequestedStatus)
-                        .Where(s => s == ActivityStatus.Cancelled)
-                        .Take(1)
-                        .Subscribe(
-                            _ =>
-                            {
-                                logger?.LogInformation("Indexing activity {Path} cancel requested", activityPath);
-                                try { cts.Cancel(); } catch { /* already disposed */ }
-                            },
-                            ex => logger?.LogDebug(ex,
-                                "Indexing activity {Path} cancel-watch could not attach; cancel requests will not be observed",
-                                activityPath));
-
-                    var ctx = new ContentIndexingActivityContext(activityPath, cts.Token,
-                        messages => Append(workspace, accessService, owner, activityPath, messages, logger));
-
-                    return command(ctx)
-                        .DefaultIfEmpty(Unit.Default)
-                        .TakeLast(1)
-                        .SelectMany(_ => Finish(workspace, accessService, owner, activityPath, ActivityStatus.Succeeded, null, logger))
-                        .Catch<Unit, Exception>(ex =>
+            // 🚨 RunAsSystem/RunAs, never `Observable.Using(AccessContextScope.FromNode, …)`
+            // (#1444/#1790). `FromNode` is `SwitchAccessContext(owner)` — the banned shape wearing a
+            // helper's name. `Using` opens the AsyncLocal on the SUBSCRIBING thread and disposes it
+            // when the inner observable TERMINATES, which for this run is whichever IoPool/response
+            // thread the command finishes on: the subscriber (an MCP session hub turn, the portal
+            // host hub behind a click) is left latched as the activity OWNER for everything it does
+            // next. RunAs seals both ends inside one Subscribe — the run below is still composed and
+            // subscribed under the owner, and the per-write re-stamps in Append/Finish cover the
+            // writes that fire past it, exactly as before.
+            //
+            // The identity is resolved HERE rather than inside a scope factory so the fallback is
+            // visible: FromNode's rule is CreatedBy, else LastModifiedBy, else System.
+            var scopeIdentity = owner ?? ContextOf(created.LastModifiedBy);
+            IObservable<string> Run()
+            {
+                var cts = new CancellationTokenSource();
+                // Cancel watcher: RequestedStatus = Cancelled trips the command's token (Activity
+                // Control Plane). Subscribed for the life of the run; disposed on completion.
+                //
+                // 🚨 Gated on an EXACT-PATH query first, never a bare exact-path subscribe AND
+                // never a children listing. STEP 1 above (CreateNode) proves the activity is
+                // PERSISTED, not that it is ROUTABLE — the read route can answer an authoritative
+                // NotFound for a path whose write has already landed (Systemorph/MeshWeaver#2229
+                // item A: "the create SUCCEEDS and the REPLY is lost" / reads that lie for minutes
+                // under load). An exact-path GetMeshNodeStream hitting that NotFound TERMINATES the
+                // stream with an error — and this subscribe had no onError, so an unhandled
+                // OnError rethrows on whatever thread is delivering it.
+                //
+                // `path:{x}` with no `scope:` qualifier is QueryScope.Exact, whose contract for an
+                // absent path is "answered ZERO ROWS with no error" — empty-on-absent, no routing
+                // NotFound, no storm-breaker window, same as a listing. UNLIKE a `scope:children …`
+                // listing, it cannot page past the one row it can return — `_Activity` is
+                // explicitly un-pruned (StaticRepoImport.md), so it grows without bound, and a
+                // children listing anchored at the CONTAINER can miss this activity once the
+                // partition has enough of them (the same false "not there yet" this fix exists to
+                // remove, reintroduced by a rarer route). See PackageInstaller.WaitForGating and
+                // CqrsAndContentAccess.md → "An OPTIONAL node".
+                //
+                // No `select:` projection: MeshNode.Path is COMPUTED (Namespace + "/" + Id), so a
+                // projection omitting either input yields an empty path — the query below relies
+                // on Count, not a path comparison, but the same trap applies to any `select:`
+                // added here later.
+                var cancelWatch = meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                        $"path:{activityPath} nodeType:Activity"))
+                    .Where(change => change.Items.Count > 0)
+                    .Take(1)
+                    .SelectMany(_ => workspace.GetMeshNodeStream(activityPath))
+                    .Select(n => n.ContentAs<ActivityLog>(hub.JsonSerializerOptions)?.RequestedStatus)
+                    .Where(s => s == ActivityStatus.Cancelled)
+                    .Take(1)
+                    .Subscribe(
+                        _ =>
                         {
-                            var cancelled = ex is OperationCanceledException || cts.IsCancellationRequested;
-                            logger?.LogWarning(ex, "Indexing activity {Path} {Outcome}", activityPath,
-                                cancelled ? "cancelled" : "failed");
-                            return Finish(workspace, accessService, owner, activityPath,
-                                    cancelled ? ActivityStatus.Cancelled : ActivityStatus.Failed,
-                                    cancelled ? "Cancelled." : ex.Message, logger)
-                                // A genuine failure (not a user cancel) is surfaced to platform
-                                // admins — the graceful sink for an infrastructure failure. Best
-                                // effort: never re-throws, so it cannot turn one failed activity
-                                // into a second failure. See the /storm + /async skills.
-                                .SelectMany(_ => cancelled
-                                    ? Observable.Return(Unit.Default)
-                                    : NotifyAdminsOfFailure(hub, accessService, activityPath, ex.Message, logger));
-                        })
-                        .Finally(() =>
-                        {
-                            cancelWatch.Dispose();
-                            cts.Dispose();
-                        })
-                        .Select(_ => activityPath);
-                });
+                            logger?.LogInformation("Indexing activity {Path} cancel requested", activityPath);
+                            try { cts.Cancel(); } catch { /* already disposed */ }
+                        },
+                        ex => logger?.LogDebug(ex,
+                            "Indexing activity {Path} cancel-watch could not attach; cancel requests will not be observed",
+                            activityPath));
+
+                var ctx = new ContentIndexingActivityContext(activityPath, cts.Token,
+                    messages => Append(workspace, accessService, owner, activityPath, messages, logger));
+
+                return command(ctx)
+                    .DefaultIfEmpty(Unit.Default)
+                    .TakeLast(1)
+                    .SelectMany(_ => Finish(workspace, accessService, owner, activityPath, ActivityStatus.Succeeded, null, logger))
+                    .Catch<Unit, Exception>(ex =>
+                    {
+                        var cancelled = ex is OperationCanceledException || cts.IsCancellationRequested;
+                        logger?.LogWarning(ex, "Indexing activity {Path} {Outcome}", activityPath,
+                            cancelled ? "cancelled" : "failed");
+                        return Finish(workspace, accessService, owner, activityPath,
+                                cancelled ? ActivityStatus.Cancelled : ActivityStatus.Failed,
+                                cancelled ? "Cancelled." : ex.Message, logger)
+                            // A genuine failure (not a user cancel) is surfaced to platform
+                            // admins — the graceful sink for an infrastructure failure. Best
+                            // effort: never re-throws, so it cannot turn one failed activity
+                            // into a second failure. See the /storm + /async skills.
+                            .SelectMany(_ => cancelled
+                                ? Observable.Return(Unit.Default)
+                                : NotifyAdminsOfFailure(hub, accessService, activityPath, ex.Message, logger));
+                    })
+                    .Finally(() =>
+                    {
+                        cancelWatch.Dispose();
+                        cts.Dispose();
+                    })
+                    .Select(_ => activityPath);
+            }
+
+            return scopeIdentity is null
+                ? accessService.RunAsSystem(Run)
+                : accessService.RunAs(scopeIdentity, Run);
         });
     }
+
+    /// <summary>An identity-scope principal from a raw principal id; null when there is none.</summary>
+    private static AccessContext? ContextOf(string? principalId) =>
+        string.IsNullOrEmpty(principalId)
+            ? null
+            : new AccessContext { ObjectId = principalId, Name = principalId };
 
     /// <summary>
     /// The owner identity to re-stamp on every activity-execution write — the created
     /// node's <see cref="MeshNode.CreatedBy"/>. Null for framework-owned nodes with no
-    /// CreatedBy (the outer <c>FromNode</c> already chose System for that case).
+    /// CreatedBy; the outer scope (<c>RunAs</c>/<c>RunAsSystem</c>) has already resolved
+    /// that case to LastModifiedBy or System.
     /// </summary>
     private static AccessContext? OwnerContextOf(MeshNode created) =>
-        string.IsNullOrEmpty(created.CreatedBy)
-            ? null
-            : new AccessContext { ObjectId = created.CreatedBy, Name = created.CreatedBy };
+        ContextOf(created.CreatedBy);
 
     /// <summary>
     /// Appends <paramref name="messages"/> to the activity log in ONE <c>stream.Update</c>.

--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -403,33 +403,39 @@ public static class JsonSynchronizationStream
         // yet. That would resurrect the orphaned stream in exactly the fast local case this fix
         // exists for, and only sometimes: the classic invisible race.
         var rejectedByRecycle = new System.Reactive.Subjects.ReplaySubject<string>(1);
-        var observeSubscription = Observable
-            .Using(
-                // Apply an explicit identity SCOPE for the post — do NOT rely on the ambient AsyncLocal
-                // still being set. Observable.Using's factory runs at SUBSCRIBE time, and a sync
-                // re-subscribe / keep-alive / Blazor re-render fan-out fires on a background Rx
-                // scheduler where AsyncLocal is WIPED. Previously a real user applied no scope and
-                // trusted AsyncLocal: when it was wiped the SubscribeRequest delivery got a NULL
-                // AccessContext → PostPipeline fail-closed → owner DENIES the subscribe → the consumer
-                // re-opens it → flood of denied SubscribeRequests that wedged the Space hub
-                // (AgenticPension). Re-apply the CAPTURED user (SwitchAccessContext(ambient)) so the
-                // post carries the right identity regardless of thread; non-user → System. Either way
-                // AccessContext is NEVER null, so the subscribe is authorised (RLS still gates the
-                // user's actual Read) instead of fail-closed-denied.
-                () => (isRealUser ? accessService?.SwitchAccessContext(ambient) : accessService?.ImpersonateAsSystem())
-                      ?? (IDisposable)System.Reactive.Disposables.Disposable.Empty,
-                _ => hub.Observe(
-                        new SubscribeRequest(reduced.StreamId, reference)
-                        {
-                            Identity = identityForSubscribe,
-                            // Declared by the assembly that also OWNS the applier
-                            // (ApplyPatchWithCorrectUnescaping below), so the claim can never be
-                            // wrong: whatever version of this code posts the subscribe is the version
-                            // that folds the frames.
-                            AcceptsStringSplice = true,
-                        },
-                        o => impersonateAsHub ? o.WithTarget(owner).ImpersonateAsHub(hub.Address) : o.WithTarget(owner))
-                    .Take(1))
+        // Apply an explicit identity SCOPE for the post — do NOT rely on the ambient AsyncLocal
+        // still being set. The scope is entered at SUBSCRIBE time, and a sync re-subscribe /
+        // keep-alive / Blazor re-render fan-out fires on a background Rx scheduler where AsyncLocal
+        // is WIPED. Previously a real user applied no scope and trusted AsyncLocal: when it was
+        // wiped the SubscribeRequest delivery got a NULL AccessContext → PostPipeline fail-closed →
+        // owner DENIES the subscribe → the consumer re-opens it → flood of denied SubscribeRequests
+        // that wedged the Space hub (AgenticPension). Re-apply the CAPTURED user
+        // (RunAs(ambient)) so the post carries the right identity regardless of thread;
+        // non-user → RunAsSystem. Either way AccessContext is NEVER null, so the subscribe is
+        // authorised (RLS still gates the user's actual Read) instead of fail-closed-denied.
+        //
+        // 🚨 RunAs/RunAsSystem, never `Observable.Using(() => access.SwitchAccessContext(…), …)`
+        // (#1444/#1790). `Using` opens the AsyncLocal on the SUBSCRIBING thread and disposes it when
+        // the inner observable TERMINATES — for this cross-hub request/response, the OWNER hub's
+        // response thread — so the subscribing thread (a Blazor circuit, a hub turn, a re-render
+        // fan-out) was left latched as the captured user or as `system-security`. RunAs owns both
+        // ends inside one Subscribe, and keeps exactly the property the paragraph above needs: the
+        // post below is still issued inside the scope.
+        var postSubscribeRequest = () => hub.Observe(
+                new SubscribeRequest(reduced.StreamId, reference)
+                {
+                    Identity = identityForSubscribe,
+                    // Declared by the assembly that also OWNS the applier
+                    // (ApplyPatchWithCorrectUnescaping below), so the claim can never be
+                    // wrong: whatever version of this code posts the subscribe is the version
+                    // that folds the frames.
+                    AcceptsStringSplice = true,
+                },
+                o => impersonateAsHub ? o.WithTarget(owner).ImpersonateAsHub(hub.Address) : o.WithTarget(owner))
+            .Take(1);
+        var observeSubscription = (isRealUser
+                ? accessService.RunAs(ambient, postSubscribeRequest)
+                : accessService.RunAsSystem(postSubscribeRequest))
             .Subscribe(
                 _ =>
                     // The owner sends the first DataChangedEvent as the response; it is already

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessContextPropagation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessContextPropagation.md
@@ -26,7 +26,7 @@ This document explains the model, the six propagation phases, the sanctioned exc
 |---|---|---|
 | **User** | User-facing hubs — the per-circuit portal hub, HTTP-request hubs, per-node hubs handling a user's request | The user's `AccessContext` is live on the AsyncLocal (`AccessService.Context` / `CircuitContext`) when the hub posts. This is the **default** posting identity. |
 | **System** | Framework infrastructure — **routing** (the courier) and **persistence** (the store) | The hub is declared `WithPostingIdentity(PostingIdentity.System)`; its own otherwise-unattributed posts are stamped `system-security` automatically (bypasses RLS — the courier/store is not user-gated). |
-| **Owner** | Threads & activities | `AccessContextScope.FromNode(node)` → `node.CreatedBy` — the post runs under the thread/activity owner's credential. |
+| **Owner** | Threads & activities | `AccessContextScope.FromNode(node)` → `node.CreatedBy` — the post runs under the thread/activity owner's credential. 🚨 In a REACTIVE pipeline resolve the identity and use `access.RunAs(owner, () => work)`, never `Observable.Using(() => AccessContextScope.FromNode(…), …)`: `FromNode`/`AsSystem` are `SwitchAccessContext`/`ImpersonateAsSystem` under another name, and `Using` latches the identity on the subscribing thread (#1790). |
 
 ### Posting identity is a per-hub CONFIGURATION decision, declared at hub startup
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/OwnerInjection.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OwnerInjection.md
@@ -118,7 +118,7 @@ loses the cold-start race.
 | Thread hub | `ThreadExecution.SetThreadHubIdentity` — reads the thread node's `CreatedBy` and stamps it as **both** `Context` and this hub's standing identity (`SetStandingIdentity(hub, owner)`, the carry-forward slot) on hub activation. |
 | Activity hub | The activity control-plane establishes the activity owner the same way (resolve from the activity node, inject as the hub's standing identity). |
 | Per-node data source / sync stream | `SynchronizationStream.Update` resolves the node OWNER **synchronously from the node already in its own `Current`** when neither a live AsyncLocal context nor a captured creation context survives — via `IStreamOwnerResolver`, resolved off `Host.ServiceProvider`. Genuine infra streams (doc sync) carry System. |
-| One-shot helpers | `AccessContextScope.FromNode(node, accessService)` — runs a block under the node's owner (`CreatedBy`/`LastModifiedBy`), falling back to System only for an unattributed node. |
+| One-shot helpers | `AccessContextScope.FromNode(node, accessService)` — runs a **synchronous** block under the node's owner (`CreatedBy`/`LastModifiedBy`), falling back to System only for an unattributed node. 🚨 Never as an `Observable.Using` resource factory — it is `SwitchAccessContext` under another name, and `Using` opens the scope on the subscribing thread and disposes it wherever the work terminates (#1790). Reactive callers resolve the identity and use `access.RunAs(owner, () => work)` / `RunAsSystem`; `ImpersonationScopeSiteRatchetGuard` fails a new site. |
 
 > ✅ **Status: shipped.** The synchronous owner resolver is
 > `IStreamOwnerResolver` (`src/MeshWeaver.Data/Serialization/IStreamOwnerResolver.cs`), implemented

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-system-identity-no-longer-latches-onto-a-request.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-26-system-identity-no-longer-latches-onto-a-request.md
@@ -1,0 +1,21 @@
+---
+Name: System identity no longer stays behind on the thread that started a background read
+Category: Fix
+Description: Nineteen places where the platform reads or writes as the system account left that account attached to whatever was running afterwards — including an anonymous page request.
+Icon: ShieldTask
+Order: -20260826
+---
+
+# System identity no longer stays behind on the thread that started a background read
+
+Some of the platform's own housekeeping — checking for updates, warming up compiled types, seeding
+the privacy statement, running a sync or indexing job — has to read and write as the system account
+rather than as you. That is intended. What was not intended is that the system account could stay
+attached to whatever was running next on the same thread, because the switch was made in one place
+and undone somewhere else entirely. The most visible case: loading the public privacy page, which
+anybody can request without signing in.
+
+Nothing was reported wrong, and that is the point — the effect is silent, and the only trace it
+leaves is work that should have been checked against your permissions being checked against the
+system account's instead. All nineteen places now switch identity and switch back within the same
+step, so the system account cannot outlive the job it was opened for.

--- a/src/MeshWeaver.GitSync/ActivityRunner.cs
+++ b/src/MeshWeaver.GitSync/ActivityRunner.cs
@@ -126,7 +126,7 @@ public static class ActivityRunner
             // its Append/Finish writes fire on IIoPool / reactive scheduler hops
             // where the originating AsyncLocal AccessContext has cleared — so we
             // re-establish the activity owner (created.CreatedBy) AT THE SUBSCRIBE
-            // via Observable.Using(FromNode). Mirrors the thread-round owner model
+            // via RunAs (below). Mirrors the thread-round owner model
             // (ThreadExecution.InstallExecRoundWatcher) exactly. The owner snapshot
             // is also threaded into Append/Finish so each cross-hub write re-stamps
             // it at its own .Update() invocation (those fire from arbitrary command
@@ -134,89 +134,104 @@ public static class ActivityRunner
             // Update to the partition MainNode, so only a principal who can Update
             // the partition — the owner, by construction — may write it.
             var owner = OwnerContextOf(created);
-            return ScheduleOffHubTurn(Observable.Using(
-                () => AccessContextScope.FromNode(created, accessService, logger),
-                _ =>
-                {
-                    // Register the run as in flight for the WHOLE of its life, released in the
-                    // Finally below — i.e. at TERMINAL (succeeded / failed / cancelled), not when
-                    // it was merely dispatched. Teardown quiesces on this: it stops starting new
-                    // work and waits for what is running, instead of walking away from it while
-                    // the command still executes against a tearing-down mesh.
-                    var runRegistration = hub.ServiceProvider.GetService<ActivityTracker>()?.Track();
+            // 🚨 RunAsSystem/RunAs, never `Observable.Using(AccessContextScope.FromNode, …)`
+            // (#1444/#1790). `FromNode` is `SwitchAccessContext(owner)` — the banned shape wearing a
+            // helper's name. `Using` opens the AsyncLocal on the SUBSCRIBING thread and disposes it
+            // when the inner observable TERMINATES, which for this run is whichever IoPool/response
+            // thread the command finishes on: the subscriber (an MCP session hub turn, the portal
+            // host hub behind a click) is left latched as the activity OWNER for everything it does
+            // next. RunAs seals both ends inside one Subscribe — the run below is still composed and
+            // subscribed under the owner, and the per-write re-stamps in Append/Finish cover the
+            // writes that fire past it, exactly as before.
+            //
+            // The identity is resolved HERE rather than inside a scope factory so the fallback is
+            // visible: FromNode's rule is CreatedBy, else LastModifiedBy, else System.
+            var scopeIdentity = owner ?? ContextOf(created.LastModifiedBy);
+            IObservable<string> Run()
+            {
+                // Register the run as in flight for the WHOLE of its life, released in the
+                // Finally below — i.e. at TERMINAL (succeeded / failed / cancelled), not when
+                // it was merely dispatched. Teardown quiesces on this: it stops starting new
+                // work and waits for what is running, instead of walking away from it while
+                // the command still executes against a tearing-down mesh.
+                var runRegistration = hub.ServiceProvider.GetService<ActivityTracker>()?.Track();
 
-                    var cts = new CancellationTokenSource();
-                    // Cancel watcher: RequestedStatus = Cancelled trips the command's token
-                    // (Activity Control Plane). Subscribed for the life of the run; disposed on
-                    // completion.
-                    //
-                    // 🚨 Gated on an EXACT-PATH query first, never a bare exact-path subscribe AND
-                    // never a children listing. STEP 1 above (CreateNode) proves the activity is
-                    // PERSISTED, not that it is ROUTABLE — the read route can answer an authoritative
-                    // NotFound for a path whose write has already landed (Systemorph/MeshWeaver#2229
-                    // item A: "the create SUCCEEDS and the REPLY is lost" / reads that lie for minutes
-                    // under load). An exact-path GetMeshNodeStream hitting that NotFound TERMINATES the
-                    // stream with an error — and this subscribe had no onError, so an unhandled
-                    // OnError rethrows on whatever thread is delivering it.
-                    //
-                    // `path:{x}` with no `scope:` qualifier is QueryScope.Exact, whose contract for an
-                    // absent path is "answered ZERO ROWS with no error" — empty-on-absent, no routing
-                    // NotFound, no storm-breaker window, same as a listing. UNLIKE a `scope:children …`
-                    // listing, it cannot page past the one row it can return — `_Activity` is
-                    // explicitly un-pruned (StaticRepoImport.md), so it grows without bound, and a
-                    // children listing anchored at the CONTAINER can miss this activity once the
-                    // partition has enough of them (the same false "not there yet" this fix exists to
-                    // remove, reintroduced by a rarer route). See PackageInstaller.WaitForGating and
-                    // CqrsAndContentAccess.md → "An OPTIONAL node".
-                    //
-                    // No `select:` projection: MeshNode.Path is COMPUTED (Namespace + "/" + Id), so a
-                    // projection omitting either input yields an empty path — the query below relies
-                    // on Count, not a path comparison, but the same trap applies to any `select:`
-                    // added here later.
-                    var cancelWatch = meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(
-                            $"path:{activityPath} nodeType:Activity"))
-                        .Where(change => change.Items.Count > 0)
-                        .Take(1)
-                        .SelectMany(_ => workspace.GetMeshNodeStream(activityPath))
-                        .Select(n => n.ContentAs<ActivityLog>(hub.JsonSerializerOptions)?.RequestedStatus)
-                        .Where(s => s == ActivityStatus.Cancelled)
-                        .Take(1)
-                        .Subscribe(
-                            _ =>
-                            {
-                                logger?.LogInformation("Activity {Path} cancel requested", activityPath);
-                                try { cts.Cancel(); } catch { /* already disposed */ }
-                            },
-                            ex => logger?.LogDebug(ex,
-                                "Activity {Path} cancel-watch could not attach; cancel requests will not be observed",
-                                activityPath));
-
-                    var ctx = new ActivityContext(activityPath, cts.Token,
-                        (msg, level) => Append(workspace, accessService, owner, activityPath, msg, level, logger));
-
-                    // Run the command; on terminal, write the final Status + dispose watcher/cts.
-                    return command(ctx)
-                        .DefaultIfEmpty(Unit.Default)
-                        .TakeLast(1)
-                        .SelectMany(_ => Finish(workspace, accessService, owner, activityPath, ActivityStatus.Succeeded, null, logger))
-                        .Catch<Unit, Exception>(ex =>
+                var cts = new CancellationTokenSource();
+                // Cancel watcher: RequestedStatus = Cancelled trips the command's token
+                // (Activity Control Plane). Subscribed for the life of the run; disposed on
+                // completion.
+                //
+                // 🚨 Gated on an EXACT-PATH query first, never a bare exact-path subscribe AND
+                // never a children listing. STEP 1 above (CreateNode) proves the activity is
+                // PERSISTED, not that it is ROUTABLE — the read route can answer an authoritative
+                // NotFound for a path whose write has already landed (Systemorph/MeshWeaver#2229
+                // item A: "the create SUCCEEDS and the REPLY is lost" / reads that lie for minutes
+                // under load). An exact-path GetMeshNodeStream hitting that NotFound TERMINATES the
+                // stream with an error — and this subscribe had no onError, so an unhandled
+                // OnError rethrows on whatever thread is delivering it.
+                //
+                // `path:{x}` with no `scope:` qualifier is QueryScope.Exact, whose contract for an
+                // absent path is "answered ZERO ROWS with no error" — empty-on-absent, no routing
+                // NotFound, no storm-breaker window, same as a listing. UNLIKE a `scope:children …`
+                // listing, it cannot page past the one row it can return — `_Activity` is
+                // explicitly un-pruned (StaticRepoImport.md), so it grows without bound, and a
+                // children listing anchored at the CONTAINER can miss this activity once the
+                // partition has enough of them (the same false "not there yet" this fix exists to
+                // remove, reintroduced by a rarer route). See PackageInstaller.WaitForGating and
+                // CqrsAndContentAccess.md → "An OPTIONAL node".
+                //
+                // No `select:` projection: MeshNode.Path is COMPUTED (Namespace + "/" + Id), so a
+                // projection omitting either input yields an empty path — the query below relies
+                // on Count, not a path comparison, but the same trap applies to any `select:`
+                // added here later.
+                var cancelWatch = meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                        $"path:{activityPath} nodeType:Activity"))
+                    .Where(change => change.Items.Count > 0)
+                    .Take(1)
+                    .SelectMany(_ => workspace.GetMeshNodeStream(activityPath))
+                    .Select(n => n.ContentAs<ActivityLog>(hub.JsonSerializerOptions)?.RequestedStatus)
+                    .Where(s => s == ActivityStatus.Cancelled)
+                    .Take(1)
+                    .Subscribe(
+                        _ =>
                         {
-                            var cancelled = ex is OperationCanceledException || cts.IsCancellationRequested;
-                            logger?.LogWarning(ex, "Activity {Path} {Outcome}", activityPath,
-                                cancelled ? "cancelled" : "failed");
-                            return Finish(workspace, accessService, owner, activityPath,
-                                cancelled ? ActivityStatus.Cancelled : ActivityStatus.Failed,
-                                cancelled ? "Cancelled." : ex.Message, logger);
-                        })
-                        .Finally(() =>
-                        {
-                            cancelWatch.Dispose();
-                            cts.Dispose();
-                            // Terminal: the run is no longer in flight, so teardown may proceed.
-                            runRegistration?.Dispose();
-                        })
-                        .Select(_ => activityPath);
-                }));
+                            logger?.LogInformation("Activity {Path} cancel requested", activityPath);
+                            try { cts.Cancel(); } catch { /* already disposed */ }
+                        },
+                        ex => logger?.LogDebug(ex,
+                            "Activity {Path} cancel-watch could not attach; cancel requests will not be observed",
+                            activityPath));
+
+                var ctx = new ActivityContext(activityPath, cts.Token,
+                    (msg, level) => Append(workspace, accessService, owner, activityPath, msg, level, logger));
+
+                // Run the command; on terminal, write the final Status + dispose watcher/cts.
+                return command(ctx)
+                    .DefaultIfEmpty(Unit.Default)
+                    .TakeLast(1)
+                    .SelectMany(_ => Finish(workspace, accessService, owner, activityPath, ActivityStatus.Succeeded, null, logger))
+                    .Catch<Unit, Exception>(ex =>
+                    {
+                        var cancelled = ex is OperationCanceledException || cts.IsCancellationRequested;
+                        logger?.LogWarning(ex, "Activity {Path} {Outcome}", activityPath,
+                            cancelled ? "cancelled" : "failed");
+                        return Finish(workspace, accessService, owner, activityPath,
+                            cancelled ? ActivityStatus.Cancelled : ActivityStatus.Failed,
+                            cancelled ? "Cancelled." : ex.Message, logger);
+                    })
+                    .Finally(() =>
+                    {
+                        cancelWatch.Dispose();
+                        cts.Dispose();
+                        // Terminal: the run is no longer in flight, so teardown may proceed.
+                        runRegistration?.Dispose();
+                    })
+                    .Select(_ => activityPath);
+            }
+
+            return ScheduleOffHubTurn(scopeIdentity is null
+                ? accessService.RunAsSystem(Run)
+                : accessService.RunAs(scopeIdentity, Run));
         });
 
         // 🚨 THE ACTIVITY EXECUTION MUST NOT RUN ON THE CALLING HUB'S TURN — it self-deadlocks.
@@ -257,17 +272,21 @@ public static class ActivityRunner
                 : source.SubscribeOn(TaskPoolScheduler.Default);
     }
 
+    /// <summary>An identity-scope principal from a raw principal id; null when there is none.</summary>
+    private static AccessContext? ContextOf(string? principalId) =>
+        string.IsNullOrEmpty(principalId)
+            ? null
+            : new AccessContext { ObjectId = principalId, Name = principalId };
+
     /// <summary>
     /// The owner identity to re-stamp on every activity-execution write. Reads the
     /// created node's <see cref="MeshNode.CreatedBy"/> (the principal who triggered
     /// the activity). Null for framework-owned nodes with no CreatedBy — Append/Finish
-    /// then leave the ambient untouched (the outer <c>FromNode</c> already chose System
-    /// for that case).
+    /// then leave the ambient untouched; the outer scope (<c>RunAs</c>/<c>RunAsSystem</c>)
+    /// has already resolved that case to LastModifiedBy or System.
     /// </summary>
     private static AccessContext? OwnerContextOf(MeshNode created) =>
-        string.IsNullOrEmpty(created.CreatedBy)
-            ? null
-            : new AccessContext { ObjectId = created.CreatedBy, Name = created.CreatedBy };
+        ContextOf(created.CreatedBy);
 
     private static void Append(
         IWorkspace workspace, AccessService? accessService, AccessContext? owner,

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -789,14 +789,18 @@ internal class MeshNodeCompilationService(
                 // so it never pre-empts a healthy set but is never lost either.
                 .Where(s => !s.IsEstablished || s.Sources.Count > 0));
 
-        return Observable
-            // Observable.Using INSIDE DelaySubscription, never around it: the resource factory
-            // then runs on the delayed subscribe — the very tick that calls mesh.Query and reads
-            // the ambient identity — instead of on the composing thread whose AsyncLocal the hop
-            // discards. Same ordering as GetSourceCollection.
-            .Using(
-                () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
-                _ => probe)
+        return accessService
+            // The scope INSIDE DelaySubscription, never around it: it is then entered on the
+            // delayed subscribe — the very tick that calls mesh.Query and reads the ambient
+            // identity — instead of on the composing thread whose AsyncLocal the hop discards.
+            // Same ordering as GetSourceCollection.
+            //
+            // 🚨 RunAsSystem, never `Observable.Using(access.ImpersonateAsSystem, …)` (#1444/#1790).
+            // Both enter the scope at Subscribe, which is the property this ordering needs; only
+            // `Using` also defers the DISPOSE to whichever thread the probe terminates on, leaving
+            // the subscriber latched as System. RunAsSystem keeps the entry and closes the exit.
+            .RunAsSystem(
+                () => probe)
             // A fault ESCAPING the per-leg catches (the whole CombineLatest, not one query) is
             // still unestablishment — the probe found out nothing.
             .Catch((Exception ex) => Observable.Return(SourceSnapshot.Unavailable(

--- a/src/MeshWeaver.Graph/NodeTypeRecompileExtensions.cs
+++ b/src/MeshWeaver.Graph/NodeTypeRecompileExtensions.cs
@@ -68,9 +68,16 @@ public static class NodeTypeRecompileExtensions
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         var accessService = hub.ServiceProvider.GetService<AccessService>();
 
-        return Observable.Using(
-                () => AccessContextScope.AsSystem(accessService),
-                _ => meshService
+        // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790).
+        // `AsSystem(x)` IS `x.ImpersonateAsSystem()`, so the helper only hides the shape: `Using`
+        // opens the AsyncLocal on the SUBSCRIBING thread and disposes it on whichever thread the
+        // query terminates, latching the subscriber — here a content-update pipeline that continues
+        // as the USER who pushed. Only the enumeration needs System; the release trigger below
+        // already opens its own synchronous `using (accessService?.ImpersonateAsSystem())` around
+        // the loop, and the prebuilt-adoption leg (ShippedPrebuiltBundles.SeedBundles) opens its
+        // own, so nothing downstream depends on this scope leaking past the query.
+        return accessService.RunAsSystem(
+                () => meshService
                     .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
                     .Take(1)
                     .Timeout(TypeEnumerationBudget))

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -324,11 +324,22 @@ public static class DynamicTypePreWarmer
 
         // 🚨 System-scoped: enumerating + activating dynamic NodeType defs across EVERY
         // partition is infrastructure, not a user-attributable read (mirrors the enrichment
-        // probe + activation reads). Observable.Using holds the scope across the live
-        // subscription, not just the synchronous build.
-        return Observable.Using(
-            () => AccessContextScope.AsSystem(accessService),
-            _ => meshService
+        // probe + activation reads).
+        //
+        // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790) —
+        // and `AccessContextScope.AsSystem(x)` IS `x.ImpersonateAsSystem()`, so routing through the
+        // helper does not make it a different animal. `Using` opens the AsyncLocal on the
+        // SUBSCRIBING thread and disposes it when the inner observable TERMINATES (for these
+        // cross-hub reads, the owning hub's response thread), so the subscriber — the bootstrap
+        // hosted service — is left holding `system-security` for everything it does afterwards.
+        // What used to stand here read "Observable.Using holds the scope across the live
+        // subscription, not just the synchronous build", i.e. the defect described as the feature.
+        // RunAsSystem seals both ends inside one Subscribe: the whole cold pipeline below is
+        // composed and subscribed impersonated (so every Query/stream read is issued as System and
+        // every continuation it schedules captures that ExecutionContext), and the scope is left on
+        // the way out of that same Subscribe.
+        return accessService.RunAsSystem(
+            () => meshService
                 .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
                 .Take(1)
                 .Timeout(EnumerationBudget)
@@ -434,10 +445,10 @@ public static class DynamicTypePreWarmer
         var accessService = mesh.ServiceProvider.GetService<AccessService>();
 
         // System-scoped for the same reason the sweep is: enumerating NodeType definitions across
-        // every partition is infrastructure, not a user-attributable read.
-        return Observable.Using(
-            () => AccessContextScope.AsSystem(accessService),
-            _ => meshService
+        // every partition is infrastructure, not a user-attributable read. RunAsSystem, never
+        // `Observable.Using(AccessContextScope.AsSystem, …)` — see WarmDynamicTypes (#1444/#1790).
+        return accessService.RunAsSystem(
+            () => meshService
                 .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
                 .Take(1)
                 .Timeout(EnumerationBudget)
@@ -815,9 +826,11 @@ public static class DynamicTypePreWarmer
         string typePath,
         TimeSpan budget,
         ILogger? logger)
-        => Observable.Using(
-                () => AccessContextScope.AsSystem(accessService),
-                _ =>
+        // RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` — see
+        // WarmDynamicTypes (#1444/#1790). The whole flip-and-wait below stays inside the work
+        // factory, so its emission-time behaviour is unchanged.
+        => accessService.RunAsSystem(
+                () =>
                 {
                     var stream = workspace.GetMeshNodeStream(typePath);
                     return stream
@@ -1076,11 +1089,14 @@ public static class DynamicTypePreWarmer
         var workspace = mesh.GetWorkspace();
         var accessService = mesh.ServiceProvider.GetService<AccessService>();
         // System-scoped for the same reason the sweep's reads are: watching a NodeType record
-        // across partitions is infrastructure, not a user-attributable read.
-        return Observable
-            .Using(
-                () => AccessContextScope.AsSystem(accessService),
-                _ =>
+        // across partitions is infrastructure, not a user-attributable read. RunAsSystem, never
+        // `Observable.Using(AccessContextScope.AsSystem, …)` — see WarmDynamicTypes (#1444/#1790).
+        // This one is the worst shape of the family: the watch is LONG-LIVED, so `Using` would hold
+        // the scope open until recovery lands (or shutdown) while the subscriber — a hosted service
+        // — ran on latched as System the whole time.
+        return accessService
+            .RunAsSystem(
+                () =>
                 {
                     // One shared handle (IMeshNodeStreamCache): the baseline read and the wait are
                     // the SAME stream, and it replays its latest node to the second subscriber — so
@@ -1164,9 +1180,10 @@ public static class DynamicTypePreWarmer
         // its compile watcher settling, the state write coming back. That is the number worth
         // having, because it is the one the bootstrap's liveness deadline is actually spent on.
         var clock = System.Diagnostics.Stopwatch.StartNew();
-        return Observable.Using(
-                () => AccessContextScope.AsSystem(accessService),
-                _ => workspace.GetMeshNodeStream(typePath)
+        // RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` — see
+        // WarmDynamicTypes (#1444/#1790).
+        return accessService.RunAsSystem(
+                () => workspace.GetMeshNodeStream(typePath)
                     // Unavailable is terminal too — a driver already gave up determining
                     // the state, so waiting out the rest of the budget for a write that
                     // is not coming only slows the sweep down.

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -209,11 +209,15 @@ internal static class NodeTypeBatchBake
 
         // 🚨 System-scoped: source discovery across every partition is framework infrastructure,
         // not a user-attributable read — the same rule as the compiler's own GetSourceCollection.
-        // Observable.Using holds the scope across the live subscription (the queries emit on IO
-        // threads where the ambient AsyncLocal is gone).
-        return Observable.Using(
-                () => AccessContextScope.AsSystem(accessService),
-                _ =>
+        //
+        // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790):
+        // `AsSystem` IS `ImpersonateAsSystem`, and `Using` splits that AsyncLocal store/restore
+        // pair across two threads — opened on the subscriber, disposed on whichever IO/response
+        // thread the fetch terminates on — so the subscriber stays latched as System. The queries
+        // still run impersonated: they are composed and subscribed INSIDE the work factory, which
+        // RunAsSystem enters before subscribing and leaves on the way out of that same Subscribe.
+        return accessService.RunAsSystem(
+                () =>
                 {
                     var globalFetch = needsGlobalFetch
                         ? GlobalCodeQueries
@@ -491,9 +495,10 @@ internal static class NodeTypeBatchBake
 
         // 🚨 System-scoped end-to-end: the compile reads sources across the mesh and the stamp
         // writes framework state — infrastructure, exactly like RunCompile's deferred pipelines.
-        return Observable.Using(
-                () => AccessContextScope.AsSystem(accessService),
-                _ => compiler
+        // RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790) — see
+        // the source-discovery pipeline above.
+        return accessService.RunAsSystem(
+                () => compiler
                     .CompileAndGetConfigurations(typeNode, sources)
                     .Take(1)
                     .Select(result => (Result: result, Error: (Exception?)null))

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -326,10 +326,17 @@ public static class ShippedPrebuiltBundles
 
             // 🚨 System-scoped end-to-end: reading NodeType records across every partition and
             // stamping adopted builds is framework infrastructure, exactly like the sweep this
-            // runs in front of. Observable.Using holds the scope across the live subscription.
-            return Observable.Using(
-                    () => AccessContextScope.AsSystem(accessService),
-                    _ => pool
+            // runs in front of.
+            //
+            // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790).
+            // `AccessContextScope.AsSystem(x)` IS `x.ImpersonateAsSystem()`, so the helper hides the
+            // shape rather than changing it: `Using` opens the AsyncLocal on the SUBSCRIBING thread
+            // and disposes it wherever the inner observable terminates — here an IoPool thread —
+            // leaving the bootstrap subscriber latched as `system-security`. RunAsSystem opens and
+            // closes inside one Subscribe; the whole cold pipeline below stays in the work factory,
+            // so the IoPool work and every stamp write are still issued as System.
+            return accessService.RunAsSystem(
+                    () => pool
                         .InvokeBlocking(_ => enumerateBundles())
                         .SelectMany(bundles =>
                         {

--- a/src/MeshWeaver.Mesh.Contract/Security/AccessContextScope.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/AccessContextScope.cs
@@ -16,6 +16,22 @@ namespace MeshWeaver.Mesh.Security;
 /// pattern (no restore — leaks). Each call returns a scoped disposable that
 /// restores the previous AsyncLocal value on Dispose.</para>
 ///
+/// <para>🚨 <b>NEVER as an <c>Observable.Using</c> resource factory.</b>
+/// <c>Observable.Using(() =&gt; AccessContextScope.AsSystem(access), _ =&gt; work)</c>
+/// is the identity-latch defect (#1444/#1790) — these factories are
+/// <c>ImpersonateAsSystem</c> / <c>SwitchAccessContext</c> under another name,
+/// so wearing this helper's name changes nothing about the shape. Rx runs the
+/// factory on the SUBSCRIBING thread and disposes it when the inner observable
+/// TERMINATES — for a cross-hub read or write, the owning hub's response thread
+/// — so the subscriber is left running as the impersonated identity with
+/// nothing to restore it. Use
+/// <c>ImpersonationScopeExtensions.RunAsSystem/RunAsHub/RunAs</c>, which owns
+/// both ends inside one <c>Subscribe</c>; where the capture is genuinely
+/// SYNCHRONOUS, a plain <c>using</c> around the call and its
+/// <c>Subscribe</c> is equally correct — that is what these factories are for.
+/// <c>ImpersonationScopeSiteRatchetGuard</c> fails a new site of either
+/// spelling.</para>
+///
 /// <para><b>Operation classes — choose the right factory:</b></para>
 /// <list type="bullet">
 ///   <item><see cref="FromNode"/> — for operations that should run under the

--- a/test/ImpersonationScopeSites.allow
+++ b/test/ImpersonationScopeSites.allow
@@ -4,6 +4,13 @@
 #
 #     Observable.Using(() => access.ImpersonateAsSystem(), _ => work)
 #
+# …including the shapes that wear a helper's name. `AccessContextScope.AsSystem(x)` IS
+# `x.ImpersonateAsSystem()` and `AccessContextScope.FromNode(node, x)` IS `x.SwitchAccessContext(owner)`,
+# so both count. The guard only sees a factory whose text contains one of the substrings in
+# ImpersonationScopeSiteRatchetGuard.ScopeFactories — that list is LOAD-BEARING: a new identity-scope
+# helper named after none of them is invisible, which is how 19 sites across 10 files went uncounted
+# until #2441. Add the name there in the same change that introduces the helper.
+#
 # Impersonation is an AsyncLocal store/restore pair. Rx runs the resource factory on the
 # SUBSCRIBING thread and disposes the resource when the inner observable TERMINATES — for a
 # cross-hub call, the owning hub's response thread. The subscriber is therefore left running as
@@ -30,8 +37,6 @@
 #
 # format: <path>	<count>
 
-memex/Memex.Client/Prefs/PreferencesService.cs	2
-memex/Memex.Client/Services/DeviceOnboarding.cs	1
 memex/Memex.Portal.Shared/Api/SeoEndpoints.cs	1
 memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs	1
 memex/Memex.Portal.Shared/Authentication/BootstrapController.cs	1
@@ -42,12 +47,8 @@ memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs	1
 memex/Memex.Portal.Shared/Authentication/UserOnboardingService.cs	3
 memex/Memex.Portal.Shared/Email/InvitationEmailSender.cs	2
 memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs	1
-memex/Memex.Portal.Shared/Models/ModelProviderService.cs	1
-memex/Memex.Portal.Shared/Pages/Onboarding.razor	1
 memex/Memex.Portal.Shared/Settings/InboxSettingsTab.cs	1
-src/MeshWeaver.AI.OpenAI/OpenAICompatibleModelSync.cs	1
 src/MeshWeaver.AI/ChatClientCredentialResolver.cs	2
-src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs	1
 src/MeshWeaver.GitSync/GitHubSyncService.cs	2
 src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs	4
 src/MeshWeaver.Graph/Configuration/CellSurfaceAssemblyProvider.cs	2
@@ -70,11 +71,7 @@ src/MeshWeaver.Hosting/NodeUpdatePipeline.cs	1
 src/MeshWeaver.InstanceSync/InstanceSyncCoordinator.cs	1
 src/MeshWeaver.InstanceSync/InstanceSyncService.cs	1
 src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs	1
-src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs	1
-src/MeshWeaver.Mail.MicrosoftGraph/EmailInboundProcessor.cs	2
 src/MeshWeaver.Mesh.Contract/MeshExtensions.cs	1
-src/MeshWeaver.Observability/LogIncidentControlPlane.cs	1
-src/MeshWeaver.Observability/LogIncidentIngestService.cs	1
 src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs	6
 src/MeshWeaver.PluginCatalog/InstanceComboReader.cs	1
 src/MeshWeaver.PluginCatalog/ModuleDiscoveryService.cs	4
@@ -82,5 +79,4 @@ src/MeshWeaver.PluginCatalog/PackageInstaller.cs	10
 src/MeshWeaver.PluginCatalog/PackageUpdateReconciler.cs	2
 src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs	1
 src/MeshWeaver.PluginCatalog/RegistrationKeyService.cs	1
-src/MeshWeaver.Teams/TeamsInboundProcessor.cs	1
 tools/MeshWeaver.PluginTester/PluginGateRunner.cs	1

--- a/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace MeshWeaver.Documentation.Test;
@@ -36,6 +37,20 @@ namespace MeshWeaver.Documentation.Test;
 /// than live incidents. What is left at each of them is the subscribing-thread latch, and that only
 /// the call site can close.</para>
 ///
+/// <para><b>What the guard can SEE is itself a moving part.</b> A site is matched by two things
+/// and only two: <see cref="MarkerPattern"/> (the <c>Observable.Using</c> call, whitespace-tolerant)
+/// and <see cref="ScopeFactories"/> (substrings its resource factory must contain). Both have been
+/// wrong in ways that made the ratchet report a clean tree it had never looked at (#2441). The
+/// factory list missed <c>AccessContextScope.AsSystem/FromNode</c> — an alias for
+/// <c>ImpersonateAsSystem</c> / <c>SwitchAccessContext</c> — and a LITERAL marker missed
+/// <c>Observable</c>-newline-<c>.Using</c>. Together they hid <b>19 sites across 10 files</b>: 18
+/// that the widened factory list alone surfaces, plus one that needed the marker fixed too. The
+/// literal marker also mis-reported <c>PackageInstaller</c>'s honest 10 as 9 — i.e. it invited
+/// someone to lower a budget against a site that is still there. <b>A new way to open an identity
+/// scope, or a new spelling of the call, must be taught to this guard in the same change that
+/// introduces it</b> — otherwise the inventory below silently describes a smaller tree than the one
+/// that exists.</para>
+///
 /// <para><b>The ratchet may only SHRINK.</b> A new file, a raised count, or a raised TOTAL is a
 /// failure. A line that has become stale (its site was fixed) is reported, not failed: two PRs
 /// closing sites concurrently would otherwise red <c>main</c> on whichever merged second, and a
@@ -49,18 +64,43 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
     /// the shape; this stops the list as a WHOLE from growing — including by the trick of adding a
     /// new file's line. Lower it whenever you delete or lower an entry.
     /// </summary>
-    private const int TotalBudget = 98;
+    private const int TotalBudget = 83;
 
     /// <summary>Production roots. <c>test/</c> and <c>samples/</c> are deliberately out of scope —
     /// the leak there costs test isolation, not a user's permissions, and listing 21 more entries
     /// would bury the ones that matter.</summary>
     private static readonly string[] ScannedRoots = ["src", "memex", "tools"];
 
-    private const string Marker = "Observable.Using";
+    /// <summary>
+    /// 🚨 The call being matched, as a PATTERN and not a literal. <c>Observable.Using</c> and the
+    /// same call wrapped after <c>Observable</c> are one call, and a literal substring sees only the
+    /// first: before #2441 the wrapped form hid a site in <c>DynamicTypePreWarmer</c>, one in
+    /// <c>MeshNodeCompilationService</c>, one in <c>AiSourcesInstallHook</c>, one in
+    /// <c>JsonSynchronizationStream</c>, and made <c>PackageInstaller</c>'s honest 10 read as 9 —
+    /// i.e. it reported a live site as a STALE allowance, which is a ratchet inviting someone to
+    /// lower a budget against evidence that was never there.
+    /// </summary>
+    private static readonly Regex MarkerPattern =
+        new(@"Observable\s*\.\s*Using", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    /// <summary>The identity-scope factories. All three return an <see cref="IDisposable"/> whose
-    /// Dispose writes an <c>AsyncLocal</c>, which is what makes them thread-affine.</summary>
-    private static readonly string[] ScopeFactories = ["Impersonate", "SwitchAccessContext"];
+    /// <summary>The cheap pre-filter for <see cref="MarkerPattern"/> — must stay WEAKER than the
+    /// pattern (a literal "Observable.Using" here would re-introduce exactly the blindness the
+    /// pattern removes).</summary>
+    private const string MarkerPreFilter = "Using";
+
+    /// <summary>
+    /// 🚨 THE LOAD-BEARING LIST. A site is only seen if its resource factory contains one of these
+    /// substrings, so an identity-scope helper whose name contains NONE of them is invisible to this
+    /// guard — the whole shape passes as zero. That is not hypothetical: <c>AccessContextScope</c>
+    /// (whose <c>AsSystem</c> is literally <c>accessService.ImpersonateAsSystem()</c> and whose
+    /// <c>FromNode</c> is <c>SwitchAccessContext</c>) hid 19 sites across 10 files until #2441, two
+    /// of them in a file the guard reported as clean and one of those on a self-heal path whose own
+    /// doc comment cites #1790. <b>Adding a new way to open an identity scope means adding it
+    /// here</b>, in the same change — every entry returns an <see cref="IDisposable"/> whose Dispose
+    /// writes an <c>AsyncLocal</c>, and that is the whole criterion.
+    /// </summary>
+    private static readonly string[] ScopeFactories =
+        ["Impersonate", "SwitchAccessContext", "AccessContextScope"];
 
     private const string AllowFileName = "ImpersonationScopeSites.allow";
 
@@ -132,7 +172,9 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
             + "make the ratchet above pass on no evidence.");
 
         // The doc comments in ImpersonationScopeExtensions and AccessService QUOTE the shape. A
-        // scanner that counted them would ratchet against prose, so prove the masking works.
+        // scanner that counted them would ratchet against prose, so prove the masking works. The
+        // quoted form is the whitespace-free one, which MarkerPattern also matches — so this is a
+        // live check of the masker, not an accident of the marker's spelling.
         var seam = Path.Combine(root, "src", "MeshWeaver.Messaging.Hub", "ImpersonationScopeExtensions.cs");
         Assert.True(File.Exists(seam), "the seam file must exist for this check to mean anything");
         Assert.True(File.ReadAllText(seam).Contains("Observable.Using(access.ImpersonateAsSystem"),
@@ -141,6 +183,54 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
                 .Replace(Path.DirectorySeparatorChar, '/')),
             "the scanner counted a DOC COMMENT as a call site — comment masking is broken, and every "
             + "count in the allow file is therefore unreliable.");
+    }
+
+    /// <summary>
+    /// 🚨 NON-VACUITY OF THE MATCHER, spelling by spelling. Sibling to
+    /// <see cref="TheScannerFindsTheShapeItIsRatcheting"/>, which only proves the scanner sees
+    /// SOMETHING. This proves it sees each thing it claims to — and, just as importantly, that it
+    /// still ignores a bare <c>Observable.Using</c> that opens no identity scope, so the ratchet
+    /// cannot be "fixed" by making it match everything.
+    ///
+    /// <para>Both halves have been wrong in production (#2441): <c>AccessContextScope</c> was
+    /// missing from <see cref="ScopeFactories"/>, and the marker was a literal that could not see
+    /// the call wrapped after <c>Observable</c>. Neither failure was visible from the tree, because
+    /// a matcher that sees nothing and a tree that contains nothing produce the same green.</para>
+    /// </summary>
+    [Fact]
+    public void TheMatcherSeesEverySpellingItClaimsTo()
+    {
+        // Every factory name in the load-bearing list, in the shape it appears at a real site.
+        Assert.Equal(1, CountSitesIn(
+            "return Observable.Using(() => access.ImpersonateAsSystem(), _ => work);"));
+        Assert.Equal(1, CountSitesIn(
+            "return Observable.Using(() => access.ImpersonateAsHub(hub), _ => work);"));
+        Assert.Equal(1, CountSitesIn(
+            "return Observable.Using(() => access.SwitchAccessContext(ctx), _ => work);"));
+        Assert.Equal(1, CountSitesIn(
+            "return Observable.Using(() => AccessContextScope.AsSystem(access), _ => work);"));
+        Assert.Equal(1, CountSitesIn(
+            "return Observable.Using(() => AccessContextScope.FromNode(n, access), _ => work);"));
+
+        // The call SPELLED across lines — the form a literal marker cannot see.
+        Assert.Equal(1, CountSitesIn(
+            "return Observable\n    .Using(\n        () => AccessContextScope.AsSystem(access),\n        _ => work);"));
+        Assert.Equal(1, CountSitesIn(
+            "return Observable\n    .Using(() => access.ImpersonateAsSystem(), _ => work);"));
+
+        // …and what it must NOT see, so widening never becomes matching everything.
+        Assert.Equal(0, CountSitesIn(
+            "return Observable.Using(() => new CancellationTokenSource(), cts => work);"));
+        Assert.Equal(0, CountSitesIn(
+            "// Observable.Using(() => access.ImpersonateAsSystem(), _ => work) is the defect."));
+        Assert.Equal(0, CountSitesIn(
+            "var doc = \"Observable.Using(() => access.ImpersonateAsSystem(), _ => work)\";"));
+
+        // The resource factory is the FIRST argument, never a later one: a scope named in the work
+        // factory is a different (and legitimate) thing — e.g. a RunAsSystem call inside it.
+        Assert.Equal(0, CountSitesIn(
+            "return Observable.Using(() => new CancellationTokenSource(), "
+            + "_ => access.RunAsSystem(() => work));"));
     }
 
     private static Dictionary<string, int> Scan(string root) =>
@@ -160,15 +250,26 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
         try { text = File.ReadAllText(path); }
         catch (IOException) { return 0; } // a file a concurrent build is writing is not evidence
 
-        if (!text.Contains(Marker, StringComparison.Ordinal)) return 0;
+        return CountSitesIn(text);
+    }
+
+    /// <summary>
+    /// The matcher itself, over TEXT rather than a path — so
+    /// <see cref="TheMatcherSeesEverySpellingItClaimsTo"/> can pin what it can see without needing
+    /// a live example of every spelling to survive in the tree. Once a spelling is converted to
+    /// zero occurrences, the tree stops being evidence that the matcher still recognises it, and a
+    /// narrowed <see cref="ScopeFactories"/> or a re-literalised <see cref="MarkerPattern"/> would
+    /// pass unnoticed — which is the failure this whole guard exists to prevent, one level up.
+    /// </summary>
+    internal static int CountSitesIn(string text)
+    {
+        if (!text.Contains(MarkerPreFilter, StringComparison.Ordinal)) return 0;
 
         var code = SourceScan.MaskCommentsAndStrings(text);
         var count = 0;
-        var at = 0;
-        while ((at = code.IndexOf(Marker, at, StringComparison.Ordinal)) >= 0)
+        foreach (Match marker in MarkerPattern.Matches(code))
         {
-            var open = code.IndexOf('(', at + Marker.Length);
-            at += Marker.Length;
+            var open = code.IndexOf('(', marker.Index + marker.Length);
             if (open < 0) continue;
             var firstArg = SourceScan.FirstArgument(code, open);
             if (ScopeFactories.Any(f => firstArg.Contains(f, StringComparison.Ordinal)))


### PR DESCRIPTION
Closes #2441.

## The gap, and the second one found while fixing it

`ImpersonationScopeSiteRatchetGuard` decides a site is a site with exactly two matchers, and **both were blind in the same direction** — they made a tree the guard had never looked at read as clean:

1. **`ScopeFactories = ["Impersonate", "SwitchAccessContext"]`.** `AccessContextScope.AsSystem(x)` **IS** `x.ImpersonateAsSystem()` and `AccessContextScope.FromNode(node, x)` **IS** `x.SwitchAccessContext(owner)` — the banned shape wearing a helper's name, containing neither substring, counted as **zero**. This is the issue as filed.
2. **`Marker` was the literal `"Observable.Using"`** — found while fixing (1). It cannot see the same call wrapped after `Observable`. That hid a 5th `AccessContextScope` site in `DynamicTypePreWarmer`, one in `MeshNodeCompilationService`, one each in `AiSourcesInstallHook` and `JsonSynchronizationStream` (files absent from the allow file entirely), and — worse than hiding — it reported **`PackageInstaller`'s honest 10 as 9**, i.e. printed a `STALE (please tidy)` line inviting someone to lower a budget against a site that is still there.

Together they hid **19 sites across 10 files**.

## Proof the widened guard goes RED before the fix

Widening `ScopeFactories` alone, on the unmodified tree, fails with exactly the issue's inventory:

```
NEW SITE   memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs (2)
NEW SITE   memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs (1)
NEW SITE   memex/Memex.Portal.Shared/Settings/PrivacyStatementNode.cs (2)
NEW SITE   memex/Memex.Portal.Shared/ShippedReleaseSeed.cs (3)
NEW SITE   src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingActivity.cs (1)
NEW SITE   src/MeshWeaver.GitSync/ActivityRunner.cs (1)
NEW SITE   src/MeshWeaver.Graph/NodeTypeRecompileExtensions.cs (1)
NEW SITE   src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs (4)
NEW SITE   src/MeshWeaver.Hosting/NodeTypeBatchBake.cs (2)
NEW SITE   src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs (1)
Failed!  - Failed: 1, Passed: 1
```

That is a one-shot observation, so it is also pinned as a **test**: a new `TheMatcherSeesEverySpellingItClaimsTo` exercises the matcher on synthetic text — every factory name in the load-bearing list, the call spelled across lines, and the things it must still *not* match (a bare `Observable.Using` over a `CancellationTokenSource`, a comment, a string literal, a scope named in the *work* factory). Two negative controls were run against it and each turns it red:

| control | result |
|---|---|
| narrow `ScopeFactories` back to the pre-#2441 pair | `TheMatcherSeesEverySpellingItClaimsTo [FAIL]` |
| re-literalise `MarkerPattern` to `Observable\.Using` | `TheMatcherSeesEverySpellingItClaimsTo [FAIL]` |

That matters because the tree-scan alone can no longer catch either regression: with all 19 sites converted, a narrowed matcher scans to the same green.

## All 19 converted — no allowance added, budget goes DOWN

The issue's "Preferred" outcome. `TotalBudget` **98 → 83**: −19 for the conversions is not how it lands (none of these files were ever allow-listed), so the drop is 11 already-dead lines tidied, which is exactly what the guard's own `STALE (please tidy)` output was asking for. **Zero new entries.**

Each site becomes `RunAsSystem` / `RunAs`, which enters the scope at Subscribe and leaves it on the way out of that same Subscribe, instead of letting Rx dispose it on whichever thread the work terminated on:

- **Bootstrap / compile infrastructure**, subscriber is a hosted service — `DynamicTypePreWarmer` (5), `NodeTypeBatchBake` (2), `ShippedPrebuiltBundles`, `NodeTypeRecompileExtensions`, `MeshNodeCompilationService`, `AiSourcesInstallHook`.
- **Self-update / seeds** — `ShippedReleaseSeed` (3), `UpdatePolicyNodeType`, `SelfUpdateHostedService` (2), `PrivacyStatementNode` (2). `PrivacyStatementNode.GetStatement` is the sharpest instance in the tree: its subscriber is the **anonymous `/privacy` request**, which was left holding `system-security` after the read.
- **The `FromNode` pair** — `ActivityRunner`, `ContentIndexingActivity`.
- **`JsonSynchronizationStream`** — the captured-user/System pick for the cross-hub `SubscribeRequest`, whose subscriber is a Blazor circuit, a hub turn, or a re-render fan-out.

### The one place `RunAsSystem` was NOT a drop-in

`AccessContextScope.FromNode` resolves **`CreatedBy`, else `LastModifiedBy`, else System** — and `RunAs(identity: null, work)` runs *unswitched*, which is not the same thing (an unswitched activity run posts a null `AccessContext` and fails closed). So the two activity runners do **not** get a mechanical `RunAs(owner, …)`. The identity is resolved at the call site with FromNode's own rule spelled out, and the System fallback is explicit:

```csharp
var scopeIdentity = owner ?? ContextOf(created.LastModifiedBy);
return ScheduleOffHubTurn(scopeIdentity is null
    ? accessService.RunAsSystem(Run)
    : accessService.RunAs(scopeIdentity, Run));
```

`OwnerContextOf` (the per-write re-stamp used by `Append`/`Finish`) keeps its `CreatedBy`-only semantics unchanged — only the outer scope gained the fallback it always had.

`ScheduleOffHubTurn` still wraps the scope, not the other way round, so the scope is still entered on the pool thread that actually subscribes. Same for `MeshNodeCompilationService`, where the scope must stay **inside** `DelaySubscription`.

### Nothing else needed a scope it did not already have

Two conversions were checked for the "redundant, not merely mis-shaped" case and kept: `NodeTypeRecompileExtensions`'s downstream release trigger already opens its own synchronous `using (accessService?.ImpersonateAsSystem())` around the loop, and its prebuilt-adoption leg is `ShippedPrebuiltBundles.SeedBundles`, which opens its own — so scoping only the enumeration is correct, and nothing downstream depended on the old scope leaking past the query.

## The comments that defended the defect

Fixed at every site, per the issue. `DynamicTypePreWarmer` said *"Observable.Using holds the scope across the live subscription, not just the synchronous build"* — the defect stated as the feature — and both activity runners said *"re-establish the owner AT THE SUBSCRIBE via Observable.Using(FromNode)"*. Beyond the call sites:

- **`AccessContextScope`'s own doc** now carries a 🚨 saying never to use it as an `Observable.Using` resource factory, and pointing at `RunAsSystem`/`RunAs` — this is the type whose name made the shape invisible, so it is where the next reader will look.
- **The guard's doc** now says `ScopeFactories` and `MarkerPattern` are **load-bearing**: a new identity-scope helper, or a new spelling of the call, must be taught to the guard in the same change that introduces it.
- `AccessContextPropagation.md` and `OwnerInjection.md` — the two docs that recommend `FromNode` — now say the same in the row that recommends it.

Note the two `NodeTypeEnrichmentHelpers.cs` sites were already converted by #2435 and are untouched here.

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation, all `0 Error(s)`: `MeshWeaver.Data`, `.Graph`, `.Hosting`, `.AI`, `.GitSync`, `.ContentCollections.Indexing.Graph`, `.Mesh.Contract`, `Memex.Portal.Shared`, `MeshWeaver.Documentation.Test` (the last two of the source projects re-run with `--no-incremental` after the final edits, to prove a real compile).

Test projects run in full, all green:

| project | result |
|---|---|
| `MeshWeaver.Documentation.Test` | 80 → 81 passed (the guard's 3, incl. the new matcher test) |
| `MeshWeaver.Messaging.Hub.Test` | 279 passed (incl. `ImpersonationScopeThreadAffinityTest`, `SystemScopeDoesNotEscapeTest`) |
| `MeshWeaver.GitSync.Test` | 187 passed (incl. `ActivityOwnerCredentialTest` — the regression test for the `FromNode` conversion) |
| `Memex.Portal.Shared.Test` | 371 passed |
| `MeshWeaver.Hosting.Test` | 240 passed |
| `MeshWeaver.Data.Test` | 390 passed |
| `MeshWeaver.ContentCollections.Indexing.Graph.Test` | 32 passed |
| `MeshWeaver.Graph.Test` | 1653 passed |
| `MeshWeaver.Hosting.Monolith.Test` | 769 passed, 3 skipped (incl. `SelfUpdate*`, `DynamicTypePreWarmerTest`, `NodeTypeBatchBake*`) |

## What's New

`Category: Fix` — the latch is silent but user-visible in consequence (work that should have been checked against the viewer's permissions was checked against the system account's, on paths that include an anonymous page request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)