### PR TITLE
PluginTester: bound the gate's fetch/install waits — silence becomes a named timeout

### DIFF
--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -42,6 +42,21 @@ public sealed record GateOptions
     public TimeSpan RenderTimeout { get; init; } = TimeSpan.FromMinutes(2);
 
     /// <summary>
+    /// Budget for one package fetch or install pass (each of the two installs — the gate proper
+    /// and the idempotence re-install — gets its own). These phases were the LAST unbounded waits
+    /// in the gate: compile, render and Tests are all time-bounded with a named verdict, but an
+    /// install whose node write is stored and never announced (the Systemorph/MeshWeaver#817
+    /// class — the row lands, no hub wakes, the observable never emits) threw nothing, so the
+    /// stage-labelling <c>Catch</c> never fired and the whole gate went SILENT mid-package — a
+    /// bake that runs for hours producing no further output, killed only by the CI runner. A
+    /// timeout is an ANSWER here, not a cure: the run fails loudly, named
+    /// <c>[install] TimeoutException</c> by the stage marker, instead of hanging unlabelled.
+    /// Generous by default — installs write nodes but never wait on compiles (that budget is
+    /// <see cref="CompileTimeout"/>, per type, in its own stage).
+    /// </summary>
+    public TimeSpan InstallTimeout { get; init; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
     /// When set, the gate PERSISTS what it compiled: one prebuilt-assembly bundle per package
     /// (every NodeType that reached <see cref="CompilationStatus.Ok"/>) is written into this
     /// directory, keyed to the run's framework MVID — the artifact half of issue #1660 WS1 (the
@@ -200,7 +215,12 @@ public static class PluginGateRunner
         // never taken. Packages run strictly sequentially (Concat in RunPackages), so a captured
         // stage marker is exact.
         var stage = "fetch";
+        // Every phase below is TIME-BOUNDED. The Catch at the bottom names the stage that THREW —
+        // but a wait that never completes throws nothing, and fetch/install were the last phases
+        // without a bound: a stored-but-never-announced node write (#817) left the gate silent
+        // mid-package for hours. The Timeout turns that silence into `[<stage>] TimeoutException`.
         return source.FetchPackageFiles(package, "HEAD")
+            .Timeout(options.InstallTimeout)
             .SelectMany(files =>
             {
                 stage = "install";
@@ -219,6 +239,7 @@ public static class PluginGateRunner
                 return PackageInstaller
                     .Install(harness.Mesh, package, files, snapshot.CommitSha,
                         authorizingUserId: GateMesh.AuthorizingUserId)
+                    .Timeout(options.InstallTimeout)
                     .SelectMany(install =>
                     {
                         stage = "checks";
@@ -236,6 +257,9 @@ public static class PluginGateRunner
                             .SelectMany(typeResults => PackageInstaller
                                 .Install(harness.Mesh, package, files, snapshot.CommitSha,
                                     authorizingUserId: GateMesh.AuthorizingUserId)
+                                // Same bound as the first install; its own Catch below already
+                                // folds a TimeoutException into IdempotenceError by name.
+                                .Timeout(options.InstallTimeout)
                                 .Select(second => new PackageResult(package.Id)
                                 {
                                     Upstream = upstream,


### PR DESCRIPTION
The plugin/content gate (the tool behind the education repo's bake jobs) had exactly one class of unbounded wait left: **fetch and the two install passes**. Compile, render and Tests are all time-bounded and fold a `TimeoutException` into a named verdict — but the stage-labelling `Catch` at the bottom of `RunPackage` only fires on a THROW, and a stored-but-never-announced node write (#817: the row lands, no hub wakes, the install observable never emits) throws nothing. The result is the observed CI shape: a bake that runs for hours mid-package with no further output, killed only by the runner, with nothing naming the package or stage (#1360 documented the same silhouette).

**Change**: `GateOptions.InstallTimeout` (default 10 min) bounds `FetchPackageFiles` and both `PackageInstaller.Install` passes. The existing stage marker then names the hang — `[install] TimeoutException` on the package that wedged — and the idempotence re-install's own `Catch` folds it into `IdempotenceError` by name. Installs write nodes and never wait on compiles (that budget stays `CompileTimeout`, per type, in its own stage), so 10 minutes is generous.

A timeout is the ANSWER here, not a cure: the run fails loudly and diagnosably instead of hanging unlabelled — the next wedge names itself.

Builds clean (`dotnet build tools/MeshWeaver.PluginTester -c Release`, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHQXwGUJF8WT7MQAFvrUUA