### PR TITLE
fix(modules): the closure lane lays out the CALLER's inventory, not this file's

### DIFF
--- a/memex/MeshModulesPublish.targets
+++ b/memex/MeshModulesPublish.targets
@@ -138,6 +138,28 @@
     <MeshModuleClosure Include="$(MSBuildThisFileDirectory)../src/MeshWeaver.Social/MeshWeaver.Social.csproj" />
   </ItemGroup>
 
+  <!-- 🚨 THE CALLER'S INVENTORY, NOT THIS FILE'S. The closure-lane worker targets below run as an
+       INNER build of this file, which evaluates only the rows written above — a host's own rows
+       (Remove by %(Filename) + Include after the import, the shape MeshWeaver.Plugins' hosts use for
+       Cosmos/Snowflake since the projects moved there, #2485) never reached it. Measured
+       2026-08-27: before the move the lane silently laid out CORE's copy of a backend, not the
+       host's; after it, the subset lane named modules an empty inventory could not find and the
+       Plugins hosts job went red on `names no module in the inventory`. So each caller passes its
+       evaluated @(MeshModuleClosure) as MeshModulesClosureProjects (pipe-joined — the Properties
+       attribute is itself ';'-separated) and, in the inner build, it REPLACES the inventory at
+       evaluation time, so restore and layout both act on what the host declared. A host that
+       imports this file never sets the property, so its own evaluation is untouched. -->
+  <PropertyGroup Condition="'$(MeshModulesClosureProjects)' != ''">
+    <!-- The ';' a property FUNCTION produces are ESCAPED (%3B) and stay escaped through a property
+         hop, so the Include would see one literal spec naming all the paths as ONE project file
+         (measured: MSB3202). [MSBuild]::Unescape turns them back into item separators. -->
+    <_MeshModulesCallerClosureList>$(MeshModulesClosureProjects.Replace('|', ';'))</_MeshModulesCallerClosureList>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(MeshModulesClosureProjects)' != ''">
+    <MeshModuleClosure Remove="@(MeshModuleClosure)" />
+    <MeshModuleClosure Include="$([MSBuild]::Unescape('$(_MeshModulesCallerClosureList)'))" />
+  </ItemGroup>
+
   <!--
     MeshModulesClosureSubset — narrow the CLOSURE lane to the named modules (semicolon-separated,
     no extension). The inventory above stays the ONE place a module's path is written; a consumer
@@ -254,10 +276,13 @@
          module's own dll in the app root (in a dev bin/ that is routinely a STALE file from the
          pre-flip era, not a re-added reference), and a HOST may turn even that off — see
          MeshModulesGuardPublishAppRoot below. -->
+    <PropertyGroup>
+      <_MeshModulesCallerClosure>@(MeshModuleClosure, '|')</_MeshModulesCallerClosure>
+    </PropertyGroup>
     <MSBuild Projects="$(MSBuildThisFileFullPath)"
              Targets="LayoutMeshModuleClosures"
              BuildInParallel="false"
-             Properties="MeshModulesAppDir=$(_AppPublishDir);Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=$(MeshModulesGuardPublishAppRoot);MeshModulesClosureSubset=$([MSBuild]::Escape('$(MeshModulesClosureSubset)'))" />
+             Properties="MeshModulesClosureProjects=$(_MeshModulesCallerClosure);MeshModulesAppDir=$(_AppPublishDir);Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=$(MeshModulesGuardPublishAppRoot);MeshModulesClosureSubset=$([MSBuild]::Escape('$(MeshModulesClosureSubset)'))" />
 
     <ItemGroup>
       <_ModuleFileKept Include="$(_AppPublishDir)modules/**/*.*" />
@@ -272,10 +297,13 @@
        same folder ResolveModulePath probes first. Thin-lane modules deliberately stay out: their
        DLLs already ride the app output via the ProjectReference. -->
   <Target Name="LayoutMeshModuleClosuresAfterBuild" AfterTargets="Build" Condition="'$(PublishMeshModules)' != 'false'">
+    <PropertyGroup>
+      <_MeshModulesCallerClosure>@(MeshModuleClosure, '|')</_MeshModulesCallerClosure>
+    </PropertyGroup>
     <MSBuild Projects="$(MSBuildThisFileFullPath)"
              Targets="LayoutMeshModuleClosures"
              BuildInParallel="false"
-             Properties="MeshModulesAppDir=$([System.IO.Path]::GetFullPath('$(OutDir)', '$(MSBuildProjectDirectory)'));Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=false;MeshModulesClosureSubset=$([MSBuild]::Escape('$(MeshModulesClosureSubset)'))" />
+             Properties="MeshModulesClosureProjects=$(_MeshModulesCallerClosure);MeshModulesAppDir=$([System.IO.Path]::GetFullPath('$(OutDir)', '$(MSBuildProjectDirectory)'));Configuration=$(Configuration);MeshModulesTargetFramework=$(TargetFramework);NetCoreTargetingPackRoot=$(NetCoreTargetingPackRoot);MeshModulesGuardAppRoot=false;MeshModulesClosureSubset=$([MSBuild]::Escape('$(MeshModulesClosureSubset)'))" />
   </Target>
 
   <!--
@@ -298,7 +326,7 @@
              Targets="Restore"
              BuildInParallel="false"
              Properties="Configuration=$(Configuration)"
-             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
+             RemoveProperties="MeshModulesClosureProjects;MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
     <!-- Says ONCE per build, however many lanes are open — which is the whole assertion this target
          makes, and the cheapest way to notice if a property leak ever forks the configuration again
          (two of these lines in one log means the dedupe is gone and #2127 is live). -->
@@ -386,7 +414,7 @@
              Targets="Build"
              BuildInParallel="false"
              Properties="Configuration=$(Configuration)"
-             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
+             RemoveProperties="MeshModulesClosureProjects;MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishDir;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
     <!-- SatelliteResourceLanguages=en: without it the closure publish lays out a culture folder
          per Roslyn localization (cs/de/es/… via Kernel.Hub), every one a same-identity duplicate
          of the app's own satellite folders. Suppressing them at the SOURCE beats deleting them
@@ -397,7 +425,7 @@
              Targets="Publish"
              BuildInParallel="false"
              Properties="Configuration=$(Configuration);NoBuild=true;SatelliteResourceLanguages=en;PublishDir=$(_AppDir)modules/%(Filename)/"
-             RemoveProperties="MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
+             RemoveProperties="MeshModulesClosureProjects;MeshModulesAppDir;MeshModulesTargetFramework;MeshModulesHostName;MeshModulesGuardAppRoot;MeshModulesClosureSubset;NetCoreTargetingPackRoot;PublishMeshModules;RuntimeIdentifier;RuntimeIdentifiers;SelfContained;ContainerRuntimeIdentifier;ContainerRuntimeIdentifiers;PublishReadyToRun;PublishSingleFile;PublishTrimmed" />
 
     <!-- Prune (0): the UNREACHABLE half of the RID tree — everything except runtimes/<rid>/native.
 


### PR DESCRIPTION
LayoutMeshModuleClosures runs as an inner MSBuild of MeshModulesPublish.targets itself, which
evaluates only the rows written in that file. A host's own rows — Remove by %(Filename) +
Include after the import, the shape #2485 prescribes for MeshWeaver.Plugins' hosts now that
Cosmos/Snowflake live there — never reached it. Measured 2026-08-27 on the Plugins hosts job:
before #2485 the lane silently laid out CORE's copy of a backend (the host's row was never
consulted); after it, the subset lane named modules an empty inventory could not find and
Plugins main went red on "names no module in the inventory".

Each caller now passes its evaluated @(MeshModuleClosure) as MeshModulesClosureProjects
(pipe-joined — the Properties attribute is ';'-separated; an item expression inside it is
MSB4012), and the inner build REPLACES its inventory with that list at evaluation time, so
restore and layout both act on what the host declared. Two MSBuild traps met on the way and
recorded in the file: a property function's ';' stay escaped through a property hop, so the
Include needs [MSBuild]::Unescape; and the nested RestoreMeshModuleClosures call must keep the
property while a module's own build must not inherit it.

Verified: Plugins' Memex.Hosts.Test builds against this tree and lays out Cosmos + Snowflake
from the Plugins projects (24/24 tests pass); core's Memex.Portal.Shared.Test still builds.
Refs #2485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)