### PR TITLE
Fix #2468: the content gate died before judging — a virtual provider's fault had no error arm

### DIFF
--- a/src/MeshWeaver.Data/TransientNodeProbe.cs
+++ b/src/MeshWeaver.Data/TransientNodeProbe.cs
@@ -19,6 +19,17 @@ namespace MeshWeaver.Data;
 ///
 /// <para>Streams are still created LAZILY when a request actually needs one — the guard removes
 /// only the eager start nobody consumes.</para>
+///
+/// <para>🚨 <b>A probe hub HAS NO MESH NODE, and the read path enforces that.</b> The instance
+/// configuration a probe applies is content written for a REAL per-node hub, where the hub's
+/// address IS its mesh path — so a loader deriving a path from <c>Hub.Address</c> and reading it is
+/// ordinary, correct code that collapses onto the probe's own synthetic address here. Posted to the
+/// probe, such a read parks behind the <c>DataContextInit</c> / <c>MeshNodeInit</c> gates that the
+/// probe's own data-context initialization opens — a CYCLE whose only exit was the read's full
+/// budget, ending on a <c>CancellationTokenSource</c> timer thread (Systemorph/MeshWeaver#2468).
+/// <c>MeshNodeStreamExtensions.GetMeshNodeOutcome</c> therefore answers a probe's read of its OWN
+/// address <c>Absent</c> immediately — the truthful answer, since there is no node there and never
+/// will be. Reads of any REAL path from a probe are untouched.</para>
 /// </summary>
 /// <param name="StartDataSources">Whether the probe still STARTS its data sources on the init
 /// turn. Default TRUE — the pre-existing behaviour, which probes that snapshot actual data (the

--- a/src/MeshWeaver.Data/VirtualDataSource.cs
+++ b/src/MeshWeaver.Data/VirtualDataSource.cs
@@ -112,7 +112,29 @@ public record VirtualDataSource(object Id, IWorkspace Workspace)
                                 return (ChangeItem<EntityStore>?)
                                     new ChangeItem<EntityStore>(newStore, Id.ToString()!, stream.StreamId, ChangeType.Full, stream.Hub.Version, []);
                             }, _ => { });
-                    })
+                    },
+                    // 🚨 THE ERROR ARM IS NOT OPTIONAL — omitting it is a PROCESS KILLER, not a
+                    // missing log line. A virtual type's provider is arbitrary composed content
+                    // (a mesh read, a query hop, a CombineLatest over other streams), so it CAN
+                    // fault; and Rx's default onError handler for a one-argument Subscribe is
+                    // Stubs.Throw, which RETHROWS the fault on whatever thread carried it. That
+                    // thread is almost never one with a catch: in Systemorph/MeshWeaver#2468 the
+                    // provider's `hub.GetMeshNode(...)` timed out, so the OnError originated in a
+                    // CancellationTokenSource callback on a TimerQueue thread — the rethrow became
+                    // an UNHANDLED exception, the host aborted (core dumped), and the Doc content
+                    // gate reported "failed before it produced a verdict — no check was judged".
+                    // A gate that dies before judging is worse than a gate that fails.
+                    //
+                    // Reported, never swallowed: the fault is real and this collection is now
+                    // frozen at its last emission. The data source's own initialization observes
+                    // the SAME faulted Replay(1) (VirtualTypeSource.StreamUpdates), so a fault
+                    // during init still fails the hub's startup through the normal path — this arm
+                    // exists so a fault can never take the process with it.
+                    error => Logger.LogError(error,
+                        "Virtual data source {DataSource}: the provider for collection "
+                        + "'{Collection}' faulted. That collection is frozen at its last emission "
+                        + "and will receive no further updates on hub {Address}",
+                        Id, typeSource.CollectionName, Workspace.Hub.Address))
             );
         }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
@@ -315,6 +315,27 @@ pendingFlush.Disposable = Observable.Timer(TimeSpan.FromMilliseconds(100))
 
 Holding it in a field is **not** the same as owning it — the field has to be disposed by the owner's teardown, on every path. Full treatment, with both leak shapes, the measured truth table of which primitives actually root, and why there is deliberately no analyzer: [Subscription Ownership](/Doc/Architecture/SubscriptionOwnership).
 
+### 🚨 …and a subscription on a path that can FAULT needs an error arm — omitting it kills the process
+
+`Subscribe(onNext)` is not "subscribe and ignore errors". Rx's default `onError` for the one-argument overload is `Stubs.Throw`, which **rethrows the fault on whatever thread carried it** — and that thread is chosen by whatever produced the error, not by you. A timeout raises `OnError` from a `CancellationTokenSource` callback on a **`TimerQueue` thread**, where there is no `catch` anywhere above the frame. The result is an unhandled exception and an aborted process, not a logged error.
+
+```csharp
+// ❌ No error arm. A provider timeout here ends the PROCESS on a timer thread.
+typeSource.GetStreamUpdates().Subscribe(instances => Apply(instances));
+
+// ✅ Reported, on the thread the fault arrived on, and the process survives.
+typeSource.GetStreamUpdates().Subscribe(
+    instances => Apply(instances),
+    error => Logger.LogError(error, "…{Collection} faulted; it is frozen at its last emission", name));
+```
+
+Two corollaries worth stating separately:
+
+- **A `try`/`catch` around the `Subscribe` CALL catches nothing.** The fault travels through the stream and arrives later, on another thread; the `try` block has long since exited. Fault handling is fluent — an error arm, or `.Catch(...)` — never `try`.
+- **An error arm is not a swallow.** It must SAY what stopped working. Where another subscriber already owns the verdict (a data source's initialization observing the same `Replay(1)`, which fails the hub's startup), the arm's job is to report and let that path decide — its existence is what stops a fault from taking the host with it.
+
+This is the defect behind [#2468](https://github.com/Systemorph/MeshWeaver/issues/2468): a virtual data source's live-update subscription had no error arm, so a content loader's `GetMeshNode` timeout aborted the CI content gate — which then reported *"failed before it produced a verdict — no check was judged"*. A gate that dies before judging is worse than a gate that fails.
+
 ---
 
 ## 🚨 `MeshNode.Content` is always typed at the `GetMeshNodeStream` boundary

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-content-gate-no-verdict.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-content-gate-no-verdict.md
@@ -1,0 +1,19 @@
+---
+Name: Data views survive a failing data provider
+Category: Fix
+Description: A data source whose provider fails now reports the failure instead of taking the whole process down.
+Icon: Sparkle
+Order: -20260827
+---
+
+# Data views survive a failing data provider
+
+A view backed by computed ("virtual") data could take the whole application down when the
+computation behind it failed — for example when a lookup it needed timed out. The failure was
+re-thrown on a background timer, where nothing could catch it, so instead of one view showing an
+error the process ended abruptly and whatever it was doing produced no result at all.
+
+That failure is now reported: the affected collection stops updating and says so in the log, and
+everything else keeps running. A related cause is fixed too — the short-lived hub used to work out
+a node type's data model no longer stalls for ten seconds when the type's own code looks up the
+node it is running on.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -2145,8 +2145,10 @@ public static class MeshNodeStreamExtensions
     /// <list type="bullet">
     ///   <item><see cref="NodeReadStatus.Present"/> — a node came back.</item>
     ///   <item><see cref="NodeReadStatus.Absent"/> — routing said
-    ///     <see cref="ErrorType.NotFound"/>, the owner answered with no data, or a read validator
-    ///     hid it (a hidden node is invisible by contract).</item>
+    ///     <see cref="ErrorType.NotFound"/>, the owner answered with no data, a read validator
+    ///     hid it (a hidden node is invisible by contract), or the reader is a TRANSIENT NODE
+    ///     PROBE being asked for its OWN address, which by contract is never a mesh node — that
+    ///     one is answered without a round-trip at all (see the guard in the body).</item>
     ///   <item><see cref="NodeReadStatus.DeleteInProgress"/> — the owner answered with its delete
     ///     tombstone (<c>GetDataResponse.Absence</c>).</item>
     ///   <item><see cref="NodeReadStatus.Unavailable"/> — the delivery failed for any other
@@ -2180,6 +2182,51 @@ public static class MeshNodeStreamExtensions
             // "DeliveryFailure … (sender: Plugins/_DefaultInstallLedger)"). Same seam MeshService
             // uses for CRUD; a non-router caller gets itself back, unchanged.
             var issuingHub = hub.NodeOperationIssuingHub();
+
+            // ♻️ A TRANSIENT NODE PROBE HAS NO MESH NODE — so reading its OWN address is a CYCLE,
+            // and the only way it ever ended was by spending the entire budget.
+            //
+            // A probe hub (`$model-probe/{guid}`, `$schema-probe/{guid}`) exists to have a
+            // NodeType's INSTANCE configuration applied to it so its type registry / schema can be
+            // snapshotted, and is disposed in the same breath. AsTransientNodeProbe states the
+            // contract outright: "with no own-node subscription and no persistence sampler it has
+            // no node identity". But that instance configuration is content written for a REAL
+            // per-node hub, where the hub's address IS its mesh path — so deriving a path from
+            // `Hub.Address` and reading it is an ordinary, correct thing for a loader to do. On the
+            // probe that same derivation collapses onto the probe's own synthetic address.
+            //
+            // The read is then posted to the probe itself, where it parks behind the
+            // DataContextInit / MeshNodeInit gates — and it is the probe's OWN data-context
+            // initialization that issued it, so the gates cannot open until the read completes and
+            // the read cannot complete until the gates open. Systemorph/MeshWeaver#2468: every such
+            // read burned its full 10 s and then errored from the CTS timer thread.
+            //
+            // Absent is the TRUTHFUL answer, not a shortcut: there is no node at this address and
+            // there never will be. Answering immediately is the same reasoning as "a gate that can
+            // never open must answer immediately rather than sit on a timeout" — and it is scoped
+            // to the probe's own address, so a probe reading any REAL path is untouched.
+            if (issuingHub.Configuration.Get<TransientNodeProbe>() is not null
+                && string.Equals(path, issuingHub.Address.ToString(), StringComparison.Ordinal))
+            {
+                try
+                {
+                    issuingHub.ServiceProvider.GetService<ILoggerFactory>()
+                        ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode")
+                        ?.LogDebug(
+                            "GetMeshNode('{Path}') on a transient node probe reads the probe's OWN "
+                            + "address — a probe has no mesh node, so this is answered Absent "
+                            + "immediately rather than parked behind the probe's own init gates.",
+                            path);
+                }
+                catch
+                {
+                    // Logging must never mask the verdict it is reporting.
+                }
+                observer.OnNext(NodeReadOutcome.Absent);
+                observer.OnCompleted();
+                return Disposable.Empty;
+            }
+
             var budget = timeout ?? TimeSpan.FromSeconds(10);
             var started = Stopwatch.StartNew();
             var cts = new CancellationTokenSource(budget);

--- a/test/MeshWeaver.Data.Test/VirtualDataSourceProviderFaultTest.cs
+++ b/test/MeshWeaver.Data.Test/VirtualDataSourceProviderFaultTest.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>A row produced by the faulting virtual provider below.</summary>
+/// <param name="Id">Key.</param>
+/// <param name="Name">Payload.</param>
+public record FaultingRow([property: Key] int Id, string Name);
+
+/// <summary>
+/// Pins the ERROR ARM on <c>VirtualDataSource</c>'s live-update subscription
+/// (Systemorph/MeshWeaver#2468).
+///
+/// <para>A virtual type's provider is arbitrary composed content — a mesh read, a query hop, a
+/// <c>CombineLatest</c> over other streams — so it CAN fault. The subscription that pushes its
+/// later emissions into the data source used to be a one-argument <c>Subscribe(onNext)</c>, and
+/// Rx's default <c>onError</c> for that overload is <c>Stubs.Throw</c>: it RETHROWS the fault on
+/// whatever thread carried it.</para>
+///
+/// <para>That thread is almost never one with a catch. In #2468 the provider's
+/// <c>hub.GetMeshNode(...)</c> timed out, so the <c>OnError</c> originated inside a
+/// <c>CancellationTokenSource</c> callback on a <c>TimerQueue</c> thread; the rethrow was an
+/// UNHANDLED exception, the host aborted (core dumped), and the Doc content gate reported
+/// <i>"failed before it produced a verdict — no check was judged"</i>. A gate that dies before
+/// judging is worse than a gate that fails, so this is pinned rather than left to review.</para>
+///
+/// <para>The test drives the fault from the TEST thread precisely because the rethrow is
+/// synchronous on the emitting thread — that is what makes it observable here at all, and it is
+/// the same rethrow that has no catch in production.</para>
+/// </summary>
+public class VirtualDataSourceProviderFaultTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private readonly BehaviorSubject<IEnumerable<FaultingRow>> rows =
+        new([new FaultingRow(1, "seed")]);
+
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData(data => data
+                .WithVirtualDataSource("Faulting", vds =>
+                    vds.WithVirtualType<FaultingRow>(_ => rows)));
+
+    /// <summary>
+    /// A faulting provider must be REPORTED by the data source, never rethrown onto the thread
+    /// that produced the fault.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ProviderFault_IsReported_NeverRethrownOnTheEmittingThread()
+    {
+        var workspace = GetHost().GetWorkspace();
+
+        // Let the source come up first, so the live-update subscription — the one under test — is
+        // the subscriber that is still attached when the fault lands (initialization's Take(1) has
+        // already released).
+        var stream = workspace.GetStream(typeof(FaultingRow));
+        await stream.Should().Within(TimeSpan.FromSeconds(10)).Emit();
+
+        var fault = new TimeoutException(
+            "GetMeshNode('$model-probe/deadbeef') timed out after 10.0s — the shape of #2468");
+
+        var act = () => rows.OnError(fault);
+
+        act.Should().NotThrow(
+            "a virtual provider's fault must be reported by the data source, not rethrown onto "
+            + "the emitting thread — in production that thread is a CTS TimerQueue thread with "
+            + "no catch anywhere above it, so the rethrow aborts the process");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NodeTypeModelProbeTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeModelProbeTest.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -55,9 +56,28 @@ public class NodeTypeModelProbeTest(ITestOutputHelper output) : MonolithMeshTest
         => base.ConfigureMesh(builder)
             .ConfigureServices(services => services.AddSingleton<ILoggerProvider>(recorder));
 
+    public record ProbeSelfRead(string Id, string Verdict);
+
     /// <summary>The instance configuration a NodeType would apply to its instances.</summary>
     private static MessageHubConfiguration InstanceConfig(MessageHubConfiguration config)
         => config.AddMeshDataSource(source => source.WithContentType<ProbeOrder>());
+
+    /// <summary>
+    /// The same instance configuration plus what real NodeType content routinely does: derive a
+    /// mesh path from the hub's OWN address and read it. On a real per-node hub the address IS the
+    /// node's path, so this is correct code; on the probe it collapses onto the synthetic
+    /// <c>$model-probe/{guid}</c>. See the test below for why that used to cost 10 s and a process.
+    /// </summary>
+    private static MessageHubConfiguration SelfReadingInstanceConfig(MessageHubConfiguration config)
+        => config
+            .AddMeshDataSource(source => source.WithContentType<ProbeOrder>())
+            .AddData(data => data
+                .WithVirtualDataSource("SelfRead", vds =>
+                    vds.WithVirtualType<ProbeSelfRead>(workspace =>
+                        workspace.Hub
+                            .GetMeshNode(workspace.Hub.Address.ToString(), TimeSpan.FromSeconds(10))
+                            .Select(node => (IEnumerable<ProbeSelfRead>)
+                                [new ProbeSelfRead("1", node?.Path ?? "absent")]))));
 
     [Fact(Timeout = 60000)]
     public async Task ProbeInstanceModel_SnapshotsContentTypeAndSchema()
@@ -140,6 +160,40 @@ public class NodeTypeModelProbeTest(ITestOutputHelper output) : MonolithMeshTest
             "a probe hub carries no per-node control plane, so disposing it faults nothing");
         underProbe.Count.Should().BeLessThanOrEqualTo(5,
             "the probe needs its data context, not a sync/ sub-hub per NodeType watcher");
+    }
+
+    /// <summary>
+    /// A probe hub has NO MESH NODE — so a read of its own address must be answered immediately,
+    /// not parked behind the probe's own initialization gates (Systemorph/MeshWeaver#2468).
+    ///
+    /// <para>The read is issued by the probe's own data-context initialization and posted to the
+    /// probe itself, where it defers behind <c>DataContextInit</c> / <c>MeshNodeInit</c> — the very
+    /// gates that initialization opens. A cycle: the read could only ever end by spending its whole
+    /// budget. In CI that budget elapsed on a <c>CancellationTokenSource</c> timer thread, which is
+    /// how a <b>content</b> loader's mesh read ended up aborting the Doc content gate's process.</para>
+    ///
+    /// <para>The bar is elapsed time, deliberately: the assertion has to fail if the read parks,
+    /// and 8 s is under the read's own 10 s budget while leaving a loaded runner room for the
+    /// probe's ordinary cost (~1 s locally).</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task ProbeInstanceModel_OwnAddressRead_IsAnsweredWithoutBurningTheBudget()
+    {
+        var started = Stopwatch.StartNew();
+        var model = await NodeTypeDataModelAreas
+            .ProbeInstanceModel(Mesh, SelfReadingInstanceConfig)
+            .Should().Within(40.Seconds()).Emit();
+        started.Stop();
+
+        Output.WriteLine($"probe with a self-reading provider completed in {started.Elapsed}");
+
+        model.Should().NotBeNull(
+            "content that reads its own address must not stop the probe from snapshotting");
+        model!.ContentTypeName.Should().Be(nameof(ProbeOrder));
+
+        started.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(8),
+            "a read of the probe's own address is answered Absent immediately — parking it behind "
+            + "the probe's own init gates is a cycle that can only end by burning the full budget");
     }
 
     private bool ProbeStillLive(string address)


### PR DESCRIPTION
Fixes #2468.

## What was failing

`Doc content compiles and runs` reported **"The content gate failed before it produced a verdict — no check was judged."** — on unrelated PRs (#2467, #2461) and, on 2026-08-27, on **`main`** (run 33085734292 @ `46fde128`). The host had aborted (`Aborted (core dumped)`), so the gate learned nothing and reported it in the same red as "your content is wrong".

## Root cause — two defects, chained

The CI stack matches, frame for frame, this chain:

```
FutuReDataLoader.LoadLocalDataCube        (samples/Graph/Data/FutuRe/GroupAnalysis/Source/)
  hub.GetMeshNode(buPath, 10s)  .Select(…)  .SelectMany(…)  .CombineLatest(…)  .DistinctUntilChanged()
    → VirtualTypeSource.StreamUpdates()  .Replay(1).RefCount()      ← the ReplaySubject in the stack
      → VirtualDataSource.SetupDataSourceStream:  .Subscribe(instances => …)   ← NO ERROR ARM
        → Rx Stubs.Throw → rethrow on the CancellationTokenSource TimerQueue thread → UNHANDLED
```

**1. The timeout (`src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs`).** `LoadLocalDataCube` derives a mesh path from `workspace.Hub.Address` — correct code on a real per-node hub, where the address *is* the node's path. On the NodeType **model probe** that address is the synthetic `$model-probe/{guid}`, so `buPath` collapses onto the probe's own address. The read is posted to the probe itself, where it parks behind `DataContextInit` / `MeshNodeInit` — the very gates the probe's own data-context initialization opens. A cycle: the read could only ever end by spending its full 10 s budget, on a timer thread. That is the `Target: this hub itself.` in the log line.

**2. The crash (`src/MeshWeaver.Data/VirtualDataSource.cs`).** The live-update subscription on each virtual type source was a one-argument `Subscribe(onNext)`. Rx's default `onError` for that overload is `Stubs.Throw` — it **rethrows on whatever thread carried the fault**. Here that is the CTS timer thread, where nothing catches it: unhandled exception, process abort, no verdict.

## The fix

- **`GetMeshNodeOutcome`** answers a **transient node probe's read of its OWN address** `Absent` immediately, with no round-trip. Truthful, not a shortcut — `AsTransientNodeProbe` already states a probe "has no node identity", so there is no node there and never will be. Same reasoning as "a gate that can never open must answer immediately rather than sit on a timeout". Scoped to the probe's own address; a probe reading any real path is untouched.
- **`VirtualDataSource.SetupDataSourceStream`** gets the error arm: the fault is **reported** (`LogError`, naming the data source, the collection and the hub, and saying that collection is now frozen), never rethrown. It is not swallowed — the data source's own initialization observes the same faulted `Replay(1)`, so a fault during init still fails the hub's startup through the normal path. The arm exists so a fault can never take the process with it.
- Both are pinned by tests, and the contract is written into `TransientNodeProbe`'s doc comment and `GetMeshNodeOutcome`'s `Absent` mapping.

## Proof (each fix verified against a control)

| | control (fix reverted) | with the fix |
|---|---|---|
| `VirtualDataSourceProviderFaultTest` (new) | **FAIL** — `but found TimeoutException` escaping `subject.OnError(...)`, i.e. the production rethrow | **PASS** |
| `NodeTypeModelProbeTest.ProbeInstanceModel_OwnAddressRead_…` (new) | **FAIL** — reproduces the CI line verbatim: `GetMeshNode('$model-probe/ebe98d3d…') timed out after 10.0s … Target: this hub itself.`, probe never emits | **PASS**, whole class 4/4 in 785 ms |

Both gates run locally on this branch and **produce a verdict**:

- `bake-then-gate.sh` samples stage → `GREEN — 1 known-debt failure(s) allowed`, `FutuRe/LocalAnalysis: compile=Ok render=ok`, exit 0. **Zero `timed out` lines** in the gate log (was the 10 s per probe).
- `bake-then-gate.sh` doc stage → `[PASS] Doc (864 node(s), 4 type(s))`, exit 0.

The samples gate log now carries the new arm doing its job instead of a core dump:

```
fail: MeshWeaver.Data.VirtualDataSource[0] Virtual data source LocalData: the provider for
  collection 'FutuReDataCube' faulted. That collection is frozen at its last emission and will
  receive no further updates on hub $model-probe/8728ff86fca94…
```

Full-solution `dotnet build -c Release -p:CIRun=true -warnaserror`: **0 Warning(s), 0 Error(s)**.

## Answers to the questions #2468 asks

- **Is the timeout itself the defect, or only its handling?** Both, and both are fixed. The timeout was a real self-deadlock (not a budget that is too tight), so nothing here widens a bound.
- **Is the `$model-probe` hub a transient probe whose data sources never start?** No — it is a `TransientNodeProbe` with `StartDataSources: true`. That is deliberate and was measured: `5ddaf0d4b` turned the start off for the *schema* probes only, because turning it off universally reddened six probe tests. So the model probe genuinely runs content loaders, and the cure has to be that a probe answers its own-address read rather than that it stops running them.
- **Is the `BuildupAction` line the same defect as #2444?** **No — two causes.** #2444 is an `ObjectDisposedException` from a disposed Autofac `LifetimeScope` in `SubscribeToOwnDeletionInit`. The lines in this job are (a) our own `TimeoutException` reported through `HandleInitialize`, and (b) `ArgumentException: Collection 'attachments' not found` — both downstream of the same probe-identity root, neither a disposed scope.
- **Does the annotation distinguish "no verdict" from "verdict: fail"?** It already did — `dotnet-test.yml` emits the no-verdict message only when no `GATE FAILED` line was produced. No change needed there.

## Not in scope (named, not silently skipped)

- `ArgumentException: Collection 'attachments' not found` is pre-existing and appears on the **real** `FutuRe/EuropeRe/Analysis` hub too in the gate's staged environment (the gate stages `samples/Graph/Data`, not `samples/Graph/attachments`). It has always been present on green runs; it is now *reported* rather than able to escape. Not a gate failure.
- A repo-wide sweep of single-arm `.Subscribe(` — a scan finds **114** in `src/`, most on UI/click paths that cannot fault. Worth a separate pass; ratcheting them here would be an allow-list, not a fix.

## Local verification

| | |
|---|---|
| Full solution, Release, CIRun, warnaserror | 0 Warning(s), 0 Error(s) |
| `MeshWeaver.Data.Test` | 391 / 391 |
| `MeshWeaver.Graph.Test` | 1658 / 1658 |
| `MeshWeaver.PluginCatalog.Test` — `StaleStampRootBindingTest`, `IncrementalUpdateTest` (the probe-adjacent suites `TransientNodeProbe` names) | 4 / 4 |
| `MeshWeaver.Documentation.Test` | green |
| doc gate + samples gate (`bake-then-gate.sh`, both stages) | exit 0, verdict produced |
