### PR TITLE
Portal ingress accepts a module bundle — the 1 MB default answered 413 before the portal saw it

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -382,6 +382,14 @@ ingress:
     # (ERR_CONNECTION_CLOSED) — the "page renders a random subset / stops prematurely" bug. The
     # stream must flush frame-by-frame, so response buffering MUST be off.
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    # 🚨 MODULE BUNDLES ARE POSTED THROUGH THIS INGRESS. /api/plugins/bundles/{package} is the
+    # registry's acquisition half (ModulePublish → ModuleLandingService.ShelveModule), and a real
+    # bundle is tens of MB — DefaultViews is ~19 MB with its 254 static assets. nginx's DEFAULT
+    # body limit is 1 MB, so without this the route answers 413 before the request ever reaches
+    # the portal, and no module can ever be published to a chart-deployed registry. The MCP
+    # ingress has carried this for its own uploads since it was written; the portal ingress —
+    # which is the one serving /api — did not, so the two disagreed about how big a POST may be.
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
 # ---- Next.js React portal (experimental frontend — FEATURE-FLAGGED) --------
 # When enabled, a Next.js streaming-SSR build of the React GUI (clients/portal-next)
 # runs as its OWN Deployment beside memex-portal, and the portal ingress gains a


### PR DESCRIPTION
## What

Adds `nginx.ingress.kubernetes.io/proxy-body-size: "100m"` to `ingress.annotations` in
`deploy/helm/values.yaml`, so the `memex-portal` ingress accepts a module-bundle-sized POST.

## Why

`/api/plugins/bundles/{package}` — the registry's acquisition half (`ModulePublish` →
`ModuleLandingService.ShelveModule`) — is served by the `memex-portal` ingress, and a real module
bundle is tens of MB. `DefaultViews` is ~19 MB with its 254 static assets.

That ingress carried no `proxy-body-size`, so nginx refused the upload at its **1 MB default** with
a 413 the portal never saw. **No module could be published to any chart-deployed registry.**

Two things made this invisible until now:

1. `memex-portal-mcp`, defined in the *same* template
   (`deploy/helm/templates/memex-portal/ingress.yaml`), has carried `100m` for its own uploads since
   it was written. Two ingresses on the same host disagreed about how big a POST may be — and the one
   serving `/api` was the smaller.
2. The AKS manifests set it independently (`deploy/aks/manifests/portal-ingress.yaml:36`), so
   production was never affected. Only chart-based deployments were.

## Evidence

Against a local chart-deployed portal, POSTing the real 19 MB `DefaultViews` bundle:

```
before:  HTTP 413  (nginx, "Request Entity Too Large" — the portal is never reached)
after:   HTTP 200  {"module":"MeshWeaver.Blazor.Views","version":"1.1.1","files":70,"held":false}
```

Confirmed in the controller's generated config that `memex.localhost` `/` moved from
`client_max_body_size 1m` to `100m`, and that the portal then answered on its own — an invalid token
returns `401 {"error":"the presented publish token is not valid"}` from
`ModulePublish.DeclineAuthorization` with the full 18,901,905 bytes uploaded.

## Scope

The annotation lands on `ingress.annotations`, which the template renders through
`{{- with .Values.ingress.annotations }}` — so a deployment can still override it.

## What's New

Skipped deliberately: this is deployment configuration with no user-visible effect on the portal.
The 413 was reachable only by an operator publishing a module to a chart-deployed registry, and
production (AKS) already set the annotation by another path.

## Related

Found while landing `DefaultViews`/`GraphViews` onto a local install for #2417. It is an
independent defect and does not depend on how #2417 is scoped.