### PR TITLE
fix(cd): the bake outruns its own credential — re-login before publishing

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1469,6 +1469,33 @@ jobs:
       # produced its bytes). The platform CONTENT bake above has no such coupling — its key is the
       # framework identity, which the promoted image resolves identically however many times it is
       # asked — so the reconcile re-asserts that and stops there.
+      # 🚨 RE-AUTHENTICATE IMMEDIATELY BEFORE PUBLISHING — the job outruns its own credential.
+      # The OIDC assertion is minted by the `Azure login` step at the TOP of this job and is valid
+      # for ~5 minutes. Everything between here and there is the bake: it compiles every shipped
+      # NodeType twice over (Doc + samples) inside the container, which takes longer than that. So
+      # the publish below reached Azure with an assertion that had already expired:
+      #
+      #   ERROR: AADSTS700024: Client assertion is not within its valid time range.
+      #     Current time: 2026-08-27T00:20:39Z, expiry time of assertion: 2026-08-27T00:14:34Z
+      #
+      # Measured on CD run 33024861072: promote had succeeded, the image pulled on attempt 1, the
+      # bake compiled — and the run still published nothing, six minutes past the credential.
+      #
+      # 🚨 This failure was LATENT, not new: the login has always been taken at job start, and the
+      # bake has always been the long part. It surfaces now because #2452 makes this job run in
+      # situations where it previously did not, so the window is exercised far more often.
+      #
+      # A fresh login here costs seconds and removes the coupling between bake duration and
+      # credential lifetime entirely. It is NOT `continue-on-error`: if the identity cannot be
+      # obtained, publishing must fail loudly rather than skip — a bake that produced bundles and
+      # published none is the exact state the bake lane exists to prevent.
+      - name: "Azure login (OIDC) — refreshed for the publish"
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: "Publish the plugin bundles to every portal target (same identity, same version)"
         if: needs.gate.outputs.bake_only != 'true'
         env:


### PR DESCRIPTION
## The failure

The OIDC assertion is minted by the `Azure login` step at the **top** of `publish-bake` and is valid for **~5 minutes**. Everything between that step and the publish is the bake, which compiles every shipped NodeType twice over (Doc + samples) inside the container. It takes longer than the credential lives:

```
ERROR: AADSTS700024: Client assertion is not within its valid time range.
  Current time: 2026-08-27T00:20:39Z,
  expiry time of assertion: 2026-08-27T00:14:34Z
```

Measured on [CD run 33024861072](https://github.com/Systemorph/MeshWeaver/actions/runs/33024861072): promote had succeeded, the image pulled on attempt 1, the bake compiled — **and the run still published nothing**, six minutes past its own credential.

## 🚨 Latent, not new — and why it matters now

The login has always been taken at job start, and the bake has always been the long part. The window simply was not exercised often.

**#2452 changes that.** A reconcile whose images are already complete now still re-asserts the content bake, so this job runs in situations where it previously did not — and hits the same gap routinely rather than rarely. Fixing the reconciler without this would trade "the bake never runs" for "the bake runs and cannot publish", which is no better: pods still compile at boot.

## The change

A fresh `azure/login` immediately before the publish. Seconds of cost, and it removes the coupling between bake duration and credential lifetime entirely.

Placed so it covers **both** publishes:

| step | | runs on reconcile? |
|---|---|---|
| 12 | Azure login — refreshed | always |
| 13 | Publish the **plugin** bundles (version-keyed) | no (`bake_only != 'true'`) |
| 14 | Publish **platform content** bundles | **yes** |

Step 14 is the one the reconcile path depends on, so it is the one that most needs a live credential.

Deliberately **not** `continue-on-error`: if the identity cannot be obtained, publishing must fail loudly. A bake that produced bundles and published none is exactly the state this lane exists to prevent.

## Noted, not fixed here

The step's existing error text points at the wrong subsystem for this failure — *"could not log in to meshweaver.azurecr.io … this is a REGISTRY/INFRA failure"* is about ACR, while the expiry is on the Azure **publish** identity. Left alone to keep this diff to one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)