### PR TITLE
Email misconfiguration can no longer abort portal startup (#2510)

### DIFF
--- a/memex/Memex.Portal.Shared/Email/EmailDeliveryGuard.cs
+++ b/memex/Memex.Portal.Shared/Email/EmailDeliveryGuard.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using MeshWeaver.Mesh;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -5,8 +6,9 @@ using Microsoft.Extensions.Logging;
 namespace Memex.Portal.Shared.Email;
 
 /// <summary>
-/// 🚨 <b><c>Email:Enabled=true</c> with a sender that does not deliver is a REFUSED
-/// configuration, not a working one</b> (#2023).
+/// 🚨 <b><c>Email:Enabled=true</c> on an install that cannot actually deliver is a REFUSED
+/// configuration, not a working one</b> (#2023) — and reaching that verdict must never cost more
+/// than the mail it guards (#2510).
 ///
 /// <para><b>The defect this closes.</b> While the Graph sender was compiled into the portal,
 /// "a sender is registered" and "mail can be delivered" were the same question, and
@@ -20,15 +22,20 @@ namespace Memex.Portal.Shared.Email;
 /// were spent hunting inboxes, junk folders and message traces because <c>Sent</c> was trusted.</para>
 ///
 /// <para><b>Why refusing beats succeeding quietly.</b> Mail that stays <c>New</c> is recoverable:
-/// land the module and it goes out, with no data repair. Mail stamped <c>Sent</c> that was never
-/// sent is unrecoverable, because nothing distinguishes it from mail that WAS sent. So the
-/// watchers do not start at all on this configuration, and the no-op sender fails loudly for
-/// every other caller instead of returning <c>true</c>.</para>
+/// complete the configuration and it goes out, with no data repair. Mail stamped <c>Sent</c> that
+/// was never sent is unrecoverable, because nothing distinguishes it from mail that WAS sent. So
+/// the watchers do not start at all on a refused configuration, and the no-op sender fails loudly
+/// for every other caller instead of returning <c>true</c>.</para>
 ///
 /// <para>The refusal is logged at <see cref="LogLevel.Error"/> from <c>StartAsync</c> — inside the
 /// startup window — so <c>StartupErrorNotifier</c> folds it into the Admin bell notification that
 /// reports a degraded boot, rather than it sitting at Information under a Warning default where
 /// nobody would ever see it.</para>
+///
+/// <para>🚨 <b>Two refused configurations, asked in a fixed order.</b> See
+/// <see cref="RefuseToStart"/>: the CONFIGURATION verdict is reached first, from inert data, and
+/// only a completely-configured install goes on to ask the CONTAINER. That order is the whole of
+/// #2510 and it is load-bearing — not a micro-optimisation.</para>
 /// </summary>
 internal static class EmailDeliveryGuard
 {
@@ -37,15 +44,28 @@ internal static class EmailDeliveryGuard
     internal const string SenderModule = "MeshWeaver.Mail.MicrosoftGraph";
 
     /// <summary>
-    /// True when this install is configured to send mail but the resolved sender cannot deliver
-    /// it. A <c>null</c> sender counts: no sender at all certainly does not deliver, and treating
-    /// "could not resolve" as "probably fine" would be the skip-trapdoor this guard exists to
-    /// remove.
+    /// The CONFIGURATION verdict: the <c>Email:*</c> keys this install is enabled-but-missing, or
+    /// empty when there is nothing to refuse on this ground. A disabled section is never refused —
+    /// blank keys are exactly what <c>Email:Enabled=false</c> means.
+    ///
+    /// <para>🚨 Reached without touching the service provider, and that is the point: see
+    /// <see cref="EmailOptions.MissingCredentialKeys"/>. Everything a container could tell us here
+    /// costs a construction that can throw; everything this tells us costs a string comparison.</para>
+    /// </summary>
+    internal static ImmutableArray<string> MissingConfiguration(EmailOptions options)
+        => options.Enabled ? options.MissingCredentialKeys() : ImmutableArray<string>.Empty;
+
+    /// <summary>
+    /// The CONTAINER verdict: this install is configured to send mail, but the sender it resolved
+    /// cannot deliver it. A <c>null</c> sender counts: no sender at all certainly does not deliver,
+    /// and treating "could not resolve" as "probably fine" would be the skip-trapdoor this guard
+    /// exists to remove.
     /// </summary>
     internal static bool RefusesDelivery(EmailOptions options, IEmailSender? sender)
         => options.Enabled && sender?.DeliversMail is not true;
 
-    /// <summary>The one wording, so the sender, the watchers and the tests all say the same thing.</summary>
+    /// <summary>The one wording for the module-absent refusal, so the sender, the watchers and the
+    /// tests all say the same thing.</summary>
     /// <param name="what">What is being refused (a component that will not start, or the send itself).</param>
     internal static string Explain(string what)
         => $"Email:Enabled=true but the resolved {nameof(IEmailSender)} does NOT deliver mail — this "
@@ -55,9 +75,56 @@ internal static class EmailDeliveryGuard
            + "Sent that was never sent is not.";
 
     /// <summary>
-    /// The watcher-side gate: resolves the sender this install would actually use and, when it
-    /// cannot deliver, logs the refusal at Error and answers <c>true</c> so the caller returns
-    /// WITHOUT starting its watch. Queued mail then visibly stays <c>New</c>.
+    /// The one wording for the INCOMPLETE-configuration refusal. Deliberately does not blame the
+    /// module: on this path the module may well be present and perfectly healthy — what is missing
+    /// is the credential the operator never set, so the message names the keys instead. Telling an
+    /// operator to "land the module" when the module is already landed is the kind of confidently
+    /// wrong diagnosis that costs an afternoon.
+    /// </summary>
+    /// <param name="missingKeys">The keys from <see cref="MissingConfiguration"/>; never empty.</param>
+    /// <param name="what">What is being refused (a component that will not start, or the send itself).</param>
+    internal static string ExplainIncomplete(ImmutableArray<string> missingKeys, string what)
+        => $"Email:Enabled=true but the Email section is INCOMPLETE — {string.Join(", ", missingKeys)} "
+           + $"{(missingKeys.Length == 1 ? "is" : "are")} not set, so no {nameof(IEmailSender)} on this "
+           + $"install can authenticate. {what} Set {string.Join(", ", missingKeys)}, or set "
+           + "Email:UseManagedIdentity=true and grant the managed identity the Mail.Send app role, to "
+           + "restore delivery. Refusing rather than reporting success: mail left queued is recoverable "
+           + "once the section is completed, mail stamped Sent that was never sent is not.";
+
+    /// <summary>
+    /// The refusal wording that fits THIS install — incomplete configuration when that is the
+    /// cause, the module-absent wording otherwise. One entry point so a caller holding only the
+    /// options (the no-op sender) reports the same cause the watchers logged, instead of the two
+    /// disagreeing about why the same install refused.
+    /// </summary>
+    internal static string ExplainRefusal(EmailOptions options, string what)
+        => MissingConfiguration(options) is { IsEmpty: false } missing
+            ? ExplainIncomplete(missing, what)
+            : Explain(what);
+
+    /// <summary>
+    /// The watcher-side gate: answers <c>true</c> when this install cannot deliver mail, having
+    /// logged the refusal at Error, so the caller returns WITHOUT starting its watch. Queued mail
+    /// then visibly stays <c>New</c>.
+    ///
+    /// <para>🚨 <b>The order of the two questions is the fix for #2510.</b> This runs inside
+    /// <c>IHostedService.StartAsync</c>, where a throw does not degrade a feature — it aborts the
+    /// HOST. Asking the container first meant ACTIVATING the module's sender there, and the
+    /// reference sender validates its Azure credential in its constructor: an unset
+    /// <c>Email:TenantId</c> became <c>ArgumentException: Invalid tenant id provided</c> →
+    /// <c>Hosting failed to start</c> → a pod that never becomes ready. A half-configured optional
+    /// integration took down the entire portal, twice, on two rollouts.</para>
+    ///
+    /// <para>So the configuration is asked FIRST, from data that cannot throw. An install missing
+    /// its credentials is refused here and the sender is never resolved at all — which is the
+    /// difference between a portal that serves without mail and a portal that does not serve. Only
+    /// a COMPLETELY configured install goes on to ask the container, which is the question #2023
+    /// needs (is the module actually here?) and the one that has no configuration-shaped answer.</para>
+    ///
+    /// <para>This is not a <c>catch</c> around the resolution, deliberately. Swallowing an
+    /// activation failure would also swallow the ones that mean something is genuinely broken; not
+    /// asking a question whose answer we already hold leaves every other failure exactly as loud as
+    /// it was.</para>
     /// </summary>
     /// <param name="services">The provider the host's sender singleton lives in.</param>
     /// <param name="options">The bound <c>Email</c> section.</param>
@@ -66,13 +133,22 @@ internal static class EmailDeliveryGuard
     internal static bool RefuseToStart(
         IServiceProvider services, EmailOptions options, ILogger? logger, string component)
     {
+        var what = $"{component} will not claim or send anything, so outbound mail stays visibly queued.";
+
+        // 1. CONFIGURATION — inert, cannot throw, cannot activate anything.
+        var missing = MissingConfiguration(options);
+        if (!missing.IsEmpty)
+        {
+            logger?.LogError(
+                "{Component} is NOT starting. {Explanation}", component, ExplainIncomplete(missing, what));
+            return true;
+        }
+
+        // 2. CONTAINER — only now, and only for an install whose configuration is complete.
         if (!RefusesDelivery(options, services.GetService<IEmailSender>()))
             return false;
 
-        logger?.LogError(
-            "{Component} is NOT starting. {Explanation}",
-            component,
-            Explain($"{component} will not claim or send anything, so outbound mail stays visibly queued."));
+        logger?.LogError("{Component} is NOT starting. {Explanation}", component, Explain(what));
         return true;
     }
 }

--- a/memex/Memex.Portal.Shared/Email/EmailDeliveryGuard.cs
+++ b/memex/Memex.Portal.Shared/Email/EmailDeliveryGuard.cs
@@ -22,8 +22,11 @@ namespace Memex.Portal.Shared.Email;
 /// were spent hunting inboxes, junk folders and message traces because <c>Sent</c> was trusted.</para>
 ///
 /// <para><b>Why refusing beats succeeding quietly.</b> Mail that stays <c>New</c> is recoverable:
-/// complete the configuration and it goes out, with no data repair. Mail stamped <c>Sent</c> that
-/// was never sent is unrecoverable, because nothing distinguishes it from mail that WAS sent. So
+/// complete the configuration, restart the portal, and it goes out — with no data repair and
+/// nothing to re-queue by hand. (The restart is required, not incidental: the <c>Email</c> section
+/// is bound once at host start and these watchers start with it, so neither re-reads it at
+/// runtime.) Mail stamped <c>Sent</c> that was never sent is unrecoverable, because nothing
+/// distinguishes it from mail that WAS sent. So
 /// the watchers do not start at all on a refused configuration, and the no-op sender fails loudly
 /// for every other caller instead of returning <c>true</c>.</para>
 ///
@@ -70,9 +73,10 @@ internal static class EmailDeliveryGuard
     internal static string Explain(string what)
         => $"Email:Enabled=true but the resolved {nameof(IEmailSender)} does NOT deliver mail — this "
            + $"install has no mail sender. {what} Land the {SenderModule} module on this deployment "
-           + "(Modules:Assemblies / the plugin bundle) to restore delivery. Refusing rather than "
-           + "reporting success: mail left queued is recoverable once the module lands, mail stamped "
-           + "Sent that was never sent is not.";
+           + "(Modules:Assemblies / the plugin bundle) and RESTART the portal to restore delivery — "
+           + "the Email section is read once at host start and the mail watchers start with it. "
+           + "Refusing rather than reporting success: mail left queued is recoverable on that "
+           + "restart, mail stamped Sent that was never sent is not.";
 
     /// <summary>
     /// The one wording for the INCOMPLETE-configuration refusal. Deliberately does not blame the
@@ -87,9 +91,10 @@ internal static class EmailDeliveryGuard
         => $"Email:Enabled=true but the Email section is INCOMPLETE — {string.Join(", ", missingKeys)} "
            + $"{(missingKeys.Length == 1 ? "is" : "are")} not set, so no {nameof(IEmailSender)} on this "
            + $"install can authenticate. {what} Set {string.Join(", ", missingKeys)}, or set "
-           + "Email:UseManagedIdentity=true and grant the managed identity the Mail.Send app role, to "
-           + "restore delivery. Refusing rather than reporting success: mail left queued is recoverable "
-           + "once the section is completed, mail stamped Sent that was never sent is not.";
+           + "Email:UseManagedIdentity=true and grant the managed identity the Mail.Send app role, "
+           + "then RESTART the portal to restore delivery — the Email section is read once at host "
+           + "start and the mail watchers start with it. Refusing rather than reporting success: mail "
+           + "left queued is recoverable on that restart, mail stamped Sent that was never sent is not.";
 
     /// <summary>
     /// The refusal wording that fits THIS install — incomplete configuration when that is the

--- a/memex/Memex.Portal.Shared/Email/NoOpEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/NoOpEmailSender.cs
@@ -44,8 +44,11 @@ public sealed class NoOpEmailSender(EmailOptions options, ILogger<NoOpEmailSende
     {
         if (options.Enabled)
         {
-            var explanation = EmailDeliveryGuard.Explain(
-                "This send is REFUSED rather than reported as delivered.");
+            // ExplainRefusal, not Explain: this install may have the module and be missing only a
+            // credential key (#2510). Naming the module in that case sends the operator to fix
+            // something that is not broken.
+            var explanation = EmailDeliveryGuard.ExplainRefusal(
+                options, "This send is REFUSED rather than reported as delivered.");
             logger?.LogError(
                 "Refusing to send to {To} (subject: {Subject}, attachments: {Attachments}). {Explanation}",
                 toAddress, subject, attachments.Count, explanation);

--- a/src/MeshWeaver.Documentation/Data/Architecture/SendingEmail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SendingEmail.md
@@ -101,15 +101,45 @@ local dev and tests never send mail.
 > inbound (inbox subscription + read) needs **`Mail.ReadWrite`**. Both are tenant-admin-consented
 > application permissions on the mailbox's app registration.
 
-Registration (in the portal's `MemexConfiguration.ConfigureMemexServices`):
+Registration is split between the host and the module, and the pairing is deliberately
+**order-independent**: the host registers its no-op with `TryAddSingleton` and the
+`MeshWeaver.Mail.MicrosoftGraph` module registers the Graph sender with a plain `AddSingleton`.
+Whichever runs first, the last registration of a service type wins and `TryAdd` declines when one
+already exists — so module listed ⇒ the Graph sender; module absent ⇒ the no-op keeps the two
+`GetRequiredService<IEmailSender>()` call sites resolvable instead of throwing at startup.
 
 ```csharp
 var email = builder.Configuration.GetSection(EmailOptions.SectionName).Get<EmailOptions>() ?? new();
 services.AddSingleton(email);
-services.AddSingleton<IEmailSender>(email.Enabled
-    ? sp => new GraphEmailSender(...)      // Microsoft Graph /sendMail
-    : sp => new NoOpEmailSender(...));
+services.TryAddSingleton<IEmailSender, NoOpEmailSender>();   // host fallback
+// …and, when the module is listed under Modules:Assemblies:
+services.AddSingleton<IEmailSender, GraphEmailSender>();     // MeshWeaver.Mail.MicrosoftGraph
 ```
+
+### 🚨 Refused configurations
+
+`Email:Enabled=true` on an install that cannot actually deliver is **refused**, never quietly
+succeeded. There are two such configurations and they are diagnosed separately, because they need
+opposite fixes:
+
+| Configuration | Verdict reached from | What the operator is told |
+|---|---|---|
+| Enabled, but the credential keys the selected flow needs are unset (`EmailOptions.MissingCredentialKeys()`) | **Configuration** — inert data | The exact keys to set, e.g. `Email:TenantId` |
+| Enabled, complete, but the resolved sender reports `DeliversMail == false` (the module is not on this install) | The **container** | Land the `MeshWeaver.Mail.MicrosoftGraph` module |
+
+On either, `OutboundEmailSender` and `InvitationEmailSender` **do not start at all**, so queued mail
+stays visibly `New` — recoverable the moment the configuration is completed, with no data repair —
+and every other caller gets a loud failure instead of `true`. Mail stamped `Sent` that was never
+sent is indistinguishable from mail that really was sent, which is why refusing is the safer
+direction (#2023).
+
+🚨 **The order the two questions are asked in is load-bearing** (#2510). The guard runs inside
+`IHostedService.StartAsync`, where a throw aborts the **host**, not a feature. It therefore asks the
+configuration *first*, from data that cannot throw, and only a completely-configured install goes on
+to resolve the sender. Asking the container first meant activating the Graph sender there — and it
+built an Azure `ClientSecretCredential` in its constructor, which validates the tenant id eagerly —
+so an unset `Email:TenantId` produced `Hosting failed to start` and a pod that never became ready.
+A half-configured optional integration must never be able to do that.
 
 ---
 
@@ -117,7 +147,9 @@ services.AddSingleton<IEmailSender>(email.Enabled
 
 `GraphEmailSender` calls Graph
 `/users/{mailbox}/sendMail` using the `Mail.Send` **application** permission, bridging the async Graph
-call to the reactive surface via `Observable.FromAsync`. Credentials come from `EmailOptions`:
+call to the reactive surface through a bounded `IIoPool` (`_http.Run(...)`) — **never**
+`Observable.FromAsync`, which is forbidden outside `IoPool` (see
+[Controlled I/O Pooling](/Doc/Architecture/ControlledIoPooling)). Credentials come from `EmailOptions`:
 `DefaultAzureCredential` (managed identity) in production, or a `ClientSecretCredential` for self-host.
 
 The one-time Azure setup — a dedicated app registration, **admin-consented `Mail.Send`** (plus

--- a/src/MeshWeaver.Documentation/Data/Architecture/SendingEmail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SendingEmail.md
@@ -128,10 +128,15 @@ opposite fixes:
 | Enabled, complete, but the resolved sender reports `DeliversMail == false` (the module is not on this install) | The **container** | Land the `MeshWeaver.Mail.MicrosoftGraph` module |
 
 On either, `OutboundEmailSender` and `InvitationEmailSender` **do not start at all**, so queued mail
-stays visibly `New` — recoverable the moment the configuration is completed, with no data repair —
-and every other caller gets a loud failure instead of `true`. Mail stamped `Sent` that was never
-sent is indistinguishable from mail that really was sent, which is why refusing is the safer
-direction (#2023).
+stays visibly `New` and every other caller gets a loud failure instead of `true`.
+
+🚨 **Recovery needs a restart, and the refusal says so.** The `Email` section is bound **once at host
+start** (`Configuration.GetSection(...).Get<EmailOptions>()` into a singleton — not `IOptionsMonitor`),
+and both watchers are `IHostedService`s that start with it, so neither re-reads configuration at
+runtime. Completing the section therefore takes effect on the next portal start / rollout — at which
+point the queued `New` mail goes out by itself, with no data repair and nothing to re-queue by hand.
+That is the whole reason refusing beats succeeding quietly: mail stamped `Sent` that was never sent
+is indistinguishable from mail that really was sent, and no restart recovers it (#2023).
 
 🚨 **The order the two questions are asked in is load-bearing** (#2510). The guard runs inside
 `IHostedService.StartAsync`, where a throw aborts the **host**, not a feature. It therefore asks the

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-email-config-cannot-block-startup.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-email-config-cannot-block-startup.md
@@ -15,5 +15,6 @@ the incomplete credential, so an optional integration took the entire site down.
 
 The check now reads the configuration directly, which cannot fail. A portal with mail half-configured
 starts and serves normally; mail alone is switched off, with an error naming the exact keys still to set.
-Anything already queued stays visibly unsent and goes out by itself once the configuration is completed —
-it is never marked as delivered when it was not.
+Anything already queued stays visibly unsent, and goes out by itself once the keys are set and the portal
+restarts — mail settings are read at startup, so completing them takes effect on the next roll. Nothing
+is ever marked as delivered when it was not.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-email-config-cannot-block-startup.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-email-config-cannot-block-startup.md
@@ -1,0 +1,19 @@
+---
+Name: Half-configured email no longer blocks the portal from starting
+Category: Fix
+Description: A portal with mail switched on but its credentials unset now starts normally and reports exactly which key is missing.
+Icon: Sparkle
+Order: -20260827
+---
+
+# Half-configured email no longer blocks the portal from starting
+
+Turning mail on (`Email:Enabled=true`) without finishing the credential — an unset `Email:TenantId`, for
+instance — used to stop the whole portal from starting, not just mail. The check that protects against
+undelivered mail asked the application to build its mail sender during startup, and that sender rejected
+the incomplete credential, so an optional integration took the entire site down.
+
+The check now reads the configuration directly, which cannot fail. A portal with mail half-configured
+starts and serves normally; mail alone is switched off, with an error naming the exact keys still to set.
+Anything already queued stays visibly unsent and goes out by itself once the configuration is completed —
+it is never marked as delivered when it was not.

--- a/src/MeshWeaver.Mesh.Contract/EmailOptions.cs
+++ b/src/MeshWeaver.Mesh.Contract/EmailOptions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace MeshWeaver.Mesh;
 
 /// <summary>
@@ -51,4 +53,46 @@ public sealed record EmailOptions
 
     /// <summary>Shared secret echoed by Graph on every notification; the webhook rejects mismatches. Generate a random value per deployment.</summary>
     public string SubscriptionClientState { get; init; } = "";
+
+    /// <summary>
+    /// The <c>Email:*</c> keys this section is MISSING for the credential flow it selected — empty
+    /// when the section carries everything that flow needs. Says nothing about
+    /// <see cref="Enabled"/>: a disabled section is legitimately blank, and it is the CALLER that
+    /// decides whether an incomplete section matters (see <c>EmailDeliveryGuard</c>).
+    ///
+    /// <para>🚨 <b>This is inert data, and that is the entire point.</b> It answers "can this
+    /// install authenticate?" from the bound values alone — no container, no credential object, no
+    /// I/O — so it cannot throw and cannot activate anything. The question used to be answerable
+    /// only by CONSTRUCTING the sender, and the reference sender builds an Azure
+    /// <c>ClientSecretCredential</c> in its constructor, which validates the tenant id eagerly.
+    /// Asking it from an <c>IHostedService.StartAsync</c> therefore turned a half-filled
+    /// <c>Email</c> section into <c>Hosting failed to start</c> — the whole portal down because an
+    /// OPTIONAL integration was misconfigured (#2510). A verdict reached from configuration cannot
+    /// do that.</para>
+    ///
+    /// <para>Managed identity needs no keys here at all: <c>DefaultAzureCredential</c> takes no
+    /// tenant id, which is also why <c>Email:UseManagedIdentity=true</c> was never affected by that
+    /// crash. The client-secret flow needs all three, and each is named with its full configuration
+    /// key so an operator is told what to set rather than that "email is broken".</para>
+    ///
+    /// <para>Note what this deliberately does NOT do: it does not judge whether a PRESENT value is
+    /// a valid tenant id. Re-implementing <c>Azure.Identity</c>'s validator here would be a second
+    /// copy free to drift from the real one. A present-but-malformed value is the sender's own
+    /// business, and the sender must therefore not validate it during construction either.</para>
+    /// </summary>
+    public ImmutableArray<string> MissingCredentialKeys()
+    {
+        // Managed identity carries no secrets in configuration — nothing here can be missing.
+        if (UseManagedIdentity)
+            return ImmutableArray<string>.Empty;
+
+        var missing = ImmutableArray.CreateBuilder<string>(3);
+        if (string.IsNullOrWhiteSpace(TenantId)) missing.Add(Key(nameof(TenantId)));
+        if (string.IsNullOrWhiteSpace(ClientId)) missing.Add(Key(nameof(ClientId)));
+        if (string.IsNullOrWhiteSpace(ClientSecret)) missing.Add(Key(nameof(ClientSecret)));
+        return missing.ToImmutable();
+    }
+
+    /// <summary>The full configuration key for one of this section's properties, e.g. <c>Email:TenantId</c>.</summary>
+    private static string Key(string property) => $"{SectionName}:{property}";
 }

--- a/test/Memex.Portal.Shared.Test/EmailMisconfigurationRefusalTest.cs
+++ b/test/Memex.Portal.Shared.Test/EmailMisconfigurationRefusalTest.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Email;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>A half-configured OPTIONAL integration must not be able to stop the portal from
+/// starting</b> (#2510).
+///
+/// <para><b>The defect.</b> <c>Email:Enabled=true</c> with <c>Email:TenantId</c> unset crashed the
+/// host outright: <c>Hosting failed to start … An exception was thrown while activating
+/// GraphEmailSender … ArgumentException: Invalid tenant id provided</c>, and the pod never became
+/// ready. Nothing about mail should be able to do that — the blast radius of an unconfigured mail
+/// sender is mail.</para>
+///
+/// <para><b>What actually pulled the trigger</b> is the interesting part, and it is why this file
+/// sits next to <see cref="NoOpEmailSenderRefusalTest"/>: it was <c>EmailDeliveryGuard</c>, the
+/// guard added for #2023 to stop mail being falsely stamped <c>Sent</c>. It ran in
+/// <c>IHostedService.StartAsync</c> — where a throw aborts the HOST, not a feature — and its first
+/// act was to ask the CONTAINER for an <see cref="IEmailSender"/>. Resolving it ACTIVATES the
+/// module's Graph sender, which builds an Azure <c>ClientSecretCredential</c> in its constructor,
+/// which validates the tenant id eagerly. So the guard against silent data loss became a
+/// deterministic startup crash: a guard that can fail worse than the thing it guards.</para>
+///
+/// <para><b>The fix, and what these cases pin.</b> The guard now reaches its verdict from the
+/// CONFIGURATION first — inert data that cannot throw and cannot activate anything — and only a
+/// completely-configured install goes on to ask the container. So both halves have to hold, and
+/// each is asserted below:</para>
+/// <list type="number">
+/// <item><description>the portal <b>STARTS</b> with the section half-filled, even though the
+/// registered sender cannot be constructed at all; and</description></item>
+/// <item><description>a send attempt on that install <b>REFUSES</b>, naming the missing key —
+/// never the silent success that #2023 was about.</description></item>
+/// </list>
+///
+/// <para>Both are needed, and neither implies the other: "starts" alone is satisfied by quietly
+/// dropping mail, which is the worse bug; "refuses" alone is satisfied by a portal that never
+/// starts, which is this one.</para>
+/// </summary>
+public class EmailMisconfigurationRefusalTest
+{
+    private static readonly TimeSpan TestBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>The section as a deployment that never finished wiring mail leaves it: switched ON,
+    /// with the client-secret credential blank. This is the memex configuration from the incident.</summary>
+    private static EmailOptions HalfConfigured() => new()
+    {
+        Enabled = true,
+        MailboxAddress = "no-reply@example.test",
+        // TenantId / ClientId / ClientSecret deliberately unset.
+    };
+
+    private static EmailOptions FullyConfigured() => new()
+    {
+        Enabled = true,
+        MailboxAddress = "no-reply@example.test",
+        TenantId = "00000000-0000-0000-0000-000000000000",
+        ClientId = "client",
+        ClientSecret = "secret",
+    };
+
+    // ───────────────────────── half 1: the portal starts ─────────────────────────
+
+    /// <summary>
+    /// 🚨 The regression pin, at the level the incident happened: a REAL generic host, running the
+    /// real mail hosted services, with a sender registered BY TYPE so the container has to
+    /// construct it — and that constructor throws exactly the way
+    /// <c>Azure.Identity</c>'s does on an unset tenant id.
+    ///
+    /// <para>Before the fix this is <c>Hosting failed to start</c>, which in production is a pod
+    /// that never becomes ready. After it, the host starts: the guard reads the missing key out of
+    /// the configuration and refuses there, so nothing ever asks the container for the sender.</para>
+    /// </summary>
+    [Fact]
+    public async Task HalfConfiguredEmail_TheHostStillStarts_AnOptionalIntegrationCannotAbortStartup()
+    {
+        using var cts = new CancellationTokenSource(TestBudget);
+        using var host = BuildHost(HalfConfigured());
+
+        // No try/catch and no assertion helper on purpose: the failure mode IS the throw, and the
+        // xUnit failure then carries the real stack — the same one the pod logged.
+        await host.StartAsync(cts.Token);
+
+        Assert.False(
+            SenderProbe.Of(host).WasConstructed,
+            "the sender must never be CONSTRUCTED on a half-configured install: constructing it is "
+            + "what threw, and the whole point is that the verdict comes from configuration instead.");
+
+        await host.StopAsync(cts.Token);
+    }
+
+    /// <summary>
+    /// The control, and it is what stops the case above from being satisfied by a guard that
+    /// refuses everything: a fully-configured install DOES resolve its sender at startup. That
+    /// resolution is the #2023 question ("is a real sender actually here?"), which has no
+    /// configuration-shaped answer and must keep being asked.
+    /// </summary>
+    [Fact]
+    public async Task FullyConfiguredEmail_TheSenderIsStillResolvedAtStartup_SoTheModuleAbsentCheckSurvives()
+    {
+        using var cts = new CancellationTokenSource(TestBudget);
+        using var host = BuildHost(FullyConfigured());
+
+        await host.StartAsync(cts.Token);
+
+        Assert.True(
+            SenderProbe.Of(host).WasConstructed,
+            "a complete configuration must still resolve the sender — otherwise #2023's "
+            + "module-absent refusal would silently stop being checked.");
+
+        await host.StopAsync(cts.Token);
+    }
+
+    /// <summary>
+    /// Managed identity needs no keys in configuration at all (<c>DefaultAzureCredential</c> takes
+    /// no tenant id), which is exactly why <c>Email:UseManagedIdentity=true</c> was never hit by
+    /// the crash. Pinned so the new configuration gate cannot start refusing the production
+    /// deployment shape — a false refusal here would stop mail on every install that works today.
+    /// </summary>
+    [Fact]
+    public async Task ManagedIdentity_NeedsNoCredentialKeys_AndIsNeverRefused()
+    {
+        using var cts = new CancellationTokenSource(TestBudget);
+        var options = new EmailOptions
+        {
+            Enabled = true,
+            UseManagedIdentity = true,
+            MailboxAddress = "no-reply@example.test",
+        };
+
+        Assert.Empty(options.MissingCredentialKeys());
+
+        using var host = BuildHost(options);
+        await host.StartAsync(cts.Token);
+
+        Assert.True(
+            SenderProbe.Of(host).WasConstructed,
+            "managed identity is a COMPLETE configuration — it must reach the container check.");
+
+        await host.StopAsync(cts.Token);
+    }
+
+    /// <summary>
+    /// The same verdict one level down, observed on the provider rather than through a host: the
+    /// guard must not so much as ASK for the sender. Asserting "the host started" alone would also
+    /// pass if the resolution were merely wrapped in a <c>catch</c> — which is not the fix, because
+    /// a catch there would swallow real activation failures too.
+    /// </summary>
+    [Fact]
+    public async Task HalfConfiguredEmail_TheWatcherNeverEvenAsksTheContainerForASender()
+    {
+        var options = HalfConfigured();
+        var services = new ServiceCollection()
+            .AddSingleton<IEmailSender, CredentialValidatingSender>()
+            .AddSingleton(options)
+            .BuildServiceProvider();
+        var recording = new SenderRequestCountingProvider(services);
+        using var lifetime = new StartableLifetime();
+
+        var watcher = new OutboundEmailSender(recording, lifetime, options);
+        await watcher.StartAsync(CancellationToken.None);
+        lifetime.NotifyStarted();
+
+        Assert.Equal(0, recording.SenderRequests);
+        watcher.Dispose();
+    }
+
+    // ───────────────────────── half 2: a send refuses ─────────────────────────
+
+    /// <summary>
+    /// 🚨 The other half. A portal that starts and then silently swallows mail is a WORSE outcome
+    /// than the crash — that is #2023, and it cost an afternoon of inbox archaeology. So on the
+    /// same half-configured install a send must surface as a failure, and the message must name the
+    /// key to set: an operator told "email is broken" goes hunting; one told
+    /// <c>Email:TenantId</c> is done.
+    /// </summary>
+    [Fact]
+    public async Task HalfConfiguredEmail_ASendAttemptRefuses_AndNamesTheMissingKey()
+    {
+        IEmailSender sender = new NoOpEmailSender(HalfConfigured());
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sender.SendEmail("x@example.test", "s", "<p>b</p>").FirstAsync().ToTask());
+
+        Assert.Contains("Email:TenantId", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("Email:ClientId", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("Email:ClientSecret", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("Email:Enabled=true", failure.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The refusal must diagnose the RIGHT cause. On this install the module may be present and
+    /// perfectly healthy — only a credential is missing — so telling the operator to land a module
+    /// they already have is a confidently wrong answer that sends them somewhere there is nothing
+    /// to find.
+    /// </summary>
+    [Fact]
+    public void TheIncompleteConfigurationRefusal_DoesNotBlameTheModule()
+    {
+        var explanation = EmailDeliveryGuard.ExplainRefusal(HalfConfigured(), "The send is refused.");
+
+        Assert.Contains("Email:TenantId", explanation, StringComparison.Ordinal);
+        Assert.DoesNotContain(EmailDeliveryGuard.SenderModule, explanation, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// And the converse: a COMPLETE configuration whose sender still cannot deliver is the
+    /// module-absent case, and there the module name IS the whole diagnosis (#2023). Pinned
+    /// together with the case above because the failure mode of "one wording for everything" is
+    /// that each install gets told the other one's cause.
+    /// </summary>
+    [Fact]
+    public void TheModuleAbsentRefusal_StillNamesTheModule()
+    {
+        var explanation = EmailDeliveryGuard.ExplainRefusal(FullyConfigured(), "The send is refused.");
+
+        Assert.Contains(EmailDeliveryGuard.SenderModule, explanation, StringComparison.Ordinal);
+    }
+
+    // ───────────────────────── the verdict table ─────────────────────────
+
+    /// <summary>
+    /// What "configured" means, stated once. The client-secret flow needs all three keys; managed
+    /// identity needs none. Whitespace counts as unset — a Helm value templated from an empty
+    /// secret arrives as <c>" "</c> and would fail Azure's validator exactly like <c>""</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(false, "t", "c", "s", 0)]              // client secret, complete
+    [InlineData(false, "", "c", "s", 1)]               // 🚨 the incident: tenant id unset
+    [InlineData(false, "  ", "c", "s", 1)]             // whitespace is not a tenant id
+    [InlineData(false, "", "", "", 3)]                 // nothing configured at all
+    [InlineData(true, "", "", "", 0)]                  // managed identity needs no keys
+    public void MissingCredentialKeys_NamesExactlyWhatTheSelectedFlowNeeds(
+        bool useManagedIdentity, string tenantId, string clientId, string clientSecret, int expected)
+    {
+        var options = new EmailOptions
+        {
+            Enabled = true,
+            UseManagedIdentity = useManagedIdentity,
+            TenantId = tenantId,
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+        };
+
+        Assert.Equal(expected, options.MissingCredentialKeys().Length);
+        Assert.All(options.MissingCredentialKeys(),
+            key => Assert.StartsWith($"{EmailOptions.SectionName}:", key, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A DISABLED section is legitimately blank — that is what <c>Email:Enabled=false</c> means, and
+    /// it is every local dev run and every test host. Refusing it would break all of them, so the
+    /// guard's verdict is empty regardless of what the keys hold.
+    /// </summary>
+    [Fact]
+    public void Disabled_IsNeverRefusedForIncompleteConfiguration()
+        => Assert.Empty(EmailDeliveryGuard.MissingConfiguration(HalfConfigured() with { Enabled = false }));
+
+    // ───────────────────────── fixtures ─────────────────────────
+
+    /// <summary>
+    /// A host wired the way the portal is: the bound <see cref="EmailOptions"/>, an
+    /// <see cref="IEmailSender"/> registered BY TYPE (so the container must construct it — an
+    /// already-built instance would never reproduce the defect), and the two mail hosted services
+    /// whose <c>StartAsync</c> runs the guard.
+    /// </summary>
+    private static IHost BuildHost(EmailOptions options)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(settings: null);
+        // Empty: no console provider, so the refusals these cases EXPECT do not read as test noise.
+        builder.Services.AddLogging();
+        builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
+        builder.Services.AddSingleton(options);
+        builder.Services.AddSingleton<SenderProbe>();
+        builder.Services.AddSingleton<IEmailSender, CredentialValidatingSender>();
+        builder.Services.AddHostedService<OutboundEmailSender>();
+        builder.Services.AddHostedService<InvitationEmailSender>();
+        return builder.Build();
+    }
+
+    /// <summary>Records whether the container ever constructed the sender — the outward sign of the
+    /// activation that used to abort the host.</summary>
+    private sealed class SenderProbe
+    {
+        public bool WasConstructed { get; private set; }
+
+        public void Constructed() => WasConstructed = true;
+
+        public static SenderProbe Of(IHost host) => host.Services.GetRequiredService<SenderProbe>();
+    }
+
+    /// <summary>
+    /// Stands in for the module's <c>GraphEmailSender</c>, and faithfully in the one respect that
+    /// matters: it builds and VALIDATES its credential in the CONSTRUCTOR. That is what
+    /// <c>new ClientSecretCredential(options.TenantId, …)</c> does — <c>Azure.Identity</c>'s
+    /// <c>Validations.ValidateTenantId</c> was the top frame of the production stack — so activating
+    /// it on a blank tenant id throws at exactly the point the real one did.
+    ///
+    /// <para>Not a mock: it is a real <see cref="IEmailSender"/> the container constructs by type,
+    /// which is the whole mechanism under test. Substituting a pre-built instance would pass
+    /// whether or not the fix is present.</para>
+    /// </summary>
+    private sealed class CredentialValidatingSender : IEmailSender
+    {
+        public CredentialValidatingSender(EmailOptions options, SenderProbe probe)
+        {
+            probe.Constructed();
+            if (string.IsNullOrWhiteSpace(options.TenantId) && !options.UseManagedIdentity)
+                throw new ArgumentException("Invalid tenant id provided.", "tenantId");
+        }
+
+        public IObservable<bool> SendEmail(string toAddress, string subject, string htmlBody)
+            => Observable.Return(true);
+
+        public IObservable<bool> SendEmail(
+            string toAddress, string subject, string htmlBody,
+            IReadOnlyCollection<EmailAttachment> attachments)
+            => Observable.Return(true);
+    }
+
+    /// <summary>Counts how often anything asked the container for an <see cref="IEmailSender"/> —
+    /// zero is the assertion that the guard never reached for it.</summary>
+    private sealed class SenderRequestCountingProvider(IServiceProvider inner) : IServiceProvider
+    {
+        private int senderRequests;
+
+        public int SenderRequests => Volatile.Read(ref senderRequests);
+
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IEmailSender))
+                Interlocked.Increment(ref senderRequests);
+            return inner.GetService(serviceType);
+        }
+    }
+
+    /// <summary>A lifetime whose <see cref="IHostApplicationLifetime.ApplicationStarted"/> can be
+    /// fired on demand — the real token the watcher registers its watch on.</summary>
+    private sealed class StartableLifetime : IHostApplicationLifetime, IDisposable
+    {
+        private readonly CancellationTokenSource started = new();
+
+        public CancellationToken ApplicationStarted => started.Token;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+        public void StopApplication() { }
+        public void NotifyStarted() => started.Cancel();
+        public void Dispose() => started.Dispose();
+    }
+}


### PR DESCRIPTION
Fixes #2510.

## The defect

`Email:Enabled=true` with `Email:TenantId` unset crashed the host outright — `Hosting failed to start … activating GraphEmailSender … ArgumentException: Invalid tenant id provided` — and the pod never became ready. It happened twice, on two rollouts, ~20 h apart. **An optional integration took down the whole portal.**

## Which reading it is

Not a missing null-check. The crash is an **eager DI activation performed at host start by something that did not need to perform it** — the "don't run what cannot run" shape, and the trigger is ironic: it is `EmailDeliveryGuard`, the guard added for #2023 to stop mail being falsely stamped `Sent`.

The guard runs inside `IHostedService.StartAsync`, where a throw aborts the **host** rather than degrading a feature, and its first act was `services.GetService<IEmailSender>()`. Resolving that **activates** the module's `GraphEmailSender`, which builds an Azure `ClientSecretCredential` **in its constructor**, which validates the tenant id eagerly. A guard that can fail worse than the thing it guards.

`EmailDeliveryGuard.RefuseToStart` is the only host-start-fatal resolution of `IEmailSender` in the tree — checked; `OutboundEmailSender.BeginWatching`, `InvitationEmailSender.BeginWatching`, `NotificationTriageService` and `GraphSubscriptionService` all defer to `ApplicationStarted` behind a try/catch, and `GraphMail` already builds its credential lazily for exactly this reason. `GraphEmailSender` never got that treatment.

## The fix — the ORDER of the two questions

- **`EmailOptions.MissingCredentialKeys()`** answers "can this install authenticate?" from the bound values alone. Inert: no container, no credential object, no I/O, so it cannot throw and cannot activate anything. Managed identity needs no keys (which is exactly why `Email:UseManagedIdentity=true` was never hit by the crash); the client-secret flow needs all three, each named with its full configuration key.
- **`RefuseToStart` asks that FIRST** and refuses there, so a half-configured install never resolves the sender at all. Only a **completely** configured install goes on to ask the container — which is #2023's question (*is the module actually here?*) and the one that has no configuration-shaped answer.

Deliberately **not** a `catch` around the resolution: swallowing an activation failure would also swallow the ones that mean something is genuinely broken. Not asking a question whose answer we already hold leaves every other failure exactly as loud as it was.

## 🚨 Both halves, because neither implies the other

| | |
|---|---|
| **The portal starts** | A half-configured section no longer reaches the container, so nothing can abort startup. |
| **A send refuses** | Unchanged and still loud. The watchers do not start, so queued mail stays visibly `New` — recoverable once the section is completed, and never stamped `Sent`. `NoOpEmailSender` still throws on send. |

"Starts" alone would be satisfied by quietly dropping mail — which is #2023, the *worse* bug. What changed is only the **diagnosis**: an incomplete section now names the keys to set (`Email:TenantId`, …) instead of telling an operator to land a module they already have.

## Tests — `EmailMisconfigurationRefusalTest`

Against a **real generic host** running the real mail hosted services, with the sender registered **by type** so the container must construct it, and a stand-in whose constructor throws exactly where `Azure.Identity.Validations.ValidateTenantId` did:

- half-configured ⇒ `host.StartAsync()` succeeds, and the sender is never constructed;
- half-configured ⇒ a send throws, naming `Email:TenantId`;
- **control** — fully configured ⇒ the sender IS still resolved at startup, so #2023's module-absent check cannot silently stop being made;
- **control** — `UseManagedIdentity=true` is never refused (a false refusal here would stop mail on every install that works today);
- the guard never even *asks* the container on a half-configured install (a `catch` would pass "the host started" but fail this);
- the verdict table for `MissingCredentialKeys()`, including whitespace-is-unset.

**Demonstrated by reverting**, not asserted: swapping the two questions back reproduces the production stack verbatim —

```
System.ArgumentException : Invalid tenant id provided. (Parameter 'tenantId')
   at …CredentialValidatingSender..ctor
   at …EmailDeliveryGuard.RefuseToStart
   at …OutboundEmailSender.StartAsync
   at Microsoft.Extensions.Hosting.Internal.Host.StartAsync
```

— 2 failures; restored, 23/23 pass (13 new + the 10 existing #2023 cases, unchanged).

## Follow-up (not this PR)

This closes the **unset**-credential case at the seam that was fatal. A *present but malformed* tenant id would still throw from `GraphEmailSender`'s constructor on a fully-configured install. The durable fix for that is in `MeshWeaver.Plugins`: build the credential lazily the way `GraphMail` already does, and report `DeliversMail` honestly. Filed as a follow-up rather than folded in here, since it lands in the other repo and this half alone stops the outage.

## Verification

- `dotnet build -c Release -warnaserror`: `MeshWeaver.Mesh.Contract`, `Memex.Portal.Shared`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test` — 0 warnings, 0 errors.
- `DocumentationLinkIntegrityTest` green (the `SendingEmail.md` update adds a `/Doc/Architecture/ControlledIoPooling` link and drops a stale `Observable.FromAsync` claim that contradicted the repo's own rule).
- What's New entry: `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)