### PR TITLE
fix(#2235): the release broadcast's subscriber set was readable by code and settable by nobody

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1631,14 +1631,23 @@ jobs:
   #     satellite and no PAT. memex does the fan-out with the GitHub App it ALREADY holds for
   #     GitSync (`FrameworkReleaseBroadcaster`, `src/MeshWeaver.GitSync`); the release only signs a
   #     POST to memex, exactly like every other `notify-*` job here.
-  #   • no hand-maintained list here — the subscriber set lives in the Hosting fleet registry ON
-  #     memex ("register a new repo in Hosting"), the graph memex already owns; nothing is named in
-  #     this file.
+  #   • no hand-maintained list HERE — the subscriber set is the control instance's own
+  #     configuration (`FrameworkBroadcast:Subscribers`, rendered as
+  #     `FrameworkBroadcast__Subscribers__0..N` by deploy/helm/templates/memex-portal/config.yaml);
+  #     nothing is named in this file.
+  # 🚨 THIS BLOCK USED TO SAY the set "lives in the Hosting fleet registry ON memex", and that
+  # sentence cost #2235 three days: no such registry was ever built — there is no subscriber node
+  # type under Hosting/ and no code in any repo reads one — while the seam that DOES exist
+  # (FrameworkBroadcast:Subscribers) was rendered by no chart in either repo, so no deploy could
+  # set it. Every broadcast therefore dispatched to an empty set and logged it as the normal state
+  # of a non-control mesh. Do not re-describe a registry here until one ships with a reader; a
+  # mechanism named in prose and absent from the code is what stops the next reader looking.
   # 🚨 `BAKE_SUBSCRIBER_REPOS` IS GONE — deleted as a repo variable on 2026-08-25, not merely
   # unused. It survived the 2026-08-23 redesign holding one stale repo name, and a leftover
   # variable that LOOKS like the live subscriber list is worse than none: the next person to debug
   # a missing rebake reads it, believes the fan-out targets exactly that repo, and stops looking.
-  # If you need to know who is subscribed, ask the Hosting registry on the control instance.
+  # If you need to know who is subscribed, read `FrameworkBroadcast__Subscribers__0..N` on the
+  # control instance's deployment — that is the only source there is.
   # Pull stays the fallback: each repo's `schedule` run still reads the registry
   # (`Resolve the bake target` in each ci.yml) and bakes for the identity it finds, so a lost
   # dispatch costs at most one delayed rebake wave and a repo that stops baking still shows up as an

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -93,6 +93,22 @@ config:
     # so the platform-build target silently never took effect even though the ConfigMap was
     # correct. Leave empty when only one target is needed.
     WebhookInbox__Targets__1: ""
+    # ---- Framework-release broadcast subscribers ----------------------------
+    # 🚨 #2235: the subscriber set of the release wave. The control instance (the one whose
+    # WebhookInbox__Targets accepts Hosting/PlatformBuilds) verifies each platform-build
+    # delivery and fans a `meshweaver-framework-released` repository_dispatch out to every
+    # repo listed here, so each satellite re-bakes against the new framework in seconds
+    # instead of at its next schedule poll.
+    #
+    # No chart in EITHER repo rendered this key until #2235, so no deploy could set it: every
+    # broadcast dispatched to an empty set and logged it as the normal state of a non-control
+    # mesh. Zero dispatches, no error, nothing red. Leaving the slots empty here is correct —
+    # a deployment is inert until its overlay names its subscribers — but the slots must EXIST,
+    # or the overlay that names them reaches no container (the #1925 shape).
+    FrameworkBroadcast__Subscribers__0: ""
+    FrameworkBroadcast__Subscribers__1: ""
+    FrameworkBroadcast__Subscribers__2: ""
+    FrameworkBroadcast__Subscribers__3: ""
     # ---- Instance branding (per-env) ----------------------------------------
     # Large Safari bookmark / Start-Page / Add-to-Dock tile (apple-touch-icon, 180×180 PNG).
     # This ships the PROJECT's own mark (Systemorph builds MeshWeaver — the chart's

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -327,6 +327,27 @@ data:
   # 404'd on every promoted build with no error anywhere until #2268 made the 404 fail loud. A
   # deployment needing more than one inbox target sets __0 AND __1 (not two writers of __0).
   WebhookInbox__Targets__1: "{{ .Values.config.memex_portal.WebhookInbox__Targets__1 | default "" }}"
+  # ---- Framework-release broadcast subscribers (#2235) -----------------------------------
+  # 🚨 THE KEY NO CHART RENDERED, IN EITHER REPO, FOR THE WHOLE LIFE OF THE FEATURE. The control
+  # instance turns a verified platform-build delivery into one repository_dispatch per subscriber
+  # (FrameworkReleaseBroadcaster, src/MeshWeaver.GitSync) and reads that set from
+  # FrameworkBroadcast:Subscribers. Nothing rendered the key, so no deploy could set it, so every
+  # broadcast resolved to an EMPTY set — 0 dispatched, 0 failed, logged at Information as the
+  # normal state of a non-control mesh. Zero dispatches and nothing red anywhere: the same
+  # silent-deletion shape as SelfUpdate__PollInterval (#1778) and SelfUpdate__MinRollInterval
+  # (#1925), except here the key was never wired at all rather than renamed out from under one.
+  #
+  # It stayed unnoticed because main-cd.yml said the subscriber set "lives in the Hosting fleet
+  # registry ON memex". No such registry was ever built — no subscriber node type in Hosting/, no
+  # code anywhere reading one — so the sentence sent every reader away from the only seam there is.
+  #
+  # Empty on every deployment EXCEPT the control instance (the one whose WebhookInbox__Targets
+  # accepts Hosting/PlatformBuilds); one owner/name per slot, written out index by index because
+  # this ConfigMap names every key explicitly. An empty slot is dropped by NormalizeSubscribers.
+  FrameworkBroadcast__Subscribers__0: "{{ .Values.config.memex_portal.FrameworkBroadcast__Subscribers__0 | default "" }}"
+  FrameworkBroadcast__Subscribers__1: "{{ .Values.config.memex_portal.FrameworkBroadcast__Subscribers__1 | default "" }}"
+  FrameworkBroadcast__Subscribers__2: "{{ .Values.config.memex_portal.FrameworkBroadcast__Subscribers__2 | default "" }}"
+  FrameworkBroadcast__Subscribers__3: "{{ .Values.config.memex_portal.FrameworkBroadcast__Subscribers__3 | default "" }}"
   # The MODULES a deployment refuses to run without (MeshBuilderModuleActivation.RequiredKey).
   # The image ships a baseline list in appsettings; a deployment OVERRIDES an entry by name here,
   # and blanks one it cannot satisfy.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -433,9 +433,23 @@ promote ✅                            WebhookInbox: Hosting/PlatformBuilds
 
 - **No credential in the release path.** The platform holds no write access to any satellite and no
   PAT; it signs one POST. The fan-out uses the App memex already has.
-- **No list in this repo.** The subscriber set lives in memex's own Hosting fleet registry. The
-  vestigial `BAKE_SUBSCRIBER_REPOS` repo variable was **deleted on 2026-08-25** — a leftover that
-  looks like the live subscriber list is worse than none.
+- **No list in this repo.** The subscriber set is the control instance's own configuration —
+  `FrameworkBroadcast:Subscribers`, rendered as `FrameworkBroadcast__Subscribers__0..N` by
+  `deploy/helm/templates/memex-portal/config.yaml`. The vestigial `BAKE_SUBSCRIBER_REPOS` repo
+  variable was **deleted on 2026-08-25** — a leftover that looks like the live subscriber list is
+  worse than none.
+
+🚨 **This paragraph used to say the set "lives in memex's own Hosting fleet registry", and that
+sentence is why the wave stayed silent after the notify job was fixed.** No such registry was ever
+built — no subscriber node type under `Hosting/`, no code in any repo reading one — while the seam
+that *does* exist was rendered by **no chart in either repo**, so no deployment could set it. Every
+broadcast therefore ran against an empty subscriber set: `0 dispatched, 0 failed`, logged at
+`Information` as the correct state of a mesh that is not the control instance. A key the code reads
+and no chart renders is a **silent deletion** (`SelfUpdate__PollInterval` #1778,
+`SelfUpdate__MinRollInterval` #1925 — here the key was simply never wired), and naming a mechanism
+that does not exist is what stops the next reader from looking at the one that does.
+`ReleaseDeliveryChainGuard` (`test/MeshWeaver.Documentation.Test`) now fails RED for any joint of
+this chain whose configuration key no chart renders.
 
 🚨 **The notify job is a GATE, not a reporter (#2235).** It was written reporter-class — "losing one
 notification costs one delayed rebake wave" — with an input-shaped `if [ -z "$SECRET" ] … exit 0`

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseEventBus.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseEventBus.md
@@ -44,10 +44,29 @@ An event asserts *something happened*; only a query establishes *what is true no
 | **Ingest** | `POST /webhooks/github` — `GitHubWebhookEndpoints`, HMAC-verified (`GitHub:Webhook:Secret`), dispatched by `GitHubWebhookProcessor.Process(eventType, payload)` | **exists** — already switches on `push`, `workflow_run`, `issues`, `issue_comment`; needs a `release` branch |
 | **Storage** | a `Release` node per `(repository, packageId, version)` | to build |
 | **Query** | "are all my dependencies satisfied?" | `ModulePublish` already gates a placement on the module's declared `MinMeshVersion` — the same predicate, widened from one floor to a declared set |
-| **Fan-out** | `FrameworkReleaseBroadcaster` — memex holds the GitHub App and the subscriber list | **exists** |
+| **Fan-out** | `FrameworkReleaseBroadcaster` — memex holds the GitHub App and the subscriber list | **exists, and has never dispatched** — see below |
 
 The ingest surface is not new, which matters: a new public endpoint is a new thing to secure, and
 this one is already HMAC-verified and already routes by event type.
+
+🚨 **"Exists" is not "delivers", and the fan-out is the standing proof (#2235).** The broadcaster
+has been built, unit-tested and DI-registered since 2026-08-23 and has dispatched **zero** events.
+Three joints have to be closed for one release to reach one satellite, and each is silent when it
+is open:
+
+| joint | switched on by | when it is open |
+|---|---|---|
+| the inbox accepts the release event | `WebhookInbox__Targets__N` on the control instance | 404 — byte-identical to a wrong URL |
+| the delivery verifies | `Hosting__PlatformWebhookSecret` | the watcher drops it as unverifiable; the POST already answered 2xx |
+| the verified release fans out | a caller of `Broadcast(...)`, and `FrameworkBroadcast__Subscribers__N` | `0 dispatched, 0 failed` — identical to a mesh that is not the control instance |
+
+Two lessons the rest of this design should inherit. **A key the code reads and no chart renders can
+never be set**, so its feature is permanently off while reading as "off by choice" —
+`FrameworkBroadcast:Subscribers` was in that state, in both repos, for the whole life of the
+feature. And **prose naming a mechanism that does not exist stops the search**: `main-cd.yml` said
+the subscriber set "lives in the Hosting fleet registry", a registry with no node type, no reader
+and no writer anywhere, and that sentence survived two investigations into why nothing arrived.
+`ReleaseDeliveryChainGuard` (`test/MeshWeaver.Documentation.Test`) fails RED on both shapes.
 
 ## The release fact
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-release-broadcast-subscribers-can-be-configured.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-release-broadcast-subscribers-can-be-configured.md
@@ -1,0 +1,23 @@
+---
+Name: A deployment can finally name who gets told about a new release
+Category: Fix
+Description: The subscriber list for the platform-release broadcast is now a real deployment setting, and an instance that receives release events but has nobody to tell says so.
+Icon: Sparkle
+Order: -20260827
+---
+
+# A deployment can finally name who gets told about a new release
+
+When a new platform build ships, the instance that receives it is meant to tell every dependent
+repository straight away, so each rebuilds against the new version in seconds rather than waiting
+for its next scheduled check.
+
+That list of dependents was read from a setting no deployment could actually set — nothing in the
+deployment configuration ever produced it. Every broadcast therefore ran against an empty list and
+reported the same thing an instance with genuinely nobody to tell reports: nothing sent, nothing
+failed. No error, no warning, no dependent ever notified.
+
+The setting is now part of a deployment's configuration, so a list can be given. And the two cases
+no longer look alike: an instance that receives release events and has no list now says so plainly,
+naming the setting to fill in, while an instance that simply is not the one distributing releases
+stays quiet, as it should.

--- a/src/MeshWeaver.GitSync/FrameworkBroadcastOptions.cs
+++ b/src/MeshWeaver.GitSync/FrameworkBroadcastOptions.cs
@@ -2,20 +2,43 @@ namespace MeshWeaver.GitSync;
 
 /// <summary>
 /// Configuration for the <see cref="FrameworkReleaseBroadcaster"/>, bound from the
-/// <c>FrameworkBroadcast</c> configuration section. This is the <b>interim</b> source of the
-/// subscriber set: the durable home is the Hosting fleet's subscriber registry on the control
-/// instance (a repo registers there — "set up a new repo in Hosting"), and the Hosting watcher
-/// passes that list straight to <see cref="FrameworkReleaseBroadcaster.Broadcast"/>. When no list
-/// is passed, the broadcaster falls back to <see cref="Subscribers"/> here so a mesh can be wired
-/// from config alone until the registry is populated.
+/// <see cref="ConfigSection"/> configuration section.
+///
+/// <para>🚨 <b>This is the ONLY source of the subscriber set that exists</b> (#2235). Both
+/// <c>main-cd.yml</c> and the first draft of this file described it as an "interim" fallback whose
+/// durable home was "the Hosting fleet registry on the control instance" — that registry was never
+/// built (there is no subscriber node type in <c>Hosting/</c> and no code anywhere reads one), and
+/// naming a mechanism that does not exist is what stopped four separate investigations from looking
+/// at the seam that does. Until a registry is actually built and its reader ships, a repo is
+/// subscribed by being listed here and by nothing else.</para>
 /// </summary>
 public sealed record FrameworkBroadcastOptions
 {
+    /// <summary>The configuration section this options record binds from.</summary>
+    public const string ConfigSection = "FrameworkBroadcast";
+
+    /// <summary>
+    /// The environment-variable form of the first <see cref="Subscribers"/> slot
+    /// (<c>FrameworkBroadcast__Subscribers__0</c>) — the exact name a deployment sets and the
+    /// chart renders. Named here because a key the code reads and no chart renders cannot be set
+    /// by any deploy, and reads as "deliberately off" rather than as missing.
+    /// </summary>
+    public const string SubscribersEnvKeyPrefix = "FrameworkBroadcast__Subscribers__";
+
+    /// <summary>
+    /// The webhook-inbox target that carries platform-build facts. An instance whose
+    /// <c>WebhookInbox:Targets</c> allowlist contains this path IS the control instance: it
+    /// receives release events and is therefore the one instance for which an empty
+    /// <see cref="Subscribers"/> list is a misconfiguration rather than the normal state.
+    /// </summary>
+    public const string PlatformBuildsTarget = "Hosting/PlatformBuilds";
+
     /// <summary>
     /// The subscriber repositories, each <c>owner/name</c> (a leading
     /// <c>https://github.com/</c> and a trailing <c>.git</c> are tolerated and stripped). Only the
-    /// control instance — the one memex that holds the GitHub App — should carry a non-empty list;
-    /// everywhere else it stays empty and the broadcaster is inert.
+    /// control instance — the one memex that holds the GitHub App and receives platform-build
+    /// deliveries — should carry a non-empty list; everywhere else it stays empty and the
+    /// broadcaster is inert.
     /// </summary>
     public string[] Subscribers { get; init; } = [];
 

--- a/src/MeshWeaver.GitSync/FrameworkReleaseBroadcaster.cs
+++ b/src/MeshWeaver.GitSync/FrameworkReleaseBroadcaster.cs
@@ -3,7 +3,9 @@ using System.Net.Http.Headers;
 using System.Reactive.Linq;
 using System.Text;
 using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -40,6 +42,7 @@ public sealed class FrameworkReleaseBroadcaster
     private readonly IoPoolRegistry ioPools;
     private readonly GitHubAppOptions appOptions;
     private readonly FrameworkBroadcastOptions options;
+    private readonly IConfiguration? configuration;
     private readonly HttpClient http;
     private readonly ILogger? logger;
 
@@ -47,7 +50,11 @@ public sealed class FrameworkReleaseBroadcaster
     /// <param name="tokens">Mints the GitHub App installation token the dispatches authenticate with.</param>
     /// <param name="ioPools">Registry the HTTP I/O pool is resolved from, so every POST runs off the hub.</param>
     /// <param name="appOptions">The App options — reused only for <see cref="GitHubAppOptions.ApiBaseUrl"/> (GHES parity).</param>
-    /// <param name="options">The bound <see cref="FrameworkBroadcastOptions"/> (the config-seam subscriber list + event type).</param>
+    /// <param name="options">The bound <see cref="FrameworkBroadcastOptions"/> (the subscriber list + event type).</param>
+    /// <param name="configuration">The instance configuration — read ONLY to tell a mesh that is not
+    /// the control instance (an empty subscriber list is correct there) from the control instance
+    /// with nobody registered (an empty list there means the wave silently never runs). Optional;
+    /// absent, an empty list is reported as the former.</param>
     /// <param name="logger">Optional logger.</param>
     /// <param name="httpClient">Optional <see cref="HttpClient"/> to reuse; a default one is created when null.</param>
     public FrameworkReleaseBroadcaster(
@@ -55,6 +62,7 @@ public sealed class FrameworkReleaseBroadcaster
         IoPoolRegistry ioPools,
         IOptions<GitHubAppOptions> appOptions,
         IOptions<FrameworkBroadcastOptions> options,
+        IConfiguration? configuration = null,
         ILogger<FrameworkReleaseBroadcaster>? logger = null,
         HttpClient? httpClient = null)
     {
@@ -62,6 +70,7 @@ public sealed class FrameworkReleaseBroadcaster
         this.ioPools = ioPools;
         this.appOptions = appOptions.Value;
         this.options = options.Value;
+        this.configuration = configuration;
         this.logger = logger;
         http = httpClient ?? new HttpClient();
         if (!http.DefaultRequestHeaders.UserAgent.Any())
@@ -107,9 +116,31 @@ public sealed class FrameworkReleaseBroadcaster
         }
         if (repos.Length == 0)
         {
-            logger?.LogInformation(
-                "Framework-release broadcast: no subscribers configured — nothing to dispatch "
-                + "(satellites rebake on their own schedule).");
+            // 🚨 #2235 — THE STATE THAT LOOKED LIKE SUCCESS FOR THREE DAYS. "Nobody to dispatch
+            // to" has two causes that are IDENTICAL in the outcome (0 dispatched, 0 failed), and
+            // telling them apart is the whole defect: on a mesh that does not receive
+            // platform-build deliveries an empty list is the correct, permanent state; on the
+            // CONTROL instance it is a misconfiguration whose only symptom is a wave that never
+            // runs — the release event verifies, the broadcast "succeeds" with zero dispatches,
+            // and nothing anywhere is red. This is the one place in the chain that can see both
+            // facts (the subscriber list AND whether this instance accepts release events), so
+            // it is the one place that can say WHICH happened. The level difference is the
+            // point, not verbosity tuning: it fires once per release, never in a loop.
+            if (AcceptsPlatformBuildDeliveries())
+                logger?.LogWarning(
+                    "Framework-release broadcast: this instance ACCEPTS platform-build deliveries "
+                    + "({Target} is allowlisted in {TargetsKey}) but has NO subscribers, so the "
+                    + "release wave dispatches to nobody and every node repo falls back to its "
+                    + "schedule poll. Set {SubscribersKey}0..N (one owner/name per slot) on this "
+                    + "deployment.",
+                    FrameworkBroadcastOptions.PlatformBuildsTarget,
+                    WebhookInbox.TargetsConfigSection,
+                    FrameworkBroadcastOptions.SubscribersEnvKeyPrefix);
+            else
+                logger?.LogInformation(
+                    "Framework-release broadcast: no subscribers configured and this instance does "
+                    + "not receive platform-build deliveries — nothing to dispatch (satellites "
+                    + "rebake on their own schedule).");
             return Observable.Return(new BroadcastOutcome([]));
         }
 
@@ -137,6 +168,18 @@ public sealed class FrameworkReleaseBroadcaster
                     [.. repos.Select(r => new RepoDispatch(r, false, $"token: {ex.Message}"))]));
             });
     }
+
+    /// <summary>
+    /// Whether THIS instance is the control instance — i.e. its webhook inbox allowlist accepts
+    /// <see cref="FrameworkBroadcastOptions.PlatformBuildsTarget"/>, which is what makes it the
+    /// mesh that receives release events and therefore the one that must have subscribers.
+    /// </summary>
+    private bool AcceptsPlatformBuildDeliveries() =>
+        configuration?.GetSection(WebhookInbox.TargetsConfigSection).GetChildren()
+            .Any(c => string.Equals(
+                WebhookInbox.NormalizeTarget(c.Value),
+                FrameworkBroadcastOptions.PlatformBuildsTarget,
+                StringComparison.OrdinalIgnoreCase)) == true;
 
     // One repo's dispatch, already isolated: a non-2xx status OR a thrown exception both become a
     // RepoDispatch(ok:false), so Concat never short-circuits on the first failure. Invoke, not

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -43,15 +43,19 @@ public static class GitHubSyncConfiguration
             sp.GetService<ILogger<GitHubAppTokenService>>()));
         // Framework-release broadcaster (memex is the broadcast hub): fans a platform release out
         // to the node-repo satellites as repository_dispatch, authenticated with the App above.
-        // The subscriber set is INJECTED by the caller (the Hosting registry) or read from the
-        // FrameworkBroadcast config section as the interim fallback. Inert unless the App is
+        // The subscriber set is either INJECTED by the caller or read from the
+        // FrameworkBroadcast:Subscribers config section — which, until a subscriber registry is
+        // actually built, is the ONLY source that exists (#2235). Inert unless the App is
         // configured, so registering it everywhere is safe — only the control instance has a list.
+        // IConfiguration is passed so an empty list can be reported as what it is: normal on any
+        // other mesh, a silent non-delivery on the instance that receives release events.
         services.AddOptions<FrameworkBroadcastOptions>();
         services.AddSingleton(sp => new FrameworkReleaseBroadcaster(
             sp.GetRequiredService<GitHubAppTokenService>(),
             sp.GetRequiredService<IoPoolRegistry>(),
             sp.GetRequiredService<IOptions<GitHubAppOptions>>(),
             sp.GetRequiredService<IOptions<FrameworkBroadcastOptions>>(),
+            sp.GetService<IConfiguration>(),
             sp.GetService<ILogger<FrameworkReleaseBroadcaster>>()));
         // The production repo client: BULK transfer (push/fetch) over the git protocol — REST
         // paid one request PER FILE, so one big-repo sync exhausted the GitHub App installation's

--- a/test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj
+++ b/test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj
@@ -11,6 +11,11 @@
          READ it (the _complete sentinel, the _releases marker directory), so the guard has to see
          the reader's own constants rather than restate them. -->
     <ProjectReference Include="..\..\src\MeshWeaver.PluginCatalog\MeshWeaver.PluginCatalog.csproj" />
+    <!-- ReleaseDeliveryChainGuard pins the release-broadcast chain's CONFIGURATION KEYS against the
+         constants that read them (FrameworkBroadcastOptions.SubscribersEnvKeyPrefix), for the same
+         reason as above: a guard that restates a key instead of referencing it goes green through
+         the rename it exists to catch. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/MeshWeaver.Documentation.Test/ReleaseDeliveryChainGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ReleaseDeliveryChainGuard.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard for the release-broadcast chain (<c>#2235</c>) — CD's promoted build →
+/// the control instance's webhook inbox → HMAC verify → one <c>repository_dispatch</c> per
+/// subscriber. Every joint of that chain is switched on by a CONFIGURATION KEY, and every one of
+/// them is silent when it is off: an unlisted inbox target answers 404 (identical to a wrong URL),
+/// an empty subscriber set reports <c>0 dispatched, 0 failed</c> (identical to a mesh that is not
+/// the control instance).
+///
+/// <para>🚨 <b>The failure this file exists for.</b> <c>FrameworkBroadcast:Subscribers</c> — the
+/// only source of the subscriber set that exists — was rendered by <b>no chart in either repo</b>
+/// for the whole life of the feature, so no deployment could set it. Every broadcast ran against an
+/// empty set and logged it at <c>Information</c> as normal. Nothing was red, because a key that no
+/// chart renders cannot be distinguished from a key a deployment chose to leave empty. The
+/// companion defect was prose: <c>main-cd.yml</c> and the CD contract both said the set "lives in
+/// the Hosting fleet registry on memex", and no such registry was ever built — so every reader who
+/// went looking for the seam was sent to a mechanism that does not exist.</para>
+///
+/// <para><see cref="PlatformReleaseNotifyGuard"/> pins the SENDER (CD's notify leg cannot skip or
+/// downgrade a failed delivery). This file pins the RECEIVER's provisioning: each joint's key must
+/// be reachable by a deploy, and the key each guard entry names must still be the key the code
+/// reads — which is why the entries reference the readers' constants instead of restating
+/// them.</para>
+/// </summary>
+public class ReleaseDeliveryChainGuard
+{
+    private const string ConfigMap = "deploy/helm/templates/memex-portal/config.yaml";
+    private const string ValuesAks = "deploy/aks/values.aks.yaml";
+    private const string Workflow = ".github/workflows/main-cd.yml";
+    private const string ContractDoc =
+        "src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md";
+
+    /// <summary>
+    /// One joint of the delivery chain: the configuration key that switches it on, in the
+    /// double-underscore environment form a deployment actually sets, plus what silently does not
+    /// happen while the key cannot be set at all.
+    /// </summary>
+    /// <param name="Joint">The joint's name, for the failure message.</param>
+    /// <param name="EnvKey">The env-var form the ConfigMap must render and a values file must declare.</param>
+    /// <param name="Consequence">What is silently lost when no deployment can set the key.</param>
+    private sealed record ChainKey(string Joint, string EnvKey, string Consequence);
+
+    /// <summary>
+    /// The chain's keys, each derived from the CONSTANT its reader owns — never a literal. A
+    /// literal would restate the key, and the guard would then go green through exactly the rename
+    /// it is here to catch (AGENTS.md: a renamed config key is a silent deletion).
+    /// </summary>
+    private static IEnumerable<ChainKey> ChainKeys()
+    {
+        // Joint 1 — CD's signed POST is accepted at all. The inbox is fail-closed: a target
+        // missing from this allowlist answers 404, byte-identical to a wrong URL.
+        yield return new ChainKey(
+            "the webhook inbox accepts the release event",
+            EnvForm(WebhookInbox.TargetsConfigSection) + "__0",
+            "CD's notify-platform-update 404s on every promoted build and no release event ever "
+            + "reaches the mesh");
+
+        // Joint 2 — the verified release fans out. FrameworkBroadcastOptions owns the env-key
+        // prefix precisely so this entry cannot drift from what the broadcaster reads.
+        yield return new ChainKey(
+            "the release wave has subscribers",
+            FrameworkBroadcastOptions.SubscribersEnvKeyPrefix + "0",
+            "every broadcast dispatches to an empty set — 0 dispatched, 0 failed, logged as the "
+            + "normal state of a non-control mesh — so no satellite ever re-bakes promptly");
+    }
+
+    /// <summary>
+    /// 🚨 THE CONTROL. A key the code READS and no chart RENDERS cannot be set by any deployment,
+    /// and its feature is therefore permanently off — while reading exactly like a feature a
+    /// deployment left off on purpose. Both ends are asserted: the ConfigMap must name the key
+    /// (the Deployment's only env path is <c>envFrom</c> on it, and it carries no catch-all range),
+    /// and a values file must declare the slot so an overlay that sets it has something to override.
+    /// </summary>
+    [Fact]
+    public void EveryConfigKeyTheReleaseChainReads_IsRenderedByTheChart()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var configMap = File.ReadAllText(Path.Combine(root, ConfigMap.Replace('/', Path.DirectorySeparatorChar)));
+        var values = File.ReadAllText(Path.Combine(root, ValuesAks.Replace('/', Path.DirectorySeparatorChar)));
+
+        var broken = ChainKeys()
+            .Select(k => (k, inConfigMap: RendersKey(configMap, k.EnvKey), inValues: DeclaresKey(values, k.EnvKey)))
+            .Where(x => !x.inConfigMap || !x.inValues)
+            .ToList();
+
+        Assert.True(broken.Count == 0,
+            "These release-delivery-chain keys cannot be set by ANY deployment — the code reads "
+            + "them and the chart does not render them, so the joint they switch on is "
+            + "permanently off and indistinguishable from one a deployment turned off:\n"
+            + string.Join("\n", broken.Select(x =>
+                $"  • {x.k.EnvKey} ({x.k.Joint}) — "
+                + (x.inConfigMap ? "" : $"not rendered by {ConfigMap}; ")
+                + (x.inValues ? "" : $"no slot declared in {ValuesAks}; ")
+                + $"consequence: {x.k.Consequence}")));
+    }
+
+    /// <summary>
+    /// 🚨 THE COMPANION DEFECT — prose naming a mechanism that does not exist. `main-cd.yml` and the
+    /// CD contract are the two places a reader goes to ask "who is subscribed?", and for the whole
+    /// life of the feature both answered "the Hosting fleet registry on memex" — a registry with no
+    /// node type, no reader and no writer in any repo. That sentence is why the empty subscriber set
+    /// survived two rounds of investigation into why nothing was delivered. Both must name the seam
+    /// that actually exists, so the next reader lands on something they can set.
+    /// </summary>
+    [Fact]
+    public void TheDocumentedSubscriberSource_IsTheOneThatExists()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var section = FrameworkBroadcastOptions.ConfigSection;
+
+        foreach (var file in new[] { Workflow, ContractDoc })
+        {
+            var text = File.ReadAllText(Path.Combine(root, file.Replace('/', Path.DirectorySeparatorChar)));
+            Assert.True(text.Contains(section, StringComparison.Ordinal),
+                $"{file} explains where the release wave's subscribers come from and never names "
+                + $"'{section}' — the only source that exists. It used to name a Hosting fleet "
+                + "registry instead; that registry was never built, and pointing readers at it is "
+                + "what kept #2235's empty subscriber set invisible through two investigations.");
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>A configuration path (<c>A:B</c>) in the env-var form a container receives.</summary>
+    private static string EnvForm(string configPath) => configPath.Replace(":", "__", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The ConfigMap renders the key when it appears as a mapping key whose value interpolates the
+    /// SAME name out of <c>config.memex_portal</c>. Checking both halves is deliberate: a line that
+    /// names the key but interpolates a different one is the #1925 shape wearing the right label.
+    /// </summary>
+    private static bool RendersKey(string configMap, string key) =>
+        configMap.Split('\n').Any(l =>
+        {
+            var t = l.Trim();
+            return !t.StartsWith('#')
+                   && t.StartsWith(key + ":", StringComparison.Ordinal)
+                   && t.Contains("config.memex_portal." + key, StringComparison.Ordinal);
+        });
+
+    /// <summary>A values file declares the slot when it carries the key as a mapping key.</summary>
+    private static bool DeclaresKey(string values, string key) =>
+        values.Split('\n').Any(l =>
+        {
+            var t = l.Trim();
+            return !t.StartsWith('#') && t.StartsWith(key + ":", StringComparison.Ordinal);
+        });
+}

--- a/test/MeshWeaver.Documentation.Test/ReleaseDeliveryChainGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ReleaseDeliveryChainGuard.cs
@@ -38,6 +38,16 @@ public class ReleaseDeliveryChainGuard
     private const string Workflow = ".github/workflows/main-cd.yml";
     private const string ContractDoc =
         "src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md";
+    private const string SecretTemplate = "deploy/aks/envs/example/secretproviderclass.yaml";
+
+    /// <summary>
+    /// The shared HMAC's env key. A literal, unlike every other key here, and the exception is
+    /// worth naming rather than hiding: the constant that reads it
+    /// (<c>PlatformBuildInboxWatcher.SecretConfigKey</c>) lives in MeshWeaver.Plugins, so this
+    /// repository cannot reference it. What this repository DOES own is the template every
+    /// environment's SecretProviderClass is copied from — so that is what is pinned.
+    /// </summary>
+    private const string WebhookSecretEnvKey = "Hosting__PlatformWebhookSecret";
 
     /// <summary>
     /// One joint of the delivery chain: the configuration key that switches it on, in the
@@ -45,9 +55,17 @@ public class ReleaseDeliveryChainGuard
     /// happen while the key cannot be set at all.
     /// </summary>
     /// <param name="Joint">The joint's name, for the failure message.</param>
-    /// <param name="EnvKey">The env-var form the ConfigMap must render and a values file must declare.</param>
+    /// <param name="EnvKeyPrefix">The env-var prefix; slots are this plus <c>0..Slots-1</c>.</param>
+    /// <param name="Slots">
+    /// How many indexed slots a deployment must be able to use. 🚨 EVERY slot is asserted, not just
+    /// <c>__0</c> — this repo's own incident is the reason. memex-cloud cannot use
+    /// <c>WebhookInbox__Targets__0</c> at all (a stray inline <c>env:</c> shadows it permanently),
+    /// so the release target lives on <c>__1</c>; a guard that only checked <c>__0</c> would stay
+    /// green while the one slot the control instance actually depends on disappeared from the
+    /// chart, re-creating the identical silent misconfiguration one index over.
+    /// </param>
     /// <param name="Consequence">What is silently lost when no deployment can set the key.</param>
-    private sealed record ChainKey(string Joint, string EnvKey, string Consequence);
+    private sealed record ChainKey(string Joint, string EnvKeyPrefix, int Slots, string Consequence);
 
     /// <summary>
     /// The chain's keys, each derived from the CONSTANT its reader owns — never a literal. A
@@ -57,18 +75,24 @@ public class ReleaseDeliveryChainGuard
     private static IEnumerable<ChainKey> ChainKeys()
     {
         // Joint 1 — CD's signed POST is accepted at all. The inbox is fail-closed: a target
-        // missing from this allowlist answers 404, byte-identical to a wrong URL.
+        // missing from this allowlist answers 404, byte-identical to a wrong URL. TWO slots,
+        // because index 0 is not the chart's alone to give: the control instance's live Deployment
+        // carries a hand-set inline `env:` for __0 that beats `envFrom` forever, which is why the
+        // release target had to move to __1 (#2352). __1 is the slot that actually carries it.
         yield return new ChainKey(
             "the webhook inbox accepts the release event",
-            EnvForm(WebhookInbox.TargetsConfigSection) + "__0",
+            EnvForm(WebhookInbox.TargetsConfigSection) + "__", 2,
             "CD's notify-platform-update 404s on every promoted build and no release event ever "
             + "reaches the mesh");
 
         // Joint 2 — the verified release fans out. FrameworkBroadcastOptions owns the env-key
-        // prefix precisely so this entry cannot drift from what the broadcaster reads.
+        // prefix precisely so this entry cannot drift from what the broadcaster reads. FOUR slots:
+        // one per node repo in the fan-out (Plugins, Education, Reinsurance, SocialMedia). Losing
+        // the tail slots does not read as an error either — it silently SHRINKS the wave, and the
+        // only evidence is a repo that stops re-baking promptly.
         yield return new ChainKey(
             "the release wave has subscribers",
-            FrameworkBroadcastOptions.SubscribersEnvKeyPrefix + "0",
+            FrameworkBroadcastOptions.SubscribersEnvKeyPrefix, 4,
             "every broadcast dispatches to an empty set — 0 dispatched, 0 failed, logged as the "
             + "normal state of a non-control mesh — so no satellite ever re-bakes promptly");
     }
@@ -88,7 +112,9 @@ public class ReleaseDeliveryChainGuard
         var values = File.ReadAllText(Path.Combine(root, ValuesAks.Replace('/', Path.DirectorySeparatorChar)));
 
         var broken = ChainKeys()
-            .Select(k => (k, inConfigMap: RendersKey(configMap, k.EnvKey), inValues: DeclaresKey(values, k.EnvKey)))
+            .SelectMany(k => Enumerable.Range(0, k.Slots).Select(i => (k, EnvKey: k.EnvKeyPrefix + i)))
+            .Select(x => (x.k, x.EnvKey,
+                inConfigMap: RendersKey(configMap, x.EnvKey), inValues: DeclaresKey(values, x.EnvKey)))
             .Where(x => !x.inConfigMap || !x.inValues)
             .ToList();
 
@@ -97,7 +123,7 @@ public class ReleaseDeliveryChainGuard
             + "them and the chart does not render them, so the joint they switch on is "
             + "permanently off and indistinguishable from one a deployment turned off:\n"
             + string.Join("\n", broken.Select(x =>
-                $"  • {x.k.EnvKey} ({x.k.Joint}) — "
+                $"  • {x.EnvKey} ({x.k.Joint}) — "
                 + (x.inConfigMap ? "" : $"not rendered by {ConfigMap}; ")
                 + (x.inValues ? "" : $"no slot declared in {ValuesAks}; ")
                 + $"consequence: {x.k.Consequence}")));
@@ -128,6 +154,49 @@ public class ReleaseDeliveryChainGuard
         }
     }
 
+    /// <summary>
+    /// 🚨 THE THIRD JOINT, which is provisioned through the OTHER path — a Key Vault secret mounted
+    /// by the CSI driver, not a ConfigMap entry — and is therefore invisible to the ledger above. It
+    /// is the one joint CD structurally cannot see: the inbox stores the delivery and answers 2xx
+    /// whatever the secret is, and the watcher then drops an unverifiable delivery in silence. Every
+    /// environment's SecretProviderClass is copied from this template, so an entry quietly lost here
+    /// propagates into the next environment stood up, and its only symptom is a release wave that
+    /// never starts.
+    /// </summary>
+    [Fact]
+    public void TheSharedHmacIsProvisionedByTheSecretTemplate()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var template = File.ReadAllText(
+            Path.Combine(root, SecretTemplate.Replace('/', Path.DirectorySeparatorChar)));
+
+        // Both halves: the Key Vault object must be FETCHED, and it must be PROJECTED onto the env
+        // key the watcher reads. Either alone is a secret that is mounted nowhere or a key that
+        // names nothing — and both render as a perfectly healthy pod.
+        //
+        // 🚨 Two ways this assertion was written wrong before the reverts were actually RUN, and
+        // both left it permanently green:
+        //   * `Contains` on a key name is satisfied by any LONGER key starting with it, so
+        //     `key: Hosting__PlatformWebhookSecretRENAMED` passed the projection check. Hence
+        //     whole-line matching.
+        //   * the SAME `objectName:` line appears in BOTH blocks, so searching the whole document
+        //     let the projection block satisfy the fetch check — deleting the Key Vault fetch
+        //     outright still passed. Hence each half is searched in its OWN section.
+        // A guard that cannot be shown failing is not a guard.
+        var fetch = SectionBefore(template, "secretObjects:");
+        var projection = SectionFrom(template, "secretObjects:");
+
+        Assert.True(HasLine(fetch, "objectName: Hosting-PlatformWebhookSecret"),
+            $"{SecretTemplate} no longer fetches the platform-build webhook secret from Key Vault. "
+            + "Every environment's SecretProviderClass is copied from this template; without the "
+            + "secret the Hosting watcher drops every release delivery as unverifiable while CD's "
+            + "POST still answers 2xx, so the wave stops with nothing red anywhere (#2235).");
+        Assert.True(HasLine(projection, "key: " + WebhookSecretEnvKey),
+            $"{SecretTemplate} fetches the platform-build webhook secret but no longer projects it "
+            + $"onto {WebhookSecretEnvKey}, so it reaches the container under no name the watcher "
+            + "reads — a mounted secret and an unset one are indistinguishable from inside the pod.");
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
 
     /// <summary>A configuration path (<c>A:B</c>) in the env-var form a container receives.</summary>
@@ -146,6 +215,32 @@ public class ReleaseDeliveryChainGuard
                    && t.StartsWith(key + ":", StringComparison.Ordinal)
                    && t.Contains("config.memex_portal." + key, StringComparison.Ordinal);
         });
+
+    /// <summary>Everything BEFORE the <paramref name="marker"/> line — the CSI driver's Key Vault
+    /// fetch list, which is a different question from what the fetched objects are projected onto.</summary>
+    private static string SectionBefore(string text, string marker)
+    {
+        var i = text.IndexOf("\n  " + marker, StringComparison.Ordinal);
+        Assert.True(i >= 0, $"'{marker}' is gone from {SecretTemplate} — the template's shape changed "
+                            + "and this guard is no longer reading what it claims to read.");
+        return text[..i];
+    }
+
+    /// <summary>Everything from the <paramref name="marker"/> line on — the env projections.</summary>
+    private static string SectionFrom(string text, string marker)
+    {
+        var i = text.IndexOf("\n  " + marker, StringComparison.Ordinal);
+        Assert.True(i >= 0, $"'{marker}' is gone from {SecretTemplate}.");
+        return text[i..];
+    }
+
+    /// <summary>
+    /// The text carries <paramref name="line"/> as a COMPLETE line (whitespace and any YAML list
+    /// dash aside). Whole-line, because <c>Contains</c> on a key name is satisfied by any longer
+    /// key that starts with it — which is precisely the rename these assertions exist to catch.
+    /// </summary>
+    private static bool HasLine(string text, string line) =>
+        text.Split('\n').Any(l => l.Trim().TrimStart('-').Trim() == line);
 
     /// <summary>A values file declares the slot when it carries the key as a mapping key.</summary>
     private static bool DeclaresKey(string values, string key) =>

--- a/test/MeshWeaver.GitSync.Test/FrameworkReleaseBroadcasterTest.cs
+++ b/test/MeshWeaver.GitSync.Test/FrameworkReleaseBroadcasterTest.cs
@@ -11,7 +11,10 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -110,6 +113,91 @@ public class FrameworkReleaseBroadcasterTest
         Assert.Empty(outcome.Results);
     }
 
+    // ── behavior: the CONFIG SEAM — the only source of the subscriber set that exists ────────
+
+    /// <summary>
+    /// 🚨 #2235: <see cref="FrameworkReleaseBroadcaster.BroadcastToConfigured"/> had NO test and NO
+    /// caller, and the key it reads (<c>FrameworkBroadcast:Subscribers</c>) was rendered by no
+    /// chart in either repo — so the one path that turns a release into a wave was unexercised at
+    /// every level at once. This pins that a configured subscriber list actually reaches GitHub.
+    /// </summary>
+    [Fact]
+    public async Task BroadcastToConfigured_DispatchesToEverySubscriberInConfiguration()
+    {
+        var (pem, rsa) = NewKey();
+        using var _ = rsa;
+        var appOptions = new GitHubAppOptions { ClientId = "Iv23liTest", PrivateKey = pem, InstallationId = 7 };
+
+        var dispatched = new List<Uri>();
+        var broadcaster = new FrameworkReleaseBroadcaster(
+            new GitHubAppTokenService(new IoPoolRegistry(), Options.Create(appOptions),
+                httpClient: new HttpClient(TokenHandler())),
+            new IoPoolRegistry(),
+            Options.Create(appOptions),
+            // Exactly what FrameworkBroadcast__Subscribers__0/__1 binds to.
+            Options.Create(new FrameworkBroadcastOptions
+            {
+                Subscribers = ["Systemorph/MeshWeaver.Plugins", "Systemorph/MeshWeaver.Education"],
+            }),
+            httpClient: new HttpClient(new StubHandler(req =>
+            {
+                dispatched.Add(req.RequestUri!);
+                return new HttpResponseMessage(HttpStatusCode.NoContent);
+            })));
+
+        var outcome = await broadcaster.BroadcastToConfigured("3.0.0-rc8.ci.5083")
+            .Timeout(TimeSpan.FromSeconds(10)).ToTask();
+
+        Assert.Equal(2, outcome.Succeeded);
+        Assert.Equal(0, outcome.Failed);
+        Assert.Equal(
+            new[]
+            {
+                "https://api.github.com/repos/Systemorph/MeshWeaver.Plugins/dispatches",
+                "https://api.github.com/repos/Systemorph/MeshWeaver.Education/dispatches",
+            },
+            dispatched.Select(u => u.AbsoluteUri).ToArray());
+    }
+
+    /// <summary>
+    /// 🚨 THE STATE THAT LOOKED LIKE SUCCESS. An empty subscriber set produces the same outcome
+    /// (0 dispatched, 0 failed) whether this mesh simply is not the control instance or IS the
+    /// control instance with nobody registered — and only the second is a defect. The broadcaster
+    /// is the one place that can see both facts, so it must say which one happened: an instance
+    /// whose webhook inbox accepts platform-build deliveries and has no subscribers WARNS, naming
+    /// the key to set.
+    /// </summary>
+    [Fact]
+    public async Task Broadcast_NoSubscribers_OnAnInstanceThatReceivesReleaseEvents_Warns()
+    {
+        var log = new CapturingLogger();
+        var broadcaster = NewInertBroadcaster(log, Configuration(
+            (WebhookInbox.TargetsConfigSection + ":0", FrameworkBroadcastOptions.PlatformBuildsTarget)));
+
+        await broadcaster.Broadcast([]).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+
+        var warning = Assert.Single(log.Entries, e => e.Level == LogLevel.Warning);
+        Assert.Contains(FrameworkBroadcastOptions.SubscribersEnvKeyPrefix, warning.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The other half, and the reason the level is a judgement rather than a blanket warning: on
+    /// every mesh that does NOT receive release events an empty subscriber set is the correct,
+    /// permanent state. Warning there would train people to ignore the line that matters.
+    /// </summary>
+    [Fact]
+    public async Task Broadcast_NoSubscribers_OnAnInstanceThatDoesNot_IsInformationOnly()
+    {
+        var log = new CapturingLogger();
+        var broadcaster = NewInertBroadcaster(log, Configuration(
+            (WebhookInbox.TargetsConfigSection + ":0", "Store/Payments")));
+
+        await broadcaster.Broadcast([]).Timeout(TimeSpan.FromSeconds(5)).ToTask();
+
+        Assert.DoesNotContain(log.Entries, e => e.Level >= LogLevel.Warning);
+        Assert.Contains(log.Entries, e => e.Level == LogLevel.Information);
+    }
+
     // ── behavior: per-repo isolation — one failure does not abort the others ──
 
     [Fact]
@@ -172,6 +260,44 @@ public class FrameworkReleaseBroadcasterTest
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>A broadcaster with a usable App identity whose only variable is configuration —
+    /// used by the two empty-subscriber-set tests, which never reach an HTTP call.</summary>
+    private static FrameworkReleaseBroadcaster NewInertBroadcaster(
+        ILogger<FrameworkReleaseBroadcaster> logger, IConfiguration configuration)
+    {
+        var (pem, rsa) = NewKey();
+        rsa.Dispose();
+        var appOptions = new GitHubAppOptions { ClientId = "Iv23liTest", PrivateKey = pem, InstallationId = 1 };
+        return new FrameworkReleaseBroadcaster(
+            NewTokenService(appOptions), new IoPoolRegistry(), Options.Create(appOptions),
+            Options.Create(new FrameworkBroadcastOptions()), configuration, logger);
+    }
+
+    private static IConfiguration Configuration(params (string Key, string Value)[] entries) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(entries.Select(e => new KeyValuePair<string, string?>(e.Key, e.Value)))
+            .Build();
+
+    private static StubHandler TokenHandler() => new(req =>
+        req.RequestUri!.AbsolutePath.EndsWith("/access_tokens", StringComparison.Ordinal)
+            ? Json(HttpStatusCode.Created,
+                $"{{\"token\":\"ghs_test\",\"expires_at\":\"{DateTimeOffset.UtcNow.AddMinutes(50):o}\"}}")
+            : throw new InvalidOperationException($"unexpected token call {req.RequestUri}"));
+
+    /// <summary>Captures what the broadcaster reported — the level IS the assertion here.</summary>
+    private sealed class CapturingLogger : ILogger<FrameworkReleaseBroadcaster>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception)));
+    }
 
     private static GitHubAppTokenService NewTokenService(GitHubAppOptions options) =>
         new(new IoPoolRegistry(), Options.Create(options));


### PR DESCRIPTION
## The finding

The webhook-target shadow fixed in #2352 + Memex `47d6c73` is **one of three joints** in the
release-delivery chain. Closing it does not make the wave deliver, and the live control instance
says so in one screen — `kubectl -n memex-cloud exec … printenv`, the diagnostic AGENTS.md
prescribes because nothing in the helm chain ever inspects a pod's *resolved* environment:

| where | `WebhookInbox__Targets__0` |
|---|---|
| ConfigMap `memex-portal-config` | `Hosting/PlatformBuilds` ✅ what helm rendered |
| Deployment inline `env:` | `Store/Payments` ← explicit `env:` beats `envFrom`, forever |
| **the running pod** | `Store/Payments` ❌ still 404s |

…and, from the same probe:

```
Hosting__PlatformWebhookSecret = <set, non-empty>     ← this joint IS closed
WebhookInbox__Targets__1        ABSENT                ← #2352 + 47d6c73 not deployed yet
FrameworkBroadcast__Subscribers__*  ABSENT ENTIRELY   ← this PR
```

### Three joints, each silent when it is open

| joint | switched on by | state today | what it reports when open |
|---|---|---|---|
| the inbox accepts the release event | `WebhookInbox__Targets__N` | **merged, NOT deployed** (Memex #116 drift sentinel) | 404 — byte-identical to a wrong URL |
| the delivery verifies | `Hosting__PlatformWebhookSecret` | **closed** (verified on the pod) | watcher drops it; the POST already answered 2xx |
| the verified release fans out | a caller of `Broadcast(…)` **and** `FrameworkBroadcast__Subscribers__N` | **both open** | `0 dispatched, 0 failed` — identical to a non-control mesh |

**So `47d6c73` alone would not have delivered.** After it deploys, the `MW_IMAGE_DIGEST` pin-bump
PRs *should* start appearing (joints 1+2 are then closed and `PlatformPinUpdater` does not need the
broadcaster) while `repository_dispatch` runs still will **not** — that asymmetry is the cleanest
available discriminator between the two halves.

## What this PR fixes: the subscriber set had no source at all

`FrameworkReleaseBroadcaster` reads its subscriber set from `FrameworkBroadcast:Subscribers`, and
**no chart in either repo has ever rendered that key** — not `deploy/helm`, not `values.aks.yaml`,
not any overlay in the private deploy repo (`git grep FrameworkBroadcast` → zero hits in both). No
deployment could set it, so every broadcast ran against an empty set and logged it at
`Information` as the correct state of a mesh that is not the control instance. The same
silent-deletion shape as `SelfUpdate__PollInterval` (#1778) and `SelfUpdate__MinRollInterval`
(#1925) — except this key was never wired at all rather than renamed out from under one.

It survived two investigations because the **prose named a mechanism that does not exist**:
`main-cd.yml` and the CD contract both said the set *"lives in the Hosting fleet registry on
memex."* There is no subscriber node type under `Hosting/` (checked the live mesh) and no code in
any repo reads one. Every reader who went looking for the seam was sent where there was nothing.

- render `FrameworkBroadcast__Subscribers__0..3` in the ConfigMap; declare the slots in `values.aks.yaml`
- the broadcaster now says **which** empty set it is looking at: an instance whose inbox accepts
  `Hosting/PlatformBuilds` **is** the control instance, so an empty list there is a misconfiguration
  whose only symptom is a wave that never runs — it warns naming the key, while every other mesh
  keeps the quiet `Information` line it should have. This is the one place in the chain that can
  see both facts at once
- correct `main-cd.yml`, `ContinuousDeliveryContract.md`, `ReleaseEventBus.md` to name the seam that
  exists, and record the three joints

## The control — and proof it can fail

`ReleaseDeliveryChainGuard` (`test/MeshWeaver.Documentation.Test`) goes **RED** when a key the chain
*reads* is rendered by no chart, and when the two files a reader consults stop naming the subscriber
source that exists. Each key is derived from **the constant its reader owns**, never a literal — a
guard that restates a key goes green through exactly the rename it exists to catch.

Every control demonstrated failing, then green again on restore:

| revert | result |
|---|---|
| drop the ConfigMap line | RED — *"cannot be set by ANY deployment … the joint they switch on is permanently off"* |
| drop the `values.aks.yaml` slot | RED — *"no slot declared in deploy/aks/values.aks.yaml"* |
| rename the workflow away from the seam | RED — *"never names 'FrameworkBroadcast' — the only source that exists"* |
| neuter the control-instance check | RED — the warn test fails |

`BroadcastToConfigured` also gets its first test: the config seam had **no test and no caller**, so
the one path turning a release into a wave was unexercised at every level simultaneously.

## Explicitly NOT fixed here

`FrameworkReleaseBroadcaster.Broadcast()` still has **no caller in any repo**. MeshWeaver.Plugins#660
wired it and was reverted: in-mesh source compiles against the newest *published* framework
(`v3.0.0-rc7`, 2026-08-22) and the broadcaster landed 2026-08-23, so the pack lane fails CS0246 and
takes every package in that repo with it. That re-land belongs to the change that raises the floor,
and forcing it now would be the band-aid the rules forbid.

**#2235 stays open on its close condition** — a `repository_dispatch` run on the satellites plus the
`MW_IMAGE_DIGEST` bump PRs. This PR does not claim to satisfy it; it makes the joint it fixes
impossible to leave open silently again.

Refs #2235

🤖 Generated with [Claude Code](https://claude.com/claude-code)