### PR TITLE
Generations GC can no longer break a module a running process still needs

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -235,9 +235,20 @@ public static class MemexConfiguration
                 // and a baseline entry keeps ResolveModulePath's probes. The provenance comes from
                 // the union itself rather than being re-derived here; the gate and the resolver
                 // each deciding for themselves where a module's bytes live is exactly #1949.
+                //
+                // 🚨 #2509: a store-landed generation is then PINNED — copied to process-local
+                // storage and loaded from there. The shared modules/ tree has reference-set
+                // lifetime: an auto-update that lands a newer generation makes THIS pod's loaded
+                // one unreferenced, and a sibling pod's boot GC reclaims it while this process
+                // still lazily loads dependency DLLs from it (first chat after that was
+                // FileNotFoundException 'OpenAI' — the 2026-08-27 outage). Baseline entries stay
+                // un-pinned: they resolve into the image's own immutable closure.
                 .Select(module => (
                     Module: module,
-                    Path: ModuleActivationBoot.ResolveLoadPath(moduleRoot, module)))
+                    Path: module.Landed is not null
+                        ? ModuleGenerationPin.PinnedLoadPath(moduleRoot, module.Landed,
+                            onWarn: msg => Console.Error.WriteLine($"[ModuleActivation] {msg}"))
+                        : ModuleActivationBoot.ResolveLoadPath(moduleRoot, module)))
                 .Where(candidate =>
                 {
                     if (File.Exists(candidate.Path))

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -240,6 +240,40 @@ reclamation, it does not disable it. The two writes of a real landing are back-t
 between them, so the actual exposure the window has to cover is low-single-digit seconds even over
 a slow network volume; five minutes is generous headroom on top of that.
 
+### 🚨 GC vs a RUNNING process — three more holes, closed after the 2026-08-27 outage (#2509)
+
+The grace window protects a landing IN FLIGHT; #2509 measured three ways GC still broke modules
+that had landed long ago, on both prods at once:
+
+1. **Unreadable is never unreferenced.** The reference set GC deletes against comes from
+   `ModuleActivationSidecar.Read`, which — correctly, for boot (#2189) — skips a per-module entry
+   file it cannot read and keeps the rest. For GC that per-module resilience inverts into a hazard:
+   one transient SMB read fault makes that module's ACTIVE generation indistinguishable from an
+   orphan, and the pass deletes the very bytes its entry references — a dangling activation entry
+   with nothing naming why. `CollectGarbage` is now fail-closed: any entry-file read fault skips
+   EVERY generation delete that pass (transient `.staging-`/`.pending-`/`.trash-` folders still
+   collect — nothing references those by design), and a later boot re-reads and sweeps.
+
+2. **Removal is atomic per directory.** Deleting a generation in place could fail PARTWAY — one
+   locked file aborts the recursion — and the skip-on-locked catch then preserved a HALF-GUTTED
+   generation: entry DLL present, lazily-loaded dependency DLLs gone. A generation is now first
+   renamed to a `.trash-*` sibling (one atomic rename, after which resolution can no longer see
+   it) and only then recursively deleted; a refused rename leaves the directory fully intact, an
+   interrupted delete leaves only a `.trash-*` folder a later pass finishes. There is no
+   half-deleted state either way.
+
+3. **A running process loads from PROCESS-LOCAL storage** (`ModuleGenerationPin`). The shared
+   `modules/` tree has reference-set lifetime, but a process needs its loaded generation for its
+   own lifetime: dependency DLLs load LAZILY, and Roslyn content compiles
+   (`CompileReferences.ComposeWithModules`) re-read module files by path hours after boot. An
+   auto-update that lands a newer generation makes the one THIS pod loaded unreferenced, and a
+   sibling pod's boot GC then reclaims it — correctly, by the sidecar's lights — so the pod's
+   first lazy load afterwards was `FileNotFoundException: Could not load file or assembly
+   'OpenAI'`. Boot now copies each store-landed generation into a per-process folder under the OS
+   temp path and loads from there; the shared tree stays a transport that GC may reclaim freely.
+   The pin is protection, not a gate: a boot that cannot copy warns loudly and falls back to the
+   shared path.
+
 Why a sidecar file and not a mesh node: the list is consumed before any storage provider, hub, or
 connection string exists, and it must move with the DLLs it describes — the landing service writes
 both in one operation onto the same volume, so they cannot drift apart.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-module-updates-no-longer-break-running-portals.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-module-updates-no-longer-break-running-portals.md
@@ -1,0 +1,38 @@
+---
+Name: Module updates no longer break running portals
+Category: Fix
+Description: A Store-module auto-update could break the copy a running portal was still using — chat via an updated AI provider failed with a missing-file error until the pod restarted. Portals now load modules from their own process-local copy, and the boot-time cleanup of old module folders can no longer delete or half-delete anything a pod still needs.
+Icon: Sparkle
+Order: -20260827
+---
+
+# Module updates no longer break running portals
+
+When a Store module auto-updates, its new files land beside the old ones and pods pick the new
+version up at their next restart. Until then, a running pod keeps using the version it loaded at
+boot — and parts of that version load lazily, on first use, possibly hours later.
+
+The boot-time cleanup that reclaims old module folders did not know that. Once the update had made
+the old folder "no longer current", any pod that happened to boot would clean it up — out from
+under the sibling pods still running it. The first lazy use after that failed with a missing-file
+error: on 2026-08-27 that was chat through an updated AI provider answering
+`Could not load file or assembly 'OpenAI'` on every model, until the pod was restarted.
+
+Two rarer variants of the same cleanup could leave a module folder half-deleted (its main file
+present, its dependencies gone) or delete a module's current folder outright after a transient
+read glitch on the shared volume — both leaving the module marked installed with broken or missing
+files behind it.
+
+## What changed
+
+- Each pod now copies the modules it loads to its own process-local storage at boot, so cleanup of
+  the shared folders can never reach into a running pod.
+- Cleanup now removes a folder in one atomic step — a folder is either fully there or fully gone,
+  never half-deleted.
+- When the installed-module list cannot be read completely, cleanup skips reclaiming module folders
+  that pass instead of treating the unreadable ones as unused.
+
+## What you will notice
+
+Store-module auto-updates roll out without breaking the pods still running the previous version —
+no more sudden missing-file errors between an update landing and the restart that applies it.

--- a/src/MeshWeaver.PluginCatalog/ModuleGenerationPin.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleGenerationPin.cs
@@ -1,0 +1,101 @@
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Pins a store-landed module generation to PROCESS-LOCAL storage before it is loaded (#2509).
+///
+/// <para>🚨 <b>Why loading from the shared volume is not safe for a running process.</b> A landed
+/// generation lives under the deployment's shared <c>modules/</c> tree (<c>/data</c>, mounted by
+/// every replica). The process loads the module's ENTRY assembly at boot, but its dependency DLLs
+/// load LAZILY — first use, hours later. In between, the generation can legitimately stop being
+/// referenced: an auto-update lands a NEWER generation and moves the activation pointer, this pod
+/// keeps running the old one until its restart, and any SIBLING pod's boot GC then reclaims the
+/// old directory — correctly, by the sidecar's lights. The first lazy load after that is
+/// <c>FileNotFoundException: Could not load file or assembly 'OpenAI'</c> with nothing connecting
+/// it to a GC pass on another pod two hours earlier — the 2026-08-27 outage, verbatim. Roslyn
+/// content compiles (<c>CompileReferences.ComposeWithModules</c>) re-read module files by path the
+/// same way and had the same exposure.</para>
+///
+/// <para>The root cause is storage lifetime: resources with PROCESS lifetime were being served
+/// from a directory with REFERENCE-SET lifetime. The fix is to give the loaded bytes process-local
+/// storage — each boot copies the generation directory it is about to load into a per-process
+/// folder under the OS temp path and loads from there. No lease files, no cross-replica
+/// coordination, no GC coupling: the shared tree stays a transport, and reclaiming it can no
+/// longer reach into a running process. The copy is a few MB per module, on storage whose
+/// lifecycle already matches the process (a container's tmp dies with the pod).</para>
+///
+/// <para>🚨 <b>The pin is protection, not a gate.</b> A boot that cannot copy (temp full,
+/// read-only tmp) warns loudly and falls back to the shared path — exactly today's behavior. A
+/// portal that will not start cannot be given the fix for what is wrong with it.</para>
+/// </summary>
+public static class ModuleGenerationPin
+{
+    /// <summary>Where pinned copies live by default: under the OS temp path, whose lifecycle
+    /// matches the process's environment (a container's tmp dies with the pod; a dev machine's is
+    /// OS-managed).</summary>
+    public static string DefaultPinRoot => Path.Combine(Path.GetTempPath(), "meshweaver-pinned-modules");
+
+    /// <summary>
+    /// Copies the generation directory <paramref name="entry"/> points at into a process-local
+    /// folder and returns the entry DLL path INSIDE the copy — the path boot hands to
+    /// <c>MeshBuilder.InstallAssemblies</c>. Dependency DLLs, static assets, everything in the
+    /// generation travels: lazy loads and Roslyn metadata reads must all resolve from the pinned
+    /// copy, or the protection has a hole exactly where the outage was.
+    ///
+    /// <para>On ANY failure it warns through <paramref name="onWarn"/> and returns the SHARED
+    /// landed path (<see cref="ModuleActivationBoot.LandedDllPath"/>) — the pre-#2509 behavior,
+    /// degraded but bootable.</para>
+    /// </summary>
+    /// <param name="moduleRoot">The deployment root the shared <c>modules/</c> tree lives under —
+    /// the same root <see cref="ModuleLandingService"/> writes.</param>
+    /// <param name="entry">The activation entry naming the generation to pin.</param>
+    /// <param name="pinRoot">Test seam for the process-local root; production uses
+    /// <see cref="DefaultPinRoot"/>.</param>
+    /// <param name="onWarn">The loud channel for a failed pin — pre-DI boot passes stderr.</param>
+    public static string PinnedLoadPath(
+        string moduleRoot,
+        ModuleActivationEntry entry,
+        string? pinRoot = null,
+        Action<string>? onWarn = null)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        var sharedDirectory = ModuleLandingService.ModuleDirectoryFor(moduleRoot, entry.Name, entry);
+        var sharedDll = ModuleActivationBoot.LandedDllPath(moduleRoot, entry);
+        try
+        {
+            var leaf = Path.GetFileName(sharedDirectory);
+            // Unique per process AND per call: two hosts on one machine (a dev portal beside a
+            // test run) or two boots in one long-lived process must never share or overwrite a
+            // pinned tree an earlier load is still using.
+            var pinnedDirectory = Path.Combine(
+                pinRoot ?? DefaultPinRoot,
+                $"{Environment.ProcessId}-{Guid.NewGuid():N}"[..(Environment.ProcessId.ToString().Length + 9)],
+                leaf);
+            CopyTree(sharedDirectory, pinnedDirectory);
+            var pinnedDll = Path.Combine(pinnedDirectory, entry.Name + ".dll");
+            if (!File.Exists(pinnedDll))
+                throw new FileNotFoundException(
+                    $"the copied generation has no entry DLL at '{pinnedDll}' — the shared "
+                    + "directory is incomplete", pinnedDll);
+            return pinnedDll;
+        }
+        catch (Exception ex)
+        {
+            onWarn?.Invoke(
+                $"module '{entry.Name}': could not pin generation '{entry.Directory ?? entry.Name}' "
+                + $"to process-local storage ({ex.GetType().Name}: {ex.Message}) — loading from the "
+                + "shared modules/ tree instead. A GC pass on another replica can reclaim that "
+                + "directory while this process still lazily loads from it (#2509); restart to "
+                + "re-attempt the pin.");
+            return sharedDll;
+        }
+    }
+
+    private static void CopyTree(string source, string destination)
+    {
+        Directory.CreateDirectory(destination);
+        foreach (var directory in Directory.EnumerateDirectories(source, "*", SearchOption.AllDirectories))
+            Directory.CreateDirectory(Path.Combine(destination, Path.GetRelativePath(source, directory)));
+        foreach (var file in Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories))
+            File.Copy(file, Path.Combine(destination, Path.GetRelativePath(source, file)), overwrite: false);
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/ModuleGenerationPin.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleGenerationPin.cs
@@ -92,10 +92,21 @@ public static class ModuleGenerationPin
 
     private static void CopyTree(string source, string destination)
     {
+        // Reparse points (symlinks/junctions) are never followed: a landed generation is plain
+        // files by construction, so a link inside one is corruption or crafting, and following it
+        // would pull arbitrary filesystem content into the pin (huge copies, unintended reads).
+        // Parent directories are created per file, so no directory pass traverses links either.
         Directory.CreateDirectory(destination);
-        foreach (var directory in Directory.EnumerateDirectories(source, "*", SearchOption.AllDirectories))
-            Directory.CreateDirectory(Path.Combine(destination, Path.GetRelativePath(source, directory)));
-        foreach (var file in Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories))
-            File.Copy(file, Path.Combine(destination, Path.GetRelativePath(source, file)), overwrite: false);
+        var options = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            AttributesToSkip = FileAttributes.ReparsePoint,
+        };
+        foreach (var file in Directory.EnumerateFiles(source, "*", options))
+        {
+            var target = Path.Combine(destination, Path.GetRelativePath(source, file));
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            File.Copy(file, target, overwrite: false);
+        }
     }
 }

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -60,7 +60,7 @@ namespace MeshWeaver.PluginCatalog;
 ///
 /// <para><b>…except boot-time GC against a CONCURRENT landing (#2303).</b> A landing's two writes
 /// (move the bytes, then <see cref="ModuleActivationSidecar.WriteEntry"/>) are not atomic across
-/// replicas, so another replica's <see cref="CollectGarbage"/> can observe the new generation
+/// replicas, so another replica's <see cref="CollectGarbage(string, Microsoft.Extensions.Logging.ILogger?, TimeSpan?, DateTime?)"/> can observe the new generation
 /// directory before the entry that claims it exists and delete it as "unreferenced" — leaving a
 /// real activation entry pointing at nothing a moment later. See
 /// <see cref="DefaultGarbageMinAge"/> for the race and the grace-period fix.</para>
@@ -79,7 +79,7 @@ public sealed class ModuleLandingService : IDisposable
 
     /// <summary>
     /// How long an UNREFERENCED directory under <c>modules/</c> must sit before
-    /// <see cref="CollectGarbage"/> treats it as truly orphaned rather than the first half of a
+    /// <see cref="CollectGarbage(string, Microsoft.Extensions.Logging.ILogger?, TimeSpan?, DateTime?)"/> treats it as truly orphaned rather than the first half of a
     /// landing this replica has not seen the SECOND half of yet — the race behind #2303.
     ///
     /// <para>🚨 <b>The race.</b> A landing is two writes on the shared <c>/data</c> volume,
@@ -113,12 +113,32 @@ public sealed class ModuleLandingService : IDisposable
     /// <summary>
     /// Boot-time garbage collection over <c>modules/</c>: deletes generation directories
     /// (<c>&lt;name&gt;@&lt;id&gt;</c>) no activation entry references, leftover
-    /// <c>.staging-*</c>, and the retired <c>.pending-*</c> folders of the abandoned deferred-swap
-    /// scheme — but only once they are older than <paramref name="minAge"/>
-    /// (<see cref="DefaultGarbageMinAge"/>): see that constant for why an UNREFERENCED directory is
-    /// not proof of an orphan (#2303). Skip-on-locked: a directory some still-running pod holds
-    /// open simply survives to the next boot. Never touches legacy <c>&lt;name&gt;/</c> folders —
-    /// entries without a generation still resolve there.
+    /// <c>.staging-*</c>, <c>.trash-*</c> from an earlier pass's interrupted delete, and the
+    /// retired <c>.pending-*</c> folders of the abandoned deferred-swap scheme — but (except for
+    /// <c>.trash-*</c>, which is unreferenced by construction) only once they are older than
+    /// <paramref name="minAge"/> (<see cref="DefaultGarbageMinAge"/>): see that constant for why an
+    /// UNREFERENCED directory is not proof of an orphan (#2303). Never touches legacy
+    /// <c>&lt;name&gt;/</c> folders — entries without a generation still resolve there.
+    ///
+    /// <para>🚨 <b>Fail-closed on an unreliable reference set (#2509).</b> The reference set comes
+    /// from <see cref="ModuleActivationSidecar.Read"/>, which — correctly, for BOOT (#2189) — skips
+    /// a per-module entry file it cannot read and keeps the rest. For GC that per-module resilience
+    /// inverts into a hazard: a transient SMB read fault on ONE entry file makes that module's
+    /// ACTIVE generation indistinguishable from an orphan, and a pass that trusted the incomplete
+    /// set deleted the very bytes the entry references — the dangling activation entries #2509
+    /// measured on both prods. So any read fault skips every generation delete this pass
+    /// (transient <c>.staging-/.pending-/.trash-</c> folders still collect — nothing references
+    /// those by design); a later boot re-reads and sweeps then. Unreadable is never unreferenced.</para>
+    ///
+    /// <para>🚨 <b>Removal is atomic per directory (#2509).</b> A generation is first renamed to a
+    /// <c>.trash-*</c> sibling — one atomic rename, after which it no longer exists as far as
+    /// resolution (<see cref="ModuleDirectoryFor"/>) is concerned — and only then recursively
+    /// deleted. The old delete-in-place could fail PARTWAY (one locked file on SMB aborts the
+    /// recursion) and its skip-on-locked catch then preserved a HALF-GUTTED generation: entry DLL
+    /// present, lazily-loaded dependency DLLs gone — the <c>Could not load file or assembly
+    /// 'OpenAI'</c> shape of the 2026-08-27 outage. With rename-first, a refused rename (held open
+    /// on SMB) leaves the directory fully intact, and an interrupted delete leaves only a
+    /// <c>.trash-*</c> folder a later pass finishes. There is no half-deleted state either way.</para>
     /// </summary>
     /// <param name="baseDirectory">The deployment root whose <c>modules/</c> folder is swept.</param>
     /// <param name="logger">Diagnostics — every removal and every age-deferred skip is logged.</param>
@@ -127,36 +147,69 @@ public sealed class ModuleLandingService : IDisposable
     /// <param name="nowUtc">The reference "now" the age check compares against. Defaults to
     /// <see cref="DateTime.UtcNow"/>; a test seam so the race and its fix are provable without a
     /// real sleep.</param>
-    /// <returns>How many directories were removed.</returns>
+    /// <returns>How many directories were removed — where "removed" means gone from the
+    /// <c>modules/</c> namespace (a rename into <c>.trash-*</c> counts even when the final delete
+    /// is finished by a later pass).</returns>
     public static int CollectGarbage(
         string baseDirectory, ILogger? logger = null, TimeSpan? minAge = null, DateTime? nowUtc = null)
+        => CollectGarbage(baseDirectory, logger, minAge, nowUtc, deleteDirectory: null);
+
+    /// <summary>The implementation behind <see cref="CollectGarbage(string, ILogger?, TimeSpan?,
+    /// DateTime?)"/> with the delete operation as a seam, so the interrupted-delete path — the one
+    /// that used to leave a half-gutted generation — is provable in a test without a real SMB lock.</summary>
+    internal static int CollectGarbage(
+        string baseDirectory, ILogger? logger, TimeSpan? minAge, DateTime? nowUtc,
+        Action<string>? deleteDirectory)
     {
         var modulesRoot = Path.Combine(baseDirectory, "modules");
         if (!Directory.Exists(modulesRoot))
             return 0;
+        var delete = deleteDirectory ?? (dir => Directory.Delete(dir, recursive: true));
+        var readFaults = 0;
         var activation = ModuleActivationSidecar.Read(baseDirectory,
-            msg => logger?.LogError("{Message}", msg));
+            msg =>
+            {
+                readFaults++;
+                logger?.LogError("{Message}", msg);
+            });
         var referenced = activation.Entries
             .Where(e => !string.IsNullOrWhiteSpace(e.Directory))
             .Select(e => e.Directory!)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        // 🚨 #2509: with any entry file unreadable, `referenced` is INCOMPLETE — an ACTIVE
+        // generation would read as an orphan. Generation deletes are skipped wholesale this pass.
+        var referencesReliable = readFaults == 0;
+        var reportedUnreliable = false;
         var cutoff = (nowUtc ?? DateTime.UtcNow) - (minAge ?? DefaultGarbageMinAge);
         var removed = 0;
         foreach (var dir in Directory.EnumerateDirectories(modulesRoot))
         {
             var leaf = Path.GetFileName(dir);
-            var collectable =
-                leaf.StartsWith(".staging-", StringComparison.OrdinalIgnoreCase)
-                || leaf.StartsWith(".pending-", StringComparison.OrdinalIgnoreCase)
-                || (leaf.Contains('@') && !referenced.Contains(leaf));
-            if (!collectable)
+            var isTrash = leaf.StartsWith(".trash-", StringComparison.OrdinalIgnoreCase);
+            var isTransient = isTrash
+                || leaf.StartsWith(".staging-", StringComparison.OrdinalIgnoreCase)
+                || leaf.StartsWith(".pending-", StringComparison.OrdinalIgnoreCase);
+            var isOrphanGeneration = !isTransient && leaf.Contains('@') && !referenced.Contains(leaf);
+            if (!isTransient && !isOrphanGeneration)
                 continue;
+            if (isOrphanGeneration && !referencesReliable)
+            {
+                if (!reportedUnreliable)
+                    logger?.LogWarning(
+                        "Modules GC: {Faults} activation entry file(s) could not be read, so the "
+                        + "reference set is incomplete — SKIPPING every generation delete this pass "
+                        + "(unreadable is never unreferenced, #2509). A later boot re-reads and "
+                        + "sweeps.", readFaults);
+                reportedUnreliable = true;
+                continue;
+            }
             // 🚨 #2303: an unreferenced directory younger than the grace window may simply be a
             // landing this replica has not seen the ACTIVATION ENTRY for yet — see
             // DefaultGarbageMinAge. Left for a later pass, which re-reads the sidecar and either
             // finds the entry now present (survives, correctly) or is still unreferenced and past
-            // the window (a genuine orphan, collected then).
-            if (Directory.GetLastWriteTimeUtc(dir) > cutoff)
+            // the window (a genuine orphan, collected then). `.trash-*` is exempt: it exists only
+            // as the second half of a removal this or an earlier pass already committed.
+            if (!isTrash && Directory.GetLastWriteTimeUtc(dir) > cutoff)
             {
                 logger?.LogDebug(
                     "Modules GC: {Dir} is unreferenced but younger than the {MinAge} grace period "
@@ -164,16 +217,43 @@ public sealed class ModuleLandingService : IDisposable
                     leaf, minAge ?? DefaultGarbageMinAge);
                 continue;
             }
+            var target = dir;
+            if (isOrphanGeneration)
+            {
+                // Atomic removal (#2509): one rename takes the generation out of the modules/
+                // namespace; a refusal (held open on SMB) leaves it FULLY intact for the next boot.
+                var trash = Path.Combine(modulesRoot,
+                    $".trash-{leaf}-{Guid.NewGuid():N}"[..(".trash-".Length + leaf.Length + 9)]);
+                try
+                {
+                    Directory.Move(dir, trash);
+                    removed++;
+                    logger?.LogInformation("Modules GC: removed {Dir}", leaf);
+                }
+                catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+                {
+                    // Held open by a still-running pod — intact, the next boot collects it.
+                    logger?.LogDebug("Modules GC: {Dir} is in use, skipped ({Reason})", leaf, e.Message);
+                    continue;
+                }
+                target = trash;
+            }
             try
             {
-                Directory.Delete(dir, recursive: true);
-                removed++;
-                logger?.LogInformation("Modules GC: removed {Dir}", leaf);
+                delete(target);
+                if (!isOrphanGeneration)
+                {
+                    removed++;
+                    logger?.LogInformation("Modules GC: removed {Dir}", leaf);
+                }
             }
             catch (Exception e) when (e is IOException or UnauthorizedAccessException)
             {
-                // Held open by a still-running pod — the next boot collects it.
-                logger?.LogDebug("Modules GC: {Dir} is in use, skipped ({Reason})", leaf, e.Message);
+                // An interrupted delete of a .trash-*/staging folder is harmless — nothing resolves
+                // or loads it — and a later pass finishes the job.
+                logger?.LogDebug(
+                    "Modules GC: delete of {Target} did not finish ({Reason}) — a later pass "
+                    + "collects the remainder.", Path.GetFileName(target), e.Message);
             }
         }
         return removed;

--- a/test/MeshWeaver.PluginCatalog.Test/GenerationGcHardeningTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/GenerationGcHardeningTest.cs
@@ -1,0 +1,156 @@
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The #2509 hardening, pinned: generations GC must never turn a readable-yesterday module into a
+/// broken one. Three invariants, each of which was violated on prod 2026-08-27:
+/// (1) an UNREADABLE activation entry file makes the reference set incomplete, so no generation
+/// may be deleted that pass — unreadable is never unreferenced;
+/// (2) removal is ATOMIC per directory — an interrupted delete must never leave a half-gutted
+/// generation (entry DLL present, lazily-loaded dependency DLLs gone);
+/// (3) a store-landed generation is PINNED to process-local storage before loading, so a GC pass
+/// on another replica reclaiming the shared directory cannot break this process's lazy loads.
+/// </summary>
+public class GenerationGcHardeningTest : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-gc-" + Guid.NewGuid().ToString("N"));
+
+    public GenerationGcHardeningTest() => Directory.CreateDirectory(Path.Combine(root, "modules"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+    }
+
+    private string Modules => Path.Combine(root, "modules");
+
+    private void Write(string folder, string file, string content)
+    {
+        Directory.CreateDirectory(Path.Combine(Modules, folder));
+        File.WriteAllText(Path.Combine(Modules, folder, file), content);
+    }
+
+    private static void Backdate(string dir) =>
+        Directory.SetLastWriteTimeUtc(dir,
+            DateTime.UtcNow - ModuleLandingService.DefaultGarbageMinAge - TimeSpan.FromMinutes(1));
+
+    [Fact]
+    public void CollectGarbage_SkipsEveryGenerationDelete_WhenAnEntryFileIsUnreadable()
+    {
+        // Widget's generation is ACTIVE — but its entry file is unreadable garbage, so the read
+        // skips it (per-module resilience, #2189) and the reference set no longer knows the
+        // generation is claimed. Before the fix, GC deleted it: the dangling activation entries
+        // #2509 measured on both prods.
+        Write("MeshWeaver.Widget@live0001", "MeshWeaver.Widget.dll", "LIVE");
+        Backdate(Path.Combine(Modules, "MeshWeaver.Widget@live0001"));
+        var entries = Path.Combine(Modules, ModuleActivationSidecar.EntriesDirectoryName);
+        Directory.CreateDirectory(entries);
+        File.WriteAllText(Path.Combine(entries, "MeshWeaver.Widget.json"), "{ not json");
+
+        // A genuine orphan of ANOTHER module sits beside it. With the reference set unreliable,
+        // GC cannot tell these two cases apart — so it must delete NEITHER.
+        Write("MeshWeaver.Other@dead0001", "MeshWeaver.Other.dll", "DEAD");
+        Backdate(Path.Combine(Modules, "MeshWeaver.Other@dead0001"));
+
+        // Transient folders are still collectable — nothing references .staging-* by design.
+        Write(".staging-MeshWeaver.Widget-x", "half.dll", "H");
+        Backdate(Path.Combine(Modules, ".staging-MeshWeaver.Widget-x"));
+
+        var removed = ModuleLandingService.CollectGarbage(root);
+
+        Assert.Equal(1, removed);
+        Assert.True(Directory.Exists(Path.Combine(Modules, "MeshWeaver.Widget@live0001")),
+            "the ACTIVE generation of the module with the unreadable entry must survive — deleting "
+            + "it is exactly the dangling-entry outage (#2509)");
+        Assert.True(Directory.Exists(Path.Combine(Modules, "MeshWeaver.Other@dead0001")),
+            "with the reference set incomplete, even a genuine orphan must wait for a pass that "
+            + "can actually tell it apart from an active generation");
+        Assert.False(Directory.Exists(Path.Combine(Modules, ".staging-MeshWeaver.Widget-x")),
+            ".staging-* is unreferenced by design and still collects on an unreliable pass");
+    }
+
+    [Fact]
+    public void CollectGarbage_RemovalIsAtomic_AnInterruptedDeleteLeavesNoHalfGuttedGeneration()
+    {
+        // An unreferenced old generation with an entry DLL and a lazily-loaded dependency — the
+        // shape whose PARTIAL deletion (entry survives a locked-file abort, dependency does not)
+        // produced `Could not load file or assembly 'OpenAI'` on prod.
+        Write("MeshWeaver.Widget@dead0001", "MeshWeaver.Widget.dll", "ENTRY");
+        Write("MeshWeaver.Widget@dead0001", "OpenAI.dll", "LAZY-DEP");
+        Backdate(Path.Combine(Modules, "MeshWeaver.Widget@dead0001"));
+
+        // The delete is interrupted (an SMB lock mid-recursion). The rename must already have
+        // committed the removal: gone from modules/ resolution, fully intact in .trash-*.
+        var removed = ModuleLandingService.CollectGarbage(
+            root, logger: null, minAge: null, nowUtc: null,
+            deleteDirectory: _ => throw new IOException("locked mid-recursion"));
+
+        Assert.Equal(1, removed);
+        Assert.False(Directory.Exists(Path.Combine(Modules, "MeshWeaver.Widget@dead0001")),
+            "the generation must be OUT of the modules/ namespace in one atomic rename");
+        var trash = Directory.EnumerateDirectories(Modules, ".trash-*").ToArray();
+        var trashed = Assert.Single(trash);
+        Assert.True(File.Exists(Path.Combine(trashed, "MeshWeaver.Widget.dll")));
+        Assert.True(File.Exists(Path.Combine(trashed, "OpenAI.dll")),
+            "the trash folder holds the COMPLETE generation — no state in which the entry DLL "
+            + "exists and the dependency does not");
+
+        // A later pass finishes the job — .trash-* is exempt from the age grace (it is
+        // unreferenced by construction).
+        var secondPass = ModuleLandingService.CollectGarbage(root);
+        Assert.Equal(1, secondPass);
+        Assert.Empty(Directory.EnumerateDirectories(Modules, ".trash-*"));
+    }
+
+    [Fact]
+    public void PinnedLoadPath_SurvivesTheSharedGenerationBeingReclaimed()
+    {
+        Write("MeshWeaver.Widget@gen00001", "MeshWeaver.Widget.dll", "ENTRY");
+        Write("MeshWeaver.Widget@gen00001", "OpenAI.dll", "LAZY-DEP");
+        var entry = new ModuleActivationEntry
+        {
+            Name = "MeshWeaver.Widget",
+            Directory = "MeshWeaver.Widget@gen00001",
+        };
+        var pinRoot = Path.Combine(root, "pin");
+
+        var pinned = ModuleGenerationPin.PinnedLoadPath(root, entry, pinRoot);
+
+        Assert.StartsWith(pinRoot, pinned);
+        Assert.Equal("ENTRY", File.ReadAllText(pinned));
+
+        // Another replica's GC reclaims the shared generation — the pod keeps running.
+        Directory.Delete(Path.Combine(Modules, "MeshWeaver.Widget@gen00001"), recursive: true);
+
+        Assert.True(File.Exists(pinned), "the pinned entry DLL has process lifetime");
+        // The lazily-loaded dependency is pinned WITH the entry — the outage was precisely a
+        // dependency resolving after the shared directory was gone.
+        Assert.Equal("LAZY-DEP",
+            File.ReadAllText(Path.Combine(Path.GetDirectoryName(pinned)!, "OpenAI.dll")));
+    }
+
+    [Fact]
+    public void PinnedLoadPath_FallsBackToTheSharedPath_WhenPinningFails()
+    {
+        Write("MeshWeaver.Widget@gen00001", "MeshWeaver.Widget.dll", "ENTRY");
+        var entry = new ModuleActivationEntry
+        {
+            Name = "MeshWeaver.Widget",
+            Directory = "MeshWeaver.Widget@gen00001",
+        };
+        // A pin root that cannot be a directory: an existing FILE at that path.
+        var blocked = Path.Combine(root, "blocked");
+        File.WriteAllText(blocked, "not a directory");
+        string? warning = null;
+
+        var resolved = ModuleGenerationPin.PinnedLoadPath(root, entry, blocked, msg => warning = msg);
+
+        Assert.Equal(ModuleActivationBoot.LandedDllPath(root, entry), resolved);
+        Assert.NotNull(warning);
+        Assert.Contains("could not pin", warning);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2509 — the 2026-08-27 engine outage (chat via the auto-updated OpenAI provider failing with `Could not load file or assembly 'OpenAI'` on every model), root-caused to three distinct holes in the generations GC, each fixed at its root:

1. **Unreadable is never unreferenced.** GC's reference set comes from `ModuleActivationSidecar.Read`, which (correctly, for boot — #2189) skips a per-module entry file it cannot read. For GC that inverts into a hazard: one transient SMB read fault makes that module's ACTIVE generation look like an orphan, and the pass deletes bytes a real entry references — the dangling activation entries #2509 measured (`@8f4e6f6b` active, not on disk). `CollectGarbage` is now fail-closed: any entry-file read fault skips every generation delete that pass; `.staging-`/`.pending-`/`.trash-` still collect (nothing references those by design).

2. **Removal is atomic per directory.** Delete-in-place could fail partway (one locked file aborts the recursion) and the skip-on-locked catch preserved a HALF-GUTTED generation — entry DLL present, lazily-loaded deps gone (`@27718c7b` with no `OpenAI.dll`). A generation is now renamed to a `.trash-*` sibling first — one atomic rename, after which resolution cannot see it — then deleted; a refused rename leaves it fully intact, an interrupted delete leaves a `.trash-*` folder a later pass finishes.

3. **A running process loads from process-local storage** (`ModuleGenerationPin`, new). A superseded-but-loaded generation is *legitimately* unreferenced — the auto-update moved the pointer — yet the running pod still lazily loads dependency DLLs from it, and Roslyn content compiles (`ComposeWithModules`) re-read module files by path hours after boot. A sibling pod's boot GC reclaiming it was correct by the sidecar's lights and still broke the running pod: storage with reference-set lifetime was serving resources with process lifetime. Boot now copies each store-landed generation into a per-process folder under the OS temp path and loads from there; the shared tree stays a transport. The pin is protection, not a gate — a failed copy warns loudly and falls back to the shared path.

## Tests

`GenerationGcHardeningTest` (new, 4 tests) pins each mechanism: fail-closed GC under an unreadable entry file, atomic removal under an interrupted delete (via the internal delete seam), pin surviving shared-tree reclaim including the lazy-dep file, and the loud fallback. The existing `PendingLandingTest` suite (6) passes unchanged. All 10 green locally under `-c Release -warnaserror`.

## Notes

- Wiring is one call-site in `MemexConfiguration.ConfigureMemexMesh` (the boot path all hosts share), so the plugins-built portal hosts pick this up on their next platform pin bump with no plugins-side change.
- Mitigation already applied on prod (rollout restart); this removes the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz1i2fFcJhvR1Eje8yFH5F