### PR TITLE
One publish directory is ONE RID flavor — refuse the multi-arch -o collapse in PublishMeshModules

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -179,6 +179,40 @@
       <_AppPublishDir>$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$(PublishDir)', '$(MSBuildProjectDirectory)'))))</_AppPublishDir>
     </PropertyGroup>
 
+    <!-- 🚨 ONE publish directory = ONE RID flavor, asserted before anything is laid out.
+
+         The shape this refuses (measured, Plugins CI "Build + test the portal hosts", 2026-08-26):
+         `dotnet publish -o <dir>` on a host whose csproj arms the container profile
+         (PublishProfile=DefaultContainer) and declares RuntimeIdentifiers=linux-x64;linux-arm64.
+         The SDK's _PublishMultiArchContainers then re-invokes Publish once per RID, IN PARALLEL
+         (BuildInParallel=true), each inner build inheriting every global property — including the
+         `-o` PublishDir. Result: the portable outer publish AND both per-RID publishes collapse
+         into ONE directory, so (a) the app root becomes a nondeterministic RID mix (last writer
+         wins per file — the repro left a linux-x64 apphost over linux-arm64 leftovers), and
+         (b) THREE of these module-closure lanes run over one modules/ tree, where one lane's
+         dedupe <Delete> lands between another lane's glob and its GetFileHash — the racy
+         MSB3954 "Failed to compute hash … does not exist" that is impossible to diagnose from
+         the error alone. Without `-o` the shape is fine by construction: each inner RID publish
+         defaults to its own bin/…/<rid>/publish/ (which is why main-cd is green).
+
+         The stamp records the flavor that laid this directory out; a different flavor arriving is
+         refused BEFORE it mutates anything. In the collapsed shape above the outer portable lane
+         always completes before the container target starts its inner builds, so the first inner
+         lane hits this Error deterministically — the two inner lanes racing each other can only
+         happen after the outer stamp already fired. A stale stamp from an EARLIER different-RID
+         publish into the same directory is refused too, deliberately: publish never cleans, so
+         such a directory is already a mixed-RID hazard. The `rid=` prefix keeps the portable
+         stamp non-empty so "no stamp yet" and "portable stamp" cannot be confused. -->
+    <PropertyGroup>
+      <_MeshModulesRidStampFile>$(_AppPublishDir)modules/.mesh-modules-rid</_MeshModulesRidStampFile>
+      <_MeshModulesRidStamp>rid=$(RuntimeIdentifier)</_MeshModulesRidStamp>
+      <_MeshModulesRidStampExisting Condition="Exists('$(_MeshModulesRidStampFile)')">$([System.IO.File]::ReadAllText('$(_MeshModulesRidStampFile)').Trim())</_MeshModulesRidStampExisting>
+    </PropertyGroup>
+    <Error Condition="'$(_MeshModulesRidStampExisting)' != '' And '$(_MeshModulesRidStampExisting)' != '$(_MeshModulesRidStamp)'"
+           Text="PublishMeshModules: publish directory '$(_AppPublishDir)' was laid out for '$(_MeshModulesRidStampExisting)' and this publish is '$(_MeshModulesRidStamp)' — two RID flavors must not share one publish directory. This is the multi-arch-container `-o` collapse: PublishProfile=DefaultContainer + RuntimeIdentifiers makes the SDK re-run Publish per RID in parallel, and a global -o/PublishDir funnels all of them (and their module-closure lanes) into this one folder — a nondeterministic RID mix plus the racy MSB3954 in the closure dedupe. Either pin one RID for the whole publish (-p:RuntimeIdentifier=linux-x64 --no-self-contained), or drop -o so each RID publishes to its default per-RID directory, or — if this stamp is stale from an earlier different-RID publish — clean the directory." />
+    <MakeDir Directories="$(_AppPublishDir)modules" />
+    <WriteLinesToFile File="$(_MeshModulesRidStampFile)" Lines="$(_MeshModulesRidStamp)" Overwrite="true" />
+
     <!-- Build each module (already built as part of the host's graph in the double-ship state —
          this is an incremental no-op then) and collect its primary output. Serial on purpose:
          parallel builds have wedged the shared compiler on this repo's build hosts. -->


### PR DESCRIPTION
## What this refuses, and why loudly

Measured on MeshWeaver.Plugins' required `Build + test the portal hosts` job (red since it exists): `dotnet publish -o <dir>` on a host that arms `PublishProfile=DefaultContainer` and declares `RuntimeIdentifiers=linux-x64;linux-arm64` (Memex.Portal.Distributed) makes the SDK's `_PublishMultiArchContainers` re-run `Publish` once per RID **in parallel**, each inner build inheriting the `-o` `PublishDir`. The portable outer publish plus both per-RID publishes collapse into one directory:

- the app root becomes a nondeterministic RID mix (repro: a linux-x64 ELF apphost over linux-arm64 leftovers), and
- **three** `LayoutMeshModuleClosures` lanes run over one `modules/` tree, where one lane's dedupe `<Delete>` lands between another lane's glob and its `GetFileHash` — the racy, undiagnosable `MSB3954: Failed to compute hash … does not exist` (on exactly the app-closure duplicate names), with CONTAINER1020 as the alternate symptom when the race happens not to fire.

Without `-o` the shape is fine by construction — each inner RID publish defaults to its own `bin/…/<rid>/publish/` — which is why main-cd's explicit `ContainerRuntimeIdentifiers` publish has always been green.

## The guard

`PublishMeshModules` stamps `modules/.mesh-modules-rid` with the flavor that laid the directory out and **refuses a different flavor arriving, before it mutates anything**. In the collapse, the outer portable lane always completes before the container target starts its inner builds, so the first inner lane hits the Error **deterministically**, with the cause and the three exits named (pin one RID / drop `-o` / clean a stale dir) — instead of a race that files itself as a hash failure. A stale different-RID stamp from an earlier publish into the same directory is refused too: publish never cleans, so that directory is already a mixed-RID hazard. The `rid=` prefix keeps the portable stamp distinguishable from "no stamp".

Companion (plugins): Systemorph/MeshWeaver.Plugins#734 — the gate itself now pins `-p:RuntimeIdentifier=linux-x64 --no-self-contained`, which takes the SDK's single-RID in-instance path and turns the job green on its own. This PR is the fail-loud backstop for the next `-o` on a multi-arch host.

## Verification (local, core main + plugins main)

- Broken flags (unpinned, `-o`): both inner lanes fail with the named Error, exit 1, deterministic — instead of MSB3954-or-green-by-luck
- Pinned flags: exit 0, exactly one closure lane on the out dir, 44-entry `meshweaver-surface.manifest`, coherent linux-x64 output, container tarball written
- main-cd's exact multi-arch shape (`-t:PublishContainer -p:PublishProfile= -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"`, no `-o`): publishes per-RID directories, guard never trips
- Same-RID re-publish into the same directory: no false positive
- `dotnet build memex/Memex.Portal.Shared -c Release -warnaserror`: 0 warnings, 0 errors
- `ModuleDeclarationIntegrityTest` parses only `<MeshModule>/<MeshModuleClosure>` declarations — untouched

No What's New entry: internal build tooling, no user-visible effect (noted per the pullrequest skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
