### PR TITLE
feat(gate): the gate INSTALLS its upstream packages from the seed

### DIFF
--- a/test/MeshWeaver.PluginTester.Test/GateInstallsUpstreamPackagesTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/GateInstallsUpstreamPackagesTest.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Plugin.Packaging;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// <b>The gate INSTALLS its upstreams — the satellite shape, pinned end to end.</b>
+///
+/// <para>Repo 2 ships a package whose nodes are TYPED by repo 1's NodeType, and repo 1 reaches the
+/// gate only as a bundle in the seed directory (exactly how the reusable gate stages it: the
+/// fetched upstream publication's zips are copied beside the repo's own bake). Before
+/// <see cref="SeedPackages"/> the seed's assemblies were adopted but the upstream's NODE
+/// DEFINITIONS never entered the mesh, so the satellite died at install — measured 2026-08-27 on
+/// the first run that ever got this far (Reinsurance run 33092019158): <c>Install of
+/// 'RiskTransfer' failed: NodeType(s) not registered: Edu/Lesson, Edu/Exercise, …</c>.</para>
+///
+/// <para>Three claims, each of which failed or was unguarded before: the upstream is materialized
+/// and INSTALLED (so the satellite's typed nodes install green); the upstream is NOT gated here
+/// (its compile/render/Tests verdicts belong to its own repo); and the upstream's bundle is NOT
+/// re-emitted from this gate's bake output (consumed, never republished under another repo's
+/// name — the #1814 identity class).</para>
+/// </summary>
+public class GateInstallsUpstreamPackagesTest(ITestOutputHelper output)
+{
+    // ── Repo 1: the upstream. Same Base/Widget shape as BundleCarriesTheUpstreamTest. ──
+    private const string BaseIndexJson =
+        """{"$type":"MeshNode","id":"Base","namespace":"","path":"Base","mainNode":"Base","name":"Base Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"The upstream package."}}""";
+
+    private const string BaseTypeJson =
+        """{"$type":"MeshNode","id":"Widget","namespace":"Base","path":"Base/Widget","mainNode":"Base/Widget","name":"Widget","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A widget.","configuration":"config => config.WithContentType<Widget>().AddDefaultLayoutAreas()","includeGlobalTypes":true}}""";
+
+    private const string BaseSource =
+        """
+        public record Widget
+        {
+            public string Name { get; init; } = string.Empty;
+        }
+        """;
+
+    // ── Repo 2: the satellite. Its content is TYPED by the upstream's NodeType. ──
+    private const string CourseIndexJson =
+        """{"$type":"MeshNode","id":"Course","namespace":"","path":"Course","mainNode":"Course","name":"Course Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"The satellite package."}}""";
+
+    private const string CourseLessonJson =
+        """{"$type":"MeshNode","id":"Lesson1","namespace":"Course","path":"Course/Lesson1","mainNode":"Course/Lesson1","name":"Lesson 1","nodeType":"Base/Widget","state":"Active","content":{"$type":"Widget","name":"lesson one"}}""";
+
+    // The satellite's OWN NodeType — gated here (and baked into the gate's own output), unlike
+    // the upstream's. Its presence pins that satellite compiles ride beside upstream typing.
+    private const string CourseCardJson =
+        """{"$type":"MeshNode","id":"Card","namespace":"Course","path":"Course/Card","mainNode":"Course/Card","name":"Card","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A card.","configuration":"config => config.WithContentType<Card>().AddDefaultLayoutAreas()","includeGlobalTypes":true}}""";
+
+    private const string CourseCardSource =
+        """
+        public record Card
+        {
+            public string Title { get; init; } = string.Empty;
+        }
+        """;
+
+    [Fact(Timeout = 900_000)]
+    public async Task TheSatelliteInstalls_BecauseTheGateInstalledItsUpstream()
+    {
+        var repo1 = TempDirectory("mw-up-src");
+        var repo2 = TempDirectory("mw-up-satellite");
+        var seedDir = TempDirectory("mw-up-seed");
+        var gateBake = TempDirectory("mw-up-gate-bake");
+        try
+        {
+            Write(repo1, "Base/index.json", BaseIndexJson);
+            Write(repo1, "Base/Widget.json", BaseTypeJson);
+            Write(repo1, "Base/Widget/Source/Widget.cs", BaseSource);
+            Write(repo2, "Course/index.json", CourseIndexJson);
+            Write(repo2, "Course/Lesson1.json", CourseLessonJson);
+            Write(repo2, "Course/Card.json", CourseCardJson);
+            Write(repo2, "Course/Card/Source/Card.cs", CourseCardSource);
+
+            // ── Repo 1 BAKES (no mesh) and its bundle lands in the seed directory… ──
+            var bake1 = TreeBake.Run(new TreeBake.Options
+            {
+                RepoRoot = repo1, OutputDirectory = seedDir, SourceSha = "cafebabe",
+                Output = TextWriter.Null,
+            });
+            Assert.Null(bake1.FatalError);
+            Assert.All(bake1.Types, t => Assert.Null(t.Error));
+
+            // ── …beside repo 2's OWN bake — exactly how the reusable gate stages the two. ──
+            var bake2 = TreeBake.Run(new TreeBake.Options
+            {
+                RepoRoot = repo2, OutputDirectory = seedDir, SourceSha = "cafebabe",
+                Output = TextWriter.Null,
+            });
+            Assert.Null(bake2.FatalError);
+
+            var (seed, problem) = BakeSeed.Read(seedDir, PrebuiltAssemblySeeder.LiveFrameworkMvid);
+            Assert.Null(problem);
+
+            // ── The GATE on repo 2 alone. Repo 1 exists only as a bundle in the seed. ──
+            var log = new StringWriter();
+            var report = await PluginGateRunner.Run(new GateOptions
+            {
+                RepoRoot = repo2,
+                Output = log,
+                Seed = seed,
+                BakeOutputDirectory = gateBake,
+                SourceSha = "cafebabe",
+                CompileTimeout = TimeSpan.FromMinutes(4),
+                RenderTimeout = TimeSpan.FromMinutes(2),
+            }).FirstAsync().ToTask();
+            output.WriteLine(log.ToString());
+            report.WriteSummary(new StringWriterAdapter(output));
+
+            Assert.Null(report.FatalError);
+
+            // 1. The upstream was INSTALLED — and marked as such, with none of its types gated.
+            var upstream = report.Packages.Single(p => p.Id == "Base");
+            Assert.True(upstream.Upstream, "the seed-borne package must be marked upstream");
+            Assert.Null(upstream.InstallError);
+            Assert.Empty(upstream.NodeTypes);
+
+            // 2. The satellite installed GREEN — its Base/Widget-typed node registered. This is
+            //    the line that read "NodeType(s) not registered: …" before SeedPackages existed.
+            var satellite = report.Packages.Single(p => p.Id == "Course");
+            Assert.False(satellite.Upstream);
+            Assert.Null(satellite.InstallError);
+            Assert.Equal(0, report.ExitCode);
+
+            // 3. Consumed, never re-emitted: the gate's own bake output carries the satellite's
+            //    bundle and NOT the upstream's.
+            var emitted = Directory.EnumerateFiles(gateBake, "*.zip")
+                .Select(Path.GetFileName).ToList();
+            Assert.DoesNotContain("Base.zip", emitted);
+            Assert.Contains("Course.zip", emitted);
+        }
+        finally
+        {
+            Cleanup(repo1);
+            Cleanup(repo2);
+            Cleanup(seedDir);
+            Cleanup(gateBake);
+        }
+    }
+
+    private sealed class StringWriterAdapter(ITestOutputHelper output) : StringWriter
+    {
+        public override void WriteLine(string? value) => output.WriteLine(value ?? string.Empty);
+    }
+
+    private static string TempDirectory(string prefix) =>
+        Path.Combine(Path.GetTempPath(), prefix + "-" + Guid.NewGuid().ToString("N"));
+
+    private static void Write(string root, string relative, string content)
+    {
+        var full = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static void Cleanup(string directory)
+    {
+        try { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+        catch { /* best effort */ }
+    }
+}

--- a/tools/MeshWeaver.PluginTester/GateReport.cs
+++ b/tools/MeshWeaver.PluginTester/GateReport.cs
@@ -68,6 +68,14 @@ public sealed record PackageResult(string Id)
     public int NodeCount { get; init; }
 
     /// <summary>
+    /// True when the package arrived from the bake seed's upstream publication: it is INSTALLED
+    /// (a failure still fails the run - a gate that cannot install its dependencies proves
+    /// nothing) but its types are not gated here; their verdicts belong to the repo that owns
+    /// them. See <see cref="SeedPackages"/>.
+    /// </summary>
+    public bool Upstream { get; init; }
+
+    /// <summary>
     /// Whether <see cref="NodeCount"/> / <see cref="NodeTypes"/> are a MEASUREMENT. False when the
     /// package pipeline threw before the install reported, in which case both are defaults and
     /// printing them asserts a count nobody took.
@@ -170,7 +178,8 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
             output.WriteLine($"[{Label(package, verdict)}] {package.Id} " +
                              (package.CountsMeasured
                                  ? $"({package.NodeCount} node(s), {package.NodeTypes.Count} type(s))"
-                                 : "(counts unavailable — the pipeline threw before the install reported)"));
+                                 : "(counts unavailable — the pipeline threw before the install reported)") +
+                             (package.Upstream ? " [upstream: installed, not gated here]" : ""));
             if (package.InstallError is not null)
                 output.WriteLine($"    install{Debt(verdict, package.Id, "install")}: {package.InstallError}");
             if (package.IdempotenceError is not null)

--- a/tools/MeshWeaver.PluginTester/LocalNodeRepo.cs
+++ b/tools/MeshWeaver.PluginTester/LocalNodeRepo.cs
@@ -74,7 +74,7 @@ public static class LocalNodeRepo
 
     // Strict UTF-8 probe (throw-on-invalid decoder) so an arbitrary byte stream — a video, a
     // font — is classified binary rather than lossily decoded. Mirrors OctokitGitHubRepoClient.
-    private static bool TryDecodeUtf8(byte[] bytes, out string text)
+    internal static bool TryDecodeUtf8(byte[] bytes, out string text)
     {
         try
         {

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -100,14 +100,23 @@ public static class PluginGateRunner
             var pool = harness.ServiceProvider.GetRequiredService<IoPoolRegistry>()
                 .Get("plugin-test:files");
             return LocalNodeRepo.Load(options.RepoRoot, pool)
-                .SelectMany(snapshot => LocalNodeRepo.DiscoverPackages(snapshot)
-                    .SelectMany(packages => RunPackages(harness, options, snapshot, packages)
+                // The seed's UPSTREAM packages are materialized into the snapshot so the gate
+                // INSTALLS its dependencies (node definitions register their types; the seed's
+                // assemblies stamp their compiles) - see SeedPackages for the failure this ends.
+                .Select(snapshot => SeedPackages.Materialize(snapshot, options.Seed, options.Output))
+                .SelectMany(m => LocalNodeRepo.DiscoverPackages(m.Snapshot)
+                    .SelectMany(packages => RunPackages(harness, options, m.Snapshot, packages, m.UpstreamIds)
                         // The bake artifact rides the compile the gate just performed (#1660 WS1):
                         // persisting is part of the run, INSIDE the outer Catch, so a bake fault is
                         // a FatalError and the run exits RED — an artifact stage must never fail
                         // into a green gate.
+                        // The upstream seed is CONSUMED, never re-emitted: persisting an
+                        // upstream's bundle as this repo's own would let one repo publish
+                        // another's bytes under its own name (the #1814 identity class).
                         .SelectMany(report => BakeOutput.Persist(
-                            harness.Mesh, options, snapshot, packages, report))))
+                            harness.Mesh, options, m.Snapshot,
+                            packages.Where(p => !m.UpstreamIds.Contains(p.Id)).ToImmutableList(),
+                            report))))
                 // The CONSUMPTION postcondition (#1763), applied to every report the run PRODUCES
                 // — a red one included, so a shortfall neither masks an unrelated failure nor is
                 // masked by one. Adoption leaves no trace in a gate verdict (an adopted type
@@ -151,7 +160,7 @@ public static class PluginGateRunner
 
     private static IObservable<GateReport> RunPackages(
         GateMesh harness, GateOptions options, RepoSnapshot snapshot,
-        IReadOnlyList<PackageManifest> packages)
+        IReadOnlyList<PackageManifest> packages, ImmutableHashSet<string> upstreamIds)
     {
         if (packages.Count == 0)
             return Observable.Return(new GateReport([])
@@ -168,13 +177,15 @@ public static class PluginGateRunner
         // Sequential (Concat): installs respect the dependency order; compiles keep running in
         // the background while later packages install.
         return ordered
-            .Select(package => TestPackage(harness, options, snapshot, package))
+            .Select(package => TestPackage(
+                harness, options, snapshot, package, upstreamIds.Contains(package.Id)))
             .ToObservable().Concat().ToList()
             .Select(results => new GateReport(results.ToImmutableList()));
     }
 
     private static IObservable<PackageResult> TestPackage(
-        GateMesh harness, GateOptions options, RepoSnapshot snapshot, PackageManifest package)
+        GateMesh harness, GateOptions options, RepoSnapshot snapshot, PackageManifest package,
+        bool upstream)
     {
         var source = new NodeRepoPackageSource(
             (_, _, _, _) => Observable.Return(snapshot), repoUrl: "local");
@@ -195,7 +206,13 @@ public static class PluginGateRunner
             {
                 stage = "install";
                 options.Output.WriteLine($"── {package.Id}: installing {files.Count} file(s)…");
-                var types = DiscoverNodeTypes(package, files);
+                // An upstream package is INSTALLED, not gated: its types register and its
+                // assemblies adopt from the seed, but compile/render/Tests verdicts belong to
+                // the repo that owns it - running them here would double-judge every upstream
+                // on every satellite and let an upstream flake red a repo that changed nothing.
+                var types = upstream
+                    ? (IReadOnlyList<NodeTypeUnderTest>)[]
+                    : DiscoverNodeTypes(package, files);
                 // The authorizing principal is EXPLICIT — see GateMesh.AuthorizingUserId. Passing
                 // nothing means "nobody authorized this", which PackageEntitlement refuses for any
                 // priced package; the gate would then report a commercial package as failed
@@ -222,6 +239,7 @@ public static class PluginGateRunner
                                     authorizingUserId: GateMesh.AuthorizingUserId)
                                 .Select(second => new PackageResult(package.Id)
                                 {
+                                    Upstream = upstream,
                                     NodeCount = install.Total,
                                     IdempotenceError = second.Written == 0
                                         ? null
@@ -235,6 +253,7 @@ public static class PluginGateRunner
                                 })
                                 .Catch((Exception ex) => Observable.Return(new PackageResult(package.Id)
                                 {
+                                    Upstream = upstream,
                                     NodeCount = install.Total,
                                     IdempotenceError = $"re-install failed: {ex.GetType().Name}: {ex.Message}",
                                     NodeTypes = typeResults.ToImmutableList(),
@@ -243,6 +262,7 @@ public static class PluginGateRunner
             })
             .Catch((Exception ex) => Observable.Return(new PackageResult(package.Id)
             {
+                Upstream = upstream,
                 // Named for the stage that actually threw, and marked as NOT a measurement so
                 // WriteSummary prints "counts unavailable" instead of a fabricated "0 node(s)".
                 CountsMeasured = false,

--- a/tools/MeshWeaver.PluginTester/SeedPackages.cs
+++ b/tools/MeshWeaver.PluginTester/SeedPackages.cs
@@ -1,0 +1,113 @@
+using System.Collections.Immutable;
+using System.Text;
+using MeshWeaver.GitSync;
+using MeshWeaver.Plugin.Packaging;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// Materializes the UPSTREAM packages a bake seed carries into the gate's repo snapshot, so the
+/// gate INSTALLS its dependencies instead of expecting the repo to carry their source.
+///
+/// <para>🚨 <b>Why stamping assemblies alone was not an install.</b> A seed's bytes "only stamp
+/// nodes that already exist" (<see cref="BundleReader.Manifest.Content"/>): without the upstream's
+/// NODE DEFINITIONS in the mesh, its NodeTypes never register, and every satellite module typed by
+/// them dies at install. Measured 2026-08-27 on the first run that ever reached this point
+/// (Reinsurance run 33092019158): <c>Install of 'RiskTransfer' failed: NodeType(s) not registered:
+/// Edu/Lesson, Edu/Exercise, Edu/Page, Edu/CourseInvite, Edu/Quiz</c> — the Edu bundle sat in the
+/// seed with its assemblies adopted and its nodes nowhere. MeshWeaver#2478 put the definitions in
+/// the bundle precisely so a consumer can reconstruct the package; this is that consumer.</para>
+///
+/// <para>The discriminator between "mine" and "upstream" is the repo itself: a bundle whose package
+/// id already has a top-level folder in the snapshot is the repo's OWN module (its bundle sits in
+/// the same seed directory because the gate seeds its own bake too) and is left alone — the gate
+/// judges the repo's tree, never a bundle's copy of it. Everything else came from an upstream
+/// publication and is materialized for INSTALL: its types register from the seed's node
+/// definitions, its assemblies adopt from the seed's bytes (no recompile), and
+/// <see cref="PluginGateRunner"/> excludes it from gating and from
+/// <see cref="BakeOutput"/> persistence — consumed, never re-emitted and never judged here.</para>
+/// </summary>
+public static class SeedPackages
+{
+    /// <summary>The merged snapshot plus which package ids arrived from the seed.</summary>
+    public sealed record Materialized(RepoSnapshot Snapshot, ImmutableHashSet<string> UpstreamIds);
+
+    /// <summary>
+    /// Merges the seed's upstream package trees into <paramref name="repo"/>. Pure over its
+    /// inputs apart from reading the seed's bundle files; a null seed returns the snapshot
+    /// unchanged with an empty upstream set.
+    /// </summary>
+    public static Materialized Materialize(RepoSnapshot repo, BakeSeed? seed, TextWriter output)
+    {
+        var none = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.Ordinal);
+        if (seed is null)
+            return new Materialized(repo, none);
+
+        var present = repo.Files
+            .Select(f => f.Path.IndexOf('/') is > 0 and var i ? f.Path[..i] : null)
+            .Where(id => id is not null)
+            .Select(id => id!)
+            .ToImmutableHashSet(StringComparer.Ordinal);
+
+        var added = new List<RepoFile>();
+        var upstream = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+        foreach (var bundle in seed.Bundles)
+        {
+            BundleReader.Manifest? manifest;
+            IReadOnlyList<BundleReader.ContentFile> files;
+            try
+            {
+                (manifest, files) = BundleReader.ReadContent(File.ReadAllBytes(bundle));
+            }
+            catch (Exception ex) when (ex is IOException or InvalidDataException)
+            {
+                // BakeSeed.Read already proved every bundle's manifest readable; a content read
+                // failing here is a torn file, and installing half a package would be worse than
+                // naming the miss. The install of whatever depends on it then fails LOUDLY.
+                output.WriteLine(
+                    $"::warning::{Path.GetFileName(bundle)}: content unreadable "
+                    + $"({ex.GetType().Name}: {ex.Message}) — its package will not be installed");
+                continue;
+            }
+            var id = manifest?.Plugin;
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+            if (present.Contains(id))
+                continue; // the repo's own module — under gate from its tree, never from a bundle
+            if (files.Count == 0)
+            {
+                output.WriteLine(
+                    $"::warning::{Path.GetFileName(bundle)} carries no node definitions "
+                    + "(assemblies-only bundle, pre MeshWeaver#2478) — "
+                    + $"'{id}' cannot be installed from it");
+                continue;
+            }
+            foreach (var file in files)
+                added.Add(Decode($"{id}/{file.RelativePath}", file.Bytes));
+            upstream.Add(id);
+        }
+
+        var ids = upstream.ToImmutable();
+        if (ids.Count == 0)
+            return new Materialized(repo, ids);
+
+        output.WriteLine(
+            $"seed: materialized {ids.Count} upstream package(s) to INSTALL (never rebuild): "
+            + string.Join(", ", ids.OrderBy(x => x, StringComparer.Ordinal)));
+        var merged = repo with
+        {
+            Files = repo.Files
+                .Concat(added)
+                .OrderBy(f => f.Path, StringComparer.Ordinal)
+                .ToImmutableList(),
+        };
+        return new Materialized(merged, ids);
+    }
+
+    // The SAME strict UTF-8 classification LocalNodeRepo applies to the repo's own files — which
+    // files are text must not fork between the two ways a package reaches the gate.
+    private static RepoFile Decode(string path, byte[] bytes) =>
+        LocalNodeRepo.TryDecodeUtf8(bytes, out var text)
+            ? new RepoFile(path, text)
+            : new RepoFile(path, string.Empty, bytes);
+}


### PR DESCRIPTION
Stamping assemblies alone was not an install: a seed's bytes only stamp nodes that already
exist, so without the upstream's NODE DEFINITIONS in the mesh its NodeTypes never registered,
and every satellite module typed by them died at install. Measured 2026-08-27 on the first run
that ever reached this point (Reinsurance run 33092019158): "Install of 'RiskTransfer' failed:
NodeType(s) not registered: Edu/Lesson, Edu/Exercise, Edu/Page, Edu/CourseInvite, Edu/Quiz" —
the Edu bundle sat in the seed with its assemblies adopted and its nodes nowhere. #2478 put the
definitions in the bundle precisely so a consumer can reconstruct the package; SeedPackages is
that consumer.

The discriminator between "mine" and "upstream" is the repo itself: a bundle whose package id
already has a top-level folder in the snapshot is the repo's own module and is judged from its
tree; everything else materializes for INSTALL — its types register from the seed's node
definitions, its assemblies adopt from the seed's bytes (no recompile), it is excluded from
gating (compile/render/Tests verdicts belong to the repo that owns it — running them here would
double-judge every upstream on every satellite and let an upstream flake red a repo that
changed nothing) and from BakeOutput persistence (consumed, never re-emitted under another
repo's name — the #1814 identity class).

GateInstallsUpstreamPackagesTest pins the satellite shape end to end: repo 2's Base/Widget-typed
node installs green with repo 1 present only as a seed bundle; the upstream row is marked and
un-gated; the gate's own bake carries Course.zip and never Base.zip. 91/91 tester tests green.

Refs #2478, #2481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)