### PR TITLE
fix(portal): an unknown /api/… path is a 404, never the app shell

### DIFF
--- a/src/MeshWeaver.Hosting.AspNetCore/Portal/NonfileRouteConstraint.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/Portal/NonfileRouteConstraint.cs
@@ -28,6 +28,13 @@ public class NonfileRouteConstraint : IRouteConstraint
     {
         "_framework", "_content", "_blazor", "favicon.ico",
         "auth", "dev",
+        // 🚨 "api" — every mapped API endpoint outranks the catch-all anyway; this entry is for the
+        // UNMAPPED ones. Without it an unknown /api/… path (a typo, or an endpoint the running build
+        // does not have yet) is served the app shell with 200, and every API client reads that as
+        // success: the plugin gate's upstream-seed fetch took memex's HTML for a sealed-but-empty
+        // publication index (2026-08-27, MeshWeaver.SocialMedia#84) because the registry was one
+        // build behind #2487. An API miss must be a 404 a machine can act on, never a web page.
+        "api",
         "signin-microsoft", "signin-google", "signin-linkedin", "signin-apple"
     };
 

--- a/test/Memex.Portal.Shared.Test/McpRoutingTest.cs
+++ b/test/Memex.Portal.Shared.Test/McpRoutingTest.cs
@@ -129,6 +129,41 @@ public class McpRoutingTest
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
+    /// <summary>
+    /// An UNMAPPED /api/… path must be a 404, never the app shell. Every API client — curl in a CI
+    /// gate, a plugin fetcher, a webhook sender — reads a 200 as success and then parses HTML as
+    /// data. Measured 2026-08-27: the plugin gate's upstream-seed fetch took memex's HTML for a
+    /// sealed-but-empty publication index because the registry was one build behind #2487.
+    /// Mapped API endpoints are untouched (they outrank the catch-all); a partition page still renders.
+    /// </summary>
+    [Fact]
+    public async Task UnknownApiPath_AnswersAnHonest404_NeverTheShell()
+    {
+        await using var app = BuildApp(mapMcpEndpoint: true);
+        await app.StartAsync();
+        using var client = app.GetTestClient();
+
+        foreach (var accept in new[] { "application/json", "text/html,application/xhtml+xml" })
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "/api/plugins/bundles/prebuilt/s0/plugins");
+            request.Headers.TryAddWithoutValidation("Accept", accept);
+            var response = await client.SendAsync(request);
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+                because: $"an unmapped /api path with Accept '{accept}' must fail loud, not render the shell");
+        }
+
+        // Control: the exclusion is root-anchored on the `api` segment only — a partition named
+        // anything else still reaches the page, and a mesh path merely CONTAINING "api" is untouched.
+        foreach (var path in new[] { "/Apiary", "/Docs/api" })
+        {
+            var browser = new HttpRequestMessage(HttpMethod.Get, path);
+            browser.Headers.TryAddWithoutValidation("Accept", "text/html");
+            var page = await client.SendAsync(browser);
+            page.StatusCode.Should().Be(HttpStatusCode.OK, because: $"{path} is a page, not an API path");
+            (await page.Content.ReadAsStringAsync()).Should().Be("page:" + path.TrimStart('/'));
+        }
+    }
+
     [Fact]
     public async Task ModuleNotLoaded_JsonPostAnswersAnHonest404_NeverTheShell()
     {


### PR DESCRIPTION
Every mapped API endpoint outranks the root catch-all, so this only changes UNMAPPED /api paths:
a typo, or an endpoint the running build does not have yet. Those were served the Blazor app
shell with 200, and every API client reads a 200 as success and then parses HTML as data.
Measured 2026-08-27: the plugin gate's upstream-seed fetch took memex's HTML for a
sealed-but-empty publication index (MeshWeaver.SocialMedia#84) because the registry was one
build behind #2487 — the step failed naming the wrong condition.

"api" joins NonfileRouteConstraint's root-anchored exclusions, so the miss falls through to a
real 404 exactly like _framework/_content/auth already do. Pinned in McpRoutingTest with a
control that /Apiary and /Docs/api still render as pages. The gate-side defence (refuse a
non-JSON index) is #2497; this is the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)