### PR TITLE
The portal hands its configuration to the module system (#2507)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -265,6 +265,17 @@ public static class MemexConfiguration
                 Console.WriteLine,
                 Console.Error.WriteLine);
 
+            // 🚨 #2507 — HAND THE CONFIGURATION TO THE BUILDER BEFORE ANYTHING INSTALLS. A module
+            // attribute's BuilderConfigurations run inside InstallAssemblies and read
+            // builder.Configuration for the deployment's answers; this method had every answer in
+            // its `configuration` parameter and never passed it on, so every module folding on a
+            // PORTAL saw null — AiMeshModuleAttribute.ServeFromPartitions(null) put the whole AI
+            // catalog on the in-memory path and skipped the AI content sources on both prods,
+            // while the deployed config plainly listed the partitions. InstallConfiguredModules
+            // (the tester/LocalMesh path) already hands it over, which is exactly why the defect
+            // was portal-specific. Unconditional: modules are not the only readers, and a null
+            // Configuration must mean "the deployment supplied nothing", never "the host forgot".
+            builder.WithConfiguration(configuration);
             if (resolvedModules.Length > 0)
                 builder.InstallAssemblies(resolvedModules);
             // Restart-as-activation: this boot IS the restart the sidecar was waiting for —

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-model-catalog-reaches-the-database-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-model-catalog-reaches-the-database-again.md
@@ -1,0 +1,32 @@
+---
+Name: Model catalog reaches the database again
+Category: Fix
+Description: On deployed portals the AI model and provider catalog silently stayed in memory — the Provider partition never materialized in the database, so git-governed model management had nothing to sync against. The portal now hands its configuration to the module system at boot, and the catalog lands in the database as configured.
+Icon: Sparkle
+Order: -20260827
+---
+
+# Model catalog reaches the database again
+
+Deployments configure which AI content partitions are served from the database
+(`Features:StaticRepoSync:Partitions`), and the model/provider catalog is one of them: serving it
+from the database is what makes it durable, queryable, and manageable through git-governed sync.
+
+On deployed portals that configuration was silently ignored. The AI engine activates as a module at
+boot, and modules read the deployment's configuration through the mesh builder — but the portal's
+boot path never handed its configuration over. The engine saw "nothing configured", fell back to
+in-memory serving (the documented answer for an absent key), and skipped registering its content
+sources. The result: sixteen models serving happily from memory, zero rows in the `model` schema,
+no `provider` schema at all, and nothing in any log naming why — every part behaved correctly for
+the inputs it saw.
+
+## What changed
+
+The portal hands its configuration to the module system before any module installs, so module
+activations now see exactly what the deployment configured. A regression test pins the hand-over.
+
+## What you will notice
+
+The Provider and Model partitions materialize in the database as configured, which unblocks
+git-governed model catalog management (`Provider/_GitSync`) and makes provider/model changes durable
+across restarts instead of re-projected from configuration each boot.

--- a/test/Memex.Portal.Shared.Test/ConfigurationHandOverTest.cs
+++ b/test/Memex.Portal.Shared.Test/ConfigurationHandOverTest.cs
@@ -1,9 +1,15 @@
 using Memex.Portal.Shared;
+using Memex.Portal.Shared.Test;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+
+// The probe module: this TEST assembly is itself a loadable module (ResolveModulePath passes an
+// absolute path straight through), so pointing Modules:Assemblies at it makes the REAL fold —
+// ConfigureMemexMesh → InstallAssemblies → attribute BuilderConfigurations — observable.
+[assembly: ConfigurationProbeModule]
 
 namespace Memex.Portal.Shared.Test;
 
@@ -18,11 +24,16 @@ namespace Memex.Portal.Shared.Test;
 /// while the deployed config plainly listed the partitions. The tester/LocalMesh path goes
 /// through <c>InstallConfiguredModules</c>, which hands it over — exactly why the defect was
 /// portal-specific and invisible to every gate.
+///
+/// <para>🚨 The assertion is on what the probe module OBSERVED AT FOLD TIME, not merely on
+/// <c>builder.Configuration</c> after the call — a hand-over moved to AFTER
+/// <c>InstallAssemblies</c> would satisfy the weaker assertion while re-breaking every module,
+/// which is precisely the #2507 shape (Copilot review).</para>
 /// </summary>
 public class ConfigurationHandOverTest
 {
     [Fact]
-    public void ConfigureMemexMesh_HandsTheHostConfigurationToTheBuilder()
+    public void ConfigureMemexMesh_HandsTheHostConfigurationToTheBuilder_BeforeModulesFold()
     {
         var temp = Directory.CreateTempSubdirectory("mw-2507-").FullName;
         try
@@ -32,14 +43,28 @@ public class ConfigurationHandOverTest
                 {
                     ["Graph:Storage:Type"] = "FileSystem",
                     ["Graph:Storage:BasePath"] = temp,
+                    // This test assembly IS the module: its ConfigurationProbeModuleAttribute
+                    // records builder.Configuration the moment the fold runs.
+                    ["Modules:Assemblies:0"] = typeof(ConfigurationHandOverTest).Assembly.Location,
                 })
                 .Build();
-            var services = new ServiceCollection();
-            var builder = new MeshBuilder(configure => configure(services), new Address("mesh", "test"));
+            var serviceConfigurations = new List<Func<IServiceCollection, IServiceCollection>>();
+            var builder = new MeshBuilder(
+                configure => serviceConfigurations.Add(configure), new Address("mesh", "test"));
 
             builder.ConfigureMemexMesh(configuration);
 
             Assert.Same(configuration, builder.Configuration);
+
+            var services = serviceConfigurations.Aggregate(
+                (IServiceCollection)new ServiceCollection(),
+                (collection, configure) => configure(collection));
+            var observed = services
+                .Select(d => d.ImplementationInstance)
+                .OfType<ObservedModuleFoldConfiguration>()
+                .ToList();
+            var observation = Assert.Single(observed);
+            Assert.Same(configuration, observation.Value);
         }
         finally
         {
@@ -47,4 +72,21 @@ public class ConfigurationHandOverTest
             catch { /* temp cleanup is the OS's problem, never a test failure */ }
         }
     }
+}
+
+/// <summary>What the probe saw as <c>builder.Configuration</c> when its fold ran — null means the
+/// fold ran BEFORE the host handed its configuration over, the #2507 defect.</summary>
+public sealed record ObservedModuleFoldConfiguration(IConfiguration? Value);
+
+/// <summary>The probe module attribute — records the fold-time <c>builder.Configuration</c> into
+/// the mesh service collection, where the test can read it back.</summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class ConfigurationProbeModuleAttribute : MeshNodeProviderAttribute
+{
+    /// <inheritdoc />
+    public override IEnumerable<Func<MeshBuilder, MeshBuilder>> BuilderConfigurations =>
+    [
+        builder => builder.ConfigureServices(services =>
+            services.AddSingleton(new ObservedModuleFoldConfiguration(builder.Configuration)))
+    ];
 }

--- a/test/Memex.Portal.Shared.Test/ConfigurationHandOverTest.cs
+++ b/test/Memex.Portal.Shared.Test/ConfigurationHandOverTest.cs
@@ -1,0 +1,50 @@
+using Memex.Portal.Shared;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// #2507, pinned: the portal boot path must hand the host configuration to the builder BEFORE
+/// modules install. A module attribute's <c>BuilderConfigurations</c> run inside
+/// <c>InstallAssemblies</c> and read <c>builder.Configuration</c> for the deployment's answers —
+/// on both prods that read null (<c>ConfigureMemexMesh</c> had every answer in its parameter and
+/// never passed it on), so <c>AiMeshModuleAttribute.ServeFromPartitions(null)</c> put the whole
+/// AI catalog on the in-memory path and the AI content sources were never registered: no
+/// <c>[StaticRepoImport] Provider</c> on any pod, no <c>provider</c> schema in either database,
+/// while the deployed config plainly listed the partitions. The tester/LocalMesh path goes
+/// through <c>InstallConfiguredModules</c>, which hands it over — exactly why the defect was
+/// portal-specific and invisible to every gate.
+/// </summary>
+public class ConfigurationHandOverTest
+{
+    [Fact]
+    public void ConfigureMemexMesh_HandsTheHostConfigurationToTheBuilder()
+    {
+        var temp = Directory.CreateTempSubdirectory("mw-2507-").FullName;
+        try
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Graph:Storage:Type"] = "FileSystem",
+                    ["Graph:Storage:BasePath"] = temp,
+                })
+                .Build();
+            var services = new ServiceCollection();
+            var builder = new MeshBuilder(configure => configure(services), new Address("mesh", "test"));
+
+            builder.ConfigureMemexMesh(configuration);
+
+            Assert.Same(configuration, builder.Configuration);
+        }
+        finally
+        {
+            try { Directory.Delete(temp, recursive: true); }
+            catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2507 — the Provider partition never materializing on deployed portals, root-caused (issue thread) to the module-fold configuration: `ConfigureMemexMesh` computes the module union and calls `builder.InstallAssemblies(...)` without ever calling `builder.WithConfiguration(configuration)`, so every module attribute folding on a portal reads `builder.Configuration == null`. `AiMeshModuleAttribute.ServeFromPartitions(null)` then answers in-memory serving (the documented absent-key answer) and `AddAiComposition` returns before registering the AI `IStaticRepoSource`s — both halves of what the issue measured on ci.6105 (16 models serving, 0 rows in `model`, no `provider` schema, no `[StaticRepoImport] Provider` line).

The tester/LocalMesh path goes through `InstallConfiguredModules`, which hands the configuration over ("not passing it on was the whole of the gap", per its own comment) — exactly why the defect was portal-specific and invisible to every gate.

## The fix

One unconditional `builder.WithConfiguration(configuration)` in `ConfigureMemexMesh`, before `InstallAssemblies`. Unconditional on purpose: modules are not the only readers, and a null `Configuration` must mean "the deployment supplied nothing", never "the host forgot".

## Test

`ConfigurationHandOverTest` calls the real `ConfigureMemexMesh` with an in-memory configuration and asserts the same instance reaches `builder.Configuration` — red-proven against the unfixed method, green with the fix.

## Notes

- This matters doubly after the registry cutover (Plugins#687): the engine becomes a store module on portals, folding through this same path.
- What's New entry included (Category: Fix — git-governed model management was blocked on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz1i2fFcJhvR1Eje8yFH5F