### PR TITLE
Waiting for disposal is a Subscribe, never a .ToTask() — the #2301 deadlock

### DIFF
--- a/src/MeshWeaver.AI.Orleans.TestBase/SharedOrleansFixture.cs
+++ b/src/MeshWeaver.AI.Orleans.TestBase/SharedOrleansFixture.cs
@@ -189,20 +189,60 @@ public class SharedOrleansFixture : IAsyncLifetime
             catch { /* tearing-down — swallow so other cleanups still run */ }
         }
 
+        // Captured while the hub's scope is still alive — a late fault has to land SOMEWHERE, and
+        // "somewhere" cannot be a service resolved after disposal began (the same rule
+        // MeshTeardownExtensions states for every teardown service).
+        var logger = SafeLogger(reg.Hub);
+
         try { reg.Hub.Dispose(); }
         catch { /* same */ }
         if (reg.Hub.IsDisposing)
         {
-            // Bridge reactive completion → Task at this teardown edge; swallow faults/timeout.
+            // 🚨 SUBSCRIBE; bound the WAIT with a token, never a Timeout spliced into the signal
+            // (#2301/#2488). The old shape — `Catch(…).FirstOrDefaultAsync().ToTask().WaitAsync(10s)`
+            // inside a bare `catch { }` — resumed this cleanup INLINE on the client hub's own
+            // disposal thread (Rx completes a ToTask() TCS without RunContinuationsAsynchronously),
+            // and then discarded three different outcomes as one silence: a disposal fault, a fault
+            // arriving after the bridge settled, and the budget expiring. Cleanup still proceeds on
+            // all three (a test fixture must not hang on a client hub), but it no longer rides a hub
+            // thread to get there, and each outcome is now SAID.
+            using var disposalBudget = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             try
             {
-                await reg.Hub.DisposalCompleted
-                    .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
-                    .FirstOrDefaultAsync()
-                    .ToTask()
-                    .WaitAsync(TimeSpan.FromSeconds(10));
+                await reg.Hub.DisposalCompleted.ObserveCompletion(
+                    ex => logger?.LogError(ex,
+                        "Client hub {Address}: disposal faulted AFTER cleanup stopped waiting on it "
+                        + "— reported rather than orphaned.", reg.Hub.Address),
+                    disposalBudget.Token);
             }
-            catch { /* timeout / already-faulted — don't block teardown */ }
+            catch (OperationCanceledException)
+            {
+                logger?.LogError(
+                    "Client hub {Address}: disposal did not complete within 10s during test cleanup. "
+                    + "Something on its action block is not finishing.", reg.Hub.Address);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Client hub {Address}: disposal FAULTED during test cleanup.",
+                    reg.Hub.Address);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A logger from a hub whose scope may be mid-teardown — resolved defensively so cleanup can
+    /// never fail on the act of preparing to REPORT something.
+    /// </summary>
+    private static ILogger? SafeLogger(IMessageHub hub)
+    {
+        try
+        {
+            return hub.ServiceProvider.GetService<ILoggerFactory>()?
+                .CreateLogger("MeshWeaver.Hosting.Orleans.Test.Cleanup");
+        }
+        catch
+        {
+            return null;
         }
     }
 

--- a/src/MeshWeaver.Connection.Orleans/IoPoolSiloTeardown.cs
+++ b/src/MeshWeaver.Connection.Orleans/IoPoolSiloTeardown.cs
@@ -93,8 +93,33 @@ public sealed class IoPoolSiloTeardown(
 
     // 🚨 NOT `async`, and nothing here awaits. AGENTS.md: everything is IObservable<T> end-to-end —
     // compose and Subscribe, never await. The single Task exists only because ILifecycleObserver
-    // demands one, and it is produced by ONE .ToTask() at the boundary — the sanctioned shape for a
-    // framework surface whose body stays reactive.
+    // demands one, and it is produced by ONE .ToTask() at the boundary.
+    //
+    // 🚨 THAT Task IS GENUINELY REQUIRED, and it was re-verified rather than inherited from the
+    // IMessageHub.DisposalCompleted documentation that turned out to be wrong (#2301). Orleans'
+    // Orleans.ILifecycleObserver declares `Task OnStop(CancellationToken)`; the silo AWAITS what it
+    // returns, and that await IS the guarantee that the silo does not release over live pool
+    // threads. There is no observable-shaped overload to move to.
+    //
+    // 🚨 THE DEADLOCK QUESTION FIRST — "whose thread am I blocking, and does the signal I am
+    // waiting for need it?" Here: NOBODY'S. This method composes and RETURNS; it never awaits, so
+    // no scheduler is held while registry.Disposed is pending. The bridge sits at the OUTERMOST
+    // edge, which is the whole rule: a .ToTask() that is HANDED to the API demanding it is safe,
+    // a .ToTask() that you then `await` in the middle of your own work is how #2301 parked the
+    // grain scheduler its next wait needed. (/async skill, Rule 1a: subscribe, hand back a Task,
+    // do not await inside the turn.)
+    //
+    // The two secondary properties, both checked:
+    //   • every fault is observed BEFORE the bridge — the .Catch below is inside the composition,
+    //     so nothing can fault past .ToTask() into an unobserved task;
+    //   • IoPoolRegistry.Disposed is an AsyncSubject<int>: it fires ONCE and replays. It cannot
+    //     emit a value and then fault, so there is no "late fault after the interesting value"
+    //     for the settled Task to miss. (Where a signal CAN do that — anything composed, merged,
+    //     or polled — use ReactiveCompletion.ObserveCompletion, which keeps its error arm
+    //     attached after the task settles AND completes with RunContinuationsAsynchronously.)
+    //   • the .Timeout is a REPORTED budget on a join, not a silent race: expiry lands in Report(-1)
+    //     as a LogError naming the consequence. It is the weaker class #2488 lists at 4–5, kept
+    //     because a silo that never releases is worse than one that releases loudly.
     //
     // Orleans awaits the returned Task, which is what holds the silo back until the pools report.
     // That is the whole guarantee, and it costs no thread: nothing is parked here, the completion

--- a/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
@@ -250,6 +250,91 @@ var nodePaths = level.NodePaths.ToInlineObservable();
 
 ---
 
+## 🚨 Waiting for a completion signal: `Subscribe`, never `.ToTask()`
+
+Disposal, teardown, a drain report, a grain deactivation — every "wait for X to finish" in the mesh
+is an `IObservable<T>` that fires once and terminates. **Waiting for one means
+`signal.Subscribe(onNext, onError)` and nothing else.** No poll, no `SpinWait`, no
+`.Wait()`/`.Result`, no `Timeout` operator raced against the signal, and no `Task` gate.
+
+### The reason is DEADLOCK, not a lost exception
+
+**These completions are produced BY THE VERY SCHEDULER the waiter is occupying.** A hub's disposal
+finishes when its single-threaded action block drains; a grain's deactivation finishes when its turn
+scheduler is free. Wait on one of those from that same scheduler and the thing you are waiting for
+can never happen — the Task never settles, and the only thing that ever ends the wait is whatever
+timeout was raced against it. This is [Rule 1 of the `/async` skill](/Doc/Architecture/AsynchronousCalls)
+applied to lifecycle signals.
+
+🚨 **You do not have to write the block to get it — Rx hands it to you.** `ToTask()` completes its
+`TaskCompletionSource` from inside the pipeline **without `RunContinuationsAsynchronously`**, so
+`TrySetResult` resumes the awaiter **inline on the signalling thread**. Everything after that
+`await` — the rest of your method — then runs on the hub's disposal thread or the grain's turn
+scheduler. And it is sticky: with no `SynchronizationContext`, `await` captures
+`TaskScheduler.Current`, so **one** inline resumption routes **every later await in that method**
+onto the same scheduler.
+
+That is issue #2301. `OrleansGrainTeardownStragglerTest` resumed inline on the deactivating grain's
+scheduler and then held it, waiting for that grain's activation to leave the silo catalog — which
+needed the scheduler it was holding. It failed at **exactly 30 s**, its `Timeout` budget, every
+time, while a healthy activation leaves the catalog in **0.10 s**. A number that is always the
+budget rather than a distribution around it is the signature of a deadlock, not of contention.
+
+### The lost fault is the second-order effect
+
+When that timeout finally fires it settles the Task, and a fault still travelling the chain has **no
+observer left** — an unobserved exception, surfaced on the finalizer as
+`UnobservedTaskException`, which xUnit v3 escalates into a Catastrophic failure that poisons the
+*next* test class. That is #2301's `HOST_CRASHED` marker: what the deadlock does on its way out.
+
+`IMessageHub.DisposalCompleted`'s own documentation used to recommend the broken bridge (*"at a
+genuine async edge (test teardown, grain deactivation) bridge once with
+`DisposalCompleted.FirstOrDefaultAsync()` / `.ToTask()`"*), which is why four attempted fixes all
+aimed at the timeout. That sentence is gone.
+
+```csharp
+// ❌ WRONG — resumes the caller INLINE on the hub's disposal thread, then holds it; and the
+//    Catch DISCARDS a faulted disposal on top.
+await hub.DisposalCompleted
+    .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
+    .FirstOrDefaultAsync()
+    .ToTask()
+    .WaitAsync(timeout);                                            // …racing what it waits for
+
+// ✅ RIGHT — the turn returns immediately and the follow-on work belongs to the signal. The error
+//    arm is fluent (.Catch) because a fault arrives LATER and on ANOTHER thread: a try/catch
+//    around the Subscribe CALL cannot see it. This is MessageHubGrain.OnDeactivateAsync.
+hub.DisposalCompleted
+    .Take(1)
+    .Catch<Unit, Exception>(ex => { logger.LogError(ex, "… KEEPING its load context"); return Observable.Empty<Unit>(); })
+    .Subscribe(_ => UnloadContextIfSafe(reason, grainId));
+return Task.CompletedTask;
+```
+
+### Where an API genuinely demands a `Task`
+
+`ILifecycleObserver.OnStop`, `IHostedService`, an `async Task` test method. Bridge with
+`ReactiveCompletion.ObserveCompletion`, which subscribes, completes its task with
+`RunContinuationsAsynchronously` — so the caller is **never** resumed on the signalling scheduler —
+and keeps its error arm attached after the task settles. Two rules go with it:
+
+- **Put the bridge at the OUTERMOST edge.** Return the Task to whoever demanded it; never wrap it
+  around a wait whose completion needs the thread you are holding. `IoPoolSiloTeardown.OnStop` is
+  the reference: it composes and **returns**, blocking nothing.
+- **The bound belongs to the edge, not to the signal.** `[Fact(Timeout = …)]`, a host's shutdown
+  token, a `CancellationToken` — never a `Timeout` operator spliced into the wait, which settles the
+  waiter while the work it bounded is still in flight.
+- **A poll is the same defect wearing a loop.** If you are sampling state on an interval because
+  there is no completion signal to subscribe to, publish the signal. #2301's test polled
+  `IManagementGrain.GetDetailedGrainStatistics()` every 100 ms against a 30 s `Timeout` because
+  nothing exposed "this activation is fully gone"; the fix was `GrainDeactivationCompleted`, which
+  the grain publishes from Orleans' own `IGrainContext.Deactivated`.
+
+Both properties are pinned by `DisposalWaitBridgeTest` (test/MeshWeaver.Messaging.Hub.Test), whose
+control test asserts that `.ToTask()` really does resume inline on the signalling thread.
+
+Related: issue #2488 catalogues the remaining poll / timeout-escape sites.
+
 ## 🚨 Cold observables: Subscribe is mandatory
 
 Every method that performs a write or side effect returns a cold `IObservable<T>` — **the side effect runs on `Subscribe`, not on call.** Forgetting to subscribe means the work silently never happens.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-teardown-reports-its-faults.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-teardown-reports-its-faults.md
@@ -1,0 +1,23 @@
+---
+Name: Shutdown says what went wrong
+Category: Fix
+Description: A fault while a mesh shuts down is now reported instead of being silently discarded.
+Icon: Sparkle
+Order: -20260827
+---
+
+# Shutdown says what went wrong
+
+When a mesh shuts down, the code that waits for it to finish used to convert the wait into a
+one-shot handle that could only ever report one thing. Anything that went wrong after that
+handle had already settled — a hub whose teardown failed a moment later, a background job that
+faulted on its way to idle — reached nobody at all: no log line, no error, nothing to search for
+afterwards.
+
+Every one of those waits now stays subscribed for as long as the shutdown can still say
+something, so a late failure is written to the log with the address it came from. The shutdown
+report also carries two facts it previously threw away: whether the shutdown itself faulted, and
+whether running activities actually finished before the mesh was torn down.
+
+Nothing about a healthy shutdown changes. What changes is that an unhealthy one is now visible
+instead of looking identical to a clean one.

--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1613,36 +1613,72 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     }
 
     /// <summary>
-    /// Awaits <see cref="IMessageHub.DisposalCompleted"/> with periodic progress snapshots.
+    /// Waits for <see cref="IMessageHub.DisposalCompleted"/> with periodic progress snapshots.
     /// Every <see cref="DisposeProgressInterval"/>, dumps
     /// <see cref="IMessageHub.GetDisposalDiagnostics"/> to <see cref="MeshWeaver.Fixture.TestBase.FileOutput"/>
     /// so a hang shows up as a stream of snapshots converging on the offending hub
     /// — instead of one big snapshot at the timeout.
+    ///
+    /// <para>🚨 <b>Both halves are SUBSCRIPTIONS now (#2301, #2488 site 3).</b> This used to bridge
+    /// the reactive signal to a Task with <c>Catch(…).FirstOrDefaultAsync().ToTask()</c> and then
+    /// POLL that Task in a <c>while (!disposal.IsCompleted)</c> loop — the canonical
+    /// "wait for disposal" every test in the suite runs, so it shaped what teardown failures look
+    /// like everywhere.</para>
+    ///
+    /// <para>The first defect was DEADLOCK, not the discarded fault. Rx completes a
+    /// <c>ToTask()</c> <c>TaskCompletionSource</c> from inside the pipeline WITHOUT
+    /// <c>RunContinuationsAsynchronously</c>, so <c>DisposeAsync</c> resumed INLINE on the thread
+    /// that signalled disposal — the mesh hub's own — and then ran the rest of teardown there,
+    /// including <c>ioPools.DrainAll()</c>, a SYNCHRONOUS JOIN of every pooled I/O leaf. The
+    /// second was that the <c>Catch</c> discarded a disposal fault outright, and the Task could
+    /// observe nothing once it settled. The progress ticker is now an <c>Observable.Interval</c>
+    /// that stops on the signal's own terminal, and the wait is one <c>Subscribe</c> whose task
+    /// completes asynchronously, with an error arm.</para>
     /// </summary>
     private async Task WaitWithProgressAsync(string testName, Stopwatch sw, CancellationToken ct)
     {
-        // Bridge the reactive completion to a Task once, at this test-teardown edge. Catch folds
-        // a disposal fault into completion (teardown only waits for "done", not why).
-        var disposal = Mesh.DisposalCompleted
-            .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
-            .FirstOrDefaultAsync()
-            .ToTask();
-        while (!disposal.IsCompleted)
+        var disposal = Mesh.DisposalCompleted;
+
+        // Progress ticker: stops on the signal's terminal, whatever it is. Materialize() so a
+        // FAULTED disposal ends the ticker as data rather than pushing an error into a
+        // subscription that has no arm for it.
+        using var progress = Observable.Interval(DisposeProgressInterval)
+            .TakeUntil(disposal.Materialize())
+            .Subscribe(
+                _ =>
+                {
+                    FileOutput.WriteLine(
+                        $"[DISPOSE] {testName}: still waiting after {sw.ElapsedMilliseconds}ms — snapshot:");
+                    FileOutput.WriteLine(SafeGetDiagnostics());
+                },
+                ex => FileOutput.WriteLine(
+                    $"[DISPOSE] {testName}: progress ticker faulted: {ex.GetType().Name}: {ex.Message}"));
+
+        try
         {
-            using var progressCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            progressCts.CancelAfter(DisposeProgressInterval);
-            try
-            {
-                await disposal.WaitAsync(progressCts.Token);
-                return; // disposal completed
-            }
-            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-            {
-                // Progress tick fired before disposal completed — log a snapshot and loop.
-                FileOutput.WriteLine(
-                    $"[DISPOSE] {testName}: still waiting after {sw.ElapsedMilliseconds}ms — snapshot:");
-                FileOutput.WriteLine(SafeGetDiagnostics());
-            }
+            await disposal.ObserveCompletion(
+                ex => FileOutput.WriteLine(
+                    $"[DISPOSE] {testName}: disposal faulted AFTER the wait settled — reported, "
+                    + $"not orphaned: {ex.GetType().Name}: {ex.Message}"),
+                ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // The hang path — unchanged. DisposeAsync turns this into a loud TimeoutException
+            // carrying the hub diagnostics.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A disposal FAULT arriving as the answer. Teardown still waits for "done", not "why"
+            // — but the fault is now REPORTED into the per-test output and the phase trace instead
+            // of being discarded by a .Catch nobody could see. (Whether it should also FAIL the
+            // class is an escalation decision of its own; see TeardownReport.DisposalFault.)
+            FileOutput.WriteLine(
+                $"[DISPOSE] {testName}: disposal FAULTED after {sw.ElapsedMilliseconds}ms: "
+                + $"{ex.GetType().Name}: {ex.Message}");
+            TestPhaseTrace(testName, "DISPOSE_FAULTED", sw.ElapsedMilliseconds,
+                $"{ex.GetType().Name}: {ex.Message}");
         }
     }
 

--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -95,6 +95,16 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
     private IDisposable? _activationSubscription;
 
     /// <summary>
+    /// The activation's own "I am completely gone" signal, handed to hub code as
+    /// <see cref="GrainDeactivationCompleted"/> so anything that has to wait for THIS activation to
+    /// die can <c>Subscribe</c> to it instead of sampling the silo catalog on an interval.
+    /// <see cref="AsyncSubject{T}"/> is the exact shape wanted: it fires once, at the end, and
+    /// replays that terminal to every later subscriber — a waiter that attaches after the
+    /// deactivation already finished is answered immediately rather than parking forever.
+    /// </summary>
+    private readonly AsyncSubject<Unit> _deactivationCompleted = new();
+
+    /// <summary>
     /// Set at the START of <see cref="OnDeactivateAsync"/>. Grain-lifetime calls arriving
     /// after this point (see <see cref="TryDeactivateOnIdle"/> / <see cref="TryDelayDeactivation"/>)
     /// are graceful no-ops: reactive continuations — an activation-source emission racing
@@ -185,6 +195,38 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         var address = meshHub.GetAddress(streamId);
         var addressPath = address.ToString();
         var grainScheduler = TaskScheduler.Current;
+
+        // Arm the deactivation-completed signal FIRST, before anything can request deactivation.
+        // GrainContext.Deactivated is Orleans' own completion source for this activation: in
+        // 10.2.2 ActivationData.FinishDeactivating sets it on its LAST line — after
+        // OnDeactivateAsync, after the lifecycle OnStop, after GrainLocator.Unregister, after
+        // UnregisterMessageTarget() has removed the activation from the silo catalog and after
+        // DisposeAsync() has put it in State=Invalid. So "this signal fired" means exactly
+        // "the activation is gone", which is what the catalog poll in OrleansGrainTeardownStragglerTest
+        // was approximating on a 100 ms interval against a 30 s Timeout (#2301).
+        //
+        // The error arm is not decoration: that completion source is only ever
+        // TrySetResult today, but a bridge whose fault has nowhere to go is the defect this whole
+        // change removes, so it gets one on principle and the subject carries the fault to
+        // whoever is waiting.
+        // 🚨 The subscription is deliberately NOT stored and NOT disposed. It must outlive
+        // OnDeactivateAsync — the signal it carries fires strictly AFTER that callback returns —
+        // so a field to dispose would only be an invitation to kill the signal on the way out.
+        // Nothing leaks: Orleans' completion source roots the continuation and dies with the
+        // activation, and the subscription releases itself on that terminal.
+        //
+        // This is the ONE bridge between Orleans' Task-shaped runtime signal and the mesh's
+        // reactive world, and it runs in the sanctioned DIRECTION: a Task SOURCE becomes an
+        // observable once, with an error arm, so every mesh-side waiter can Subscribe. (The
+        // forbidden direction is the other one — an observable bridged to a Task with .ToTask(),
+        // which settles once and can no longer observe anything; issue #2301.)
+        _ = GrainContext.Deactivated.ToObservable().Subscribe(
+            _ =>
+            {
+                _deactivationCompleted.OnNext(Unit.Default);
+                _deactivationCompleted.OnCompleted();
+            },
+            ex => _deactivationCompleted.OnError(ex));
 
         // Keep-alive timer — independent of node resolution, no-op until the hub
         // starts processing long-running work.
@@ -510,6 +552,11 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                     .WithTaskScheduler(grainScheduler)
                     .Set(new GrainKeepAliveCallback(() => TryDelayDeactivation(TimeSpan.FromMinutes(10))))
                     .Set(new GrainLongRunningOperationCallback(BeginLongRunningOperation))
+                    // The completion counterpart to the three callbacks around it: they are what a
+                    // straggler DOES to this activation, this is what the activation TELLS anyone
+                    // waiting for it to be gone. Subscribing to it is the alternative to polling
+                    // the silo catalog — see GrainDeactivationCompleted and #2301/#2488.
+                    .Set(new GrainDeactivationCompleted(_deactivationCompleted.AsObservable()))
                     // #147 escape hatch: the hub's action block runs on THIS grain's
                     // ActivationTaskScheduler (WithTaskScheduler above), so when a stuck round
                     // wedges that scheduler, any rescue that is itself a hub message can never be

--- a/src/MeshWeaver.Mesh.Contract/MeshTeardownExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshTeardownExtensions.cs
@@ -1,9 +1,7 @@
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Mesh;
 
@@ -57,6 +55,7 @@ public static class MeshTeardownExtensions
         var asyncDisposeQueue = mesh.ServiceProvider.GetService<AsyncDisposeQueue>();
         var activities = mesh.ServiceProvider.GetService<ActivityTracker>();
         var teardownSignal = mesh.ServiceProvider.GetService<MeshTeardownSignal>();
+        var logger = TeardownLogger(mesh);
 
         // (0) QUIESCE ACTIVITIES FIRST — before anything is disposed.
         //
@@ -70,14 +69,45 @@ public static class MeshTeardownExtensions
         // status. It must run BEFORE Dispose because those Append/Finish writes go back through
         // hubs that are still alive. Bounded, so a run that never settles surfaces as a timeout
         // rather than hanging teardown forever.
+        //
+        // 🚨 SUBSCRIBED, not bridged, and BOUNDED BY A TOKEN rather than by a Timeout spliced into
+        // the signal (#2301/#2488). The old shape was
+        // `WhenIdle.Timeout(timeout).Catch(_ => Observable.Return(Unit.Default)).ToTask()`, which
+        // is wrong three ways. (1) DEADLOCK: Rx completes a ToTask() TCS inline, so this method
+        // resumed on whichever hub thread signalled idle — and the very next statement is
+        // `mesh.Dispose()`, driven from that same thread. (2) The Catch folds "the budget expired
+        // with a run still writing" into a value indistinguishable from "idle". (3) Once the Task
+        // settles it can observe nothing, so a fault arriving afterwards has nowhere to go.
+        // ObserveCompletion completes with RunContinuationsAsynchronously (no hub thread carries
+        // us onward), cancelling the WAIT leaves the observation attached (a late fault is still
+        // reported), and the expiry is DATA now (ActivitiesQuiesced on the report), not a silence.
+        var activitiesQuiesced = true;
         if (activities is not null)
-            await activities.WhenIdle.Timeout(timeout)
-                .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
-                .ToTask();
+        {
+            using var quiesceBudget = new CancellationTokenSource(timeout);
+            try
+            {
+                await activities.WhenIdle.ObserveCompletion(
+                    ex => logger?.LogError(ex,
+                        "Mesh {Address}: the activity quiesce signal faulted AFTER teardown stopped "
+                        + "waiting on it. Reported rather than orphaned; investigate the activity that "
+                        + "faulted on its way to idle.", mesh.Address),
+                    quiesceBudget.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                activitiesQuiesced = false;
+                logger?.LogError(
+                    "Mesh {Address}: activities did not reach idle within {Timeout} — teardown is "
+                    + "proceeding over a run that is still writing. Find the activity that will not "
+                    + "settle; do not widen the budget.", mesh.Address, timeout);
+            }
+        }
 
         mesh.Dispose();
 
-        return await mesh.WaitForDisposalAndIoDrainAsync(ioPools, asyncDisposeQueue, timeout, teardownSignal);
+        return await DrainAsync(
+            mesh, ioPools, asyncDisposeQueue, timeout, teardownSignal, activitiesQuiesced);
     }
 
     /// <summary>
@@ -106,16 +136,77 @@ public static class MeshTeardownExtensions
     /// surface a dirty report (fail the test class, error-log the shutdown) — proceeding
     /// silently over live work is the use-after-unload SIGSEGV.
     /// </returns>
-    public static async Task<TeardownReport> WaitForDisposalAndIoDrainAsync(
+    /// <param name="mesh">The mesh root hub whose disposal is being awaited.</param>
+    /// <param name="ioPools">The <see cref="IoPoolRegistry"/> captured BEFORE disposal began.</param>
+    /// <param name="asyncDisposeQueue">The <see cref="AsyncDisposeQueue"/> captured BEFORE disposal began.</param>
+    /// <param name="timeout">Budget for each wait; an expiry surfaces as a
+    /// <see cref="TimeoutException"/> (phase 1) or on the report, never as silence.</param>
+    /// <param name="teardownSignal">Fired with the returned report, when supplied.</param>
+    public static Task<TeardownReport> WaitForDisposalAndIoDrainAsync(
         this IMessageHub mesh, IoPoolRegistry? ioPools, AsyncDisposeQueue? asyncDisposeQueue,
-        TimeSpan timeout, MeshTeardownSignal? teardownSignal = null)
+        TimeSpan timeout, MeshTeardownSignal? teardownSignal = null) =>
+        DrainAsync(mesh, ioPools, asyncDisposeQueue, timeout, teardownSignal, activitiesQuiesced: true);
+
+    // 🚨 The public signature above is UNCHANGED on purpose. Threading the quiesce outcome through
+    // as an extra optional parameter would have been source-compatible and BINARY-BREAKING — a
+    // module compiled against the five-parameter method binds that exact signature and would fail
+    // with MissingMethodException, which no source build in this repo can see (memory:
+    // "A source build cannot see a BINARY break").
+    private static async Task<TeardownReport> DrainAsync(
+        IMessageHub mesh, IoPoolRegistry? ioPools, AsyncDisposeQueue? asyncDisposeQueue,
+        TimeSpan timeout, MeshTeardownSignal? teardownSignal, bool activitiesQuiesced)
     {
+        var logger = TeardownLogger(mesh);
+
         // (1) Action blocks + message round-trips.
-        await mesh.DisposalCompleted
-            .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
-            .FirstOrDefaultAsync()
-            .ToTask()
-            .WaitAsync(timeout);
+        //
+        // 🚨 SUBSCRIBED, never bridged with `.ToTask()` — and the FIRST reason is deadlock, not
+        // fault observation. The previous shape was
+        // `Catch(_ => Return(Unit)).FirstOrDefaultAsync().ToTask().WaitAsync(timeout)`, and Rx
+        // completes a ToTask() TCS from inside the pipeline WITHOUT
+        // RunContinuationsAsynchronously — so this method resumed INLINE on the thread that
+        // signalled disposal, i.e. the mesh hub's own disposal thread. Everything below then ran
+        // there, including `ioPools.DrainAll()`, which is a SYNCHRONOUS JOIN of every pooled I/O
+        // leaf: the hub's own thread, parked, waiting for work that may need the hub. That is the
+        // /async skill's Rule 1 in the teardown path. ObserveCompletion completes with
+        // RunContinuationsAsynchronously, so phases (2)–(4) below can never run on a hub thread.
+        //
+        // The second reason is the one #2488 lists: the `Catch` turned a FAULTED disposal into an
+        // indistinguishable success, and once the Task settled nothing was left to observe a fault
+        // arriving afterwards. Now the fault is the answer when it comes first (recorded on the
+        // report and logged), and is still REPORTED when it comes late, because the subscription
+        // outlives the wait.
+        Exception? disposalFault = null;
+        using (var disposalBudget = new CancellationTokenSource(timeout))
+        {
+            try
+            {
+                await mesh.DisposalCompleted.ObserveCompletion(
+                    ex => logger?.LogError(ex,
+                        "Mesh {Address}: disposal faulted AFTER teardown stopped waiting on it. "
+                        + "Reported rather than orphaned — an unobserved fault here is the "
+                        + "UnobservedTaskException that poisons the next test class (#2301).",
+                        mesh.Address),
+                    disposalBudget.Token);
+            }
+            catch (OperationCanceledException) when (disposalBudget.IsCancellationRequested)
+            {
+                // Preserve the shape callers already branch on: HubTestBase and MonolithMeshTestBase
+                // both treat a TimeoutException here as HANG DETECTED and dump hub diagnostics.
+                throw new TimeoutException(
+                    $"Mesh {mesh.Address}: disposal did not complete within {timeout}. "
+                    + "Something on the action block is not finishing — find it; do not widen the budget.");
+            }
+            catch (Exception ex)
+            {
+                // A disposal FAULT, which the old .Catch silently rendered as success. Carried on
+                // the report and logged; see TeardownReport.DisposalFault for why it does not (yet)
+                // flip Clean.
+                disposalFault = ex;
+                logger?.LogError(ex, "Mesh {Address}: disposal FAULTED — teardown continues, but the "
+                    + "fault is now on the teardown report instead of being discarded.", mesh.Address);
+            }
+        }
 
         // (2) Offloaded ThreadPool I/O — the half DisposalCompleted does not cover. CANCEL + JOIN
         //     synchronously: a live change-feed leaf never completes on its own, so the old
@@ -134,8 +225,21 @@ public static class MeshTeardownExtensions
         //     the drains so a subscriber that proceeds on it (scope disposal, ALC unload, next
         //     test's mesh) never runs concurrently with surviving teardown work — and the report
         //     tells it when that guarantee could NOT be kept.
-        var report = new TeardownReport(leakedIoLeaves, asyncDisposeClean);
+        var report = new TeardownReport(leakedIoLeaves, asyncDisposeClean)
+        {
+            DisposalFault = disposalFault,
+            ActivitiesQuiesced = activitiesQuiesced
+        };
         teardownSignal?.SignalCompleted(report);
         return report;
     }
+
+    /// <summary>
+    /// The logger teardown reports through — resolved WHILE THE SCOPE IS STILL ALIVE, exactly like
+    /// every other teardown service here, and null-tolerant so a mesh without logging still tears
+    /// down. It is what makes a late fault REPORTED rather than swallowed: the observation arm has
+    /// to land somewhere, and "somewhere" cannot be a service resolved after disposal began.
+    /// </summary>
+    private static ILogger? TeardownLogger(IMessageHub mesh) =>
+        mesh.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Mesh.Teardown");
 }

--- a/src/MeshWeaver.Mesh.Contract/Threading/MeshTeardownSignal.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/MeshTeardownSignal.cs
@@ -19,15 +19,44 @@ namespace MeshWeaver.Mesh.Threading;
 /// ran (or unwound after cancellation) within its quiesce budget.</param>
 public sealed record TeardownReport(int LeakedIoLeaves, bool AsyncDisposeClean)
 {
+    /// <summary>
+    /// The exception the hub's <c>DisposalCompleted</c> reported instead of a completion, or
+    /// <c>null</c> when disposal finished normally.
+    ///
+    /// <para>🚨 This used to be DISCARDED. The wait was
+    /// <c>DisposalCompleted.Catch(_ =&gt; Observable.Return(Unit.Default))</c>, which turns a
+    /// faulted disposal into an indistinguishable success — issue #2488 lists it as one of the
+    /// swallow-and-continue sites. It is now OBSERVED and carried here, and logged at Error by the
+    /// orchestrator. It deliberately does NOT (yet) affect <see cref="Clean"/>: whether a faulted
+    /// disposal should FAIL a test class or a host shutdown is an escalation decision of its own,
+    /// separate from the observation defect this record's population fixes.</para>
+    /// </summary>
+    public Exception? DisposalFault { get; init; }
+
+    /// <summary>
+    /// Whether the pre-dispose activity quiesce reached idle within its budget. <c>false</c> means
+    /// a run was still writing when teardown proceeded — previously indistinguishable from idle,
+    /// because the timeout was folded into a successful completion (#2488, site 2).
+    /// </summary>
+    public bool ActivitiesQuiesced { get; init; } = true;
+
     /// <summary>True iff nothing survived teardown — the scope may be disposed and node ALCs
     /// unloaded with no thread still executing their code.</summary>
     public bool Clean => LeakedIoLeaves == 0 && AsyncDisposeClean;
 
     /// <summary>One-line summary for logs and failure messages.</summary>
-    public override string ToString() => Clean
-        ? "teardown clean — all pooled I/O joined, async dispose queue drained"
-        : $"teardown DIRTY — {LeakedIoLeaves} pooled I/O leaf(s) still running, "
-          + $"async dispose queue {(AsyncDisposeClean ? "drained" : "still running")}";
+    public override string ToString()
+    {
+        var notes = string.Empty;
+        if (!ActivitiesQuiesced)
+            notes += "; activities did NOT quiesce within budget";
+        if (DisposalFault is not null)
+            notes += $"; disposal FAULTED: {DisposalFault.GetType().Name}: {DisposalFault.Message}";
+        return (Clean
+            ? "teardown clean — all pooled I/O joined, async dispose queue drained"
+            : $"teardown DIRTY — {LeakedIoLeaves} pooled I/O leaf(s) still running, "
+              + $"async dispose queue {(AsyncDisposeClean ? "drained" : "still running")}") + notes;
+    }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Messaging.Hub/GrainDeactivationCompleted.cs
+++ b/src/MeshWeaver.Messaging.Hub/GrainDeactivationCompleted.cs
@@ -1,0 +1,35 @@
+using System.Reactive;
+
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// The hosting activation's own "I am completely gone" signal, registered on the hub
+/// configuration by the Orleans grain during activation alongside
+/// <see cref="GrainKeepAliveCallback"/>, <see cref="GrainLongRunningOperationCallback"/> and
+/// <see cref="GrainDeactivateCallback"/>. Those three are things a straggler DOES to the
+/// activation; this is the one thing the activation TELLS anyone waiting on it.
+///
+/// <para><see cref="Deactivated"/> fires <see cref="Unit"/> exactly once — and replays that
+/// terminal to every later subscriber — when the activation has FULLY deactivated: Orleans has
+/// run <c>OnDeactivateAsync</c>, stopped the grain lifecycle, unregistered the directory entry,
+/// removed the activation from the silo catalog (<c>UnregisterMessageTarget</c>) and disposed it
+/// (<c>State = Invalid</c>). In Orleans 10.2.2 that is precisely
+/// <c>IGrainContext.Deactivated</c>, whose completion source is set on the last line of
+/// <c>ActivationData.FinishDeactivating</c>, strictly after the catalog removal.</para>
+///
+/// <para>🚨 <b>Why this exists.</b> Nothing outside the silo could observe the END of a
+/// deactivation, so anything that needed to wait for one SAMPLED the silo catalog on an interval
+/// and raced a <c>Timeout</c> against it — the shape AGENTS.md and issue #2488 forbid, and the
+/// direct cause of the recurring teardown crash in #2301: the timeout settled the waiting task
+/// while a fresh batch of catalog queries was still in flight against a silo mid-teardown, and
+/// each of those could then fault into nothing. A poll exists because a signal does not; this is
+/// the signal.</para>
+///
+/// <para>In monolith mode no value is set — there is no activation to deactivate, so callers
+/// treat the absence as "not grain-hosted" exactly as they do for the three callbacks above.</para>
+/// </summary>
+/// <param name="Deactivated">Fires <see cref="Unit"/> once and completes when the hosting
+/// activation is fully gone; replays to late subscribers. Subscribe with an error arm — never
+/// bridge it to a <see cref="System.Threading.Tasks.Task"/> except through
+/// <see cref="ReactiveCompletion.ObserveCompletion{T}"/> at a genuine async edge.</param>
+public record GrainDeactivationCompleted(IObservable<Unit> Deactivated);

--- a/src/MeshWeaver.Messaging.Hub/IMessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/IMessageHub.cs
@@ -268,8 +268,52 @@ public interface IMessageHub : IMessageHandlerRegistry, IDisposable
     /// SYNCHRONOUSLY (only the mesh-level IO pools drain async), so disposal completion is
     /// OBSERVED, never awaited on a hub thread. There is no <see cref="Task"/> on the disposal
     /// surface. A subscriber that attaches after disposal has already finished still receives
-    /// the completion immediately. At a genuine async edge (test teardown, grain deactivation)
-    /// bridge once with <c>DisposalCompleted.FirstOrDefaultAsync()</c> / <c>.ToTask()</c>.
+    /// the completion immediately.
+    ///
+    /// <para><b>Waiting for it means one thing: <c>Subscribe(onNext, onError)</c>.</b> The
+    /// continuation lives in the subscription. No poll, no <c>SpinWait</c>, no
+    /// <c>.Wait()</c>/<c>.Result</c>, no <c>Timeout</c> raced against the disposal, and no
+    /// <c>Task</c> gate. <c>MessageHubGrain.OnDeactivateAsync</c> is the reference shape: it
+    /// subscribes, handles the fault arm FLUENTLY with <c>.Catch</c> (a fault travels the stream
+    /// later and on another thread, so a <c>try</c>/<c>catch</c> wrapped around the
+    /// <c>Subscribe</c> CALL cannot see it), and does its follow-on work in the callback.</para>
+    ///
+    /// <para>🚨 <b>Do NOT bridge with <c>FirstOrDefaultAsync()</c> / <c>.ToTask()</c>. This
+    /// documentation used to prescribe exactly that "at a genuine async edge (test teardown, grain
+    /// deactivation)", and it was wrong in the place it mattered most</b> — those two edges are
+    /// where issue #2301 crashed four times, and every attempted fix aimed at the timeout because
+    /// this sentence said the bridge was correct.</para>
+    ///
+    /// <para><b>The reason is DEADLOCK, not a lost exception.</b> A hub's disposal completes when
+    /// its single-threaded action block finishes draining; a grain's deactivation completes when
+    /// its turn scheduler is free. Wait on one of those from that same scheduler and the thing you
+    /// are waiting for can never happen. The trap is that you do not have to write a block to get
+    /// one: Rx's <c>ToTask()</c> completes its <c>TaskCompletionSource</c> from inside the pipeline
+    /// WITHOUT <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/>, so the awaiter
+    /// resumes INLINE on the signalling thread — and everything after that <c>await</c> then runs
+    /// on the hub's disposal thread or the grain's turn. It is sticky: with no
+    /// <see cref="System.Threading.SynchronizationContext"/>, <c>await</c> captures
+    /// <see cref="TaskScheduler"/>.<see cref="TaskScheduler.Current"/>, so ONE inline resumption
+    /// routes every later await in that method onto the same scheduler. #2301 failed at exactly
+    /// 30 s — its <c>Timeout</c> budget — every time, while a healthy activation leaves the catalog
+    /// in 0.10 s; a number that is always the budget rather than a distribution around it is the
+    /// signature of a deadlock, not of contention.</para>
+    ///
+    /// <para>The unobserved fault is the SECOND-ORDER effect, and it is what turns the deadlock
+    /// into a crash: when the timeout finally settles the Task, a fault still travelling the
+    /// observable has NO OBSERVER, becomes an unobserved exception, surfaces on the finalizer as
+    /// <see cref="TaskScheduler.UnobservedTaskException"/>, and xUnit v3 escalates that to a
+    /// Catastrophic failure that poisons the NEXT test class (#2301's <c>HOST_CRASHED</c> marker).
+    /// <c>Subscribe(onNext, onError)</c> neither blocks nor loses the fault; <c>.ToTask()</c> does
+    /// both.</para>
+    ///
+    /// <para>Where an API genuinely demands a <see cref="Task"/> — an <c>ILifecycleObserver.OnStop</c>,
+    /// an <c>IHostedService</c>, an <c>async Task</c> test method — the bridge is
+    /// <c>ReactiveCompletion.ObserveCompletion</c>, which subscribes, completes its task with
+    /// <c>RunContinuationsAsynchronously</c> (so the caller is never resumed on the signalling
+    /// scheduler) and keeps its error arm attached after the task settles. Put that bridge at the
+    /// OUTERMOST edge — return the Task, never wrap it around a wait whose completion needs the
+    /// thread being held. See the <c>/async</c> skill (Rule 1a) and issues #2301, #2488.</para>
     /// </summary>
     IObservable<Unit> DisposalCompleted { get; }
     /// <summary>The hub's type registry, mapping message type names to CLR types for (de)serialization and routing.</summary>

--- a/src/MeshWeaver.Messaging.Hub/ReactiveCompletion.cs
+++ b/src/MeshWeaver.Messaging.Hub/ReactiveCompletion.cs
@@ -1,0 +1,148 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// The ONE sanctioned bridge from a reactive completion signal — a hub's
+/// <see cref="IMessageHub.DisposalCompleted"/>, a drain report, a grain's deactivation — to a
+/// <see cref="Task"/>, for the signatures that are not ours to change (an
+/// <c>ILifecycleObserver.OnStop</c>, an <c>IHostedService</c>, an <c>async Task</c> test method).
+/// Everywhere else, waiting means <c>signal.Subscribe(onNext, onError)</c> and nothing else —
+/// see the <c>/async</c> skill, Rule 1 and Rule 1a.
+///
+/// <para>🚨 <b>Why <c>.ToTask()</c> is dangerous: it DEADLOCKS. That is the primary failure, not a
+/// lost exception.</b> `await`ing a completion parks the awaiting flow until the observable
+/// produces — and mesh completions are produced BY THE VERY SCHEDULER the awaiting flow is
+/// occupying. A hub's disposal finishes when its single-threaded action block drains; a grain's
+/// deactivation finishes when its turn scheduler is free. Wait on one of those from that same
+/// scheduler and the thing you are waiting for can never happen: the Task never settles, and the
+/// only thing that ever ends the wait is whatever timeout was raced against it.</para>
+///
+/// <para><b>The trap is that you do not have to WRITE the block to get it</b> — Rx hands it to
+/// you. <c>ToTask()</c> completes its <c>TaskCompletionSource</c> from INSIDE the Rx pipeline,
+/// without <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/>, so
+/// <c>TrySetResult</c> resumes the awaiter INLINE on the signalling thread. Everything after that
+/// <c>await</c> — the rest of the method — then runs on the hub's disposal thread or the grain's
+/// turn scheduler. Worse, it is sticky: <c>await</c> captures
+/// <see cref="TaskScheduler"/>.<see cref="TaskScheduler.Current"/> when there is no
+/// <see cref="System.Threading.SynchronizationContext"/>, so once one continuation lands on that
+/// scheduler, EVERY later await in the same method schedules onto it too. That is issue #2301:
+/// <c>OrleansGrainTeardownStragglerTest</c> resumed inline on the deactivating grain's scheduler
+/// and then held it, waiting for that grain's activation to leave the catalog — which needed the
+/// scheduler it was holding. It failed at exactly 30 s, its <c>Timeout</c> budget, every time; a
+/// healthy activation leaves the catalog in 0.10 s, and a number that is always the budget rather
+/// than a distribution around it is the signature of a deadlock, not of contention.</para>
+///
+/// <para><b>The unobserved-fault problem is real but SECONDARY.</b> When the timeout finally fires
+/// it settles the Task, and anything still travelling the chain has no observer left — an
+/// unobserved exception, surfaced on the finalizer as
+/// <see cref="TaskScheduler.UnobservedTaskException"/>, which xUnit v3 escalates to a Catastrophic
+/// failure that poisons the NEXT test class (the <c>HOST_CRASHED</c> marker on #2301). It is what
+/// the deadlock does on its way out.</para>
+///
+/// <para><b>What this method guarantees.</b> It never blocks and it never resumes its caller on the
+/// signalling thread: the wait is a <c>Subscribe</c>, and the task is completed through a
+/// <see cref="TaskCompletionSource{TResult}"/> created with
+/// <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/> — which is load-bearing, not
+/// tidiness. It is the line that stops the caller's continuation from running on the hub or grain
+/// scheduler that signalled, and therefore the line that stops the deadlock. Additionally, the
+/// subscription is NOT torn down when the task settles, so a fault arriving afterwards still has
+/// an error arm to reach.</para>
+///
+/// <para>🚨 <b>What this is NOT.</b> Not a general-purpose <c>FirstAsync</c>, and not for a hot
+/// stream that never terminates (the subscription would live forever by design). It is for
+/// COMPLETION SIGNALS: sources that fire once and then complete or fault — the contract every
+/// signal named above already has.</para>
+///
+/// <para><b>And no <c>Timeout</c>.</b> A bound composed INTO the wait races the thing being waited
+/// for and settles the waiter while that work is still in flight. A caller that needs a wall-clock
+/// bound takes one from the edge it already lives at — xUnit's <c>[Fact(Timeout = …)]</c>, a host's
+/// shutdown token, a <see cref="CancellationToken"/> passed here. A wait that does not finish is a
+/// wedge to find (AGENTS.md: no band-aids), not a budget to spend.</para>
+/// </summary>
+public static class ReactiveCompletion
+{
+    /// <summary>
+    /// Subscribes to <paramref name="source"/> with an error arm and returns a <see cref="Task"/>
+    /// that settles on its FIRST notification — the value, its completion, or its fault — WITHOUT
+    /// blocking and WITHOUT resuming the caller on the thread that signalled.
+    ///
+    /// <para>The subscription outlives the returned task on purpose: a fault arriving after the
+    /// task has settled is reported to <paramref name="reportLateFault"/> rather than becoming an
+    /// unobserved exception.</para>
+    /// </summary>
+    /// <typeparam name="T">The signal's payload type (typically <see cref="System.Reactive.Unit"/>).</typeparam>
+    /// <param name="source">The completion signal. Must terminate (complete or fault) — see the
+    /// type remarks; pointing this at a never-ending stream leaks the subscription.</param>
+    /// <param name="reportLateFault">Receives a fault that arrives AFTER the task settled — the
+    /// case a <see cref="Task"/> cannot represent. Log it, write it to test output, fail the
+    /// class: anything except discarding it. Never <c>null</c>, and never an empty lambda: an
+    /// ignored late fault is half of what this method exists to remove.</param>
+    /// <param name="cancellationToken">Cancels the WAIT, not the source. The error arm stays
+    /// attached afterwards, so a fault that lands after cancellation is still reported.</param>
+    /// <returns>The first value, or <c>default</c> if the source completed without one.</returns>
+    public static Task<T?> ObserveCompletion<T>(
+        this IObservable<T> source,
+        Action<Exception> reportLateFault,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(reportLateFault);
+
+        // 🚨 RunContinuationsAsynchronously IS THE DEADLOCK FIX. Without it — which is exactly
+        // what Rx's own ToTask() does — TrySetResult below resumes the awaiting caller INLINE on
+        // whichever thread signalled: the hub's disposal thread, the grain's turn scheduler. The
+        // caller then does the rest of its work there, holding a scheduler that the work it is
+        // about to wait for needs. With it, the continuation is queued instead, and the signalling
+        // thread returns to its own business immediately. Pinned by
+        // DisposalWaitBridgeTest.ObserveCompletion_NeverResumesItsCallerOnTheSignallingThread.
+        var completion = new TaskCompletionSource<T?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        if (cancellationToken.CanBeCanceled)
+        {
+            var registration = cancellationToken.Register(
+                static state => ((TaskCompletionSource<T?>)state!).TrySetCanceled(),
+                completion);
+            // Release the registration once the wait is over, whichever way it ended. Not a wait
+            // of its own: the continuation only disposes, and the task itself is observed by the
+            // caller that awaits it.
+            completion.Task.ContinueWith(
+                static (_, state) => ((CancellationTokenRegistration)state!).Dispose(),
+                registration,
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        // 🚨 The returned IDisposable is deliberately dropped. Unsubscribing on settle is what
+        // .ToTask() does and what loses a late fault; the subscription instead releases itself
+        // when the SOURCE terminates, which is the only moment after which no fault can still
+        // arrive. The observer is rooted by the source until then.
+        source.Subscribe(
+            value => completion.TrySetResult(value),
+            error =>
+            {
+                // Before the task settled this IS the answer; after it, the task can no longer
+                // carry it — so it goes to the reporter rather than nowhere.
+                if (completion.TrySetException(error))
+                    return;
+                try
+                {
+                    reportLateFault(error);
+                }
+                catch (Exception reporterFailure)
+                {
+                    // A reporter that throws would send BOTH exceptions up the producer's call
+                    // stack — a fault with no observer, on whatever thread signalled disposal.
+                    // Reporters are usually loggers, and a logger whose provider was disposed with
+                    // the scope DOES throw. Fall back to the one sink that cannot: keep the
+                    // information, never propagate.
+                    System.Diagnostics.Trace.TraceError(
+                        "ObserveCompletion: the late-fault reporter threw ({0}: {1}) while reporting {2}: {3}",
+                        reporterFailure.GetType().Name, reporterFailure.Message,
+                        error.GetType().Name, error.Message);
+                }
+            },
+            () => completion.TrySetResult(default));
+
+        return completion.Task;
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansGrainTeardownStragglerTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansGrainTeardownStragglerTest.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Linq;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -44,6 +41,47 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// GRACEFUL TERMINAL for grain-lifetime calls — "deactivate" is already achieved and
 /// "keep alive" is moot — so the callbacks must log-and-no-op, never throw. Pre-fix this
 /// fails with the exact incident exception.</para>
+///
+/// <para>🚨 <b>HOW IT WAITS IS PART OF WHAT IT TESTS — it was DEADLOCKING (issue #2301, four
+/// recurrences, the fourth on <c>main</c> with a <c>HOST_CRASHED</c> marker).</b> The setup above
+/// used to be reached by BRIDGING every wait to a Task: the request/response reads and
+/// <c>DisposalCompleted</c> through <c>FirstAsync()/FirstOrDefaultAsync().ToTask()</c>, and "the
+/// activation left the catalog" through a 100 ms POLL of
+/// <c>IManagementGrain.GetDetailedGrainStatistics()</c> raced against a 30 s <c>Timeout</c>.</para>
+///
+/// <para>Rx's <c>ToTask()</c> completes its <c>TaskCompletionSource</c> from inside the pipeline
+/// WITHOUT <c>RunContinuationsAsynchronously</c>, so the <c>await</c> resumed this test method
+/// INLINE on whichever thread signalled — and for <c>DisposalCompleted</c> that thread is the hub's
+/// disposal thread, which runs on THE DEACTIVATING GRAIN'S OWN TURN SCHEDULER
+/// (<c>CompleteActivation</c> builds the hub <c>.WithTaskScheduler(grainScheduler)</c>). The rest
+/// of the method then ran there, holding that scheduler for up to 30 s while waiting for that same
+/// grain's activation to leave the catalog — which needs
+/// <c>ActivationData.FinishDeactivating</c> to make progress on the scheduler being held. The
+/// failure was <b>always exactly 30 s</b>, the <c>Timeout</c> budget, never a distribution around
+/// it; a healthy activation leaves the catalog in 0.10 s. That shape is a deadlock, not
+/// contention.</para>
+///
+/// <para>The unobserved fault is the second-order effect that turned it into a crash: when the
+/// <c>Timeout</c> settled the wait, a fresh batch of catalog queries was still in flight against a
+/// silo mid-teardown, and each could fault into nothing, become an <c>UnobservedTaskException</c>,
+/// and be escalated by xUnit v3 into the very Catastrophic failure this docstring describes above.
+/// The test that exists to prove stragglers are handled gracefully was itself producing an
+/// unobservable straggler.</para>
+///
+/// <para><b>Every wait in this method is now
+/// <see cref="ReactiveCompletion.ObserveCompletion{T}"/></b> — a <c>Subscribe</c> whose task
+/// completes with <c>RunContinuationsAsynchronously</c>, so no continuation can land on a hub or
+/// grain scheduler. 🚨 <i>All</i> of them, including the two request/response reads, which the
+/// <c>/async</c> skill would otherwise permit as <c>.ToTask()</c> in a test: with no
+/// <c>SynchronizationContext</c>, <c>await</c> captures <c>TaskScheduler.Current</c>, so a SINGLE
+/// inline resumption earlier in the method routes every LATER await onto that scheduler too.
+/// Fixing only the last wait would leave the trap armed at the first one.</para>
+///
+/// <para>The poll is gone entirely, because the thing it was approximating now exists as a signal:
+/// <see cref="GrainDeactivationCompleted"/>, published by the grain from Orleans' own
+/// <c>IGrainContext.Deactivated</c>. Nothing here races a timeout against the work it is waiting
+/// for; the wall-clock bound belongs to <c>[Fact(Timeout = …)]</c> and the cancellation token,
+/// which is where a bound cannot orphan anything.</para>
 /// </summary>
 public class OrleansGrainTeardownStragglerTest(ITestOutputHelper output) : OrleansSharedTestBase(output)
 {
@@ -58,50 +96,72 @@ public class OrleansGrainTeardownStragglerTest(ITestOutputHelper output) : Orlea
         //    a TestUser/_Thread/... MessageHubGrain).
         var threadNode = ThreadNodeType.BuildThreadNode("TestUser", $"Teardown straggler {suffix}", "TestUser");
         var createResp = await client.Observe(new CreateNodeRequest(threadNode), o => o.WithTarget(new Address("TestUser")))
-            .FirstAsync().ToTask(ct);
-        createResp.Message.Success.Should().BeTrue(createResp.Message.Error ?? "");
+            .ObserveCompletion(ex => Output.WriteLine($"[LATE FAULT] CreateNodeRequest stream faulted after answering: {ex}"), ct);
+        createResp.Should().NotBeNull("the create request must be ANSWERED, not merely completed");
+        createResp!.Message.Success.Should().BeTrue(createResp.Message.Error ?? "");
         var threadPath = createResp.Message.Node!.Path!;
         Output.WriteLine($"Thread: {threadPath}");
 
         // 2. Activate the grain by routing a read to it (grain activation → hub build →
         //    CompleteActivation stamps the lifetime callbacks on the hub configuration).
         var getResp = await client.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(threadPath)))
-            .FirstAsync().ToTask(ct);
-        getResp.Message.Data.Should().NotBeNull("the grain must have activated and served its node");
+            .ObserveCompletion(ex => Output.WriteLine($"[LATE FAULT] GetDataRequest stream faulted after answering: {ex}"), ct);
+        getResp.Should().NotBeNull("the read must be ANSWERED, not merely completed");
+        getResp!.Message.Data.Should().NotBeNull("the grain must have activated and served its node");
 
         // 3. Reach the silo-side grain-hosted hub and capture the callbacks the grain
         //    hands out to hub code (heartbeats → KeepAlive, rounds → BeginOperation,
         //    stuck-round watchdog → Invoke). These are exactly what stragglers call.
+        //    Alongside them, the grain's own completion signal — what the activation TELLS
+        //    a waiter, as opposed to what a straggler DOES to it.
         var hub = FindSiloHostedHub(threadPath);
         hub.Should().NotBeNull($"the grain-hosted hub for {threadPath} must exist on the silo");
         var keepAlive = hub!.Configuration.Get<GrainKeepAliveCallback>();
         var longRunning = hub.Configuration.Get<GrainLongRunningOperationCallback>();
         var deactivate = hub.Configuration.Get<GrainDeactivateCallback>();
+        var deactivationCompleted = hub.Configuration.Get<GrainDeactivationCompleted>();
         keepAlive.Should().NotBeNull();
         longRunning.Should().NotBeNull();
         deactivate.Should().NotBeNull();
+        deactivationCompleted.Should().NotBeNull(
+            "a grain-hosted hub must publish its activation's deactivation-completed signal — " +
+            "without it every waiter is back to polling the silo catalog (#2301)");
 
         // 4. Deactivate while ALIVE (legal — the #147 escape hatch) and wait for the
         //    activation to be FULLY gone: first the hub's own disposal completes
-        //    (OnDeactivateAsync), then the activation disappears from the silo catalog,
-        //    which happens only after ActivationData.FinishDeactivating set
-        //    State=Invalid. No sleeps — both waits are on the actual condition.
+        //    (OnDeactivateAsync), then the activation itself reports that it is gone.
+        //
+        //    No sleeps, no polls, no timeouts. Both waits SUBSCRIBE, and their tasks complete
+        //    with RunContinuationsAsynchronously — so this method is NEVER resumed on the
+        //    disposing hub's thread, which is the deactivating grain's own turn scheduler. That
+        //    is the #2301 deadlock: the old .ToTask() bridge resumed here inline on that
+        //    scheduler and then held it for 30 s waiting for the deactivation that needed it.
+        //    The error arm is the second half: a fault arriving after the wait settled is
+        //    REPORTED (into the test output below) instead of orphaned into an unobserved task.
         deactivate!.Invoke();
-        await hub.DisposalCompleted
-            .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
-            .FirstOrDefaultAsync()
-            .ToTask(ct);
+        await hub.DisposalCompleted.ObserveCompletion(
+            ex => Output.WriteLine($"[LATE FAULT] hub disposal for {threadPath} faulted AFTER it completed: {ex}"),
+            ct);
         Output.WriteLine("Hub disposal completed — waiting for the activation to leave the catalog...");
 
+        await deactivationCompleted!.Deactivated.ObserveCompletion(
+            ex => Output.WriteLine($"[LATE FAULT] deactivation of {threadPath} faulted AFTER it completed: {ex}"),
+            ct);
+        Output.WriteLine("Activation reports itself fully deactivated. Confirming it left the catalog...");
+
+        // The signal's CONTRACT, asserted rather than assumed. Orleans 10.2.2 completes
+        // IGrainContext.Deactivated on the LAST line of ActivationData.FinishDeactivating —
+        // after UnregisterMessageTarget() removed the activation from the silo catalog and after
+        // DisposeAsync() set State=Invalid. This is ONE awaited call that answers a question, not
+        // a loop that waits for an answer to change: the wait already happened, reactively, above.
         var grainId = $"messagehub/{threadPath}";
         var mgmt = Fixture.ClusterClient.GetGrain<IManagementGrain>(0);
-        await Observable.Interval(TimeSpan.FromMilliseconds(100))
-            .StartWith(0L)
-            .SelectMany(_ => mgmt.GetDetailedGrainStatistics().ToObservable())
-            .Where(stats => stats.All(s => !string.Equals(s.GrainId.ToString(), grainId, StringComparison.OrdinalIgnoreCase)))
-            .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(30))
-            .ToTask(ct);
+        var catalog = await mgmt.GetDetailedGrainStatistics();
+        catalog.Should().NotContain(
+            s => string.Equals(s.GrainId.ToString(), grainId, StringComparison.OrdinalIgnoreCase),
+            "GrainDeactivationCompleted fires from IGrainContext.Deactivated, which Orleans sets " +
+            "AFTER UnregisterMessageTarget() — if this ever fails, that ordering changed and every " +
+            "waiter built on the signal needs re-reading, not a poll bolted back on");
         Output.WriteLine("Activation is gone from the catalog (State=Invalid). Now the stragglers fire.");
 
         // 5. THE RACE, DISTILLED. Pre-fix each of these throws

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposalWaitBridgeTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposalWaitBridgeTest.cs
@@ -1,0 +1,243 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// The root cause of issue #2301, pinned as tests. Two properties, in the order they matter:
+///
+/// <list type="number">
+/// <item><b>THE DEADLOCK (primary).</b> Rx's <c>ToTask()</c> completes its
+///   <c>TaskCompletionSource</c> from inside the pipeline WITHOUT
+///   <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/>, so <c>await</c>ing it
+///   resumes the caller <b>INLINE on the thread that signalled</b>. On the mesh that thread is a
+///   hub's single-threaded action block or a grain's turn scheduler — the very scheduler the
+///   caller's NEXT wait needs in order to finish. It is sticky, too: with no
+///   <see cref="SynchronizationContext"/>, <c>await</c> captures
+///   <see cref="TaskScheduler"/>.<see cref="TaskScheduler.Current"/>, so one inline resumption
+///   routes every later await in the method onto that scheduler as well. #2301 failed at exactly
+///   30 s — its <c>Timeout</c> budget — every time, while a healthy activation leaves the catalog
+///   in 0.10 s. A number that is always the budget rather than a distribution around it is a
+///   deadlock, not contention.</item>
+/// <item><b>THE LOST FAULT (secondary).</b> When that timeout finally fires it settles the Task,
+///   and a fault still travelling the chain has no observer left — an unobserved exception,
+///   surfaced on the finalizer, escalated by xUnit v3 into a Catastrophic failure that poisons the
+///   NEXT test class. That is the <c>HOST_CRASHED</c> marker; it is what the deadlock does on its
+///   way out.</item>
+/// </list>
+///
+/// <para>#2301 recurred four times because <c>IMessageHub.DisposalCompleted</c>'s own
+/// documentation recommended the broken bridge — <i>"at a genuine async edge (test teardown, grain
+/// deactivation) bridge once with <c>DisposalCompleted.FirstOrDefaultAsync()</c> /
+/// <c>.ToTask()</c>"</i> — so every attempted fix aimed at the timeout instead. That sentence is
+/// gone.</para>
+///
+/// <para>These tests use a bare <see cref="Subject{T}"/> rather than a real hub ON PURPOSE. It
+/// makes "which thread signalled" observable with no timing in the test at all, and
+/// <c>MessageHub.disposalCompleted</c> is CAS-guarded so one hub can never produce the
+/// emit-then-fault shape property 2 needs (that shape belongs to COMPOSED signals: a merge over a
+/// subtree of hubs, a drain chain, or #2301's poll whose per-tick calls were still in flight when
+/// the outer wait settled).</para>
+/// </summary>
+public class DisposalWaitBridgeTest
+{
+    /// <summary>A cross-thread flag: a captured local cannot be read with <c>Volatile.Read</c>.</summary>
+    private sealed class Flag
+    {
+        public volatile bool Value;
+    }
+
+    // ── 1. THE DEADLOCK ────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// THE PRIMARY PROOF. <c>ObserveCompletion</c> never resumes its caller on the thread that
+    /// signalled, so a waiter can never end up holding the scheduler whose progress it is waiting
+    /// for. Deterministic: with <c>RunContinuationsAsynchronously</c> the continuation is queued,
+    /// so it cannot possibly run on the signalling thread while that thread is still inside
+    /// <c>OnNext</c>.
+    /// </summary>
+    [Fact]
+    public async Task ObserveCompletion_NeverResumesItsCallerOnTheSignallingThread()
+    {
+        var signal = new Subject<Unit>();
+        var wait = signal.ObserveCompletion(_ => { });
+
+        var signallingThread = Environment.CurrentManagedThreadId;
+        var insideOnNext = new Flag();
+        var resumedInline = new Flag();
+
+        var probe = wait.ContinueWith(
+            _ => resumedInline.Value =
+                insideOnNext.Value && Environment.CurrentManagedThreadId == signallingThread,
+            CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+        insideOnNext.Value = true;
+        signal.OnNext(Unit.Default);
+        insideOnNext.Value = false;
+
+        await probe;
+
+        resumedInline.Value.Should().BeFalse(
+            "RunContinuationsAsynchronously is what keeps the waiter off the hub/grain scheduler " +
+            "that signalled — resuming there is how #2301 held the very scheduler it was then " +
+            "waiting on");
+    }
+
+    /// <summary>
+    /// THE CONTROL, and the shape the interface documentation used to prescribe: <c>.ToTask()</c>
+    /// resumes its caller INLINE, on the signalling thread, even with an
+    /// <c>ExecuteSynchronously</c> continuation asked to run on <see cref="TaskScheduler.Default"/>.
+    /// On the mesh that thread is the hub's action block or the grain's turn — and everything the
+    /// caller does next runs there.
+    /// </summary>
+    [Fact]
+    public async Task TheOldToTaskBridge_ResumesItsCallerInlineOnTheSignallingThread()
+    {
+        var signal = new Subject<Unit>();
+        var wait = signal.FirstOrDefaultAsync().ToTask();
+
+        var signallingThread = Environment.CurrentManagedThreadId;
+        var insideOnNext = new Flag();
+        var resumedInline = new Flag();
+
+        var probe = wait.ContinueWith(
+            _ => resumedInline.Value =
+                insideOnNext.Value && Environment.CurrentManagedThreadId == signallingThread,
+            CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+        insideOnNext.Value = true;
+        signal.OnNext(Unit.Default);
+        insideOnNext.Value = false;
+
+        await probe;
+
+        resumedInline.Value.Should().BeTrue(
+            "this is the defect, asserted rather than described: Rx's ToTask() creates its " +
+            "TaskCompletionSource WITHOUT RunContinuationsAsynchronously, so the awaiter runs on " +
+            "whatever thread produced the completion");
+    }
+
+    // ── 2. THE LOST FAULT ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The signal emits its interesting value, the waiter settles on it, and THEN the signal
+    /// faults. With <c>ObserveCompletion</c> the error arm is still attached, so the late fault is
+    /// reported — it never becomes an unobserved exception.
+    /// </summary>
+    [Fact]
+    public async Task LateFault_AfterTheCompletionValue_IsReported()
+    {
+        var signal = new Subject<Unit>();
+        Exception? reported = null;
+
+        var wait = signal.ObserveCompletion(ex => reported = ex);
+
+        signal.OnNext(Unit.Default);     // the interesting value — disposal finished
+        await wait;                      // …and the waiter has settled on it
+
+        var late = new InvalidOperationException("disposal faulted after it completed");
+        signal.OnError(late);            // THE LATE FAULT
+
+        reported.Should().BeSameAs(late,
+            "the subscription's error arm outlives the task on purpose — .ToTask() unsubscribes " +
+            "on settle and the fault then reaches nobody at all");
+    }
+
+    /// <summary>
+    /// The same late fault through the old bridge reaches NOBODY — not even the <c>.Catch</c> that
+    /// was supposed to handle it. Nothing throws, nothing logs, nothing fails.
+    /// </summary>
+    [Fact]
+    public async Task LateFault_ThroughTheOldToTaskBridge_ReachesNobody()
+    {
+        var signal = new Subject<Unit>();
+        Exception? seenByAnyone = null;
+
+        // The exact bridge the interface documentation prescribed until this change.
+        var wait = signal
+            .Catch<Unit, Exception>(ex => { seenByAnyone = ex; return Observable.Return(Unit.Default); })
+            .FirstOrDefaultAsync()
+            .ToTask();
+
+        signal.OnNext(Unit.Default);
+        await wait;                      // FirstOrDefaultAsync has already unsubscribed
+
+        signal.OnError(new InvalidOperationException("disposal faulted after it completed"));
+
+        seenByAnyone.Should().BeNull(
+            "once the bridge settled, the fault had no observer at all — this is the unobserved " +
+            "exception that xUnit v3 escalates into the HOST_CRASHED failure");
+    }
+
+    /// <summary>
+    /// The case #2301 actually took: the wait is abandoned (a <c>Timeout</c> there, a cancellation
+    /// here) and the fault lands afterwards. The abandoned waiter still reports it.
+    /// </summary>
+    [Fact]
+    public async Task FaultAfterTheWaitWasAbandoned_IsStillReported()
+    {
+        var signal = new Subject<Unit>();
+        Exception? reported = null;
+        using var cts = new CancellationTokenSource();
+
+        var wait = signal.ObserveCompletion(ex => reported = ex, cts.Token);
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait);
+
+        var late = new InvalidOperationException("faulted after the waiter gave up");
+        signal.OnError(late);
+
+        reported.Should().BeSameAs(late,
+            "cancelling the WAIT must not detach the observation — a bound that orphans the work " +
+            "it bounded is the #2301 mechanism");
+    }
+
+    /// <summary>A fault that arrives BEFORE any value is the task's own answer, not a late fault.</summary>
+    [Fact]
+    public async Task FaultBeforeAnyValue_FaultsTheReturnedTask()
+    {
+        var signal = new Subject<Unit>();
+        Exception? reported = null;
+
+        var wait = signal.ObserveCompletion(ex => reported = ex);
+        signal.OnError(new InvalidOperationException("disposal faulted"));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => wait);
+        thrown.Message.Should().Be("disposal faulted");
+        reported.Should().BeNull("the task carried it, so the late-fault reporter must NOT double-report");
+    }
+
+    /// <summary>
+    /// A signal that already finished answers a late subscriber immediately — the replay contract
+    /// <c>DisposalCompleted</c> (ReplaySubject) and <see cref="GrainDeactivationCompleted"/>
+    /// (AsyncSubject) both have, and the reason subscribing can never be "too late".
+    /// </summary>
+    [Fact]
+    public async Task SubscribingAfterTheSignalAlreadyFired_CompletesImmediately()
+    {
+        var signal = new AsyncSubject<Unit>();
+        signal.OnNext(Unit.Default);
+        signal.OnCompleted();
+
+        var wait = signal.ObserveCompletion(_ => Assert.Fail("no fault is possible here"));
+
+        await wait;
+        wait.IsCompletedSuccessfully.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A reporter is MANDATORY. Nothing may pass an empty lambda "because it cannot fault" —
+    /// that is how the fault stops being reported again.
+    /// </summary>
+    [Fact]
+    public void AReporterIsRequired()
+    {
+        var signal = new Subject<Unit>();
+        Assert.Throws<ArgumentNullException>(() => { _ = signal.ObserveCompletion(null!); });
+    }
+}


### PR DESCRIPTION
Fixes #2301. Addresses sites 2–5 of #2488.

## The mechanism: DEADLOCK, not a lost exception

`await …ToTask()` on a completion signal **deadlocks**, and that is the primary failure — the
`UnobservedTaskException` → `HOST_CRASHED` is what the deadlock does on its way out.

Rx completes a `ToTask()` `TaskCompletionSource` from inside the pipeline **without
`RunContinuationsAsynchronously`**, so the awaiter resumes **INLINE on the signalling thread**. For
`hub.DisposalCompleted` that thread is the hub's disposal thread — and for a grain-hosted hub that
is **the deactivating grain's own turn scheduler** (`CompleteActivation` builds the hub
`.WithTaskScheduler(grainScheduler)`).

So `OrleansGrainTeardownStragglerTest` resumed onto that scheduler and then held it for 30 s,
polling the silo catalog for the very deactivation that needed the scheduler it was holding.

**The signature is in the number.** The failure was *always exactly 30 s* — the `Timeout` budget —
never a distribution around it, while a healthy activation leaves the catalog in **0.10 s**. That is
a deadlock, not contention. It is also sticky: with no `SynchronizationContext`, `await` captures
`TaskScheduler.Current`, so **one** inline resumption routes **every later await in the method**
onto the same scheduler — which is why all four waits in that test are converted, not just the last.

## The signal that was missing

`GrainDeactivationCompleted` (new, `MeshWeaver.Messaging.Hub`) joins the three existing
grain-lifetime callbacks on the hub configuration. Those three are what a straggler *does to* an
activation; this is what the activation *tells* anyone waiting for it to be gone.

`MessageHubGrain` publishes it from Orleans' own `IGrainContext.Deactivated`, which
`ActivationData.FinishDeactivating` sets on its **last line** — after `UnregisterMessageTarget()`
removed the activation from the catalog and `DisposeAsync()` set `State=Invalid` (verified by
decompiling Orleans 10.2.2, and now asserted by the test rather than assumed). `AsyncSubject`: fires
once, replays to late subscribers.

The 100 ms poll and its 30 s `Timeout` are gone. The test now asserts the catalog is empty with one
direct call — a question, not a wait.

## The bridge, for signatures that are not ours

`ReactiveCompletion.ObserveCompletion` subscribes with an error arm and completes its task with
`RunContinuationsAsynchronously` — the line that stops a caller being resumed on the scheduler that
signalled. The subscription is deliberately **not** torn down on settle, so a fault arriving
afterwards is reported instead of orphaned.

## Sites, with the deadlock question asked at each

| Site | whose thread was blocked | verdict |
|---|---|---|
| `OrleansGrainTeardownStragglerTest` ×4 | the deactivating grain's turn scheduler | **converted** — this is #2301 |
| `MeshTeardownExtensions` ×2 | the mesh hub's own disposal thread, which then ran `ioPools.DrainAll()` — a **synchronous JOIN** of every pooled leaf | **converted** |
| `MonolithMeshTestBase.WaitWithProgressAsync` | same, and it is the wait every test in the suite runs | **converted** (progress is now an `Observable.Interval` stopping on the signal's terminal) |
| `SharedOrleansFixture.CleanupClientAsync` | the client hub's disposal thread | **converted** |
| `IoPoolSiloTeardown.OnStop` | **nobody's** — it composes and RETURNS | **kept, verified.** Orleans' `ILifecycleObserver` genuinely declares `Task OnStop(CancellationToken)`; the bridge is at the outermost edge, which is the rule. Comment rewritten to record that rather than cite the doc below. |

Two outcomes teardown used to discard are now **data**: `TeardownReport.DisposalFault` and
`TeardownReport.ActivitiesQuiesced`, both logged at Error. They deliberately do **not** flip
`Clean` — whether a faulted disposal should *fail* a test class is an escalation decision of its
own, and folding it in here would redden the trunk for a reason unrelated to this fix. The public
`WaitForDisposalAndIoDrainAsync` signature is unchanged (an added optional parameter would be
binary-breaking for an already-published module).

## The documentation that caused the recurrence

`IMessageHub.DisposalCompleted`'s own remarks prescribed the crashing shape:

> *"At a genuine async edge (test teardown, grain deactivation) bridge once with
> `DisposalCompleted.FirstOrDefaultAsync()` / `.ToTask()`."*

"test teardown, grain deactivation" is exactly where this crashed — and that sentence is why four
fixes all aimed at the timeout. Replaced, leading with the deadlock. `AsynchronousCalls.md` gains a
matching section.

## Proof

`DisposalWaitBridgeTest` (8 tests, deterministic, no timing) pins both properties **and includes the
controls**:

- `ObserveCompletion_NeverResumesItsCallerOnTheSignallingThread` — the fix;
- `TheOldToTaskBridge_ResumesItsCallerInlineOnTheSignallingThread` — **the control**, asserting that
  `.ToTask()` really does resume inline on the signalling thread;
- `LateFault_AfterTheCompletionValue_IsReported` — a disposal that faults after the interesting
  value has been emitted is now reported;
- `LateFault_ThroughTheOldToTaskBridge_ReachesNobody` — **the control**: the same fault reaches
  nobody at all, not even the `.Catch` meant to handle it.

Local runs (Release, `DOTNET_PROCESSOR_COUNT=4`):

- `MeshWeaver.Hosting.Orleans.Test` **215/215**; the straggler test alone completes in **1 s**
  (against the 30 s timeout it hit in CI).
- `MeshWeaver.Messaging.Hub.Test` **298/298** (+8 new).
- `MeshWeaver.Hosting.Monolith.Test` **740/743** (3 skipped by design) — the largest consumer of the
  changed `MonolithMeshTestBase`.
- `DocumentationLinkIntegrityTest` green.

## Explicitly NOT in this PR

- **`CompilationCacheService.cs:664` (#2488 site 1)** — the `SpinWait` + 5 s "unload anyway". Still
  open; it is a different mechanism (an ALC-unload safety decision, not a Task bridge).
- **`DataContext.cs:449`** — the `Task.WhenAny(allInit, Task.Delay(…)).ContinueWith(…)` init
  watchdog. Assessed and **it is not the same root**: (1) it blocks no thread — it hangs a
  `ContinueWith` on `TaskScheduler.Default` and returns, so it cannot park a grain turn; (2) its
  budget is 120 s, while every #2301 occurrence stalled at exactly 30 s, which is the test's own
  `Timeout`; (3) the failing traces stall between "hub disposal completed" and catalog departure,
  with no init gate in them. It *is* a genuine instance of the banned timer-race shape and deserves
  a reactive rewrite — but one that preserves the `Hub.IsShuttingDown` → `FailGate` branch (#1270),
  the disarm-on-dispose (#1122) and the time-box itself (the 2026-06-26 storm). That is its own PR
  with its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
