### PR TITLE
Module pack: a node repo names the src/ projects that ship in the image, and bundles never carry them

### DIFF
--- a/.github/scripts/module-owned-platform.sh
+++ b/.github/scripts/module-owned-platform.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# The MODULE-OWNED MeshWeaver.* assemblies of a node repo: every MeshWeaver.* project directory in
+# The MODULE-OWNED MeshWeaver.* assemblies of a node repo: every MeshWeaver.* project DIRECTORY in
 # its src/ EXCEPT the ones its src/platform-shipped.txt names — projects that live there but ship
 # in the portal IMAGE (the storage backends and transports that moved out of the platform with the
 # hosts). A module bundle may carry the former (they exist nowhere in /app) and must never carry the
@@ -11,12 +11,17 @@
 #
 # An absent platform-shipped.txt means "nothing is image-shipped" — the state of every node repo
 # before the storage carve-out — and is deliberately not an error: the list DECLARES exclusions.
+# An EMPTY result (a repo whose every MeshWeaver.* project is image-shipped, or one with none) is
+# valid too, and prints an empty line rather than failing.
 set -euo pipefail
 src="${1:?usage: module-owned-platform.sh <node-repo>/src}"
 shipped=""
 if [ -f "$src/platform-shipped.txt" ]; then
   shipped="$(grep -v '^[[:space:]]*#' "$src/platform-shipped.txt" | sed 's/[[:space:]]*$//' | grep -v '^$' || true)"
 fi
-ls "$src" 2>/dev/null | grep '^MeshWeaver\.' | while read -r name; do
-  if ! grep -qxF "$name" <<<"$shipped"; then printf '%s\n' "$name"; fi
-done | paste -sd';' -
+own=()
+while IFS= read -r dir; do
+  name="$(basename "$dir")"
+  if ! grep -qxF "$name" <<<"$shipped"; then own+=("$name"); fi
+done < <(find "$src" -mindepth 1 -maxdepth 1 -type d -name 'MeshWeaver.*' | sort)
+( IFS=';'; printf '%s\n' "${own[*]-}" )

--- a/.github/scripts/module-owned-platform.sh
+++ b/.github/scripts/module-owned-platform.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# The MODULE-OWNED MeshWeaver.* assemblies of a node repo: every MeshWeaver.* project directory in
+# its src/ EXCEPT the ones its src/platform-shipped.txt names — projects that live there but ship
+# in the portal IMAGE (the storage backends and transports that moved out of the platform with the
+# hosts). A module bundle may carry the former (they exist nowhere in /app) and must never carry the
+# latter (a same-identity duplicate beside the app's copy). Printed semicolon-separated, the shape
+# `meshweaver-plugin-build module-pack --own-platform` takes; the bundle inspection in
+# node-repo-module-pack.yml calls this same script so the two cannot disagree.
+#
+#   module-owned-platform.sh <node-repo>/src
+#
+# An absent platform-shipped.txt means "nothing is image-shipped" — the state of every node repo
+# before the storage carve-out — and is deliberately not an error: the list DECLARES exclusions.
+set -euo pipefail
+src="${1:?usage: module-owned-platform.sh <node-repo>/src}"
+shipped=""
+if [ -f "$src/platform-shipped.txt" ]; then
+  shipped="$(grep -v '^[[:space:]]*#' "$src/platform-shipped.txt" | sed 's/[[:space:]]*$//' | grep -v '^$' || true)"
+fi
+ls "$src" 2>/dev/null | grep '^MeshWeaver\.' | while read -r name; do
+  if ! grep -qxF "$name" <<<"$shipped"; then printf '%s\n' "$name"; fi
+done | paste -sd';' -

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -180,7 +180,7 @@ jobs:
           --plugin "${{ matrix.entry.package }}"
           --package-version "${{ steps.identity.outputs.version }}"
           --min-mesh-version "${{ steps.identity.outputs.floor }}"
-          --own-platform "$(ls "$GITHUB_WORKSPACE/src" 2>/dev/null | grep '^MeshWeaver\.' | paste -sd';' -)"
+          --own-platform "$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src")"
           --out "$RUNNER_TEMP/bundles"
 
       # A bundle that PACKED is not yet a bundle that LANDS: assert the closure and the manifest a
@@ -212,7 +212,11 @@ jobs:
           # repo's src/, so they exist nowhere in /app — Import's DataSetReader family) are the
           # deliberate exception: for them, NOT riding is the fault. The jq mirrors the pack's
           # --own-platform set exactly, so the two cannot disagree about what "platform" means.
-          own="$(ls "$GITHUB_WORKSPACE/src" 2>/dev/null | grep '^MeshWeaver\.' | paste -sd';' -)"
+          # …EXCEPT the projects the repo lists in src/platform-shipped.txt: they live in its src/
+          # yet ship in the portal IMAGE (the storage backends and transports that moved out of the
+          # platform with the hosts), so a bundle carrying one would land a same-identity duplicate
+          # beside the app's copy. ONE script computes the set for the pack AND for this check.
+          own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src")"
           jq -e --arg m "$MODULE" --arg own "$own" \
             '($own | split(";")) as $owned
              | [.module.assemblies[]


### PR DESCRIPTION
## What

`node-repo-module-pack.yml` computed the "module-owned" set as every `MeshWeaver.*` directory in the node repo's `src/`. That held while everything there existed nowhere in `/app`. With the storage backends and transports moving into MeshWeaver.Plugins beside the hosts (still shipped in the portal image — a Store-installed module needs storage to already work), a registry bundle whose module references one of them (`Indexing.PostgreSql` → `Hosting.PostgreSql`, `Mcp` → `InstanceSync`) would carry a same-identity duplicate beside the app's copy.

One script, `.github/scripts/module-owned-platform.sh`, now computes the set for both the pack's `--own-platform` and the bundle inspection: `src/` minus the names in the repo's `src/platform-shipped.txt`. An absent list is the pre-carve-out state (nothing excluded) — it declares exclusions, it is not a gate input.

Needed on `main` before the plugins move-in PR merges (its `src/platform-shipped.txt` lists the eight moved projects).

Self-test: with `platform-shipped.txt` naming `MeshWeaver.B`, `[MeshWeaver.A]`; without it, `[MeshWeaver.A;MeshWeaver.B]`.

No What's New entry: CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8RtDNQGywnbbY2T5j5T28