### PR TITLE
fix(#2423): the test harness stops driving the mesh through the ROUTER

### DIFF
--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -974,9 +974,19 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
 
     /// <summary>
     /// Test-only Task wrapper around <see cref="MessageHubExtensions.Observe{TResponse}"/>:
-    /// posts <paramref name="request"/> via <paramref name="hub"/> (defaults to <see cref="Mesh"/>)
-    /// and awaits the typed response, propagating <see cref="DeliveryFailureException"/> /
-    /// <see cref="TimeoutException"/> as the awaited Task's exception.
+    /// posts <paramref name="request"/> via <paramref name="hub"/> (defaults to
+    /// <see cref="RequestHub"/>, NOT <see cref="Mesh"/> — see that property for why the router must
+    /// not be an end of the delivery) and awaits the typed response, propagating
+    /// <see cref="DeliveryFailureException"/> / <see cref="TimeoutException"/> as the awaited Task's
+    /// exception.
+    /// <para>
+    /// 🚨 The default hub is a CLIENT, so a TARGET-LESS request is delivered to that client, which
+    /// has no handlers. Node CRUD must therefore name its target —
+    /// <c>o =&gt; o.WithTarget(RequestHub.NodeOperationTarget())</c>, or use
+    /// <see cref="ObserveNodeOperation{TResponse}"/>. Before #2423 the default was <see cref="Mesh"/>
+    /// and a target-less request silently EXECUTED on the router's action block, which is the
+    /// starvation shape the <c>ROUTER_TRAFFIC</c> detector exists to surface.
+    /// </para>
     /// <para>
     /// Use ONLY in test code — production hub handlers / click actions / services MUST stay
     /// on the observable form (<c>hub.Observe(request).Subscribe(...)</c>). The Task return
@@ -1009,7 +1019,7 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     {
         try
         {
-            return await (hub ?? Mesh).Observe(request, options)
+            return await (hub ?? RequestHub).Observe(request, options)
                 .FirstAsync()
                 .ToTask(ct ?? TestContext.Current.CancellationToken);
         }
@@ -1145,8 +1155,93 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
         return client;
     }
 
+    private IMessageHub? _requestHub;
+    private readonly object _requestHubLock = new();
+
+    /// <summary>
+    /// 🚨 The DEFAULT request origin for a test that addresses a NODE — use this, never
+    /// <see cref="Mesh"/>. One lazily-created <see cref="GetClient"/> client hub per test method,
+    /// disposed with the rest at teardown.
+    ///
+    /// <para><see cref="Mesh"/> resolves the ROOT <c>mesh/{id}</c> hub — the mesh's ROUTER.
+    /// <c>Mesh.Observe(request, o =&gt; o.WithTarget(new Address(nodePath)))</c> therefore makes the
+    /// router an END of the delivery in BOTH directions: the request goes out stamped
+    /// <c>Sender = mesh/{id}</c> and its response is addressed straight back at <c>mesh/{id}</c>.
+    /// That is exactly what the <c>ROUTER_TRAFFIC</c> detector reports
+    /// (<c>RouterTrafficRule.RoleOf</c>), and because the detector fires once per
+    /// role+message-type it costs every affected test class two <c>[Error]</c> lines — errors that
+    /// everyone learns to ignore, which is how a real router-starvation report gets missed (#2423).
+    /// It is also the wrong SHAPE: no production caller drives the mesh from the router. Requests
+    /// come from an MCP session hub, the Blazor portal hub, a layout-area hub, a per-node hub — a
+    /// hub whose traffic the router merely FORWARDS. This client hub is the test-side equivalent,
+    /// and the router is then only a hop, which the detector deliberately does not report.</para>
+    ///
+    /// <para>Two shapes do NOT use this property directly. A test whose subject IS the router —
+    /// the mesh hub's own drain, or its callback bookkeeping — keeps using <see cref="Mesh"/>, and
+    /// says so at the site. Node CRUD uses <see cref="ObserveNodeOperation{TResponse}"/>: it needs
+    /// an explicit target as well as a non-router origin, because a target-less delivery is handled
+    /// by the POSTING hub and this one is a client with no handlers.</para>
+    ///
+    /// <para>Sibling of the private <c>ReadHub</c>, which makes the same argument for single-node
+    /// reads. A test that needs a client with extra wiring (<c>AddData()</c>, a layout client, a
+    /// second isolated identity) still calls <see cref="GetClient"/> directly — this property is
+    /// the default, not the only option; classes that need it wired differently override
+    /// <see cref="ConfigureClient"/>.</para>
+    /// </summary>
+    protected IMessageHub RequestHub
+    {
+        get
+        {
+            lock (_requestHubLock)
+                return _requestHub ??= GetClient();
+        }
+    }
+
+    /// <summary>
+    /// Issues a NODE-CRUD request (<c>CreateNodeRequest</c>, <c>CreateNodesRequest</c>,
+    /// <c>CreateOrUpdateNodeRequest</c>, <c>DeleteNodeRequest</c>, <c>MoveNodeRequest</c>,
+    /// <c>CopyNodeRequest</c>) exactly as production does: posted from a client hub and ADDRESSED at
+    /// <see cref="MeshExtensions.NodeOperationTarget"/> — the mesh's dedicated
+    /// <c>portal/nodeops-{meshId}</c> execution hub.
+    ///
+    /// <para>🚨 Node CRUD is the one shape where "not the router" is not enough. A test used to
+    /// either aim it at <c>Mesh.Address</c> or leave it TARGET-LESS, and a target-less delivery is
+    /// handled by the POSTING hub — both of which ran the write on the router's single-threaded
+    /// action block. A burst there starves the routing the mesh hub exists to do (prod 2026-06-11:
+    /// "11× CreateOrUpdateNodeRequest + 3× CreateNodeRequest@mesh/&lt;self&gt; stale &gt;60s while
+    /// real user SubscribeRequests starved"). <c>MeshService</c> stopped doing that; this helper is
+    /// how a test that posts the raw request stops too. Both ends of the resulting delivery are the
+    /// nodeops hub, so nothing about it touches the router — the shape
+    /// <c>NodeOperationOriginTest</c> pins by reading <c>RouterTrafficRule.RoleOf</c> over a real
+    /// delivery.</para>
+    ///
+    /// <para>Cold: the underlying <c>Observe</c> posts on CALL, so the request is issued when this
+    /// method runs, and the returned observable replays the response to any later subscriber.</para>
+    /// </summary>
+    /// <typeparam name="TResponse">The response type declared by <paramref name="request"/>.</typeparam>
+    /// <param name="request">The node-operation request.</param>
+    /// <param name="options">
+    /// Optional further delivery configuration (an explicit <c>AccessContext</c>, properties). It is
+    /// applied AFTER the target, so a caller that genuinely needs a different target can still
+    /// override it.
+    /// </param>
+    /// <returns>The response delivery observable.</returns>
+    protected IObservable<IMessageDelivery<TResponse>> ObserveNodeOperation<TResponse>(
+        IRequest<TResponse> request,
+        Func<PostOptions, PostOptions>? options = null)
+    {
+        var hub = RequestHub;
+        var target = hub.NodeOperationTarget();
+        return hub.Observe(request, o =>
+        {
+            o = o.WithTarget(target);
+            return options is null ? o : options(o);
+        });
+    }
+
     private void DisposeTestClients(string testName, Stopwatch sw)
     {
+        lock (_requestHubLock) _requestHub = null;
         IMessageHub[] snapshot;
         lock (_clientsCreated)
         {

--- a/test/MeshWeaver.AI.Test/ActivityLogStreamTest.cs
+++ b/test/MeshWeaver.AI.Test/ActivityLogStreamTest.cs
@@ -73,7 +73,7 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
 
         // Dispatch via ExecuteScriptRequest; capture the ActivityLog path from the
         // response. That path points at the activity node the Code hub just created.
-        var exec = (await Mesh.Observe(
+        var exec = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(path)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -134,7 +134,7 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
 
         var gatePath = await ProgressGate.Seed(mesh, ScriptsPartition);
 
-        var exec = (await Mesh.Observe(
+        var exec = (await RequestHub.Observe(
             new ExecuteScriptRequest { Inputs = ProgressGate.Inputs(gatePath) },
             o => o.WithTarget(new Address(path)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -201,7 +201,7 @@ public class ActivityLogStreamTest : MonolithMeshTestBase
             }
         }).Should().Within(30.Seconds()).Emit();
 
-        var exec = (await Mesh.Observe(
+        var exec = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(path)))
             .Should().Within(60.Seconds()).Emit()).Message;

--- a/test/MeshWeaver.AI.Test/CodeCellLayoutTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellLayoutTest.cs
@@ -170,7 +170,7 @@ public class CodeCellLayoutTest(ITestOutputHelper output) : MonolithMeshTestBase
                 && HasArea(s, CodeLayoutAreas.CellArea)))!;
         var cellArea = FindArea(root, CodeLayoutAreas.CellArea);
 
-        var exec = (await Mesh.Observe(
+        var exec = (await RequestHub.Observe(
                 new ExecuteScriptRequest(),
                 o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;

--- a/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
@@ -85,7 +85,7 @@ public class CodeCellOutputCaptureTest(ITestOutputHelper output) : MonolithMeshT
 
     private async Task<string> RunScript(string codePath)
     {
-        var exec = (await Mesh.Observe(
+        var exec = (await RequestHub.Observe(
                 new ExecuteScriptRequest(),
                 o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;

--- a/test/MeshWeaver.AI.Test/CollaborationPluginGrainFailureTest.cs
+++ b/test/MeshWeaver.AI.Test/CollaborationPluginGrainFailureTest.cs
@@ -55,7 +55,7 @@ public class CollaborationPluginGrainFailureTest(ITestOutputHelper output) : Mon
 
         // The observable must ERROR (routing fails fast). Materialize folds the
         // OnError into a value so we assert it reactively — no await, no ThrowAsync.
-        var notification = await Mesh.Observe(new CreateCommentRequest
+        var notification = await RequestHub.Observe(new CreateCommentRequest
                 {
                     DocumentId = "NonExistent/Document/definitely-not-here",
                     SelectedText = "foo",

--- a/test/MeshWeaver.AI.Test/McpImmediateFailureObservationTest.cs
+++ b/test/MeshWeaver.AI.Test/McpImmediateFailureObservationTest.cs
@@ -60,7 +60,7 @@ public class McpImmediateFailureObservationTest(ITestOutputHelper output) : Mono
         // Observe(request, options) posts EAGERLY and registers the response subject
         // BEFORE the post. Hold the returned observable WITHOUT subscribing.
         var deletedAddress = new Address($"{TestPartition}/{doomedId}");
-        var pending = Mesh.Observe(
+        var pending = RequestHub.Observe(
             new MoveNodeRequest($"{TestPartition}/{doomedId}", $"{TestPartition}/dest-{Guid.NewGuid():N}"),
             o => o.WithTarget(deletedAddress));
 
@@ -70,8 +70,8 @@ public class McpImmediateFailureObservationTest(ITestOutputHelper output) : Mono
         // this is the interleaving in which the old Post-then-Observe(delivery)
         // shape had already dropped it.
         var fenceAddress = new Address($"{TestPartition}/{fenceId}");
-        await Mesh.Observe(new PingRequest(), o => o.WithTarget(fenceAddress)).Should().Emit();
-        await Mesh.Observe(new PingRequest(), o => o.WithTarget(fenceAddress)).Should().Emit();
+        await RequestHub.Observe(new PingRequest(), o => o.WithTarget(fenceAddress)).Should().Emit();
+        await RequestHub.Observe(new PingRequest(), o => o.WithTarget(fenceAddress)).Should().Emit();
 
         // LATE subscribe: the buffered terminal event must still be delivered —
         // as a response (Move handler answering Success=false) or as an error

--- a/test/MeshWeaver.AI.Test/MultiLanguageCodeExecutionTest.cs
+++ b/test/MeshWeaver.AI.Test/MultiLanguageCodeExecutionTest.cs
@@ -82,7 +82,7 @@ public class MultiLanguageCodeExecutionTest(ITestOutputHelper output) : Monolith
             }
         }).Should().Within(30.Seconds()).Emit();
 
-        var exec = (await Mesh.Observe(new ExecuteScriptRequest(), o => o.WithTarget(new Address($"{Partition}/{id}")))
+        var exec = (await RequestHub.Observe(new ExecuteScriptRequest(), o => o.WithTarget(new Address($"{Partition}/{id}")))
             .Should().Within(60.Seconds()).Emit()).Message;
         exec.Success.Should().BeTrue(exec.Error ?? "exec failed");
 
@@ -116,7 +116,7 @@ public class MultiLanguageCodeExecutionTest(ITestOutputHelper output) : Monolith
             }
         }).Should().Within(30.Seconds()).Emit();
 
-        var exec = (await Mesh.Observe(new ExecuteScriptRequest(), o => o.WithTarget(new Address($"{Partition}/{id}")))
+        var exec = (await RequestHub.Observe(new ExecuteScriptRequest(), o => o.WithTarget(new Address($"{Partition}/{id}")))
             .Should().Within(60.Seconds()).Emit()).Message;
         // The run STARTS (the ActivityLog is created); the no-worker failure surfaces on that log,
         // exactly like an in-process C# script error does.
@@ -185,7 +185,7 @@ public class MultiLanguageCodeExecutionTest(ITestOutputHelper output) : Monolith
             Content = new CodeConfiguration { Language = language, IsExecutable = true, Code = "run" }
         }).Should().Within(30.Seconds()).Emit();
 
-        var exec = (await Mesh.Observe(new ExecuteScriptRequest(), o => o.WithTarget(new Address($"{Partition}/{id}")))
+        var exec = (await RequestHub.Observe(new ExecuteScriptRequest(), o => o.WithTarget(new Address($"{Partition}/{id}")))
             .Should().Within(60.Seconds()).Emit()).Message;
         exec.Success.Should().BeTrue(exec.Error ?? "exec failed");
 

--- a/test/MeshWeaver.AI.Test/PatchDataRequestTest.cs
+++ b/test/MeshWeaver.AI.Test/PatchDataRequestTest.cs
@@ -70,14 +70,14 @@ public class PatchDataRequestTest : MonolithMeshTestBase
         // Post the PatchDataRequest with only { name: "Patched" } — the hub handler
         // applies this as a merge patch on its own MeshNode workspace stream.
         var patchJson = JsonSerializer.Serialize(new { name = "Patched" });
-        var patchResp = (await Mesh.Observe(
+        var patchResp = (await RequestHub.Observe(
             new PatchDataRequest(new MeshNodeReference(), new RawJson(patchJson)),
             o => o.WithTarget(new Address(path)))
             .Should().Emit()).Message;
         patchResp.Success.Should().BeTrue(patchResp.Error ?? "no error provided");
 
         // Round-trip: GetDataRequest on MeshNodeReference must see the merged state.
-        var getResponse = await Mesh.Observe(
+        var getResponse = await RequestHub.Observe(
             new GetDataRequest(new MeshNodeReference()),
             o => o.WithTarget(new Address(path)))
             .Should().Emit();
@@ -112,7 +112,7 @@ public class PatchDataRequestTest : MonolithMeshTestBase
         var path = $"ACME/{id}";
 
         // Intervening write (no base ⇒ applies last-write-wins): uppercase word 1, Quantity 1 → 5.
-        (await Mesh.Observe(
+        (await RequestHub.Observe(
             new PatchDataRequest(new MeshNodeReference(),
                 new RawJson("""{"name":"HELLO world","content":{"quantity":5}}""")),
             o => o.WithTarget(new Address(path))).Should().Emit())
@@ -120,7 +120,7 @@ public class PatchDataRequestTest : MonolithMeshTestBase
 
         // Reordered/stale patch: computed against the ORIGINAL base ("hello world", quantity 1).
         // It uppercases word 2 and tries to set Quantity 9.
-        (await Mesh.Observe(
+        (await RequestHub.Observe(
             new PatchDataRequest(new MeshNodeReference(),
                 new RawJson("""{"name":"hello WORLD","content":{"quantity":9}}"""))
             {
@@ -129,7 +129,7 @@ public class PatchDataRequestTest : MonolithMeshTestBase
             o => o.WithTarget(new Address(path))).Should().Emit())
             .Message.Success.Should().BeTrue();
 
-        var node = (await Mesh.Observe(new GetDataRequest(new MeshNodeReference()),
+        var node = (await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()),
             o => o.WithTarget(new Address(path))).Should().Emit()).Message.Data as MeshNode;
         node.Should().NotBeNull();
         node!.Name.Should().Be("HELLO WORLD",

--- a/test/MeshWeaver.AI.Test/ScriptExecutionInUserHomeTest.cs
+++ b/test/MeshWeaver.AI.Test/ScriptExecutionInUserHomeTest.cs
@@ -69,7 +69,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
         var (codePath, mesh) = await SeedExecutableCode(FireworksScript);
 
         // Fire ExecuteScriptRequest. Response carries the activity path.
-        var execMessage = (await Mesh.Observe(
+        var execMessage = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -151,7 +151,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
         var (codePath, mesh) = await SeedExecutableCode(GatedFireworksScript);
         var gatePath = await ProgressGate.Seed(mesh, UserHome);
 
-        var execMessage = (await Mesh.Observe(
+        var execMessage = (await RequestHub.Observe(
             new ExecuteScriptRequest { Inputs = ProgressGate.Inputs(gatePath) },
             o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -243,7 +243,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
             "should not get here"
         """);
 
-        var execMessage = (await Mesh.Observe(
+        var execMessage = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -297,7 +297,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
     public async Task DefaultActivityParent_IsPartitionRoot()
     {
         var (codePath, _) = await SeedExecutableCode("\"hi\"");
-        var respMessage = (await Mesh.Observe(
+        var respMessage = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -334,7 +334,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
             }
         }).Should().Within(30.Seconds()).Emit();
 
-        var respMessage = (await Mesh.Observe(
+        var respMessage = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(path)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -354,7 +354,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
     public async Task CodeNode_StampsLastExecutionFields()
     {
         var (codePath, _) = await SeedExecutableCode("\"x\"");
-        var respMessage = (await Mesh.Observe(
+        var respMessage = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -397,7 +397,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
             $"erf(1) = {SpecialFunctions.Erf(1.0):F6}"
         """);
 
-        var execMessage = (await Mesh.Observe(
+        var execMessage = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -461,7 +461,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
             $"icon-id:{icon.Id}"
         """);
 
-        var execMessage = (await Mesh.Observe(
+        var execMessage = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -500,7 +500,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
         var (codePath, _) = await SeedExecutableCode(
             "Log.LogInformation(\"first run\");\n1");
 
-        var firstMessage = (await Mesh.Observe(
+        var firstMessage = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -510,7 +510,7 @@ public class ScriptExecutionInUserHomeTest(ITestOutputHelper output) : MonolithM
         // Wait for first run to complete so the test isn't racing the second submit.
         await WaitForCompletion(firstActivity);
 
-        var secondMessage = (await Mesh.Observe(
+        var secondMessage = (await RequestHub.Observe(
             new ExecuteScriptRequest(),
             o => o.WithTarget(new Address(codePath)))
             .Should().Within(60.Seconds()).Emit()).Message;

--- a/test/MeshWeaver.Data.Test/StreamRouteSelfParentTerminationTest.cs
+++ b/test/MeshWeaver.Data.Test/StreamRouteSelfParentTerminationTest.cs
@@ -53,6 +53,9 @@ public class StreamRouteSelfParentTerminationTest(ITestOutputHelper output) : Hu
             + "makes RouteStreamMessage's walk non-terminating");
 
         // Warm up: prove the drain is live (and initialization has completed) before the poison.
+        // 🚨 Both Pings address the ROUTER on purpose — do NOT move them to a client hub (#2423).
+        // What is under test is the mesh hub's OWN drain staying responsive, so the mesh hub has to
+        // be the target; the ROUTER_TRAFFIC line this emits reports exactly what the test intends.
         (await Mesh.Observe(new Ping(), o => o.WithTarget(Mesh.Address))
             .Should().Within(15.Seconds()).Emit())
             .Message.Should().BeOfType<Pong>();

--- a/test/MeshWeaver.Documentation.Test/RouterAsTestRequestOriginRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/RouterAsTestRequestOriginRatchetGuard.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance ratchet for the router-as-request-origin defect class (#2423): a test may not issue a
+/// request/response exchange FROM the root mesh hub at a new site.
+///
+/// <para><b>Why this is a defect and not a style preference.</b> <c>MonolithMeshTestBase.Mesh</c> (and
+/// <c>HubTestBase.Mesh</c>) resolve the ROOT <c>mesh/{id}</c> hub — the mesh's ROUTER.
+/// <c>Mesh.Observe(request, o =&gt; o.WithTarget(new Address(nodePath)))</c> therefore makes the router
+/// an END of the delivery in BOTH directions: the request leaves stamped <c>Sender = mesh/{id}</c> and
+/// the response is addressed straight back at <c>mesh/{id}</c>. <c>RouterTrafficRule.RoleOf</c> reports
+/// both, so every affected test class logs two <c>[Error]</c> lines — and a channel that errors on
+/// ordinary test traffic is a channel people learn to skip, which is how a real router-starvation
+/// report (prod 2026-06-11: node-CRUD bursts starving <c>SubscribeRequest</c>) goes unread. It is also
+/// the wrong SHAPE: no production caller drives the mesh from the router — requests come from an MCP
+/// session hub, the Blazor portal hub, a layout-area hub, a per-node hub, all of which the router
+/// merely FORWARDS (a hop, which the detector deliberately does not report).</para>
+///
+/// <para><b>The fix at a site</b> is <c>MonolithMeshTestBase.RequestHub</c> — one lazily-created client
+/// hub per test method — for anything addressing a NODE, and
+/// <c>MonolithMeshTestBase.ObserveNodeOperation</c> for node CRUD, which additionally aims the
+/// request at <c>NodeOperationTarget()</c>: the production seam <c>MeshService</c> uses and
+/// <c>NodeOperationOriginTest</c> pins.</para>
+///
+/// <para><b>Why the file is seeded rather than empty.</b> Four files are LEGITIMATE and are expected
+/// to stay: in each, the router is the SUBJECT of the test rather than its transport.
+/// <c>RouterTrafficDetectorTest</c> asserts the detector still FIRES for a mesh-hub sender — it must
+/// produce the shape. <c>StreamRouteSelfParentTerminationTest</c> asserts the mesh hub's own drain
+/// stays responsive after a poison StreamMessage, so the mesh hub has to be the target.
+/// <c>UpsertInnerCreateObservationTest</c> pins the #981 leak, which is literally a self-targeted
+/// <c>CreateNodeRequest@mesh/&lt;self&gt;</c> whose reply the router's own <c>HandleCallbacks</c>
+/// drops. <c>ShutdownRoutingRejectClassificationTest</c> depends on an ORDERING on the router's
+/// action block — stall, then probe, then <c>Dispose()</c> — that a routed hop from a client hub
+/// would no longer guarantee. Each carries a 🚨 comment at the site saying so.</para>
+///
+/// <para><b>Deliberately NOT matched, and why each is a separate job.</b>
+/// <list type="bullet">
+///   <item><c>Mesh.Post(...)</c> — fire-and-forget from the router covers genuine routing duties (a
+///     <c>HeartBeatEvent</c>, which <c>RouterTrafficRule</c> itself excludes; a
+///     <c>DisposeRequest</c> to a hub the mesh hosts) alongside real violations (a target-less
+///     <c>TrackActivityRequest</c>, which EXECUTES on the router's action block). One marker cannot
+///     tell them apart, and a ratchet that fires on the router's actual job is the one that gets
+///     muted — the same argument <c>ReportRouterTraffic</c> makes for keying on the delivery's ends
+///     rather than the handling hub.</item>
+///   <item><c>client.Observe(req, o =&gt; o.WithTarget(Mesh.Address))</c> — the TARGET half. The
+///     origin is already off the router, but the request still executes ON it, so the detector
+///     reports the <c>"target"</c> role. ~60 such sites remain (mostly node CRUD in
+///     <c>RlsIntegrationTests</c> and <c>MeshWeaver.Threading.Test</c>); retargeting them at
+///     <c>NodeOperationTarget()</c> moves execution onto a hub with a different permission surface,
+///     which is a judgement call per security assertion rather than a rename.</item>
+/// </list>
+/// Both are tracked on #2423 for a follow-up.</para>
+///
+/// <para><b>The ratchet may only SHRINK.</b> A new file, a raised count, or a raised TOTAL is a
+/// failure. A stale line (its site was migrated) is reported, not failed — a gate that reds
+/// <c>main</c> on the direction it is asking for teaches people to stop shrinking. Delete the stale
+/// line and lower <see cref="TotalBudget"/> in the same change.</para>
+/// </summary>
+public class RouterAsTestRequestOriginRatchetGuard(ITestOutputHelper output)
+{
+    /// <summary>
+    /// The seeded inventory's size. Per-file entries stop a new site in a file that already carries
+    /// the shape; this stops the list as a WHOLE from growing — including by the trick of adding a
+    /// new file's line. Lower it whenever you delete or lower an entry.
+    /// </summary>
+    private const int TotalBudget = 6;
+
+    /// <summary>
+    /// <c>test/</c> only. In <c>src/</c> the same shape is already handled by the shared
+    /// <c>MeshExtensions.NodeOperationIssuingHub</c> seam, which hops a root-hub caller off the
+    /// router; this guard exists because the test harness was treated as exempt.
+    /// </summary>
+    private static readonly string[] ScannedRoots = ["test"];
+
+    /// <summary>
+    /// Both spellings of the request/response entry point — the non-generic
+    /// <c>Observe(request, options)</c> and the explicit <c>Observe&lt;TResponse&gt;(...)</c> — and
+    /// tolerant of the line break C# style puts between the receiver and the call.
+    ///
+    /// <para>🚨 Both tolerances were LEARNED, not guessed. #2423's inventory grepped the contiguous
+    /// <c>Mesh.Observe(</c>; over <c>test/</c> that finds 56 of the 85 sites this regex finds, so a
+    /// substring marker missed <b>29</b> — <c>Mesh.Observe&lt;TResponse&gt;(</c> is a different
+    /// string, and eighteen sites wrap as <c>await Mesh</c> ⏎ <c>.Observe&lt;…&gt;(</c>. Among the
+    /// misses were eleven target-less node-CRUD requests that EXECUTED on the router. A marker that
+    /// matches one spelling of a shape measures the spelling, not the shape.</para>
+    ///
+    /// <para>The leading look-behind is what keeps <c>siloMesh.Observe&lt;…&gt;</c> — a different,
+    /// local hub in the Orleans harness — out of the count.</para>
+    /// </summary>
+    private static readonly Regex Marker =
+        new(@"(?<![A-Za-z0-9_])Mesh\s*\.\s*Observe\s*[(<]", RegexOptions.Compiled);
+
+    private const string AllowFileName = "RouterRequestOriginSites.allow";
+
+    [Fact]
+    public void NoNewTestIssuesARequestFromTheRootMeshHub()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var allowed = SourceScan.ReadAllowFile(Path.Combine(root, "test", AllowFileName), AllowFileName);
+        var found = Scan(root);
+
+        var failures = new List<string>();
+
+        foreach (var (file, count) in found.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            if (!allowed.TryGetValue(file, out var budget))
+                failures.Add(
+                    $"  NEW SITE   {file} ({count}) — issue the request from MonolithMeshTestBase."
+                    + "RequestHub (a client hub), and for node CRUD aim it at "
+                    + "RequestHub.NodeOperationTarget(). Do NOT add a line to " + AllowFileName + ".");
+            else if (count > budget)
+                failures.Add(
+                    $"  MORE       {file} ({count} > {budget} allowed) — a router-issued request was "
+                    + "ADDED to a file that already carries the shape.");
+        }
+
+        var total = allowed.Values.Sum();
+        if (total > TotalBudget)
+            failures.Add(
+                $"  TOTAL      {total} allowances > {TotalBudget} budgeted — the inventory GREW. "
+                + "Adding a line to " + AllowFileName + " is not a fix.");
+
+        foreach (var (file, budget) in allowed.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            var count = found.GetValueOrDefault(file, 0);
+            if (count < budget)
+                output.WriteLine(
+                    $"STALE (please tidy): {file} — {count} found, {budget} allowed. "
+                    + $"{(count == 0 ? "Delete the line" : $"Lower it to {count}")} and lower "
+                    + $"TotalBudget by {budget - count}.");
+        }
+
+        Assert.True(failures.Count == 0,
+            "A test that drives the mesh through the ROUTER puts the mesh hub on both ends of the "
+            + "delivery — two ROUTER_TRAFFIC [Error] lines per class, and a shape no production "
+            + "caller uses (#2423). Issue it from RequestHub instead.\n"
+            + string.Join("\n", failures));
+    }
+
+    /// <summary>
+    /// Non-vacuity, pinned in the same run: the scanner must actually SEE the shape. The seeded allow
+    /// file is non-empty, so a scanner that silently matched nothing — a renamed marker, a masking bug
+    /// that blanked every file — would report every entry as STALE rather than fail, and the ratchet
+    /// above would pass on no evidence.
+    /// </summary>
+    [Fact]
+    public void TheScannerFindsTheShapeItIsRatcheting()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var found = Scan(root);
+
+        Assert.True(found.Count > 0,
+            "The scanner found no router-issued request anywhere under " + string.Join(", ", ScannedRoots)
+            + ". Either every site was migrated — in which case empty " + AllowFileName
+            + " and delete this assertion — or the scanner is broken.");
+
+        // Masking canary — THIS file. Its remarks quote the shape verbatim and the assertion below
+        // carries it as a string literal, so every occurrence here is prose or data and none is a
+        // call site. A scanner that counted them would be ratcheting against its own documentation,
+        // and every number in the allow file would be wrong.
+        var self = Path.Combine(root, "test", "MeshWeaver.Documentation.Test",
+            "RouterAsTestRequestOriginRatchetGuard.cs");
+        Assert.True(File.Exists(self), "the canary file must exist for this check to mean anything");
+        Assert.Contains("Mesh.Observe(", File.ReadAllText(self), StringComparison.Ordinal);
+        Assert.False(
+            found.ContainsKey("test/MeshWeaver.Documentation.Test/RouterAsTestRequestOriginRatchetGuard.cs"),
+            "the scanner counted a COMMENT or a string literal as a call site — comment/string "
+            + "masking is broken, and every count in the allow file is therefore unreliable.");
+
+        // `siloMesh.Observe<…>` (Orleans harness) must NOT be counted: it is a different local hub,
+        // and a marker that swallowed any identifier ending in `Mesh` would inflate every count.
+        Assert.False(found.ContainsKey("test/MeshWeaver.Hosting.Orleans.Test/OrleansPythonCodeNodeGateDeliveryTest.cs"),
+            "the scanner matched an identifier merely ENDING in `Mesh` — every count is then unreliable.");
+    }
+
+    private static Dictionary<string, int> Scan(string root) =>
+        SourceScan.SourceFiles(root, ScannedRoots)
+            .Select(f => (Relative: SourceScan.Relative(root, f), Count: CountSites(f)))
+            .Where(x => x.Count > 0)
+            .ToDictionary(x => x.Relative, x => x.Count, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Occurrences of <see cref="Marker"/>, with comments and string literals masked first so the
+    /// remarks that quote the shape are not counted as call sites.
+    /// </summary>
+    private static int CountSites(string path)
+    {
+        string text;
+        try { text = File.ReadAllText(path); }
+        catch (IOException) { return 0; } // a file a concurrent build is writing is not evidence
+
+        if (!text.Contains("Observe", StringComparison.Ordinal)) return 0;
+
+        return Marker.Matches(SourceScan.MaskCommentsAndStrings(text)).Count;
+    }
+}

--- a/test/MeshWeaver.Graph.Test/CodeNodeSegmentNameValidatorTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeNodeSegmentNameValidatorTest.cs
@@ -179,8 +179,8 @@ public class CodeNodeSegmentNameValidatorRegistrationTest(ITestOutputHelper outp
             Content = new CodeConfiguration { Code = "public static class Spine { }" }
         }).Should().Within(30.Seconds()).Emit();
 
-        var delivery = await Mesh
-            .Observe<MoveNodeResponse>(new MoveNodeRequest(sourcePath, $"{ns}/Model/Source"), o => o)
+        var delivery = await ObserveNodeOperation(
+                new MoveNodeRequest(sourcePath, $"{ns}/Model/Source"))
             .Should().Within(30.Seconds()).Emit();
 
         delivery.Message.Success.Should().BeFalse(

--- a/test/MeshWeaver.Hosting.Grpc.Test/PythonCodeNodeGateDeliveryTest.cs
+++ b/test/MeshWeaver.Hosting.Grpc.Test/PythonCodeNodeGateDeliveryTest.cs
@@ -74,7 +74,7 @@ public class PythonCodeNodeGateDeliveryTest(ITestOutputHelper output) : Monolith
 
         // 3) Run it. HandleExecuteScript sees the gate as CONNECTED (presence), so it does NOT fail
         //    fast — it posts the SubmitCodeRequest to py/python-kernel, which the gate must receive.
-        var exec = await Mesh.Observe<ExecuteScriptResponse>(
+        var exec = await RequestHub.Observe<ExecuteScriptResponse>(
                 new ExecuteScriptRequest(), o => o.WithTarget(new Address($"{Partition}/{id}")))
             .Take(1).ToTask(ct);
         Assert.True(exec.Message.Success, exec.Message.Error ?? "the run should start");

--- a/test/MeshWeaver.Hosting.Monolith.Test/ColdReactivationPatchReadYourWriteTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ColdReactivationPatchReadYourWriteTest.cs
@@ -39,7 +39,7 @@ public class ColdReactivationPatchReadYourWriteTest(ITestOutputHelper output) : 
             .Should().Emit();
 
         // Warm the per-node hub and wait until the CREATE is durable.
-        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
             .Should().Emit();
         var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
         await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)

--- a/test/MeshWeaver.Hosting.Monolith.Test/CompileFinishAndDisposeTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CompileFinishAndDisposeTest.cs
@@ -84,7 +84,7 @@ public class CompileFinishAndDisposeTest(ITestOutputHelper output) : MonolithMes
                 }))
                 .Aggregate(Observable.Return<MeshNode?>(null), (chain, next) =>
                     chain.SelectMany(_ => next.Select(n => (MeshNode?)n))))
-            .SelectMany(_ => Mesh.Observe(
+            .SelectMany(_ => RequestHub.Observe(
                     new GetCompilationPathRequest(),
                     o => o.WithTarget(new Address(nodeTypePath))))
             .Select(d => d.Message);

--- a/test/MeshWeaver.Hosting.Monolith.Test/CompileSingleDriverConsistencyTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CompileSingleDriverConsistencyTest.cs
@@ -79,7 +79,7 @@ public class CompileSingleDriverConsistencyTest(ITestOutputHelper output) : Mono
     }
 
     private IObservable<GetCompilationPathResponse> Compile(string nodeTypePath) =>
-        Mesh.Observe(
+        RequestHub.Observe(
                 (IRequest<GetCompilationPathResponse>)new GetCompilationPathRequest(),
                 o => o.WithTarget(new Address(nodeTypePath)))
             .Select(d => d.Message);

--- a/test/MeshWeaver.Hosting.Monolith.Test/CreateNodesRequestTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CreateNodesRequestTest.cs
@@ -117,8 +117,7 @@ public class CreateNodesRequestTest(ITestOutputHelper output)
         var satellitePath = $"{stem}/_Activity/act-1";
         var plainPath = $"{stem}-plain";
 
-        var response = await Mesh
-            .Observe<CreateNodesResponse>(new CreateNodesRequest(ImmutableList.Create(
+        var response = await ObserveNodeOperation(new CreateNodesRequest(ImmutableList.Create(
                 Node(plainPath, "# plain"),
                 Node(satellitePath, "# satellite"))))
             .Select(d => d.Message)
@@ -146,8 +145,7 @@ public class CreateNodesRequestTest(ITestOutputHelper output)
         var validPath = $"{stem}-valid";
         var bogus = Node($"{stem}-bogus", "# bogus") with { NodeType = $"NoSuchType{Guid.NewGuid():N}" };
 
-        var response = await Mesh
-            .Observe<CreateNodesResponse>(new CreateNodesRequest(ImmutableList.Create(
+        var response = await ObserveNodeOperation(new CreateNodesRequest(ImmutableList.Create(
                 Node(validPath, "# valid"), bogus)))
             .Select(d => d.Message)
             .Should().Emit();
@@ -171,8 +169,7 @@ public class CreateNodesRequestTest(ITestOutputHelper output)
     {
         var path = $"{TestPartition}/bulk-dup-{Guid.NewGuid():N}";
 
-        var response = await Mesh
-            .Observe<CreateNodesResponse>(new CreateNodesRequest(ImmutableList.Create(
+        var response = await ObserveNodeOperation(new CreateNodesRequest(ImmutableList.Create(
                 Node(path, "# first"), Node(path, "# second"))))
             .Select(d => d.Message)
             .Should().Emit();
@@ -192,8 +189,7 @@ public class CreateNodesRequestTest(ITestOutputHelper output)
     {
         var path = $"{TestPartition}/bulk-null-{Guid.NewGuid():N}";
 
-        var response = await Mesh
-            .Observe<CreateNodesResponse>(new CreateNodesRequest(ImmutableList.Create(
+        var response = await ObserveNodeOperation(new CreateNodesRequest(ImmutableList.Create(
                 Node(path, "# fine"), null!)))
             .Select(d => d.Message)
             .Should().Emit();

--- a/test/MeshWeaver.Hosting.Monolith.Test/CreateOrUpdateNodeRequestTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CreateOrUpdateNodeRequestTest.cs
@@ -46,8 +46,7 @@ public class CreateOrUpdateNodeRequestTest(ITestOutputHelper output)
             State = MeshNodeState.Active,
         };
 
-        var resp = await Mesh
-            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(sourceNode))
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(sourceNode))
             .Select(d => d.Message)
             .Should().Emit();
 
@@ -98,8 +97,7 @@ public class CreateOrUpdateNodeRequestTest(ITestOutputHelper output)
             State = MeshNodeState.Active,
         };
 
-        var resp = await Mesh
-            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(sourceNode))
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(sourceNode))
             .Select(d => d.Message)
             .Should().Emit();
 
@@ -147,8 +145,7 @@ public class CreateOrUpdateNodeRequestTest(ITestOutputHelper output)
         var originalCreatedDate = before!.CreatedDate;
         var originalCreatedBy = before.CreatedBy;
 
-        var resp = await Mesh
-            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(
                 new MeshNode(path.Split('/').Last(), TestPartition)
                 {
                     Name = "Renamed",
@@ -194,8 +191,7 @@ public class CreateOrUpdateNodeRequestTest(ITestOutputHelper output)
         var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
         var before = await ReadStable(storage, path);
 
-        var resp = await Mesh
-            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(Node()))
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(Node()))
             .Select(d => d.Message)
             .Should().Emit();
 
@@ -231,8 +227,7 @@ public class CreateOrUpdateNodeRequestTest(ITestOutputHelper output)
         var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
         var before = await ReadStable(storage, path);
 
-        var resp = await Mesh
-            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(
                 new MeshNode(path.Split('/').Last(), TestPartition)
                 {
                     Name = "After",
@@ -296,8 +291,7 @@ public class CreateOrUpdateNodeRequestTest(ITestOutputHelper output)
         }).Should().Emit();
 
         // The upsert: authored change + a stale verdict the writer happened to be holding.
-        var resp = await Mesh
-            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(
                 new MeshNode(id, TestPartition)
                 {
                     Name = "Widget",

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeleteTimeoutStageDiagnosticsTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeleteTimeoutStageDiagnosticsTest.cs
@@ -85,7 +85,7 @@ public class DeleteTimeoutStageDiagnosticsTest(ITestOutputHelper output) : Monol
         await NodeFactory.CreateNode(new MeshNode($"child{SilentSuffix}", space)
         { Name = "Silent", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
 
-        var response = (await Mesh
+        var response = (await RequestHub
             .Observe(new DeleteNodeRequest(space) { Recursive = true, ConfirmWarnings = true },
                 o => o.WithTarget(new Address(space)))
             .Should().Within(60.Seconds()).Emit()).Message;
@@ -132,7 +132,7 @@ public class DeleteTimeoutStageDiagnosticsTest(ITestOutputHelper output) : Monol
         await NodeFactory.CreateNode(new MeshNode($"child{CommitStallSuffix}", space)
         { Name = "Stalled", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
 
-        var response = (await Mesh
+        var response = (await RequestHub
             .Observe(new DeleteNodeRequest(space) { Recursive = true, ConfirmWarnings = true },
                 o => o.WithTarget(new Address(space)))
             .Should().Within(60.Seconds()).Emit()).Message;

--- a/test/MeshWeaver.Hosting.Monolith.Test/DisposalPendingSaveFlushTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DisposalPendingSaveFlushTest.cs
@@ -46,7 +46,7 @@ public class DisposalPendingSaveFlushTest(ITestOutputHelper output) : MonolithMe
 
         // Activate the per-node hub (lazy) and grab its workspace — same shape as
         // WorkspaceUpdateMeshNodePropagationTest.
-        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
             .Should().Emit();
         var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
         nodeHub.Should().NotBeNull("the per-node hub must be activated by the GetDataRequest above");

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicGraphIntegrationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicGraphIntegrationTest.cs
@@ -332,7 +332,7 @@ public class DynamicGraphIntegrationTest : MonolithMeshTestBase
         await WaitForQueryPathSet(subtreeQuery, set => set.Contains(src));
 
         // Act
-        var response = await Mesh.Observe<MoveNodeResponse>(new MoveNodeRequest(src, dst), o => o).Should().Emit();
+        var response = await ObserveNodeOperation(new MoveNodeRequest(src, dst)).Should().Emit();
         var moved = response.Message.Node;
 
         // Assert
@@ -374,7 +374,7 @@ public class DynamicGraphIntegrationTest : MonolithMeshTestBase
                 && set.Contains($"{parent}/child1/grandchild"));
 
         // Act
-        await Mesh.Observe<MoveNodeResponse>(new MoveNodeRequest(parent, newParentPath), o => o).Should().Emit();
+        await ObserveNodeOperation(new MoveNodeRequest(parent, newParentPath)).Should().Emit();
 
         // Assert - old paths should not exist, new paths should exist (catalog-bound).
         // ReadNode on the old paths would falsely succeed via the TestPartition
@@ -427,7 +427,7 @@ public class DynamicGraphIntegrationTest : MonolithMeshTestBase
         await WaitForQueryPathSet(subtreeQuery, set => set.Contains(src));
 
         // Act - move via MoveNodeRequest
-        var response = await Mesh.Observe<MoveNodeResponse>(new MoveNodeRequest(src, dst), o => o).Should().Emit();
+        var response = await ObserveNodeOperation(new MoveNodeRequest(src, dst)).Should().Emit();
 
         // Assert - node should be at new path
         response.Message.Success.Should().BeTrue("Move should succeed");
@@ -452,7 +452,9 @@ public class DynamicGraphIntegrationTest : MonolithMeshTestBase
     public async Task MoveNodeAsync_ThrowsWhenSourceNotFound()
     {
         // Act - move via MoveNodeRequest (unique names to avoid filesystem collisions)
-        var response = await Mesh.Observe<MoveNodeResponse>(new MoveNodeRequest($"{TestPartition}/nonexistent-{_uid}", $"{TestPartition}/newpath-{_uid}"), o => o).Should().Within(20.Seconds()).Emit();
+        var response = await ObserveNodeOperation(
+                new MoveNodeRequest($"{TestPartition}/nonexistent-{_uid}", $"{TestPartition}/newpath-{_uid}"))
+            .Should().Within(20.Seconds()).Emit();
 
         // Assert - should fail with source not found
         response.Message.Success.Should().BeFalse("Move should fail when source doesn't exist");
@@ -472,7 +474,7 @@ public class DynamicGraphIntegrationTest : MonolithMeshTestBase
         await NodeFactory.CreateNode(MeshNode.FromPath(dst) with { Name = "Target", NodeType = "Markdown" }).Should().Within(20.Seconds()).Emit();
 
         // Act - move via MoveNodeRequest
-        var response = await Mesh.Observe<MoveNodeResponse>(new MoveNodeRequest(src, dst), o => o).Should().Within(20.Seconds()).Emit();
+        var response = await ObserveNodeOperation(new MoveNodeRequest(src, dst)).Should().Within(20.Seconds()).Emit();
 
         // Assert - should fail because target already exists
         response.Message.Success.Should().BeFalse("Move should fail when target already exists");

--- a/test/MeshWeaver.Hosting.Monolith.Test/FrameworkStaleInstanceRenderTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/FrameworkStaleInstanceRenderTest.cs
@@ -130,7 +130,7 @@ public class FrameworkStaleInstanceRenderTest(ITestOutputHelper output) : Monoli
                     : $"[compile-diag +{diagSw.ElapsedMilliseconds}ms] Content is {n?.Content?.GetType().Name ?? "null"} "
                       + "(NOT NodeTypeDefinition — untyped JsonElement?)"));
 
-        await Mesh.Observe(new GetCompilationPathRequest(), o => o.WithTarget(new Address(nodeTypePath)))
+        await RequestHub.Observe(new GetCompilationPathRequest(), o => o.WithTarget(new Address(nodeTypePath)))
             .Should().Within(90.Seconds()).Emit();
         await workspace.GetMeshNodeStream(nodeTypePath)
             .Should().Within(60.Seconds())

--- a/test/MeshWeaver.Hosting.Monolith.Test/FrameworkStaleProactiveRebuildTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/FrameworkStaleProactiveRebuildTest.cs
@@ -175,7 +175,7 @@ public class FrameworkStaleProactiveRebuildTest(ITestOutputHelper output) : Mono
             Content = new CodeConfiguration { Code = source, Language = "csharp" }
         }).Should().Emit();
 
-        await Mesh.Observe(new GetCompilationPathRequest(), o => o.WithTarget(new Address(nodeTypePath)))
+        await RequestHub.Observe(new GetCompilationPathRequest(), o => o.WithTarget(new Address(nodeTypePath)))
             .Should().Within(90.Seconds()).Emit();
         var okNode = await Mesh.GetWorkspace().GetMeshNodeStream(nodeTypePath)
             .Should().Within(60.Seconds())

--- a/test/MeshWeaver.Hosting.Monolith.Test/LateNackReenqueueTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/LateNackReenqueueTest.cs
@@ -45,7 +45,7 @@ public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestB
                 new MeshNode("late-nack-node", TestPartition) { Name = "initial", NodeType = "Markdown" })
             .Should().Emit();
 
-        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
             .Should().Emit();
         var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
         await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
@@ -88,7 +88,7 @@ public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestB
 
             // Fence: the patch handler has provably run on the owner (registered the
             // disposal NACK) before the dispose below.
-            await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+            await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
                 .Should().Within(10.Seconds()).Emit();
 
             // Dispose the owner AFTER the optimistic emit — its OwnerDisposing NACK

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshChangeFeedTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshChangeFeedTest.cs
@@ -48,7 +48,11 @@ public class MeshChangeFeedTest(ITestOutputHelper output) : MonolithMeshTestBase
 
     private async Task DeleteTestNode(string path)
     {
-        var response = await Mesh.Observe(new DeleteNodeRequest(path), o => o.WithTarget(Mesh.Address)).Should().Emit();
+        // Node CRUD is issued off the ROUTER and aimed at the mesh's dedicated node-operation hub —
+        // the production seam (MeshService.IssuingHub / NodeOperationTarget) pinned by
+        // NodeOperationOriginTest. Posting from `Mesh` targeted at `Mesh.Address` made the router
+        // both ends of the delivery, which is what ROUTER_TRAFFIC reports (#2423).
+        var response = await ObserveNodeOperation(new DeleteNodeRequest(path)).Should().Emit();
         response.Message.Error.Should().BeNullOrEmpty();
     }
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/NeverCompiledFailureRedriveTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NeverCompiledFailureRedriveTest.cs
@@ -251,7 +251,7 @@ public class NeverCompiledFailureRedriveTest(ITestOutputHelper output) : Monolit
         string prefix, Func<string, string> source)
     {
         var typePath = await CreateType(prefix, source);
-        await Mesh.Observe(new GetCompilationPathRequest(), o => o.WithTarget(new Address(typePath)))
+        await RequestHub.Observe(new GetCompilationPathRequest(), o => o.WithTarget(new Address(typePath)))
             .Should().Within(90.Seconds()).Emit();
         var okNode = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
             .Should().Within(60.Seconds())

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypePathRegistrationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypePathRegistrationTest.cs
@@ -95,7 +95,7 @@ public class NodeTypePathRegistrationTest(ITestOutputHelper output) : MonolithMe
 
         // Activate the per-node hub — this is what applies the NodeType's HubConfiguration, and
         // therefore what runs WithContentType with the stamped path in scope.
-        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
             .Should().Emit();
 
         // 🚨 THE ASSERTION: the NodeType PATH is a key in the mesh-wide registry. This is what was
@@ -191,7 +191,7 @@ public class NodeTypePathRegistrationTest(ITestOutputHelper output) : MonolithMe
 
         // Activate the definition node's own hub — this applies NodeTypeNodeType's configuration
         // and therefore runs its WithContentType<NodeTypeDefinition>().
-        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(definitionPath)))
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(definitionPath)))
             .Should().Emit();
 
         // THE ASSERTION: the definition's own path is the key its INSTANCES read. Nothing the

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRebindTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeRebindTest.cs
@@ -130,7 +130,7 @@ public class NodeTypeRebindTest(ITestOutputHelper output) : MonolithMeshTestBase
         // 2. ACTIVATE its hub in that state. Ping is answered by every hub, so the response is
         //    proof the hub exists — and from here on it is PINNED by address: routing
         //    short-circuits on GetHostedHub and never resolves the path again.
-        await Mesh.Observe(new PingRequest(), o => o.WithTarget(new Address(instancePath)))
+        await RequestHub.Observe(new PingRequest(), o => o.WithTarget(new Address(instancePath)))
             .Should().Within(60.Seconds()).Emit();
         Output.WriteLine(
             $"Activated {instancePath} as NodeType '{activationNodeType ?? "(none)"}'.");

--- a/test/MeshWeaver.Hosting.Monolith.Test/OwnerDisposalNackTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/OwnerDisposalNackTest.cs
@@ -45,7 +45,7 @@ public class OwnerDisposalNackTest(ITestOutputHelper output) : MonolithMeshTestB
 
         // Warm the per-node hub and wait until the CREATE is durable, so the owner's
         // data-source streams are fully initialized before the gate goes in.
-        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
             .Should().Emit();
         var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
         await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
@@ -84,11 +84,11 @@ public class OwnerDisposalNackTest(ITestOutputHelper output) : MonolithMeshTestB
                 ?? nameof(MeshNode.Name);
             var patchJson = new System.Text.Json.Nodes.JsonObject { [nameKey] = "never-applied" }
                 .ToJsonString(Mesh.JsonSerializerOptions);
-            var respTask = Mesh.Observe(
+            var respTask = RequestHub.Observe(
                     new PatchDataRequest(new MeshNodeReference(), new RawJson(patchJson)),
                     o => o.WithTarget(new Address(path)))
                 .FirstAsync().Timeout(10.Seconds()).ToTask(ct);
-            await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+            await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
                 .Should().Within(10.Seconds()).Emit();
 
             nodeHub!.Dispose();

--- a/test/MeshWeaver.Hosting.Monolith.Test/PartitionRootBootstrapTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/PartitionRootBootstrapTest.cs
@@ -150,7 +150,7 @@ public class PartitionRootBootstrapTest(ITestOutputHelper output) : MonolithMesh
         };
         var resp = await AwaitResponseAsync(
             new CreateNodeRequest(node) { CreatedBy = WellKnownUsers.System },
-            o => o.WithTarget(Mesh.Address).WithAccessContext(sys));
+            o => o.WithTarget(RequestHub.NodeOperationTarget()).WithAccessContext(sys));
         resp.Message.Success.Should().BeTrue(resp.Message.Error ?? "create should succeed");
 
         // The Space root is still materialized (a missing root would break routing).

--- a/test/MeshWeaver.Hosting.Monolith.Test/ShutdownRoutingRejectClassificationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ShutdownRoutingRejectClassificationTest.cs
@@ -113,6 +113,13 @@ public class ShutdownRoutingRejectClassificationTest(ITestOutputHelper output) :
                 "the stalling handler must own the action block before the interleaving is queued");
 
             // 2. Queue the probe. Observe pre-registers the response callback before posting.
+            // 🚨 Posted on `Mesh` DELIBERATELY — do NOT move this to RequestHub (#2423). The
+            // interleaving under test is an ORDERING on the router's own action block: the stall
+            // owns it, this probe must land in that queue, and only THEN may the ShutdownRequest
+            // from step 3 queue behind it. Posting from a client hub makes the enqueue a routed
+            // hop, so Mesh.Dispose() could beat the probe into the queue and the reject would come
+            // from a different branch. The router IS the subject here, so the ROUTER_TRAFFIC line
+            // this emits is honest.
             probe = Mesh.Observe(
                     new GetDataRequest(new MeshNodeReference()),
                     o => o.WithTarget(new Address(path)))

--- a/test/MeshWeaver.Hosting.Monolith.Test/SpaceCreateAtomicityTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SpaceCreateAtomicityTest.cs
@@ -69,7 +69,7 @@ public class SpaceCreateAtomicityTest(ITestOutputHelper output) : MonolithMeshTe
                 State = MeshNodeState.Active,
             })
             { CreatedBy = Creator },
-            o => o.WithTarget(Mesh.Address)
+            o => o.WithTarget(RequestHub.NodeOperationTarget())
                 .WithAccessContext(new AccessContext { ObjectId = Creator, Name = Creator }));
 
     [Fact(Timeout = 60_000)]

--- a/test/MeshWeaver.Hosting.Monolith.Test/StaleBuildBannerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/StaleBuildBannerTest.cs
@@ -75,7 +75,7 @@ public class StaleBuildBannerTest(ITestOutputHelper output) : MonolithMeshTestBa
         };
         await MeshService.CreateNode(typeNode).Should().Within(60.Seconds()).Emit();
 
-        var compiled = await Mesh.Observe(
+        var compiled = await RequestHub.Observe(
                 (IRequest<GetCompilationPathResponse>)new GetCompilationPathRequest(),
                 o => o.WithTarget(new Address(nodeTypePath)))
             .Select(d => d.Message)

--- a/test/MeshWeaver.Hosting.Monolith.Test/StarvedPermissionReadTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/StarvedPermissionReadTest.cs
@@ -117,7 +117,8 @@ public class StarvedPermissionReadTest(ITestOutputHelper output) : MonolithMeshT
             new CreateNodeRequest(new MeshNode("leaf", HealthyScope)
             {
                 Name = "Healthy leaf", NodeType = "Markdown"
-            }));
+            }),
+            o => o.WithTarget(RequestHub.NodeOperationTarget()));
         healthy.Message.Success.Should().Be(true,
             $"a healthy scope must be unaffected — got {healthy.Message.RejectionReason}: {healthy.Message.Error}");
 
@@ -127,7 +128,8 @@ public class StarvedPermissionReadTest(ITestOutputHelper output) : MonolithMeshT
             new CreateNodeRequest(new MeshNode("leaf", StarvedScope)
             {
                 Name = "Starved leaf", NodeType = "Markdown"
-            }));
+            }),
+            o => o.WithTarget(RequestHub.NodeOperationTarget()));
         started.Stop();
         Output.WriteLine(
             $"=== STARVED CREATE → {starved.Message.RejectionReason}: {starved.Message.Error} "

--- a/test/MeshWeaver.Hosting.Monolith.Test/TypedContentUpdateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/TypedContentUpdateTest.cs
@@ -52,7 +52,7 @@ public class TypedContentUpdateTest(ITestOutputHelper output) : MonolithMeshTest
         }).Should().Emit();
 
         // Per-node hubs activate lazily — any inbound message brings the hub up.
-        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
             .Should().Emit();
 
         var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);

--- a/test/MeshWeaver.Hosting.Monolith.Test/UpsertInnerCreateObservationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/UpsertInnerCreateObservationTest.cs
@@ -70,6 +70,11 @@ public class UpsertInnerCreateObservationTest(ITestOutputHelper output) : Monoli
     public async Task SelfTargetedCreate_OnTheMeshHub_DropsItsReply_WhenTheSubjectIsRegisteredAfterPost()
     {
         // ARM 1 — the #981 shape: post first, register the callback afterwards.
+        // 🚨 Everything in this test posts on `Mesh` targeted at `Mesh.Address` DELIBERATELY — do
+        // NOT move it to RequestHub (#2423). The leak being pinned is literally
+        // `CreateNodeRequest@mesh/<self>`: a self-targeted create on the ROUTER, whose reply the
+        // router's own HandleCallbacks drops. Change either end and the test stops reproducing the
+        // shape it exists to pin, so the ROUTER_TRAFFIC line it emits is the subject, not noise.
         var doomedId = $"upsert-race-doomed-{Guid.NewGuid():N}";
         var doomedPath = $"{TestPartition}/{doomedId}";
         var doomed = Mesh.Post(
@@ -121,8 +126,7 @@ public class UpsertInnerCreateObservationTest(ITestOutputHelper output) : Monoli
         var id = $"upsert-answers-{Guid.NewGuid():N}";
         var node = new MeshNode(id, TestPartition) { Name = id, NodeType = "Markdown" };
 
-        var response = await Mesh
-            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
+        var response = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(node))
             .Should().Within(30.Seconds()).Emit(
                 "the upsert's inner CreateNodeRequest must never lose its reply");
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/WorkspaceCacheEvictionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/WorkspaceCacheEvictionTest.cs
@@ -170,16 +170,16 @@ public class WorkspaceCacheEvictionTest(ITestOutputHelper output) : MonolithMesh
         // (1) OLD shape — register the response subject AFTER posting, with a deliberate preemption
         //     between Post and Observe. The warm owner replies during the delay; the hub has no
         //     subject for that requestId yet, so it drops the reply. Observing afterwards never emits.
-        var droppedDelivery = Mesh.Post(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(addr));
+        var droppedDelivery = RequestHub.Post(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(addr));
         droppedDelivery.Should().NotBeNull();
         await Task.Delay(300); // force the warm round-trip to complete before we register the subject
-        await Mesh.Observe(droppedDelivery!).Select(d => (object?)d.Message)
+        await RequestHub.Observe(droppedDelivery!).Select(d => (object?)d.Message)
             .Should().NotEmit(within: 2.Seconds());
 
         // (2) FIX shape — Observe<TResponse> registers the subject BEFORE posting, so the same
         //     preemption is harmless: the reply is buffered in the AsyncSubject and replayed to the
         //     late subscriber.
-        var safe = Mesh.Observe<GetDataResponse>(
+        var safe = RequestHub.Observe<GetDataResponse>(
             new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(addr));
         await Task.Delay(300); // same preemption — but the subject was registered before the post
         await safe.Select(d => d.Message.Data as MeshNode)

--- a/test/MeshWeaver.Hosting.Monolith.Test/WorkspaceUpdateMeshNodePropagationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/WorkspaceUpdateMeshNodePropagationTest.cs
@@ -54,7 +54,7 @@ public class WorkspaceUpdateMeshNodePropagationTest(ITestOutputHelper output) : 
         // 2. Activate the per-node hub by sending it any inbound message — Orleans
         //    grain activation is lazy. Monolith hubs activate eagerly via routing
         //    so this is a no-op there but keeps the test portable.
-        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
             .Should().Emit();
 
         // 3. Reach into the per-node hub's own workspace.

--- a/test/MeshWeaver.Messaging.Hub.Test/RouterTrafficDetectorTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/RouterTrafficDetectorTest.cs
@@ -145,6 +145,9 @@ public class RouterTrafficDetectorTest : HubTestBase
     {
         GetHost();
 
+        // 🚨 Posted on `Mesh` DELIBERATELY — do NOT migrate this to a client hub (#2423). PRODUCING
+        // the shape is the point: this is the only place that proves the "sender" role still fires,
+        // so a future narrowing of RouterTrafficRule cannot switch the detector off unnoticed.
         var response = await Mesh
             .Observe<Pong>(new MeshSentRequest(), o => o.WithTarget(CreateHostAddress()))
             .FirstAsync()

--- a/test/MeshWeaver.NodeOperations.Test/CancellationIsNotAFaultTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/CancellationIsNotAFaultTest.cs
@@ -151,11 +151,11 @@ public class CancellationIsNotAFaultTest(ITestOutputHelper output) : MonolithMes
             Name = "Doomed", NodeType = "Markdown", Content = "victim",
         };
         var created = await AwaitResponseAsync<CreateNodeResponse>(
-            new CreateNodeRequest(node), o => o.WithTarget(Mesh.Address));
+            new CreateNodeRequest(node), o => o.WithTarget(RequestHub.NodeOperationTarget()));
         created.Message.Success.Should().BeTrue("the fixture needs a node to delete");
 
         var deleted = await AwaitResponseAsync<DeleteNodeResponse>(
-            new DeleteNodeRequest(node.Path), o => o.WithTarget(Mesh.Address));
+            new DeleteNodeRequest(node.Path), o => o.WithTarget(RequestHub.NodeOperationTarget()));
 
         deleted.Message.Success.Should().BeFalse("the delete did not happen");
         deleted.Message.Error.Should().Contain("cancelled",
@@ -206,7 +206,7 @@ public class CancellationIsNotAFaultTest(ITestOutputHelper output) : MonolithMes
             Name = id, NodeType = "Markdown", Content = "fixture",
         };
         var response = await AwaitResponseAsync<CreateNodeResponse>(
-            new CreateNodeRequest(node), o => o.WithTarget(Mesh.Address));
+            new CreateNodeRequest(node), o => o.WithTarget(RequestHub.NodeOperationTarget()));
         return response.Message;
     }
 

--- a/test/MeshWeaver.NodeOperations.Test/NodeOperationsTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/NodeOperationsTest.cs
@@ -251,10 +251,12 @@ public class NodeOperationsTest(ITestOutputHelper output) : MonolithMeshTestBase
         var child = new MeshNode("HierChild", $"{TestPartition}/HierParent") { Name = "Child", NodeType = "Markdown" };
         await NodeFactory.CreateNode(child).Should().Emit();
 
-        // DeleteNodeRequest handler lives on the mesh hub — target Mesh.Address, not the partition hub.
-        var deleteResponse = await Mesh.Observe(
-                new DeleteNodeRequest($"{TestPartition}/HierParent"),
-                o => o.WithTarget(Mesh.Address))
+        // The DeleteNodeRequest handler lives on the mesh's node-operation EXECUTION hub, not on the
+        // partition hub — and not on the ROUTER either: NodeOperationTarget resolves the dedicated
+        // portal/nodeops-{meshId} hub, so neither end of the delivery is mesh/{id} (#2423). Issue it
+        // from a client, exactly as NodeOperationOriginTest pins the production shape.
+        var deleteResponse = await ObserveNodeOperation(
+                new DeleteNodeRequest($"{TestPartition}/HierParent"))
             .Should().Emit();
 
         deleteResponse.Message.Success.Should().BeFalse();

--- a/test/MeshWeaver.NodeOperations.Test/PermissionRequestMissingNodeTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/PermissionRequestMissingNodeTest.cs
@@ -55,7 +55,7 @@ public class PermissionRequestMissingNodeTest(ITestOutputHelper output)
         // deadlock symptom. With the fix the routing service returns a
         // NotFound DeliveryFailure within milliseconds, which the framework
         // surfaces as DeliveryFailureException on the observable.
-        Func<Task> act = async () => await Mesh.Observe<GetPermissionResponse>(
+        Func<Task> act = async () => await RequestHub.Observe<GetPermissionResponse>(
                 new GetPermissionRequest(),
                 o => o.WithTarget(new Address(missingPath)))
             .FirstAsync().ToTask();
@@ -84,7 +84,7 @@ public class PermissionRequestMissingNodeTest(ITestOutputHelper output)
         var deepMissingPath =
             $"{TestPartition}/_Thread/{Guid.NewGuid():N}/{Guid.NewGuid():N}/{Guid.NewGuid():N}/{Guid.NewGuid():N}";
 
-        Func<Task> act = async () => await Mesh.Observe<GetPermissionResponse>(
+        Func<Task> act = async () => await RequestHub.Observe<GetPermissionResponse>(
                 new GetPermissionRequest(),
                 o => o.WithTarget(new Address(deepMissingPath)))
             .FirstAsync().ToTask();
@@ -107,7 +107,7 @@ public class PermissionRequestMissingNodeTest(ITestOutputHelper output)
         // quickly, NOT throw DeliveryFailure.
         var existingPath = TestPartition;
 
-        var delivery = await Mesh.Observe<GetPermissionResponse>(
+        var delivery = await RequestHub.Observe<GetPermissionResponse>(
                 new GetPermissionRequest(),
                 o => o.WithTarget(new Address(existingPath)))
             .Should().Within(20.Seconds()).Emit();

--- a/test/MeshWeaver.Persistence.Test/FileSystemObservableQueryTests.cs
+++ b/test/MeshWeaver.Persistence.Test/FileSystemObservableQueryTests.cs
@@ -401,7 +401,11 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
         receivedChanges[0].Items.Should().HaveCount(1);
 
         var movedPath = NodePath("Project1Moved");
-        await Mesh.Observe(new MoveNodeRequest(proj1, movedPath), o => o).Should().Emit();
+        // Target the mesh's dedicated node-operation hub explicitly. A target-less post from `Mesh`
+        // addressed the ROUTER itself (it defaults to the posting hub), making it both ends of the
+        // delivery — the shape ROUTER_TRAFFIC reports (#2423) — and executed the move on the
+        // router's action block. NodeOperationTarget is the seam production uses.
+        await ObserveNodeOperation(new MoveNodeRequest(proj1, movedPath)).Should().Emit();
         await WaitForChanges(receivedChanges, 2);
 
         receivedChanges.Count.Should().BeGreaterThanOrEqualTo(2);

--- a/test/MeshWeaver.PluginCatalog.Test/InstanceComboReaderTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/InstanceComboReaderTest.cs
@@ -412,8 +412,10 @@ public class InstanceComboReaderTest(ITestOutputHelper output) : MonolithMeshTes
             },
         };
 
-        await AsSystem(() => Mesh.Observe<CreateOrUpdateNodeResponse>(
-                new CreateOrUpdateNodeRequest(node)))
+        // Off-router: issued from a client and aimed at the mesh's dedicated node-operation hub.
+        // A target-less post on `Mesh` defaults to the ROUTER itself, so it made the router both
+        // ends of the delivery AND ran the upsert on its action block (#2423).
+        await AsSystem(() => ObserveNodeOperation(new CreateOrUpdateNodeRequest(node)))
             .FirstAsync().Timeout(60.Seconds()).ToTask();
     }
 

--- a/test/MeshWeaver.Query.Test/SyncedQueryCrossSiloTest.cs
+++ b/test/MeshWeaver.Query.Test/SyncedQueryCrossSiloTest.cs
@@ -361,7 +361,7 @@ public class SyncedQueryCrossSiloTest(ITestOutputHelper output)
         // compile (~15-20s), so the wait window must cover the compile — the
         // default 10s .Emit() budget is too short. The original awaited under the
         // [Fact(Timeout = 60000)] envelope; await restore that budget explicitly.
-        await Mesh.Observe(new CreateReleaseRequest(),
+        await RequestHub.Observe(new CreateReleaseRequest(),
                 o => o.WithTarget(new Address(typePath)))
             .Should().Within(60.Seconds()).Emit();
 

--- a/test/MeshWeaver.Security.Test/AccessControlPipelineTest.cs
+++ b/test/MeshWeaver.Security.Test/AccessControlPipelineTest.cs
@@ -218,7 +218,7 @@ public class UserHubAccessTest(ITestOutputHelper output) : MonolithMeshTestBase(
         var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
         accessService.SetHostIdentity(new AccessContext { ObjectId = "unprivileged@example.com", Name = "Unprivileged User" });
 
-        var response = await Mesh
+        var response = await RequestHub
             .Observe(new GetDataRequest(new UnifiedReference("data:")), o => o.WithTarget(new Address("User")))
             .Should().Emit();
 
@@ -233,7 +233,7 @@ public class UserHubAccessTest(ITestOutputHelper output) : MonolithMeshTestBase(
         accessService.SetHostIdentity(new AccessContext { ObjectId = "", Name = "" });
 
         Func<Task> act = () =>
-            Mesh.Observe(new GetDataRequest(new UnifiedReference("data:")), o => o.WithTarget(new Address("User")))
+            RequestHub.Observe(new GetDataRequest(new UnifiedReference("data:")), o => o.WithTarget(new Address("User")))
                 .FirstAsync()
                 .ToTask();
 

--- a/test/MeshWeaver.Security.Test/ViewerRoutedScriptRunTest.cs
+++ b/test/MeshWeaver.Security.Test/ViewerRoutedScriptRunTest.cs
@@ -112,7 +112,7 @@ public class ViewerRoutedScriptRunTest(ITestOutputHelper output) : MonolithMeshT
         SignInAsOrdinaryUser();
         try
         {
-            var dispatch = (await Mesh
+            var dispatch = (await RequestHub
                 .Observe<ExecuteScriptResponse>(
                     new ExecuteScriptRequest(), o => o.WithTarget(new Address(ScriptPath)))
                 .Should().Within(60.Seconds()).Emit()).Message;
@@ -151,7 +151,7 @@ public class ViewerRoutedScriptRunTest(ITestOutputHelper output) : MonolithMeshT
         SignInAsOrdinaryUser();
         try
         {
-            var dispatch = (await Mesh
+            var dispatch = (await RequestHub
                 .Observe<ExecuteScriptResponse>(
                     new ExecuteScriptRequest(), o => o.WithTarget(new Address(ScriptPath)))
                 .Should().Within(60.Seconds()).Emit()).Message;

--- a/test/RouterRequestOriginSites.allow
+++ b/test/RouterRequestOriginSites.allow
@@ -1,0 +1,41 @@
+# RouterRequestOriginSites.allow — the router-as-request-origin ratchet (#2423).
+#
+# Each line is a test file that still issues a request/response exchange FROM the root mesh hub:
+#
+#     Mesh.Observe(request, o => o.WithTarget(...))     Mesh.Observe<TResponse>(...)
+#
+# `Mesh` resolves the ROOT mesh/{id} hub — the mesh's ROUTER. A request posted there leaves stamped
+# `Sender = mesh/{id}` and its response is addressed straight back at `mesh/{id}`, so
+# RouterTrafficRule.RoleOf reports BOTH ends and the class logs two [Error] lines. Errors that
+# everyone learns to ignore are how a real router-starvation report gets missed.
+#
+# The fix at a site is MonolithMeshTestBase.RequestHub — one client hub per test method — and, for
+# node CRUD, MonolithMeshTestBase.ObserveNodeOperation, which additionally aims the request at
+# NodeOperationTarget(): the production seam MeshService uses and NodeOperationOriginTest pins.
+#
+# THE FOUR ENTRIES BELOW ARE NOT DEBT. In each of them the ROUTER IS THE SUBJECT of the test, so
+# the ROUTER_TRAFFIC line it emits reports exactly what the test intends. Each site carries a 🚨
+# comment saying so. Do not "fix" them; do not add a fifth line to make a new site pass.
+#
+# Format: relative/path.cs<TAB>count   ('#' starts a comment)
+
+# The detector's own test. TheMeshHubAsSender_IsStillReported PRODUCES the shape on purpose and
+# asserts ROUTER_TRAFFIC fires with role "sender" — migrating it would delete the coverage that
+# stops a future narrowing of RouterTrafficRule from silently switching the detector off.
+test/MeshWeaver.Messaging.Hub.Test/RouterTrafficDetectorTest.cs	1
+
+# The mesh hub's OWN drain is what is asserted: a poison StreamMessage is posted to the mesh, and
+# the Pings before and after must be answered BY the mesh hub. Retargeting them at a client hub
+# would stop testing the thing that wedged (RouteStreamMessage's non-terminating parent walk).
+test/MeshWeaver.Data.Test/StreamRouteSelfParentTerminationTest.cs	2
+
+# The leak being pinned is literally `CreateNodeRequest@mesh/<self>` (#981): a self-targeted create
+# on the ROUTER whose reply the router's own HandleCallbacks drops for want of a registered subject.
+# Change either end and the test no longer reproduces the shape it exists to pin.
+test/MeshWeaver.Hosting.Monolith.Test/UpsertInnerCreateObservationTest.cs	2
+
+# The interleaving under test is an ORDERING on the router's action block: a stalling handler owns
+# it, the probe must land in that queue, and only then may Dispose()'s ShutdownRequest queue behind
+# it. From a client hub the enqueue becomes a routed hop, so Dispose() could beat the probe in and
+# the reject would come from a different branch — a flake, not a stricter test.
+test/MeshWeaver.Hosting.Monolith.Test/ShutdownRoutingRejectClassificationTest.cs	1


### PR DESCRIPTION
Closes #2423.

`MonolithMeshTestBase.Mesh` **is** the root mesh hub, so a test using it as its
request client made the ROUTER genuinely both ends of the delivery — request out
stamped `Sender = mesh/{id}`, response addressed straight back at `mesh/{id}`.
That is exactly what `RouterTrafficRule.RoleOf` reports, and because the detector
fires once per role+type, every affected class emitted two `[Error]` lines.

## Classified by what each site ADDRESSES, not by how it is spelled

| Bucket | Count | Change |
|---|---:|---|
| Addresses a **NODE** | 58 | → `RequestHub` (new: one `GetClient()` per test method, disposed with the rest) |
| **Node CRUD** (aimed at `Mesh.Address`, or target-less) | 21 | → `ObserveNodeOperation(...)` — a client origin **and** `NodeOperationTarget()` |
| `AwaitResponseAsync` default hub | 7 | `Mesh` → `RequestHub`; the sites relying on the old default got an explicit target |
| Addresses the **ROUTER** (kept) | 6 | unchanged, each with a 🚨 comment saying why |

**Why node CRUD needed more than "not the router":** a **target-less** delivery is
handled by the POSTING hub, so those requests *executed* on the router's action
block — the starvation shape from prod 2026-06-11. `ObserveNodeOperation` aims
them at `portal/nodeops-{meshId}`, so neither end is the router. That is the seam
`MeshService` already uses and `NodeOperationOriginTest` pins.

**The 6 kept sites are not debt** — in each, the router is the *subject*:

- `RouterTrafficDetectorTest` must **produce** the shape (it asserts the "sender"
  role still fires; migrating it would delete the only guard against a future
  narrowing of `RouterTrafficRule` silently switching the detector off).
- `StreamRouteSelfParentTerminationTest` asserts the mesh hub's **own drain** stays
  responsive after a poison `StreamMessage`.
- `UpsertInnerCreateObservationTest` (arm 1) pins #981's literal
  `CreateNodeRequest@mesh/<self>` — a self-targeted create on the router whose
  reply the router's own `HandleCallbacks` drops.
- `ShutdownRoutingRejectClassificationTest` depends on a **synchronous enqueue
  ordering** on the router's action block (stall → probe → `Dispose()`); from a
  client hub the enqueue becomes a routed hop and `Dispose()` could beat the
  probe in, so the reject would come from a different branch — a flake, not a
  stricter test.

## The issue's inventory was an undercount — now measured, and ratcheted

`Mesh.Observe(` as a **substring** finds **56** of the **85** sites in `test/`. It
misses **29**: `Mesh.Observe<TResponse>(` is a different string, and eighteen sites
wrap as `await Mesh` ⏎ `.Observe<…>(`. Eleven of the misses were target-less node
CRUD executing on the router. So the new `RouterAsTestRequestOriginRatchetGuard`
scans with a **whitespace-tolerant regex** over comment/string-masked source
(`SourceScan`), seeded at 6 in `test/RouterRequestOriginSites.allow`, and may only
shrink. It carries the usual non-vacuity test plus two masking canaries (its own
file, and `siloMesh.Observe<…>` which the identifier-boundary look-behind must
exclude).

**The guard was shown FAILING before it was trusted.** Injecting one wrapped site
into a file with no allowance:

```
  NEW SITE   test/MeshWeaver.AI.Test/CodeCellLayoutTest.cs (1) — issue the request from
  MonolithMeshTestBase.RequestHub (a client hub), and for node CRUD aim it at
  RequestHub.NodeOperationTarget(). Do NOT add a line to RouterRequestOriginSites.allow.
Failed!  - Failed: 1, Passed: 1
```

(injection reverted; the tree is the committed one.)

## Evidence — measured, not asserted

`ScriptExecutionInUserHomeTest.Run_StreamsProgressTimely_NotBuffered`, the issue's
own example, run **before** the change (file restored from `origin/main`, rebuilt,
same command):

```
[Error] ROUTER_TRAFFIC: RawJson has the mesh hub as sender
  (sender: mesh/XnvduYALJ0adLXeUOWdNGQ, target: rbuergi/demo-42cdbbc4898f4d129ffe029d9b719587)
[Error] ROUTER_TRAFFIC: ExecuteScriptResponse has the mesh hub as target
  (sender: rbuergi/demo-42cdbbc4898f4d129ffe029d9b719587, target: mesh/XnvduYALJ0adLXeUOWdNGQ)
```

**After: 0 lines** — and 0 across all 9 tests of that class.

- **155 tests green locally**, 13 projects, 0 failures.
- **17 projects build clean** at `dotnet build -c Release -warnaserror`.
- Every site reconciled: 85 before, 85 after (`Mesh.Observe` + `RequestHub.Observe`
  + `ObserveNodeOperation`), so nothing was dropped rather than migrated.

## Deliberately out of scope — filed as #2477

1. **A production `ROUTER_TRAFFIC` source**, visible only once the harness stopped
   generating noise: `MeshExtensions.PreValidateDescendantsObs(meshHub, …)` posts
   `ValidateDeleteRequest` from the **root mesh hub**, so every recursive delete
   logs two lines. Reproduced independently by
   `NodeOperationsTest.DeleteNode_WithChildren_Recursive_ShouldSucceed` (production
   APIs only) and `DeleteTimeoutStageDiagnosticsTest`. Fix is
   `meshHub.NodeOperationIssuingHub()`, but it moves a permission-sensitive
   pipeline and belongs in its own reviewed change.
2. **The TARGET half in tests** — 61 `client.Observe(req, o => o.WithTarget(Mesh.Address))`
   sites (27 `RlsIntegrationTests`, 22 `MeshWeaver.Threading.Test`, 6
   `MeshNodeAuditingTest`, 6 others). Origin is already off the router but the
   request still *executes* on it; retargeting moves execution onto a hub with a
   different permission surface — a judgement call per security assertion.
3. **`Mesh.Post(...)`** — 12 sites mixing the router's genuine duties
   (`HeartBeatEvent`, `DisposeRequest` to a hub it hosts) with real violations
   (target-less `TrackActivityRequest` in `Query.Test`/`Auth.Test`). One marker
   cannot tell them apart, which is why the ratchet does not match it.

No What's New entry: test-harness only, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
