### PR TITLE
Cross-silo replies: a grain-directory handover is TRANSIENT, not a permanent failure (#1742)

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -546,8 +546,68 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             or HttpRequestException
             or TimeoutException
             or global::Orleans.Runtime.OrleansMessageRejectionException
+            || IsDirectoryUnstable(ex)
             || (ex.InnerException != null && IsTransientFailure(ex.InnerException));
     }
+
+    /// <summary>
+    /// Orleans could not ADDRESS the call because its own grain directory is mid-handoff — a silo is
+    /// joining or leaving and the directory partition that owns the target's entry has not settled.
+    /// Every rolling deploy produces this window, and it is over in seconds.
+    ///
+    /// <para>🚨 <b>Why this needs its own predicate at all, and why the type test above cannot see
+    /// it — issue #1742 / #2357.</b> Orleans' <c>MessageCenter.OnAddressingFailure</c> rejects the
+    /// message with <c>RejectionTypes.Unrecoverable</c> AND the causing exception attached, and the
+    /// caller-side <c>CallbackData.HandleRejectionResponse</c> resolves that as
+    /// <c>rejection?.Exception ?? new OrleansMessageRejectionException(…)</c> — <b>the carried
+    /// exception WINS</b>. So the caller does not receive the
+    /// <see cref="global::Orleans.Runtime.OrleansMessageRejectionException"/> the line above matches;
+    /// it receives the BARE <c>Orleans.Runtime.OrleansException</c>
+    /// <c>LocalGrainDirectory.LookupAsync</c> threw. Nothing in the classifier matched it, so the
+    /// delivery was never retried and was reported to the sender as TERMINAL — for a condition
+    /// Orleans' own message ends with the words "Retry later.".</para>
+    ///
+    /// <para><b>This is not a retry bolted onto a failure.</b> The retry-with-fresh-resolve already
+    /// exists (<c>RoutingGrain.DeliverToGrainObservable</c>, <see cref="DispatchObservable"/>) and is
+    /// already applied to exactly this class of condition; the defect was that the classifier
+    /// gating it could not read this input, which is the same inert-classifier shape as #2451's
+    /// <c>GetFailureErrorType</c>. Recognising the condition is what makes the existing machinery
+    /// reachable — nothing new spins.</para>
+    ///
+    /// <para>🚨 <b>Matched on the message, deliberately, and PINNED by a test.</b> Orleans gives this
+    /// condition no type of its own — it is a bare <c>OrleansException</c>, whose other uses
+    /// (extension not installed, a limit exceeded) are genuinely terminal, so widening the type test
+    /// would make real defects retry six times. Text classification is this codebase's established
+    /// contract for precisely this decision — see <see cref="ClassifyRoutedFailure"/>, which lists
+    /// the four layers that already do it. <c>OrleansDirectoryInstabilityClassificationTest</c> pins
+    /// both phrases against the shipped Orleans build: <b>if that test fails after an Orleans
+    /// upgrade, this classifier has gone INERT — repair the phrase, never delete the test.</b></para>
+    /// </summary>
+    /// <param name="ex">The exception a grain call faulted with.</param>
+    /// <returns><c>true</c> when the grain directory said "ask again once membership settles".</returns>
+    internal static bool IsDirectoryUnstable(Exception ex) =>
+        (ex is global::Orleans.Runtime.OrleansException
+         && (ex.Message.Contains(DirectoryRetryLaterMarker, StringComparison.OrdinalIgnoreCase)
+             || ex.Message.Contains(DirectoryHopLimitMarker, StringComparison.OrdinalIgnoreCase)))
+        // Walks its own inner chain rather than relying on a caller's: this is consulted BOTH from
+        // IsTransientFailure (which walks) and from RoutingGrain.ClassifyDeliveryException (which
+        // does not, and which is handed an AggregateException by PostFailure's two-transport arm).
+        || (ex is AggregateException aggregate
+            ? aggregate.InnerExceptions.Any(IsDirectoryUnstable)
+            : ex.InnerException is not null && IsDirectoryUnstable(ex.InnerException));
+
+    /// <summary>
+    /// Orleans' own instruction, from <c>"Current directory at {silo} is not stable to perform the
+    /// lookup for grainId {id} (it maps to {silo}, which is not a valid silo). Retry later."</c>
+    /// </summary>
+    internal const string DirectoryRetryLaterMarker = "Retry later";
+
+    /// <summary>
+    /// The directory-handoff variant, from <c>"Silo {silo} is not owner of {grainId}, cannot forward
+    /// LookUpAsync to owner {silo} because hop limit is reached"</c> — the shape prod logged during
+    /// two rolling deploys (issue #2357).
+    /// </summary>
+    internal const string DirectoryHopLimitMarker = "hop limit is reached";
 
     /// <summary>
     /// How the SENDER should read a delivery the grain returned <see cref="MessageDeliveryState.Failed"/>:

--- a/src/MeshWeaver.Documentation/Data/Architecture/OrleansStreamPubSubDurability.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OrleansStreamPubSubDurability.md
@@ -167,6 +167,15 @@ manufactured by every deploy. Two residual silent-loss windows remain:
 2. **A genuinely absent subscriber.** A hub whose subscription attach failed, or which is torn down
    between publish and pull, still absorbs the message without a `DeliveryFailure`.
 
+> 🚨 **Both of those residuals now live on a FALLBACK path, and that changes who should pay for
+> them.** Since the transport swap ([Pod-Hub Delivery](/Doc/Architecture/PodHubDeliveryRollPlan))
+> the primary route to a pod-process hub is a directed grain call; the stream carries only the roll
+> window and hubs owned by an Orleans *client* process, which cannot host a grain. So making the
+> stream durable no longer buys the #1742 headline — it buys #2320 and #2322, which are stream-leg
+> tickets. The primary path traded the stream's fragility for the **grain directory's**, and that is
+> a different (classification) fix, written up in the roll plan's "What the swap traded" section.
+> Size the pre-release-package decision on the stream tickets alone.
+
 Plus one deployment-shaped residual: **the `AzureTables` / Azure Container Apps route still runs a
 memory PubSubStore**, and it is a multi-silo shape. Anyone taking that route to production must pass
 a durable `configurePubSubStore` (Azure Table or Blob grain storage under the name `PubSubStore`)

--- a/src/MeshWeaver.Documentation/Data/Architecture/PodHubDeliveryRollPlan.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PodHubDeliveryRollPlan.md
@@ -129,6 +129,56 @@ That last row is the one that matters most and the one a producer-side check can
 *reply* cannot be delivered, the party that needs to know is the original requester — and it is
 precisely the party that is unreachable. Making the reply land is the only answer.
 
+## 🚨 What the swap traded — read this before calling #1742 closed
+
+The table above is about the *stream's* residuals, and it is accurate. It is also only half the
+ledger, because **the directed call is not free of a shared dependency — it moved onto a different
+one.** Orleans' own grain directory is the address→silo map (that is the whole trick, and why this
+design needed no directory of ours). The grain directory is *also* the component that is unstable
+while cluster membership changes — i.e. during a rolling deploy, which is the exact window every
+production symptom in #1729 / #1742 was measured in. Same window, new dependency:
+
+```
+Orleans cannot address the call
+  → MessageCenter.OnAddressingFailure
+  → RejectMessage(msg, RejectionTypes.Unrecoverable, ex)     ← the DIRECTORY's exception, attached
+  → caller: CallbackData.HandleRejectionResponse
+        exception = rejection?.Exception ?? new OrleansMessageRejectionException(…)
+                    ^^^^^^^^^^^^^^^^^^^^ the carried one WINS
+  → RoutingGrain sees a BARE Orleans.Runtime.OrleansException
+        "…is not stable to perform the lookup … Retry later."
+        "…cannot forward LookUpAsync to owner … because hop limit is reached"
+```
+
+`RoutingGrain.IsTransientFailure` matched `TimeoutException` and
+`OrleansMessageRejectionException` — neither of which this is. So for a condition whose own message
+ends in *"Retry later."*:
+
+1. the delivery was **never retried**, although the retry-with-fresh-resolve primitive it needed was
+   already sitting one line away and already applied to exactly this class of condition;
+2. both exception arms then NACK'd the sender with a **hard-coded terminal `ErrorType.Failed`** — the
+   same defect #2346 / #2451 removed from the neighbouring `result.State == Failed` arm and left
+   standing on these two. That verdict is what costs a *subscription* rather than a message:
+   `SynchronizationStream`'s resubscribe latch and `MeshNodeStreamCache.IsTransientOwnerFailure` ride
+   out `ShuttingDown` and **tear down** on `Failed`;
+3. and when `PostFailure`'s own directed NACK hit the same unstable directory it took
+   `LogUndeliverableNack` — the stream fallback was reached only for `PodHubNotHereException` — so
+   the sender was told **nothing at all**. That is #1742's headline symptom, reproduced on the
+   transport that replaced it.
+
+Production evidence: **#2357**, 16 occurrences across two rolling deploys, naming
+`IPodHubGrain.Deliver` and `IMessageHubGrain.DeliverMessage` among the dropped targets.
+
+**The cure is classification, not a new mechanism** (`OrleansRoutingService.IsDirectoryUnstable`,
+`RoutingGrain.ClassifyDeliveryException`, and `PostFailure` falling back to the stream on ANY failed
+directed NACK rather than only on `PodHubNotHere`). Nothing new spins: the retry existed and was
+unreachable, which is the same inert-classifier shape as #2451.
+
+> 🚨 **This is also why the "durable stream provider" decision does NOT close #1742.** A durable
+> provider improves the *fallback* — residual A below, plus hubs owned by an Orleans client process.
+> It cannot touch the primary reply path, because the directed call never goes near the stream
+> provider. Size that decision on #2320 / #2322 (both stream-leg tickets), not on this issue.
+
 ## Related
 
 - [Orleans Stream Pub-Sub Durability](/Doc/Architecture/OrleansStreamPubSubDurability) — the defect,

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-a-deploy-no-longer-cancels-what-you-were-doing.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-a-deploy-no-longer-cancels-what-you-were-doing.md
@@ -1,0 +1,50 @@
+---
+Name: A deploy no longer cancels what you were doing
+Category: Fix
+Description: For a few seconds during every update, the platform briefly cannot tell which server holds which piece of your work. It used to report that momentary confusion as a permanent failure — dropping the request and tearing down the live page behind it — instead of simply asking again a moment later. It now waits for the moving to finish.
+Icon: Sparkle
+Order: -20260827
+---
+
+# A deploy no longer cancels what you were doing
+
+Updates are rolled out one server at a time, so for a few seconds there are two: the one being
+retired and the one taking over. While that handover happens, the platform's map of which server
+holds which piece of your work is briefly out of date — it is being rewritten. That window is normal,
+it is short, and it ends by itself.
+
+The problem was what happened to a message that arrived inside it. The underlying platform said, in
+so many words, *"ask again in a moment"* — and we were not reading that. The message was treated as
+having failed permanently: it was not sent again, and the thing waiting for it was told the failure
+was final.
+
+## Why that was worse than losing one message
+
+Losing one message costs you a click. But a live page — an open document, a chat that is streaming, a
+list that updates as data changes — keeps a standing connection, and that connection is built to
+survive exactly this kind of hiccup: told *"the server is moving"*, it waits and reconnects; told
+*"this failed"*, it gives up and closes. Because the handover was reported as a permanent failure,
+pages that would have carried straight on through the update instead went quiet and stayed quiet
+until reloaded.
+
+There was also a rarer version with no visible error at all. When the reply that says *"this did not
+work"* was itself sent during the same handover, it could go nowhere — leaving the request to sit
+until it timed out roughly a minute later, with nothing on screen to explain the wait.
+
+## What changed
+
+The handover is now recognised for what it is. A message that arrives mid-move is simply sent again
+once the move completes — using machinery that was already there and was only ever missing the cue to
+run. If it still cannot be delivered afterwards, the answer now says *"the server is moving"* rather
+than *"this failed"*, so a live page waits it out instead of tearing itself down. And a failure
+notice that cannot take the direct route now takes the second one rather than vanishing, so nothing
+is left waiting on an answer that was never coming.
+
+Genuine failures are still reported as final and still arrive immediately — a real error is not made
+slower or quieter by any of this.
+
+## What you will notice
+
+Nothing at all, most of the time, which is the point: pages that used to go blank or stop updating
+during an update should now carry on through it, and the occasional minute-long pause with no
+explanation should not happen.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-a-deploy-no-longer-cancels-what-you-were-doing.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-a-deploy-no-longer-cancels-what-you-were-doing.md
@@ -1,7 +1,7 @@
 ---
 Name: A deploy no longer cancels what you were doing
 Category: Fix
-Description: For a few seconds during every update, the platform briefly cannot tell which server holds which piece of your work. It used to report that momentary confusion as a permanent failure — dropping the request and tearing down the live page behind it — instead of simply asking again a moment later. It now waits for the moving to finish.
+Description: For a few seconds during every update, the platform briefly cannot tell which server holds which piece of your work. It used to report that momentary confusion as a permanent failure — dropping the request and tearing down the live page behind it — instead of simply asking again a moment later. It now waits for the move to finish.
 Icon: Sparkle
 Order: -20260827
 ---

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -431,10 +431,14 @@ internal class RoutingGrain(
         IObservable<Unit> TerminalCallFailure(Exception ex)
         {
             RoutingGrainTrace.Write($"RoutingGrain.RouteMessage POD_HUB_FAULT addr={addressPath} id={delivery.Id} ex={ex.Message}");
+            // 🚨 CLASSIFY — this line read ErrorType.Failed unconditionally. See
+            // ClassifyDeliveryException: a silo leaving mid-roll and a directory mid-handoff are
+            // TRANSIENT, and telling the sender otherwise tears down mirrors that would have resumed.
+            var errorType = ClassifyDeliveryException(ex);
             logger.LogError(ex,
-                "[ROUTE] Directed delivery to pod hub {Address} failed — surfacing DeliveryFailure to sender {Sender}",
-                addressPath, delivery.Sender);
-            PostFailureToSender($"Delivery to '{addressPath}' failed: {ex.Message}", ErrorType.Failed);
+                "[ROUTE] Directed delivery to pod hub {Address} failed — surfacing {ErrorType} DeliveryFailure to sender {Sender}",
+                addressPath, errorType, delivery.Sender);
+            PostFailureToSender($"Delivery to '{addressPath}' failed: {ex.Message}", errorType);
             return Observable.Return(Unit.Default);
         }
     }
@@ -780,13 +784,36 @@ internal class RoutingGrain(
                 RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_POD_HUB_OK id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
                 return Unit.Default;
             })
-            .Catch<Unit, Exception>(ex => IsPodHubNotHere(ex)
-                ? Observable.Defer(() =>
-                {
-                    RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_POD_HUB_NOT_HERE id={delivery.Id} sender={delivery.Sender}");
-                    return PublishFailureOverStream();
-                })
-                : LogUndeliverableNack(ex)));
+            // 🚨 EVERY failure of the directed NACK falls back to the stream — not only
+            // PodHubNotHere. There is no NACK for a NACK, so this leg's alternative to trying the
+            // second transport is SILENCE, which is the whole of issue #1742. The two are genuinely
+            // independent failure surfaces: the directed call needs the SENDER's pod-hub activation
+            // to be addressable, while the publish needs only the sender's stream subscription — so
+            // a directory mid-handoff (#2357), a connection blip to the owning pod, or a placement
+            // that could not be made all leave the stream perfectly able to carry the answer. And
+            // the fallback is not a return to silence: it probes for a subscriber first and says so
+            // at Error when there is none (PublishFailureOverStream / RefuseNoSubscriber), so the
+            // outcome is either delivered or LOUD. LogUndeliverableNack is now reached only when
+            // BOTH transports have failed, which is the only state in which "the sender will never
+            // hear about this" is actually true.
+            //
+            // This does NOT weaken the answer-once contract (see AnswerPolicy). That rule exists so
+            // one request cannot get two DIFFERENT verdicts and have Observe resolve on whichever
+            // lands first. Here both transports carry the SAME DeliveryFailure, matched on the same
+            // RequestId, so a duplicate that arrives after a directed call which secretly succeeded
+            // is an exact repeat of an answer the caller has already resolved on — inert, not a
+            // coin toss.
+            .Catch<Unit, Exception>(ex => Observable.Defer(() =>
+            {
+                RoutingGrainTrace.Write(IsPodHubNotHere(ex)
+                    ? $"RoutingGrain.RouteMessage FAILURE_POD_HUB_NOT_HERE id={delivery.Id} sender={delivery.Sender}"
+                    : $"RoutingGrain.RouteMessage FAILURE_POD_HUB_FAULT id={delivery.Id} sender={delivery.Sender} ex={ex.Message}");
+                return PublishFailureOverStream()
+                    .Catch<Unit, Exception>(streamEx => LogUndeliverableNack(
+                        new AggregateException(
+                            "Neither the directed pod-hub call nor the stream publish could carry the NACK.",
+                            ex, streamEx)));
+            })));
         return;
 
         // The NACK is fire-and-forget by nature — there is no NACK for a NACK — so the one thing a
@@ -838,8 +865,9 @@ internal class RoutingGrain(
             RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_FAIL id={delivery.Id} ex={ex.Message}");
             logger.LogError(ex,
                 "[ROUTE] Cannot deliver the {ErrorType} DeliveryFailure for {DeliveryId} to sender {Sender}: "
-                + "the directed call to its pod-hub activation failed. The sender will wait out its own "
-                + "request budget — the original failure was: {FailureMessage}",
+                + "BOTH transports failed — the directed call to its pod-hub activation AND the stream "
+                + "publish. The sender will wait out its own request budget — the original failure "
+                + "was: {FailureMessage}",
                 errorType, delivery.Id, delivery.Sender, failureMessage);
             return Observable.Return(Unit.Default);
         }
@@ -1062,10 +1090,13 @@ internal class RoutingGrain(
                     // message and the GUI resubscribe loop stops spinning on Orleans noise.
                     var activationError = resolveActivationError?.Invoke(grainKey);
                     var detail = string.IsNullOrEmpty(activationError) ? ex.Message : activationError;
+                    // 🚨 CLASSIFY — this line read ErrorType.Failed unconditionally, which is the same
+                    // defect #2346/#2451 removed from the result arm above and left standing here.
+                    var errorType = ClassifyDeliveryException(ex);
                     logger.LogWarning(ex,
-                        "[ROUTE] Grain {GrainKey} delivery failed after transient retries (or a non-transient fault) → NACK sender: {Detail}",
-                        grainKey, detail);
-                    postFailureToSender($"Delivery to '{addressPath}' failed: {detail}", ErrorType.Failed);
+                        "[ROUTE] Grain {GrainKey} delivery failed after transient retries (or a non-transient fault) → NACK sender as {ErrorType}: {Detail}",
+                        grainKey, errorType, detail);
+                    postFailureToSender($"Delivery to '{addressPath}' failed: {detail}", errorType);
                 });
     }
 
@@ -1121,5 +1152,61 @@ internal class RoutingGrain(
     internal static bool IsTransientFailure(Exception ex) =>
         ex is TimeoutException
             or global::Orleans.Runtime.OrleansMessageRejectionException
+        // 🚨 THE BARE OrleansException THE TYPE TEST ABOVE CANNOT SEE — issue #1742 / #2357. Orleans
+        // rejects an un-addressable call with the DIRECTORY's exception attached, and the caller-side
+        // resolution is `rejection?.Exception ?? new OrleansMessageRejectionException(…)` — the
+        // carried one wins — so a grain call made while the directory is mid-handoff arrives here as
+        // a bare Orleans.Runtime.OrleansException whose own text ends "Retry later.". Nothing matched
+        // it, so it was never retried and became a TERMINAL DeliveryFailure for the sender. Full
+        // reasoning (and why this is a message match, and what pins it) on IsDirectoryUnstable.
+        || OrleansRoutingService.IsDirectoryUnstable(ex)
         || (ex.InnerException != null && IsTransientFailure(ex.InnerException));
+
+    /// <summary>
+    /// How a routing failure that arrived as an EXCEPTION should be classified for the sender.
+    ///
+    /// <para>🚨 Both exception arms in this file used to hard-code <see cref="ErrorType.Failed"/> —
+    /// TERMINAL, unconditionally — which is the same defect #2346/#2451 removed from the neighbouring
+    /// <c>result.State == Failed</c> arm and left standing here. It matters for exactly the reason
+    /// that fix records: the consumers with their own recovery machinery
+    /// (<c>SynchronizationStream</c>'s resubscribe latch, <c>MeshNodeStreamCache</c>'s transient-owner
+    /// rule) RIDE OUT <see cref="ErrorType.ShuttingDown"/> and TEAR DOWN on
+    /// <see cref="ErrorType.Failed"/>. So a rolling deploy — a silo leaving, the grain directory
+    /// mid-handoff, the connection to a departing pod dropping — permanently tore down live mirrors
+    /// that would have resumed seconds later, and the user-visible shape of that is a reply that
+    /// never arrives.</para>
+    ///
+    /// <para>🚨 <b>Deliberately NARROWER than <see cref="IsTransientFailure"/>, and the difference
+    /// is load-bearing.</b> That predicate answers "is another attempt worth making <i>right
+    /// now</i>", which is safe to say generously — it is bounded by a retry budget. This one answers
+    /// "should the SENDER keep its recovery machinery armed", which is unbounded on the other side:
+    /// a consumer told <see cref="ErrorType.ShuttingDown"/> resubscribes. So a bare
+    /// <see cref="TimeoutException"/> — a target that did not answer across the WHOLE retry budget,
+    /// i.e. plausibly wedged rather than restarting — must stay terminal, or the answer becomes a
+    /// resubscribe storm against a hub that never comes back (the 2026-06-08 production shape).
+    /// Only the two conditions that ARE a lifecycle transition by construction qualify: the grain
+    /// directory mid-handoff, and the host going away.</para>
+    ///
+    /// <para>Anything this does not recognise stays terminal, so a genuine defect is still reported
+    /// as one.</para>
+    /// </summary>
+    /// <param name="ex">The exception the delivery attempt faulted with.</param>
+    /// <returns>The <see cref="ErrorType"/> the sender's NACK should carry.</returns>
+    internal static ErrorType ClassifyDeliveryException(Exception ex) =>
+        OrleansRoutingService.IsDirectoryUnstable(ex) || IsShutdownShaped(ex)
+            ? ErrorType.ShuttingDown
+            : ErrorType.Failed;
+
+    /// <summary>
+    /// The silo hosting the target is going away — an expected lifecycle event during every roll,
+    /// never a defect. Kept beside <see cref="IsTransientFailure"/> because the two answer different
+    /// questions: that one decides whether to try AGAIN, this one decides what to TELL the sender
+    /// once trying again has run out.
+    /// </summary>
+    /// <param name="ex">The exception the delivery attempt faulted with.</param>
+    /// <returns><c>true</c> when the failure is a silo/host shutdown.</returns>
+    internal static bool IsShutdownShaped(Exception ex) =>
+        ex is global::Orleans.Runtime.SiloUnavailableException
+            or global::Orleans.Runtime.OrleansLifecycleCanceledException
+        || (ex.InnerException != null && IsShutdownShaped(ex.InnerException));
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansCrossSiloReplyTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansCrossSiloReplyTest.cs
@@ -5,10 +5,12 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading;
 using System.Threading.Tasks;
+using MeshWeaver.Connection.Orleans;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Orleans;
 using Orleans.TestingHost;
 using Xunit;
 
@@ -97,6 +99,118 @@ public class OrleansCrossSiloReplyTest : IClassFixture<TwoSiloCacheUpdateFixture
                 + "IS core#694 layer 2 (the memex 35/60 static-content failure at 2 replicas)");
             node!.Path.Should().Be(path);
         }
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE INPUT THIS CLASS LOST — issue #1742.</b> The fact above no longer posts from
+    /// <c>mesh/{id}</c> at all (<c>2c796d297</c> moved <c>GetMeshNode</c> onto
+    /// <c>portal/nodeops-…</c>), so the class named for the root-mesh-hub reply leg stopped
+    /// exercising it — the gate silently stopped testing its own input, and #1729 is what that cost.
+    /// This restores it in the smallest possible shape.
+    ///
+    /// <para><c>PingRequest</c> is answered by EVERY hub (<c>MessageHub.HandlePingRequest</c>) and
+    /// its answer is a separate post targeted back at the SENDER — so a ping issued on
+    /// <c>mesh/{id}</c> against a per-node hub grain is precisely the exchange this issue is named
+    /// for, with nothing else in the way. Issuing from BOTH silos' root hubs makes the repro
+    /// deterministic without knowing the placement: the node's grain hashes onto exactly ONE silo,
+    /// so one of the two legs is guaranteed to be the cross-silo reply.</para>
+    ///
+    /// <para>Deliberately a REQUEST/RESPONSE round trip and not a forward delivery: the forward leg
+    /// is an Orleans grain call that is retried and NACK'd, while the reply leg is the one that had
+    /// no delivery guarantee and no failure signal. That asymmetry IS the bug this issue reports.</para>
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task RootMeshHubRequest_ReceivesItsReply_FromBothSilos()
+    {
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(100));
+        var ct = deadline.Token;
+        var cluster = _fixture.Cluster;
+        cluster.Silos.Count.Should().BeGreaterThanOrEqualTo(2, "one of the two legs has to CROSS silos");
+
+        var hubA = SiloMeshHub(cluster, 0);
+        var hubB = SiloMeshHub(cluster, 1);
+
+        var ns = $"rootping-{Guid.NewGuid():N}";
+        var path = $"{ns}/Doc";
+        var create = await hubA
+            .Observe(new CreateNodeRequest(new MeshNode("Doc", ns)
+            {
+                NodeType = "Markdown",
+                Name = "Doc",
+                State = MeshNodeState.Active,
+            }), o => o.WithTarget(hubA.Address))
+            .FirstAsync().ToTask(ct);
+        create.Message.Success.Should().BeTrue(create.Message.Error ?? "");
+
+        foreach (var (hub, label) in new[] { (hubA, "silo A"), (hubB, "silo B") })
+        {
+            var pong = await hub.Observe(new PingRequest(), o => o.WithTarget((Address)path))
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(40))
+                .ToTask(ct);
+
+            pong.Message.Should().NotBeNull(
+                $"the ping issued on {label}'s ROOT MESH HUB must receive its PingResponse. When "
+                + "this is the non-owning silo the reply crosses silos back to mesh/{id}, which is "
+                + "the exchange issue #1742 is named for — a hang here is that defect, live");
+        }
+    }
+
+    /// <summary>
+    /// 🚨 <b>WHICH TRANSPORT the reply above actually took — and this is the fact that decides
+    /// whether #1742 is fixed or merely quiet.</b>
+    ///
+    /// <para>Cross-silo delivery to a pod-process hub has two transports. The directed
+    /// <c>IPodHubGrain</c> call either LANDS or ANSWERS; the Orleans memory-stream publish is
+    /// fire-and-forget over a NON-DURABLE queue whose grain dies with its silo, so it can succeed and
+    /// discard. The router silently prefers the first and falls back to the second, which means the
+    /// round trip above passes either way — and would go on passing if the root hub's claim quietly
+    /// stopped landing.</para>
+    ///
+    /// <para>That is not hypothetical for THIS address specifically. Every other stream-routed hub
+    /// claims itself from application code, but <c>mesh/{id}</c> is registered by
+    /// <c>RootMeshHubReplyStreamService</c> — an <c>IHostedService</c> running at host start — and
+    /// <c>OrleansRoutingService.AttachPodHub</c> is best-effort with a bounded (~3 s) claim retry,
+    /// while the stream subscription it sits beside is ordered on a 120 s
+    /// <c>OrleansStreamingReadiness</c> gate. A claim that failed to land degrades SILENTLY to the
+    /// stream — i.e. straight back onto the transport this issue is about — and nothing else would
+    /// notice.</para>
+    ///
+    /// <para>So this asks the transport directly, from the silo that does NOT host the address:
+    /// <c>PodHubNotHereException</c> means no process claims it and every cross-silo reply to it is
+    /// riding the memory stream.</para>
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task RootMeshHub_IsClaimedForItsProcess_SoItsRepliesTakeTheDirectedTransport()
+    {
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var ct = deadline.Token;
+        var cluster = _fixture.Cluster;
+        cluster.Silos.Count.Should().BeGreaterThanOrEqualTo(2,
+            "asking from the OWNING silo would be answered by its own local route and prove nothing");
+
+        var rootA = SiloMeshHub(cluster, 0).Address;
+
+        // Silo B's grain factory, so the call is genuinely cross-silo. A PingRequest is inert on
+        // arrival — every hub answers it — so this probes the transport without leaving state behind.
+        var grains = ((InProcessSiloHandle)cluster.Silos[1]).SiloHost.Services
+            .GetRequiredService<IGrainFactory>();
+
+        var probe = new MessageDelivery<PingRequest>(
+            new PingRequest(),
+            new PostOptions(rootA).WithTarget(rootA),
+            System.Text.Json.JsonSerializerOptions.Default);
+
+        var delivered = await grains.GetGrain<IPodHubGrain>(rootA.ToString())
+            .Deliver(probe)
+            .WaitAsync(TimeSpan.FromSeconds(30), ct);
+
+        delivered.State.Should().Be(MessageDeliveryState.Forwarded,
+            $"the root mesh hub {rootA} must be claimed for its own process, so that a cross-silo "
+            + "reply to it is a directed grain call with an outcome rather than a publish onto a "
+            + "non-durable memory stream that succeeds whether or not anybody is listening. A "
+            + "PodHubNotHereException here means the claim never landed and this hub is back on the "
+            + "transport issue #1742 reports — silently");
     }
 
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansDirectoryInstabilityClassificationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansDirectoryInstabilityClassificationTest.cs
@@ -217,8 +217,12 @@ public class OrleansDirectoryInstabilityClassificationTest
         // silently stop looking. The result is reduced to a BOOL before asserting: handing a
         // multi-megabyte subject to a string assertion makes its failure message the whole assembly.
         var literals = Encoding.Unicode.GetString(File.ReadAllBytes(runtimeAssembly));
+        // 🚨 OrdinalIgnoreCase, matching the classifier at OrleansRoutingService.cs:590. With
+        // Ordinal this pin would go RED for a recasing Orleans could make freely and the classifier
+        // would still handle — a false alarm on the one assertion whose entire value is being
+        // believed when it fires.
         var present = literals.Contains(
-            OrleansRoutingService.DirectoryRetryLaterMarker, StringComparison.Ordinal);
+            OrleansRoutingService.DirectoryRetryLaterMarker, StringComparison.OrdinalIgnoreCase);
 
         present.Should().BeTrue(
             $"'{OrleansRoutingService.DirectoryRetryLaterMarker}' is the phrase "

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansDirectoryInstabilityClassificationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansDirectoryInstabilityClassificationTest.cs
@@ -1,0 +1,230 @@
+using System;
+using System.IO;
+using System.Reactive.Concurrency;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Threading.Tasks;
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Runtime;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #1742 / #2357 — the reply leg's remaining silent-loss mechanism, and it is a
+/// CLASSIFIER, not a transport.</b>
+///
+/// <para>The pod-hub transport swap took cross-silo delivery to a pod-process hub off the Orleans
+/// stream and onto a directed grain call, using Orleans' OWN grain directory as the address→silo
+/// map. That closed the "a publish to nobody succeeds" mechanism — and made the reply leg depend on
+/// the grain directory, which is precisely the thing that is UNSTABLE during a rolling deploy. Same
+/// window, new dependency.</para>
+///
+/// <para><b>What the router did with it, and why nothing saw it.</b> When Orleans cannot address a
+/// call it rejects the message with <c>RejectionTypes.Unrecoverable</c> <i>and the causing exception
+/// attached</i>, and the caller-side resolution
+/// (<c>CallbackData.HandleRejectionResponse</c>) is
+/// <c>rejection?.Exception ?? new OrleansMessageRejectionException(…)</c> — <b>the carried exception
+/// WINS</b>. So the router does not receive the
+/// <see cref="OrleansMessageRejectionException"/> its classifier pattern-matches; it receives the
+/// BARE <see cref="OrleansException"/> that <c>LocalGrainDirectory.LookupAsync</c> threw, whose own
+/// text ends with the words <i>"Retry later."</i>. <c>RoutingGrain.IsTransientFailure</c> matched
+/// neither, so the delivery was never retried, and both exception arms in the router then NACK'd the
+/// sender with a hard-coded terminal <c>ErrorType.Failed</c>.</para>
+///
+/// <para>Both halves matter to a caller. The missing retry costs the message; the terminal
+/// classification costs the SUBSCRIPTION — <c>SynchronizationStream</c>'s resubscribe latch and
+/// <c>MeshNodeStreamCache</c>'s transient-owner rule ride out
+/// <see cref="ErrorType.ShuttingDown"/> and tear down on <see cref="ErrorType.Failed"/>, so a
+/// membership transition permanently killed mirrors that would have resumed seconds later. Prod:
+/// 16 occurrences across two rolling deploys, naming <c>IPodHubGrain.Deliver</c> and
+/// <c>IMessageHubGrain.DeliverMessage</c> among the dropped targets (#2357).</para>
+///
+/// <para>These facts are pure and need no cluster — the two classifiers and the retry primitive are
+/// <c>internal static</c>, and the exception texts are quoted verbatim from the production log.</para>
+/// </summary>
+public class OrleansDirectoryInstabilityClassificationTest
+{
+    private static readonly Func<int, TimeSpan> NoBackoff = _ => TimeSpan.Zero;
+
+    /// <summary>
+    /// Verbatim from the production log (#2357) — the directory-handoff variant, i.e. the local silo
+    /// is no longer the owner of the entry and the forward chain ran out of hops.
+    /// </summary>
+    private const string HopLimitText =
+        "Silo S10.244.4.87:11111:146498551 is not owner of messagehub/LocalSyncDemo/_Sync/party-1, "
+        + "cannot forward LookUpAsync to owner S10.244.3.44:11111:146515001 because hop limit is reached";
+
+    /// <summary>
+    /// Verbatim from Orleans' own <c>LocalGrainDirectory</c> — the variant that names its own
+    /// retryability. This is the string pinned against the shipped build below.
+    /// </summary>
+    private const string NotStableText =
+        "Current directory at S10.244.4.87:11111:146498551 is not stable to perform the lookup for "
+        + "grainId messagehub/Doc (it maps to S10.244.3.44:11111:146515001, which is not a valid silo). "
+        + "Retry later.";
+
+    [Theory]
+    [InlineData(HopLimitText)]
+    [InlineData(NotStableText)]
+    public void DirectoryInstability_IsTransient(string message)
+    {
+        // The bare OrleansException the caller actually receives — NOT an
+        // OrleansMessageRejectionException. Before this fix nothing in IsTransientFailure matched it,
+        // so DeliverToGrainObservable rethrew on the FIRST attempt and the message died there.
+        RoutingGrain.IsTransientFailure(new OrleansException(message)).Should().BeTrue(
+            "Orleans' grain directory is mid-handoff — a rolling deploy's normal, seconds-long "
+            + "window — and Orleans' own message says to ask again. The retry-with-fresh-resolve "
+            + "that serves this already exists; the defect was a classifier that could not read "
+            + "its input, so the machinery gated on it was unreachable");
+    }
+
+    /// <summary>
+    /// 🚨 The rule must stay NARROW. <see cref="OrleansException"/> is also Orleans' base for
+    /// genuinely terminal conditions (an extension that is not installed, a limit that is exceeded),
+    /// and widening the classifier to the TYPE would make every one of those retry six times before
+    /// answering — turning a clear defect into a slow one. Only the directory's own retryability
+    /// markers qualify.
+    /// </summary>
+    [Fact]
+    public void AnOrdinaryOrleansException_StaysTerminal()
+    {
+        RoutingGrain.IsTransientFailure(
+                new OrleansException("Grain extension not installed on target grain."))
+            .Should().BeFalse(
+                "widening the match to the OrleansException TYPE would retry real defects — the "
+                + "rule is the directory's retryability marker, not the exception's base class");
+    }
+
+    /// <summary>
+    /// The behavioural half: with the condition classified, the EXISTING retry primitive re-invokes
+    /// the grain call — re-resolving the grain each time, which is what lets a directory that has
+    /// settled serve the message on a later attempt. Pre-fix this test observes <c>calls == 1</c>
+    /// and a faulted task.
+    /// </summary>
+    [Fact]
+    public async Task DirectoryInstability_IsRetriedWithFreshResolve_NotTerminalOnTheFirstAttempt()
+    {
+        var calls = 0;
+
+        var result = await RoutingGrain.DeliverToGrainObservable(
+                grainCall: () =>
+                {
+                    calls++;
+                    return calls <= 2
+                        ? Task.FromException<IMessageDelivery>(new OrleansException(HopLimitText))
+                        : Task.FromResult<IMessageDelivery>(new MessageDelivery<string>());
+                },
+                grainKey: "mesh/IJ1R4qkKGkOB0k8Nnn2n0g",
+                deliveryId: "dir-instability-1",
+                logger: NullLogger.Instance,
+                backoff: NoBackoff,
+                scheduler: Scheduler.Immediate)
+            .ToTask(TestContext.Current.CancellationToken);
+
+        calls.Should().Be(3,
+            "the directory settles within seconds of a membership change, so re-resolving is the "
+            + "whole cure — pre-fix the classifier did not match and the call was made exactly once");
+        result.State.Should().NotBe(MessageDeliveryState.Failed);
+    }
+
+    /// <summary>
+    /// 🚨 The second half, and the one that costs a SUBSCRIPTION rather than a message. Both
+    /// exception arms in <c>RoutingGrain</c> hard-coded <c>ErrorType.Failed</c> — the same defect
+    /// #2346/#2451 removed from the neighbouring result arm and left standing here.
+    /// </summary>
+    [Fact]
+    public void ExhaustedDirectoryInstability_IsNackedAsTransient()
+    {
+        RoutingGrain.ClassifyDeliveryException(new OrleansException(NotStableText))
+            .Should().Be(ErrorType.ShuttingDown,
+                "a membership transition is transient BY CONSTRUCTION, and the consumers with their "
+                + "own recovery machinery (SynchronizationStream's resubscribe latch, "
+                + "MeshNodeStreamCache's transient-owner rule) ride out ShuttingDown and TEAR DOWN "
+                + "on Failed — so a terminal verdict here kills mirrors a roll would have restored");
+    }
+
+    /// <summary>
+    /// 🚨 And it must stay NARROWER than <see cref="RoutingGrain.IsTransientFailure"/>. That
+    /// predicate is bounded by a retry budget, so it can afford to be generous; this one arms an
+    /// UNBOUNDED resubscribe on the sender's side. A bare timeout — a target silent across the whole
+    /// budget, i.e. plausibly wedged rather than restarting — must stay terminal, or the answer is a
+    /// resubscribe storm against a hub that never comes back (2026-06-08).
+    /// </summary>
+    [Fact]
+    public void ATimeout_IsRetryableButStillTerminalToTheSender()
+    {
+        var timeout = new TimeoutException("Response did not arrive on time in 00:00:30");
+
+        RoutingGrain.IsTransientFailure(timeout).Should().BeTrue("retrying a timeout is bounded");
+        RoutingGrain.ClassifyDeliveryException(timeout).Should().Be(ErrorType.Failed,
+            "telling the sender 'transient' arms an unbounded resubscribe, which is a storm when "
+            + "the target is wedged rather than restarting");
+    }
+
+    /// <summary>
+    /// The host going away is the other genuine lifecycle transition, and it already had this
+    /// classification everywhere else (<c>MessageHubGrain.DeliverMessage</c>'s completion arm,
+    /// <c>OrleansRoutingService</c>'s shutdown branch, <c>MonolithRoutingService.PostNotFound</c>).
+    /// This is the fourth layer agreeing with the other three.
+    /// </summary>
+    [Fact]
+    public void SiloUnavailable_IsNackedAsTransient()
+    {
+        var siloGone = (Exception)System.Runtime.CompilerServices.RuntimeHelpers
+            .GetUninitializedObject(typeof(SiloUnavailableException));
+
+        RoutingGrain.ClassifyDeliveryException(siloGone).Should().Be(ErrorType.ShuttingDown,
+            "the silo hosting the target is leaving — an expected event on every roll, and the "
+            + "address answers again moments later on another silo");
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE ANTI-INERT PIN. If this fact fails after an Orleans upgrade, the classifier above
+    /// has gone SILENTLY INERT — repair the marker, never delete the test.</b>
+    ///
+    /// <para>Orleans gives this condition no exception type of its own, so the rule has to match its
+    /// prose (which is this codebase's established contract for exactly this decision — see
+    /// <c>OrleansRoutingService.ClassifyRoutedFailure</c>, which names the four layers already doing
+    /// it). Prose can be reworded by a dependency bump, and a classifier that stops matching fails
+    /// OPEN into the very silence it removes: no error, no log, just replies dying in a roll again.
+    /// That is exactly how #2451's <c>GetFailureErrorType</c> sat inert from the day it landed.</para>
+    ///
+    /// <para>So the marker is asserted against the SHIPPED Orleans assembly's own string literals,
+    /// not against a copy of them. Only <see cref="OrleansRoutingService.DirectoryRetryLaterMarker"/>
+    /// is pinned this way: the hop-limit wording is quoted from the production log (#2357) and is not
+    /// a literal of the currently-pinned build, so it is additive coverage rather than a
+    /// build-verified rule — deliberately kept, because the deployed image is not always the version
+    /// this repo pins.</para>
+    /// </summary>
+    [Fact]
+    public void RetryLaterMarker_IsStillTheShippedOrleansWording()
+    {
+        // The phrase is a literal of Orleans.Runtime (LocalGrainDirectory lives there), NOT of
+        // Orleans.Core.Abstractions where OrleansException is declared — so the file is located by
+        // name beside the test binary rather than off the exception's own assembly.
+        var runtimeAssembly = Path.Combine(AppContext.BaseDirectory, "Orleans.Runtime.dll");
+
+        File.Exists(runtimeAssembly).Should().BeTrue(
+            $"this fact reads Orleans' own string literals out of {runtimeAssembly}; without the "
+            + "file it would pass having verified nothing, which is precisely the failure mode it "
+            + "exists to prevent");
+
+        // Managed string literals live in the #US heap as UTF-16 — decoding the whole file and
+        // searching is crude, and that is the point: it needs no Orleans-internal API and cannot
+        // silently stop looking. The result is reduced to a BOOL before asserting: handing a
+        // multi-megabyte subject to a string assertion makes its failure message the whole assembly.
+        var literals = Encoding.Unicode.GetString(File.ReadAllBytes(runtimeAssembly));
+        var present = literals.Contains(
+            OrleansRoutingService.DirectoryRetryLaterMarker, StringComparison.Ordinal);
+
+        present.Should().BeTrue(
+            $"'{OrleansRoutingService.DirectoryRetryLaterMarker}' is the phrase "
+            + "OrleansRoutingService.IsDirectoryUnstable matches on, and it comes from Orleans' own "
+            + "LocalGrainDirectory. If Orleans reworded it, the classifier no longer recognises a "
+            + "grain directory mid-handoff — deliveries stop being retried and are NACK'd as "
+            + "permanent again (#1742/#2357). REPAIR THE MARKER; do not delete this assertion");
+    }
+}


### PR DESCRIPTION
Root-causes **#1742** and fixes the mechanism that is actually still live.

## The headline mechanism is already closed — measured, not assumed

With `MESHWEAVER_MSG_TRACE=1`, a two-silo `PingRequest` issued **on `mesh/{id}`** against a per-node hub returns `POD_HUB_OK` for the reply leg. The directed pod-hub call carries it; the memory stream is not on that path any more. The issue's title ("the reply leg rides a non-durable in-memory stream") is no longer true of the primary path — as the maintainer's own last comment suspected.

Also settled: **`mesh` is not the discriminator.** It has been in `MeshConfiguration.DefaultStreamRoutedAddressTypes` since #1736. What went missing was the *test's* input, not the address type — see below.

## What the transport swap traded, and nobody had named

The directed call uses **Orleans' own grain directory** as the address→silo map — that is the whole trick, and why the design needed no directory of ours. The grain directory is *also* what is unstable while cluster membership changes, i.e. **during a rolling deploy** — the exact window every production symptom in #1729/#1742 was measured in. Same window, new dependency.

The router could not see it:

```
MessageCenter.OnAddressingFailure
  → RejectMessage(msg, RejectionTypes.Unrecoverable, ex)      ← the DIRECTORY's exception, attached
  → CallbackData.HandleRejectionResponse
        exception = rejection?.Exception ?? new OrleansMessageRejectionException(…)
                    ^^^^^^^^^^^^^^^^^^^^ the carried one WINS
  → RoutingGrain sees a BARE Orleans.Runtime.OrleansException, "… Retry later."
```

`RoutingGrain.IsTransientFailure` matched `TimeoutException` and `OrleansMessageRejectionException` — neither of which this is. Three silent consequences:

1. **never retried**, though the retry-with-fresh-resolve it needed sits one line away and is already applied to exactly this class of condition;
2. both exception arms then NACK'd the sender with a **hard-coded terminal `ErrorType.Failed`** — the same defect #2346/#2451 removed from the neighbouring `result.State == Failed` arm and left standing here. That costs a *subscription*, not a message: `SynchronizationStream`'s resubscribe latch and `MeshNodeStreamCache.IsTransientOwnerFailure` ride out `ShuttingDown` and **tear down** on `Failed`;
3. when `PostFailure`'s own directed NACK hit the same directory it took `LogUndeliverableNack` — the stream fallback was reached only for `PodHubNotHereException` — so the sender was told **nothing at all**. #1742's headline symptom, reproduced on the transport that replaced it.

Prod evidence: **#2357**, 16 occurrences across two rolling deploys, naming `IPodHubGrain.Deliver` and `IMessageHubGrain.DeliverMessage` among the dropped targets.

## The fix is classification — nothing new spins

- `OrleansRoutingService.IsDirectoryUnstable` recognises the condition, making the **existing bounded retry** reachable. Matched on Orleans' own retryability wording because Orleans gives it no type (widening to the `OrleansException` TYPE would retry genuinely terminal conditions), and **pinned against the shipped Orleans assembly's string literals** so an upgrade that rewords it fails RED rather than leaving the classifier silently inert — the #2451 lesson.
- `RoutingGrain.ClassifyDeliveryException` replaces both hard-coded `ErrorType.Failed` arms. Deliberately **narrower** than `IsTransientFailure`: that one is bounded by a retry budget and can be generous; this one arms an *unbounded* resubscribe on the sender's side, so a bare timeout stays terminal (a resubscribe storm against a wedged hub is the 2026-06-08 shape).
- `PostFailure` falls back to the stream on **any** failed directed NACK, not only `PodHubNotHere`. There is no NACK for a NACK, so the alternative to the second transport is silence; both carry the same `DeliveryFailure` on the same `RequestId`, so a duplicate is inert, not a coin toss.

## Tests

`OrleansDirectoryInstabilityClassificationTest` is **non-vacuous, measured**: 5 of its 8 facts fail on the unfixed classifier (verified by neutering both predicates and re-running), including the behavioural one that observes `calls == 1` instead of `3`.

`OrleansCrossSiloReplyTest` gets its **input back**. Its own docstring records that `2c796d297` moved `GetMeshNode` onto `portal/nodeops-…`, so the class named for the `mesh/{id}` reply leg stopped posting from `mesh/{id}` at all — a gate that silently stopped testing its own input, which is what #1729 cost. Two facts restore it:

- a `PingRequest` round trip issued on **both** root mesh hubs (the node's grain hashes onto one silo, so one leg is guaranteed cross-silo);
- and the one that decides whether this issue is *fixed* or merely *quiet*: a directed `IPodHubGrain` probe from the non-owning silo proving `mesh/{id}` is **claimed for its process**. Without it the round trip passes over the stream fallback and would go on passing if the claim quietly stopped landing — a live risk for this address specifically, since it is registered by an `IHostedService` at host start while `AttachPodHub` is best-effort with a ~3 s claim budget, beside a stream subscription gated on 120 s of streaming readiness.

## 🚨 The durable-stream-provider decision does NOT close this issue

It improves the **fallback** — `MemoryStreamQueueGrain`'s RAM, plus hubs owned by an Orleans *client* process, which cannot host a grain. It cannot touch the primary reply path, which never goes near the stream provider. **Size that decision on #2320 / #2322 (both stream-leg tickets), not on #1742.** Recorded in both `OrleansStreamPubSubDurability` and `PodHubDeliveryRollPlan`.

| issue | covered here? |
|---|---|
| **#2357** | **YES** — its defect item 1 verbatim ("do `DeliverMessage`/`Deliver` treat transient addressing failures as retryable, or let the delivery die"). They let it die; now they retry. Item 2 (why memory streams at all) is the durable-provider decision — not covered. |
| **#2321** | **PARTLY** — for the `Failed to address message` → `IMessageHubGrain.DeliverMessage` shape it names, the requester now gets a retried, correctly-classified answer. Its log-parser-truncation half (`tools/MeshWeaver.LogWatcher/LogLineParser`) is untouched. |
| **#2320** | **NO** — producer registration on the durable PubSubStore is the stream leg. Blast radius shrank to the fallback; its `HasLiveSubscriber` structural objection stands. |
| **#2322** | **NO** — a wedged `MemoryStreamQueueGrain.Enqueue` is the stream leg. Same shrink-to-fallback note; its "60 s vs 30 s" item is a separate log-message defect. |

## Verification

- Orleans test project **215/215**
- Documentation **91/91** (link integrity + What's New integrity), DLL rebuilt after the doc edits
- `-c Release -warnaserror` clean: `MeshWeaver.Connection.Orleans`, `MeshWeaver.Hosting.Orleans`, `MeshWeaver.Hosting.Orleans.Test`

Closes nothing on its own — see the table. Addresses #1742's live residual; #2357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)