### PR TITLE
An Orleans failure can be read: the window is traced, silo faults are recorded, and a crashed host is a failed result (#2495)

### DIFF
--- a/.github/scripts/record-host-crash.py
+++ b/.github/scripts/record-host-crash.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Turn a test host that DIED into a failed test result inside its own .trx.
+
+Why this exists (issue #2495)
+-----------------------------
+Pass/fail evidence and liveness evidence used to live in two different channels:
+
+  * the ``.trx`` — what the host managed to *stream* before it stopped;
+  * the ``[CI] <name> exit=<n>`` marker — whether the host *survived*.
+
+Every reporter in the pipeline reads only the first. So a host that ran three tests,
+reported them green and then took a SIGSEGV produced a trx saying ``3 passed`` and a
+summary line, a per-shard check and a consolidated check all announcing a pass over a
+process that had crashed. That is exactly what ``MeshWeaver.Content.Test`` did with
+``exit=139``, and it is the failure mode this repo keeps being bitten by: a green signal
+measuring the wrong thing.
+
+The exit-marker gate does still red the shard — but it runs LAST and reports a number,
+while everything a human or an agent actually reads has already said "passed". Adding a
+seventh place that also checks the marker would not fix that; the next reporter added
+would inherit the same blind spot.
+
+So the fix is to make the evidence single-channel: a crash becomes a first-class
+``<UnitTestResult outcome="Failed">`` in the very file every reporter already parses.
+After that, no summary CAN report a pass over a crashed host, because the data it
+summarises contains the failure.
+
+Usage
+-----
+    record-host-crash.py <trx-path> <label> <exit-code> <classification>
+
+``<trx-path>`` need not exist: a host killed at the wall-clock cap writes no trx at all,
+and that case must produce evidence too — a complete one-result trx is written instead.
+
+Exits 0 when the crash was recorded, 1 (with a ``::error::``) when it could not be.
+A diagnostic that cannot fail is not a diagnostic, so this never degrades quietly.
+"""
+
+import os
+import sys
+import uuid
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+
+NS = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"
+UNIT_TEST_TYPE = "13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b"
+TEST_LIST_ID = "8c84fa94-04c1-424b-9868-57a2d4851a1d"
+
+# TRX is schema-ordered; vstest and the GitHub reporters both reject/ignore out-of-order
+# children. Rebuild the document in this order after inserting.
+ELEMENT_ORDER = ["Times", "TestSettings", "Results", "TestDefinitions", "TestEntries",
+                 "TestLists", "ResultSummary"]
+
+
+def q(tag):
+    return f"{{{NS}}}{tag}"
+
+
+def now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def build_empty_run(label):
+    ts = now()
+    run = ET.Element(q("TestRun"), {"id": str(uuid.uuid4()),
+                                    "name": f"{label} (host crash)",
+                                    "runUser": os.environ.get("USER", "ci")})
+    ET.SubElement(run, q("Times"), {"creation": ts, "queuing": ts, "start": ts, "finish": ts})
+    ET.SubElement(run, q("TestSettings"), {"name": "default", "id": str(uuid.uuid4())})
+    ET.SubElement(run, q("Results"))
+    ET.SubElement(run, q("TestDefinitions"))
+    ET.SubElement(run, q("TestEntries"))
+    lists = ET.SubElement(run, q("TestLists"))
+    ET.SubElement(lists, q("TestList"), {"name": "Results Not in a List", "id": TEST_LIST_ID})
+    summary = ET.SubElement(run, q("ResultSummary"), {"outcome": "Failed"})
+    ET.SubElement(summary, q("Counters"), {k: "0" for k in COUNTER_KEYS})
+    return run
+
+
+COUNTER_KEYS = ["total", "executed", "passed", "failed", "error", "timeout", "aborted",
+                "inconclusive", "passedButRunAborted", "notRunnable", "notExecuted",
+                "disconnected", "warning", "completed", "inProgress", "pending"]
+
+
+def ensure(parent, tag, attrib=None):
+    found = parent.find(q(tag))
+    if found is None:
+        found = ET.SubElement(parent, q(tag), attrib or {})
+    return found
+
+
+def reorder(run):
+    children = list(run)
+    run[:] = sorted(children, key=lambda c: ELEMENT_ORDER.index(c.tag.split("}")[1])
+                    if c.tag.split("}")[1] in ELEMENT_ORDER else len(ELEMENT_ORDER))
+
+
+def record(trx_path, label, exit_code, classification):
+    ET.register_namespace("", NS)
+
+    existing_results = 0
+    if os.path.isfile(trx_path) and os.path.getsize(trx_path) > 0:
+        try:
+            run = ET.parse(trx_path).getroot()
+            existing_results = len(run.findall(f"{q('Results')}/{q('UnitTestResult')}"))
+        except ET.ParseError as exc:
+            # A truncated trx is itself crash evidence — do not silently discard the fact
+            # that the host died mid-write. Start a fresh document that SAYS so.
+            classification += f" | the host's own trx was unparseable ({exc}) — it died mid-write"
+            run = build_empty_run(label)
+    else:
+        classification += " | the host wrote no trx at all"
+        run = build_empty_run(label)
+
+    test_id = str(uuid.uuid4())
+    test_name = f"{label}.HOST_CRASHED"
+    storage = os.path.abspath(trx_path)
+    ts = now()
+
+    results = ensure(run, "Results")
+    result = ET.Element(q("UnitTestResult"), {
+        "testName": test_name,
+        "outcome": "Failed",
+        "testType": UNIT_TEST_TYPE,
+        "testListId": TEST_LIST_ID,
+        "testId": test_id,
+        "executionId": test_id,
+        "computerName": os.environ.get("RUNNER_NAME", "unknown"),
+        "duration": "00:00:00.0000000",
+        "startTime": ts,
+        "endTime": ts,
+    })
+    output = ET.SubElement(result, q("Output"))
+    error = ET.SubElement(output, q("ErrorInfo"))
+    ET.SubElement(error, q("Message")).text = (
+        f"The test host for {label} exited {exit_code} — it did NOT complete.\n"
+        f"{classification}\n\n"
+        f"{existing_results} test result(s) were streamed before it stopped. Those results are "
+        f"real, but they are NOT the run: every test that was in flight or not yet started is "
+        f"missing from this file entirely, so the counts here are a floor, not a verdict.\n\n"
+        f"This entry is synthesized by .github/scripts/record-host-crash.py so that the crash "
+        f"lives in the same evidence every reporter reads. Without it the trx said "
+        f"'{existing_results} passed, 0 failed' and every summary repeated that over a dead "
+        f"process (issue #2495)."
+    )
+    ET.SubElement(error, q("StackTrace")).text = (
+        f"exit={exit_code}\nat <test host process for {label}>"
+    )
+    results.append(result)
+
+    definitions = ensure(run, "TestDefinitions")
+    unit_test = ET.SubElement(definitions, q("UnitTest"),
+                              {"name": test_name, "id": test_id, "storage": storage})
+    ET.SubElement(unit_test, q("Execution"), {"id": test_id})
+    ET.SubElement(unit_test, q("TestMethod"), {
+        "codeBase": storage,
+        "className": label,
+        "name": "HOST_CRASHED",
+        "adapterTypeName": "record-host-crash",
+    })
+
+    entries = ensure(run, "TestEntries")
+    ET.SubElement(entries, q("TestEntry"),
+                  {"testListId": TEST_LIST_ID, "testId": test_id, "executionId": test_id})
+
+    lists = ensure(run, "TestLists")
+    if lists.find(q("TestList")) is None:
+        ET.SubElement(lists, q("TestList"), {"name": "Results Not in a List", "id": TEST_LIST_ID})
+
+    summary = ensure(run, "ResultSummary", {"outcome": "Failed"})
+    summary.set("outcome", "Failed")
+    counters = ensure(summary, "Counters", {k: "0" for k in COUNTER_KEYS})
+    for key in ("total", "executed", "failed"):
+        counters.set(key, str(int(counters.get(key, "0") or "0") + 1))
+
+    reorder(run)
+    ET.ElementTree(run).write(trx_path, encoding="utf-8", xml_declaration=True)
+    return test_name
+
+
+def main(argv):
+    if len(argv) != 5:
+        print("::error::record-host-crash.py <trx-path> <label> <exit-code> <classification>",
+              file=sys.stderr)
+        return 1
+    _, trx_path, label, exit_code, classification = argv
+    try:
+        name = record(trx_path, label, exit_code, classification)
+    except Exception as exc:  # noqa: BLE001 — the failure must be loud, whatever it is
+        print(f"::error::could not record the crash of {label} (exit={exit_code}) into "
+              f"{trx_path}: {exc}. The trx therefore still reports whatever the host managed "
+              f"to stream, which would let a summary announce a pass over a dead process — "
+              f"the exact defect issue #2495 exists to remove. Failing rather than degrading.",
+              file=sys.stderr)
+        return 1
+    print(f"recorded host crash as a failed trx result: {name} (exit={exit_code})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -992,6 +992,13 @@ jobs:
           if [ ! -d "$(dirname "$csproj")/bin" ]; then
             echo "::error::$name: bin tree absent — this shard's artifact did not contain it (build/test shard-assign mismatch)."
             echo "[CI] $name exit=97 MISSING_BIN (artifact did not contain this project)" >> test/test-results.log
+            # Same reason as the crash recorder below: a project that produced NO verdict must
+            # not be invisible to every trx reader. It has no bin dir, so the result goes beside
+            # the csproj where the artifact glob (test/**/*.trx) still picks it up.
+            mkdir -p "$(dirname "$csproj")/TestResults"
+            python3 .github/scripts/record-host-crash.py \
+              "$(dirname "$csproj")/TestResults/$name.trx" "$name" 97 \
+              "MISSING_BIN: this shard's artifact did not contain the project, so it never ran. Build/test shard-assign mismatch."
             continue
           fi
           if [ ! -f "$dir/$name.dll" ] || [ ! -f "$dir/xunit.v3.core.dll" ]; then
@@ -1022,6 +1029,9 @@ jobs:
             if [ "${#allclasses[@]}" -eq 0 ]; then
               echo "::error::$label: could not enumerate test classes — refusing to run a partial shard silently."
               echo "[CI] $name exit=96 NO_CLASSES (class enumeration failed for a split project)" >> test/test-results.log
+              python3 .github/scripts/record-host-crash.py \
+                "$dir/TestResults/$name.part$part.trx" "$label" 96 \
+                "NO_CLASSES: class enumeration failed for a split project, so this part ran nothing."
               continue
             fi
             for ((ci=part-1; ci<${#allclasses[@]}; ci+=parts)); do
@@ -1065,24 +1075,52 @@ jobs:
           if [ -f "$trxfile" ]; then
             trxfails=$(grep -oE '<UnitTestResult[^>]*outcome="Failed"' "$trxfile" | wc -l | tr -d ' ')
           fi
+          # `crash` is set for every outcome in which the host did NOT complete. It is the
+          # single switch that decides whether the crash gets written INTO the trx below —
+          # deliberately one variable rather than a call per branch, so a new exit code added
+          # to this case cannot be given a marker without also being given a trx result.
+          crash=""
           case "$rc" in
             0)
               marker="[CI] $name exit=0" ;;
             124|137)
-              marker="[CI] $label exit=$rc TIMEOUT (8m wall-clock cap hit — likely fixture/init hang)" ;;
-            132) marker="[CI] $label exit=$rc SIGNAL SIGILL (host died on a signal, not an assertion)" ;;
-            134) marker="[CI] $label exit=$rc SIGNAL SIGABRT (host died on a signal, not an assertion)" ;;
-            135) marker="[CI] $label exit=$rc SIGNAL SIGBUS (host died on a signal, not an assertion)" ;;
-            139) marker="[CI] $label exit=$rc SIGNAL SIGSEGV (host died on a signal, not an assertion)" ;;
+              marker="[CI] $label exit=$rc TIMEOUT (8m wall-clock cap hit — likely fixture/init hang)"
+              crash="TIMEOUT: killed at the 8m wall-clock cap — a fixture/init hang, not a test failure. The last TEST_START without a matching TEST_END in collected-logs/_meshweaver-test-trace.log names the test it was stuck in." ;;
+            132) marker="[CI] $label exit=$rc SIGNAL SIGILL (host died on a signal, not an assertion)"
+              crash="SIGNAL SIGILL: the host died on a signal, not an assertion." ;;
+            134) marker="[CI] $label exit=$rc SIGNAL SIGABRT (host died on a signal, not an assertion)"
+              crash="SIGNAL SIGABRT: the host died on a signal, not an assertion (FailFast / abort)." ;;
+            135) marker="[CI] $label exit=$rc SIGNAL SIGBUS (host died on a signal, not an assertion)"
+              crash="SIGNAL SIGBUS: the host died on a signal, not an assertion." ;;
+            139) marker="[CI] $label exit=$rc SIGNAL SIGSEGV (host died on a signal, not an assertion)"
+              crash="SIGNAL SIGSEGV: the host died on a signal, not an assertion — see #613 (use-after-unload of a collectible ALC). A mini dump is in collected-logs/." ;;
             *)
               if [ "$rc" = "$trxfails" ]; then
                 marker="[CI] $name exit=$rc TESTFAIL ($trxfails failing test(s) recorded in trx — xunit v3 exits with the failure count; the host completed normally)"
               elif [ ! -f "$trxfile" ]; then
                 marker="[CI] $label exit=$rc MASKED (no trx written — the host died before recording any result)"
+                crash="MASKED: exit=$rc with no trx — the host died before recording any result."
               else
                 marker="[CI] $label exit=$rc MASKED (trx records $trxfails failing test(s), which does not explain exit=$rc — host crashed after streaming results)"
+                crash="MASKED: exit=$rc, but the trx records only $trxfails failing test(s) — that does not explain the exit code, so the host crashed AFTER streaming results."
               fi ;;
           esac
+          # ── The crash becomes a FAILED RESULT in the trx ────────────────────
+          # 🚨 Not a seventh place that re-checks the exit marker — the point is that pass/fail
+          # evidence and liveness evidence stop being two channels. Every reporter downstream
+          # (the trx gate, this shard's summary, the per-shard and consolidated GitHub checks)
+          # reads the trx and ONLY the trx; a host that streamed three green results and then
+          # took a SIGSEGV therefore had all four of them announce "3 passed" over a dead
+          # process. That is what MeshWeaver.Content.Test's exit=139 did (#2495). Writing the
+          # crash into the file they all parse is what makes a pass over a crash unstateable,
+          # including by a reporter added later that nobody remembers to teach.
+          if [ -n "$crash" ]; then
+            mkdir -p "$(dirname "$trxfile")"
+            if ! python3 .github/scripts/record-host-crash.py "$trxfile" "$name" "$rc" "$crash"; then
+              echo "::error::$label: could not record the host crash into $trxfile — the trx still reports only what the host streamed."
+              echo "[CI] $name exit=95 CRASH_RECORD_FAILED (the crash could not be written into the trx — read the marker above, not the trx)" >> test/test-results.log
+            fi
+          fi
           echo "$marker elapsed=${elapsed}s"
           echo "$marker elapsed=${elapsed}s" >> test/test-results.log
           echo "::endgroup::"
@@ -1225,7 +1263,7 @@ jobs:
           fi
         done
         if [ "$any" = "0" ]; then
-          echo "_No failed tests in trx for shard ${{ matrix.shard }} (a crashed/killed host fails via the exit-marker gate below)._" >> "$GITHUB_STEP_SUMMARY"
+          echo "_No failed tests in trx for shard ${{ matrix.shard }}. A crashed/killed host is NOT covered by this silence: since #2495 it is written INTO the trx as a \`<project>.HOST_CRASHED\` failure by .github/scripts/record-host-crash.py, so it would be listed above; the exit-marker gate below is the second, independent check._" >> "$GITHUB_STEP_SUMMARY"
         else
           # 🚨 GATE (TRX-based, reporter-independent): fail the shard on any test
           # failure recorded in the trx. The Publish step below is a best-effort
@@ -1685,7 +1723,7 @@ jobs:
           exit 1
         fi
         if [ "$any" = "0" ]; then
-          echo "_No failed tests in ${trx_count} trx file(s) (a crashed/killed host fails via the exit-marker gate below)._" >> "$GITHUB_STEP_SUMMARY"
+          echo "_No failed tests in ${trx_count} trx file(s). A crashed/killed host is NOT covered by this silence: since #2495 it is written INTO the trx as a \`<project>.HOST_CRASHED\` failure, so it would be listed above; the exit-marker gate below is the second, independent check._" >> "$GITHUB_STEP_SUMMARY"
           echo "No failed tests found in trx across all shards (${trx_count} result files)."
         else
           # 🚨 GATE (TRX-based, reporter-independent): the consolidated run pass/fail

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -996,9 +996,12 @@ jobs:
             # not be invisible to every trx reader. It has no bin dir, so the result goes beside
             # the csproj where the artifact glob (test/**/*.trx) still picks it up.
             mkdir -p "$(dirname "$csproj")/TestResults"
-            python3 .github/scripts/record-host-crash.py \
+            if ! python3 .github/scripts/record-host-crash.py \
               "$(dirname "$csproj")/TestResults/$name.trx" "$name" 97 \
-              "MISSING_BIN: this shard's artifact did not contain the project, so it never ran. Build/test shard-assign mismatch."
+              "MISSING_BIN: this shard's artifact did not contain the project, so it never ran. Build/test shard-assign mismatch."; then
+              echo "::error::$name: could not record MISSING_BIN into a trx — this project stays invisible to every trx reader."
+              echo "[CI] $name exit=95 CRASH_RECORD_FAILED (MISSING_BIN could not be written into a trx — read the marker above, not the trx)" >> test/test-results.log
+            fi
             continue
           fi
           if [ ! -f "$dir/$name.dll" ] || [ ! -f "$dir/xunit.v3.core.dll" ]; then
@@ -1029,9 +1032,12 @@ jobs:
             if [ "${#allclasses[@]}" -eq 0 ]; then
               echo "::error::$label: could not enumerate test classes — refusing to run a partial shard silently."
               echo "[CI] $name exit=96 NO_CLASSES (class enumeration failed for a split project)" >> test/test-results.log
-              python3 .github/scripts/record-host-crash.py \
+              if ! python3 .github/scripts/record-host-crash.py \
                 "$dir/TestResults/$name.part$part.trx" "$label" 96 \
-                "NO_CLASSES: class enumeration failed for a split project, so this part ran nothing."
+                "NO_CLASSES: class enumeration failed for a split project, so this part ran nothing."; then
+                echo "::error::$label: could not record NO_CLASSES into a trx — this part stays invisible to every trx reader."
+                echo "[CI] $name exit=95 CRASH_RECORD_FAILED (NO_CLASSES could not be written into a trx — read the marker above, not the trx)" >> test/test-results.log
+              fi
               continue
             fi
             for ((ci=part-1; ci<${#allclasses[@]}; ci+=parts)); do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,15 @@ When CI fails, **DO NOT run entire test projects** — iterate one test at a tim
 3. `dotnet test <project> --filter "FullyQualifiedName~<TestName>" --no-build`
 4. **No skipping** — CI-only failures catch real timing/state bugs
 
+🚨 **Read the run's evidence before reasoning about it.** The shard artifact carries three things and
+they answer different questions: the per-project `.trx` (output lives in `<Output><TextMessages>`,
+**not** `<StdOut>` — the native xUnit v3 writer does not use `StdOut`, so finding it empty says
+nothing); `collected-logs/_meshweaver-test-trace.log`, the ONLY log that survives a host killed at
+the wall-clock cap, carrying `TEST_START`/`TEST_END` window markers and `[FAULT]` records with
+stacks, joinable by `pid=` and timestamp; and the classified `[CI] <name> exit=<n>` markers. A host
+that CRASHED is written into the trx as a `<project>.HOST_CRASHED` failure, so no summary can report
+a pass over a dead process. Full map: [WritingTests.md](src/MeshWeaver.Documentation/Data/Architecture/WritingTests.md) → "Reading a CI Failure".
+
 Full guidance: [WritingTests.md](src/MeshWeaver.Documentation/Data/Architecture/WritingTests.md) · [CqrsAndContentAccess.md](src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md) · [TestStateIsolation.md](src/MeshWeaver.Documentation/Data/Architecture/TestStateIsolation.md)
 
 ## GitHub PR Operations

--- a/src/MeshWeaver.Documentation/Data/Architecture/AsyncLocalAcrossHops.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AsyncLocalAcrossHops.md
@@ -110,6 +110,24 @@ The consequence is a working rule, not just a curiosity:
 > running squarely inside a "45 seconds of complete silence" window whose silo log contained two
 > lines, neither of them the `LogInformation` calls that had just executed.
 
+### One half of this is now repaired: a FAULT survives, an Information line still does not (#2495)
+
+`XUnitLogger.Log` writes a record carrying an exception at `Warning` or worse to
+[TestTraceLog](/Doc/Architecture/WritingTests) **before** it consults the output helper, exactly as
+`XUnitFileLogger` already did. So a silo-side exception now reaches the one file CI keeps even on a
+grain-scheduler thread with an empty `AsyncLocal`. It was not doing this, and the asymmetry was
+expensive: the two loggers split the process by *service provider*, not by importance —
+`XUnitFileLogger` serves the `TestBase` container, `XUnitLogger` serves everything built by a HOST,
+which in an Orleans test is the silo, the client, and every mesh hub and grain inside them. Measured
+on CI run 33062668925: the Orleans host ran 208 tests over 272 s and wrote **4** lines to that file,
+against 819 / 606 / 1789 from its three Monolith-derived shard-mates. With the fault sink wired, the
+same suite writes **129**.
+
+The rule above is unchanged for everything else. A silo-side `LogInformation`, `LogDebug`, or a
+`LogWarning` with no exception still reaches nothing when the helper is absent — so a gap in a silo
+log still carries no information. What you may now read as evidence is the *presence* of a fault
+record, not the absence of anything.
+
 Reading that silence as "the request never reached the grain" is what sent a previous session down
 the wrong path entirely; a message trace showed routing, activation, subscribe, ack and the render
 round-trip all completing in ~260 ms.

--- a/src/MeshWeaver.Documentation/Data/Architecture/WritingTests.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WritingTests.md
@@ -371,6 +371,71 @@ Fix the bug. Re-running a hung test "to see if it was a flake" hides the race �
 
 ---
 
+## Reading a CI Failure — What the Run Actually Carries
+
+A red test on CI hands you three artifacts, and knowing which one answers which question is the
+difference between attributing a failure and arguing about it.
+
+**1. The `.trx`, per project.** The shards run each project's NATIVE xUnit v3 host
+(`dotnet <Name>.dll -trx …`), and that writer puts captured output in
+`<Output><TextMessages><Message>` — **not** in `<StdOut>`, which the vstest writer uses. `<StdOut>`
+is populated only when a test writes to the process console (`MeshWeaver.Portal.E2E.Test` and
+`MeshWeaver.PluginImage.Test` do; nothing else does). Looking for `StdOut` and finding it empty
+therefore says nothing about the project — issue #2495 was filed on exactly that reading.
+
+The trx also carries `startTime` / `endTime` per result, which is how you compute **what else was
+running**. That matters in a project that opts into intra-project parallelism: in
+`MeshWeaver.Hosting.Orleans.Test` each test class boots its own Orleans cluster and
+`maxParallelThreads: 4`, so a failing test can have six other classes — and their silos — live in
+the same process.
+
+**2. `collected-logs/_meshweaver-test-trace.log`, one file per shard.** This is the only test log CI
+keeps, and it is the only evidence that survives a host killed at the wall-clock cap, which writes
+no trx at all. Two kinds of line, both carrying `pid=` because every project in a shard appends to
+this one file:
+
+- **Window markers**, written by `AutoTestLoggingAttribute` for every `TestBase` subclass in every
+  project: `TEST_START <method>` and `TEST_END elapsed=<n>ms <method> outcome=<…>` (plus the
+  exception type and message on a failure). `elapsed` is measured between the two hooks — the trx
+  `duration` is larger because it includes fixture construction.
+- **Fault records** — `[FAULT] [<level>] [<category>]` plus the exception's type and stack, written
+  by both xUnit loggers for any record at `Warning` or worse that carries an exception, whether or
+  not a test output helper is active.
+
+Joining them is the point: `grep pid=<n>` for the window brackets, and every `[FAULT]` timestamp
+between a `TEST_START` and its `TEST_END` belongs to that window. A `TEST_START` with **no**
+matching `TEST_END` names the test a killed host was stuck in. In a parallel project the join
+narrows a fault to the handful of windows open at that instant rather than to one test — say so
+when you use it.
+
+Records are rate-bounded (`FaultRecordBudget`: 100 per 10 s) and every suppressed stretch announces
+itself, so `grep FAULT-BUDGET` answers "is this log complete?".
+
+**3. The `[CI] <name> exit=<n>` markers in `test/test-results.log`.** The host's own exit code,
+classified (`TESTFAIL` / `TIMEOUT` / `SIGNAL` / `MASKED`).
+
+### 🚨 A crashed host is a FAILED test result, not a silence
+
+A host that streams green results and then dies leaves a trx that says "N passed, 0 failed", and
+every reporter that parses it repeats that over a dead process. `MeshWeaver.Content.Test` did this
+with `exit=139`. Pass/fail evidence and liveness evidence were two channels and only the first was
+read.
+
+They are one channel now: for any exit the trx cannot explain, the shard runs
+`.github/scripts/record-host-crash.py`, which writes a `<project>.HOST_CRASHED` failure **into the
+trx** — creating the file when the host wrote none. So the shard summary, the per-shard check and
+the consolidated check all name the crash, and a reporter added later inherits the behaviour
+instead of the blind spot. `CrashedHostIsNeverAPassGuard` runs the real script against both shapes
+and is pinned by its own negative controls.
+
+**Known gap, so you do not read it as evidence:** the window markers come from an attribute applied
+to `TestBase`, so a test class that does not derive from it writes none. In
+`MeshWeaver.Hosting.Orleans.Test` that is 25 classes / 86 of 208 tests (`RoutingGrain*`,
+`OrleansCrossSilo*`, `TwoSiloRecycleConvergenceTest`, …). Their faults still reach the file; only
+the brackets are missing.
+
+---
+
 ## Coverage Expectations
 
 The [/code skill](/Skill/code) sets the bar for NodeTypes and data models: **a test per invariant, per branch, per boundary, per degenerate input** — plus a serialization round-trip. A NodeType with a single happy-path test is demoed, not tested.

--- a/src/MeshWeaver.Fixture/AutoTestLoggingAttribute.cs
+++ b/src/MeshWeaver.Fixture/AutoTestLoggingAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics;
+using System.Reflection;
 using Xunit;
 using Xunit.v3;
 
@@ -7,11 +8,52 @@ namespace MeshWeaver.Fixture;
 /// <summary>
 /// Automatically logs test method start and end markers to help correlate test execution with debug logs.
 /// This attribute is automatically applied to all test methods through the TestBase class.
+///
+/// <para>🚨 The markers go to TWO sinks, and the second one is the point. The xUnit output helper
+/// is per-test and reaches the trx — useful, but only for a host that lives long enough to write
+/// one. <see cref="TestTraceLog"/> is the single file CI keeps per shard, and it is the only
+/// evidence that survives a host killed at the wall-clock cap (<c>exit=124</c>, no trx at all) or
+/// dying on a signal.</para>
+///
+/// <para><b>Why this lives here rather than on a mesh test base.</b> Until #2495 the per-test
+/// phase trace was written ONLY by <c>MonolithMeshTestBase</c>. Measured on CI run 33062668925,
+/// shard 3: the <c>MeshWeaver.Hosting.Orleans.Test</c> host ran <b>208 tests over 272 seconds and
+/// contributed FOUR lines</b> to that file, while its three shard-mates — all Monolith-derived —
+/// contributed 819, 606 and 1789. So an Orleans failure could not be placed in time at all: the
+/// trace covered the run but not the window, which is exactly what issue #2495 records. This
+/// attribute is already applied to every <see cref="TestBase"/> subclass in every project, so
+/// writing the window markers HERE is what makes the coverage universal instead of one base
+/// class's private habit.</para>
+///
+/// <para>What the two lines buy, concretely: a <c>[FAULT]</c> record (the fault sink writes the
+/// exception + stack to the same file) can be bracketed by the test that was running when it
+/// landed; a hung host's last <c>TEST_START</c> with no matching <c>TEST_END</c> NAMES the stuck
+/// test, which no trx can do; and under intra-assembly parallelism (Orleans.Test runs
+/// <c>maxParallelThreads: 4</c>) the overlapping <c>TEST_START</c>/<c>TEST_END</c> brackets show
+/// which OTHER classes were live during a failure.</para>
 /// </summary>
 public class AutoTestLoggingAttribute : BeforeAfterTestAttribute
 {
-   
-    
+    // One failure message can be a multi-KB assertion dump. The trace is a per-shard artifact
+    // shared by every test host, so the message is clamped and flattened to ONE line — the file's
+    // value is that `grep TEST_END` yields one row per test.
+    private const int MaxFailureChars = 400;
+
+    // 🚨 The elapsed time is MEASURED here, not read off TestResultState.ExecutionTime — and that
+    // is not defensive taste, it is a wrong number avoided. xUnit v3.2.2 documents ExecutionTime
+    // as "the time spent executing the test, in seconds", and it is not: for a test the trx
+    // records at duration="00:00:01.5306690" it reports 1523.705, i.e. MILLISECONDS. Trusting the
+    // doc puts an elapsed 1000x too large on every line, and the duration is precisely what this
+    // cluster's attributions turn on ("read the DURATION, then read whether it is a VALUE or a
+    // BUDGET" — #2346). A wrong number is worse than none.
+    //
+    // The stamp is keyed by the test's UniqueID rather than held on this attribute instance: one
+    // attribute instance serves every test, and MeshWeaver.Hosting.Orleans.Test runs
+    // maxParallelThreads: 4, so an instance field would be a straight race between concurrent
+    // tests. KeyValueStorage is one container for the whole pipeline (xUnit's own words), which is
+    // why the key must carry the test id.
+    private const string StartStampPrefix = "MeshWeaver.Fixture.AutoTestLogging.start:";
+
     /// <summary>
     /// Runs before each test method, writing a "TEST START" marker to the active file output helper.
     /// </summary>
@@ -19,14 +61,18 @@ public class AutoTestLoggingAttribute : BeforeAfterTestAttribute
     /// <param name="test">The xUnit test being executed.</param>
     public override void Before(MethodInfo methodUnderTest, IXunitTest test)
     {
-        var testName = $"{methodUnderTest.DeclaringType?.Name}.{methodUnderTest.Name}";
+        var className = methodUnderTest.DeclaringType?.Name ?? "UnknownTest";
+        var testName = $"{className}.{methodUnderTest.Name}";
         var logMessage = $"=== TEST START: {testName} ===";
-        
-        
+
+
         // Also log to file output if available
         var fileOutput = XUnitFileOutputRegistry.GetAnyActiveOutputHelper();
         fileOutput?.SetCurrentTestMethod(methodUnderTest.Name);
         fileOutput?.WriteLine(logMessage);
+
+        TestContext.Current.KeyValueStorage[StartStampPrefix + test.UniqueID] = Stopwatch.GetTimestamp();
+        TestTraceLog.AppendPhase(className, "TEST_START", extra: methodUnderTest.Name);
     }
 
     /// <summary>
@@ -40,18 +86,57 @@ public class AutoTestLoggingAttribute : BeforeAfterTestAttribute
         // Also log to file output if available
         var fileOutput = XUnitFileOutputRegistry.GetAnyActiveOutputHelper();
 
+        var state = TestContext.Current.TestState;
 
-        if (TestContext.Current.TestState?.Result == TestResult.Failed)
+        if (state?.Result == TestResult.Failed)
         {
-            var message = $"""=== TEST FAILED: {string.Join("\n", TestContext.Current.TestState.ExceptionMessages ?? [])}""";
+            var message = $"""=== TEST FAILED: {string.Join("\n", state.ExceptionMessages ?? [])}""";
             fileOutput?.WriteLine(message);
         }
 
-        var testName = $"{methodUnderTest.DeclaringType?.Name}.{methodUnderTest.Name}";
+        var className = methodUnderTest.DeclaringType?.Name ?? "UnknownTest";
+        var testName = $"{className}.{methodUnderTest.Name}";
         var logMessage = $"=== TEST END: {testName} ===";
-        
-        
+
+
         fileOutput?.WriteLine(logMessage);
         fileOutput?.ClearCurrentTestMethod();
+
+        TestTraceLog.AppendPhase(
+            className,
+            "TEST_END",
+            ElapsedMs(test),
+            $"{methodUnderTest.Name} outcome={OutcomeOf(state)}{FailureDetail(state)}");
+    }
+
+    private static long? ElapsedMs(IXunitTest test)
+    {
+        var key = StartStampPrefix + test.UniqueID;
+        if (!TestContext.Current.KeyValueStorage.TryRemove(key, out var stamp) || stamp is not long started)
+            return null;   // no stamp, no number — never a guessed one
+
+        return (long)Stopwatch.GetElapsedTime(started).TotalMilliseconds;
+    }
+
+    // The outcome is written even when xUnit could not produce a state, and it is written as
+    // "Unknown" rather than omitted: a reader must be able to tell "this test ended without a
+    // verdict" from "this test passed", and an absent field reads as neither.
+    private static string OutcomeOf(TestResultState? state) =>
+        state is null ? "Unknown" : state.Result.ToString();
+
+    private static string? FailureDetail(TestResultState? state)
+    {
+        if (state is null || state.Result != TestResult.Failed)
+            return null;
+
+        var type = state.ExceptionTypes?.FirstOrDefault(t => t is not null) ?? "(no exception type)";
+        var message = state.ExceptionMessages?.FirstOrDefault(m => m is not null) ?? "(no message)";
+
+        // Newlines would break the one-row-per-test property the file is read with.
+        var flattened = message.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ');
+        if (flattened.Length > MaxFailureChars)
+            flattened = flattened[..MaxFailureChars] + $"… (+{message.Length - MaxFailureChars} chars, full text in the trx)";
+
+        return $" :: {type}: {flattened}";
     }
 }

--- a/src/MeshWeaver.Fixture/LoggingBuilderExtensions.cs
+++ b/src/MeshWeaver.Fixture/LoggingBuilderExtensions.cs
@@ -176,21 +176,51 @@ public class XUnitLogger(
         Func<TState, Exception?, string> formatter
     )
     {
+        if (formatter == null)
+            throw new ArgumentNullException(nameof(formatter));
+        if (!IsEnabled(logLevel))
+            return;
+
+        // 🚨 A fault with a stack goes to the ONE file CI keeps, BEFORE the output-helper guard
+        // below — the same ordering, and for the same reason, as XUnitFileLogger.Log.
+        //
+        // This logger did not do it, and the asymmetry was invisible and expensive. The two
+        // loggers split the process by SERVICE PROVIDER, not by importance: XUnitFileLogger
+        // serves the TestBase container, this one serves everything built by a HOST — which in
+        // MeshWeaver.Hosting.Orleans.Test is the silo, the Orleans client, and every mesh hub,
+        // grain and I/O leaf inside them, i.e. essentially the entire system under test. So an
+        // exception logged anywhere in an Orleans silo reached NO artifact CI keeps: not the trx
+        // (the helper is null outside a test method's window — fixture init, teardown, and every
+        // reactive continuation on a background scheduler, which is exactly when a wedge faults),
+        // and not the fault log, because nothing here ever wrote to it.
+        //
+        // Measured on CI run 33062668925, shard 3: the Orleans host ran 208 tests over 272 s and
+        // contributed FOUR lines to the fault log, against 819 / 606 / 1789 from its three
+        // Monolith-derived shard-mates. That is issue #2495's "an Orleans red hands you the
+        // assertion and nothing else", one level below where it was reported.
+        //
+        // Records are rate-bounded by FaultRecordBudget and announce their own suppression, so a
+        // storming silo cannot fill the runner's disk silently.
+        string? message = null;
+        if (exception is not null && logLevel >= LogLevel.Warning)
+        {
+            message = formatter(state, exception);
+            TestTraceLog.AppendFault(categoryName, logLevel, message, exception);
+        }
+
         var outputHelper = testOutputHelperAccessor.OutputHelper
             ?? XUnitFileOutputRegistry.GetAnyActiveOutputHelper();
         if (outputHelper == null)
             return;
-        if (!IsEnabled(logLevel))
-            return;
-        if (formatter == null)
-            throw new ArgumentNullException(nameof(formatter));
+
+        message ??= formatter(state, exception);
 
         var sb = new StringBuilder();
         sb.Append(GetLogLevelString(logLevel))
             .Append($",{DateTime.UtcNow:hh:mm:ss.fff tt},")
             .Append(categoryName)
             .Append(",")
-            .Append(formatter(state, exception));
+            .Append(message);
 
         if (exception != null)
         {

--- a/src/MeshWeaver.Fixture/LoggingBuilderExtensions.cs
+++ b/src/MeshWeaver.Fixture/LoggingBuilderExtensions.cs
@@ -178,6 +178,25 @@ public class XUnitLogger(
     {
         if (formatter == null)
             throw new ArgumentNullException(nameof(formatter));
+
+        // Only a Warning-or-worse record CARRYING AN EXCEPTION can reach the fault sink, and that
+        // is a small minority of what a silo logs. Everything else keeps the ORIGINAL fast path —
+        // one null check and out — because this logger sits on the hot path of an Orleans silo
+        // logging at Information, where the helper is null on every grain-scheduler thread.
+        //
+        // Hoisting IsEnabled above that null check (the first shape of this change) made every
+        // such record walk the filter rules for nothing. Measured on MeshWeaver.Hosting.Orleans.Test
+        // on an otherwise-quiet machine: 67.1 s without the fault sink, 72.2 s with it hoisted
+        // (72.167 / 72.264 — reproducible). Attributing all 5 s to the hoist would overstate the
+        // evidence, since the sink's own ~125 records are in that delta too; what is certain is
+        // that the hoist buys nothing, so it is not worth paying for either way.
+        var isFaultCandidate = exception is not null && logLevel >= LogLevel.Warning;
+
+        var outputHelper = testOutputHelperAccessor.OutputHelper
+            ?? XUnitFileOutputRegistry.GetAnyActiveOutputHelper();
+        if (outputHelper is null && !isFaultCandidate)
+            return;
+
         if (!IsEnabled(logLevel))
             return;
 
@@ -202,15 +221,13 @@ public class XUnitLogger(
         // Records are rate-bounded by FaultRecordBudget and announce their own suppression, so a
         // storming silo cannot fill the runner's disk silently.
         string? message = null;
-        if (exception is not null && logLevel >= LogLevel.Warning)
+        if (isFaultCandidate)
         {
             message = formatter(state, exception);
-            TestTraceLog.AppendFault(categoryName, logLevel, message, exception);
+            TestTraceLog.AppendFault(categoryName, logLevel, message, exception!);
         }
 
-        var outputHelper = testOutputHelperAccessor.OutputHelper
-            ?? XUnitFileOutputRegistry.GetAnyActiveOutputHelper();
-        if (outputHelper == null)
+        if (outputHelper is null)
             return;
 
         message ??= formatter(state, exception);

--- a/src/MeshWeaver.Fixture/TestTraceLog.cs
+++ b/src/MeshWeaver.Fixture/TestTraceLog.cs
@@ -47,6 +47,37 @@ public static class TestTraceLog
     }
 
     /// <summary>
+    /// Appends ONE phase line in the file's canonical shape:
+    /// <c>HH:mm:ss.fff pid=&lt;n&gt; [TestClass] PHASE [elapsed=&lt;n&gt;ms] [extra]</c>.
+    ///
+    /// <para>The formatter lives here rather than on a test base because there are now two
+    /// callers and they must not drift: <c>MonolithMeshTestBase</c>'s init/dispose phases, and
+    /// <see cref="AutoTestLoggingAttribute"/>'s per-test <c>TEST_START</c>/<c>TEST_END</c> window
+    /// markers, which every test project writes. A reader greps ONE format across all of them.</para>
+    ///
+    /// <para>pid is on every line for the reason the fault records carry it: every test host in a
+    /// CI shard (one process per project) appends to this one file, and a core dump is named
+    /// <c>dotnet-&lt;pid&gt;.dmp</c>, so <c>grep pid=&lt;n&gt;</c> is what ties a dump to a trace.</para>
+    /// </summary>
+    /// <param name="testClass">The test class the phase belongs to.</param>
+    /// <param name="phase">The phase name (<c>TEST_START</c>, <c>DISPOSE_DONE</c>, …).</param>
+    /// <param name="elapsedMs">Optional elapsed milliseconds for the phase.</param>
+    /// <param name="extra">Optional trailing detail (test method, outcome, failure text).</param>
+    public static void AppendPhase(string testClass, string phase, long? elapsedMs = null, string? extra = null)
+    {
+        try
+        {
+            Append($"{DateTime.UtcNow:HH:mm:ss.fff} pid={Environment.ProcessId} [{testClass}] {phase}"
+                + (elapsedMs.HasValue ? $" elapsed={elapsedMs}ms" : "")
+                + (extra is null ? "" : $" {extra}"));
+        }
+        catch
+        {
+            // Tracing must never throw out of the test pipeline.
+        }
+    }
+
+    /// <summary>
     /// Flushes/creates the file so preceding lines reach disk before an
     /// <c>Environment.FailFast</c>.
     /// </summary>

--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -319,10 +319,7 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             // the one that crashed. A core dump is named `dotnet-<pid>.dmp`, so `grep pid=<n>`
             // is what ties the dump to the trace. Diagnosing the 2026-08-04 FutuRe SIGSEGV
             // started by reading another project's lines for exactly this reason.
-            var line = $"{DateTime.UtcNow:HH:mm:ss.fff} pid={Environment.ProcessId} [{testClass}] {phase}"
-                + (elapsedMs.HasValue ? $" elapsed={elapsedMs}ms" : "")
-                + (extra is null ? "" : $" {extra}");
-            Fixture.TestTraceLog.Append(line);
+            Fixture.TestTraceLog.AppendPhase(testClass, phase, elapsedMs, extra);
         }
         catch
         {

--- a/test/MeshWeaver.Documentation.Test/CrashedHostIsNeverAPassGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CrashedHostIsNeverAPassGuard.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>A test host that DIED must never be summarised as a pass</b> (#2495).
+///
+/// <para><b>The defect this pins.</b> Pass/fail evidence and liveness evidence used to live in two
+/// separate channels: the <c>.trx</c> (what the host managed to stream) and the
+/// <c>[CI] &lt;name&gt; exit=&lt;n&gt;</c> marker (whether the host survived). Every reporter in
+/// <c>dotnet-test.yml</c> reads only the first — the shard's failure summary, the per-shard GitHub
+/// check, the consolidated check, and the collector's summary. So when
+/// <c>MeshWeaver.Content.Test</c> took an <c>exit=139</c> after streaming three green results,
+/// all four announced a pass over a crashed process. Only the last step in the job, which reports
+/// a number rather than a test name, disagreed.</para>
+///
+/// <para><b>Why a seventh checker would not have been the fix.</b> Adding one more place that also
+/// consults the exit marker leaves the next reporter — added by someone who never read this — with
+/// the identical blind spot. The fix makes the evidence single-channel: the crash is written INTO
+/// the trx as a <c>&lt;project&gt;.HOST_CRASHED</c> failure, so a pass over a dead host becomes
+/// unstateable by anything that parses the file.</para>
+///
+/// <para>🚨 <b>This guard is the negative control, and it runs the real script.</b> A diagnostic
+/// change that cannot itself fail is worth nothing — which is the whole point of the issue it
+/// closes — so this does not pattern-match the workflow and call it proven. It executes
+/// <c>.github/scripts/record-host-crash.py</c> against both shapes a dead host actually leaves
+/// behind (a trx full of green results, and no trx at all) and asserts with the shard gate's OWN
+/// grep that the outcome is red and names the crash.</para>
+/// </summary>
+public class CrashedHostIsNeverAPassGuard
+{
+    private const string Workflow = ".github/workflows/dotnet-test.yml";
+    private const string Recorder = ".github/scripts/record-host-crash.py";
+    private static readonly XNamespace Trx = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+
+    /// <summary>
+    /// The exact grep the shard's "Summarize test failures" step and the collector's
+    /// "Summarize test failures (all shards)" step both run. Reproduced rather than approximated:
+    /// this guard's claim is about what THOSE steps will do, so it must ask the question the way
+    /// they ask it.
+    /// </summary>
+    private static readonly Regex ShardGate =
+        new(@"<UnitTestResult[^>]*outcome=""Failed""[^>]*>", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The shape that shipped the bug: a host that streamed green results and then died. The trx
+    /// is genuine and complete as far as it goes — which is exactly why every reporter believed it.
+    /// </summary>
+    [Fact]
+    public void AHostThatCrashedAfterStreamingGreenResults_IsRed_AndNamesTheCrash()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var trx = Path.Combine(dir, "MeshWeaver.Content.Test.trx");
+            File.WriteAllText(trx, ThreeGreenResults());
+
+            // Before: this is precisely what the gate saw for Content.Test's exit=139.
+            Assert.Empty(ShardGate.Matches(File.ReadAllText(trx)));
+
+            var (exitCode, stdout, stderr) = RunRecorder(trx, "MeshWeaver.Content.Test", 139,
+                "SIGNAL SIGSEGV: the host died on a signal, not an assertion.");
+
+            Assert.True(exitCode == 0, $"the recorder failed: {stdout}\n{stderr}");
+
+            var body = File.ReadAllText(trx);
+            var failures = ShardGate.Matches(body);
+
+            Assert.True(failures.Count == 1,
+                "The crash did not become a failed result, so the shard summary, the per-shard "
+                + "check and the consolidated check would all still report '3 passed' over a "
+                + "process that died. That is the defect #2495 exists to remove.");
+
+            Assert.Contains("MeshWeaver.Content.Test.HOST_CRASHED", failures[0].Value);
+            Assert.Contains("exited 139", body);
+
+            var doc = XDocument.Parse(body);
+            var counters = doc.Descendants(Trx + "Counters").Single();
+
+            // The three real results are KEPT. A crash does not make the tests that genuinely
+            // passed disappear — it makes the RUN a non-verdict, which is a different statement
+            // and the one the extra result carries.
+            Assert.Equal("3", counters.Attribute("passed")!.Value);
+            Assert.Equal("1", counters.Attribute("failed")!.Value);
+            Assert.Equal("4", counters.Attribute("total")!.Value);
+            Assert.Equal("Failed", doc.Descendants(Trx + "ResultSummary").Single().Attribute("outcome")!.Value);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The other shape, and the one with no evidence at all: a host killed at the 8-minute
+    /// wall-clock cap writes NO trx. The gate then has nothing to parse — and "nothing to parse"
+    /// is silence, which reads exactly like "nothing went wrong".
+    /// </summary>
+    [Fact]
+    public void AHostKilledBeforeItWroteAnyTrx_StillProducesRedEvidence()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var trx = Path.Combine(dir, "MeshWeaver.Hosting.Orleans.Test.trx");
+            Assert.False(File.Exists(trx));
+
+            var (exitCode, stdout, stderr) = RunRecorder(trx, "MeshWeaver.Hosting.Orleans.Test", 137,
+                "TIMEOUT: killed at the 8m wall-clock cap.");
+
+            Assert.True(exitCode == 0, $"the recorder failed: {stdout}\n{stderr}");
+            Assert.True(File.Exists(trx),
+                "A killed host leaves no trx, so if the recorder does not CREATE one there is "
+                + "nothing for any reporter to be red about.");
+
+            var body = File.ReadAllText(trx);
+            Assert.Single(ShardGate.Matches(body));
+            Assert.Contains("MeshWeaver.Hosting.Orleans.Test.HOST_CRASHED", body);
+            Assert.Contains("exited 137", body);
+
+            // Well-formed enough for the GitHub reporters, which parse the whole document rather
+            // than grepping it: a malformed trx would make the per-shard check silently report
+            // nothing, reintroducing the same silence one level along.
+            var doc = XDocument.Parse(body);
+            Assert.Single(doc.Descendants(Trx + "TestDefinitions").Single().Elements(Trx + "UnitTest"));
+            Assert.Single(doc.Descendants(Trx + "TestEntries").Single().Elements(Trx + "TestEntry"));
+            Assert.Equal("Failed", doc.Descendants(Trx + "ResultSummary").Single().Attribute("outcome")!.Value);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A truncated trx — the host died mid-write — must not be treated as "no crash to report"
+    /// by an exception that escapes. It is itself crash evidence, and the recorder must say so.
+    /// </summary>
+    [Fact]
+    public void AnUnparseableTrx_IsTreatedAsEvidenceOfTheCrash_NotAsAnError()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var trx = Path.Combine(dir, "MeshWeaver.FutuRe.Test.trx");
+            File.WriteAllText(trx, ThreeGreenResults()[..400]);   // cut mid-element
+
+            var (exitCode, stdout, stderr) = RunRecorder(trx, "MeshWeaver.FutuRe.Test", 139,
+                "SIGNAL SIGSEGV.");
+
+            Assert.True(exitCode == 0, $"the recorder failed: {stdout}\n{stderr}");
+
+            var body = File.ReadAllText(trx);
+            Assert.Single(ShardGate.Matches(body));
+            Assert.Contains("died mid-write", body);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// 🚨 The wiring half. Every exit code the classifier can name as a death must ALSO set
+    /// <c>crash=</c>, which is the single switch that decides whether the crash reaches the trx.
+    /// Without this, someone adding <c>136) marker=…</c> tomorrow gets a marker and no trx entry —
+    /// i.e. exactly the pre-#2495 behaviour, reintroduced for one exit code, silently.
+    /// </summary>
+    [Fact]
+    public void EveryDeathBranchOfTheClassifier_AlsoRecordsTheCrashIntoTheTrx()
+    {
+        var body = File.ReadAllText(Path.Combine(SourceScan.FindRepoRoot(), Workflow));
+
+        var caseStart = body.IndexOf("case \"$rc\" in", StringComparison.Ordinal);
+        Assert.True(caseStart > 0,
+            $"{Workflow} no longer classifies the host exit code with `case \"$rc\" in`. This guard "
+            + "can no longer see the classifier — re-point it deliberately rather than letting it rot.");
+        var caseEnd = body.IndexOf("esac", caseStart, StringComparison.Ordinal);
+        var classifier = body[caseStart..caseEnd];
+
+        // Each branch runs from its `<pattern>)` to the next one.
+        var branches = Regex.Matches(classifier, @"^\s*(?<pattern>[0-9|*]+)\)", RegexOptions.Multiline)
+            .Select(m => (Pattern: m.Groups["pattern"].Value, Start: m.Index))
+            .ToList();
+
+        Assert.True(branches.Count >= 6,
+            $"expected the classifier to still enumerate the signal/timeout exit codes; found "
+            + $"{branches.Count} branch(es): {string.Join(", ", branches.Select(b => b.Pattern))}");
+
+        var missing = new List<string>();
+        for (var i = 0; i < branches.Count; i++)
+        {
+            var (pattern, start) = branches[i];
+            var end = i + 1 < branches.Count ? branches[i + 1].Start : classifier.Length;
+            var branch = classifier[start..end];
+
+            // `0)` is a healthy host. `*)` contains BOTH the ordinary-test-failure sub-branch
+            // (which must NOT be recorded as a crash — the host completed) and the two MASKED
+            // sub-branches (which must). Requiring `crash=` to appear at all in `*)` is the
+            // strongest claim that holds for a branch with mixed outcomes; the MASKED text is
+            // asserted separately below.
+            if (pattern == "0")
+                continue;
+
+            if (!branch.Contains("crash=\"", StringComparison.Ordinal))
+                missing.Add(pattern);
+        }
+
+        Assert.True(missing.Count == 0,
+            "These classifier branches name a dead test host but never set `crash=`, so the death "
+            + "would be recorded ONLY in the exit marker — and every trx reader (the shard summary, "
+            + "the per-shard check, the consolidated check) would keep reporting whatever the host "
+            + "streamed, over a process that died: " + string.Join(", ", missing));
+
+        // Both MASKED sub-branches, individually — they are the ones that carry a trx and are
+        // therefore the ones a reporter can most convincingly misreport.
+        var masked = Regex.Matches(classifier, @"MASKED").Count;
+        Assert.True(masked >= 2, $"expected both MASKED sub-branches to survive; found {masked}");
+
+        // 🚨 No skip-trapdoor on the recorder call. An `if: <secret is set>` / `continue-on-error`
+        // on a gate's own input is this repo's standing lesson (AGENTS.md → "A gate NEVER tests
+        // its own inputs"); the equivalent here would be swallowing the recorder's failure so the
+        // trx quietly keeps saying "passed".
+        var invocation = Regex.Match(body,
+            @"if ! python3 \.github/scripts/record-host-crash\.py [^\n]*\n(?<body>(?:.*\n)*?)\s*fi\n");
+        Assert.True(invocation.Success,
+            $"{Workflow} no longer invokes {Recorder} with its failure handled. The recorder is the "
+            + "only thing that puts a crash into the evidence every reporter reads; a call whose "
+            + "failure is discarded is the same silence with an extra step.");
+        Assert.Contains("::error::", invocation.Groups["body"].Value);
+        Assert.Contains("CRASH_RECORD_FAILED", invocation.Groups["body"].Value);
+    }
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-2495-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static (int ExitCode, string StdOut, string StdErr) RunRecorder(
+        string trxPath, string label, int exitCode, string classification)
+    {
+        var script = Path.Combine(SourceScan.FindRepoRoot(), Recorder);
+        Assert.True(File.Exists(script), $"{Recorder} is missing — the crash evidence has no writer.");
+
+        var psi = new ProcessStartInfo("python3")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var arg in new[] { script, trxPath, label, exitCode.ToString(), classification })
+            psi.ArgumentList.Add(arg);
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException(
+                "python3 could not be started. It is required by this guard AND by the CI job that "
+                + "runs the recorder (and by .github/scripts/check-licenses.py), so this is a real "
+                + "missing prerequisite, not a reason to skip the control.");
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, stdout, stderr);
+    }
+
+    /// <summary>
+    /// A minimal but faithful xUnit-v3-native trx: three passed results, the counters that go with
+    /// them, and <c>ResultSummary outcome="Completed"</c> — i.e. the file that said "3 passed" over
+    /// <c>MeshWeaver.Content.Test</c>'s dead process.
+    /// </summary>
+    private static string ThreeGreenResults()
+    {
+        var results = string.Concat(Enumerable.Range(1, 3).Select(i =>
+            $"""
+                 <UnitTestResult testName="MeshWeaver.Content.Test.SomeTest.Case{i}" outcome="Passed" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" testId="00000000-0000-0000-0000-00000000000{i}" executionId="00000000-0000-0000-0000-00000000000{i}" computerName="unknown" duration="00:00:00.1000000" startTime="2026-08-27T00:00:0{i}.0000000+00:00" endTime="2026-08-27T00:00:0{i}.1000000+00:00" />
+
+             """));
+
+        return $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <TestRun id="11111111-1111-1111-1111-111111111111" name="proof" runUser="ci" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+              <Times creation="2026-08-27T00:00:00.0000000+00:00" queuing="2026-08-27T00:00:00.0000000+00:00" start="2026-08-27T00:00:00.0000000+00:00" finish="2026-08-27T00:00:03.0000000+00:00" />
+              <TestSettings name="default" id="22222222-2222-2222-2222-222222222222" />
+              <Results>
+            {results}  </Results>
+              <TestDefinitions />
+              <TestEntries />
+              <TestLists>
+                <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+              </TestLists>
+              <ResultSummary outcome="Completed">
+                <Counters total="3" executed="3" passed="3" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+              </ResultSummary>
+            </TestRun>
+            """;
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/CrashedHostIsNeverAPassGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CrashedHostIsNeverAPassGuard.cs
@@ -224,18 +224,28 @@ public class CrashedHostIsNeverAPassGuard
         var masked = Regex.Matches(classifier, @"MASKED").Count;
         Assert.True(masked >= 2, $"expected both MASKED sub-branches to survive; found {masked}");
 
-        // 🚨 No skip-trapdoor on the recorder call. An `if: <secret is set>` / `continue-on-error`
-        // on a gate's own input is this repo's standing lesson (AGENTS.md → "A gate NEVER tests
-        // its own inputs"); the equivalent here would be swallowing the recorder's failure so the
-        // trx quietly keeps saying "passed".
-        var invocation = Regex.Match(body,
-            @"if ! python3 \.github/scripts/record-host-crash\.py [^\n]*\n(?<body>(?:.*\n)*?)\s*fi\n");
-        Assert.True(invocation.Success,
-            $"{Workflow} no longer invokes {Recorder} with its failure handled. The recorder is the "
-            + "only thing that puts a crash into the evidence every reporter reads; a call whose "
-            + "failure is discarded is the same silence with an extra step.");
-        Assert.Contains("::error::", invocation.Groups["body"].Value);
-        Assert.Contains("CRASH_RECORD_FAILED", invocation.Groups["body"].Value);
+        // 🚨 No skip-trapdoor on ANY recorder call — every one of them, not just the main branch.
+        // A gate that swallows its own input's failure is this repo's standing lesson (AGENTS.md →
+        // "A gate NEVER tests its own inputs"); here the equivalent is discarding the recorder's
+        // exit code so the trx quietly keeps saying "passed". Two of the three call sites shipped
+        // in the first revision of this change doing exactly that, which is why the assertion
+        // counts invocations rather than finding one.
+        var invocations = Regex.Matches(body,
+            @"(?<guarded>if ! )?python3 \.github/scripts/record-host-crash\.py[^\n]*\n(?<body>(?:.*\n)*?)\s*fi\n");
+
+        Assert.True(invocations.Count >= 3,
+            $"{Workflow} should invoke {Recorder} on every path that produces no verdict — the "
+            + $"classifier's death branches, MISSING_BIN and NO_CLASSES. Found {invocations.Count}.");
+
+        foreach (Match invocation in invocations)
+        {
+            Assert.True(invocation.Groups["guarded"].Success,
+                "A recorder call whose exit code is discarded is the same silence with an extra "
+                + "step: the trx keeps reporting whatever the host streamed. Wrap it in "
+                + "`if ! python3 …; then … fi`.");
+            Assert.Contains("::error::", invocation.Groups["body"].Value);
+            Assert.Contains("CRASH_RECORD_FAILED", invocation.Groups["body"].Value);
+        }
     }
 
     private static string NewTempDir()

--- a/test/MeshWeaver.Query.Test/TestOutputLoggingLifecycleTest.cs
+++ b/test/MeshWeaver.Query.Test/TestOutputLoggingLifecycleTest.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
+using System.Threading;
 using MeshWeaver.Fixture;
+using Microsoft.Extensions.Options;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -33,6 +35,16 @@ namespace MeshWeaver.Query.Test;
 /// </summary>
 public class TestOutputLoggingLifecycleTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
+    // 🚨 Captured in a FIELD INITIALIZER, which runs before the base constructor and therefore
+    // long before AutoTestLoggingAttribute.Before writes this test's TEST_START line.
+    //
+    // The first version of the window pin below read the file WHOLE, and it passed with the
+    // mechanism deleted — because a previous green run of this very test had left a matching line
+    // in a file that is append-only and shared by every test host on the machine. That is a
+    // verification step that cannot fail, in a change whose entire subject is verification steps
+    // that cannot fail. Anchoring at construction is what makes the assertion about THIS run.
+    private readonly long traceLengthAtConstruction = CurrentTraceLength();
+
     /// <summary>
     /// The lifecycle pin: a test class whose <c>InitializeAsync</c> is <c>async</c> (which
     /// <see cref="MonolithMeshTestBase"/>'s is) must still have a LIVE log sink by the time its
@@ -49,6 +61,97 @@ public class TestOutputLoggingLifecycleTest(ITestOutputHelper output) : Monolith
         FileOutput.IsInTestMethod().Should().BeTrue(
             "XUnitFileLogger drops every record unless the helper is inside a test method; this "
             + "flag being false is what made the #993 Debug channels emit nothing on CI");
+    }
+
+    /// <summary>
+    /// The WINDOW pin (#2495). Until this landed, the per-test phase trace was written only by
+    /// <see cref="MonolithMeshTestBase"/>, so an assembly built on a different base — Orleans's,
+    /// say — contributed almost nothing to the one log CI keeps. Measured on CI run 33062668925,
+    /// shard 3: <c>MeshWeaver.Hosting.Orleans.Test</c> ran 208 tests over 272 seconds and wrote
+    /// FOUR lines, while its three Monolith-derived shard-mates wrote 819, 606 and 1789. A fault
+    /// recorded in that file could therefore not be placed in time at all, and a host killed at
+    /// the wall-clock cap (which writes no trx whatsoever) left nothing that named the test it
+    /// was stuck in.
+    ///
+    /// <para>The markers now come from <c>AutoTestLoggingAttribute</c>, which every
+    /// <see cref="TestBase"/> subclass in every project already carries — so this assertion holds
+    /// for the whole suite, not for one base class.</para>
+    /// </summary>
+    [Fact(Timeout = 20_000)]
+    public void TheTestWindow_IsWrittenToTheOneLogCiKeeps()
+    {
+        // pid too: every test host in a CI shard appends to this one file, so without it a
+        // concurrent run of the same test elsewhere would satisfy the assertion.
+        ReadTraceTailFrom(traceLengthAtConstruction).Should().Contain(
+            $"pid={Environment.ProcessId} [{nameof(TestOutputLoggingLifecycleTest)}] "
+            + $"TEST_START {nameof(TheTestWindow_IsWrittenToTheOneLogCiKeeps)}",
+            "without a TEST_START line the fault records in this file cannot be attributed to a "
+            + "test, and a killed host leaves nothing that names where it wedged");
+    }
+
+    /// <summary>
+    /// The FAULT-SINK pin (#2495), and the asymmetry it closes.
+    ///
+    /// <para>There are two xUnit loggers and they split the process by SERVICE PROVIDER, not by
+    /// importance: <c>XUnitFileLogger</c> serves the <see cref="TestBase"/> container,
+    /// <see cref="XUnitLogger"/> serves everything built by a HOST. In an Orleans test that second
+    /// set is the silo, the client, and every mesh hub and grain inside them — essentially the
+    /// whole system under test. Only the first wrote fault records, so an exception logged
+    /// anywhere in a silo reached NO artifact CI keeps.</para>
+    ///
+    /// <para>🚨 The probe runs with <b>no active test output helper</b>, on a thread whose
+    /// ExecutionContext flow is suppressed, because that is the case that matters: fixture init,
+    /// teardown and reactive continuations on background schedulers are precisely when a wedge
+    /// faults, and precisely when every other sink is closed.</para>
+    /// </summary>
+    [Fact(Timeout = 20_000)]
+    public void AFaultLoggedWithNoActiveTest_StillReachesTheOneLogCiKeeps()
+    {
+        // A standalone logging container, so the pin exercises the LOGGER rather than whatever
+        // the mesh happens to register: the default filter (MinLevel = Information) lets an Error
+        // through, which is all this assertion needs.
+        using var logging = new ServiceCollection().AddLogging().BuildServiceProvider();
+
+        var logger = new XUnitLogger(
+            "MeshWeaver.Test.FaultSinkPin",
+            new TestOutputHelperAccessor(),           // no helper — the wedge case
+            new LoggerExternalScopeProvider(),
+            logging.GetRequiredService<IOptionsMonitor<LoggerFilterOptions>>());
+
+        var marker = "fault-sink-pin-" + Guid.NewGuid().ToString("N");
+        var before = CurrentTraceLength();
+
+        // SuppressFlow so the new thread does NOT inherit this test's AsyncLocal output-helper
+        // registration — otherwise the logger would find a helper and the probe would be testing
+        // the wrong path.
+        using (ExecutionContext.SuppressFlow())
+        {
+            var thread = new Thread(() => logger.Log(
+                LogLevel.Error, default, marker, new InvalidOperationException(marker),
+                (state, _) => state)) { IsBackground = true };
+            thread.Start();
+            thread.Join(TimeSpan.FromSeconds(10)).Should().BeTrue("the probe thread must finish");
+        }
+
+        ReadTraceTailFrom(before).Should().Contain(marker,
+            "a Warning-or-worse record carrying an exception must reach the fault log even when "
+            + "no test output helper is active — that is the only sink a wedge can still write to");
+    }
+
+    private static long CurrentTraceLength()
+        => new FileInfo(TestTraceLog.Path) is { Exists: true } file ? file.Length : 0L;
+
+    /// <summary>
+    /// Reads only what this test appended. The file is shared by every test host in a CI shard
+    /// (and by every concurrent local run), so reading it whole would be both slow and ambiguous.
+    /// </summary>
+    private static string ReadTraceTailFrom(long offset)
+    {
+        using var stream = new FileStream(
+            TestTraceLog.Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        stream.Seek(offset, SeekOrigin.Begin);
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2495.

## What the measurement actually said

Taken from CI run [33062668925](https://github.com/Systemorph/MeshWeaver/actions/runs/33062668925), shard 3, where `MeshWeaver.Hosting.Orleans.Test` ran 208 tests over 272 s and failed on `OrleansAutoExecuteTest.AutoExecute_UpdateThreadMessageContent_RoutesToResponseGrain`.

**The `StdOut` reading was a false lead, and the contrast settles it.** The shards run the NATIVE xUnit v3 host (`dotnet <Name>.dll -trx …`), whose trx writer puts captured output in `<Output><TextMessages><Message>` — `<StdOut>` is used only when a test writes to the process console. Across that whole run: Orleans 0/208 `StdOut`, PluginCatalog 0/640, Graph 0/1657 — and `Portal.E2E` 192/194, `PluginImage` 4/4, because those two shell out. Nothing needs fixing to make `StdOut` appear.

**But the substance of the issue is right, and worse.** The failing test's captured output is 167 lines, of which **165 predate `=== TEST START ===`** — Orleans silo boot. The 13.8-second failure window holds **two** lines, both Orleans GC-watchdog warnings. Zero MeshWeaver lines.

**And the trace genuinely did not cover the window.** The per-test phase trace was written only by `MonolithMeshTestBase`. Lines in `_meshweaver-test-trace.log` by pid, same shard, same file:

| host | lines |
|---|---|
| `MeshWeaver.Hosting.Orleans.Test` (208 tests, 272 s) | **4** |
| its three Monolith-derived shard-mates | 819 / 606 / 1789 |

Those four are all `[FAULT]` records. `OrleansSharedTestBase` extends `TestBase` directly, so it wrote no phase lines at all.

## What changed

**1. Every project writes its test window.** The markers move to `AutoTestLoggingAttribute`, which every `TestBase` subclass in every project already carries: `TEST_START <method>` / `TEST_END elapsed=<n>ms <method> outcome=<…> :: <type>: <message>`, with `pid` so a shard's several hosts stay apart. A `TEST_START` with no matching `TEST_END` **names the test a killed host wedged in** — the only evidence that survives `exit=124`, which writes no trx at all.

`elapsed` is measured between the hooks, **not** read off `TestResultState.ExecutionTime`: xUnit v3.2.2 documents that as seconds and it reports milliseconds (1523.705 for a test the trx records at `00:00:01.5306690`), so trusting the doc would put every line out by 1000×.

**2. Silo-side faults reach the file.** The two xUnit loggers split the process by **service provider**, not by importance: `XUnitFileLogger` serves the `TestBase` container and wrote fault records; `XUnitLogger` serves everything built by a HOST — in an Orleans test the silo, the client, and every mesh hub and grain inside them — and wrote none. It now records a `Warning`-or-worse record carrying an exception to the same file, before the output-helper guard, exactly as `XUnitFileLogger` already did.

Same suite, same 208 green tests, locally at `DOTNET_PROCESSOR_COUNT=4`: **4 → 129 fault records**, including categories that were entirely invisible — `MeshWeaver.AI.ThreadExecution` (13), `Data.Serialization.SynchronizationStream` (8), `Hosting.MeshNodeStreamCache` (3), `Graph.Configuration.MeshNodeCompilationService` (4), `Orleans.Runtime.Messaging.Connection` (65). `FaultRecordBudget` did not suppress once, so the healthy rate is inside budget.

**3. 🚨 A crashed host is a FAILED result, not a silence.** Pass/fail evidence (the trx) and liveness evidence (the exit marker) were two channels, and every reporter reads only the first — which is why `MeshWeaver.Content.Test`'s `exit=139` had the shard summary, the per-shard check and the consolidated check all announce a pass over three tests while the process had died. Adding a seventh checker would leave the next reporter with the same blind spot, so the evidence is single-channel now: for any exit the trx cannot explain, `.github/scripts/record-host-crash.py` writes a `<project>.HOST_CRASHED` failure **into the trx**, creating the file when the host wrote none.

## Proof it fails loudly — every claim has a negative control

| control | result |
|---|---|
| real host killed mid-run (`SIGKILL`, no trx written) → classify + record | shard gate goes **RED**, naming `MeshWeaver.Threading.Test.HOST_CRASHED` |
| real 366-passed trx + `rc=139` (the Content.Test shape) | counters `366/0` → `366 passed / 1 failed`, `ResultSummary` → `Failed`, gate RED |
| recorder replaced by a no-op | **3 of 4** guard tests fail, naming the defect |
| `crash=` dropped from the SIGSEGV branch | classifier guard fails, naming exit code `139` |
| fault sink removed from `XUnitLogger` | `AFaultLoggedWithNoActiveTest_StillReachesTheOneLogCiKeeps` fails |
| window markers removed | `TheTestWindow_IsWrittenToTheOneLogCiKeeps` fails |

`CrashedHostIsNeverAPassGuard` executes the real script (it does not pattern-match the workflow) against both shapes a dead host leaves behind, and asserts with the shard gate's own grep. Its wiring half fails if any death branch stops setting `crash=`, so a new exit code cannot be given a marker without also being given a trx result.

🚨 **The window pin's first version passed with the mechanism deleted** — it read a shared, append-only file whole and found a previous green run's line. In a change whose entire subject is verification steps that cannot fail, that is the one mistake not to ship: it is now anchored to a length captured in the constructor and matches on `pid`.

## What it already tells you about an unattributed #2346 member

`AutoExecute_UpdateThreadMessageContent_RoutesToResponseGrain` is still listed as unfixed and unattributed. Joining the window brackets to the trx times says what no artifact previously did:

- it failed with **six other test classes executing in the same process** — `OrleansChatHistoryTest`, `OrleansHostedHubRoutingTest`, `OrleansReentrancyTest`, `OrleansStaticRepoImportTest`, `OrleansThreadStreamingTest`, `SiloShutdownActivationGateTest` — and `OrleansSharedTestBase` boots **one Orleans cluster per class**;
- the one `[FAULT] [Critical]` record inside its window (`portal/silo-shutdown-sender`, "cross-process routing DISABLED", 10:31:30.292) belongs to `SiloShutdownActivationGateTest.ShutdownFlippingAfterTheGate_IsRefusedAsTransient_NotTerminal` (10:31:28.893 → 10:31:30.309) — **a concurrent class deliberately shutting a silo down**, four seconds before the assertion failed;
- the two watchdog lines in the window are the same event from the runtime's side: "stalled for 00:00:02.17, GC Pause 00:00:01.59", and a timer 4.86 s late.

Detail and caveats in the issue comment. Locally the suite is 208/208 green, so this is a lead with named candidates, not a root cause.

## Known gap, stated rather than implied

The window markers come from an attribute on `TestBase`, so a class that does not derive from it writes none — **25 classes / 86 of 208 tests** in Orleans.Test (`RoutingGrain*`, `OrleansCrossSilo*`, `TwoSiloRecycleConvergenceTest`, …). Their faults still reach the file; only the brackets are missing. Closing it needs an assembly-level attribute in an assembly every test project references, which today is neither `MeshWeaver.Fixture` (21 of 45 projects do not reference it) nor `MeshWeaver.Reactive.Assertions` (a published package whose contract is "depends only on System.Reactive"). Left as follow-up rather than smuggled in.

## Verification

Release + `-warnaserror` throughout. `Orleans.Test` 208/208 at `DOTNET_PROCESSOR_COUNT=4` (twice, 67 s and 90 s), `Query.Test` 409/409, `Documentation.Test` 91/91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)