### PR TITLE
fix: a framework roll is FrameworkStale, not a phantom dependency drift

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-bake-state-names-the-framework-roll.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-bake-state-names-the-framework-roll.md
@@ -1,0 +1,20 @@
+---
+Name: Stale NodeTypes now say what actually went stale
+Category: Fix
+Description: After a platform update, NodeTypes waiting to rebuild are reported as framework-stale instead of blaming a module change, and a genuine dependency drift now names the dependency.
+Icon: Sparkle
+Order: -20260827
+---
+
+# Stale NodeTypes now say what actually went stale
+
+After a platform update, every NodeType has to be rebuilt against the new platform. That is normal
+and harmless. Until now the portal described those NodeTypes as having a changed module or toolchain
+dependency, which read as a fault in your content when nothing about your content had changed.
+
+Types waiting for an ordinary post-update rebuild are now reported as framework-stale, which is the
+state that has always been documented as benign. The message that blames a changed dependency is now
+reserved for the case where the platform did NOT move and something a type binds genuinely did — and
+in that case it names the dependency that moved, instead of leaving you to guess.
+
+This is a reporting change only: exactly the same NodeTypes are rebuilt, at the same time, as before.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeBakeStatus.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeBakeStatus.cs
@@ -60,6 +60,18 @@ public enum BakeState
     /// — while the FRAMEWORK identity still matches. 🚨 Checked BEFORE the store's bytes-win rule:
     /// the store key carries the framework tag but NOT the dependency record, so a bytes-hit under
     /// the live framework can be exactly the drifted build this state exists to replace.
+    ///
+    /// <para>🚨 <b>"while the FRAMEWORK identity still matches" is now ENFORCED, not just
+    /// described.</b> It never held: the reserved <c>!toolchain</c> entry hashes the
+    /// <see cref="Compiler.FrameworkBuildIdentity.FullMvidAssemblies"/> closure's implementation MVIDs and
+    /// <see cref="Compiler.FrameworkBuildIdentity.FrameworkVersion"/> folds those same MVIDs, so a framework
+    /// roll moves the record BY CONSTRUCTION. This state therefore reported every ordinary deploy
+    /// as a dependency drift and made <see cref="FrameworkStale"/> unreachable for any
+    /// record-stamped type — measured on memex-cloud 2026-08-27 as 273 of 273 uncovered types
+    /// DependencyStale and zero FrameworkStale, with nothing changed but the image. A mismatch the
+    /// framework identity already accounts for is now classified <see cref="FrameworkStale"/>;
+    /// reaching THIS state means the framework held still and a binding genuinely moved, and the
+    /// entry that moved is named in <see cref="NodeTypeBakeEntry.Detail"/>.</para>
     /// </summary>
     DependencyStale,
 }
@@ -188,11 +200,32 @@ public static class NodeTypeBakeStatus
         string liveFrameworkVersion,
         Func<string, string?>? liveDependencyIdOf = null,
         string? liveToolchainId = null)
+        => ClassifyDetailed(
+            definition, storeHasBytes, liveFrameworkVersion, liveDependencyIdOf, liveToolchainId)
+            .State;
+
+    /// <summary>
+    /// <see cref="Classify"/> plus the dependency record's FIRST mismatch, when one decided the
+    /// verdict.
+    ///
+    /// <para>🚨 The reason exists and was being thrown away. <see cref="Classify"/> asked
+    /// <c>FindMismatch(…) is not null</c> and the caller then printed a fixed sentence — "a bound
+    /// module/toolchain dependency changed" — so the one string that says WHICH dependency moved
+    /// (<c>'name' built against X, live is Y</c>) never reached an operator. Three independent
+    /// investigations across three repos could not tell an ordinary framework roll from a module
+    /// drift because of it. The verdict is unchanged; only the diagnostics are recovered.</para>
+    /// </summary>
+    internal static (BakeState State, string? DependencyMismatch) ClassifyDetailed(
+        NodeTypeDefinition definition,
+        bool storeHasBytes,
+        string liveFrameworkVersion,
+        Func<string, string?>? liveDependencyIdOf = null,
+        string? liveToolchainId = null)
     {
         ArgumentNullException.ThrowIfNull(definition);
 
         if (definition.CompilationStatus == CompilationStatus.Error)
-            return BakeState.PreviouslyBroken;
+            return (BakeState.PreviouslyBroken, null);
 
         var hasRecordedAssembly =
             !string.IsNullOrEmpty(definition.LatestAssemblyCollection)
@@ -200,7 +233,10 @@ public static class NodeTypeBakeStatus
             && definition.LastCompiledVersion is not null;
 
         if (!hasRecordedAssembly)
-            return BakeState.NeverBuilt;
+            return (BakeState.NeverBuilt, null);
+
+        var frameworkMoved = !string.Equals(
+            definition.CompiledFrameworkVersion, liveFrameworkVersion, StringComparison.Ordinal);
 
         // 🚨 The per-type dependency record (#1707 slice 2) is checked BEFORE the bytes-win rule:
         // the store key carries the framework tag but NOT the record, so a bytes-hit under the
@@ -211,8 +247,29 @@ public static class NodeTypeBakeStatus
         if (definition.CompiledDependencies is { } record
             && liveDependencyIdOf is not null
             && Compiler.CompiledDependencies.FindMismatch(
-                record, liveDependencyIdOf, liveToolchainId ?? "") is not null)
-            return BakeState.DependencyStale;
+                record, liveDependencyIdOf, liveToolchainId ?? "") is { } mismatch)
+            // 🚨 ATTRIBUTE THE MISMATCH TO THE FRAMEWORK WHEN THE FRAMEWORK EXPLAINS IT.
+            // The reserved '!toolchain' entry is a hash over the FullMvidAssemblies closure's
+            // implementation MVIDs, and FrameworkVersion folds those SAME MVIDs (every closure
+            // member is a ContentSurfaceAssemblies member). A framework roll therefore moves
+            // '!toolchain' BY CONSTRUCTION, and every platform ref-asm entry moves with it — so
+            // for any record-stamped type the dependency check fires on every deploy and
+            // DependencyStale swallowed FrameworkStale whole, leaving the ordinary,
+            // documented-as-benign every-deploy state unreachable in practice.
+            //
+            // Measured on memex-cloud 2026-08-27: 273 of 273 uncovered types reported
+            // DependencyStale ("a bound module/toolchain dependency changed") and ZERO reported
+            // FrameworkStale, while the only thing that had actually changed was the image —
+            // the types carried framework sceaefc9…/'!toolchain' mvid:bc0ed79d… against a live
+            // s66ba35f…/mvid:f8a7cc07…. Three separate investigations then hunted a module
+            // drift that did not exist.
+            //
+            // The DECLINE is unchanged (both states are NeedsBake and WasHealthy, and this still
+            // preempts the bytes-win rule below) — only the NAME changes, and only when the
+            // framework identity already accounts for it.
+            return frameworkMoved
+                ? (BakeState.FrameworkStale, mismatch)
+                : (BakeState.DependencyStale, mismatch);
 
         // 🚨 BYTES WIN OVER THE RECORD, in both directions — this is the whole premise.
         //
@@ -223,13 +280,13 @@ public static class NodeTypeBakeStatus
         // Reporting that FrameworkStale would rebuild something already sitting on the volume, which
         // is exactly the wasted work this probe exists to avoid.
         if (storeHasBytes)
-            return BakeState.Baked;
+            return (BakeState.Baked, null);
 
-        if (!string.Equals(definition.CompiledFrameworkVersion, liveFrameworkVersion, StringComparison.Ordinal))
-            return BakeState.FrameworkStale;
+        if (frameworkMoved)
+            return (BakeState.FrameworkStale, null);
 
         // The record claims a live-framework build and the store does not have it.
-        return BakeState.BytesMissing;
+        return (BakeState.BytesMissing, null);
     }
 
     /// <summary>
@@ -306,14 +363,17 @@ public static class NodeTypeBakeStatus
 
             if (!probeable)
                 return Observable.Return(Describe(typePath, definition,
-                    Classify(definition, false, framework, liveDependencyIdOf, liveToolchainId)));
+                    ClassifyDetailed(
+                        definition, false, framework, liveDependencyIdOf, liveToolchainId)));
 
             return store
                 .TryGetAssemblyPath(typePath, definition.LastCompiledVersion!.Value)
                 .Take(1)
                 .Select(path => Describe(
                     typePath, definition,
-                    Classify(definition, !string.IsNullOrEmpty(path), framework, liveDependencyIdOf, liveToolchainId)))
+                    ClassifyDetailed(
+                        definition, !string.IsNullOrEmpty(path), framework,
+                        liveDependencyIdOf, liveToolchainId)))
                 // Fail SAFE, never fail OPEN: an unreadable store must mean "bake it", not "trust
                 // the record and serve bytes that may not exist".
                 .Catch<NodeTypeBakeEntry, Exception>(ex =>
@@ -326,19 +386,33 @@ public static class NodeTypeBakeStatus
                 });
         });
 
-    private static NodeTypeBakeEntry Describe(string typePath, NodeTypeDefinition definition, BakeState state)
-        => new(typePath, state, state switch
+    private static NodeTypeBakeEntry Describe(
+        string typePath,
+        NodeTypeDefinition definition,
+        (BakeState State, string? DependencyMismatch) verdict)
+        => new(typePath, verdict.State, verdict.State switch
         {
             BakeState.Baked => null,
             BakeState.NeverBuilt => "no assembly recorded",
+            // The framework line is the explanation; the record mismatch that came with it is a
+            // CONSEQUENCE of the roll, so it is named as corroboration rather than as a cause.
             BakeState.FrameworkStale =>
-                $"built against framework {Short(definition.CompiledFrameworkVersion)}",
+                $"built against framework {Short(definition.CompiledFrameworkVersion)}"
+                + (verdict.DependencyMismatch is { } corroboration
+                    ? $" (its dependency record moved with it: {corroboration})"
+                    : string.Empty),
             BakeState.BytesMissing =>
                 $"record claims {definition.LatestAssemblyCollection}/{definition.LatestAssemblyPath} "
                 + "but the store has no bytes",
             BakeState.PreviouslyBroken => "last compile settled at Error",
-            BakeState.DependencyStale => "the stamped dependency record no longer validates here "
-                + "(a bound module/toolchain dependency changed)",
+            // 🚨 NAME THE DEPENDENCY. This state now means what it says — the framework did NOT
+            // move and something this build binds did — so the entry that moved is the whole
+            // finding, and printing it is the difference between an actionable line and a sweep.
+            BakeState.DependencyStale =>
+                "the stamped dependency record no longer validates here"
+                + (verdict.DependencyMismatch is { } drift
+                    ? $": {drift}"
+                    : " (a bound module/toolchain dependency changed)"),
             _ => null,
         });
 

--- a/test/MeshWeaver.Graph.Test/CompiledDependencyRecordTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompiledDependencyRecordTest.cs
@@ -209,4 +209,75 @@ public class CompiledDependencyRecordTest
                 def, storeHasBytes: true, NodeTypeCompilationHelpers.FrameworkVersion)
             .Should().Be(BakeState.Baked);
     }
+
+    /// <summary>
+    /// 🚨 A framework roll must be reported as <see cref="BakeState.FrameworkStale"/> — the
+    /// ordinary, documented-as-benign every-deploy state — and NOT as a dependency drift.
+    ///
+    /// <para>The reserved <c>!toolchain</c> entry hashes the <c>FullMvidAssemblies</c> closure's
+    /// implementation MVIDs, and the framework identity folds those same MVIDs, so a roll moves
+    /// the record BY CONSTRUCTION and the dependency check fires on every deploy. Before this was
+    /// enforced, DependencyStale swallowed FrameworkStale whole: memex-cloud 2026-08-27 reported
+    /// 273 of 273 uncovered types as "a bound module/toolchain dependency changed" with zero
+    /// FrameworkStale, and nothing had changed but the image.</para>
+    /// </summary>
+    [Fact]
+    public void Classify_FrameworkRoll_ReportsFrameworkStale_NotADependencyDrift()
+    {
+        // Stamped under the PREVIOUS image: its toolchain id and every platform ref-asm hash
+        // moved with the framework, exactly as a real roll produces.
+        var record = CompiledDependencies.Compute(
+            ["MeshWeaver.Layout"], Resolver(("MeshWeaver.Layout", "ref:old")), "mvid:toolchain-old");
+        var rolled = UsableDef(record) with { CompiledFrameworkVersion = "s-the-previous-image" };
+
+        NodeTypeBakeStatus.Classify(
+                rolled, storeHasBytes: false,
+                NodeTypeCompilationHelpers.FrameworkVersion,
+                Resolver(("MeshWeaver.Layout", "ref:new")), Toolchain)
+            .Should().Be(BakeState.FrameworkStale,
+                "the framework identity already accounts for the record moving");
+
+        // The verdict is unchanged in every way that matters operationally: it still needs a bake,
+        // and it is still a regression-gate candidate.
+        var entry = new NodeTypeBakeEntry("T", BakeState.FrameworkStale);
+        entry.NeedsBake.Should().BeTrue();
+        entry.WasHealthy.Should().BeTrue();
+
+        // A drift under an UNCHANGED framework is still a genuine DependencyStale.
+        NodeTypeBakeStatus.Classify(
+                UsableDef(CompiledDependencies.Compute(
+                    ["Custom.Module"], Resolver(("Custom.Module", "mvid:v1")), Toolchain)),
+                storeHasBytes: false,
+                NodeTypeCompilationHelpers.FrameworkVersion,
+                Resolver(("Custom.Module", "mvid:v2")), Toolchain)
+            .Should().Be(BakeState.DependencyStale,
+                "the framework held still, so the moved binding IS the finding");
+    }
+
+    /// <summary>
+    /// The mismatch reason must reach the caller. It was computed and discarded, so every stale
+    /// type printed one fixed sentence and no operator could tell WHICH dependency moved.
+    /// </summary>
+    [Fact]
+    public void ClassifyDetailed_NamesTheDependencyThatMoved()
+    {
+        var record = CompiledDependencies.Compute(
+            ["Custom.Module"], Resolver(("Custom.Module", "mvid:v1")), Toolchain);
+
+        var verdict = NodeTypeBakeStatus.ClassifyDetailed(
+            UsableDef(record), storeHasBytes: true,
+            NodeTypeCompilationHelpers.FrameworkVersion,
+            Resolver(("Custom.Module", "mvid:v2")), Toolchain);
+
+        verdict.State.Should().Be(BakeState.DependencyStale);
+        verdict.DependencyMismatch.Should().NotBeNull()
+            .And.Contain("Custom.Module").And.Contain("mvid:v1").And.Contain("mvid:v2");
+
+        // A clean build carries no reason to report.
+        NodeTypeBakeStatus.ClassifyDetailed(
+                UsableDef(record), storeHasBytes: true,
+                NodeTypeCompilationHelpers.FrameworkVersion,
+                Resolver(("Custom.Module", "mvid:v1")), Toolchain)
+            .DependencyMismatch.Should().BeNull();
+    }
 }


### PR DESCRIPTION
## The finding

Investigating "prebuilt bundle adoption fails even when a correct bundle exists" across
Education#216 / SocialMedia#75 / Plugins#723. **The single-predicate hypothesis is refuted** — no
predicate declines a correct bundle. What *is* real is a mislabel that made three unrelated problems
look like one.

### Measurement (memex-cloud, `memex-portal-ai:3.0.0-rc8.ci.6028`, 2026-08-27)

```
ShippedPrebuiltBundles: 79 prebuilt assembly(ies) from 34 shipped bundle(s) under
  /data/prebuilt-bundles/s66ba35f452e54574b804c25724edda75 are backed by the assembly store
  — 1 adopted now, 78 already current
DynamicTypePreWarmer: 273 dynamic NodeType(s) were NOT covered … (DependencyStale: the stamped
  dependency record no longer validates here (a bound module/toolchain dependency changed)) ×273
```

- Adoption **works**: every bundle addressed to the live identity was adopted or already current.
- `grep -c 'dependency record mismatch'` over 48 h of logs on **both** prod portals: **0**. Zero
  `DECLINED` lines of any kind. The seeder's dependency gate has not declined a bundle in production.
- The 273 are **not baked by any bundle** (partition content no CI bake covers). They are
  *framework*-stale, and they said so: `AgenticBusiness/Menu` and `Claims/Claim` carry
  `compiledFrameworkVersion=sceaefc9…`, `!toolchain=mvid:bc0ed79d…`, against a live `s66ba35f…` /
  `mvid:f8a7cc07…` — the value `Store/Plugin` stamped compiling on this image the same morning.

### Why they were mislabeled

`Classify` checked the dependency record **before** the framework comparison, and the two are not
independent. `!toolchain` hashes the `FullMvidAssemblies` closure's impl MVIDs; `FrameworkVersion`
folds those same MVIDs — all 16 closure members are `ContentSurfaceAssemblies` members, and both sets
are pinned by `FrameworkBuildIdentityTest`. So a framework roll moves the record **by construction**,
the dependency check always wins the race, and `FrameworkStale` — "the ordinary every-deploy state …
ABI safety, not a bug" — is unreachable for any record-stamped type. 273/273 vs 0/273 is that
theorem showing up in a log.

Compounding it, the mismatch reason was **computed and discarded**: `Describe` printed one fixed
sentence, so the string naming *which* dependency moved never reached anyone.

## The fix

- A mismatch the framework identity already accounts for → `FrameworkStale`. Reaching
  `DependencyStale` now means the framework held still and a binding genuinely moved.
- `ClassifyDetailed` returns the first mismatch; `DependencyStale`'s detail names it.

**The decline is unchanged.** Both states are `NeedsBake` + `WasHealthy`, the dependency check still
preempts the bytes-win rule, `IsAlreadyAdopted` still requires `Baked`. Same NodeTypes rebuild at the
same time — only the name and the diagnostics change.

## What this does and does not explain

| Symptom | Explained? |
|---|---|
| SocialMedia#75 — `DependencyStale` on 93/101 | **Yes.** The ordinary framework roll, not a module drift. Its other pillar is also a misread: `latestAssemblyCollection: "local"` is `FileSystemAssemblyStore.FileSystemCollectionName`, set by `PutWithLocation` for adopted and compiled builds alike — never evidence of non-adoption. |
| Education#216 | **No — distinct.** Identity matches, `DECLINED: 0`. Its own thread root-caused it: the 60 s `Timeout` in `PackageInstaller.SeedPrebuiltAssemblies`. |
| Plugins#723 | **No — distinct.** Distribution-side: bundle *version* doesn't move on a platform-identity rebuild, so the pull side never fetches. Untouched here. |
| `Edu/CourseCatalog` gate failures | **No — distinct.** On memex it is `Ok`, framework- and toolchain-current. `compile=Ok render=ok tests=FAILED` is downstream of loading. |

## Testing

`dotnet build -c Release -warnaserror` clean; `MeshWeaver.Graph.Test` 71/71 pass across
`CompiledDependencyRecordTest`, `NodeTypeBakeStatusTest`, `FrameworkBuildIdentityTest`,
`LoadableBuildPredicateTest`, `NodeTypeCompileStateTest`. Two new tests pin the framework-roll
attribution and the recovered reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)