### PR TITLE
fix(data): a Conflict NACK re-reads and re-applies instead of surfacing

### DIFF
--- a/scripts/type-forwards.allow
+++ b/scripts/type-forwards.allow
@@ -25,12 +25,3 @@
 # $(MeshWeaverRoot) (core, MeshWeaver.Plugins, MeshWeaver.SocialMedia — the latter pinned
 # pre-split). A forwarder is impossible here: the base would have to reference the AI assembly,
 # which references the base (the documented reference-cycle case).
-MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.OrleansSharedTestBase  #2501 — test machinery, no module binds it
-MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.OrleansTestBase  #2501 — test machinery, no module binds it
-MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.OrleansTestMeshExtensions  #2501 — test machinery, no module binds it
-MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.OrleansTestMeshNodeAttribute  #2501 — test machinery, no module binds it
-MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.OrleansTestSeedProvider  #2501 — test machinery, no module binds it
-MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.SharedOrleansFixture  #2501 — test machinery, no module binds it
-MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.SharedSiloConfigurator  #2501 — test machinery, no module binds it
-MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.TestClientConfigurator  #2501 — test machinery, no module binds it
-MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.TestSiloConfigurator  #2501 — test machinery, no module binds it

--- a/scripts/type-forwards.allow
+++ b/scripts/type-forwards.allow
@@ -34,4 +34,3 @@ MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.SharedOrlean
 MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.SharedSiloConfigurator  #2501 — test machinery, no module binds it
 MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.TestClientConfigurator  #2501 — test machinery, no module binds it
 MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.TestSiloConfigurator  #2501 — test machinery, no module binds it
-MeshWeaver.Hosting.Orleans.TestBase:MeshWeaver.Hosting.Orleans.Test.TwoSiloCacheUpdateFixture  #2501 — test machinery, no module binds it

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -437,7 +437,11 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         // deadlock, where the import's own progress log could not be written into the partition it
         // was repairing. Captured synchronously at ENQUEUE (the caller's thread, scope live) and
         // re-established around the dispatch below.
-        AccessContext? Caller = null);
+        AccessContext? Caller = null,
+        // 🚨 Conflict-retry counter. A Conflict NACK from the owner means "re-read and re-apply";
+        // this queue re-invokes Update on the CURRENT mirror on every attempt, so a bounded
+        // re-enqueue IS that prescription. See the failure handler in BuildUpdateQueueObservable.
+        int Attempt = 0);
 
     /// <summary>Cached effective-permission probe with expiry.</summary>
     private sealed record AccessEntry(Permission Permissions, DateTimeOffset ValidUntil);
@@ -1646,6 +1650,20 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         return accessService?.Context ?? accessService?.CircuitContext;
     }
 
+    // Conflict-NACK retry policy: how many times a field-merge Update is re-enqueued after the
+
+    // owner refused it on a stale base, and how long to wait so the mirror can catch the
+
+    // intervening write. Measured 2026-08-27 on memex: two pods stamping compile status on the
+
+    // SAME NodeType node ('Store/Plugin') conflicted, the surfaced NACK wedged type preparation,
+
+    // and every course cover rendered the "build did not settle" fallback (#2463's class).
+
+    internal const int MaxConflictRetries = 2;
+
+    internal static readonly TimeSpan ConflictRetryDelay = TimeSpan.FromMilliseconds(400);
+
     private long _updateSeq;
 
     /// <summary>
@@ -1891,6 +1909,40 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                         if (IsMissingNodeFailure(ex))
                             RecordNegative(path, ex);
                         entry.Touch();
+                        // 🚨 A Conflict NACK is the owner PRESCRIBING the remedy: "re-read and
+                        // re-apply". This queue re-invokes the caller's mutation on the CURRENT
+                        // mirror on every attempt, so a bounded, delayed re-enqueue IS that remedy —
+                        // the delay lets the mirror catch the intervening write that staled the
+                        // base. Only field-merge Updates retry; the caller's Result stays untouched
+                        // until the retried attempt settles (same ReplaySubject rides along).
+                        if (ShouldRetryConflict(ex, req.FullNode is not null, req.Attempt, MaxConflictRetries)
+                            && System.Threading.Volatile.Read(ref _disposed) == 0)
+                        {
+                            var retry = req with { Attempt = req.Attempt + 1, EnteredAt = DateTimeOffset.UtcNow };
+                            logger.LogInformation(
+                                "[UpdateQueue] CONFLICT path={Path} seq={Seq} — re-reading and re-applying (attempt {Attempt}/{Max})",
+                                path, req.Seq, retry.Attempt, MaxConflictRetries);
+                            SettleHandoff();
+                            Settle();
+                            Observable.Timer(ConflictRetryDelay).Subscribe(_ =>
+                            {
+                                try
+                                {
+                                    if (System.Threading.Volatile.Read(ref _disposed) != 0)
+                                        req.Result.OnError(ex);
+                                    else
+                                        GetOrCreateUpdateQueue(path).OnNext(retry);
+                                }
+                                catch (Exception requeueEx)
+                                {
+                                    logger.LogWarning(requeueEx,
+                                        "[UpdateQueue] conflict retry could not re-enqueue path={Path} seq={Seq} — surfacing the original conflict",
+                                        path, req.Seq);
+                                    req.Result.OnError(ex);
+                                }
+                            });
+                            return;
+                        }
                         req.Result.OnError(ex);
                         // Nothing landed, so there is no base to hand forward and nothing to wait
                         // for: the successor must re-read the mirror, and must do it NOW.
@@ -2014,6 +2066,18 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             static n => n, result, path, seq, DateTimeOffset.UtcNow, node, CaptureCaller()));
         return result;
     }
+
+
+    /// <summary>
+    /// TRUE when a failed queued write should be re-enqueued instead of surfaced: the owner
+    /// answered with a Conflict NACK ("re-read and re-apply"), the request is a field-merge
+    /// Update (an Overwrite carries no base — its conflicts mean something else), and the
+    /// bounded retry budget is not exhausted. Pure, so the policy is pinned by a unit test.
+    /// </summary>
+    internal static bool ShouldRetryConflict(Exception ex, bool isOverwrite, int attempt, int maxRetries) =>
+        ex is MeshNodeStreamException { Error.Code: MeshNodeErrorCode.Conflict }
+        && !isOverwrite
+        && attempt < maxRetries;
 
     private static MeshNode ConvertContentJsonElementToTyped(
         MeshNode node, JsonSerializerOptions options, ILogger logger,

--- a/test/MeshWeaver.Hosting.Test/ConflictRetryPolicyTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ConflictRetryPolicyTest.cs
@@ -1,0 +1,68 @@
+using System;
+using MeshWeaver.Mesh;
+using MeshWeaver.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins the update queue's conflict-retry POLICY (<see cref="MeshNodeStreamCache.ShouldRetryConflict"/>).
+///
+/// <para>The owner's Conflict NACK carries its own prescription — "re-read and re-apply" — and the
+/// per-path update queue re-invokes the caller's mutation on the CURRENT mirror on every attempt,
+/// so a bounded re-enqueue IS that prescription. Before this policy existed the NACK surfaced to
+/// the caller: measured 2026-08-27 on memex, two pods stamping compile status on the SAME NodeType
+/// node ('Store/Plugin') conflicted, type preparation died on the surfaced exception, and every
+/// course cover in the store rendered the "build did not settle" fallback for hours (#2463's class).</para>
+/// </summary>
+public class ConflictRetryPolicyTest
+{
+    private static Exception Conflict() =>
+        new MeshNodeStreamException(new MeshNodeError(
+            MeshNodeErrorCode.Conflict, "Store/Plugin",
+            "cross-hub write refused: 2 field(s) changed on the owner since the writer's base "
+            + "and nothing was applied — re-read and re-apply"));
+
+    [Fact]
+    public void AConflictedFieldMergeUpdate_Retries_WhileBudgetRemains()
+    {
+        Assert.True(MeshNodeStreamCache.ShouldRetryConflict(
+            Conflict(), isOverwrite: false, attempt: 0, MeshNodeStreamCache.MaxConflictRetries));
+        Assert.True(MeshNodeStreamCache.ShouldRetryConflict(
+            Conflict(), isOverwrite: false, attempt: MeshNodeStreamCache.MaxConflictRetries - 1,
+            MeshNodeStreamCache.MaxConflictRetries));
+    }
+
+    [Fact]
+    public void TheBudgetIsABound_NotASuggestion()
+    {
+        // At the bound the conflict SURFACES — an unbounded retry against a genuinely contested
+        // node would be a write loop wearing a remedy's clothing.
+        Assert.False(MeshNodeStreamCache.ShouldRetryConflict(
+            Conflict(), isOverwrite: false, attempt: MeshNodeStreamCache.MaxConflictRetries,
+            MeshNodeStreamCache.MaxConflictRetries));
+    }
+
+    [Fact]
+    public void AnOverwrite_NeverRetries()
+    {
+        // An Overwrite carries no base — its conflict is not "your base went stale", and
+        // re-sending the same full node would stomp the intervening write on purpose.
+        Assert.False(MeshNodeStreamCache.ShouldRetryConflict(
+            Conflict(), isOverwrite: true, attempt: 0, MeshNodeStreamCache.MaxConflictRetries));
+    }
+
+    [Fact]
+    public void OnlyAConflictNack_Retries()
+    {
+        // Any other failure keeps its meaning: NotFound opens the storm-breaker, Unauthorized is
+        // a denial, a transport fault is a fault. None of them prescribed a re-apply.
+        Assert.False(MeshNodeStreamCache.ShouldRetryConflict(
+            new MeshNodeStreamException(new MeshNodeError(
+                MeshNodeErrorCode.NotFound, "X", "no such node")),
+            isOverwrite: false, attempt: 0, MeshNodeStreamCache.MaxConflictRetries));
+        Assert.False(MeshNodeStreamCache.ShouldRetryConflict(
+            new TimeoutException("owner never answered"),
+            isOverwrite: false, attempt: 0, MeshNodeStreamCache.MaxConflictRetries));
+    }
+}


### PR DESCRIPTION
The owner's Conflict NACK carries its own prescription — "re-read and re-apply" — and the
per-path update queue re-invokes the caller's mutation on the CURRENT mirror on every attempt,
so a bounded, delayed re-enqueue IS that prescription. Until now the NACK surfaced to the
caller: measured 2026-08-27 on memex, two pods stamping compile status on the SAME NodeType
node ('Store/Plugin') conflicted ("2 field(s) changed on the owner since the writer's base"),
type preparation died on the surfaced exception, and every course cover in the store rendered
the "build did not settle" fallback for hours. #2463 is the same class seen from the plugin
gate.

Policy (pinned pure in ConflictRetryPolicyTest): only a MeshNodeErrorCode.Conflict retries;
only field-merge Updates (an Overwrite carries no base — re-sending the full node would stomp
the intervening write on purpose); at most MaxConflictRetries (2) with a 400ms delay so the
mirror catches the write that staled the base; at the bound the conflict surfaces — an
unbounded retry against a genuinely contested node would be a write loop wearing a remedy's
clothing. The caller's ReplaySubject rides the retried request, so its terminal is fed exactly
once by whichever attempt settles.

Refs #2463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)